### PR TITLE
Enable official builds from dev/defaultintf

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -111,7 +111,7 @@
   <!-- Packaging properties -->
   <PropertyGroup>
     <LicenseUrl>https://github.com/dotnet/coreclr/blob/master/LICENSE.TXT</LicenseUrl>
-    <PreReleaseLabel>preview1</PreReleaseLabel>
+    <PreReleaseLabel>dev-di</PreReleaseLabel>
     <PackageDescriptionFile>$(SourceDir).nuget/descriptions.json</PackageDescriptionFile>
     <PackageLicenseFile>$(ProjectDir)LICENSE.TXT</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(ProjectDir)THIRD-PARTY-NOTICES.TXT</PackageThirdPartyNoticesFile>


### PR DESCRIPTION
Updating the PreReleaseLabel name so we get official Default Interface's builds.

/cc: @yizhang82 @ellismg 