### PR TITLE
[ARM32/RyuJIT] Enable passing struct argument that use stack only

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -587,9 +587,9 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
             // in ARM64/ARM
             // Setup loReg (and hiReg) from the internal registers that we reserved in lower.
             //
-            regNumber loReg   = treeNode->ExtractTempReg();
+            regNumber loReg = treeNode->ExtractTempReg();
 #ifdef _TARGET_ARM64_
-            regNumber hiReg   = treeNode->GetSingleTempReg();
+            regNumber hiReg = treeNode->GetSingleTempReg();
 #endif // _TARGET_ARM64_
             regNumber addrReg = REG_NA;
 
@@ -626,10 +626,10 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
             // the xor ensures that only one of the two is setup, not both
             assert((varNode != nullptr) ^ (addrNode != nullptr));
 
-            BYTE*    gcPtrs = nullptr;
-            BYTE     gcPtrArray[MAX_ARG_REG_COUNT] = {}; // TYPE_GC_NONE = 0
+            BYTE* gcPtrs                        = nullptr;
+            BYTE  gcPtrArray[MAX_ARG_REG_COUNT] = {}; // TYPE_GC_NONE = 0
 
-            unsigned gcPtrCount;                     // The count of GC pointers in the struct
+            unsigned gcPtrCount; // The count of GC pointers in the struct
             int      structSize;
             bool     isHfa;
 
@@ -650,14 +650,14 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
 
                 structSize = varDsc->lvSize(); // This yields the roundUp size, but that is fine
                                                // as that is how much stack is allocated for this LclVar
-                isHfa      = varDsc->lvIsHfa();
+                isHfa  = varDsc->lvIsHfa();
 #ifdef _TARGET_ARM64_
-                gcPtrs = gcPtrArray;
+                gcPtrs     = gcPtrArray;
                 gcPtrCount = varDsc->lvStructGcCount;
                 for (unsigned i = 0; i < gcPtrCount; ++i)
                     gcPtrs[i]   = varDsc->lvGcLayout[i];
 #else // _TARGET_ARM_
-                gcPtrs = treeNode->gtGcPtrs;
+                gcPtrs     = treeNode->gtGcPtrs;
                 gcPtrCount = treeNode->gtNumSlots;
 #endif // _TARGET_ARM_
             }
@@ -683,7 +683,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
 
                 structSize = compiler->info.compCompHnd->getClassSize(objClass);
                 isHfa      = compiler->IsHfa(objClass);
-                gcPtrs = gcPtrArray;
+                gcPtrs     = gcPtrArray;
                 gcPtrCount = compiler->info.compCompHnd->getClassGClayout(objClass, &gcPtrs[0]);
             }
 
@@ -743,7 +743,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
                 structOffset += (2 * TARGET_POINTER_SIZE);
                 nextIndex += 2;
             }
-#else // _TARGET_ARM_
+#else  // _TARGET_ARM_
             // For a >= 4 byte structSize we will generate a ldr and str instruction each loop
             //             ldr     r2, [r0]
             //             str     r2, [sp, #16]

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -650,7 +650,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
 
                 structSize = varDsc->lvSize(); // This yields the roundUp size, but that is fine
                                                // as that is how much stack is allocated for this LclVar
-                isHfa  = varDsc->lvIsHfa();
+                isHfa = varDsc->lvIsHfa();
 #ifdef _TARGET_ARM64_
                 gcPtrs     = gcPtrArray;
                 gcPtrCount = varDsc->lvStructGcCount;

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -717,6 +717,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
         case GT_PINVOKE_PROLOG:
         case GT_JCC:
         case GT_MEMORYBARRIER:
+        case GT_OBJ:
             info->dstCount = tree->IsValue() ? 1 : 0;
             if (kind & (GTK_CONST | GTK_LEAF))
             {

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -654,8 +654,13 @@ void Lowering::TreeNodeInfoInitPutArgStk(GenTreePutArgStk* argNode, fgArgTabEntr
         }
         else
         {
+#ifdef _TARGET_ARM64_
             // We could use a ldp/stp sequence so we need two internal registers
             argNode->gtLsraInfo.internalIntCount = 2;
+#else // _TARGET_ARM_
+            // We could use a ldr/str sequence so we need a internal register
+            argNode->gtLsraInfo.internalIntCount = 1;
+#endif // _TARGET_ARM_
 
             if (putArgChild->OperGet() == GT_OBJ)
             {

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -657,7 +657,7 @@ void Lowering::TreeNodeInfoInitPutArgStk(GenTreePutArgStk* argNode, fgArgTabEntr
 #ifdef _TARGET_ARM64_
             // We could use a ldp/stp sequence so we need two internal registers
             argNode->gtLsraInfo.internalIntCount = 2;
-#else // _TARGET_ARM_
+#else  // _TARGET_ARM_
             // We could use a ldr/str sequence so we need a internal register
             argNode->gtLsraInfo.internalIntCount = 1;
 #endif // _TARGET_ARM_


### PR DESCRIPTION
Enable passing struct argument when it uses stack only.
Cannot pass splitted struct argument that uses stack and register(s) yet.

related issue: #10722 