### PR TITLE
[Local GC] Add TrapReturningThreads to the GC/EE interface

### DIFF
--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -49,6 +49,7 @@ public:
     static bool IsPreemptiveGCDisabled(Thread * pThread);
     static void EnablePreemptiveGC(Thread * pThread);
     static void DisablePreemptiveGC(Thread * pThread);
+    static bool TrapReturningThreads();
 
     static gc_alloc_context * GetAllocContext(Thread * pThread);
     static bool CatchAtSafePoint(Thread * pThread);

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -1496,7 +1496,7 @@ void WaitLongerNoInstru (int i)
     }
 
     // if we're waiting for gc to finish, we should block immediately
-    if (!g_TrapReturningThreads)
+    if (!GCToEEInterface::TrapReturningThreads())
     {
         if  (g_num_processors > 1)
         {
@@ -1516,7 +1516,7 @@ void WaitLongerNoInstru (int i)
     // is in a tight loop.  If the thread has high priority, the perf is going to be very BAD.
     if (pCurThread)
     {
-        if (bToggleGC || g_TrapReturningThreads)
+        if (bToggleGC || GCToEEInterface::TrapReturningThreads())
         {
 #ifdef _DEBUG
             // In debug builds, all enter_spin_lock operations go through this code.  If a GC has
@@ -1537,7 +1537,7 @@ void WaitLongerNoInstru (int i)
             }
         }
     }
-    else if (g_TrapReturningThreads)
+    else if (GCToEEInterface::TrapReturningThreads())
     {
         g_theGCHeap->WaitUntilGCComplete();
     }

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -134,6 +134,12 @@ ALWAYS_INLINE void GCToEEInterface::DisablePreemptiveGC(Thread * pThread)
     g_theGCToCLR->DisablePreemptiveGC(pThread);
 }
 
+ALWAYS_INLINE bool GCToEEInterface::TrapReturningThreads()
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->TrapReturningThreads();
+}
+
 ALWAYS_INLINE gc_alloc_context * GCToEEInterface::GetAllocContext(Thread * pThread)
 {
     assert(g_theGCToCLR != nullptr);

--- a/src/gc/gcimpl.h
+++ b/src/gc/gcimpl.h
@@ -254,7 +254,7 @@ private:
         // to threads returning to cooperative mode is down after gc.
         // In other words, if the sequence in GCHeap::RestartEE changes,
         // the condition here may have to change as well.
-        return g_TrapReturningThreads == 0;
+        return !GCToEEInterface::TrapReturningThreads();
     }
 public:
     //return TRUE if GC actually happens, otherwise FALSE

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -77,6 +77,10 @@ public:
     virtual
     void DisablePreemptiveGC(Thread * pThread) = 0;
 
+    // Returns whether or not a thread suspension is pending.
+    virtual
+    bool TrapReturningThreads() = 0;
+
     // Retrieves the alloc context associated with a given thread.
     virtual
     gc_alloc_context * GetAllocContext(Thread * pThread) = 0;

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -190,6 +190,11 @@ void GCToEEInterface::DisablePreemptiveGC(Thread * pThread)
     pThread->DisablePreemptiveGC();
 }
 
+bool GCToEEInterface::TrapReturningThreads()
+{
+    return !!g_TrapReturningThreads;
+}
+
 gc_alloc_context * GCToEEInterface::GetAllocContext(Thread * pThread)
 {
     return pThread->GetAllocContext();

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -356,6 +356,12 @@ void GCToEEInterface::DisablePreemptiveGC(Thread * pThread)
     pThread->DisablePreemptiveGC();
 }
 
+bool GCToEEInterface::TrapReturningThreads()
+{
+    WRAPPER_NO_CONTRACT;
+    return !!g_TrapReturningThreads;
+}
+
 struct BackgroundThreadStubArgs
 {
     Thread* thread;

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -31,6 +31,7 @@ public:
     bool IsPreemptiveGCDisabled(Thread * pThread);
     void EnablePreemptiveGC(Thread * pThread);
     void DisablePreemptiveGC(Thread * pThread);
+    bool TrapReturningThreads();
     gc_alloc_context * GetAllocContext(Thread * pThread);
     bool CatchAtSafePoint(Thread * pThread);
     void GcEnumAllocContexts(enum_alloc_context_func* fn, void* param);


### PR DESCRIPTION
This fixes another linker error (https://github.com/dotnet/coreclr/issues/11513) that manifests when building standalone. This approach is the same as the one in https://github.com/dotnet/coreclr/pull/12036.

Of note is that at least one call to `GCToEEInterface::TrapReturningThreads` lies on a code path that is called every 8th spin of a spin lock. It seems to me that it should be okay to add an indirection on a spin lock path since we are likely about to yield to the scheduler or go to sleep anyway.