### PR TITLE
[Linux] Invoke jitShutdown during ProcessShutdownWork

### DIFF
--- a/src/jit/ee_il_dll.cpp
+++ b/src/jit/ee_il_dll.cpp
@@ -126,6 +126,8 @@ void jitShutdown()
 #ifdef FEATURE_TRACELOGGING
     JitTelemetry::NotifyDllProcessDetach();
 #endif
+
+    g_jitInitialized = false;
 }
 
 #ifndef FEATURE_MERGE_JIT_AND_ENGINE
@@ -345,9 +347,7 @@ void CILJit::ProcessShutdownWork(ICorStaticInfo* statInfo)
         // Continue, by shutting down this JIT as well.
     }
 
-#ifdef FEATURE_MERGE_JIT_AND_ENGINE
     jitShutdown();
-#endif
 
     Compiler::ProcessShutdownWork(statInfo);
 }


### PR DESCRIPTION
jitShutdown is currently not invoked in Linux (#12031).

This commit revises CILJit::ProcessShutdownWork to invoke jitShutdown even when VM and JIT are implemented as separated shared libraries.

In addition, this commit prevent possible issues related with multiple jitShutdown calls.