### PR TITLE
Restore logic for when to use satellite resource lookup under AppX

### DIFF
--- a/src/mscorlib/src/System/HResults.cs
+++ b/src/mscorlib/src/System/HResults.cs
@@ -71,7 +71,6 @@ namespace System
         internal const int COR_E_INVALIDOPERATION = unchecked((int)0x80131509);
         internal const int COR_E_INVALIDPROGRAM = unchecked((int)0x8013153a);
         internal const int COR_E_KEYNOTFOUND = unchecked((int)0x80131577);
-        internal const int COR_E_LOADING_REFERENCE_ASSEMBLY = unchecked((int)0x80131058);
         internal const int COR_E_MARSHALDIRECTIVE = unchecked((int)0x80131535);
         internal const int COR_E_MEMBERACCESS = unchecked((int)0x8013151A);
         internal const int COR_E_METHODACCESS = unchecked((int)0x80131510);

--- a/src/mscorlib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimeAssembly.cs
@@ -19,20 +19,6 @@ namespace System.Reflection
 {
     internal class RuntimeAssembly : Assembly
     {
-#if FEATURE_APPX
-        // The highest byte is the flags and the lowest 3 bytes are 
-        // the cached ctor token of [DynamicallyInvocableAttribute].
-        private enum ASSEMBLY_FLAGS : uint
-        {
-            ASSEMBLY_FLAGS_UNKNOWN = 0x00000000,
-            ASSEMBLY_FLAGS_INITIALIZED = 0x01000000,
-            ASSEMBLY_FLAGS_FRAMEWORK = 0x02000000,
-            ASSEMBLY_FLAGS_TOKEN_MASK = 0x00FFFFFF,
-        }
-#endif // FEATURE_APPX
-
-        private const uint COR_E_LOADING_REFERENCE_ASSEMBLY = 0x80131058U;
-
         internal RuntimeAssembly() { throw new NotSupportedException(); }
 
         #region private data members
@@ -41,28 +27,7 @@ namespace System.Reflection
         private object m_syncRoot;   // Used to keep collectible types alive and as the syncroot for reflection.emit
         private IntPtr m_assembly;    // slack for ptr datum on unmanaged side
 
-#if FEATURE_APPX
-        private ASSEMBLY_FLAGS m_flags;
-#endif
         #endregion
-
-#if FEATURE_APPX
-        private ASSEMBLY_FLAGS Flags
-        {
-            get
-            {
-                if ((m_flags & ASSEMBLY_FLAGS.ASSEMBLY_FLAGS_INITIALIZED) == 0)
-                {
-                    ASSEMBLY_FLAGS flags = ASSEMBLY_FLAGS.ASSEMBLY_FLAGS_UNKNOWN
-                        | ASSEMBLY_FLAGS.ASSEMBLY_FLAGS_FRAMEWORK;
-
-                    m_flags = flags | ASSEMBLY_FLAGS.ASSEMBLY_FLAGS_INITIALIZED;
-                }
-
-                return m_flags;
-            }
-        }
-#endif // FEATURE_APPX
 
         internal object SyncRoot
         {
@@ -398,14 +363,6 @@ namespace System.Reflection
                 pPrivHostBinder,
                 throwOnFileNotFound, ptrLoadContextBinder);
         }
-
-#if FEATURE_APPX
-        internal bool IsFrameworkAssembly()
-        {
-            ASSEMBLY_FLAGS flags = Flags;
-            return (flags & ASSEMBLY_FLAGS.ASSEMBLY_FLAGS_FRAMEWORK) != 0;
-        }
-#endif
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern RuntimeAssembly nLoad(AssemblyName fileName,

--- a/src/mscorlib/src/System/Resources/ResourceManager.cs
+++ b/src/mscorlib/src/System/Resources/ResourceManager.cs
@@ -881,16 +881,6 @@ namespace System.Resources
 
         // When running under AppX, the following rules apply for resource lookup:
         //
-        // Desktop
-        // -------
-        //
-        // 1) For Framework assemblies, we always use satellite assembly based lookup.
-        // 2) For non-FX assemblies, we use modern resource manager, with the premise being that app package
-        //    contains the PRI resources since such assemblies are expected to be application assemblies.
-        //
-        // CoreCLR
-        // -------
-        //
         // 1) For Framework assemblies, we always use satellite assembly based lookup.
         // 2) For non-FX assemblies:
         //    
@@ -901,7 +891,7 @@ namespace System.Resources
         //       contains the PRI resources.
         private bool ShouldUseSatelliteAssemblyResourceLookupUnderAppX(RuntimeAssembly resourcesAssembly)
         {
-            bool fUseSatelliteAssemblyResourceLookupUnderAppX = resourcesAssembly.IsFrameworkAssembly();
+            bool fUseSatelliteAssemblyResourceLookupUnderAppX = typeof(Object).Assembly == resourcesAssembly;
 
             if (!fUseSatelliteAssemblyResourceLookupUnderAppX)
             {
@@ -926,8 +916,8 @@ namespace System.Resources
 
             return fUseSatelliteAssemblyResourceLookupUnderAppX;
         }
-
 #endif // FEATURE_APPX
+
         // Only call SetAppXConfiguration from ResourceManager constructors, and nowhere else.
         // Throws MissingManifestResourceException and WinRT HResults
 
@@ -993,8 +983,6 @@ namespace System.Resources
 
                         if (!bUsingSatelliteAssembliesUnderAppX)
                         {
-                            // See AssemblyNative::IsFrameworkAssembly for details on which kinds of assemblies are considered Framework assemblies.
-                            // The Modern Resource Manager is not used for such assemblies - they continue to use satellite assemblies (i.e. .resources.dll files).
                             _bUsingModernResourceManagement = !ShouldUseSatelliteAssemblyResourceLookupUnderAppX(resourcesAssembly);
 
                             if (_bUsingModernResourceManagement)

--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -1896,9 +1896,6 @@ class AssemblyBaseObject : public Object
     STRINGREF     m_fullname;              // Slot for storing assemblies fullname
     OBJECTREF     m_pSyncRoot;             // Pointer to loader allocator to keep collectible types alive, and to serve as the syncroot for assembly building in ref.emit
     DomainAssembly* m_pAssembly;           // Pointer to the Assembly Structure
-#ifdef FEATURE_APPX
-    UINT32        m_flags;
-#endif
 
   protected:
     AssemblyBaseObject() { LIMITED_METHOD_CONTRACT; }


### PR DESCRIPTION
Remove unused cache of Assembly flags while I was on it