### PR TITLE
Do not copy bin subdirectories to test core_root

### DIFF
--- a/build-test.cmd
+++ b/build-test.cmd
@@ -286,7 +286,7 @@ if exist "%CORE_ROOT%" rd /s /q "%CORE_ROOT%"
 if exist "%CORE_ROOT_STAGE%" rd /s /q "%CORE_ROOT_STAGE%"
 md "%CORE_ROOT%"
 md "%CORE_ROOT_STAGE%"
-xcopy /s "%__BinDir%" "%CORE_ROOT_STAGE%"
+xcopy "%__BinDir%" "%CORE_ROOT_STAGE%"
 
 
 if defined __BuildAgainstPackagesArg ( 

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -180,7 +180,7 @@ echo %__MsgPrefix%Using Default CORE_ROOT as %CORE_ROOT%
 echo %__MsgPrefix%Copying Built binaries from %__BinDir% to %CORE_ROOT%
 if exist "%CORE_ROOT%" rd /s /q "%CORE_ROOT%"
 md "%CORE_ROOT%"
-xcopy /s "%__BinDir%" "%CORE_ROOT%"
+xcopy "%__BinDir%" "%CORE_ROOT%"
 
 :SkipCoreRootSetup
 

--- a/tests/runtest.proj
+++ b/tests/runtest.proj
@@ -365,47 +365,6 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
              Condition=" '$(BuildTestsAgainstPackages)'=='true' " />
   </Target>
 
-  <!-- All the test projects need to add dependency to currently built runtime as they require that to run. 
-       In addition the version number of built runtime can change so all project.json needs to be dynamically generated.
-       Instead the following task creates a project.json with dependencies like  Microsoft.netcore.runtime.coreclr ..etc.
-        -->
-  <Target Name="CreateTestRuntimeJsonFile">
-    <ItemGroup>
-      <CoreclrPackage Include="$(CORE_ROOT)\.nuget\**\Microsoft.NETCore.Runtime.CoreCLR.*.nupkg"/>
-    </ItemGroup>
-    <PropertyGroup>
-      <CoreclrPackageFileName>%(CoreclrPackage.Filename)</CoreclrPackageFileName>
-      <!-- Get package version number from nuget package filename at core_root -->
-      <CoreClrPackageVersion Condition="'$(BuildTestsAgainstPackages)'!='true'">$([System.String]::Copy('$(CoreclrPackageFileName)').Replace('Microsoft.NETCore.Runtime.CoreCLR.',''))</CoreClrPackageVersion>
-      <TestRuntimeJsonContents>
-        <![CDATA[
-{
-  "dependencies": {
-    "Microsoft.NETCore.Runtime.CoreCLR": "$(CoreClrPackageVersion)",
-    "Microsoft.NETCore.TestHost": "1.0.0-rc3-24117-00"
-  },
-  "frameworks": {
-    "dnxcore50": {}
-  },
-  "runtimes": {
-    "$(TestNugetRuntimeId)":{}
-  }
-}
-
-        ]]>
-      </TestRuntimeJsonContents>
-    </PropertyGroup>
-
-    <MakeDir Directories="$(TestRuntimeProjectJsonDir)" Condition="!Exists('$(TestRuntimeProjectJsonDir)')" />
-
-    <!-- Write the file -->
-    <WriteLinesToFile
-      File="$(TestRuntimeProjectJson)"
-      Lines="$(TestRuntimeJsonContents)"
-      Overwrite="true" />
-
-  </Target>
-
   <Target Name="RunPerfTests" Condition="'$(Performance)'=='true'">  
     <Message Text="Executing steps for perf tests" Importance="High"/>  
     
@@ -422,11 +381,6 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
 
 
   <Target Name="Build">
-
-    <!-- generate project.json for runtime dependency -->
-    <MSBuild Projects="$(MSBuildProjectFile)"
-             Targets="CreateTestRuntimeJsonFile"
-             Condition=" '$(BuildWrappers)'=='true' " />
 
     <!-- generate project.lock.json file corresponding to above json file -->
     <MSBuild Projects="src\Common\test_dependencies\test_dependencies.csproj"

--- a/tests/src/dir.common.props
+++ b/tests/src/dir.common.props
@@ -51,13 +51,5 @@
     <TestPath Condition="'$(TestPath)'==''">$(TestWorkingDir)$(OSPlatformConfig)\$(MSBuildProjectName)/</TestPath>
   </PropertyGroup>
 
-  <!-- Setup the output location for the project.json generated for the local CoreCLR build. -->
-  <PropertyGroup>
-    <TestRuntimeProjectJsonDir>$(BaseOutputPath)\test_runtime</TestRuntimeProjectJsonDir>
-    <TestRuntimeProjectJson>$(TestRuntimeProjectJsonDir)\project.json</TestRuntimeProjectJson>
-    <TestRuntimeProjectLockJson>$(TestRuntimeProjectJsonDir)\project.lock.json</TestRuntimeProjectLockJson>
-  </PropertyGroup>
-
-
 </Project>
 


### PR DESCRIPTION
As far as I can tell there's no need to copy various bin subdirectories (PDB, .nuget, IL etc.) to core_root when running tests and they have hundreds of megabytes.