### PR TITLE
[ARM32/RyuJIT] Lowering: split struct argument less than 16 bytes

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -11342,6 +11342,68 @@ void Compiler::gtGetLateArgMsg(
         {
             sprintf_s(bufp, bufLength, "this in %s%c", compRegVarName(argReg), 0);
         }
+#ifdef _TARGET_ARM_
+        else if (curArgTabEntry->isSplit)
+        {
+            regNumber firstReg = curArgTabEntry->regNum;
+            unsigned  argNum   = curArgTabEntry->argNum;
+            if (listCount == -1)
+            {
+                if (curArgTabEntry->numRegs == 1)
+                {
+                    sprintf_s(bufp, bufLength, "arg%d %s out+%02x%c", argNum, compRegVarName(firstReg),
+                              (curArgTabEntry->slotNum) * TARGET_POINTER_SIZE, 0);
+                }
+                else
+                {
+                    regNumber lastReg   = REG_STK;
+                    char      separator = (curArgTabEntry->numRegs == 2) ? ',' : '-';
+                    if (curArgTabEntry->isHfaRegArg)
+                    {
+                        unsigned lastRegNum = genMapFloatRegNumToRegArgNum(firstReg) + curArgTabEntry->numRegs - 1;
+                        lastReg             = genMapFloatRegArgNumToRegNum(lastRegNum);
+                    }
+                    else
+                    {
+                        unsigned lastRegNum = genMapIntRegNumToRegArgNum(firstReg) + curArgTabEntry->numRegs - 1;
+                        lastReg             = genMapIntRegArgNumToRegNum(lastRegNum);
+                    }
+                    sprintf_s(bufp, bufLength, "arg%d %s%c%s out+%02x%c", argNum, compRegVarName(firstReg), separator,
+                              compRegVarName(lastReg), (curArgTabEntry->slotNum) * TARGET_POINTER_SIZE, 0);
+                }
+            }
+            else
+            {
+                unsigned curArgNum = BAD_VAR_NUM;
+                bool     isFloat   = curArgTabEntry->isHfaRegArg;
+                if (isFloat)
+                {
+                    curArgNum = genMapFloatRegNumToRegArgNum(firstReg) + listCount;
+                }
+                else
+                {
+                    curArgNum = genMapIntRegNumToRegArgNum(firstReg) + listCount;
+                }
+
+                if (!isFloat && curArgNum < MAX_REG_ARG)
+                {
+                    regNumber curReg = genMapIntRegArgNumToRegNum(curArgNum);
+                    sprintf_s(bufp, bufLength, "arg%d m%d %s%c", argNum, listCount, compRegVarName(curReg), 0);
+                }
+                else if (isFloat && curArgNum < MAX_FLOAT_REG_ARG)
+                {
+                    regNumber curReg = genMapFloatRegArgNumToRegNum(curArgNum);
+                    sprintf_s(bufp, bufLength, "arg%d m%d %s%c", argNum, listCount, compRegVarName(curReg), 0);
+                }
+                else
+                {
+                    unsigned stackSlot = listCount - curArgTabEntry->numRegs;
+                    sprintf_s(bufp, bufLength, "arg%d m%d out+%s%c", argNum, listCount, stackSlot, 0);
+                }
+            }
+            return;
+        }
+#endif // _TARGET_ARM_
         else
         {
 #if FEATURE_MULTIREG_ARGS

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -771,6 +771,11 @@ void Lowering::TreeNodeInfoInitPutArgSplit(GenTreePutArgSplit* argNode, TreeNode
     }
     argNode->gtLsraInfo.setDstCandidates(m_lsra, argMask);
 
+    if (putArgChild->OperGet() == GT_FIELD_LIST)
+    {
+        NYI_ARM("LSRA: Oper for split struct argument is GT_FIELD_LIST");
+    }
+
     assert(putArgChild->TypeGet() == TYP_STRUCT);
     assert(putArgChild->OperGet() == GT_OBJ);
     // We could use a ldr/str sequence so we need a internal register

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -4769,17 +4769,12 @@ GenTreePtr Compiler::fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr f
     {
         if (fgEntryPtr->isHfaRegArg)
         {
-            // We cannot handle split struct morphed to GT_FIELD_LIST yet
+            // We cannot handle HFA split struct morphed to GT_FIELD_LIST yet
             NYI_ARM("Struct split between float registers and stack");
         }
         else if (fgEntryPtr->numSlots + fgEntryPtr->numRegs > 4)
         {
             return arg;
-        }
-        else
-        {
-            // We cannot handle split struct morphed to GT_FIELD_LIST yet
-            NYI_ARM("Struct split between integer registers and stack");
         }
     }
     else if (!fgEntryPtr->isHfaRegArg && fgEntryPtr->numSlots > 4)


### PR DESCRIPTION
Enable passing split struct (less than 16 bytes) 
- morphing phase
- Lowering phase

Block at LSRA phase
- add NYI_ARM in TreeNodeInfoInitPutArgSplit()

Print split struct

related issue: #10722