### PR TITLE
[Linux/x86] Fix clang 4.0 build

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -6595,7 +6595,7 @@ void CodeGen::genIntToIntCast(GenTreePtr treeNode)
                 }
                 else
                 {
-                    typeMask = 0xFFFFFFFF80000000LL;
+                    typeMask = ssize_t((int)0x80000000);
                     typeMin  = INT_MIN;
                     typeMax  = INT_MAX;
                 }

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -1478,7 +1478,7 @@ extern "C" DWORD __stdcall getcpuid(DWORD arg, unsigned char result[16])
             "  mov %%edx, 12(%[result])\n" \
         : "=a"(eax) /*output in eax*/\
         : "a"(arg), [result]"r"(result) /*inputs - arg in eax, result in any register*/\
-        : "eax", "ebx", "ecx", "edx", "memory" /* registers that are clobbered, *result is clobbered */
+        : "ebx", "ecx", "edx", "memory" /* registers that are clobbered, *result is clobbered */
         );
     return eax;
 }
@@ -1486,14 +1486,15 @@ extern "C" DWORD __stdcall getcpuid(DWORD arg, unsigned char result[16])
 extern "C" DWORD __stdcall getextcpuid(DWORD arg1, DWORD arg2, unsigned char result[16])
 {
     DWORD eax;
+    DWORD ecx;
     __asm("  cpuid\n" \
             "  mov %%eax, 0(%[result])\n" \
             "  mov %%ebx, 4(%[result])\n" \
             "  mov %%ecx, 8(%[result])\n" \
             "  mov %%edx, 12(%[result])\n" \
-        : "=a"(eax) /*output in eax*/\
+        : "=a"(eax), "=c"(ecx) /*output in eax, ecx is rewritten*/\
         : "c"(arg1), "a"(arg2), [result]"r"(result) /*inputs - arg1 in ecx, arg2 in eax, result in any register*/\
-        : "eax", "ebx", "ecx", "edx", "memory" /* registers that are clobbered, *result is clobbered */
+        : "ebx", "edx", "memory" /* registers that are clobbered, *result is clobbered */
         );
     return eax;
 }
@@ -1504,7 +1505,7 @@ extern "C" DWORD __stdcall xmmYmmStateSupport()
     __asm("  xgetbv\n" \
         : "=a"(eax) /*output in eax*/\
         : "c"(0) /*inputs - 0 in ecx*/\
-        : "eax", "edx" /* registers that are clobbered*/
+        : "edx" /* registers that are clobbered*/
         );
     // check OS has enabled both XMM and YMM state support
     return ((eax & 0x06) == 0x06) ? 1 : 0;


### PR DESCRIPTION
Fixes the following compiler errors:
```
src/vm/i386/cgenx86.cpp:1481:11: error: asm-specifier for input or output variable conflicts with asm
      clobber list
        : "eax", "ebx", "ecx", "edx", "memory" /* registers that are clobbered, *result is clobbered */
          ^
src/vm/i386/cgenx86.cpp:1496:11: error: asm-specifier for input or output variable conflicts with asm
      clobber list
        : "eax", "ebx", "ecx", "edx", "memory" /* registers that are clobbered, *result is clobbered */
          ^
src/vm/i386/cgenx86.cpp:1507:11: error: asm-specifier for input or output variable conflicts with asm
      clobber list
        : "eax", "edx" /* registers that are clobbered*/
          ^

src/jit/codegenxarch.cpp:6598:32: error: implicit conversion from 'unsigned long long' to 'ssize_t'
      (aka 'int') changes value from 18446744071562067968 to -2147483648 [-Werror,-Wconstant-conversion]
                    typeMask = 0xFFFFFFFF80000000LL;
                             ~ ^~~~~~~~~~~~~~~~~~~~
```