### PR TITLE
Avoid throwing in the globalization managed callbacks

### DIFF
--- a/src/mscorlib/shared/System/Globalization/CalendarData.Unix.cs
+++ b/src/mscorlib/shared/System/Globalization/CalendarData.Unix.cs
@@ -306,21 +306,29 @@ namespace System.Globalization
 
         private static void EnumCalendarInfoCallback(string calendarString, IntPtr context)
         {
-            CallbackContext callbackContext = (CallbackContext)((GCHandle)context).Target;
-
-            if (callbackContext.DisallowDuplicates)
+            try
             {
-                foreach (string existingResult in callbackContext.Results)
+                CallbackContext callbackContext = (CallbackContext)((GCHandle)context).Target;
+
+                if (callbackContext.DisallowDuplicates)
                 {
-                    if (string.Equals(calendarString, existingResult, StringComparison.Ordinal))
+                    foreach (string existingResult in callbackContext.Results)
                     {
-                        // the value is already in the results, so don't add it again
-                        return;
+                        if (string.Equals(calendarString, existingResult, StringComparison.Ordinal))
+                        {
+                            // the value is already in the results, so don't add it again
+                            return;
+                        }
                     }
                 }
-            }
 
-            callbackContext.Results.Add(calendarString);
+                callbackContext.Results.Add(calendarString);
+            }
+            catch
+            {
+                // we ignore the managed exceptions here because EnumCalendarInfoCallback will get called from the native code.
+                // If we don't ignore the exception here that can cause the runtime to fail fast.
+            }
         }
 
         private class CallbackContext

--- a/src/mscorlib/shared/System/Globalization/CalendarData.Unix.cs
+++ b/src/mscorlib/shared/System/Globalization/CalendarData.Unix.cs
@@ -324,8 +324,9 @@ namespace System.Globalization
 
                 callbackContext.Results.Add(calendarString);
             }
-            catch
+            catch (Exception e)
             {
+                Debug.Assert(false, e.ToString());
                 // we ignore the managed exceptions here because EnumCalendarInfoCallback will get called from the native code.
                 // If we don't ignore the exception here that can cause the runtime to fail fast.
             }


### PR DESCRIPTION
Fixes #11432

This fix is for catching and ignoring the exceptions thrown in the managed callback called from the native side. 
For the exceptions thrown from the native side, it is tracked by the issue #11404 