### PR TITLE
[RyuJIT/ARM32][LSRA] Fix restoring TYP_DOUBLE interval in ARM32

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -6448,13 +6448,7 @@ void LinearScan::unassignPhysReg(RegRecord* regRec, RefPosition* spillRefPositio
     {
         assignedInterval->assignedReg = regRec;
     }
-#ifdef _TARGET_ARM_
     else if (canRestorePreviousInterval(regRec, assignedInterval))
-#else
-    else if (regRec->previousInterval != nullptr && regRec->previousInterval != assignedInterval &&
-             regRec->previousInterval->assignedReg == regRec &&
-             regRec->previousInterval->getNextRefPosition() != nullptr)
-#endif
     {
         regRec->assignedInterval = regRec->previousInterval;
         regRec->previousInterval = nullptr;
@@ -6657,6 +6651,7 @@ bool LinearScan::isSecondHalfReg(RegRecord* regRec, Interval* interval)
 
     return false;
 }
+#endif
 
 //--------------------------------------------------------------------------------------
 // canRestorePreviousInterval: Test if we can restore previous interval
@@ -6677,17 +6672,18 @@ bool LinearScan::canRestorePreviousInterval(RegRecord* regRec, Interval* assigne
         (regRec->previousInterval != nullptr && regRec->previousInterval != assignedInterval &&
          regRec->previousInterval->assignedReg == regRec && regRec->previousInterval->getNextRefPosition() != nullptr);
 
+#ifdef _TARGET_ARM_
     if (retVal && regRec->previousInterval->registerType == TYP_DOUBLE)
     {
         regNumber  nextRegNum = REG_NEXT(regRec->regNum);
         RegRecord* nextRegRec = getRegisterRecord(nextRegNum);
 
-        retVal = retVal &&
-                 (nextRegRec->assignedInterval == nullptr && regRec->previousInterval == nextRegRec->previousInterval);
+        retVal = retVal && nextRegRec->assignedInterval == nullptr;
     }
+#endif
+
     return retVal;
 }
-#endif
 
 //------------------------------------------------------------------------
 // processBlockStartLocations: Update var locations on entry to 'currentBlock'

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -696,8 +696,8 @@ private:
 
 #ifdef _TARGET_ARM_
     bool isSecondHalfReg(RegRecord* regRec, Interval* interval);
-    bool LinearScan::canRestorePreviousInterval(RegRecord* regRec, Interval* assignedInterval);
 #endif
+    bool canRestorePreviousInterval(RegRecord* regRec, Interval* assignedInterval);
 
     RefType CheckBlockType(BasicBlock* block, BasicBlock* prevBlock);
 

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -696,6 +696,7 @@ private:
 
 #ifdef _TARGET_ARM_
     bool isSecondHalfReg(RegRecord* regRec, Interval* interval);
+    bool LinearScan::canRestorePreviousInterval(RegRecord* regRec, Interval* assignedInterval);
 #endif
 
     RefType CheckBlockType(BasicBlock* block, BasicBlock* prevBlock);

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -696,6 +696,7 @@ private:
 
 #ifdef _TARGET_ARM_
     bool isSecondHalfReg(RegRecord* regRec, Interval* interval);
+    RegRecord* findAnotherHalfRegRec(RegRecord* regRec);
 #endif
     bool canRestorePreviousInterval(RegRecord* regRec, Interval* assignedInterval);
 


### PR DESCRIPTION
Fix #11779 

- Fix segmentation fault by defining `nextRegRec` when `nextRegRec` is not defined yet

- Introduce `canRestorePreviousInterval()`
  This helper check whether previous interval can be restored by considering `TYP_DOUBLE` for ARM32

After this PR, segmentation fault due to uninitialized `nextRegRec` is gone with `COMPlus_AltJit=* COMPlus_AltJitAssertOnNYI=0`.
Among 10 tests reported from #11779,
- 3 tests are passed
```
JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b48614/b48614
JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b63726/b63726
JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b69225/b69225
```

- 6 tests are failed with other assertions which are reported in other issues
```
JIT/Methodical/fp/exgen/10w5d_cs_do
JIT/Methodical/fp/exgen/10w5d_cs_r
JIT/Methodical/fp/exgen/200w1d-02_cs_do
JIT/Methodical/fp/exgen/200w1d-02_cs_ro
JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b59782/b59782
JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b69227/b69227
```

- 1 test is failed due to segmentation fault due to other reason (no change by this PR)
```
JIT/Regression/JitBlue/DevDiv_283795/DevDiv_283795
```
