### PR TITLE
Disable AppDomainLeaks configuration option for now until it is removed

### DIFF
--- a/src/vm/eeconfig.h
+++ b/src/vm/eeconfig.h
@@ -534,7 +534,12 @@ public:
 
 #ifdef _DEBUG
     inline bool AppDomainLeaks() const
-    {LIMITED_METHOD_DAC_CONTRACT;  return fAppDomainLeaks; }
+    {
+        // Workaround for CoreCLR bug #12075, until this configuration option is removed
+        // (CoreCLR Bug #12094)
+        LIMITED_METHOD_DAC_CONTRACT;
+        return false;
+    }
 #endif
 
     inline bool DeveloperInstallation() const


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/12075, per https://github.com/dotnet/coreclr/issues/12075#issuecomment-306280918.

Related: https://github.com/dotnet/coreclr/issues/12094

cc @Maoni0 @jkotas 