### PR TITLE
Delete default copy/move of RelativePointer/RelativeFixupPointer

### DIFF
--- a/src/inc/fixuppointer.h
+++ b/src/inc/fixuppointer.h
@@ -30,6 +30,24 @@ template<typename PTR_TYPE>
 class RelativePointer
 {
 public:
+#ifndef DACCESS_COMPILE
+    RelativePointer()
+    {
+        m_delta = (TADDR)NULL;
+
+        _ASSERTE (IsNull());
+    }
+#else // DACCESS_COMPILE
+    RelativePointer() =delete;
+#endif // DACCESS_COMPILE
+
+    // Implicit copy/move is not allowed
+    // Bitwise copy is implemented by BitwiseCopyTo method
+    RelativePointer<PTR_TYPE>(const RelativePointer<PTR_TYPE> &) =delete;
+    RelativePointer<PTR_TYPE>(RelativePointer<PTR_TYPE> &&) =delete;
+    RelativePointer<PTR_TYPE>& operator = (const RelativePointer<PTR_TYPE> &) =delete;
+    RelativePointer<PTR_TYPE>& operator = (RelativePointer<PTR_TYPE> &&) =delete;
+
     // Returns whether the encoded pointer is NULL.
     BOOL IsNull() const
     {
@@ -143,6 +161,13 @@ public:
         dac_cast<DPTR(RelativePointer<PTR_TYPE>)>(base)->SetValueMaybeNull(base, addr);
     }
 
+#ifndef DACCESS_COMPILE
+    void BitwiseCopyTo(RelativePointer<PTR_TYPE> &dest) const
+    {
+        dest.m_delta = m_delta;
+    }
+#endif // DACCESS_COMPILE
+
 private:
 #ifndef DACCESS_COMPILE
     Volatile<TADDR> m_delta;
@@ -234,6 +259,12 @@ template<typename PTR_TYPE>
 class RelativeFixupPointer
 {
 public:
+    // Implicit copy/move is not allowed
+    RelativeFixupPointer<PTR_TYPE>(const RelativeFixupPointer<PTR_TYPE> &) =delete;
+    RelativeFixupPointer<PTR_TYPE>(RelativeFixupPointer<PTR_TYPE> &&) =delete;
+    RelativeFixupPointer<PTR_TYPE>& operator = (const RelativeFixupPointer<PTR_TYPE> &) =delete;
+    RelativeFixupPointer<PTR_TYPE>& operator = (RelativeFixupPointer<PTR_TYPE> &&) =delete;
+
     // Returns whether the encoded pointer is NULL.
     BOOL IsNull() const
     {

--- a/src/vm/field.h
+++ b/src/vm/field.h
@@ -43,6 +43,8 @@ class FieldDesc
   protected:
     RelativePointer<PTR_MethodTable> m_pMTOfEnclosingClass;  // This is used to hold the log2 of the field size temporarily during class loading.  Yuck.
 
+    // See also: FieldDesc::InitializeFrom method
+
 #if defined(DACCESS_COMPILE)
     union { //create a union so I can get the correct offset for ClrDump.
         unsigned m_dword1;
@@ -85,10 +87,33 @@ class FieldDesc
     LPUTF8 m_debugName;
 #endif
 
-    // Allocated by special heap means, don't construct me
-    FieldDesc() {};
-
 public:
+    // Allocated by special heap means, don't construct me
+    FieldDesc() =delete;
+
+#ifndef DACCESS_COMPILE
+    void InitializeFrom(const FieldDesc& sourceField, MethodTable *pMT)
+    {
+        m_pMTOfEnclosingClass.SetValue(pMT);
+
+        m_mb = sourceField.m_mb;
+        m_isStatic = sourceField.m_isStatic;
+        m_isThreadLocal = sourceField.m_isThreadLocal;
+        m_isRVA = sourceField.m_isRVA;
+        m_prot = sourceField.m_prot;
+        m_requiresFullMbValue = sourceField.m_requiresFullMbValue;
+
+        m_dwOffset = sourceField.m_dwOffset;
+        m_type = sourceField.m_type;
+
+#ifdef _DEBUG
+        m_isDangerousAppDomainAgileField = sourceField.m_isDangerousAppDomainAgileField;
+
+        m_debugName = sourceField.m_debugName;
+#endif // _DEBUG
+    }
+#endif // !DACCESS_COMPILE
+
 #ifdef _DEBUG
     inline LPUTF8 GetDebugName()
     {

--- a/src/vm/generics.cpp
+++ b/src/vm/generics.cpp
@@ -597,8 +597,7 @@ ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation(
 
             for (DWORD i = 0; i < pOldMT->GetNumStaticFields(); i++)
             {
-                pStaticFieldDescs[i] = pOldFD[i];
-                pStaticFieldDescs[i].SetMethodTable(pMT);
+                pStaticFieldDescs[i].InitializeFrom(pOldFD[i], pMT);
             }
         }
         pMT->SetupGenericsStaticsInfo(pStaticFieldDescs);

--- a/src/vm/ngenhash.h
+++ b/src/vm/ngenhash.h
@@ -475,6 +475,13 @@ public:
     // Call this during the ngen Fixup phase to adjust the relative pointer to account for ngen image layout.
     void Fixup(DataImage *pImage, NgenHashTable<NGEN_HASH_ARGS> *pTable);
 #endif // FEATURE_PREJIT
+
+    NgenHashEntryRef<NGEN_HASH_ARGS>& operator = (const NgenHashEntryRef<NGEN_HASH_ARGS> &src)
+    {
+        src.m_rpEntryRef.BitwiseCopyTo(m_rpEntryRef);
+
+        return *this;
+    }
 #endif // !DACCESS_COMPILE
 
 private:


### PR DESCRIPTION
As value of `RelativePointer`/`RelativeFixupPointer` depends on pointer's location, it is usually not valid to perform bitwise copy of the pointer objects.
The changes remove the implicit copy/move constructors and assignment operators for the classes to catch incorrect copying at compile-time.
Bitwise copy of `RelativePointer` is added as separate method `BitwiseCopyTo` for exceptional cases, in which it is necessary.