### PR TITLE
Remove relocations from SECTION_MethodDesc for ngened images for fields accessed from jit code

### DIFF
--- a/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -1573,6 +1573,7 @@ void MethodContext::recGetCallInfo(CORINFO_RESOLVED_TOKEN* pResolvedToken,
             value.stubLookup.runtimeLookup.indirections = (DWORD)pResult->stubLookup.runtimeLookup.indirections;
             value.stubLookup.runtimeLookup.testForNull  = (DWORD)pResult->stubLookup.runtimeLookup.testForNull;
             value.stubLookup.runtimeLookup.testForFixup = (DWORD)pResult->stubLookup.runtimeLookup.testForFixup;
+            value.stubLookup.runtimeLookup.indirectFirstOffset = (DWORD)pResult->stubLookup.runtimeLookup.indirectFirstOffset;
             for (int i                                    = 0; i < CORINFO_MAXINDIRECTIONS; i++)
                 value.stubLookup.runtimeLookup.offsets[i] = (DWORDLONG)pResult->stubLookup.runtimeLookup.offsets[i];
         }
@@ -1583,6 +1584,7 @@ void MethodContext::recGetCallInfo(CORINFO_RESOLVED_TOKEN* pResolvedToken,
             value.stubLookup.runtimeLookup.indirections = (DWORD)0;
             value.stubLookup.runtimeLookup.testForNull  = (DWORD)0;
             value.stubLookup.runtimeLookup.testForFixup = (DWORD)0;
+            value.stubLookup.runtimeLookup.indirectFirstOffset = (DWORD)0;
             for (int i                                    = 0; i < CORINFO_MAXINDIRECTIONS; i++)
                 value.stubLookup.runtimeLookup.offsets[i] = (DWORDLONG)0;
 
@@ -1761,6 +1763,7 @@ void MethodContext::repGetCallInfo(CORINFO_RESOLVED_TOKEN* pResolvedToken,
         pResult->stubLookup.runtimeLookup.indirections = (WORD)value.stubLookup.runtimeLookup.indirections;
         pResult->stubLookup.runtimeLookup.testForNull  = value.stubLookup.runtimeLookup.testForNull != 0;
         pResult->stubLookup.runtimeLookup.testForFixup = value.stubLookup.runtimeLookup.testForFixup != 0;
+        pResult->stubLookup.runtimeLookup.indirectFirstOffset = value.stubLookup.runtimeLookup.indirectFirstOffset != 0;
         for (int i                                       = 0; i < CORINFO_MAXINDIRECTIONS; i++)
             pResult->stubLookup.runtimeLookup.offsets[i] = (SIZE_T)value.stubLookup.runtimeLookup.offsets[i];
     }
@@ -3218,6 +3221,7 @@ void MethodContext::recEmbedGenericHandle(CORINFO_RESOLVED_TOKEN*       pResolve
         value.lookup.runtimeLookup.indirections = (DWORD)pResult->lookup.runtimeLookup.indirections;
         value.lookup.runtimeLookup.testForNull  = (DWORD)pResult->lookup.runtimeLookup.testForNull;
         value.lookup.runtimeLookup.testForFixup = (DWORD)pResult->lookup.runtimeLookup.testForFixup;
+        value.lookup.runtimeLookup.indirectFirstOffset = (DWORD)pResult->lookup.runtimeLookup.indirectFirstOffset;
         for (int i                                = 0; i < CORINFO_MAXINDIRECTIONS; i++)
             value.lookup.runtimeLookup.offsets[i] = (DWORDLONG)pResult->lookup.runtimeLookup.offsets[i];
     }
@@ -3228,6 +3232,7 @@ void MethodContext::recEmbedGenericHandle(CORINFO_RESOLVED_TOKEN*       pResolve
         value.lookup.runtimeLookup.indirections = (DWORD)0;
         value.lookup.runtimeLookup.testForNull  = (DWORD)0;
         value.lookup.runtimeLookup.testForFixup = (DWORD)0;
+        value.lookup.runtimeLookup.indirectFirstOffset = (DWORD)0;
         for (int i                                = 0; i < CORINFO_MAXINDIRECTIONS; i++)
             value.lookup.runtimeLookup.offsets[i] = (DWORDLONG)0;
         // copy the constLookup view of the union
@@ -3305,6 +3310,7 @@ void MethodContext::repEmbedGenericHandle(CORINFO_RESOLVED_TOKEN*       pResolve
         pResult->lookup.runtimeLookup.indirections = (WORD)value.lookup.runtimeLookup.indirections;
         pResult->lookup.runtimeLookup.testForNull  = value.lookup.runtimeLookup.testForNull != 0;
         pResult->lookup.runtimeLookup.testForFixup = value.lookup.runtimeLookup.testForFixup != 0;
+        pResult->lookup.runtimeLookup.indirectFirstOffset = value.lookup.runtimeLookup.indirectFirstOffset != 0;
         for (int i                                   = 0; i < CORINFO_MAXINDIRECTIONS; i++)
             pResult->lookup.runtimeLookup.offsets[i] = (size_t)value.lookup.runtimeLookup.offsets[i];
     }

--- a/src/ToolBox/superpmi/superpmi-shared/methodcontext.h
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontext.h
@@ -240,6 +240,7 @@ public:
         DWORD     testForNull;
         DWORD     testForFixup;
         DWORDLONG offsets[CORINFO_MAXINDIRECTIONS];
+        DWORD     indirectFirstOffset;
     };
     struct Agnostic_CORINFO_CONST_LOOKUP
     {

--- a/src/debug/daccess/nidump.cpp
+++ b/src/debug/daccess/nidump.cpp
@@ -7905,7 +7905,7 @@ void NativeImageDumper::DumpMethodDesc( PTR_MethodDesc md, PTR_Module module )
         if( !CHECK_OPT(METHODDESCS) )
             CoverageReadString( TO_TADDR(nd->m_pszLibName) );
 
-        PTR_NDirectWriteableData wnd( nd->m_pWriteableData );
+        PTR_NDirectWriteableData wnd( ndmd->GetWriteableData() );
         DisplayStartStructureWithOffset( m_pWriteableData,
                                          DPtrToPreferredAddr(wnd),
                                          sizeof(*wnd),
@@ -8066,7 +8066,7 @@ void NativeImageDumper::DumpMethodDesc( PTR_MethodDesc md, PTR_Module module )
         }
         //now handle the contents of the m_pMethInst/m_pPerInstInfo union.
         unsigned numSlots = imd->m_wNumGenericArgs;
-        PTR_Dictionary inst(imd->m_pPerInstInfo);
+        PTR_Dictionary inst(imd->IMD_GetMethodDictionary());
         unsigned dictSize;
         if( kind == InstantiatedMethodDesc::SharedMethodInstantiation )
         {

--- a/src/inc/corinfo.h
+++ b/src/inc/corinfo.h
@@ -1323,6 +1323,13 @@ struct CORINFO_RUNTIME_LOOKUP
     bool                    testForFixup;
 
     SIZE_T                  offsets[CORINFO_MAXINDIRECTIONS];
+
+    // If set, first offset is indirect.
+    // 0 means that value stored at first offset (offsets[0]) from pointer is next pointer, to which the next offset
+    // (offsets[1]) is added and so on.
+    // 1 means that value stored at first offset (offsets[0]) from pointer is offset1, and the next pointer is
+    // stored at pointer+offsets[0]+offset1.
+    bool                indirectFirstOffset;
 } ;
 
 // Result of calling embedGenericHandle

--- a/src/vm/dllimport.cpp
+++ b/src/vm/dllimport.cpp
@@ -2294,7 +2294,19 @@ void NDirectStubLinker::DoNDirect(ILCodeStream *pcsEmit, DWORD dwStubFlags, Meth
                     //pcsEmit->EmitCALL(METHOD__STUBHELPERS__GET_NDIRECT_TARGET, 1, 1);
                     pcsEmit->EmitLDC(offsetof(NDirectMethodDesc, ndirect.m_pWriteableData));
                     pcsEmit->EmitADD();
+
+                    if (decltype(NDirectMethodDesc::ndirect.m_pWriteableData)::isRelative)
+                    {
+                        pcsEmit->EmitDUP();
+                    }
+
                     pcsEmit->EmitLDIND_I();
+
+                    if (decltype(NDirectMethodDesc::ndirect.m_pWriteableData)::isRelative)
+                    {
+                        pcsEmit->EmitADD();
+                    }
+
                     pcsEmit->EmitLDIND_I();
                 }
             }

--- a/src/vm/genmeth.cpp
+++ b/src/vm/genmeth.cpp
@@ -1518,9 +1518,9 @@ void InstantiatedMethodDesc::SetupGenericMethodDefinition(IMDInternalImport *pIM
     S_SIZE_T dwAllocSize = S_SIZE_T(numTyPars) * S_SIZE_T(sizeof(TypeHandle));
 
     // the memory allocated for m_pMethInst will be freed if the declaring type fails to load
-    m_pPerInstInfo = (Dictionary *) pamTracker->Track(pAllocator->GetLowFrequencyHeap()->AllocMem(dwAllocSize));
+    m_pPerInstInfo.SetValue((Dictionary *) pamTracker->Track(pAllocator->GetLowFrequencyHeap()->AllocMem(dwAllocSize)));
 
-    TypeHandle * pInstDest = (TypeHandle *)m_pPerInstInfo;
+    TypeHandle * pInstDest = (TypeHandle *) IMD_GetMethodDictionaryNonNull();
     for(unsigned int i = 0; i < numTyPars; i++)
     {
         hEnumTyPars.EnumNext(&tkTyPar);
@@ -1553,7 +1553,7 @@ void InstantiatedMethodDesc::SetupWrapperStubWithInstantiations(MethodDesc* wrap
 
     m_pWrappedMethodDesc.SetValue(wrappedMD);
     m_wFlags2 = WrapperStubWithInstantiations | (m_wFlags2 & ~KindMask);
-    m_pPerInstInfo = (Dictionary*)pInst;
+    m_pPerInstInfo.SetValueMaybeNull((Dictionary*)pInst);
 
     _ASSERTE(FitsIn<WORD>(numGenericArgs));
     m_wNumGenericArgs = static_cast<WORD>(numGenericArgs);
@@ -1571,7 +1571,7 @@ void InstantiatedMethodDesc::SetupSharedMethodInstantiation(DWORD numGenericArgs
     _ASSERTE(numGenericArgs != 0);
     // Initially the dictionary layout is empty
     m_wFlags2 = SharedMethodInstantiation | (m_wFlags2 & ~KindMask);
-    m_pPerInstInfo = (Dictionary *)pPerInstInfo;
+    m_pPerInstInfo.SetValueMaybeNull((Dictionary *)pPerInstInfo);
 
     _ASSERTE(FitsIn<WORD>(numGenericArgs));
     m_wNumGenericArgs = static_cast<WORD>(numGenericArgs);
@@ -1589,7 +1589,7 @@ void InstantiatedMethodDesc::SetupUnsharedMethodInstantiation(DWORD numGenericAr
 
     // The first field is never used
     m_wFlags2 = UnsharedMethodInstantiation | (m_wFlags2 & ~KindMask);
-    m_pPerInstInfo = (Dictionary *)pInst;
+    m_pPerInstInfo.SetValueMaybeNull((Dictionary *)pInst);
 
     _ASSERTE(FitsIn<WORD>(numGenericArgs));
     m_wNumGenericArgs = static_cast<WORD>(numGenericArgs);

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -3085,6 +3085,8 @@ void CEEInfo::ComputeRuntimeLookupForSharedGenericToken(DictionaryEntryKind entr
     CORINFO_RUNTIME_LOOKUP *pResult = &pResultLookup->runtimeLookup;
     pResult->signature = NULL;
 
+    pResult->indirectFirstOffset = 0;
+
     // Unless we decide otherwise, just do the lookup via a helper function
     pResult->indirections = CORINFO_USEHELPER;
 
@@ -3207,6 +3209,11 @@ void CEEInfo::ComputeRuntimeLookupForSharedGenericToken(DictionaryEntryKind entr
                 pResult->testForFixup = 0;
 #endif
                 pResult->offsets[0] = offsetof(InstantiatedMethodDesc, m_pPerInstInfo);
+
+                if (decltype(InstantiatedMethodDesc::m_pPerInstInfo)::isRelative)
+                {
+                    pResult->indirectFirstOffset = 1;
+                }
 
                 ULONG data;
                 IfFailThrow(sigptr.GetData(&data));
@@ -3512,6 +3519,11 @@ NoSpecialCase:
 
             // Indirect through dictionary table pointer in InstantiatedMethodDesc
             pResult->offsets[0] = offsetof(InstantiatedMethodDesc, m_pPerInstInfo);
+
+            if (decltype(InstantiatedMethodDesc::m_pPerInstInfo)::isRelative)
+            {
+                pResult->indirectFirstOffset = 1;
+            }
         }
     }
 

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -3495,7 +3495,14 @@ MethodDesc::Fixup(
             }
         }
 
-        image->FixupPointerField(this, offsetof(InstantiatedMethodDesc, m_pPerInstInfo));
+        if (decltype(InstantiatedMethodDesc::m_pPerInstInfo)::isRelative)
+        {
+            image->FixupRelativePointerField(this, offsetof(InstantiatedMethodDesc, m_pPerInstInfo));
+        }
+        else
+        {
+            image->FixupPointerField(this, offsetof(InstantiatedMethodDesc, m_pPerInstInfo));
+        }
 
         // Generic methods are dealt with specially to avoid encoding the formal method type parameters
         if (IsTypicalMethodDefinition())
@@ -3574,7 +3581,14 @@ MethodDesc::Fixup(
 
         NDirectMethodDesc *pNMD = (NDirectMethodDesc *)this;
 
-        image->FixupPointerField(this, offsetof(NDirectMethodDesc, ndirect.m_pWriteableData));
+        if (decltype(NDirectMethodDesc::ndirect.m_pWriteableData)::isRelative)
+        {
+            image->FixupRelativePointerField(this, offsetof(NDirectMethodDesc, ndirect.m_pWriteableData));
+        }
+        else
+        {
+            image->FixupPointerField(this, offsetof(NDirectMethodDesc, ndirect.m_pWriteableData));
+        }
 
         NDirectWriteableData *pWriteableData = pNMD->GetWriteableData();
         NDirectImportThunkGlue *pImportThunkGlue = pNMD->GetNDirectImportThunkGlue();

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -2576,7 +2576,11 @@ public:
         };
 
         // The writeable part of the methoddesc.
-        PTR_NDirectWriteableData    m_pWriteableData;
+#if defined(PLATFORM_UNIX) && defined(_TARGET_ARM_)
+        RelativePointer<PTR_NDirectWriteableData>    m_pWriteableData;
+#else
+        PlainPointer<PTR_NDirectWriteableData>    m_pWriteableData;
+#endif
 
 #ifdef HAS_NDIRECT_IMPORT_PRECODE
         PTR_NDirectImportThunkGlue  m_pImportThunkGlue;        
@@ -2789,11 +2793,11 @@ public:
         return (ndirect.m_wFlags & kStdCallWithRetBuf) != 0;
     }
 
-    NDirectWriteableData* GetWriteableData() const
+    PTR_NDirectWriteableData GetWriteableData() const
     {
-        LIMITED_METHOD_CONTRACT;
+        LIMITED_METHOD_DAC_CONTRACT;
 
-        return ndirect.m_pWriteableData;
+        return ReadPointer(this, &NDirectMethodDesc::ndirect, &decltype(NDirectMethodDesc::ndirect)::m_pWriteableData);
     }
 
     NDirectImportThunkGlue* GetNDirectImportThunkGlue()
@@ -3196,7 +3200,7 @@ public:
         if (IMD_IsGenericMethodDefinition())
             return TRUE;
         else
-            return m_pPerInstInfo != NULL;
+            return !m_pPerInstInfo.IsNull();
     }
 
     // All varieties of InstantiatedMethodDesc's support this method.
@@ -3204,13 +3208,21 @@ public:
     {
         LIMITED_METHOD_DAC_CONTRACT;
 
-        return Instantiation(m_pPerInstInfo->GetInstantiation(), m_wNumGenericArgs);
+        return Instantiation(IMD_GetMethodDictionary()->GetInstantiation(), m_wNumGenericArgs);
     }
 
     PTR_Dictionary IMD_GetMethodDictionary()
     {
         LIMITED_METHOD_DAC_CONTRACT;
-        return m_pPerInstInfo;
+
+        return ReadPointerMaybeNull(this, &InstantiatedMethodDesc::m_pPerInstInfo);
+    }
+
+    PTR_Dictionary IMD_GetMethodDictionaryNonNull()
+    {
+        LIMITED_METHOD_DAC_CONTRACT;
+
+        return ReadPointer(this, &InstantiatedMethodDesc::m_pPerInstInfo);
     }
 
     BOOL IMD_IsGenericMethodDefinition()
@@ -3360,7 +3372,11 @@ public: // <TODO>make private: JITinterface.cpp accesses through this </TODO>
         //
         // For generic method definitions that are not the typical method definition (e.g. C<int>.m<U>)
         // this field is null; to obtain the instantiation use LoadMethodInstantiation
-    PTR_Dictionary m_pPerInstInfo;  //SHARED
+#if defined(PLATFORM_UNIX) && defined(_TARGET_ARM_)
+    RelativePointer<PTR_Dictionary> m_pPerInstInfo;  //SHARED
+#else
+    PlainPointer<PTR_Dictionary> m_pPerInstInfo;  //SHARED
+#endif
 
 private:
     WORD          m_wFlags2;

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -5913,8 +5913,8 @@ MethodTableBuilder::InitMethodDesc(
             NDirectMethodDesc *pNewNMD = (NDirectMethodDesc*)pNewMD;
 
             // Allocate writeable data
-            pNewNMD->ndirect.m_pWriteableData = (NDirectWriteableData*)
-                AllocateFromHighFrequencyHeap(S_SIZE_T(sizeof(NDirectWriteableData)));
+            pNewNMD->ndirect.m_pWriteableData.SetValue((NDirectWriteableData*)
+                AllocateFromHighFrequencyHeap(S_SIZE_T(sizeof(NDirectWriteableData))));
 
 #ifdef HAS_NDIRECT_IMPORT_PRECODE 
             pNewNMD->ndirect.m_pImportThunkGlue = Precode::Allocate(PRECODE_NDIRECT_IMPORT, pNewMD,

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -2383,6 +2383,9 @@ void ProcessDynamicDictionaryLookup(TransitionBlock *           pTransitionBlock
 
     pResult->testForFixup = pResult->testForNull = false;
     pResult->signature = NULL;
+
+    pResult->indirectFirstOffset = 0;
+
     pResult->indirections = CORINFO_USEHELPER;
 
     DWORD numGenericArgs = 0;
@@ -2433,6 +2436,11 @@ void ProcessDynamicDictionaryLookup(TransitionBlock *           pTransitionBlock
             pResult->indirections = 2;
             pResult->offsets[0] = offsetof(InstantiatedMethodDesc, m_pPerInstInfo);
 
+            if (decltype(InstantiatedMethodDesc::m_pPerInstInfo)::isRelative)
+            {
+                pResult->indirectFirstOffset = 1;
+            }
+
             ULONG data;
             IfFailThrow(sigptr.GetData(&data));
             pResult->offsets[1] = sizeof(TypeHandle) * data;
@@ -2471,6 +2479,11 @@ void ProcessDynamicDictionaryLookup(TransitionBlock *           pTransitionBlock
 
             // Indirect through dictionary table pointer in InstantiatedMethodDesc
             pResult->offsets[0] = offsetof(InstantiatedMethodDesc, m_pPerInstInfo);
+
+            if (decltype(InstantiatedMethodDesc::m_pPerInstInfo)::isRelative)
+            {
+                pResult->indirectFirstOffset = 1;
+            }
 
             *pDictionaryIndexAndSlot |= dictionarySlot;
         }


### PR DESCRIPTION
This pull request removes relocations from MethodDesc section for ngened images.This is second part of changes, which affects jit code. First part #11394 

Related issue: #11363

Next fields are replaced with RelativePointers for Linux ARM in this pull request
```
NDirectMethodDesc::ndirect.m_pWriteableData
InstantiatedMethodDesc::m_pPerInstInfo
```

Next fields are replaced with RelativePointers for all platforms in the first pull request #11394 
```
InstantiatedMethodDesc::m_pDictLayout
InstantiatedMethodDesc::m_pWrappedMethodDesc
MethodDesc::m_pszMethodName
MethodImpl::pImplementedMD
MethodImpl::pdwSlots
NDirectMethodDesc::ndirect.m_pImportThunkGlue
NDirectMethodDesc::ndirect.m_pszEntrypointName
NDirectMethodDesc::ndirect.m_pszLibName
StoredSigMethodDesc::m_pSig
```

After the changes, SECTION_MethodDesc completely disappears from the table shown in https://github.com/dotnet/coreclr/issues/11363#issuecomment-299180256.

Estimation on Tizen Xamarin GUI Application (specifically, Puzzle.Tizen - see tables at #10380 (comment)) is about 268 kb (4%) savings of per-application CoreCLR's memory part in Fragile mode.

@Dmitri-Botcharnikov @ruben-ayrapetyan
