### PR TITLE
[GDBJIT] Fix incomplete type build error

### DIFF
--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -15,6 +15,8 @@
 #define __GDBJIT_H__
 
 #include <stdint.h>
+#include "typekey.h"
+#include "typestring.h"
 #include "method.hpp"
 #include "dbginterface.h"
 #include "../inc/llvm/ELF.h"


### PR DESCRIPTION
Recently, CLR build is broken when FEATURE_GDBJIT is turned on (field has incomplete type 'XXX' error).

This commit fixes these FEATURE_GDBJIT build errors.