### PR TITLE
Fix performance runs

### DIFF
--- a/tests/src/Common/PerfHarness/PerfHarness.csproj
+++ b/tests/src/Common/PerfHarness/PerfHarness.csproj
@@ -1,15 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <OutputType>exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit.performance.api">
       <Version>1.0.0-beta-build0003</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.NETCore.App">
-      <Version>1.1.0</Version>
-    </PackageReference>
   </ItemGroup>
-</Project> 
+</Project>

--- a/tests/src/performance/linkbench/linkbench.cs
+++ b/tests/src/performance/linkbench/linkbench.cs
@@ -251,14 +251,15 @@ namespace LinkBench
                 "WebAPI\\bin\\release\\netcoreapp2.0\\win10-x64\\linked",
                 () => { Benchmark.AddLinkerReference("WebAPI\\WebAPI.csproj");
                         Benchmark.PreventPublishFiltering("WebAPI\\WebAPI.csproj"); }),
-            new Benchmark("MusicStore",
+            //Remove the MusicStore from the run as the scenario is currently flaky and breaking performance runs
+            /*new Benchmark("MusicStore",
                 "JitBench\\src\\MusicStore\\bin\\release\\netcoreapp2.0\\win10-x64\\unlinked",
                 "JitBench\\src\\MusicStore\\bin\\release\\netcoreapp2.0\\win10-x64\\linked",
                 () => { Benchmark.AddLinkerReference("JitBench\\src\\MusicStore\\MusicStore.csproj");
                        Benchmark.SetRuntimeFrameworkVersion("JitBench\\src\\MusicStore\\MusicStore.csproj"); }),
             new Benchmark("MusicStore_R2R",
                 "JitBench\\src\\MusicStore\\bin\\release\\netcoreapp2.0\\win10-x64\\R2R\\unlinked",
-                "JitBench\\src\\MusicStore\\bin\\release\\netcoreapp2.0\\win10-x64\\R2R\\linked"),
+                "JitBench\\src\\MusicStore\\bin\\release\\netcoreapp2.0\\win10-x64\\R2R\\linked"),*/
             new Benchmark("Corefx",
                 "corefx\\bin\\ILLinkTrimAssembly\\netcoreapp-Windows_NT-Release-x64\\pretrimmed",
                 "corefx\\bin\\ILLinkTrimAssembly\\netcoreapp-Windows_NT-Release-x64\\trimmed"),


### PR DESCRIPTION
This is a port of https://github.com/dotnet/coreclr/pull/11697.  This fixes a break in the performance tests that was introduced when we moved the dotnet tooling over to 2.0