### PR TITLE
Make JIT dumps more readable

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -394,7 +394,7 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
 #ifdef DEBUG
             char message[256];
             _snprintf_s(message, _countof(message), _TRUNCATE, "NYI: Unimplemented node type %s",
-                        GenTree::NodeName(treeNode->OperGet()));
+                        GenTree::OpName(treeNode->OperGet()));
             NYIRAW(message);
 #else
             NYI("unimplemented node");

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -1966,7 +1966,7 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
 #ifdef DEBUG
             char message[256];
             _snprintf_s(message, _countof(message), _TRUNCATE, "NYI: Unimplemented node type %s\n",
-                        GenTree::NodeName(treeNode->OperGet()));
+                        GenTree::OpName(treeNode->OperGet()));
             NYIRAW(message);
 #endif
             assert(!"Unknown node in codegen");

--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -264,7 +264,7 @@ GenTree* DecomposeLongs::DecomposeNode(GenTree* tree)
 
         default:
         {
-            JITDUMP("Illegal TYP_LONG node %s in Decomposition.", GenTree::NodeName(tree->OperGet()));
+            JITDUMP("Illegal TYP_LONG node %s in Decomposition.", GenTree::OpName(tree->OperGet()));
             assert(!"Illegal TYP_LONG node in Decomposition.");
             break;
         }

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -21,7 +21,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 /*****************************************************************************/
 
 const unsigned short GenTree::gtOperKindTable[] = {
-#define GTNODE(en, sn, st, cm, ok) ok + GTK_COMMUTE *cm,
+#define GTNODE(en, st, cm, ok) ok + GTK_COMMUTE *cm,
 #include "gtlist.h"
 };
 
@@ -208,24 +208,12 @@ static void printIndent(IndentStack* indentStack)
     indentStack->print();
 }
 
-static const char* nodeNames[] = {
-#define GTNODE(en, sn, st, cm, ok) sn,
-#include "gtlist.h"
-};
-
-const char* GenTree::NodeName(genTreeOps op)
-{
-    assert((unsigned)op < sizeof(nodeNames) / sizeof(nodeNames[0]));
-
-    return nodeNames[op];
-}
-
 #endif
 
 #if defined(DEBUG) || NODEBASH_STATS || MEASURE_NODE_SIZE || COUNT_AST_OPERS
 
 static const char* opNames[] = {
-#define GTNODE(en, sn, st, cm, ok) #en,
+#define GTNODE(en, st, cm, ok) #en,
 #include "gtlist.h"
 };
 
@@ -241,7 +229,7 @@ const char* GenTree::OpName(genTreeOps op)
 #if MEASURE_NODE_SIZE && SMALL_TREE_NODES
 
 static const char* opStructNames[] = {
-#define GTNODE(en, sn, st, cm, ok) #st,
+#define GTNODE(en, st, cm, ok) #st,
 #include "gtlist.h"
 };
 
@@ -270,7 +258,7 @@ unsigned char GenTree::s_gtNodeSizes[GT_COUNT + 1];
 #if NODEBASH_STATS || MEASURE_NODE_SIZE || COUNT_AST_OPERS
 
 unsigned char GenTree::s_gtTrueSizes[GT_COUNT + 1]{
-#define GTNODE(en, sn, st, cm, ok) sizeof(st),
+#define GTNODE(en, st, cm, ok) sizeof(st),
 #include "gtlist.h"
 };
 
@@ -9810,7 +9798,7 @@ void Compiler::gtDispNodeName(GenTree* tree)
     assert(tree);
     if (tree->gtOper < GT_COUNT)
     {
-        name = GenTree::NodeName(tree->OperGet());
+        name = GenTree::OpName(tree->OperGet());
     }
     else
     {
@@ -9829,7 +9817,7 @@ void Compiler::gtDispNodeName(GenTree* tree)
     }
     else if (tree->gtOper == GT_CALL)
     {
-        const char* callType = "call";
+        const char* callType = "CALL";
         const char* gtfType  = "";
         const char* ctType   = "";
         char        gtfTypeBuf[100];
@@ -9838,7 +9826,7 @@ void Compiler::gtDispNodeName(GenTree* tree)
         {
             if ((tree->gtFlags & GTF_CALL_VIRT_KIND_MASK) != GTF_CALL_NONVIRT)
             {
-                callType = "callv";
+                callType = "CALLV";
             }
         }
         else if (tree->gtCall.gtCallType == CT_HELPER)
@@ -11192,7 +11180,7 @@ void Compiler::gtDispLeaf(GenTree* tree, IndentStack* indentStack)
 
         case GT_JCC:
         case GT_SETCC:
-            printf(" cond=%s", GenTree::NodeName(tree->AsCC()->gtCondition));
+            printf(" cond=%s", GenTree::OpName(tree->AsCC()->gtCondition));
             break;
 
         default:

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -68,7 +68,7 @@ enum SpecialCodeKind
 
 DECLARE_TYPED_ENUM(genTreeOps, BYTE)
 {
-#define GTNODE(en, sn, st, cm, ok) GT_##en,
+#define GTNODE(en, st, cm, ok) GT_##en,
 #include "gtlist.h"
 
     GT_COUNT,
@@ -1757,10 +1757,6 @@ public:
     static bool Compare(GenTreePtr op1, GenTreePtr op2, bool swapOK = false);
 
 //---------------------------------------------------------------------
-
-#if defined(DEBUG)
-    static const char* NodeName(genTreeOps op);
-#endif
 
 #if defined(DEBUG) || NODEBASH_STATS || MEASURE_NODE_SIZE || COUNT_AST_OPERS
     static const char* OpName(genTreeOps op);

--- a/src/jit/gtlist.h
+++ b/src/jit/gtlist.h
@@ -10,141 +10,140 @@
 /*****************************************************************************/
 //
 //     Node enum
-//                      ,"Node name"
-//                                       ,GenTree struct flavor
-//                                                           ,commutative
-//                                                             ,operKind
+//                       , GenTree struct flavor
+//                                           ,commutative
+//                                             ,operKind
 
-GTNODE(NONE             , "<none>"       ,char               ,0,GTK_SPECIAL)
+GTNODE(NONE             , char               ,0,GTK_SPECIAL)
 
 //-----------------------------------------------------------------------------
 //  Leaf nodes (i.e. these nodes have no sub-operands):
 //-----------------------------------------------------------------------------
 
-GTNODE(LCL_VAR          , "lclVar"       ,GenTreeLclVar      ,0,GTK_LEAF|GTK_LOCAL)     // local variable
-GTNODE(LCL_FLD          , "lclFld"       ,GenTreeLclFld      ,0,GTK_LEAF|GTK_LOCAL)     // field in a non-primitive variable
-GTNODE(LCL_VAR_ADDR     , "&lclVar"      ,GenTreeLclVar      ,0,GTK_LEAF)               // address of local variable
-GTNODE(LCL_FLD_ADDR     , "&lclFld"      ,GenTreeLclFld      ,0,GTK_LEAF)               // address of field in a non-primitive variable
-GTNODE(STORE_LCL_VAR    , "st.lclVar"    ,GenTreeLclVar      ,0,GTK_UNOP|GTK_LOCAL|GTK_NOVALUE) // store to local variable
-GTNODE(STORE_LCL_FLD    , "st.lclFld"    ,GenTreeLclFld      ,0,GTK_UNOP|GTK_LOCAL|GTK_NOVALUE) // store to field in a non-primitive variable
-GTNODE(CATCH_ARG        , "catchArg"     ,GenTree            ,0,GTK_LEAF)               // Exception object in a catch block
-GTNODE(LABEL            , "codeLabel"    ,GenTreeLabel       ,0,GTK_LEAF)               // Jump-target
-GTNODE(FTN_ADDR         , "ftnAddr"      ,GenTreeFptrVal     ,0,GTK_LEAF)               // Address of a function
-GTNODE(RET_EXPR         , "retExpr"      ,GenTreeRetExpr     ,0,GTK_LEAF)               // Place holder for the return expression from an inline candidate
+GTNODE(LCL_VAR          , GenTreeLclVar      ,0,GTK_LEAF|GTK_LOCAL)     // local variable
+GTNODE(LCL_FLD          , GenTreeLclFld      ,0,GTK_LEAF|GTK_LOCAL)     // field in a non-primitive variable
+GTNODE(LCL_VAR_ADDR     , GenTreeLclVar      ,0,GTK_LEAF)               // address of local variable
+GTNODE(LCL_FLD_ADDR     , GenTreeLclFld      ,0,GTK_LEAF)               // address of field in a non-primitive variable
+GTNODE(STORE_LCL_VAR    , GenTreeLclVar      ,0,GTK_UNOP|GTK_LOCAL|GTK_NOVALUE) // store to local variable
+GTNODE(STORE_LCL_FLD    , GenTreeLclFld      ,0,GTK_UNOP|GTK_LOCAL|GTK_NOVALUE) // store to field in a non-primitive variable
+GTNODE(CATCH_ARG        , GenTree            ,0,GTK_LEAF)               // Exception object in a catch block
+GTNODE(LABEL            , GenTreeLabel       ,0,GTK_LEAF)               // Jump-target
+GTNODE(FTN_ADDR         , GenTreeFptrVal     ,0,GTK_LEAF)               // Address of a function
+GTNODE(RET_EXPR         , GenTreeRetExpr     ,0,GTK_LEAF)               // Place holder for the return expression from an inline candidate
 
 //-----------------------------------------------------------------------------
 //  Constant nodes:
 //-----------------------------------------------------------------------------
 
-GTNODE(CNS_INT          , "const"        ,GenTreeIntCon      ,0,GTK_LEAF|GTK_CONST)
-GTNODE(CNS_LNG          , "lconst"       ,GenTreeLngCon      ,0,GTK_LEAF|GTK_CONST)
-GTNODE(CNS_DBL          , "dconst"       ,GenTreeDblCon      ,0,GTK_LEAF|GTK_CONST)
-GTNODE(CNS_STR          , "sconst"       ,GenTreeStrCon      ,0,GTK_LEAF|GTK_CONST)
+GTNODE(CNS_INT          , GenTreeIntCon      ,0,GTK_LEAF|GTK_CONST)
+GTNODE(CNS_LNG          , GenTreeLngCon      ,0,GTK_LEAF|GTK_CONST)
+GTNODE(CNS_DBL          , GenTreeDblCon      ,0,GTK_LEAF|GTK_CONST)
+GTNODE(CNS_STR          , GenTreeStrCon      ,0,GTK_LEAF|GTK_CONST)
 
 //-----------------------------------------------------------------------------
 //  Unary  operators (1 operand):
 //-----------------------------------------------------------------------------
 
-GTNODE(NOT              , "~"            ,GenTreeOp          ,0,GTK_UNOP)
-GTNODE(NOP              , "nop"          ,GenTree            ,0,GTK_UNOP|GTK_NOCONTAIN)
-GTNODE(NEG              , "unary -"      ,GenTreeOp          ,0,GTK_UNOP)
-GTNODE(COPY             , "copy"         ,GenTreeCopyOrReload,0,GTK_UNOP)               // Copies a variable from its current location to a register that satisfies
-                                                                                        // code generation constraints.  The child is the actual lclVar node.
-GTNODE(RELOAD           , "reload"       ,GenTreeCopyOrReload,0,GTK_UNOP)
-GTNODE(CHS              , "flipsign"     ,GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR) // GT_CHS is actually unary -- op2 is ignored.
-                                                                                        // Changing to unary presently causes problems, though -- take a little work to fix.
+GTNODE(NOT              , GenTreeOp          ,0,GTK_UNOP)
+GTNODE(NOP              , GenTree            ,0,GTK_UNOP|GTK_NOCONTAIN)
+GTNODE(NEG              , GenTreeOp          ,0,GTK_UNOP)
+GTNODE(COPY             , GenTreeCopyOrReload,0,GTK_UNOP)               // Copies a variable from its current location to a register that satisfies
+                                                                        // code generation constraints.  The child is the actual lclVar node.
+GTNODE(RELOAD           , GenTreeCopyOrReload,0,GTK_UNOP)
+GTNODE(CHS              , GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR) // GT_CHS is actually unary -- op2 is ignored.
+                                                                                // Changing to unary presently causes problems, though -- take a little work to fix.
 
-GTNODE(ARR_LENGTH       , "arrLen"       ,GenTreeArrLen      ,0,GTK_UNOP|GTK_EXOP)      // array-length
+GTNODE(ARR_LENGTH       , GenTreeArrLen      ,0,GTK_UNOP|GTK_EXOP)      // array-length
 
-GTNODE(INTRINSIC        , "intrinsic"    ,GenTreeIntrinsic   ,0,GTK_BINOP|GTK_EXOP)     // intrinsics
+GTNODE(INTRINSIC        , GenTreeIntrinsic   ,0,GTK_BINOP|GTK_EXOP)     // intrinsics
 
-GTNODE(LOCKADD          , "lockAdd"      ,GenTreeOp          ,0,GTK_BINOP|GTK_NOVALUE)
-GTNODE(XADD             , "XAdd"         ,GenTreeOp          ,0,GTK_BINOP)
-GTNODE(XCHG             , "Xchg"         ,GenTreeOp          ,0,GTK_BINOP)
-GTNODE(CMPXCHG          , "cmpxchg"      ,GenTreeCmpXchg     ,0,GTK_SPECIAL)
-GTNODE(MEMORYBARRIER    , "memoryBarrier",GenTree            ,0,GTK_LEAF|GTK_NOVALUE)
+GTNODE(LOCKADD          , GenTreeOp          ,0,GTK_BINOP|GTK_NOVALUE)
+GTNODE(XADD             , GenTreeOp          ,0,GTK_BINOP)
+GTNODE(XCHG             , GenTreeOp          ,0,GTK_BINOP)
+GTNODE(CMPXCHG          , GenTreeCmpXchg     ,0,GTK_SPECIAL)
+GTNODE(MEMORYBARRIER    , GenTree            ,0,GTK_LEAF|GTK_NOVALUE)
 
-GTNODE(CAST             , "cast"         ,GenTreeCast        ,0,GTK_UNOP|GTK_EXOP)      // conversion to another type
-GTNODE(CKFINITE         , "ckfinite"     ,GenTreeOp          ,0,GTK_UNOP|GTK_NOCONTAIN) // Check for NaN
-GTNODE(LCLHEAP          , "lclHeap"      ,GenTreeOp          ,0,GTK_UNOP|GTK_NOCONTAIN) // alloca()
-GTNODE(JMP              , "jump"         ,GenTreeVal         ,0,GTK_LEAF|GTK_NOVALUE)   // Jump to another function
+GTNODE(CAST             , GenTreeCast        ,0,GTK_UNOP|GTK_EXOP)      // conversion to another type
+GTNODE(CKFINITE         , GenTreeOp          ,0,GTK_UNOP|GTK_NOCONTAIN) // Check for NaN
+GTNODE(LCLHEAP          , GenTreeOp          ,0,GTK_UNOP|GTK_NOCONTAIN) // alloca()
+GTNODE(JMP              , GenTreeVal         ,0,GTK_LEAF|GTK_NOVALUE)   // Jump to another function
 
-GTNODE(ADDR             , "addr"         ,GenTreeOp          ,0,GTK_UNOP)               // address of
-GTNODE(IND              , "indir"        ,GenTreeOp          ,0,GTK_UNOP)               // load indirection
-GTNODE(STOREIND         , "storeIndir"   ,GenTreeStoreInd    ,0,GTK_BINOP|GTK_NOVALUE)  // store indirection
+GTNODE(ADDR             , GenTreeOp          ,0,GTK_UNOP)               // address of
+GTNODE(IND              , GenTreeOp          ,0,GTK_UNOP)               // load indirection
+GTNODE(STOREIND         , GenTreeStoreInd    ,0,GTK_BINOP|GTK_NOVALUE)  // store indirection
 
-                                                                                        // TODO-Cleanup: GT_ARR_BOUNDS_CHECK should be made a GTK_BINOP now that it has only two child nodes
-GTNODE(ARR_BOUNDS_CHECK , "arrBndsChk"   ,GenTreeBoundsChk   ,0,GTK_SPECIAL|GTK_NOVALUE)// array bounds check
-GTNODE(OBJ              , "obj"          ,GenTreeObj         ,0,GTK_UNOP|GTK_EXOP)      // Object that MAY have gc pointers, and thus includes the relevant gc layout info.
-GTNODE(STORE_OBJ        , "storeObj"     ,GenTreeBlk         ,0,GTK_BINOP|GTK_EXOP|GTK_NOVALUE) // Object that MAY have gc pointers, and thus includes the relevant gc layout info.
-GTNODE(BLK              , "blk"          ,GenTreeBlk         ,0,GTK_UNOP)               // Block/object with no gc pointers, and with a known size (e.g. a struct with no gc fields)
-GTNODE(STORE_BLK        , "storeBlk"     ,GenTreeBlk         ,0,GTK_BINOP|GTK_NOVALUE)  // Block/object with no gc pointers, and with a known size (e.g. a struct with no gc fields)
-GTNODE(DYN_BLK          , "DynBlk"       ,GenTreeBlk         ,0,GTK_SPECIAL)            // Dynamically sized block object
-GTNODE(STORE_DYN_BLK    , "storeDynBlk"  ,GenTreeBlk         ,0,GTK_SPECIAL|GTK_NOVALUE)// Dynamically sized block object
-GTNODE(BOX              , "box"          ,GenTreeBox         ,0,GTK_UNOP|GTK_EXOP|GTK_NOTLIR)
+                                                                        // TODO-Cleanup: GT_ARR_BOUNDS_CHECK should be made a GTK_BINOP now that it has only two child nodes
+GTNODE(ARR_BOUNDS_CHECK , GenTreeBoundsChk   ,0,GTK_SPECIAL|GTK_NOVALUE)// array bounds check
+GTNODE(OBJ              , GenTreeObj         ,0,GTK_UNOP|GTK_EXOP)      // Object that MAY have gc pointers, and thus includes the relevant gc layout info.
+GTNODE(STORE_OBJ        , GenTreeBlk         ,0,GTK_BINOP|GTK_EXOP|GTK_NOVALUE) // Object that MAY have gc pointers, and thus includes the relevant gc layout info.
+GTNODE(BLK              , GenTreeBlk         ,0,GTK_UNOP)               // Block/object with no gc pointers, and with a known size (e.g. a struct with no gc fields)
+GTNODE(STORE_BLK        , GenTreeBlk         ,0,GTK_BINOP|GTK_NOVALUE)  // Block/object with no gc pointers, and with a known size (e.g. a struct with no gc fields)
+GTNODE(DYN_BLK          , GenTreeBlk         ,0,GTK_SPECIAL)            // Dynamically sized block object
+GTNODE(STORE_DYN_BLK    , GenTreeBlk         ,0,GTK_SPECIAL|GTK_NOVALUE)// Dynamically sized block object
+GTNODE(BOX              , GenTreeBox         ,0,GTK_UNOP|GTK_EXOP|GTK_NOTLIR)
 
 #ifdef FEATURE_SIMD
-GTNODE(SIMD_CHK         , "simdChk"      ,GenTreeBoundsChk   ,0,GTK_SPECIAL|GTK_NOVALUE)// Compare whether an index is less than the given SIMD vector length, and call CORINFO_HELP_RNGCHKFAIL if not.
-                                                                                        // TODO-CQ: In future may want to add a field that specifies different exceptions but we'll
-                                                                                        // need VM assistance for that.
-                                                                                        // TODO-CQ: It would actually be very nice to make this an unconditional throw, and expose the control flow that
-                                                                                        // does the compare, so that it can be more easily optimized.  But that involves generating qmarks at import time...
+GTNODE(SIMD_CHK         , GenTreeBoundsChk   ,0,GTK_SPECIAL|GTK_NOVALUE)// Compare whether an index is less than the given SIMD vector length, and call CORINFO_HELP_RNGCHKFAIL if not.
+                                                                        // TODO-CQ: In future may want to add a field that specifies different exceptions but we'll
+                                                                        // need VM assistance for that.
+                                                                        // TODO-CQ: It would actually be very nice to make this an unconditional throw, and expose the control flow that
+                                                                        // does the compare, so that it can be more easily optimized.  But that involves generating qmarks at import time...
 #endif // FEATURE_SIMD
 
-GTNODE(ALLOCOBJ         , "allocObj"     ,GenTreeAllocObj    ,0,GTK_UNOP|GTK_EXOP)      // object allocator
+GTNODE(ALLOCOBJ         , GenTreeAllocObj    ,0,GTK_UNOP|GTK_EXOP)      // object allocator
 
-GTNODE(INIT_VAL         , "initVal"      ,GenTreeOp          ,0,GTK_UNOP)               // Initialization value for an initBlk
+GTNODE(INIT_VAL         , GenTreeOp          ,0,GTK_UNOP)               // Initialization value for an initBlk
 
 //-----------------------------------------------------------------------------
 //  Binary operators (2 operands):
 //-----------------------------------------------------------------------------
 
-GTNODE(ADD              , "+"            ,GenTreeOp          ,1,GTK_BINOP)
-GTNODE(SUB              , "-"            ,GenTreeOp          ,0,GTK_BINOP)
-GTNODE(MUL              , "*"            ,GenTreeOp          ,1,GTK_BINOP)
-GTNODE(DIV              , "/"            ,GenTreeOp          ,0,GTK_BINOP)
-GTNODE(MOD              , "%"            ,GenTreeOp          ,0,GTK_BINOP)
+GTNODE(ADD              , GenTreeOp          ,1,GTK_BINOP)
+GTNODE(SUB              , GenTreeOp          ,0,GTK_BINOP)
+GTNODE(MUL              , GenTreeOp          ,1,GTK_BINOP)
+GTNODE(DIV              , GenTreeOp          ,0,GTK_BINOP)
+GTNODE(MOD              , GenTreeOp          ,0,GTK_BINOP)
 
-GTNODE(UDIV             , "un-/"         ,GenTreeOp          ,0,GTK_BINOP)
-GTNODE(UMOD             , "un-%"         ,GenTreeOp          ,0,GTK_BINOP)
+GTNODE(UDIV             , GenTreeOp          ,0,GTK_BINOP)
+GTNODE(UMOD             , GenTreeOp          ,0,GTK_BINOP)
 
-GTNODE(OR               , "|"            ,GenTreeOp          ,1,GTK_BINOP|GTK_LOGOP)
-GTNODE(XOR              , "^"            ,GenTreeOp          ,1,GTK_BINOP|GTK_LOGOP)
-GTNODE(AND              , "&"            ,GenTreeOp          ,1,GTK_BINOP|GTK_LOGOP)
+GTNODE(OR               , GenTreeOp          ,1,GTK_BINOP|GTK_LOGOP)
+GTNODE(XOR              , GenTreeOp          ,1,GTK_BINOP|GTK_LOGOP)
+GTNODE(AND              , GenTreeOp          ,1,GTK_BINOP|GTK_LOGOP)
 
-GTNODE(LSH              , "<<"           ,GenTreeOp          ,0,GTK_BINOP)
-GTNODE(RSH              , ">>"           ,GenTreeOp          ,0,GTK_BINOP)
-GTNODE(RSZ              , ">>>"          ,GenTreeOp          ,0,GTK_BINOP)
-GTNODE(ROL              , "rol"          ,GenTreeOp          ,0,GTK_BINOP)
-GTNODE(ROR              , "ror"          ,GenTreeOp          ,0,GTK_BINOP)
-GTNODE(MULHI            , "mulhi"        ,GenTreeOp          ,1,GTK_BINOP) // returns high bits (top N bits of the 2N bit result of an NxN multiply)
-                                                     // GT_MULHI is used in division by a constant (fgMorphDivByConst). We turn
-                                                     // the div into a MULHI + some adjustments. In codegen, we only use the
-                                                     // results of the high register, and we drop the low results.
+GTNODE(LSH              , GenTreeOp          ,0,GTK_BINOP)
+GTNODE(RSH              , GenTreeOp          ,0,GTK_BINOP)
+GTNODE(RSZ              , GenTreeOp          ,0,GTK_BINOP)
+GTNODE(ROL              , GenTreeOp          ,0,GTK_BINOP)
+GTNODE(ROR              , GenTreeOp          ,0,GTK_BINOP)
+GTNODE(MULHI            , GenTreeOp          ,1,GTK_BINOP) // returns high bits (top N bits of the 2N bit result of an NxN multiply)
+                                                           // GT_MULHI is used in division by a constant (fgMorphDivByConst). We turn
+                                                           // the div into a MULHI + some adjustments. In codegen, we only use the
+                                                           // results of the high register, and we drop the low results.
 
-GTNODE(ASG              , "="            ,GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
-GTNODE(ASG_ADD          , "+="           ,GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
-GTNODE(ASG_SUB          , "-="           ,GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
-GTNODE(ASG_MUL          , "*="           ,GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
-GTNODE(ASG_DIV          , "/="           ,GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
-GTNODE(ASG_MOD          , "%="           ,GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
+GTNODE(ASG              , GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
+GTNODE(ASG_ADD          , GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
+GTNODE(ASG_SUB          , GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
+GTNODE(ASG_MUL          , GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
+GTNODE(ASG_DIV          , GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
+GTNODE(ASG_MOD          , GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
 
-GTNODE(ASG_UDIV         , "/="           ,GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
-GTNODE(ASG_UMOD         , "%="           ,GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
+GTNODE(ASG_UDIV         , GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
+GTNODE(ASG_UMOD         , GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
 
-GTNODE(ASG_OR           , "|="           ,GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
-GTNODE(ASG_XOR          , "^="           ,GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
-GTNODE(ASG_AND          , "&="           ,GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
-GTNODE(ASG_LSH          , "<<="          ,GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
-GTNODE(ASG_RSH          , ">>="          ,GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
-GTNODE(ASG_RSZ          , ">>>="         ,GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
+GTNODE(ASG_OR           , GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
+GTNODE(ASG_XOR          , GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
+GTNODE(ASG_AND          , GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
+GTNODE(ASG_LSH          , GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
+GTNODE(ASG_RSH          , GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
+GTNODE(ASG_RSZ          , GenTreeOp          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
 
-GTNODE(EQ               , "=="           ,GenTreeOp          ,0,GTK_BINOP|GTK_RELOP)
-GTNODE(NE               , "!="           ,GenTreeOp          ,0,GTK_BINOP|GTK_RELOP)
-GTNODE(LT               , "<"            ,GenTreeOp          ,0,GTK_BINOP|GTK_RELOP)
-GTNODE(LE               , "<="           ,GenTreeOp          ,0,GTK_BINOP|GTK_RELOP)
-GTNODE(GE               , ">="           ,GenTreeOp          ,0,GTK_BINOP|GTK_RELOP)
-GTNODE(GT               , ">"            ,GenTreeOp          ,0,GTK_BINOP|GTK_RELOP)
+GTNODE(EQ               , GenTreeOp          ,0,GTK_BINOP|GTK_RELOP)
+GTNODE(NE               , GenTreeOp          ,0,GTK_BINOP|GTK_RELOP)
+GTNODE(LT               , GenTreeOp          ,0,GTK_BINOP|GTK_RELOP)
+GTNODE(LE               , GenTreeOp          ,0,GTK_BINOP|GTK_RELOP)
+GTNODE(GE               , GenTreeOp          ,0,GTK_BINOP|GTK_RELOP)
+GTNODE(GT               , GenTreeOp          ,0,GTK_BINOP|GTK_RELOP)
 #ifndef LEGACY_BACKEND
 // These are similar to GT_EQ/GT_NE but they generate "test" instead of "cmp" instructions.
 // Currently these are generated during lowering for code like ((x & y) eq|ne 0) only on 
@@ -153,39 +152,39 @@ GTNODE(GT               , ">"            ,GenTreeOp          ,0,GTK_BINOP|GTK_RE
 // codegen which emits a "test reg, reg" instruction, that would be more difficult to do
 // during lowering because the source operand is used twice so it has to be a lclvar. 
 // Because of this there is no need to also add GT_TEST_LT/LE/GE/GT opers.
-GTNODE(TEST_EQ          , "testEQ"       ,GenTreeOp          ,0,GTK_BINOP|GTK_RELOP)
-GTNODE(TEST_NE          , "testNE"       ,GenTreeOp          ,0,GTK_BINOP|GTK_RELOP)
+GTNODE(TEST_EQ          , GenTreeOp          ,0,GTK_BINOP|GTK_RELOP)
+GTNODE(TEST_NE          , GenTreeOp          ,0,GTK_BINOP|GTK_RELOP)
 #endif
 
-GTNODE(COMMA            , "comma"        ,GenTreeOp          ,0,GTK_BINOP|GTK_NOTLIR)
+GTNODE(COMMA            , GenTreeOp          ,0,GTK_BINOP|GTK_NOTLIR)
 
-GTNODE(QMARK            , "qmark"        ,GenTreeQmark       ,0,GTK_BINOP|GTK_EXOP|GTK_NOTLIR)
-GTNODE(COLON            , "colon"        ,GenTreeColon       ,0,GTK_BINOP|GTK_NOTLIR)
+GTNODE(QMARK            , GenTreeQmark       ,0,GTK_BINOP|GTK_EXOP|GTK_NOTLIR)
+GTNODE(COLON            , GenTreeColon       ,0,GTK_BINOP|GTK_NOTLIR)
 
-GTNODE(INDEX            , "[]"           ,GenTreeIndex       ,0,GTK_BINOP|GTK_EXOP|GTK_NOTLIR)   // SZ-array-element
+GTNODE(INDEX            , GenTreeIndex       ,0,GTK_BINOP|GTK_EXOP|GTK_NOTLIR)   // SZ-array-element
 
-GTNODE(MKREFANY         , "mkrefany"     ,GenTreeOp          ,0,GTK_BINOP)
+GTNODE(MKREFANY         , GenTreeOp          ,0,GTK_BINOP)
 
-GTNODE(LEA              , "lea"          ,GenTreeAddrMode    ,0,GTK_BINOP|GTK_EXOP)
+GTNODE(LEA              , GenTreeAddrMode    ,0,GTK_BINOP|GTK_EXOP)
 
 #if !defined(LEGACY_BACKEND) && !defined(_TARGET_64BIT_)
 // A GT_LONG node simply represents the long value produced by the concatenation
 // of its two (lower and upper half) operands.  Some GT_LONG nodes are transient,
 // during the decomposing of longs; others are handled by codegen as operands of
 // nodes such as calls, returns and stores of long lclVars.
-GTNODE(LONG             , "gt_long"      ,GenTreeOp          ,0,GTK_BINOP)
+GTNODE(LONG             , GenTreeOp          ,0,GTK_BINOP)
 
 // The following are nodes representing x86/arm32 specific long operators, including
 // high operators of a 64-bit operations that requires a carry/borrow, which are
 // named GT_XXX_HI for consistency, low operators of 64-bit operations that need
 // to not be modified in phases post-decompose, and operators that return 64-bit
 // results in one instruction.
-GTNODE(ADD_LO           , "+Lo"          ,GenTreeOp          ,1,GTK_BINOP)
-GTNODE(ADD_HI           , "+Hi"          ,GenTreeOp          ,1,GTK_BINOP)
-GTNODE(SUB_LO           , "-Lo"          ,GenTreeOp          ,0,GTK_BINOP)
-GTNODE(SUB_HI           , "-Hi"          ,GenTreeOp          ,0,GTK_BINOP)
-GTNODE(DIV_HI           , "/Hi"          ,GenTreeOp          ,0,GTK_BINOP)
-GTNODE(MOD_HI           , "%Hi"          ,GenTreeOp          ,0,GTK_BINOP)
+GTNODE(ADD_LO           , GenTreeOp          ,1,GTK_BINOP)
+GTNODE(ADD_HI           , GenTreeOp          ,1,GTK_BINOP)
+GTNODE(SUB_LO           , GenTreeOp          ,0,GTK_BINOP)
+GTNODE(SUB_HI           , GenTreeOp          ,0,GTK_BINOP)
+GTNODE(DIV_HI           , GenTreeOp          ,0,GTK_BINOP)
+GTNODE(MOD_HI           , GenTreeOp          ,0,GTK_BINOP)
 
 // A mul that returns the 2N bit result of an NxN multiply. This op is used for
 // multiplies that take two ints and return a long result. All other multiplies
@@ -193,9 +192,9 @@ GTNODE(MOD_HI           , "%Hi"          ,GenTreeOp          ,0,GTK_BINOP)
 // the difference being that GT_MULHI drops the lo part of the result, whereas
 // GT_MUL_LONG keeps both parts of the result.
 #if defined(_TARGET_X86_)
-GTNODE(MUL_LONG         , "*long"        ,GenTreeOp          ,1,GTK_BINOP)
+GTNODE(MUL_LONG         , GenTreeOp          ,1,GTK_BINOP)
 #elif defined (_TARGET_ARM_)
-GTNODE(MUL_LONG         , "*long"        ,GenTreeMulLong     ,1,GTK_BINOP)
+GTNODE(MUL_LONG         , GenTreeMulLong     ,1,GTK_BINOP)
 #endif
 
 // The following are nodes that specify shifts that take a GT_LONG op1. The GT_LONG
@@ -205,100 +204,100 @@ GTNODE(MUL_LONG         , "*long"        ,GenTreeMulLong     ,1,GTK_BINOP)
 // will shift the lo bits of the high operand into the lo operand). LSH_HI
 // represents the high operation of a 64-bit left shift by a constant int, and
 // RSH_LO represents the lo operation of a 64-bit right shift by a constant int.
-GTNODE(LSH_HI           , "<<Hi"         ,GenTreeOp          ,0,GTK_BINOP)
-GTNODE(RSH_LO           , ">>Lo"         ,GenTreeOp          ,0,GTK_BINOP)
+GTNODE(LSH_HI           , GenTreeOp          ,0,GTK_BINOP)
+GTNODE(RSH_LO           , GenTreeOp          ,0,GTK_BINOP)
 #endif // !defined(LEGACY_BACKEND) && !defined(_TARGET_64BIT_)
 
 #ifdef FEATURE_SIMD
-GTNODE(SIMD             , "simd"         ,GenTreeSIMD        ,0,GTK_BINOP|GTK_EXOP)     // SIMD functions/operators/intrinsics
+GTNODE(SIMD             , GenTreeSIMD        ,0,GTK_BINOP|GTK_EXOP)     // SIMD functions/operators/intrinsics
 #endif // FEATURE_SIMD
 
 //-----------------------------------------------------------------------------
 //  LIR specific compare and conditional branch/set nodes:
 //-----------------------------------------------------------------------------
 
-GTNODE(CMP              , "cmp"          ,GenTreeOp          ,0,GTK_BINOP|GTK_NOVALUE)  // Sets the condition flags according to the compare result. 
-                                                                                        // N.B. Not a relop, it does not produce a value and it cannot be reversed.
-GTNODE(JCC              , "jcc"          ,GenTreeCC          ,0,GTK_LEAF|GTK_NOVALUE)   // Checks the condition flags and branch if the condition specified
-                                                                                        // by GenTreeCC::gtCondition is true.
-GTNODE(SETCC            , "setcc"        ,GenTreeCC          ,0,GTK_LEAF)               // Checks the condition flags and produces 1 if the condition specified 
-                                                                                        // by GenTreeCC::gtCondition is true and 0 otherwise.
+GTNODE(CMP              , GenTreeOp          ,0,GTK_BINOP|GTK_NOVALUE)  // Sets the condition flags according to the compare result. 
+                                                                        // N.B. Not a relop, it does not produce a value and it cannot be reversed.
+GTNODE(JCC              , GenTreeCC          ,0,GTK_LEAF|GTK_NOVALUE)   // Checks the condition flags and branch if the condition specified
+                                                                        // by GenTreeCC::gtCondition is true.
+GTNODE(SETCC            , GenTreeCC          ,0,GTK_LEAF)               // Checks the condition flags and produces 1 if the condition specified 
+                                                                        // by GenTreeCC::gtCondition is true and 0 otherwise.
 
 //-----------------------------------------------------------------------------
 //  Other nodes that look like unary/binary operators:
 //-----------------------------------------------------------------------------
 
-GTNODE(JTRUE            , "jmpTrue"      ,GenTreeOp          ,0,GTK_UNOP|GTK_NOVALUE)
+GTNODE(JTRUE            , GenTreeOp          ,0,GTK_UNOP|GTK_NOVALUE)
 
-GTNODE(LIST             , "<list>"       ,GenTreeArgList     ,0,GTK_BINOP|GTK_NOVALUE)
-GTNODE(FIELD_LIST       , "<fldList>"    ,GenTreeFieldList   ,0,GTK_BINOP) // List of fields of a struct, when passed as an argument
+GTNODE(LIST             , GenTreeArgList     ,0,GTK_BINOP|GTK_NOVALUE)
+GTNODE(FIELD_LIST       , GenTreeFieldList   ,0,GTK_BINOP) // List of fields of a struct, when passed as an argument
 
 //-----------------------------------------------------------------------------
 //  Other nodes that have special structure:
 //-----------------------------------------------------------------------------
 
-GTNODE(FIELD            , "field"        ,GenTreeField       ,0,GTK_SPECIAL)            // Member-field
-GTNODE(ARR_ELEM         , "arrMD&"       ,GenTreeArrElem     ,0,GTK_SPECIAL)            // Multi-dimensional array-element address
-GTNODE(ARR_INDEX        , "arrMDIdx"     ,GenTreeArrIndex    ,0,GTK_BINOP|GTK_EXOP)     // Effective, bounds-checked index for one dimension of a multi-dimensional array element
-GTNODE(ARR_OFFSET       , "arrMDOffs"    ,GenTreeArrOffs     ,0,GTK_SPECIAL)            // Flattened offset of multi-dimensional array element
-GTNODE(CALL             , "call()"       ,GenTreeCall        ,0,GTK_SPECIAL|GTK_NOCONTAIN)
+GTNODE(FIELD            , GenTreeField       ,0,GTK_SPECIAL)            // Member-field
+GTNODE(ARR_ELEM         , GenTreeArrElem     ,0,GTK_SPECIAL)            // Multi-dimensional array-element address
+GTNODE(ARR_INDEX        , GenTreeArrIndex    ,0,GTK_BINOP|GTK_EXOP)     // Effective, bounds-checked index for one dimension of a multi-dimensional array element
+GTNODE(ARR_OFFSET       , GenTreeArrOffs     ,0,GTK_SPECIAL)            // Flattened offset of multi-dimensional array element
+GTNODE(CALL             , GenTreeCall        ,0,GTK_SPECIAL|GTK_NOCONTAIN)
 
 //-----------------------------------------------------------------------------
 //  Statement operator nodes:
 //-----------------------------------------------------------------------------
 
-GTNODE(BEG_STMTS        , "begStmts"     ,GenTree            ,0,GTK_SPECIAL|GTK_NOVALUE)// used only temporarily in importer by impBegin/EndTreeList()
-GTNODE(STMT             , "stmtExpr"     ,GenTreeStmt        ,0,GTK_SPECIAL|GTK_NOVALUE)// top-level list nodes in bbTreeList
+GTNODE(BEG_STMTS        , GenTree            ,0,GTK_SPECIAL|GTK_NOVALUE)// used only temporarily in importer by impBegin/EndTreeList()
+GTNODE(STMT             , GenTreeStmt        ,0,GTK_SPECIAL|GTK_NOVALUE)// top-level list nodes in bbTreeList
 
-GTNODE(RETURN           , "return"       ,GenTreeOp          ,0,GTK_UNOP|GTK_NOVALUE)   // return from current function
-GTNODE(SWITCH           , "switch"       ,GenTreeOp          ,0,GTK_UNOP|GTK_NOVALUE)   // switch
+GTNODE(RETURN           , GenTreeOp          ,0,GTK_UNOP|GTK_NOVALUE)   // return from current function
+GTNODE(SWITCH           , GenTreeOp          ,0,GTK_UNOP|GTK_NOVALUE)   // switch
 
-GTNODE(NO_OP            , "no_op"        ,GenTree            ,0,GTK_LEAF|GTK_NOVALUE)   // nop!
+GTNODE(NO_OP            , GenTree            ,0,GTK_LEAF|GTK_NOVALUE)   // nop!
 
-GTNODE(START_NONGC      , "start_nongc"  ,GenTree            ,0,GTK_LEAF|GTK_NOVALUE)   // starts a new instruction group that will be non-gc interruptible
+GTNODE(START_NONGC      , GenTree            ,0,GTK_LEAF|GTK_NOVALUE)   // starts a new instruction group that will be non-gc interruptible
 
-GTNODE(PROF_HOOK        , "prof_hook"    ,GenTree            ,0,GTK_LEAF|GTK_NOVALUE)   // profiler Enter/Leave/TailCall hook
+GTNODE(PROF_HOOK        , GenTree            ,0,GTK_LEAF|GTK_NOVALUE)   // profiler Enter/Leave/TailCall hook
 
-GTNODE(RETFILT          , "retfilt"      ,GenTreeOp          ,0,GTK_UNOP|GTK_NOVALUE)   // end filter with TYP_I_IMPL return value
+GTNODE(RETFILT          , GenTreeOp          ,0,GTK_UNOP|GTK_NOVALUE)   // end filter with TYP_I_IMPL return value
 #if !FEATURE_EH_FUNCLETS
-GTNODE(END_LFIN         , "endLFin"      ,GenTreeVal         ,0,GTK_LEAF|GTK_NOVALUE)   // end locally-invoked finally
+GTNODE(END_LFIN         , GenTreeVal         ,0,GTK_LEAF|GTK_NOVALUE)   // end locally-invoked finally
 #endif // !FEATURE_EH_FUNCLETS
 
 //-----------------------------------------------------------------------------
 //  Nodes used for optimizations.
 //-----------------------------------------------------------------------------
 
-GTNODE(PHI              , "phi"          ,GenTreeOp          ,0,GTK_UNOP)               // phi node for ssa.
-GTNODE(PHI_ARG          , "phiArg"       ,GenTreePhiArg      ,0,GTK_LEAF|GTK_LOCAL)     // phi(phiarg, phiarg, phiarg)
+GTNODE(PHI              , GenTreeOp          ,0,GTK_UNOP)               // phi node for ssa.
+GTNODE(PHI_ARG          , GenTreePhiArg      ,0,GTK_LEAF|GTK_LOCAL)     // phi(phiarg, phiarg, phiarg)
 
 //-----------------------------------------------------------------------------
 //  Nodes used by Lower to generate a closer CPU representation of other nodes
 //-----------------------------------------------------------------------------
 
 #ifndef LEGACY_BACKEND
-GTNODE(JMPTABLE         , "jumpTable"    ,GenTreeJumpTable   ,0, GTK_LEAF|GTK_NOCONTAIN) // Generates the jump table for switches
+GTNODE(JMPTABLE         , GenTreeJumpTable   ,0, GTK_LEAF|GTK_NOCONTAIN) // Generates the jump table for switches
 #endif
-GTNODE(SWITCH_TABLE     , "tableSwitch"  ,GenTreeOp          ,0, GTK_BINOP|GTK_NOVALUE) // Jump Table based switch construct
+GTNODE(SWITCH_TABLE     , GenTreeOp          ,0, GTK_BINOP|GTK_NOVALUE)  // Jump Table based switch construct
 
 //-----------------------------------------------------------------------------
 //  Nodes used only within the code generator:
 //-----------------------------------------------------------------------------
 
-GTNODE(REG_VAR          , "regVar"       ,GenTreeLclVar      ,0,GTK_LEAF|GTK_LOCAL)     // register variable
-GTNODE(CLS_VAR          , "clsVar"       ,GenTreeClsVar      ,0,GTK_LEAF)               // static data member
-GTNODE(CLS_VAR_ADDR     , "&clsVar"      ,GenTreeClsVar      ,0,GTK_LEAF)               // static data member address
-GTNODE(ARGPLACE         , "argPlace"     ,GenTreeArgPlace    ,0,GTK_LEAF)               // placeholder for a register arg
-GTNODE(NULLCHECK        , "nullcheck"    ,GenTreeOp          ,0,GTK_UNOP|GTK_NOVALUE)   // null checks the source
-GTNODE(PHYSREG          , "physregSrc"   ,GenTreePhysReg     ,0,GTK_LEAF)               // read from a physical register
-GTNODE(PHYSREGDST       , "physregDst"   ,GenTreeOp          ,0,GTK_UNOP|GTK_NOVALUE)   // write to a physical register
-GTNODE(EMITNOP          , "emitnop"      ,GenTree            ,0,GTK_LEAF|GTK_NOVALUE)   // emitter-placed nop
-GTNODE(PINVOKE_PROLOG   ,"pinvoke_prolog",GenTree            ,0,GTK_LEAF|GTK_NOVALUE)   // pinvoke prolog seq
-GTNODE(PINVOKE_EPILOG   ,"pinvoke_epilog",GenTree            ,0,GTK_LEAF|GTK_NOVALUE)   // pinvoke epilog seq
-GTNODE(PUTARG_REG       , "putarg_reg"   ,GenTreeOp          ,0,GTK_UNOP)               // operator that places outgoing arg in register
-GTNODE(PUTARG_STK       , "putarg_stk"   ,GenTreePutArgStk   ,0,GTK_UNOP|GTK_NOVALUE)   // operator that places outgoing arg in stack
-GTNODE(RETURNTRAP       , "returnTrap"   ,GenTreeOp          ,0,GTK_UNOP|GTK_NOVALUE)   // a conditional call to wait on gc
-GTNODE(SWAP             , "swap"         ,GenTreeOp          ,0,GTK_BINOP|GTK_NOVALUE)  // op1 and op2 swap (registers)
-GTNODE(IL_OFFSET        , "il_offset"    ,GenTreeStmt        ,0,GTK_LEAF|GTK_NOVALUE)   // marks an IL offset for debugging purposes
+GTNODE(REG_VAR          , GenTreeLclVar      ,0,GTK_LEAF|GTK_LOCAL)     // register variable
+GTNODE(CLS_VAR          , GenTreeClsVar      ,0,GTK_LEAF)               // static data member
+GTNODE(CLS_VAR_ADDR     , GenTreeClsVar      ,0,GTK_LEAF)               // static data member address
+GTNODE(ARGPLACE         , GenTreeArgPlace    ,0,GTK_LEAF)               // placeholder for a register arg
+GTNODE(NULLCHECK        , GenTreeOp          ,0,GTK_UNOP|GTK_NOVALUE)   // null checks the source
+GTNODE(PHYSREG          , GenTreePhysReg     ,0,GTK_LEAF)               // read from a physical register
+GTNODE(PHYSREGDST       , GenTreeOp          ,0,GTK_UNOP|GTK_NOVALUE)   // write to a physical register
+GTNODE(EMITNOP          , GenTree            ,0,GTK_LEAF|GTK_NOVALUE)   // emitter-placed nop
+GTNODE(PINVOKE_PROLOG   , GenTree            ,0,GTK_LEAF|GTK_NOVALUE)   // pinvoke prolog seq
+GTNODE(PINVOKE_EPILOG   , GenTree            ,0,GTK_LEAF|GTK_NOVALUE)   // pinvoke epilog seq
+GTNODE(PUTARG_REG       , GenTreeOp          ,0,GTK_UNOP)               // operator that places outgoing arg in register
+GTNODE(PUTARG_STK       , GenTreePutArgStk   ,0,GTK_UNOP|GTK_NOVALUE)   // operator that places outgoing arg in stack
+GTNODE(RETURNTRAP       , GenTreeOp          ,0,GTK_UNOP|GTK_NOVALUE)   // a conditional call to wait on gc
+GTNODE(SWAP             , GenTreeOp          ,0,GTK_BINOP|GTK_NOVALUE)  // op1 and op2 swap (registers)
+GTNODE(IL_OFFSET        , GenTreeStmt        ,0,GTK_LEAF|GTK_NOVALUE)   // marks an IL offset for debugging purposes
 
 /*****************************************************************************/
 #undef  GTNODE

--- a/src/jit/loopcloning.h
+++ b/src/jit/loopcloning.h
@@ -473,7 +473,7 @@ struct LC_Condition
     void Print()
     {
         op1.Print();
-        printf(" %s ", GenTree::NodeName(oper));
+        printf(" %s ", GenTree::OpName(oper));
         op2.Print();
     }
 #endif

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3576,7 +3576,7 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
             GenTree*         node    = kvp.Key();
             LocationInfoList defList = kvp.Value();
 
-            JITDUMP("%sN%03u. %s -> (", first ? "" : "; ", node->gtSeqNum, GenTree::NodeName(node->OperGet()));
+            JITDUMP("%sN%03u. %s -> (", first ? "" : "; ", node->gtSeqNum, GenTree::OpName(node->OperGet()));
             for (LocationInfoListNode *def = defList.Begin(), *end = defList.End(); def != end; def = def->Next())
             {
                 JITDUMP("%s%d.N%03u", def == defList.Begin() ? "" : ", ", def->loc, def->treeNode->gtSeqNum);
@@ -10926,7 +10926,7 @@ void LinearScan::lsraDispNode(GenTreePtr tree, LsraTupleDumpMode mode, bool hasD
     else if (tree->OperIsAssignment())
     {
         assert(!tree->gtHasReg());
-        printf("  asg%s  ", GenTree::NodeName(tree->OperGet()));
+        printf("  asg%s  ", GenTree::OpName(tree->OperGet()));
     }
     else
     {

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -729,7 +729,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
 #ifdef DEBUG
             char message[256];
             _snprintf_s(message, _countof(message), _TRUNCATE, "NYI: Unimplemented node type %s",
-                        GenTree::NodeName(tree->OperGet()));
+                        GenTree::OpName(tree->OperGet()));
             NYIRAW(message);
 #else
             NYI_ARM("TreeNodeInfoInit default case");

--- a/src/jit/lsraxarch.cpp
+++ b/src/jit/lsraxarch.cpp
@@ -770,7 +770,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
 
         case GT_CLS_VAR:
             // These nodes are eliminated by rationalizer.
-            JITDUMP("Unexpected node %s in Lower.\n", GenTree::NodeName(tree->OperGet()));
+            JITDUMP("Unexpected node %s in Lower.\n", GenTree::OpName(tree->OperGet()));
             unreached();
             break;
     } // end switch (tree->OperGet())

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -1937,7 +1937,7 @@ public:
             lst                  = dsc->csdTreeList;
             GenTreePtr firstTree = lst->tslTree;
             printf("In %s, CSE (oper = %s, type = %s) has differing VNs: ", info.compFullName,
-                   GenTree::NodeName(firstTree->OperGet()), varTypeName(firstTree->TypeGet()));
+                   GenTree::OpName(firstTree->OperGet()), varTypeName(firstTree->TypeGet()));
             while (lst != NULL)
             {
                 if (IS_CSE_INDEX(lst->tslTree->gtCSEnum))

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -1340,7 +1340,7 @@ void Compiler::optPrintLoopRecording(unsigned loopInd)
     {
         printf(" [over V%02u", optLoopTable[loopInd].lpIterVar());
         printf(" (");
-        printf(GenTree::NodeName(optLoopTable[loopInd].lpIterOper()));
+        printf(GenTree::OpName(optLoopTable[loopInd].lpIterOper()));
         printf(" ");
         printf("%d )", optLoopTable[loopInd].lpIterConst());
 
@@ -1354,7 +1354,7 @@ void Compiler::optPrintLoopRecording(unsigned loopInd)
         }
 
         // If a simple test condition print operator and the limits */
-        printf(GenTree::NodeName(optLoopTable[loopInd].lpTestOper()));
+        printf(GenTree::OpName(optLoopTable[loopInd].lpTestOper()));
 
         if (optLoopTable[loopInd].lpFlags & LPFLG_CONST_LIMIT)
         {
@@ -7593,7 +7593,7 @@ bool Compiler::optIdentifyLoopOptInfo(unsigned loopNum, LoopCloneContext* contex
            (pLoop->lpIterOper() == GT_SUB || pLoop->lpIterOper() == GT_ASG_SUB))))
     {
         JITDUMP("> Loop test (%s) doesn't agree with the direction (%s) of the pLoop->\n",
-                GenTree::NodeName(pLoop->lpTestOper()), GenTree::NodeName(pLoop->lpIterOper()));
+                GenTree::OpName(pLoop->lpTestOper()), GenTree::OpName(pLoop->lpIterOper()));
         return false;
     }
 

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -401,7 +401,7 @@ static void RewriteAssignmentIntoStoreLclCore(GenTreeOp* assignment,
     genTreeOps storeOp = storeForm(locationOp);
 
 #ifdef DEBUG
-    JITDUMP("rewriting asg(%s, X) to %s(X)\n", GenTree::NodeName(locationOp), GenTree::NodeName(storeOp));
+    JITDUMP("rewriting asg(%s, X) to %s(X)\n", GenTree::OpName(locationOp), GenTree::OpName(storeOp));
 #endif // DEBUG
 
     assignment->SetOper(storeOp);
@@ -583,8 +583,8 @@ void Rationalizer::RewriteAssignment(LIR::Use& use)
                 default:
                     unreached();
             }
-            JITDUMP("Rewriting GT_ASG(%s(X), Y) to %s(X,Y):\n", GenTree::NodeName(location->gtOper),
-                    GenTree::NodeName(storeOper));
+            JITDUMP("Rewriting GT_ASG(%s(X), Y) to %s(X,Y):\n", GenTree::OpName(location->gtOper),
+                    GenTree::OpName(storeOper));
             storeBlk->SetOperRaw(storeOper);
             storeBlk->gtFlags &= ~GTF_DONT_CSE;
             storeBlk->gtFlags |=

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -4153,7 +4153,7 @@ const char* ValueNumStore::VNFuncName(VNFunc vnf)
 {
     if (vnf < VNF_Boundary)
     {
-        return GenTree::NodeName(genTreeOps(vnf));
+        return GenTree::OpName(genTreeOps(vnf));
     }
     else
     {


### PR DESCRIPTION
Replace all uses of NodeName with OpName so we get proper names instead of symbols (e.g. ADD instead of +).  Names stand out better, especially in JIT dumps where we use various symbols to draw tree lines.

Fixes #11952 
