### PR TITLE
[RyuJit/ARM32] Adjust alignment for TYP_DOUBLE in tmpPreAllocateTemps

### DIFF
--- a/src/jit/regset.cpp
+++ b/src/jit/regset.cpp
@@ -3320,6 +3320,14 @@ void Compiler::tmpPreAllocateTemps(var_types type, unsigned count)
         tmpCount++;
         tmpSize += size;
 
+#ifdef _TARGET_ARM_
+        if (type == TYP_DOUBLE)
+        {
+            // Adjust tmpSize in case it needs alignment
+            tmpSize += TARGET_POINTER_SIZE;
+        }
+#endif // _TARGET_ARM_
+
         TempDsc* temp = new (this, CMK_Unknown) TempDsc(-((int)tmpCount), size, type);
 
 #ifdef DEBUG

--- a/src/jit/regset.cpp
+++ b/src/jit/regset.cpp
@@ -3323,7 +3323,8 @@ void Compiler::tmpPreAllocateTemps(var_types type, unsigned count)
 #ifdef _TARGET_ARM_
         if (type == TYP_DOUBLE)
         {
-            // Adjust tmpSize in case it needs alignment
+            // Adjust tmpSize to accommodate possible alignment padding.
+            // Note that at this point the offsets aren't yet finalized, so we don't yet know if it will be required.
             tmpSize += TARGET_POINTER_SIZE;
         }
 #endif // _TARGET_ARM_


### PR DESCRIPTION
In #11782,

Assertion failed 'spillTempSize <= lvaGetMaxSpillTempSize()' has been occurred in code generation phase.

Adjusting alignment for TYP_DOUBLE in tmpPreAllocateTemps is needed.