### PR TITLE
[RyuJIT/ARM32] Enable casting from small int to float

### DIFF
--- a/src/jit/lowerarmarch.cpp
+++ b/src/jit/lowerarmarch.cpp
@@ -276,7 +276,6 @@ void Lowering::LowerCast(GenTree* tree)
     // Case of src is a small type and dst is a floating point type.
     if (varTypeIsSmall(srcType) && varTypeIsFloating(dstType))
     {
-        NYI_ARM("Lowering for cast from small type to float"); // Not tested yet.
         // These conversions can never be overflow detecting ones.
         noway_assert(!tree->gtOverflow());
         tmpType = TYP_INT;


### PR DESCRIPTION
This just enable casting from small int to float by removing assertion and generated code is verified with tests.


Fix #11603

# Example
`JIT/Methodical/fp/exgen/10w250d_cs_d/10w250d_cs_d.exe`


## Before

```
LowerCast for: N007 (  8,  7) [000070] ---XG--------             *  cast      double <- int

testout1:Func_0_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1():double - NYI (/opt/code/github/hqueue/coreclr/src/jit/lowerarmarch.cpp:279 - NYI_ARM: Lowering for cast from small type to float)
./run.sh: line 1: 15226 Aborted                 (core dumped) COMPlus_JitDump=Func_0_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1 COMPlus_AltJit=Func_0_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1 /mnt/albireo/mywork/device/rpi3/unittests/coreoverlays/coreoverlay.test20170515/corerun 10w250d_cs_d.exe
```

## After (Ryujit)

```
               [000070] ---XG--------             |  |     \--*  cast      double <- int
               [000069] ---XG--------             |  |        \--*  field     short  a4_0_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1_1
               [000068] -------------             |  |           \--*  lclVar    ref    V00 loc0

...(omitted)...

LowerCast for: N007 (  8,  7) [000070] ---XG--------             *  cast      double <- int

...(omitted)...

Generating: N203 (  1,  1) [000068] -------------       t68 =    lclVar    ref    V00 loc0          REG r3
IN0063:             ldr     r3, [sp+0x14]       // [V00 loc0]
                                                        GC regs: 0000 {} => 0008 {r3}
                                                              /--*  t68    ref
Generating: N205 (???,???) [000211] -------------      t211 = *  lea(b+20) byref  REG NA
                                                              /--*  t211   byref
Generating: N207 (  5,  3) [000069] ---XG--------       t69 = *  indir     short  REG r3
                                                        GC regs: 0008 {r3} => 0000 {}
IN0064:             ldrsh   r3, [r3+20]
                                                              /--*  t69    short
Generating: N209 (???,???) [000212] ---XG--------      t212 = *  cast      int <- int REG r3
                                                              /--*  t212   int
Generating: N211 (  8,  7) [000070] ---XG--------       t70 = *  cast      double <- int REG f8
IN0065:             vmov.i2f s8, r3    
IN0066:             vcvt.i2d d8, s8

...(omitted)...

IN0063: 000146      ldr     r3, [sp+0x14]       // [V00 loc0]
IN0064: 000148      ldrsh   r3, [r3+20]
IN0065: 00014C      vmov.i2f s8, r3
IN0066: 000150      vcvt.i2d d8, s8
```

## Legacy JIT
```
N006 (  5,  3) [000069] ---XG--------             *  indir     short
N007 (  8,  7) [000070] ---XG--------             *  cast      double <- int

...(omitted)...

IN0060:             ldr     r3, [sp+0x24]       // [V00 loc0]
                                                        GC regs: 0000 {} => 0008 {r3}
                                                        The register r3 currently holds [000068]/[000069]]
                                                        GC regs: 0008 {r3} => 0000 {}
                                                        The register r3 no longer holds [000068][000069]
IN0061:             ldrsh   r3, [r3+20]
IN0062:             vmov.i2f s15, r3
IN0063:             vcvt.i2d d14, s15
                                                        The register d14 currently holds [000070]
...(omitted)...

IN0060: 000140      ldr     r3, [sp+0x14]       // [V00 loc0]
IN0061: 000142      ldrsh   r3, [r3+20]
IN0062: 000146      vmov.i2f s15, r3
IN0063: 00014A      vcvt.i2d d14, s15
```

Same sequence of `vmov.i2f` and `vcvt.i2d` are generated for ryujit and legacy jit for casting from small int type to double.
