### PR TITLE
Fix build breakage on high-processsor machines

### DIFF
--- a/src/scripts/genEventPipe.py
+++ b/src/scripts/genEventPipe.py
@@ -262,6 +262,8 @@ def generateEventPipeCmakeFile(etwmanifest, eventpipe_directory):
         topCmake.write('            "eventpipehelpers.cpp"\n')
         topCmake.write("""        )
 
+        add_dependencies(eventpipe GeneratedEventingFiles)
+
         # Install the static eventpipe library
         install(TARGETS eventpipe DESTINATION lib)
         """)


### PR DESCRIPTION
The build calls `make -j $NumProc`. This breaks on machines with a high number of procesors (such as 25).

To reproduce this on any machine, edit build.sh and change

    buildTool install -j $NumProc

to

    buildTool install -j 100

The error trace looks like this:

    In file included from coreclr/bin/obj/Linux.x64.Debug/Generated/eventpipe/dotnetruntime.cpp:12:
    In file included from coreclr/src/vm/common.h:306:
    In file included from coreclr/src/vm/eepolicy.h:15:
    In file included from coreclr/src/vm/vars.hpp:70:
    In file included from coreclr/src/vm/eeprofinterfaces.h:19:
    In file included from coreclr/src/inc/profilepriv.h:128:
    In file included from coreclr/src/inc/profilepriv.inl:18:
    In file included from coreclr/src/vm/eetoprofinterfaceimpl.h:23:
    coreclr/src/inc/eventtracebase.h:306:10: fatal error: 'clretwallmain.h' file not found

It turns out that the eventpipe code has a dependency on clretwallmain.h. src/CMakeLists.txt points out that clretwallmain.h is a generated file. But there's no actual dependency between the eventpipe
target and the header file(s).

Fix that by fixing the generator script to insert an explicit dependency between `eventpipe` module and `GeneratedEventingFiles` module.