### PR TITLE
[RyuJIT/ARM32] Fix assertion in 'unreached' when using emitIns_R_L

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -344,7 +344,7 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             genPendingCallLabel       = genCreateTempLabel();
             treeNode->gtLabel.gtLabBB = genPendingCallLabel;
 #if defined(_TARGET_ARM_)
-            emit->emitIns_J_R(INS_adr, EA_PTRSIZE, genPendingCallLabel, treeNode->gtRegNum);
+            emit->emitIns_J_R(INS_adr, EA_PTRSIZE, genPendingCallLabel, targetReg);
 #elif defined(_TARGET_ARM64_)
             emit->emitIns_R_L(INS_adr, EA_PTRSIZE, genPendingCallLabel, targetReg);
 #endif

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -343,7 +343,11 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
         case GT_LABEL:
             genPendingCallLabel       = genCreateTempLabel();
             treeNode->gtLabel.gtLabBB = genPendingCallLabel;
+#if defined(_TARGET_ARM)
+            emit->emitIns_J_R(INS_adr, EA_PTRSIZE, genPendingCallLabel, treeNode->gtRegNum);
+#elif defined(_TARGET_ARM64)
             emit->emitIns_R_L(INS_adr, EA_PTRSIZE, genPendingCallLabel, targetReg);
+#endif
             break;
 
         case GT_STORE_OBJ:

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -343,9 +343,9 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
         case GT_LABEL:
             genPendingCallLabel       = genCreateTempLabel();
             treeNode->gtLabel.gtLabBB = genPendingCallLabel;
-#if defined(_TARGET_ARM)
+#if defined(_TARGET_ARM_)
             emit->emitIns_J_R(INS_adr, EA_PTRSIZE, genPendingCallLabel, treeNode->gtRegNum);
-#elif defined(_TARGET_ARM64)
+#elif defined(_TARGET_ARM64_)
             emit->emitIns_R_L(INS_adr, EA_PTRSIZE, genPendingCallLabel, targetReg);
 #endif
             break;


### PR DESCRIPTION
Now, All of CodeGenBringUpTests have failed.

message : Assertion failed 'unreached' in 'DomainNeutralILStubClass:IL_STUB_PInvoke(ref)'

I found the problem was caused by #11377 that 'genCodeForTreeNode' is merged to codegenarmarch.cpp.