### PR TITLE
Fix minidump hang under shipping lldb 3.9.1

### DIFF
--- a/src/debug/createdump/dumpwriter.cpp
+++ b/src/debug/createdump/dumpwriter.cpp
@@ -209,7 +209,7 @@ DumpWriter::WriteDump()
     // Write all the thread's state and registers
     for (const ThreadInfo* thread : m_crashInfo.Threads()) 
     {
-        if (!WriteThread(*thread, 0)) {
+        if (!WriteThread(*thread, SIGABRT)) {
             return false;
         }
     }


### PR DESCRIPTION
The threads in the dump need a stop reason SIGABRT in this case.

Issue: #11590