### PR TITLE
Quiet warning C2220

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -18062,7 +18062,7 @@ GenTreePtr Compiler::fgMorphImplicitByRefArgs(GenTreePtr tree, bool isAddr)
     LclVarDsc* lclVarDsc  = &lvaTable[lclNum];
 
     CORINFO_FIELD_HANDLE fieldHnd;
-    unsigned             fieldOffset;
+    unsigned             fieldOffset  = 0;
     var_types            fieldRefType = TYP_UNKNOWN;
 
     if (lvaIsImplicitByRefLocal(lclNum))


### PR DESCRIPTION
This warning reports "potentially uninitialized local variable
`fieldOffset` used".  The use is guarded by a check on `fieldHnd` being
non-null, and `fieldOffset` gets initialized properly on all paths that
set `fieldHnd` to something other than null, so the fix is simply to
initialize `fieldOffset` to 0 at its declaration so the compiler won't
complain.

Resolves #11800.