### PR TITLE
Make all publish legs of CoreCLR uniform and match existing ones.  

### DIFF
--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -219,9 +219,9 @@
             "AzureContainerSymbolPackageGlob": "symbolpkg\\*.nupkg"
           },
           "ReportingParameters": {
-            "SubType":  "Publish",
+            "TaskName":  "Publish",
             "Type": "build/publish/",
-            "PB_BuildType": "Release"
+            "ConfigurationGroup": "Release"
           }
         }
       ],
@@ -246,9 +246,9 @@
             "GitHubRepositoryName": "coreclr"
           },
           "ReportingParameters": {
-            "SubType": "Publish",
+            "TaskName": "Publish",
             "Type": "build/publish/",
-            "PB_BuildType": "Debug"
+            "ConfigurationGroup": "Debug"
           }
         }
       ],
@@ -273,7 +273,7 @@
           "ReportingParameters": {
             "TaskName": "Symbol Publish",
             "Type": "build/publish/",
-            "ConfigurationGroup": "Release - Publish Symbols"
+            "ConfigurationGroup": "Release"
           }
         }
       ],
@@ -298,9 +298,9 @@
             "GitHubRepositoryName": "coreclr"
           },
           "ReportingParameters": {
-            "SubType": "Publish",
+            "TaskName": "Publish",
             "Type": "build/publish/",
-            "PB_BuildType": "Checked"
+            "ConfigurationGroup": "Checked"
           }
         }
       ],


### PR DESCRIPTION
I noticed this while making a workaround for https://github.com/dotnet/core-eng/pull/873.  @wtgodbe feel free to do this differently, but one way or another (this will work ...) ideally there should be one set of properties used for CoreCLR publish views.

Previously Release - Publish symbols was in the CoreFX-style format and the other three were not.  This unifies them.  Can use whatever format desired but ideally should not be using PB_ variables as these are a build-orchestration-implementation detail and not really a property.

