### PR TITLE
StreamingContext Context equality fix

### DIFF
--- a/src/mscorlib/shared/System/Runtime/Serialization/StreamingContext.cs
+++ b/src/mscorlib/shared/System/Runtime/Serialization/StreamingContext.cs
@@ -27,7 +27,7 @@ namespace System.Runtime.Serialization
                 return false;
             }
             StreamingContext ctx = (StreamingContext)obj;
-            return ctx._additionalContext == _additionalContext && ctx._state == _state;
+            return Object.Equals(ctx._additionalContext, _additionalContext) && ctx._state == _state;
         }
 
         public override int GetHashCode() => (int)_state;


### PR DESCRIPTION
StreamingContext currently compares its Context with an equality operator which isn't wise as most types are implementing an equal override but no equality operator.