### PR TITLE
Fix procCount assertion

### DIFF
--- a/src/mscorlib/src/System/Threading/SpinWait.cs
+++ b/src/mscorlib/src/System/Threading/SpinWait.cs
@@ -297,8 +297,8 @@ namespace System.Threading
                     s_lastProcessorCountRefreshTicks = now;
                 }
 
-                Debug.Assert(procCount > 0 && procCount <= 64,
-                    "Processor count not within the expected range (1 - 64).");
+                Debug.Assert(procCount > 0,
+                    "Processor count should be greater than 0.");
 
                 return procCount;
             }


### PR DESCRIPTION
This PR fixes `procCount` assertion in `SpinWait.cs`. Otherwise the debug build crashes on machines with more than 64 cores.