### PR TITLE
Clear GTF_CALL from non-calls in rationalize

### DIFF
--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -970,10 +970,19 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, ArrayStack<G
             node->gtFlags &= ~GTF_ALL_EFFECT;
         }
     }
-    else if (!node->OperIsStore())
+    else
     {
-        // Clear the GTF_ASG flag for all nodes but stores
-        node->gtFlags &= ~GTF_ASG;
+        if (!node->OperIsStore())
+        {
+            // Clear the GTF_ASG flag for all nodes but stores
+            node->gtFlags &= ~GTF_ASG;
+        }
+
+        if (!node->IsCall())
+        {
+            // Clear the GTF_CALL flag for all nodes but calls
+            node->gtFlags &= ~GTF_CALL;
+        }
     }
 
     assert(isLateArg == ((use.Def()->gtFlags & GTF_LATE_ARG) != 0));


### PR DESCRIPTION
Since rationalization hoists comma antecedents out into separate
statements, any side-effects that the antecedent had might no longer apply
to the comma's ancestor nodes.  Moreover, in LIR, side-effect flags need
only describe the immediate node; summary flags are computed when Ranges
are constructed.  So, update rationalize to clear the `GTF_CALL` flag from
any node that is not a call.  Failure to do so gives an
overly-conservative view of side-effects, which can inhibit dead store
removal.