### PR TITLE
Removed Dictionary<TKey, TValue>.GetValueOrDefault Methods

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
@@ -706,22 +706,6 @@ namespace System.Collections.Generic
             value = default(TValue);
             return false;
         }
-
-        // Method similar to TryGetValue that returns the value instead of putting it in an out param.
-        public TValue GetValueOrDefault(TKey key) => GetValueOrDefault(key, default(TValue));
-
-        // Method similar to TryGetValue that returns the value instead of putting it in an out param. If the entry
-        // doesn't exist, returns the defaultValue instead.
-        public TValue GetValueOrDefault(TKey key, TValue defaultValue)
-        {
-            int i = FindEntry(key);
-            if (i >= 0)
-            {
-                return entries[i].value;
-            }
-            return defaultValue;
-        }
-
         public bool TryAdd(TKey key, TValue value) => TryInsert(key, value, InsertionBehavior.None);
 
         bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly

--- a/src/mscorlib/src/System/Reflection/CustomAttribute.cs
+++ b/src/mscorlib/src/System/Reflection/CustomAttribute.cs
@@ -2040,7 +2040,7 @@ namespace System.Reflection
             count = 0;
 
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
-            if (!all && s_pca.ContainsKey(caType) == false && !IsSecurityAttribute(caType))
+            if (!all && !s_pca.ContainsKey(caType) && !IsSecurityAttribute(caType))
                 return Array.Empty<Attribute>();
 
             List<Attribute> pcas = new List<Attribute>();
@@ -2078,7 +2078,7 @@ namespace System.Reflection
         internal static bool IsDefined(RuntimeType type, RuntimeType caType)
         {
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
-            if (!all && s_pca.ContainsKey(caType) == false && !IsSecurityAttribute(caType))
+            if (!all && !s_pca.ContainsKey(caType) && !IsSecurityAttribute(caType))
                 return false;
 
             if (all || caType == (RuntimeType)typeof(SerializableAttribute))
@@ -2107,7 +2107,7 @@ namespace System.Reflection
             count = 0;
 
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
-            if (!all && s_pca.ContainsKey(caType)==false && !IsSecurityAttribute(caType))
+            if (!all && !s_pca.ContainsKey(caType) && !IsSecurityAttribute(caType))
                 return Array.Empty<Attribute>();
 
             List<Attribute> pcas = new List<Attribute>();
@@ -2140,7 +2140,7 @@ namespace System.Reflection
         internal static bool IsDefined(RuntimeMethodInfo method, RuntimeType caType)
         {
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
-            if (!all && s_pca.ContainsKey(caType) == false)
+            if (!all && !s_pca.ContainsKey(caType))
                 return false;
 
             if (all || caType == (RuntimeType)typeof(DllImportAttribute))
@@ -2170,7 +2170,7 @@ namespace System.Reflection
             count = 0;
 
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
-            if (!all && s_pca.ContainsKey(caType) == false)
+            if (!all && !s_pca.ContainsKey(caType))
                 return null;
 
             Attribute[] pcas = new Attribute[s_pcasCount];
@@ -2201,7 +2201,7 @@ namespace System.Reflection
         internal static bool IsDefined(RuntimeParameterInfo parameter, RuntimeType caType)
         {
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
-            if (!all && s_pca.ContainsKey(caType) == false)
+            if (!all && !s_pca.ContainsKey(caType))
                 return false;
 
 
@@ -2283,7 +2283,7 @@ namespace System.Reflection
             count = 0;
 
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
-            if (!all && s_pca.ContainsKey(caType) == false)
+            if (!all && !s_pca.ContainsKey(caType))
                 return null;
 
             Attribute[] pcas = new Attribute[s_pcasCount];
@@ -2309,7 +2309,7 @@ namespace System.Reflection
         internal static bool IsDefined(RuntimeFieldInfo field, RuntimeType caType)
         {
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
-            if (!all && s_pca.ContainsKey(caType) == false)
+            if (!all && !s_pca.ContainsKey(caType))
                 return false;
 
             if (all || caType == (RuntimeType)typeof(MarshalAsAttribute))
@@ -2334,7 +2334,7 @@ namespace System.Reflection
 
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
 
-            if (!all && s_pca.ContainsKey(caType) == false && !IsSecurityAttribute(caType))
+            if (!all && !s_pca.ContainsKey(caType) && !IsSecurityAttribute(caType))
                 return Array.Empty<Attribute>();
 
             List<Attribute> pcas = new List<Attribute>();
@@ -2357,7 +2357,7 @@ namespace System.Reflection
         {
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
 
-            if (!all && s_pca.ContainsKey(caType) == false)
+            if (!all && !s_pca.ContainsKey(caType))
                 return false;
 
             if (all || IsSecurityAttribute(caType))

--- a/src/mscorlib/src/System/Reflection/CustomAttribute.cs
+++ b/src/mscorlib/src/System/Reflection/CustomAttribute.cs
@@ -2040,7 +2040,7 @@ namespace System.Reflection
             count = 0;
 
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
-            if (!all && s_pca.GetValueOrDefault(caType) == null && !IsSecurityAttribute(caType))
+            if (!all && s_pca.ContainsKey(caType) == false && !IsSecurityAttribute(caType))
                 return Array.Empty<Attribute>();
 
             List<Attribute> pcas = new List<Attribute>();
@@ -2078,7 +2078,7 @@ namespace System.Reflection
         internal static bool IsDefined(RuntimeType type, RuntimeType caType)
         {
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
-            if (!all && s_pca.GetValueOrDefault(caType) == null && !IsSecurityAttribute(caType))
+            if (!all && s_pca.ContainsKey(caType) == false && !IsSecurityAttribute(caType))
                 return false;
 
             if (all || caType == (RuntimeType)typeof(SerializableAttribute))
@@ -2107,7 +2107,7 @@ namespace System.Reflection
             count = 0;
 
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
-            if (!all && s_pca.GetValueOrDefault(caType) == null && !IsSecurityAttribute(caType))
+            if (!all && s_pca.ContainsKey(caType)==false && !IsSecurityAttribute(caType))
                 return Array.Empty<Attribute>();
 
             List<Attribute> pcas = new List<Attribute>();
@@ -2140,7 +2140,7 @@ namespace System.Reflection
         internal static bool IsDefined(RuntimeMethodInfo method, RuntimeType caType)
         {
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
-            if (!all && s_pca.GetValueOrDefault(caType) == null)
+            if (!all && s_pca.ContainsKey(caType) == false)
                 return false;
 
             if (all || caType == (RuntimeType)typeof(DllImportAttribute))
@@ -2170,7 +2170,7 @@ namespace System.Reflection
             count = 0;
 
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
-            if (!all && s_pca.GetValueOrDefault(caType) == null)
+            if (!all && s_pca.ContainsKey(caType) == false)
                 return null;
 
             Attribute[] pcas = new Attribute[s_pcasCount];
@@ -2201,7 +2201,7 @@ namespace System.Reflection
         internal static bool IsDefined(RuntimeParameterInfo parameter, RuntimeType caType)
         {
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
-            if (!all && s_pca.GetValueOrDefault(caType) == null)
+            if (!all && s_pca.ContainsKey(caType) == false)
                 return false;
 
 
@@ -2231,7 +2231,7 @@ namespace System.Reflection
 
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
 
-            if (!all && s_pca.GetValueOrDefault(caType) == null && !IsSecurityAttribute(caType))
+            if (!all && s_pca.ContainsKey(caType) == false && !IsSecurityAttribute(caType))
                 return Array.Empty<Attribute>();
 
             List<Attribute> pcas = new List<Attribute>();
@@ -2283,7 +2283,7 @@ namespace System.Reflection
             count = 0;
 
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
-            if (!all && s_pca.GetValueOrDefault(caType) == null)
+            if (!all && s_pca.ContainsKey(caType) == false)
                 return null;
 
             Attribute[] pcas = new Attribute[s_pcasCount];
@@ -2309,7 +2309,7 @@ namespace System.Reflection
         internal static bool IsDefined(RuntimeFieldInfo field, RuntimeType caType)
         {
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
-            if (!all && s_pca.GetValueOrDefault(caType) == null)
+            if (!all && s_pca.ContainsKey(caType) == false)
                 return false;
 
             if (all || caType == (RuntimeType)typeof(MarshalAsAttribute))
@@ -2334,7 +2334,7 @@ namespace System.Reflection
 
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
 
-            if (!all && s_pca.GetValueOrDefault(caType) == null && !IsSecurityAttribute(caType))
+            if (!all && s_pca.ContainsKey(caType) == false && !IsSecurityAttribute(caType))
                 return Array.Empty<Attribute>();
 
             List<Attribute> pcas = new List<Attribute>();
@@ -2357,7 +2357,7 @@ namespace System.Reflection
         {
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
 
-            if (!all && s_pca.GetValueOrDefault(caType) == null)
+            if (!all && s_pca.ContainsKey(caType) == false)
                 return false;
 
             if (all || IsSecurityAttribute(caType))

--- a/src/mscorlib/src/System/Reflection/CustomAttribute.cs
+++ b/src/mscorlib/src/System/Reflection/CustomAttribute.cs
@@ -2231,7 +2231,7 @@ namespace System.Reflection
 
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
 
-            if (!all && s_pca.ContainsKey(caType) == false && !IsSecurityAttribute(caType))
+            if (!all && !s_pca.ContainsKey(caType) && !IsSecurityAttribute(caType))
                 return Array.Empty<Attribute>();
 
             List<Attribute> pcas = new List<Attribute>();

--- a/src/mscorlib/src/System/RtType.cs
+++ b/src/mscorlib/src/System/RtType.cs
@@ -1200,7 +1200,7 @@ namespace System
                         {
                             string name = eventInfo.Name;
 
-                            if (csEventInfos.ContainsKey(name) ==true)
+                            if (csEventInfos.ContainsKey(name))
                                 continue;
 
                             csEventInfos[name] = eventInfo;
@@ -1355,10 +1355,8 @@ namespace System
                             if (csPropertyInfos != null)
                             {
                                 string name = propertyInfo.Name;
-
                                 List<RuntimePropertyInfo> cache;
-                                csPropertyInfos.TryGetValue(name,out cache);
-                                if (cache == null)
+                                if (!csPropertyInfos.TryGetValue(name, out cache))
                                 {
                                     cache = new List<RuntimePropertyInfo>(1);
                                     csPropertyInfos[name] = cache;

--- a/src/mscorlib/src/System/RtType.cs
+++ b/src/mscorlib/src/System/RtType.cs
@@ -1200,7 +1200,7 @@ namespace System
                         {
                             string name = eventInfo.Name;
 
-                            if (csEventInfos.GetValueOrDefault(name) != null)
+                            if (csEventInfos.ContainsKey(name) ==true)
                                 continue;
 
                             csEventInfos[name] = eventInfo;
@@ -1356,8 +1356,8 @@ namespace System
                             {
                                 string name = propertyInfo.Name;
 
-                                List<RuntimePropertyInfo> cache = csPropertyInfos.GetValueOrDefault(name);
-
+                                List<RuntimePropertyInfo> cache;
+                                csPropertyInfos.TryGetValue(name,out cache);
                                 if (cache == null)
                                 {
                                     cache = new List<RuntimePropertyInfo>(1);


### PR DESCRIPTION
As Per [dotnet/corefx/#17917](https://github.com/dotnet/corefx/issues/17917)  ,`Dictionary<TKey, TValue>.GetValueOrDefault` Methods have been decided to be removed.As new Extension Methods in the `CollectionExtenstions.cs` are added which do the same job.

The Usage of `Dictionary<TKey, TValue>.GetValueOrDefault` Method in the `src/mscorlib/src/system/reflection/CustomAttribute.cs` , `src/mscorlib/src/System/RtType` has also been replaced with the existing `Dictionary<TKey, TValue>.ContainsKey` & `Dictionary<TKey, TValue>.TryGetValue` methods.

@safern Please Review The Changes.