### PR TITLE
Partially remove relocations from Class section of NGEN-ed images

### DIFF
--- a/src/debug/daccess/nidump.cpp
+++ b/src/debug/daccess/nidump.cpp
@@ -4745,7 +4745,7 @@ void NativeImageDumper::TraverseTypeHashEntry(void *pContext, PTR_EETypeHashEntr
              * all that much harm here (bloats m_discoveredMTs though,
              * but not by a huge amount.
              */
-            PTR_MethodTable mt(ptd->m_TemplateMT.GetValue());
+            PTR_MethodTable mt(ptd->GetTemplateMethodTableInternal());
             if (isInRange(PTR_TO_TADDR(mt)))
             {
                 m_discoveredMTs.AppendEx(mt);
@@ -6201,7 +6201,7 @@ void NativeImageDumper::TypeDescToString( PTR_TypeDesc td, SString& buf )
         if( td->IsArray()  )
         {
             //td->HasTypeParam() may also be true.
-            PTR_MethodTable mt = ptd->m_TemplateMT.GetValue();
+            PTR_MethodTable mt = ptd->GetTemplateMethodTableInternal();
             _ASSERTE( PTR_TO_TADDR(mt) );
             if( CORCOMPILE_IS_POINTER_TAGGED(PTR_TO_TADDR(mt)) )
             {
@@ -8793,7 +8793,7 @@ void NativeImageDumper::DumpTypeDesc( PTR_TypeDesc td )
     {
         PTR_ParamTypeDesc ptd(td);
         DisplayStartVStructure( "ParamTypeDesc", TYPEDESCS );
-        WriteFieldMethodTable( m_TemplateMT, ptd->m_TemplateMT.GetValue(), 
+        WriteFieldMethodTable( m_TemplateMT, ptd->GetTemplateMethodTableInternal(),
                                ParamTypeDesc, TYPEDESCS );
         WriteFieldTypeHandle( m_Arg, ptd->m_Arg, 
                               ParamTypeDesc, TYPEDESCS );

--- a/src/debug/daccess/nidump.cpp
+++ b/src/debug/daccess/nidump.cpp
@@ -8451,7 +8451,7 @@ NativeImageDumper::DumpEEClassForMethodTable( PTR_MethodTable mt )
                                      VERBOSE_TYPES );
         DisplayWriteFieldInt( m_numCTMFields, eecli->m_numCTMFields,
                               EEClassLayoutInfo, VERBOSE_TYPES );
-        PTR_FieldMarshaler fmArray( TO_TADDR(eecli->m_pFieldMarshalers) );
+        PTR_FieldMarshaler fmArray = eecli->GetFieldMarshalers();
         DisplayWriteFieldAddress( m_pFieldMarshalers,
                                   DPtrToPreferredAddr(fmArray),
                                   eecli->m_numCTMFields

--- a/src/inc/fixuppointer.h
+++ b/src/inc/fixuppointer.h
@@ -249,6 +249,15 @@ public:
     static constexpr bool isRelative = true;
     typedef PTR_TYPE type;
 
+#ifndef DACCESS_COMPILE
+    RelativeFixupPointer()
+    {
+        SetValueMaybeNull(NULL);
+    }
+#else // DACCESS_COMPILE
+    RelativeFixupPointer() =delete;
+#endif // DACCESS_COMPILE
+
     // Implicit copy/move is not allowed
     RelativeFixupPointer<PTR_TYPE>(const RelativeFixupPointer<PTR_TYPE> &) =delete;
     RelativeFixupPointer<PTR_TYPE>(RelativeFixupPointer<PTR_TYPE> &&) =delete;
@@ -272,6 +281,15 @@ public:
              return (*PTR_TADDR(addr - FIXUP_POINTER_INDIRECTION) & 1) != 0;
         return FALSE;
     }
+
+#ifndef DACCESS_COMPILE
+    FORCEINLINE BOOL IsTagged() const
+    {
+        LIMITED_METHOD_CONTRACT;
+        TADDR base = (TADDR) this;
+        return IsTagged(base);
+    }
+#endif // !DACCESS_COMPILE
 
     // Returns value of the encoded pointer. Assumes that the pointer is not NULL.
     FORCEINLINE PTR_TYPE GetValue(TADDR base) const
@@ -343,7 +361,7 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
         PRECONDITION(addr != NULL);
-        m_delta = (TADDR)addr - (TADDR)this;
+        m_delta = dac_cast<TADDR>(addr) - (TADDR)this;
     }
 
     // Set encoded value of the pointer. The value can be NULL.
@@ -353,7 +371,7 @@ public:
         if (addr == NULL)
             m_delta = NULL;
         else
-            m_delta = (TADDR)addr - (TADDR)base;
+            m_delta = dac_cast<TADDR>(addr) - (TADDR)base;
     }
 
     // Set encoded value of the pointer. The value can be NULL.
@@ -372,6 +390,15 @@ public:
         _ASSERTE((addr & FIXUP_POINTER_INDIRECTION) != 0);
         return dac_cast<DPTR(PTR_TYPE)>(addr - FIXUP_POINTER_INDIRECTION);
     }
+
+#ifndef DACCESS_COMPILE
+    PTR_TYPE * GetValuePtr() const
+    {
+        LIMITED_METHOD_CONTRACT;
+        TADDR base = (TADDR) this;
+        return GetValuePtr(base);
+    }
+#endif // !DACCESS_COMPILE
 
     // Returns value of the encoded pointer. Assumes that the pointer is not NULL. 
     // Allows the value to be tagged.

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -10702,7 +10702,7 @@ void Module::RestoreMethodDescPointer(RelativeFixupPointer<PTR_MethodDesc> * ppM
 }
 
 /*static*/
-void Module::RestoreFieldDescPointer(FixupPointer<PTR_FieldDesc> * ppFD)
+void Module::RestoreFieldDescPointer(RelativeFixupPointer<PTR_FieldDesc> * ppFD)
 {
     CONTRACTL
     {
@@ -10711,6 +10711,9 @@ void Module::RestoreFieldDescPointer(FixupPointer<PTR_FieldDesc> * ppFD)
         MODE_ANY;
     }
     CONTRACTL_END;
+
+    if (!ppFD->IsTagged())
+        return;
 
     PTR_FieldDesc * ppValue = ppFD->GetValuePtr();
 
@@ -10723,7 +10726,7 @@ void Module::RestoreFieldDescPointer(FixupPointer<PTR_FieldDesc> * ppFD)
         CONSISTENCY_CHECK((CORCOMPILE_UNTAG_TOKEN(fixup)>>32) == 0);
 #endif
 
-        Module * pContainingModule = ExecutionManager::FindZapModule(dac_cast<TADDR>(ppValue));
+        Module * pContainingModule = ExecutionManager::FindZapModule((TADDR)ppValue);
         PREFIX_ASSUME(pContainingModule != NULL);
 
         RVA fixupRva = (RVA) CORCOMPILE_UNTAG_TOKEN(fixup);

--- a/src/vm/ceeload.h
+++ b/src/vm/ceeload.h
@@ -2901,8 +2901,7 @@ public:
     static void RestoreMethodDescPointer(RelativeFixupPointer<PTR_MethodDesc> * ppMD,
                                          Module *pContainingModule = NULL,
                                          ClassLoadLevel level = CLASS_LOADED);
-
-    static void RestoreFieldDescPointer(FixupPointer<PTR_FieldDesc> * ppFD);
+    static void RestoreFieldDescPointer(RelativeFixupPointer<PTR_FieldDesc> * ppFD);
 
     static void RestoreModulePointer(RelativeFixupPointer<PTR_Module> * ppModule, Module *pContainingModule);
 

--- a/src/vm/class.cpp
+++ b/src/vm/class.cpp
@@ -2818,13 +2818,13 @@ void EEClass::Save(DataImage *image, MethodTable *pMT)
 
         if (pInfo->m_numCTMFields > 0)
         {
-            ZapStoredStructure * pNode = image->StoreStructure(pInfo->m_pFieldMarshalers,
+            ZapStoredStructure * pNode = image->StoreStructure(pInfo->GetFieldMarshalers(),
                                             pInfo->m_numCTMFields * MAXFIELDMARSHALERSIZE,
                                             DataImage::ITEM_FIELD_MARSHALERS);
 
             for (UINT iField = 0; iField < pInfo->m_numCTMFields; iField++)
             {
-                FieldMarshaler *pFM = (FieldMarshaler*)((BYTE *)pInfo->m_pFieldMarshalers + iField * MAXFIELDMARSHALERSIZE);
+                FieldMarshaler *pFM = (FieldMarshaler*)((BYTE *)pInfo->GetFieldMarshalers() + iField * MAXFIELDMARSHALERSIZE);
                 pFM->Save(image);
 
                 if (iField > 0)
@@ -3029,11 +3029,11 @@ void EEClass::Fixup(DataImage *image, MethodTable *pMT)
 
     if (HasLayout())
     {
-        image->FixupPointerField(this, offsetof(LayoutEEClass, m_LayoutInfo.m_pFieldMarshalers));
+        image->FixupRelativePointerField(this, offsetof(LayoutEEClass, m_LayoutInfo.m_pFieldMarshalers));
 
         EEClassLayoutInfo *pInfo = &((LayoutEEClass*)this)->m_LayoutInfo;
 
-        FieldMarshaler *pFM = pInfo->m_pFieldMarshalers;
+        FieldMarshaler *pFM = pInfo->GetFieldMarshalers();
         FieldMarshaler *pFMEnd = (FieldMarshaler*) ((BYTE *)pFM + pInfo->m_numCTMFields*MAXFIELDMARSHALERSIZE);
         while (pFM < pFMEnd)
         {

--- a/src/vm/class.h
+++ b/src/vm/class.h
@@ -109,6 +109,7 @@ class LoaderAllocator;
 class ComCallWrapperTemplate;
 
 typedef DPTR(DictionaryLayout) PTR_DictionaryLayout;
+typedef DPTR(FieldMarshaler) PTR_FieldMarshaler;
 
 
 //---------------------------------------------------------------------------------
@@ -439,7 +440,7 @@ class EEClassLayoutInfo
         // An array of FieldMarshaler data blocks, used to drive call-time
         // marshaling of NStruct reference parameters. The number of elements
         // equals m_numCTMFields.
-        FieldMarshaler *m_pFieldMarshalers;
+        RelativePointer<PTR_FieldMarshaler> m_pFieldMarshalers;
 
 
     public:
@@ -468,11 +469,19 @@ class EEClassLayoutInfo
             return m_numCTMFields;
         }
 
-        FieldMarshaler *GetFieldMarshalers() const
+        PTR_FieldMarshaler GetFieldMarshalers() const
         {
             LIMITED_METHOD_CONTRACT;
-            return m_pFieldMarshalers;
+            return ReadPointerMaybeNull(this, &EEClassLayoutInfo::m_pFieldMarshalers);
         }
+
+#ifndef DACCESS_COMPILE
+        void SetFieldMarshalers(FieldMarshaler *pFieldMarshallers)
+        {
+            LIMITED_METHOD_CONTRACT;
+            m_pFieldMarshalers.SetValueMaybeNull(pFieldMarshallers);
+        }
+#endif // DACCESS_COMPILE
 
         BOOL IsBlittable() const
         {

--- a/src/vm/fieldmarshaler.cpp
+++ b/src/vm/fieldmarshaler.cpp
@@ -3726,7 +3726,7 @@ VOID FieldMarshaler_SafeArray::UpdateNativeImpl(OBJECTREF* pCLRValue, LPVOID pNa
     pSafeArray = (LPSAFEARRAY*)pNativeValue;
 
     VARTYPE vt = m_vt;
-    MethodTable* pMT = m_pMT.GetValue();
+    MethodTable* pMT = m_pMT.GetValueMaybeNull();
 
     GCPROTECT_BEGIN(pArray)
     {
@@ -3771,7 +3771,7 @@ VOID FieldMarshaler_SafeArray::UpdateCLRImpl(const VOID *pNativeValue, OBJECTREF
     }
 
     VARTYPE vt = m_vt;
-    MethodTable* pMT = m_pMT.GetValue();
+    MethodTable* pMT = m_pMT.GetValueMaybeNull();
 
     // If we have an empty vartype, get it from the safearray vartype
     if (vt == VT_EMPTY)
@@ -4868,3 +4868,10 @@ IMPLEMENT_FieldMarshaler_METHOD(void, Restore,
     (),
     ,
     ())
+
+#ifndef DACCESS_COMPILE
+IMPLEMENT_FieldMarshaler_METHOD(VOID, CopyTo,
+    (VOID *pDest, SIZE_T destSize) const,
+    ,
+    (pDest, destSize))
+#endif // !DACCESS_COMPILE

--- a/src/vm/fieldmarshaler.cpp
+++ b/src/vm/fieldmarshaler.cpp
@@ -1318,7 +1318,7 @@ VOID EEClassLayoutInfo::CollectLayoutFieldMetadataThrowing(
     }
 
     pEEClassLayoutInfoOut->m_numCTMFields        = fHasNonTrivialParent ? pParentMT->GetLayoutInfo()->m_numCTMFields : 0;
-    pEEClassLayoutInfoOut->m_pFieldMarshalers    = NULL;
+    pEEClassLayoutInfoOut->SetFieldMarshalers(NULL);
     pEEClassLayoutInfoOut->SetIsBlittable(TRUE);
     if (fHasNonTrivialParent)
         pEEClassLayoutInfoOut->SetIsBlittable(pParentMT->IsBlittable());
@@ -1599,7 +1599,7 @@ VOID EEClassLayoutInfo::CollectLayoutFieldMetadataThrowing(
 
     if (pEEClassLayoutInfoOut->m_numCTMFields)
     {
-        pEEClassLayoutInfoOut->m_pFieldMarshalers = (FieldMarshaler*)(pamTracker->Track(pAllocator->GetLowFrequencyHeap()->AllocMem(S_SIZE_T(MAXFIELDMARSHALERSIZE) * S_SIZE_T(pEEClassLayoutInfoOut->m_numCTMFields))));
+        pEEClassLayoutInfoOut->SetFieldMarshalers((FieldMarshaler*)(pamTracker->Track(pAllocator->GetLowFrequencyHeap()->AllocMem(S_SIZE_T(MAXFIELDMARSHALERSIZE) * S_SIZE_T(pEEClassLayoutInfoOut->m_numCTMFields)))));
 
         // Bring in the parent's fieldmarshalers
         if (fHasNonTrivialParent)
@@ -1608,8 +1608,8 @@ VOID EEClassLayoutInfo::CollectLayoutFieldMetadataThrowing(
             PREFAST_ASSUME(pParentLayoutInfo != NULL);  // See if (fParentHasLayout) branch above
             
             UINT numChildCTMFields = pEEClassLayoutInfoOut->m_numCTMFields - pParentLayoutInfo->m_numCTMFields;
-            memcpyNoGCRefs( ((BYTE*)pEEClassLayoutInfoOut->m_pFieldMarshalers) + MAXFIELDMARSHALERSIZE*numChildCTMFields,
-                            pParentLayoutInfo->m_pFieldMarshalers,
+            memcpyNoGCRefs( ((BYTE*)pEEClassLayoutInfoOut->GetFieldMarshalers()) + MAXFIELDMARSHALERSIZE*numChildCTMFields,
+                            pParentLayoutInfo->GetFieldMarshalers(),
                             MAXFIELDMARSHALERSIZE * (pParentLayoutInfo->m_numCTMFields) );
         }
 

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -4142,11 +4142,11 @@ VOID    MethodTableBuilder::InitializeFieldDescs(FieldDesc *pFieldDescList,
             {
                 if (pwalk->m_MD == bmtMetaData->pFields[i])
                 {
-
                     pLayoutFieldInfo = pwalk;
-                    CopyMemory(pNextFieldMarshaler,
-                               &(pwalk->m_FieldMarshaler),
-                               MAXFIELDMARSHALERSIZE);
+
+                    const FieldMarshaler *pSrcFieldMarshaler = (const FieldMarshaler *) &pwalk->m_FieldMarshaler;
+
+                    pSrcFieldMarshaler->CopyTo(pNextFieldMarshaler, MAXFIELDMARSHALERSIZE);
 
                     pNextFieldMarshaler->SetFieldDesc(pFD);
                     pNextFieldMarshaler->SetExternalOffset(pwalk->m_offset);

--- a/src/vm/typedesc.h
+++ b/src/vm/typedesc.h
@@ -254,7 +254,7 @@ public:
 
         LIMITED_METHOD_CONTRACT;
 
-        m_TemplateMT.SetValue(pMT);
+        m_TemplateMT.SetValueMaybeNull(pMT);
 
         // ParamTypeDescs start out life not fully loaded
         m_typeAndFlags |= TypeDesc::enum_flag_IsNotFullyLoaded;
@@ -323,8 +323,13 @@ public:
     friend class ArrayOpLinker;
 #endif
 protected:
+    PTR_MethodTable GetTemplateMethodTableInternal() {
+        WRAPPER_NO_CONTRACT;
+        return ReadPointerMaybeNull(this, &ParamTypeDesc::m_TemplateMT);
+    }
+
     // the m_typeAndFlags field in TypeDesc tell what kind of parameterized type we have
-    FixupPointer<PTR_MethodTable> m_TemplateMT; // The shared method table, some variants do not use this field (it is null)
+    RelativeFixupPointer<PTR_MethodTable> m_TemplateMT; // The shared method table, some variants do not use this field (it is null)
     TypeHandle      m_Arg;              // The type that is being modified
     LOADERHANDLE    m_hExposedClassObject;  // handle back to the internal reflection Type object
 };
@@ -380,8 +385,8 @@ public:
         WRAPPER_NO_CONTRACT;
 
         _ASSERTE(!m_TemplateMT.IsNull());
-        _ASSERTE(m_TemplateMT.GetValue()->IsArray());
-        _ASSERTE(m_TemplateMT.GetValue()->ParentEquals(g_pArrayClass));
+        _ASSERTE(GetTemplateMethodTableInternal()->IsArray());
+        _ASSERTE(GetTemplateMethodTableInternal()->ParentEquals(g_pArrayClass));
 
         return g_pArrayClass;
     }
@@ -416,16 +421,16 @@ public:
     void Fixup(DataImage *image);
 #endif
 
-    MethodTable * GetTemplateMethodTable() {
+    PTR_MethodTable GetTemplateMethodTable() {
         WRAPPER_NO_CONTRACT;
-        MethodTable * pTemplateMT = m_TemplateMT.GetValue();
-        _ASSERTE(pTemplateMT->IsArray());
-        return pTemplateMT;
+        PTR_MethodTable ptrTemplateMT = GetTemplateMethodTableInternal();
+        _ASSERTE(ptrTemplateMT->IsArray());
+        return ptrTemplateMT;
     }
 
     TADDR GetTemplateMethodTableMaybeTagged() {
         WRAPPER_NO_CONTRACT;
-        return m_TemplateMT.GetValueMaybeTagged();
+        return m_TemplateMT.GetValueMaybeTagged(dac_cast<TADDR>(this) + offsetof(ArrayTypeDesc, m_TemplateMT));
     }
 
 #ifdef FEATURE_COMINTEROP

--- a/src/vm/typedesc.inl
+++ b/src/vm/typedesc.inl
@@ -31,7 +31,7 @@ inline PTR_MethodTable  TypeDesc::GetMethodTable() {
     if (GetInternalCorElementType() == ELEMENT_TYPE_VALUETYPE)
         return dac_cast<PTR_MethodTable>(asParam->m_Arg.AsMethodTable());
     else
-        return(asParam->m_TemplateMT.GetValue());
+        return(asParam->GetTemplateMethodTableInternal());
 }
 
 inline TypeHandle TypeDesc::GetTypeParam() {


### PR DESCRIPTION
Partially remove relocations from Class section (ZapVirtualSectionType) of NGEN-ed images

On application, which is referenced in #10380 (comment), the following memory consumption changes occur for mappings of images:

  Rss: 8604 -> 8588 (0.1% improvement)
  Private_Dirty: 2708 -> 2572 (5% improvement)
  Private_Clean: 504 -> 544
  Shared_Clean: 5392 -> 5472

// The base for measurements is another than was used in #10380
// Fix of #10382 increased count of relocated images, so the absolute values of memory consumption
// became greater, and so absolute difference related to relocations removal also became greater.

Related issue: #10380

@Dmitri-Botcharnikov @gbalykov 