### PR TITLE
Add support for flat vtables in RyuJIT

### DIFF
--- a/src/inc/corinfo.h
+++ b/src/inc/corinfo.h
@@ -1513,7 +1513,8 @@ enum CORINFO_CALL_KIND
     CORINFO_VIRTUALCALL_VTABLE
 };
 
-
+// Indicates that the CORINFO_VIRTUALCALL_VTABLE lookup needn't do a chunk indirection
+#define CORINFO_VIRTUALCALL_NO_CHUNK 0xFFFFFFFF
 
 enum CORINFO_THIS_TRANSFORM
 {

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -18863,14 +18863,17 @@ regMaskTP CodeGen::genCodeForCall(GenTreeCall* call, bool valUsed)
                     compiler->info.compCompHnd->getMethodVTableOffset(call->gtCallMethHnd, &vtabOffsOfIndirection,
                                                                       &vtabOffsAfterIndirection);
 
-                    /* Get the appropriate vtable chunk */
-
                     /* The register no longer holds a live pointer value */
                     gcInfo.gcMarkRegSetNpt(vptrMask);
 
-                    // MOV vptrReg, [REG_CALL_IND_SCRATCH + vtabOffsOfIndirection]
-                    getEmitter()->emitIns_R_AR(ins_Load(TYP_I_IMPL), EA_PTRSIZE, vptrReg, vptrReg,
-                                               vtabOffsOfIndirection);
+                    /* Get the appropriate vtable chunk */
+
+                    if (vtabOffsOfIndirection != CORINFO_VIRTUALCALL_NO_CHUNK)
+                    {
+                        // MOV vptrReg, [REG_CALL_IND_SCRATCH + vtabOffsOfIndirection]
+                        getEmitter()->emitIns_R_AR(ins_Load(TYP_I_IMPL), EA_PTRSIZE, vptrReg, vptrReg,
+                                                   vtabOffsOfIndirection);
+                    }
 
                     /* Call through the appropriate vtable slot */
 

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -3589,8 +3589,11 @@ GenTree* Lowering::LowerVirtualVtableCall(GenTreeCall* call)
                                                   &vtabOffsAfterIndirection);
 
     // Get the appropriate vtable chunk
-    // result = [REG_CALL_IND_SCRATCH + vtabOffsOfIndirection]
-    result = Ind(Offset(result, vtabOffsOfIndirection));
+    if (vtabOffsOfIndirection != CORINFO_VIRTUALCALL_NO_CHUNK)
+    {
+        // result = [REG_CALL_IND_SCRATCH + vtabOffsOfIndirection]
+        result = Ind(Offset(result, vtabOffsOfIndirection));
+    }
 
     // Load the function address
     // result = [reg+vtabOffs]

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7150,8 +7150,11 @@ void Compiler::fgMorphTailCall(GenTreeCall* call)
 
         /* Get the appropriate vtable chunk */
 
-        add  = gtNewOperNode(GT_ADD, TYP_I_IMPL, vtbl, gtNewIconNode(vtabOffsOfIndirection, TYP_I_IMPL));
-        vtbl = gtNewOperNode(GT_IND, TYP_I_IMPL, add);
+        if (vtabOffsOfIndirection != CORINFO_VIRTUALCALL_NO_CHUNK)
+        {
+            add  = gtNewOperNode(GT_ADD, TYP_I_IMPL, vtbl, gtNewIconNode(vtabOffsOfIndirection, TYP_I_IMPL));
+            vtbl = gtNewOperNode(GT_IND, TYP_I_IMPL, add);
+        }
 
         /* Now the appropriate vtable slot */
 


### PR DESCRIPTION
CoreRT needs one less indirection to get to the virtual method.

On CoreCLR a virtual method call resolution goes like:

```
this -> MethodTable -> chunk(?) -> slot
```

On CoreRT, it's more flat:

```
this -> EEType -> slot
```