### PR TITLE
[Arm64] Use the x64 managed tests for arm64 unix

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -2177,13 +2177,18 @@ combinedScenarios.each { scenario ->
                         testBuildScenario = 'default'
                     }
                     def inputWindowTestsBuildName = ''
+                    def inputWindowsTestBuildArch = architecture
+                    if (architecture == "arm64") {
+                        // Use the x64 test build for arm64 unix
+                        inputWindowsTestBuildArch = "x64"
+                    }
                     if (Constants.jitStressModeScenarios.containsKey(testBuildScenario)) {
                         inputWindowTestsBuildName = projectFolder + '/' +
-                            Utilities.getFullJobName(project, getJobName(configuration, architecture, 'windows_nt', 'default', true), isPR)
+                            Utilities.getFullJobName(project, getJobName(configuration, inputWindowsTestBuildArch, 'windows_nt', 'default', true), isPR)
                     }
                     else {
                         inputWindowTestsBuildName = projectFolder + '/' +
-                            Utilities.getFullJobName(project, getJobName(configuration, architecture, 'windows_nt', testBuildScenario, true), isPR)
+                            Utilities.getFullJobName(project, getJobName(configuration, inputWindowsTestBuildArch, 'windows_nt', testBuildScenario, true), isPR)
                     }
                     // Enable Server GC for Ubuntu PR builds
                     def serverGCString = ''


### PR DESCRIPTION
Use the x64 _bld jobs for arm64 unix tests.

@mmitche ptal
/cc @dotnet/arm64-contrib 