### PR TITLE
LinkBench: Enable Roslyn

### DIFF
--- a/tests/src/performance/linkbench/linkbench.cs
+++ b/tests/src/performance/linkbench/linkbench.cs
@@ -187,7 +187,7 @@ namespace LinkBench
                 xdoc.Root.Add(new XElement(ns + "ItemGroup",
                     new XElement(ns + "PackageReference",
                         new XAttribute("Include", "ILLink.Tasks"),
-                        new XAttribute("Version", "0.1.4-preview"))));
+                        new XAttribute("Version", "0.1.4-preview-737646"))));
                 added = true;
             }
             using (var fs = new FileStream(csproj, FileMode.Create))
@@ -262,16 +262,16 @@ namespace LinkBench
             new Benchmark("Corefx",
                 "corefx\\bin\\ILLinkTrimAssembly\\netcoreapp-Windows_NT-Release-x64\\pretrimmed",
                 "corefx\\bin\\ILLinkTrimAssembly\\netcoreapp-Windows_NT-Release-x64\\trimmed"),
-            /*new Benchmark("Roslyn",
+            new Benchmark("Roslyn",
                 "roslyn\\Binaries\\Release\\Exes\\CscCore\\win7-x64\\publish",
-                "roslyn\\Binaries\\Release\\Exes\\CscCore\\win7-x64\\Linked") */
+                "roslyn\\Binaries\\Release\\Exes\\CscCore\\win7-x64\\Linked") 
         };
 
         static int UsageError()
         {
             Console.WriteLine("Usage: LinkBench [--nosetup] [--nobuild] [--perf:runid <id>] [<benchmarks>]");
             Console.WriteLine("  --nosetup: Don't clone and fixup benchmark repositories");
-            Console.WriteLine("  --nosetup: Don't build and link benchmarks");
+            Console.WriteLine("  --nobuild: Don't build and link benchmarks");
             Console.WriteLine("  --perf:runid: Specify the ID to append to benchmark result files");
             Console.WriteLine("    Benchmarks: HelloWorld, WebAPI, MusicStore, MusicStore_R2R, CoreFX, Roslyn");
             Console.WriteLine("                Default is to run all the above benchmarks.");
@@ -370,6 +370,7 @@ namespace LinkBench
             AssetsDir = linkBenchSrcDir + "assets\\";
 
             Environment.SetEnvironmentVariable("LinkBenchRoot", LinkBenchRoot);
+            Environment.SetEnvironmentVariable("__dotnet", LinkBenchRoot + "\\.Net\\dotnet.exe");
             Environment.SetEnvironmentVariable("__dotnet1", LinkBenchRoot + "\\.Net1\\dotnet.exe");
             Environment.SetEnvironmentVariable("__dotnet2", LinkBenchRoot + "\\.Net2\\dotnet.exe");
 

--- a/tests/src/performance/linkbench/scripts/clone.cmd
+++ b/tests/src/performance/linkbench/scripts/clone.cmd
@@ -1,10 +1,10 @@
 setlocal ENABLEDELAYEDEXPANSION 
-@echo off
+@echo on
 
 set EXITCODE=0
 pushd %LinkBenchRoot%
 
-if not exist %__dotnet1% call :DotNet
+call :DotNet
 
 if defined __test_HelloWorld call :HelloWorld
 if defined __test_WebAPI call :WebAPI
@@ -17,35 +17,57 @@ popd
 exit /b %EXITCODE%
 
 :DotNet
-REM Roslyn needs SDK 1.0.0, other benchmarks need SDK 2.0.0
-mkdir .Net1
-mkdir .Net2
+REM We clone three different versions of .Net CLI in order to cope with 
+REM different runtimes that the benchmarks target, and certain limitations 
+REM in the ILLink/CLI integration and packaging.
+REM
+REM .Net => .Net 2.0.0-preview2-005905
+REM      This version is used to build most benchmarks.
+REM      We use this specific version instead of the latest available from 
+REM      the master branch, because the latest CLI generates R2R images for 
+REM      system binaries, while ILLink cannot yet. We need pure MSIL images
+REM      in the unlinked version in order to be able to do a fair dir-size comparison.
+REM .Net2 => This is the latest CLI for .Net 2.0.0
+REM      Roslyn build needs the latest Roslyn 15.3 compilers which are only available   
+REM      with the latest CLI. But Roslyn targets netcoreapp v1, so the latest .Net CLI
+REM      does not output R2R images in this case.
+REM .Net1 => This is .Net CLI v 1.1.0
+REM      Since Roslyn targets netcoreapp v1, it cannot use the IlLink.Tasks package.
+REM      We use the ILLink package to get the linker and run it manually.
+REM      Since IlLink.exe from this package only runs on .Net v1
+REM
+REM HelloWorld, WebAPI, and MusicStore use .Net
+REM Roslyn uses .Net1 and .Net2
+REM CoreFX downloads its own .Net CLI in its build.
+
 powershell -noprofile -executionPolicy RemoteSigned wget  https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1 -OutFile dotnet-install.ps1
-powershell -noprofile -executionPolicy RemoteSigned -file dotnet-install.ps1 -InstallDir .Net1
-powershell -noprofile -executionPolicy RemoteSigned -file dotnet-install.ps1 -Channel master -InstallDir .Net2 -version 2.0.0-preview2-005905
-if not exist %__dotnet1% set EXITCODE=1&& echo DotNet.1.0.0 uninstalled
-if not exist %__dotnet2% set EXITCODE=1&& echo DotNet.2.0.0 uninstalled
+if not exist %__dotnet%  mkdir .Net  && powershell -noprofile -executionPolicy RemoteSigned -file dotnet-install.ps1 -Channel master -InstallDir .Net -version 2.0.0-preview2-005905
+if not exist %__dotnet1% mkdir .Net1 && powershell -noprofile -executionPolicy RemoteSigned -file dotnet-install.ps1 -InstallDir .Net1
+if not exist %__dotnet2% mkdir .Net2 && powershell -noprofile -executionPolicy RemoteSigned -file dotnet-install.ps1 -Channel master -InstallDir .Net2
+if not exist %__dotnet% set EXITCODE=1&& echo DotNet not installed
+if not exist %__dotnet1% set EXITCODE=1&& echo DotNet.1 not installed
+if not exist %__dotnet2% set EXITCODE=1&& echo DotNet.2 not installed
 exit /b 
 
 :HelloWorld
 mkdir HelloWorld
 cd HelloWorld
-call %__dotnet2% new console
-if errorlevel 1 set EXITCODE=1
+call %__dotnet% new console
+if errorlevel 1 set EXITCODE=1&&echo Setup HelloWorld failed
 cd ..
 exit /b 
 
 :WebAPI
 mkdir WebAPI
 cd WebAPI
-call %__dotnet2% new webapi
-if errorlevel 1 set EXITCODE=1
+call %__dotnet% new webapi
+if errorlevel 1 set EXITCODE=1&&echo Setup WebAPI failed
 cd ..
 exit /b
 
 :MusicStore
 git clone https://github.com/aspnet/JitBench -b dev
-if errorlevel 1 set EXITCODE=1
+if errorlevel 1 set EXITCODE=1&&echo Setup MusicStore failed
 exit /b
 
 :MusicStore_R2R
@@ -55,10 +77,10 @@ exit /b
 
 :CoreFx
 git clone http://github.com/dotnet/corefx
-if errorlevel 1 set EXITCODE=1
+if errorlevel 1 set EXITCODE=1&&echo Setup CoreFX failed
 exit /b
 
 :Roslyn
 git clone https://github.com/dotnet/roslyn.git
-if errorlevel 1 set EXITCODE=1
+if errorlevel 1 set EXITCODE=1&&echo Setup Roslyn failed
 exit /b


### PR DESCRIPTION
This change enables Roslyn runs as part of ILLink.

Roslyn was previously disabled because .Net CLI didnt use the latest
Roslyn compilers. Now that this issue is fixed, we re-enable Roslyn.
The different .Net versions necessary to run the benchmarks are
all downloaded, and the benchmarks are built using them.