### PR TITLE
Internal hashtable serialization attribute removed

### DIFF
--- a/src/mscorlib/src/System/Collections/Hashtable.cs
+++ b/src/mscorlib/src/System/Collections/Hashtable.cs
@@ -66,7 +66,6 @@ namespace System.Collections
     // 
     [DebuggerTypeProxy(typeof(System.Collections.Hashtable.HashtableDebugView))]
     [DebuggerDisplay("Count = {Count}")]
-    [Serializable]
     internal class Hashtable : IDictionary, ISerializable, IDeserializationCallback, ICloneable
     {
         /*


### PR DESCRIPTION
cc @danmosemsft 

we missed that one change.