### PR TITLE
Propagate assertions for more checked bounds

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5493,11 +5493,11 @@ protected:
 
     typedef SimplerHashTable<GenTreePtr, PtrKeyFuncs<GenTree>, GenTreePtr, JitSimplerHashBehavior> NodeToNodeMap;
 
-    NodeToNodeMap* optCseArrLenMap; // Maps array length nodes to ancestor compares that should be
-                                    // re-numbered with the array length to improve range check elimination
+    NodeToNodeMap* optCseCheckedBoundMap; // Maps bound nodes to ancestor compares that should be
+                                          // re-numbered with the bound to improve range check elimination
 
-    // Given a compare, look for a cse candidate arrlen feeding it and add a map entry if found.
-    void optCseUpdateArrLenMap(GenTreePtr compare);
+    // Given a compare, look for a cse candidate checked bound feeding it and add a map entry if found.
+    void optCseUpdateCheckedBoundMap(GenTreePtr compare);
 
     void optCSEstop();
 
@@ -5726,8 +5726,8 @@ public:
         O1K_INVALID,
         O1K_LCLVAR,
         O1K_ARR_BND,
-        O1K_ARRLEN_OPER_BND,
-        O1K_ARRLEN_LOOP_BND,
+        O1K_BOUND_OPER_BND,
+        O1K_BOUND_LOOP_BND,
         O1K_CONSTANT_LOOP_BND,
         O1K_EXACT_TYPE,
         O1K_SUBTYPE,
@@ -5792,13 +5792,13 @@ public:
             };
         } op2;
 
-        bool IsArrLenArithBound()
+        bool IsCheckedBoundArithBound()
         {
-            return ((assertionKind == OAK_EQUAL || assertionKind == OAK_NOT_EQUAL) && op1.kind == O1K_ARRLEN_OPER_BND);
+            return ((assertionKind == OAK_EQUAL || assertionKind == OAK_NOT_EQUAL) && op1.kind == O1K_BOUND_OPER_BND);
         }
-        bool IsArrLenBound()
+        bool IsCheckedBoundBound()
         {
-            return ((assertionKind == OAK_EQUAL || assertionKind == OAK_NOT_EQUAL) && op1.kind == O1K_ARRLEN_LOOP_BND);
+            return ((assertionKind == OAK_EQUAL || assertionKind == OAK_NOT_EQUAL) && op1.kind == O1K_BOUND_LOOP_BND);
         }
         bool IsConstantBound()
         {

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -4104,6 +4104,13 @@ inline void* Compiler::compGetMem(size_t sz, CompMemKind cmk)
 
 #endif
 
+// Wrapper for Compiler::compGetMem that can be forward-declared for use in template
+// types which Compiler depends on but which need to allocate heap memory.
+inline void* compGetMem(Compiler* comp, size_t sz)
+{
+    return comp->compGetMem(sz);
+}
+
 /*****************************************************************************
  *
  * A common memory allocation for arrays of structures involves the

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -507,8 +507,8 @@ void Compiler::optValnumCSE_Init()
     optCSECandidateCount = 0;
     optDoCSE             = false; // Stays false until we find duplicate CSE tree
 
-    // optCseArrLenMap is unused in most functions, allocated only when used
-    optCseArrLenMap = nullptr;
+    // optCseCheckedBoundMap is unused in most functions, allocated only when used
+    optCseCheckedBoundMap = nullptr;
 }
 
 /*****************************************************************************
@@ -705,10 +705,10 @@ unsigned Compiler::optValnumCSE_Locate()
             {
                 if (tree->OperIsCompare() && stmtHasArrLenCandidate)
                 {
-                    // Check if this compare is a function of (one of) the arrary
-                    // length candidate(s); we may want to update its value number
+                    // Check if this compare is a function of (one of) the checked
+                    // bound candidate(s); we may want to update its value number.
                     // if the array length gets CSEd
-                    optCseUpdateArrLenMap(tree);
+                    optCseUpdateCheckedBoundMap(tree);
                 }
 
                 if (!optIsCSEcandidate(tree))
@@ -763,16 +763,16 @@ unsigned Compiler::optValnumCSE_Locate()
 }
 
 //------------------------------------------------------------------------
-// optCseUpdateArrLenMap: Check if this compare is a tractable function of
-//                     an array length that is a CSE candidate, and insert
-//                     an entry in the optCseArrLenMap if so.  This facilitates
+// optCseUpdateCheckedBoundMap: Check if this compare is a tractable function of
+//                     a checked bound that is a CSE candidate, and insert
+//                     an entry in the optCseCheckedBoundMap if so.  This facilitates
 //                     subsequently updating the compare's value number if
-//                     the array length gets CSEd.
+//                     the bound gets CSEd.
 //
 // Arguments:
 //    compare - The compare node to check
 
-void Compiler::optCseUpdateArrLenMap(GenTreePtr compare)
+void Compiler::optCseUpdateCheckedBoundMap(GenTreePtr compare)
 {
     assert(compare->OperIsCompare());
 
@@ -787,73 +787,72 @@ void Compiler::optCseUpdateArrLenMap(GenTreePtr compare)
         return;
     }
 
-    // Now look for an array length feeding the compare
-    ValueNumStore::ArrLenArithBoundInfo info;
-    GenTreePtr                          arrLenParent = nullptr;
+    // Now look for a checked bound feeding the compare
+    ValueNumStore::CompareCheckedBoundArithInfo info;
 
-    if (vnStore->IsVNArrLenBound(compareVN))
+    GenTreePtr boundParent = nullptr;
+
+    if (vnStore->IsVNCompareCheckedBound(compareVN))
     {
-        // Simple compare of an array legnth against something else.
+        // Simple compare of an bound against something else.
 
-        vnStore->GetArrLenBoundInfo(compareVN, &info);
-        arrLenParent = compare;
+        vnStore->GetCompareCheckedBound(compareVN, &info);
+        boundParent = compare;
     }
-    else if (vnStore->IsVNArrLenArithBound(compareVN))
+    else if (vnStore->IsVNCompareCheckedBoundArith(compareVN))
     {
-        // Compare of an array length +/- some offset to something else.
+        // Compare of a bound +/- some offset to something else.
 
         GenTreePtr op1 = compare->gtGetOp1();
         GenTreePtr op2 = compare->gtGetOp2();
 
-        vnStore->GetArrLenArithBoundInfo(compareVN, &info);
+        vnStore->GetCompareCheckedBoundArithInfo(compareVN, &info);
         if (GetVNFuncForOper(op1->OperGet(), op1->IsUnsigned()) == (VNFunc)info.arrOper)
         {
-            // The arithmetic node is the array length's parent.
-            arrLenParent = op1;
+            // The arithmetic node is the bound's parent.
+            boundParent = op1;
         }
         else if (GetVNFuncForOper(op2->OperGet(), op2->IsUnsigned()) == (VNFunc)info.arrOper)
         {
-            // The arithmetic node is the array length's parent.
-            arrLenParent = op2;
+            // The arithmetic node is the bound's parent.
+            boundParent = op2;
         }
     }
 
-    if (arrLenParent != nullptr)
+    if (boundParent != nullptr)
     {
-        GenTreePtr arrLen = nullptr;
+        GenTreePtr bound = nullptr;
 
-        // Find which child of arrLenParent is the array length.  Abort if its
-        // conservative value number doesn't match the one from the compare VN.
+        // Find which child of boundParent is the bound.  Abort if neither
+        // conservative value number matches the one from the compare VN.
 
-        GenTreePtr child1 = arrLenParent->gtGetOp1();
-        if ((child1->OperGet() == GT_ARR_LENGTH) && IS_CSE_INDEX(child1->gtCSEnum) &&
-            (info.vnArray == child1->AsArrLen()->ArrRef()->gtVNPair.GetConservative()))
+        GenTreePtr child1 = boundParent->gtGetOp1();
+        if ((info.vnBound == child1->gtVNPair.GetConservative()) && IS_CSE_INDEX(child1->gtCSEnum))
         {
-            arrLen = child1;
+            bound = child1;
         }
         else
         {
-            GenTreePtr child2 = arrLenParent->gtGetOp2();
-            if ((child2->OperGet() == GT_ARR_LENGTH) && IS_CSE_INDEX(child2->gtCSEnum) &&
-                (info.vnArray == child2->AsArrLen()->ArrRef()->gtVNPair.GetConservative()))
+            GenTreePtr child2 = boundParent->gtGetOp2();
+            if ((info.vnBound == child2->gtVNPair.GetConservative()) && IS_CSE_INDEX(child2->gtCSEnum))
             {
-                arrLen = child2;
+                bound = child2;
             }
         }
 
-        if (arrLen != nullptr)
+        if (bound != nullptr)
         {
-            // Found an arrayLen feeding a compare that is a tracatable function of it;
-            // record this in the map so we can update the compare VN if the array length
+            // Found a checked bound feeding a compare that is a tractable function of it;
+            // record this in the map so we can update the compare VN if the bound
             // node gets CSEd.
 
-            if (optCseArrLenMap == nullptr)
+            if (optCseCheckedBoundMap == nullptr)
             {
                 // Allocate map on first use.
-                optCseArrLenMap = new (getAllocator()) NodeToNodeMap(getAllocator());
+                optCseCheckedBoundMap = new (getAllocator()) NodeToNodeMap(getAllocator());
             }
 
-            optCseArrLenMap->Set(arrLen, compare);
+            optCseCheckedBoundMap->Set(bound, compare);
         }
     }
 }
@@ -2023,31 +2022,40 @@ public:
                     // conservative VN to this use.  This can help range check elimination later on.
                     cse->gtVNPair.SetConservative(defConservativeVN);
 
+                    // If the old VN was flagged as a checked bound, propagate that to the new VN
+                    // to make sure assertion prop will pay attention to this VN.
+                    ValueNumStore* vnStore = m_pCompiler->vnStore;
+                    ValueNum       oldVN   = exp->gtVNPair.GetConservative();
+                    if (!vnStore->IsVNConstant(defConservativeVN) && vnStore->IsVNCheckedBound(oldVN))
+                    {
+                        vnStore->SetVNIsCheckedBound(defConservativeVN);
+                    }
+
                     GenTreePtr cmp;
-                    if ((exp->OperGet() == GT_ARR_LENGTH) && (m_pCompiler->optCseArrLenMap != nullptr) &&
-                        (m_pCompiler->optCseArrLenMap->Lookup(exp, &cmp)))
+                    if ((m_pCompiler->optCseCheckedBoundMap != nullptr) &&
+                        (m_pCompiler->optCseCheckedBoundMap->Lookup(exp, &cmp)))
                     {
                         // Propagate the new value number to this compare node as well, since
                         // subsequent range check elimination will try to correlate it with
                         // the other appearances that are getting CSEd.
 
-                        ValueNumStore*                      vnStore  = m_pCompiler->vnStore;
-                        ValueNum                            oldCmpVN = cmp->gtVNPair.GetConservative();
-                        ValueNumStore::ArrLenArithBoundInfo info;
-                        ValueNum                            newCmpArgVN;
-                        if (vnStore->IsVNArrLenBound(oldCmpVN))
+                        ValueNum oldCmpVN = cmp->gtVNPair.GetConservative();
+                        ValueNum newCmpArgVN;
+
+                        ValueNumStore::CompareCheckedBoundArithInfo info;
+                        if (vnStore->IsVNCompareCheckedBound(oldCmpVN))
                         {
-                            // Comparison is against the array length directly.
+                            // Comparison is against the bound directly.
 
                             newCmpArgVN = defConservativeVN;
-                            vnStore->GetArrLenBoundInfo(oldCmpVN, &info);
+                            vnStore->GetCompareCheckedBound(oldCmpVN, &info);
                         }
                         else
                         {
-                            // Comparison is against the array length +/- some offset.
+                            // Comparison is against the bound +/- some offset.
 
-                            assert(vnStore->IsVNArrLenArithBound(oldCmpVN));
-                            vnStore->GetArrLenArithBoundInfo(oldCmpVN, &info);
+                            assert(vnStore->IsVNCompareCheckedBoundArith(oldCmpVN));
+                            vnStore->GetCompareCheckedBoundArithInfo(oldCmpVN, &info);
                             newCmpArgVN = vnStore->VNForFunc(vnStore->TypeOfVN(info.arrOp), (VNFunc)info.arrOper,
                                                              info.arrOp, defConservativeVN);
                         }

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -68,6 +68,8 @@ bool RangeCheck::BetweenBounds(Range& range, int lower, GenTreePtr upper)
     }
 #endif // DEBUG
 
+    ValueNumStore* vnStore = m_pCompiler->vnStore;
+
     // Get the VN for the upper limit.
     ValueNum uLimitVN = upper->gtVNPair.GetConservative();
 
@@ -75,15 +77,14 @@ bool RangeCheck::BetweenBounds(Range& range, int lower, GenTreePtr upper)
     JITDUMP("VN%04X upper bound is: ", uLimitVN);
     if (m_pCompiler->verbose)
     {
-        m_pCompiler->vnStore->vnDump(m_pCompiler, uLimitVN);
+        vnStore->vnDump(m_pCompiler, uLimitVN);
     }
     JITDUMP("\n");
 #endif
 
-    ValueNum arrRefVN = ValueNumStore::NoVN;
-    int      arrSize  = 0;
+    int arrSize = 0;
 
-    if (m_pCompiler->vnStore->IsVNConstant(uLimitVN))
+    if (vnStore->IsVNConstant(uLimitVN))
     {
         ssize_t  constVal  = -1;
         unsigned iconFlags = 0;
@@ -93,47 +94,38 @@ bool RangeCheck::BetweenBounds(Range& range, int lower, GenTreePtr upper)
             arrSize = (int)constVal;
         }
     }
-    else if (m_pCompiler->vnStore->IsVNArrLen(uLimitVN))
+    else if (vnStore->IsVNArrLen(uLimitVN))
     {
         // Get the array reference from the length.
-        arrRefVN = m_pCompiler->vnStore->GetArrForLenVn(uLimitVN);
+        ValueNum arrRefVN = vnStore->GetArrForLenVn(uLimitVN);
         // Check if array size can be obtained.
-        arrSize = m_pCompiler->vnStore->GetNewArrSize(arrRefVN);
+        arrSize = vnStore->GetNewArrSize(arrRefVN);
     }
-    else
+    else if (!vnStore->IsVNCheckedBound(uLimitVN))
     {
         // If the upper limit is not length, then bail.
         return false;
     }
 
-#ifdef DEBUG
-    JITDUMP("Array ref VN");
-    if (m_pCompiler->verbose)
-    {
-        m_pCompiler->vnStore->vnDump(m_pCompiler, arrRefVN);
-    }
-    JITDUMP("\n");
-#endif
-
     JITDUMP("Array size is: %d\n", arrSize);
 
-    // Upper limit: a.len + ucns (upper limit constant).
+    // Upper limit: len + ucns (upper limit constant).
     if (range.UpperLimit().IsBinOpArray())
     {
-        if (range.UpperLimit().vn != arrRefVN)
+        if (range.UpperLimit().vn != uLimitVN)
         {
             return false;
         }
 
         int ucns = range.UpperLimit().GetConstant();
 
-        // Upper limit: a.Len + [0..n]
+        // Upper limit: Len + [0..n]
         if (ucns >= 0)
         {
             return false;
         }
 
-        // If lower limit is a.len return false.
+        // If lower limit is len return false.
         if (range.LowerLimit().IsArray())
         {
             return false;
@@ -152,8 +144,8 @@ bool RangeCheck::BetweenBounds(Range& range, int lower, GenTreePtr upper)
         }
 
         // At this point,
-        // upper limit = a.len + ucns. ucns < 0
-        // lower limit = a.len + lcns.
+        // upper limit = len + ucns. ucns < 0
+        // lower limit = len + lcns.
         if (range.LowerLimit().IsBinOpArray())
         {
             int lcns = range.LowerLimit().GetConstant();
@@ -161,7 +153,7 @@ bool RangeCheck::BetweenBounds(Range& range, int lower, GenTreePtr upper)
             {
                 return false;
             }
-            return (range.LowerLimit().vn == arrRefVN && lcns <= ucns);
+            return (range.LowerLimit().vn == uLimitVN && lcns <= ucns);
         }
     }
     // If upper limit is constant
@@ -185,13 +177,13 @@ bool RangeCheck::BetweenBounds(Range& range, int lower, GenTreePtr upper)
         if (range.LowerLimit().IsBinOpArray())
         {
             int lcns = range.LowerLimit().GetConstant();
-            // a.len + lcns, make sure we don't subtract too much from a.len.
+            // len + lcns, make sure we don't subtract too much from len.
             if (lcns >= 0 || -lcns > arrSize)
             {
                 return false;
             }
             // Make sure a.len + lcns <= ucns.
-            return (range.LowerLimit().vn == arrRefVN && (arrSize + lcns) <= ucns);
+            return (range.LowerLimit().vn == uLimitVN && (arrSize + lcns) <= ucns);
         }
     }
 
@@ -508,8 +500,9 @@ void RangeCheck::MergeEdgeAssertions(GenTreePtr tree, const ASSERT_VALARG_TP ass
 
         Compiler::AssertionDsc* curAssertion = m_pCompiler->optGetAssertion((AssertionIndex)index);
 
-        // Current assertion is about array length.
-        if (!curAssertion->IsArrLenArithBound() && !curAssertion->IsArrLenBound() && !curAssertion->IsConstantBound())
+        // Current assertion is about compare against constant or checked bound.
+        if (!curAssertion->IsCheckedBoundArithBound() && !curAssertion->IsCheckedBoundBound() &&
+            !curAssertion->IsConstantBound())
         {
             continue;
         }
@@ -521,20 +514,20 @@ void RangeCheck::MergeEdgeAssertions(GenTreePtr tree, const ASSERT_VALARG_TP ass
         }
 #endif
 
-        assert(m_pCompiler->vnStore->IsVNArrLenArithBound(curAssertion->op1.vn) ||
-               m_pCompiler->vnStore->IsVNArrLenBound(curAssertion->op1.vn) ||
+        assert(m_pCompiler->vnStore->IsVNCompareCheckedBoundArith(curAssertion->op1.vn) ||
+               m_pCompiler->vnStore->IsVNCompareCheckedBound(curAssertion->op1.vn) ||
                m_pCompiler->vnStore->IsVNConstantBound(curAssertion->op1.vn));
 
         Limit      limit(Limit::keUndef);
         genTreeOps cmpOper = GT_NONE;
 
-        // Current assertion is of the form (i < a.len - cns) != 0
-        if (curAssertion->IsArrLenArithBound())
+        // Current assertion is of the form (i < len - cns) != 0
+        if (curAssertion->IsCheckedBoundArithBound())
         {
-            ValueNumStore::ArrLenArithBoundInfo info;
+            ValueNumStore::CompareCheckedBoundArithInfo info;
 
-            // Get i, a.len, cns and < as "info."
-            m_pCompiler->vnStore->GetArrLenArithBoundInfo(curAssertion->op1.vn, &info);
+            // Get i, len, cns and < as "info."
+            m_pCompiler->vnStore->GetCompareCheckedBoundArithInfo(curAssertion->op1.vn, &info);
 
             if (m_pCompiler->lvaTable[lcl->gtLclNum].GetPerSsaData(lcl->gtSsaNum)->m_vnPair.GetConservative() !=
                 info.cmpOp)
@@ -547,26 +540,26 @@ void RangeCheck::MergeEdgeAssertions(GenTreePtr tree, const ASSERT_VALARG_TP ass
                 case GT_SUB:
                 case GT_ADD:
                 {
-                    // If the operand that operates on the array is not constant, then done.
+                    // If the operand that operates on the bound is not constant, then done.
                     if (!m_pCompiler->vnStore->IsVNConstant(info.arrOp) ||
                         m_pCompiler->vnStore->TypeOfVN(info.arrOp) != TYP_INT)
                     {
                         break;
                     }
                     int cons = m_pCompiler->vnStore->ConstantValue<int>(info.arrOp);
-                    limit    = Limit(Limit::keBinOpArray, info.vnArray, info.arrOper == GT_SUB ? -cons : cons);
+                    limit    = Limit(Limit::keBinOpArray, info.vnBound, info.arrOper == GT_SUB ? -cons : cons);
                 }
             }
 
             cmpOper = (genTreeOps)info.cmpOper;
         }
-        // Current assertion is of the form (i < a.len) != 0
-        else if (curAssertion->IsArrLenBound())
+        // Current assertion is of the form (i < len) != 0
+        else if (curAssertion->IsCheckedBoundBound())
         {
-            ValueNumStore::ArrLenArithBoundInfo info;
+            ValueNumStore::CompareCheckedBoundArithInfo info;
 
-            // Get the info as "i", "<" and "a.len"
-            m_pCompiler->vnStore->GetArrLenBoundInfo(curAssertion->op1.vn, &info);
+            // Get the info as "i", "<" and "len"
+            m_pCompiler->vnStore->GetCompareCheckedBound(curAssertion->op1.vn, &info);
 
             ValueNum lclVn =
                 m_pCompiler->lvaTable[lcl->gtLclNum].GetPerSsaData(lcl->gtSsaNum)->m_vnPair.GetConservative();
@@ -576,7 +569,7 @@ void RangeCheck::MergeEdgeAssertions(GenTreePtr tree, const ASSERT_VALARG_TP ass
                 continue;
             }
             limit.type = Limit::keArray;
-            limit.vn   = info.vnArray;
+            limit.vn   = info.vnBound;
             cmpOper    = (genTreeOps)info.cmpOper;
         }
         // Current assertion is of the form (i < 100) != 0
@@ -624,30 +617,31 @@ void RangeCheck::MergeEdgeAssertions(GenTreePtr tree, const ASSERT_VALARG_TP ass
         noway_assert(limit.IsBinOpArray() || limit.IsArray() || limit.IsConstant());
 
         ValueNum arrLenVN = m_pCurBndsChk->gtArrLen->gtVNPair.GetConservative();
-        ValueNum arrRefVN = ValueNumStore::NoVN;
 
-        if (m_pCompiler->vnStore->IsVNArrLen(arrLenVN))
+        if (m_pCompiler->vnStore->IsVNConstant(arrLenVN))
         {
-            // Get the array reference from the length.
-            arrRefVN = m_pCompiler->vnStore->GetArrForLenVn(arrLenVN);
+            // Set arrLenVN to NoVN; this will make it match the "vn" recorded on
+            // constant limits (where we explicitly track the constant and don't
+            // redundantly store its VN in the "vn" field).
+            arrLenVN = ValueNumStore::NoVN;
         }
 
         // During assertion prop we add assertions of the form:
         //
-        //      (i < a.Length) == 0
-        //      (i < a.Length) != 0
+        //      (i < length) == 0
+        //      (i < length) != 0
         //      (i < 100) == 0
         //      (i < 100) != 0
         //
-        // At this point, we have detected that op1.vn is (i < a.Length) or (i < a.Length + cns) or
+        // At this point, we have detected that op1.vn is (i < length) or (i < length + cns) or
         // (i < 100) and the op2.vn is 0.
         //
         // Now, let us check if we are == 0 (i.e., op1 assertion is false) or != 0 (op1 assertion
         // is true.),
         //
         // If we have an assertion of the form == 0 (i.e., equals false), then reverse relop.
-        // The relop has to be reversed because we have: (i < a.Length) is false which is the same
-        // as (i >= a.Length).
+        // The relop has to be reversed because we have: (i < length) is false which is the same
+        // as (i >= length).
         if (curAssertion->assertionKind == Compiler::OAK_EQUAL)
         {
             cmpOper = GenTree::ReverseRelop(cmpOper);
@@ -665,26 +659,26 @@ void RangeCheck::MergeEdgeAssertions(GenTreePtr tree, const ASSERT_VALARG_TP ass
         }
 
         // Doesn't tighten the current bound. So skip.
-        if (pRange->uLimit.IsConstant() && limit.vn != arrRefVN)
+        if (pRange->uLimit.IsConstant() && limit.vn != arrLenVN)
         {
             continue;
         }
 
         // Check if the incoming limit from assertions tightens the existing upper limit.
-        if ((pRange->uLimit.IsArray() || pRange->uLimit.IsBinOpArray()) && pRange->uLimit.vn == arrRefVN)
+        if ((pRange->uLimit.IsArray() || pRange->uLimit.IsBinOpArray()) && pRange->uLimit.vn == arrLenVN)
         {
             // We have checked the current range's (pRange's) upper limit is either of the form:
-            //      a.Length
-            //      a.Length + cns
-            //      and a == the bndsChkCandidate's arrRef
+            //      length
+            //      length + cns
+            //      and length == the bndsChkCandidate's arrLen
             //
-            // We want to check if the incoming limit tightens the bound, and for that the
-            // we need to make sure that incoming limit is also on a.Length or a.Length + cns
-            // and not b.Length or some c.Length.
+            // We want to check if the incoming limit tightens the bound, and for that
+            // we need to make sure that incoming limit is also on the same length (or
+            // length + cns) and not some other length.
 
-            if (limit.vn != arrRefVN)
+            if (limit.vn != arrLenVN)
             {
-                JITDUMP("Array ref did not match cur=$%x, assert=$%x\n", arrRefVN, limit.vn);
+                JITDUMP("Array length VN did not match cur=$%x, assert=$%x\n", arrLenVN, limit.vn);
                 continue;
             }
 
@@ -700,14 +694,14 @@ void RangeCheck::MergeEdgeAssertions(GenTreePtr tree, const ASSERT_VALARG_TP ass
         }
         else
         {
-            // Current range's upper bound is not "a.Length or a.Length + cns" and the
-            // incoming limit is not on the same arrRef as the bounds check candidate.
+            // Current range's upper bound is not "length or length + cns" and the
+            // incoming limit is not on the same length as the bounds check candidate.
             // So we could skip this assertion. But in cases, of Dependent or Unknown
             // type of upper limit, the incoming assertion still tightens the upper
             // bound to a saner value. So do not skip the assertion.
         }
 
-        // cmpOp (loop index i) cmpOper a.len +/- cns
+        // cmpOp (loop index i) cmpOper len +/- cns
         switch (cmpOper)
         {
             case GT_LT:

--- a/src/jit/smallhash.h
+++ b/src/jit/smallhash.h
@@ -5,6 +5,14 @@
 #ifndef _SMALLHASHTABLE_H_
 #define _SMALLHASHTABLE_H_
 
+// Since compiler depends on valuenum which depends on smallhash, forward declare
+// a wrapper for comp->compGetMem here (implemented in compiler.hpp) that can be used below.
+class Compiler;
+void* compGetMem(Compiler* comp, size_t sz);
+
+// genLog2 is defined in compiler.hpp
+unsigned genLog2(unsigned value);
+
 //------------------------------------------------------------------------
 // HashTableInfo: a concept that provides equality and hashing methods for
 //                a particular key type. Used by HashTableBase and its
@@ -34,6 +42,42 @@ struct HashTableInfo<TKey*>
 
         // Truncate and return the result
         return static_cast<unsigned>(keyval);
+    }
+};
+
+//------------------------------------------------------------------------
+// HashTableInfo<int>: specialized version of HashTableInfo for int-
+//                     typed keys.
+template <>
+struct HashTableInfo<int>
+{
+    static bool Equals(int x, int y)
+    {
+        return x == y;
+    }
+
+    static unsigned GetHashCode(int key)
+    {
+        // Cast and return the key
+        return static_cast<unsigned>(key);
+    }
+};
+
+//------------------------------------------------------------------------
+// HashTableInfo<unsigned>: specialized version of HashTableInfo for unsigned-
+//                          typed keys.
+template <>
+struct HashTableInfo<unsigned>
+{
+    static bool Equals(unsigned x, unsigned y)
+    {
+        return x == y;
+    }
+
+    static unsigned GetHashCode(unsigned key)
+    {
+        // Return the key itself
+        return key;
     }
 };
 
@@ -261,7 +305,7 @@ private:
         size_t   allocSize     = sizeof(Bucket) * newNumBuckets;
         assert((sizeof(Bucket) * m_numBuckets) < allocSize);
 
-        auto* newBuckets = reinterpret_cast<Bucket*>(m_compiler->compGetMem(allocSize));
+        auto* newBuckets = reinterpret_cast<Bucket*>(compGetMem(m_compiler, allocSize));
         memset(newBuckets, 0, allocSize);
 
         for (unsigned currentIndex = 0; currentIndex < m_numBuckets; currentIndex++)
@@ -558,7 +602,7 @@ public:
     HashTable(Compiler* compiler, unsigned initialSize)
         : TBase(compiler,
                 reinterpret_cast<typename TBase::Bucket*>(
-                    compiler->compGetMem(RoundUp(initialSize) * sizeof(typename TBase::Bucket))),
+                    compGetMem(compiler, RoundUp(initialSize) * sizeof(typename TBase::Bucket))),
                 RoundUp(initialSize))
     {
     }

--- a/src/jit/valuenum.h
+++ b/src/jit/valuenum.h
@@ -30,6 +30,8 @@
 #include "gentree.h"
 // Defines the type ValueNum.
 #include "valuenumtype.h"
+// Defines the type SmallHashTable.
+#include "smallhash.h"
 
 // A "ValueNumStore" represents the "universe" of value numbers used in a single
 // compilation.
@@ -537,27 +539,39 @@ public:
     // Returns true iff the VN represents an integeral constant.
     bool IsVNInt32Constant(ValueNum vn);
 
-    struct ArrLenUnsignedBoundInfo
+    typedef SmallHashTable<ValueNum, bool, 8U> CheckedBoundVNSet;
+
+    // Returns true if the VN is known or likely to appear as the conservative value number
+    // of the length argument to a GT_ARR_BOUNDS_CHECK node.
+    bool IsVNCheckedBound(ValueNum vn);
+
+    // Record that a VN is known to appear as the conservative value number of the length
+    // argument to a GT_ARR_BOUNDS_CHECK node.
+    void SetVNIsCheckedBound(ValueNum vn);
+
+    // Information about the individual components of a value number representing an unsigned
+    // comparison of some value against a checked bound VN.
+    struct UnsignedCompareCheckedBoundInfo
     {
         unsigned cmpOper;
         ValueNum vnIdx;
-        ValueNum vnLen;
+        ValueNum vnBound;
 
-        ArrLenUnsignedBoundInfo() : cmpOper(GT_NONE), vnIdx(NoVN), vnLen(NoVN)
+        UnsignedCompareCheckedBoundInfo() : cmpOper(GT_NONE), vnIdx(NoVN), vnBound(NoVN)
         {
         }
     };
 
-    struct ArrLenArithBoundInfo
+    struct CompareCheckedBoundArithInfo
     {
-        // (vnArr.len - 1) > vnOp
-        // (vnArr.len arrOper arrOp) cmpOper cmpOp
-        ValueNum vnArray;
+        // (vnBound - 1) > vnOp
+        // (vnBound arrOper arrOp) cmpOper cmpOp
+        ValueNum vnBound;
         unsigned arrOper;
         ValueNum arrOp;
         unsigned cmpOper;
         ValueNum cmpOp;
-        ArrLenArithBoundInfo() : vnArray(NoVN), arrOper(GT_NONE), arrOp(NoVN), cmpOper(GT_NONE), cmpOp(NoVN)
+        CompareCheckedBoundArithInfo() : vnBound(NoVN), arrOper(GT_NONE), arrOp(NoVN), cmpOper(GT_NONE), cmpOp(NoVN)
         {
         }
 #ifdef DEBUG
@@ -567,7 +581,7 @@ public:
             printf(" ");
             printf(vnStore->VNFuncName((VNFunc)cmpOper));
             printf(" ");
-            vnStore->vnDump(vnStore->m_pComp, vnArray);
+            vnStore->vnDump(vnStore->m_pComp, vnBound);
             if (arrOper != GT_NONE)
             {
                 printf(vnStore->VNFuncName((VNFunc)arrOper));
@@ -618,26 +632,26 @@ public:
     // If "vn" is constant bound, then populate the "info" fields for constVal, cmpOp, cmpOper.
     void GetConstantBoundInfo(ValueNum vn, ConstantBoundInfo* info);
 
-    // If "vn" is of the form "(uint)var < (uint)a.len" (or equivalent) return true.
-    bool IsVNArrLenUnsignedBound(ValueNum vn, ArrLenUnsignedBoundInfo* info);
+    // If "vn" is of the form "(uint)var < (uint)len" (or equivalent) return true.
+    bool IsVNUnsignedCompareCheckedBound(ValueNum vn, UnsignedCompareCheckedBoundInfo* info);
 
-    // If "vn" is of the form "var < a.len" or "a.len <= var" return true.
-    bool IsVNArrLenBound(ValueNum vn);
+    // If "vn" is of the form "var < len" or "len <= var" return true.
+    bool IsVNCompareCheckedBound(ValueNum vn);
 
-    // If "vn" is arr len bound, then populate the "info" fields for the arrVn, cmpOp, cmpOper.
-    void GetArrLenBoundInfo(ValueNum vn, ArrLenArithBoundInfo* info);
+    // If "vn" is checked bound, then populate the "info" fields for the boundVn, cmpOp, cmpOper.
+    void GetCompareCheckedBound(ValueNum vn, CompareCheckedBoundArithInfo* info);
 
-    // If "vn" is of the form "a.len +/- var" return true.
-    bool IsVNArrLenArith(ValueNum vn);
+    // If "vn" is of the form "len +/- var" return true.
+    bool IsVNCheckedBoundArith(ValueNum vn);
 
-    // If "vn" is arr len arith, then populate the "info" fields for arrOper, arrVn, arrOp.
-    void GetArrLenArithInfo(ValueNum vn, ArrLenArithBoundInfo* info);
+    // If "vn" is checked bound arith, then populate the "info" fields for arrOper, arrVn, arrOp.
+    void GetCheckedBoundArithInfo(ValueNum vn, CompareCheckedBoundArithInfo* info);
 
-    // If "vn" is of the form "var < a.len +/- k" return true.
-    bool IsVNArrLenArithBound(ValueNum vn);
+    // If "vn" is of the form "var < len +/- k" return true.
+    bool IsVNCompareCheckedBoundArith(ValueNum vn);
 
-    // If "vn" is arr len arith bound, then populate the "info" fields for cmpOp, cmpOper.
-    void GetArrLenArithBoundInfo(ValueNum vn, ArrLenArithBoundInfo* info);
+    // If "vn" is checked bound arith, then populate the "info" fields for cmpOp, cmpOper.
+    void GetCompareCheckedBoundArithInfo(ValueNum vn, CompareCheckedBoundArithInfo* info);
 
     // Returns the flags on the current handle. GTF_ICON_SCOPE_HDL for example.
     unsigned GetHandleFlags(ValueNum vn);
@@ -1039,6 +1053,9 @@ private:
 
     // Returns true if "sel(map, ind)" is a member of "m_fixedPointMapSels".
     bool SelectIsBeingEvaluatedRecursively(ValueNum map, ValueNum ind);
+
+    // This is the set of value numbers that have been flagged as arguments to bounds checks, in the length position.
+    CheckedBoundVNSet m_checkedBoundVNs;
 
     // This is a map from "chunk number" to the attributes of the chunk.
     ExpandArrayStack<Chunk*> m_chunks;


### PR DESCRIPTION
Generalize (and rename) the assertion/limit code for tracking array
lengths (which have until now been recognized by the VNFunc being
GT_ARR_LENGTH) to track all values that appear in the function as
length arguments to bounds chcks nodes.  Add a hashtable to identify that
set of value numbers, `m_checkedBoundVNs` to the VNStore object, and
populate it during value-numbering.  Wherever names were adjusted, the
generalization of "array length" is called "checked bound".

This allows the array bound check removal machinery to operate on span
bound checks as well.