### PR TITLE
[WIP - Do not merge] Default to portable build in dev and official builds

### DIFF
--- a/build-packages.sh
+++ b/build-packages.sh
@@ -3,16 +3,15 @@
 usage()
 {
     echo "Builds the NuGet packages from the binaries that were built in the Build product binaries step."
-    echo "Usage: build-packages -BuildArch -BuildType [-portable]"
+    echo "Usage: build-packages -BuildArch -BuildType"
     echo "BuildArch can be x64, x86, arm, arm64 (default is x64)"
     echo "BuildType can be release, checked, debug (default is debug)"
-    echo "-portable - build for Portable Distribution"
     echo
     exit 1
 }
 
 __ProjectRoot="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-__PortableBuild=0
+__IsPortableBuild=1
 
 # Use uname to determine what the OS is.
 OSName=$(uname -s)
@@ -71,8 +70,9 @@ while :; do
         __Arch=$(echo $1| cut -d'=' -f 2)
         ;;
 
-        -portableBuild)
-            __PortableBuild=1
+        -PortableBuild=false)
+            unprocessedBuildArgs="$unprocessedBuildArgs $1"
+            __IsPortableBuild=0
             ;;
         *)
         unprocessedBuildArgs="$unprocessedBuildArgs $1"
@@ -81,7 +81,7 @@ while :; do
 done
 
 # Portable builds target the base RID
-if [ $__PortableBuild == 1 ]; then
+if [ $__IsPortableBuild == 1 ]; then
     if [ "$__BuildOS" == "Linux" ]; then
         export __DistroRid="linux-$__Arch"
     elif [ "$__BuildOS" == "OSX" ]; then

--- a/build.cmd
+++ b/build.cmd
@@ -97,9 +97,6 @@ set __BuildPackages=1
 set __BuildNativeCoreLib=1
 set __RestoreOptData=1
 
-REM Is this a portable build?
-set __IsPortableBuild=
-
 :Arg_Loop
 if "%1" == "" goto ArgsDone
 
@@ -116,8 +113,6 @@ if /i "%1" == "arm64"               (set __BuildArchArm64=1&set processedArgs=!p
 if /i "%1" == "debug"               (set __BuildTypeDebug=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "checked"             (set __BuildTypeChecked=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "release"             (set __BuildTypeRelease=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
-
-if /i "%1" == "-portable"             (set __IsPortableBuild=-portable&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 
 REM All arguments after this point will be passed through directly to build.cmd on nested invocations
 REM using the "all" argument, and must be added to the __PassThroughArgs variable.
@@ -468,7 +463,7 @@ if %__BuildPackages% EQU 1 (
 	set __MsbuildErr=/flp2:ErrorsOnly;LogFile="%__LogsDir%\Nuget_%__BuildOS%__%__BuildArch%__%__BuildType%.err"
 
     REM The conditions as to what to build are captured in the builds file.
-    @call %__ProjectDir%\run.cmd build -Project=%__SourceDir%\.nuget\packages.builds %__IsPortableBuild% -platform=%__BuildArch% -MsBuildLog=!__MsbuildLog! -MsBuildWrn=!__MsbuildWrn! -MsBuildErr=!__MsbuildErr! %__RunArgs% %__UnprocessedBuildArgs%
+    @call %__ProjectDir%\run.cmd build -Project=%__SourceDir%\.nuget\packages.builds -platform=%__BuildArch% -MsBuildLog=!__MsbuildLog! -MsBuildWrn=!__MsbuildWrn! -MsBuildErr=!__MsbuildErr! %__RunArgs% %__UnprocessedBuildArgs%
 
     if not !errorlevel! == 0 (
         echo %__MsgPrefix%Error: Nuget package generation failed build failed. Refer to the build log files for details:

--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,6 @@ usage()
     echo "skiptests - skip the tests in the 'tests' subdirectory."
     echo "skipnuget - skip building nuget packages."
     echo "skiprestoreoptdata - skip restoring optimization data used by profile-based optimizations."
-    echo "portable - build for portable RID."
     echo "verbose - optional argument to enable verbose build output."
     echo "-skiprestore: skip restoring packages ^(default: packages are restored during build^)."
 	echo "-disableoss: Disable Open Source Signing for System.Private.CoreLib."
@@ -617,7 +616,7 @@ __DistroRid=""
 __cmakeargs=""
 __SkipGenerateVersion=0
 __DoCrossArchBuild=0
-__PortableBuild=0
+__PortableBuild=1
 __msbuildonunsupportedplatform=0
 __PgoOptDataVersion=""
 __IbcOptDataVersion=""
@@ -674,8 +673,8 @@ while :; do
             __CrossBuild=1
             ;;
             
-        -portable)
-            __PortableBuild=1
+        -portablebuild=false)
+            __PortableBuild=0
             ;;
 
         verbose)
@@ -832,10 +831,20 @@ if [[ $__ClangMajorVersion == 0 && $__ClangMinorVersion == 0 ]]; then
             __ClangMajorVersion=3
             __ClangMinorVersion=6
         fi
+
+        if [[ "$__BuildArch" == "armel" ]]; then
+            # Armel cross build is Tizen specific and does not support Portable RID build
+            __PortableBuild=0
+        fi
+
     else
         __ClangMajorVersion=3
         __ClangMinorVersion=5
     fi
+fi
+
+if [ $__PortableBuild == 0 ]; then
+	__RunArgs="$__RunArgs -PortableBuild=false"
 fi
 
 # Set dependent variables

--- a/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
@@ -139,7 +139,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm -e ROOTFS_DIR $(DockerCommonRunArgs) ./build.sh $(PB_BuildType) $(Architecture) $(portableBuild) skipnuget cross -skiprestore stripSymbols -OfficialBuildId=$(OfficialBuildId) -- /flp:\"v=diag\"",
+        "arguments": "run --rm -e ROOTFS_DIR $(DockerCommonRunArgs) ./build.sh $(PB_BuildType) $(Architecture) skipnuget cross -skiprestore stripSymbols -OfficialBuildId=$(OfficialBuildId) -- /flp:\"v=diag\"",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -157,7 +157,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs) ./build-packages.sh $(portableBuild) -BuildType=$(PB_BuildType) -BuildArch=$(Architecture)",
+        "arguments": "run --rm $(DockerCommonRunArgs) ./build-packages.sh -BuildType=$(PB_BuildType) -BuildArch=$(Architecture)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -415,9 +415,6 @@
     "DockerCopyDest": {
       "value": "$(Build.BinariesDirectory)/docker_repo"
     },
-    "portableBuild": {
-      "value": ""
-    },
     "ROOTFS_DIR": {
       "value": "/crossrootfs/$(Architecture)"
     },
@@ -450,7 +447,7 @@
       "deleteTestResults": true
     }
   ],
-  "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)-$(DockerTag)$(portableBuild)",
+  "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)-$(DockerTag)",
   "jobAuthorizationScope": "projectCollection",
   "jobTimeoutInMinutes": 90,
   "repository": {

--- a/buildpipeline/DotNet-CoreClr-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Linux.json
@@ -121,7 +121,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs) ./build.sh $(PB_BuildType) $(Architecture) $(portableBuild) skipnuget -skiprestore stripSymbols -OfficialBuildId=$(OfficialBuildId) -- /flp:\"v=diag\"",
+        "arguments": "run --rm $(DockerCommonRunArgs) ./build.sh $(PB_BuildType) $(Architecture) skipnuget -skiprestore stripSymbols -OfficialBuildId=$(OfficialBuildId) -- /flp:\"v=diag\"",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -139,7 +139,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs) ./build-packages.sh $(portableBuild) -BuildType=$(PB_BuildType) -BuildArch=$(Architecture)",
+        "arguments": "run --rm $(DockerCommonRunArgs) ./build-packages.sh -BuildType=$(PB_BuildType) -BuildArch=$(Architecture)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -376,9 +376,6 @@
       "value": "HEAD",
       "allowOverride": true
     },
-    "portableBuild": {
-      "value": ""
-    },
     "DockerVolumeName": {
       "value": "coreclr-$(Build.BuildId)"
     },
@@ -411,7 +408,7 @@
       "deleteTestResults": true
     }
   ],
-  "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)-$(DockerTag)$(portableBuild)",
+  "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)-$(DockerTag)",
   "jobAuthorizationScope": "projectCollection",
   "jobTimeoutInMinutes": 90,
   "repository": {

--- a/buildpipeline/DotNet-CoreClr-Trusted-Mac.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Mac.json
@@ -49,7 +49,7 @@
       },
       "inputs": {
         "filename": "$(Agent.BuildDirectory)/s/build.sh",
-        "arguments": "$(PB_BuildType) $(Architecture) $(portableBuild) skipnuget -skiprestore stripSymbols -OfficialBuildId=$(OfficialBuildId)",
+        "arguments": "$(PB_BuildType) $(Architecture) skipnuget -skiprestore stripSymbols -OfficialBuildId=$(OfficialBuildId)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -67,7 +67,7 @@
       },
       "inputs": {
         "filename": "$(Agent.BuildDirectory)/s/build-packages.sh",
-        "arguments": "-BuildType=$(PB_BuildType) -BuildArch=$(Architecture) $(portableBuild)",
+        "arguments": "-BuildType=$(PB_BuildType) -BuildArch=$(Architecture)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -176,9 +176,6 @@
     },
     "Label": {
       "value": "$(Build.BuildNumber)"
-    },
-    "portableBuild": {
-      "value": ""
     }
   },
   "demands": [

--- a/buildpipeline/DotNet-CoreClr-Trusted-Windows-x86.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Windows-x86.json
@@ -86,7 +86,7 @@
       },
       "inputs": {
         "filename": "build.cmd",
-        "arguments": "$(Architecture) $(PB_BuildType) skiptests skipbuildpackages -OfficialBuildId=$(OfficialBuildId) -skiprestore -Priority=$(Priority) $(portableBuild)",
+        "arguments": "$(Architecture) $(PB_BuildType) skiptests skipbuildpackages -OfficialBuildId=$(OfficialBuildId) -skiprestore -Priority=$(Priority)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -131,7 +131,7 @@
       },
       "inputs": {
         "filename": "build-packages.cmd",
-        "arguments": "-BuildArch=$(Architecture) -BuildType=$(PB_BuildType) $(portableBuild)",
+        "arguments": "-BuildArch=$(Architecture) -BuildType=$(PB_BuildType)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -294,9 +294,6 @@
     "VsoPassword": {
       "value": null,
       "isSecret": true
-    },
-    "portableBuild": {
-      "value": ""
     }
   },
   "retentionRules": [

--- a/buildpipeline/DotNet-CoreClr-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Windows.json
@@ -86,7 +86,7 @@
       },
       "inputs": {
         "filename": "build.cmd",
-        "arguments": "$(Architecture) $(PB_BuildType) skiptests skipbuildpackages toolset_dir C:\\tools\\clr -OfficialBuildId=$(OfficialBuildId) -Priority=$(Priority) -skiprestore -disableoss $(portableBuild) -- /flp:\"v=diag\"",
+        "arguments": "$(Architecture) $(PB_BuildType) skiptests skipbuildpackages toolset_dir C:\\tools\\clr -OfficialBuildId=$(OfficialBuildId) -Priority=$(Priority) -skiprestore -disableoss -- /flp:\"v=diag\"",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -131,7 +131,7 @@
       },
       "inputs": {
         "filename": "build-packages.cmd",
-        "arguments": "-BuildArch=$(Architecture) -BuildType=$(PB_BuildType) $(portableBuild)",
+        "arguments": "-BuildArch=$(Architecture) -BuildType=$(PB_BuildType)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -284,9 +284,6 @@
     },
     "TeamName": {
       "value": "DotNetCore"
-    },
-    "portableBuild": {
-      "value": ""
     }
   },
   "retentionRules": [

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -12,99 +12,7 @@
         {
           "Name": "DotNet-CoreClr-Trusted-Linux",
           "Parameters": {
-            "DockerTag": "debian82_prereqs_2",
-            "Rid": "debian.8"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Debian 8.2",
-            "Type": "build/product/",
-            "Architecture": "x64",
-            "PB_BuildType": null
-          }
-        },
-        {
-          "Name": "DotNet-CoreClr-Trusted-Linux",
-          "Parameters": {
             "DockerTag": "rhel7_prereqs_2",
-            "Rid": "rhel.7"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "RedHat 7",
-            "Type": "build/product/",
-            "Architecture": "x64",
-            "PB_BuildType": null
-          }
-        },
-        {
-          "Name": "DotNet-CoreClr-Trusted-Linux",
-          "Parameters": {
-            "DockerTag": "ubuntu1404_prereqs_v3",
-            "Rid": "ubuntu.14.04"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Ubuntu 14.04",
-            "Type": "build/product/",
-            "Architecture": "x64",
-            "PB_BuildType": null
-          }
-        },
-        {
-          "Name": "DotNet-CoreClr-Trusted-Linux",
-          "Parameters": {
-            "DockerTag": "ubuntu1604_prereqs",
-            "Rid": "ubuntu.16.04"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Ubuntu 16.04",
-            "Type": "build/product/",
-            "Architecture": "x64",
-            "PB_BuildType": null
-          }
-        },
-        {
-          "Name": "DotNet-CoreClr-Trusted-Linux",
-          "Parameters": {
-            "DockerTag": "ubuntu1610_prereqs_v2",
-            "Rid": "ubuntu.16.10"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Ubuntu 16.10",
-            "Type": "build/product/",
-            "Architecture": "x64",
-            "PB_BuildType": null
-          }
-        },
-        {
-          "Name": "DotNet-CoreClr-Trusted-Linux",
-          "Parameters": {
-            "DockerTag": "fedora24_prereqs_v4",
-            "Rid": "fedora.24"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Fedora 24",
-            "Type": "build/product/",
-            "Architecture": "x64",
-            "PB_BuildType": null
-          }
-        },
-        {
-          "Name": "DotNet-CoreClr-Trusted-Linux",
-          "Parameters": {
-            "DockerTag": "opensuse421_prereqs_v3",
-            "Rid": "opensuse.42.1"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "openSUSE 42.1",
-            "Type": "build/product/",
-            "Architecture": "x64",
-            "PB_BuildType": null
-          }
-        },
-        {
-          "Name": "DotNet-CoreClr-Trusted-Linux",
-          "Parameters": {
-            "DockerTag": "rhel7_prereqs_2",
-            "portableBuild": "-portable",
             "Rid": "linux"
           },
           "ReportingParameters": {
@@ -117,20 +25,7 @@
         {
           "Name": "DotNet-CoreClr-Trusted-Mac",
           "Parameters": {
-            "Rid": "osx.10.12"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "OSX 10.12",
-            "Type": "build/product/",
-            "Architecture": "x64",
-            "PB_BuildType": null
-          }
-        },
-        {
-          "Name": "DotNet-CoreClr-Trusted-Mac",
-          "Parameters": {
-            "Rid": "osx",
-            "portableBuild": "-portable"
+            "Rid": "osx"
           },
           "ReportingParameters": {
             "OperatingSystem": "OSX",
@@ -148,19 +43,6 @@
           "ReportingParameters": {
             "OperatingSystem": "Windows",
             "Type": "build/product/",
-            "Architecture": "x64",
-            "PB_BuildType": null
-          }
-        },
-        {
-          "Name": "DotNet-CoreClr-Trusted-Windows",
-          "Parameters": {
-            "Architecture": "x64",
-            "portableBuild": "-portable"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Windows",
-            "Type": "build/product/",
             "SubType" : "PortableBuild",
             "Architecture": "x64",
             "PB_BuildType": null
@@ -170,19 +52,6 @@
           "Name": "DotNet-CoreClr-Trusted-Windows",
           "Parameters": {
             "Architecture": "arm64"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Windows",
-            "Type": "build/product/",
-            "Architecture": "arm64",
-            "PB_BuildType": null
-          }
-        },
-        {
-          "Name": "DotNet-CoreClr-Trusted-Windows",
-          "Parameters": {
-            "Architecture": "arm64",
-            "portableBuild": "-portable"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
@@ -200,19 +69,6 @@
           "ReportingParameters": {
             "OperatingSystem": "Windows",
             "Type": "build/product/",
-            "Architecture": "arm",
-            "PB_BuildType": null
-          }
-        },
-        {
-          "Name": "DotNet-CoreClr-Trusted-Windows",
-          "Parameters": {
-            "Architecture": "arm",
-            "portableBuild": "-portable"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Windows",
-            "Type": "build/product/",
             "SubType" : "PortableBuild",
             "Architecture": "arm",
             "PB_BuildType": null
@@ -220,17 +76,8 @@
         },
         {
           "Name": "DotNet-CoreClr-Trusted-Windows-x86",
-          "ReportingParameters": {
-            "OperatingSystem": "Windows",
-            "Type": "build/product/",
-            "Architecture": "x86",
-            "PB_BuildType": null
-          }
-        },
-        {
-          "Name": "DotNet-CoreClr-Trusted-Windows-x86",
           "Parameters": {
-            "portableBuild": "-portable"
+            "Architecture": "x86"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
@@ -250,42 +97,11 @@
           "Parameters": {
             "DockerTag": "ubuntu-14.04-cross-0cd4667-20172211042239",
             "Architecture": "arm",
-            "Rid": "ubuntu.14.04"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Ubuntu 14.04",
-            "SubType": "CrossBuild",
-            "Type": "build/product/",
-            "Architecture": "arm",
-            "PB_BuildType": null
-          }
-        },
-        {
-          "Name": "DotNet-CoreClr-Trusted-Linux-Crossbuild",
-          "Parameters": {
-            "DockerTag": "ubuntu-14.04-cross-0cd4667-20172211042239",
-            "Architecture": "arm",
-            "portableBuild": "-portable",
-            "Rid": "ubuntu.14.04"
+            "Rid": "linux"
           },
           "ReportingParameters": {
             "OperatingSystem": "Linux",
             "SubType": "PortableCrossBuild",
-            "Type": "build/product/",
-            "Architecture": "arm",
-            "PB_BuildType": null
-          }
-        },
-        {
-          "Name": "DotNet-CoreClr-Trusted-Linux-Crossbuild",
-          "Parameters": {
-            "DockerTag": "ubuntu-16.04-cross-ef0ac75-20175511035548",
-            "Architecture": "arm",
-            "Rid": "ubuntu.16.04"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Ubuntu 16.04",
-            "SubType": "CrossBuild",
             "Type": "build/product/",
             "Architecture": "arm",
             "PB_BuildType": null

--- a/config.json
+++ b/config.json
@@ -225,8 +225,8 @@
     "PortableBuild": {
       "description": "Indicates if this is a portable build.",
       "valueType": "property",
-      "values": [ "0", "1"],
-      "defaultValue": "0"
+      "values": [ "false", "true"],
+      "defaultValue": "true"
     },
     "Rebuild": {
       "description": "Specifies rebuild target.",
@@ -462,12 +462,6 @@
             "RestoreDuringBuild": false
           }
         },
-        "portable": {
-          "description": "Triggers a portable build.",
-          "settings": {
-            "PortableBuild": "1"
-          }
-        },
         "BuildTarget": {
           "description": "Runs the build target.",
           "settings": {
@@ -483,6 +477,7 @@
           "MsBuildErr": "default",
           "MsBuildEventLogging": "default",
           "RestoreDefaultOptimizationDataPackage": "false",
+          "PortableBuild": "true",
           "UsePartialNGENOptimization": "false"
         }
       }
@@ -636,12 +631,6 @@
             "__BuildArch": "default"
           }
         },
-        "portable": {
-          "description": "Triggers a portable build.",
-          "settings": {
-            "PortableBuild": "1"
-          }
-        },
         "buildType": {
           "description": "Specifies configuration to publish, can be Release, Debug or Checked.",
           "settings": {
@@ -661,6 +650,7 @@
           "__BuildOS": "default",
           "MsBuildFileLogging": "/flp:v=detailed;Append;LogFile=build-packages.log",
           "MsBuildEventLogging": "default",
+          "PortableBuild": "true",
           "Project": "src/.nuget/packages.builds"
         }
       }

--- a/dir.props
+++ b/dir.props
@@ -78,6 +78,9 @@
 
     <Platform Condition="'$(Platform)' == ''">$(BuildArch)</Platform>
     <Platform Condition="'$(Platform)' == 'amd64'">x64</Platform>
+
+    <!-- Default to portable build if not explicitly set -->
+    <PortableBuild Condition="'$(PortableBuild)' == ''">true</PortableBuild>
   </PropertyGroup>
 
   <!-- Output paths -->

--- a/src/.nuget/dir.props
+++ b/src/.nuget/dir.props
@@ -26,8 +26,12 @@
     <SupportedPackageOSGroups Condition="'$(SupportedPackageOSGroups)' == ''">Windows_NT;OSX;Linux</SupportedPackageOSGroups>
     <SupportedPackageOSGroups>;$(SupportedPackageOSGroups);</SupportedPackageOSGroups>
 
+    <!-- Identify OS family based upon the RuntimeOS, which could be distro specific (e.g. osx.10.12) or 
+         portable (e.g. osx). 
+    -->
     <_runtimeOSVersionIndex>$(RuntimeOS.IndexOfAny(".-0123456789"))</_runtimeOSVersionIndex>
     <_runtimeOSFamily Condition="'$(_runtimeOSVersionIndex)' != '-1'">$(RuntimeOS.SubString(0, $(_runtimeOSVersionIndex)))</_runtimeOSFamily>
+    <_runtimeOSFamily Condition="'$(_runtimeOSVersionIndex)' == '-1'">$(RuntimeOS)</_runtimeOSFamily>
     <_isSupportedOSGroup>true</_isSupportedOSGroup>
   </PropertyGroup>
 
@@ -66,7 +70,7 @@
         <RIDPlatform Condition="'$(ArchGroup)' == 'arm64'">win10</RIDPlatform>
         
         <!-- Set the platform part of the RID if we are doing a portable build -->
-        <RIDPlatform Condition="'$(PortableBuild)' == '1'">win</RIDPlatform>
+        <RIDPlatform Condition="'$(PortableBuild)' == 'true'">win</RIDPlatform>
         <PackageRID>$(RIDPlatform)-$(ArchGroup)</PackageRID>
       </PropertyGroup>
     </When>
@@ -74,21 +78,21 @@
       <PropertyGroup>
         <PackageRID>osx.10.12-$(ArchGroup)</PackageRID>
         <!-- Set the platform part of the RID if we are doing a portable build -->
-        <PackageRID Condition="'$(PortableBuild)' == '1'">osx-$(ArchGroup)</PackageRID>
+        <PackageRID Condition="'$(PortableBuild)' == 'true'">osx-$(ArchGroup)</PackageRID>
       </PropertyGroup>
     </When>
     <When Condition="'$(_runtimeOSFamily)' == 'rhel'">
       <PropertyGroup>
         <PackageRID>rhel.7-$(ArchGroup)</PackageRID>
         <!-- Set the platform part of the RID if we are doing a portable build -->
-        <PackageRID Condition="'$(PortableBuild)' == '1'">linux-$(ArchGroup)</PackageRID>
+        <PackageRID Condition="'$(PortableBuild)' == 'true'">linux-$(ArchGroup)</PackageRID>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
         <PackageRID>$(RuntimeOS)-$(ArchGroup)</PackageRID>
         <!-- Set the platform part of the RID if we are doing a portable build -->
-        <PackageRID Condition="'$(PortableBuild)' == '1'">linux-$(ArchGroup)</PackageRID>
+        <PackageRID Condition="'$(PortableBuild)' == 'true'">linux-$(ArchGroup)</PackageRID>
       </PropertyGroup>
     </Otherwise>
   </Choose>
@@ -111,48 +115,22 @@
   </Choose>
 
   <ItemGroup Condition="$(SupportedPackageOSGroups.Contains(';Linux;'))">
-    <OfficialBuildRID Include="alpine.3.4.3-x64" />
-    <OfficialBuildRID Include="debian.8-x64" />
-    <OfficialBuildRID Include="fedora.23-x64" />
-    <OfficialBuildRID Include="fedora.24-x64" />
     <OfficialBuildRID Include="linux-x64" />
     <OfficialBuildRID Include="linux-arm">
       <Platform>arm</Platform>
     </OfficialBuildRID>
-    <OfficialBuildRID Include="opensuse.42.1-x64" />
-    <OfficialBuildRID Include="rhel.7-x64" />
     <OfficialBuildRID Include="tizen.4.0.0-armel">
       <Platform>armel</Platform>
     </OfficialBuildRID>
-    <OfficialBuildRID Include="ubuntu.14.04-arm">
-      <Platform>arm</Platform>
-    </OfficialBuildRID>
-    <OfficialBuildRID Include="ubuntu.14.04-x64" />
-    <OfficialBuildRID Include="ubuntu.16.04-arm">
-      <Platform>arm</Platform>
-    </OfficialBuildRID>
-    <OfficialBuildRID Include="ubuntu.16.04-x64" />
-    <OfficialBuildRID Include="ubuntu.16.10-x64" />
   </ItemGroup>
   <ItemGroup Condition="$(SupportedPackageOSGroups.Contains(';OSX;'))">
-    <OfficialBuildRID Include="osx.10.12-x64" />
     <OfficialBuildRID Include="osx-x64" />
   </ItemGroup>
   <ItemGroup Condition="$(SupportedPackageOSGroups.Contains(';Windows_NT;'))">
-    <OfficialBuildRID Include="win7-x86">
-      <Platform>x86</Platform>
-    </OfficialBuildRID>
     <OfficialBuildRID Include="win-x86">
       <Platform>x86</Platform>
     </OfficialBuildRID>
-    <OfficialBuildRID Include="win7-x64" />
     <OfficialBuildRID Include="win-x64" />
-    <OfficialBuildRID Include="win8-arm">
-      <Platform>arm</Platform>
-    </OfficialBuildRID>
-    <OfficialBuildRID Include="win10-arm64">
-      <Platform>arm64</Platform>
-    </OfficialBuildRID>
     <OfficialBuildRID Include="win-arm">
       <Platform>arm</Platform>
     </OfficialBuildRID>


### PR DESCRIPTION
This change defaults the dev and official builds to be portable, removes the distro specific RIDs and pipeline build entries. This change does not include CI changes - I will have those as seperate commit.

@wtgodbe @ramarag Is there anything in test infrastructure (Helix or non-Helix) that relies on RID specific builds and could break?

@weshaggard @wtgodbe @chcosta PTAL

CC @RussKeldorph 