### PR TITLE
Configure auto-update to use upstream 2.0.0 builds [release/2.0.0]

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -19,7 +19,7 @@
   <!-- Package dependency verification/auto-upgrade configuration. -->
   <PropertyGroup>
     <BaseDotNetBuildInfo>build-info/dotnet/</BaseDotNetBuildInfo>
-    <DependencyBranch>master</DependencyBranch>
+    <DependencyBranch>release/2.0.0</DependencyBranch>
     <CurrentRefXmlPath>$(MSBuildThisFileFullPath)</CurrentRefXmlPath>
   </PropertyGroup>
 

--- a/dependencies.props
+++ b/dependencies.props
@@ -1,18 +1,18 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Source of truth for dependency tooling: the commit hash of the dotnet/versions master branch as of the last auto-upgrade. -->
   <PropertyGroup>
-    <CoreFxCurrentRef>c9fa785e7049638603fca518d56198f60d901203</CoreFxCurrentRef>
-    <CoreClrCurrentRef>fcd99ed86a703a16698fcd0027707739c8ef3501</CoreClrCurrentRef>
+    <CoreFxCurrentRef>dfaf5828f1552bb782b2198e6d3405eaa54384fc</CoreFxCurrentRef>
+    <CoreClrCurrentRef>dfaf5828f1552bb782b2198e6d3405eaa54384fc</CoreClrCurrentRef>
   </PropertyGroup>
 
   <!-- Auto-upgraded properties for each build info dependency. -->
   <PropertyGroup>
-    <CoreFxExpectedPrerelease>preview2-25319-01</CoreFxExpectedPrerelease>
+    <CoreFxExpectedPrerelease>preview2-25322-03</CoreFxExpectedPrerelease>
   </PropertyGroup>
 
   <!-- Full package version strings that are used in other parts of the build. -->
   <PropertyGroup>
-    <CoreClrPackageVersion>2.0.0-preview2-25316-03</CoreClrPackageVersion>
+    <CoreClrPackageVersion>2.0.0-preview2-25322-01</CoreClrPackageVersion>
     <XunitPackageVersion>2.2.0-beta2-build3300</XunitPackageVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes #11754. Pull in updates from CoreFX and CoreCLR release/2.0.0 builds rather than master builds. I did an auto-update, too, so `VerifyDependencies` doesn't fail.