### PR TITLE
Disable IEnumerable.GetEnumerator on RCW through IDispatch

### DIFF
--- a/src/vm/mngstdinterfaces.cpp
+++ b/src/vm/mngstdinterfaces.cpp
@@ -994,8 +994,12 @@ FCIMPL1(Object*, StdMngIEnumerable::GetEnumerator, Object* refThisUNSAFE)
 
     if (retVal == NULL)
     {
+#ifndef FEATURE_CORECLR
         // classic COM interop scenario
         retVal = ObjectToOBJECTREF((Object*)GetEnumeratorWorker(args));
+#else
+        COMPlusThrow(kPlatformNotSupportedException, IDS_EE_ERROR_IDISPATCH);
+#endif // FEATURE_CORECLR
     }
 
     GCPROTECT_END();

--- a/src/vm/mngstdinterfaces.cpp
+++ b/src/vm/mngstdinterfaces.cpp
@@ -994,12 +994,9 @@ FCIMPL1(Object*, StdMngIEnumerable::GetEnumerator, Object* refThisUNSAFE)
 
     if (retVal == NULL)
     {
-#ifndef FEATURE_CORECLR
-        // classic COM interop scenario
-        retVal = ObjectToOBJECTREF((Object*)GetEnumeratorWorker(args));
-#else
+        // In desktop CLR we'll attempt to call through IDispatch(DISPID_NEWENUM)
+        // This is not supported in CoreCLR
         COMPlusThrow(kPlatformNotSupportedException, IDS_EE_ERROR_IDISPATCH);
-#endif // FEATURE_CORECLR
     }
 
     GCPROTECT_END();


### PR DESCRIPTION
CoreCLR doesn't really support IDispatch and this is probably one of the more obscure cases that we don't block it properly. When calling IEnumerable.GetEnumerator, we will try 3 possibilities (IBindableIterable, IIterable<T>, and IDispatch.Invoke with DISPID_NEWENUM). When we go through the last one we end up going through EnumerableToDispatchMarshaler code (which is implemented in C++/CLI for whatever reason) using ComTypes.IEnumerable and both of these are currently missing. We can revisit IDispatch support at some point in the future but for now it's good to be consistent.

This makes sure we throw a good error message:
 
Exception caught from 'GetEnumerator()': IDispatch and IDispatchEx are not supported
StackTrace:
   at System.Collections.IEnumerable.GetEnumerator()
   at COMTest.Program.Main(String[] args) 

@jkotas PTAL