### PR TITLE
Fix copy error in perf script

### DIFF
--- a/tests/scripts/run-xunit-perf.cmd
+++ b/tests/scripts/run-xunit-perf.cmd
@@ -107,8 +107,12 @@ setlocal
   )
 
   rem Save off the results to the root directory for recovery later in Jenkins
-  call :run_cmd xcopy "Perf-%BENCHNAME%.xml" "%CORECLR_REPO%\Perf-%BENCHNAME%-%COLLECTION_FLAGS%.xml" || exit /b 1
-  call :run_cmd xcopy "Perf-%BENCHNAME%.etl" "%CORECLR_REPO%\Perf-%BENCHNAME%-%COLLECTION_FLAGS%.etl" || exit /b 1
+  IF EXIST "Perf-%BENCHNAME%.xml" (
+    call :run_cmd copy "Perf-%BENCHNAME%.xml" "%CORECLR_REPO%\Perf-%BENCHNAME%-%COLLECTION_FLAGS%.xml" || exit /b 1
+  )
+  IF EXIST "Perf-%BENCHNAME%.etl" (
+    call :run_cmd copy "Perf-%BENCHNAME%.etl" "%CORECLR_REPO%\Perf-%BENCHNAME%-%COLLECTION_FLAGS%.etl" || exit /b 1
+  )
 
   exit /b 0
 

--- a/tests/scripts/run-xunit-perf.cmd
+++ b/tests/scripts/run-xunit-perf.cmd
@@ -107,8 +107,8 @@ setlocal
   )
 
   rem Save off the results to the root directory for recovery later in Jenkins
-  call :run_cmd xcopy "Perf-%BENCHNAME%*.xml" "%CORECLR_REPO%\" || exit /b 1
-  call :run_cmd xcopy "Perf-%BENCHNAME%*.etl" "%CORECLR_REPO%\" || exit /b 1
+  call :run_cmd xcopy "Perf-%BENCHNAME%.xml" "%CORECLR_REPO%\Perf-%BENCHNAME%-%COLLECTION_FLAGS%.xml" || exit /b 1
+  call :run_cmd xcopy "Perf-%BENCHNAME%.etl" "%CORECLR_REPO%\Perf-%BENCHNAME%-%COLLECTION_FLAGS%.etl" || exit /b 1
 
   exit /b 0
 

--- a/tests/scripts/run-xunit-perf.cmd
+++ b/tests/scripts/run-xunit-perf.cmd
@@ -108,10 +108,10 @@ setlocal
 
   rem Save off the results to the root directory for recovery later in Jenkins
   IF EXIST "Perf-%BENCHNAME%.xml" (
-    call :run_cmd copy "Perf-%BENCHNAME%.xml" "%CORECLR_REPO%\Perf-%BENCHNAME%-%COLLECTION_FLAGS%.xml" || exit /b 1
+    call :run_cmd copy "Perf-%BENCHNAME%.xml" "%CORECLR_REPO%\Perf-%BENCHNAME%-%ETW_COLLECTION%.xml" || exit /b 1
   )
   IF EXIST "Perf-%BENCHNAME%.etl" (
-    call :run_cmd copy "Perf-%BENCHNAME%.etl" "%CORECLR_REPO%\Perf-%BENCHNAME%-%COLLECTION_FLAGS%.etl" || exit /b 1
+    call :run_cmd copy "Perf-%BENCHNAME%.etl" "%CORECLR_REPO%\Perf-%BENCHNAME%-%ETW_COLLECTION%.etl" || exit /b 1
   )
 
   exit /b 0


### PR DESCRIPTION
When I merged the PR that enabled the lean runs I added another call to
our run script.  This run script had an assumption that it would only
ever be called once and as such would try and copy two files that had
the same name.  This would cause it to prompt to overwrite or not and
fail the run.  This change makes each copy unique based on the
collection flags that were used for collection.