### PR TITLE
[RyuJIT/ARM32] Clean up remaining GT_LONG NYIs

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -379,6 +379,11 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             genProduceReg(treeNode);
             break;
 
+        case GT_LONG:
+            assert(treeNode->isUsedFromReg());
+            genConsumeRegs(treeNode);
+            break;
+
 #endif // _TARGET_ARM_
 
         case GT_IL_OFFSET:


### PR DESCRIPTION
Removes the following NYIs:
```
    484 codegenarm.cpp:1295 - NYI: Long compare
     33 codegenarmarch.cpp:394 - NYI: Unimplemented node type gt_long
```

cc @dotnet/arm32-contrib 