### PR TITLE
Remove Debian Armel

### DIFF
--- a/src/.nuget/dir.props
+++ b/src/.nuget/dir.props
@@ -112,9 +112,6 @@
 
   <ItemGroup Condition="$(SupportedPackageOSGroups.Contains(';Linux;'))">
     <OfficialBuildRID Include="alpine.3.4.3-x64" />
-    <OfficialBuildRID Include="debian.8-armel">
-      <Platform>armel</Platform>
-    </OfficialBuildRID>
     <OfficialBuildRID Include="debian.8-x64" />
     <OfficialBuildRID Include="fedora.23-x64" />
     <OfficialBuildRID Include="fedora.24-x64" />


### PR DESCRIPTION
Confirmed with @jyoungyun that Debian.8-armel is no longer required. Removing it from the identity package of CoreCLR.

@ericstj @weshaggard PTAL.

CC @Petermarcu @RussKeldorph 