### PR TITLE
[release/2.0.0] Delete special handling of IJW RVA fields at NGen time (#11818)

### DIFF
--- a/src/inc/corcompile.h
+++ b/src/inc/corcompile.h
@@ -468,15 +468,6 @@ struct CORCOMPILE_EE_INFO_TABLE
     DWORD                      threadTlsIndex;
 
     DWORD                      rvaStaticTlsIndex;
-
-// These are used by the 64-bit JITs to detect calls to thunks in the .nep section
-// and conditionally eliminate double-thunking (managed-to-native-to-managed).
-// During prejit these are set to the RVAs of the .nep section. When the prejitted
-// image is actually loaded, these are fixed up to point to the actual .nep section
-// of the ijw image (not the native image).
-
-    BYTE *                     nativeEntryPointStart;
-    BYTE *                     nativeEntryPointEnd;
 };
 
 /*********************************************************************************/

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -9550,7 +9550,7 @@ void Module::Arrange(DataImage *image)
             else if (TypeFromToken(token) == mdtFieldDef)
             {
                 FieldDesc *pFD = LookupFieldDef(token);
-                if (pFD && pFD->IsILOnlyRVAField())
+                if (pFD && pFD->IsRVA())
                 {
                     if (entry->flags & (1 << RVAFieldData))
                     {

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -652,22 +652,6 @@ HRESULT CEECompileInfo::SetCompilationTarget(CORINFO_ASSEMBLY_HANDLE     assembl
         }
     }
 
-#ifdef FEATURE_READYTORUN_COMPILER
-    if (IsReadyToRunCompilation() && !pModule->IsILOnly())
-    {
-        GetSvcLogger()->Printf(LogLevel_Error, W("Error: /readytorun not supported for mixed mode assemblies\n"));
-        return E_FAIL;
-    }
-#endif
-
-#ifdef FEATURE_READYTORUN_COMPILER
-    if (IsReadyToRunCompilation() && !pModule->IsILOnly())
-    {
-        GetSvcLogger()->Printf(LogLevel_Error, W("Error: /readytorun not supported for mixed mode assemblies\n"));
-        return E_FAIL;
-    }
-#endif
-
     return S_OK;
 }
 
@@ -6809,7 +6793,7 @@ void CEEPreloader::GetRVAFieldData(mdFieldDef fd, PVOID * ppData, DWORD * pcbSiz
     if (pFD == NULL)
         ThrowHR(COR_E_TYPELOAD);
 
-    _ASSERTE(pFD->IsILOnlyRVAField());
+    _ASSERTE(pFD->IsRVA());
 
     UINT size = pFD->LoadSize();
 

--- a/src/vm/field.cpp
+++ b/src/vm/field.cpp
@@ -738,7 +738,7 @@ void FieldDesc::SaveContents(DataImage *image)
     // image.
     // 
 
-    if (IsILOnlyRVAField())
+    if (IsRVA())
     {
         //
         // Move the RVA data into the prejit image.

--- a/src/vm/field.h
+++ b/src/vm/field.h
@@ -274,12 +274,6 @@ public:
                       : dwOffset;
     }
 
-    BOOL IsILOnlyRVAField()
-    {
-        WRAPPER_NO_CONTRACT;
-        return (IsRVA() && GetModule()->GetFile()->IsILOnly());
-    }
-
     DWORD   IsStatic() const
     {
         LIMITED_METHOD_DAC_CONTRACT;

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -2656,41 +2656,6 @@ void ZapInfo::getModuleNativeEntryPointRange(void** pStart, void** pEnd)
     // Initialize outparams to default range of (0,0).
     *pStart = 0;
     *pEnd = 0;
-
-    // If this is ILONLY, there are no native entry points.
-    if (m_pImage->m_ModuleDecoder.IsILOnly())
-    {
-        return;
-    }
-
-    rvaStart = rvaEnd = 0;
-
-    // Walk the section table looking for a section named .nep.
-
-    IMAGE_SECTION_HEADER *section = m_pImage->m_ModuleDecoder.FindFirstSection();
-    IMAGE_SECTION_HEADER *sectionEnd = section + m_pImage->m_ModuleDecoder.GetNumberOfSections();
-    while (section < sectionEnd)
-    {
-        if (strncmp((const char *)(section->Name), ".nep", IMAGE_SIZEOF_SHORT_NAME) == 0)
-        {
-            rvaStart = VAL32(section->VirtualAddress);
-            rvaEnd = rvaStart + VAL32(section->Misc.VirtualSize);
-            if (rvaStart < rvaEnd)
-            {
-                // RVA will be fixed up to the actual address at runtime
-                CORCOMPILE_EE_INFO_TABLE * pEEInfoTable = (CORCOMPILE_EE_INFO_TABLE *)m_pImage->m_pEEInfoTable->GetData();
-                pEEInfoTable->nativeEntryPointStart = (BYTE*)((ULONG_PTR)rvaStart);
-                pEEInfoTable->nativeEntryPointEnd = (BYTE*)((ULONG_PTR)rvaEnd);
-
-                *pStart = m_pImage->GetInnerPtr(m_pImage->m_pEEInfoTable,
-                    offsetof(CORCOMPILE_EE_INFO_TABLE, nativeEntryPointStart));
-                *pEnd = m_pImage->GetInnerPtr(m_pImage->m_pEEInfoTable,
-                    offsetof(CORCOMPILE_EE_INFO_TABLE, nativeEntryPointEnd));
-            }
-            break;
-        }
-        section++;
-    }
 }
 
 DWORD ZapInfo::getExpectedTargetArchitecture()
@@ -3193,10 +3158,6 @@ unsigned ZapInfo::getArrayRank(CORINFO_CLASS_HANDLE cls)
 void * ZapInfo::getArrayInitializationData(CORINFO_FIELD_HANDLE field, DWORD size)
 {
     if (m_pEEJitInfo->getClassModule(m_pEEJitInfo->getFieldClass(field)) != m_pImage->m_hModule)
-        return NULL;
-
-    // FieldDesc::SaveContents() does not save the RVA blob for IJW modules.
-    if (!m_pImage->m_ModuleDecoder.IsILOnly())
         return NULL;
 
     void * arrayData = m_pEEJitInfo->getArrayInitializationData(field, size);


### PR DESCRIPTION
Mixed mode managed C++ is not supported by CoreCLR so this is not needed for anything.

Fixes #11761