### PR TITLE
Get rid of double-import of Buildversion.targets

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -87,8 +87,6 @@
     <OutputPath Condition="'$(OutputPath)' == ''">$(BinDir)</OutputPath>
   </PropertyGroup>
 
-  <Import Condition="Exists('$(ToolsDir)BuildVersion.targets')" Project="$(ToolsDir)BuildVersion.targets" />
-
   <!-- Import Build tools common props file where repo-independent properties are found -->
   <Import Condition="Exists('$(ToolsDir)Build.Common.props')" Project="$(ToolsDir)Build.Common.props" />
 


### PR DESCRIPTION
Attempts to resolve https://github.com/dotnet/coreclr/issues/11716. Build.Common.Props now imports Buildversion.targets, so there's no need to explicitly import Buildversion.targets in the same file where we import Build.Common.Props