### PR TITLE
Fix FieldDesc::GetExactFieldType when FieldDesc doesn't exactly represent the owner type

### DIFF
--- a/src/vm/field.cpp
+++ b/src/vm/field.cpp
@@ -888,6 +888,10 @@ TypeHandle FieldDesc::GetExactFieldType(TypeHandle owner)
         GetSig(&pSig, &cSig);
         SigPointer sig(pSig, cSig);
 
+        ULONG callConv;
+        IfFailThrow(sig.GetCallingConv(&callConv));
+        _ASSERTE(callConv == IMAGE_CEE_CS_CALLCONV_FIELD);
+
         // Get the generics information
         SigTypeContext sigTypeContext(GetExactClassInstantiation(owner), Instantiation());
 

--- a/src/vm/field.cpp
+++ b/src/vm/field.cpp
@@ -895,9 +895,8 @@ TypeHandle FieldDesc::GetExactFieldType(TypeHandle owner)
         // Get the generics information
         SigTypeContext sigTypeContext(GetExactClassInstantiation(owner), Instantiation());
 
-        TypeHandle thApproxFieldType = GetApproxFieldTypeHandleThrowing();
         // Load the exact type
-        RETURN (sig.GetTypeHandleThrowing(thApproxFieldType.GetModule(), &sigTypeContext));
+        RETURN (sig.GetTypeHandleThrowing(GetModule(), &sigTypeContext));
     }
 }
 


### PR DESCRIPTION
This PR is a copy of #10941 but for release/2.0.0 branch.
We will upgrade coreclr upstream branch on Tizen soon from release/2.0.0 branch.

This PR fix FieldDesc::GetExactFieldType when FieldDesc doesn't exactly represent the owner type (like in generics).

To get the exact type from FieldDesc, field signature should point past the calling convention.

@janvorli, @jkotas PTAL

cc @Dmitri-Botcharnikov @chunseoklee @seanshpark