### PR TITLE
[Local GC] Add async pinned handle methods to the handle interface

### DIFF
--- a/src/gc/gchandletable.cpp
+++ b/src/gc/gchandletable.cpp
@@ -56,6 +56,13 @@ OBJECTHANDLE GCHandleStore::CreateDependentHandle(Object* primary, Object* secon
     return handle;
 }
 
+void GCHandleStore::RelocateAsyncPinnedHandles(IGCHandleStore* pTarget)
+{
+    // assumption - the IGCHandleStore is an instance of GCHandleStore
+    GCHandleStore* other = static_cast<GCHandleStore*>(pTarget);
+    ::Ref_RelocateAsyncPinHandles(&_underlyingBucket, &other->_underlyingBucket);
+}
+
 GCHandleStore::~GCHandleStore()
 {
     ::Ref_DestroyHandleTableBucket(&_underlyingBucket);
@@ -160,4 +167,9 @@ Object* GCHandleManager::GetDependentHandleSecondary(OBJECTHANDLE handle)
 Object* GCHandleManager::InterlockedCompareExchangeObjectInHandle(OBJECTHANDLE handle, Object* object, Object* comparandObject)
 {
     return (Object*)::HndInterlockedCompareExchangeHandle(handle, ObjectToOBJECTREF(object), ObjectToOBJECTREF(comparandObject));
+}
+
+bool GCHandleManager::HandleAsyncPinnedHandles()
+{
+    return !!::Ref_HandleAsyncPinHandles();
 }

--- a/src/gc/gchandletable.cpp
+++ b/src/gc/gchandletable.cpp
@@ -63,7 +63,7 @@ void GCHandleStore::RelocateAsyncPinnedHandles(IGCHandleStore* pTarget)
     ::Ref_RelocateAsyncPinHandles(&_underlyingBucket, &other->_underlyingBucket);
 }
 
-bool GCHandleStore::EnumerateAsyncPinnedHandles(bool (*callback)(Object*, void*), void* context)
+bool GCHandleStore::EnumerateAsyncPinnedHandles(async_pin_enum_fn callback, void* context)
 {
     return !!::Ref_HandleAsyncPinHandles(callback, context);
 }

--- a/src/gc/gchandletable.cpp
+++ b/src/gc/gchandletable.cpp
@@ -63,7 +63,7 @@ void GCHandleStore::RelocateAsyncPinnedHandles(IGCHandleStore* pTarget)
     ::Ref_RelocateAsyncPinHandles(&_underlyingBucket, &other->_underlyingBucket);
 }
 
-bool GCHandleStore::HandleAsyncPinnedHandles(bool (*callback)(Object*, void*), void* context)
+bool GCHandleStore::EnumerateAsyncPinnedHandles(bool (*callback)(Object*, void*), void* context)
 {
     return !!::Ref_HandleAsyncPinHandles(callback, context);
 }

--- a/src/gc/gchandletable.cpp
+++ b/src/gc/gchandletable.cpp
@@ -63,6 +63,11 @@ void GCHandleStore::RelocateAsyncPinnedHandles(IGCHandleStore* pTarget)
     ::Ref_RelocateAsyncPinHandles(&_underlyingBucket, &other->_underlyingBucket);
 }
 
+bool GCHandleStore::HandleAsyncPinnedHandles(bool (*callback)(Object*, void*), void* context)
+{
+    return !!::Ref_HandleAsyncPinHandles(callback, context);
+}
+
 GCHandleStore::~GCHandleStore()
 {
     ::Ref_DestroyHandleTableBucket(&_underlyingBucket);
@@ -167,9 +172,4 @@ Object* GCHandleManager::GetDependentHandleSecondary(OBJECTHANDLE handle)
 Object* GCHandleManager::InterlockedCompareExchangeObjectInHandle(OBJECTHANDLE handle, Object* object, Object* comparandObject)
 {
     return (Object*)::HndInterlockedCompareExchangeHandle(handle, ObjectToOBJECTREF(object), ObjectToOBJECTREF(comparandObject));
-}
-
-bool GCHandleManager::HandleAsyncPinnedHandles()
-{
-    return !!::Ref_HandleAsyncPinHandles();
 }

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -23,6 +23,8 @@ public:
 
     virtual OBJECTHANDLE CreateDependentHandle(Object* primary, Object* secondary);
 
+    virtual void RelocateAsyncPinnedHandles(IGCHandleStore* pTarget);
+
     virtual ~GCHandleStore();
 
     HandleTableBucket _underlyingBucket;
@@ -64,6 +66,8 @@ public:
     virtual Object* GetDependentHandleSecondary(OBJECTHANDLE handle);
 
     virtual Object* InterlockedCompareExchangeObjectInHandle(OBJECTHANDLE handle, Object* object, Object* comparandObject);
+
+    virtual bool HandleAsyncPinnedHandles();
 };
 
 #endif  // GCHANDLETABLE_H_

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -25,6 +25,8 @@ public:
 
     virtual void RelocateAsyncPinnedHandles(IGCHandleStore* pTarget);
 
+    virtual bool HandleAsyncPinnedHandles(bool (*callback)(Object*, void*), void* context);
+
     virtual ~GCHandleStore();
 
     HandleTableBucket _underlyingBucket;
@@ -66,8 +68,6 @@ public:
     virtual Object* GetDependentHandleSecondary(OBJECTHANDLE handle);
 
     virtual Object* InterlockedCompareExchangeObjectInHandle(OBJECTHANDLE handle, Object* object, Object* comparandObject);
-
-    virtual bool HandleAsyncPinnedHandles();
 };
 
 #endif  // GCHANDLETABLE_H_

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -25,7 +25,7 @@ public:
 
     virtual void RelocateAsyncPinnedHandles(IGCHandleStore* pTarget);
 
-    virtual bool EnumerateAsyncPinnedHandles(bool (*callback)(Object*, void*), void* context);
+    virtual bool EnumerateAsyncPinnedHandles(async_pin_enum_fn callback, void* context);
 
     virtual ~GCHandleStore();
 

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -25,7 +25,7 @@ public:
 
     virtual void RelocateAsyncPinnedHandles(IGCHandleStore* pTarget);
 
-    virtual bool HandleAsyncPinnedHandles(bool (*callback)(Object*, void*), void* context);
+    virtual bool EnumerateAsyncPinnedHandles(bool (*callback)(Object*, void*), void* context);
 
     virtual ~GCHandleStore();
 

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -399,6 +399,7 @@ typedef void (* record_surv_fn)(uint8_t* begin, uint8_t* end, ptrdiff_t reloc, v
 typedef void (* fq_walk_fn)(bool, void*);
 typedef void (* fq_scan_fn)(Object** ppObject, ScanContext *pSC, uint32_t dwFlags);
 typedef void (* handle_scan_fn)(Object** pRef, Object* pSec, uint32_t flags, ScanContext* context, bool isDependent);
+typedef bool (* async_pin_enum_fn)(Object* object, void* context);
 
 // Opaque type for tracking object pointers
 #ifndef DACCESS_COMPILE
@@ -428,7 +429,7 @@ public:
 
     virtual void RelocateAsyncPinnedHandles(IGCHandleStore* pTarget) = 0;
 
-    virtual bool EnumerateAsyncPinnedHandles(bool (*callback)(Object*, void*), void* context) = 0;
+    virtual bool EnumerateAsyncPinnedHandles(async_pin_enum_fn callback, void* context) = 0;
 
     virtual ~IGCHandleStore() {};
 };

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -428,6 +428,8 @@ public:
 
     virtual void RelocateAsyncPinnedHandles(IGCHandleStore* pTarget) = 0;
 
+    virtual bool HandleAsyncPinnedHandles(bool (*callback)(Object*, void*), void* context) = 0;
+
     virtual ~IGCHandleStore() {};
 };
 
@@ -465,8 +467,6 @@ public:
     virtual Object* GetDependentHandleSecondary(OBJECTHANDLE handle) = 0;
 
     virtual Object* InterlockedCompareExchangeObjectInHandle(OBJECTHANDLE handle, Object* object, Object* comparandObject) = 0;
-
-    virtual bool HandleAsyncPinnedHandles() = 0;
 };
 
 // IGCHeap is the interface that the VM will use when interacting with the GC.

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -428,7 +428,7 @@ public:
 
     virtual void RelocateAsyncPinnedHandles(IGCHandleStore* pTarget) = 0;
 
-    virtual bool HandleAsyncPinnedHandles(bool (*callback)(Object*, void*), void* context) = 0;
+    virtual bool EnumerateAsyncPinnedHandles(bool (*callback)(Object*, void*), void* context) = 0;
 
     virtual ~IGCHandleStore() {};
 };

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -426,6 +426,8 @@ public:
 
     virtual OBJECTHANDLE CreateDependentHandle(Object* primary, Object* secondary) = 0;
 
+    virtual void RelocateAsyncPinnedHandles(IGCHandleStore* pTarget) = 0;
+
     virtual ~IGCHandleStore() {};
 };
 
@@ -463,6 +465,8 @@ public:
     virtual Object* GetDependentHandleSecondary(OBJECTHANDLE handle) = 0;
 
     virtual Object* InterlockedCompareExchangeObjectInHandle(OBJECTHANDLE handle, Object* object, Object* comparandObject) = 0;
+
+    virtual bool HandleAsyncPinnedHandles() = 0;
 };
 
 // IGCHeap is the interface that the VM will use when interacting with the GC.

--- a/src/gc/handletable.cpp
+++ b/src/gc/handletable.cpp
@@ -1286,7 +1286,7 @@ uint32_t HndCountAllHandles(BOOL fUseLocks)
     return uCount;
 }
 
-BOOL  Ref_HandleAsyncPinHandles(bool (*asyncPinCallback)(Object*, void*), void* context)
+BOOL  Ref_HandleAsyncPinHandles(async_pin_enum_fn asyncPinCallback, void* context)
 {
 #ifndef FEATURE_REDHAWK
     CONTRACTL

--- a/src/gc/handletable.cpp
+++ b/src/gc/handletable.cpp
@@ -1286,9 +1286,9 @@ uint32_t HndCountAllHandles(BOOL fUseLocks)
     return uCount;
 }
 
-#ifndef FEATURE_REDHAWK
 BOOL  Ref_HandleAsyncPinHandles()
 {
+#ifndef FEATURE_REDHAWK
     CONTRACTL
     {
         NOTHROW;
@@ -1309,10 +1309,14 @@ BOOL  Ref_HandleAsyncPinHandles()
     }
 
     return result;
+#else
+    return true;
+#endif // !FEATURE_REDHAWK
 }
 
 void  Ref_RelocateAsyncPinHandles(HandleTableBucket *pSource, HandleTableBucket *pTarget)
 {
+#ifndef FEATURE_REDHAWK
     CONTRACTL
     {
         NOTHROW;
@@ -1325,8 +1329,8 @@ void  Ref_RelocateAsyncPinHandles(HandleTableBucket *pSource, HandleTableBucket 
     {
         TableRelocateAsyncPinHandles(Table(pSource->pTable[n]), Table(pTarget->pTable[n]));
     }
-}
 #endif // !FEATURE_REDHAWK
+}
 
 /*--------------------------------------------------------------------------*/
 

--- a/src/gc/handletable.cpp
+++ b/src/gc/handletable.cpp
@@ -1286,7 +1286,7 @@ uint32_t HndCountAllHandles(BOOL fUseLocks)
     return uCount;
 }
 
-BOOL  Ref_HandleAsyncPinHandles()
+BOOL  Ref_HandleAsyncPinHandles(bool (*asyncPinCallback)(Object*, void*), void* context)
 {
 #ifndef FEATURE_REDHAWK
     CONTRACTL
@@ -1297,12 +1297,13 @@ BOOL  Ref_HandleAsyncPinHandles()
     }
     CONTRACTL_END;
 
+    AsyncPinCallbackContext callbackCtx(asyncPinCallback, context);
     HandleTableBucket *pBucket = g_HandleTableMap.pBuckets[0];
     BOOL result = FALSE;
     int limit = getNumberOfSlots();
     for (int n = 0; n < limit; n ++ )
     {
-        if (TableHandleAsyncPinHandles(Table(pBucket->pTable[n])))
+        if (TableHandleAsyncPinHandles(Table(pBucket->pTable[n]), callbackCtx))
         {
             result = TRUE;
         }

--- a/src/gc/handletablepriv.h
+++ b/src/gc/handletablepriv.h
@@ -348,7 +348,7 @@ struct HandleTypeCache
 class AsyncPinCallbackContext
 {
 private:
-    bool (*m_callback)(Object*, void*);
+    async_pin_enum_fn m_callback;
     void* m_context;
 
 public:
@@ -357,7 +357,7 @@ public:
      * which will be passed to the callback as its second parameter every time
      * it is invoked.
      */
-    AsyncPinCallbackContext(bool (*callback)(Object*, void*), void* context)
+    AsyncPinCallbackContext(async_pin_enum_fn callback, void* context)
         : m_callback(callback), m_context(context)
     {}
 
@@ -367,6 +367,7 @@ public:
      */
     bool Invoke(Object* argument) const
     {
+        assert(m_callback != nullptr);
         return m_callback(argument, m_context);
     }
 };

--- a/src/gc/handletablepriv.h
+++ b/src/gc/handletablepriv.h
@@ -341,6 +341,36 @@ struct HandleTypeCache
     int32_t lFreeIndex;
 };
 
+/*
+ * Async pin EE callback context, used to call back tot he EE when enumerating
+ * over async pinned handles.
+ */
+class AsyncPinCallbackContext
+{
+private:
+    bool (*m_callback)(Object*, void*);
+    void* m_context;
+
+public:
+    /*
+     * Constructs a new AsyncPinCallbackContext from a callback and a context,
+     * which will be passed to the callback as its second parameter every time
+     * it is invoked.
+     */
+    AsyncPinCallbackContext(bool (*callback)(Object*, void*), void* context)
+        : m_callback(callback), m_context(context)
+    {}
+
+    /*
+     * Invokes the callback with the given argument, returning the callback's
+     * result.'
+     */
+    bool Invoke(Object* argument) const
+    {
+        return m_callback(argument, m_context);
+    }
+};
+
 
 /*---------------------------------------------------------------------------*/
 
@@ -759,7 +789,7 @@ void SegmentFree(TableSegment *pSegment);
  * Mark ready for all non-pending OverlappedData that get moved to default domain.
  *
  */
-BOOL TableHandleAsyncPinHandles(HandleTable *pTable);
+BOOL TableHandleAsyncPinHandles(HandleTable *pTable, const AsyncPinCallbackContext& callbackCtx);
 
 /*
  * TableRelocateAsyncPinHandles

--- a/src/gc/objecthandle.h
+++ b/src/gc/objecthandle.h
@@ -87,7 +87,7 @@ bool Ref_Initialize();
 void Ref_Shutdown();
 HandleTableBucket* Ref_CreateHandleTableBucket(void* context);
 bool Ref_InitializeHandleTableBucket(HandleTableBucket* bucket, void* context);
-BOOL Ref_HandleAsyncPinHandles(bool (*asyncPinCallback)(Object*, void*), void* context);
+BOOL Ref_HandleAsyncPinHandles(async_pin_enum_fn callback, void* context);
 void Ref_RelocateAsyncPinHandles(HandleTableBucket *pSource, HandleTableBucket *pTarget);
 void Ref_RemoveHandleTableBucket(HandleTableBucket *pBucket);
 void Ref_DestroyHandleTableBucket(HandleTableBucket *pBucket);

--- a/src/gc/objecthandle.h
+++ b/src/gc/objecthandle.h
@@ -87,7 +87,7 @@ bool Ref_Initialize();
 void Ref_Shutdown();
 HandleTableBucket* Ref_CreateHandleTableBucket(void* context);
 bool Ref_InitializeHandleTableBucket(HandleTableBucket* bucket, void* context);
-BOOL Ref_HandleAsyncPinHandles();
+BOOL Ref_HandleAsyncPinHandles(bool (*asyncPinCallback)(Object*, void*), void* context);
 void Ref_RelocateAsyncPinHandles(HandleTableBucket *pSource, HandleTableBucket *pTarget);
 void Ref_RemoveHandleTableBucket(HandleTableBucket *pBucket);
 void Ref_DestroyHandleTableBucket(HandleTableBucket *pBucket);

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -9220,18 +9220,16 @@ void AppDomain::HandleAsyncPinHandles()
     }
     CONTRACTL_END;
 
-    // TODO: Temporarily casting stuff here until Ref_RelocateAsyncPinHandles is moved to the interface.
-    HandleTableBucket *pBucket = (HandleTableBucket*)m_handleStore;
+    IGCHandleStore *pBucket = m_handleStore;
 
     // IO completion port picks IO job using FIFO.  Here is how we know which AsyncPinHandle can be freed.
     // 1. We mark all non-pending AsyncPinHandle with READYTOCLEAN.
     // 2. We queue a dump Overlapped to the IO completion as a marker.
     // 3. When the Overlapped is picked up by completion port, we wait until all previous IO jobs are processed.
     // 4. Then we can delete all AsyncPinHandle marked with READYTOCLEAN.
-    HandleTableBucket *pBucketInDefault = (HandleTableBucket*)SystemDomain::System()->DefaultDomain()->m_handleStore;
+    IGCHandleStore *pBucketInDefault = SystemDomain::System()->DefaultDomain()->m_handleStore;
 
-    // TODO: When this function is moved to the interface it will take void*s
-    Ref_RelocateAsyncPinHandles(pBucket, pBucketInDefault);
+    pBucket->RelocateAsyncPinnedHandles(pBucketInDefault);
 
     OverlappedDataObject::RequestCleanup();
 }

--- a/src/vm/nativeoverlapped.cpp
+++ b/src/vm/nativeoverlapped.cpp
@@ -262,7 +262,7 @@ void OverlappedDataObject::StartCleanup()
     if (FastInterlockExchange((LONG*)&s_CleanupInProgress, TRUE) == FALSE)
     {
         {
-            BOOL HasJob = Ref_HandleAsyncPinHandles();
+            bool HasJob = GCHandleUtilities::GetGCHandleManager()->HandleAsyncPinnedHandles();
             if (!HasJob)
             {
                 s_CleanupInProgress = FALSE;
@@ -292,7 +292,7 @@ void OverlappedDataObject::FinishCleanup(bool wasDrained)
         GCX_COOP();
 
         s_CleanupFreeHandle = TRUE;
-        Ref_HandleAsyncPinHandles();
+        GCHandleUtilities::GetGCHandleManager()->HandleAsyncPinnedHandles();
         s_CleanupFreeHandle = FALSE;
 
         s_CleanupInProgress = FALSE;

--- a/src/vm/nativeoverlapped.cpp
+++ b/src/vm/nativeoverlapped.cpp
@@ -233,7 +233,7 @@ BOOL HandleAsyncPinHandles()
     };
 
     IGCHandleManager* mgr = GCHandleUtilities::GetGCHandleManager();
-    return mgr->GetGlobalHandleStore()->HandleAsyncPinnedHandles(callback, nullptr);
+    return mgr->GetGlobalHandleStore()->EnumerateAsyncPinnedHandles(callback, nullptr);
 }
 
 } // anonymous namespace


### PR DESCRIPTION
This is a stopgap PR for `Ref_RelocateAsyncPinHandles` and `Ref_HandleAsyncPinHandles` that fixes the interface violations that occur in the EE -> GC direction. The implementations of `Ref_RelocateAsyncPinHandles` and `Ref_HandleAsyncPinHandles` in the GC still call into the EE, which will need to be addressed at some point in the future. My understanding is that this is all dead code on CoreCLR anyway (dealing with the migration of pending async pinned handles when an appdomain unloads), so even if it were addressed for CoreCLR, we wouldn't be able to test it.

@Maoni0 @adityamandaleeka (already reviewed offline) @jkotas @sergiy-k ptal?