### PR TITLE
[x86/Linux] Thread-safe UMThunkMarshInfo::RunTimeInit

### DIFF
--- a/src/vm/dllimportcallback.cpp
+++ b/src/vm/dllimportcallback.cpp
@@ -1382,9 +1382,9 @@ VOID UMThunkMarshInfo::RunTimeInit()
     UINT16 cbRetPop = 0;
 
     //
-    // m_cbStackArgSize represents the number of arg bytes for the MANAGED signature
+    // cbStackArgSize represents the number of arg bytes for the MANAGED signature
     //
-    m_cbStackArgSize = 0;
+    UINT32 cbStackArgSize = 0;
 
     int offs = 0;
 
@@ -1410,9 +1410,10 @@ VOID UMThunkMarshInfo::RunTimeInit()
         else
         {
             offs += StackElemSize(cbSize);
-            m_cbStackArgSize += StackElemSize(cbSize);
+            cbStackArgSize += StackElemSize(cbSize);
         }
     }
+    m_cbStackArgSize = cbStackArgSize;
     m_cbActualArgSize = (pStubMD != NULL) ? pStubMD->AsDynamicMethodDesc()->GetNativeStackArgSize() : offs;
 
     PInvokeStaticSigInfo sigInfo;


### PR DESCRIPTION
It is possible that RunTimeInit changes UMThunkMarshInfo object while SetupArguments is running, which causes assert failure in SetupArguments.

Here is the detailed scenario of how assert failure happens:
 - Thread T1 and T2 invoke RunTimeInit on the same UMThunkMarshInfo object.
 - Thread T1 invokes UMThunkMarshInfo::SetupArguments (after returned from UMThunkMarshInfo::RunTimeInit).
 - Thread T2 updates m_cbStackArgSize as 0 just before RunTimeInit is running.
 - Thread T1 reads m_cbStackArgSize.
 - Thread T1 hits assertion (pDst == pCurDst) failure.

This commit attempts to prevent this potential assertion failure via setting m_cbStackArgSize only after its final value is ready.