### PR TITLE
Defer EventPipe Provider Deletion Until Tracing Stop

### DIFF
--- a/src/scripts/genEventPipe.py
+++ b/src/scripts/genEventPipe.py
@@ -122,7 +122,7 @@ def generateClrEventPipeWriteEventsImpl(
     WriteEventImpl.append(
         "    EventPipeProvider" +
         providerPrettyName +
-        " = new EventPipeProvider(" +
+        " = EventPipe::CreateProvider(" +
         providerPrettyName +
         "GUID);\n")
     for eventNode in eventNodes:

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -14,6 +14,7 @@ class EventPipeFile;
 class EventPipeJsonFile;
 class EventPipeBuffer;
 class EventPipeBufferManager;
+class EventPipeProvider;
 class MethodDesc;
 class SampleProfilerEventInstance;
 struct EventPipeProviderConfiguration;
@@ -178,6 +179,12 @@ class EventPipe
 
         // Specifies whether or not the event pipe is enabled.
         static bool Enabled();
+
+        // Create a provider.
+        static EventPipeProvider* CreateProvider(const GUID &providerID, EventPipeCallback pCallbackFunction = NULL, void *pCallbackData = NULL);
+
+        // Delete a provider.
+        static void DeleteProvider(EventPipeProvider *pProvider);
 
         // Write out an event.
         // Data is written as a serialized blob matching the ETW serialization conventions.

--- a/src/vm/eventpipeconfiguration.h
+++ b/src/vm/eventpipeconfiguration.h
@@ -71,6 +71,9 @@ public:
     // Get the event used to write metadata to the event stream.
     EventPipeEventInstance* BuildEventMetadataEvent(EventPipeEventInstance &sourceInstance);
 
+    // Delete deferred providers.
+    void DeleteDeferredProviders();
+
 private:
 
     // Get the provider without taking the lock.

--- a/src/vm/eventpipeprovider.cpp
+++ b/src/vm/eventpipeprovider.cpp
@@ -208,6 +208,18 @@ void EventPipeProvider::InvokeCallback()
     }
 }
 
+bool EventPipeProvider::GetDeleteDeferred() const
+{
+    LIMITED_METHOD_CONTRACT;
+    return m_deleteDeferred;
+}
+
+void EventPipeProvider::SetDeleteDeferred()
+{
+    LIMITED_METHOD_CONTRACT;
+    m_deleteDeferred = true;
+}
+
 void EventPipeProvider::RefreshAllEvents()
 {
     CONTRACTL

--- a/src/vm/eventpipeprovider.h
+++ b/src/vm/eventpipeprovider.h
@@ -26,6 +26,7 @@ typedef void (*EventPipeCallback)(
 class EventPipeProvider
 {
     // Declare friends.
+    friend class EventPipe;
     friend class EventPipeConfiguration;
     friend class SampleProfiler;
 
@@ -55,9 +56,15 @@ private:
     // The configuration object.
     EventPipeConfiguration *m_pConfig;
 
+    // True if the provider has been deleted, but that deletion
+    // has been deferred until tracing is stopped.
+    bool m_deleteDeferred;
+
+    // Private constructor because all providers are created through EventPipe::CreateProvider.
+    EventPipeProvider(const GUID &providerID, EventPipeCallback pCallbackFunction = NULL, void *pCallbackData = NULL);
+
 public:
 
-    EventPipeProvider(const GUID &providerID, EventPipeCallback pCallbackFunction = NULL, void *pCallbackData = NULL);
     ~EventPipeProvider();
 
     // Get the provider ID.
@@ -96,6 +103,13 @@ public:
 
     // Invoke the provider callback.
     void InvokeCallback();
+
+    // Specifies whether or not the provider was deleted, but that deletion
+    // was deferred until after tracing is stopped.
+    bool GetDeleteDeferred() const;
+
+    // Defer deletion of the provider.
+    void SetDeleteDeferred();
 };
 
 #endif // FEATURE_PERFTRACING

--- a/src/vm/sampleprofiler.cpp
+++ b/src/vm/sampleprofiler.cpp
@@ -34,7 +34,7 @@ void SampleProfiler::Enable()
 
     if(s_pEventPipeProvider == NULL)
     {
-        s_pEventPipeProvider = new EventPipeProvider(s_providerID);
+        s_pEventPipeProvider = EventPipe::CreateProvider(s_providerID);
         s_pThreadTimeEvent = s_pEventPipeProvider->AddEvent(
             0, /* eventID */
             0, /* keywords */


### PR DESCRIPTION
Fixes #11556.

When events are logged to the EventPipe, the EventPipeProvider and EventPipeEvent objects must remain in-memory until the events that reference them are flushed to disk.  Today, it's possible for EventSources to unload the EventPipeProvider and EventPipeEvent objects during tracing, which results in an AV when the trace is being flushed to disk.

This change defers deletion of these objects until after tracing has been stopped and the events have been flushed to disk.
