### PR TITLE
Enable linux perf runs

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -239,11 +239,11 @@ def static getOSGroup(def os) {
         def newJob = job(Utilities.getFullJobName(project, "perf_${os}", isPR)) {
 
             label('linux_clr_perf')
-                wrappers {
-                    credentialsBinding {
-                        string('BV_UPLOAD_SAS_TOKEN', 'CoreCLR Perf BenchView Sas')
-                    }
+            wrappers {
+                credentialsBinding {
+                    string('BV_UPLOAD_SAS_TOKEN', 'CoreCLR Perf BenchView Sas')
                 }
+            }
 
             if (isPR)
             {
@@ -252,6 +252,13 @@ def static getOSGroup(def os) {
                     stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
                 }
             }
+
+            // Cap the maximum number of iterations to 21.
+            parameters {
+                stringParam('XUNIT_PERFORMANCE_MAX_ITERATION', '21', 'Sets the number of iterations to twenty one.  We are doing this to limit the amount of data that we upload as 20 iterations is enought to get a good sample')
+                stringParam('XUNIT_PERFORMANCE_MAX_ITERATION_INNER_SPECIFIED', '21', 'Sets the number of iterations to twenty one.  We are doing this to limit the amount of data that we upload as 20 iterations is enought to get a good sample')
+            }
+
             def osGroup = getOSGroup(os)
             def architecture = 'x64'
             def configuration = 'Release'

--- a/perf.groovy
+++ b/perf.groovy
@@ -24,6 +24,7 @@ def static getOSGroup(def os) {
     assert osGroup != null : "Could not find os group for ${os}"
     return osGroupMap[os]
 }
+
 // Setup perflab tests runs
 [true, false].each { isPR ->
     ['Windows_NT'].each { os ->
@@ -51,34 +52,34 @@ def static getOSGroup(def os) {
                         }
                     }
 
-                if (isPR)
-                {
-                    parameters
+                    if (isPR)
                     {
-                        stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
+                        parameters
+                        {
+                            stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
+                        }
                     }
-                }
-                if (isSmoketest)
-                {
-                    parameters
+                    if (isSmoketest)
                     {
-                        stringParam('XUNIT_PERFORMANCE_MAX_ITERATION', '2', 'Sets the number of iterations to two.  We want to do this so that we can run as fast as possible as this is just for smoke testing')
-                        stringParam('XUNIT_PERFORMANCE_MAX_ITERATION_INNER_SPECIFIED', '2', 'Sets the number of iterations to two.  We want to do this so that we can run as fast as possible as this is just for smoke testing')
+                        parameters
+                        {
+                            stringParam('XUNIT_PERFORMANCE_MAX_ITERATION', '2', 'Sets the number of iterations to two.  We want to do this so that we can run as fast as possible as this is just for smoke testing')
+                            stringParam('XUNIT_PERFORMANCE_MAX_ITERATION_INNER_SPECIFIED', '2', 'Sets the number of iterations to two.  We want to do this so that we can run as fast as possible as this is just for smoke testing')
+                        }
                     }
-                }
-                else
-                {
-                    parameters
+                    else
                     {
-                        stringParam('XUNIT_PERFORMANCE_MAX_ITERATION', '21', 'Sets the number of iterations to twenty one.  We are doing this to limit the amount of data that we upload as 20 iterations is enought to get a good sample')
-                        stringParam('XUNIT_PERFORMANCE_MAX_ITERATION_INNER_SPECIFIED', '21', 'Sets the number of iterations to twenty one.  We are doing this to limit the amount of data that we upload as 20 iterations is enought to get a good sample')
+                        parameters
+                        {
+                            stringParam('XUNIT_PERFORMANCE_MAX_ITERATION', '21', 'Sets the number of iterations to twenty one.  We are doing this to limit the amount of data that we upload as 20 iterations is enought to get a good sample')
+                            stringParam('XUNIT_PERFORMANCE_MAX_ITERATION_INNER_SPECIFIED', '21', 'Sets the number of iterations to twenty one.  We are doing this to limit the amount of data that we upload as 20 iterations is enought to get a good sample')
+                        }
                     }
-                }
-                def configuration = 'Release'
-                def runType = isPR ? 'private' : 'rolling'
-                def benchViewName = isPR ? 'coreclr private %BenchviewCommitName%' : 'coreclr rolling %GIT_BRANCH_WITHOUT_ORIGIN% %GIT_COMMIT%'
-                def uploadString = isSmoketest ? '' : '-uploadToBenchview'
-                    
+                    def configuration = 'Release'
+                    def runType = isPR ? 'private' : 'rolling'
+                    def benchViewName = isPR ? 'coreclr private %BenchviewCommitName%' : 'coreclr rolling %GIT_BRANCH_WITHOUT_ORIGIN% %GIT_COMMIT%'
+                    def uploadString = isSmoketest ? '' : '-uploadToBenchview'
+
                     steps {
                         // Batch
 
@@ -114,7 +115,7 @@ def static getOSGroup(def os) {
                         batchFile("tests\\scripts\\run-xunit-perf.cmd -arch ${arch} -configuration ${configuration} -testBinLoc bin\\tests\\${os}.${architecture}.${configuration}\\Jit\\Performance\\CodeQuality -generateBenchviewData \"%WORKSPACE%\\Microsoft.Benchview.JSONFormat\\tools\" ${uploadString} -runtype ${runType} -collectionFlags default+BranchMispredictions+CacheMisses+InstructionRetired+gcapi -stabilityPrefix \"START \"CORECLR_PERF_RUN\" /B /WAIT /HIGH /AFFINITY 0x2\"")
                     }
                 }
-                
+
                 if (isSmoketest)
                 {
                     Utilities.setMachineAffinity(newJob, "Windows_NT", '20170427-elevated')
@@ -126,7 +127,7 @@ def static getOSGroup(def os) {
                 Utilities.addArchival(newJob, archiveSettings)
 
                 Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
-                
+
                 newJob.with {
                     wrappers {
                         timeout {
@@ -134,7 +135,7 @@ def static getOSGroup(def os) {
                         }
                     }
                 }
-                
+
                 if (isPR) {
                     TriggerBuilder builder = TriggerBuilder.triggerOnPullRequest()
                     if (isSmoketest)
@@ -185,7 +186,7 @@ def static getOSGroup(def os) {
             def configuration = 'Release'
             def runType = isPR ? 'private' : 'rolling'
             def benchViewName = isPR ? 'coreclr-throughput private %BenchviewCommitName%' : 'coreclr-throughput rolling %GIT_BRANCH_WITHOUT_ORIGIN% %GIT_COMMIT%'
-                
+
                 steps {
                     // Batch
 
@@ -235,14 +236,14 @@ def static getOSGroup(def os) {
 [true, false].each { isPR ->
     ['Ubuntu14.04'].each { os ->
         def newJob = job(Utilities.getFullJobName(project, "perf_${os}", isPR)) {
-            
+
             label('linux_clr_perf')
                 wrappers {
                     credentialsBinding {
                         string('BV_UPLOAD_SAS_TOKEN', 'CoreCLR Perf BenchView Sas')
                     }
                 }
-            
+
             if (isPR)
             {
                 parameters
@@ -255,15 +256,15 @@ def static getOSGroup(def os) {
             def configuration = 'Release'
             def runType = isPR ? 'private' : 'rolling'
             def benchViewName = isPR ? 'coreclr private \$BenchviewCommitName' : 'coreclr rolling \$GIT_BRANCH_WITHOUT_ORIGIN \$GIT_COMMIT'
-            
+
             steps {
-                shell("bash ./tests/scripts/perf-prep.sh")
+                shell("./tests/scripts/perf-prep.sh")
                 shell("./init-tools.sh")
                 shell("./build.sh ${architecture} ${configuration}")
                 shell("GIT_BRANCH_WITHOUT_ORIGIN=\$(echo \$GIT_BRANCH | sed \"s/[^/]*\\/\\(.*\\)/\\1 /\")\n" +
                 "python3.5 \"\${WORKSPACE}/tests/scripts/Microsoft.BenchView.JSONFormat/tools/submission-metadata.py\" --name \" ${benchViewName} \" --user \"dotnet-bot@microsoft.com\"\n" +
                 "python3.5 \"\${WORKSPACE}/tests/scripts/Microsoft.BenchView.JSONFormat/tools/build.py\" git --branch \$GIT_BRANCH_WITHOUT_ORIGIN --type ${runType}")
-                shell("""sudo -E bash ./tests/scripts/run-xunit-perf.sh \\
+                shell("""./tests/scripts/run-xunit-perf.sh \\
                 --testRootDir=\"\${WORKSPACE}/bin/tests/Windows_NT.${architecture}.${configuration}\" \\
                 --testNativeBinDir=\"\${WORKSPACE}/bin/obj/${osGroup}.${architecture}.${configuration}/tests\" \\
                 --coreClrBinDir=\"\${WORKSPACE}/bin/Product/${osGroup}.${architecture}.${configuration}\" \\
@@ -271,6 +272,8 @@ def static getOSGroup(def os) {
                 --coreFxBinDir=\"\${WORKSPACE}/corefx\" \\
                 --runType=\"${runType}\" \\
                 --benchViewOS=\"${os}\" \\
+                --generatebenchviewdata=\"${WORKSPACE}/tests/scripts/Microsoft.BenchView.JSONFormat/tools\" \\
+                --stabilityPrefix=\"taskset 0x00000002 nice --adjustment=-10\" \\
                 --uploadToBenchview""")
             }
         }
@@ -313,14 +316,14 @@ def static getOSGroup(def os) {
 [true, false].each { isPR ->
     ['Ubuntu14.04'].each { os ->
         def newJob = job(Utilities.getFullJobName(project, "perf_throughput_${os}", isPR)) {
-            
+
             label('linux_clr_perf')
                 wrappers {
                     credentialsBinding {
                         string('BV_UPLOAD_SAS_TOKEN', 'CoreCLR Perf BenchView Sas')
                     }
                 }
-            
+
             if (isPR)
             {
                 parameters
@@ -333,7 +336,7 @@ def static getOSGroup(def os) {
             def configuration = 'Release'
             def runType = isPR ? 'private' : 'rolling'
             def benchViewName = isPR ? 'coreclr private \$BenchviewCommitName' : 'coreclr rolling \$GIT_BRANCH_WITHOUT_ORIGIN \$GIT_COMMIT'
-            
+
             steps {
                 shell("bash ./tests/scripts/perf-prep.sh --throughput")
                 shell("./init-tools.sh")

--- a/perf.groovy
+++ b/perf.groovy
@@ -273,7 +273,7 @@ def static getOSGroup(def os) {
                 --coreFxBinDir=\"\${WORKSPACE}/corefx\" \\
                 --runType=\"${runType}\" \\
                 --benchViewOS=\"${os}\" \\
-                --generatebenchviewdata=\"${WORKSPACE}/tests/scripts/Microsoft.BenchView.JSONFormat/tools\" \\
+                --generatebenchviewdata=\"\${WORKSPACE}/tests/scripts/Microsoft.BenchView.JSONFormat/tools\" \\
                 --stabilityPrefix=\"taskset 0x00000002 nice --adjustment=-10\" \\
                 --uploadToBenchview""")
             }

--- a/perf.groovy
+++ b/perf.groovy
@@ -124,6 +124,7 @@ def static getOSGroup(def os) {
                 def archiveSettings = new ArchivalSettings()
                 archiveSettings.addFiles('Perf-*.xml')
                 archiveSettings.addFiles('Perf-*.etl')
+                archiveSettings.addFiles('machinedata.json')
                 Utilities.addArchival(newJob, archiveSettings)
 
                 Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
@@ -280,7 +281,7 @@ def static getOSGroup(def os) {
 
         // Save machinedata.json to /artifact/bin/ Jenkins dir
         def archiveSettings = new ArchivalSettings()
-        archiveSettings.addFiles('sandbox/perf-*.xml')
+        archiveSettings.addFiles('Perf-*.xml')
         archiveSettings.addFiles('machinedata.json')
         Utilities.addArchival(newJob, archiveSettings)
 

--- a/tests/scripts/run-xunit-perf.sh
+++ b/tests/scripts/run-xunit-perf.sh
@@ -213,7 +213,7 @@ coreClrBinDir=
 mscorlibDir=
 coreFxBinDir=
 uploadToBenchview=
-benchViewOS=`uname -s`
+benchViewOS=`lsb_release -i -s``lsb_release -r -s`
 runType=local
 BENCHVIEW_TOOLS_PATH=
 benchViewGroup=CoreCLR
@@ -336,8 +336,20 @@ for testcase in ${tests[@]}; do
     run_command ./corerun PerfHarness.dll $test --perf:runid Perf --perf:collect stopwatch || exit 1
 
     if [ -d "$BENCHVIEW_TOOLS_PATH" ]; then
-        run_command python3.5 "$BENCHVIEW_TOOLS_PATH/measurement.py" xunit "Perf-$filename.xml" --better desc $hasWarmupRun --append || {
-            echo ERROR;
+        args=
+        args+=" --build ../../../../../build.json"
+        args+=" --machine-data ../../../../../machinedata.json"
+        args+=" --metadata ../../../../../submission-metadata.json"
+        args+=" --group $benchViewGroup"
+        args+=" --type $runType"
+        args+=" --config-name Release"
+        args+=" --config Configuration Release"
+        args+=" --config OS $benchViewOS"
+        args+=" --config Profile $perfCollection"
+        args+=" --arch x64"
+        args+=" --machinepool Perfsnake"
+        run_command python3.5 "$BENCHVIEW_TOOLS_PATH/measurement.py" xunit $args || {
+            echo [ERROR] Failed to generate BenchView data;
             exit 1;
         }
     fi

--- a/tests/scripts/run-xunit-perf.sh
+++ b/tests/scripts/run-xunit-perf.sh
@@ -336,19 +336,7 @@ for testcase in ${tests[@]}; do
     run_command ./corerun PerfHarness.dll $test --perf:runid Perf --perf:collect stopwatch || exit 1
 
     if [ -d "$BENCHVIEW_TOOLS_PATH" ]; then
-        args=
-        args+=" --build ../../../../../build.json"
-        args+=" --machine-data ../../../../../machinedata.json"
-        args+=" --metadata ../../../../../submission-metadata.json"
-        args+=" --group $benchViewGroup"
-        args+=" --type $runType"
-        args+=" --config-name Release"
-        args+=" --config Configuration Release"
-        args+=" --config OS $benchViewOS"
-        args+=" --config Profile $perfCollection"
-        args+=" --arch x64"
-        args+=" --machinepool Perfsnake"
-        run_command python3.5 "$BENCHVIEW_TOOLS_PATH/measurement.py" xunit $args || {
+        run_command python3.5 "$BENCHVIEW_TOOLS_PATH/measurement.py" xunit "Perf-$filename.xml" --better desc $hasWarmupRun --append || {
             echo [ERROR] Failed to generate BenchView data;
             exit 1;
         }
@@ -356,7 +344,22 @@ for testcase in ${tests[@]}; do
 done
 
 if [ -d "$BENCHVIEW_TOOLS_PATH" ]; then
-    run_command python3.5 "$BENCHVIEW_TOOLS_PATH/submission.py" measurement.json --build ../../../../../build.json --machine-data ../../../../../machinedata.json --metadata ../../../../../submission-metadata.json --group "$benchViewGroup" --type "$runType" --config-name "Release" --config Configuration "Release" --config OS "$benchViewOS" --config Profile "$perfCollection" --arch "x64" --machinepool "Perfsnake"
+    args=measurement.json
+    args+=" --build ../../../../../build.json"
+    args+=" --machine-data ../../../../../machinedata.json"
+    args+=" --metadata ../../../../../submission-metadata.json"
+    args+=" --group $benchViewGroup"
+    args+=" --type $runType"
+    args+=" --config-name Release"
+    args+=" --config Configuration Release"
+    args+=" --config OS $benchViewOS"
+    args+=" --config Profile $perfCollection"
+    args+=" --arch x64"
+    args+=" --machinepool Perfsnake"
+    run_command python3.5 "$BENCHVIEW_TOOLS_PATH/submission.py" $args || {
+        echo [ERROR] Failed to generate BenchView submission data;
+        exit 1;
+    }
 fi
 
 if [ "$uploadToBenchview" == "TRUE" ]; then

--- a/tests/scripts/run-xunit-perf.sh
+++ b/tests/scripts/run-xunit-perf.sh
@@ -336,10 +336,11 @@ for testcase in ${tests[@]}; do
     # TODO: Do we need this here.
     chmod u+x ./corerun
 
+    echo ""
     echo "----------"
     echo "  Running $testname"
     echo "----------"
-    run_command $stabilityPrefix ./corerun PerfHarness.dll $test --perf:runid Perf --perf:collect stopwatch || exit 1
+    run_command $stabilityPrefix ./corerun PerfHarness.dll $test --perf:runid Perf --perf:collect $collectionflags || exit 1
     if [ -d "$BENCHVIEW_TOOLS_PATH" ]; then
         run_command python3.5 "$BENCHVIEW_TOOLS_PATH/measurement.py" xunit "Perf-$filename.xml" --better desc $hasWarmupRun --append || {
             echo [ERROR] Failed to generate BenchView data;

--- a/tests/scripts/run-xunit-perf.sh
+++ b/tests/scripts/run-xunit-perf.sh
@@ -330,8 +330,7 @@ for testcase in ${tests[@]}; do
     run_command ./corerun PerfHarness.dll $test --perf:runid Perf --perf:collect stopwatch || exit 1
 
     if [ -d "$BENCHVIEW_TOOLS_PATH" ]; then
-        xUnitMeasurementArgs="Perf-$filename.xml" --better desc $hasWarmupRun --append
-        run_command python3.5 "$BENCHVIEW_TOOLS_PATH/measurement.py" xunit $xUnitMeasurementArgs
+        run_command python3.5 "$BENCHVIEW_TOOLS_PATH/measurement.py" xunit "Perf-$filename.xml" --better desc $hasWarmupRun --append
     fi
 done
 

--- a/tests/scripts/run-xunit-perf.sh
+++ b/tests/scripts/run-xunit-perf.sh
@@ -22,23 +22,23 @@ function print_usage {
     echo '    --coreFxBinDir="corefx/bin/Linux.AnyCPU.Debug"'
     echo ''
     echo 'Required arguments:'
-    echo '  --testRootDir=<path>             : Root directory of the test build (e.g. coreclr/bin/tests/Windows_NT.x64.Debug).'
-    echo '  --testNativeBinDir=<path>        : Directory of the native CoreCLR test build (e.g. coreclr/bin/obj/Linux.x64.Debug/tests).'
+    echo '  --testRootDir=<path>              : Root directory of the test build (e.g. coreclr/bin/tests/Windows_NT.x64.Debug).'
+    echo '  --testNativeBinDir=<path>         : Directory of the native CoreCLR test build (e.g. coreclr/bin/obj/Linux.x64.Debug/tests).'
     echo '  (Also required: Either --coreOverlayDir, or all of the switches --coreOverlayDir overrides)'
     echo ''
     echo 'Optional arguments:'
-    echo '  --coreOverlayDir=<path>          : Directory containing core binaries and test dependencies. If not specified, the'
-    echo '                                     default is testRootDir/Tests/coreoverlay. This switch overrides --coreClrBinDir,'
-    echo '                                     --mscorlibDir, and --coreFxBinDir.'
-    echo '  --coreClrBinDir=<path>           : Directory of the CoreCLR build (e.g. coreclr/bin/Product/Linux.x64.Debug).'
-    echo '  --mscorlibDir=<path>             : Directory containing the built mscorlib.dll. If not specified, it is expected to be'
+    echo '  --coreOverlayDir=<path>           : Directory containing core binaries and test dependencies. If not specified, the'
+    echo '                                      default is testRootDir/Tests/coreoverlay. This switch overrides --coreClrBinDir,'
+    echo '                                      --mscorlibDir, and --coreFxBinDir.'
+    echo '  --coreClrBinDir=<path>            : Directory of the CoreCLR build (e.g. coreclr/bin/Product/Linux.x64.Debug).'
+    echo '  --mscorlibDir=<path>              : Directory containing the built mscorlib.dll. If not specified, it is expected to be'
     echo '                                       in the directory specified by --coreClrBinDir.'
-    echo '  --coreFxBinDir="<path>"          : The path to the unpacked runtime folder that is produced as part of a CoreFX build'
-    echo '  --uploadToBenchview              : Specify this flag in order to have the results of the run uploaded to Benchview.'
-    echo '                                     This also requires that the os flag and runtype flag to be set.  Lastly you must'
-    echo '                                     also have the BV_UPLOAD_SAS_TOKEN set to a SAS token for the Benchview upload container'
-    echo '  --benchViewOS=<os>               : Specify the os that will be used to insert data into Benchview.'
-    echo '  --runType=<private|rolling>      : Specify the runType for Benchview.'
+    echo '  --coreFxBinDir="<path>"           : The path to the unpacked runtime folder that is produced as part of a CoreFX build'
+    echo '  --uploadToBenchview               : Specify this flag in order to have the results of the run uploaded to Benchview.'
+    echo '                                      This also requires that the os flag and runtype flag to be set.  Lastly you must'
+    echo '                                      also have the BV_UPLOAD_SAS_TOKEN set to a SAS token for the Benchview upload container'
+    echo '  --benchViewOS=<os>                : Specify the os that will be used to insert data into Benchview.'
+    echo '  --runType=<local|private|rolling> : Specify the runType for Benchview.'
 }
 
 # libExtension determines extension for dynamic library files
@@ -251,10 +251,10 @@ do
         --runType=*)
             runType=${i#*=}
             ;;
-        --collectionflags)
+        --collectionflags=*)
             collectionflags=${i#*=}
             ;;
-        --generatebenchviewdata)
+        --generatebenchviewdata=*)
             BENCHVIEW_TOOLS_PATH=${i#*=}
             ;;
         --uploadToBenchview)

--- a/tests/scripts/run-xunit-perf.sh
+++ b/tests/scripts/run-xunit-perf.sh
@@ -278,7 +278,7 @@ if [ ! -d "$testRootDir" ]; then
     echo "Directory specified by --testRootDir does not exist: $testRootDir"
     exit $EXIT_CODE_EXCEPTION
 fi
-if [ ! -z "$BENCHVIEW_TOOLS_PATH" && ! -d "$BENCHVIEW_TOOLS_PATH" ]; then
+if [ ! -z "$BENCHVIEW_TOOLS_PATH" ] && { [ ! -d "$BENCHVIEW_TOOLS_PATH" ]; }; then
     echo BenchView path: "$BENCHVIEW_TOOLS_PATH" was specified, but it does not exist.
     exit $EXIT_CODE_EXCEPTION
 fi

--- a/tests/scripts/run-xunit-perf.sh
+++ b/tests/scripts/run-xunit-perf.sh
@@ -26,11 +26,11 @@ function print_usage {
     echo '  --mscorlibDir=<path>             : Directory containing the built mscorlib.dll. If not specified, it is expected to be'
     echo '                                       in the directory specified by --coreClrBinDir.'
     echo '  --coreFxBinDir="<path>"          : The path to the unpacked runtime folder that is produced as part of a CoreFX build'
-	echo '  --uploadToBenchview              : Specify this flag in order to have the results of the run uploaded to Benchview.'
-	echo '                                     This also requires that the os flag and runtype flag to be set.  Lastly you must'
-	echo '                                     also have the BV_UPLOAD_SAS_TOKEN set to a SAS token for the Benchview upload container'
-	echo '  --benchViewOS=<os>               : Specify the os that will be used to insert data into Benchview.'
-	echo '  --runType=<private|rolling>      : Specify the runType for Benchview.'
+    echo '  --uploadToBenchview              : Specify this flag in order to have the results of the run uploaded to Benchview.'
+    echo '                                     This also requires that the os flag and runtype flag to be set.  Lastly you must'
+    echo '                                     also have the BV_UPLOAD_SAS_TOKEN set to a SAS token for the Benchview upload container'
+    echo '  --benchViewOS=<os>               : Specify the os that will be used to insert data into Benchview.'
+    echo '  --runType=<private|rolling>      : Specify the runType for Benchview.'
 }
 
 # Variables for xUnit-style XML output. XML format: https://xunit.github.io/docs/format-xml-v2.html
@@ -59,95 +59,6 @@ case $OSName in
         ;;
 esac
 
-function xunit_output_end {
-    local errorSource=$1
-    local errorMessage=$2
-
-    local errorCount
-    if [ -z "$errorSource" ]; then
-        ((errorCount = 0))
-    else
-        ((errorCount = 1))
-    fi
-
-    echo '<?xml version="1.0" encoding="utf-8"?>' >>"$xunitOutputPath"
-    echo '<assemblies>' >>"$xunitOutputPath"
-
-    local line
-
-    # <assembly ...>
-    line="  "
-    line="${line}<assembly"
-    line="${line} name=\"CoreClrTestAssembly\""
-    line="${line} total=\"${countTotalTests}\""
-    line="${line} passed=\"${countPassedTests}\""
-    line="${line} failed=\"${countFailedTests}\""
-    line="${line} skipped=\"${countSkippedTests}\""
-    line="${line} errors=\"${errorCount}\""
-    line="${line}>"
-    echo "$line" >>"$xunitOutputPath"
-
-    # <collection ...>
-    line="    "
-    line="${line}<collection"
-    line="${line} name=\"CoreClrTestCollection\""
-    line="${line} total=\"${countTotalTests}\""
-    line="${line} passed=\"${countPassedTests}\""
-    line="${line} failed=\"${countFailedTests}\""
-    line="${line} skipped=\"${countSkippedTests}\""
-    line="${line}>"
-    echo "$line" >>"$xunitOutputPath"
-
-    # <test .../> <test .../> ...
-    if [ -f "$xunitTestOutputPath" ]; then
-        cat "$xunitTestOutputPath" >>"$xunitOutputPath"
-        rm -f "$xunitTestOutputPath"
-    fi
-
-    # </collection>
-    line="    "
-    line="${line}</collection>"
-    echo "$line" >>"$xunitOutputPath"
-
-    if [ -n "$errorSource" ]; then
-        # <errors>
-        line="    "
-        line="${line}<errors>"
-        echo "$line" >>"$xunitOutputPath"
-
-        # <error ...>
-        line="      "
-        line="${line}<error"
-        line="${line} type=\"TestHarnessError\""
-        line="${line} name=\"${errorSource}\""
-        line="${line}>"
-        echo "$line" >>"$xunitOutputPath"
-
-        # <failure .../>
-        line="        "
-        line="${line}<failure>${errorMessage}</failure>"
-        echo "$line" >>"$xunitOutputPath"
-
-        # </error>
-        line="      "
-        line="${line}</error>"
-        echo "$line" >>"$xunitOutputPath"
-
-        # </errors>
-        line="    "
-        line="${line}</errors>"
-        echo "$line" >>"$xunitOutputPath"
-    fi
-
-    # </assembly>
-    line="  "
-    line="${line}</assembly>"
-    echo "$line" >>"$xunitOutputPath"
-
-    # </assemblies>
-    echo '</assemblies>' >>"$xunitOutputPath"
-}
-
 function exit_with_error {
     local errorSource=$1
     local errorMessage=$2
@@ -158,7 +69,6 @@ function exit_with_error {
     fi
 
     echo "$errorMessage"
-    xunit_output_end "$errorSource" "$errorMessage"
     if ((printUsage != 0)); then
         print_usage
     fi
@@ -188,8 +98,9 @@ function create_core_overlay {
         return
     fi
 
-    # Check inputs to make sure we have enough information to create the core layout. $testRootDir/Tests/Core_Root should
-    # already exist and contain test dependencies that are not built.
+    # Check inputs to make sure we have enough information to create the core
+    # layout. $testRootDir/Tests/Core_Root should already exist and contain test
+    # dependencies that are not built.
     local testDependenciesDir=$testRootDir/Tests/Core_Root
     if [ ! -d "$testDependenciesDir" ]; then
         exit_with_error "$errorSource" "Did not find the test dependencies directory: $testDependenciesDir"
@@ -212,7 +123,7 @@ function create_core_overlay {
     fi
     mkdir "$coreOverlayDir"
 
-	cp -f -v "$coreFxBinDir"/* "$coreOverlayDir/" 2>/dev/null
+    cp -f -v "$coreFxBinDir"/* "$coreOverlayDir/" 2>/dev/null
     cp -f -v "$coreClrBinDir/"* "$coreOverlayDir/" 2>/dev/null
     cp -n -v "$testDependenciesDir"/* "$coreOverlayDir/" 2>/dev/null
 }
@@ -307,10 +218,10 @@ do
         --coreFxBinDir=*)
             coreFxBinDir=${i#*=}
             ;;
-		--benchViewOS=*)
+        --benchViewOS=*)
             benchViewOS=${i#*=}
             ;;
-		--runType=*)
+        --runType=*)
             runType=${i#*=}
             ;;
         --uploadToBenchview)
@@ -344,28 +255,30 @@ if [ -d "$mscorlibDir" ] && [ -d "$mscorlibDir/bin" ]; then
 fi
 
 # Install xunit performance packages
-export NUGET_PACKAGES=$testNativeBinDir/../../../../packages
+CORECLR_REPO=$testNativeBinDir/../../../..
+DOTNETCLI_PATH=$CORECLR_REPO/Tools/dotnetcli
+
+export NUGET_PACKAGES=$CORECLR_REPO/packages
 echo "NUGET_PACKAGES = $NUGET_PACKAGES"
 
-pushd $testNativeBinDir/../../../../tests/scripts
-$testNativeBinDir/../../../../Tools/dotnetcli/dotnet restore --fallbacksource https://dotnet.myget.org/F/dotnet-buildtools/ --fallbacksource https://dotnet.myget.org/F/dotnet-core/
+pushd $CORECLR_REPO/tests/scripts
+    $DOTNETCLI_PATH/dotnet restore --fallbacksource https://dotnet.myget.org/F/dotnet-buildtools/ --fallbacksource https://dotnet.myget.org/F/dotnet-core/
 popd
 
 # Creat coreoverlay dir which contains all dependent binaries
-create_core_overlay
-precompile_overlay_assemblies
-copy_test_native_bin_to_test_root
+create_core_overlay                 || exit 1
+precompile_overlay_assemblies       || exit 1
+copy_test_native_bin_to_test_root   || exit 1
 
 # Deploy xunit performance packages
+# TODO: Why? Aren't we already in CORE_ROOT?
 cd $CORE_ROOT
-echo "CORE_ROOT dir = $CORE_ROOT"
+echo "CORE_ROOT=$CORE_ROOT"
 
 DO_SETUP=TRUE
-
 if [ ${DO_SETUP} == "TRUE" ]; then
-cp  $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.runner.cli/1.0.0-alpha-build0040/lib/netstandard1.3/Microsoft.DotNet.xunit.performance.runner.cli.dll .
-cp  $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.analysis.cli/1.0.0-alpha-build0040/lib/netstandard1.3/Microsoft.DotNet.xunit.performance.analysis.cli.dll .
-cp  $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.run.core/1.0.0-alpha-build0040/lib/dotnet/*.dll .
+    $DOTNETCLI_PATH/dotnet restore $CORECLR_REPO/tests/src/Common/PerfHarness/PerfHarness.csproj
+    $DOTNETCLI_PATH/dotnet publish $CORECLR_REPO/tests/src/Common/PerfHarness/PerfHarness.csproj -c Release -o .
 fi
 
 # Run coreclr performance tests
@@ -373,29 +286,28 @@ echo "Test root dir is: $testRootDir"
 tests=($(find $testRootDir/JIT/Performance/CodeQuality -name '*.exe') $(find $testRootDir/performance/perflab/PerfLab -name '*.dll'))
 
 echo "current dir is $PWD"
-rm measurement.json
-for testcase in ${tests[@]}; do
-
-test=$(basename $testcase)
-testname=$(basename $testcase .exe)
-echo "....Running $testname"
-cp $testcase .
-cp $testcase-*.txt .
-
-chmod u+x ./corerun
-echo "./corerun Microsoft.DotNet.xunit.performance.runner.cli.dll $test -runner xunit.console.netcore.exe -runnerhost ./corerun -verbose -runid perf-$testname"
-./corerun Microsoft.DotNet.xunit.performance.runner.cli.dll $test -runner xunit.console.netcore.exe -runnerhost ./corerun -verbose -runid perf-$testname
-echo "./corerun Microsoft.DotNet.xunit.performance.analysis.cli.dll perf-$testname.xml -xml perf-$testname-summary.xml"
-./corerun Microsoft.DotNet.xunit.performance.analysis.cli.dll perf-$testname.xml -xml perf-$testname-summary.xml
-if [ "$uploadToBenchview" == "TRUE" ]
-    then
-	python3.5 ../../../../../tests/scripts/Microsoft.BenchView.JSONFormat/tools/measurement.py xunit perf-$testname.xml --better desc --drop-first-value --append
+if [ -f measurement.json ]; then
+    rm measurement.json || exit $EXIT_CODE_EXCEPTION
 fi
+
+for testcase in ${tests[@]}; do
+    test=$(basename $testcase)
+    testname=$(basename $testcase .exe)
+    echo "....Running $testname"
+    cp $testcase .
+    cp $testcase-*.txt .
+
+    chmod u+x ./corerun
+    echo "./corerun PerfHarness.dll $test -perf:runid Perf"
+    ./corerun PerfHarness.dll $test -perf:runid Perf
+    if [ "$uploadToBenchview" == "TRUE" ] then
+        python3.5 ../../../../../tests/scripts/Microsoft.BenchView.JSONFormat/tools/measurement.py xunit Perf-$testname.xml --better desc --drop-first-value --append
+    fi
 done
-if [ "$uploadToBenchview" == "TRUE" ]
-    then
-	python3.5 ../../../../../tests/scripts/Microsoft.BenchView.JSONFormat/tools/submission.py measurement.json --build ../../../../../build.json --machine-data ../../../../../machinedata.json --metadata ../../../../../submission-metadata.json --group "CoreCLR" --type "$runType" --config-name "Release" --config Configuration "Release" --config OS "$benchViewOS" --arch "x64" --machinepool "Perfsnake"
-	python3.5 ../../../../../tests/scripts/Microsoft.BenchView.JSONFormat/tools/upload.py submission.json --container coreclr
+
+if [ "$uploadToBenchview" == "TRUE" ]; then
+    python3.5 ../../../../../tests/scripts/Microsoft.BenchView.JSONFormat/tools/submission.py measurement.json --build ../../../../../build.json --machine-data ../../../../../machinedata.json --metadata ../../../../../submission-metadata.json --group "CoreCLR" --type "$runType" --config-name "Release" --config Configuration "Release" --config OS "$benchViewOS" --arch "x64" --machinepool "Perfsnake"
+    python3.5 ../../../../../tests/scripts/Microsoft.BenchView.JSONFormat/tools/upload.py submission.json --container coreclr
 fi
 mkdir ../../../../../sandbox
 cp *.xml ../../../../../sandbox

--- a/tests/scripts/run-xunit-perf.sh
+++ b/tests/scripts/run-xunit-perf.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 function run_command {
+    echo ""
     echo $USER@`hostname` "$PWD"
     echo `date +"[%m/%d/%Y %H:%M:%S]"`" $ $@"
     $@

--- a/tests/scripts/run-xunit-perf.sh
+++ b/tests/scripts/run-xunit-perf.sh
@@ -220,6 +220,7 @@ benchViewGroup=CoreCLR
 perfCollection=
 collectionflags=stopwatch
 hasWarmupRun=--drop-first-value
+stabilityPrefix=
 
 for i in "$@"
 do
@@ -257,6 +258,9 @@ do
             ;;
         --generatebenchviewdata=*)
             BENCHVIEW_TOOLS_PATH=${i#*=}
+            ;;
+        --stabilityPrefix=*)
+            stabilityPrefix=${i#*=}
             ;;
         --uploadToBenchview)
             uploadToBenchview=TRUE
@@ -333,7 +337,7 @@ for testcase in ${tests[@]}; do
     # TODO: Do we need this here.
     chmod u+x ./corerun
 
-    run_command ./corerun PerfHarness.dll $test --perf:runid Perf --perf:collect stopwatch || exit 1
+    run_command $stabilityPrefix ./corerun PerfHarness.dll $test --perf:runid Perf --perf:collect stopwatch || exit 1
 
     if [ -d "$BENCHVIEW_TOOLS_PATH" ]; then
         run_command python3.5 "$BENCHVIEW_TOOLS_PATH/measurement.py" xunit "Perf-$filename.xml" --better desc $hasWarmupRun --append || {

--- a/tests/scripts/run-xunit-perf.sh
+++ b/tests/scripts/run-xunit-perf.sh
@@ -336,15 +336,22 @@ for testcase in ${tests[@]}; do
     # TODO: Do we need this here.
     chmod u+x ./corerun
 
-    echo "Running $testname"
+    echo "----------"
+    echo "  Running $testname"
+    echo "----------"
     run_command $stabilityPrefix ./corerun PerfHarness.dll $test --perf:runid Perf --perf:collect stopwatch || exit 1
-
     if [ -d "$BENCHVIEW_TOOLS_PATH" ]; then
         run_command python3.5 "$BENCHVIEW_TOOLS_PATH/measurement.py" xunit "Perf-$filename.xml" --better desc $hasWarmupRun --append || {
             echo [ERROR] Failed to generate BenchView data;
             exit 1;
         }
     fi
+
+    # Rename file to be archived by Jenkins.
+    mv -f "Perf-$filename.xml" "$CORECLR_REPO/Perf-$filename-$perfCollection.xml" || {
+        echo [ERROR] Failed to move "Perf-$filename.xml" to "$CORECLR_REPO".
+        exit 1;
+    }
 done
 
 if [ -d "$BENCHVIEW_TOOLS_PATH" ]; then

--- a/tests/scripts/run-xunit-perf.sh
+++ b/tests/scripts/run-xunit-perf.sh
@@ -34,11 +34,12 @@ function print_usage {
     echo '  --mscorlibDir=<path>              : Directory containing the built mscorlib.dll. If not specified, it is expected to be'
     echo '                                       in the directory specified by --coreClrBinDir.'
     echo '  --coreFxBinDir="<path>"           : The path to the unpacked runtime folder that is produced as part of a CoreFX build'
+    echo '  --generatebenchviewdata           : BenchView tools directory.'
     echo '  --uploadToBenchview               : Specify this flag in order to have the results of the run uploaded to Benchview.'
-    echo '                                      This also requires that the os flag and runtype flag to be set.  Lastly you must'
+    echo '                                      This requires that the generatebenchviewdata, os and runtype flags to be set, and'
     echo '                                      also have the BV_UPLOAD_SAS_TOKEN set to a SAS token for the Benchview upload container'
     echo '  --benchViewOS=<os>                : Specify the os that will be used to insert data into Benchview.'
-    echo '  --runType=<local|private|rolling> : Specify the runType for Benchview.'
+    echo '  --runType=<local|private|rolling> : Specify the runType for Benchview. [Default: local]'
 }
 
 # libExtension determines extension for dynamic library files
@@ -327,8 +328,6 @@ for testcase in ${tests[@]}; do
     test=$(basename $testcase)
     testname=$(basename $testcase .exe)
 
-    echo "Running $testname"
-
     cp $testcase .                    || exit 1
     if [ stat -t "$directory/$filename"*.txt 1>/dev/null 2>&1 ]; then
         cp "$directory/$filename"*.txt .  || exit 1
@@ -337,6 +336,7 @@ for testcase in ${tests[@]}; do
     # TODO: Do we need this here.
     chmod u+x ./corerun
 
+    echo "Running $testname"
     run_command $stabilityPrefix ./corerun PerfHarness.dll $test --perf:runid Perf --perf:collect stopwatch || exit 1
 
     if [ -d "$BENCHVIEW_TOOLS_PATH" ]; then
@@ -366,6 +366,6 @@ if [ -d "$BENCHVIEW_TOOLS_PATH" ]; then
     }
 fi
 
-if [ "$uploadToBenchview" == "TRUE" ]; then
+if [ -d "$BENCHVIEW_TOOLS_PATH" ] && { [ "$uploadToBenchview" == "TRUE" ]; }; then
     run_command python3.5 "$BENCHVIEW_TOOLS_PATH/upload.py" submission.json --container coreclr
 fi

--- a/tests/scripts/run-xunit-perf.sh
+++ b/tests/scripts/run-xunit-perf.sh
@@ -4,7 +4,7 @@ function run_command {
     echo ""
     echo $USER@`hostname` "$PWD"
     echo `date +"[%m/%d/%Y %H:%M:%S]"`" $ $@"
-    $@
+    "$@"
     return $?
 }
 

--- a/tests/src/Common/PerfHarness/PerfHarness.csproj
+++ b/tests/src/Common/PerfHarness/PerfHarness.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="xunit.performance.api">
-      <Version>1.0.0-beta-build0004</Version>
+      <Version>1.0.0-beta-build0006</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/tests/src/Common/external/external.depproj
+++ b/tests/src/Common/external/external.depproj
@@ -22,16 +22,16 @@
       <Version>1.1.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.performance.api">
-      <Version>1.0.0-beta-build0004</Version>
+      <Version>1.0.0-beta-build0006</Version>
     </PackageReference>
     <PackageReference Include="xunit.performance.core">
-      <Version>1.0.0-beta-build0004</Version>
+      <Version>1.0.0-beta-build0006</Version>
     </PackageReference>
     <PackageReference Include="xunit.performance.execution">
-      <Version>1.0.0-beta-build0004</Version>
+      <Version>1.0.0-beta-build0006</Version>
     </PackageReference>
     <PackageReference Include="xunit.performance.metrics">
-      <Version>1.0.0-beta-build0004</Version>
+      <Version>1.0.0-beta-build0006</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent">
       <Version>1.0.3-alpha-experimental</Version>

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Adams/Adams.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Adams/Adams.cs
@@ -15,7 +15,6 @@ using Microsoft.Xunit.Performance;
 
 #if XUNIT_PERF
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 #endif // XUNIT_PERF
 
 namespace Benchstone.BenchF

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/BenchMk2/BenchMk2.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/BenchMk2/BenchMk2.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchF
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/BenchMrk/BenchMrk.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/BenchMrk/BenchMrk.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchF
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Bisect/Bisect.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Bisect/Bisect.cs
@@ -10,7 +10,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchF
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/DMath/DMath.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/DMath/DMath.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchF
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/FFT/FFT.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/FFT/FFT.cs
@@ -11,7 +11,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchF
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/InProd/InProd.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/InProd/InProd.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchF
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/InvMt/InvMt.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/InvMt/InvMt.cs
@@ -10,7 +10,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchF
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/LLoops/LLoops.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/LLoops/LLoops.cs
@@ -58,7 +58,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchF
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Lorenz/Lorenz.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Lorenz/Lorenz.cs
@@ -10,7 +10,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchF
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/MatInv4/MatInv4.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/MatInv4/MatInv4.cs
@@ -8,7 +8,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchF
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/NewtE/NewtE.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/NewtE/NewtE.cs
@@ -11,7 +11,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchF
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/NewtR/NewtR.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/NewtR/NewtR.cs
@@ -10,7 +10,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchF
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Regula/Regula.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Regula/Regula.cs
@@ -10,7 +10,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchF
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Romber/Romber.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Romber/Romber.cs
@@ -10,7 +10,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchF
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Secant/Secant.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Secant/Secant.cs
@@ -10,7 +10,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchF
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Simpsn/Simpsn.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Simpsn/Simpsn.cs
@@ -10,7 +10,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchF
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/SqMtx/SqMtx.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/SqMtx/SqMtx.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchF
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Trap/Trap.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Trap/Trap.cs
@@ -10,7 +10,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchF
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Whetsto/Whetsto.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Whetsto/Whetsto.cs
@@ -10,7 +10,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchF
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/8Queens/8Queens.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/8Queens/8Queens.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Ackermann/Ackermann.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Ackermann/Ackermann.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/AddArray/AddArray.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/AddArray/AddArray.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/AddArray2/AddArray2.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/AddArray2/AddArray2.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Array1/Array1.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Array1/Array1.cs
@@ -16,7 +16,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Array2/Array2.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Array2/Array2.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/BenchE/BenchE.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/BenchE/BenchE.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/BubbleSort/BubbleSort.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/BubbleSort/BubbleSort.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/BubbleSort2/BubbleSort2.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/BubbleSort2/BubbleSort2.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/CSieve/CSieve.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/CSieve/CSieve.cs
@@ -10,7 +10,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Fib/Fib.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Fib/Fib.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/HeapSort/HeapSort.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/HeapSort/HeapSort.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/IniArray/IniArray.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/IniArray/IniArray.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/LogicArray/LogicArray.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/LogicArray/LogicArray.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Midpoint/Midpoint.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Midpoint/Midpoint.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/MulMatrix/MulMatrix.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/MulMatrix/MulMatrix.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/NDhrystone/NDhrystone.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/NDhrystone/NDhrystone.cs
@@ -14,7 +14,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Permutate/Permutate.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Permutate/Permutate.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Pi/Pi.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Pi/Pi.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Puzzle/Puzzle.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Puzzle/Puzzle.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/QuickSort/QuickSort.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/QuickSort/QuickSort.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/TreeInsert/TreeInsert.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/TreeInsert/TreeInsert.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/TreeSort/TreeSort.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/TreeSort/TreeSort.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/XposMatrix/XposMatrix.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/XposMatrix/XposMatrix.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Benchstone.BenchI
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/binarytrees/binarytrees.csharp.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/binarytrees/binarytrees.csharp.cs
@@ -15,7 +15,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 [assembly: MeasureGCCounts]
 
 namespace BenchmarksGame

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/binarytrees/binarytrees.csharp3.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/binarytrees/binarytrees.csharp3.cs
@@ -16,7 +16,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 [assembly: MeasureGCCounts]
 
 namespace BenchmarksGame

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/fasta/fasta.csharp-2.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/fasta/fasta.csharp-2.cs
@@ -16,7 +16,6 @@ using System.IO;
 using System.Text;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace BenchmarksGame
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/fastaredux/fastaredux.csharp.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/fastaredux/fastaredux.csharp.cs
@@ -16,7 +16,6 @@ using System.IO;
 using System.Text;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace BenchmarksGame
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/k-nucleotide/k-nucleotide.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/k-nucleotide/k-nucleotide.cs
@@ -2,7 +2,7 @@
    http://benchmarksgame.alioth.debian.org/
  *
  * submitted by Josh Goldfoot
- * 
+ *
  */
 
 using System;
@@ -14,7 +14,6 @@ using Microsoft.Xunit.Performance;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 [assembly: MeasureGCCounts]
 
 namespace BenchmarksGame
@@ -24,13 +23,13 @@ public class knucleotide
 {
 #if DEBUG
     const int Iterations = 1;
-    const string InputFile = "knucleotide-input.txt"; 
+    const string InputFile = "knucleotide-input.txt";
     static int[] expectedCountLetter = new int[] { 1480, 974, 970, 1576 };
     static int[] expectedCountPairs = new int[] { 420, 272, 292, 496, 273, 202, 201, 298, 316, 185, 167, 302, 470, 315, 310, 480 };
     static int[] expectedCountFragments = new int[] { 54, 24, 4, 0, 0 };
 #else
     const int Iterations = 10;
-    const string InputFile = "knucleotide-input-big.txt"; 
+    const string InputFile = "knucleotide-input-big.txt";
     static int[] expectedCountLetter = new int[] { 302923, 198136, 197566, 301375 };
     static int[] expectedCountPairs = new int[] { 91779, 60030, 59889, 91225, 60096, 39203, 39081, 59756, 59795, 39190, 39023, 59557, 91253, 59713, 59572, 90837 };
     static int[] expectedCountFragments = new int[] { 11765, 3572, 380, 7, 7 };
@@ -90,7 +89,7 @@ public class knucleotide
     public static int Main(string[] args)
     {
         int iterations = Iterations;
-        
+
         string inputFile = FindInput(InputFile);
         if (inputFile == null)
         {
@@ -258,7 +257,7 @@ public class knucleotide
         {
             throw new Exception("unable to find input");
         }
-        foreach (var iteration in Benchmark.Iterations) 
+        foreach (var iteration in Benchmark.Iterations)
         {
             using (iteration.StartMeasurement())
             {
@@ -284,7 +283,7 @@ public class knucleotide
         {
             throw new Exception("unable to find input");
         }
-        foreach (var iteration in Benchmark.Iterations) 
+        foreach (var iteration in Benchmark.Iterations)
         {
             using (iteration.StartMeasurement())
             {

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/nbody/nbody.csharp-3.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/nbody/nbody.csharp-3.cs
@@ -13,7 +13,6 @@ using Microsoft.Xunit.Performance;
 using System;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace BenchmarksGame
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/pidigits/pi-digits.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/pidigits/pi-digits.cs
@@ -18,7 +18,6 @@ using System.Numerics;
 using System.Text;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace BenchmarksGame
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/regexdna/regexdna.csharp-6.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/regexdna/regexdna.csharp-6.cs
@@ -19,7 +19,6 @@ using System.Text.RegularExpressions;
 using System.Threading;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace BenchmarksGame
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/revcomp/revcomp.csharp-1.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/revcomp/revcomp.csharp-1.cs
@@ -16,7 +16,6 @@ using System.Diagnostics;
 using System.IO;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace BenchmarksGame
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/spectralnorm/spectralnorm.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/spectralnorm/spectralnorm.cs
@@ -13,7 +13,6 @@ using Microsoft.Xunit.Performance;
 using System;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace BenchmarksGame
 {

--- a/tests/src/JIT/Performance/CodeQuality/Burgers/Burgers.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Burgers/Burgers.cs
@@ -4,7 +4,7 @@
 //
 // .NET SIMD to solve Burgers' equation
 //
-// Benchmark based on 
+// Benchmark based on
 // https://github.com/taumuon/SIMD-Vectorisation-Burgers-Equation-CSharp
 // http://www.taumuon.co.uk/2014/10/net-simd-to-solve-burgers-equation.html
 
@@ -15,7 +15,6 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 public class Burgers
 {
@@ -192,7 +191,7 @@ public class Burgers
         double[] x = linspace(0.0, 2.0 * Math.PI, nx);
         double[] initial = GetAnalytical(x, 0.0, nu);
 
-        // Warmup 
+        // Warmup
 
         GetCalculated0(1, nx, dx, dt, nu, initial);
         GetCalculated1(1, nx, dx, dt, nu, initial);

--- a/tests/src/JIT/Performance/CodeQuality/Bytemark/ByteMark.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Bytemark/ByteMark.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 /*
 ** This program was translated to C# and adapted for xunit-performance.
-** New variants of several tests were added to compare class versus 
+** New variants of several tests were added to compare class versus
 ** struct and to compare jagged arrays vs multi-dimensional arrays.
 */
 
@@ -24,7 +24,7 @@
 ** are error-free.  Consequently, McGraw-HIll and BYTE Magazine make
 ** no claims in regard to the fitness of the source code, executable
 ** code, and documentation of the BYTEmark.
-** 
+**
 ** Furthermore, BYTE Magazine, McGraw-Hill, and all employees
 ** of McGraw-Hill cannot be held responsible for any damages resulting
 ** from the use of this code or the results obtained from using
@@ -36,7 +36,6 @@ using System;
 using System.IO;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 internal class global
 {
@@ -1273,7 +1272,7 @@ public class ByteMark
         {
             using (iteration.StartMeasurement())
             {
-                for (int i = 0; i < NumericSortJaggedIterations; i++) 
+                for (int i = 0; i < NumericSortJaggedIterations; i++)
                 {
                     t.Run();
                 }
@@ -1295,7 +1294,7 @@ public class ByteMark
         {
             using (iteration.StartMeasurement())
             {
-                for (int i = 0; i < NumericSortRectangularIterations; i++) 
+                for (int i = 0; i < NumericSortRectangularIterations; i++)
                 {
                     t.Run();
                 }
@@ -1317,7 +1316,7 @@ public class ByteMark
         {
             using (iteration.StartMeasurement())
             {
-                for (int i = 0; i < StringSortIterations; i++) 
+                for (int i = 0; i < StringSortIterations; i++)
                 {
                     t.Run();
                 }
@@ -1338,7 +1337,7 @@ public class ByteMark
         {
             using (iteration.StartMeasurement())
             {
-                for (int i = 0; i < BitOpsIterations; i++) 
+                for (int i = 0; i < BitOpsIterations; i++)
                 {
                     t.Run();
                 }
@@ -1360,7 +1359,7 @@ public class ByteMark
         {
             using (iteration.StartMeasurement())
             {
-                for (int i = 0; i < EmFloatIterations; i++) 
+                for (int i = 0; i < EmFloatIterations; i++)
                 {
                     t.Run();
                 }
@@ -1382,7 +1381,7 @@ public class ByteMark
         {
             using (iteration.StartMeasurement())
             {
-                for (int i = 0; i < EmFloatClassIterations; i++) 
+                for (int i = 0; i < EmFloatClassIterations; i++)
                 {
                     t.Run();
                 }
@@ -1403,7 +1402,7 @@ public class ByteMark
         {
             using (iteration.StartMeasurement())
             {
-                for (int i = 0; i < FourierIterations; i++) 
+                for (int i = 0; i < FourierIterations; i++)
                 {
                     t.Run();
                 }
@@ -1425,7 +1424,7 @@ public class ByteMark
         {
             using (iteration.StartMeasurement())
             {
-                for (int i = 0; i < AssignJaggedIterations; i++) 
+                for (int i = 0; i < AssignJaggedIterations; i++)
                 {
                     t.Run();
                 }
@@ -1447,7 +1446,7 @@ public class ByteMark
         {
             using (iteration.StartMeasurement())
             {
-                for (int i = 0; i < AssignRectangularIterations; i++) 
+                for (int i = 0; i < AssignRectangularIterations; i++)
                 {
                     t.Run();
                 }
@@ -1469,7 +1468,7 @@ public class ByteMark
         {
             using (iteration.StartMeasurement())
             {
-                for (int i = 0; i < IDEAEncryptionIterations; i++) 
+                for (int i = 0; i < IDEAEncryptionIterations; i++)
                 {
                     t.Run();
                 }
@@ -1491,7 +1490,7 @@ public class ByteMark
         {
             using (iteration.StartMeasurement())
             {
-                for (int i = 0; i < NeuralJaggedIterations; i++) 
+                for (int i = 0; i < NeuralJaggedIterations; i++)
                 {
                     t.Run();
                 }
@@ -1513,7 +1512,7 @@ public class ByteMark
         {
             using (iteration.StartMeasurement())
             {
-                for (int i = 0; i < NeuralIterations; i++) 
+                for (int i = 0; i < NeuralIterations; i++)
                 {
                     t.Run();
                 }
@@ -1535,7 +1534,7 @@ public class ByteMark
         {
             using (iteration.StartMeasurement())
             {
-                for (int i = 0; i < LUDecompIterations; i++) 
+                for (int i = 0; i < LUDecompIterations; i++)
                 {
                     t.Run();
                 }

--- a/tests/src/JIT/Performance/CodeQuality/FractalPerf/FractalPerf.cs
+++ b/tests/src/JIT/Performance/CodeQuality/FractalPerf/FractalPerf.cs
@@ -13,7 +13,6 @@ using System.Threading.Tasks;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace FractalPerf
 {
@@ -103,11 +102,11 @@ namespace FractalPerf
 
             // set the Julia Set constant
             complex seed = new complex(Real, Imaginary);
-            // run through every point on the screen, setting 
+            // run through every point on the screen, setting
             // m and n to the coordinates
             for (double m = XB; m < XE; m += XS) {
                 for (double n = YB; n < YE; n += YS) {
-                    // the initial z value is the current pixel,  
+                    // the initial z value is the current pixel,
                     // so x and y have to be set to m and n
                     complex accum = new complex(m, n);
                     // perform the iteration
@@ -120,8 +119,8 @@ namespace FractalPerf
                         accum = accum.square() + seed;
                     }
                     // determine the color using the number of
-                    // iterations it took for the number to become too big 
-                    // char color = num % number_of_colors; 
+                    // iterations it took for the number to become too big
+                    // char color = num % number_of_colors;
                     // plot the point
                     result += num;
                 }
@@ -168,7 +167,7 @@ namespace FractalPerf
             }
             return result;
         }
-    
+
         public static int Main() {
             bool result = TestBase();
             return (result ? 100 : -1);

--- a/tests/src/JIT/Performance/CodeQuality/Inlining/InlineGCStruct.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/InlineGCStruct.cs
@@ -20,7 +20,6 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Inlining
 {

--- a/tests/src/JIT/Performance/CodeQuality/Inlining/NoThrowInline.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/NoThrowInline.cs
@@ -11,7 +11,6 @@ using System.Collections.Generic;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Inlining
 {

--- a/tests/src/JIT/Performance/CodeQuality/Linq/Linq.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Linq/Linq.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.Linq;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 public class Product
 {

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Functions.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Functions.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using Microsoft.Xunit.Performance;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Functions
 {

--- a/tests/src/JIT/Performance/CodeQuality/Roslyn/CscBench.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Roslyn/CscBench.cs
@@ -13,7 +13,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 public static class CscBench
 {

--- a/tests/src/JIT/Performance/CodeQuality/SIMD/ConsoleMandel/ConsoleMandel.cs
+++ b/tests/src/JIT/Performance/CodeQuality/SIMD/ConsoleMandel/ConsoleMandel.cs
@@ -9,7 +9,6 @@ using System.Diagnostics;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace SIMD
 {

--- a/tests/src/JIT/Performance/CodeQuality/SIMD/RayTracer/RayTracerBench.cs
+++ b/tests/src/JIT/Performance/CodeQuality/SIMD/RayTracer/RayTracerBench.cs
@@ -14,7 +14,6 @@ using System.Threading.Tasks;
 using System.Collections.Concurrent;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace SIMD
 {

--- a/tests/src/JIT/Performance/CodeQuality/SIMD/SeekUnroll/SeekUnroll.cs
+++ b/tests/src/JIT/Performance/CodeQuality/SIMD/SeekUnroll/SeekUnroll.cs
@@ -12,7 +12,6 @@ using System.Collections.Generic;
 using Xunit;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 public static class SeekUnroll
 {

--- a/tests/src/JIT/Performance/CodeQuality/SciMark/kernel.cs
+++ b/tests/src/JIT/Performance/CodeQuality/SciMark/kernel.cs
@@ -4,9 +4,9 @@
 /// <license>
 /// This is a port of the SciMark2a Java Benchmark to C# by
 /// Chris Re (cmr28@cornell.edu) and Werner Vogels (vogels@cs.cornell.edu)
-/// 
+///
 /// For details on the original authors see http://math.nist.gov/scimark2
-/// 
+///
 /// This software is likely to burn your processor, bitflip your memory chips
 /// anihilate your screen and corrupt all your disks, so you it at your
 /// own risk.
@@ -17,7 +17,6 @@ using Microsoft.Xunit.Performance;
 using System;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace SciMark2
 {
@@ -217,7 +216,7 @@ namespace SciMark2
             //             +**  *   *        +
             //             +* *   *   *      +
             //             +*  *   *    *    +
-            //             +*   *    *    *  + 
+            //             +*   *    *    *  +
             //             +-----------------+
             //
             // (as best reproducible with integer artihmetic)

--- a/tests/src/JIT/Performance/CodeQuality/Serialization/Deserialize.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Serialization/Deserialize.cs
@@ -13,7 +13,6 @@ using Newtonsoft.Json.Bson;
 using Microsoft.Xunit.Performance;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Serialization
 {

--- a/tests/src/JIT/Performance/CodeQuality/Serialization/Serialize.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Serialization/Serialize.cs
@@ -12,7 +12,6 @@ using Newtonsoft.Json.Bson;
 using Microsoft.Xunit.Performance;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Serialization
 {

--- a/tests/src/JIT/Performance/CodeQuality/Span/Indexer.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Span/Indexer.cs
@@ -14,7 +14,6 @@ using Xunit;
 using Microsoft.Xunit.Performance;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Span
 {
@@ -526,7 +525,7 @@ namespace Span
             Invoke((int innerIterationCount) =>
             {
                 byte result = TestKnownSizeArray(innerIterationCount);
-                return result; 
+                return result;
             },
             "KnownSizeArray({0})", length);
         }
@@ -1014,7 +1013,7 @@ namespace Span
                 Console.WriteLine("Some tests failed validation");
                 return -1;
             }
-            
+
             return 100;
         }
     }

--- a/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
@@ -14,7 +14,6 @@ using Xunit;
 using Microsoft.Xunit.Performance;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace Span
 {
@@ -1109,7 +1108,7 @@ namespace Span
         #endregion
 
         #region TestSpanAsSpanStringChar<T>
-        
+
         [Benchmark(InnerIterationCount = BaseIterations)]
         [InlineData(1)]
         [InlineData(10)]
@@ -1146,7 +1145,7 @@ namespace Span
             }
         }
 
-        #endregion      
+        #endregion
 
         #endregion // TestSpanAPIs
 
@@ -1186,7 +1185,7 @@ namespace Span
                     }
                 }
             }
-            
+
             // The only failure modes are crash/exception.
             return 100;
         }

--- a/tests/src/JIT/Performance/CodeQuality/V8/Crypto/Crypto.cs
+++ b/tests/src/JIT/Performance/CodeQuality/V8/Crypto/Crypto.cs
@@ -44,7 +44,6 @@ using System.Collections.Generic;
 using System.Globalization;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 namespace V8.Crypto
 {

--- a/tests/src/JIT/Performance/CodeQuality/V8/Richards/Richards.cs
+++ b/tests/src/JIT/Performance/CodeQuality/V8/Richards/Richards.cs
@@ -15,7 +15,6 @@ using System;
 using System.Collections.Generic;
 
 [assembly: OptimizeForBenchmarks]
-[assembly: MeasureInstructionsRetired]
 
 // using System.Diagnostics;
 // using System.Text.RegularExpressions;

--- a/tests/src/JIT/config/benchmark+roslyn/benchmark+roslyn.csproj
+++ b/tests/src/JIT/config/benchmark+roslyn/benchmark+roslyn.csproj
@@ -11,16 +11,16 @@
       <Version>1.1.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.performance.api">
-      <Version>1.0.0-beta-build0004</Version>
+      <Version>1.0.0-beta-build0006</Version>
     </PackageReference>
     <PackageReference Include="xunit.performance.core">
-      <Version>1.0.0-beta-build0004</Version>
+      <Version>1.0.0-beta-build0006</Version>
     </PackageReference>
     <PackageReference Include="xunit.performance.execution">
-      <Version>1.0.0-beta-build0004</Version>
+      <Version>1.0.0-beta-build0006</Version>
     </PackageReference>
     <PackageReference Include="xunit.performance.metrics">
-      <Version>1.0.0-beta-build0004</Version>
+      <Version>1.0.0-beta-build0006</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent">
       <Version>1.0.3-alpha-experimental</Version>

--- a/tests/src/JIT/config/benchmark+serialize/benchmark+serialize.csproj
+++ b/tests/src/JIT/config/benchmark+serialize/benchmark+serialize.csproj
@@ -8,16 +8,16 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit.performance.api">
-      <Version>1.0.0-beta-build0004</Version>
+      <Version>1.0.0-beta-build0006</Version>
     </PackageReference>
     <PackageReference Include="xunit.performance.core">
-      <Version>1.0.0-beta-build0004</Version>
+      <Version>1.0.0-beta-build0006</Version>
     </PackageReference>
     <PackageReference Include="xunit.performance.execution">
-      <Version>1.0.0-beta-build0004</Version>
+      <Version>1.0.0-beta-build0006</Version>
     </PackageReference>
     <PackageReference Include="xunit.performance.metrics">
-      <Version>1.0.0-beta-build0004</Version>
+      <Version>1.0.0-beta-build0006</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent">
       <Version>1.0.3-alpha-experimental</Version>

--- a/tests/src/performance/performance.csproj
+++ b/tests/src/performance/performance.csproj
@@ -8,16 +8,16 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit.performance.api">
-      <Version>1.0.0-beta-build0004</Version>
+      <Version>1.0.0-beta-build0006</Version>
     </PackageReference>
     <PackageReference Include="xunit.performance.core">
-      <Version>1.0.0-beta-build0004</Version>
+      <Version>1.0.0-beta-build0006</Version>
     </PackageReference>
     <PackageReference Include="xunit.performance.execution">
-      <Version>1.0.0-beta-build0004</Version>
+      <Version>1.0.0-beta-build0006</Version>
     </PackageReference>
     <PackageReference Include="xunit.performance.metrics">
-      <Version>1.0.0-beta-build0004</Version>
+      <Version>1.0.0-beta-build0006</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent">
       <Version>1.0.3-alpha-experimental</Version>


### PR DESCRIPTION
- Update the xUnit Performance package with a bug fixed that was silently making the tests fail
- Removed the `[MeasureInstructionsRetired]` attribute from the benchmarks source code, as it's not use, the reason the tests were failing, and this is now passed on the command line when profiling the tests.
- Updated the `run-xunit-perf.sh` and `perf.groovy` files with the appropriate changes.
