### PR TITLE
Disable opt-sensitive tests under tailcall stress and balance pushd.

### DIFF
--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -85,7 +85,7 @@ fi
 $(BashCLRTestEnvironmentCompatibilityCheck)
 if [ \( ! -z "$COMPlus_JitStress" \) -o \( ! -z "$COMPlus_JitStressRegs" \) -o \( ! -z "$COMPlus_JITMinOpts" \) -o \( ! -z "$COMPlus_TailcallStress" \) ]
 then
-  echo "SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts) IS SET"
+  echo "SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts, COMPlus_TailcallStress) IS SET"
   exit $(GCBashScriptExitCode)
 fi
       ]]></BashCLRTestEnvironmentCompatibilityCheck>

--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -83,7 +83,7 @@ fi
       ]]></BashCLRTestEnvironmentCompatibilityCheck>
       <BashCLRTestEnvironmentCompatibilityCheck Condition="'$(JitOptimizationSensitive)' == 'true'"><![CDATA[
 $(BashCLRTestEnvironmentCompatibilityCheck)
-if [ \( ! -z "$COMPlus_JitStress" \) -o \( ! -z "$COMPlus_JitStressRegs" \) -o \( ! -z "$COMPlus_JITMinOpts" \) ]
+if [ \( ! -z "$COMPlus_JitStress" \) -o \( ! -z "$COMPlus_JitStressRegs" \) -o \( ! -z "$COMPlus_JITMinOpts" \) -o \( ! -z "$COMPlus_TailcallStress" \) ]
 then
   echo "SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts) IS SET"
   exit $(GCBashScriptExitCode)

--- a/tests/src/CLRTest.Execute.Batch.targets
+++ b/tests/src/CLRTest.Execute.Batch.targets
@@ -79,7 +79,7 @@ IF NOT "%COMPlus_GCStress%"=="" (
       <BatchCLRTestEnvironmentCompatibilityCheck Condition="'$(JitOptimizationSensitive)' == 'true'"><![CDATA[
 $(BatchCLRTestEnvironmentCompatibilityCheck)
 IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_JITMinOpts%"=="" IF "%COMPlus_TailcallStress%"=="" goto :Compatible1
-  ECHO SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts) IS SET
+  ECHO SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts, COMPlus_TailcallStress) IS SET
   popd
   Exit /b 0
 :Compatible1

--- a/tests/src/CLRTest.Execute.Batch.targets
+++ b/tests/src/CLRTest.Execute.Batch.targets
@@ -72,13 +72,15 @@ WARNING:   When setting properties based on their current state (for example:
 $(BatchCLRTestEnvironmentCompatibilityCheck)
 IF NOT "%COMPlus_GCStress%"=="" (
   ECHO SKIPPING EXECUTION BECAUSE COMPlus_GCStress IS SET
+  popd
   Exit /b 0
 )
       ]]></BatchCLRTestEnvironmentCompatibilityCheck>
       <BatchCLRTestEnvironmentCompatibilityCheck Condition="'$(JitOptimizationSensitive)' == 'true'"><![CDATA[
 $(BatchCLRTestEnvironmentCompatibilityCheck)
-IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_JITMinOpts%"=="" goto :Compatible1
+IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_JITMinOpts%"=="" IF "%COMPlus_TailcallStress%"=="" goto :Compatible1
   ECHO SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts) IS SET
+  popd
   Exit /b 0
 :Compatible1
       ]]></BatchCLRTestEnvironmentCompatibilityCheck>
@@ -86,6 +88,7 @@ IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_JITMi
 $(BatchCLRTestEnvironmentCompatibilityCheck)
 IF NOT "%COMPlus_HeapVerify%"=="" (
   ECHO SKIPPING EXECUTION BECAUSE COMPlus_HeapVerify IS SET
+  popd
   Exit /b 0
 )
       ]]></BatchCLRTestEnvironmentCompatibilityCheck>
@@ -108,10 +111,12 @@ ECHO Actual: %CLRTestExitCode%
 IF NOT "%CLRTestExitCode%"=="%CLRTestExpectedExitCode%" (
   ECHO END EXECUTION - FAILED
   ECHO FAILED
+  popd
   Exit /b 1
 ) ELSE (
   ECHO END EXECUTION - PASSED
   ECHO PASSED
+  popd
   Exit /b 0
 )
 
@@ -121,11 +126,13 @@ IF NOT "!ERRORLEVEL!"=="0" (
 timeout /t 10 /nobreak
 goto :TakeLock
 )
+popd
 Exit /b 2
 
 
 :ReleaseLock
 if exist %lockFolder% rd /s /q %lockFolder%
+popd
 Exit /b 0
       ]]></BatchCLRTestExitCodeCheck>
     </PropertyGroup>
@@ -182,6 +189,7 @@ set Assemblies=-a System.Private.CoreLib
 IF defined DoLink ( 
     IF NOT EXIST !ILLINK! (
       ECHO ILLink executable [%ILLINK%] Invalid
+      popd
       Exit /b 1
     )
     
@@ -208,6 +216,7 @@ IF defined DoLink (
       IF NOT defined KeepLinkedBinaries (
           IF EXIST %LinkBin% rmdir /s /q %LinkBin%
       )
+      popd
       Exit /b 1
     )
 
@@ -333,6 +342,7 @@ ECHO                         - OPTIONS -
 @(BatchCLRTestExecutionScriptArgument -> 'ECHO -%(Identity) %(ParamName)
 ECHO      %(Description)', '
 ')
+popd
 Exit /b 1
 
 :ArgsDone


### PR DESCRIPTION
Just what it says on the tin.