### PR TITLE
gdbjit symbols exported

### DIFF
--- a/functions.cmake
+++ b/functions.cmake
@@ -86,7 +86,10 @@ function(preprocess_def_file inputFilename outputFilename)
                               PROPERTIES GENERATED TRUE)
 endfunction()
 
-function(generate_exports_file inputFilename outputFilename)
+function(generate_exports_file)
+  set(INPUT_LIST ${ARGN})
+  list(GET INPUT_LIST -1 outputFilename)
+  list(REMOVE_AT INPUT_LIST -1)
 
   if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
     set(AWK_SCRIPT generateexportedsymbols.awk)
@@ -96,8 +99,8 @@ function(generate_exports_file inputFilename outputFilename)
 
   add_custom_command(
     OUTPUT ${outputFilename}
-    COMMAND ${AWK} -f ${CMAKE_SOURCE_DIR}/${AWK_SCRIPT} ${inputFilename} >${outputFilename}
-    DEPENDS ${inputFilename} ${CMAKE_SOURCE_DIR}/${AWK_SCRIPT}
+    COMMAND ${AWK} -f ${CMAKE_SOURCE_DIR}/${AWK_SCRIPT} ${INPUT_LIST} >${outputFilename}
+    DEPENDS ${INPUT_LIST} ${CMAKE_SOURCE_DIR}/${AWK_SCRIPT}
     COMMENT "Generating exports file ${outputFilename}"
   )
   set_source_files_properties(${outputFilename}

--- a/src/dlls/mscoree/CMakeLists.txt
+++ b/src/dlls/mscoree/CMakeLists.txt
@@ -22,6 +22,11 @@ else()
 set (DEF_SOURCES
   mscorwks_unixexports.src
 )
+if(FEATURE_GDBJIT)
+  list(APPEND DEF_SOURCES
+    gdbjit_unixexports.src
+  )
+endif(FEATURE_GDBJIT)
 endif(WIN32)
 
 convert_to_absolute_path(DEF_SOURCES ${DEF_SOURCES})

--- a/src/dlls/mscoree/gdbjit_unixexports.src
+++ b/src/dlls/mscoree/gdbjit_unixexports.src
@@ -1,0 +1,3 @@
+; exported for GDBJIT 
+__jit_debug_register_code
+__jit_debug_descriptor


### PR DESCRIPTION
Two symbols are exported to enable gdbjit feature. In tizen build system, these symbols are stripped during rpmbuild.
Symbols added are :
    __jit_debug_register_code
    __jit_descriptor