### PR TITLE
Improve BitVecOps<>::Iter::NextElem

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -169,7 +169,7 @@ void Compiler::optAddCopies()
         bool isDominatedByFirstBB = false;
 
         BLOCKSET_ITER_INIT(this, iter, varDsc->lvRefBlks, blkNum);
-        while (iter.NextElem(this, &blkNum))
+        while (iter.NextElem(&blkNum))
         {
             /* Find the block 'blkNum' */
             BasicBlock* block = fgFirstBB;
@@ -322,7 +322,7 @@ void Compiler::optAddCopies()
             /* We have already calculated paramImportantUseDom above. */
 
             BLOCKSET_ITER_INIT(this, iter, paramImportantUseDom, blkNum);
-            while (iter.NextElem(this, &blkNum))
+            while (iter.NextElem(&blkNum))
             {
                 /* Advance block to point to 'blkNum' */
                 /* This assumes that the iterator returns block number is increasing lexical order. */
@@ -2853,7 +2853,7 @@ GenTreePtr Compiler::optAssertionProp_LclVar(ASSERT_VALARG_TP assertions, const 
 
     BitVecOps::Iter iter(apTraits, assertions);
     unsigned        index = 0;
-    while (iter.NextElem(apTraits, &index))
+    while (iter.NextElem(&index))
     {
         index++;
         if (index > optAssertionCount)
@@ -2973,7 +2973,7 @@ AssertionIndex Compiler::optGlobalAssertionIsEqualOrNotEqual(ASSERT_VALARG_TP as
     }
     BitVecOps::Iter iter(apTraits, assertions);
     unsigned        index = 0;
-    while (iter.NextElem(apTraits, &index))
+    while (iter.NextElem(&index))
     {
         index++;
         if (index > optAssertionCount)
@@ -3534,7 +3534,7 @@ AssertionIndex Compiler::optAssertionIsNonNullInternal(GenTreePtr op, ASSERT_VAL
         // Check each assertion to find if we have a vn == or != null assertion.
         BitVecOps::Iter iter(apTraits, assertions);
         unsigned        index = 0;
-        while (iter.NextElem(apTraits, &index))
+        while (iter.NextElem(&index))
         {
             index++;
             if (index > optAssertionCount)
@@ -3708,7 +3708,7 @@ GenTreePtr Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, const
 
     BitVecOps::Iter iter(apTraits, assertions);
     unsigned        index = 0;
-    while (iter.NextElem(apTraits, &index))
+    while (iter.NextElem(&index))
     {
         index++;
         if (index > optAssertionCount)
@@ -3961,7 +3961,7 @@ void Compiler::optImpliedAssertions(AssertionIndex assertionIndex, ASSERT_TP& ac
         // Check each assertion in chkAssertions to see if it can be applied to curAssertion
         BitVecOps::Iter chkIter(apTraits, chkAssertions);
         unsigned        chkIndex = 0;
-        while (chkIter.NextElem(apTraits, &chkIndex))
+        while (chkIter.NextElem(&chkIndex))
         {
             chkIndex++;
             if (chkIndex > optAssertionCount)
@@ -4010,7 +4010,7 @@ void Compiler::optImpliedByTypeOfAssertions(ASSERT_TP& activeAssertions)
     // Check each assertion in activeAssertions to see if it can be applied to constAssertion
     BitVecOps::Iter chkIter(apTraits, activeAssertions);
     unsigned        chkIndex = 0;
-    while (chkIter.NextElem(apTraits, &chkIndex))
+    while (chkIter.NextElem(&chkIndex))
     {
         chkIndex++;
         if (chkIndex > optAssertionCount)
@@ -4107,7 +4107,7 @@ void Compiler::optImpliedByConstAssertion(AssertionDsc* constAssertion, ASSERT_T
     // Check each assertion in chkAssertions to see if it can be applied to constAssertion
     BitVecOps::Iter chkIter(apTraits, chkAssertions);
     unsigned        chkIndex = 0;
-    while (chkIter.NextElem(apTraits, &chkIndex))
+    while (chkIter.NextElem(&chkIndex))
     {
         chkIndex++;
         if (chkIndex > optAssertionCount)

--- a/src/jit/bitset.cpp
+++ b/src/jit/bitset.cpp
@@ -39,7 +39,7 @@ void BitSetSupport::RunTests(Env env)
     typename LclBitSetOps::Iter bsi(env, bs1);
     unsigned                    bitNum = 0;
     unsigned                    k      = 0;
-    while (bsi.NextElem(env, &bitNum))
+    while (bsi.NextElem(&bitNum))
     {
         assert(bitNum == bs1bits[k]);
         k++;
@@ -64,7 +64,7 @@ void BitSetSupport::RunTests(Env env)
     k      = 0;
     bsi    = typename LclBitSetOps::Iter(env, bsU12);
     bitNum = 0;
-    while (bsi.NextElem(env, &bitNum))
+    while (bsi.NextElem(&bitNum))
     {
         assert(bitNum == unionBits[k]);
         k++;
@@ -74,7 +74,7 @@ void BitSetSupport::RunTests(Env env)
     k                                = 0;
     typename LclBitSetOps::Iter bsiL = typename LclBitSetOps::Iter(env, bsU12);
     bitNum                           = 0;
-    while (bsiL.NextElem(env, &bitNum))
+    while (bsiL.NextElem(&bitNum))
     {
         assert(bitNum == unionBits[k]);
         k++;
@@ -87,7 +87,7 @@ void BitSetSupport::RunTests(Env env)
     k      = 0;
     bsi    = typename LclBitSetOps::Iter(env, bsI12);
     bitNum = 0;
-    while (bsi.NextElem(env, &bitNum))
+    while (bsi.NextElem(&bitNum))
     {
         assert(bitNum == intersectionBits[k]);
         k++;

--- a/src/jit/bitset.h
+++ b/src/jit/bitset.h
@@ -436,15 +436,16 @@ public:
     class Iter
     {
         BaseIter m_iter;
+        Env      m_env;
 
     public:
-        Iter(Env env, BitSetValueArgType bs) : m_iter(env, bs)
+        Iter(Env env, BitSetValueArgType bs) : m_iter(env, bs), m_env(env)
         {
         }
 
         bool NextElem(unsigned* pElem)
         {
-            BitSetTraits::GetOpCounter(env)->RecordOp(BitSetSupport::BSOP_NextBit);
+            BitSetTraits::GetOpCounter(m_env)->RecordOp(BitSetSupport::BSOP_NextBit);
             return m_iter.NextElem(pElem);
         }
     };

--- a/src/jit/bitset.h
+++ b/src/jit/bitset.h
@@ -271,7 +271,7 @@ class BitSetOps
     class Iter {
       public:
         Iter(Env env, BitSetValueArgType bs) {}
-        bool NextElem(Env env, unsigned* pElem) { return false; }
+        bool NextElem(unsigned* pElem) { return false; }
     };
 
     typename ValArgType;
@@ -442,10 +442,10 @@ public:
         {
         }
 
-        bool NextElem(Env env, unsigned* pElem)
+        bool NextElem(unsigned* pElem)
         {
             BitSetTraits::GetOpCounter(env)->RecordOp(BitSetSupport::BSOP_NextBit);
-            return m_iter.NextElem(env, pElem);
+            return m_iter.NextElem(pElem);
         }
     };
 };

--- a/src/jit/bitsetasshortlong.h
+++ b/src/jit/bitsetasshortlong.h
@@ -491,7 +491,7 @@ public:
                 m_bits = bs[0];
 
                 unsigned len = BitSetTraits::GetArrSize(env, sizeof(size_t));
-                m_bsEnd = bs + len;
+                m_bsEnd      = bs + len;
             }
         }
 

--- a/src/jit/bitsetasshortlong.h
+++ b/src/jit/bitsetasshortlong.h
@@ -474,12 +474,12 @@ public:
         {
             if (BitSetOps::IsShort(env))
             {
-                m_bits  = (size_t)bs;
+                m_bits = (size_t)bs;
             }
             else
             {
                 assert(bs != BitSetOps::UninitVal());
-                m_bits  = bs[0];
+                m_bits = bs[0];
             }
         }
 
@@ -523,7 +523,7 @@ public:
                         }
                         // Otherwise...
                         m_bitNum += sizeof(size_t) * BitSetSupport::BitsInByte;
-                        m_bits   = m_bs[m_index];
+                        m_bits = m_bs[m_index];
                         continue;
                     }
                 }

--- a/src/jit/bitsetasshortlong.h
+++ b/src/jit/bitsetasshortlong.h
@@ -525,7 +525,9 @@ public:
                     // and exit.
                     ++m_bs;
                     if (m_bs == m_bsEnd)
+                    {
                         return false;
+                    }
 
                     // If we get here, it's not a short type, so get the next size_t element.
                     m_bitNum += sizeof(size_t) * BitSetSupport::BitsInByte;

--- a/src/jit/bitsetasshortlong.h
+++ b/src/jit/bitsetasshortlong.h
@@ -457,20 +457,29 @@ public:
 
     class Iter
     {
-        BitSetShortLongRep m_bs;   // The BitSet that we're iterating over.
-        size_t             m_bits; // The "current" bits remaining to be iterated over.
+        // The BitSet that we're iterating over.
+        BitSetShortLongRep m_bs;
+
+        // The "current" bits remaining to be iterated over.
         // In the "short" case, these are all the remaining bits.
         // In the "long" case, these are remaining bits in element "m_index";
         // these and the bits in the remaining elements comprise the remaining bits.
-        unsigned m_index; // If "m_bs" uses the long (indirect) representation, the current index in the array.
+        size_t m_bits;
+
+        // If "m_bs" uses the long (indirect) representation, the current index in the array.
         // the index of the element in A(bs) that is currently being iterated.
-        unsigned m_bitNum; // The number of bits that have already been iterated over (set or clear).  If you
+        unsigned m_index;
+
+        // The number of bits that have already been iterated over (set or clear).  If you
         // add this to the bit number of the next bit in "m_bits", you get the proper bit number of that
         // bit in "m_bs".
-        Env m_env;
+        unsigned m_bitNum;
+
+        // Cached array size, as returned by BitSetTraits::GetArrSize().
+        unsigned m_arraySize;
 
     public:
-        Iter(Env env, const BitSetShortLongRep& bs) : m_env(env), m_bs(bs), m_bitNum(0), m_index(0)
+        Iter(Env env, const BitSetShortLongRep& bs) : m_bs(bs), m_index(0), m_bitNum(0)
         {
             if (BitSetOps::IsShort(env))
             {
@@ -481,6 +490,8 @@ public:
                 assert(bs != BitSetOps::UninitVal());
                 m_bits = bs[0];
             }
+
+            m_arraySize = BitSetTraits::GetArrSize(env, sizeof(size_t));
         }
 
         bool NextElem(unsigned* pElem)
@@ -509,15 +520,14 @@ public:
                 }
                 else
                 {
-                    unsigned len = BitSetTraits::GetArrSize(m_env, sizeof(size_t));
-                    if (len <= 1)
+                    if (m_arraySize <= 1)
                     {
                         return false;
                     }
                     else
                     {
                         m_index++;
-                        if (m_index == len)
+                        if (m_index == m_arraySize)
                         {
                             return false;
                         }

--- a/src/jit/bitsetasuint64.h
+++ b/src/jit/bitsetasuint64.h
@@ -208,26 +208,28 @@ public:
     {
         UINT64 m_bits;
 
+        // The number of bits that have already been iterated over (set or clear).
+        unsigned m_bitNum;
+
     public:
-        Iter(Env env, const UINT64& bits) : m_bits(bits)
+        Iter(Env env, const UINT64& bits) : m_bits(bits), m_bitNum(0)
         {
         }
 
         bool NextElem(unsigned* pElem)
         {
             // TODO-Throughtput: use BitScanForward64() intrinsic (see short/long implementation).
-            // REVIEW-Bug: This assumes *pElem comes in as the last bit numbered returned, or zero to start.
-            // This doesn't seem right; the current position should be carried with the iterator.
             if (m_bits)
             {
-                unsigned bitNum = *pElem;
+                unsigned bitNum = m_bitNum;
                 while ((m_bits & 0x1) == 0)
                 {
                     bitNum++;
                     m_bits >>= 1;
                 }
                 *pElem = bitNum;
-                m_bits &= ~0x1;
+                m_bitNum = bitNum + 1;
+                m_bits >>= 1;
                 return true;
             }
             else

--- a/src/jit/bitsetasuint64.h
+++ b/src/jit/bitsetasuint64.h
@@ -227,7 +227,7 @@ public:
                     bitNum++;
                     m_bits >>= 1;
                 }
-                *pElem = bitNum;
+                *pElem   = bitNum;
                 m_bitNum = bitNum + 1;
                 m_bits >>= 1;
                 return true;

--- a/src/jit/bitsetasuint64.h
+++ b/src/jit/bitsetasuint64.h
@@ -213,8 +213,11 @@ public:
         {
         }
 
-        bool NextElem(Env env, unsigned* pElem)
+        bool NextElem(unsigned* pElem)
         {
+            // TODO-Throughtput: use BitScanForward64() intrinsic (see short/long implementation).
+            // REVIEW-Bug: This assumes *pElem comes in as the last bit numbered returned, or zero to start.
+            // This doesn't seem right; the current position should be carried with the iterator.
             if (m_bits)
             {
                 unsigned bitNum = *pElem;

--- a/src/jit/bitsetasuint64inclass.h
+++ b/src/jit/bitsetasuint64inclass.h
@@ -295,7 +295,7 @@ public:
     {
     }
 
-    bool NextElem(Env env, unsigned* pElem)
+    bool NextElem(unsigned* pElem)
     {
         static const unsigned UINT64_SIZE = 64;
 

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -1100,7 +1100,7 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife DEBUGARG(GenTreePtr tree)
     // This is because, in the RyuJIT backend case, they may occupy registers that
     // will be occupied by another var that is newly live.
     VARSET_ITER_INIT(this, deadIter, deadSet, deadVarIndex);
-    while (deadIter.NextElem(this, &deadVarIndex))
+    while (deadIter.NextElem(&deadVarIndex))
     {
         unsigned varNum = lvaTrackedToVarNum[deadVarIndex];
         varDsc          = lvaTable + varNum;
@@ -1135,7 +1135,7 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife DEBUGARG(GenTreePtr tree)
     }
 
     VARSET_ITER_INIT(this, bornIter, bornSet, bornVarIndex);
-    while (bornIter.NextElem(this, &bornVarIndex))
+    while (bornIter.NextElem(&bornVarIndex))
     {
         unsigned varNum = lvaTrackedToVarNum[bornVarIndex];
         varDsc          = lvaTable + varNum;
@@ -1305,7 +1305,7 @@ regMaskTP CodeGenInterface::genLiveMask(VARSET_VALARG_TP liveSet)
     regMaskTP liveMask = 0;
 
     VARSET_ITER_INIT(compiler, iter, liveSet, varIndex);
-    while (iter.NextElem(compiler, &varIndex))
+    while (iter.NextElem(&varIndex))
     {
 
         // If the variable is not enregistered, then it can't contribute to the liveMask

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -53,7 +53,7 @@ void CodeGen::genDyingVars(VARSET_VALARG_TP beforeSet, VARSET_VALARG_TP afterSet
     /* iterate through the dead variables */
 
     VARSET_ITER_INIT(compiler, iter, deadSet, varIndex);
-    while (iter.NextElem(compiler, &varIndex))
+    while (iter.NextElem(&varIndex))
     {
         varNum = compiler->lvaTrackedToVarNum[varIndex];
         varDsc = compiler->lvaTable + varNum;
@@ -5654,7 +5654,7 @@ void CodeGen::genCodeForQmark(GenTreePtr tree, regMaskTP destReg, regMaskTP best
                                          VarSetOps::Intersection(compiler, compiler->raRegVarsMask, rsLiveNow));
 
             VARSET_ITER_INIT(compiler, iter, regVarLiveNow, varIndex);
-            while (iter.NextElem(compiler, &varIndex))
+            while (iter.NextElem(&varIndex))
             {
                 // Find the variable in compiler->lvaTable
                 unsigned   varNum = compiler->lvaTrackedToVarNum[varIndex];
@@ -12602,7 +12602,7 @@ void CodeGen::genCodeForBBlist()
         noway_assert((specialUseMask & regSet.rsMaskVars) == 0);
 
         VARSET_ITER_INIT(compiler, iter, liveSet, varIndex);
-        while (iter.NextElem(compiler, &varIndex))
+        while (iter.NextElem(&varIndex))
         {
             varNum = compiler->lvaTrackedToVarNum[varIndex];
             varDsc = compiler->lvaTable + varNum;
@@ -15272,7 +15272,7 @@ unsigned CodeGen::genRegCountForLiveIntEnregVars(GenTreePtr tree)
     unsigned regCount = 0;
 
     VARSET_ITER_INIT(compiler, iter, compiler->compCurLife, varNum);
-    while (iter.NextElem(compiler, &varNum))
+    while (iter.NextElem(&varNum))
     {
         unsigned   lclNum = compiler->lvaTrackedToVarNum[varNum];
         LclVarDsc* varDsc = &compiler->lvaTable[lclNum];

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -168,7 +168,7 @@ void CodeGen::genCodeForBBlist()
         VARSET_TP VARSET_INIT_NOCOPY(addedGCVars, VarSetOps::MakeEmpty(compiler));
 #endif
         VARSET_ITER_INIT(compiler, iter, block->bbLiveIn, varIndex);
-        while (iter.NextElem(compiler, &varIndex))
+        while (iter.NextElem(&varIndex))
         {
             unsigned   varNum = compiler->lvaTrackedToVarNum[varIndex];
             LclVarDsc* varDsc = &(compiler->lvaTable[varNum]);
@@ -500,7 +500,7 @@ void CodeGen::genCodeForBBlist()
         VARSET_TP VARSET_INIT_NOCOPY(extraLiveVars, VarSetOps::Diff(compiler, block->bbLiveOut, compiler->compCurLife));
         VarSetOps::UnionD(compiler, extraLiveVars, VarSetOps::Diff(compiler, compiler->compCurLife, block->bbLiveOut));
         VARSET_ITER_INIT(compiler, extraLiveVarIter, extraLiveVars, extraLiveVarIndex);
-        while (extraLiveVarIter.NextElem(compiler, &extraLiveVarIndex))
+        while (extraLiveVarIter.NextElem(&extraLiveVarIndex))
         {
             unsigned   varNum = compiler->lvaTrackedToVarNum[extraLiveVarIndex];
             LclVarDsc* varDsc = compiler->lvaTable + varNum;

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -8287,7 +8287,7 @@ void dumpConvertedVarSet(Compiler* comp, VARSET_VALARG_TP vars)
     memset(pVarNumSet, 0, varNumSetBytes); // empty the set
 
     VARSET_ITER_INIT(comp, iter, vars, varIndex);
-    while (iter.NextElem(comp, &varIndex))
+    while (iter.NextElem(&varIndex))
     {
         unsigned varNum = comp->lvaTrackedToVarNum[varIndex];
         assert(varNum < comp->lvaCount);

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -1936,7 +1936,7 @@ void Compiler::fgComputeEnterBlocksSet()
     {
         printf("Enter blocks: ");
         BLOCKSET_ITER_INIT(this, iter, fgEnterBlks, bbNum);
-        while (iter.NextElem(this, &bbNum))
+        while (iter.NextElem(&bbNum))
         {
             printf("BB%02u ", bbNum);
         }
@@ -2286,7 +2286,7 @@ BlockSet_ValRet_T Compiler::fgDomFindStartNodes()
     {
         printf("\nDominator computation start blocks (those blocks with no incoming edges):\n");
         BLOCKSET_ITER_INIT(this, iter, startNodes, bbNum);
-        while (iter.NextElem(this, &bbNum))
+        while (iter.NextElem(&bbNum))
         {
             printf("BB%02u ", bbNum);
         }
@@ -19594,7 +19594,7 @@ void Compiler::fgDispReach()
     {
         printf("BB%02u : ", block->bbNum);
         BLOCKSET_ITER_INIT(this, iter, block->bbReach, bbNum);
-        while (iter.NextElem(this, &bbNum))
+        while (iter.NextElem(&bbNum))
         {
             printf("BB%02u ", bbNum);
         }

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -986,7 +986,7 @@ void Compiler::fgExtendDbgLifetimes()
         unsigned blockWeight = block->getBBWeight(this);
 
         VARSET_ITER_INIT(this, iter, initVars, varIndex);
-        while (iter.NextElem(this, &varIndex))
+        while (iter.NextElem(&varIndex))
         {
             /* Create initialization tree */
 
@@ -1359,7 +1359,7 @@ bool Compiler::fgMarkIntf(VARSET_VALARG_TP varSet1, VARSET_VALARG_TP varSet2)
     VarSetOps::UnionD(this, fgMarkIntfUnionVS, varSet2);
 
     VARSET_ITER_INIT(this, iter, fgMarkIntfUnionVS, refIndex);
-    while (iter.NextElem(this, &refIndex))
+    while (iter.NextElem(&refIndex))
     {
         // if varSet1 has this bit set then it interferes with varSet2
         if (VarSetOps::IsMember(this, varSet1, refIndex))
@@ -1412,7 +1412,7 @@ bool Compiler::fgMarkIntf(VARSET_VALARG_TP varSet)
     bool addedIntf = false; // This is set to true if we add any new interferences
 
     VARSET_ITER_INIT(this, iter, varSet, refIndex);
-    while (iter.NextElem(this, &refIndex))
+    while (iter.NextElem(&refIndex))
     {
         // Calculate the set of new interference to add
         VARSET_TP VARSET_INIT_NOCOPY(newIntf, VarSetOps::Diff(this, varSet, lvaVarIntf[refIndex]));

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -1806,7 +1806,7 @@ void LinearScan::recordVarLocationsAtStartOfBB(BasicBlock* bb)
     unsigned    count = 0;
 
     VARSET_ITER_INIT(compiler, iter, bb->bbLiveIn, varIndex);
-    while (iter.NextElem(compiler, &varIndex))
+    while (iter.NextElem(&varIndex))
     {
         unsigned   varNum = compiler->lvaTrackedToVarNum[varIndex];
         LclVarDsc* varDsc = &(compiler->lvaTable[varNum]);
@@ -1899,7 +1899,7 @@ void LinearScan::identifyCandidatesExceptionDataflow()
         'explicitly initialized' (volatile and must-init) for GC-ref types */
 
     VARSET_ITER_INIT(compiler, iter, exceptVars, varIndex);
-    while (iter.NextElem(compiler, &varIndex))
+    while (iter.NextElem(&varIndex))
     {
         unsigned   varNum = compiler->lvaTrackedToVarNum[varIndex];
         LclVarDsc* varDsc = compiler->lvaTable + varNum;
@@ -2616,7 +2616,7 @@ void LinearScan::checkLastUses(BasicBlock* block)
 
     {
         VARSET_ITER_INIT(compiler, iter, temp, varIndex);
-        while (iter.NextElem(compiler, &varIndex))
+        while (iter.NextElem(&varIndex))
         {
             unsigned varNum = compiler->lvaTrackedToVarNum[varIndex];
             if (compiler->lvaTable[varNum].lvLRACandidate)
@@ -2629,7 +2629,7 @@ void LinearScan::checkLastUses(BasicBlock* block)
 
     {
         VARSET_ITER_INIT(compiler, iter, temp2, varIndex);
-        while (iter.NextElem(compiler, &varIndex))
+        while (iter.NextElem(&varIndex))
         {
             unsigned varNum = compiler->lvaTrackedToVarNum[varIndex];
             if (compiler->lvaTable[varNum].lvLRACandidate)
@@ -2888,7 +2888,7 @@ bool LinearScan::buildKillPositionsForNode(GenTree* tree, LsraLocation currentLo
         {
 
             VARSET_ITER_INIT(compiler, iter, currentLiveVars, varIndex);
-            while (iter.NextElem(compiler, &varIndex))
+            while (iter.NextElem(&varIndex))
             {
                 unsigned   varNum = compiler->lvaTrackedToVarNum[varIndex];
                 LclVarDsc* varDsc = compiler->lvaTable + varNum;
@@ -3331,7 +3331,7 @@ LinearScan::buildUpperVectorSaveRefPositions(GenTree* tree, LsraLocation current
             VarSetOps::AssignNoCopy(compiler, liveLargeVectors,
                                     VarSetOps::Intersection(compiler, currentLiveVars, largeVectorVars));
             VARSET_ITER_INIT(compiler, iter, liveLargeVectors, varIndex);
-            while (iter.NextElem(compiler, &varIndex))
+            while (iter.NextElem(&varIndex))
             {
                 unsigned  varNum         = compiler->lvaTrackedToVarNum[varIndex];
                 Interval* varInterval    = getIntervalForLocalVar(varNum);
@@ -3358,7 +3358,7 @@ void LinearScan::buildUpperVectorRestoreRefPositions(GenTree*         tree,
     if (!VarSetOps::IsEmpty(compiler, liveLargeVectors))
     {
         VARSET_ITER_INIT(compiler, iter, liveLargeVectors, varIndex);
-        while (iter.NextElem(compiler, &varIndex))
+        while (iter.NextElem(&varIndex))
         {
             unsigned  varNum       = compiler->lvaTrackedToVarNum[varIndex];
             Interval* varInterval  = getIntervalForLocalVar(varNum);
@@ -4179,7 +4179,7 @@ void LinearScan::insertZeroInitRefPositions()
     // insert defs for this, then a block boundary
 
     VARSET_ITER_INIT(compiler, iter, compiler->fgFirstBB->bbLiveIn, varIndex);
-    while (iter.NextElem(compiler, &varIndex))
+    while (iter.NextElem(&varIndex))
     {
         unsigned   varNum = compiler->lvaTrackedToVarNum[varIndex];
         LclVarDsc* varDsc = compiler->lvaTable + varNum;
@@ -4637,7 +4637,7 @@ void LinearScan::buildIntervals()
 
             JITDUMP("Creating dummy definitions\n");
             VARSET_ITER_INIT(compiler, iter, newLiveIn, varIndex);
-            while (iter.NextElem(compiler, &varIndex))
+            while (iter.NextElem(&varIndex))
             {
                 unsigned   varNum = compiler->lvaTrackedToVarNum[varIndex];
                 LclVarDsc* varDsc = compiler->lvaTable + varNum;
@@ -4729,7 +4729,7 @@ void LinearScan::buildIntervals()
         {
             JITDUMP("Exposed uses:");
             VARSET_ITER_INIT(compiler, iter, expUseSet, varIndex);
-            while (iter.NextElem(compiler, &varIndex))
+            while (iter.NextElem(&varIndex))
             {
                 unsigned   varNum = compiler->lvaTrackedToVarNum[varIndex];
                 LclVarDsc* varDsc = compiler->lvaTable + varNum;
@@ -4747,7 +4747,7 @@ void LinearScan::buildIntervals()
         // Clear the "last use" flag on any vars that are live-out from this block.
         {
             VARSET_ITER_INIT(compiler, iter, block->bbLiveOut, varIndex);
-            while (iter.NextElem(compiler, &varIndex))
+            while (iter.NextElem(&varIndex))
             {
                 unsigned         varNum = compiler->lvaTrackedToVarNum[varIndex];
                 LclVarDsc* const varDsc = &compiler->lvaTable[varNum];
@@ -6552,7 +6552,7 @@ void LinearScan::processBlockStartLocations(BasicBlock* currentBlock, bool alloc
 #endif // DEBUG
     regMaskTP liveRegs = RBM_NONE;
     VARSET_ITER_INIT(compiler, iter, liveIn, varIndex);
-    while (iter.NextElem(compiler, &varIndex))
+    while (iter.NextElem(&varIndex))
     {
         unsigned varNum = compiler->lvaTrackedToVarNum[varIndex];
         if (!compiler->lvaTable[varNum].lvLRACandidate)
@@ -6766,7 +6766,7 @@ void LinearScan::processBlockEndLocations(BasicBlock* currentBlock)
 #endif // DEBUG
     regMaskTP liveRegs = RBM_NONE;
     VARSET_ITER_INIT(compiler, iter, liveOut, varIndex);
-    while (iter.NextElem(compiler, &varIndex))
+    while (iter.NextElem(&varIndex))
     {
         unsigned  varNum   = compiler->lvaTrackedToVarNum[varIndex];
         Interval* interval = getIntervalForLocalVar(varNum);
@@ -9066,7 +9066,7 @@ regNumber LinearScan::getTempRegForResolution(BasicBlock* fromBlock, BasicBlock*
 
     // We are only interested in the variables that are live-in to the "to" block.
     VARSET_ITER_INIT(compiler, iter, toBlock->bbLiveIn, varIndex);
-    while (iter.NextElem(compiler, &varIndex) && freeRegs != RBM_NONE)
+    while (iter.NextElem(&varIndex) && freeRegs != RBM_NONE)
     {
         regNumber fromReg = fromVarToRegMap[varIndex];
         regNumber toReg   = toVarToRegMap[varIndex];
@@ -9184,7 +9184,7 @@ void LinearScan::handleOutgoingCriticalEdges(BasicBlock* block)
     // even the registers that remain the same across the edge are preserved correctly.
     regMaskTP liveOutRegs = RBM_NONE;
     VARSET_ITER_INIT(compiler, iter1, block->bbLiveOut, varIndex1);
-    while (iter1.NextElem(compiler, &varIndex1))
+    while (iter1.NextElem(&varIndex1))
     {
         unsigned  varNum  = compiler->lvaTrackedToVarNum[varIndex1];
         regNumber fromReg = getVarReg(outVarToRegMap, varNum);
@@ -9227,7 +9227,7 @@ void LinearScan::handleOutgoingCriticalEdges(BasicBlock* block)
     //     sameResolutionSet
 
     VARSET_ITER_INIT(compiler, iter, outResolutionSet, varIndex);
-    while (iter.NextElem(compiler, &varIndex))
+    while (iter.NextElem(&varIndex))
     {
         unsigned  varNum              = compiler->lvaTrackedToVarNum[varIndex];
         regNumber fromReg             = getVarReg(outVarToRegMap, varNum);
@@ -9355,7 +9355,7 @@ void LinearScan::handleOutgoingCriticalEdges(BasicBlock* block)
             VARSET_TP   VARSET_INIT_NOCOPY(edgeResolutionSet,
                                          VarSetOps::Intersection(compiler, diffResolutionSet, succBlock->bbLiveIn));
             VARSET_ITER_INIT(compiler, iter, edgeResolutionSet, varIndex);
-            while (iter.NextElem(compiler, &varIndex))
+            while (iter.NextElem(&varIndex))
             {
                 unsigned  varNum   = compiler->lvaTrackedToVarNum[varIndex];
                 Interval* interval = getIntervalForLocalVar(varNum);
@@ -9560,7 +9560,7 @@ void LinearScan::resolveEdges()
             BasicBlock* predBlock       = pred->flBlock;
             VarToRegMap fromVarToRegMap = getOutVarToRegMap(predBlock->bbNum);
             VARSET_ITER_INIT(compiler, iter, block->bbLiveIn, varIndex);
-            while (iter.NextElem(compiler, &varIndex))
+            while (iter.NextElem(&varIndex))
             {
                 unsigned  varNum  = compiler->lvaTrackedToVarNum[varIndex];
                 regNumber fromReg = getVarReg(fromVarToRegMap, varNum);
@@ -9716,7 +9716,7 @@ void LinearScan::resolveEdge(BasicBlock*      fromBlock,
     // that will scale better than the live variables
 
     VARSET_ITER_INIT(compiler, iter, liveSet, varIndex);
-    while (iter.NextElem(compiler, &varIndex))
+    while (iter.NextElem(&varIndex))
     {
         unsigned  varNum    = compiler->lvaTrackedToVarNum[varIndex];
         bool      isSpilled = false;
@@ -11795,7 +11795,7 @@ void LinearScan::verifyFinalAllocation()
                     // Validate the locations at the end of the previous block.
                     VarToRegMap outVarToRegMap = outVarToRegMaps[currentBlock->bbNum];
                     VARSET_ITER_INIT(compiler, iter, currentBlock->bbLiveOut, varIndex);
-                    while (iter.NextElem(compiler, &varIndex))
+                    while (iter.NextElem(&varIndex))
                     {
                         unsigned  varNum = compiler->lvaTrackedToVarNum[varIndex];
                         regNumber regNum = getVarReg(outVarToRegMap, varNum);
@@ -11821,7 +11821,7 @@ void LinearScan::verifyFinalAllocation()
                 {
                     VarToRegMap inVarToRegMap = inVarToRegMaps[currentBlock->bbNum];
                     VARSET_ITER_INIT(compiler, iter, currentBlock->bbLiveIn, varIndex);
-                    while (iter.NextElem(compiler, &varIndex))
+                    while (iter.NextElem(&varIndex))
                     {
                         unsigned  varNum                  = compiler->lvaTrackedToVarNum[varIndex];
                         regNumber regNum                  = getVarReg(inVarToRegMap, varNum);
@@ -12063,7 +12063,7 @@ void LinearScan::verifyFinalAllocation()
             // Set the incoming register assignments
             VarToRegMap inVarToRegMap = getInVarToRegMap(currentBlock->bbNum);
             VARSET_ITER_INIT(compiler, iter, currentBlock->bbLiveIn, varIndex);
-            while (iter.NextElem(compiler, &varIndex))
+            while (iter.NextElem(&varIndex))
             {
                 unsigned  varNum                  = compiler->lvaTrackedToVarNum[varIndex];
                 regNumber regNum                  = getVarReg(inVarToRegMap, varNum);
@@ -12091,7 +12091,7 @@ void LinearScan::verifyFinalAllocation()
             {
                 VarToRegMap outVarToRegMap = getOutVarToRegMap(currentBlock->bbNum);
                 VARSET_ITER_INIT(compiler, iter, currentBlock->bbLiveOut, varIndex);
-                while (iter.NextElem(compiler, &varIndex))
+                while (iter.NextElem(&varIndex))
                 {
                     unsigned  varNum   = compiler->lvaTrackedToVarNum[varIndex];
                     regNumber regNum   = getVarReg(outVarToRegMap, varNum);

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -502,7 +502,7 @@ void RangeCheck::MergeEdgeAssertions(GenTreePtr tree, const ASSERT_VALARG_TP ass
     // Walk through the "assertions" to check if the apply.
     BitVecOps::Iter iter(m_pCompiler->apTraits, assertions);
     unsigned        index = 0;
-    while (iter.NextElem(m_pCompiler->apTraits, &index))
+    while (iter.NextElem(&index))
     {
         index++;
 

--- a/src/jit/regalloc.cpp
+++ b/src/jit/regalloc.cpp
@@ -986,7 +986,7 @@ bool Compiler::rpRecordRegIntf(regMaskTP regMask, VARSET_VALARG_TP life DEBUGARG
                     if (verbose)
                     {
                         VARSET_ITER_INIT(this, newIntfIter, newIntf, varNum);
-                        while (newIntfIter.NextElem(this, &varNum))
+                        while (newIntfIter.NextElem(&varNum))
                         {
                             unsigned   lclNum = lvaTrackedToVarNum[varNum];
                             LclVarDsc* varDsc = &lvaTable[varNum];
@@ -1337,7 +1337,7 @@ RET:
 
         VARSET_TP VARSET_INIT_NOCOPY(varAsSet, VarSetOps::MakeEmpty(this));
         VARSET_ITER_INIT(this, iter, useUnion, varNum);
-        while (iter.NextElem(this, &varNum))
+        while (iter.NextElem(&varNum))
         {
             // We'll need this for one of the calls...
             VarSetOps::OldStyleClearD(this, varAsSet);
@@ -5656,7 +5656,7 @@ regMaskTP Compiler::rpPredictAssignRegVars(regMaskTP regAvail)
                 VARSET_TP VARSET_INIT_NOCOPY(pscVarSet, VarSetOps::Diff(this, unprocessedVars, lvaVarIntf[varIndex]));
 
                 VARSET_ITER_INIT(this, pscIndexIter, pscVarSet, pscIndex);
-                while (pscIndexIter.NextElem(this, &pscIndex))
+                while (pscIndexIter.NextElem(&pscIndex))
                 {
                     LclVarDsc* pscVar = lvaTable + lvaTrackedToVarNum[pscIndex];
                     totalRefCntWtd += pscVar->lvRefCntWtd;
@@ -5739,7 +5739,7 @@ regMaskTP Compiler::rpPredictAssignRegVars(regMaskTP regAvail)
             {
                 regNumber secondHalf = REG_NEXT(regNum);
                 VARSET_ITER_INIT(this, iter, lvaVarIntf[varIndex], intfIndex);
-                while (iter.NextElem(this, &intfIndex))
+                while (iter.NextElem(&intfIndex))
                 {
                     VarSetOps::AddElemD(this, raLclRegIntf[secondHalf], intfIndex);
                 }

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -459,7 +459,7 @@ void CodeGen::siBeginBlock(BasicBlock* block)
         // Check that vars which are live on entry have an open scope
 
         VARSET_ITER_INIT(compiler, iter, block->bbLiveIn, i);
-        while (iter.NextElem(compiler, &i))
+        while (iter.NextElem(&i))
         {
             unsigned varNum = compiler->lvaTrackedToVarNum[i];
             // lvRefCnt may go down to 0 after liveness-analysis.
@@ -660,7 +660,7 @@ void CodeGen::siUpdate()
     assert(VarSetOps::IsSubset(compiler, killed, compiler->lvaTrackedVars));
 
     VARSET_ITER_INIT(compiler, iter, killed, i);
-    while (iter.NextElem(compiler, &i))
+    while (iter.NextElem(&i))
     {
 #ifdef DEBUG
         unsigned   lclNum = compiler->lvaTrackedToVarNum[i];

--- a/src/jit/ssabuilder.cpp
+++ b/src/jit/ssabuilder.cpp
@@ -761,7 +761,7 @@ void SsaBuilder::InsertPhiFunctions(BasicBlock** postOrder, int count)
 
         // For each local var number "lclNum" that "block" assigns to...
         VARSET_ITER_INIT(m_pCompiler, defVars, block->bbVarDef, varIndex);
-        while (defVars.NextElem(m_pCompiler, &varIndex))
+        while (defVars.NextElem(&varIndex))
         {
             unsigned lclNum = m_pCompiler->lvaTrackedToVarNum[varIndex];
             DBG_SSA_JITDUMP("  Considering local var V%02u:\n", lclNum);


### PR DESCRIPTION
Tweak the implementation, to reduce the number of instructions
executed in the hot path.

Also, don't pass "env" to NextElem; it can be stored by Init()
if required. For non-inlined calls, this saves setting up one
argument.

Overall, this reduces instruction count of superpmi over
a minopts test run of x86 release by 2.6% (NextElem is very hot).