### PR TITLE
Clean up PAL's CMakeLists.txt

### DIFF
--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -8,11 +8,6 @@ project(coreclrpal)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-if(CORECLR_SET_RPATH)
-    # Enable @rpath support for shared libraries.
-    set(MACOSX_RPATH ON)
-endif(CORECLR_SET_RPATH)
-
 if(CMAKE_VERSION VERSION_EQUAL 3.0 OR CMAKE_VERSION VERSION_GREATER 3.0)
     cmake_policy(SET CMP0042 NEW)
 endif()


### PR DESCRIPTION
It seems that MACOSX_RPATH has no effect on PAL build.