### PR TITLE
Remove g_fEEManagedEXEStartup and g_fEEIJWStartup

### DIFF
--- a/src/inc/eventtracebase.h
+++ b/src/inc/eventtracebase.h
@@ -223,8 +223,6 @@ struct ProfilingScanContext;
 // g_nClrInstanceId is defined in Utilcode\Util.cpp. The definition goes into Utilcode.lib.
 // This enables both the VM and Utilcode to raise ETW events.
 extern UINT32 g_nClrInstanceId;
-extern BOOL g_fEEManagedEXEStartup;
-extern BOOL g_fEEIJWStartup;
 
 #define GetClrInstanceId()  (static_cast<UINT16>(g_nClrInstanceId))
 

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -282,12 +282,6 @@ BOOL    g_fSuspendOnShutdown = FALSE;
 // Flag indicating if the finalizer thread should be suspended on shutdown.
 BOOL    g_fSuspendFinalizerOnShutdown = FALSE;
 
-// Flag indicating if the EE was started up by an managed exe.
-BOOL    g_fEEManagedEXEStartup = FALSE;
-
-// Flag indicating if the EE was started up by an IJW dll.
-BOOL    g_fEEIJWStartup = FALSE;
-
 // Flag indicating if the EE was started up by COM.
 extern BOOL g_fEEComActivatedStartup;
 
@@ -306,7 +300,7 @@ HRESULT InitializeEE(COINITIEE flags)
 {
     WRAPPER_NO_CONTRACT;
 #ifdef FEATURE_EVENT_TRACE
-    if(!(g_fEEComActivatedStartup || g_fEEManagedEXEStartup || g_fEEIJWStartup))
+    if(!g_fEEComActivatedStartup)
         g_fEEOtherStartup = TRUE;
 #endif // FEATURE_EVENT_TRACE
     return EnsureEEStarted(flags);

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -4889,12 +4889,10 @@ VOID ETW::InfoLog::RuntimeInformation(INT32 type)
             UINT startupFlags = 0;
             PathString dllPath;
             UINT8 Sku = 0;
-            _ASSERTE(g_fEEManagedEXEStartup ||   //CLR started due to a managed exe
-                g_fEEIJWStartup ||               //CLR started as a mixed mode Assembly
-                CLRHosted() || g_fEEHostedStartup || //CLR started through one of the Hosting API CLRHosted() returns true if CLR started through the V2 Interface while 
-                                                    // g_fEEHostedStartup is true if CLR is hosted through the V1 API.
-                g_fEEComActivatedStartup ||      //CLR started as a COM object
-                g_fEEOtherStartup  );            //In case none of the 4 above mentioned cases are true for example ngen, ildasm then we asssume its a "other" startup
+            _ASSERTE(CLRHosted() || g_fEEHostedStartup || // CLR started through one of the Hosting API CLRHosted() returns true if CLR started through the V2 Interface while 
+                                                          // g_fEEHostedStartup is true if CLR is hosted through the V1 API.
+                     g_fEEComActivatedStartup ||          //CLR started as a COM object
+                     g_fEEOtherStartup  );                //In case none of the 4 above mentioned cases are true for example ngen, ildasm then we asssume its a "other" startup
 
             Sku = ETW::InfoLog::InfoStructs::CoreCLR;
         
@@ -4917,18 +4915,7 @@ VOID ETW::InfoLog::RuntimeInformation(INT32 type)
 
 
             // Determine the startupmode
-            if(g_fEEIJWStartup)
-            {
-                //IJW Mode
-                startupMode = ETW::InfoLog::InfoStructs::IJW;
-            }
-            else if(g_fEEManagedEXEStartup) 
-            {
-                //managed exe
-                startupMode = ETW::InfoLog::InfoStructs::ManagedExe;
-                lpwszCommandLine = WszGetCommandLine();
-            }
-            else if (CLRHosted() || g_fEEHostedStartup)
+            if (CLRHosted() || g_fEEHostedStartup)
             {
                 //Hosted CLR
                 startupMode = ETW::InfoLog::InfoStructs::HostedCLR;


### PR DESCRIPTION
I noticed some code lying around that's not applicable to CoreCLR, since we don't support these types of startup.

@jkotas 