### PR TITLE
[RyuJIT/ARM32] Implement address calculation without base register

### DIFF
--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -7580,9 +7580,18 @@ void emitter::emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataR
                 {
                     if (lsl > 0)
                     {
-                        // Generate code to set tmpReg = base + index*scale
-                        emitIns_R_R_R_I(INS_add, EA_PTRSIZE, tmpReg, memBase->gtRegNum, index->gtRegNum, lsl,
-                                        INS_FLAGS_DONT_CARE, INS_OPTS_LSL);
+                        if (memBase != nullptr)
+                        {
+                            // Generate code to set tmpReg = base + index*scale
+                            emitIns_R_R_R_I(INS_add, EA_PTRSIZE, tmpReg, memBase->gtRegNum, index->gtRegNum, lsl,
+                                            INS_FLAGS_DONT_CARE, INS_OPTS_LSL);
+                        }
+                        else
+                        {
+                            // No base register. Generate code to set tmpReg = index*scale
+                            emitIns_R_R_I(INS_lsl, EA_PTRSIZE, tmpReg, index->gtRegNum, lsl, INS_FLAGS_DONT_CARE,
+                                          INS_OPTS_NONE);
+                        }
                     }
                     else // no scale
                     {


### PR DESCRIPTION
Fix #11958 

- Implement address calculation without base register

### Before
`JIT/Regression/JitBlue/DevDiv_283795/DevDiv_283795/` raises segmentation fault during generating code for `lea((i*4)+8)` which have no base register.
```
               Generating: N033 (  1,  1) [000045] -------------       t45 =    lclVar    int    V04 cse0          r0 (last use) REG r0 RV $143
                                                                             /--*  t45    int
               Generating: N035 (???,???) [000048] -------------       t48 = *  lea((i*4)+8) int    REG NA
                                                                             /--*  t48    int
               Generating: N037 (  4,  5) [000017] a--XG--------       t17 = *  indir     int    REG r0 <l:$14b, c:$181>
                                                                V04 in reg r0 is becoming dead  [000045]
                                                                Live regs: 0001 {r0} => 0000 {}
                                                                Live vars: {V04} => {}
               ./DevDiv_283795.sh: line 240:  9545 Aborted                 (core dumped) $_DebuggerFullPath "$CORE_ROOT/corerun" $ExePath $CLRTestExecutionArguments
               Expected: 100
               Actual: 134
               END EXECUTION - FAILED

```


### After
Code generated well as below and `JIT/Regression/JitBlue/DevDiv_283795/DevDiv_283795/` is now passed without problem.

```
               Generating: N033 (  1,  1) [000047] -------------       t47 =    lclVar    int    V04 cse0          r0 (last use) REG r0 RV $143
                                                                             /--*  t47    int
               Generating: N035 (???,???) [000050] -------------       t50 = *  lea((i*4)+8) int    REG NA
                                                                             /--*  t50    int
               Generating: N037 (  4,  5) [000017] a--XG--------       t17 = *  indir     int    REG r0 <l:$14b, c:$181>
                                                                V04 in reg r0 is becoming dead  [000047]
                                                                Live regs: 0001 {r0} => 0000 {}
                                                                Live vars: {V04} => {}
               IN000a:             lsls    r3, r0, 2
               IN000b:             ldr     r0, [r3+8]
```

### LegacyJIT
```
               N011 (  1,  1) [000045] -------------             *  lclVar    int    V04 cse0          r3 (last use) $143
               N012 (  1,  1) [000032] -------N-----             *  const     int    2 $42
               N013 (  3,  3) [000033] -------N-----             *  <<        int    $145
               N014 (  1,  1) [000035] -------------             *  const     int    8 Fseq[#FirstElem] $45
               N015 (  5,  5) [000036] -------N-----             *  +         int    $244
               N016 (  4,  5) [000017] a--XG--------             *  indir     int    <l:$14b, c:$181>
...(omitted)...
                                                                The register r3 currently holds [000045]/[000017]]
                                                                The register r3 no longer holds [000045][000017]
               IN000a:             lsls    r3, r3, 2
               IN000b:             ldr     r3, [r3+8]

```