### PR TITLE
Add the case 1 % 1 to our bringup test

### DIFF
--- a/tests/src/JIT/CodeGenBringUpTests/ModConst.cs
+++ b/tests/src/JIT/CodeGenBringUpTests/ModConst.cs
@@ -201,6 +201,11 @@ static class ModProgram
             return Fail;
         }
 
+        if (ModConst.I4_Mod_1(1) != 0)
+        {
+            return Fail;
+        }
+
         if (ModConst.I4_Mod_Minus1(42) != 0)
         {
             return Fail;


### PR DESCRIPTION
Addresses lack of coverage shown in #7168.

Note this proves #7168 no longer repros.