### PR TITLE
[*64] NYI: TYP_STRUCT, fastTailCall stack fixup

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -3406,6 +3406,12 @@ var_types LclVarDsc::lvaArgType()
     var_types type = TypeGet();
 
 #ifdef _TARGET_AMD64_
+#ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
+    if (type == TYP_STRUCT)
+    {
+        NYI("lvaArgType");
+    }
+#else  //! FEATURE_UNIX_AMD64_STRUCT_PASSING
     if (type == TYP_STRUCT)
     {
         switch (lvExactSize)
@@ -3443,6 +3449,12 @@ var_types LclVarDsc::lvaArgType()
                 type = TYP_BYREF;
                 break;
         }
+    }
+#endif // !FEATURE_UNIX_AMD64_STRUCT_PASSING
+#elif defined(_TARGET_ARM64_)
+    if (type == TYP_STRUCT)
+    {
+        NYI("lvaArgType");
     }
 #elif defined(_TARGET_X86_)
 // Nothing to do; use the type as is.

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -62041,7 +62041,7 @@ RelativePath=JIT\Performance\CodeQuality\Roslyn\CscBench\CscBench.cmd
 WorkingDir=JIT\Performance\CodeQuality\Roslyn\CscBench
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;LONG_RUNNING;EXPECTED_FAIL;11533
+Categories=Pri0;LONG_RUNNING;EXPECTED_PASS
 HostStyle=0
 
 [SciMark.cmd_8027]
@@ -75873,7 +75873,7 @@ RelativePath=managed\Compilation\Compilation\Compilation.cmd
 WorkingDir=managed\Compilation\Compilation
 Expected=0
 MaxAllowedDurationSeconds=800
-Categories=RT;Pri0;LONG_RUNNING;NATIVE_INTEROP;EXPECTED_FAIL;11533
+Categories=RT;Pri0;LONG_RUNNING;NATIVE_INTEROP;EXPECTED_PASS
 HostStyle=0
 
 [generics.cmd_9787]

--- a/tests/src/JIT/opt/Tailcall/FastTailCallStackFixup.cs
+++ b/tests/src/JIT/opt/Tailcall/FastTailCallStackFixup.cs
@@ -1,0 +1,71 @@
+using System;
+
+public struct A
+{
+    public short a;
+    public short b;
+}
+
+class TailCallStructPassing
+{
+    public static int bar(int count, A temp)
+    {
+        if (count < 100)
+        {
+            return count;
+        }
+
+        else
+        {
+            count -= 100;
+            return bar(count, temp);
+        }
+    }
+
+    public static int foo(A temp, int b, int c, int d, int e, int f, int g, int h, int i, int j, int k, int l, int m, int n, int o, int p, int q, int r, int s, int t, int u, int v, int w, int decision, int count)
+    {
+        if (decision < 100)
+        {
+            return foo(temp, w, v, u, t, s, r, q, p, o, n, m, l, k, j, i, h, g, f, e, d, c, b, 500, 15);
+        }
+
+        else
+        {
+            return bar(count, temp);
+        }
+    }
+
+    public static int foo(int decision, int count, int a, int b, int c, int d, int e, int f, int g, int h, int i, int j, int k, int l, int m, int n, int o, int p, int q, int r, int s, int t, int u, int v, int w, int x, int y, int z, A temp)
+    {
+        if (decision < 100)
+        {
+            return foo(temp, w, v, u, t, s, r, q, p, o, n, m, l, k, j, i, h, g, f, e, d, c, b, 500, 15);
+        }
+
+        else
+        {
+            return bar(count, temp);
+        }
+    }
+
+    public static int Main()
+    {
+        A temp = new A();
+        temp.a = 50;
+        temp.b = 100;
+
+        int ret = foo(50, 19000, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 24, 25, 26, temp);
+
+        temp.a = (short)ret;
+
+        if (temp.a == 15)
+        {
+            return 100;
+        }
+
+        else
+        {
+            return -1;
+        }
+    } 
+}

--- a/tests/src/JIT/opt/Tailcall/FastTailCallStackFixup.csproj
+++ b/tests/src/JIT/opt/Tailcall/FastTailCallStackFixup.csproj
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <IlasmRoundTrip>true</IlasmRoundTrip>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>None</DebugType>
+    <NoLogo>True</NoLogo>
+    <NoStandardLib>True</NoStandardLib>
+    <Noconfig>True</Noconfig>
+    <Optimize>True</Optimize>
+    <JitOptimizationSensitive>True</JitOptimizationSensitive>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="FastTailCallStackFixup.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
This will add an NYI for AMD64 and Arm64 during fastTailCall stack fixup which requires
a temp. Currently this code path is very difficult to execute for the case of TYP_STRUCT
because we will have already created copies of structs that are passed on the stack
during morph. The NYI will avoid incorrect behavior in the case that we make changes in
earlier stages that will force this code path to hit.