### PR TITLE
LSRA throughput tweaks

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -2049,11 +2049,12 @@ void LinearScan::identifyCandidates()
 
         if (varDsc->lvTracked)
         {
-            // Create an interval for all tracked variables, even if the tracked variable is not
-            // a register candidate. This is probably just done for consistency (e.g., code that
-            // simply walks over all tracked variables don't need to check if they are register
-            // candidates, or if the interval exists). It might be possible to only allocate
-            // intervals for register candidate tracked variables.
+            // Create an interval for all tracked variables, even if the tracked variable
+            // is not a register candidate. This is probably just done for consistency
+            // (e.g., code that simply walks over all tracked variables don't need to check if
+            // they are register candidates, or if the interval exists). It might be possible to
+            // only allocate intervals for register candidate tracked variables, if all the code
+            // that depends on every tracked variable having a non-null Interval was fixed.
 
             newInt = newInterval((var_types)varDsc->lvType);
             newInt->setLocalNumber(compiler, lclNum, this);
@@ -3718,8 +3719,7 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
 
             if ((tree->gtFlags & GTF_VAR_DEATH) == 0)
             {
-                VarSetOps::AddElemD(compiler, currentLiveVars,
-                                    compiler->lvaTable[tree->gtLclVarCommon.gtLclNum].lvVarIndex);
+                VarSetOps::AddElemD(compiler, currentLiveVars, varIndex);
             }
         }
     }
@@ -12189,7 +12189,7 @@ void LinearScan::verifyResolutionMove(GenTree* resolutionMove, LsraLocation curr
         }
     }
 
-    Interval* interval = getIntervalForLocalVar(compiler->lvaTable[lcl->gtLclNum].lvVarIndex);
+    Interval* interval = getIntervalForLocalVarNode(lcl);
     assert(interval->physReg == srcRegNum || (srcRegNum == REG_STK && interval->physReg == REG_NA));
     if (srcRegNum != REG_STK)
     {

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3663,9 +3663,9 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
             LclVarDsc* varDsc = &compiler->lvaTable[tree->gtLclVarCommon.gtLclNum];
             assert(varDsc->lvTracked);
             unsigned varIndex = varDsc->lvVarIndex;
-            varDefInterval = getIntervalForLocalVar(varIndex);
-            defRefType     = refTypeForLocalRefNode(tree);
-            defNode        = tree;
+            varDefInterval    = getIntervalForLocalVar(varIndex);
+            defRefType        = refTypeForLocalRefNode(tree);
+            defNode           = tree;
             if (produce == 0)
             {
                 produce = 1;
@@ -9757,7 +9757,7 @@ void LinearScan::resolveEdge(BasicBlock*      fromBlock,
 
         assert(fromReg < UCHAR_MAX && toReg < UCHAR_MAX);
 
-        Interval* interval  = getIntervalForLocalVar(varIndex);
+        Interval* interval = getIntervalForLocalVar(varIndex);
 
         if (fromReg == REG_STK)
         {

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -845,9 +845,10 @@ public:
 private:
     Interval* newInterval(RegisterType regType);
 
-    Interval* getIntervalForLocalVar(unsigned varNum)
+    Interval* getIntervalForLocalVar(unsigned varIndex)
     {
-        return localVarIntervals[varNum];
+        assert(varIndex < compiler->lvaTrackedCount);
+        return localVarIntervals[varIndex];
     }
     RegRecord* getRegisterRecord(regNumber regNum);
 
@@ -1096,6 +1097,7 @@ private:
 
     RegRecord physRegs[REG_COUNT];
 
+    // Map from tracked variable index to Interval*.
     Interval** localVarIntervals;
 
     // Set of blocks that have been visited.
@@ -1238,7 +1240,7 @@ public:
     void microDump();
 #endif // DEBUG
 
-    void setLocalNumber(unsigned localNum, LinearScan* l);
+    void setLocalNumber(Compiler* compiler, unsigned lclNum, LinearScan* l);
 
     // Fixed registers for which this Interval has a preference
     regMaskTP registerPreferences;

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -850,6 +850,14 @@ private:
         assert(varIndex < compiler->lvaTrackedCount);
         return localVarIntervals[varIndex];
     }
+
+    Interval* getIntervalForLocalVarNode(GenTreeLclVarCommon* tree)
+    {
+        LclVarDsc* varDsc = &compiler->lvaTable[tree->gtLclNum];
+        assert(varDsc->lvTracked);
+        return getIntervalForLocalVar(varDsc->lvVarIndex);
+    }
+
     RegRecord* getRegisterRecord(regNumber regNum);
 
     RefPosition* newRefPositionRaw(LsraLocation nodeLocation, GenTree* treeNode, RefType refType);

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -943,7 +943,7 @@ private:
     void setOutVarRegForBB(unsigned int bbNum, unsigned int varNum, regNumber reg);
     VarToRegMap getInVarToRegMap(unsigned int bbNum);
     VarToRegMap getOutVarToRegMap(unsigned int bbNum);
-    regNumber getVarReg(VarToRegMap map, unsigned int varNum);
+    regNumber getVarReg(VarToRegMap map, unsigned int trackedVarIndex);
     // Initialize the incoming VarToRegMap to the given map values (generally a predecessor of
     // the block)
     VarToRegMap setInVarToRegMap(unsigned int bbNum, VarToRegMap srcVarToRegMap);

--- a/src/jit/lsraxarch.cpp
+++ b/src/jit/lsraxarch.cpp
@@ -2106,7 +2106,6 @@ void Lowering::TreeNodeInfoInitLclHeap(GenTree* tree)
 void Lowering::TreeNodeInfoInitLogicalOp(GenTree* tree)
 {
     TreeNodeInfo* info = &(tree->gtLsraInfo);
-    LinearScan*   l    = m_lsra;
 
     // We're not marking a constant hanging on the left of the add
     // as containable so we assign it to a register having CQ impact.


### PR DESCRIPTION
Change LSRA to create Intervals only for tracked variables

Change getIntervalForLocalVar() to take a tracked variable index, not varNum.

Convert LinearScan::getVarReg() to take a tracked var index, not varNum.

This reduces instruction count of superpmi replay over minopts tests by 0.6%.
