### PR TITLE
[x64/Linux] Use correct argument registers in InterpreterStub

### DIFF
--- a/src/vm/amd64/cgencpu.h
+++ b/src/vm/amd64/cgencpu.h
@@ -268,6 +268,14 @@ struct CalleeSavedRegistersPointers {
 #define THIS_kREG kRCX
 #endif
 
+#ifdef PLATFORM_UNIX
+#define ARG1_kREG kRDI
+#define ARG2_kREG kRSI
+#else // PLATFORM_UNIX
+#define ARG1_kREG kRCX
+#define ARG2_kREG kRDX
+#endif // !PLATFORM_UNIX
+
 #ifdef UNIX_AMD64_ABI
 
 #define NUM_FLOAT_ARGUMENT_REGISTERS 8

--- a/src/vm/amd64/cgencpu.h
+++ b/src/vm/amd64/cgencpu.h
@@ -263,18 +263,16 @@ struct CalleeSavedRegistersPointers {
 #ifdef UNIX_AMD64_ABI
 #define THIS_REG RDI
 #define THIS_kREG kRDI
+
+#define ARGUMENT_kREG1 kRDI
+#define ARGUMENT_kREG2 kRSI
 #else
 #define THIS_REG RCX
 #define THIS_kREG kRCX
-#endif
 
-#ifdef PLATFORM_UNIX
-#define ARG1_kREG kRDI
-#define ARG2_kREG kRSI
-#else // PLATFORM_UNIX
-#define ARG1_kREG kRCX
-#define ARG2_kREG kRDX
-#endif // !PLATFORM_UNIX
+#define ARGUMENT_kREG1 kRCX
+#define ARGUMENT_kREG2 kRDX
+#endif
 
 #ifdef UNIX_AMD64_ABI
 

--- a/src/vm/interpreter.cpp
+++ b/src/vm/interpreter.cpp
@@ -1431,8 +1431,8 @@ CorJitResult Interpreter::GenerateInterpreterStub(CEEInfo* comp,
         sl.X86EmitPopReg(kEBP);
         sl.X86EmitReturn(static_cast<WORD>(argState.callerArgStackSlots * sizeof(void*)));
 #elif defined(_AMD64_)
-        // EDX has "ilArgs" i.e., just the point where registers have been homed.
-        sl.X86EmitIndexLeaRSP(kEDX, static_cast<X86Reg>(kESP_Unsafe), 8);
+        // Pass "ilArgs", i.e. just the point where registers have been homed, as 2nd arg
+        sl.X86EmitIndexLeaRSP(kRSI, static_cast<X86Reg>(kESP_Unsafe), 8);
 
         // Allocate space for homing callee's (InterpretMethod's) arguments.
         // Calling convention requires a default allocation space of 4,
@@ -1450,10 +1450,10 @@ CorJitResult Interpreter::GenerateInterpreterStub(CEEInfo* comp,
 #endif
         {
             // For a non-ILStub method, push NULL as the StubContext argument.
-            sl.X86EmitZeroOutReg(kRCX);
-            sl.X86EmitMovRegReg(kR8, kRCX);
+            sl.X86EmitZeroOutReg(kRDX);
+            sl.X86EmitMovRegReg(kR8, kRDX);
         }
-        sl.X86EmitRegLoad(kRCX, reinterpret_cast<UINT_PTR>(interpMethInfo));
+        sl.X86EmitRegLoad(kRDI, reinterpret_cast<UINT_PTR>(interpMethInfo));
         sl.X86EmitCall(sl.NewExternalCodeLabel(interpretMethodFunc), 0);
         sl.X86EmitAddEsp(interpMethodArgSize);
         sl.X86EmitReturn(0);
@@ -9558,7 +9558,7 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
 
     // This is the argument slot that will be used to hold the return value.
     ARG_SLOT retVal = 0;
-#ifndef _ARM_
+#if !defined(_ARM_) && !defined(UNIX_AMD64_ABI)
     _ASSERTE (NUMBER_RETURNVALUE_SLOTS == 1);
 #endif
 

--- a/src/vm/interpreter.cpp
+++ b/src/vm/interpreter.cpp
@@ -1432,7 +1432,7 @@ CorJitResult Interpreter::GenerateInterpreterStub(CEEInfo* comp,
         sl.X86EmitReturn(static_cast<WORD>(argState.callerArgStackSlots * sizeof(void*)));
 #elif defined(_AMD64_)
         // Pass "ilArgs", i.e. just the point where registers have been homed, as 2nd arg
-        sl.X86EmitIndexLeaRSP(ARG2_kREG, static_cast<X86Reg>(kESP_Unsafe), 8);
+        sl.X86EmitIndexLeaRSP(ARGUMENT_kREG2, static_cast<X86Reg>(kESP_Unsafe), 8);
 
         // Allocate space for homing callee's (InterpretMethod's) arguments.
         // Calling convention requires a default allocation space of 4,
@@ -1450,10 +1450,10 @@ CorJitResult Interpreter::GenerateInterpreterStub(CEEInfo* comp,
 #endif
         {
             // For a non-ILStub method, push NULL as the StubContext argument.
-            sl.X86EmitZeroOutReg(ARG1_kREG);
-            sl.X86EmitMovRegReg(kR8, ARG1_kREG);
+            sl.X86EmitZeroOutReg(ARGUMENT_kREG1);
+            sl.X86EmitMovRegReg(kR8, ARGUMENT_kREG1);
         }
-        sl.X86EmitRegLoad(ARG1_kREG, reinterpret_cast<UINT_PTR>(interpMethInfo));
+        sl.X86EmitRegLoad(ARGUMENT_kREG1, reinterpret_cast<UINT_PTR>(interpMethInfo));
         sl.X86EmitCall(sl.NewExternalCodeLabel(interpretMethodFunc), 0);
         sl.X86EmitAddEsp(interpMethodArgSize);
         sl.X86EmitReturn(0);

--- a/src/vm/interpreter.cpp
+++ b/src/vm/interpreter.cpp
@@ -1431,16 +1431,8 @@ CorJitResult Interpreter::GenerateInterpreterStub(CEEInfo* comp,
         sl.X86EmitPopReg(kEBP);
         sl.X86EmitReturn(static_cast<WORD>(argState.callerArgStackSlots * sizeof(void*)));
 #elif defined(_AMD64_)
-        X86Reg argRegs[] = {
-#ifndef PLATFORM_UNIX
-          kRCX, kEDX
-#else // PLATFORM_UNIX
-          kRDI, kRSI
-#endif // PLATFORM_UNIX
-        };
-
         // Pass "ilArgs", i.e. just the point where registers have been homed, as 2nd arg
-        sl.X86EmitIndexLeaRSP(argRegs[1], static_cast<X86Reg>(kESP_Unsafe), 8);
+        sl.X86EmitIndexLeaRSP(ARG2_kREG, static_cast<X86Reg>(kESP_Unsafe), 8);
 
         // Allocate space for homing callee's (InterpretMethod's) arguments.
         // Calling convention requires a default allocation space of 4,
@@ -1458,10 +1450,10 @@ CorJitResult Interpreter::GenerateInterpreterStub(CEEInfo* comp,
 #endif
         {
             // For a non-ILStub method, push NULL as the StubContext argument.
-            sl.X86EmitZeroOutReg(argRegs[0]);
-            sl.X86EmitMovRegReg(kR8, argRegs[0]);
+            sl.X86EmitZeroOutReg(ARG1_kREG);
+            sl.X86EmitMovRegReg(kR8, ARG1_kREG);
         }
-        sl.X86EmitRegLoad(argRegs[0], reinterpret_cast<UINT_PTR>(interpMethInfo));
+        sl.X86EmitRegLoad(ARG1_kREG, reinterpret_cast<UINT_PTR>(interpMethInfo));
         sl.X86EmitCall(sl.NewExternalCodeLabel(interpretMethodFunc), 0);
         sl.X86EmitAddEsp(interpMethodArgSize);
         sl.X86EmitReturn(0);


### PR DESCRIPTION
This commit allows us to interpret Main in a simple "Hello, World" application in x64/Linux.