### PR TITLE
Disable tail call stress in GH_10780 if ZapDisable is enabled.

### DIFF
--- a/tests/src/JIT/Regression/JitBlue/GitHub_10780/GitHub_10780.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_10780/GitHub_10780.csproj
@@ -35,13 +35,16 @@
     <Compile Include="GitHub_10780.cs" />
   </ItemGroup>
   <PropertyGroup>
+    <!-- NOTE: tailcall stress should be reenabled under zapdisable when #11408 is fixed -->
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)
-set COMPlus_TailcallStress=1
+if "%COMPlus_ZapDisable%"=="" set COMPlus_TailcallStress=1
 ]]></CLRTestBatchPreCommands>
   <BashCLRTestPreCommands><![CDATA[
 $(BashCLRTestPreCommands)
-export COMPlus_TailcallStress=1
+if [ -z $COMPlus_ZapDisable ] then
+    export COMPlus_TailcallStress=1
+fi
 ]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_10780/GitHub_10780.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_10780/GitHub_10780.csproj
@@ -42,7 +42,7 @@ if "%COMPlus_ZapDisable%"=="" set COMPlus_TailcallStress=1
 ]]></CLRTestBatchPreCommands>
   <BashCLRTestPreCommands><![CDATA[
 $(BashCLRTestPreCommands)
-if [ -z $COMPlus_ZapDisable ] then
+if [ -z $COMPlus_ZapDisable ]; then
     export COMPlus_TailcallStress=1
 fi
 ]]></BashCLRTestPreCommands>


### PR DESCRIPTION
Tail call stress does not mix well with ZapDisable due to the issues
described in #11408.

Fixes #11648.