### PR TITLE
Re-morph lclVar nodes after simplifying (ind (addr (lclVar))).

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4719,7 +4719,7 @@ private:
                                          const SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR* structDescPtr));
 
     void fgFixupStructReturn(GenTreePtr call);
-    GenTreePtr fgMorphLocalVar(GenTreePtr tree, bool force);
+    GenTreePtr fgMorphLocalVar(GenTreePtr tree, bool forceRemorph);
     bool fgAddrCouldBeNull(GenTreePtr addr);
     GenTreePtr fgMorphField(GenTreePtr tree, MorphAddrContext* mac);
     bool fgCanFastTailCall(GenTreeCall* call);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4719,7 +4719,7 @@ private:
                                          const SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR* structDescPtr));
 
     void fgFixupStructReturn(GenTreePtr call);
-    GenTreePtr fgMorphLocalVar(GenTreePtr tree);
+    GenTreePtr fgMorphLocalVar(GenTreePtr tree, bool force);
     bool fgAddrCouldBeNull(GenTreePtr addr);
     GenTreePtr fgMorphField(GenTreePtr tree, MorphAddrContext* mac);
     bool fgCanFastTailCall(GenTreeCall* call);

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -13206,7 +13206,7 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
                         temp->gtDebugFlags &= ~GTF_DEBUG_NODE_MORPHED;
 #endif // DEBUG
                         const bool forceRemorph = true;
-                        temp = fgMorphLocalVar(temp, forceRemorph);
+                        temp                    = fgMorphLocalVar(temp, forceRemorph);
 #ifdef DEBUG
                         // We then set this flag on `temp` because `fgMorhpLocalVar` may not set it itself, and the
                         // caller of `fgMorphSmpOp` may assert that this flag is set on `temp` once this function

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -13195,6 +13195,19 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
                     DEBUG_DESTROY_NODE(op1);  // GT_ADD or GT_ADDR
                     DEBUG_DESTROY_NODE(tree); // GT_IND
 
+                    // If the result of the fold is a local var, we may need to perform further adjustments e.g. for
+                    // normalization.
+                    if (temp->OperIs(GT_LCL_VAR))
+                    {
+#ifdef DEBUG
+                        temp->gtDebugFlags &= ~GTF_DEBUG_NODE_MORPHED;
+#endif // DEBUG
+                        temp = fgMorphLocalVar(temp);
+#ifdef DEBUG
+                        temp->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
+#endif // DEBUG
+                    }
+
                     return temp;
                 }
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -6099,7 +6099,7 @@ GenTreePtr Compiler::fgMorphStackArgForVarArgs(unsigned lclNum, var_types varTyp
  *  Transform the given GT_LCL_VAR tree for code generation.
  */
 
-GenTreePtr Compiler::fgMorphLocalVar(GenTreePtr tree, bool force)
+GenTreePtr Compiler::fgMorphLocalVar(GenTreePtr tree, bool forceRemorph)
 {
     noway_assert(tree->gtOper == GT_LCL_VAR);
 
@@ -6129,7 +6129,7 @@ GenTreePtr Compiler::fgMorphLocalVar(GenTreePtr tree, bool force)
 
     /* If not during the global morphing phase bail */
 
-    if (!fgGlobalMorph && !force)
+    if (!fgGlobalMorph && !forceRemorph)
     {
         return tree;
     }
@@ -8522,7 +8522,8 @@ GenTreePtr Compiler::fgMorphLeaf(GenTreePtr tree)
 
     if (tree->gtOper == GT_LCL_VAR)
     {
-        return fgMorphLocalVar(tree, false);
+        const bool forceRemorph = false;
+        return fgMorphLocalVar(tree, forceRemorph);
     }
 #ifdef _TARGET_X86_
     else if (tree->gtOper == GT_LCL_FLD)
@@ -13204,10 +13205,12 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
                         // and the node in question must have this bit set (as it has already been morphed).
                         temp->gtDebugFlags &= ~GTF_DEBUG_NODE_MORPHED;
 #endif // DEBUG
-                        temp = fgMorphLocalVar(temp, true);
+                        const bool forceRemorph = true;
+                        temp = fgMorphLocalVar(temp, forceRemorph);
 #ifdef DEBUG
-                        // We then set this flag on `temp` because `fgMorhpLocalVar` may not set it itself, and the caller
-                        // of `fgMorphSmpOp` may assert that this flag is set on `temp` once this function returns.
+                        // We then set this flag on `temp` because `fgMorhpLocalVar` may not set it itself, and the
+                        // caller of `fgMorphSmpOp` may assert that this flag is set on `temp` once this function
+                        // returns.
                         temp->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
 #endif // DEBUG
                     }

--- a/tests/src/JIT/Regression/JitBlue/GitHub_11508/GitHub_11508.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_11508/GitHub_11508.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace TestApp
+{
+    public struct StructWithValue : IEquatable<StructWithValue>
+    {
+        private ushort value;
+
+        public StructWithValue(ushort v)
+        {
+            value = v;
+        }
+
+
+        public bool Equals(StructWithValue other)
+        {
+            if (value.Equals (other.value))
+                return true;
+            else
+                return false;
+        }
+    }
+
+    class Program
+    {
+        [MethodImpl(MethodImplOptions.NoOptimization)]
+        static int Main(string[] args)
+        {
+            var comparer = EqualityComparer<StructWithValue>.Default;
+
+            for (ushort i = 0; ; i++)
+            {
+                var a = new StructWithValue(i);
+                var b = new StructWithValue(i);
+
+                if (!comparer.Equals(a, b))
+                {
+                    return 0;
+                }
+
+                if (i == ushort.MaxValue)
+                {
+                    break;
+                }
+            }
+
+            return 100;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_11508/GitHub_11508.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_11508/GitHub_11508.csproj
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_11508.cs" />
+  </ItemGroup>
+  <!--  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)threading+thread\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)threading+thread\project.lock.json</ProjectLockJson>
+  </PropertyGroup>-->
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Morph simplifies (ind (addr (lclVar))) if the type of the load matches
the type of the lclVar node. This simplification is not valid, however,
if the lclVar must be normalized upon load: in that case, the lclVar
node must be normalized appropriately as part of the transformation.
This change fixes the simplification to perform this normalization if
necessary by calling `fgMorphLclVar` on the result if the result is a
lclVar node.

Fixes issue #11508.