### PR TITLE
Return 0 on success from GC Reliability Framework scripts

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1470,8 +1470,6 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                         else if (isGcReliabilityFramework(scenario)) {
                             buildCommands += "tests\\runtest.cmd ${runtestArguments} GenerateLayoutOnly"
                             buildCommands += "tests\\scripts\\run-gc-reliability-framework.cmd ${arch} ${configuration}"
-                            Utilities.addArchival(newJob, "stdout.txt")
-                            Utilities.addArchival(newJob, "Logs/**")
                         }
                         else if (architecture == 'x64' || architecture == 'x86') {
                             buildCommands += "tests\\runtest.cmd ${runtestArguments}"
@@ -2496,13 +2494,6 @@ combinedScenarios.each { scenario ->
                                 }
                             }
                         }
-                    }
-
-                    if (isGcReliabilityFramework(scenario))
-                    {
-                        // Both of these are emitted by the RF
-                        Utilities.addArchival(newJob, "stdout.txt")
-                        Utilities.addArchival(newJob, "Logs/**")
                     }
 
                     if (scenario == 'coverage') {

--- a/tests/scripts/run-gc-reliability-framework.cmd
+++ b/tests/scripts/run-gc-reliability-framework.cmd
@@ -7,4 +7,17 @@
 set CORE_ROOT=%CD%\bin\tests\Windows_NT.%1.%2\Tests\Core_Root
 set FRAMEWORK_DIR=%CD%\bin\tests\Windows_NT.%1.%2\GC\Stress\Framework\ReliabilityFramework
 powershell "%CORE_ROOT%\CoreRun.exe %FRAMEWORK_DIR%\ReliabilityFramework.exe %FRAMEWORK_DIR%\testmix_gc.config | tee stdout.txt"
+if %ERRORLEVEL% == 100 (
+    @rem The ReliabilityFramework returns 100 on success and 99 on failure
+    echo ReliabilityFramework successful
+    exit /b 0
+) else if %ERRORLEVEL% == 99 (
+    echo ReliabilityFramework test failed, some tests failed
+    exit /b 1
+) else (
+    @rem The ReliabilityFramework returns -1 when something is wrong with the
+    @rem run configuration. It should be obvious from standard out why this happened.
+    echo ReliabilityFramework returned a strange exit code %ERRORLEVEL%, perhaps some config is wrong?
+    exit /b 1
+)
 

--- a/tests/scripts/run-gc-reliability-framework.cmd
+++ b/tests/scripts/run-gc-reliability-framework.cmd
@@ -6,7 +6,7 @@
 
 set CORE_ROOT=%CD%\bin\tests\Windows_NT.%1.%2\Tests\Core_Root
 set FRAMEWORK_DIR=%CD%\bin\tests\Windows_NT.%1.%2\GC\Stress\Framework\ReliabilityFramework
-powershell "%CORE_ROOT%\CoreRun.exe %FRAMEWORK_DIR%\ReliabilityFramework.exe %FRAMEWORK_DIR%\testmix_gc.config | tee stdout.txt"
+powershell "%CORE_ROOT%\CoreRun.exe %FRAMEWORK_DIR%\ReliabilityFramework.exe %FRAMEWORK_DIR%\testmix_gc.config"
 if %ERRORLEVEL% == 100 (
     @rem The ReliabilityFramework returns 100 on success and 99 on failure
     echo ReliabilityFramework successful

--- a/tests/scripts/run-gc-reliability-framework.sh
+++ b/tests/scripts/run-gc-reliability-framework.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
-set -o pipefail
 
 export CORE_ROOT=`pwd`/bin/tests/Windows_NT.$1.$2/Tests/coreoverlay
 FRAMEWORK_DIR=`pwd`/bin/tests/Windows_NT.$1.$2/GC/Stress/Framework/ReliabilityFramework
-$CORE_ROOT/corerun $FRAMEWORK_DIR/ReliabilityFramework.exe $FRAMEWORK_DIR/testmix_gc.config | tee stdout.txt
+$CORE_ROOT/corerun $FRAMEWORK_DIR/ReliabilityFramework.exe $FRAMEWORK_DIR/testmix_gc.config
 EXIT_CODE=$?
 if [ $EXIT_CODE -eq 100 ]
 then

--- a/tests/scripts/run-gc-reliability-framework.sh
+++ b/tests/scripts/run-gc-reliability-framework.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
+set -o pipefail
 
 export CORE_ROOT=`pwd`/bin/tests/Windows_NT.$1.$2/Tests/coreoverlay
 FRAMEWORK_DIR=`pwd`/bin/tests/Windows_NT.$1.$2/GC/Stress/Framework/ReliabilityFramework
 $CORE_ROOT/corerun $FRAMEWORK_DIR/ReliabilityFramework.exe $FRAMEWORK_DIR/testmix_gc.config | tee stdout.txt
+EXIT_CODE=$?
+if [ $EXIT_CODE -eq 100 ]
+then
+    echo "ReliabilityFramework successful"
+    exit 0
+fi
 
+if [ $EXIT_CODE -eq 99 ]
+then
+    echo "ReliabilityFramework test failed, some tests failed"
+    exit 1
+fi
+
+echo "ReliabilityFramework returned a strange exit code $EXIT_CODE, perhaps some config is wrong?"
+exit 1


### PR DESCRIPTION
The Reliability Framework returns 100 on success and 99 on failure, which is what previous internal test harnesses expected. Jenkins, however, expects 0 for success and 1 on failure, so it was reporting RF jobs as having failed despite them succeeding (and returning 100).

This should make the Windows RF job green (Ubuntu is still red: https://github.com/dotnet/coreclr/issues/11981)

@Maoni0 @adityamandaleeka PTAL? I tested both of these locally and they seemed to work OK. 