### PR TITLE
[Linux] Fix CreateDump-related undefined reference on non-AMD64

### DIFF
--- a/src/ToolBox/SOS/Strike/CMakeLists.txt
+++ b/src/ToolBox/SOS/Strike/CMakeLists.txt
@@ -150,6 +150,7 @@ if(CLR_CMAKE_PLATFORM_ARCH_AMD64)
       SOS_LIBRARY 
       createdump_lib
     )
+    add_definitions(-DCREATE_DUMP_SUPPORTED)
   endif(CLR_CMAKE_PLATFORM_LINUX)
   set(SOS_SOURCES_ARCH
     disasmX86.cpp

--- a/src/ToolBox/SOS/Strike/strike.cpp
+++ b/src/ToolBox/SOS/Strike/strike.cpp
@@ -14370,17 +14370,17 @@ _EFN_GetManagedObjectFieldInfo(
 
 #ifdef FEATURE_PAL
 
-#ifdef __linux__
+#ifdef CREATE_DUMP_SUPPORTED
 #include <dumpcommon.h>
 #include "datatarget.h"
 extern bool CreateDumpForSOS(const char* programPath, const char* dumpPathTemplate, pid_t pid, MINIDUMP_TYPE minidumpType, ICLRDataTarget* dataTarget);
 extern bool g_diagnostics;
-#endif // __linux__
+#endif // CREATE_DUMP_SUPPORTED
 
 DECLARE_API(CreateDump)
 {
     INIT_API();
-#ifdef __linux__
+#ifdef CREATE_DUMP_SUPPORTED
     StringHolder sFileName;
     BOOL normal = FALSE;
     BOOL withHeap = FALSE;
@@ -14440,9 +14440,9 @@ DECLARE_API(CreateDump)
     {
         Status = E_FAIL;
     } 
-#else // __linux__
+#else // CREATE_DUMP_SUPPORTED
     ExtErr("CreateDump not supported on this platform\n");
-#endif // __linux__
+#endif // CREATE_DUMP_SUPPORTED
     return Status;
 }
 


### PR DESCRIPTION
The current implementation leaves undefined references on g_diagnostics and CreateDumpForSOS(char const*, char const*, int, _MINIDUMP_TYPE, ICLRDataTarget*) on non-ADM64 (including x86 and ARM).

This commit removes these CreateDump-related undefined references.