### PR TITLE
[RyuJIT/ARM32] Fix assertion failed 'remainingSize == TARGET_POINTER_SIZE'

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -756,8 +756,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
                 else
                 {
                     // check for case of destroying the addrRegister while we still need it
-                    assert(loReg != addrReg);
-                    noway_assert(remainingSize == TARGET_POINTER_SIZE);
+                    assert(loReg != addrReg || remainingSize == TARGET_POINTER_SIZE);
 
                     // Load from our address expression source
                     emit->emitIns_R_R_I(INS_ldr, emitTypeSize(type), loReg, addrReg, structOffset);


### PR DESCRIPTION
Fix assertion failed by 'remainingSize == TARGET_POINTER_SIZE'
Fix to check register allocation correctly

related issue: #11837 

cc/ @dotnet/arm32-contrib 