### PR TITLE
Fix a bug in LoadNativeStringResource to honor the contract properly when the buffer is not big enough

### DIFF
--- a/src/nativeresources/resourcestring.cpp
+++ b/src/nativeresources/resourcestring.cpp
@@ -39,7 +39,13 @@ int LoadNativeStringResource(const NativeStringResourceTable &nativeStringResour
         {
             len = PAL_GetResourceString(NULL, resourceEntry->resourceString, szBuffer, iMax);
             if (len == 0)
-                return HRESULT_FROM_GetLastError();
+            {
+                int hr = HRESULT_FROM_GetLastError();
+
+                // Tell the caller if the buffer isn't big enough
+                if (hr == ERROR_INSUFFICIENT_BUFFER && pcwchUsed)
+                    *pcwchUsed = iMax;
+            }
         }
         else
         {

--- a/src/nativeresources/resourcestring.cpp
+++ b/src/nativeresources/resourcestring.cpp
@@ -43,7 +43,7 @@ int LoadNativeStringResource(const NativeStringResourceTable &nativeStringResour
                 int hr = HRESULT_FROM_GetLastError();
 
                 // Tell the caller if the buffer isn't big enough
-                if (hr == ERROR_INSUFFICIENT_BUFFER && pcwchUsed)
+                if (hr == HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER) && pcwchUsed)
                     *pcwchUsed = iMax;
                     
                 return hr;

--- a/src/nativeresources/resourcestring.cpp
+++ b/src/nativeresources/resourcestring.cpp
@@ -45,6 +45,8 @@ int LoadNativeStringResource(const NativeStringResourceTable &nativeStringResour
                 // Tell the caller if the buffer isn't big enough
                 if (hr == ERROR_INSUFFICIENT_BUFFER && pcwchUsed)
                     *pcwchUsed = iMax;
+                    
+                return hr;
             }
         }
         else

--- a/src/nativeresources/resourcestring.cpp
+++ b/src/nativeresources/resourcestring.cpp
@@ -38,6 +38,8 @@ int LoadNativeStringResource(const NativeStringResourceTable &nativeStringResour
         if (resourceEntry != NULL)
         {
             len = PAL_GetResourceString(NULL, resourceEntry->resourceString, szBuffer, iMax);
+            if (len == 0)
+                return HRESULT_FROM_GetLastError();
         }
         else
         {
@@ -47,6 +49,8 @@ int LoadNativeStringResource(const NativeStringResourceTable &nativeStringResour
             {   
                 // The only possible failure is that that string didn't fit the buffer. So the buffer contains 
                 // partial string terminated by '\0'
+                // We could return ERROR_INSUFFICIENT_BUFFER, but we'll error on the side of caution here and
+                // actually show something (given that this is likely a scenario involving a bug/deployment issue)
                 len = iMax - 1;
             }
         }

--- a/src/utilcode/ccomprc.cpp
+++ b/src/utilcode/ccomprc.cpp
@@ -852,9 +852,8 @@ HRESULT CCompRC::LoadString(ResourceCategory eCategory, LocaleID langId, UINT iR
 
     return hr;
 #else // !FEATURE_PAL
-    LoadNativeStringResource(NATIVE_STRING_RESOURCE_TABLE(NATIVE_STRING_RESOURCE_NAME), iResourceID,
+    return LoadNativeStringResource(NATIVE_STRING_RESOURCE_TABLE(NATIVE_STRING_RESOURCE_NAME), iResourceID,
       szBuffer, iMax, pcwchUsed);
-    return S_OK;
 #endif // !FEATURE_PAL
 }
 

--- a/src/utilcode/sstring_com.cpp
+++ b/src/utilcode/sstring_com.cpp
@@ -60,7 +60,7 @@ HRESULT SString::LoadResourceAndReturnHR(CCompRC* pResourceDLL, CCompRC::Resourc
                 // In fatal error reporting scenarios, we may not have enough memory to 
                 // allocate a larger buffer.
             
-                hr = pResourceDLL->LoadString(eCategory, resourceID, GetRawUnicode(), GetRawCount()+1,&size);
+                hr = pResourceDLL->LoadString(eCategory, resourceID, GetRawUnicode(), GetRawCount()+1, &size);
                 if (hr != HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER))
                 {
                     if (FAILED(hr))


### PR DESCRIPTION
Fixes bad error message in https://github.com/dotnet/coreclr/issues/12029. The code in https://github.com/dotnet/coreclr/blob/master/src/vm/fieldmarshaler.cpp#L4255-L4256 relies on proper reporting of ERROR_INSUFFICIENT_BUFFER and setting the size - otherwise it'll show the default fallback error "Unknown error". 
LoadNativeStringResource now aligns with what we do in windows. 
@jkotas PTAL