### PR TITLE
Ensure several runtime file descriptors are CLOEXEC

### DIFF
--- a/src/pal/src/config.h.in
+++ b/src/pal/src/config.h.in
@@ -61,6 +61,7 @@
 #cmakedefine01 HAS_SYSV_SEMAPHORES
 #cmakedefine01 HAS_PTHREAD_MUTEXES
 #cmakedefine01 HAVE_TTRACE
+#cmakedefine01 HAVE_PIPE2
 #cmakedefine01 HAVE_SCHED_GETAFFINITY
 #cmakedefine HAVE_UNW_GET_SAVE_LOC
 #cmakedefine HAVE_UNW_GET_ACCESSORS

--- a/src/pal/src/configure.cmake
+++ b/src/pal/src/configure.cmake
@@ -100,6 +100,7 @@ check_function_exists(directio HAVE_DIRECTIO)
 check_function_exists(semget HAS_SYSV_SEMAPHORES)
 check_function_exists(pthread_mutex_init HAS_PTHREAD_MUTEXES)
 check_function_exists(ttrace HAVE_TTRACE)
+check_function_exists(pipe2 HAVE_PIPE2)
 set(CMAKE_REQUIRED_LIBRARIES unwind unwind-generic)
 check_cxx_source_compiles("
 #include <libunwind.h>

--- a/src/pal/src/file/file.cpp
+++ b/src/pal/src/file/file.cpp
@@ -4056,14 +4056,14 @@ CorUnix::InternalCreatePipe(
 
     /* enable close-on-exec for both pipes; if one gets passed to CreateProcess
        it will be "uncloseonexeced" in order to be inherited */
-    if(-1 == fcntl(readWritePipeDes[0],F_SETFD,1))
+    if(-1 == fcntl(readWritePipeDes[0],F_SETFD,FD_CLOEXEC))
     {
         ASSERT("can't set close-on-exec flag; fcntl() failed. errno is %d "
              "(%s)\n", errno, strerror(errno));
         palError = ERROR_INTERNAL_ERROR;
         goto InternalCreatePipeExit;
     }
-    if(-1 == fcntl(readWritePipeDes[1],F_SETFD,1))
+    if(-1 == fcntl(readWritePipeDes[1],F_SETFD,FD_CLOEXEC))
     {
         ASSERT("can't set close-on-exec flag; fcntl() failed. errno is %d "
              "(%s)\n", errno, strerror(errno));

--- a/src/pal/src/file/file.cpp
+++ b/src/pal/src/file/file.cpp
@@ -4564,7 +4564,7 @@ static HANDLE init_std_handle(HANDLE * pStd, FILE *stream)
 
     /* duplicate the FILE *, so that we can fclose() in FILECloseHandle without
        closing the original */
-    new_fd = dup(fileno(stream));
+    new_fd = fcntl(fileno(stream), F_DUPFD_CLOEXEC, 0); // dup, but with CLOEXEC
     if(-1 == new_fd)
     {
         ERROR("dup() failed; errno is %d (%s)\n", errno, strerror(errno));

--- a/src/pal/src/map/map.cpp
+++ b/src/pal/src/map/map.cpp
@@ -246,7 +246,7 @@ FileMappingInitializationRoutine(
 
     pProcessLocalData->UnixFd = InternalOpen(
         pImmutableData->szFileName,
-        MAPProtectionToFileOpenFlags(pImmutableData->flProtect)
+        MAPProtectionToFileOpenFlags(pImmutableData->flProtect) | O_CLOEXEC
         );
 
     if (-1 == pProcessLocalData->UnixFd)
@@ -510,7 +510,7 @@ CorUnix::InternalCreateFileMapping(
 
 #if HAVE_MMAP_DEV_ZERO
 
-        UnixFd = InternalOpen(pImmutableData->szFileName, O_RDWR);
+        UnixFd = InternalOpen(pImmutableData->szFileName, O_RDWR | O_CLOEXEC);
         if ( -1 == UnixFd )
         {
             ERROR( "Unable to open the file.\n");
@@ -587,7 +587,7 @@ CorUnix::InternalCreateFileMapping(
             // information, though...
             //
             
-            UnixFd = dup(pFileLocalData->unix_fd);
+            UnixFd = fcntl(pFileLocalData->unix_fd, F_DUPFD_CLOEXEC, 0); // dup, but with CLOEXEC
             if (-1 == UnixFd)
             {
                 ERROR( "Unable to duplicate the Unix file descriptor!\n" );


### PR DESCRIPTION
I modified the System.Native.so shim's ForkAndExecProcess function to print out between the fork and the exec a list of all file descriptors held open by the process that are no CLOEXEC and as such that will be inherited by the child process.  I then wrote short .NET app that uses Process.Start to spawn a copy of itself as a child recursively down to some specified limit.  Prior to this PR, this is what I see in the 20th descendant:
```
0 (/dev/pts/2)
1 (/dev/pts/2)
2 (/dev/pts/2)
3 (pipe:[100661])
4 (pipe:[100661])
5 (/dev/pts/2)
6 (/dev/pts/2)
7 (/dev/pts/2)
8 (pipe:[100663])
9 (pipe:[100663])
10 (/dev/pts/2)
11 (/home/stoub/tmpapp/bin/Debug/netcoreapp1.1/tmpapp.dll)
12 (/dev/pts/2)
13 (/home/stoub/coreclrtest/System.Runtime.dll)
14 (pipe:[101549])
15 (pipe:[101549])
16 (/dev/pts/2)
17 (/home/stoub/coreclrtest/System.Console.dll)
18 (pipe:[101553])
19 (/home/stoub/coreclrtest/System.Diagnostics.Process.dll)
20 (pipe:[101553])
21 (/home/stoub/coreclrtest/System.ComponentModel.Primitives.dll)
22 (/dev/pts/2)
23 (/home/stoub/coreclrtest/System.Runtime.Extensions.dll)
24 (/home/stoub/tmpapp/bin/Debug/netcoreapp1.1/tmpapp.dll)
25 (/home/stoub/coreclrtest/System.Threading.dll)
26 (/dev/pts/2)
27 (/home/stoub/coreclrtest/System.Diagnostics.Debug.dll)
28 (/dev/pts/2)
29 (/home/stoub/coreclrtest/System.Runtime.dll)
30 (/home/stoub/coreclrtest/System.Text.Encoding.Extensions.dll)
31 (pipe:[100669])
32 (/home/stoub/coreclrtest/System.IO.FileSystem.dll)
33 (pipe:[100669])
34 (/home/stoub/coreclrtest/Microsoft.Win32.Primitives.dll)
35 (/dev/pts/2)
36 (/home/stoub/coreclrtest/System.Collections.dll)
37 (/home/stoub/coreclrtest/System.Console.dll)
38 (/home/stoub/coreclrtest/System.Runtime.InteropServices.dll)
39 (pipe:[100672])
40 (/home/stoub/coreclrtest/System.Diagnostics.Process.dll)
41 (pipe:[100672])
42 (/home/stoub/coreclrtest/System.ComponentModel.Primitives.dll)
43 (/dev/pts/2)
44 (/home/stoub/coreclrtest/System.Runtime.Extensions.dll)
45 (/home/stoub/tmpapp/bin/Debug/netcoreapp1.1/tmpapp.dll)
46 (/home/stoub/coreclrtest/System.Threading.dll)
47 (/dev/pts/2)
48 (/home/stoub/coreclrtest/System.Diagnostics.Debug.dll)
49 (/dev/pts/2)
50 (/home/stoub/coreclrtest/System.Runtime.dll)
51 (/home/stoub/coreclrtest/System.Text.Encoding.Extensions.dll)
52 (pipe:[101558])
53 (/home/stoub/coreclrtest/System.IO.FileSystem.dll)
54 (pipe:[101558])
55 (/home/stoub/coreclrtest/Microsoft.Win32.Primitives.dll)
56 (/dev/pts/2)
57 (/home/stoub/coreclrtest/System.Collections.dll)
58 (/home/stoub/coreclrtest/System.Console.dll)
59 (/home/stoub/coreclrtest/System.Runtime.InteropServices.dll)
60 (pipe:[101561])
61 (/home/stoub/coreclrtest/System.Diagnostics.Process.dll)
62 (pipe:[101561])
63 (/home/stoub/coreclrtest/System.ComponentModel.Primitives.dll)
64 (/dev/pts/2)
65 (/home/stoub/coreclrtest/System.Runtime.Extensions.dll)
66 (/home/stoub/tmpapp/bin/Debug/netcoreapp1.1/tmpapp.dll)
67 (/home/stoub/coreclrtest/System.Threading.dll)
68 (/dev/pts/2)
69 (/home/stoub/coreclrtest/System.Diagnostics.Debug.dll)
70 (/dev/pts/2)
71 (/home/stoub/coreclrtest/System.Runtime.dll)
72 (/home/stoub/coreclrtest/System.Text.Encoding.Extensions.dll)
73 (pipe:[100677])
74 (/home/stoub/coreclrtest/System.IO.FileSystem.dll)
75 (pipe:[100677])
76 (/home/stoub/coreclrtest/Microsoft.Win32.Primitives.dll)
77 (/dev/pts/2)
78 (/home/stoub/coreclrtest/System.Collections.dll)
79 (/home/stoub/coreclrtest/System.Console.dll)
80 (/home/stoub/coreclrtest/System.Runtime.InteropServices.dll)
81 (pipe:[100680])
82 (/home/stoub/coreclrtest/System.Diagnostics.Process.dll)
83 (pipe:[100680])
84 (/home/stoub/coreclrtest/System.ComponentModel.Primitives.dll)
85 (/dev/pts/2)
86 (/home/stoub/coreclrtest/System.Runtime.Extensions.dll)
87 (/home/stoub/tmpapp/bin/Debug/netcoreapp1.1/tmpapp.dll)
88 (/home/stoub/coreclrtest/System.Threading.dll)
89 (/dev/pts/2)
90 (/home/stoub/coreclrtest/System.Diagnostics.Debug.dll)
91 (/dev/pts/2)
92 (/home/stoub/coreclrtest/System.Runtime.dll)
93 (/home/stoub/coreclrtest/System.Text.Encoding.Extensions.dll)
94 (pipe:[101566])
95 (/home/stoub/coreclrtest/System.IO.FileSystem.dll)
96 (pipe:[101566])
97 (/home/stoub/coreclrtest/Microsoft.Win32.Primitives.dll)
98 (/dev/pts/2)
99 (/home/stoub/coreclrtest/System.Collections.dll)
100 (/home/stoub/coreclrtest/System.Console.dll)
101 (/home/stoub/coreclrtest/System.Runtime.InteropServices.dll)
102 (pipe:[101569])
103 (/home/stoub/coreclrtest/System.Diagnostics.Process.dll)
104 (pipe:[101569])
105 (/home/stoub/coreclrtest/System.ComponentModel.Primitives.dll)
106 (/dev/pts/2)
107 (/home/stoub/coreclrtest/System.Runtime.Extensions.dll)
108 (/home/stoub/tmpapp/bin/Debug/netcoreapp1.1/tmpapp.dll)
109 (/home/stoub/coreclrtest/System.Threading.dll)
110 (/dev/pts/2)
111 (/home/stoub/coreclrtest/System.Diagnostics.Debug.dll)
112 (/dev/pts/2)
113 (/home/stoub/coreclrtest/System.Runtime.dll)
114 (/home/stoub/coreclrtest/System.Text.Encoding.Extensions.dll)
115 (pipe:[100685])
116 (/home/stoub/coreclrtest/System.IO.FileSystem.dll)
117 (pipe:[100685])
118 (/home/stoub/coreclrtest/Microsoft.Win32.Primitives.dll)
119 (/dev/pts/2)
120 (/home/stoub/coreclrtest/System.Collections.dll)
121 (/home/stoub/coreclrtest/System.Console.dll)
122 (/home/stoub/coreclrtest/System.Runtime.InteropServices.dll)
123 (pipe:[100688])
124 (/home/stoub/coreclrtest/System.Diagnostics.Process.dll)
125 (pipe:[100688])
126 (/home/stoub/coreclrtest/System.ComponentModel.Primitives.dll)
127 (/dev/pts/2)
128 (/home/stoub/coreclrtest/System.Runtime.Extensions.dll)
129 (/home/stoub/tmpapp/bin/Debug/netcoreapp1.1/tmpapp.dll)
130 (/home/stoub/coreclrtest/System.Threading.dll)
131 (/dev/pts/2)
132 (/home/stoub/coreclrtest/System.Diagnostics.Debug.dll)
133 (/dev/pts/2)
134 (/home/stoub/coreclrtest/System.Runtime.dll)
135 (/home/stoub/coreclrtest/System.Text.Encoding.Extensions.dll)
136 (pipe:[101574])
137 (/home/stoub/coreclrtest/System.IO.FileSystem.dll)
138 (pipe:[101574])
139 (/home/stoub/coreclrtest/Microsoft.Win32.Primitives.dll)
140 (/dev/pts/2)
141 (/home/stoub/coreclrtest/System.Collections.dll)
142 (/home/stoub/coreclrtest/System.Console.dll)
143 (/home/stoub/coreclrtest/System.Runtime.InteropServices.dll)
144 (pipe:[102609])
145 (/home/stoub/coreclrtest/System.Diagnostics.Process.dll)
146 (pipe:[102609])
147 (/home/stoub/coreclrtest/System.ComponentModel.Primitives.dll)
148 (/dev/pts/2)
149 (/home/stoub/coreclrtest/System.Runtime.Extensions.dll)
150 (/home/stoub/tmpapp/bin/Debug/netcoreapp1.1/tmpapp.dll)
151 (/home/stoub/coreclrtest/System.Threading.dll)
152 (/dev/pts/2)
153 (/home/stoub/coreclrtest/System.Diagnostics.Debug.dll)
154 (/dev/pts/2)
155 (/home/stoub/coreclrtest/System.Runtime.dll)
156 (/home/stoub/coreclrtest/System.Text.Encoding.Extensions.dll)
157 (pipe:[100693])
158 (/home/stoub/coreclrtest/System.IO.FileSystem.dll)
159 (pipe:[100693])
160 (/home/stoub/coreclrtest/Microsoft.Win32.Primitives.dll)
161 (/dev/pts/2)
162 (/home/stoub/coreclrtest/System.Collections.dll)
163 (/home/stoub/coreclrtest/System.Console.dll)
164 (/home/stoub/coreclrtest/System.Runtime.InteropServices.dll)
165 (pipe:[103602])
166 (/home/stoub/coreclrtest/System.Diagnostics.Process.dll)
167 (pipe:[103602])
168 (/home/stoub/coreclrtest/System.ComponentModel.Primitives.dll)
169 (/dev/pts/2)
170 (/home/stoub/coreclrtest/System.Runtime.Extensions.dll)
171 (/home/stoub/tmpapp/bin/Debug/netcoreapp1.1/tmpapp.dll)
172 (/home/stoub/coreclrtest/System.Threading.dll)
173 (/dev/pts/2)
174 (/home/stoub/coreclrtest/System.Diagnostics.Debug.dll)
175 (/dev/pts/2)
176 (/home/stoub/coreclrtest/System.Runtime.dll)
177 (/home/stoub/coreclrtest/System.Text.Encoding.Extensions.dll)
178 (pipe:[102614])
179 (/home/stoub/coreclrtest/System.IO.FileSystem.dll)
180 (pipe:[102614])
181 (/home/stoub/coreclrtest/Microsoft.Win32.Primitives.dll)
182 (/dev/pts/2)
183 (/home/stoub/coreclrtest/System.Collections.dll)
184 (/home/stoub/coreclrtest/System.Console.dll)
185 (/home/stoub/coreclrtest/System.Runtime.InteropServices.dll)
186 (pipe:[102617])
187 (/home/stoub/coreclrtest/System.Diagnostics.Process.dll)
188 (pipe:[102617])
189 (/home/stoub/coreclrtest/System.ComponentModel.Primitives.dll)
190 (/dev/pts/2)
191 (/home/stoub/coreclrtest/System.Runtime.Extensions.dll)
192 (/home/stoub/tmpapp/bin/Debug/netcoreapp1.1/tmpapp.dll)
193 (/home/stoub/coreclrtest/System.Threading.dll)
194 (/dev/pts/2)
195 (/home/stoub/coreclrtest/System.Diagnostics.Debug.dll)
196 (/dev/pts/2)
197 (/home/stoub/coreclrtest/System.Runtime.dll)
198 (/home/stoub/coreclrtest/System.Text.Encoding.Extensions.dll)
199 (pipe:[103607])
200 (/home/stoub/coreclrtest/System.IO.FileSystem.dll)
201 (pipe:[103607])
202 (/home/stoub/coreclrtest/Microsoft.Win32.Primitives.dll)
203 (/dev/pts/2)
204 (/home/stoub/coreclrtest/System.Collections.dll)
205 (/home/stoub/coreclrtest/System.Console.dll)
206 (/home/stoub/coreclrtest/System.Runtime.InteropServices.dll)
207 (pipe:[103610])
208 (/home/stoub/coreclrtest/System.Diagnostics.Process.dll)
209 (pipe:[103610])
210 (/home/stoub/coreclrtest/System.ComponentModel.Primitives.dll)
211 (/dev/pts/2)
212 (/home/stoub/coreclrtest/System.Runtime.Extensions.dll)
213 (/home/stoub/tmpapp/bin/Debug/netcoreapp1.1/tmpapp.dll)
214 (/home/stoub/coreclrtest/System.Threading.dll)
215 (/dev/pts/2)
216 (/home/stoub/coreclrtest/System.Diagnostics.Debug.dll)
217 (/dev/pts/2)
218 (/home/stoub/coreclrtest/System.Runtime.dll)
219 (/home/stoub/coreclrtest/System.Text.Encoding.Extensions.dll)
220 (pipe:[102622])
221 (/home/stoub/coreclrtest/System.IO.FileSystem.dll)
222 (pipe:[102622])
223 (/home/stoub/coreclrtest/Microsoft.Win32.Primitives.dll)
224 (/dev/pts/2)
225 (/home/stoub/coreclrtest/System.Collections.dll)
226 (/home/stoub/coreclrtest/System.Console.dll)
227 (/home/stoub/coreclrtest/System.Runtime.InteropServices.dll)
228 (pipe:[101166])
229 (/home/stoub/coreclrtest/System.Diagnostics.Process.dll)
230 (pipe:[101166])
231 (/home/stoub/coreclrtest/System.ComponentModel.Primitives.dll)
232 (/dev/pts/2)
233 (/home/stoub/coreclrtest/System.Runtime.Extensions.dll)
234 (/home/stoub/tmpapp/bin/Debug/netcoreapp1.1/tmpapp.dll)
235 (/home/stoub/coreclrtest/System.Threading.dll)
236 (/dev/pts/2)
237 (/home/stoub/coreclrtest/System.Diagnostics.Debug.dll)
238 (/dev/pts/2)
239 (/home/stoub/coreclrtest/System.Runtime.dll)
240 (/home/stoub/coreclrtest/System.Text.Encoding.Extensions.dll)
241 (pipe:[103615])
242 (/home/stoub/coreclrtest/System.IO.FileSystem.dll)
243 (pipe:[103615])
244 (/home/stoub/coreclrtest/Microsoft.Win32.Primitives.dll)
245 (/dev/pts/2)
246 (/home/stoub/coreclrtest/System.Collections.dll)
247 (/home/stoub/coreclrtest/System.Console.dll)
248 (/home/stoub/coreclrtest/System.Runtime.InteropServices.dll)
249 (pipe:[102095])
250 (/home/stoub/coreclrtest/System.Diagnostics.Process.dll)
251 (pipe:[102095])
252 (/home/stoub/coreclrtest/System.ComponentModel.Primitives.dll)
253 (/dev/pts/2)
254 (/home/stoub/coreclrtest/System.Runtime.Extensions.dll)
255 (/home/stoub/tmpapp/bin/Debug/netcoreapp1.1/tmpapp.dll)
256 (/home/stoub/coreclrtest/System.Threading.dll)
257 (/dev/pts/2)
258 (/home/stoub/coreclrtest/System.Diagnostics.Debug.dll)
259 (/dev/pts/2)
260 (/home/stoub/coreclrtest/System.Runtime.dll)
261 (/home/stoub/coreclrtest/System.Text.Encoding.Extensions.dll)
262 (pipe:[101171])
263 (/home/stoub/coreclrtest/System.IO.FileSystem.dll)
264 (pipe:[101171])
265 (/home/stoub/coreclrtest/Microsoft.Win32.Primitives.dll)
266 (/dev/pts/2)
267 (/home/stoub/coreclrtest/System.Collections.dll)
268 (/home/stoub/coreclrtest/System.Console.dll)
269 (/home/stoub/coreclrtest/System.Runtime.InteropServices.dll)
270 (pipe:[101174])
271 (/home/stoub/coreclrtest/System.Diagnostics.Process.dll)
272 (pipe:[101174])
273 (/home/stoub/coreclrtest/System.ComponentModel.Primitives.dll)
274 (/dev/pts/2)
275 (/home/stoub/coreclrtest/System.Runtime.Extensions.dll)
276 (/home/stoub/tmpapp/bin/Debug/netcoreapp1.1/tmpapp.dll)
277 (/home/stoub/coreclrtest/System.Threading.dll)
278 (/dev/pts/2)
279 (/home/stoub/coreclrtest/System.Diagnostics.Debug.dll)
280 (/dev/pts/2)
281 (/home/stoub/coreclrtest/System.Runtime.dll)
282 (/home/stoub/coreclrtest/System.Text.Encoding.Extensions.dll)
283 (pipe:[102100])
284 (/home/stoub/coreclrtest/System.IO.FileSystem.dll)
285 (pipe:[102100])
286 (/home/stoub/coreclrtest/Microsoft.Win32.Primitives.dll)
287 (/dev/pts/2)
288 (/home/stoub/coreclrtest/System.Collections.dll)
289 (/home/stoub/coreclrtest/System.Console.dll)
290 (/home/stoub/coreclrtest/System.Runtime.InteropServices.dll)
291 (pipe:[102105])
292 (/home/stoub/coreclrtest/System.Diagnostics.Process.dll)
293 (pipe:[102105])
294 (/home/stoub/coreclrtest/System.ComponentModel.Primitives.dll)
295 (/dev/pts/2)
296 (/home/stoub/coreclrtest/System.Runtime.Extensions.dll)
297 (/home/stoub/tmpapp/bin/Debug/netcoreapp1.1/tmpapp.dll)
298 (/home/stoub/coreclrtest/System.Threading.dll)
299 (/dev/pts/2)
300 (/home/stoub/coreclrtest/System.Diagnostics.Debug.dll)
301 (/dev/pts/2)
302 (/home/stoub/coreclrtest/System.Runtime.dll)
303 (/home/stoub/coreclrtest/System.Text.Encoding.Extensions.dll)
304 (pipe:[101179])
305 (/home/stoub/coreclrtest/System.IO.FileSystem.dll)
306 (pipe:[101179])
307 (/home/stoub/coreclrtest/Microsoft.Win32.Primitives.dll)
308 (/dev/pts/2)
309 (/home/stoub/coreclrtest/System.Collections.dll)
310 (/home/stoub/coreclrtest/System.Console.dll)
311 (/home/stoub/coreclrtest/System.Runtime.InteropServices.dll)
312 (pipe:[101183])
313 (/home/stoub/coreclrtest/System.Diagnostics.Process.dll)
314 (pipe:[101183])
315 (/home/stoub/coreclrtest/System.ComponentModel.Primitives.dll)
316 (/dev/pts/2)
317 (/home/stoub/coreclrtest/System.Runtime.Extensions.dll)
318 (/home/stoub/tmpapp/bin/Debug/netcoreapp1.1/tmpapp.dll)
319 (/home/stoub/coreclrtest/System.Threading.dll)
320 (/dev/pts/2)
321 (/home/stoub/coreclrtest/System.Diagnostics.Debug.dll)
322 (/dev/pts/2)
323 (/home/stoub/coreclrtest/System.Runtime.dll)
324 (/home/stoub/coreclrtest/System.Text.Encoding.Extensions.dll)
325 (pipe:[102110])
326 (/home/stoub/coreclrtest/System.IO.FileSystem.dll)
327 (pipe:[102110])
328 (/home/stoub/coreclrtest/Microsoft.Win32.Primitives.dll)
329 (/dev/pts/2)
330 (/home/stoub/coreclrtest/System.Collections.dll)
331 (/home/stoub/coreclrtest/System.Console.dll)
332 (/home/stoub/coreclrtest/System.Runtime.InteropServices.dll)
333 (pipe:[102113])
334 (/home/stoub/coreclrtest/System.Diagnostics.Process.dll)
335 (pipe:[102113])
336 (/home/stoub/coreclrtest/System.ComponentModel.Primitives.dll)
337 (/dev/pts/2)
338 (/home/stoub/coreclrtest/System.Runtime.Extensions.dll)
339 (/home/stoub/tmpapp/bin/Debug/netcoreapp1.1/tmpapp.dll)
340 (/home/stoub/coreclrtest/System.Threading.dll)
341 (/dev/pts/2)
342 (/home/stoub/coreclrtest/System.Diagnostics.Debug.dll)
343 (/dev/pts/2)
344 (/home/stoub/coreclrtest/System.Runtime.dll)
345 (/home/stoub/coreclrtest/System.Text.Encoding.Extensions.dll)
346 (pipe:[101188])
347 (/home/stoub/coreclrtest/System.IO.FileSystem.dll)
348 (pipe:[101188])
349 (/home/stoub/coreclrtest/Microsoft.Win32.Primitives.dll)
350 (/dev/pts/2)
351 (/home/stoub/coreclrtest/System.Collections.dll)
352 (/home/stoub/coreclrtest/System.Console.dll)
353 (/home/stoub/coreclrtest/System.Runtime.InteropServices.dll)
354 (pipe:[101191])
355 (/home/stoub/coreclrtest/System.Diagnostics.Process.dll)
356 (pipe:[101191])
357 (/home/stoub/coreclrtest/System.ComponentModel.Primitives.dll)
358 (/dev/pts/2)
359 (/home/stoub/coreclrtest/System.Runtime.Extensions.dll)
360 (/home/stoub/tmpapp/bin/Debug/netcoreapp1.1/tmpapp.dll)
361 (/home/stoub/coreclrtest/System.Threading.dll)
362 (/dev/pts/2)
363 (/home/stoub/coreclrtest/System.Diagnostics.Debug.dll)
364 (/dev/pts/2)
365 (/home/stoub/coreclrtest/System.Runtime.dll)
366 (/home/stoub/coreclrtest/System.Text.Encoding.Extensions.dll)
367 (pipe:[102118])
368 (/home/stoub/coreclrtest/System.IO.FileSystem.dll)
369 (pipe:[102118])
370 (/home/stoub/coreclrtest/Microsoft.Win32.Primitives.dll)
371 (/dev/pts/2)
372 (/home/stoub/coreclrtest/System.Collections.dll)
373 (/home/stoub/coreclrtest/System.Console.dll)
374 (/home/stoub/coreclrtest/System.Runtime.InteropServices.dll)
375 (pipe:[102121])
376 (/home/stoub/coreclrtest/System.Diagnostics.Process.dll)
377 (pipe:[102121])
378 (/home/stoub/coreclrtest/System.ComponentModel.Primitives.dll)
379 (/dev/pts/2)
380 (/home/stoub/coreclrtest/System.Runtime.Extensions.dll)
381 (/home/stoub/tmpapp/bin/Debug/netcoreapp1.1/tmpapp.dll)
382 (/home/stoub/coreclrtest/System.Threading.dll)
383 (/dev/pts/2)
384 (/home/stoub/coreclrtest/System.Diagnostics.Debug.dll)
385 (/dev/pts/2)
386 (/home/stoub/coreclrtest/System.Runtime.dll)
387 (/home/stoub/coreclrtest/System.Text.Encoding.Extensions.dll)
388 (pipe:[101196])
389 (/home/stoub/coreclrtest/System.IO.FileSystem.dll)
390 (pipe:[101196])
391 (/home/stoub/coreclrtest/Microsoft.Win32.Primitives.dll)
392 (/dev/pts/2)
393 (/home/stoub/coreclrtest/System.Collections.dll)
394 (/home/stoub/coreclrtest/System.Console.dll)
395 (/home/stoub/coreclrtest/System.Runtime.InteropServices.dll)
396 (pipe:[101199])
397 (/home/stoub/coreclrtest/System.Diagnostics.Process.dll)
398 (pipe:[101199])
399 (/home/stoub/coreclrtest/System.ComponentModel.Primitives.dll)
400 (/dev/pts/2)
401 (/home/stoub/coreclrtest/System.Runtime.Extensions.dll)
402 (/home/stoub/tmpapp/bin/Debug/netcoreapp1.1/tmpapp.dll)
403 (/home/stoub/coreclrtest/System.Threading.dll)
404 (/dev/pts/2)
405 (/home/stoub/coreclrtest/System.Diagnostics.Debug.dll)
406 (/dev/pts/2)
407 (/home/stoub/coreclrtest/System.Runtime.dll)
408 (/home/stoub/coreclrtest/System.Text.Encoding.Extensions.dll)
409 (pipe:[102126])
410 (/home/stoub/coreclrtest/System.IO.FileSystem.dll)
411 (pipe:[102126])
412 (/home/stoub/coreclrtest/Microsoft.Win32.Primitives.dll)
413 (/dev/pts/2)
414 (/home/stoub/coreclrtest/System.Collections.dll)
415 (/home/stoub/coreclrtest/System.Console.dll)
416 (/home/stoub/coreclrtest/System.Runtime.InteropServices.dll)
418 (/home/stoub/coreclrtest/System.Diagnostics.Process.dll)
420 (/home/stoub/coreclrtest/System.ComponentModel.Primitives.dll)
422 (/home/stoub/coreclrtest/System.Runtime.Extensions.dll)
423 (/home/stoub/tmpapp/bin/Debug/netcoreapp1.1/tmpapp.dll)
424 (/home/stoub/coreclrtest/System.Threading.dll)
426 (/home/stoub/coreclrtest/System.Diagnostics.Debug.dll)
427 (/dev/pts/2)
428 (/home/stoub/coreclrtest/System.Runtime.dll)
429 (/home/stoub/coreclrtest/System.Text.Encoding.Extensions.dll)
430 (pipe:[101204])
431 (/home/stoub/coreclrtest/System.IO.FileSystem.dll)
432 (pipe:[101204])
433 (/home/stoub/coreclrtest/Microsoft.Win32.Primitives.dll)
435 (/home/stoub/coreclrtest/System.Collections.dll)
436 (/home/stoub/coreclrtest/System.Console.dll)
437 (/home/stoub/coreclrtest/System.Runtime.InteropServices.dll)
439 (/home/stoub/coreclrtest/System.Diagnostics.Process.dll)
441 (/home/stoub/coreclrtest/System.ComponentModel.Primitives.dll)
443 (/home/stoub/coreclrtest/System.Runtime.Extensions.dll)
445 (/home/stoub/coreclrtest/System.Threading.dll)
447 (/home/stoub/coreclrtest/System.Diagnostics.Debug.dll)
448 (/dev/pts/2)
450 (/home/stoub/coreclrtest/System.Text.Encoding.Extensions.dll)
452 (/home/stoub/coreclrtest/System.IO.FileSystem.dll)
454 (/home/stoub/coreclrtest/Microsoft.Win32.Primitives.dll)
456 (/home/stoub/coreclrtest/System.Collections.dll)
458 (/home/stoub/coreclrtest/System.Runtime.InteropServices.dll)
```
After this PR, I get this:
```
0 (/dev/pts/2)
1 (/dev/pts/2)
2 (/dev/pts/2)
5 (/dev/pts/2)
6 (/dev/pts/2)
7 (/dev/pts/2)
8 (/dev/pts/2)
9 (/dev/pts/2)
10 (/dev/pts/2)
11 (/dev/pts/2)
12 (/dev/pts/2)
13 (/dev/pts/2)
14 (/dev/pts/2)
15 (/dev/pts/2)
16 (/dev/pts/2)
17 (/dev/pts/2)
18 (/dev/pts/2)
19 (/dev/pts/2)
20 (/dev/pts/2)
21 (/dev/pts/2)
22 (/dev/pts/2)
23 (/dev/pts/2)
24 (/dev/pts/2)
25 (/dev/pts/2)
26 (/dev/pts/2)
27 (/dev/pts/2)
28 (/dev/pts/2)
29 (/dev/pts/2)
30 (/dev/pts/2)
31 (/dev/pts/2)
32 (/dev/pts/2)
33 (/dev/pts/2)
34 (/dev/pts/2)
35 (/dev/pts/2)
36 (/dev/pts/2)
37 (/dev/pts/2)
38 (/dev/pts/2)
39 (/dev/pts/2)
40 (/dev/pts/2)
41 (/dev/pts/2)
42 (/dev/pts/2)
43 (/dev/pts/2)
44 (/dev/pts/2)
45 (/dev/pts/2)
46 (/dev/pts/2)
47 (/dev/pts/2)
48 (/dev/pts/2)
49 (/dev/pts/2)
50 (/dev/pts/2)
51 (/dev/pts/2)
52 (/dev/pts/2)
53 (/dev/pts/2)
54 (/dev/pts/2)
55 (/dev/pts/2)
56 (/dev/pts/2)
57 (/dev/pts/2)
58 (/dev/pts/2)
59 (/dev/pts/2)
60 (/dev/pts/2)
61 (/dev/pts/2)
62 (/dev/pts/2)
63 (/dev/pts/2)
64 (/dev/pts/2)
65 (/dev/pts/2)
66 (/dev/pts/2)
67 (/dev/pts/2)
68 (/dev/pts/2)
69 (/dev/pts/2)
70 (/dev/pts/2)
71 (/dev/pts/2)
72 (/dev/pts/2)
73 (/dev/pts/2)
74 (/dev/pts/2)
75 (/dev/pts/2)
76 (/dev/pts/2)
77 (/dev/pts/2)
78 (/dev/pts/2)
79 (/dev/pts/2)
80 (/dev/pts/2)
81 (/dev/pts/2)
84 (/dev/pts/2)
88 (/dev/pts/2)
92 (/dev/pts/2)
96 (/dev/pts/2)
100 (/dev/pts/2)
104 (/dev/pts/2)
108 (/dev/pts/2)
```
I'm not sure how to address the /dev/pts/2 file descriptors, so I've not addressed those.  I've also not gone through the runtime looking for other cases proactively; I only addressed the ones that appeared to be contributing to the list (note that one of the changes, for /dev/zero, was showing up when using a slightly stale CoreCLR build I had locally... it appears to no longer be an issue, but I changed it anyway).

cc: @janvorli, @tmds
Contributes to #11982 