### PR TITLE
Make Perf Tests by Comment only

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -140,6 +140,8 @@ def static getOSGroup(def os) {
                     if (isSmoketest)
                     {
                         builder.setGithubContext("${os} ${arch} CoreCLR Perf Tests Correctness")
+                        builder.triggerOnlyOnComment()
+                        builder.setCustomTriggerPhrase("(?i).*test\\W+${os}\\W+${arch}\\W+perf correctness.*")
                     }
                     else
                     {


### PR DESCRIPTION
@DrewScoggins is this the right way to disable these tests, for now? I'll re-enable them when I figure out the failures from by 2.0.0 BuildTools PR - should be tomorrow.

CC @gkhanna79 