### PR TITLE
Remove the check that requires an instrumented flags for SPC when collecting IBC data

### DIFF
--- a/src/vm/pefile.cpp
+++ b/src/vm/pefile.cpp
@@ -1232,17 +1232,6 @@ BOOL PEAssembly::CheckNativeImageVersion(PEImage *peimage)
 
     CorCompileConfigFlags configFlags = PEFile::GetNativeImageConfigFlagsWithOverrides();
 
-    if (IsSystem())
-    {
-        // Require instrumented flags for mscorlib when collecting IBC data
-        CorCompileConfigFlags instrumentationConfigFlags = (CorCompileConfigFlags) (configFlags & CORCOMPILE_CONFIG_INSTRUMENTATION);
-        if ((info->wConfigFlags & instrumentationConfigFlags) != instrumentationConfigFlags)
-        {
-            ExternalLog(LL_ERROR, "Instrumented native image for System.Private.CoreLib.dll expected.");
-            ThrowHR(COR_E_NI_AND_RUNTIME_VERSION_MISMATCH);
-        }
-    }
-
     // Otherwise, match regardless of the instrumentation flags
     configFlags = (CorCompileConfigFlags) (configFlags & ~(CORCOMPILE_CONFIG_INSTRUMENTATION_NONE | CORCOMPILE_CONFIG_INSTRUMENTATION));
 


### PR DESCRIPTION
This check is not needed on CoreCLR and blocks some valuable usage cases.

Fixes #11918