### PR TITLE
[RyuJIT/ARM32] Fix GT_NEG decomposition

### DIFF
--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -922,7 +922,7 @@ GenTree* DecomposeLongs::DecomposeNeg(LIR::Use& use)
     loResult->gtType     = TYP_INT;
     loResult->gtOp.gtOp1 = loOp1;
 
-    GenTree* zero     = m_compiler->gtNewZeroConNode(TYP_INT);
+    GenTree* zero = m_compiler->gtNewZeroConNode(TYP_INT);
 #if defined(_TARGET_X86_)
     GenTree* hiAdjust = m_compiler->gtNewOperNode(GT_ADD_HI, TYP_INT, hiOp1, zero);
     GenTree* hiResult = m_compiler->gtNewOperNode(GT_NEG, TYP_INT, hiAdjust);

--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -923,10 +923,14 @@ GenTree* DecomposeLongs::DecomposeNeg(LIR::Use& use)
     loResult->gtOp.gtOp1 = loOp1;
 
     GenTree* zero     = m_compiler->gtNewZeroConNode(TYP_INT);
+#if defined(_TARGET_X86_)
     GenTree* hiAdjust = m_compiler->gtNewOperNode(GT_ADD_HI, TYP_INT, hiOp1, zero);
     GenTree* hiResult = m_compiler->gtNewOperNode(GT_NEG, TYP_INT, hiAdjust);
-
     Range().InsertAfter(loResult, zero, hiAdjust, hiResult);
+#elif defined(_TARGET_ARM_)
+    GenTree* hiResult = m_compiler->gtNewOperNode(GT_SUB_HI, TYP_INT, zero, hiOp1);
+    Range().InsertAfter(loResult, zero, hiResult);
+#endif
 
     return FinalizeDecomposition(use, loResult, hiResult, hiResult);
 }


### PR DESCRIPTION
Fixes these tests:
```
JIT/Directed/perffix/primitivevt/mixed1_cs_d
JIT/Directed/perffix/primitivevt/mixed1_cs_r
JIT/IL_Conformance/Old/Conformance_Base/ldc_neg_i8
JIT/Methodical/fp/exgen/1000w1d_cs_d
JIT/Methodical/fp/exgen/1000w1d_cs_do
JIT/Methodical/fp/exgen/1000w1d_cs_r
JIT/Methodical/fp/exgen/1000w1d_cs_ro
JIT/Methodical/fp/exgen/10w5d_cs_d
JIT/Methodical/fp/exgen/10w5d_cs_r
JIT/Methodical/fp/exgen/200w1d-02_cs_d
JIT/Methodical/fp/exgen/200w1d-02_cs_do
JIT/Methodical/fp/exgen/200w1d-02_cs_r
JIT/Methodical/fp/exgen/200w1d-02_cs_ro
JIT/Methodical/MDArray/DataTypes/long_cs_d
JIT/Methodical/MDArray/DataTypes/long_cs_r
...
```

[codegenlegacy.cpp#L14500-L14513](https://github.com/dotnet/coreclr/blob/c78891ae1cc668a77377b2b0fb03c7e1a6894b29/src/jit/codegenlegacy.cpp#L14500-L14513):
```c++
// ARM doesn't have an opcode that sets the carry bit like
// x86, so we can't use neg/addc/neg.  Instead we use subtract
// with carry.  Too bad this uses an extra register.
...
inst_RV_IV(INS_rsb, regLo, 0, EA_4BYTE, INS_FLAGS_SET);
getEmitter()->emitIns_R_R_R_I(INS_sbc, EA_4BYTE, regHi, regZero, regHi, 0);
```

cc @dotnet/arm32-contrib 