### PR TITLE
Only restore optdata during a release build

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -242,7 +242,7 @@ REM === Restore optimization profile data
 REM ===
 REM =========================================================================================
 
-if %__RestoreOptData% EQU 1 (
+if %__RestoreOptData% EQU 1 if %__BuildTypeRelease% EQU 1 (
     echo %__MsgPrefix%Restoring the OptimizationData Package
     @call %__ProjectDir%\run.cmd sync -optdata
     if not !errorlevel! == 0 (

--- a/build.sh
+++ b/build.sh
@@ -135,6 +135,9 @@ restore_optdata()
 {
     # if msbuild is not supported, then set __SkipRestoreOptData to 1
     if [ $__isMSBuildOnNETCoreSupported == 0 ]; then __SkipRestoreOptData=1; fi
+    # we only need optdata on a Release build
+    if [[ "$__BuildType" != "Release" ]]; then __SkipRestoreOptData=1; fi
+
     if [ $__SkipRestoreOptData == 0 ]; then
         echo "Restoring the OptimizationData package"
         "$__ProjectRoot/run.sh" sync -optdata


### PR DESCRIPTION
Avoid restoring optdata during a non-release build to minimize work done by build.sh/cmd.
Fix #12126 