### PR TITLE
[RyuJIT/ARM32] Fix assertion when using invalid imm for INS_add

### DIFF
--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -7773,7 +7773,17 @@ regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, 
 
     if (intConst != nullptr)
     {
-        emitIns_R_R_I(ins, attr, dst->gtRegNum, nonIntReg->gtRegNum, intConst->IconValue(), flags);
+        int iconValue = intConst->IconValue();
+
+        if (emitIns_valid_imm_for_add(iconValue, flags))
+        {
+            emitIns_R_R_I(ins, attr, dst->gtRegNum, nonIntReg->gtRegNum, iconValue, flags);
+        }
+        else
+        {
+            codeGen->instGen_Set_Reg_To_Imm(EA_PTRSIZE, dst->gtRegNum, iconValue);
+            emitIns_R_R_R(ins, attr, dst->gtRegNum, dst->gtRegNum, nonIntReg->gtRegNum, flags);
+        }
     }
     else
     {

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -7773,17 +7773,7 @@ regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, 
 
     if (intConst != nullptr)
     {
-        int iconValue = intConst->IconValue();
-
-        if (emitIns_valid_imm_for_add(iconValue, flags))
-        {
-            emitIns_R_R_I(ins, attr, dst->gtRegNum, nonIntReg->gtRegNum, iconValue, flags);
-        }
-        else
-        {
-            codeGen->instGen_Set_Reg_To_Imm(EA_PTRSIZE, dst->gtRegNum, iconValue);
-            emitIns_R_R_R(ins, attr, dst->gtRegNum, dst->gtRegNum, nonIntReg->gtRegNum, flags);
-        }
+        emitIns_R_R_I(ins, attr, dst->gtRegNum, nonIntReg->gtRegNum, intConst->IconValue(), flags);
     }
     else
     {

--- a/src/jit/lowerarmarch.cpp
+++ b/src/jit/lowerarmarch.cpp
@@ -96,6 +96,7 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode)
         ssize_t  immVal = childNode->gtIntCon.gtIconVal;
         emitAttr attr   = emitActualTypeSize(childNode->TypeGet());
         emitAttr size   = EA_SIZE(attr);
+        insFlags flags  = parentNode->gtSetFlags() ? INS_FLAGS_SET : INS_FLAGS_DONT_CARE;
 
         switch (parentNode->OperGet())
         {
@@ -107,7 +108,7 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode)
 #ifdef _TARGET_ARM64_
                 return emitter::emitIns_valid_imm_for_add(immVal, size);
 #elif defined(_TARGET_ARM_)
-                return emitter::emitIns_valid_imm_for_add(immVal, INS_FLAGS_DONT_CARE);
+                return emitter::emitIns_valid_imm_for_add(immVal, flags);
 #endif
                 break;
 

--- a/src/jit/lowerarmarch.cpp
+++ b/src/jit/lowerarmarch.cpp
@@ -96,7 +96,9 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode)
         ssize_t  immVal = childNode->gtIntCon.gtIconVal;
         emitAttr attr   = emitActualTypeSize(childNode->TypeGet());
         emitAttr size   = EA_SIZE(attr);
-        insFlags flags  = parentNode->gtSetFlags() ? INS_FLAGS_SET : INS_FLAGS_DONT_CARE;
+#ifdef _TARGET_ARM_
+        insFlags flags = parentNode->gtSetFlags() ? INS_FLAGS_SET : INS_FLAGS_DONT_CARE;
+#endif
 
         switch (parentNode->OperGet())
         {


### PR DESCRIPTION
#12080 

`JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b54611/b54611/b54611.sh`

Assertion failed '!"Instruction cannot be encoded" has been occurred.

INS_add couldn't process with the invalid imm of -273 on this test.
So in this PR, If it get the value that cannot be processed, moving to register that after changing status would be ran so that it can be processed.

The result is below
```
IN00b1:             mvn     r3, 272
IN00b2:             adds    r3, r3, r0
```