### PR TITLE
[x86/Linux] Set CDECL as STDMETHODCALLTYPE

### DIFF
--- a/src/debug/di/classfactory.h
+++ b/src/debug/di/classfactory.h
@@ -18,7 +18,7 @@
 
 
 // This typedef is for a function which will create a new instance of an object.
-typedef HRESULT (__stdcall * PFN_CREATE_OBJ)(REFIID riid, void **ppvObject);
+typedef HRESULT (STDMETHODCALLTYPE * PFN_CREATE_OBJ)(REFIID riid, void **ppvObject);
 
 
 //*****************************************************************************

--- a/src/debug/di/rsmain.cpp
+++ b/src/debug/di/rsmain.cpp
@@ -583,9 +583,9 @@ namespace
     public:
         DefaultManagedCallback2(ICorDebug* pDebug);
         virtual ~DefaultManagedCallback2() { }
-        virtual HRESULT __stdcall QueryInterface(REFIID iid, void** pInterface);
-        virtual ULONG __stdcall AddRef();
-        virtual ULONG __stdcall Release();
+        virtual HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void** pInterface);
+        virtual ULONG STDMETHODCALLTYPE AddRef();
+        virtual ULONG STDMETHODCALLTYPE Release();
         COM_METHOD FunctionRemapOpportunity(ICorDebugAppDomain* pAppDomain,
                                                  ICorDebugThread* pThread,
                                                  ICorDebugFunction* pOldFunction,
@@ -787,9 +787,9 @@ namespace
     public:
         DefaultManagedCallback3(ICorDebug* pDebug);
         virtual ~DefaultManagedCallback3() { }
-        virtual HRESULT __stdcall QueryInterface(REFIID iid, void** pInterface);
-        virtual ULONG __stdcall AddRef();
-        virtual ULONG __stdcall Release();
+        virtual HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void** pInterface);
+        virtual ULONG STDMETHODCALLTYPE AddRef();
+        virtual ULONG STDMETHODCALLTYPE Release();
         COM_METHOD CustomNotification(ICorDebugThread * pThread, ICorDebugAppDomain * pAppDomain);
     private:
         // not implemented

--- a/src/debug/di/rspriv.h
+++ b/src/debug/di/rspriv.h
@@ -1607,8 +1607,8 @@ public:
 
 // IUnknown interface
     virtual COM_METHOD QueryInterface(REFIID riid, VOID** ppInterface);
-    virtual ULONG __stdcall AddRef();
-    virtual ULONG __stdcall Release();
+    virtual ULONG STDMETHODCALLTYPE AddRef();
+    virtual ULONG STDMETHODCALLTYPE Release();
 
 // ICorDebugEnum interface
     virtual COM_METHOD Clone(ICorDebugEnum **ppEnum);

--- a/src/inc/ceegentokenmapper.h
+++ b/src/inc/ceegentokenmapper.h
@@ -55,10 +55,10 @@ public:
 //*****************************************************************************
 // IUnknown implementation.  
 //*****************************************************************************
-    virtual ULONG __stdcall AddRef()
+    virtual ULONG STDMETHODCALLTYPE AddRef()
     {LIMITED_METHOD_CONTRACT;  return ++m_cRefs; }
 
-    virtual ULONG __stdcall Release()
+    virtual ULONG STDMETHODCALLTYPE Release()
     {   
         STATIC_CONTRACT_NOTHROW;
         STATIC_CONTRACT_FORBID_FAULT;
@@ -78,14 +78,14 @@ public:
         return cRefs;
     }
 
-    virtual HRESULT __stdcall QueryInterface(REFIID iid, PVOID *ppIUnk);
+    virtual HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, PVOID *ppIUnk);
 
 //*****************************************************************************
 // Called by the meta data engine when a token is remapped to a new location.
 // This value is recorded in the m_rgMap array based on type and rid of the
 // from token value.
 //*****************************************************************************
-    virtual HRESULT __stdcall Map(mdToken tkImp, mdToken tkEmit);
+    virtual HRESULT STDMETHODCALLTYPE Map(mdToken tkImp, mdToken tkEmit);
 
 //*****************************************************************************
 // Check the given token to see if it has moved to a new location.  If so,

--- a/src/md/ceefilegen/ceegentokenmapper.cpp
+++ b/src/md/ceefilegen/ceegentokenmapper.cpp
@@ -40,7 +40,7 @@ int CeeGenTokenMapper::IndexForType(mdToken tk)
 // This value is recorded in the m_rgMap array based on type and rid of the
 // from token value.
 //*****************************************************************************
-HRESULT __stdcall CeeGenTokenMapper::Map(
+HRESULT STDMETHODCALLTYPE CeeGenTokenMapper::Map(
     mdToken     tkFrom, 
     mdToken     tkTo)
 {
@@ -144,7 +144,7 @@ HRESULT CeeGenTokenMapper::GetMetaData(
 }
 
 
-HRESULT __stdcall CeeGenTokenMapper::QueryInterface(REFIID iid, PVOID *ppIUnk)
+HRESULT STDMETHODCALLTYPE CeeGenTokenMapper::QueryInterface(REFIID iid, PVOID *ppIUnk)
 {
     if (iid == IID_IUnknown || iid == IID_IMapToken)
         *ppIUnk = static_cast<IMapToken*>(this);

--- a/src/md/compiler/regmeta_import.cpp
+++ b/src/md/compiler/regmeta_import.cpp
@@ -67,7 +67,7 @@ ErrExit:
 //*****************************************************************************
 // Close an enumerator.
 //*****************************************************************************
-void __stdcall RegMeta::CloseEnum(
+void STDMETHODCALLTYPE RegMeta::CloseEnum(
     HCORENUM        hEnum)          // The enumerator.
 {
     BEGIN_CLEANUP_ENTRYPOINT;

--- a/src/pal/inc/rt/palrt.h
+++ b/src/pal/inc/rt/palrt.h
@@ -249,7 +249,7 @@ inline void *__cdecl operator new(size_t, void *_P)
 
 #define interface struct
 
-#define STDMETHODCALLTYPE    __stdcall
+#define STDMETHODCALLTYPE    __cdecl
 #define STDMETHODVCALLTYPE   __cdecl
 
 #define STDAPICALLTYPE       __cdecl

--- a/src/vm/profilingenumerators.h
+++ b/src/vm/profilingenumerators.h
@@ -39,20 +39,20 @@ public:
 
     // IUnknown functions
 
-    virtual HRESULT __stdcall QueryInterface(REFIID id, void** pInterface);
-    virtual ULONG __stdcall AddRef();
-    virtual ULONG __stdcall Release();
+    virtual HRESULT STDMETHODCALLTYPE QueryInterface(REFIID id, void** pInterface);
+    virtual ULONG STDMETHODCALLTYPE AddRef();
+    virtual ULONG STDMETHODCALLTYPE Release();
 
 
     // This template assumes that the enumerator confors to the interface
     //
     // (this matches the IEnumXXX interface documented in MSDN)
 
-    virtual HRESULT __stdcall Skip(ULONG count);
-    virtual HRESULT __stdcall Reset();
-    virtual HRESULT __stdcall Clone(EnumInterface** ppEnum);
-    virtual HRESULT __stdcall GetCount(ULONG *count);
-    virtual HRESULT __stdcall Next(ULONG count,
+    virtual HRESULT STDMETHODCALLTYPE Skip(ULONG count);
+    virtual HRESULT STDMETHODCALLTYPE Reset();
+    virtual HRESULT STDMETHODCALLTYPE Clone(EnumInterface** ppEnum);
+    virtual HRESULT STDMETHODCALLTYPE GetCount(ULONG *count);
+    virtual HRESULT STDMETHODCALLTYPE Next(ULONG count,
         Element elements[],
         ULONG* elementsFetched);
 

--- a/src/vm/rejit.h
+++ b/src/vm/rejit.h
@@ -40,14 +40,14 @@ public:
     virtual ~ProfilerFunctionControl();
 
     // IUnknown functions
-    virtual HRESULT __stdcall QueryInterface(REFIID id, void** pInterface);
-    virtual ULONG __stdcall AddRef();
-    virtual ULONG __stdcall Release();
+    virtual HRESULT STDMETHODCALLTYPE QueryInterface(REFIID id, void** pInterface);
+    virtual ULONG STDMETHODCALLTYPE AddRef();
+    virtual ULONG STDMETHODCALLTYPE Release();
 
     // ICorProfilerFunctionControl functions
-    virtual HRESULT __stdcall SetCodegenFlags(DWORD flags);
-    virtual HRESULT __stdcall SetILFunctionBody(ULONG cbNewILMethodHeader, LPCBYTE pbNewILMethodHeader);
-    virtual HRESULT __stdcall SetILInstrumentedCodeMap(ULONG cILMapEntries, COR_IL_MAP * rgILMapEntries);
+    virtual HRESULT STDMETHODCALLTYPE SetCodegenFlags(DWORD flags);
+    virtual HRESULT STDMETHODCALLTYPE SetILFunctionBody(ULONG cbNewILMethodHeader, LPCBYTE pbNewILMethodHeader);
+    virtual HRESULT STDMETHODCALLTYPE SetILInstrumentedCodeMap(ULONG cILMapEntries, COR_IL_MAP * rgILMapEntries);
 
     // Accessors
     DWORD GetCodegenFlags();

--- a/src/vm/typeparse.cpp
+++ b/src/vm/typeparse.cpp
@@ -22,7 +22,7 @@
 //
 // TypeNameFactory
 //
-HRESULT __stdcall TypeNameFactory::QueryInterface(REFIID riid, void **ppUnk)
+HRESULT STDMETHODCALLTYPE TypeNameFactory::QueryInterface(REFIID riid, void **ppUnk)
 {
     WRAPPER_NO_CONTRACT;
     
@@ -64,7 +64,7 @@ HRESULT TypeNameFactoryCreateObject(REFIID riid, void **ppUnk)
 }
 
 
-HRESULT __stdcall TypeNameFactory::ParseTypeName(LPCWSTR szTypeName, DWORD* pError, ITypeName** ppTypeName)
+HRESULT STDMETHODCALLTYPE TypeNameFactory::ParseTypeName(LPCWSTR szTypeName, DWORD* pError, ITypeName** ppTypeName)
 {
     CONTRACTL
     {
@@ -107,7 +107,7 @@ HRESULT __stdcall TypeNameFactory::ParseTypeName(LPCWSTR szTypeName, DWORD* pErr
     return hr;
 }
 
-HRESULT __stdcall TypeNameFactory::GetTypeNameBuilder(ITypeNameBuilder** ppTypeNameBuilder)
+HRESULT STDMETHODCALLTYPE TypeNameFactory::GetTypeNameBuilder(ITypeNameBuilder** ppTypeNameBuilder)
 {
     CONTRACTL
     {
@@ -166,7 +166,7 @@ SString* TypeName::ToString(SString* pBuf, BOOL bAssemblySpec, BOOL bSignature, 
 }
 
 
-DWORD __stdcall TypeName::AddRef() 
+DWORD STDMETHODCALLTYPE TypeName::AddRef()
 { 
     LIMITED_METHOD_CONTRACT; 
 
@@ -175,7 +175,7 @@ DWORD __stdcall TypeName::AddRef()
     return m_count; 
 }
 
-DWORD __stdcall TypeName::Release() 
+DWORD STDMETHODCALLTYPE TypeName::Release()
 { 
     CONTRACTL
     {
@@ -210,7 +210,7 @@ TypeName::~TypeName()
         m_genericArguments[i]->Release();
 }
 
-HRESULT __stdcall TypeName::QueryInterface(REFIID riid, void **ppUnk)
+HRESULT STDMETHODCALLTYPE TypeName::QueryInterface(REFIID riid, void **ppUnk)
 {
     WRAPPER_NO_CONTRACT;
     
@@ -227,7 +227,7 @@ HRESULT __stdcall TypeName::QueryInterface(REFIID riid, void **ppUnk)
     return S_OK;
 }
 
-HRESULT __stdcall TypeName::GetNameCount(DWORD* pCount)
+HRESULT STDMETHODCALLTYPE TypeName::GetNameCount(DWORD* pCount)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -239,7 +239,7 @@ HRESULT __stdcall TypeName::GetNameCount(DWORD* pCount)
     return S_OK;
 }
 
-HRESULT __stdcall TypeName::GetNames(DWORD count, BSTR* bszName, DWORD* pFetched)
+HRESULT STDMETHODCALLTYPE TypeName::GetNames(DWORD count, BSTR* bszName, DWORD* pFetched)
 {
     CONTRACTL
     {
@@ -270,7 +270,7 @@ HRESULT __stdcall TypeName::GetNames(DWORD count, BSTR* bszName, DWORD* pFetched
     return hr;
 }
 
-HRESULT __stdcall TypeName::GetTypeArgumentCount(DWORD* pCount)
+HRESULT STDMETHODCALLTYPE TypeName::GetTypeArgumentCount(DWORD* pCount)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -282,7 +282,7 @@ HRESULT __stdcall TypeName::GetTypeArgumentCount(DWORD* pCount)
     return S_OK;
 }
 
-HRESULT __stdcall TypeName::GetTypeArguments(DWORD count, ITypeName** ppArguments, DWORD* pFetched)
+HRESULT STDMETHODCALLTYPE TypeName::GetTypeArguments(DWORD count, ITypeName** ppArguments, DWORD* pFetched)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -306,7 +306,7 @@ HRESULT __stdcall TypeName::GetTypeArguments(DWORD count, ITypeName** ppArgument
     return S_OK;
 }
 
-HRESULT __stdcall TypeName::GetModifierLength(DWORD* pCount)
+HRESULT STDMETHODCALLTYPE TypeName::GetModifierLength(DWORD* pCount)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -318,7 +318,7 @@ HRESULT __stdcall TypeName::GetModifierLength(DWORD* pCount)
     return S_OK;
 }
 
-HRESULT __stdcall TypeName::GetModifiers(DWORD count, DWORD* pModifiers, DWORD* pFetched)
+HRESULT STDMETHODCALLTYPE TypeName::GetModifiers(DWORD count, DWORD* pModifiers, DWORD* pFetched)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -339,7 +339,7 @@ HRESULT __stdcall TypeName::GetModifiers(DWORD count, DWORD* pModifiers, DWORD* 
     return S_OK;
 }
 
-HRESULT __stdcall TypeName::GetAssemblyName(BSTR* pszAssemblyName)
+HRESULT STDMETHODCALLTYPE TypeName::GetAssemblyName(BSTR* pszAssemblyName)
 {
     CONTRACTL
     {

--- a/src/vm/typeparse.h
+++ b/src/vm/typeparse.h
@@ -59,13 +59,13 @@ public:
     static HRESULT CreateObject(REFIID riid, void **ppUnk);
     
 public:
-    virtual HRESULT __stdcall QueryInterface(REFIID riid, void **ppUnk);
-    virtual ULONG __stdcall AddRef() { LIMITED_METHOD_CONTRACT; m_count++; return m_count; }
-    virtual ULONG __stdcall Release() { LIMITED_METHOD_CONTRACT; SUPPORTS_DAC_HOST_ONLY; m_count--; ULONG count = m_count; if (count == 0) delete this; return count; }
+    virtual HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void **ppUnk);
+    virtual ULONG STDMETHODCALLTYPE AddRef() { LIMITED_METHOD_CONTRACT; m_count++; return m_count; }
+    virtual ULONG STDMETHODCALLTYPE Release() { LIMITED_METHOD_CONTRACT; SUPPORTS_DAC_HOST_ONLY; m_count--; ULONG count = m_count; if (count == 0) delete this; return count; }
 
 public:
-    virtual HRESULT __stdcall ParseTypeName(LPCWSTR szName, DWORD* pError, ITypeName** ppTypeName);
-    virtual HRESULT __stdcall GetTypeNameBuilder(ITypeNameBuilder** ppTypeBuilder);
+    virtual HRESULT STDMETHODCALLTYPE ParseTypeName(LPCWSTR szName, DWORD* pError, ITypeName** ppTypeName);
+    virtual HRESULT STDMETHODCALLTYPE GetTypeNameBuilder(ITypeNameBuilder** ppTypeBuilder);
 
 public:
     TypeNameFactory() : m_count(0)
@@ -278,18 +278,18 @@ private:
     friend class TypeName::TypeNameParser;
     
 public:
-    virtual HRESULT __stdcall QueryInterface(REFIID riid, void **ppUnk);
-    virtual ULONG __stdcall AddRef();
-    virtual ULONG __stdcall Release();
+    virtual HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void **ppUnk);
+    virtual ULONG STDMETHODCALLTYPE AddRef();
+    virtual ULONG STDMETHODCALLTYPE Release();
 
 public:
-    virtual HRESULT __stdcall GetNameCount(DWORD* pCount);
-    virtual HRESULT __stdcall GetNames(DWORD count, BSTR* rgbszNames, DWORD* pFetched);
-    virtual HRESULT __stdcall GetTypeArgumentCount(DWORD* pCount);
-    virtual HRESULT __stdcall GetTypeArguments(DWORD count, ITypeName** rgpArguments, DWORD* pFetched);
-    virtual HRESULT __stdcall GetModifierLength(DWORD* pCount);
-    virtual HRESULT __stdcall GetModifiers(DWORD count, DWORD* rgModifiers, DWORD* pFetched);
-    virtual HRESULT __stdcall GetAssemblyName(BSTR* rgbszAssemblyNames);
+    virtual HRESULT STDMETHODCALLTYPE GetNameCount(DWORD* pCount);
+    virtual HRESULT STDMETHODCALLTYPE GetNames(DWORD count, BSTR* rgbszNames, DWORD* pFetched);
+    virtual HRESULT STDMETHODCALLTYPE GetTypeArgumentCount(DWORD* pCount);
+    virtual HRESULT STDMETHODCALLTYPE GetTypeArguments(DWORD count, ITypeName** rgpArguments, DWORD* pFetched);
+    virtual HRESULT STDMETHODCALLTYPE GetModifierLength(DWORD* pCount);
+    virtual HRESULT STDMETHODCALLTYPE GetModifiers(DWORD count, DWORD* rgModifiers, DWORD* pFetched);
+    virtual HRESULT STDMETHODCALLTYPE GetAssemblyName(BSTR* rgbszAssemblyNames);
     
 public:
     TypeName(LPCWSTR szTypeName, DWORD* pError) : m_bIsGenericArgument(FALSE), m_count(0) 

--- a/src/vm/typestring.cpp
+++ b/src/vm/typestring.cpp
@@ -1415,7 +1415,7 @@ bool TypeString::ContainsReservedChar(LPCWSTR pTypeName)
     return false;
 }
 
-HRESULT __stdcall TypeNameBuilderWrapper::QueryInterface(REFIID riid, void **ppUnk)
+HRESULT STDMETHODCALLTYPE TypeNameBuilderWrapper::QueryInterface(REFIID riid, void **ppUnk)
 {
     CONTRACTL
     {
@@ -1439,7 +1439,7 @@ HRESULT __stdcall TypeNameBuilderWrapper::QueryInterface(REFIID riid, void **ppU
     return S_OK;
 }
 
-ULONG __stdcall TypeNameBuilderWrapper::AddRef()
+ULONG STDMETHODCALLTYPE TypeNameBuilderWrapper::AddRef()
 {
     CONTRACTL
     {
@@ -1453,7 +1453,7 @@ ULONG __stdcall TypeNameBuilderWrapper::AddRef()
     return InterlockedIncrement(&m_ref);
 }
 
-ULONG __stdcall TypeNameBuilderWrapper::Release()
+ULONG STDMETHODCALLTYPE TypeNameBuilderWrapper::Release()
 {
     CONTRACTL
     {
@@ -1479,7 +1479,7 @@ ULONG __stdcall TypeNameBuilderWrapper::Release()
 }
 
 
-HRESULT __stdcall TypeNameBuilderWrapper::OpenGenericArguments()
+HRESULT STDMETHODCALLTYPE TypeNameBuilderWrapper::OpenGenericArguments()
 {
     CONTRACTL
     {
@@ -1496,7 +1496,7 @@ HRESULT __stdcall TypeNameBuilderWrapper::OpenGenericArguments()
     return hr;
 }
 
-HRESULT __stdcall TypeNameBuilderWrapper::CloseGenericArguments()
+HRESULT STDMETHODCALLTYPE TypeNameBuilderWrapper::CloseGenericArguments()
 {
     CONTRACTL
     {
@@ -1513,7 +1513,7 @@ HRESULT __stdcall TypeNameBuilderWrapper::CloseGenericArguments()
     return hr;
 }
 
-HRESULT __stdcall TypeNameBuilderWrapper::OpenGenericArgument()
+HRESULT STDMETHODCALLTYPE TypeNameBuilderWrapper::OpenGenericArgument()
 {
     CONTRACTL
     {
@@ -1530,7 +1530,7 @@ HRESULT __stdcall TypeNameBuilderWrapper::OpenGenericArgument()
     return hr;
 }
 
-HRESULT __stdcall TypeNameBuilderWrapper::CloseGenericArgument()
+HRESULT STDMETHODCALLTYPE TypeNameBuilderWrapper::CloseGenericArgument()
 {
     CONTRACTL
     {
@@ -1547,7 +1547,7 @@ HRESULT __stdcall TypeNameBuilderWrapper::CloseGenericArgument()
     return hr;
 }
 
-HRESULT __stdcall TypeNameBuilderWrapper::AddName(LPCWSTR szName)
+HRESULT STDMETHODCALLTYPE TypeNameBuilderWrapper::AddName(LPCWSTR szName)
 {
     CONTRACTL
     {
@@ -1564,7 +1564,7 @@ HRESULT __stdcall TypeNameBuilderWrapper::AddName(LPCWSTR szName)
     return hr;
 }
 
-HRESULT __stdcall TypeNameBuilderWrapper::AddPointer()
+HRESULT STDMETHODCALLTYPE TypeNameBuilderWrapper::AddPointer()
 {
     CONTRACTL
     {
@@ -1581,7 +1581,7 @@ HRESULT __stdcall TypeNameBuilderWrapper::AddPointer()
     return hr;
 }
 
-HRESULT __stdcall TypeNameBuilderWrapper::AddByRef()
+HRESULT STDMETHODCALLTYPE TypeNameBuilderWrapper::AddByRef()
 {
     CONTRACTL
     {
@@ -1598,7 +1598,7 @@ HRESULT __stdcall TypeNameBuilderWrapper::AddByRef()
     return hr;
 }
 
-HRESULT __stdcall TypeNameBuilderWrapper::AddSzArray()
+HRESULT STDMETHODCALLTYPE TypeNameBuilderWrapper::AddSzArray()
 {
     CONTRACTL
     {
@@ -1615,7 +1615,7 @@ HRESULT __stdcall TypeNameBuilderWrapper::AddSzArray()
     return hr;
 }
 
-HRESULT __stdcall TypeNameBuilderWrapper::AddArray(DWORD rank)
+HRESULT STDMETHODCALLTYPE TypeNameBuilderWrapper::AddArray(DWORD rank)
 {
     CONTRACTL
     {
@@ -1632,7 +1632,7 @@ HRESULT __stdcall TypeNameBuilderWrapper::AddArray(DWORD rank)
     return hr;
 }
 
-HRESULT __stdcall TypeNameBuilderWrapper::AddAssemblySpec(LPCWSTR szAssemblySpec)
+HRESULT STDMETHODCALLTYPE TypeNameBuilderWrapper::AddAssemblySpec(LPCWSTR szAssemblySpec)
 {
     CONTRACTL
     {
@@ -1649,7 +1649,7 @@ HRESULT __stdcall TypeNameBuilderWrapper::AddAssemblySpec(LPCWSTR szAssemblySpec
     return hr;
 }
 
-HRESULT __stdcall TypeNameBuilderWrapper::ToString(BSTR* pszStringRepresentation)
+HRESULT STDMETHODCALLTYPE TypeNameBuilderWrapper::ToString(BSTR* pszStringRepresentation)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1660,7 +1660,7 @@ HRESULT __stdcall TypeNameBuilderWrapper::ToString(BSTR* pszStringRepresentation
     return hr;
 }
 
-HRESULT __stdcall TypeNameBuilderWrapper::Clear()
+HRESULT STDMETHODCALLTYPE TypeNameBuilderWrapper::Clear()
 {
     CONTRACTL
     {

--- a/src/vm/typestring.h
+++ b/src/vm/typestring.h
@@ -153,22 +153,22 @@ private:
 class TypeNameBuilderWrapper : public ITypeNameBuilder
 {
 public:
-    virtual HRESULT __stdcall QueryInterface(REFIID riid, void **ppUnk);
-    virtual ULONG __stdcall AddRef();
-    virtual ULONG __stdcall Release();
+    virtual HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void **ppUnk);
+    virtual ULONG STDMETHODCALLTYPE AddRef();
+    virtual ULONG STDMETHODCALLTYPE Release();
 
-    virtual HRESULT __stdcall OpenGenericArguments(); 
-    virtual HRESULT __stdcall CloseGenericArguments(); 
-    virtual HRESULT __stdcall OpenGenericArgument(); 
-    virtual HRESULT __stdcall CloseGenericArgument();
-    virtual HRESULT __stdcall AddName(LPCWSTR szName); 
-    virtual HRESULT __stdcall AddPointer(); 
-    virtual HRESULT __stdcall AddByRef(); 
-    virtual HRESULT __stdcall AddSzArray(); 
-    virtual HRESULT __stdcall AddArray(DWORD rank);
-    virtual HRESULT __stdcall AddAssemblySpec(LPCWSTR szAssemblySpec);
-    virtual HRESULT __stdcall ToString(BSTR* pszStringRepresentation);
-    virtual HRESULT __stdcall Clear();
+    virtual HRESULT STDMETHODCALLTYPE OpenGenericArguments();
+    virtual HRESULT STDMETHODCALLTYPE CloseGenericArguments();
+    virtual HRESULT STDMETHODCALLTYPE OpenGenericArgument();
+    virtual HRESULT STDMETHODCALLTYPE CloseGenericArgument();
+    virtual HRESULT STDMETHODCALLTYPE AddName(LPCWSTR szName);
+    virtual HRESULT STDMETHODCALLTYPE AddPointer();
+    virtual HRESULT STDMETHODCALLTYPE AddByRef();
+    virtual HRESULT STDMETHODCALLTYPE AddSzArray();
+    virtual HRESULT STDMETHODCALLTYPE AddArray(DWORD rank);
+    virtual HRESULT STDMETHODCALLTYPE AddAssemblySpec(LPCWSTR szAssemblySpec);
+    virtual HRESULT STDMETHODCALLTYPE ToString(BSTR* pszStringRepresentation);
+    virtual HRESULT STDMETHODCALLTYPE Clear();
 
     TypeNameBuilderWrapper() : m_ref(0) { WRAPPER_NO_CONTRACT; }
     virtual ~TypeNameBuilderWrapper() {}


### PR DESCRIPTION
This commit fixes lexical mismatch between declarations and definitions, and sets CDECL as STDMETHODCALLTYPE .
