### PR TITLE
Fix incorrect metadata on SOS.NETCore.dll

### DIFF
--- a/src/ToolBox/SOS/NETCore/SOS.NETCore.csproj
+++ b/src/ToolBox/SOS/NETCore/SOS.NETCore.csproj
@@ -36,6 +36,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyInfoLines Include="[assembly: AssemblyMetadata(&quot;.NETFrameworkAssembly&quot;, &quot;&quot;)]" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="SymbolReader.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
Issue #11381

All the other assembly attributes are correct in 2.0.  Added AssemblyMetadata.