### PR TITLE
Removes unnecessary shift count masking

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -167,6 +167,14 @@ GenTree* Lowering::LowerNode(GenTree* node)
             LowerRotate(node);
             break;
 
+#ifdef _TARGET_XARCH_
+        case GT_LSH:
+        case GT_RSH:
+        case GT_RSZ:
+            LowerShift(node->AsOp());
+            break;
+#endif
+
         case GT_STORE_BLK:
         case GT_STORE_OBJ:
         case GT_STORE_DYN_BLK:

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -256,6 +256,7 @@ private:
     void LowerStoreLoc(GenTreeLclVarCommon* tree);
     GenTree* LowerArrElem(GenTree* node);
     void LowerRotate(GenTree* tree);
+    void LowerShift(GenTreeOp* shift);
 
     // Utility functions
     void MorphBlkIntoHelperCall(GenTreePtr pTree, GenTreePtr treeStmt);

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -35,6 +35,50 @@ void Lowering::LowerRotate(GenTreePtr tree)
 }
 
 //------------------------------------------------------------------------
+// LowerShift: Lower shift nodes
+//
+// Arguments:
+//    shift - the shift node (GT_LSH, GT_RSH or GT_RSZ)
+//
+// Notes:
+//    Remove unnecessary shift count masking, xarch shift instructions
+//    mask the shift count to 5 bits (or 6 bits for 64 bit operations).
+
+void Lowering::LowerShift(GenTreeOp* shift)
+{
+    assert(shift->OperIs(GT_LSH, GT_RSH, GT_RSZ));
+
+    size_t mask = 0x1f;
+#ifdef _TARGET_AMD64_
+    if (varTypeIsLong(shift->TypeGet()))
+    {
+        mask = 0x3f;
+    }
+#else
+    assert(!varTypeIsLong(shift->TypeGet()));
+#endif
+
+    for (GenTree* andOp = shift->gtGetOp2(); andOp->OperIs(GT_AND); andOp = andOp->gtGetOp1())
+    {
+        GenTree* maskOp = andOp->gtGetOp2();
+
+        if (!maskOp->IsCnsIntOrI())
+        {
+            break;
+        }
+
+        if ((static_cast<size_t>(maskOp->AsIntCon()->IconValue()) & mask) != mask)
+        {
+            break;
+        }
+
+        shift->gtOp2 = andOp->gtGetOp1();
+        BlockRange().Remove(andOp);
+        BlockRange().Remove(maskOp);
+    }
+}
+
+//------------------------------------------------------------------------
 // LowerStoreLoc: Lower a store of a lclVar
 //
 // Arguments:


### PR DESCRIPTION
The C# compiler translates code like `x << y` to `x << (y & 31)` because the behavior of IL shift operations is unspecified if the shift count is greater than or equal to the bit width of the shifted value. However, x86/x64 shift instructions do mask the shift count so `& 31` is redundant.

It's also possible that developers also mask the shift count, not knowing that the C# language specification guarantees masking. In that case we end up with 2 `and x, 31` instructions.