### PR TITLE
EventPipe: Put the serialization marker under its own IFDEF

### DIFF
--- a/src/vm/eventpipeeventinstance.cpp
+++ b/src/vm/eventpipeeventinstance.cpp
@@ -89,7 +89,7 @@ void EventPipeEventInstance::FastSerialize(FastSerializer *pSerializer, StreamLa
     }
     CONTRACTL_END;
 
-#ifdef _DEBUG
+#ifdef EVENTPIPE_EVENT_MARKER
     // Useful for diagnosing serialization bugs.
     const unsigned int value = 0xDEADBEEF;
     pSerializer->WriteBuffer((BYTE*)&value, sizeof(value));


### PR DESCRIPTION
Fixes #11562.