### PR TITLE
Return null from CultureData.GetLocaleInfoEx

### DIFF
--- a/src/mscorlib/src/System/Globalization/CalendarData.Windows.cs
+++ b/src/mscorlib/src/System/Globalization/CalendarData.Windows.cs
@@ -343,7 +343,7 @@ namespace System.Globalization
                     string res = CultureData.GetLocaleInfoEx(localeName, lcType);
 
                     // if it succeeded remember the override for the later callers
-                    if (res != "")
+                    if (res != null)
                     {
                         // Remember this was the override (so we can look for duplicates later in the enum function)
                         context.userOverride = res;

--- a/src/mscorlib/src/System/Globalization/CultureData.Windows.cs
+++ b/src/mscorlib/src/System/Globalization/CultureData.Windows.cs
@@ -179,7 +179,7 @@ namespace System.Globalization
                 return new String(pBuffer);
             }
 
-            return "";
+            return null;
         }
 
         internal static unsafe int GetLocaleInfoExInt(String localeName, uint field)


### PR DESCRIPTION
**Note:** This PR replicates [this change](https://github.com/dotnet/corert/pull/3476) I submitted a few days ago to the .NET Core Runtime (CoreRT)

There are a few callers for this specific primitive of `CultureData.GetLocaleInfoEx` method, yet some check for null value returned, while others check for empty string...

As it currently stands, if the API call fails, an empty string will be returned from this method, which makes [this](https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/Globalization/CultureInfo.Windows.cs#L57) check irrelevant as it will never be null!

So makes sense to me that this should always return null, or change the caller to check for null AND empty string.

I went for the first option, making it return null and always check for null value returned on the callers.