### PR TITLE
Update Unix SafeHandle to throw NotFound correctly

### DIFF
--- a/src/mscorlib/shared/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/mscorlib/shared/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Win32.SafeHandles
 
             if (handle.IsInvalid)
             {
+                handle.Dispose();
                 Interop.ErrorInfo error = Interop.Sys.GetLastErrorInfo();
 
                 // If we fail to open the file due to a path not existing, we need to know whether to blame
@@ -54,7 +55,7 @@ namespace Microsoft.Win32.SafeHandles
 
                 bool isDirectory = (error.Error == Interop.Error.ENOENT) &&
                     ((flags & Interop.Sys.OpenFlags.O_CREAT) != 0
-                    || !DirectoryExists(Path.GetDirectoryName(path.TrimEnd(Path.DirectorySeparatorChar))));
+                    || !DirectoryExists(Path.GetDirectoryName(PathInternal.TrimEndingDirectorySeparator(path))));
 
                 Interop.CheckIo(
                     error.Error,

--- a/src/mscorlib/shared/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/mscorlib/shared/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Win32.SafeHandles
@@ -38,18 +39,29 @@ namespace Microsoft.Win32.SafeHandles
         internal static SafeFileHandle Open(string path, Interop.Sys.OpenFlags flags, int mode)
         {
             Debug.Assert(path != null);
+            SafeFileHandle handle = Interop.Sys.Open(path, flags, mode);
 
-            // If we fail to open the file due to a path not existing, we need to know whether to blame
-            // the file itself or its directory.  If we're creating the file, then we blame the directory,
-            // otherwise we blame the file.
-            bool enoentDueToDirectory = (flags & Interop.Sys.OpenFlags.O_CREAT) != 0;
+            if (handle.IsInvalid)
+            {
+                Interop.ErrorInfo error = Interop.Sys.GetLastErrorInfo();
 
-            // Open the file. 
-            SafeFileHandle handle = Interop.CheckIo(
-                Interop.Sys.Open(path, flags, mode),
-                path, 
-                isDirectory: enoentDueToDirectory,
-                errorRewriter: e => (e.Error == Interop.Error.EISDIR) ? Interop.Error.EACCES.Info() : e);
+                // If we fail to open the file due to a path not existing, we need to know whether to blame
+                // the file itself or its directory.  If we're creating the file, then we blame the directory,
+                // otherwise we blame the file.
+                //
+                // When opening, we need to align with Windows, which considers a missing path to be
+                // FileNotFound only if the containing directory exists.
+
+                bool isDirectory = (error.Error == Interop.Error.ENOENT) &&
+                    ((flags & Interop.Sys.OpenFlags.O_CREAT) != 0
+                    || !DirectoryExists(Path.GetDirectoryName(path.TrimEnd(Path.DirectorySeparatorChar))));
+
+                Interop.CheckIo(
+                    error.Error,
+                    path,
+                    isDirectory,
+                    errorRewriter: e => (e.Error == Interop.Error.EISDIR) ? Interop.Error.EACCES.Info() : e);
+            }
 
             // Make sure it's not a directory; we do this after opening it once we have a file descriptor 
             // to avoid race conditions.
@@ -66,6 +78,31 @@ namespace Microsoft.Win32.SafeHandles
             }
 
             return handle;
+        }
+
+        private static bool DirectoryExists(string fullPath)
+        {
+            int fileType = Interop.Sys.FileTypes.S_IFDIR;
+
+            Interop.Sys.FileStatus fileinfo;
+            Interop.ErrorInfo errorInfo = default(Interop.ErrorInfo);
+
+            // First use stat, as we want to follow symlinks.  If that fails, it could be because the symlink
+            // is broken, we don't have permissions, etc., in which case fall back to using LStat to evaluate
+            // based on the symlink itself.
+            if (Interop.Sys.Stat(fullPath, out fileinfo) < 0 &&
+                Interop.Sys.LStat(fullPath, out fileinfo) < 0)
+            {
+                errorInfo = Interop.Sys.GetLastErrorInfo();
+                return false;
+            }
+
+            // Something exists at this path.  If the caller is asking for a directory, return true if it's
+            // a directory and false for everything else.  If the caller is asking for a file, return false for
+            // a directory and true for everything else.
+            return
+                (fileType == Interop.Sys.FileTypes.S_IFDIR) ==
+                ((fileinfo.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR);
         }
 
         /// <summary>Opens a SafeFileHandle for a file descriptor created by a provided delegate.</summary>

--- a/src/mscorlib/shared/System/IO/PathInternal.Unix.cs
+++ b/src/mscorlib/shared/System/IO/PathInternal.Unix.cs
@@ -100,5 +100,10 @@ namespace System.IO
             // As long as the path is rooted in Unix it doesn't use the current directory and therefore is fully qualified.
             return !Path.IsPathRooted(path);
         }
+
+        internal static string TrimEndingDirectorySeparator(string path) =>
+            path.Length > 1 && IsDirectorySeparator(path[path.Length - 1]) ? // exclude root "/"
+            path.Substring(0, path.Length - 1) :
+            path;
     }
 }

--- a/src/mscorlib/shared/System/IO/PathInternal.Windows.cs
+++ b/src/mscorlib/shared/System/IO/PathInternal.Windows.cs
@@ -438,5 +438,10 @@ namespace System.IO
         {
             return IsDirectorySeparator(ch) || VolumeSeparatorChar == ch;
         }
+
+        internal static string TrimEndingDirectorySeparator(string path) =>
+            EndsInDirectorySeparator(path) ?
+            path.Substring(0, path.Length - 1) :
+            path;
     }
 }


### PR DESCRIPTION
Need to match Windows semantics for missing files. This means throwing
FileNotFound only if the last segment of the path can't be found.

Related to https://github.com/dotnet/corefx/pull/19959 and https://github.com/dotnet/corefx/issues/19850.
