### PR TITLE
Remove unneeded Serializable attributes

### DIFF
--- a/src/mscorlib/shared/System/AsyncCallback.cs
+++ b/src/mscorlib/shared/System/AsyncCallback.cs
@@ -12,6 +12,5 @@
 
 namespace System
 {
-    [Serializable]
     public delegate void AsyncCallback(IAsyncResult ar);
 }

--- a/src/mscorlib/shared/System/AttributeTargets.cs
+++ b/src/mscorlib/shared/System/AttributeTargets.cs
@@ -10,7 +10,6 @@ namespace System
     // Enum used to indicate all the elements of the
     // VOS it is valid to attach this element to.
     [Flags]
-    [Serializable]
     public enum AttributeTargets
     {
         Assembly = 0x0001,

--- a/src/mscorlib/shared/System/DateTimeKind.cs
+++ b/src/mscorlib/shared/System/DateTimeKind.cs
@@ -7,7 +7,6 @@ namespace System
     // This enum is used to indentify DateTime instances in cases when they are known to be in local time, 
     // UTC time or if this information has not been specified or is not applicable.
 
-    [Serializable]
     public enum DateTimeKind
     {
         Unspecified = 0,

--- a/src/mscorlib/shared/System/DayOfWeek.cs
+++ b/src/mscorlib/shared/System/DayOfWeek.cs
@@ -13,7 +13,6 @@
 
 namespace System
 {
-    [Serializable]
     public enum DayOfWeek
     {
         Sunday = 0,

--- a/src/mscorlib/shared/System/EventHandler.cs
+++ b/src/mscorlib/shared/System/EventHandler.cs
@@ -6,9 +6,7 @@ using System;
 
 namespace System
 {
-    [Serializable]
     public delegate void EventHandler(Object sender, EventArgs e);
 
-    [Serializable]
     public delegate void EventHandler<TEventArgs>(Object sender, TEventArgs e); // Removed TEventArgs constraint post-.NET 4
 }

--- a/src/mscorlib/shared/System/Globalization/CalendarWeekRule.cs
+++ b/src/mscorlib/shared/System/Globalization/CalendarWeekRule.cs
@@ -4,7 +4,6 @@
 
 namespace System.Globalization
 {
-    [Serializable]
     public enum CalendarWeekRule
     {
         FirstDay = 0,           // Week 1 begins on the first day of the year

--- a/src/mscorlib/shared/System/Globalization/GregorianCalendarTypes.cs
+++ b/src/mscorlib/shared/System/Globalization/GregorianCalendarTypes.cs
@@ -6,7 +6,6 @@ namespace System.Globalization
 {
     // Note: The values of the members of this enum must match the coresponding values
     // in the CalendarId enum (since we cast between GregorianCalendarTypes and CalendarId).
-    [Serializable]
     public enum GregorianCalendarTypes
     {
         Localized = CalendarId.GREGORIAN,

--- a/src/mscorlib/shared/System/IO/FileAccess.cs
+++ b/src/mscorlib/shared/System/IO/FileAccess.cs
@@ -9,7 +9,6 @@ namespace System.IO
     // Contains constants for specifying the access you want for a file.
     // You can have Read, Write or ReadWrite access.
     // 
-    [Serializable]
     [Flags]
     public enum FileAccess
     {

--- a/src/mscorlib/shared/System/Runtime/CompilerServices/CompilationRelaxations.cs
+++ b/src/mscorlib/shared/System/Runtime/CompilerServices/CompilationRelaxations.cs
@@ -6,7 +6,6 @@ namespace System.Runtime.CompilerServices
 {
     /// IMPORTANT: Keep this in sync with corhdr.h
     [Flags]
-    [Serializable]
     public enum CompilationRelaxations : int
     {
         NoStringInterning = 0x0008  // Start in 0x0008, we had other non public flags in this enum before,

--- a/src/mscorlib/shared/System/Runtime/CompilerServices/LoadHint.cs
+++ b/src/mscorlib/shared/System/Runtime/CompilerServices/LoadHint.cs
@@ -4,7 +4,6 @@
 
 namespace System.Runtime.CompilerServices
 {
-    [Serializable]
     public enum LoadHint
     {
         Default = 0x0000,           // No preference specified

--- a/src/mscorlib/shared/System/Runtime/CompilerServices/MethodCodeType.cs
+++ b/src/mscorlib/shared/System/Runtime/CompilerServices/MethodCodeType.cs
@@ -6,7 +6,6 @@ using System.Reflection;
 
 namespace System.Runtime.CompilerServices
 {
-    [Serializable]
     public enum MethodCodeType
     {
         IL = MethodImplAttributes.IL,

--- a/src/mscorlib/shared/System/Runtime/ConstrainedExecution/Cer.cs
+++ b/src/mscorlib/shared/System/Runtime/ConstrainedExecution/Cer.cs
@@ -4,7 +4,6 @@
 
 namespace System.Runtime.ConstrainedExecution
 {
-    [Serializable]
     public enum Cer : int
     {
         None = 0,

--- a/src/mscorlib/shared/System/Runtime/ConstrainedExecution/Consistency.cs
+++ b/src/mscorlib/shared/System/Runtime/ConstrainedExecution/Consistency.cs
@@ -4,7 +4,6 @@
 
 namespace System.Runtime.ConstrainedExecution
 {
-    [Serializable]
     public enum Consistency : int
     {
         MayCorruptProcess = 0,

--- a/src/mscorlib/shared/System/StringComparison.cs
+++ b/src/mscorlib/shared/System/StringComparison.cs
@@ -4,7 +4,6 @@
 
 namespace System
 {
-    [Serializable]
     public enum StringComparison
     {
         CurrentCulture = 0,

--- a/src/mscorlib/shared/System/TypeCode.cs
+++ b/src/mscorlib/shared/System/TypeCode.cs
@@ -23,7 +23,6 @@
 
 namespace System
 {
-    [Serializable]
     public enum TypeCode
     {
         Empty = 0,          // Null reference

--- a/src/mscorlib/shared/System/UnhandledExceptionEventHandler.cs
+++ b/src/mscorlib/shared/System/UnhandledExceptionEventHandler.cs
@@ -4,6 +4,5 @@
 
 namespace System
 {
-    [Serializable]
     public delegate void UnhandledExceptionEventHandler(Object sender, UnhandledExceptionEventArgs e);
 }

--- a/src/mscorlib/src/System/AppDomain.cs
+++ b/src/mscorlib/src/System/AppDomain.cs
@@ -36,7 +36,6 @@ namespace System
     using System.Diagnostics.Contracts;
     using System.Runtime.ExceptionServices;
 
-    [Serializable]
     internal delegate void AppDomainInitializer(string[] args);
 
     internal class AppDomainInitializerInfo

--- a/src/mscorlib/src/System/AppDomainAttributes.cs
+++ b/src/mscorlib/src/System/AppDomainAttributes.cs
@@ -13,7 +13,6 @@
 
 namespace System
 {
-    [Serializable]
     internal enum LoaderOptimization
     {
         NotSpecified = 0,

--- a/src/mscorlib/src/System/AppDomainSetup.cs
+++ b/src/mscorlib/src/System/AppDomainSetup.cs
@@ -25,7 +25,6 @@ namespace System
     [Serializable]
     internal sealed class AppDomainSetup
     {
-        [Serializable]
         internal enum LoaderInformation
         {
             // If you add a new value, add the corresponding property

--- a/src/mscorlib/src/System/BCLDebug.cs
+++ b/src/mscorlib/src/System/BCLDebug.cs
@@ -22,7 +22,6 @@ namespace System
     using System.Security;
     using System.Diagnostics.Contracts;
 
-    [Serializable]
     internal enum LogLevel
     {
         Trace = 0,

--- a/src/mscorlib/src/System/Diagnostics/AssertFilters.cs
+++ b/src/mscorlib/src/System/Diagnostics/AssertFilters.cs
@@ -16,7 +16,6 @@ using System;
 
 namespace System.Diagnostics
 {
-    [Serializable]
     internal enum AssertFilters
     {
         FailDebug = 0,

--- a/src/mscorlib/src/System/Diagnostics/LoggingLevels.cs
+++ b/src/mscorlib/src/System/Diagnostics/LoggingLevels.cs
@@ -21,7 +21,6 @@ namespace System.Diagnostics
     // Constants representing the importance level of messages to be logged.
     // This level can be used to organize messages, and also to filter which
     // messages are displayed.
-    [Serializable]
     internal enum LoggingLevels
     {
         TraceLevel0 = 0,

--- a/src/mscorlib/src/System/Diagnostics/SymbolStore/SymAddressKind.cs
+++ b/src/mscorlib/src/System/Diagnostics/SymbolStore/SymAddressKind.cs
@@ -17,7 +17,6 @@ using System;
 
 namespace System.Diagnostics.SymbolStore
 {
-    [Serializable]
     internal enum SymAddressKind
     {
         // ILOffset: addr1 = IL local var or param index.

--- a/src/mscorlib/src/System/Diagnostics/log.cs
+++ b/src/mscorlib/src/System/Diagnostics/log.cs
@@ -19,7 +19,6 @@ namespace System.Diagnostics
     // NOTE: These are NOT triggered when the log switch setting is changed from the 
     // attached debugger.
     // 
-    [Serializable]
     internal delegate void LogSwitchLevelHandler(LogSwitch ls, LoggingLevels newLevel);
 
 

--- a/src/mscorlib/src/System/GC.cs
+++ b/src/mscorlib/src/System/GC.cs
@@ -28,7 +28,6 @@ using System.Diagnostics.Contracts;
 
 namespace System
 {
-    [Serializable]
     public enum GCCollectionMode
     {
         Default = 0,
@@ -39,7 +38,6 @@ namespace System
     // !!!!!!!!!!!!!!!!!!!!!!!
     // make sure you change the def in vm\gc.h 
     // if you change this!
-    [Serializable]
     internal enum InternalGCCollectionMode
     {
         NonBlocking = 0x00000001,
@@ -51,7 +49,6 @@ namespace System
     // !!!!!!!!!!!!!!!!!!!!!!!
     // make sure you change the def in vm\gc.h 
     // if you change this!
-    [Serializable]
     public enum GCNotificationStatus
     {
         Succeeded = 0,

--- a/src/mscorlib/src/System/Globalization/BidiCategory.cs
+++ b/src/mscorlib/src/System/Globalization/BidiCategory.cs
@@ -12,7 +12,6 @@
 
 namespace System.Globalization
 {
-    [Serializable]
     internal enum BidiCategory
     {
         LeftToRight = 0,

--- a/src/mscorlib/src/System/Globalization/CompareInfo.cs
+++ b/src/mscorlib/src/System/Globalization/CompareInfo.cs
@@ -20,7 +20,6 @@ using System.Runtime.Serialization;
 namespace System.Globalization
 {
     [Flags]
-    [Serializable]
     public enum CompareOptions
     {
         None = 0x00000000,

--- a/src/mscorlib/src/System/IO/SearchOption.cs
+++ b/src/mscorlib/src/System/IO/SearchOption.cs
@@ -20,7 +20,6 @@ using System;
 
 namespace System.IO
 {
-    [Serializable]
     internal enum SearchOption
     {
         // Include only the current directory in the search operation

--- a/src/mscorlib/src/System/Reflection/CustomAttribute.cs
+++ b/src/mscorlib/src/System/Reflection/CustomAttribute.cs
@@ -965,7 +965,6 @@ namespace System.Reflection
         internal MetadataToken tkCtor;
     }
 
-    [Serializable]
     internal enum CustomAttributeEncoding : int
     {
         Undefined = 0,

--- a/src/mscorlib/src/System/Reflection/Emit/AssemblyBuilderAccess.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/AssemblyBuilderAccess.cs
@@ -9,7 +9,6 @@ using System;
 
 namespace System.Reflection.Emit
 {
-    [Serializable]
     [Flags]
     public enum AssemblyBuilderAccess
     {

--- a/src/mscorlib/src/System/Reflection/Emit/FlowControl.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/FlowControl.cs
@@ -16,7 +16,6 @@ using System;
 
 namespace System.Reflection.Emit
 {
-    [Serializable]
     public enum FlowControl
     {
         Branch = 0,

--- a/src/mscorlib/src/System/Reflection/Emit/ILGenerator.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/ILGenerator.cs
@@ -1605,7 +1605,6 @@ namespace System.Reflection.Emit
     * takes place.
     *
     ***************************/
-    [Serializable]
     internal enum ScopeAction
     {
         Open = 0x0,

--- a/src/mscorlib/src/System/Reflection/Emit/OpcodeType.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/OpcodeType.cs
@@ -17,7 +17,6 @@ using System;
 
 namespace System.Reflection.Emit
 {
-    [Serializable]
     public enum OpCodeType
     {
         [Obsolete("This API has been deprecated. http://go.microsoft.com/fwlink/?linkid=14202")]

--- a/src/mscorlib/src/System/Reflection/Emit/OperandType.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/OperandType.cs
@@ -17,7 +17,6 @@ using System;
 
 namespace System.Reflection.Emit
 {
-    [Serializable]
     public enum OperandType
     {
         InlineBrTarget = 0,

--- a/src/mscorlib/src/System/Reflection/Emit/PEFileKinds.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/PEFileKinds.cs
@@ -8,7 +8,6 @@ using System;
 namespace System.Reflection.Emit
 {
     // This Enum matchs the CorFieldAttr defined in CorHdr.h
-    [Serializable]
     public enum PEFileKinds
     {
         Dll = 0x0001,

--- a/src/mscorlib/src/System/Reflection/Emit/StackBehaviour.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/StackBehaviour.cs
@@ -17,7 +17,6 @@ using System;
 
 namespace System.Reflection.Emit
 {
-    [Serializable]
     public enum StackBehaviour
     {
         Pop0 = 0,

--- a/src/mscorlib/src/System/Reflection/Emit/SymbolType.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/SymbolType.cs
@@ -12,7 +12,6 @@ namespace System.Reflection.Emit
     using System.Diagnostics.Contracts;
     using CultureInfo = System.Globalization.CultureInfo;
 
-    [Serializable]
     internal enum TypeKind
     {
         IsArray = 1,

--- a/src/mscorlib/src/System/Reflection/Emit/TypeBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/TypeBuilder.cs
@@ -20,7 +20,6 @@ namespace System.Reflection.Emit
     using System.Diagnostics.Contracts;
 
 
-    [Serializable]
     public enum PackingSize
     {
         Unspecified = 0,

--- a/src/mscorlib/src/System/Reflection/MdImport.cs
+++ b/src/mscorlib/src/System/Reflection/MdImport.cs
@@ -20,7 +20,6 @@ using System.Diagnostics.Contracts;
 
 namespace System.Reflection
 {
-    [Serializable]
     internal enum CorElementType : byte
     {
         End = 0x00,
@@ -61,7 +60,6 @@ namespace System.Reflection
         Pinned = 0x45,
     }
 
-    [Serializable]
     [Flags()]
     internal enum MdSigCallingConvention : byte
     {
@@ -85,7 +83,6 @@ namespace System.Reflection
     }
 
 
-    [Serializable]
     [Flags()]
     internal enum PInvokeAttributes
     {
@@ -122,7 +119,6 @@ namespace System.Reflection
     }
 
 
-    [Serializable]
     [Flags()]
     internal enum MethodSemanticsAttributes
     {
@@ -135,7 +131,6 @@ namespace System.Reflection
     }
 
 
-    [Serializable]
     internal enum MetadataTokenType
     {
         Module = 0x00000000,

--- a/src/mscorlib/src/System/Runtime/GcSettings.cs
+++ b/src/mscorlib/src/System/Runtime/GcSettings.cs
@@ -13,14 +13,12 @@ namespace System.Runtime
     // These settings are the same format as in clr\src\vm\gcpriv.h
     // make sure you change that file if you change this file!
 
-    [Serializable]
     public enum GCLargeObjectHeapCompactionMode
     {
         Default = 1,
         CompactOnce = 2
     }
 
-    [Serializable]
     public enum GCLatencyMode
     {
         Batch = 0,

--- a/src/mscorlib/src/System/Runtime/InteropServices/Attributes.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/Attributes.cs
@@ -46,7 +46,6 @@ namespace System.Runtime.InteropServices
         public int Value { get { return _val; } }
     }
 
-    [Serializable]
     public enum ComInterfaceType
     {
         InterfaceIsDual = 0,
@@ -84,7 +83,6 @@ namespace System.Runtime.InteropServices
         public Type Value { get { return _val; } }
     }
 
-    [Serializable]
     public enum ClassInterfaceType
     {
         None = 0,

--- a/src/mscorlib/src/System/Runtime/InteropServices/ComMemberType.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/ComMemberType.cs
@@ -9,7 +9,6 @@ using System;
 
 namespace System.Runtime.InteropServices
 {
-    [Serializable]
     public enum ComMemberType
     {
         Method = 0,

--- a/src/mscorlib/src/System/Runtime/InteropServices/ComTypes/ITypeComp.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/ComTypes/ITypeComp.cs
@@ -15,7 +15,6 @@ using System;
 
 namespace System.Runtime.InteropServices.ComTypes
 {
-    [Serializable]
     public enum DESCKIND
     {
         DESCKIND_NONE = 0,

--- a/src/mscorlib/src/System/Runtime/InteropServices/ComTypes/ITypeInfo.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/ComTypes/ITypeInfo.cs
@@ -15,7 +15,6 @@ using System;
 
 namespace System.Runtime.InteropServices.ComTypes
 {
-    [Serializable]
     public enum TYPEKIND
     {
         TKIND_ENUM = 0,
@@ -29,7 +28,6 @@ namespace System.Runtime.InteropServices.ComTypes
         TKIND_MAX = TKIND_UNION + 1
     }
 
-    [Serializable]
     [Flags()]
     public enum TYPEFLAGS : short
     {
@@ -50,7 +48,6 @@ namespace System.Runtime.InteropServices.ComTypes
         TYPEFLAG_FPROXY = 0x4000
     }
 
-    [Serializable]
     [Flags()]
     public enum IMPLTYPEFLAGS
     {
@@ -106,7 +103,6 @@ namespace System.Runtime.InteropServices.ComTypes
         public Int16 wFuncFlags;            //WORD wFuncFlags;
     }
 
-    [Serializable]
     [Flags()]
     public enum IDLFLAG : short
     {
@@ -125,7 +121,6 @@ namespace System.Runtime.InteropServices.ComTypes
         public IDLFLAG wIDLFlags;
     }
 
-    [Serializable]
     [Flags()]
     public enum PARAMFLAG : short
     {
@@ -173,7 +168,6 @@ namespace System.Runtime.InteropServices.ComTypes
         public DESCUNION desc;
     }
 
-    [Serializable]
     public enum VARKIND : int
     {
         VAR_PERINSTANCE = 0x0,
@@ -231,7 +225,6 @@ namespace System.Runtime.InteropServices.ComTypes
         public Int32 scode;
     }
 
-    [Serializable]
     public enum FUNCKIND : int
     {
         FUNC_VIRTUAL = 0,
@@ -241,7 +234,6 @@ namespace System.Runtime.InteropServices.ComTypes
         FUNC_DISPATCH = 4
     }
 
-    [Serializable]
     [Flags]
     public enum INVOKEKIND : int
     {
@@ -251,7 +243,6 @@ namespace System.Runtime.InteropServices.ComTypes
         INVOKE_PROPERTYPUTREF = 0x8
     }
 
-    [Serializable]
     public enum CALLCONV : int
     {
         CC_CDECL = 1,
@@ -266,7 +257,6 @@ namespace System.Runtime.InteropServices.ComTypes
         CC_MAX = 9
     }
 
-    [Serializable]
     [Flags()]
     public enum FUNCFLAGS : short
     {
@@ -285,7 +275,6 @@ namespace System.Runtime.InteropServices.ComTypes
         FUNCFLAG_FIMMEDIATEBIND = 0x1000
     }
 
-    [Serializable]
     [Flags()]
     public enum VARFLAGS : short
     {

--- a/src/mscorlib/src/System/Runtime/InteropServices/ComTypes/ITypeLib.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/ComTypes/ITypeLib.cs
@@ -15,7 +15,6 @@ using System;
 
 namespace System.Runtime.InteropServices.ComTypes
 {
-    [Serializable]
     public enum SYSKIND
     {
         SYS_WIN16 = 0,
@@ -24,7 +23,6 @@ namespace System.Runtime.InteropServices.ComTypes
         SYS_WIN64 = SYS_MAC + 1
     }
 
-    [Serializable]
     [Flags()]
     public enum LIBFLAGS : short
     {

--- a/src/mscorlib/src/System/Runtime/InteropServices/GcHandle.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/GcHandle.cs
@@ -18,7 +18,6 @@ namespace System.Runtime.InteropServices
     // IMPORTANT: These must match the definitions in ObjectHandle.h in the EE. 
     // IMPORTANT: If new values are added to the enum the GCHandle::MaxHandleType
     //            constant must be updated.
-    [Serializable]
     public enum GCHandleType
     {
         Weak = 0,

--- a/src/mscorlib/src/System/Runtime/InteropServices/ICustomQueryInterface.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/ICustomQueryInterface.cs
@@ -19,7 +19,6 @@ namespace System.Runtime.InteropServices
     //====================================================================
     // The enum of the return value of IQuerable.GetInterface
     //====================================================================
-    [Serializable]
     public enum CustomQueryInterfaceResult
     {
         Handled = 0,

--- a/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
@@ -33,7 +33,6 @@ namespace System.Runtime.InteropServices
     using System.Runtime.InteropServices.ComTypes;
     using System.StubHelpers;
 
-    [Serializable]
     public enum CustomQueryInterfaceMode
     {
         Ignore = 0,

--- a/src/mscorlib/src/System/Runtime/InteropServices/PInvokeMap.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/PInvokeMap.cs
@@ -16,7 +16,6 @@ using System;
 namespace System.Runtime.InteropServices
 {
     // This Enum matchs the CorPinvokeMap defined in CorHdr.h
-    [Serializable]
     internal enum PInvokeMap
     {
         NoMangle = 0x0001,   // Pinvoke is to use the member name as specified.

--- a/src/mscorlib/src/System/Threading/Tasks/Task.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/Task.cs
@@ -6254,7 +6254,6 @@ namespace System.Threading.Tasks
     // NOTE: These options are a subset of TaskContinuationsOptions, thus before adding a flag check it is
     // not already in use.
     [Flags]
-    [Serializable]
     public enum TaskCreationOptions
     {
         /// <summary>
@@ -6306,7 +6305,6 @@ namespace System.Threading.Tasks
     /// Task creation flags which are only used internally.
     /// </summary>
     [Flags]
-    [Serializable]
     internal enum InternalTaskOptions
     {
         /// <summary> Specifies "No internal task options" </summary>
@@ -6338,7 +6336,6 @@ namespace System.Threading.Tasks
     /// Specifies flags that control optional behavior for the creation and execution of continuation tasks.
     /// </summary>
     [Flags]
-    [Serializable]
     public enum TaskContinuationOptions
     {
         /// <summary>

--- a/src/mscorlib/src/System/Threading/Thread.cs
+++ b/src/mscorlib/src/System/Threading/Thread.cs
@@ -555,7 +555,6 @@ namespace System.Threading
     // declaring a local var of this enum type and passing it by ref into a function that needs to do a
     // stack crawl will both prevent inlining of the calle and pass an ESP point to stack crawl to
     // Declaring these in EH clauses is illegal; they must declared in the main method body
-    [Serializable]
     internal enum StackCrawlMark
     {
         LookForMe = 0,


### PR DESCRIPTION
Removes unneeded Serializable attributes from enums and delegates. They can be serialized without attributes and this will remove noise from future serialization changes.

CC @danmosemsft @joshfree @stephentoub 