### PR TITLE
[lldb-plugin] Include PAL headers instead of embedding its declarations

### DIFF
--- a/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
+++ b/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
@@ -98,6 +98,8 @@ include_directories(inc)
 include_directories("${LLDB_H}")
 include_directories(${CLR_DIR}/src/debug/inc)
 include_directories(${CLR_DIR}/src/inc)
+include_directories(${CLR_DIR}/src/pal/inc)
+include_directories(${CLR_DIR}/src/pal/inc/rt)
 include_directories(${CLR_DIR}/src/coreclr/hosts/inc)
 include_directories(${CLR_DIR}/src/coreclr/hosts/unixcoreruncommon)
 

--- a/src/ToolBox/SOS/lldbplugin/inc/lldbservices.h
+++ b/src/ToolBox/SOS/lldbplugin/inc/lldbservices.h
@@ -12,6 +12,8 @@
 #define __LLDBSERVICES_H__
 
 #include <stdarg.h>
+#include <palrt.h>
+#include <unknwn.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -108,25 +110,6 @@ extern "C" {
 #define DEBUG_STATUS_MASK                0x1f
 
 #define DEBUG_EVENT_EXCEPTION            0x00000002
-
-#ifdef DEFINE_EXCEPTION_RECORD
-
-#define EXCEPTION_MAXIMUM_PARAMETERS     15
-
-// This copy of the "64" bit record has been modified
-// by removing the alignment field to make it the same
-// as the _EXCEPTION_RECORD used in the pal defined in 
-// pal.h.
-typedef struct _EXCEPTION_RECORD64 {
-    DWORD ExceptionCode;
-    DWORD ExceptionFlags;
-    DWORD64 ExceptionRecord;
-    DWORD64 ExceptionAddress;
-    DWORD NumberParameters;
-    DWORD64 ExceptionInformation[EXCEPTION_MAXIMUM_PARAMETERS];
-} EXCEPTION_RECORD64, *PEXCEPTION_RECORD64;
-
-#endif // DEFINE_EXCEPTION_RECORD
 
 typedef struct _DEBUG_LAST_EVENT_INFO_EXCEPTION
 {

--- a/src/ToolBox/SOS/lldbplugin/mstypes.h
+++ b/src/ToolBox/SOS/lldbplugin/mstypes.h
@@ -6,14 +6,7 @@
 // etc. because they have various conflicits with the linux standard
 // runtime h files like wchar_t, memcpy, etc.
 
-#include <../../../pal/inc/pal_mstypes.h>
-
-#define S_OK                             (HRESULT)0x00000000
-#define S_FALSE                          (HRESULT)0x00000001
-#define E_NOTIMPL                        (HRESULT)0x80004001
-#define E_FAIL                           (HRESULT)0x80004005
-#define E_INVALIDARG                     (HRESULT)0x80070057
-#define E_NOINTERFACE                    (HRESULT)0x80004002
+#include <pal_mstypes.h>
 
 #define MAX_PATH                         260 
 
@@ -32,75 +25,3 @@
 #define MAKEDLLNAME_W(name) u"lib" name u".so"
 #define MAKEDLLNAME_A(name)  "lib" name  ".so"
 #endif
-
-#if defined(_MSC_VER) || defined(__llvm__)
-#define DECLSPEC_ALIGN(x)   __declspec(align(x))
-#else
-#define DECLSPEC_ALIGN(x) 
-#endif
-
-#define interface struct
-#define DECLSPEC_UUID(x)    __declspec(uuid(x))
-#define DECLSPEC_NOVTABLE
-#define MIDL_INTERFACE(x)   struct DECLSPEC_UUID(x) DECLSPEC_NOVTABLE
-
-#ifdef __cplusplus
-#define REFGUID const GUID &
-#else
-#define REFGUID const GUID *
-#endif
-
-#ifdef __cplusplus
-extern "C++" {
-#include "string.h"
-#if !defined _SYS_GUID_OPERATOR_EQ_ && !defined _NO_SYS_GUID_OPERATOR_EQ_
-#define _SYS_GUID_OPERATOR_EQ_
-inline int IsEqualGUID(REFGUID rguid1, REFGUID rguid2)
-    { return !memcmp(&rguid1, &rguid2, sizeof(GUID)); }
-inline int operator==(REFGUID guidOne, REFGUID guidOther)
-    { return IsEqualGUID(guidOne,guidOther); }
-inline int operator!=(REFGUID guidOne, REFGUID guidOther)
-    { return !IsEqualGUID(guidOne,guidOther); }
-#endif
-};
-#endif // __cplusplus
-
-typedef GUID IID;
-#ifdef __cplusplus
-#define REFIID const IID &
-#else
-#define REFIID const IID *
-#endif
-#define IID_NULL GUID_NULL
-#define IsEqualIID(riid1, riid2) IsEqualGUID(riid1, riid2)
-
-MIDL_INTERFACE("00000000-0000-0000-C000-000000000046")
-IUnknown
-{
-public:
-    virtual HRESULT QueryInterface( 
-        REFIID riid,
-        void **ppvObject) = 0;
-        
-    virtual ULONG AddRef( void) = 0;
-        
-    virtual ULONG Release( void) = 0;
-};
-
-EXTERN_C
-inline
-LONG
-InterlockedIncrement(
-    LONG volatile *lpAddend)
-{
-    return __sync_add_and_fetch(lpAddend, (LONG)1);
-}
-
-EXTERN_C
-inline
-LONG
-InterlockedDecrement(
-    LONG volatile *lpAddend)
-{
-    return __sync_sub_and_fetch(lpAddend, (LONG)1);
-}

--- a/src/ToolBox/SOS/lldbplugin/services.h
+++ b/src/ToolBox/SOS/lldbplugin/services.h
@@ -32,13 +32,13 @@ public:
     // IUnknown
     //----------------------------------------------------------------------------
 
-    HRESULT QueryInterface(
+    HRESULT STDMETHODCALLTYPE QueryInterface(
         REFIID InterfaceId,
         PVOID* Interface);
 
-    ULONG AddRef();
+    ULONG STDMETHODCALLTYPE AddRef();
 
-    ULONG Release();
+    ULONG STDMETHODCALLTYPE Release();
 
     //----------------------------------------------------------------------------
     // ILLDBServices

--- a/src/pal/inc/rt/x86intrin.h
+++ b/src/pal/inc/rt/x86intrin.h
@@ -1,0 +1,1 @@
+#include "xmmintrin.h"


### PR DESCRIPTION
LLDB plugin embeds some PAL-related declarations internally, but there was a mismatch between PAL and SOS declarations (related with calling convention).

This mismatch results in #11704.

This commit revises LLDB plugin to include related PAL headers instead of embedding related declarations.