### PR TITLE
[ARM32/Linux] Copy tests.zip only for CI test

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -2012,7 +2012,7 @@ combinedScenarios.each { scenario ->
 
                                     // Copy the Windows test binaries and the Corefx build binaries
                                     copyArtifacts(WindowTestsName) {
-                                        excludePatterns('**/testResults.xml', '**/*.ni.dll')
+                                        includePatterns('bin/tests/tests.zip')
                                         buildSelector {
                                             latestSuccessful(true)
                                         }


### PR DESCRIPTION
Copy tests.zip only from x64 Windows build for CI test
We can reduce saved build results of linux/arm in CI machine