### PR TITLE
Only call EventActivityIdControl ETW function on Windows

### DIFF
--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventSource_CoreCLR.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventSource_CoreCLR.cs
@@ -33,7 +33,7 @@ namespace System.Diagnostics.Tracing
         {
             if (TplEtwProvider.Log != null)
                 TplEtwProvider.Log.SetActivityId(activityId);
-#if FEATURE_MANAGED_ETW
+#if FEATURE_MANAGED_ETW && PLATFORM_WINDOWS
 #if FEATURE_ACTIVITYSAMPLING
             Guid newId = activityId;
 #endif // FEATURE_ACTIVITYSAMPLING
@@ -57,7 +57,7 @@ namespace System.Diagnostics.Tracing
                 }
 #endif // FEATURE_ACTIVITYSAMPLING
             }
-#endif // FEATURE_MANAGED_ETW
+#endif // FEATURE_MANAGED_ETW && PLATFORM_WINDOWS
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes a break introduced by https://github.com/dotnet/coreclr/pull/11435.