### PR TITLE
[RyuJIT/ARM32] Fix src register trashing in genFloatToIntCast

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -1856,9 +1856,11 @@ void CodeGen::genFloatToIntCast(GenTreePtr treeNode)
 
     genConsumeOperands(treeNode->AsOp());
 
+    regNumber tmpReg = treeNode->GetSingleTempReg();
+
     assert(insVcvt != INS_invalid);
-    getEmitter()->emitIns_R_R(insVcvt, dstSize, op1->gtRegNum, op1->gtRegNum);
-    getEmitter()->emitIns_R_R(INS_vmov_f2i, dstSize, treeNode->gtRegNum, op1->gtRegNum);
+    getEmitter()->emitIns_R_R(insVcvt, dstSize, tmpReg, op1->gtRegNum);
+    getEmitter()->emitIns_R_R(INS_vmov_f2i, dstSize, treeNode->gtRegNum, tmpReg);
 
     genProduceReg(treeNode);
 }

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -321,7 +321,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             }
 
             // FloatToIntCast needs a temporary register
-            if (varTypeIsFloating(castOpType))
+            if (varTypeIsFloating(castOpType) && varTypeIsIntOrI(tree))
             {
                 info->setInternalCandidates(m_lsra, RBM_ALLFLOAT);
                 info->internalFloatCount     = 1;

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -320,6 +320,14 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
                 info->srcCount = 2;
             }
 
+            // FloatToIntCast needs a temporary register
+            if (varTypeIsFloating(castOpType))
+            {
+                info->setInternalCandidates(m_lsra, RBM_ALLFLOAT);
+                info->internalFloatCount     = 1;
+                info->isInternalRegDelayFree = true;
+            }
+
             CastInfo castInfo;
 
             // Get information about the cast.


### PR DESCRIPTION
Fixes the issue described in #11603.

cc @dotnet/arm32-contrib 