### PR TITLE
Stop extraneously setting tail call stress

### DIFF
--- a/tests/src/JIT/Regression/JitBlue/GitHub_10780/GitHub_10780.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_10780/GitHub_10780.csproj
@@ -34,19 +34,6 @@
   <ItemGroup>
     <Compile Include="GitHub_10780.cs" />
   </ItemGroup>
-  <PropertyGroup>
-    <!-- NOTE: tailcall stress should be reenabled under zapdisable when #11408 is fixed -->
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-if "%COMPlus_ZapDisable%"=="" set COMPlus_TailcallStress=1
-]]></CLRTestBatchPreCommands>
-  <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-if [ -z $COMPlus_ZapDisable ]; then
-    export COMPlus_TailcallStress=1
-fi
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_11689/GitHub_11689.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_11689/GitHub_11689.csproj
@@ -34,19 +34,6 @@
   <ItemGroup>
     <Compile Include="GitHub_11689.cs" />
   </ItemGroup>
-  <PropertyGroup>
-    <!-- NOTE: tailcall stress should be reenabled under zapdisable when #11408 is fixed -->
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-if "%COMPlus_ZapDisable%"=="" set COMPlus_TailcallStress=1
-]]></CLRTestBatchPreCommands>
-  <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-if [ -z $COMPlus_ZapDisable ]; then
-    export COMPlus_TailcallStress=1
-fi
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>


### PR DESCRIPTION
Tests GitHub_10780 and GitHub_11689 are repro cases for issues that don't
have anything to do with tail calls; the bit of code in their csproj's
that sets COMPlus_TailCallStress was an accidental copy-paste inclusion
from GitHub_11408.  Remove that extra code.