### PR TITLE
Allow EventPipe Rundown at Process Shutdown

### DIFF
--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -1563,6 +1563,11 @@ void STDMETHODCALLTYPE EEShutDownHelper(BOOL fIsDllUnloading)
         ETW::EnumerationLog::ProcessShutdown();
     }
 
+#ifdef FEATURE_PERFTRACING
+    // Shutdown the event pipe.
+    EventPipe::Shutdown();
+#endif // FEATURE_PERFTRACING
+
 #if defined(FEATURE_COMINTEROP)
     // Get the current thread.
     Thread * pThisThread = GetThread();
@@ -1694,11 +1699,6 @@ void STDMETHODCALLTYPE EEShutDownHelper(BOOL fIsDllUnloading)
         // Flush and close the perf map file.
         PerfMap::Destroy();
 #endif
-
-#ifdef FEATURE_PERFTRACING
-        // Shutdown the event pipe.
-        EventPipe::Shutdown();
-#endif // FEATURE_PERFTRACING
 
 #ifdef FEATURE_PREJIT
         {


### PR DESCRIPTION
Currently, if a tracing session is not disabled via the configuration APIs, then no rundown occurs because the rundown call is made after EEShutdown has started and the necessary data structures are not guaranteed to be consistent (thus rundown is safely skipped).

This change moves the rundown call to the same code site as ETW rundown in the shutdown path to make sure that it can properly do rundown.

#11936