### PR TITLE
[x86/Linux] Remove unused GetFrameFromRedirectedStubStackFrame stub

### DIFF
--- a/src/vm/i386/excepcpu.h
+++ b/src/vm/i386/excepcpu.h
@@ -97,10 +97,6 @@ EXTERN_C LPVOID STDCALL COMPlusEndCatch(LPVOID ebp, DWORD ebx, DWORD edi, DWORD 
 PTR_CONTEXT GetCONTEXTFromRedirectedStubStackFrame(CONTEXT * pContext);
 #ifdef WIN64EXCEPTIONS
 PTR_CONTEXT GetCONTEXTFromRedirectedStubStackFrame(T_DISPATCHER_CONTEXT * pDispatcherContext);
-
-class FaultingExceptionFrame;
-
-FaultingExceptionFrame *GetFrameFromRedirectedStubStackFrame (DISPATCHER_CONTEXT *pDispatcherContext);
 #endif // WIN64EXCEPTIONS
 
 // Determine the address of the instruction that made the current call.

--- a/src/vm/i386/unixstubs.cpp
+++ b/src/vm/i386/unixstubs.cpp
@@ -56,9 +56,3 @@ PTR_CONTEXT GetCONTEXTFromRedirectedStubStackFrame(T_DISPATCHER_CONTEXT * pDispa
     PORTABILITY_ASSERT("GetCONTEXTFromRedirectedStubStackFrame");
     return NULL;
 }
-
-FaultingExceptionFrame *GetFrameFromRedirectedStubStackFrame(DISPATCHER_CONTEXT *pDispatcherContext)
-{
-    PORTABILITY_ASSERT("GetFrameFromRedirectedStubStackFrame");
-    return NULL;
-}


### PR DESCRIPTION
GetFrameFromRedirectedStubStackFrame stub was introduced during x86/Linux bring up, but it is now no loner required for Linux. (It is currently required only when FEATURE_PAL is not set).

This commit removes this unused stub.