### PR TITLE
merger takes MC file names as UTF8 names.

### DIFF
--- a/src/ToolBox/superpmi/mcs/CMakeLists.txt
+++ b/src/ToolBox/superpmi/mcs/CMakeLists.txt
@@ -1,8 +1,5 @@
 project(mcs)
 
-remove_definitions(-DUNICODE)
-remove_definitions(-D_UNICODE)
-
 add_definitions(-DFEATURE_NO_HOST)
 add_definitions(-DSELF_NO_HOST)
 

--- a/src/ToolBox/superpmi/mcs/verbmerge.cpp
+++ b/src/ToolBox/superpmi/mcs/verbmerge.cpp
@@ -27,7 +27,7 @@ LPWSTR verbMerge::MergePathStrings(LPCWSTR dir, LPCWSTR file)
     return newpath;
 }
 
-char* verbMerge::ConvertUTF8ToMultiByte(LPCWSTR wstr)
+char* verbMerge::ConvertWideCharToMultiByte(LPCWSTR wstr)
 {
     unsigned int codePage   = CP_UTF8;
     int          sizeNeeded = WideCharToMultiByte(codePage, 0, wstr, -1, NULL, 0, NULL, NULL);
@@ -46,7 +46,7 @@ int verbMerge::AppendFile(HANDLE hFileOut, LPCWSTR fileName, unsigned char* buff
 {
     int result = 0; // default to zero == success
 
-    char* fileNameAsChar = ConvertUTF8ToMultiByte(fileName);
+    char* fileNameAsChar = ConvertWideCharToMultiByte(fileName);
     LogInfo("Appending file '%s'", fileNameAsChar);
 
     HANDLE hFileIn = CreateFileW(fileName, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING,
@@ -312,7 +312,7 @@ int verbMerge::AppendAllInDir(HANDLE              hFileOut,
         const _WIN32_FIND_DATAW& findData     = fileArray[i];
         LPWSTR                   fileFullPath = MergePathStrings(dir, findData.cFileName);
 
-        if (wcslen(fileFullPath) > 260) // It is too long path, use \\?\ to access it.
+        if (wcslen(fileFullPath) > MAX_PATH) // It is too long path, use \\?\ to access it.
         {
             LPWSTR newBuffer = new WCHAR[wcslen(fileFullPath) + 30];
             wcscpy(newBuffer, W("\\\\?\\"));
@@ -338,7 +338,7 @@ int verbMerge::AppendAllInDir(HANDLE              hFileOut,
         // Is it zero length? If so, skip it.
         if ((findData.nFileSizeLow == 0) && (findData.nFileSizeHigh == 0))
         {
-            char* fileFullPathAsChar = ConvertUTF8ToMultiByte(fileFullPath);
+            char* fileFullPathAsChar = ConvertWideCharToMultiByte(fileFullPath);
             LogInfo("Skipping zero-length file '%s'", fileFullPathAsChar);
             delete[] fileFullPathAsChar;
         }

--- a/src/ToolBox/superpmi/mcs/verbmerge.cpp
+++ b/src/ToolBox/superpmi/mcs/verbmerge.cpp
@@ -22,7 +22,7 @@ LPTSTR verbMerge::MergePathStrings(LPCTSTR dir, LPCTSTR file)
     size_t newlen  = dirlen + 1 /* slash */ + filelen + 1 /* null */;
     LPTSTR newpath = new WCHAR[newlen];
     wcscpy(newpath, dir);
-    wcscat(newpath, DIRECTORY_SEPARATOR_STR_A);
+    wcscat(newpath, DIRECTORY_SEPARATOR_STR_W);
     wcscat(newpath, file);
     return newpath;
 }

--- a/src/ToolBox/superpmi/mcs/verbmerge.h
+++ b/src/ToolBox/superpmi/mcs/verbmerge.h
@@ -27,7 +27,7 @@ private:
 
     static LPWSTR MergePathStrings(LPCWSTR dir, LPCWSTR file);
 
-    static char* ConvertUTF8ToMultiByte(LPCWSTR wstr);
+    static char* ConvertWideCharToMultiByte(LPCWSTR wstr);
 
     static int AppendFile(HANDLE hFileOut, LPCWSTR fileName, unsigned char* buffer, size_t bufferSize);
     static int AppendAllInDir(HANDLE              hFileOut,

--- a/src/ToolBox/superpmi/mcs/verbmerge.h
+++ b/src/ToolBox/superpmi/mcs/verbmerge.h
@@ -5,6 +5,7 @@
 
 //----------------------------------------------------------
 // verbMerge.h - verb that merges multiple .MC into one .MCH file
+// It allows .MC names to be Unicode names with long paths.
 //----------------------------------------------------------
 #ifndef _verbMerge
 #define _verbMerge
@@ -15,21 +16,23 @@ public:
     static int DoWork(const char* nameOfOutputFile, const char* pattern, bool recursive);
 
 private:
-    typedef bool (*DirectoryFilterFunction_t)(WIN32_FIND_DATAA*);
-    static bool DirectoryFilterDirectories(WIN32_FIND_DATAA* findData);
-    static bool DirectoryFilterFile(WIN32_FIND_DATAA* findData);
-    static int __cdecl WIN32_FIND_DATAA_qsort_helper(const void* p1, const void* p2);
-    static int FilterDirectory(const char*                  searchPattern,
+    typedef bool (*DirectoryFilterFunction_t)(WIN32_FIND_DATAW*);
+    static bool DirectoryFilterDirectories(WIN32_FIND_DATAW* findData);
+    static bool DirectoryFilterFile(WIN32_FIND_DATAW* findData);
+    static int __cdecl WIN32_FIND_DATAW_qsort_helper(const void* p1, const void* p2);
+    static int FilterDirectory(LPCTSTR                      searchPattern,
                                DirectoryFilterFunction_t    filter,
-                               /* out */ WIN32_FIND_DATAA** ppFileArray,
+                               /* out */ WIN32_FIND_DATAW** ppFileArray,
                                int*                         pElemCount);
 
-    static char* MergePathStrings(const char* dir, const char* file);
+    static LPTSTR MergePathStrings(LPCTSTR dir, LPCTSTR file);
 
-    static int AppendFile(HANDLE hFileOut, const char* fileName, unsigned char* buffer, size_t bufferSize);
+    static char* ConvertUTF8ToMultiByte(LPCTSTR wstr);
+
+    static int AppendFile(HANDLE hFileOut, LPCTSTR fileName, unsigned char* buffer, size_t bufferSize);
     static int AppendAllInDir(HANDLE              hFileOut,
-                              const char*         dir,
-                              const char*         file,
+                              LPCTSTR             dir,
+                              LPCTSTR             file,
                               unsigned char*      buffer,
                               size_t              bufferSize,
                               bool                recursive,

--- a/src/ToolBox/superpmi/mcs/verbmerge.h
+++ b/src/ToolBox/superpmi/mcs/verbmerge.h
@@ -20,19 +20,19 @@ private:
     static bool DirectoryFilterDirectories(WIN32_FIND_DATAW* findData);
     static bool DirectoryFilterFile(WIN32_FIND_DATAW* findData);
     static int __cdecl WIN32_FIND_DATAW_qsort_helper(const void* p1, const void* p2);
-    static int FilterDirectory(LPCTSTR                      searchPattern,
+    static int FilterDirectory(LPCWSTR                      searchPattern,
                                DirectoryFilterFunction_t    filter,
                                /* out */ WIN32_FIND_DATAW** ppFileArray,
                                int*                         pElemCount);
 
-    static LPTSTR MergePathStrings(LPCTSTR dir, LPCTSTR file);
+    static LPWSTR MergePathStrings(LPCWSTR dir, LPCWSTR file);
 
-    static char* ConvertUTF8ToMultiByte(LPCTSTR wstr);
+    static char* ConvertUTF8ToMultiByte(LPCWSTR wstr);
 
-    static int AppendFile(HANDLE hFileOut, LPCTSTR fileName, unsigned char* buffer, size_t bufferSize);
+    static int AppendFile(HANDLE hFileOut, LPCWSTR fileName, unsigned char* buffer, size_t bufferSize);
     static int AppendAllInDir(HANDLE              hFileOut,
-                              LPCTSTR             dir,
-                              LPCTSTR             file,
+                              LPCWSTR             dir,
+                              LPCWSTR             file,
                               unsigned char*      buffer,
                               size_t              bufferSize,
                               bool                recursive,

--- a/src/ToolBox/superpmi/superpmi-shared/standardpch.h
+++ b/src/ToolBox/superpmi/superpmi-shared/standardpch.h
@@ -88,6 +88,9 @@
 #ifndef DIRECTORY_SEPARATOR_STR_A
 #define DIRECTORY_SEPARATOR_STR_A "\\"
 #endif
+#ifndef DIRECTORY_SEPARATOR_STR_W
+#define DIRECTORY_SEPARATOR_STR_W W("\\")
+#endif
 
 #ifndef W
 #ifdef PLATFORM_UNIX

--- a/src/ToolBox/superpmi/superpmi-shared/standardpch.h
+++ b/src/ToolBox/superpmi/superpmi-shared/standardpch.h
@@ -88,9 +88,6 @@
 #ifndef DIRECTORY_SEPARATOR_STR_A
 #define DIRECTORY_SEPARATOR_STR_A "\\"
 #endif
-#ifndef DIRECTORY_SEPARATOR_STR_W
-#define DIRECTORY_SEPARATOR_STR_W W("\\")
-#endif
 
 #ifndef W
 #ifdef PLATFORM_UNIX
@@ -99,6 +96,10 @@
 #define W(str) L##str
 #endif // PLATFORM_UNIX
 #endif // !W
+
+#ifndef DIRECTORY_SEPARATOR_STR_W
+#define DIRECTORY_SEPARATOR_STR_W W("\\")
+#endif
 
 #ifdef FEATURE_PAL
 #define PLATFORM_SHARED_LIB_SUFFIX_A PAL_SHLIB_SUFFIX


### PR DESCRIPTION
There were problems with:
1. Arabick and Japanese symbols in CLR_SH;
2. path + MC name length were bigger than 260.

We didn't see these problem before, because we moved all MC files and
renamed them with short numbers names.
Now if we want to:
1. avoid  MC files moving;
2. save information that is encoded in this names for spmi diff between
different collections we want this fix.

So this fix work with MC names as they came from "FilterDirectory" that returns "WIN32_FIND_DATAW" that represent .MC names as "_Field_z_ WCHAR  cFileName[ MAX_PATH ];"