### PR TITLE
Fix clang version detection in src/pal/tools/gen-buildsys-clang.sh

### DIFF
--- a/src/pal/tools/gen-buildsys-clang.sh
+++ b/src/pal/tools/gen-buildsys-clang.sh
@@ -155,7 +155,7 @@ if [ "$build_arch" == "armel" ]; then
     cmake_extra_defines="$cmake_extra_defines -DARM_SOFTFP=1"
 fi
 
-clang_version=$(echo $CC | awk -F- '{ print $NF }')
+clang_version=$( $CC --version | head -1 | sed 's/[^0-9]*\([0-9]*\.[0-9]*\).*/\1/' )
 # Use O1 option when the clang version is smaller than 3.9
 # Otherwise use O3 option in release build
 if [[ ( ${clang_version%.*} -eq 3  &&  ${clang_version#*.} -lt 9 ) &&


### PR DESCRIPTION
The version detection that was added recently for the purpose of selecting
optimization options for ARM builds was not working properly when the
clang binary doesn't have version in its name. This resulted in syntax
error being reported on OSX and some Linux distros:
`/Users/janvorli/git/coreclr/src/pal/tools/gen-buildsys-clang.sh:
line 162: : /usr/bin/clang: syntax error: operand expected (error token is "/usr/bin/clang")`