### PR TITLE
Path.GetDirectoryName() throw exception when path is empty or has only white spaces

### DIFF
--- a/src/mscorlib/shared/System/IO/Path.cs
+++ b/src/mscorlib/shared/System/IO/Path.cs
@@ -76,19 +76,27 @@ namespace System.IO
         // "\\server\share").
         public static string GetDirectoryName(string path)
         {
-            if (path != null)
+            if (path == null)
             {
-                PathInternal.CheckInvalidPathChars(path);
-                path = PathInternal.NormalizeDirectorySeparators(path);
-                int root = PathInternal.GetRootLength(path);
-
-                int i = path.Length;
-                if (i > root)
-                {
-                    while (i > root && !PathInternal.IsDirectorySeparator(path[--i])) ;
-                    return path.Substring(0, i);
-                }
+                return null;
             }
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException(SR.Arg_PathIllegal, nameof(path));
+            }
+
+            PathInternal.CheckInvalidPathChars(path);
+            path = PathInternal.NormalizeDirectorySeparators(path);
+            int root = PathInternal.GetRootLength(path);
+
+            int i = path.Length;
+            if (i > root)
+            {
+                while (i > root && !PathInternal.IsDirectorySeparator(path[--i])) ;
+                return path.Substring(0, i);
+            }
+            
             return null;
         }
 

--- a/src/mscorlib/shared/System/IO/Path.cs
+++ b/src/mscorlib/shared/System/IO/Path.cs
@@ -76,13 +76,9 @@ namespace System.IO
         // "\\server\share").
         public static string GetDirectoryName(string path)
         {
-            if (path == null)
-            {
-                return null;
-            }
-
             if (string.IsNullOrWhiteSpace(path))
             {
+                if (path == null) return null;
                 throw new ArgumentException(SR.Arg_PathIllegal, nameof(path));
             }
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/19337

Tests added on: https://github.com/dotnet/corefx/pull/19343

cc: @danmosemsft 