### PR TITLE
Fix typo in CRL_CMAKE_WARNINGS_ARE_ERRORS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,7 +53,7 @@ else()
     )
 endif(WIN32)
 
-if(CRL_CMAKE_WARNINGS_ARE_ERRORS)
+if(CLR_CMAKE_WARNINGS_ARE_ERRORS)
     set(PYTHON_WARNING_FLAGS -Wall -Werror)
 else()
     set(PYTHON_WARNING_FLAGS -Wall)


### PR DESCRIPTION
I made a typo in https://github.com/dotnet/coreclr/pull/12039

`CRL_CMAKE_WARNINGS_ARE_ERRORS` should have been `CLR_CMAKE_WARNINGS_ARE_ERRORS`. This fixes that.

Sorry, @janvorli 