### PR TITLE
[RyuJIT/ARM][LSRA] Update register mask for GC helper

### DIFF
--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -1440,7 +1440,7 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
 
   // The registers trashed by the CORINFO_HELP_STOP_FOR_GC helper
   // See vm\arm\amshelpers.asm for more details.
-  #define RBM_STOP_FOR_GC_TRASH     (RBM_CALLEE_TRASH & ~(RBM_FLOATRET | RBM_INTRET))
+  #define RBM_STOP_FOR_GC_TRASH     (RBM_CALLEE_TRASH & ~(RBM_DOUBLERET | RBM_INTRET))
 
   // The registers trashed by the CORINFO_HELP_INIT_PINVOKE_FRAME helper.
   #define RBM_INIT_PINVOKE_FRAME_TRASH (RBM_CALLEE_TRASH | RBM_PINVOKE_TCB | RBM_PINVOKE_SCRATCH)

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -1438,9 +1438,9 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define RBM_FLOATRET             RBM_F0
   #define RBM_DOUBLERET           (RBM_F0|RBM_F1)
 
-  // The registers trashed by the CORINFO_HELP_STOP_FOR_GC helper
+  // The registers trashed by the CORINFO_HELP_STOP_FOR_GC helper (JIT_RareDisableHelper).
   // See vm\arm\amshelpers.asm for more details.
-  #define RBM_STOP_FOR_GC_TRASH     (RBM_CALLEE_TRASH & ~(RBM_DOUBLERET | RBM_INTRET))
+  #define RBM_STOP_FOR_GC_TRASH     (RBM_CALLEE_TRASH & ~(RBM_LNGRET|RBM_R7|RBM_R8|RBM_R11|RBM_DOUBLERET|RBM_F2|RBM_F3|RBM_F4|RBM_F5|RBM_F6|RBM_F7))
 
   // The registers trashed by the CORINFO_HELP_INIT_PINVOKE_FRAME helper.
   #define RBM_INIT_PINVOKE_FRAME_TRASH (RBM_CALLEE_TRASH | RBM_PINVOKE_TCB | RBM_PINVOKE_SCRATCH)


### PR DESCRIPTION
CORINFO_HELP_STOP_FOR_GC helper preserves integer and double return register.

Fix #11784 


This removes `Assertion failed 'genIsValidDoubleReg(regRec->regNum)'` from following tests.
```
JIT/jit64/hfa/main/testA/hfa_nd2A_d
JIT/jit64/hfa/main/testA/hfa_nd2A_r
JIT/jit64/hfa/main/testA/hfa_sd2A_d
JIT/jit64/hfa/main/testA/hfa_sd2A_r
JIT/jit64/hfa/main/testB/hfa_nd2B_d
JIT/jit64/hfa/main/testB/hfa_nd2B_r
JIT/jit64/hfa/main/testB/hfa_sd2B_d
JIT/jit64/hfa/main/testB/hfa_sd2B_r
JIT/jit64/hfa/main/testC/hfa_nd2C_d
JIT/jit64/hfa/main/testC/hfa_nd2C_r
JIT/jit64/hfa/main/testC/hfa_sd2C_d
JIT/jit64/hfa/main/testC/hfa_sd2C_r
JIT/jit64/hfa/main/testG/hfa_nd2G_d
JIT/jit64/hfa/main/testG/hfa_nd2G_r
JIT/jit64/hfa/main/testG/hfa_sd2G_d
JIT/jit64/hfa/main/testG/hfa_sd2G_r
JIT/Regression/JitBlue/DevDiv_278376/DevDiv_278376
JIT/Regression/VS-ia64-JIT/V1.2-M02/b108129/b108129
```

## Example

With `COMPlus_AltJit=C:Test` option, `JIT/Regression/JitBlue/DevDiv_278376/DevDiv_278376`

### Before
```
FAILED   - [   0][   2s]JIT/Regression/JitBlue/DevDiv_278376/DevDiv_278376/DevDiv_278376.sh
               BEGIN EXECUTION
               /mnt/albireo/mywork/device/rpi3/unittests/coreoverlays/coreoverlay.test20170523.checked/corerun DevDiv_278376.exe
               
               Assert failure(PID 25738 [0x0000648a], Thread: 25738 [0x648a]): Assertion failed 'genIsValidDoubleReg(regRec->regNum)' in 'C:Test(bool):int' (IL size 17)
               
                   File: /opt/code/github/hqueue/coreclr/src/jit/lsra.cpp Line: 6334
                   Image: /mnt/albireo/mywork/device/rpi3/unittests/coreoverlays/coreoverlay.test20170523.checked/corerun
               
               ./DevDiv_278376.sh: line 240: 25738 Aborted                 (core dumped) $_DebuggerFullPath "$CORE_ROOT/corerun" $ExePath $CLRTestExecutionArguments
               Expected: 100
               Actual: 134
               END EXECUTION - FAILED
```

### After
```
PASSED   - [   0][   2s]JIT/Regression/JitBlue/DevDiv_278376/DevDiv_278376/DevDiv_278376.sh
               BEGIN EXECUTION
               /mnt/albireo/mywork/device/rpi3/unittests/coreoverlays/coreoverlay.test20170523.checked.working/corerun DevDiv_278376.exe
               Expected: 100
               Actual: 100
               END EXECUTION - PASSED
```
