### PR TITLE
Add support for not breaking build on warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ if(CORECLR_SET_RPATH)
 endif(CORECLR_SET_RPATH)
 
 OPTION(CMAKE_ENABLE_CODE_COVERAGE "Enable code coverage" OFF)
+OPTION(CLR_CMAKE_WARNINGS_ARE_ERRORS "Warnings are errors" ON)
 
 # Ensure that python is present
 find_program(PYTHON python)

--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ fi
 
 usage()
 {
-    echo "Usage: $0 [BuildArch] [BuildType] [verbose] [coverage] [cross] [clangx.y] [ninja] [configureonly] [skipconfigure] [skipnative] [skipmscorlib] [skiptests] [stripsymbols] [cmakeargs] [bindir]"
+    echo "Usage: $0 [BuildArch] [BuildType] [verbose] [coverage] [cross] [clangx.y] [ninja] [configureonly] [skipconfigure] [skipnative] [skipmscorlib] [skiptests] [stripsymbols] [ignorewarnings] [cmakeargs] [bindir]"
     echo "BuildArch can be: x64, x86, arm, armel, arm64"
     echo "BuildType can be: debug, checked, release"
     echo "coverage - optional argument to enable code coverage build (currently supported only for Linux and OSX)."
@@ -47,6 +47,7 @@ usage()
 	echo "-Rebuild: passes /t:rebuild to the build projects."
     echo "stripSymbols - Optional argument to strip native symbols during the build."
     echo "skipgenerateversion - disable version generation even if MSBuild is supported."
+    echo "ignorewarnings - do not treat warnings as errors"
     echo "cmakeargs - user-settable additional arguments passed to CMake."
     echo "bindir - output directory (defaults to $__ProjectRoot/bin)"
     echo "buildstandalonegc - builds the GC in a standalone mode. Can't be used with \"cmakeargs\"."
@@ -173,11 +174,17 @@ generate_event_logging_sources()
 
     mkdir -p "$__GeneratedIntermediateEventProvider"
     mkdir -p "$__GeneratedIntermediateEventPipe"
+
+    __PythonWarningFlags="-Wall"
+    if [[ $__IgnoreWarnings == 0 ]]; then
+        __PythonWarningFlags="$__PythonWarningFlags -Werror"
+    fi
+
     
     if [[ $__SkipCoreCLR == 0 || $__ConfigureOnly == 1 ]]; then
         echo "Laying out dynamically generated files consumed by the build system "
         echo "Laying out dynamically generated Event Logging Test files"
-        $PYTHON -B -Wall -Werror "$__ProjectRoot/src/scripts/genXplatEventing.py" --man "$__ProjectRoot/src/vm/ClrEtwAll.man" --exc "$__ProjectRoot/src/vm/ClrEtwAllMeta.lst" --testdir "$__GeneratedIntermediateEventProvider/tests"
+        $PYTHON -B $__PythonWarningFlags "$__ProjectRoot/src/scripts/genXplatEventing.py" --man "$__ProjectRoot/src/vm/ClrEtwAll.man" --exc "$__ProjectRoot/src/vm/ClrEtwAllMeta.lst" --testdir "$__GeneratedIntermediateEventProvider/tests"
 
         if  [[ $? != 0 ]]; then
             exit
@@ -186,7 +193,7 @@ generate_event_logging_sources()
         case $__BuildOS in
             Linux)
                 echo "Laying out dynamically generated EventPipe Implementation"
-                $PYTHON -B -Wall -Werror "$__ProjectRoot/src/scripts/genEventPipe.py" --man "$__ProjectRoot/src/vm/ClrEtwAll.man" --intermediate "$__GeneratedIntermediateEventPipe" --exc "$__ProjectRoot/src/vm/ClrEtwAllMeta.lst"
+                $PYTHON -B $__PythonWarningFlags "$__ProjectRoot/src/scripts/genEventPipe.py" --man "$__ProjectRoot/src/vm/ClrEtwAll.man" --intermediate "$__GeneratedIntermediateEventPipe" --exc "$__ProjectRoot/src/vm/ClrEtwAllMeta.lst"
                 if  [[ $? != 0 ]]; then
                     exit
                 fi
@@ -199,7 +206,7 @@ generate_event_logging_sources()
         case $__BuildOS in
             Linux)
                 echo "Laying out dynamically generated Event Logging Implementation of Lttng"
-                $PYTHON -B -Wall -Werror "$__ProjectRoot/src/scripts/genXplatLttng.py" --man "$__ProjectRoot/src/vm/ClrEtwAll.man" --intermediate "$__GeneratedIntermediateEventProvider"
+                $PYTHON -B $__PythonWarningFlags "$__ProjectRoot/src/scripts/genXplatLttng.py" --man "$__ProjectRoot/src/vm/ClrEtwAll.man" --intermediate "$__GeneratedIntermediateEventProvider"
                 if  [[ $? != 0 ]]; then
                     exit
                 fi
@@ -210,7 +217,7 @@ generate_event_logging_sources()
     fi
 
     echo "Cleaning the temp folder of dynamically generated Event Logging files"
-    $PYTHON -B -Wall -Werror -c "import sys;sys.path.insert(0,\"$__ProjectRoot/src/scripts\"); from Utilities import *;UpdateDirectory(\"$__GeneratedIntermediate/eventprovider\",\"$__GeneratedIntermediateEventProvider\")"
+    $PYTHON -B $__PythonWarningFlags -c "import sys;sys.path.insert(0,\"$__ProjectRoot/src/scripts\"); from Utilities import *;UpdateDirectory(\"$__GeneratedIntermediate/eventprovider\",\"$__GeneratedIntermediateEventProvider\")"
     if  [[ $? != 0 ]]; then
         exit
     fi
@@ -218,7 +225,7 @@ generate_event_logging_sources()
     rm -rf "$__GeneratedIntermediateEventProvider"
 
     echo "Cleaning the temp folder of dynamically generated EventPipe files"
-    $PYTHON -B -Wall -Werror -c "import sys;sys.path.insert(0,\"$__ProjectRoot/src/scripts\"); from Utilities import *;UpdateDirectory(\"$__GeneratedIntermediate/eventpipe\",\"$__GeneratedIntermediateEventPipe\")"
+    $PYTHON -B $__PythonWarningFlags -c "import sys;sys.path.insert(0,\"$__ProjectRoot/src/scripts\"); from Utilities import *;UpdateDirectory(\"$__GeneratedIntermediate/eventpipe\",\"$__GeneratedIntermediateEventPipe\")"
     if  [[ $? != 0 ]]; then
         exit
     fi
@@ -587,6 +594,7 @@ esac
 __BuildType=Debug
 __CodeCoverage=
 __IncludeTests=Include_Tests
+__IgnoreWarnings=0
 
 # Set the various build properties here so that CMake and MSBuild can pick them up
 __ProjectDir="$__ProjectRoot"
@@ -772,6 +780,11 @@ while :; do
 
         skipnuget)
             __SkipNuget=1
+            ;;
+
+        ignorewarnings)
+            __IgnoreWarnings=1
+            __cmakeargs="$__cmakeargs -DCLR_CMAKE_WARNINGS_ARE_ERRORS=OFF"
             ;;
 
         cmakeargs)

--- a/compileoptions.cmake
+++ b/compileoptions.cmake
@@ -23,8 +23,10 @@ if (CLR_CMAKE_PLATFORM_UNIX)
   # after hitting just about 20 errors.
   add_compile_options(-ferror-limit=4096)
 
-  # All warnings that are not explicitly disabled are reported as errors
-  add_compile_options(-Werror)
+  if (CLR_CMAKE_WARNINGS_ARE_ERRORS)
+    # All warnings that are not explicitly disabled are reported as errors
+    add_compile_options(-Werror)
+  endif(CLR_CMAKE_WARNINGS_ARE_ERRORS)
 
   # Disabled warnings
   add_compile_options(-Wno-unused-private-field)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,9 +53,15 @@ else()
     )
 endif(WIN32)
 
+if(CRL_CMAKE_WARNINGS_ARE_ERRORS)
+    set(PYTHON_WARNING_FLAGS -Wall -Werror)
+else()
+    set(PYTHON_WARNING_FLAGS -Wall)
+endif(CLR_CMAKE_WARNINGS_ARE_ERRORS)
+
 add_custom_command(
   COMMENT "Generating Eventing Files"
-  COMMAND ${PYTHON} -B -Wall -Werror ${GenEventFilesScript} ${GenEventArgs} --man "${VM_DIR}/ClrEtwAll.man" --exc "${VM_DIR}/ClrEtwAllMeta.lst" --dummy "${GENERATED_INCLUDE_DIR}/etmdummy.h"
+  COMMAND ${PYTHON} -B ${PYTHON_WARNING_FLAGS} ${GenEventFilesScript} ${GenEventArgs} --man "${VM_DIR}/ClrEtwAll.man" --exc "${VM_DIR}/ClrEtwAllMeta.lst" --dummy "${GENERATED_INCLUDE_DIR}/etmdummy.h"
   OUTPUT ${ScriptGeneratedEventFiles}
   DEPENDS ${GenEventFilesScript} "${VM_DIR}/ClrEtwAll.man" "${VM_DIR}/ClrEtwAllMeta.lst" "${CLR_DIR}/src/scripts/genXplatEventing.py"
 )


### PR DESCRIPTION
Add a build flag to make `-Werror` optional and let the build continue even in the presence of warnings.

This option is very useful for anyone compiling with a different (version of the) compiler. A different (version of the) compiler may produce a different set of warnings and a piece of code that compiles
without warnings may emit warnings with a different (version of the) compiler.

Resolves https://github.com/dotnet/coreclr/issues/8586