### PR TITLE
Streamline LSRA for non-enregistered lclVars

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -7986,16 +7986,16 @@ void JitTimer::PrintCsvHeader()
         if (ftell(fp) == 0)
         {
             fprintf(fp, "\"Method Name\",");
-            fprintf(fp, "\"Method Index\",");
+            fprintf(fp, "\"Assembly or SPMI Index\",");
             fprintf(fp, "\"IL Bytes\",");
             fprintf(fp, "\"Basic Blocks\",");
-            fprintf(fp, "\"Opt Level\",");
+            fprintf(fp, "\"Min Opts\",");
             fprintf(fp, "\"Loops Cloned\",");
 
             for (int i = 0; i < PHASE_NUMBER_OF; i++)
             {
                 fprintf(fp, "\"%s\",", PhaseNames[i]);
-                if (PhaseReportsIRSize[i])
+                if ((JitConfig.JitMeasureIR() != 0) && PhaseReportsIRSize[i])
                 {
                     fprintf(fp, "\"Node Count After %s\",", PhaseNames[i]);
                 }
@@ -8039,7 +8039,16 @@ void JitTimer::PrintCsvMethodStats(Compiler* comp)
 
     FILE* fp = _wfopen(jitTimeLogCsv, W("a"));
     fprintf(fp, "\"%s\",", methName);
-    fprintf(fp, "%d,", index);
+    if (index != 0)
+    {
+        fprintf(fp, "%d,", index);
+    }
+    else
+    {
+        const char* methodAssemblyName = comp->info.compCompHnd->getAssemblyName(
+            comp->info.compCompHnd->getModuleAssembly(comp->info.compCompHnd->getClassModule(comp->info.compClassHnd)));
+        fprintf(fp, "\"%s\",", methodAssemblyName);
+    }
     fprintf(fp, "%u,", comp->info.compILCodeSize);
     fprintf(fp, "%u,", comp->fgBBcount);
     fprintf(fp, "%u,", comp->opts.MinOpts());
@@ -8053,7 +8062,7 @@ void JitTimer::PrintCsvMethodStats(Compiler* comp)
         }
         fprintf(fp, "%I64u,", m_info.m_cyclesByPhase[i]);
 
-        if (PhaseReportsIRSize[i])
+        if ((JitConfig.JitMeasureIR() != 0) && PhaseReportsIRSize[i])
         {
             fprintf(fp, "%u,", m_info.m_nodeCountAfterPhase[i]);
         }

--- a/src/jit/compphases.h
+++ b/src/jit/compphases.h
@@ -22,6 +22,8 @@
 //     true.
 
 // clang-format off
+//                 enumName                      stringName                        shortName hasChildren measureIR
+//                                                                                                   parent
 CompPhaseNameMacro(PHASE_PRE_IMPORT,             "Pre-import",                     "PRE-IMP",  false, -1, false)
 CompPhaseNameMacro(PHASE_IMPORTATION,            "Importation",                    "IMPORT",   false, -1, true)
 CompPhaseNameMacro(PHASE_POST_IMPORT,            "Post-import",                    "POST-IMP", false, -1, false)

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -2027,7 +2027,7 @@ void LinearScan::identifyCandidates()
     unsigned int floatVarCount        = 0;
     unsigned int thresholdFPRefCntWtd = 4 * BB_UNITY_WEIGHT;
     unsigned int maybeFPRefCntWtd     = 2 * BB_UNITY_WEIGHT;
-    VARSET_TP fpMaybeCandidateVars(VarSetOps::UninitVal());
+    VARSET_TP    fpMaybeCandidateVars(VarSetOps::UninitVal());
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
     unsigned int largeVectorVarCount           = 0;
     unsigned int thresholdLargeVectorRefCntWtd = 4 * BB_UNITY_WEIGHT;
@@ -4697,15 +4697,15 @@ void LinearScan::buildIntervals()
         if (predBlock)
         {
             JITDUMP("\n\nSetting BB%02u as the predecessor for determining incoming variable registers of BB%02u\n",
-                block->bbNum, predBlock->bbNum);
-            assert(predBlock->bbNum <= bbNumMaxBeforeResolution);
+                    block->bbNum, predBlock->bbNum);
+            assert(predBlock->bbNum <= bbNumMaxBeforeResolution); 
             blockInfo[block->bbNum].predBBNum = predBlock->bbNum;
         }
 
         if (enregisterLocalVars)
         {
             VarSetOps::AssignNoCopy(compiler, currentLiveVars,
-                                VarSetOps::Intersection(compiler, registerCandidateVars, block->bbLiveIn));
+                                    VarSetOps::Intersection(compiler, registerCandidateVars, block->bbLiveIn));
 
             if (block == compiler->fgFirstBB)
             {
@@ -4749,8 +4749,8 @@ void LinearScan::buildIntervals()
                     if (isCandidateVar(varDsc) && (predBlock != nullptr || !varDsc->lvIsParam))
                     {
                         Interval*    interval = getIntervalForLocalVar(varIndex);
-                        RefPosition* pos =
-                            newRefPosition(interval, currentLoc, RefTypeDummyDef, nullptr, allRegs(interval->registerType));
+                        RefPosition* pos      = newRefPosition(interval, currentLoc, RefTypeDummyDef, nullptr,
+                                                               allRegs(interval->registerType));
                     }
                 }
                 JITDUMP("Finished creating dummy definitions\n\n");

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -4698,7 +4698,7 @@ void LinearScan::buildIntervals()
         {
             JITDUMP("\n\nSetting BB%02u as the predecessor for determining incoming variable registers of BB%02u\n",
                     block->bbNum, predBlock->bbNum);
-            assert(predBlock->bbNum <= bbNumMaxBeforeResolution); 
+            assert(predBlock->bbNum <= bbNumMaxBeforeResolution);
             blockInfo[block->bbNum].predBBNum = predBlock->bbNum;
         }
 
@@ -4750,7 +4750,7 @@ void LinearScan::buildIntervals()
                     {
                         Interval*    interval = getIntervalForLocalVar(varIndex);
                         RefPosition* pos      = newRefPosition(interval, currentLoc, RefTypeDummyDef, nullptr,
-                                                               allRegs(interval->registerType));
+                                                          allRegs(interval->registerType));
                     }
                 }
                 JITDUMP("Finished creating dummy definitions\n\n");


### PR DESCRIPTION
- Don't create any lclVar intervals if no lclVars are ever enregistered.
- Don't create intervals for tracked lclVars that are not register candidates.
- Don't create any `RegToVarMap`s when no lclVars are ever enregistered.
- Don't do edge resolution if no lclVars are enregistered.
- Eliminate non-candidate lclVars from the sets used by LSRA.

Also:
- Change VarToRegMap to use regNumberSmall.
- Enhance `COMPLus_JitLsraStats` and `COMPlus_JitTimeLogCsv` dumping.