### PR TITLE
Fix improper handling of GenTreeAddrMode offset

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -3148,7 +3148,7 @@ void CodeGen::genLeaInstruction(GenTreeAddrMode* lea)
     genConsumeOperands(lea);
     emitter* emit   = getEmitter();
     emitAttr size   = emitTypeSize(lea);
-    unsigned offset = lea->gtOffset;
+    int      offset = lea->Offset();
 
     // In ARM we can only load addresses of the form:
     //
@@ -3168,7 +3168,6 @@ void CodeGen::genLeaInstruction(GenTreeAddrMode* lea)
     {
         GenTree* memBase = lea->Base();
         GenTree* index   = lea->Index();
-        unsigned offset  = lea->gtOffset;
 
         DWORD lsl;
 

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2473,6 +2473,8 @@ FOUND_AM:
 #if SCALED_ADDR_MODES
     *mulPtr = mul;
 #endif
+    // TODO-Cleanup: The offset is signed and it should be returned as such. See also
+    // GenTreeAddrMode::gtOffset and its associated cleanup note.
     *cnsPtr = (unsigned)cns;
 
     return true;

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -5826,16 +5826,16 @@ void CodeGen::genLeaInstruction(GenTreeAddrMode* lea)
     {
         regNumber baseReg  = lea->Base()->gtRegNum;
         regNumber indexReg = lea->Index()->gtRegNum;
-        getEmitter()->emitIns_R_ARX(INS_lea, size, lea->gtRegNum, baseReg, indexReg, lea->gtScale, lea->gtOffset);
+        getEmitter()->emitIns_R_ARX(INS_lea, size, lea->gtRegNum, baseReg, indexReg, lea->gtScale, lea->Offset());
     }
     else if (lea->Base())
     {
-        getEmitter()->emitIns_R_AR(INS_lea, size, lea->gtRegNum, lea->Base()->gtRegNum, lea->gtOffset);
+        getEmitter()->emitIns_R_AR(INS_lea, size, lea->gtRegNum, lea->Base()->gtRegNum, lea->Offset());
     }
     else if (lea->Index())
     {
         getEmitter()->emitIns_R_ARX(INS_lea, size, lea->gtRegNum, REG_NA, lea->Index()->gtRegNum, lea->gtScale,
-                                    lea->gtOffset);
+                                    lea->Offset());
     }
 
     genProduceReg(lea);

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -10966,7 +10966,7 @@ void cNodeIR(Compiler* comp, GenTree* tree)
             GenTree*         base   = lea->Base();
             GenTree*         index  = lea->Index();
             unsigned         scale  = lea->gtScale;
-            unsigned         offset = lea->gtOffset;
+            int              offset = lea->Offset();
 
             chars += printf(" [");
             if (base != nullptr)
@@ -10991,7 +10991,7 @@ void cNodeIR(Compiler* comp, GenTree* tree)
                 {
                     chars += printf("+");
                 }
-                chars += printf("%u", offset);
+                chars += printf("%d", offset);
             }
             chars += printf("]");
             break;

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -7629,7 +7629,7 @@ void emitter::emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataR
 
         if (addr->OperGet() == GT_LEA)
         {
-            offset += (int)addr->AsAddrMode()->gtOffset;
+            offset += addr->AsAddrMode()->Offset();
             if (addr->AsAddrMode()->gtScale > 0)
             {
                 assert(isPow2(addr->AsAddrMode()->gtScale));

--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -11082,7 +11082,7 @@ void emitter::emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataR
 
         if (addr->OperGet() == GT_LEA)
         {
-            offset = (int)addr->AsAddrMode()->gtOffset;
+            offset = addr->AsAddrMode()->Offset();
             if (addr->AsAddrMode()->gtScale > 0)
             {
                 assert(isPow2(addr->AsAddrMode()->gtScale));

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -2599,7 +2599,7 @@ void emitter::emitHandleMemOp(GenTreeIndir* indir, instrDesc* id, insFormat fmt,
         id->idInsFmt(emitMapFmtForIns(fmt, ins));
 
         // disp must have already been set in the instrDesc constructor.
-        assert(emitGetInsAmdAny(id) == ssize_t(indir->Offset())); // make sure "disp" is stored properly
+        assert(emitGetInsAmdAny(id) == indir->Offset()); // make sure "disp" is stored properly
     }
 }
 
@@ -2670,7 +2670,7 @@ void emitter::emitInsLoadInd(instruction ins, emitAttr attr, regNumber dstReg, G
     }
 
     assert(addr->OperIsAddrMode() || (addr->IsCnsIntOrI() && addr->isContained()) || !addr->isContained());
-    size_t     offset = mem->Offset();
+    ssize_t    offset = mem->Offset();
     instrDesc* id     = emitNewInstrAmd(attr, offset);
     id->idIns(ins);
     id->idReg1(dstReg);
@@ -2727,7 +2727,7 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
         return;
     }
 
-    size_t         offset = mem->Offset();
+    ssize_t        offset = mem->Offset();
     UNATIVE_OFFSET sz;
     instrDesc*     id;
 
@@ -3101,8 +3101,8 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
     }
     else // [mem], reg OR reg, [mem]
     {
-        size_t offset = mem->Offset();
-        id            = emitNewInstrAmd(attr, offset);
+        ssize_t offset = mem->Offset();
+        id             = emitNewInstrAmd(attr, offset);
         id->idIns(ins);
 
         GenTree* regTree = (src == mem) ? dst : src;
@@ -3218,7 +3218,7 @@ void emitter::emitInsRMW(instruction ins, emitAttr attr, GenTreeStoreInd* storeI
     instrDesc*     id = nullptr;
     UNATIVE_OFFSET sz;
 
-    size_t offset = 0;
+    ssize_t offset = 0;
     if (addr->OperGet() != GT_CLS_VAR_ADDR)
     {
         offset = storeInd->Offset();
@@ -3279,7 +3279,7 @@ void emitter::emitInsRMW(instruction ins, emitAttr attr, GenTreeStoreInd* storeI
     assert(addr->OperGet() == GT_LCL_VAR || addr->OperGet() == GT_LCL_VAR_ADDR || addr->OperGet() == GT_CLS_VAR_ADDR ||
            addr->OperGet() == GT_LEA || addr->OperGet() == GT_CNS_INT);
 
-    size_t offset = 0;
+    ssize_t offset = 0;
     if (addr->OperGet() != GT_CLS_VAR_ADDR)
     {
         offset = storeInd->Offset();

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -4533,9 +4533,24 @@ struct GenTreeAddrMode : public GenTreeOp
         return gtOp2;
     }
 
-    unsigned gtScale;  // The scale factor
+    int Offset()
+    {
+        return static_cast<int>(gtOffset);
+    }
+
+    unsigned gtScale; // The scale factor
+
+#ifndef LEGACY_BACKEND
+private:
+#endif
+    // TODO-Cleanup: gtOffset should be changed to 'int' to match the getter function and avoid accidental
+    // zero extension to 64 bit. However, this is used by legacy code and initialized, via the offset
+    // parameter of the constructor, by Lowering::TryCreateAddrMode & CodeGenInterface::genCreateAddrMode.
+    // The later computes the offset as 'ssize_t' but returns it as 'unsigned'. We should change
+    // genCreateAddrMode to return 'int' or 'ssize_t' and then update this as well.
     unsigned gtOffset; // The offset to add
 
+public:
     GenTreeAddrMode(var_types type, GenTreePtr base, GenTreePtr index, unsigned scale, unsigned offset)
         : GenTreeOp(GT_LEA, type, base, index)
     {
@@ -4570,7 +4585,7 @@ struct GenTreeIndir : public GenTreeOp
     GenTree* Base();
     GenTree* Index();
     unsigned Scale();
-    size_t   Offset();
+    ssize_t  Offset();
 
     GenTreeIndir(genTreeOps oper, var_types type, GenTree* addr, GenTree* data) : GenTreeOp(oper, type, addr, data)
     {

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -5117,7 +5117,7 @@ bool Lowering::IndirsAreEquivalent(GenTreePtr candidate, GenTreePtr storeInd)
             GenTreeAddrMode* gtAddr2 = pTreeB->AsAddrMode();
             return NodesAreEquivalentLeaves(gtAddr1->Base(), gtAddr2->Base()) &&
                    NodesAreEquivalentLeaves(gtAddr1->Index(), gtAddr2->Index()) &&
-                   gtAddr1->gtScale == gtAddr2->gtScale && gtAddr1->gtOffset == gtAddr2->gtOffset;
+                   (gtAddr1->gtScale == gtAddr2->gtScale) && (gtAddr1->Offset() == gtAddr2->Offset());
         }
         default:
             // We don't handle anything that is not either a constant,

--- a/src/jit/lowerarmarch.cpp
+++ b/src/jit/lowerarmarch.cpp
@@ -594,7 +594,7 @@ void Lowering::ContainCheckIndir(GenTreeIndir* indirNode)
         GenTreeAddrMode* lea   = addr->AsAddrMode();
         GenTree*         base  = lea->Base();
         GenTree*         index = lea->Index();
-        unsigned         cns   = lea->gtOffset;
+        int              cns   = lea->Offset();
 
 #ifdef _TARGET_ARM_
         // ARM floating-point load/store doesn't support a form similar to integer

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -569,7 +569,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
         case GT_LEA:
         {
             GenTreeAddrMode* lea    = tree->AsAddrMode();
-            unsigned         offset = lea->gtOffset;
+            int              offset = lea->Offset();
 
             // This LEA is instantiating an address, so we set up the srcCount and dstCount here.
             info->srcCount = 0;

--- a/src/jit/lsraarm64.cpp
+++ b/src/jit/lsraarm64.cpp
@@ -589,7 +589,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
 
             GenTree* base  = lea->Base();
             GenTree* index = lea->Index();
-            unsigned cns   = lea->gtOffset;
+            int      cns   = lea->Offset();
 
             // This LEA is instantiating an address, so we set up the srcCount here.
             info->srcCount = 0;

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -176,7 +176,7 @@ void Lowering::TreeNodeInfoInitIndir(GenTreeIndir* indirTree)
 
     GenTree* addr  = indirTree->Addr();
     GenTree* index = nullptr;
-    unsigned cns   = 0;
+    int      cns   = 0;
 
 #ifdef _TARGET_ARM_
     // Unaligned loads/stores for floating point values must first be loaded into integer register(s)
@@ -208,7 +208,7 @@ void Lowering::TreeNodeInfoInitIndir(GenTreeIndir* indirTree)
         assert(addr->OperGet() == GT_LEA);
         GenTreeAddrMode* lea = addr->AsAddrMode();
         index                = lea->Index();
-        cns                  = lea->gtOffset;
+        cns                  = lea->Offset();
 
         // On ARM we may need a single internal register
         // (when both conditions are true then we still only need a single internal register)


### PR DESCRIPTION
For unknown reasons `GenTreeAddrMode::gtOffset` is `unsigned` rather than `int`. On 32 bit hosts this doesn't really matter but on 64 bit hosts we end up zero extending instead of sign extending it, `GetTreeIndir::Offset()` does that by casting from `unsigned` to `size_t`.

It doesn't appear possible for this to cause correctness issues (because the address mode displacement is 32 bit anyway) but it's confusing and hurts CQ because the emitter can't recognize small negative displacements that can be encoded in a single byte.

It's worth noting that 
* `CodeGen::genCreateAddrMode` uses `ssize_t` internally to represent the offset but then returns it as `unsigned`
* the emitter works with either `int` or `ssize_t` displacements (e.g. `emitIns_R_ARX` & co. have `int disp` arguments, `emitNewInstrAmd` has `ssize_t dsp` argument)

Contributes to #10980