### PR TITLE
Add lclVar semantic checks to CheckLIR.

### DIFF
--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -1573,7 +1573,7 @@ bool LIR::Range::CheckLIR(Compiler* compiler, bool checkUnusedValues) const
             AliasSet::NodeInfo operandInfo(compiler, operand);
             if (operandInfo.IsLclVarRead())
             {
-                int count;
+                int        count;
                 const bool removed = unconsumedLclVarReads.TryRemove(operandInfo.LclNum(), &count);
                 assert(removed);
 

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -4,6 +4,7 @@
 
 #include "jitpch.h"
 #include "smallhash.h"
+#include "sideeffects.h"
 
 #ifdef _MSC_VER
 #pragma hdrstop
@@ -1553,6 +1554,47 @@ bool LIR::Range::CheckLIR(Compiler* compiler, bool checkUnusedValues) const
         {
             GenTree* node = kvp.Key();
             assert(((node->gtLIRFlags & LIR::Flags::IsUnusedValue) != 0) && "found an unmarked unused value");
+        }
+    }
+
+    // Check lclVar semantics: specifically, ensure that an unaliasable lclVar is not redefined between the
+    // point at which a use appears in linear order and the point at which that use is consumed by its user.
+    // This ensures that it is always safe to treat a lclVar use as happening at the user (rather than at
+    // the lclVar node).
+    //
+    // This happens as a second pass because unused lclVar reads may otherwise appear as outstanding reads
+    // and produce false indications that a write to a lclVar occurs while outstanding reads of that lclVar
+    // exist.
+    SmallHashTable<int, int, 32> unconsumedLclVarReads(compiler);
+    for (GenTree* node : *this)
+    {
+        for (GenTree* operand : node->Operands())
+        {
+            AliasSet::NodeInfo operandInfo(compiler, operand);
+            if (operandInfo.IsLclVarRead())
+            {
+                int count = 0;
+                if (unconsumedLclVarReads.TryRemove(operandInfo.LclNum(), &count) && count > 1)
+                {
+                    unconsumedLclVarReads.AddOrUpdate(operandInfo.LclNum(), count - 1);
+                }
+            }
+        }
+
+        AliasSet::NodeInfo nodeInfo(compiler, node);
+
+        bool unused;
+        if (nodeInfo.IsLclVarRead() && !unusedDefs.TryGetValue(node, &unused))
+        {
+            int count = 0;
+            unconsumedLclVarReads.TryGetValue(nodeInfo.LclNum(), &count);
+            unconsumedLclVarReads.AddOrUpdate(nodeInfo.LclNum(), count + 1);
+        }
+
+        if (nodeInfo.IsLclVarWrite())
+        {
+            int unused;
+            assert(!unconsumedLclVarReads.TryGetValue(nodeInfo.LclNum(), &unused));
         }
     }
 

--- a/src/jit/smallhash.h
+++ b/src/jit/smallhash.h
@@ -579,6 +579,21 @@ public:
         *value = m_buckets[index].m_value;
         return true;
     }
+
+    //------------------------------------------------------------------------
+    // HashTableBase::Contains: returns true if a key exists in the table and
+    //                          false otherwise.
+    //
+    // Arguments:
+    //    key   - The key to find from the table.
+    //
+    // Returns:
+    //    True if the key was found in the table; false otherwise.
+    bool Contains(const TKey& key) const
+    {
+        unsigned unused, index;
+        return TryGetBucket(TKeyInfo::GetHashCode(key), key, &unused, &index);
+    }
 };
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
Specifically, ensure that an unaliasable lclVar is not redefined between the
point at which a use appears in linear order and the point at which that
use is consumed by its user. This ensures that it is always safe to treat
a lclVar use as happening at the user (rather than at the lclVar node).