### PR TITLE
Revert "Revert "Make Perf Tests by Comment only""

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -140,6 +140,8 @@ def static getOSGroup(def os) {
                     if (isSmoketest)
                     {
                         builder.setGithubContext("${os} ${arch} CoreCLR Perf Tests Correctness")
+                        builder.triggerOnlyOnComment()
+                        builder.setCustomTriggerPhrase("(?i).*test\\W+${os}\\W+${arch}\\W+perf correctness.*")
                     }
                     else
                     {


### PR DESCRIPTION
Reverts dotnet/coreclr#11675

@DrewScoggins this change did not disable Perf tests on PR's, as I expected it would - what else needs to be done?