### PR TITLE
Update Corelib to use SetThreadErrorMode

### DIFF
--- a/src/mscorlib/shared/Interop/Windows/Kernel32/Interop.SetThreadErrorMode.cs
+++ b/src/mscorlib/shared/Interop/Windows/Kernel32/Interop.SetThreadErrorMode.cs
@@ -8,8 +8,8 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, SetLastError = false, EntryPoint = "SetErrorMode", ExactSpelling = true)]
-        internal static extern uint SetErrorMode(uint newMode);
+        [DllImport(Libraries.Kernel32, SetLastError = true, ExactSpelling = true)]
+        internal static extern bool SetThreadErrorMode(uint dwNewMode, out uint lpOldMode);
 
         internal const uint SEM_FAILCRITICALERRORS = 1;
     }

--- a/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
@@ -491,7 +491,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.SECURITY_ATTRIBUTES.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.SecurityOptions.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.SetEndOfFile.cs"/>
-    <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.SetErrorMode.cs"/>
+    <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.SetThreadErrorMode.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.SetFilePointerEx.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.WideCharToMultiByte.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.WriteFile_SafeHandle_IntPtr.cs"/>

--- a/src/mscorlib/shared/System/IO/FileStream.Win32.cs
+++ b/src/mscorlib/shared/System/IO/FileStream.Win32.cs
@@ -2,13 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Buffers;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
-using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.IO
 {
@@ -38,7 +33,8 @@ namespace System.IO
             flagsAndAttributes |= (Interop.Kernel32.SecurityOptions.SECURITY_SQOS_PRESENT | Interop.Kernel32.SecurityOptions.SECURITY_ANONYMOUS);
 
             // Don't pop up a dialog for reading from an empty floppy drive
-            uint oldMode = Interop.Kernel32.SetErrorMode(Interop.Kernel32.SEM_FAILCRITICALERRORS);
+            uint oldMode;
+            bool success = Interop.Kernel32.SetThreadErrorMode(Interop.Kernel32.SEM_FAILCRITICALERRORS, out oldMode);
             try
             {
                 SafeFileHandle fileHandle = Interop.Kernel32.CreateFile(_path, fAccess, share, ref secAttrs, mode, flagsAndAttributes, IntPtr.Zero);
@@ -70,7 +66,8 @@ namespace System.IO
             }
             finally
             {
-                Interop.Kernel32.SetErrorMode(oldMode);
+                if (success)
+                    Interop.Kernel32.SetThreadErrorMode(oldMode, out oldMode);
             }
         }
     }

--- a/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
+++ b/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
@@ -473,9 +473,6 @@ namespace Microsoft.Win32
         internal const String SECUR32 = "secur32.dll";
         internal const String MSCORWKS = "coreclr.dll";
 
-        // From WinBase.h
-        internal const int SEM_FAILCRITICALERRORS = 1;
-
         [DllImport(KERNEL32, CharSet = CharSet.Auto, BestFitMapping = true)]
         internal static extern int FormatMessage(int dwFlags, IntPtr lpSource,
                     int dwMessageId, int dwLanguageId, [Out]StringBuilder lpBuffer,
@@ -775,18 +772,6 @@ namespace Microsoft.Win32
 
         [DllImport(KERNEL32, SetLastError = true, CharSet = CharSet.Auto, BestFitMapping = false)]
         internal static extern bool SetCurrentDirectory(String path);
-
-        [DllImport(KERNEL32, SetLastError = false, EntryPoint = "SetErrorMode", ExactSpelling = true)]
-        private static extern int SetErrorMode_VistaAndOlder(int newMode);
-
-        // RTM versions of Win7 and Windows Server 2008 R2
-        private static readonly Version ThreadErrorModeMinOsVersion = new Version(6, 1, 7600);
-
-        // this method uses the thread-safe version of SetErrorMode on Windows 7 / Windows Server 2008 R2 operating systems.
-        internal static int SetErrorMode(int newMode)
-        {
-            return SetErrorMode_VistaAndOlder(newMode);
-        }
 
         internal const int LCID_SUPPORTED = 0x00000002;  // supported locale ids
 


### PR DESCRIPTION
See #19738. Note that the enumerable is only used on Unix- but updated
it anyway. Conditioned the set/unset for ! Unix. SetErrorMode in the
PAL is a no-op, want to use the shared interop.

