### PR TITLE
Improvements to LinkBench

### DIFF
--- a/tests/src/performance/linkbench/assets/MusicStore/Get-Crossgen.ps1
+++ b/tests/src/performance/linkbench/assets/MusicStore/Get-Crossgen.ps1
@@ -1,0 +1,77 @@
+# Gets crossgen.exe
+#
+# Downloads NuGet.exe
+# Installs crossgen.exe and clrjit.dll using NuGet
+# Copies the files to $path
+
+param([string]$path = ".")
+
+$ErrorActionPreference = "Stop"
+
+Write-Host -ForegroundColor Green "Installing crossgen.exe to $path"
+
+if (-not (Test-Path $path))
+{
+    New-Item -Path $path -ItemType Directory -Force | Out-Null
+}
+
+$path = Get-Item $path
+
+function Get-NETCoreAppVersion()
+{
+    if (-not (Test-Path $PSScriptRoot\obj\project.assets.json))
+    {
+        Write-Error "project.assets.json is missing. do a dotnet restore."
+        exit
+    }
+    
+    # ConvertFrom-Json can't be used here as it has an arbitrary size limit.
+    [void][System.Reflection.Assembly]::LoadWithPartialName("System.Web.Extensions")
+    $serializer = New-Object -TypeName System.Web.Script.Serialization.JavaScriptSerializer 
+    $serializer.MaxJsonLength  = 67108864
+    
+    $json = $serializer.DeserializeObject((Get-Content $PSScriptRoot\obj\project.assets.json -Raw))
+
+    foreach ($name in $json["libraries"].Keys)
+    {
+        if ($name.StartsWith("Microsoft.NETCore.App/"))
+        {
+            $version = $name.SubString("Microsoft.NETCore.App/".Length)
+            break
+        }
+    }
+    
+    return $version
+}
+
+$version = Get-NETCoreAppVersion
+Write-Host -ForegroundColor Green "autodetected shared framework version $version"
+
+$platform = "win-x64"
+
+$netcoreapppackage = "runtime.$platform.microsoft.netcore.app"
+$netcoreappversion = $version
+
+Write-Host -ForegroundColor Green "Getting NuGet.exe"
+
+$nugeturl = "https://dist.nuget.org/win-x86-commandline/v3.4.4/NuGet.exe"
+$nugetfeed = "https://dotnet.myget.org/F/dotnet-core/api/v3/index.json"
+$nugetexepath = "$path\NuGet.exe"
+$wc = New-Object System.Net.WebClient
+$wc.DownloadFile($nugeturl, $nugetexepath)
+
+
+Write-Host -ForegroundColor Green "Getting $netcoreapppackage $netcoreappversion"
+
+& "$nugetexepath" "install", "$netcoreapppackage", "-Source", "$nugetfeed", "-Version", "$netcoreappversion", "-OutputDirectory", "$path"
+if ($LastExitCode -ne 0) {
+    throw "NuGet install of $netcoreapppackage failed."
+}
+
+Copy-Item "$path\$netcoreapppackage.$netcoreappversion\tools\crossgen.exe" "$path\crossgen.exe" -Force
+Copy-Item "$path\$netcoreapppackage.$netcoreappversion\runtimes\$platform\native\clrjit.dll" "$path\clrjit.dll" -Force
+Remove-Item "$path\$netcoreapppackage.$netcoreappversion\" -recurse
+
+Remove-Item "$path\NuGet.exe"
+
+Write-Host -ForegroundColor Green "Success"

--- a/tests/src/performance/linkbench/assets/Roslyn/illinkcsproj
+++ b/tests/src/performance/linkbench/assets/Roslyn/illinkcsproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <RuntimeIdentifiers>win7-x86;win7-x64</RuntimeIdentifiers>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ILLink.Tasks" Version="0.1.0-preview" />
+    <PackageReference Include="Microsoft.NETCore.ILLink" Version="0.1.9-preview" />
   </ItemGroup>
 </Project>
+

--- a/tests/src/performance/linkbench/linkbench.cs
+++ b/tests/src/performance/linkbench/linkbench.cs
@@ -1,3 +1,5 @@
+using Microsoft.Xunit.Performance;
+using Microsoft.Xunit.Performance.Api;
 using System;
 using System.Diagnostics;
 using System.Collections.Generic;
@@ -8,8 +10,6 @@ using System.Text;
 using System.Globalization;
 using System.Linq;
 using System.Xml.Linq;
-using Microsoft.Xunit.Performance;
-using Microsoft.Xunit.Performance.Api;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -18,7 +18,8 @@ namespace LinkBench
     public class Benchmark
     {
         public string Name;
-
+        public bool ShouldRun;
+        public string ProjFile;
         public string UnlinkedDir;
         public string LinkedDir;
         public double UnlinkedMsilSize;
@@ -28,18 +29,29 @@ namespace LinkBench
         public double MsilSizeReduction;
         public double DirSizeReduction;
 
+        public delegate void SetupDelegate();
+        public SetupDelegate Setup;
+
         private DirectoryInfo unlinkedDirInfo;
         private DirectoryInfo linkedDirInfo;
         private double certDiff;
         const double MB = 1024 * 1024;
 
-        public Benchmark(string _Name, string _UnlinkedDir, string _LinkedDir)
+        public Benchmark(string _Name, string _UnlinkedDir, string _LinkedDir, SetupDelegate _setup = null, bool _shouldRun = false)
         {
             Name = _Name;
             UnlinkedDir = _UnlinkedDir;
             LinkedDir = _LinkedDir;
             unlinkedDirInfo = new DirectoryInfo(UnlinkedDir);
             linkedDirInfo = new DirectoryInfo(LinkedDir);
+            ShouldRun = _shouldRun;
+            Setup = _setup;
+        }
+
+        public void SetToRun()
+        {
+            ShouldRun = true;
+            Environment.SetEnvironmentVariable("__test_" + Name, "true");
         }
 
         public void Compute()
@@ -82,20 +94,10 @@ namespace LinkBench
 
             foreach (string file in files)
             {
-                if (file.EndsWith(".ni.dll") || file.EndsWith(".ni.exe"))
+                if (IsMSIL(file))
                 {
-                    continue;
+                    msilSize += new FileInfo(file).Length;
                 }
-                try
-                {
-                    AssemblyLoadContext.GetAssemblyName(file);
-                }
-                catch (BadImageFormatException)
-                {
-                    continue;
-                }
-
-                msilSize += new FileInfo(file).Length;
             }
 
             return msilSize / MB;
@@ -126,22 +128,104 @@ namespace LinkBench
 
             foreach (string file in files)
             {
-                try
+                if (IsMSIL(file))
                 {
-                    AssemblyLoadContext.GetAssemblyName(file);
+                    FileInfo fileInfo = new FileInfo(file);
+                    long linkedCert = GetCertSize(file);
+                    long unlinkedCert = GetCertSize(UnlinkedDir + "\\" + fileInfo.Name);
+                    totalDiff += (unlinkedCert - linkedCert);
                 }
-                catch (BadImageFormatException)
-                {
-                    continue;
-                }
-
-                FileInfo fileInfo = new FileInfo(file);
-                long linkedCert = GetCertSize(file);
-                long unlinkedCert = GetCertSize(UnlinkedDir + "\\" + fileInfo.Name);
-                totalDiff += (unlinkedCert - linkedCert);
             }
 
             return totalDiff / MB;
+        }
+
+        //Use AssemblyLoadContext.GetAssemblyName(file);
+        private bool IsMSIL(string file)
+        {
+            if (file.EndsWith(".ni.dll") || file.EndsWith(".ni.exe"))
+            {
+                // Likely Native Image.
+                return false;
+            }
+
+            try
+            {
+                AssemblyLoadContext.GetAssemblyName(file);
+            }
+            catch (Exception)
+            {
+                // We should check only for BadImageFormatException.
+                // But Checking for any exception until the following
+                // issue is fixed:
+                // https://github.com/dotnet/coreclr/issues/11499 
+
+                return false;
+            }
+
+            return true;
+        }
+
+        public static void AddLinkerReference(string csproj)
+        {
+            var xdoc = XDocument.Load(csproj);
+            var ns = xdoc.Root.GetDefaultNamespace();
+            bool added = false;
+            foreach (var el in xdoc.Root.Elements(ns + "ItemGroup"))
+            {
+                if (el.Elements(ns + "PackageReference").Any())
+                {
+                    el.Add(new XElement(ns + "PackageReference",
+                        new XAttribute("Include", "ILLink.Tasks"),
+                        new XAttribute("Version", "0.1.4-preview")));
+                    added = true;
+                    break;
+                }
+            }
+            if (!added)
+            {
+                xdoc.Root.Add(new XElement(ns + "ItemGroup",
+                    new XElement(ns + "PackageReference",
+                        new XAttribute("Include", "ILLink.Tasks"),
+                        new XAttribute("Version", "0.1.4-preview"))));
+                added = true;
+            }
+            using (var fs = new FileStream(csproj, FileMode.Create))
+            {
+                xdoc.Save(fs);
+            }
+        }
+
+        // TODO: remove this once the linker is able to handle
+        // ready-to-run assembies
+        public static void SetRuntimeFrameworkVersion(string csproj)
+        {
+            var xdoc = XDocument.Load(csproj);
+            var ns = xdoc.Root.GetDefaultNamespace();
+            var versionElement = xdoc.Root.Descendants(ns + "RuntimeFrameworkVersion").First();
+            string runtimeFrameworkVersion = "2.0.0-preview2-002093-00";
+            versionElement.Value = runtimeFrameworkVersion;
+            using (var fs = new FileStream(csproj, FileMode.Create))
+            {
+                xdoc.Save(fs);
+            }
+        }
+
+        // TODO: Remove this once we figure out what to do about apps
+        // that have the publish output filtered by a manifest
+        // file. It looks like aspnet has made this the default. See
+        // the bug at https://github.com/dotnet/sdk/issues/1160.
+        public static void PreventPublishFiltering(string csproj)
+        {
+            var xdoc = XDocument.Load(csproj);
+            var ns = xdoc.Root.GetDefaultNamespace();
+            var propertygroup = xdoc.Root.Element(ns + "PropertyGroup");
+            propertygroup.Add(new XElement(ns + "PublishWithAspNetCoreTargetManifest",
+                                           "false"));
+            using (var fs = new FileStream(csproj, FileMode.Create))
+            {
+                xdoc.Save(fs);
+            }
         }
     }
 
@@ -149,42 +233,128 @@ namespace LinkBench
     {
         private static ScenarioConfiguration scenarioConfiguration = new ScenarioConfiguration(new TimeSpan(2000000));
         private static MetricModel SizeMetric = new MetricModel { Name = "Size", DisplayName = "File Size", Unit = "MB" };
-        private static MetricModel PercMetric = new MetricModel { Name = "Perc", DisplayName = "% Reduction", Unit = "%" };
+        private static MetricModel PercMetric = new MetricModel { Name = "Perc", DisplayName = "Reduction", Unit = "%" };
         public static string Workspace;
         public static string ScriptDir;
         public static string AssetsDir;
         private static Benchmark CurrentBenchmark;
 
+        private static Benchmark[] Benchmarks =
+        {
+            new Benchmark("HelloWorld",
+                "LinkBench\\HelloWorld\\bin\\release\\netcoreapp2.0\\win10-x64\\unlinked",
+                "LinkBench\\HelloWorld\\bin\\release\\netcoreapp2.0\\win10-x64\\linked",
+                () => Benchmark.AddLinkerReference("LinkBench\\HelloWorld\\HelloWorld.csproj")),
+            new Benchmark("WebAPI",
+                "LinkBench\\WebAPI\\bin\\release\\netcoreapp2.0\\win10-x64\\unlinked",
+                "LinkBench\\WebAPI\\bin\\release\\netcoreapp2.0\\win10-x64\\linked",
+                () => { Benchmark.AddLinkerReference("LinkBench\\WebAPI\\WebAPI.csproj");
+                        Benchmark.PreventPublishFiltering("LinkBench\\WebAPI\\WebAPI.csproj"); }),
+            new Benchmark("MusicStore",
+                "LinkBench\\JitBench\\src\\MusicStore\\bin\\release\\netcoreapp2.0\\win10-x64\\unlinked",
+                "LinkBench\\JitBench\\src\\MusicStore\\bin\\release\\netcoreapp2.0\\win10-x64\\linked",
+                () => { Benchmark.AddLinkerReference("LinkBench\\JitBench\\src\\MusicStore\\MusicStore.csproj");
+                       Benchmark.SetRuntimeFrameworkVersion("LinkBench\\JitBench\\src\\MusicStore\\MusicStore.csproj"); }),
+            new Benchmark("MusicStore_R2R",
+                "LinkBench\\JitBench\\src\\MusicStore\\bin\\release\\netcoreapp2.0\\win10-x64\\R2R\\unlinked",
+                "LinkBench\\JitBench\\src\\MusicStore\\bin\\release\\netcoreapp2.0\\win10-x64\\R2R\\linked"),
+            new Benchmark("Corefx",
+                "LinkBench\\corefx\\bin\\ILLinkTrimAssembly\\netcoreapp-Windows_NT-Release-x64\\pretrimmed",
+                "LinkBench\\corefx\\bin\\ILLinkTrimAssembly\\netcoreapp-Windows_NT-Release-x64\\trimmed"),
+            new Benchmark("Roslyn",
+                "LinkBench\\roslyn\\Binaries\\Release\\Exes\\CscCore\\win7-x64\\publish",
+                "LinkBench\\roslyn\\Binaries\\Release\\Exes\\CscCore\\win7-x64\\Linked")
+        };
+
+        static int UsageError()
+        {
+            Console.WriteLine("Usage: LinkBench [--clean] [--nosetup] [--nobuild] [--perf:runid <id>] [<benchmarks>]");
+            Console.WriteLine("  --clean: Remove LinkBench working directory at start");
+            Console.WriteLine("  --nosetup: Don't clone and fixup benchmark repositories");
+            Console.WriteLine("  --nosetup: Don't build and link benchmarks");
+            Console.WriteLine("  --perf:runid: Specify the ID to append to benchmark result files");
+            Console.WriteLine("    Benchmarks: HelloWorld, WebAPI, MusicStore, MusicStore_R2R, CoreFX, Roslyn");
+            Console.WriteLine("                Default is to run all the above benchmarks.");
+            return -4;
+        }
+
         public static int Main(String [] args)
         {
-            // Workspace is the ROOT of the coreclr tree.
-            // If CORECLR_REPO is not set, the script assumes that the location of sandbox
-            // is <path>\coreclr\sandbox.
-            bool doClone = true;
+            bool doClean = false;
+            bool doSetup = true;
             bool doBuild = true;
+            string runId = "";
+            string runOne = null;
+            bool benchmarkSpecified = false;
 
-            for(int i=0; i < args.Length; i++)
+            for (int i = 0; i < args.Length; i++)
             {
-                if (String.Compare(args[i], "noclone", true) == 0)
+                if (String.Compare(args[i], "--clean", true) == 0)
                 {
-                    doClone = false;
+                    doClean = true;
                 }
-                else if (String.Compare(args[i], "nobuild", true) == 0)
+                else if (String.Compare(args[i], "--nosetup", true) == 0)
                 {
-                    doClone = false;
+                    doSetup = false;
+                }
+                else if (String.Compare(args[i], "--nobuild", true) == 0)
+                {
+                    doSetup = false;
                     doBuild = false;
+                }
+                else if (String.Compare(args[i], "--perf:runid", true) == 0)
+                {
+                    if (i + 1 < args.Length)
+                    {
+                        runId = args[++i] + "-";
+                    }
+                    else
+                    {
+                        Console.WriteLine("Missing runID ");
+                        return UsageError();
+                    }
+                }
+                else if (args[i][0] == '-')
+                {
+                    Console.WriteLine("Unknown Option {0}", args[i]);
+                    return UsageError();
                 }
                 else
                 {
-                    Console.WriteLine("Unknown argument");
-                    return -4;
+                    foreach (Benchmark benchmark in Benchmarks)
+                    {
+                        if (String.Compare(args[i], benchmark.Name, true) == 0)
+                        {
+                            benchmark.SetToRun();
+                            benchmarkSpecified = true;
+                            break;
+                        }
+                    }
+
+                    if (!benchmarkSpecified)
+                    {
+                        Console.WriteLine("Unknown Benchmark {0}", args[i]);
+                    }
                 }
             }
 
+            // If benchmarks are not explicitly specified, run all benchmarks
+            if (!benchmarkSpecified)
+            {
+                foreach (Benchmark benchmark in Benchmarks)
+                {
+                    benchmark.SetToRun();
+                }
+            }
+
+            // Workspace is the ROOT of the coreclr tree.
+            // If CORECLR_REPO is not set, the script assumes that the location of sandbox
+            // is <path>\coreclr\sandbox.
+            string sandbox = Directory.GetCurrentDirectory();
             Workspace = Environment.GetEnvironmentVariable("CORECLR_REPO");
             if (Workspace == null)
             {
-                Workspace = Directory.GetParent(Directory.GetCurrentDirectory()).FullName;
+                Workspace = Directory.GetParent(sandbox).FullName;
             }
             if (Workspace == null)
             {
@@ -192,38 +362,45 @@ namespace LinkBench
                 return -1;
             }
 
-            string LinkBenchDir = Workspace + "\\tests\\src\\performance\\linkbench\\";
-            ScriptDir = LinkBenchDir + "scripts\\";
-            AssetsDir = LinkBenchDir + "assets\\";
+            string linkBenchSrcDir = Workspace + "\\tests\\src\\performance\\linkbench\\";
+            ScriptDir = linkBenchSrcDir + "scripts\\";
+            AssetsDir = linkBenchSrcDir + "assets\\";
 
-            Benchmark[] Benchmarks =
+            string linkBenchRoot = sandbox + "\\LinkBench";
+            string __dotNet = linkBenchRoot + "\\.dotNet\\dotnet.exe";
+            Environment.SetEnvironmentVariable("LinkBenchRoot", linkBenchRoot );
+            Environment.SetEnvironmentVariable("__dotnet1", linkBenchRoot + "\\.dotNet\\1.0.0\\dotnet.exe");
+            Environment.SetEnvironmentVariable("__dotnet2", linkBenchRoot + "\\.dotNet\\2.0.0\\dotnet.exe");
+
+            if (doClean)
             {
-                new Benchmark("HelloWorld", 
-                              "LinkBench\\HelloWorld\\bin\\release\\netcoreapp2.0\\win10-x64\\publish", 
-                              "LinkBench\\HelloWorld\\bin\\release\\netcoreapp2.0\\win10-x64\\linked"),
-                new Benchmark("WebAPI",
-                              "LinkBench\\WebAPI\\bin\\release\\netcoreapp2.0\\win10-x64\\publish",
-                              "LinkBench\\WebAPI\\bin\\release\\netcoreapp2.0\\win10-x64\\linked"),
-                new Benchmark("MusicStore", 
-                              "LinkBench\\JitBench\\src\\MusicStore\\bin\\release\\netcoreapp2.0\\win10-x64\\publish",
-                              "LinkBench\\JitBench\\src\\MusicStore\\bin\\release\\netcoreapp2.0\\win10-x64\\linked"),
-                new Benchmark("MusicStore_R2R", 
-                              "LinkBench\\JitBench\\src\\MusicStore\\bin\\release\\netcoreapp2.0\\win10-x64\\publish_r2r",
-                              "LinkBench\\JitBench\\src\\MusicStore\\bin\\release\\netcoreapp2.0\\win10-x64\\linked_r2r"),
-                new Benchmark("Corefx", 
-                              "LinkBench\\corefx\\bin\\ILLinkTrimAssembly\\netcoreapp-Windows_NT-Release-x64\\pretrimmed",
-                              "LinkBench\\corefx\\bin\\ILLinkTrimAssembly\\netcoreapp-Windows_NT-Release-x64\\trimmed"),
-                new Benchmark("Roslyn", 
-                              "LinkBench\\roslyn\\Binaries\\Release\\Exes\\CscCore",
-                              "LinkBench\\roslyn\\Binaries\\Release\\Exes\\Linked"),
-            };
+                Directory.Delete("LinkBench", true);
+            }
 
             // Update the build files to facilitate the link step
-            if(doClone)
+            if (doSetup)
             {
-                if(!Setup())
+                // Clone the benchmarks
+                using (var setup = new Process())
                 {
-                    return -2;
+                    setup.StartInfo.FileName = ScriptDir + "clone.cmd";
+                    setup.Start();
+                    setup.WaitForExit();
+                    if (setup.ExitCode != 0)
+                    {
+                        Console.WriteLine("clone failed");
+                        return -2;
+                    }
+                }
+
+                // Setup the benchmarks
+
+                foreach (Benchmark benchmark in Benchmarks)
+                {
+                    if (benchmark.ShouldRun && benchmark.Setup != null)
+                    {
+                        benchmark.Setup();
+                    }
                 }
             }
 
@@ -255,8 +432,12 @@ namespace LinkBench
             for (int i = 0; i < Benchmarks.Length; i++)
             {
                 CurrentBenchmark = Benchmarks[i];
-                string[] scriptArgs = { "--perf:runid", CurrentBenchmark.Name };
+                if (!CurrentBenchmark.ShouldRun)
+                {
+                    continue;
+                }
 
+                string[] scriptArgs = { "--perf:runid", runId + CurrentBenchmark.Name };
                 using (var h = new XunitPerformanceHarness(scriptArgs))
                 {
                     h.RunScenario(emptyCmd, null, null, PostRun, scenarioConfiguration);
@@ -280,79 +461,12 @@ namespace LinkBench
 
             addMeasurement(ref scenario, "MSIL Unlinked", SizeMetric, CurrentBenchmark.UnlinkedMsilSize);
             addMeasurement(ref scenario, "MSIL Linked", SizeMetric, CurrentBenchmark.LinkedMsilSize);
-            addMeasurement(ref scenario, "MSIL %Reduction", PercMetric, CurrentBenchmark.MsilSizeReduction);
+            addMeasurement(ref scenario, "MSIL Reduction", PercMetric, CurrentBenchmark.MsilSizeReduction);
             addMeasurement(ref scenario, "Total Uninked", SizeMetric, CurrentBenchmark.UnlinkedDirSize);
             addMeasurement(ref scenario, "Total Linked", SizeMetric, CurrentBenchmark.LinkedDirSize);
-            addMeasurement(ref scenario, "Total %Reduction", PercMetric, CurrentBenchmark.DirSizeReduction);
+            addMeasurement(ref scenario, "Total Reduction", PercMetric, CurrentBenchmark.DirSizeReduction);
 
             return scenario;
-        }
-
-        private static bool Setup()
-        {
-            // Clone the benchmarks
-            using (var setup = new Process())
-            {
-                setup.StartInfo.FileName = ScriptDir + "clone.cmd";
-                Console.WriteLine("Run {0}", setup.StartInfo.FileName);
-                setup.Start();
-                setup.WaitForExit();
-                if (setup.ExitCode != 0)
-                {
-                    Console.WriteLine("clone failed");
-                    return false;
-                }
-            }
-
-            //Update the project files
-            AddLinkerReference("LinkBench\\HelloWorld\\HelloWorld.csproj");
-            AddLinkerReference("LinkBench\\WebAPI\\WebAPI.csproj");
-            AddLinkerReference("LinkBench\\JitBench\\src\\MusicStore\\MusicStore.csproj");
-            RemoveCrossgenTarget("LinkBench\\JitBench\\src\\MusicStore\\MusicStore.csproj");
-
-            return true;
-        }
-
-        private static void AddLinkerReference(string csproj)
-        {
-            var xdoc = XDocument.Load(csproj);
-            var ns = xdoc.Root.GetDefaultNamespace();
-            bool added = false;
-            foreach (var el in xdoc.Root.Elements(ns + "ItemGroup"))
-            {
-                if (el.Elements(ns + "PackageReference").Any())
-                {
-                    el.Add(new XElement(ns + "PackageReference",
-                        new XAttribute("Include", "ILLink.Tasks"),
-                        new XAttribute("Version", "0.1.0-preview")));
-                    added = true;
-                    break;
-                }
-            }
-            if (!added)
-            {
-                xdoc.Root.Add(new XElement(ns + "ItemGroup",
-                    new XElement(ns + "PackageReference",
-                        new XAttribute("Include", "ILLink.Tasks"),
-                        new XAttribute("Version", "0.1.0-preview"))));
-                added = true;
-            }
-            using (var fs = new FileStream(csproj, FileMode.Create))
-            {
-                xdoc.Save(fs);
-            }
-        }
-
-        private static void RemoveCrossgenTarget(string csproj)
-        {
-            var xdoc = XDocument.Load(csproj);
-            var ns = xdoc.Root.GetDefaultNamespace();
-            var target = xdoc.Root.Element(ns + "Target");
-            target.Remove();
-            using (var fs = new FileStream(csproj, FileMode.Create))
-            {
-                xdoc.Save(fs);
-            }
         }
 
         private static void addMeasurement(ref ScenarioBenchmark scenario, string name, MetricModel metric, double value)

--- a/tests/src/performance/linkbench/scripts/clone.cmd
+++ b/tests/src/performance/linkbench/scripts/clone.cmd
@@ -1,30 +1,68 @@
 @echo off
 
-rmdir /s /q LinkBench
-
 set ROOT=%cd%\LinkBench
-mkdir LinkBench 2> nul
-pushd %ROOT%
+set EXITCODE=0
 
+if not exist %LinkBenchRoot% mkdir %LinkBenchRoot% 
+pushd %LinkBenchRoot%
+
+if not exist .dotnet call :DotNet
+if defined __test_HelloWorld call :HelloWorld
+if defined __test_WebAPI call :WebAPI
+if defined __test_MusicStore call :MusicStore
+if defined __test_MusicStore_R2R call :MusicStore_R2R 
+if defined __test_CoreFx call :CoreFx
+if defined __test_Roslyn call :Roslyn
+
+popd
+exit /b %EXITCODE%
+
+:DotNet
+REM Roslyn needs SDK 1.0.0, other benchmarks need SDK 2.0.0
+mkdir .dotnet
+cd .dotnet
+mkdir 1.0.0
+mkdir 2.0.0
+powershell -noprofile -executionPolicy RemoteSigned wget  https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1 -OutFile dotnet-install.ps1
+powershell -noprofile -executionPolicy RemoteSigned -file dotnet-install.ps1 -InstallDir 1.0.0
+powershell -noprofile -executionPolicy RemoteSigned -file dotnet-install.ps1 -Channel master -InstallDir 2.0.0
+if not exist %__dotnet1% set EXITCODE=1
+if not exist %__dotnet2% set EXITCODE=1
+cd ..
+exit /b 
+
+:HelloWorld
 mkdir HelloWorld
 cd HelloWorld
 dotnet new console
-if errorlevel 1 exit /b 1
+if errorlevel 1 set EXITCODE=1
 cd ..
+exit /b 
 
+:WebAPI
 mkdir WebAPI
 cd WebAPI
 dotnet new webapi
-if errorlevel 1 exit /b 1
+if errorlevel 1 set EXITCODE=1
 cd ..
+exit /b
 
+:MusicStore
 git clone https://github.com/aspnet/JitBench -b dev
-if errorlevel 1 exit /b 1
+if errorlevel 1 set EXITCODE=1
+exit /b
 
+:MusicStore_R2R
+REM MusicStore_R2R requires a previous MusicStore run.
+REM No Additional Setup
+exit /b
+
+:CoreFx
 git clone http://github.com/dotnet/corefx
-if errorlevel 1 exit /b 1
+if errorlevel 1 set EXITCODE=1
+exit /b
 
+:Roslyn
 git clone https://github.com/dotnet/roslyn.git
-if errorlevel 1 exit /b 1
-
-popd
+if errorlevel 1 set EXITCODE=1
+exit /b


### PR DESCRIPTION
This change has the following improvements to LinkBench

1) Move the testing to the latest version of ILLink package
   (for all benchmarks except for Roslyn, which is still on netcoreapp1.1)
2) Support for LinkBench to run individual benchmarks in the suite --
   helps local testing.
3) Support for running without clean, cloning, build etc --
   for local runs during continuous development.
4) Support to obtain the correct version(s) of DotNet CLI required to run
   the benchmarks
5) Get-Crossgen.ps1 is required to crossgen MusicStore binaries (before/after linking).
   Since it was recently dropped from JitBench repo, it is added to linkBench as an asset.
6) Add the --perf:runid parameter to generate output file names suitable
   to upload the results to BenchView.