### PR TITLE
[Arm64 Unix CI] Build linux arm64 mscorlib for cross

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1428,6 +1428,10 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                         buildCommands += "build.cmd ${lowerConfiguration} ${arch} linuxmscorlib"
                         buildCommands += "build.cmd ${lowerConfiguration} ${arch} freebsdmscorlib"
                         buildCommands += "build.cmd ${lowerConfiguration} ${arch} osxmscorlib"
+                       
+                        if (arch == "x64") {
+                            buildCommands += "build.cmd ${lowerConfiguration} ${arch} linuxmscorlib"
+                        }
 
                         // Zip up the tests directory so that we don't use so much space/time copying
                         // 10s of thousands of files around.


### PR DESCRIPTION
This will enable cross building the linux arm64 System.Private.Corelib
in every amd64 windows build in netci.

** Note, this is a merge into dev/unix_test_workflow **