### PR TITLE
Yield thread when using SleepEx(0, false) on Linux

### DIFF
--- a/src/pal/src/include/pal/corunix.hpp
+++ b/src/pal/src/include/pal/corunix.hpp
@@ -1098,6 +1098,10 @@ namespace CorUnix
             ) = 0;
 
         virtual
+        void
+        YieldThread() = 0;
+
+        virtual
         PAL_ERROR
         AbandonObjectsOwnedByThread(
             CPalThread *pCallingThread,

--- a/src/pal/src/synchmgr/synchmanager.cpp
+++ b/src/pal/src/synchmgr/synchmanager.cpp
@@ -434,6 +434,11 @@ namespace CorUnix
         return palErr;
     }
 
+    void CPalSynchronizationManager::YieldThread()
+    {
+        sched_yield();
+    }
+
     PAL_ERROR CPalSynchronizationManager::ThreadNativeWait(
         ThreadNativeWaitData * ptnwdNativeWaitData,
         DWORD dwTimeout,

--- a/src/pal/src/synchmgr/synchmanager.hpp
+++ b/src/pal/src/synchmgr/synchmanager.hpp
@@ -824,6 +824,8 @@ namespace CorUnix
             ThreadWakeupReason *ptwrWakeupReason,
             DWORD *pdwSignaledObject);
 
+        virtual void YieldThread();
+
         virtual PAL_ERROR AbandonObjectsOwnedByThread(
             CPalThread *pthrCurrent,
             CPalThread *pthrTarget);

--- a/src/pal/src/synchmgr/wait.cpp
+++ b/src/pal/src/synchmgr/wait.cpp
@@ -702,6 +702,7 @@ DWORD CorUnix::InternalSleepEx (
     }
     else
     {
+        g_pSynchronizationManager->YieldThread();
         dwRet = 0;
     }
 


### PR DESCRIPTION
This PR makes the calling thread to relinquish the CPU when calling SleepEx(0, false) so that SleepEx(0, false) behaves same on Windows and Linux.