### PR TITLE
Convert some very common noway_assert to simple assert

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -804,8 +804,8 @@ void Compiler::optPrintAssertion(AssertionDsc* curAssertion, AssertionIndex asse
 Compiler::AssertionDsc* Compiler::optGetAssertion(AssertionIndex assertIndex)
 {
     assert(NO_ASSERTION_INDEX == 0);
-    noway_assert(assertIndex != NO_ASSERTION_INDEX);
-    noway_assert(assertIndex <= optAssertionCount);
+    assert(assertIndex != NO_ASSERTION_INDEX);
+    assert(assertIndex <= optAssertionCount);
     AssertionDsc* assertion = &optAssertionTabPrivate[assertIndex - 1];
 #ifdef DEBUG
     optDebugCheckAssertion(assertion);

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -886,8 +886,8 @@ void Compiler::fgRemoveReturnBlock(BasicBlock* block)
 
 flowList* Compiler::fgGetPredForBlock(BasicBlock* block, BasicBlock* blockPred)
 {
-    noway_assert(block);
-    noway_assert(blockPred);
+    assert(block);
+    assert(blockPred);
     assert(!fgCheapPredsValid);
 
     flowList* pred;

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -2390,7 +2390,7 @@ void Compiler::lvaSetClass(unsigned varNum, GenTreePtr tree, CORINFO_CLASS_HANDL
 
 void Compiler::lvaUpdateClass(unsigned varNum, CORINFO_CLASS_HANDLE clsHnd, bool isExact)
 {
-    noway_assert(varNum < lvaCount);
+    assert(varNum < lvaCount);
 
     // If we are just importing, we cannot reliably track local ref types,
     // since the jit maps CORINFO_TYPE_VAR to TYP_REF.
@@ -2495,7 +2495,7 @@ void Compiler::lvaUpdateClass(unsigned varNum, GenTreePtr tree, CORINFO_CLASS_HA
 
 BYTE* Compiler::lvaGetGcLayout(unsigned varNum)
 {
-    noway_assert(varTypeIsStruct(lvaTable[varNum].lvType) && (lvaTable[varNum].lvExactSize >= TARGET_POINTER_SIZE));
+    assert(varTypeIsStruct(lvaTable[varNum].lvType) && (lvaTable[varNum].lvExactSize >= TARGET_POINTER_SIZE));
 
     return lvaTable[varNum].lvGcLayout;
 }
@@ -2511,7 +2511,7 @@ BYTE* Compiler::lvaGetGcLayout(unsigned varNum)
 
 unsigned Compiler::lvaLclSize(unsigned varNum)
 {
-    noway_assert(varNum < lvaCount);
+    assert(varNum < lvaCount);
 
     var_types varType = lvaTable[varNum].TypeGet();
 
@@ -2554,7 +2554,7 @@ unsigned Compiler::lvaLclSize(unsigned varNum)
 //
 unsigned Compiler::lvaLclExactSize(unsigned varNum)
 {
-    noway_assert(varNum < lvaCount);
+    assert(varNum < lvaCount);
 
     var_types varType = lvaTable[varNum].TypeGet();
 
@@ -2756,7 +2756,7 @@ void Compiler::lvaDecRefCnts(BasicBlock* block, GenTreePtr tree)
 
             lclNum = info.compLvFrameListRoot;
 
-            noway_assert(lclNum <= lvaCount);
+            assert(lclNum <= lvaCount);
             varDsc = lvaTable + lclNum;
 
             /* Decrement the reference counts twice */
@@ -2775,7 +2775,7 @@ void Compiler::lvaDecRefCnts(BasicBlock* block, GenTreePtr tree)
 
         lclNum = tree->gtLclVarCommon.gtLclNum;
 
-        noway_assert(lclNum < lvaCount);
+        assert(lclNum < lvaCount);
         varDsc = lvaTable + lclNum;
 
         /* Decrement its lvRefCnt and lvRefCntWtd */
@@ -2815,7 +2815,7 @@ void Compiler::lvaIncRefCnts(GenTreePtr tree)
 
             lclNum = info.compLvFrameListRoot;
 
-            noway_assert(lclNum <= lvaCount);
+            assert(lclNum <= lvaCount);
             varDsc = lvaTable + lclNum;
 
             /* Increment the reference counts twice */
@@ -2835,7 +2835,7 @@ void Compiler::lvaIncRefCnts(GenTreePtr tree)
 
         lclNum = tree->gtLclVarCommon.gtLclNum;
 
-        noway_assert(lclNum < lvaCount);
+        assert(lclNum < lvaCount);
         varDsc = lvaTable + lclNum;
 
         /* Increment its lvRefCnt and lvRefCntWtd */
@@ -3596,7 +3596,7 @@ void Compiler::lvaMarkLclRefs(GenTreePtr tree)
             if (op2->gtOper == GT_LCL_VAR)
             {
                 unsigned lclNum = op2->gtLclVarCommon.gtLclNum;
-                noway_assert(lclNum < lvaCount);
+                assert(lclNum < lvaCount);
                 lvaTable[lclNum].setPrefReg(REG_ECX, this);
             }
         }
@@ -3612,7 +3612,7 @@ void Compiler::lvaMarkLclRefs(GenTreePtr tree)
 
     /* This must be a local variable reference */
 
-    noway_assert((tree->gtOper == GT_LCL_VAR) || (tree->gtOper == GT_LCL_FLD));
+    assert((tree->gtOper == GT_LCL_VAR) || (tree->gtOper == GT_LCL_FLD));
     unsigned lclNum = tree->gtLclVarCommon.gtLclNum;
 
     noway_assert(lclNum < lvaCount);

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -1630,7 +1630,7 @@ bool Compiler::fgComputeLifeLocal(VARSET_TP& life, VARSET_VALARG_TP keepAliveVar
 {
     unsigned lclNum = lclVarNode->gtLclVarCommon.gtLclNum;
 
-    noway_assert(lclNum < lvaCount);
+    assert(lclNum < lvaCount);
     LclVarDsc* varDsc = &lvaTable[lclNum];
 
     unsigned  varIndex;
@@ -1640,7 +1640,7 @@ bool Compiler::fgComputeLifeLocal(VARSET_TP& life, VARSET_VALARG_TP keepAliveVar
     if (varDsc->lvTracked)
     {
         varIndex = varDsc->lvVarIndex;
-        noway_assert(varIndex < lvaTrackedCount);
+        assert(varIndex < lvaTrackedCount);
 
         /* Is this a definition or use? */
 

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3019,7 +3019,7 @@ int LinearScan::buildInternalRegisterDefsForNode(GenTree*     tree,
             defineNewInternalTemp(tree, FloatRegisterType, currentLoc, internalFPCands DEBUG_ARG(minRegCandidateCount));
     }
 
-    noway_assert(count < MaxInternalRegisters);
+    assert(count < MaxInternalRegisters);
     assert(count == (internalIntCount + internalFloatCount));
     return count;
 }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -6123,7 +6123,7 @@ GenTreePtr Compiler::fgMorphStackArgForVarArgs(unsigned lclNum, var_types varTyp
 
 GenTreePtr Compiler::fgMorphLocalVar(GenTreePtr tree, bool forceRemorph)
 {
-    noway_assert(tree->gtOper == GT_LCL_VAR);
+    assert(tree->gtOper == GT_LCL_VAR);
 
     unsigned   lclNum  = tree->gtLclVarCommon.gtLclNum;
     var_types  varType = lvaGetRealType(lclNum);
@@ -8547,7 +8547,7 @@ NO_TAIL_CALL:
 
 GenTreePtr Compiler::fgMorphConst(GenTreePtr tree)
 {
-    noway_assert(tree->OperKind() & GTK_CONST);
+    assert(tree->OperKind() & GTK_CONST);
 
     /* Clear any exception flags or other unnecessary flags
      * that may have been set before folding this node to a constant */
@@ -8604,7 +8604,7 @@ GenTreePtr Compiler::fgMorphConst(GenTreePtr tree)
 
 GenTreePtr Compiler::fgMorphLeaf(GenTreePtr tree)
 {
-    noway_assert(tree->OperKind() & GTK_LEAF);
+    assert(tree->OperKind() & GTK_LEAF);
 
     if (tree->gtOper == GT_LCL_VAR)
     {
@@ -10850,7 +10850,7 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
     // flow and gcc thinks that the function never returns
     {
         ALLOCA_CHECK();
-        noway_assert(tree->OperKind() & GTK_SMPOP);
+        assert(tree->OperKind() & GTK_SMPOP);
 
         /* The steps in this function are :
            o Perform required preorder processing
@@ -11344,7 +11344,6 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
                 // Note that gtFoldExpr may return a non-leaf even if successful
                 // e.g. for something like "expr / 1" - see also bug #290853
                 if (tree->OperIsLeaf() || (oldTree != tree))
-
                 {
                     return (oldTree != tree) ? fgMorphTree(tree) : fgMorphLeaf(tree);
                 }
@@ -11681,7 +11680,7 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
              *
              * NOTE: Don't reset the exception flags on nodes that may throw */
 
-            noway_assert(tree->gtOper != GT_CALL);
+            assert(tree->gtOper != GT_CALL);
 
             if ((tree->gtOper != GT_INTRINSIC) || !IsIntrinsicImplementedByUserCall(tree->gtIntrinsic.gtIntrinsicId))
             {
@@ -13572,7 +13571,7 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
                 break;
         }
 
-        noway_assert(oper == tree->gtOper);
+        assert(oper == tree->gtOper);
 
         // If we are in the Valuenum CSE phase then don't morph away anything as these
         // nodes may have CSE defs/uses in them.
@@ -14791,11 +14790,11 @@ GenTreePtr Compiler::fgMorphToEmulatedFP(GenTreePtr tree)
 
         if (typ == TYP_DOUBLE)
         {
-            noway_assert(CPX_R4_NEG + 1 == CPX_R8_NEG);
-            noway_assert(CPX_R4_ADD + 1 == CPX_R8_ADD);
-            noway_assert(CPX_R4_SUB + 1 == CPX_R8_SUB);
-            noway_assert(CPX_R4_MUL + 1 == CPX_R8_MUL);
-            noway_assert(CPX_R4_DIV + 1 == CPX_R8_DIV);
+            static_assert_no_msg(CPX_R4_NEG + 1 == CPX_R8_NEG);
+            static_assert_no_msg(CPX_R4_ADD + 1 == CPX_R8_ADD);
+            static_assert_no_msg(CPX_R4_SUB + 1 == CPX_R8_SUB);
+            static_assert_no_msg(CPX_R4_MUL + 1 == CPX_R8_MUL);
+            static_assert_no_msg(CPX_R4_DIV + 1 == CPX_R8_DIV);
 
             helper++;
         }
@@ -14803,12 +14802,12 @@ GenTreePtr Compiler::fgMorphToEmulatedFP(GenTreePtr tree)
         {
             noway_assert(tree->OperIsCompare());
 
-            noway_assert(CPX_R4_EQ + 1 == CPX_R8_EQ);
-            noway_assert(CPX_R4_NE + 1 == CPX_R8_NE);
-            noway_assert(CPX_R4_LT + 1 == CPX_R8_LT);
-            noway_assert(CPX_R4_LE + 1 == CPX_R8_LE);
-            noway_assert(CPX_R4_GE + 1 == CPX_R8_GE);
-            noway_assert(CPX_R4_GT + 1 == CPX_R8_GT);
+            static_assert_no_msg(CPX_R4_EQ + 1 == CPX_R8_EQ);
+            static_assert_no_msg(CPX_R4_NE + 1 == CPX_R8_NE);
+            static_assert_no_msg(CPX_R4_LT + 1 == CPX_R8_LT);
+            static_assert_no_msg(CPX_R4_LE + 1 == CPX_R8_LE);
+            static_assert_no_msg(CPX_R4_GE + 1 == CPX_R8_GE);
+            static_assert_no_msg(CPX_R4_GT + 1 == CPX_R8_GT);
         }
 
         tree = fgMorphIntoHelperCall(tree, helper, args);
@@ -14873,8 +14872,8 @@ GenTreePtr Compiler::fgMorphToEmulatedFP(GenTreePtr tree)
 
 GenTreePtr Compiler::fgMorphTree(GenTreePtr tree, MorphAddrContext* mac)
 {
-    noway_assert(tree);
-    noway_assert(tree->gtOper != GT_STMT);
+    assert(tree);
+    assert(tree->gtOper != GT_STMT);
 
 #ifdef DEBUG
     if (verbose)
@@ -14973,7 +14972,7 @@ GenTreePtr Compiler::fgMorphTree(GenTreePtr tree, MorphAddrContext* mac)
                     /* newTree is non-Null if we propagated an assertion */
                     newTree = optAssertionProp(apFull, tree, nullptr);
                 }
-                noway_assert(tree != nullptr);
+                assert(tree != nullptr);
             }
         }
         PREFAST_ASSUME(tree != nullptr);
@@ -15784,7 +15783,7 @@ void Compiler::fgMorphStmts(BasicBlock* block, bool* mult, bool* lnot, bool* loa
     GenTreePtr   prev = nullptr;
     for (; stmt != nullptr; prev = stmt->gtStmtExpr, stmt = stmt->gtNextStmt)
     {
-        noway_assert(stmt->gtOper == GT_STMT);
+        assert(stmt->gtOper == GT_STMT);
 
         if (fgRemoveRestOfBlock)
         {
@@ -16113,7 +16112,7 @@ void Compiler::fgMorphBlocks()
         {
             for (tree = block->bbTreeList; tree; tree = tree->gtNext)
             {
-                noway_assert(tree->gtOper == GT_STMT);
+                assert(tree->gtOper == GT_STMT);
                 GenTreePtr last = tree->gtStmt.gtStmtExpr;
 
                 if (last->gtOper == GT_ASG_ADD || last->gtOper == GT_ASG_SUB)


### PR DESCRIPTION
With these few changes, I measured a JIT instruction count reduction
of 0.37% of SuperPMI over the tests, and 0.17% for MinOpts.

Related to #10421