### PR TITLE
Skip argTable assignment for split struct when remorphing

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1339,7 +1339,9 @@ public:
                                unsigned   numSlots,
                                unsigned alignment FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY_ARG(const bool isStruct));
 
+#ifdef DEBUG
     void             RemorphReset();
+#endif
     fgArgTabEntryPtr RemorphRegArg(
         unsigned argNum, GenTreePtr node, GenTreePtr parent, regNumber regNum, unsigned numRegs, unsigned alignment);
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1340,7 +1340,7 @@ public:
                                unsigned alignment FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY_ARG(const bool isStruct));
 
 #ifdef DEBUG
-    void             RemorphReset();
+    void RemorphReset();
 #endif
     fgArgTabEntryPtr RemorphRegArg(
         unsigned argNum, GenTreePtr node, GenTreePtr parent, regNumber regNum, unsigned numRegs, unsigned alignment);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1339,15 +1339,13 @@ public:
                                unsigned   numSlots,
                                unsigned alignment FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY_ARG(const bool isStruct));
 
-#ifdef DEBUG
-    void RemorphReset();
-#endif
+    void             RemorphReset();
     fgArgTabEntryPtr RemorphRegArg(
         unsigned argNum, GenTreePtr node, GenTreePtr parent, regNumber regNum, unsigned numRegs, unsigned alignment);
 
     void RemorphStkArg(unsigned argNum, GenTreePtr node, GenTreePtr parent, unsigned numSlots, unsigned alignment);
 
-    void SplitArg(unsigned argNum, unsigned numRegs, unsigned numSlots, bool isReMorph);
+    void SplitArg(unsigned argNum, unsigned numRegs, unsigned numSlots);
 
     void EvalToTmp(unsigned argNum, unsigned tmpNum, GenTreePtr newNode);
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1345,7 +1345,7 @@ public:
 
     void RemorphStkArg(unsigned argNum, GenTreePtr node, GenTreePtr parent, unsigned numSlots, unsigned alignment);
 
-    void SplitArg(unsigned argNum, unsigned numRegs, unsigned numSlots);
+    void SplitArg(unsigned argNum, unsigned numRegs, unsigned numSlots, bool isReMorph);
 
     void EvalToTmp(unsigned argNum, unsigned tmpNum, GenTreePtr newNode);
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -4147,8 +4147,8 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                             NYI_ARM("Struct split between integer registers and stack");
 #endif // !LEGACY_BACKEND
                             // This indicates a partial enregistration of a struct type
-                            assert((isStructArg) || argx->OperIsFieldList() ||
-                                   argx->OperIsCopyBlkOp() || (argx->gtOper == GT_COMMA && (args->gtFlags & GTF_ASG)));
+                            assert((isStructArg) || argx->OperIsFieldList() || argx->OperIsCopyBlkOp() ||
+                                   (argx->gtOper == GT_COMMA && (args->gtFlags & GTF_ASG)));
                             unsigned numRegsPartial = size - (intArgRegNum - MAX_REG_ARG);
                             assert((unsigned char)numRegsPartial == numRegsPartial);
                             call->fgArgInfo->SplitArg(argIndex, numRegsPartial, size - numRegsPartial, reMorphing);

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2831,7 +2831,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
             fgPtrArgCntCur -= callStkLevel;
         }
         assert(call->fgArgInfo != nullptr);
-#ifndef DEBUG
+#ifdef DEBUG
         call->fgArgInfo->RemorphReset();
 #endif
 
@@ -4131,7 +4131,9 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
 #ifndef DEBUG
                             if (!reMorphing)
 #endif
-                            call->fgArgInfo->SplitArg(argIndex, numRegsPartial, size - numRegsPartial, reMorphing);
+                            {
+                                call->fgArgInfo->SplitArg(argIndex, numRegsPartial, size - numRegsPartial, reMorphing);
+                            }
                             fltArgRegNum = MAX_FLOAT_REG_ARG;
                         }
 #endif // _TARGET_ARM_
@@ -4167,7 +4169,9 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
 #ifndef DEBUG
                             if (!reMorphing)
 #endif
-                            call->fgArgInfo->SplitArg(argIndex, numRegsPartial, size - numRegsPartial, reMorphing);
+                            {
+                                call->fgArgInfo->SplitArg(argIndex, numRegsPartial, size - numRegsPartial, reMorphing);
+                            }
                             intArgRegNum = MAX_REG_ARG;
                             fgPtrArgCntCur += size - numRegsPartial;
                         }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -1319,9 +1319,7 @@ void fgArgInfo::RemorphStkArg(
         }
     }
 
-#ifdef DEBUG
     nextSlotNum = (unsigned)roundUp(nextSlotNum, alignment);
-#endif
 
     assert(curArgTabEntry->argNum == argNum);
     assert(curArgTabEntry->slotNum == nextSlotNum);

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -1367,7 +1367,7 @@ void fgArgInfo::RemorphStkArg(
     nextSlotNum += numSlots;
 }
 
-void fgArgInfo::SplitArg(unsigned argNum, unsigned numRegs, unsigned numSlots)
+void fgArgInfo::SplitArg(unsigned argNum, unsigned numRegs, unsigned numSlots, bool isReMorph)
 {
     fgArgTabEntryPtr curArgTabEntry = nullptr;
     assert(argNum < argCount);
@@ -1383,9 +1383,18 @@ void fgArgInfo::SplitArg(unsigned argNum, unsigned numRegs, unsigned numSlots)
     assert(numRegs > 0);
     assert(numSlots > 0);
 
-    curArgTabEntry->isSplit  = true;
-    curArgTabEntry->numRegs  = numRegs;
-    curArgTabEntry->numSlots = numSlots;
+    if (isReMorph)
+    {
+        assert(curArgTabEntry->isSplit == true);
+        assert(curArgTabEntry->numRegs == numRegs);
+        assert(curArgTabEntry->numSlots == numSlots);
+    }
+    else
+    {
+        curArgTabEntry->isSplit  = true;
+        curArgTabEntry->numRegs  = numRegs;
+        curArgTabEntry->numSlots = numSlots;
+    }
 
     nextSlotNum += numSlots;
 }
@@ -4109,7 +4118,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                             assert(varTypeIsStruct(argx));
                             unsigned numRegsPartial = size - (fltArgRegNum - MAX_FLOAT_REG_ARG);
                             assert((unsigned char)numRegsPartial == numRegsPartial);
-                            call->fgArgInfo->SplitArg(argIndex, numRegsPartial, size - numRegsPartial);
+                            call->fgArgInfo->SplitArg(argIndex, numRegsPartial, size - numRegsPartial, reMorphing);
                             fltArgRegNum = MAX_FLOAT_REG_ARG;
                         }
 #endif // _TARGET_ARM_
@@ -4138,11 +4147,11 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                             NYI_ARM("Struct split between integer registers and stack");
 #endif // !LEGACY_BACKEND
                             // This indicates a partial enregistration of a struct type
-                            assert((isStructArg) || argx->OperIsCopyBlkOp() ||
-                                   (argx->gtOper == GT_COMMA && (args->gtFlags & GTF_ASG)));
+                            assert((isStructArg) || argx->OperIsFieldList() ||
+                                   argx->OperIsCopyBlkOp() || (argx->gtOper == GT_COMMA && (args->gtFlags & GTF_ASG)));
                             unsigned numRegsPartial = size - (intArgRegNum - MAX_REG_ARG);
                             assert((unsigned char)numRegsPartial == numRegsPartial);
-                            call->fgArgInfo->SplitArg(argIndex, numRegsPartial, size - numRegsPartial);
+                            call->fgArgInfo->SplitArg(argIndex, numRegsPartial, size - numRegsPartial, reMorphing);
                             intArgRegNum = MAX_REG_ARG;
                             fgPtrArgCntCur += size - numRegsPartial;
                         }


### PR DESCRIPTION
- Skip argTable no. of register & stack slot assignment for split struct when remorphing
- Modify assertion check condition for structs morphed to GT_FIELD_LIST

cc/ @dotnet/arm32-contrib 