### PR TITLE
Add back private BadImageFormatException constructor called by the VM

### DIFF
--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -317,6 +317,7 @@
     <Compile Include="$(BclSourcesRoot)\System\AppDomainUnloadedException.cs" />
     <Compile Include="$(BclSourcesRoot)\System\ArgIterator.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Attribute.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\BadImageFormatException.CoreCLR.cs" />
     <Compile Include="$(BclSourcesRoot)\System\BitConverter.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Boolean.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Buffer.cs" />

--- a/src/mscorlib/shared/System/BadImageFormatException.cs
+++ b/src/mscorlib/shared/System/BadImageFormatException.cs
@@ -18,7 +18,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
-    public class BadImageFormatException : SystemException
+    public partial class BadImageFormatException : SystemException
     {
         private String _fileName;  // The name of the corrupt PE file.
         private String _fusionLog;  // fusion log (when applicable)

--- a/src/mscorlib/src/System/BadImageFormatException.CoreCLR.cs
+++ b/src/mscorlib/src/System/BadImageFormatException.CoreCLR.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System
+{
+    public partial class BadImageFormatException
+    {
+        // Do not delete: this is invoked from native code.
+        private BadImageFormatException(string fileName, string fusionLog, int hResult)
+            : base(null)
+        {
+            HResult = hResult;
+            _fileName = fileName;
+            _fusionLog = fusionLog;
+            SetMessageField();
+        }
+    }
+}

--- a/src/vm/assemblyname.cpp
+++ b/src/vm/assemblyname.cpp
@@ -57,20 +57,11 @@ FCIMPL1(Object*, AssemblyNameNative::GetFileInformation, StringObject* filenameU
     SString sFileName(gc.filename->GetBuffer());
     PEImageHolder pImage = PEImage::OpenImage(sFileName, MDInternalImport_NoCache);
 
-    EX_TRY
-    {
-        // Allow AssemblyLoadContext.GetAssemblyName for native images on CoreCLR
-        if (pImage->HasNTHeaders() && pImage->HasCorHeader() && pImage->HasNativeHeader())
-            pImage->VerifyIsNIAssembly();
-        else
-            pImage->VerifyIsAssembly();
-    }
-    EX_CATCH
-    {
-        Exception *ex = GET_EXCEPTION();
-        EEFileLoadException::Throw(sFileName,ex->GetHR(),ex);
-    }
-    EX_END_CATCH_UNREACHABLE;
+    // Allow AssemblyLoadContext.GetAssemblyName for native images on CoreCLR
+    if (pImage->HasNTHeaders() && pImage->HasCorHeader() && pImage->HasNativeHeader())
+        pImage->VerifyIsNIAssembly();
+    else
+        pImage->VerifyIsAssembly();
 
     SString sUrl = sFileName;
     PEAssembly::PathToUrl(sUrl);


### PR DESCRIPTION
Also removed rethrowing of an exception inside AssemblyName.GetAssemblyName that sometimes resulted into two identical exceptions getting nested into each other.

Fixes #11499