### PR TITLE
[RyuJIT/ARM32] Fix assertion when struct argument passing less than 4 byte

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2040,7 +2040,7 @@ GenTreePtr Compiler::fgMakeTmpArgNode(
     if (varTypeIsStruct(type))
     {
 
-#if defined(_TARGET_AMD64_) || defined(_TARGET_ARM64_)
+#if defined(_TARGET_AMD64_) || defined(_TARGET_ARM64_) || defined(_TARGET_ARM_)
 
 #ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
 


### PR DESCRIPTION
Fix assertion when struct argument is less than 4 byte and promoted

Related issue: #11850 

cc/ @dotnet/arm32-contrib 