### PR TITLE
Fix issue #11574.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -13665,7 +13665,7 @@ GenTree* Compiler::fgMorphSmpOpOptional(GenTreeOp* tree)
     GenTree*   op2  = tree->gtOp2;
     var_types  typ  = tree->TypeGet();
 
-    if (!optValnumCSE_phase && GenTree::OperIsCommutative(oper))
+    if (fgGlobalMorph && GenTree::OperIsCommutative(oper))
     {
         /* Swap the operands so that the more expensive one is 'op1' */
 
@@ -13703,7 +13703,7 @@ GenTree* Compiler::fgMorphSmpOpOptional(GenTreeOp* tree)
     /* Change "((x+icon)+y)" to "((x+y)+icon)"
        Don't reorder floating-point operations */
 
-    if (!optValnumCSE_phase && (oper == GT_ADD) && !tree->gtOverflow() && (op1->gtOper == GT_ADD) && !op1->gtOverflow() &&
+    if (fgGlobalMorph && (oper == GT_ADD) && !tree->gtOverflow() && (op1->gtOper == GT_ADD) && !op1->gtOverflow() &&
         varTypeIsIntegralOrI(typ))
     {
         GenTreePtr ad2 = op1->gtOp.gtOp2;

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -13665,7 +13665,7 @@ GenTree* Compiler::fgMorphSmpOpOptional(GenTreeOp* tree)
     GenTree*   op2  = tree->gtOp2;
     var_types  typ  = tree->TypeGet();
 
-    if (GenTree::OperIsCommutative(oper))
+    if (!optValnumCSE_phase && GenTree::OperIsCommutative(oper))
     {
         /* Swap the operands so that the more expensive one is 'op1' */
 
@@ -13703,7 +13703,7 @@ GenTree* Compiler::fgMorphSmpOpOptional(GenTreeOp* tree)
     /* Change "((x+icon)+y)" to "((x+y)+icon)"
        Don't reorder floating-point operations */
 
-    if ((oper == GT_ADD) && !tree->gtOverflow() && (op1->gtOper == GT_ADD) && !op1->gtOverflow() &&
+    if (!optValnumCSE_phase && (oper == GT_ADD) && !tree->gtOverflow() && (op1->gtOper == GT_ADD) && !op1->gtOverflow() &&
         varTypeIsIntegralOrI(typ))
     {
         GenTreePtr ad2 = op1->gtOp.gtOp2;

--- a/tests/src/JIT/Regression/JitBlue/GitHub_11574/GitHub_11574.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_11574/GitHub_11574.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    static byte[] s_arr2;
+    static byte[] s_arr3;
+
+    static void Init()
+    {
+        s_arr2 = new byte[] { 0x11, 0x12, 0x13 };
+        s_arr3 = new byte[] { 0x21, 0x22, 0x33 };
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Check(int actual, int added, int expected, int rv)
+    {
+        return (actual == expected) ? rv : 0;
+    }
+
+    static int Main(string[] args)
+    {
+        Init();
+
+        byte[] arr1 = new byte[] { 2 };
+        byte[] arr2 = s_arr2;
+        byte[] arr3 = s_arr3;
+
+        int rv = 100;
+        int len = arr1.Length + arr2.Length + arr3.Length;
+        int cur = 0;
+        rv = Check(cur, 0, 0, rv);
+        cur += arr1.Length;
+        rv = Check(cur, arr1.Length, 1, rv);
+        cur += arr2.Length;
+        rv = Check(cur, arr2.Length, 4, rv);
+        cur += arr3.Length;
+        rv = Check(cur, arr3.Length, 7, rv);
+        return Check(cur, 0, len, rv);
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_11574/GitHub_11574.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_11574/GitHub_11574.csproj
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_11574.cs" />
+  </ItemGroup>
+  <!--  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)threading+thread\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)threading+thread\project.lock.json</ProjectLockJson>
+  </PropertyGroup>-->
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
This bug was yet another case of a transformation being performed during
remorphing that preserved a tree's value number without preserving its
assocated semantics. This fix disables the problematic transformations
in morph.