### PR TITLE
Update full-struct references to promoted IBR args

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4879,8 +4879,7 @@ private:
     bool fgMorphImplicitByRefArgs(GenTreePtr tree);
     GenTreePtr fgMorphImplicitByRefArgs(GenTreePtr tree, bool isAddr);
 
-    // Clear up annotations for any struct promotion temps created for implicit byrefs that
-    // wound up unused (due e.g. to being address-exposed and not worth promoting).
+    // Clear up annotations for any struct promotion temps created for implicit byrefs.
     void fgMarkDemotedImplicitByRefArgs();
 
     static fgWalkPreFn  fgMarkAddrTakenLocalsPreCB;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -255,7 +255,8 @@ public:
     unsigned char lvHasILStoreOp : 1;         // there is at least one STLOC or STARG on this local
     unsigned char lvHasMultipleILStoreOp : 1; // there is more than one STLOC on this local
 
-    unsigned char lvIsTemp : 1; // Short-lifetime compiler temp
+    unsigned char lvIsTemp : 1; // Short-lifetime compiler temp (if lvIsParam is false), or implicit byref parameter
+                                // (if lvIsParam is true)
 #if OPT_BOOL_OPS
     unsigned char lvIsBoolean : 1; // set if variable is boolean
 #endif
@@ -286,7 +287,9 @@ public:
                                // checks)
     unsigned char lvIsUnsafeBuffer : 1; // Does this contain an unsafe buffer requiring buffer overflow security checks?
     unsigned char lvPromoted : 1; // True when this local is a promoted struct, a normed struct, or a "split" long on a
-                                  // 32-bit target.
+                                  // 32-bit target.  For implicit byref parameters, this gets hijacked between
+                                  // fgRetypeImplicitByRefArgs and fgMarkDemotedImplicitByRefArgs to indicate whether
+                                  // references to the arg are being rewritten as references to a promoted shadow local.
     unsigned char lvIsStructField : 1;          // Is this local var a field of a promoted struct local?
     unsigned char lvContainsFloatingFields : 1; // Does this struct contains floating point fields?
     unsigned char lvOverlappingFields : 1;      // True when we have a struct with possibly overlapping fields
@@ -332,7 +335,9 @@ public:
 
     union {
         unsigned lvFieldLclStart; // The index of the local var representing the first field in the promoted struct
-                                  // local.
+                                  // local.  For implicit byref parameters, this gets hijacked between
+                                  // fgRetypeImplicitByRefArgs and fgMarkDemotedImplicitByRefArgs to point to the
+                                  // struct local created to model the parameter's struct promotion, if any.
         unsigned lvParentLcl; // The index of the local var representing the parent (i.e. the promoted struct local).
                               // Valid on promoted struct local fields.
     };
@@ -656,11 +661,16 @@ public:
 
     regMaskSmall lvPrefReg; // set of regs it prefers to live in
 
-    unsigned short lvVarIndex;  // variable tracking index
-    unsigned short lvRefCnt;    // unweighted (real) reference count
-    unsigned       lvRefCntWtd; // weighted reference count
-    int            lvStkOffs;   // stack offset of home
-    unsigned       lvExactSize; // (exact) size of the type in bytes
+    unsigned short lvVarIndex; // variable tracking index
+    unsigned short lvRefCnt;   // unweighted (real) reference count.  For implicit by reference
+                               // parameters, this gets hijacked from fgMarkImplicitByRefArgs
+                               // through fgMarkDemotedImplicitByRefArgs, to provide a static
+                               // appearance count (computed during address-exposed analysis)
+                               // that fgMakeOutgoingStructArgCopy consults during global morph
+                               // to determine if eliding its copy is legal.
+    unsigned lvRefCntWtd;      // weighted reference count
+    int      lvStkOffs;        // stack offset of home
+    unsigned lvExactSize;      // (exact) size of the type in bytes
 
     // Is this a promoted struct?
     // This method returns true only for structs (including SIMD structs), not for

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17974,11 +17974,13 @@ void Compiler::fgMarkDemotedImplicitByRefArgs()
         {
             if (varDsc->lvPromoted)
             {
-                // The parameter is simply a pointer now, so clear lvPromoted.
+                // The parameter is simply a pointer now, so clear lvPromoted.  It was left set
+                // by fgRetypeImplicitByRefArgs to communicate to fgMorphImplicitByRefArgs that
+                // appearances of this arg needed to be rewritten to a new promoted struct local.
                 varDsc->lvPromoted = false;
 
                 // Clear the lvFieldLclStart value that was set by fgRetypeImplicitByRefArgs
-                // to tell fgMorphImplicitByRefArgs how to rewrite appearances of this arg.
+                // to tell fgMorphImplicitByRefArgs which local is the new promoted struct one.
                 varDsc->lvFieldLclStart = 0;
             }
             else if (varDsc->lvFieldLclStart != 0)

--- a/tests/src/JIT/Regression/JitBlue/GitHub_11814/GitHub_11814.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_11814/GitHub_11814.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Repro case for a bug involving failure to rewrite all references
+// to a promoted implicit byref struct parameter.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class MutateStructArg
+{
+    public struct P
+    {
+        public string S;
+        public int X;
+    }
+
+    public static int Main()
+    {
+        P l1 = new P();
+        l1.S = "Hello World";
+        l1.X = 42;
+        P l2 = foo(l1);
+        Console.WriteLine(l2.S); // Print modified value "Goodbye World"
+        if ((l2.S == "Goodbye World") && (l2.X == 100))
+        {
+            return 100;   // success
+        }
+        else
+        {
+            Console.WriteLine("**** Test FAILED ***");
+            return 1;  // failure
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static P foo(P a)
+    {
+        Console.WriteLine(a.S);   // Print the incoming value "Hello World"
+        a.S = "Goodbye World";    // Mutate the incoming value
+        a.X = 100;
+        return a;                 // Copy the modified value to the return value (bug was that this was returning original unmodified arg)
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_11814/GitHub_11814.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_11814/GitHub_11814.csproj
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{7B521917-193E-48BB-86C6-FE013F3DFF35}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_11814.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Update fgMorphImplicitByRefArgs to rewrite references to struct-promoted
implicit-by-reference parameters as references to the new struct temps
created in fgRetypeImplicitByRefArgs; fgMorphStructField isn't updating
these because it's only interested in field references, and runs upstream
of fgRetypeImplicitByRefArgs where the full struct temp is created,
anyway.
Invert the sense of lvPromoted for implicit byref args in the interim
between fgRetypeImplicitByRefArgs and fgMarkDemotedImplicitByRefArgs,
since now fgMarkDemotedImplicitByRefArgs needs to update both and would
look horribly backwards the other way around.

Fixes #11814.