### PR TITLE
[RyuJIT/ARM32] Rearrange NYI related to struct

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -3407,11 +3407,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                     size = (unsigned)(roundUp(info.compCompHnd->getClassSize(argx->gtArgPlace.gtArgPlaceClsHnd),
                                               TARGET_POINTER_SIZE)) /
                            TARGET_POINTER_SIZE;
-                    if (isHfaArg)
-                    {
-                        hasMultiregStructArgs = true;
-                    }
-                    else if (size > 1 && size <= 4)
+                    if (isHfaArg || size > 1)
                     {
                         hasMultiregStructArgs = true;
                     }
@@ -3800,16 +3796,10 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
 #elif defined(_TARGET_ARM_)
                 // TODO-Arm: Need to handle the case
                 // where structs passed by value can be split between registers and stack.
-                if (size > 1 && size <= 4)
+                if (size > 1)
                 {
                     hasMultiregStructArgs = true;
                 }
-#ifndef LEGACY_BACKEND
-                else if (size > 4 && passUsingIntRegs)
-                {
-                    NYI_ARM("Struct can be split between registers and stack");
-                }
-#endif // !LEGACY_BACKEND
 #endif // _TARGET_ARM_
             }
 
@@ -4102,9 +4092,6 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
 #ifdef _TARGET_ARM_
                         if (fltArgRegNum > MAX_FLOAT_REG_ARG)
                         {
-#ifndef LEGACY_BACKEND
-                            NYI_ARM("Struct split between float registers and stack");
-#endif // !LEGACY_BACKEND
                             // This indicates a partial enregistration of a struct type
                             assert(varTypeIsStruct(argx));
                             unsigned numRegsPartial = size - (fltArgRegNum - MAX_FLOAT_REG_ARG);
@@ -4134,9 +4121,6 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
 #ifdef _TARGET_ARM_
                         if (intArgRegNum > MAX_REG_ARG)
                         {
-#ifndef LEGACY_BACKEND
-                            NYI_ARM("Struct split between integer registers and stack");
-#endif // !LEGACY_BACKEND
                             // This indicates a partial enregistration of a struct type
                             assert((isStructArg) || argx->OperIsCopyBlkOp() ||
                                    (argx->gtOper == GT_COMMA && (args->gtFlags & GTF_ASG)));
@@ -4758,6 +4742,29 @@ GenTreePtr Compiler::fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr f
 
 #ifndef _TARGET_ARMARCH_
     NYI("fgMorphMultiregStructArg requires implementation for this target");
+#endif
+
+#ifdef _TARGET_ARM_
+    if (fgEntryPtr->isSplit)
+    {
+        if(fgEntryPtr->isHfaRegArg)
+        {
+            NYI_ARM("HFA struct splitted between float registers and stack");
+        }
+        else if (fgEntryPtr->numRegs + fgEntryPtr->numSlots <= 4)
+        {
+            NYI_ARM("Struct smaller than 16 bytes splitted between integer registers and stack");
+        }
+        else
+        {
+            NYI_ARM("Struct larger than 16 bytes splitted between integer registers and stack");
+        }
+    }
+    else if (!fgEntryPtr->isHfaRegArg && fgEntryPtr->numSlots > 4)
+    {
+        // Struct larger than 16 byte is not morphed to GT_FIELD_LIST on ARM
+        return arg;
+    }
 #endif
 
 #if FEATURE_MULTIREG_ARGS

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -4747,7 +4747,7 @@ GenTreePtr Compiler::fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr f
 #ifdef _TARGET_ARM_
     if (fgEntryPtr->isSplit)
     {
-        if(fgEntryPtr->isHfaRegArg)
+        if (fgEntryPtr->isHfaRegArg)
         {
             NYI_ARM("HFA struct splitted between float registers and stack");
         }


### PR DESCRIPTION
Rearrange NYI related to struct by removing NYI from fgMorphArg to fgMorphMultiregStructArg.
It'll help dividing implementation for struct argument passing on RyuJIT/ARM32.