### PR TITLE
Enable GDBJIT feature in Tizen armel CI

### DIFF
--- a/tests/scripts/arm32_ci_script.sh
+++ b/tests/scripts/arm32_ci_script.sh
@@ -289,9 +289,14 @@ function cross_build_coreclr_with_docker {
         sudo chown -R $(id -u -n) cross/rootfs
     fi
 
+    __extraArgs=""
+    if [[ "$__buildArch" == "armel" && "$__linuxCodeName" == "tizen" ]]; then
+        __extraArgs="cmakeargs -DFEATURE_GDBJIT=TRUE"
+    fi
+
     # Cross building coreclr with rootfs in Docker
     (set +x; echo "Start cross build coreclr for $__buildArch $__linuxCodeName")
-    __buildCmd="./build.sh $__buildArch cross $__verboseFlag $__skipMscorlib $__buildConfig -rebuild"
+    __buildCmd="./build.sh $__buildArch cross $__verboseFlag $__skipMscorlib $__buildConfig $__extraArgs -rebuild"
     $__dockerCmd $__buildCmd
     sudo chown -R $(id -u -n) ./bin
 }


### PR DESCRIPTION
Tizen basically requires GDBJIT enabled libraries.
Enable GDBJIT feature to prevent related build fail issues in advance.

/cc @chunseoklee @parjong @hqueue @hseok-oh @gkhanna79 

Related issue : #11706 