### PR TITLE
Update Unix SafeHandle to throw NotFound correctly (#11757)

### DIFF
--- a/src/mscorlib/shared/System/IO/PathInternal.Unix.cs
+++ b/src/mscorlib/shared/System/IO/PathInternal.Unix.cs
@@ -100,5 +100,10 @@ namespace System.IO
             // As long as the path is rooted in Unix it doesn't use the current directory and therefore is fully qualified.
             return !Path.IsPathRooted(path);
         }
+
+        internal static string TrimEndingDirectorySeparator(string path) =>
+            path.Length > 1 && IsDirectorySeparator(path[path.Length - 1]) ? // exclude root "/"
+            path.Substring(0, path.Length - 1) :
+            path;
     }
 }

--- a/src/mscorlib/shared/System/IO/PathInternal.Windows.cs
+++ b/src/mscorlib/shared/System/IO/PathInternal.Windows.cs
@@ -438,5 +438,10 @@ namespace System.IO
         {
             return IsDirectorySeparator(ch) || VolumeSeparatorChar == ch;
         }
+
+        internal static string TrimEndingDirectorySeparator(string path) =>
+            EndsInDirectorySeparator(path) ?
+            path.Substring(0, path.Length - 1) :
+            path;
     }
 }


### PR DESCRIPTION
Port for issue https://github.com/dotnet/corefx/issues/20040. CoreFX part is https://github.com/dotnet/corefx/pull/20134.

* Update Unix SafeHandle to throw NotFound correctly

Need to match Windows semantics for missing files. This means throwing
FileNotFound only if the last segment of the path can't be found.

* Dispose handle and trim ending separator properly