### PR TITLE
Fixed memory instruction selector for integer register which contants  simd8 type

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -7444,9 +7444,11 @@ void CodeGen::genProfilingEnterCallback(regNumber initReg, bool* pInitRegZeroed)
                 continue;
             }
 
-            var_types storeType = varDsc->lvaArgType();
-            regNumber argReg    = varDsc->lvArgReg;
-            getEmitter()->emitIns_S_R(ins_Store(storeType), emitTypeSize(storeType), argReg, varNum, 0);
+            var_types   storeType = varDsc->lvaArgType();
+            regNumber   argReg    = varDsc->lvArgReg;
+            instruction store_ins =
+                ((storeType == TYP_SIMD8) && genIsValidIntReg(argReg)) ? INS_mov : ins_Store(storeType);
+            getEmitter()->emitIns_S_R(store_ins, emitTypeSize(storeType), argReg, varNum, 0);
         }
     }
 
@@ -7507,9 +7509,10 @@ void CodeGen::genProfilingEnterCallback(regNumber initReg, bool* pInitRegZeroed)
             continue;
         }
 
-        var_types loadType = varDsc->lvaArgType();
-        regNumber argReg   = varDsc->lvArgReg;
-        getEmitter()->emitIns_R_S(ins_Load(loadType), emitTypeSize(loadType), argReg, varNum, 0);
+        var_types   loadType = varDsc->lvaArgType();
+        regNumber   argReg   = varDsc->lvArgReg;
+        instruction load_ins = ((loadType == TYP_SIMD8) && genIsValidIntReg(argReg)) ? INS_mov : ins_Load(loadType);
+        getEmitter()->emitIns_R_S(load_ins, emitTypeSize(loadType), argReg, varNum, 0);
 
 #if FEATURE_VARARG
         if (compiler->info.compIsVarArgs && varTypeIsFloating(loadType))


### PR DESCRIPTION
The changes is related to issue #10857. It fixes the following SIMD test cases:

- JIT\SIMD\AddingSequence_r
- JIT\SIMD\CircleInConvex_ro
- JIT\SIMD\VectorReturn_r
- JIT\SIMD\CircleInConvex_r

The problem was in selecting the load/store mov instruction for simd8 type which is stored into i64 register (i.e `Vector2 { float x; float y; }` ).

Originally the bug occurred in the method `System.Numerics.Vector2:op_Multiply(struct, float)`.
The method prolog was: 
```
       55                   push     rbp
       4883EC30             sub      rsp, 48
       C5F877               vzeroupper
       488D6C2430           lea      rbp, [rsp+30H]
       C4E17B114D10         vmovsd   qword ptr [rbp+10H], rcx       <== wrong store
       C4E17A114D18         vmovss   dword ptr [rbp+18H], xmm1
       48B9CC1883F9FE7F0000 mov      rcx, 0x7FFEF98318CC
       488D5510             lea      rdx, [rbp+10H]
       FF158396915D         call     [CORINFO_HELP_PROF_FCN_ENTER]
       C4E17B104D10         vmovsd   rcx, qword ptr [rbp+10H]       <== wrong load
       C4E17A104D18         vmovss   xmm1, dword ptr [rbp+18H]
```
When the real assembly was (got from WinDbg)

```
00007ffe`92ab0b00 55              push    rbp
00007ffe`92ab0b01 4883ec30        sub     rsp,30h
00007ffe`92ab0b05 c5f877          vzeroupper
00007ffe`92ab0b08 488d6c2430      lea     rbp,[rsp+30h]
00007ffe`92ab0b0d c4e17b114d10    vmovsd  qword ptr [rbp+10h],xmm1       <== Actual wrong store
00007ffe`92ab0b13 c4e17a114d18    vmovss  dword ptr [rbp+18h],xmm1
00007ffe`92ab0b19 48b9cc1883f9fe7f0000 mov rcx,offset clrjit!DummyProfilerELTStub (00007ffe`f98318cc)
00007ffe`92ab0b23 488d5510        lea     rdx,[rbp+10h]
00007ffe`92ab0b27 ff158396915d    call    qword ptr [CoreCLR!hlpDynamicFuncTable+0x150 (00007ffe`f03ca1b0)]
00007ffe`92ab0b2d c4e17b104d10    vmovsd  xmm1,qword ptr [rbp+10h]       <== Actual wrong load
00007ffe`92ab0b33 c4e17a104d18    vmovss  xmm1,dword ptr [rbp+18h]
```

When the correct code should be 

```
       55                   push     rbp
       4883EC30             sub      rsp, 48
       C5F877               vzeroupper
       488D6C2430           lea      rbp, [rsp+30H]
       48894D10             mov      qword ptr [rbp+10H], rcx       <== correct store
       C4E17A114D18         vmovss   dword ptr [rbp+18H], xmm1
       48B978190BF9FE7F0000 mov      rcx, 0x7FFEF90B1978
       488D5510             lea      rdx, [rbp+10H]
       FF158596905D         call     [CORINFO_HELP_PROF_FCN_ENTER]
       488B4D10             mov      rcx, qword ptr [rbp+10H]       <== correct load
       C4E17A104D18         vmovss   xmm1, dword ptr [rbp+18H]
       48894D10             mov      qword ptr [rbp+10H], rcx
```