### PR TITLE
Keep previous cmake arguments when using buildstandalonegc

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -821,7 +821,7 @@ while :; do
             fi
             ;;
         buildstandalonegc)
-            __cmakeargs="-DFEATURE_STANDALONE_GC=1 -DFEATURE_STANDALONE_GC_ONLY=1"
+            __cmakeargs="$__cmakeargs -DFEATURE_STANDALONE_GC=1 -DFEATURE_STANDALONE_GC_ONLY=1"
             ;;
         msbuildonunsupportedplatform)
             __msbuildonunsupportedplatform=1


### PR DESCRIPTION
Currently, using `buildstandalonegc` makes `build.sh` discard any previous values of `__cmakearg` set explicitly or implicitly. Preserve those arguments.

Without this fix, the following invocations behave differently:

    $ ./build.sh ignorewarnings buildstandalonegc verbose
    ...    
    Invoking
    "/home/omajid/devel/dotnet/coreclr/src/pal/tools/gen-buildsys-clang.sh"
    "/home/omajid/devel/dotnet/coreclr" 3 5 x64 Debug Include_Tests
    -DCLR_CMAKE_TARGET_OS=Linux
    -DCLR_CMAKE_PACKAGES_DIR=/home/omajid/devel/dotnet/coreclr/packages
    -DCLR_CMAKE_PGO_INSTRUMENT=0 -DCLR_CMAKE_OPTDATA_VERSION=
    -DFEATURE_STANDALONE_GC=1 -DFEATURE_STANDALONE_GC_ONLY=1
    ... 
    $ ./build.sh buildstandalonegc ignorewarnings verbose 
    ... 
    Invoking
    "/home/omajid/devel/dotnet/coreclr/src/pal/tools/gen-buildsys-clang.sh"
    "/home/omajid/devel/dotnet/coreclr" 3 5 x64 Debug Include_Tests
    -DCLR_CMAKE_TARGET_OS=Linux
    -DCLR_CMAKE_PACKAGES_DIR=/home/omajid/devel/dotnet/coreclr/packages
    -DCLR_CMAKE_PGO_INSTRUMENT=0 -DCLR_CMAKE_OPTDATA_VERSION=
    -DFEATURE_STANDALONE_GC=1 -DFEATURE_STANDALONE_GC_ONLY=1
    -DCLR_CMAKE_WARNINGS_ARE_ERRORS=OFF
    ...

Notice that `CLR_CMAKE_WARNINGS_ARE_ERRORS` is lost in the first invocation.