### PR TITLE
Modify iteration behavior some benchmarks

### DIFF
--- a/tests/src/JIT/Performance/CodeQuality/Inlining/InlineGCStruct.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/InlineGCStruct.cs
@@ -28,7 +28,7 @@ public class InlineGCStruct
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 2500000;
+    public const int Iterations = 350000000;
 #endif
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -73,7 +73,7 @@ public class InlineGCStruct
         return param * 2;
     }
 
-    [Benchmark]
+    [Benchmark(InnerIterationCount = Iterations)]
     public static bool WithFormat()
     {
         int result = 0;
@@ -82,7 +82,7 @@ public class InlineGCStruct
         {
             using (iteration.StartMeasurement())
             {
-                for (int i = 0; i < Iterations; i++)
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                 {
                     result |= FastFunctionNotCallingStringFormat(11);
                 }
@@ -92,7 +92,7 @@ public class InlineGCStruct
         return (result == 22);
     }
 
-    [Benchmark]
+    [Benchmark(InnerIterationCount = Iterations)]
     public static bool WithoutFormat()
     {
         int result = 0;
@@ -101,7 +101,7 @@ public class InlineGCStruct
         {
             using (iteration.StartMeasurement())
             {
-                for (int i = 0; i < Iterations; i++)
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                 {
                     result |= FastFunctionNotHavingStringFormat(11);
                 }

--- a/tests/src/JIT/Performance/CodeQuality/Inlining/NoThrowInline.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/NoThrowInline.cs
@@ -19,7 +19,7 @@ public static class NoThrowInline
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 100000000;
+    public const int Iterations = 275000000;
 #endif
 
     static void ThrowIfNull(string s)
@@ -57,14 +57,17 @@ public static class NoThrowInline
         return a.Length + b.Length + c.Length + d.Length;
     }
 
-    [Benchmark]
+    [Benchmark(InnerIterationCount = Iterations)]
     public static void Test()
     {
         foreach (var iteration in Benchmark.Iterations)
         {
             using (iteration.StartMeasurement())
             {
-                Bench("a", "bc", "def", "ghij");
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                {
+                    Bench("a", "bc", "def", "ghij");
+                }
             }
         }
     }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/AbsDouble.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/AbsDouble.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const double absDoubleDelta = 0.0004;
         private const double absDoubleExpectedResult = 2499.9999999999659;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount=AbsDoubleIterations)]
         public static void AbsDoubleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    AbsDoubleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        AbsDoubleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/AcosDouble.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/AcosDouble.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const double acosDoubleDelta = 0.0004;
         private const double acosDoubleExpectedResult = 7852.4108380716079;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount=AcosDoubleIterations)]
         public static void AcosDoubleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    AcosDoubleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        AcosDoubleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/AsinDouble.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/AsinDouble.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const double asinDoubleDelta = 0.0004;
         private const double asinDoubleExpectedResult = 1.5707959028763392;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = AsinDoubleIterations)]
         public static void AsinDoubleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    AsinDoubleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        AsinDoubleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/Atan2Double.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/Atan2Double.cs
@@ -15,14 +15,17 @@ namespace Functions
         private const double atan2DoubleDeltaY = 0.0004;
         private const double atan2DoubleExpectedResult = 3926.99081698702;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = Atan2DoubleIterations)]
         public static void Atan2DoubleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    Atan2DoubleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        Atan2DoubleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/AtanDouble.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/AtanDouble.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const double atanDoubleDelta = 0.0004;
         private const double atanDoubleExpectedResult = 0.78539816322061329;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = AtanDoubleIterations)]
         public static void AtanDoubleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    AtanDoubleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        AtanDoubleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/CeilingDouble.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/CeilingDouble.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const double ceilingDoubleDelta = 0.0004;
         private const double ceilingDoubleExpectedResult = 2500;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = CeilingDoubleIterations)]
         public static void CeilingDoubleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    CeilingDoubleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        CeilingDoubleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/CosDouble.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/CosDouble.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const double cosDoubleDelta = 0.0006283185307180;
         private const double cosDoubleExpectedResult = -1.0000000005924159;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = CosDoubleIterations)]
         public static void CosDoubleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    CosDoubleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        CosDoubleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/CoshDouble.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/CoshDouble.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const double coshDoubleDelta = 0.0004;
         private const double coshDoubleExpectedResult = 5876.0060465657216;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = CoshDoubleIterations)]
         public static void CoshDoubleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    CoshDoubleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        CoshDoubleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/ExpDouble.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/ExpDouble.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const double expDoubleDelta = 0.0004;
         private const double expDoubleExpectedResult = 5877.1812477590884;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = ExpDoubleIterations)]
         public static void ExpDoubleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    ExpDoubleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        ExpDoubleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/FloorDouble.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/FloorDouble.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const double floorDoubleDelta = 0.0004;
         private const double floorDoubleExpectedResult = -2500;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = FloorDoubleIterations)]
         public static void FloorDoubleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    FloorDoubleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        FloorDoubleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/Log10Double.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/Log10Double.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const double log10DoubleDelta = 0.0004;
         private const double log10DoubleExpectedResult = -664.07384902184072;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = Log10DoubleIterations)]
         public static void Log10DoubleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    Log10DoubleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        Log10DoubleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/LogDouble.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/LogDouble.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const double logDoubleDelta = 0.0004;
         private const double logDoubleExpectedResult = -1529.0865454048721;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = LogDoubleIterations)]
         public static void LogDoubleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    LogDoubleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        LogDoubleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/PowDouble.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/PowDouble.cs
@@ -15,14 +15,17 @@ namespace Functions
         private const double powDoubleDeltaY = 0.0004;
         private const double powDoubleExpectedResult = 4659.4627376138733;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = PowDoubleIterations)]
         public static void PowDoubleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    PowDoubleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        PowDoubleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/RoundDouble.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/RoundDouble.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const double roundDoubleDelta = 0.0006283185307180;
         private const double roundDoubleExpectedResult = 2;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = RoundDoubleIterations)]
         public static void RoundDoubleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    RoundDoubleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        RoundDoubleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/SinDouble.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/SinDouble.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const double sinDoubleDelta = 0.0006283185307180;
         private const double sinDoubleExpectedResult = 1.0000000005445053;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = SinDoubleIterations)]
         public static void SinDoubleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    SinDoubleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        SinDoubleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/SinhDouble.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/SinhDouble.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const double sinhDoubleDelta = 0.0004;
         private const double sinhDoubleExpectedResult = 1.17520119337903;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = SinhDoubleIterations)]
         public static void SinhDoubleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    SinhDoubleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        SinhDoubleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/SqrtDouble.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/SqrtDouble.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const double sqrtDoubleDelta = 0.0006283185307180;
         private const double sqrtDoubleExpectedResult = 5909.0605337797215;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = SqrtDoubleIterations)]
         public static void SqrtDoubleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    SqrtDoubleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        SqrtDoubleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/TanDouble.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/TanDouble.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const double tanDoubleDelta = 0.0004;
         private const double tanDoubleExpectedResult = 1.5574077243051505;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = TanDoubleIterations)]
         public static void TanDoubleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    TanDoubleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        TanDoubleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/TanhDouble.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Double/TanhDouble.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const double tanhDoubleDelta = 0.0004;
         private const double tanhDoubleExpectedResult = 0.76159415578341827;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = TanhDoubleIterations)]
         public static void TanhDoubleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    TanhDoubleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        TanhDoubleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/MathTests.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/MathTests.cs
@@ -25,5 +25,47 @@ namespace Functions
         // of the perf testing as it ensures we get the expected value and that it is at least as precise
         // as we would have computed with the half-precision version of the function (without aggregation).
         private const float singleEpsilon = 9.77e-04f;
+
+        // While iterations covers the domain of inputs, the full span of results doesn't run long enough
+        // to meet our siginificance criteria. So each test is repeated many times, using the factors below.
+        private const int AbsDoubleIterations = 200000;
+        private const int AcosDoubleIterations = 10000;
+        private const int AsinDoubleIterations = 10000;
+        private const int Atan2DoubleIterations = 6500;
+        private const int AtanDoubleIterations = 13000;
+        private const int CeilingDoubleIterations = 80000;
+        private const int CosDoubleIterations = 16000;
+        private const int CoshDoubleIterations = 8000;
+        private const int ExpDoubleIterations = 16000;
+        private const int FloorDoubleIterations = 80000;
+        private const int Log10DoubleIterations = 16000;
+        private const int LogDoubleIterations = 20000;
+        private const int PowDoubleIterations = 4000;
+        private const int RoundDoubleIterations = 35000;
+        private const int SinDoubleIterations = 16000;
+        private const int SinhDoubleIterations = 8000;
+        private const int SqrtDoubleIterations = 40000;
+        private const int TanDoubleIterations = 16000;
+        private const int TanhDoubleIterations = 17000;
+
+        private const int AbsSingleIterations = 200000;
+        private const int AcosSingleIterations = 15000;
+        private const int AsinSingleIterations = 15000;
+        private const int Atan2SingleIterations = 9000;
+        private const int AtanSingleIterations = 17000;
+        private const int CeilingSingleIterations = 80000;
+        private const int CosSingleIterations = 20000;
+        private const int CoshSingleIterations = 10000;
+        private const int ExpSingleIterations = 24000;
+        private const int FloorSingleIterations = 80000;
+        private const int Log10SingleIterations = 20000;
+        private const int LogSingleIterations = 30000;
+        private const int PowSingleIterations = 10000;
+        private const int RoundSingleIterations = 35000;
+        private const int SinSingleIterations = 20000;
+        private const int SinhSingleIterations = 10000;
+        private const int SqrtSingleIterations = 80000;
+        private const int TanSingleIterations = 25000;
+        private const int TanhSingleIterations = 20000;
     }
 }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/AbsSingle.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/AbsSingle.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const float absSingleDelta = 0.0004f;
         private const float absSingleExpectedResult = 2500.03125f;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = AbsSingleIterations)]
         public static void AbsSingleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    AbsSingleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        AbsSingleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/AcosSingle.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/AcosSingle.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const float acosSingleDelta = 0.0004f;
         private const float acosSingleExpectedResult = 7852.41084f;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = AcosSingleIterations)]
         public static void AcosSingleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    AcosSingleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        AcosSingleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/AsinSingle.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/AsinSingle.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const float asinSingleDelta = 0.0004f;
         private const float asinSingleExpectedResult = 1.57079590f;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = AsinSingleIterations)]
         public static void AsinSingleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    AsinSingleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        AsinSingleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/Atan2Single.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/Atan2Single.cs
@@ -15,14 +15,17 @@ namespace Functions
         private const float atan2SingleDeltaY = 0.0004f;
         private const float atan2SingleExpectedResult = 3930.14282f;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = Atan2SingleIterations)]
         public static void Atan2SingleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    Atan2SingleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        Atan2SingleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/AtanSingle.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/AtanSingle.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const float atanSingleDelta = 0.0004f;
         private const float atanSingleExpectedResult = 0.841940999f;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = AtanSingleIterations)]
         public static void AtanSingleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    AtanSingleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        AtanSingleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/CeilingSingle.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/CeilingSingle.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const float ceilingSingleDelta = 0.0004f;
         private const float ceilingSingleExpectedResult = 2502.0f;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = CeilingSingleIterations)]
         public static void CeilingSingleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    CeilingSingleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        CeilingSingleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/CosSingle.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/CosSingle.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const float cosSingleDelta = 0.000628318531f;
         private const float cosSingleExpectedResult = -0.993487537f;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = CosSingleIterations)]
         public static void CosSingleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    CosSingleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        CosSingleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/CoshSingle.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/CoshSingle.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const float coshSingleDelta = 0.0004f;
         private const float coshSingleExpectedResult = 5876.02588f;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = CoshSingleIterations)]
         public static void CoshSingleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    CoshSingleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        CoshSingleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/ExpSingle.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/ExpSingle.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const float expSingleDelta = 0.0004f;
         private const float expSingleExpectedResult = 5877.28564f;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = ExpSingleIterations)]
         public static void ExpSingleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    ExpSingleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        ExpSingleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/FloorSingle.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/FloorSingle.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const float floorSingleDelta = 0.0004f;
         private const float floorSingleExpectedResult = -2498.0f;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = FloorSingleIterations)]
         public static void FloorSingleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    FloorSingleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        FloorSingleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/Log10Single.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/Log10Single.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const float log10SingleDelta = 0.0004f;
         private const float log10SingleExpectedResult = -664.094971f;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = Log10SingleIterations)]
         public static void Log10SingleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    Log10SingleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        Log10SingleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/LogSingle.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/LogSingle.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const float logSingleDelta = 0.0004f;
         private const float logSingleExpectedResult = -1529.14014f;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = LogSingleIterations)]
         public static void LogSingleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    LogSingleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        LogSingleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/PowSingle.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/PowSingle.cs
@@ -15,14 +15,17 @@ namespace Functions
         private const float powSingleDeltaY = 0.0004f;
         private const float powSingleExpectedResult = 4659.30762f;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = PowSingleIterations)]
         public static void PowSingleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    PowSingleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        PowSingleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/RoundSingle.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/RoundSingle.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const float roundSingleDelta = 0.000628318531f;
         private const float roundSingleExpectedResult = 2.0f;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = RoundSingleIterations)]
         public static void RoundSingleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    RoundSingleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        RoundSingleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/SinSingle.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/SinSingle.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const float sinSingleDelta = 0.000628318531f;
         private const float sinSingleExpectedResult = 1.03592682f;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = SinSingleIterations)]
         public static void SinSingleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    SinSingleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        SinSingleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/SinhSingle.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/SinhSingle.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const float sinhSingleDelta = 0.0004f;
         private const float sinhSingleExpectedResult = 1.26028216f;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = SinhSingleIterations)]
         public static void SinhSingleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    SinhSingleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        SinhSingleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/SqrtSingle.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/SqrtSingle.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const float sqrtSingleDelta = 0.000628318531f;
         private const float sqrtSingleExpectedResult = 5909.03027f;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = SqrtSingleIterations)]
         public static void SqrtSingleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    SqrtSingleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        SqrtSingleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/TanSingle.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/TanSingle.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const float tanSingleDelta = 0.0004f;
         private const float tanSingleExpectedResult = 1.66717815f;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = TanSingleIterations)]
         public static void TanSingleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    TanSingleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        TanSingleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/TanhSingle.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Math/Functions/Single/TanhSingle.cs
@@ -14,14 +14,17 @@ namespace Functions
         private const float tanhSingleDelta = 0.0004f;
         private const float tanhSingleExpectedResult = 0.816701353f;
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = TanhSingleIterations)]
         public static void TanhSingleBenchmark()
         {
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
-                    TanhSingleTest();
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        TanhSingleTest();
+                    }
                 }
             }
         }

--- a/tests/src/JIT/Performance/CodeQuality/Span/Indexer.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Span/Indexer.cs
@@ -267,7 +267,7 @@ namespace Span
             {
                 Span<byte> s = new Span<byte>(a);
                 byte result = 0;
-                int inner = Math.Max(1, (innerIterationCount / 10));
+                int inner = Math.Max(1, innerIterationCount);
                 for (int i = 0; i < inner ; ++i)
                 {
                     result = TestIndexer4(s, 10);

--- a/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
@@ -438,20 +438,14 @@ namespace Span
 
         #region TestSpanConstructor<T>
         [Benchmark(InnerIterationCount = BaseIterations)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanConstructorByte(int length)
         {
             InvokeTestSpanConstructor<byte>(length);
         }
 
         [Benchmark(InnerIterationCount = BaseIterations / 100)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanConstructorString(int length)
         {
             InvokeTestSpanConstructor<string>(length);
@@ -483,20 +477,14 @@ namespace Span
 
         #region TestSpanDangerousCreate<T>
         [Benchmark(InnerIterationCount = BaseIterations)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanDangerousCreateByte(int length)
         {
             InvokeTestSpanDangerousCreate<byte>(length);
         }
 
         [Benchmark(InnerIterationCount = BaseIterations)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanDangerousCreateString(int length)
         {
             InvokeTestSpanDangerousCreate<string>(length);
@@ -529,20 +517,14 @@ namespace Span
 
         #region TestSpanDangerousGetPinnableReference<T>
         [Benchmark(InnerIterationCount = BaseIterations)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanDangerousGetPinnableReferenceByte(int length)
         {
             InvokeTestSpanDangerousGetPinnableReference<byte>(length);
         }
 
         [Benchmark(InnerIterationCount = BaseIterations)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanDangerousGetPinnableReferenceString(int length)
         {
             InvokeTestSpanDangerousGetPinnableReference<string>(length);
@@ -572,20 +554,14 @@ namespace Span
 
         #region TestSpanIndexHoistable<T>
         [Benchmark(InnerIterationCount = BaseIterations)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanIndexHoistableByte(int length)
         {
             InvokeTestSpanIndexHoistable<byte>(length);
         }
 
         [Benchmark(InnerIterationCount = BaseIterations)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanIndexHoistableString(int length)
         {
             InvokeTestSpanIndexHoistable<string>(length);
@@ -612,20 +588,14 @@ namespace Span
 
         #region TestArrayIndexHoistable<T>
         [Benchmark(InnerIterationCount = BaseIterations)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestArrayIndexHoistableByte(int length)
         {
             InvokeTestArrayIndexHoistable<byte>(length);
         }
 
         [Benchmark(InnerIterationCount = BaseIterations)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestArrayIndexHoistableString(int length)
         {
             InvokeTestArrayIndexHoistable<string>(length);
@@ -650,20 +620,14 @@ namespace Span
 
         #region TestSpanIndexVariant<T>
         [Benchmark(InnerIterationCount = BaseIterations)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanIndexVariantByte(int length)
         {
             InvokeTestSpanIndexVariant<byte>(length);
         }
 
         [Benchmark(InnerIterationCount = BaseIterations)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanIndexVariantString(int length)
         {
             InvokeTestSpanIndexVariant<string>(length);
@@ -691,20 +655,14 @@ namespace Span
 
         #region TestArrayIndexVariant<T>
         [Benchmark(InnerIterationCount = BaseIterations)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestArrayIndexVariantByte(int length)
         {
             InvokeTestArrayIndexVariant<byte>(length);
         }
 
         [Benchmark(InnerIterationCount = BaseIterations)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestArrayIndexVariantString(int length)
         {
             InvokeTestArrayIndexVariant<string>(length);
@@ -733,20 +691,14 @@ namespace Span
 
         #region TestSpanSlice<T>
         [Benchmark(InnerIterationCount = BaseIterations)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanSliceByte(int length)
         {
             InvokeTestSpanSlice<byte>(length);
         }
 
         [Benchmark(InnerIterationCount = BaseIterations)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanSliceString(int length)
         {
             InvokeTestSpanSlice<string>(length);
@@ -779,20 +731,14 @@ namespace Span
 
         #region TestSpanToArray<T>
         [Benchmark(InnerIterationCount = BaseIterations / 100)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanToArrayByte(int length)
         {
             InvokeTestSpanToArray<byte>(length);
         }
 
         [Benchmark(InnerIterationCount = BaseIterations / 100)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanToArrayString(int length)
         {
             InvokeTestSpanToArray<string>(length);
@@ -819,20 +765,14 @@ namespace Span
 
         #region TestSpanCopyTo<T>
         [Benchmark(InnerIterationCount = BaseIterations / 10)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanCopyToByte(int length)
         {
             InvokeTestSpanCopyTo<byte>(length);
         }
 
         [Benchmark(InnerIterationCount = BaseIterations / 100)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanCopyToString(int length)
         {
             InvokeTestSpanCopyTo<string>(length);
@@ -860,20 +800,14 @@ namespace Span
 
         #region TestArrayCopyTo<T>
         [Benchmark(InnerIterationCount = BaseIterations / 10)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestArrayCopyToByte(int length)
         {
             InvokeTestArrayCopyTo<byte>(length);
         }
 
         [Benchmark(InnerIterationCount = BaseIterations / 100)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestArrayCopyToString(int length)
         {
             InvokeTestArrayCopyTo<string>(length);
@@ -898,20 +832,14 @@ namespace Span
 
         #region TestSpanFill<T>
         [Benchmark(InnerIterationCount = BaseIterations * 10)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanFillByte(int length)
         {
             InvokeTestSpanFill<byte>(length);
         }
 
         [Benchmark(InnerIterationCount = BaseIterations / 100)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanFillString(int length)
         {
             InvokeTestSpanFill<string>(length);
@@ -936,20 +864,14 @@ namespace Span
 
         #region TestSpanClear<T>
         [Benchmark(InnerIterationCount = BaseIterations / 10)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanClearByte(int length)
         {
             InvokeTestSpanClear<byte>(length);
         }
 
         [Benchmark(InnerIterationCount = BaseIterations / 10)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanClearString(int length)
         {
             InvokeTestSpanClear<string>(length);
@@ -974,20 +896,14 @@ namespace Span
 
         #region TestArrayClear<T>
         [Benchmark(InnerIterationCount = BaseIterations / 10)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestArrayClearByte(int length)
         {
             InvokeTestArrayClear<byte>(length);
         }
 
         [Benchmark(InnerIterationCount = BaseIterations / 10)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestArrayClearString(int length)
         {
             InvokeTestArrayClear<string>(length);
@@ -1011,20 +927,14 @@ namespace Span
 
         #region TestSpanAsBytes<T>
         [Benchmark(InnerIterationCount = BaseIterations)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanAsBytesByte(int length)
         {
             InvokeTestSpanAsBytes<byte>(length);
         }
 
         [Benchmark(InnerIterationCount = BaseIterations)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanAsBytesInt(int length)
         {
             InvokeTestSpanAsBytes<int>(length);
@@ -1059,20 +969,14 @@ namespace Span
 
         #region TestSpanNonPortableCast<T>
         [Benchmark(InnerIterationCount = BaseIterations)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanNonPortableCastFromByteToInt(int length)
         {
             InvokeTestSpanNonPortableCast<byte, int>(length);
         }
 
         [Benchmark(InnerIterationCount = BaseIterations)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanNonPortableCastFromIntToByte(int length)
         {
             InvokeTestSpanNonPortableCast<int, byte>(length);
@@ -1110,10 +1014,7 @@ namespace Span
         #region TestSpanAsSpanStringChar<T>
 
         [Benchmark(InnerIterationCount = BaseIterations)]
-        [InlineData(1)]
-        [InlineData(10)]
         [InlineData(100)]
-        [InlineData(1000)]
         public static void TestSpanAsSpanStringCharWrapper(int length)
         {
             StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
This change updates the iteration behavior for the following benchmarks, so that
they generally run for about 1 second per iteration:
* Inline/InlineGCStruct
* Inline/NoThrowInline
* Span/IndexerBench/Indexer4
* Functions/MathTests/*

It also removes the length 1, 10, and 1000 variants of the Span/SpanBench
tests, leaving just the length 100 variants. Analysis has shown that there
is no need to test varying lengths here. Iteration counts for these tests
have been left as is and will be fixed subsequently.

Partially addresses #11654.