### PR TITLE
Create a base directory before creating done marker

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -109,6 +109,7 @@ if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
 
     Tools/crossgen.sh $__scriptpath/Tools
 
+    mkdir -p "$(dirname "$__INIT_TOOLS_DONE_MARKER")"
     touch $__INIT_TOOLS_DONE_MARKER
 
     echo "Done initializing tools."


### PR DESCRIPTION
init-tools.sh failed to create a done marker, and thus tools are initialized for each build.