### PR TITLE
Additional fix for ETW failure in 32 process on 64 bit machines.

### DIFF
--- a/src/mscorlib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -1134,7 +1134,7 @@ namespace System.Diagnostics.Tracing
             /// Address where the one argument lives (if this points to managed memory you must ensure the
             /// managed object is pinned.
             /// </summary>
-            public IntPtr DataPointer { get { return (IntPtr)m_Ptr; } set { m_Ptr = unchecked((ulong)value); } }
+            public unsafe IntPtr DataPointer { get { return (IntPtr)m_Ptr; } set { m_Ptr = unchecked((ulong)(void*)value); } }
             /// <summary>
             /// Size of the argument referenced by DataPointer
             /// </summary>

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -1134,7 +1134,7 @@ namespace System.Diagnostics.Tracing
             /// Address where the one argument lives (if this points to managed memory you must ensure the
             /// managed object is pinned.
             /// </summary>
-            public unsafe IntPtr DataPointer { get { return (IntPtr)m_Ptr; } set { m_Ptr = unchecked((ulong)(void*)value); } }
+            public unsafe IntPtr DataPointer { get { return (IntPtr)(void*)m_Ptr; } set { m_Ptr = unchecked((ulong)(void*)value); } }
             /// <summary>
             /// Size of the argument referenced by DataPointer
             /// </summary>


### PR DESCRIPTION
The commit associated with Pull Request
    Fix failures in ETW logging on 4GB aware 32 bit processes #11941

Was incorrect.   Some long were changed to ulong, but the critical casting an IntPtr to ulong still does
sign extension and not zero extension.   Need to cast to a void* first.  This fixes this.

@sharwell  @brianrob 

Fixes issue #12015