### PR TITLE
[x86/Linux] Reentrant PEImage::Load

### DIFF
--- a/src/vm/peimage.cpp
+++ b/src/vm/peimage.cpp
@@ -1096,6 +1096,7 @@ void PEImage::Load()
 {
     STANDARD_VM_CONTRACT;
 
+    // Performance optimization to avoid lock acquisition
     if (HasLoadedLayout())
     {
         _ASSERTE(GetLoadedLayout()->IsMapped()||GetLoadedLayout()->IsILOnly());
@@ -1104,7 +1105,9 @@ void PEImage::Load()
 
     SimpleWriteLockHolder lock(m_pLayoutLock);
 
-    if (m_pLayouts[IMAGE_LOADED] != NULL)
+    // Re-check after lock is acquired as HasLoadedLayout here and the above line
+    // may return a different value in multi-threading environment.
+    if (HasLoadedLayout())
     {
         return;
     }

--- a/src/vm/peimage.cpp
+++ b/src/vm/peimage.cpp
@@ -1104,7 +1104,10 @@ void PEImage::Load()
 
     SimpleWriteLockHolder lock(m_pLayoutLock);
 
-    _ASSERTE(m_pLayouts[IMAGE_LOADED] == NULL);
+    if (m_pLayouts[IMAGE_LOADED] != NULL)
+    {
+        return;
+    }
 
 #ifdef PLATFORM_UNIX
     if (m_pLayouts[IMAGE_FLAT] != NULL


### PR DESCRIPTION
This commit resivse PEImage::Load as a re-entrant method in order to fix #11866.