### PR TITLE
Fix ReadMemory error reading DSO link_map name.

### DIFF
--- a/src/debug/createdump/createdump.cpp
+++ b/src/debug/createdump/createdump.cpp
@@ -15,8 +15,8 @@ CreateDumpCommon(const char* programPath, const char* dumpPathTemplate, MINIDUMP
     ReleaseHolder<DumpWriter> dumpWriter = new DumpWriter(*crashInfo);
     bool result = false;
 
-    ArrayHolder<char> dumpPath = new char[MAX_LONGPATH];
-    snprintf(dumpPath, MAX_LONGPATH, dumpPathTemplate, crashInfo->Pid());
+    ArrayHolder<char> dumpPath = new char[PATH_MAX];
+    snprintf(dumpPath, PATH_MAX, dumpPathTemplate, crashInfo->Pid());
 
     const char* dumpType = "minidump";
     switch (minidumpType)


### PR DESCRIPTION
Causes creating a minidump to silently fail.

Issue #11758