### PR TITLE
ILLink Performance Tests: Enable MusicStore

### DIFF
--- a/tests/src/performance/linkbench/linkbench.cs
+++ b/tests/src/performance/linkbench/linkbench.cs
@@ -251,15 +251,14 @@ namespace LinkBench
                 "WebAPI\\bin\\release\\netcoreapp2.0\\win10-x64\\linked",
                 () => { Benchmark.AddLinkerReference("WebAPI\\WebAPI.csproj");
                         Benchmark.PreventPublishFiltering("WebAPI\\WebAPI.csproj"); }),
-            //Remove the MusicStore from the run as the scenario is currently flaky and breaking performance runs
-            /*new Benchmark("MusicStore",
+            new Benchmark("MusicStore",
                 "JitBench\\src\\MusicStore\\bin\\release\\netcoreapp2.0\\win10-x64\\unlinked",
                 "JitBench\\src\\MusicStore\\bin\\release\\netcoreapp2.0\\win10-x64\\linked",
                 () => { Benchmark.AddLinkerReference("JitBench\\src\\MusicStore\\MusicStore.csproj");
                        Benchmark.SetRuntimeFrameworkVersion("JitBench\\src\\MusicStore\\MusicStore.csproj"); }),
             new Benchmark("MusicStore_R2R",
                 "JitBench\\src\\MusicStore\\bin\\release\\netcoreapp2.0\\win10-x64\\R2R\\unlinked",
-                "JitBench\\src\\MusicStore\\bin\\release\\netcoreapp2.0\\win10-x64\\R2R\\linked"),*/
+                "JitBench\\src\\MusicStore\\bin\\release\\netcoreapp2.0\\win10-x64\\R2R\\linked"),
             new Benchmark("Corefx",
                 "corefx\\bin\\ILLinkTrimAssembly\\netcoreapp-Windows_NT-Release-x64\\pretrimmed",
                 "corefx\\bin\\ILLinkTrimAssembly\\netcoreapp-Windows_NT-Release-x64\\trimmed"),


### PR DESCRIPTION
Enable the Musicstore tests, since the failure in JitBench is
now fixed.