### PR TITLE
Post-Serialization cleanup fixes to Reflection

### DIFF
--- a/src/mscorlib/shared/System/Reflection/Assembly.cs
+++ b/src/mscorlib/shared/System/Reflection/Assembly.cs
@@ -125,10 +125,7 @@ namespace System.Reflection
         public virtual FileStream[] GetFiles() => GetFiles(getResourceModules: false);
         public virtual FileStream[] GetFiles(bool getResourceModules) { throw NotImplemented.ByDesign; }
 
-        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            throw new PlatformNotSupportedException();
-        }
+        public virtual void GetObjectData(SerializationInfo info, StreamingContext context) { throw NotImplemented.ByDesign; }
 
         public override string ToString()
         {

--- a/src/mscorlib/shared/System/Reflection/Module.cs
+++ b/src/mscorlib/shared/System/Reflection/Module.cs
@@ -110,10 +110,7 @@ namespace System.Reflection
         public Type ResolveType(int metadataToken) => ResolveType(metadataToken, null, null);
         public virtual Type ResolveType(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments) { throw NotImplemented.ByDesign; }
 
-        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            throw new PlatformNotSupportedException();
-        }
+        public virtual void GetObjectData(SerializationInfo info, StreamingContext context) { throw NotImplemented.ByDesign; }
 
         public override bool Equals(object o) => base.Equals(o);
         public override int GetHashCode() => base.GetHashCode();

--- a/src/mscorlib/shared/System/Reflection/ParameterInfo.cs
+++ b/src/mscorlib/shared/System/Reflection/ParameterInfo.cs
@@ -54,7 +54,46 @@ namespace System.Reflection
 
         public object GetRealObject(StreamingContext context)
         {
-            throw new PlatformNotSupportedException();
+            // Once all the serializable fields have come in we can set up the real
+            // instance based on just two of them (MemberImpl and PositionImpl).
+
+            if (MemberImpl == null)
+                throw new SerializationException(SR.Serialization_InsufficientState);
+
+            ParameterInfo[] args = null;
+
+            switch (MemberImpl.MemberType)
+            {
+                case MemberTypes.Constructor:
+                case MemberTypes.Method:
+                    if (PositionImpl == -1)
+                    {
+                        if (MemberImpl.MemberType == MemberTypes.Method)
+                            return ((MethodInfo)MemberImpl).ReturnParameter;
+                        else
+                            throw new SerializationException(SR.Serialization_BadParameterInfo);
+                    }
+                    else
+                    {
+                        args = ((MethodBase)MemberImpl).GetParametersNoCopy();
+
+                        if (args != null && PositionImpl < args.Length)
+                            return args[PositionImpl];
+                        else
+                            throw new SerializationException(SR.Serialization_BadParameterInfo);
+                    }
+
+                case MemberTypes.Property:
+                    args = ((PropertyInfo)MemberImpl).GetIndexParameters();
+
+                    if (args != null && PositionImpl > -1 && PositionImpl < args.Length)
+                        return args[PositionImpl];
+                    else
+                        throw new SerializationException(SR.Serialization_BadParameterInfo);
+
+                default:
+                    throw new SerializationException(SR.Serialization_NoParameterInfo);
+            }
         }
 
         public override string ToString() => ParameterType.FormatTypeName() + " " + Name;

--- a/src/mscorlib/src/System/Reflection/MdFieldInfo.cs
+++ b/src/mscorlib/src/System/Reflection/MdFieldInfo.cs
@@ -4,12 +4,11 @@
 
 using System.Diagnostics;
 using System.Globalization;
-using System.Runtime.Serialization;
 using RuntimeTypeCache = System.RuntimeType.RuntimeTypeCache;
 
 namespace System.Reflection
 {
-    internal sealed unsafe class MdFieldInfo : RuntimeFieldInfo, ISerializable
+    internal sealed unsafe class MdFieldInfo : RuntimeFieldInfo
     {
         #region Private Data Members
         private int m_tkField;

--- a/src/mscorlib/src/System/Reflection/RuntimeConstructorInfo.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimeConstructorInfo.cs
@@ -6,12 +6,11 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Globalization;
-using System.Runtime.Serialization;
 using RuntimeTypeCache = System.RuntimeType.RuntimeTypeCache;
 
 namespace System.Reflection
 {
-    internal sealed class RuntimeConstructorInfo : ConstructorInfo, ISerializable, IRuntimeMethodInfo
+    internal sealed class RuntimeConstructorInfo : ConstructorInfo, IRuntimeMethodInfo
     {
         #region Private Data Members
         private volatile RuntimeType m_declaringType;
@@ -460,19 +459,6 @@ namespace System.Reflection
                 return retValue;
             }
             return RuntimeMethodHandle.InvokeMethod(null, null, sig, true);
-        }
-        #endregion
-
-        #region ISerializable Implementation
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            throw new PlatformNotSupportedException();
-        }
-
-        internal string SerializationToString()
-        {
-            // We don't need the return type for constructors.
-            return FormatNameAndSig(true);
         }
         #endregion
     }

--- a/src/mscorlib/src/System/Reflection/RuntimeEventInfo.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimeEventInfo.cs
@@ -5,12 +5,11 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
-using System.Runtime.Serialization;
 using RuntimeTypeCache = System.RuntimeType.RuntimeTypeCache;
 
 namespace System.Reflection
 {
-    internal unsafe sealed class RuntimeEventInfo : EventInfo, ISerializable
+    internal unsafe sealed class RuntimeEventInfo : EventInfo
     {
         #region Private Data Members
         private int m_token;
@@ -154,13 +153,6 @@ namespace System.Reflection
         public override int MetadataToken { get { return m_token; } }
         public override Module Module { get { return GetRuntimeModule(); } }
         internal RuntimeModule GetRuntimeModule() { return m_declaringType.GetRuntimeModule(); }
-        #endregion
-
-        #region ISerializable
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            throw new PlatformNotSupportedException();
-        }
         #endregion
 
         #region EventInfo Overrides

--- a/src/mscorlib/src/System/Reflection/RuntimeFieldInfo.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimeFieldInfo.cs
@@ -4,12 +4,11 @@
 
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
-using System.Runtime.Serialization;
 using RuntimeTypeCache = System.RuntimeType.RuntimeTypeCache;
 
 namespace System.Reflection
 {
-    internal abstract class RuntimeFieldInfo : FieldInfo, ISerializable
+    internal abstract class RuntimeFieldInfo : FieldInfo
     {
         #region Private Data Members
         private BindingFlags m_bindingFlags;
@@ -121,13 +120,6 @@ namespace System.Reflection
 
         #region FieldInfo Overrides
         // All implemented on derived classes
-        #endregion
-
-        #region ISerializable Implementation
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            throw new PlatformNotSupportedException();
-        }
         #endregion
     }
 }

--- a/src/mscorlib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Globalization;
-using System.Runtime.Serialization;
 using System.Security;
 using System.Text;
 using System.Threading;
@@ -14,7 +13,7 @@ using RuntimeTypeCache = System.RuntimeType.RuntimeTypeCache;
 
 namespace System.Reflection
 {
-    internal sealed class RuntimeMethodInfo : MethodInfo, ISerializable, IRuntimeMethodInfo
+    internal sealed class RuntimeMethodInfo : MethodInfo, IRuntimeMethodInfo
     {
         #region Private Data Members
         private IntPtr m_handle;
@@ -767,18 +766,6 @@ namespace System.Reflection
 
                 return false;
             }
-        }
-        #endregion
-
-        #region ISerializable Implementation
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            throw new PlatformNotSupportedException();
-        }
-
-        internal string SerializationToString()
-        {
-            return ReturnType.FormatTypeName(true) + " " + FormatNameAndSig(true);
         }
         #endregion
 

--- a/src/mscorlib/src/System/Reflection/RuntimeParameterInfo.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimeParameterInfo.cs
@@ -5,13 +5,12 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
-using System.Runtime.Serialization;
 using System.Runtime.CompilerServices;
 using MdToken = System.Reflection.MetadataToken;
 
 namespace System.Reflection
 {
-    internal unsafe sealed class RuntimeParameterInfo : ParameterInfo, ISerializable
+    internal unsafe sealed class RuntimeParameterInfo : ParameterInfo
     {
         #region Static Members
         internal unsafe static ParameterInfo[] GetParameters(IRuntimeMethodInfo method, MemberInfo member, Signature sig)
@@ -157,13 +156,6 @@ namespace System.Reflection
         internal void SetAttributes(ParameterAttributes attributes)
         {
             AttrsImpl = attributes;
-        }
-        #endregion
-
-        #region VTS magic to serialize/deserialized to/from pre-Whidbey endpoints.
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            throw new PlatformNotSupportedException();
         }
         #endregion
 

--- a/src/mscorlib/src/System/Reflection/RuntimePropertyInfo.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimePropertyInfo.cs
@@ -6,13 +6,12 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Globalization;
-using System.Runtime.Serialization;
 using System.Text;
 using RuntimeTypeCache = System.RuntimeType.RuntimeTypeCache;
 
 namespace System.Reflection
 {
-    internal unsafe sealed class RuntimePropertyInfo : PropertyInfo, ISerializable
+    internal unsafe sealed class RuntimePropertyInfo : PropertyInfo
     {
         #region Private Data Members
         private int m_token;
@@ -447,18 +446,6 @@ namespace System.Reflection
         }
         #endregion
 
-        #endregion
-
-        #region ISerializable Implementation
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            throw new PlatformNotSupportedException();
-        }
-
-        internal string SerializationToString()
-        {
-            return FormatNameAndSig(true);
-        }
         #endregion
     }
 }

--- a/src/mscorlib/src/System/RtType.cs
+++ b/src/mscorlib/src/System/RtType.cs
@@ -19,7 +19,6 @@ using System.Diagnostics;
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime;
-using System.Runtime.Serialization;
 using System.Runtime.CompilerServices;
 using System.Security;
 using System.Text;
@@ -72,7 +71,7 @@ namespace System
     }
 
     internal class RuntimeType :
-        System.Reflection.TypeInfo, ISerializable, ICloneable
+        System.Reflection.TypeInfo, ICloneable
     {
         #region Definitions
 
@@ -4441,13 +4440,6 @@ namespace System
         public Object Clone()
         {
             return this;
-        }
-        #endregion
-
-        #region ISerializable
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            throw new PlatformNotSupportedException();
         }
         #endregion
 


### PR DESCRIPTION
This is based on the following principles:

- We should not be making changes to instance/virtual methods
in the abstract base types for Reflection. These are apis
in themselves to third party classes that subclass these types.
Even if the Runtime chooses not to make its own implementations
of these type serializable, third party classes have the right
to make that choice for themselves and build off the base class
serialization infrastructure that was shipped before.

RuntimeAssembly and RuntimeModule still override with PNSE
so we'll get the desired exception for those cases.

- The Runtime's own implementations of these types will not be
serializable. Removing all [Serializable] attributes and
serialization interfaces. Runtime types are internal types and
thus have no duty to implement ISerializable if the public
abstract base type does not.