### PR TITLE
Ensure that platform is considered for LongPlatformName instead of PackagePlatform

### DIFF
--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Windows_NT.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Windows_NT.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -2,8 +2,8 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
-    <LongNamePlatform>$(PackagePlatform)</LongNamePlatform>
-    <LongNamePlatform Condition="'$(LongNamePlatform)'=='x64'">amd64</LongNamePlatform>
+    <LongNamePlatform>$(Platform)</LongNamePlatform>
+    <LongNamePlatform Condition="'$(Platform)'=='x64'">amd64</LongNamePlatform>
     <CrossTargetPlatform>$(CrossTargetComponentFolder)</CrossTargetPlatform>
     <CrossTargetPlatform Condition="'$(CrossTargetPlatform)'=='x64'">amd64</CrossTargetPlatform>
     <LongNameSuffix>_$(LongNamePlatform)_$(LongNamePlatform)_$(MajorVersion).$(MinorVersion).$(BuildNumberMajor).0$(BuildNumberMinor)</LongNameSuffix>


### PR DESCRIPTION
… overriden

Microsoft.NETCore.Runtime.CoreCLR now has mscordaccore_amd64_amd64_4.6.25324.00.dll instead of mscordaccore_AnyCPU_AnyCPU_4.6.25324.00.dll.

@ellismg 