### PR TITLE
[ARM32] Simplify getting aligment value when remorphing

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -3207,10 +3207,17 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
         }
 
         // We don't use the "size" return value from InferOpSizeAlign().
-        codeGen->InferOpSizeAlign(curArg, &argAlign);
+        if (reMorphing)
+        {
+            argAlign = argEntry->alignment;
+        }
+        else
+        {
+            codeGen->InferOpSizeAlign(curArg, &argAlign);
 
-        argAlign = roundUp(argAlign, TARGET_POINTER_SIZE);
-        argAlign /= TARGET_POINTER_SIZE;
+            argAlign = roundUp(argAlign, TARGET_POINTER_SIZE);
+            argAlign /= TARGET_POINTER_SIZE;
+        }
 
         if (argAlign == 2)
         {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -3206,13 +3206,13 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
             curArg = argEntry->node;
         }
 
-        // We don't use the "size" return value from InferOpSizeAlign().
         if (reMorphing)
         {
             argAlign = argEntry->alignment;
         }
         else
         {
+            // We don't use the "size" return value from InferOpSizeAlign().
             codeGen->InferOpSizeAlign(curArg, &argAlign);
 
             argAlign = roundUp(argAlign, TARGET_POINTER_SIZE);


### PR DESCRIPTION
Simplify getting aligment value in morphing phase when remorphing by using argument table.
It can be useful to get alignment value for struct morphed to FIELD_LIST in ARM32/RyuJIT.