### PR TITLE
Port a018c48 from master: fix legality checks in SetRegOptionalForBinOp.

### DIFF
--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -178,15 +178,19 @@ private:
     {
         assert(GenTree::OperIsBinary(tree->OperGet()));
 
-        GenTree* op1 = tree->gtGetOp1();
-        GenTree* op2 = tree->gtGetOp2();
+        GenTree* const op1 = tree->gtGetOp1();
+        GenTree* const op2 = tree->gtGetOp2();
 
-        if (tree->OperIsCommutative() && tree->TypeGet() == op1->TypeGet())
+        const unsigned operatorSize = genTypeSize(tree->TypeGet());
+
+        const bool op1Legal = tree->OperIsCommutative() && (operatorSize == genTypeSize(op1->TypeGet()));
+        const bool op2Legal = operatorSize == genTypeSize(op2->TypeGet());
+
+        if (op1Legal)
         {
-            GenTree* preferredOp = PreferredRegOptionalOperand(tree);
-            SetRegOptional(preferredOp);
+            SetRegOptional(op2Legal ? PreferredRegOptionalOperand(tree) : op1);
         }
-        else if (tree->TypeGet() == op2->TypeGet())
+        else if (op2Legal)
         {
             SetRegOptional(op2);
         }


### PR DESCRIPTION
It is not legal to make an operand register optional on xarch if the type
of the operand is narrower than the type of the operator and the contents
of the upper bits are not known to be zero. `SetRegOptionalForBinOp` was
not considering the case where `op1` was legal but `op2` was the preferred
register-optional operand and was illegal.

The original change fixed issue #11734.