### PR TITLE
Port commit 128aabe from master: disable tail call stress in GH_11689 if ZapDisable is enabled.

### DIFF
--- a/tests/src/JIT/Regression/JitBlue/GitHub_11689/GitHub_11689.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_11689/GitHub_11689.csproj
@@ -35,13 +35,16 @@
     <Compile Include="GitHub_11689.cs" />
   </ItemGroup>
   <PropertyGroup>
+    <!-- NOTE: tailcall stress should be reenabled under zapdisable when #11408 is fixed -->
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)
-set COMPlus_TailcallStress=1
+if "%COMPlus_ZapDisable%"=="" set COMPlus_TailcallStress=1
 ]]></CLRTestBatchPreCommands>
   <BashCLRTestPreCommands><![CDATA[
 $(BashCLRTestPreCommands)
-export COMPlus_TailcallStress=1
+if [ -z $COMPlus_ZapDisable ]; then
+    export COMPlus_TailcallStress=1
+fi
 ]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Tail call stress does not mix well with ZapDisable due to the issues
described in #11408.