### PR TITLE
Mark the EventPipe Crst as Host Breakable

### DIFF
--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -44,7 +44,7 @@ void EventPipe::Initialize()
 
     s_tracingInitialized = s_configCrst.InitNoThrow(
         CrstEventPipe,
-        (CrstFlags)(CRST_REENTRANCY | CRST_TAKEN_DURING_SHUTDOWN));
+        (CrstFlags)(CRST_REENTRANCY | CRST_TAKEN_DURING_SHUTDOWN | CRST_HOST_BREAKABLE));
 
     s_pConfig = new EventPipeConfiguration();
     s_pConfig->Initialize();


### PR DESCRIPTION
Fixes #11539.

The EventPipe crst is held when calling into managed code.  Thus, it must be breakable by the host.