### PR TITLE
Fix package Publish in official builds

### DIFF
--- a/config.json
+++ b/config.json
@@ -622,6 +622,7 @@
       "defaultValues": {
         "toolName": "msbuild",
         "settings": {
+          "__BuildOS": "default",
           "Project": "./src/publish.proj",
           "MsBuildFileLogging": "/flp:v=detailed;LogFile=publish-packages.log"
         }


### PR DESCRIPTION
Package publishing in official builds of master branch was failing for Windows because it looked for packages under AnyOS instead of Windows_NT. Publishing non-Windows works.

It appears that this is because ___BuildOS_ property was not being set for package publishing (https://github.com/dotnet/coreclr/blob/master/config.json#L622) while it was being set for package building (https://github.com/dotnet/coreclr/blob/master/config.json#L660).

Surprisingly, release/2.0.0 Windows builds work even though they have the same issue!

With this change, the publish step appears to be fixed and problem does not repro locally.

@weshaggard @wtgodbe @chcosta Can you PTAL?