### PR TITLE
[RyuJIT/ARM32] Dodge lowering long compares

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2011,13 +2011,13 @@ void Lowering::LowerCompare(GenTree* cmp)
 #ifdef _TARGET_ARM_
     // TODO-ARM: Later ARM32 should make use of same condition of x86 once support for GT_CMP and GT_SETCC is added.
     LIR::Use cmpUse;
-    if ((cmp->gtGetOp1()->TypeGet() == TYP_LONG) && BlockRange().TryGetUse(cmp, &cmpUse) &&            
-        cmpUse.User()->OperIs(GT_JTRUE))              
+    if ((cmp->gtGetOp1()->TypeGet() == TYP_LONG) && BlockRange().TryGetUse(cmp, &cmpUse) &&
+        cmpUse.User()->OperIs(GT_JTRUE))
 #elif defined(_TARGET_X86_)
     if (cmp->gtGetOp1()->TypeGet() == TYP_LONG)
 #endif
     {
-        // TODO-ARM: This code should be enabled for ARM32 once support for GT_CMP and GT_SETCC is added.
+// TODO-ARM: This code should be enabled for ARM32 once support for GT_CMP and GT_SETCC is added.
 #if _TARGET_X86_
         // Currently this handles only relops that produce a value or aren't used.
         // The same approach can be used for relops that feed a GT_JTRUE, see the #if 0

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2007,9 +2007,17 @@ GenTree* Lowering::LowerTailCallViaHelper(GenTreeCall* call, GenTree* callTarget
 void Lowering::LowerCompare(GenTree* cmp)
 {
 #ifndef _TARGET_64BIT_
+
+#ifdef _TARGET_ARM_
+    // TODO-ARM: Later ARM32 should make use of same condition of x86 once support for GT_CMP and GT_SETCC is added.
+    LIR::Use cmpUse;
+    if ((cmp->gtGetOp1()->TypeGet() == TYP_LONG) && BlockRange().TryGetUse(cmp, &cmpUse) &&            
+        cmpUse.User()->OperIs(GT_JTRUE))              
+#elif defined(_TARGET_X86_)
     if (cmp->gtGetOp1()->TypeGet() == TYP_LONG)
+#endif
     {
-// TODO-ARM: This code should be enabled for ARM32 once support for GT_CMP and GT_SETCC is added.
+        // TODO-ARM: This code should be enabled for ARM32 once support for GT_CMP and GT_SETCC is added.
 #if _TARGET_X86_
         // Currently this handles only relops that produce a value or aren't used.
         // The same approach can be used for relops that feed a GT_JTRUE, see the #if 0


### PR DESCRIPTION
This is a hotfix for #11870.
This just revert https://github.com/dotnet/coreclr/commit/e5d76089a7af352759ed395ecc3c2e61bd6f9640 partially for ryujit/arm32.

Let's dodge lowering long compares to avoid ryujit/arm32 failure
and enable it later when required implementation is available.

Fix #11870 