### PR TITLE
Remove relocations from SECTION_MethodDesc for ngened images

### DIFF
--- a/src/vm/dllimport.cpp
+++ b/src/vm/dllimport.cpp
@@ -4368,8 +4368,8 @@ void NDirect::PopulateNDirectMethodDesc(NDirectMethodDesc* pNMD, PInvokeStaticSi
     else
     {
         EnsureWritablePages(&pNMD->ndirect);
-        pNMD->ndirect.m_pszLibName = szLibName;
-        pNMD->ndirect.m_pszEntrypointName = szEntryPointName;
+        pNMD->ndirect.m_pszLibName.SetValueMaybeNull(szLibName);
+        pNMD->ndirect.m_pszEntrypointName.SetValueMaybeNull(szEntryPointName);
     }
 
 #ifdef _TARGET_X86_

--- a/src/vm/dynamicmethod.cpp
+++ b/src/vm/dynamicmethod.cpp
@@ -272,7 +272,7 @@ DynamicMethodDesc* DynamicMethodTable::GetDynamicMethod(BYTE *psig, DWORD sigSiz
     // the store sig part of the method desc
     pNewMD->SetStoredMethodSig((PCCOR_SIGNATURE)psig, sigSize);
     // the dynamic part of the method desc
-    pNewMD->m_pszMethodName = name;
+    pNewMD->m_pszMethodName.SetValueMaybeNull(name);
 
     pNewMD->m_dwExtendedFlags = mdPublic | mdStatic | DynamicMethodDesc::nomdLCGMethod;
 
@@ -884,16 +884,16 @@ void DynamicMethodDesc::Destroy(BOOL fDomainUnload)
     LoaderAllocator *pLoaderAllocator = GetLoaderAllocatorForCode();
 
     LOG((LF_BCL, LL_INFO1000, "Level3 - Destroying DynamicMethod {0x%p}\n", this));
-    if (m_pSig)
+    if (!m_pSig.IsNull())
     {
-        delete[] (BYTE*)m_pSig;
-        m_pSig = NULL;
+        delete[] (BYTE*)m_pSig.GetValue();
+        m_pSig.SetValueMaybeNull(NULL);
     }
     m_cSig = 0;
-    if (m_pszMethodName)
+    if (!m_pszMethodName.IsNull())
     {
-        delete[] m_pszMethodName;
-        m_pszMethodName = NULL;
+        delete[] m_pszMethodName.GetValue();
+        m_pszMethodName.SetValueMaybeNull(NULL);
     }
 
     GetLCGMethodResolver()->Destroy(fDomainUnload);

--- a/src/vm/genmeth.cpp
+++ b/src/vm/genmeth.cpp
@@ -465,7 +465,7 @@ InstantiatedMethodDesc::NewInstantiatedMethodDesc(MethodTable *pExactMT,
             {
                 if (pWrappedMD->IsSharedByGenericMethodInstantiations())
                 {
-                    pDL = pWrappedMD->AsInstantiatedMethodDesc()->m_pDictLayout;
+                    pDL = pWrappedMD->AsInstantiatedMethodDesc()->GetDictLayoutRaw();
                 }
             }
             else if (getWrappedCode)
@@ -1576,7 +1576,7 @@ void InstantiatedMethodDesc::SetupSharedMethodInstantiation(DWORD numGenericArgs
     _ASSERTE(FitsIn<WORD>(numGenericArgs));
     m_wNumGenericArgs = static_cast<WORD>(numGenericArgs);
 
-    m_pDictLayout = pDL;
+    m_pDictLayout.SetValueMaybeNull(pDL);
 
 
     _ASSERTE(IMD_IsSharedByGenericMethodInstantiations());

--- a/src/vm/ilstubcache.cpp
+++ b/src/vm/ilstubcache.cpp
@@ -167,7 +167,7 @@ MethodDesc* ILStubCache::CreateNewMethodDesc(LoaderHeap* pCreationHeap, MethodTa
     pMD->SetMemberDef(0);
     pMD->SetSlot(MethodTable::NO_SLOT);       // we can't ever use the slot for dynamic methods
     // the no metadata part of the method desc
-    pMD->m_pszMethodName   = (PTR_CUTF8)"IL_STUB";
+    pMD->m_pszMethodName.SetValue((PTR_CUTF8)"IL_STUB");
     pMD->m_dwExtendedFlags = mdPublic | DynamicMethodDesc::nomdILStub;
 
     pMD->SetTemporaryEntryPoint(pMT->GetLoaderAllocator(), pamTracker);
@@ -294,11 +294,11 @@ MethodDesc* ILStubCache::CreateNewMethodDesc(LoaderHeap* pCreationHeap, MethodTa
     {
         switch(dwStubFlags)
         {
-            case ILSTUB_ARRAYOP_GET: pMD->m_pszMethodName =  (PTR_CUTF8)"IL_STUB_Array_Get";
+            case ILSTUB_ARRAYOP_GET: pMD->m_pszMethodName.SetValue((PTR_CUTF8)"IL_STUB_Array_Get");
                                              break;
-            case ILSTUB_ARRAYOP_SET: pMD->m_pszMethodName =  (PTR_CUTF8)"IL_STUB_Array_Set";
+            case ILSTUB_ARRAYOP_SET: pMD->m_pszMethodName.SetValue((PTR_CUTF8)"IL_STUB_Array_Set");
                                              break;
-            case ILSTUB_ARRAYOP_ADDRESS: pMD->m_pszMethodName =  (PTR_CUTF8)"IL_STUB_Array_Address";
+            case ILSTUB_ARRAYOP_ADDRESS: pMD->m_pszMethodName.SetValue((PTR_CUTF8)"IL_STUB_Array_Address");
                                              break;
             default: _ASSERTE(!"Unknown array il stub");
         }
@@ -306,12 +306,12 @@ MethodDesc* ILStubCache::CreateNewMethodDesc(LoaderHeap* pCreationHeap, MethodTa
     else
 #endif
     {
-        pMD->m_pszMethodName = pMD->GetILStubResolver()->GetStubMethodName();
+        pMD->m_pszMethodName.SetValue(pMD->GetILStubResolver()->GetStubMethodName());
     }
 
 
 #ifdef _DEBUG
-    pMD->m_pszDebugMethodName = pMD->m_pszMethodName;
+    pMD->m_pszDebugMethodName = RelativePointer<PTR_CUTF8>::GetValueAtPtr(PTR_HOST_MEMBER_TADDR(DynamicMethodDesc, pMD, m_pszMethodName));
     pMD->m_pszDebugClassName  = ILStubResolver::GetStubClassName(pMD);  // must be called after type is set
     pMD->m_pszDebugMethodSignature = FormatSig(pMD, pCreationHeap, pamTracker);
     pMD->m_pDebugMethodTable.SetValue(pMT);

--- a/src/vm/methodimpl.cpp
+++ b/src/vm/methodimpl.cpp
@@ -72,7 +72,10 @@ PTR_MethodDesc MethodImpl::FindMethodDesc(DWORD slot, PTR_MethodDesc defaultRetu
         return defaultReturn;
     }
 
-    PTR_MethodDesc result = pImplementedMD[slotIndex]; // The method descs are not offset by one
+    DPTR(RelativePointer<PTR_MethodDesc>) pRelPtrForSlot = GetImpMDsNonNull();
+    // The method descs are not offset by one
+    TADDR base = dac_cast<TADDR>(pRelPtrForSlot) + slotIndex * sizeof(RelativePointer<MethodDesc *>);
+    PTR_MethodDesc result = RelativePointer<PTR_MethodDesc>::GetValueMaybeNullAtPtr(base);
 
     // Prejitted images may leave NULL in this table if
     // the methoddesc is declared in another module.
@@ -98,13 +101,13 @@ MethodDesc *MethodImpl::RestoreSlot(DWORD index, MethodTable *pMT)
         NOTHROW;
         GC_NOTRIGGER;
         FORBID_FAULT;
-        PRECONDITION(CheckPointer(pdwSlots));
+        PRECONDITION(!pdwSlots.IsNull());
     }
     CONTRACTL_END
 
     MethodDesc *result;
 
-    PREFIX_ASSUME(pdwSlots != NULL);
+    PREFIX_ASSUME(!pdwSlots.IsNull());
     DWORD slot = GetSlots()[index];
 
     // Since the overridden method is in a different module, we
@@ -126,8 +129,9 @@ MethodDesc *MethodImpl::RestoreSlot(DWORD index, MethodTable *pMT)
     _ASSERTE(result != NULL);
 
     // Don't worry about races since we would all be setting the same result
-    if (EnsureWritableExecutablePagesNoThrow(&pImplementedMD[index], sizeof(pImplementedMD[index])))
-        pImplementedMD[index] = result;
+    if (EnsureWritableExecutablePagesNoThrow(&pImplementedMD.GetValue()[index],
+                                             sizeof(pImplementedMD.GetValue()[index])))
+        pImplementedMD.GetValue()[index].SetValue(result);
 
     return result;
 }
@@ -139,7 +143,7 @@ void MethodImpl::SetSize(LoaderHeap *pHeap, AllocMemTracker *pamTracker, DWORD s
         THROWS;
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(this));
-        PRECONDITION(pdwSlots==NULL && pImplementedMD==NULL);
+        PRECONDITION(pdwSlots.GetValueMaybeNull()==NULL && pImplementedMD.GetValueMaybeNull()==NULL);
         INJECT_FAULT(ThrowOutOfMemory());
     } CONTRACTL_END;
 
@@ -149,7 +153,7 @@ void MethodImpl::SetSize(LoaderHeap *pHeap, AllocMemTracker *pamTracker, DWORD s
                                     S_SIZE_T(size) * S_SIZE_T(sizeof(DWORD)); // DWORD each for the slot numbers
 
         // MethodDesc* for each of the implemented methods
-        S_SIZE_T cbMethodDescs = S_SIZE_T(size) * S_SIZE_T(sizeof(MethodDesc *));
+        S_SIZE_T cbMethodDescs = S_SIZE_T(size) * S_SIZE_T(sizeof(RelativePointer<MethodDesc *>));
 
         // Need to align-up the slot entries so that the MethodDesc* array starts on a pointer boundary.
         cbCountAndSlots.AlignUp(sizeof(MethodDesc*));
@@ -161,29 +165,36 @@ void MethodImpl::SetSize(LoaderHeap *pHeap, AllocMemTracker *pamTracker, DWORD s
         LPBYTE pAllocData = (BYTE*)pamTracker->Track(pHeap->AllocMem(cbTotal));
 
         // Set the count and slot array
-        pdwSlots = (DWORD*)pAllocData;
+        pdwSlots.SetValue((DWORD*)pAllocData);
 
         // Set the MethodDesc* array. Make sure to adjust for alignment.
-        pImplementedMD = (MethodDesc**)ALIGN_UP(pAllocData + cbCountAndSlots.Value(), sizeof(MethodDesc*));
+        pImplementedMD.SetValue((RelativePointer<MethodDesc*> *)ALIGN_UP(pAllocData + cbCountAndSlots.Value(), sizeof(RelativePointer <MethodDesc*>)));
 
         // Store the count in the first entry
-        *pdwSlots = size;
+        *pdwSlots.GetValue() = size;
     }
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////
-void MethodImpl::SetData(DWORD* slots, MethodDesc** md)
+void MethodImpl::SetData(DWORD* slots, RelativePointer<MethodDesc*>* md)
 {
     CONTRACTL {
         NOTHROW;
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(this));
-        PRECONDITION(CheckPointer(pdwSlots));
+        PRECONDITION(!pdwSlots.IsNull());
     } CONTRACTL_END;
 
-    DWORD dwSize = *pdwSlots;
-    memcpy(&(pdwSlots[1]), slots, dwSize*sizeof(DWORD));
-    memcpy(pImplementedMD, md, dwSize*sizeof(MethodDesc*));
+    DWORD *pdwSize = pdwSlots.GetValue();
+    DWORD dwSize = *pdwSize;
+    memcpy(&(pdwSize[1]), slots, dwSize*sizeof(DWORD));
+
+    RelativePointer<MethodDesc *> *pImplMD = pImplementedMD.GetValue();
+
+    for (uint32_t i = 0; i < dwSize; ++i)
+    {
+        pImplMD[i].SetValue(md[i].GetValue());
+    }
 }
 
 #ifdef FEATURE_NATIVE_IMAGE_GENERATION
@@ -194,10 +205,10 @@ void MethodImpl::Save(DataImage *image)
     DWORD size = GetSize();
     _ASSERTE(size > 0);
 
-    image->StoreStructure(pdwSlots, (size+1)*sizeof(DWORD),
+    image->StoreStructure(pdwSlots.GetValue(), (size+1)*sizeof(DWORD),
                                     DataImage::ITEM_METHOD_DESC_COLD,
                                     sizeof(DWORD));
-    image->StoreStructure(pImplementedMD, size*sizeof(MethodDesc*),
+    image->StoreStructure(pImplementedMD.GetValue(), size*sizeof(RelativePointer<MethodDesc*>),
                                     DataImage::ITEM_METHOD_DESC_COLD,
                                     sizeof(MethodDesc*));
 }
@@ -214,21 +225,22 @@ void MethodImpl::Fixup(DataImage *image, PVOID p, SSIZE_T offset)
         // <TODO> Why not use FixupMethodDescPointer? </TODO>
         // <TODO> Does it matter if the MethodDesc needs a restore? </TODO>              
 
-        MethodDesc * pMD = pImplementedMD[iMD];
+        RelativePointer<MethodDesc *> *pRelPtr = pImplementedMD.GetValue();
+        MethodDesc * pMD = pRelPtr[iMD].GetValueMaybeNull();
 
         if (image->CanEagerBindToMethodDesc(pMD) &&
             image->CanHardBindToZapModule(pMD->GetLoaderModule()))
         {
-            image->FixupPointerField(pImplementedMD, iMD * sizeof(MethodDesc *));
+            image->FixupRelativePointerField(pImplementedMD.GetValue(), iMD * sizeof(RelativePointer<MethodDesc *>));
         }
         else
         {
-            image->ZeroPointerField(pImplementedMD, iMD * sizeof(MethodDesc *));
+            image->ZeroPointerField(pImplementedMD.GetValue(), iMD * sizeof(RelativePointer<MethodDesc *>));
         }
     }
 
-    image->FixupPointerField(p, offset + offsetof(MethodImpl, pdwSlots));
-    image->FixupPointerField(p, offset + offsetof(MethodImpl, pImplementedMD));
+    image->FixupRelativePointerField(p, offset + offsetof(MethodImpl, pdwSlots));
+    image->FixupRelativePointerField(p, offset + offsetof(MethodImpl, pImplementedMD));
 }
 
 #endif // FEATURE_NATIVE_IMAGE_GENERATION
@@ -247,19 +259,20 @@ MethodImpl::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
     // 'this' memory should already be enumerated as
     // part of the base MethodDesc.
 
-    if (pdwSlots.IsValid() && GetSize())
+    if (GetSlotsRaw().IsValid() && GetSize())
     {
         ULONG32 numSlots = GetSize();
-        DacEnumMemoryRegion(dac_cast<TADDR>(pdwSlots),
+        DacEnumMemoryRegion(dac_cast<TADDR>(GetSlotsRawNonNull()),
                             (numSlots + 1) * sizeof(DWORD));
 
-        if (pImplementedMD.IsValid())
+        if (GetImpMDs().IsValid())
         {
-            DacEnumMemoryRegion(dac_cast<TADDR>(pImplementedMD),
-                                numSlots * sizeof(PTR_MethodDesc));
+            DacEnumMemoryRegion(dac_cast<TADDR>(GetImpMDsNonNull()),
+                                numSlots * sizeof(RelativePointer<MethodDesc *>));
             for (DWORD i = 0; i < numSlots; i++)
             {
-                PTR_MethodDesc methodDesc = pImplementedMD[i];
+                DPTR(RelativePointer<PTR_MethodDesc>) pRelPtr = GetImpMDsNonNull();
+                PTR_MethodDesc methodDesc = pRelPtr[i].GetValueMaybeNull();
                 if (methodDesc.IsValid())
                 {
                     methodDesc->EnumMemoryRegions(flags);

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -5917,8 +5917,8 @@ MethodTableBuilder::InitMethodDesc(
                 AllocateFromHighFrequencyHeap(S_SIZE_T(sizeof(NDirectWriteableData)));
 
 #ifdef HAS_NDIRECT_IMPORT_PRECODE 
-            pNewNMD->ndirect.m_pImportThunkGlue = Precode::Allocate(PRECODE_NDIRECT_IMPORT, pNewMD,
-                GetLoaderAllocator(), GetMemTracker())->AsNDirectImportPrecode();
+            pNewNMD->ndirect.m_pImportThunkGlue.SetValue(Precode::Allocate(PRECODE_NDIRECT_IMPORT, pNewMD,
+                GetLoaderAllocator(), GetMemTracker())->AsNDirectImportPrecode());
 #else // !HAS_NDIRECT_IMPORT_PRECODE
             pNewNMD->GetNDirectImportThunkGlue()->Init(pNewNMD);
 #endif // !HAS_NDIRECT_IMPORT_PRECODE
@@ -6163,7 +6163,7 @@ MethodTableBuilder::PlaceMethodImpls()
     // Allocate some temporary storage. The number of overrides for a single method impl
     // cannot be greater then the number of vtable slots.
     DWORD * slots = new (&GetThread()->m_MarshalAlloc) DWORD[bmtVT->cVirtualSlots];
-    MethodDesc ** replaced = new (&GetThread()->m_MarshalAlloc) MethodDesc*[bmtVT->cVirtualSlots];
+    RelativePointer<MethodDesc *> * replaced = new (&GetThread()->m_MarshalAlloc) RelativePointer<MethodDesc*>[bmtVT->cVirtualSlots];
 
     DWORD iEntry = 0;
     bmtMDMethod * pCurImplMethod = bmtMethodImpl->GetImplementationMethod(iEntry);
@@ -6250,7 +6250,7 @@ MethodTableBuilder::WriteMethodImplData(
     bmtMDMethod * pImplMethod, 
     DWORD         cSlots, 
     DWORD *       rgSlots, 
-    MethodDesc ** rgDeclMD)
+    RelativePointer<MethodDesc *> * rgDeclMD)
 {
     STANDARD_VM_CONTRACT;
     
@@ -6280,9 +6280,9 @@ MethodTableBuilder::WriteMethodImplData(
             {
                 if (rgSlots[j] < rgSlots[i])
                 {
-                    MethodDesc * mTmp = rgDeclMD[i];
-                    rgDeclMD[i] = rgDeclMD[j];
-                    rgDeclMD[j] = mTmp;
+                    MethodDesc * mTmp = rgDeclMD[i].GetValue();
+                    rgDeclMD[i].SetValue(rgDeclMD[j].GetValue());
+                    rgDeclMD[j].SetValue(mTmp);
 
                     DWORD sTmp = rgSlots[i];
                     rgSlots[i] = rgSlots[j];
@@ -6304,7 +6304,7 @@ MethodTableBuilder::PlaceLocalDeclaration(
     bmtMDMethod * pDecl, 
     bmtMDMethod * pImpl, 
     DWORD *       slots, 
-    MethodDesc ** replaced, 
+    RelativePointer<MethodDesc *> * replaced,
     DWORD *       pSlotIndex)
 {
     CONTRACTL
@@ -6361,7 +6361,7 @@ MethodTableBuilder::PlaceLocalDeclaration(
 
     // We implement this slot, record it
     slots[*pSlotIndex] = pDecl->GetSlotIndex();
-    replaced[*pSlotIndex] = pDecl->GetMethodDesc();
+    replaced[*pSlotIndex].SetValue(pDecl->GetMethodDesc());
 
     // increment the counter
     (*pSlotIndex)++;
@@ -6372,7 +6372,7 @@ VOID MethodTableBuilder::PlaceInterfaceDeclaration(
     bmtRTMethod *     pDecl,
     bmtMDMethod *     pImpl,
     DWORD*            slots,
-    MethodDesc**      replaced,
+    RelativePointer<MethodDesc *> *      replaced,
     DWORD*            pSlotIndex)
 {
     CONTRACTL {
@@ -6477,7 +6477,7 @@ MethodTableBuilder::PlaceParentDeclaration(
     bmtRTMethod * pDecl, 
     bmtMDMethod * pImpl, 
     DWORD *       slots, 
-    MethodDesc ** replaced, 
+    RelativePointer<MethodDesc *> * replaced,
     DWORD *       pSlotIndex)
 {
     CONTRACTL {
@@ -6522,7 +6522,7 @@ MethodTableBuilder::PlaceParentDeclaration(
 
     // We implement this slot, record it
     slots[*pSlotIndex] = pDeclMD->GetSlot();
-    replaced[*pSlotIndex] = pDeclMD;
+    replaced[*pSlotIndex].SetValue(pDeclMD);
 
     // increment the counter
     (*pSlotIndex)++;

--- a/src/vm/methodtablebuilder.h
+++ b/src/vm/methodtablebuilder.h
@@ -2734,7 +2734,7 @@ private:
         bmtMDMethod *       pImplMethod,
         DWORD               cSlots,
         DWORD *             rgSlots,
-        MethodDesc **       rgDeclMD);
+        RelativePointer<MethodDesc *> *       rgDeclMD);
 
     // --------------------------------------------------------------------------------------------
     // Places a methodImpl pair where the decl is declared by the type being built.
@@ -2743,7 +2743,7 @@ private:
         bmtMDMethod *    pDecl,
         bmtMDMethod *    pImpl,
         DWORD*           slots,
-        MethodDesc**     replaced,
+        RelativePointer<MethodDesc *> *     replaced,
         DWORD*           pSlotIndex);
 
     // --------------------------------------------------------------------------------------------
@@ -2753,7 +2753,7 @@ private:
         bmtRTMethod *     pDecl,
         bmtMDMethod *     pImpl,
         DWORD*            slots,
-        MethodDesc**      replaced,
+        RelativePointer<MethodDesc *> *      replaced,
         DWORD*            pSlotIndex);
 
     // --------------------------------------------------------------------------------------------
@@ -2763,7 +2763,7 @@ private:
         bmtRTMethod *     pDecl,
         bmtMDMethod *     pImpl,
         DWORD*            slots,
-        MethodDesc**      replaced,
+        RelativePointer<MethodDesc *> *      replaced,
         DWORD*            pSlotIndex);
 
     // --------------------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request removes relocations from MethodDesc section for ngened images.This is first part of changes, which doesn't affect jit code. Second part #11963

Related issue: #11363

Next fields are replaced with RelativePointers for all platforms in this pull request 
```
InstantiatedMethodDesc::m_pDictLayout
InstantiatedMethodDesc::m_pWrappedMethodDesc
MethodDesc::m_pszMethodName
MethodImpl::pImplementedMD
MethodImpl::pdwSlots
NDirectMethodDesc::ndirect.m_pImportThunkGlue
NDirectMethodDesc::ndirect.m_pszEntrypointName
NDirectMethodDesc::ndirect.m_pszLibName
StoredSigMethodDesc::m_pSig
```

Next fields are replaced with RelativePointers for all platforms in the second pull request #11963
```
NDirectMethodDesc::ndirect.m_pWriteableData
InstantiatedMethodDesc::m_pPerInstInfo
```

After the changes, SECTION_MethodDesc completely disappears from the table shown in https://github.com/dotnet/coreclr/issues/11363#issuecomment-299180256.

Estimation on Tizen Xamarin GUI Application (specifically, Puzzle.Tizen - see tables at #10380 (comment)) is about 268 kb (4%) savings of per-application CoreCLR's memory part in Fragile mode.

@Dmitri-Botcharnikov @ruben-ayrapetyan
