### PR TITLE
[WIP] Clean up of "secret" parameters

### DIFF
--- a/src/inc/corjit.h
+++ b/src/inc/corjit.h
@@ -140,7 +140,7 @@ public:
         CORJIT_FLAG_BBOPT                   = 30, // Optimize method based on profile information
         CORJIT_FLAG_FRAMED                  = 31, // All methods have an EBP frame
         CORJIT_FLAG_ALIGN_LOOPS             = 32, // add NOPs before loops to align them at 16 byte boundaries
-        CORJIT_FLAG_PUBLISH_SECRET_PARAM    = 33, // JIT must place stub secret param into local 0.  (used by IL stubs)
+        CORJIT_FLAG_PUBLISH_STUB_CONTEXT    = 33, // JIT must place the "stub context" param into stack frame (used by IL stubs)
         CORJIT_FLAG_GCPOLL_INLINE           = 34, // JIT must inline calls to GCPoll when possible
         CORJIT_FLAG_SAMPLING_JIT_BACKGROUND = 35, // JIT is being invoked as a result of stack sampling for hot methods in the background
         CORJIT_FLAG_USE_PINVOKE_HELPERS     = 36, // The JIT should use the PINVOKE_{BEGIN,END} helpers instead of emitting inline transitions

--- a/src/inc/gcinfodecoder.h
+++ b/src/inc/gcinfodecoder.h
@@ -538,8 +538,8 @@ private:
     // Pre-decoded information
     bool    m_IsInterruptible;
     bool    m_IsVarArg;
-    bool    m_GenericSecretParamIsMD;
-    bool    m_GenericSecretParamIsMT;
+    bool    m_GenericContextParamIsMD;
+    bool    m_GenericContextParamIsMT;
     bool    m_WantsReportOnlyLeaf;
     INT32   m_SecurityObjectStackSlot;
     INT32   m_GSCookieStackSlot;

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -5562,7 +5562,7 @@ void CodeGen::genCheckUseBlockInit()
         // be live when we do block init.
         if (compiler->info.compPublishStubParam)
         {
-            maskCalleeRegArgMask &= ~RBM_SECRET_STUB_PARAM;
+            maskCalleeRegArgMask &= ~RBM_STUB_CONTEXT;
         }
 
 #ifdef _TARGET_XARCH_
@@ -6017,7 +6017,7 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
     const size_t pageSize = compiler->eeGetPageSize();
 
 #ifdef _TARGET_ARM_
-    assert(!compiler->info.compPublishStubParam || (REG_SECRET_STUB_PARAM != initReg));
+    assert(!compiler->info.compPublishStubParam || (REG_STUB_CONTEXT != initReg));
 #endif // _TARGET_ARM_
 
 #ifdef _TARGET_XARCH_
@@ -6086,10 +6086,10 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
 
 #ifdef _TARGET_XARCH_
         bool pushedStubParam = false;
-        if (compiler->info.compPublishStubParam && (REG_SECRET_STUB_PARAM == initReg))
+        if (compiler->info.compPublishStubParam && (REG_STUB_CONTEXT == initReg))
         {
             // push register containing the StubParam
-            inst_RV(INS_push, REG_SECRET_STUB_PARAM, TYP_I_IMPL);
+            inst_RV(INS_push, REG_STUB_CONTEXT, TYP_I_IMPL);
             pushedStubParam = true;
         }
 #endif // !_TARGET_XARCH_
@@ -6197,8 +6197,8 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
         if (pushedStubParam)
         {
             // pop eax
-            inst_RV(INS_pop, REG_SECRET_STUB_PARAM, TYP_I_IMPL);
-            regTracker.rsTrackRegTrash(REG_SECRET_STUB_PARAM);
+            inst_RV(INS_pop, REG_STUB_CONTEXT, TYP_I_IMPL);
+            regTracker.rsTrackRegTrash(REG_STUB_CONTEXT);
         }
 #endif // _TARGET_XARCH_
 
@@ -8843,17 +8843,17 @@ void CodeGen::genFnProlog()
     if (compiler->info.compPublishStubParam)
     {
 #if CPU_LOAD_STORE_ARCH
-        getEmitter()->emitIns_R_R_I(ins_Store(TYP_I_IMPL), EA_PTRSIZE, REG_SECRET_STUB_PARAM, genFramePointerReg(),
+        getEmitter()->emitIns_R_R_I(ins_Store(TYP_I_IMPL), EA_PTRSIZE, REG_STUB_CONTEXT, genFramePointerReg(),
                                     compiler->lvaTable[compiler->lvaStubArgumentVar].lvStkOffs);
 #else
         // mov [lvaStubArgumentVar], EAX
-        getEmitter()->emitIns_AR_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, REG_SECRET_STUB_PARAM, genFramePointerReg(),
+        getEmitter()->emitIns_AR_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, REG_STUB_CONTEXT, genFramePointerReg(),
                                    compiler->lvaTable[compiler->lvaStubArgumentVar].lvStkOffs);
 #endif
-        assert(intRegState.rsCalleeRegArgMaskLiveIn & RBM_SECRET_STUB_PARAM);
+        assert(intRegState.rsCalleeRegArgMaskLiveIn & RBM_STUB_CONTEXT);
 
         // It's no longer live; clear it out so it can be used after this in the prolog
-        intRegState.rsCalleeRegArgMaskLiveIn &= ~RBM_SECRET_STUB_PARAM;
+        intRegState.rsCalleeRegArgMaskLiveIn &= ~RBM_STUB_CONTEXT;
     }
 
 #if STACK_PROBES

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -5808,7 +5808,7 @@ int Compiler::compCompileHelper(CORINFO_MODULE_HANDLE            classPtr,
 
     info.compIsContextful = (info.compClassAttr & CORINFO_FLG_CONTEXTFUL) != 0;
 
-    info.compPublishStubParam = opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PUBLISH_SECRET_PARAM);
+    info.compPublishStubParam = opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PUBLISH_STUB_CONTEXT);
 
     switch (methodInfo->args.getCallConv())
     {

--- a/src/jit/jitee.h
+++ b/src/jit/jitee.h
@@ -72,7 +72,7 @@ public:
         JIT_FLAG_BBOPT                   = 30, // Optimize method based on profile information
         JIT_FLAG_FRAMED                  = 31, // All methods have an EBP frame
         JIT_FLAG_ALIGN_LOOPS             = 32, // add NOPs before loops to align them at 16 byte boundaries
-        JIT_FLAG_PUBLISH_SECRET_PARAM    = 33, // JIT must place stub secret param into local 0.  (used by IL stubs)
+        JIT_FLAG_PUBLISH_STUB_CONTEXT    = 33, // JIT must place stub secret param into local 0.  (used by IL stubs)
         JIT_FLAG_GCPOLL_INLINE           = 34, // JIT must inline calls to GCPoll when possible
         JIT_FLAG_SAMPLING_JIT_BACKGROUND = 35, // JIT is being invoked as a result of stack sampling for hot methods in the background
         JIT_FLAG_USE_PINVOKE_HELPERS     = 36, // The JIT should use the PINVOKE_{BEGIN,END} helpers instead of emitting inline transitions
@@ -183,7 +183,7 @@ public:
         FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_BBOPT, JIT_FLAG_BBOPT);
         FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_FRAMED, JIT_FLAG_FRAMED);
         FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_ALIGN_LOOPS, JIT_FLAG_ALIGN_LOOPS);
-        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PUBLISH_SECRET_PARAM, JIT_FLAG_PUBLISH_SECRET_PARAM);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PUBLISH_STUB_CONTEXT, JIT_FLAG_PUBLISH_STUB_CONTEXT);
         FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_GCPOLL_INLINE, JIT_FLAG_GCPOLL_INLINE);
         FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_SAMPLING_JIT_BACKGROUND, JIT_FLAG_SAMPLING_JIT_BACKGROUND);
         FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_PINVOKE_HELPERS, JIT_FLAG_USE_PINVOKE_HELPERS);

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2803,7 +2803,7 @@ GenTree* Lowering::CreateFrameLinkUpdate(FrameLinkAction action)
 //  +08h    +04h    vptr for class InlinedCallFrame   offsetOfFrameVptr       method prolog
 //  +10h    +08h    m_Next                            offsetOfFrameLink       method prolog
 //  +18h    +0Ch    m_Datum                           offsetOfCallTarget      call site
-//  +20h    n/a     m_StubSecretArg                                           not set by JIT
+//  +20h    n/a     m_StubContextArg                                           not set by JIT
 //  +28h    +10h    m_pCallSiteSP                     offsetOfCallSiteSP      x86: call site, and zeroed in method
 //                                                                              prolog;
 //                                                                            non-x86: method prolog (SP remains
@@ -2856,7 +2856,7 @@ void Lowering::InsertPInvokeMethodProlog()
 #if defined(_TARGET_X86_) || defined(_TARGET_ARM_)
     GenTreeArgList* argList = comp->gtNewArgList(frameAddr);
 #else
-    GenTreeArgList*    argList = comp->gtNewArgList(frameAddr, PhysReg(REG_SECRET_STUB_PARAM));
+    GenTreeArgList*    argList = comp->gtNewArgList(frameAddr, PhysReg(REG_STUB_CONTEXT));
 #endif
 
     GenTree* call = comp->gtNewHelperCallNode(CORINFO_HELP_INIT_PINVOKE_FRAME, TYP_I_IMPL, 0, argList);

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -4579,7 +4579,7 @@ void LinearScan::buildIntervals()
     // If there is a secret stub param, it is also live in
     if (compiler->info.compPublishStubParam)
     {
-        intRegState->rsCalleeRegArgMaskLiveIn |= RBM_SECRET_STUB_PARAM;
+        intRegState->rsCalleeRegArgMaskLiveIn |= RBM_STUB_CONTEXT;
     }
 
     LocationInfoListNodePool listNodePool(compiler, 8);

--- a/src/jit/regalloc.cpp
+++ b/src/jit/regalloc.cpp
@@ -5342,7 +5342,7 @@ regMaskTP Compiler::rpPredictAssignRegVars(regMaskTP regAvail)
     // If there is a secret stub param, it is also live in
     if (info.compPublishStubParam)
     {
-        codeGen->intRegState.rsCalleeRegArgMaskLiveIn |= RBM_SECRET_STUB_PARAM;
+        codeGen->intRegState.rsCalleeRegArgMaskLiveIn |= RBM_STUB_CONTEXT;
     }
 
     if (regAvail == RBM_NONE)

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -593,9 +593,9 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   // GenericPInvokeCalliHelper cookie parameter
   #define REG_PINVOKE_COOKIE_PARAM REG_STK
 
-  // IL stub's secret parameter (JitFlags::JIT_FLAG_PUBLISH_SECRET_PARAM)
-  #define REG_SECRET_STUB_PARAM    REG_EAX
-  #define RBM_SECRET_STUB_PARAM    RBM_EAX
+  // IL stub's secret parameter (JitFlags::JIT_FLAG_PUBLISH_STUB_CONTEXT)
+  #define REG_STUB_CONTEXT    REG_EAX
+  #define RBM_STUB_CONTEXT    RBM_EAX
 
   // VSD extra parameter
   #define REG_VIRTUAL_STUB_PARAM   REG_EAX
@@ -986,9 +986,9 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define RBM_PINVOKE_TARGET_PARAM          RBM_R10
   #define PREDICT_REG_PINVOKE_TARGET_PARAM  PREDICT_REG_R10
 
-  // IL stub's secret MethodDesc parameter (JitFlags::JIT_FLAG_PUBLISH_SECRET_PARAM)
-  #define REG_SECRET_STUB_PARAM    REG_R10
-  #define RBM_SECRET_STUB_PARAM    RBM_R10
+  // IL stub's secret MethodDesc parameter (JitFlags::JIT_FLAG_PUBLISH_STUB_CONTEXT)
+  #define REG_STUB_CONTEXT    REG_R10
+  #define RBM_STUB_CONTEXT    RBM_R10
 
   // VSD extra parameter (slot address)
   #define REG_VIRTUAL_STUB_PARAM   REG_R11
@@ -1367,9 +1367,9 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define RBM_PINVOKE_TARGET_PARAM          RBM_R12
   #define PREDICT_REG_PINVOKE_TARGET_PARAM  PREDICT_REG_R12
 
-  // IL stub's secret MethodDesc parameter (JitFlags::JIT_FLAG_PUBLISH_SECRET_PARAM)
-  #define REG_SECRET_STUB_PARAM     REG_R12
-  #define RBM_SECRET_STUB_PARAM     RBM_R12
+  // IL stub's secret MethodDesc parameter (JitFlags::JIT_FLAG_PUBLISH_STUB_CONTEXT)
+  #define REG_STUB_CONTEXT     REG_R12
+  #define RBM_STUB_CONTEXT     RBM_R12
 
   // VSD extra parameter (slot address)
   #define REG_VIRTUAL_STUB_PARAM          REG_R4
@@ -1658,9 +1658,9 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define RBM_PINVOKE_TARGET_PARAM          RBM_R14
   #define PREDICT_REG_PINVOKE_TARGET_PARAM  PREDICT_REG_R14
 
-  // IL stub's secret MethodDesc parameter (JitFlags::JIT_FLAG_PUBLISH_SECRET_PARAM)
-  #define REG_SECRET_STUB_PARAM     REG_R12
-  #define RBM_SECRET_STUB_PARAM     RBM_R12
+  // IL stub's secret MethodDesc parameter (JitFlags::JIT_FLAG_PUBLISH_STUB_CONTEXT)
+  #define REG_STUB_CONTEXT     REG_R12
+  #define RBM_STUB_CONTEXT     RBM_R12
 
   // VSD extra parameter (slot address)
   #define REG_VIRTUAL_STUB_PARAM          REG_R11

--- a/src/vm/amd64/GenericComCallStubs.asm
+++ b/src/vm/amd64/GenericComCallStubs.asm
@@ -144,7 +144,7 @@ NESTED_END GenericComCallStub, _TEXT
 ; ARG_SLOT COMToCLRDispatchHelperWithStack(DWORD  dwStackSlots,    // rcx
 ;                                          ComMethodFrame *pFrame, // rdx
 ;                                          PCODE  pTarget,         // r8
-;                                          PCODE  pSecretArg,      // r9
+;                                          PCODE  pContextArg,     // r9
 ;                                          INT_PTR pDangerousThis  // rbp+40h
 ;                                          );
 NESTED_ENTRY COMToCLRDispatchHelperWithStack, _TEXT, CallDescrWorkerUnwindFrameChainHandler
@@ -201,7 +201,7 @@ ComMethodFrame_XMM_SAVE_OFFSET = GenericComCallStub_XMM_SAVE_OFFSET - GenericCom
         movdqa  xmm3, [rdx + ComMethodFrame_XMM_SAVE_OFFSET + 30h]
 
         ;
-        ; load secret arg and target
+        ; load context arg into r10 and target into rax
         ;
         mov     r10, r9
         mov     rax, r8
@@ -238,7 +238,7 @@ NESTED_END COMToCLRDispatchHelperWithStack, _TEXT
 ; ARG_SLOT COMToCLRDispatchHelper(DWORD  dwStackSlots,    // rcx
 ;                                 ComMethodFrame *pFrame, // rdx
 ;                                 PCODE  pTarget,         // r8
-;                                 PCODE  pSecretArg,      // r9
+;                                 PCODE  pContextArg,     // r9
 ;                                 INT_PTR pDangerousThis  // rsp + 28h on entry
 ;                                 );
 NESTED_ENTRY COMToCLRDispatchHelper, _TEXT, CallDescrWorkerUnwindFrameChainHandler
@@ -266,7 +266,7 @@ NESTED_ENTRY COMToCLRDispatchHelper, _TEXT, CallDescrWorkerUnwindFrameChainHandl
         movdqa  xmm3, [rdx + ComMethodFrame_XMM_SAVE_OFFSET + 30h]
 
         ;
-        ; load secret arg and target
+        ; load pContextArg into r10 and pTarget into rax
         ;
         mov     r10, r9
         mov     rax, r8

--- a/src/vm/amd64/PInvokeStubs.asm
+++ b/src/vm/amd64/PInvokeStubs.asm
@@ -101,7 +101,7 @@ LEAF_ENTRY VarargPInvokeStubHelper, _TEXT
 LEAF_END VarargPInvokeStubHelper, _TEXT
 
 ;
-; IN: METHODDESC_REGISTER (R10) stub secret param
+; IN: METHODDESC_REGISTER (R10) stub context param
 ;     PINVOKE_CALLI_SIGTOKEN_REGISTER (R11) VASigCookie*
 ;
 ; ASSUMES: we already checked for an existing stub to use

--- a/src/vm/amd64/cgenamd64.cpp
+++ b/src/vm/amd64/cgenamd64.cpp
@@ -636,7 +636,7 @@ void emitJump(LPBYTE pBuffer, LPVOID target)
     _ASSERTE(DbgIsExecutable(pBuffer, 12));
 }
 
-void UMEntryThunkCode::Encode(BYTE* pTargetCode, void* pvSecretParam)
+void UMEntryThunkCode::Encode(BYTE* pTargetCode, void* pvContextParam)
 {
     CONTRACTL
     {
@@ -659,7 +659,7 @@ void UMEntryThunkCode::Encode(BYTE* pTargetCode, void* pvSecretParam)
 #endif // _DEBUG
     m_movR10[0]  = REX_PREFIX_BASE | REX_OPERAND_SIZE_64BIT | REX_OPCODE_REG_EXT;
     m_movR10[1]  = 0xBA;
-    m_uet        = pvSecretParam;
+    m_uet        = pvContextParam;
     m_movRAX[0]  = REX_PREFIX_BASE | REX_OPERAND_SIZE_64BIT;
     m_movRAX[1]  = 0xB8;
     m_execstub   = pTargetCode;

--- a/src/vm/amd64/cgencpu.h
+++ b/src/vm/amd64/cgencpu.h
@@ -465,7 +465,7 @@ struct DECLSPEC_ALIGN(8) UMEntryThunkCode
     BYTE            m_jmpRAX[3];    // JMP RAX
     BYTE            m_padding2[5];
 
-    void Encode(BYTE* pTargetCode, void* pvSecretParam);
+    void Encode(BYTE* pTargetCode, void* pvContextParam);
 
     LPCBYTE GetEntryPoint() const
     {

--- a/src/vm/amd64/pinvokestubs.S
+++ b/src/vm/amd64/pinvokestubs.S
@@ -94,7 +94,7 @@ LEAF_ENTRY VarargPInvokeStubHelper, _TEXT
 LEAF_END VarargPInvokeStubHelper, _TEXT
 
 //
-// IN: METHODDESC_REGISTER (R10) stub secret param
+// IN: METHODDESC_REGISTER (R10) stub context param
 //     PINVOKE_CALLI_SIGTOKEN_REGISTER (R11) VASigCookie*
 //
 // ASSUMES: we already checked for an existing stub to use

--- a/src/vm/arm/asmhelpers.asm
+++ b/src/vm/arm/asmhelpers.asm
@@ -963,7 +963,7 @@ GenericComCallStub_Frame        SETA SIZEOF__FloatArgumentRegisters + GenericCom
 ;   r0          : dwStackSlots, count of argument stack slots to copy
 ;   r1          : pFrame, ComMethodFrame pushed by GenericComCallStub above
 ;   r2          : pTarget, address of code to call
-;   r3          : pSecretArg, hidden argument passed to target above in r12
+;   r3          : pContextArg, hidden argument passed to target above in r12
 ;   [sp, #0]    : pDangerousThis, managed 'this' reference
 ;
 ; On exit:

--- a/src/vm/arm/cgencpu.h
+++ b/src/vm/arm/cgencpu.h
@@ -985,9 +985,9 @@ struct DECLSPEC_ALIGN(4) UMEntryThunkCode
     WORD        m_code[4];
 
     TADDR       m_pTargetCode;
-    TADDR       m_pvSecretParam;
+    TADDR       m_pvContextParam;
 
-    void Encode(BYTE* pTargetCode, void* pvSecretParam);
+    void Encode(BYTE* pTargetCode, void* pvContextParam);
 
     LPCBYTE GetEntryPoint() const
     {

--- a/src/vm/arm/stubs.cpp
+++ b/src/vm/arm/stubs.cpp
@@ -2502,13 +2502,13 @@ class UMEntryThunk * UMEntryThunk::Decode(void *pCallback)
         (pCode->m_code[2] == 0xf8df) &&
         (pCode->m_code[3] == 0xf000))
     {
-        return (UMEntryThunk*)pCode->m_pvSecretParam;
+        return (UMEntryThunk*)pCode->m_pvContextParam;
     }
 
     return NULL;
 }
 
-void UMEntryThunkCode::Encode(BYTE* pTargetCode, void* pvSecretParam)
+void UMEntryThunkCode::Encode(BYTE* pTargetCode, void* pvContextParam)
 {
     // ldr r12, [pc + 8]
     m_code[0] = 0xf8df;
@@ -2518,7 +2518,7 @@ void UMEntryThunkCode::Encode(BYTE* pTargetCode, void* pvSecretParam)
     m_code[3] = 0xf000;
 
     m_pTargetCode = (TADDR)pTargetCode;
-    m_pvSecretParam = (TADDR)pvSecretParam;
+    m_pvContextParam = (TADDR)pvContextParam;
 
     FlushInstructionCache(GetCurrentProcess(),&m_code,sizeof(m_code));
 }

--- a/src/vm/arm64/asmhelpers.S
+++ b/src/vm/arm64/asmhelpers.S
@@ -581,7 +581,7 @@ NESTED_END ComCallPreStub, _TEXT
 //   x0          : dwStackSlots, count of argument stack slots to copy
 //   x1          : pFrame, ComMethodFrame pushed by GenericComCallStub above
 //   x2          : pTarget, address of code to call
-//   x3          : pSecretArg, hidden argument passed to target above in x12
+//   x3          : pContextArg, hidden argument passed to target above in x12
 //   x4          : pDangerousThis, managed 'this' reference
 //
 // On exit:

--- a/src/vm/arm64/asmhelpers.asm
+++ b/src/vm/arm64/asmhelpers.asm
@@ -640,7 +640,7 @@ GenericComCallStub_FirstStackAdjust     SETA GenericComCallStub_FirstStackAdjust
 ;   x0          : dwStackSlots, count of argument stack slots to copy
 ;   x1          : pFrame, ComMethodFrame pushed by GenericComCallStub above
 ;   x2          : pTarget, address of code to call
-;   x3          : pSecretArg, hidden argument passed to target above in x12
+;   x3          : pContextArg, hidden argument passed to target above in x12
 ;   x4          : pDangerousThis, managed 'this' reference
 ;
 ; On exit:

--- a/src/vm/arm64/cgencpu.h
+++ b/src/vm/arm64/cgencpu.h
@@ -478,9 +478,9 @@ struct DECLSPEC_ALIGN(16) UMEntryThunkCode
     DWORD        m_code[4];
 
     TADDR       m_pTargetCode;
-    TADDR       m_pvSecretParam;
+    TADDR       m_pvContextParam;
 
-    void Encode(BYTE* pTargetCode, void* pvSecretParam);
+    void Encode(BYTE* pTargetCode, void* pvContextParam);
 
     LPCBYTE GetEntryPoint() const
     {

--- a/src/vm/arm64/stubs.cpp
+++ b/src/vm/arm64/stubs.cpp
@@ -1217,13 +1217,13 @@ UMEntryThunk * UMEntryThunk::Decode(void *pCallback)
         (pCode->m_code[1] == 0xa9403190) &&
         (pCode->m_code[2] == 0xd61f0200))
     {
-        return (UMEntryThunk*)pCode->m_pvSecretParam;
+        return (UMEntryThunk*)pCode->m_pvContextParam;
     }
 
     return NULL;
 }
 
-void UMEntryThunkCode::Encode(BYTE* pTargetCode, void* pvSecretParam)
+void UMEntryThunkCode::Encode(BYTE* pTargetCode, void* pvContextParam)
 {
     // adr x12, _label
     // ldp x16, x12, [x12]
@@ -1231,7 +1231,7 @@ void UMEntryThunkCode::Encode(BYTE* pTargetCode, void* pvSecretParam)
     // 4bytes padding
     // _label
     // m_pTargetCode data
-    // m_pvSecretParam data
+    // m_pvContextParam data
     
     m_code[0] = 0x1000008c;
     m_code[1] = 0xa9403190;
@@ -1239,7 +1239,7 @@ void UMEntryThunkCode::Encode(BYTE* pTargetCode, void* pvSecretParam)
 
 
     m_pTargetCode = (TADDR)pTargetCode;
-    m_pvSecretParam = (TADDR)pvSecretParam;
+    m_pvContextParam = (TADDR)pvContextParam;
 
     FlushInstructionCache(GetCurrentProcess(),&m_code,sizeof(m_code));
 }

--- a/src/vm/comtoclrcall.cpp
+++ b/src/vm/comtoclrcall.cpp
@@ -186,7 +186,7 @@ extern "C" ARG_SLOT __fastcall COMToCLRDispatchHelper(
     INT_PTR dwArgECX,
     INT_PTR dwArgEDX,
     PCODE   pTarget,
-    PCODE   pSecretArg,
+    PCODE   pContextArg,
     INT_PTR *pInputStack,
     WORD    wOutputStackSlots,
     UINT16  *pOutputStackOffsets,
@@ -219,7 +219,7 @@ inline static void InvokeStub(ComCallMethodDesc *pCMD, PCODE pManagedTarget, OBJ
         *((INT_PTR *) &orThis),           // pArgECX
         EDX,                              // pArgEDX
         pStubEntryPoint,                  // pTarget
-        pManagedTarget,                   // pSecretArg
+        pManagedTarget,                   // pContextArg
         pInputStack,                      // pInputStack
         pCMD->m_wStubStackSlotCount,      // wOutputStackSlots
         pCMD->m_pwStubStackSlotOffsets,   // pOutputStackOffsets
@@ -264,7 +264,7 @@ inline static void InvokeStub(ComCallMethodDesc *pCMD, PCODE pManagedTarget, OBJ
         dwStackSlots,     // dwStackSlots
         pFrame,           // pFrame
         pStubEntryPoint,  // pTarget
-        pManagedTarget,   // pSecretArg
+        pManagedTarget,   // pContextArg
         dangerousThis);   // pDangerousThis
 }
 

--- a/src/vm/dllimport.cpp
+++ b/src/vm/dllimport.cpp
@@ -1022,28 +1022,28 @@ public:
                 
         if (m_slIL.HasInteropParamExceptionInfo())
         {
-            // This code will not use the secret parameter, so we do not
+            // This code will not use the special "stub context" parameter, so we do not
             // tell the JIT to bother with it.
             m_slIL.ClearCode();
             m_slIL.GenerateInteropParamException(pcsMarshal);
         }
         else if (SF_IsFieldGetterStub(m_dwStubFlags) || SF_IsFieldSetterStub(m_dwStubFlags))
         {
-            // Field access stubs are not shared and do not use the secret parameter.
+            // Field access stubs are not shared and do not use the special "stub context" parameter.
         }
 #ifndef _WIN64
         else if (SF_IsForwardDelegateStub(m_dwStubFlags) ||
                 (SF_IsForwardCOMStub(m_dwStubFlags) && SF_IsWinRTDelegateStub(m_dwStubFlags)))
         {
-            // Forward delegate stubs get all the context they need in 'this' so they
-            // don't use the secret parameter. Except for AMD64 where we use the secret
-            // argument to pass the real target to the stub-for-host.
+            // Forward delegate stubs get all the context they need in 'this' so they don't use
+            // the special "stub context" parameter. Except for AMD64 where we use the "stub context"
+            // parameter to pass the real target to the stub-for-host.
         }
 #endif // !_WIN64
         else
         {
-            // All other IL stubs will need to use the secret parameter.
-            jitFlags.Set(CORJIT_FLAGS::CORJIT_FLAG_PUBLISH_SECRET_PARAM);
+            // All other IL stubs will need to use the special "stub context" parameter.
+            jitFlags.Set(CORJIT_FLAGS::CORJIT_FLAG_PUBLISH_STUB_CONTEXT);
         }
 
         if (SF_IsReverseStub(m_dwStubFlags))
@@ -1380,8 +1380,8 @@ public:
         if (SF_IsWinRTDelegateStub(m_dwStubFlags))
         {
             // write the stub context (EEImplMethodDesc representing the Invoke)
-            // into the secret arg so it shows up in the InlinedCallFrame and can
-            // be used by stub for host
+            // into the special "stub context" parameter so it shows up in the 
+            // InlinedCallFrame and can be used by stub for host
 
             pcsDispatch->EmitCALL(METHOD__STUBHELPERS__GET_STUB_CONTEXT_ADDR, 0, 1);
             m_slIL.EmitLoadStubContext(pcsDispatch, dwStubFlags);
@@ -2240,7 +2240,7 @@ void NDirectStubLinker::DoNDirect(ILCodeStream *pcsEmit, DWORD dwStubFlags, Meth
             pcsEmit->EmitLoadThis();
 #ifdef _WIN64
             // on AMD64 GetDelegateTarget will return address of the generic stub for host when we are hosted
-            // and update the secret argument with real target - the secret arg will be embedded in the
+            // and update the special "stub context" parameter with real target - this will be embedded in the
             // InlinedCallFrame by the JIT and fetched via TLS->Thread->Frame->Datum by the stub for host
             pcsEmit->EmitCALL(METHOD__STUBHELPERS__GET_STUB_CONTEXT_ADDR, 0, 1);
 #else // _WIN64
@@ -2262,7 +2262,8 @@ void NDirectStubLinker::DoNDirect(ILCodeStream *pcsEmit, DWORD dwStubFlags, Meth
 
                 {
                     // for managed-to-unmanaged CALLI that requires marshaling, the target is passed
-                    // as the secret argument to the stub by GenericPInvokeCalliHelper (asmhelpers.asm)
+                    // as the special "stub context" parameter to the stub by GenericPInvokeCalliHelper
+                    /// (see asmhelpers.asm)
                     EmitLoadStubContext(pcsEmit, dwStubFlags);
                 }
 
@@ -2270,7 +2271,8 @@ void NDirectStubLinker::DoNDirect(ILCodeStream *pcsEmit, DWORD dwStubFlags, Meth
 #else // _TARGET_X86_
 
                 {
-                    // the secret arg has been shifted to left and ORed with 1 (see code:GenericPInvokeCalliHelper)
+                    // the special "stub context" parameter has been shifted to left and ORed with 1 
+                    // (see code:GenericPInvokeCalliHelper)
                     EmitLoadStubContext(pcsEmit, dwStubFlags);
 #ifndef _TARGET_ARM_
                     pcsEmit->EmitLDC(1);
@@ -2324,7 +2326,7 @@ void NDirectStubLinker::DoNDirect(ILCodeStream *pcsEmit, DWORD dwStubFlags, Meth
 #ifdef FEATURE_COMINTEROP
         else if (SF_IsCOMStub(dwStubFlags)) // COM -> CLR call
         {
-            // managed target is passed directly in the secret argument
+            // managed target is passed directly in the special "stub context" register
             EmitLoadStubContext(pcsEmit, dwStubFlags);
         }
 #endif // FEATURE_COMINTEROP
@@ -2351,12 +2353,12 @@ void NDirectStubLinker::EmitLogNativeArgument(ILCodeStream* pslILEmit, DWORD dwP
 
     if (SF_IsForwardPInvokeStub(m_dwStubFlags) && !SF_IsForwardDelegateStub(m_dwStubFlags))
     {
-        // get the secret argument via intrinsic
+        // get the "stub context" argument via intrinsic
         pslILEmit->EmitCALL(METHOD__STUBHELPERS__GET_STUB_CONTEXT, 0, 1);
     }
     else
     {
-        // no secret argument
+        // no "stub context" argument
         pslILEmit->EmitLoadNullPtr();
     }
 
@@ -2406,7 +2408,7 @@ DWORD NDirectStubLinker::EmitProfilerBeginTransitionCallback(ILCodeStream* pcsEm
 
     if (SF_IsForwardDelegateStub(dwStubFlags) || SF_IsCALLIStub(dwStubFlags))
     {
-        // secret argument does not contain MD nor UMEntryThunk
+        // no "stub context" argument
         pcsEmit->EmitLoadNullPtr();
     }
     else
@@ -2542,7 +2544,7 @@ void NDirectStubLinker::EmitObjectValidation(ILCodeStream* pcsEmit, DWORD dwStub
 }
 #endif // VERIFY_HEAP
 
-// Loads the 'secret argument' passed to the stub.
+// Loads the "stub context" argument passed to the stub.
 void NDirectStubLinker::EmitLoadStubContext(ILCodeStream* pcsEmit, DWORD dwStubFlags)
 {
     STANDARD_VM_CONTRACT;
@@ -2561,7 +2563,7 @@ void NDirectStubLinker::EmitLoadStubContext(ILCodeStream* pcsEmit, DWORD dwStubF
     else
 #endif // FEATURE_COMINTEROP
     {
-        // get the secret argument via intrinsic
+        // get the "stub context" argument via intrinsic
         pcsEmit->EmitCALL(METHOD__STUBHELPERS__GET_STUB_CONTEXT, 0, 1);
     }
 }

--- a/src/vm/frames.h
+++ b/src/vm/frames.h
@@ -822,7 +822,7 @@ private:
     friend LONG WINAPI CLRVectoredExceptionHandlerShim(PEXCEPTION_POINTERS pExceptionInfo);
 #endif // _DEBUG
 #ifdef _WIN64
-    friend Thread * __stdcall JIT_InitPInvokeFrame(InlinedCallFrame *pFrame, PTR_VOID StubSecretArg);
+    friend Thread * __stdcall JIT_InitPInvokeFrame(InlinedCallFrame *pFrame, PTR_VOID StubContextArg);
 #endif
 #ifdef WIN64EXCEPTIONS
     friend class ExceptionTracker;
@@ -2942,7 +2942,7 @@ public:
 #elif defined(_WIN64)
         // On 64bit, the actual interop MethodDesc is saved off in a field off the InlinedCrawlFrame
         // which is populated by the JIT. Refer to JIT_InitPInvokeFrame for details.
-        return PTR_MethodDesc(m_StubSecretArg);
+        return PTR_MethodDesc(m_StubContextArg);
 #else
         _ASSERTE(!"NYI - Interop method reporting for this architecture!");
         return NULL;
@@ -2961,7 +2961,7 @@ public:
     // IL stubs fill this field with the incoming secret argument when they erect
     // InlinedCallFrame so we know which interop method was invoked even if the frame
     // is not active at the moment.
-    PTR_VOID                m_StubSecretArg;
+    PTR_VOID                m_StubContextArg;
 #endif // _WIN64
 
 protected:

--- a/src/vm/gcinfodecoder.cpp
+++ b/src/vm/gcinfodecoder.cpp
@@ -126,8 +126,8 @@ GcInfoDecoder::GcInfoDecoder(
     int hasGSCookie            = headerFlags & GC_INFO_HAS_GS_COOKIE;
     int hasPSPSym              = headerFlags & GC_INFO_HAS_PSP_SYM;
     int hasGenericsInstContext = (headerFlags & GC_INFO_HAS_GENERICS_INST_CONTEXT_MASK) != GC_INFO_HAS_GENERICS_INST_CONTEXT_NONE;
-    m_GenericSecretParamIsMD   = (headerFlags & GC_INFO_HAS_GENERICS_INST_CONTEXT_MASK) == GC_INFO_HAS_GENERICS_INST_CONTEXT_MD;
-    m_GenericSecretParamIsMT   = (headerFlags & GC_INFO_HAS_GENERICS_INST_CONTEXT_MASK) == GC_INFO_HAS_GENERICS_INST_CONTEXT_MT;
+    m_GenericContextParamIsMD  = (headerFlags & GC_INFO_HAS_GENERICS_INST_CONTEXT_MASK) == GC_INFO_HAS_GENERICS_INST_CONTEXT_MD;
+    m_GenericContextParamIsMT  = (headerFlags & GC_INFO_HAS_GENERICS_INST_CONTEXT_MASK) == GC_INFO_HAS_GENERICS_INST_CONTEXT_MT;
     int hasStackBaseRegister   = headerFlags & GC_INFO_HAS_STACK_BASE_REGISTER;
     m_WantsReportOnlyLeaf      = ((headerFlags & GC_INFO_WANTS_REPORT_ONLY_LEAF) != 0);
     int hasSizeOfEditAndContinuePreservedArea = headerFlags & GC_INFO_HAS_EDIT_AND_CONTINUE_PRESERVED_SLOTS;
@@ -353,13 +353,13 @@ bool GcInfoDecoder::IsInterruptible()
 bool GcInfoDecoder::HasMethodDescGenericsInstContext()
 {
     _ASSERTE( m_Flags & DECODE_GENERICS_INST_CONTEXT );
-    return m_GenericSecretParamIsMD;
+    return m_GenericContextParamIsMD;
 }
 
 bool GcInfoDecoder::HasMethodTableGenericsInstContext()
 {
     _ASSERTE( m_Flags & DECODE_GENERICS_INST_CONTEXT );
-    return m_GenericSecretParamIsMT;
+    return m_GenericContextParamIsMT;
 }
 
 #ifdef PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED

--- a/src/vm/i386/asmhelpers.asm
+++ b/src/vm/i386/asmhelpers.asm
@@ -1458,14 +1458,14 @@ ifdef FEATURE_COMINTEROP
 ;==========================================================================
 ; This is a fast alternative to CallDescr* tailored specifically for
 ; COM to CLR calls. Stack arguments don't come in a continuous buffer
-; and secret argument can be passed in EAX.
+; and the context argument can be passed in EAX.
 ; 
 
 ; extern "C" ARG_SLOT __fastcall COMToCLRDispatchHelper(
 ;     INT_PTR dwArgECX,                 ; ecx
 ;     INT_PTR dwArgEDX,                 ; edx
 ;     PCODE   pTarget,                  ; [esp + 4]
-;     PCODE   pSecretArg,               ; [esp + 8]
+;     PCODE   pContextArg,              ; [esp + 8]
 ;     INT_PTR *pInputStack,             ; [esp + c]
 ;     WORD    wOutputStackSlots,        ; [esp +10]
 ;     UINT16  *pOutputStackOffsets,     ; [esp +14]
@@ -1477,7 +1477,7 @@ FASTCALL_FUNC COMToCLRDispatchHelper, 32
     ; edx: dwArgEDX
 
     offset_pTarget              equ 4   
-    offset_pSecretArg           equ 8   
+    offset_pContextArg          equ 8   
     offset_pInputStack          equ 0Ch 
     offset_wOutputStackSlots    equ 10h
     offset_pOutputStackOffsets  equ 14h 
@@ -1493,7 +1493,7 @@ FASTCALL_FUNC COMToCLRDispatchHelper, 32
 
     PUSH_CPFH_FOR_COM   eax, esp, offset_pCurFrame     ; trashes eax
 
-    mov     eax, [esp + offset_pSecretArg + CPFH_STACK_SIZE]
+    mov     eax, [esp + offset_pContextArg + CPFH_STACK_SIZE]
     call    [esp + offset_pTarget + CPFH_STACK_SIZE]
 ifdef _DEBUG
     nop     ; This is a tag that we use in an assert.
@@ -1539,7 +1539,7 @@ CopyStackLoop:
     ; and we've copied the stack arguments over as well, so now it's
     ; time to make the call.
 
-    mov     eax, [ebp + ebpFrame_adjust + offset_pSecretArg]
+    mov     eax, [ebp + ebpFrame_adjust + offset_pContextArg]
     call    [ebp + ebpFrame_adjust + offset_pTarget]
 ifdef _DEBUG
     nop     ; This is a tag that we use in an assert.

--- a/src/vm/i386/cgencpu.h
+++ b/src/vm/i386/cgencpu.h
@@ -503,7 +503,7 @@ struct DECLSPEC_ALIGN(4) UMEntryThunkCode
     BYTE            m_jmp;      //JMP NEAR32
     const BYTE *    m_execstub; // pointer to destination code  // make sure the backpatched portion is dword aligned.
 
-    void Encode(BYTE* pTargetCode, void* pvSecretParam);
+    void Encode(BYTE* pTargetCode, void* pvContextParam);
 
     LPCBYTE GetEntryPoint() const
     {

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -1595,7 +1595,7 @@ lDone: ;
     return param.retVal;
 }
 
-void UMEntryThunkCode::Encode(BYTE* pTargetCode, void* pvSecretParam)
+void UMEntryThunkCode::Encode(BYTE* pTargetCode, void* pvContextParam)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -1604,7 +1604,7 @@ void UMEntryThunkCode::Encode(BYTE* pTargetCode, void* pvSecretParam)
     m_alignpad[1] = X86_INSTR_INT3;
 #endif // _DEBUG
     m_movEAX     = X86_INSTR_MOV_EAX_IMM32;
-    m_uet        = pvSecretParam;
+    m_uet        = pvContextParam;
     m_jmp        = X86_INSTR_JMP_REL32;
     m_execstub   = (BYTE*) ((pTargetCode) - (4+((BYTE*)&m_execstub)));
 

--- a/src/vm/jithelpers.cpp
+++ b/src/vm/jithelpers.cpp
@@ -6358,7 +6358,7 @@ HCIMPLEND
 /* Fills out portions of an InlinedCallFrame for JIT64    */
 /* The idea here is to allocate and initalize the frame to only once, */
 /* regardless of how many PInvokes there are in the method            */
-Thread * __stdcall JIT_InitPInvokeFrame(InlinedCallFrame *pFrame, PTR_VOID StubSecretArg)
+Thread * __stdcall JIT_InitPInvokeFrame(InlinedCallFrame *pFrame, PTR_VOID StubContextArg)
 {
     CONTRACTL
     {
@@ -6373,7 +6373,7 @@ Thread * __stdcall JIT_InitPInvokeFrame(InlinedCallFrame *pFrame, PTR_VOID StubS
     _ASSERTE(pFrame != pThread->GetFrame());
 
     pFrame->Init();
-    pFrame->m_StubSecretArg = StubSecretArg;
+    pFrame->m_StubContextArg = StubContextArg;
     pFrame->m_Next = pThread->GetFrame();
 
     return pThread;

--- a/src/vm/jitinterface.h
+++ b/src/vm/jitinterface.h
@@ -1610,7 +1610,7 @@ EXTERN_C TypeHandle::CastResult STDCALL ObjIsInstanceOfNoGC(Object *pObject, Typ
 
 #ifdef _WIN64
 class InlinedCallFrame;
-Thread * __stdcall JIT_InitPInvokeFrame(InlinedCallFrame *pFrame, PTR_VOID StubSecretArg);
+Thread * __stdcall JIT_InitPInvokeFrame(InlinedCallFrame *pFrame, PTR_VOID StubContextArg);
 #endif
 
 #ifdef _DEBUG

--- a/src/vm/stackwalk.cpp
+++ b/src/vm/stackwalk.cpp
@@ -3054,7 +3054,7 @@ BOOL StackFrameIterator::CheckForSkippedFrames(void)
     {
         BOOL fReportInteropMD =
         // If we see InlinedCallFrame in certain IL stubs, we should report the MD that
-        // was passed to the stub as its secret argument. This is the true interop MD.
+        // was passed to the stub as its "stub context" arg. This is the true interop MD.
         // Note that code:InlinedCallFrame.GetFunction may return NULL in this case because
         // the call is made using the CALLI instruction.
             m_crawl.pFrame != FRAME_TOP &&

--- a/src/vm/stubgen.cpp
+++ b/src/vm/stubgen.cpp
@@ -650,7 +650,7 @@ static void LogJitFlags(DWORD facility, DWORD level, CORJIT_FLAGS jitFlags)
 
     // these are all we care about at the moment
     LOG_FLAG(CORJIT_FLAGS::CORJIT_FLAG_IL_STUB);
-    LOG_FLAG(CORJIT_FLAGS::CORJIT_FLAG_PUBLISH_SECRET_PARAM);
+    LOG_FLAG(CORJIT_FLAGS::CORJIT_FLAG_PUBLISH_STUB_CONTEXT);
 
 #undef LOG_FLAGS
 

--- a/src/vm/stubhelpers.cpp
+++ b/src/vm/stubhelpers.cpp
@@ -1502,7 +1502,7 @@ FCIMPLEND
 #endif // MDA_SUPPORTED
 
 #ifdef PROFILING_SUPPORTED
-FCIMPL3(SIZE_T, StubHelpers::ProfilerBeginTransitionCallback, SIZE_T pSecretParam, Thread* pThread, Object* unsafe_pThis)
+FCIMPL3(SIZE_T, StubHelpers::ProfilerBeginTransitionCallback, SIZE_T pContextParam, Thread* pThread, Object* unsafe_pThis)
 {
     FCALL_CONTRACT;
 
@@ -1529,13 +1529,13 @@ FCIMPL3(SIZE_T, StubHelpers::ProfilerBeginTransitionCallback, SIZE_T pSecretPara
         // This is our signal for the reverse interop cases.
         fReverseInterop = true;
         pThread = GET_THREAD();
-        // the secret param in this casee is the UMEntryThunk
-        pRealMD = ((UMEntryThunk*)pSecretParam)->GetMethod();
+        // the "stub context" param in this casee is the UMEntryThunk
+        pRealMD = ((UMEntryThunk*)pContextParam)->GetMethod();
     }
     else
-    if (pSecretParam == 0)
+    if (pContextParam == 0)
     {
-        // Secret param is null.  This is the calli pinvoke case or the unmanaged delegate case.  
+        // The "stub context" param is null.  This is the calli pinvoke case or the unmanaged delegate case.  
         // We have an unmanaged target address but no MD.  For the unmanaged delegate case, we can
         // still retrieve the MD by looking at the "this" object.
 
@@ -1558,7 +1558,7 @@ FCIMPL3(SIZE_T, StubHelpers::ProfilerBeginTransitionCallback, SIZE_T pSecretPara
     else
     {
         // This is either the COM interop or the pinvoke case.
-        pRealMD = (MethodDesc*)pSecretParam;
+        pRealMD = (MethodDesc*)pContextParam;
     }
 
     {


### PR DESCRIPTION
Zero code diffs

Change the references for most "Secret" parameters to be
"Stub Context" parameters.

In the past when we had an argument that was passed using non-standard registers we often referred to it as a "secret" parameter.
It is not really a secret and it is better to refer to it using a name that describes what it contains.

Changed the CorJit flag PUBLISH_SECRET_PARAM to PUBLISH_STUB_CONTEXT
Changed the GCEncoder's GenericSecretParam to GenericContextParam
Changed the JIT's SECRET_STUB_PARAM to STUB_CONTEXT
Changed the JIT's StubSecretArg to StubContextArg
Changed the VM's SecretArg/SecretParam to ContextArg/ContextParam