### PR TITLE
[x64/Linux] Fix FEATURE_INTERPRETER Release build

### DIFF
--- a/src/vm/interpreter.cpp
+++ b/src/vm/interpreter.cpp
@@ -2626,8 +2626,10 @@ EvalLoop:
             {
                 assert(m_curStackHt > 0);
                 m_curStackHt--;
-#ifdef _DEBUG
+#if defined(_DEBUG) || defined(_AMD64_)
                 CorInfoType cit = OpStackTypeGet(m_curStackHt).ToCorInfoType();
+#endif // _DEBUG || _AMD64_
+#ifdef _DEBUG
                 assert(cit == CORINFO_TYPE_INT || cit == CORINFO_TYPE_UINT || cit == CORINFO_TYPE_NATIVEINT);
 #endif // _DEBUG
 #if defined(_AMD64_)


### PR DESCRIPTION
For x64, cit variable is always needed, but is declared only for debug build.