### PR TITLE
Fix linker GUARD option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,8 +312,8 @@ if (WIN32)
     endforeach (Definition)
   endforeach (Config)
 
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /guard:cf")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /guard:cf")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /GUARD:CF")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /GUARD:CF")
 
   # Linker flags
   #


### PR DESCRIPTION
I have found that the `/GUARD:CF` option set in the root CMakeFiles.txt
was not being propagated to the Visual C++ project files generated
by Cmake because of a wrong casing. The CMakeFiles.txt used `/guard:cf`
but it works correctly only if it is all upper case.