### PR TITLE
Fix regression in third party ParameterInfo serialization.

### DIFF
--- a/src/mscorlib/shared/System/Reflection/Assembly.cs
+++ b/src/mscorlib/shared/System/Reflection/Assembly.cs
@@ -125,10 +125,7 @@ namespace System.Reflection
         public virtual FileStream[] GetFiles() => GetFiles(getResourceModules: false);
         public virtual FileStream[] GetFiles(bool getResourceModules) { throw NotImplemented.ByDesign; }
 
-        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            throw new PlatformNotSupportedException();
-        }
+        public virtual void GetObjectData(SerializationInfo info, StreamingContext context) { throw NotImplemented.ByDesign; }
 
         public override string ToString()
         {

--- a/src/mscorlib/shared/System/Reflection/Module.cs
+++ b/src/mscorlib/shared/System/Reflection/Module.cs
@@ -110,10 +110,7 @@ namespace System.Reflection
         public Type ResolveType(int metadataToken) => ResolveType(metadataToken, null, null);
         public virtual Type ResolveType(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments) { throw NotImplemented.ByDesign; }
 
-        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            throw new PlatformNotSupportedException();
-        }
+        public virtual void GetObjectData(SerializationInfo info, StreamingContext context) { throw NotImplemented.ByDesign; }
 
         public override bool Equals(object o) => base.Equals(o);
         public override int GetHashCode() => base.GetHashCode();

--- a/src/mscorlib/shared/System/Reflection/ParameterInfo.cs
+++ b/src/mscorlib/shared/System/Reflection/ParameterInfo.cs
@@ -54,7 +54,46 @@ namespace System.Reflection
 
         public object GetRealObject(StreamingContext context)
         {
-            throw new PlatformNotSupportedException();
+            // Once all the serializable fields have come in we can set up the real
+            // instance based on just two of them (MemberImpl and PositionImpl).
+
+            if (MemberImpl == null)
+                throw new SerializationException(SR.Serialization_InsufficientState);
+
+            ParameterInfo[] args = null;
+
+            switch (MemberImpl.MemberType)
+            {
+                case MemberTypes.Constructor:
+                case MemberTypes.Method:
+                    if (PositionImpl == -1)
+                    {
+                        if (MemberImpl.MemberType == MemberTypes.Method)
+                            return ((MethodInfo)MemberImpl).ReturnParameter;
+                        else
+                            throw new SerializationException(SR.Serialization_BadParameterInfo);
+                    }
+                    else
+                    {
+                        args = ((MethodBase)MemberImpl).GetParametersNoCopy();
+
+                        if (args != null && PositionImpl < args.Length)
+                            return args[PositionImpl];
+                        else
+                            throw new SerializationException(SR.Serialization_BadParameterInfo);
+                    }
+
+                case MemberTypes.Property:
+                    args = ((PropertyInfo)MemberImpl).GetIndexParameters();
+
+                    if (args != null && PositionImpl > -1 && PositionImpl < args.Length)
+                        return args[PositionImpl];
+                    else
+                        throw new SerializationException(SR.Serialization_BadParameterInfo);
+
+                default:
+                    throw new SerializationException(SR.Serialization_NoParameterInfo);
+            }
         }
 
         public override string ToString() => ParameterType.FormatTypeName() + " " + Name;


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/20574

The decision to make the runtime's implementation of
Reflection objects non-serializable went too far
and changed the behaviors of methods inherited by
all Reflection implementors. In particular, by
changing ParameterInfo.GetRealObject() to throw PNSE,
all third-party implementations of ParameterInfo become
undeserializable, not just the runtime's implementation.
The intended change was to make the runtime's implementation
non-serializable which is already accomplished by removing
[Serializable] from RuntimeParameterInfo.

The methods on the abstract base classes for Reflection
are "apis" to all Reflection implementors and their long-standing
behaviors should not change based on decisions made
by the runtime's particular implementation.

This commit rolls back those changes that were introduced
as part of https://github.com/dotnet/coreclr/pull/12020.