### PR TITLE
Added new crossgen flag /warnings

### DIFF
--- a/src/inc/corcompile.h
+++ b/src/inc/corcompile.h
@@ -1825,4 +1825,11 @@ inline bool IsReadyToRunCompilation()
 #endif
 }
 
+extern bool g_fCompilationWarnings;
+
+inline bool doCompilationWarnings()
+{
+    return g_fCompilationWarnings;
+}
+
 #endif /* COR_COMPILE_H_ */

--- a/src/inc/coregen.h
+++ b/src/inc/coregen.h
@@ -19,5 +19,6 @@
 #define NGENWORKER_FLAGS_READYTORUN              0x2000
 #define NGENWORKER_FLAGS_NO_METADATA             0x4000
 #define NGENWORKER_FLAGS_SILENT                  0x8000
+#define NGENWORKER_FLAGS_NOWARNINGS             0x10000
 
 #endif // _NGENCOMMON_H_

--- a/src/tools/crossgen/crossgen.cpp
+++ b/src/tools/crossgen/crossgen.cpp
@@ -109,6 +109,7 @@ void PrintUsageHelper()
        W("    /? or /help          - Display this screen\n")
        W("    /nologo              - Prevents displaying the logo\n")
        W("    /silent              - Do not display completion message\n")
+       W("    /warnings            - Display additional warning messages\n")
        W("    @response.rsp        - Process command line arguments from specified\n")
        W("                           response file\n")
        W("    /partialtrust        - Assembly will be run in a partial trust domain.\n")
@@ -465,8 +466,11 @@ int _cdecl wmain(int argc, __in_ecount(argc) WCHAR **argv)
     // By default, Crossgen will assume code-generation for fulltrust domains unless /PartialTrust switch is specified
     dwFlags |= NGENWORKER_FLAGS_FULLTRUSTDOMAIN;
 
-    // By default, Crossgen will generate readytorun images unless /FragileNonVersionable switch is specified
+    // By default, Crossgen will generate readytorun images unless the /FragileNonVersionable switch is specified
     dwFlags |= NGENWORKER_FLAGS_READYTORUN;
+
+    // By default, Crossgen will suppress warnings messages unless the /warnings switch is specified
+    dwFlags |= NGENWORKER_FLAGS_NOWARNINGS;
 
     while (argc > 0)
     {
@@ -483,6 +487,11 @@ int _cdecl wmain(int argc, __in_ecount(argc) WCHAR **argv)
         else if (MatchParameter(*argv, W("silent")))
         {
             dwFlags |= NGENWORKER_FLAGS_SILENT;
+        }
+        else if (MatchParameter(*argv, W("warnings")))
+        {
+            // Clear the no warnings flag
+            dwFlags = dwFlags & ~NGENWORKER_FLAGS_NOWARNINGS;
         }
         else if (MatchParameter(*argv, W("Tuning")))
         {
@@ -620,8 +629,9 @@ int _cdecl wmain(int argc, __in_ecount(argc) WCHAR **argv)
             argv++;
             argc--;
 
-            // Clear the /fulltrust flag - /CreatePDB does not work with any other flags.
-            dwFlags = dwFlags & ~(NGENWORKER_FLAGS_FULLTRUSTDOMAIN | NGENWORKER_FLAGS_READYTORUN);
+            // Clear some non-essential flags otherwise we reach - /CreatePDB does not work with any other flags.
+            dwFlags = dwFlags & ~(NGENWORKER_FLAGS_FULLTRUSTDOMAIN | NGENWORKER_FLAGS_READYTORUN | NGENWORKER_FLAGS_NOWARNINGS);
+
 
             // Parse: <directory to store PDB>
             wzDirectoryToStorePDB.Set(argv[0]);

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -2131,7 +2131,10 @@ void ZapInfo::getCallInfo(CORINFO_RESOLVED_TOKEN * pResolvedToken,
         if (pResult->thisTransform == CORINFO_BOX_THIS)
         {
             // READYTORUN: FUTURE: Optionally create boxing stub at runtime
-            m_zapper->Warning(W("ReadyToRun: Implicit boxing for calls to constrained methods not supported\n"));
+            if (doCompilationWarnings())
+            {
+                m_zapper->Warning(W("ReadyToRun: Implicit boxing for calls to constrained methods not supported\n"));
+            }
             ThrowHR(E_NOTIMPL);
         }
     }

--- a/src/zap/zapper.cpp
+++ b/src/zap/zapper.cpp
@@ -42,6 +42,7 @@ extern const WCHAR g_pwBaseLibrary[];
 extern bool g_fAllowNativeImages;
 bool g_fNGenMissingDependenciesOk;
 bool g_fNGenWinMDResilient;
+bool g_fCompilationWarnings;
 
 #ifdef FEATURE_READYTORUN_COMPILER
 bool g_fReadyToRunCompilation;
@@ -168,6 +169,7 @@ STDAPI NGenWorker(LPCWSTR pwzFilename, DWORD dwFlags, LPCWSTR pwzPlatformAssembl
 #ifdef FEATURE_READYTORUN_COMPILER
         g_fReadyToRunCompilation = !!(dwFlags & NGENWORKER_FLAGS_READYTORUN);
 #endif
+        g_fCompilationWarnings = !!(dwFlags & NGENWORKER_FLAGS_NOWARNINGS) == 0;
 
         if (pLogger != NULL)
         {
@@ -624,7 +626,7 @@ void Zapper::LoadAndInitializeJITForNgen(LPCWSTR pwzJitName, OUT HINSTANCE* phJi
     if (memcmp(&versionId, &JITEEVersionIdentifier, sizeof(GUID)) != 0)
     {
         // Mismatched version ID. Fail the load.
-        Error(W("Jit Compiler has wrong version identifier\r\n"));
+        Error(W("Jit/EE Version Identifier mismatch\r\n"));
         ThrowHR(E_FAIL);
     }
 


### PR DESCRIPTION
We can now disable several annoying compilations warnings messages from crossgen.

With this checkin only the most common warning:

"Implicit boxing for calls to constrained methods not supported" is suppressed.

To see this warning you will now need to add the /warnings flags to crossgen.cpp