### PR TITLE
JIT: relax method attribute assertion check in devirtualization

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -18602,8 +18602,7 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
         // the method can't be inlined, so there's no danger here in
         // seeing this particular flag bit in different states between
         // the cached and fresh values.
-        if ((freshBaseMethodAttribs & ~CORINFO_FLG_DONT_INLINE) !=
-            (baseMethodAttribs & ~CORINFO_FLG_DONT_INLINE))
+        if ((freshBaseMethodAttribs & ~CORINFO_FLG_DONT_INLINE) != (baseMethodAttribs & ~CORINFO_FLG_DONT_INLINE))
         {
             assert(!"mismatched method attributes");
         }

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -18592,7 +18592,21 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
 #if defined(DEBUG)
         // Validate that callInfo has up to date method flags
         const DWORD freshBaseMethodAttribs = info.compCompHnd->getMethodAttribs(baseMethod);
-        assert(freshBaseMethodAttribs == baseMethodAttribs);
+
+        // All the base method attributes should agree, save that
+        // CORINFO_FLG_DONT_INLINE may have changed from 0 to 1
+        // because of concurrent jitting activity.
+        //
+        // Note we don't look at this particular flag bit below, and
+        // later on (if we do try and inline) we will rediscover why
+        // the method can't be inlined, so there's no danger here in
+        // seeing this particular flag bit in different states between
+        // the cached and fresh values.
+        if ((freshBaseMethodAttribs & ~CORINFO_FLG_DONT_INLINE) !=
+            (baseMethodAttribs & ~CORINFO_FLG_DONT_INLINE))
+        {
+            assert(!"mismatched method attributes");
+        }
 #endif // DEBUG
     }
 


### PR DESCRIPTION
The jit may see `CORINFO_FLG_DONT_INLINE` change between the time it
first reads a method's attributes and the time it re-reads it, since
jitting on some other thread may have deduced the method as noinline
in between the two reads. This bit doesn't affect devirtualization
and so the bit change is harmless.

Tolerate this by masking out this flag bit when comparing attributes.

No changes to generated code.

Closes #11619.