### PR TITLE
Fixed determintaion of need to make code that contains tail.call loop fully interuptible

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -6759,6 +6759,7 @@ public:
     static fgWalkPreFn CountSharedStaticHelper;
     static bool IsSharedStaticHelper(GenTreePtr tree);
     static bool IsTreeAlwaysHoistable(GenTreePtr tree);
+    static bool IsGcSafePoint(GenTreePtr tree);
 
     static CORINFO_FIELD_HANDLE eeFindJitDataOffs(unsigned jitDataOffs);
     // returns true/false if 'field' is a Jit Data offset

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -4022,6 +4022,31 @@ inline bool Compiler::IsTreeAlwaysHoistable(GenTreePtr tree)
     }
 }
 
+inline bool Compiler::IsGcSafePoint(GenTreePtr tree)
+{
+    if (tree->IsCall())
+    {
+        GenTreeCall* call = tree->AsCall();
+        if (!call->IsFastTailCall())
+        {
+            if (call->gtCallType == CT_INDIRECT)
+            {
+                return true;
+            }
+            else if (call->gtCallType == CT_USER_FUNC)
+            {
+                if ((call->gtCallMoreFlags & GTF_CALL_M_NOGCCHECK) == 0)
+                {
+                    return true;
+                }
+            }
+            // otherwise we have a CT_HELPER
+        }
+    }
+
+    return false;
+}
+
 //
 // Note that we want to have two special FIELD_HANDLES that will both
 // be considered non-Data Offset handles

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -18488,8 +18488,7 @@ void Compiler::fgSetBlockOrder()
 
 #if FEATURE_FASTTAILCALL
 #ifndef JIT32_GCENCODER
-        if (block->endsWithTailCallOrJmp(this, true) && !(block->bbFlags & BBF_GC_SAFE_POINT) &&
-            optReachWithoutCall(fgFirstBB, block))
+        if (block->endsWithTailCallOrJmp(this, true) && optReachWithoutCall(fgFirstBB, block))
         {
             // We have a tail call that is reachable without making any other
             // 'normal' call that would have counted as a GC Poll.  If we were

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8293,25 +8293,9 @@ NO_TAIL_CALL:
     // having a call (for computing full interruptibility).
     CLANG_FORMAT_COMMENT_ANCHOR;
 
-#ifdef _TARGET_AMD64_
-    // Amd64 note: If this is a fast tail call then don't count it as a call
-    // since we don't insert GC-polls but instead make the method fully GC
-    // interruptible.
-    if (!call->IsFastTailCall())
-#endif
+    if (IsGcSafePoint(call))
     {
-        if (call->gtCallType == CT_INDIRECT)
-        {
-            compCurBB->bbFlags |= BBF_GC_SAFE_POINT;
-        }
-        else if (call->gtCallType == CT_USER_FUNC)
-        {
-            if ((call->gtCallMoreFlags & GTF_CALL_M_NOGCCHECK) == 0)
-            {
-                compCurBB->bbFlags |= BBF_GC_SAFE_POINT;
-            }
-        }
-        // otherwise we have a CT_HELPER
+        compCurBB->bbFlags |= BBF_GC_SAFE_POINT;
     }
 
     // Morph Type.op_Equality and Type.op_Inequality

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -3289,7 +3289,7 @@ void Compiler::optUnrollLoops()
 
 /*****************************************************************************
  *
- *  Return non-zero if there is a code path from 'topBB' to 'botBB' that will
+ *  Return false if there is a code path from 'topBB' to 'botBB' that might
  *  not execute a method call.
  */
 


### PR DESCRIPTION
It possible to have partial interruptible code without any reachable safepoint if two methods invoke each other using tail.call creating a loop.

```
void A() {
  if (C.stop == false) {
    B();   // Tail.Call
  } else {
    Foo(); // safepoint
    return;
  }
}

void B() {
  if (C.stop == false) {
    A();   // Tail.Call
  } else {
    Bar(); // safepoint
    return;
  }
}
```

In this case we have a loop between A() and B() so both methods have to be fully interruptible.

The PR fixes the algorithm that detects such cases, but only for caller without any recursive analysis .

Tests like JIT\Methodical\tailcall_v4\hijacking might hang on due to this bug.

Originally the problem is related to #4122 