### PR TITLE
Allow RelativePointer::SetValue usage for non-DAC builds only

### DIFF
--- a/src/inc/fixuppointer.h
+++ b/src/inc/fixuppointer.h
@@ -23,9 +23,9 @@
 // There are several flavors of conversions from/to RelativePointer:
 //  - GetValue/SetValue: The most common version. Assumes that the pointer is not NULL.
 //  - GetValueMaybeNull/SetValueMaybeNull: Pointer can be NULL.
-//  - GetValueAtPtr/SetValueAtPtr: Static version of GetValue/SetValue. It is 
+//  - GetValueAtPtr: Static version of GetValue. It is
 //    meant to simplify access to arrays of RelativePointers.
-//  - GetValueMaybeNullAtPtr/SetValueMaybeNullAtPtr
+//  - GetValueMaybeNullAtPtr
 template<typename PTR_TYPE>
 class RelativePointer
 {
@@ -112,54 +112,32 @@ public:
         return dac_cast<DPTR(RelativePointer<PTR_TYPE>)>(base)->GetValueMaybeNull(base);
     }
 
-    // Set encoded value of the pointer. Assumes that the value is not NULL.
-    void SetValue(TADDR base, PTR_TYPE addr)
-    {
-        LIMITED_METHOD_CONTRACT;
-        PRECONDITION(addr != NULL);
-        m_delta = dac_cast<TADDR>(addr) - base;
-    }
-
 #ifndef DACCESS_COMPILE
     // Set encoded value of the pointer. Assumes that the value is not NULL.
-    // Does not need explicit base and thus can be used in non-DAC builds only.
     FORCEINLINE void SetValue(PTR_TYPE addr)
     {
         LIMITED_METHOD_CONTRACT;
-        return SetValue((TADDR)this, addr);
-    }
-#endif
-
-    // Static version of SetValue. It is meant to simplify access to arrays of pointers.
-    FORCEINLINE static void SetValueAtPtr(TADDR base, PTR_TYPE addr)
-    {
-        LIMITED_METHOD_CONTRACT;
-        dac_cast<DPTR(RelativePointer<PTR_TYPE>)>(base)->SetValue(base, addr);
+        PRECONDITION(addr != NULL);
+        m_delta = (TADDR)addr - (TADDR)this;
     }
 
     // Set encoded value of the pointer. The value can be NULL.
     void SetValueMaybeNull(TADDR base, PTR_TYPE addr)
     {
         LIMITED_METHOD_CONTRACT;
-        if (addr == NULL) m_delta = NULL; else SetValue(base, addr);
+        if (addr == NULL)
+            m_delta = NULL;
+        else
+            m_delta = (TADDR)addr - (TADDR)base;
     }
 
-#ifndef DACCESS_COMPILE
     // Set encoded value of the pointer. The value can be NULL.
-    // Does not need explicit base and thus can be used in non-DAC builds only.
     FORCEINLINE void SetValueMaybeNull(PTR_TYPE addr)
     {
         LIMITED_METHOD_CONTRACT;
-        return SetValueMaybeNull((TADDR)this, addr);
+        SetValueMaybeNull((TADDR)this, addr);
     }
 #endif
-
-    // Static version of SetValueMaybeNull. It is meant to simplify access to arrays of pointers.
-    FORCEINLINE static void SetValueMaybeNullAtPtr(TADDR base, PTR_TYPE addr)
-    {
-        LIMITED_METHOD_CONTRACT;
-        dac_cast<DPTR(RelativePointer<PTR_TYPE>)>(base)->SetValueMaybeNull(base, addr);
-    }
 
 #ifndef DACCESS_COMPILE
     void BitwiseCopyTo(RelativePointer<PTR_TYPE> &dest) const
@@ -347,54 +325,32 @@ public:
         return dac_cast<DPTR(RelativeFixupPointer<PTR_TYPE>)>(base)->GetValueMaybeNull(base);
     }
 
-    // Set encoded value of the pointer. Assumes that the value is not NULL.
-    void SetValue(TADDR base, PTR_TYPE addr)
-    {
-        LIMITED_METHOD_CONTRACT;
-        PRECONDITION(addr != NULL);
-        m_delta = dac_cast<TADDR>(addr) - base;
-    }
-
 #ifndef DACCESS_COMPILE
     // Set encoded value of the pointer. Assumes that the value is not NULL.
-    // Does not need explicit base and thus can be used in non-DAC builds only.
     FORCEINLINE void SetValue(PTR_TYPE addr)
     {
         LIMITED_METHOD_CONTRACT;
-        return SetValue((TADDR)this, addr);
-    }
-#endif
-
-    // Static version of SetValue. It is meant to simplify access to arrays of pointers.
-    FORCEINLINE static void SetValueAtPtr(TADDR base, PTR_TYPE addr)
-    {
-        LIMITED_METHOD_CONTRACT;
-        dac_cast<DPTR(RelativeFixupPointer<PTR_TYPE>)>(base)->SetValue(base, addr);
+        PRECONDITION(addr != NULL);
+        m_delta = (TADDR)addr - (TADDR)this;
     }
 
     // Set encoded value of the pointer. The value can be NULL.
     void SetValueMaybeNull(TADDR base, PTR_TYPE addr)
     {
         LIMITED_METHOD_CONTRACT;
-        if (addr == NULL) m_delta = NULL; else SetValue(base, addr);
+        if (addr == NULL)
+            m_delta = NULL;
+        else
+            m_delta = (TADDR)addr - (TADDR)base;
     }
 
-#ifndef DACCESS_COMPILE
     // Set encoded value of the pointer. The value can be NULL.
-    // Does not need explicit base and thus can be used in non-DAC builds only.
     FORCEINLINE void SetValueMaybeNull(PTR_TYPE addr)
     {
         LIMITED_METHOD_CONTRACT;
-        return SetValueMaybeNull((TADDR)this, addr);
+        SetValueMaybeNull((TADDR)this, addr);
     }
 #endif
-
-    // Static version of SetValueMaybeNull. It is meant to simplify access to arrays of pointers.
-    FORCEINLINE static void SetValueMaybeNullAtPtr(TADDR base, PTR_TYPE addr)
-    {
-        LIMITED_METHOD_CONTRACT;
-        dac_cast<DPTR(RelativeFixupPointer<PTR_TYPE>)>(base)->SetValueMaybeNull(base, addr);
-    }
 
     // Returns the pointer to the indirection cell.
     PTR_TYPE * GetValuePtr(TADDR base) const

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -13659,7 +13659,10 @@ void LookupMapBase::CreateHotItemList(DataImage *image, CorProfileData *profileD
                 for (DWORD ii = 0; ii < numItems; ii++)
                 {
                     if (itemList[ii].value != NULL)
-                        RelativePointer<TADDR>::SetValueMaybeNullAtPtr(dac_cast<TADDR>(&itemList[ii].value), itemList[ii].value);
+                    {
+                        RelativePointer<TADDR> *pRelPtr = (RelativePointer<TADDR> *)&itemList[ii].value;
+                        pRelPtr->SetValueMaybeNull(itemList[ii].value);
+                    }
                 }
 
                 if (itemList != NULL)

--- a/src/vm/ceeload.h
+++ b/src/vm/ceeload.h
@@ -309,7 +309,10 @@ template <typename TYPE>
 struct LookupMap : LookupMapBase
 {
     static TYPE GetValueAt(PTR_TADDR pValue, TADDR* pFlags, TADDR supportedFlags);
+
+#ifndef DACCESS_COMPILE
     static void SetValueAt(PTR_TADDR pValue, TYPE value, TADDR flags);
+#endif // DACCESS_COMPILE
 
     TYPE GetElement(DWORD rid, TADDR* pFlags);
     void SetElement(DWORD rid, TYPE value, TADDR flags);
@@ -366,6 +369,7 @@ public:
         SetElement(rid, value, flags);
     }
 
+#ifndef DACCESS_COMPILE
     void AddFlag(DWORD rid, TADDR flag)
     {
         WRAPPER_NO_CONTRACT;
@@ -386,6 +390,7 @@ public:
         TYPE existingValue = GetValueAt(pElement, &existingFlags, supportedFlags);
         SetValueAt(pElement, existingValue, existingFlags | flag);
     }
+#endif // DACCESS_COMPILE
 
     //
     // Try to store an association in a map. Will never throw or fail.

--- a/src/vm/ceeload.inl
+++ b/src/vm/ceeload.inl
@@ -26,6 +26,8 @@ TYPE LookupMap<TYPE>::GetValueAt(PTR_TADDR pValue, TADDR* pFlags, TADDR supporte
     return (TYPE)(dac_cast<TADDR>(value) & ~supportedFlags);
 }
 
+#ifndef DACCESS_COMPILE
+
 template<typename TYPE>
 inline 
 void LookupMap<TYPE>::SetValueAt(PTR_TADDR pValue, TYPE value, TADDR flags)
@@ -34,10 +36,10 @@ void LookupMap<TYPE>::SetValueAt(PTR_TADDR pValue, TYPE value, TADDR flags)
 
     value = (TYPE)(dac_cast<TADDR>(value) | flags);
 
-    RelativePointer<TYPE>::SetValueAtPtr(dac_cast<TADDR>(pValue), value);
+    RelativePointer<TYPE> *pRelPtr = (RelativePointer<TYPE> *)pValue;
+    pRelPtr->SetValue(value);
 }
 
-#ifndef DACCESS_COMPILE
 //
 // Specialization of Get/SetValueAt methods to support maps of pointer-sized value types
 //

--- a/src/vm/class.h
+++ b/src/vm/class.h
@@ -1222,7 +1222,7 @@ public:
     inline void SetFieldDescList (FieldDesc* pFieldDescList)
     {
         LIMITED_METHOD_CONTRACT;
-        m_pFieldDescList.SetValue(PTR_HOST_MEMBER_TADDR(EEClass, this, m_pFieldDescList), pFieldDescList);
+        m_pFieldDescList.SetValue(pFieldDescList);
     }
 #endif // !DACCESS_COMPILE
 
@@ -1645,7 +1645,7 @@ public:
     inline void SetChunks (MethodDescChunk* pChunks)
     {
         LIMITED_METHOD_CONTRACT;
-        m_pChunks.SetValueMaybeNull(PTR_HOST_MEMBER_TADDR(EEClass, this, m_pChunks), pChunks);
+        m_pChunks.SetValueMaybeNull(pChunks);
     }
 #endif // !DACCESS_COMPILE
     void AddChunk (MethodDescChunk* pNewChunk);

--- a/src/vm/classhash.cpp
+++ b/src/vm/classhash.cpp
@@ -47,7 +47,7 @@ PTR_VOID EEClassHashEntry::GetData()
 }
 
 #ifndef DACCESS_COMPILE
-void EEClassHashEntry::SetData(PTR_VOID data)
+void EEClassHashEntry::SetData(void *data)
 {
     CONTRACTL
     {
@@ -60,7 +60,10 @@ void EEClassHashEntry::SetData(PTR_VOID data)
     // TypeHandles are encoded as a relative pointer rather than a regular pointer to avoid the need for image
     // fixups (any TypeHandles in this hash are defined in the same module).
     if (((TADDR)data & EECLASSHASH_TYPEHANDLE_DISCR) == 0)
-        RelativePointer<PTR_VOID>::SetValueMaybeNullAtPtr((TADDR)&m_Data, data);
+    {
+        RelativePointer<void *> *pRelPtr = (RelativePointer<void *> *) &m_Data;
+        pRelPtr->SetValueMaybeNull(data);
+    }
     else
         m_Data = data;
 }

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -2492,7 +2492,10 @@ void MethodDesc::Reset()
     }
 
     if (HasNativeCodeSlot())
-        NativeCodeSlot::SetValueMaybeNullAtPtr(GetAddrOfNativeCodeSlot(), NULL);
+    {
+        RelativePointer<TADDR> *pRelPtr = (RelativePointer<TADDR> *)GetAddrOfNativeCodeSlot();
+        pRelPtr->SetValueMaybeNull(NULL);
+    }
     _ASSERTE(!HasNativeCode());
 }
 

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -2057,7 +2057,7 @@ public:
         LIMITED_METHOD_CONTRACT;
         _ASSERTE(m_methodTable.IsNull());
         _ASSERTE(pMT != NULL);
-        m_methodTable.SetValue(PTR_HOST_MEMBER_TADDR(MethodDescChunk, this, m_methodTable), pMT);
+        m_methodTable.SetValue(pMT);
     }
 
     inline void SetSizeAndCount(ULONG sizeOfMethodDescs, COUNT_T methodDescCount)

--- a/src/vm/methodtable.h
+++ b/src/vm/methodtable.h
@@ -1671,12 +1671,13 @@ public:
     }
 
 #ifndef DACCESS_COMPILE
-    inline void SetNonVirtualSlotsArray(PTR_PCODE slots)
+    inline void SetNonVirtualSlotsArray(PCODE *slots)
     {
         LIMITED_METHOD_CONTRACT;
         _ASSERTE(HasNonVirtualSlotsArray());
-        
-        RelativePointer<PTR_PCODE>::SetValueAtPtr(GetNonVirtualSlotsPtr(), slots);
+
+        RelativePointer<PCODE *> *pRelPtr = (RelativePointer<PCODE *> *)GetNonVirtualSlotsPtr();
+        pRelPtr->SetValue(slots);
     }
 
     inline void SetHasSingleNonVirtualSlot()
@@ -2456,7 +2457,9 @@ public:
         _ASSERTE(HasDispatchMapSlot());
 
         TADDR pSlot = GetMultipurposeSlotPtr(enum_flag_HasDispatchMapSlot, c_DispatchMapSlotOffsets);
-        RelativePointer<PTR_DispatchMap>::SetValueAtPtr(pSlot, pDispatchMap);
+
+        RelativePointer<DispatchMap *> *pRelPtr = (RelativePointer<DispatchMap *> *)pSlot;
+        pRelPtr->SetValue(pDispatchMap);
     }
 #endif // !DACCESS_COMPILE
 


### PR DESCRIPTION
SetValue shouldn't be used in DAC builds, so unused based versions of SetValue are completely removed and SetValue without base is rewritten for non DAC builds. 