### PR TITLE
Define the value ID_EXTRA_RELOC_BITS as 0 when HAS_TINY_DESC is 1

### DIFF
--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -678,6 +678,8 @@ protected:
         unsigned _idTinyDsc : 1;  // is this a "tiny"  descriptor?
         unsigned _idSmallDsc : 1; // is this a "small" descriptor?
 
+#define ID_EXTRA_RELOC_BITS (0)
+
 #else // !HAS_TINY_DESC
 
         //


### PR DESCRIPTION
Otherwise there are compilation errors when this value is used in computations later on.