### PR TITLE
Port e1bc678 from master: Never enregister type-punned regStruct lclVars.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -13154,26 +13154,14 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
                         varTypeIsStruct(tempTyp) || (tempTyp == TYP_BLK) || (tempTyp == TYP_LCLBLK);
                     const unsigned varSize = useExactSize ? varDsc->lvExactSize : genTypeSize(temp);
 
+                    // Make sure we do not enregister this lclVar.
+                    lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_LocalField));
+
                     // If the size of the load is greater than the size of the lclVar, we cannot fold this access into
                     // a lclFld: the access represented by an lclFld node must begin at or after the start of the
                     // lclVar and must not extend beyond the end of the lclVar.
-                    if ((ival1 < 0) || ((ival1 + genTypeSize(typ)) > varSize))
+                    if ((ival1 >= 0) && ((ival1 + genTypeSize(typ)) <= varSize))
                     {
-                        lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_LocalField));
-                    }
-                    else
-                    {
-                        // Make sure we don't separately promote the fields of this struct.
-                        if (varDsc->lvRegStruct)
-                        {
-                            // We can enregister, but can't promote.
-                            varDsc->lvPromoted = false;
-                        }
-                        else
-                        {
-                            lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_LocalField));
-                        }
-
                         // We will turn a GT_LCL_VAR into a GT_LCL_FLD with an gtLclOffs of 'ival'
                         // or if we already have a GT_LCL_FLD we will adjust the gtLclOffs by adding 'ival'
                         // Then we change the type of the GT_LCL_FLD to match the orginal GT_IND type.

--- a/tests/src/JIT/Regression/JitBlue/GitHub_11804/GitHub_11804.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_11804/GitHub_11804.il
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern System.Private.CoreLib
+{
+  .publickeytoken = (7C EC 85 D7 BE A7 79 8E )                         // |.....y.
+  .ver 4:0:0:0
+}
+.assembly extern System.Numerics.Vectors
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
+  .ver 4:1:3:0
+}
+.assembly extern System.Runtime.CompilerServices.Unsafe
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
+  .ver 4:0:3:0
+}
+.assembly GitHub_11804
+{
+  .custom instance void [System.Private.CoreLib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
+  .custom instance void [System.Private.CoreLib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                           63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  .hash algorithm 0x00008004
+  .ver 0:0:0:0
+}
+.module GitHub_11804.exe
+// MVID: {9CC2AC15-DDA3-4ADF-9566-89AB25A8CF63}
+.imagebase 0x00400000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000001    //  ILONLY
+// Image base: 0x01590000
+
+
+.class private abstract auto ansi sealed beforefieldinit C
+       extends [System.Private.CoreLib]System.Object
+{
+  .method private hidebysig static int32 
+          UnsafeGrab() cil managed noinlining
+  {
+    // Code size       18 (0x12)
+    .maxstack  2
+    .locals init (valuetype [System.Numerics.Vectors]System.Numerics.Vector`1<int32> V_0)
+    IL_0000:  ldloca.s   V_0
+    IL_0002:  ldc.i4.s   50
+    IL_0004:  call       instance void valuetype [System.Numerics.Vectors]System.Numerics.Vector`1<int32>::.ctor(!0)
+    IL_0009:  ldloca.s   V_0
+    IL_000b:  call       !!1& [System.Runtime.CompilerServices.Unsafe]System.Runtime.CompilerServices.Unsafe::As<valuetype [System.Numerics.Vectors]System.Numerics.Vector`1<int32>,int32>(!!0&)
+    IL_0010:  ldind.i4
+    IL_0011:  ret
+  } // end of method C::UnsafeGrab
+
+  .method private hidebysig static int32 
+          IndexerGrab() cil managed noinlining
+  {
+    // Code size       18 (0x12)
+    .maxstack  2
+    .locals init (valuetype [System.Numerics.Vectors]System.Numerics.Vector`1<int32> V_0)
+    IL_0000:  ldloca.s   V_0
+    IL_0002:  ldc.i4.s   50
+    IL_0004:  call       instance void valuetype [System.Numerics.Vectors]System.Numerics.Vector`1<int32>::.ctor(!0)
+    IL_0009:  ldloca.s   V_0
+    IL_000b:  ldc.i4.0
+    IL_000c:  call       instance !0 valuetype [System.Numerics.Vectors]System.Numerics.Vector`1<int32>::get_Item(int32)
+    IL_0011:  ret
+  } // end of method C::IndexerGrab
+
+  .method private hidebysig static int32 
+          Main() cil managed
+  {
+    .entrypoint
+    // Code size       20 (0x14)
+    .maxstack  8
+
+    IL_0008:  call       int32 C::IndexerGrab()
+    IL_000d:  call       int32 C::UnsafeGrab()
+    IL_0012:  add
+    IL_0013:  ret
+  } // end of method C::Main
+
+} // end of class C

--- a/tests/src/JIT/Regression/JitBlue/GitHub_11804/GitHub_11804.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_11804/GitHub_11804.ilproj
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_11804.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
Type-punned lclVars--i.e. lclVars that are accessed via
`(INDIR Tx (ADDR (LCLVAR Ty V)))`--are currently considered
enregisterable if they are SIMD-typed, have not been the accessed by
field, and have not otherwise been declared unenregisterable. This
appears to be an oversight, as the JIT is not able to generate correct
code for the type-punned access if the lclVar is in fact enregistered.

This change removes the special case for these SIMD-typed lclVars.

The original change fixed issue #11804.