### PR TITLE
Support desktop to core serialization with InternalsVisibleTo on mscorlib

### DIFF
--- a/src/mscorlib/src/mscorlib.Friends.cs
+++ b/src/mscorlib/src/mscorlib.Friends.cs
@@ -13,3 +13,5 @@ using System.Runtime.CompilerServices;
 // Depends on WindowsRuntimeImportAttribute
 [assembly: InternalsVisibleTo("System.Runtime.WindowsRuntime.UI.Xaml, PublicKey=00000000000000000400000000000000", AllInternalsVisible = false)]
 
+// Cross framework serialization needs access to internals
+[assembly: InternalsVisibleTo("mscorlib, PublicKey=00000000000000000400000000000000", AllInternalsVisible=false)]


### PR DESCRIPTION
Relates to https://github.com/dotnet/coreclr/pull/12059
Is required for https://github.com/dotnet/corefx/pull/20697