### PR TITLE
Remove use of gtEffectiveVal in RyuJIT codegen

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -1054,7 +1054,7 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
     // Ensure that lclVar nodes are typed correctly.
     assert(!varDsc->lvNormalizeOnStore() || targetType == genActualType(varDsc->TypeGet()));
 
-    GenTreePtr  data = tree->gtOp1->gtEffectiveVal();
+    GenTreePtr  data = tree->gtOp1;
     instruction ins  = ins_Store(targetType);
     emitAttr    attr = emitTypeSize(targetType);
     if (data->isContainedIntOrIImmed())
@@ -1092,7 +1092,7 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
     // Ensure that lclVar nodes are typed correctly.
     assert(!varDsc->lvNormalizeOnStore() || targetType == genActualType(varDsc->TypeGet()));
 
-    GenTreePtr data = tree->gtOp1->gtEffectiveVal();
+    GenTreePtr data = tree->gtOp1;
 
     // var = call, where call returns a multi-reg return value
     // case is handled separately.
@@ -1284,8 +1284,8 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
     // TODO-ARM-CQ: Check for the case where we can simply transfer the carry bit to a register
     //         (signed < or >= where targetReg != REG_NA)
 
-    GenTreePtr op1     = tree->gtOp1->gtEffectiveVal();
-    GenTreePtr op2     = tree->gtOp2->gtEffectiveVal();
+    GenTreePtr op1     = tree->gtOp1;
+    GenTreePtr op2     = tree->gtOp2;
     var_types  op1Type = op1->TypeGet();
     var_types  op2Type = op2->TypeGet();
 
@@ -1350,7 +1350,7 @@ void CodeGen::genCodeForReturnTrap(GenTreeOp* tree)
     // this is nothing but a conditional call to CORINFO_HELP_STOP_FOR_GC
     // based on the contents of 'data'
 
-    GenTree* data = tree->gtOp1->gtEffectiveVal();
+    GenTree* data = tree->gtOp1;
     genConsumeIfReg(data);
     GenTreeIntCon cns = intForm(TYP_INT, 0);
     getEmitter()->emitInsBinary(INS_cmp, emitTypeSize(TYP_INT), data, &cns);

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -1647,7 +1647,7 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
     // Ensure that lclVar nodes are typed correctly.
     assert(!varDsc->lvNormalizeOnStore() || targetType == genActualType(varDsc->TypeGet()));
 
-    GenTreePtr data = tree->gtOp1->gtEffectiveVal();
+    GenTreePtr data = tree->gtOp1;
     genConsumeRegs(data);
 
     regNumber dataReg = REG_NA;
@@ -1695,7 +1695,7 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
     // Ensure that lclVar nodes are typed correctly.
     assert(!varDsc->lvNormalizeOnStore() || targetType == genActualType(varDsc->TypeGet()));
 
-    GenTreePtr data = tree->gtOp1->gtEffectiveVal();
+    GenTreePtr data = tree->gtOp1;
 
     // var = call, where call returns a multi-reg return value
     // case is handled separately.

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2447,7 +2447,7 @@ void CodeGen::genJumpKindsForTree(GenTreePtr cmpTree, emitJumpKind jmpKind[2], b
     jmpToTrueLabel[1] = true;
 
     // For integer comparisons just use genJumpKindForOper
-    if (!varTypeIsFloating(cmpTree->gtOp.gtOp1->gtEffectiveVal()))
+    if (!varTypeIsFloating(cmpTree->gtOp.gtOp1))
     {
         CompareKind compareKind = ((cmpTree->gtFlags & GTF_UNSIGNED) != 0) ? CK_UNSIGNED : CK_SIGNED;
         jmpKind[0]              = genJumpKindForOper(cmpTree->gtOper, compareKind);
@@ -2556,7 +2556,7 @@ void CodeGen::genJumpKindsForTree(GenTreePtr cmpTree, emitJumpKind jmpKind[2], b
 //
 void CodeGen::genCodeForJumpTrue(GenTreePtr tree)
 {
-    GenTree* cmp = tree->gtOp.gtOp1->gtEffectiveVal();
+    GenTree* cmp = tree->gtOp.gtOp1;
     assert(cmp->OperIsCompare());
     assert(compiler->compCurBB->bbJumpKind == BBJ_COND);
 

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -5841,7 +5841,7 @@ void CodeGen::genJumpKindsForTree(GenTreePtr cmpTree, emitJumpKind jmpKind[2], b
     jmpToTrueLabel[1] = true;
 
     // For integer comparisons just use genJumpKindForOper
-    if (!varTypeIsFloating(cmpTree->gtOp.gtOp1->gtEffectiveVal()))
+    if (!varTypeIsFloating(cmpTree->gtOp.gtOp1))
     {
         CompareKind compareKind = ((cmpTree->gtFlags & GTF_UNSIGNED) != 0) ? CK_UNSIGNED : CK_SIGNED;
         jmpKind[0]              = genJumpKindForOper(cmpTree->gtOper, compareKind);

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -2738,7 +2738,7 @@ void emitter::emitInsMov(instruction ins, emitAttr attr, GenTree* node)
         case GT_STORE_LCL_VAR:
         {
             GenTreeLclVarCommon* varNode = node->AsLclVarCommon();
-            GenTree*             data    = varNode->gtOp.gtOp1->gtEffectiveVal();
+            GenTree*             data    = varNode->gtOp.gtOp1;
             codeGen->inst_set_SV_var(varNode);
             assert(varNode->gtRegNum == REG_NA); // stack store
 

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -8791,7 +8791,7 @@ void LinearScan::resolveRegisters()
                 }
                 if (indNode != nullptr)
                 {
-                    GenTreePtr addrNode = indNode->gtOp.gtOp1->gtEffectiveVal();
+                    GenTreePtr addrNode = indNode->gtOp.gtOp1;
                     if (addrNode->OperGet() != GT_ARR_ELEM)
                     {
                         addrNode->gtRsvdRegs |= currentRefPosition->registerAssignment;
@@ -8801,7 +8801,7 @@ void LinearScan::resolveRegisters()
                 if (treeNode->OperGet() == GT_ARR_ELEM)
                 {
                     // TODO-Review: See WORKAROUND ALERT in buildRefPositionsForNode()
-                    GenTreePtr firstIndexTree = treeNode->gtArrElem.gtArrInds[0]->gtEffectiveVal();
+                    GenTreePtr firstIndexTree = treeNode->gtArrElem.gtArrInds[0];
                     assert(firstIndexTree != nullptr);
                     if (firstIndexTree->IsLocal() && (firstIndexTree->gtFlags & GTF_VAR_DEATH) == 0)
                     {


### PR DESCRIPTION
This is not required in RyuJIT at the codegen phase: COMMA and
value-producing NOPs are no longer in place.