### PR TITLE
Removed unused local variable.

### DIFF
--- a/src/mscorlib/src/System/Threading/Tasks/Task.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/Task.cs
@@ -6011,8 +6011,7 @@ namespace System.Threading.Tasks
 
             // Make a defensive copy, as the user may manipulate the tasks array
             // after we return but before the WhenAny asynchronously completes.
-            int taskCount = tasks.Length;
-            Task[] tasksCopy = new Task[taskCount];
+            Task[] tasksCopy = new Task[tasks.Length];
             for (int i = 0; i < taskCount; i++)
             {
                 Task task = tasks[i];


### PR DESCRIPTION
I checked whether it was optimised away by Roslyn, but it doesn't seem that way.

MSIL:

[...]
ldlen        
conv.i4      
stloc.0      // taskCount
[...]
ldloc.0      // taskCount
[...]