### PR TITLE
Make Debugger class static

### DIFF
--- a/src/mscorlib/src/System/Diagnostics/Debugger.cs
+++ b/src/mscorlib/src/System/Diagnostics/Debugger.cs
@@ -17,6 +17,9 @@ namespace System.Diagnostics
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void Break() => BreakInternal();
 
+        // The VM depends on this private method.
+        private static void BreakCanThrow() => BreakInternal();
+
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern void BreakInternal();
 

--- a/src/mscorlib/src/System/Diagnostics/Debugger.cs
+++ b/src/mscorlib/src/System/Diagnostics/Debugger.cs
@@ -5,101 +5,60 @@
 // The Debugger class is a part of the System.Diagnostics package
 // and is used for communicating with a debugger.
 
-using System;
-using System.IO;
-using System.Collections;
-using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Security;
-using System.Runtime.Versioning;
 
 namespace System.Diagnostics
 {
-    // No data, does not need to be marked with the serializable attribute
-    public sealed class Debugger
+    public static class Debugger
     {
-        // This should have been a static class, but wasn't as of v3.5.  Clearly, this is
-        // broken.  We'll keep this in V4 for binary compat, but marked obsolete as error
-        // so migrated source code gets fixed.
-        [Obsolete("Do not create instances of the Debugger class.  Call the static methods directly on this type instead", true)]
-        public Debugger()
-        {
-            // Should not have been instantiable - here for binary compatibility in V4.
-        }
-
         // Break causes a breakpoint to be signalled to an attached debugger.  If no debugger
-        // is attached, the user is asked if he wants to attach a debugger. If yes, then the 
+        // is attached, the user is asked if he wants to attach a debugger. If yes, then the
         // debugger is launched.
-        [MethodImplAttribute(MethodImplOptions.NoInlining)]
-        public static void Break()
-        {
-            // Causing a break is now allowed.
-            BreakInternal();
-        }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void Break() => BreakInternal();
 
-        private static void BreakCanThrow()
-        {
-            BreakInternal();
-        }
-
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern void BreakInternal();
 
         // Launch launches & attaches a debugger to the process. If a debugger is already attached,
-        // nothing happens.  
+        // nothing happens.
         //
-        public static bool Launch()
-        {
-            if (Debugger.IsAttached)
-                return (true);
-
-            // Causing the debugger to launch is now allowed.
-            return (LaunchInternal());
-        }
+        public static bool Launch() => IsAttached ? true : LaunchInternal();
 
         // This class implements code:ICustomDebuggerNotification and provides a type to be used to notify
-        // the debugger that execution is about to enter a path that involves a cross-thread dependency. 
-        // See code:NotifyOfCrossThreadDependency for more details. 
-        private class CrossThreadDependencyNotification : ICustomDebuggerNotification
-        {
-            // constructor
-            public CrossThreadDependencyNotification()
-            {
-            }
-        }
+        // the debugger that execution is about to enter a path that involves a cross-thread dependency.
+        // See code:NotifyOfCrossThreadDependency for more details.
+        private class CrossThreadDependencyNotification : ICustomDebuggerNotification { }
 
-        // Do not inline the slow path 
-        [MethodImplAttribute(MethodImplOptions.NoInlining)]
-        private static void NotifyOfCrossThreadDependencySlow()
-        {
-            CrossThreadDependencyNotification notification = new CrossThreadDependencyNotification();
-            CustomNotification(notification);
-        }
+        // Do not inline the slow path
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void NotifyOfCrossThreadDependencySlow() =>
+            CustomNotification(new CrossThreadDependencyNotification());
 
-        // Sends a notification to the debugger to indicate that execution is about to enter a path 
-        // involving a cross thread dependency. A debugger that has opted into this type of notification 
-        // can take appropriate action on receipt. For example, performing a funceval normally requires 
-        // freezing all threads but the one performing the funceval. If the funceval requires execution on 
-        // more than one thread, as might occur in remoting scenarios, the funceval will block. This 
-        // notification will apprise the debugger that it will need  to slip a thread or abort the funceval 
-        // in such a situation. The notification is subject to collection after this function returns. 
-        // 
+        // Sends a notification to the debugger to indicate that execution is about to enter a path
+        // involving a cross thread dependency. A debugger that has opted into this type of notification
+        // can take appropriate action on receipt. For example, performing a funceval normally requires
+        // freezing all threads but the one performing the funceval. If the funceval requires execution on
+        // more than one thread, as might occur in remoting scenarios, the funceval will block. This
+        // notification will apprise the debugger that it will need  to slip a thread or abort the funceval
+        // in such a situation. The notification is subject to collection after this function returns.
+        //
         public static void NotifyOfCrossThreadDependency()
         {
-            if (Debugger.IsAttached)
+            if (IsAttached)
             {
                 NotifyOfCrossThreadDependencySlow();
             }
         }
 
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern bool LaunchInternal();
 
         // Returns whether or not a debugger is attached to the process.
         //
         public static extern bool IsAttached
         {
-            [MethodImplAttribute(MethodImplOptions.InternalCall)]
+            [MethodImpl(MethodImplOptions.InternalCall)]
             get;
         }
 
@@ -108,26 +67,26 @@ namespace System.Diagnostics
         // An attached debugger can enable or disable which messages will
         // actually be reported to the user through the COM+ debugger
         // services API.  This info is communicated to the runtime so only
-        // desired events are actually reported to the debugger.  
+        // desired events are actually reported to the debugger.
         //
         // Constant representing the default category
-        public static readonly String DefaultCategory = null;
+        public static readonly string DefaultCategory = null;
 
         // Posts a message for the attached debugger.  If there is no
         // debugger attached, has no effect.  The debugger may or may not
-        // report the message depending on its settings. 
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        public static extern void Log(int level, String category, String message);
+        // report the message depending on its settings.
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        public static extern void Log(int level, string category, string message);
 
         // Checks to see if an attached debugger has logging enabled
-        //  
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        //
+        [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern bool IsLogging();
 
         // Posts a custom notification for the attached debugger.  If there is no
         // debugger attached, has no effect.  The debugger may or may not
-        // report the notification depending on its settings. 
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        // report the notification depending on its settings.
+        [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern void CustomNotification(ICustomDebuggerNotification data);
     }
 }


### PR DESCRIPTION
It's `static` in the [.NET Standard](https://github.com/dotnet/standard/blob/cc9f646354fc68a13707a82323d4032b8dbfda52/netstandard/ref/mscorlib.cs#L4982) and [.NET Core](https://github.com/dotnet/corefx/blob/40f04b15ef889d78ee4490c0950bc3a74067d639/src/System.Diagnostics.Debug/ref/System.Diagnostics.Debug.cs#L75) refs, and in [CoreRT's implementation](https://github.com/dotnet/corert/blob/d174a2e4eb8ed875e9b2b56ae564f512a4aec3e2/src/System.Private.CoreLib/src/System/Diagnostics/Debugger.cs#L9), so make it static in the CoreCLR implementation as well.

Also, minor cleanup while making changes here.