### PR TITLE
[Local GC] Remove uses of g_SystemInfo from the GC

### DIFF
--- a/src/gc/env/gcenv.os.h
+++ b/src/gc/env/gcenv.os.h
@@ -366,6 +366,12 @@ public:
     // Return:
     //  Time stamp in milliseconds
     static uint32_t GetLowPrecisionTimeStamp();
+
+    // Gets the total number of processors on the machine, not taking
+    // into account current process affinity.
+    // Return:
+    //  Number of processors on the machine
+    static uint32_t GetTotalProcessorCount();
 };
 
 #endif // __GCENV_OS_H__

--- a/src/gc/env/gcenv.os.h
+++ b/src/gc/env/gcenv.os.h
@@ -158,6 +158,15 @@ public:
     //  flags     - flags to control special settings like write watching
     // Return:
     //  Starting virtual address of the reserved range
+    // Notes:
+    //  Previous uses of this API aligned the `size` parameter to the platform
+    //  allocation granularity. This is not required by POSIX or Windows. Windows will
+    //  round the size up to the nearest page boundary. POSIX does not specify what is done,
+    //  but Linux probably also rounds up. If an implementation of GCToOSInterface needs to
+    //  align to the allocation granularity, it will do so in its implementation.
+    //
+    //  Windows guarantees that the returned mapping will be aligned to the allocation
+    //  granularity.
     static void* VirtualReserve(size_t size, size_t alignment, uint32_t flags);
 
     // Release virtual memory range previously reserved using VirtualReserve

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -33620,7 +33620,7 @@ HRESULT GCHeap::Initialize ()
     }
 
     g_gc_pFreeObjectMethodTable = GCToEEInterface::GetFreeObjectMethodTable();
-    g_num_processors = GCToOSInterface::GetCurrentProcessCpuCount();
+    g_num_processors = GCToOSInterface::GetTotalProcessorCount();
     assert(g_num_processors != 0);
 
 //Initialize the static members.

--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -115,6 +115,7 @@ extern "C" uint8_t* g_gc_highest_address;
 extern "C" GCHeapType g_gc_heap_type;
 extern "C" uint32_t g_max_generation;
 extern "C" MethodTable* g_gc_pFreeObjectMethodTable;
+extern "C" uint32_t g_num_processors;
 
 ::IGCHandleManager*  CreateGCHandleManager();
 

--- a/src/gc/gccommon.cpp
+++ b/src/gc/gccommon.cpp
@@ -44,6 +44,7 @@ uint8_t* g_gc_highest_address = 0;
 GCHeapType g_gc_heap_type = GC_HEAP_INVALID;
 uint32_t g_max_generation = max_generation;
 MethodTable* g_gc_pFreeObjectMethodTable = nullptr;
+uint32_t g_num_processors = 0;
 
 #ifdef GC_CONFIG_DRIVEN
 void record_global_mechanism (int mech_index)

--- a/src/gc/handletablecache.cpp
+++ b/src/gc/handletablecache.cpp
@@ -57,7 +57,7 @@ void SpinUntil(void *pCond, BOOL fNonZero)
 #endif //_DEBUG
 
     // on MP machines, allow ourselves some spin time before sleeping
-    uint32_t uNonSleepSpins = 8 * (g_SystemInfo.dwNumberOfProcessors - 1);
+    static uint32_t uNonSleepSpins = 8 * (GCToOSInterface::GetCurrentProcessCpuCount() - 1);
 
     // spin until the specificed condition is met
     while ((*(uintptr_t *)pCond != 0) != (fNonZero != 0))

--- a/src/gc/handletablecore.cpp
+++ b/src/gc/handletablecore.cpp
@@ -516,14 +516,14 @@ BOOL SegmentInitialize(TableSegment *pSegment, HandleTable *pTable)
 
 #ifndef FEATURE_REDHAWK // todo: implement SafeInt
     // Prefast overflow sanity check the addition
-    if (!ClrSafeInt<uint32_t>::addition(dwCommit, g_SystemInfo.dwPageSize, dwCommit))
+    if (!ClrSafeInt<uint32_t>::addition(dwCommit, OS_PAGE_SIZE, dwCommit))
     {
         return FALSE;
     }
 #endif // !FEATURE_REDHAWK
 
     // Round down to the dwPageSize
-    dwCommit &= ~(g_SystemInfo.dwPageSize - 1);
+    dwCommit &= ~(OS_PAGE_SIZE - 1);
 
     // commit the header
     if (!GCToOSInterface::VirtualCommit(pSegment, dwCommit))
@@ -1444,7 +1444,7 @@ uint32_t SegmentInsertBlockFromFreeListWorker(TableSegment *pSegment, uint32_t u
                 void * pvCommit = pSegment->rgValue + (uCommitLine * HANDLE_HANDLES_PER_BLOCK);
 
                 // we should commit one more page of handles
-                uint32_t dwCommit = g_SystemInfo.dwPageSize;
+                uint32_t dwCommit = OS_PAGE_SIZE;
 
                 // commit the memory
                 if (!GCToOSInterface::VirtualCommit(pvCommit, dwCommit))
@@ -1791,7 +1791,7 @@ BOOL DoesSegmentNeedsToTrimExcessPages(TableSegment *pSegment)
     if (uEmptyLine < uDecommitLine)
     {
         // derive some useful info about the page size
-        uintptr_t dwPageRound = (uintptr_t)g_SystemInfo.dwPageSize - 1;
+        uintptr_t dwPageRound = (uintptr_t)OS_PAGE_SIZE - 1;
         uintptr_t dwPageMask  = ~dwPageRound;
 
         // compute the address corresponding to the empty line
@@ -1835,7 +1835,7 @@ void SegmentTrimExcessPages(TableSegment *pSegment)
     if (uEmptyLine < uDecommitLine)
     {
         // derive some useful info about the page size
-        uintptr_t dwPageRound = (uintptr_t)g_SystemInfo.dwPageSize - 1;
+        uintptr_t dwPageRound = (uintptr_t)OS_PAGE_SIZE - 1;
         uintptr_t dwPageMask  = ~dwPageRound;
 
         // compute the address corresponding to the empty line
@@ -1857,7 +1857,7 @@ void SegmentTrimExcessPages(TableSegment *pSegment)
             pSegment->bCommitLine = (uint8_t)((dwLo - (size_t)pSegment->rgValue) / HANDLE_BYTES_PER_BLOCK);
 
             // compute the address for the new decommit line
-            size_t dwDecommitAddr = dwLo - g_SystemInfo.dwPageSize;
+            size_t dwDecommitAddr = dwLo - OS_PAGE_SIZE;
 
             // assume a decommit line of zero until we know otheriwse
             uDecommitLine = 0;

--- a/src/gc/objecthandle.cpp
+++ b/src/gc/objecthandle.cpp
@@ -563,10 +563,10 @@ int getNumberOfSlots()
         return 1;
 
 #ifdef FEATURE_REDHAWK
-    return g_SystemInfo.dwNumberOfProcessors;
+    return GCToOSInterface::GetCurrentProcessCpuCount();
 #else
     return (CPUGroupInfo::CanEnableGCCPUGroups() ? CPUGroupInfo::GetNumActiveProcessors() :
-                                                   g_SystemInfo.dwNumberOfProcessors);
+                                                   GCToOSInterface::GetCurrentProcessCpuCount());
 #endif
 }
 

--- a/src/gc/unix/gcenv.unix.cpp
+++ b/src/gc/unix/gcenv.unix.cpp
@@ -622,6 +622,18 @@ bool GCToOSInterface::CreateThread(GCThreadFunction function, void* param, GCThr
     return (st == 0);
 }
 
+// Gets the total number of processors on the machine, not taking
+// into account current process affinity.
+// Return:
+//  Number of processors on the machine
+uint32_t GCToOSInterface::GetTotalProcessorCount()
+{
+    // Calculated in GCToOSInterface::Initialize using
+    // sysconf(_SC_NPROCESSORS_ONLN)
+    return g_logicalCpuCount;
+}
+
+
 // Initialize the critical section
 void CLRCriticalSection::Initialize()
 {

--- a/src/gc/windows/gcenv.windows.cpp
+++ b/src/gc/windows/gcenv.windows.cpp
@@ -603,6 +603,15 @@ bool GCToOSInterface::CreateThread(GCThreadFunction function, void* param, GCThr
     return true;
 }
 
+// Gets the total number of processors on the machine, not taking
+// into account current process affinity.
+// Return:
+//  Number of processors on the machine
+uint32_t GCToOSInterface::GetTotalProcessorCount()
+{
+    return g_SystemInfo.dwNumberOfProcessors;
+}
+
 // Initialize the critical section
 void CLRCriticalSection::Initialize()
 {

--- a/src/vm/gcenv.os.cpp
+++ b/src/vm/gcenv.os.cpp
@@ -674,6 +674,13 @@ bool GCToOSInterface::CreateThread(GCThreadFunction function, void* param, GCThr
     return true;
 }
 
+uint32_t GCToOSInterface::GetTotalProcessorCount()
+{
+    LIMITED_METHOD_CONTRACT;
+
+    return g_SystemInfo.dwNumberOfProcessors;
+}
+
 // Initialize the critical section
 void CLRCriticalSection::Initialize()
 {

--- a/src/vm/gcenv.os.cpp
+++ b/src/vm/gcenv.os.cpp
@@ -171,13 +171,18 @@ void* GCToOSInterface::VirtualReserve(size_t size, size_t alignment, uint32_t fl
     LIMITED_METHOD_CONTRACT;
 
     DWORD memFlags = (flags & VirtualReserveFlags::WriteWatch) ? (MEM_RESERVE | MEM_WRITE_WATCH) : MEM_RESERVE;
+
+    // This is not strictly necessary for a correctness standpoint. Windows already guarantees
+    // allocation granularity alignment when using MEM_RESERVE, so aligning the size here has no effect.
+    // However, ClrVirtualAlloc does expect the size to be aligned to the allocation granularity.
+    size_t aligned_size = (size + g_SystemInfo.dwAllocationGranularity - 1) & ~static_cast<size_t>(g_SystemInfo.dwAllocationGranularity - 1);
     if (alignment == 0)
     {
-        return ::ClrVirtualAlloc(0, size, memFlags, PAGE_READWRITE);
+        return ::ClrVirtualAlloc(0, aligned_size, memFlags, PAGE_READWRITE);
     }
     else
     {
-        return ::ClrVirtualAllocAligned(0, size, memFlags, PAGE_READWRITE, alignment);
+        return ::ClrVirtualAllocAligned(0, aligned_size, memFlags, PAGE_READWRITE, alignment);
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/11512, part of https://github.com/dotnet/coreclr/issues/11518.

This PR removes uses of `g_SystemInfo` from within the GC. The uses of `g_SystemInfo` fall into three categories:

* Use of `g_SystemInfo.dwNumberOfProcessors` to get the number of processors. These have been replaced with a reference to `g_num_processors`, a global initialized at GC initialization time with the return result of `GCToOSInterface::GetCurrentProcessCpuCount`. Outside of the GC (i.e. the handle table), `g_SystemInfo.dwNumberOfProcessors` is replaced with a direct call to `GCToOSInterface::GetCurrentProcessCpuCount`.
* Use of `g_SystemInfo.dwPageSize` to get the OS page size. These are replaced with the `OS_PAGE_SIZE` macro.
* Use of `g_SystemInfo.dwAllocationGranularity`. When reserving the card table, the GC manually aligns the reservation size up to the OS allocation granularity. I did some reading and I don't think this is strictly necessary; Windows will do the alignment itself if necessary and the pointer it returns is always aligned to the allocation granularity. I found that I still had to align to the allocation granularity for the PAL implementation of `GCToOSInterface`, since `EEVirtualAlloc` [requires that mappings without a hint address be allocation granularity aligned](https://github.com/dotnet/coreclr/blob/master/src/vm/hosting.cpp#L220). At any rate, my solution in this PR was to remove the GC's manual alignment and rely instead on the OS's natural alignment.

I'm in the process of validating these changes.