### PR TITLE
[RyuJIT/ARM32] Unassign double register properly at BB entry

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -7005,15 +7005,21 @@ void LinearScan::processBlockStartLocations(BasicBlock* currentBlock, bool alloc
                 // Is there another interval currently assigned to this register?  If so unassign it.
                 if (assignedInterval != nullptr)
                 {
+#ifdef _TARGET_ARM_
+                    if (assignedInterval->assignedReg == targetRegRecord || isSecondHalfReg(targetRegRecord, assignedInterval))
+#else
                     if (assignedInterval->assignedReg == targetRegRecord)
+#endif
                     {
+                        regNumber assignedRegNum = assignedInterval->assignedReg->regNum;
+
                         // If the interval is active, it will be set to active when we reach its new
                         // register assignment (which we must not yet have done, or it wouldn't still be
                         // assigned to this register).
                         assignedInterval->isActive = false;
-                        unassignPhysReg(targetRegRecord, nullptr);
+                        unassignPhysReg(assignedInterval->assignedReg, nullptr);
                         if (allocationPass && assignedInterval->isLocalVar &&
-                            inVarToRegMap[assignedInterval->getVarIndex(compiler)] == targetReg)
+                            inVarToRegMap[assignedInterval->getVarIndex(compiler)] == assignedRegNum)
                         {
                             inVarToRegMap[assignedInterval->getVarIndex(compiler)] = REG_STK;
                         }

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -6823,6 +6823,15 @@ bool LinearScan::canRestorePreviousInterval(RegRecord* regRec, Interval* assigne
     return retVal;
 }
 
+bool LinearScan::isAssignedToInterval(Interval* interval, RegRecord* regRec)
+{
+    bool isAssigned = (interval->assignedReg == regRec);
+#ifdef _TARGET_ARM_
+    isAssigned |= isSecondHalfReg(regRec, interval);
+#endif
+    return isAssigned;
+}
+
 //------------------------------------------------------------------------
 // processBlockStartLocations: Update var locations on entry to 'currentBlock' and clear constant
 //                             registers.
@@ -7005,12 +7014,7 @@ void LinearScan::processBlockStartLocations(BasicBlock* currentBlock, bool alloc
                 // Is there another interval currently assigned to this register?  If so unassign it.
                 if (assignedInterval != nullptr)
                 {
-#ifdef _TARGET_ARM_
-                    if (assignedInterval->assignedReg == targetRegRecord ||
-                        isSecondHalfReg(targetRegRecord, assignedInterval))
-#else
-                    if (assignedInterval->assignedReg == targetRegRecord)
-#endif
+                    if (isAssignedToInterval(assignedInterval, targetRegRecord))
                     {
                         regNumber assignedRegNum = assignedInterval->assignedReg->regNum;
 

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -7027,14 +7027,11 @@ void LinearScan::processBlockStartLocations(BasicBlock* currentBlock, bool alloc
                     }
                     else
                     {
-                        // This interval is no longer assigned to this register.
-                        targetRegRecord->assignedInterval = nullptr;
+// This interval is no longer assigned to this register.
 #ifdef _TARGET_ARM_
-                        if (assignedInterval->registerType == TYP_DOUBLE)
-                        {
-                            RegRecord* anotherHalfRegRec        = findAnotherHalfRegRec(targetRegRecord);
-                            anotherHalfRegRec->assignedInterval = nullptr;
-                        }
+                        updateAssignedInterval(targetRegRecord, nullptr, assignedInterval->registerType);
+#else
+                        targetRegRecord->assignedInterval = nullptr;
 #endif
                     }
                 }

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -7031,12 +7031,8 @@ void LinearScan::processBlockStartLocations(BasicBlock* currentBlock, bool alloc
                     }
                     else
                     {
-// This interval is no longer assigned to this register.
-#ifdef _TARGET_ARM_
+                        // This interval is no longer assigned to this register.
                         updateAssignedInterval(targetRegRecord, nullptr, assignedInterval->registerType);
-#else
-                        targetRegRecord->assignedInterval = nullptr;
-#endif
                     }
                 }
                 assignPhysReg(targetRegRecord, interval);
@@ -8027,11 +8023,8 @@ void LinearScan::allocateRegisters()
 #endif // DEBUG
 }
 
-#ifdef _TARGET_ARM_
 //-----------------------------------------------------------------------------
-// updateAssignedInterval: Update assigned interval of register for ARM32
-// considering register type. When register type is TYP_DOUBLE, update
-// two float registers consisting a double register.
+// updateAssignedInterval: Update assigned interval of register.
 //
 // Arguments:
 //    reg      -    register to be updated
@@ -8042,13 +8035,18 @@ void LinearScan::allocateRegisters()
 //    None
 //
 // Assumptions:
-//    When "regType" is TYP_DOUBLE, "reg" should be a even-numbered float register,
-//    i.e. lower half of double register.
+//    For ARM32, when "regType" is TYP_DOUBLE, "reg" should be a even-numbered
+//    float register, i.e. lower half of double register.
+//
+// Note:
+//    For ARM32, two float registers consisting a double register are updated
+//    together when "regType" is TYP_DOUBLE.
 //
 void LinearScan::updateAssignedInterval(RegRecord* reg, Interval* interval, RegisterType regType)
 {
     reg->assignedInterval = interval;
 
+#ifdef _TARGET_ARM_
     // Update overlapping floating point register for TYP_DOUBLE
     if (regType == TYP_DOUBLE)
     {
@@ -8058,8 +8056,8 @@ void LinearScan::updateAssignedInterval(RegRecord* reg, Interval* interval, Regi
 
         anotherHalfReg->assignedInterval = interval;
     }
-}
 #endif
+}
 
 // LinearScan::resolveLocalRef
 // Description:
@@ -8136,11 +8134,7 @@ void LinearScan::resolveLocalRef(BasicBlock* block, GenTreePtr treeNode, RefPosi
         varDsc->lvRegNum = REG_STK;
         if (interval->assignedReg != nullptr && interval->assignedReg->assignedInterval == interval)
         {
-#ifdef _TARGET_ARM_
             updateAssignedInterval(interval->assignedReg, nullptr, interval->registerType);
-#else
-            interval->assignedReg->assignedInterval = nullptr;
-#endif
         }
         interval->assignedReg = nullptr;
         interval->physReg     = REG_NA;
@@ -8168,11 +8162,7 @@ void LinearScan::resolveLocalRef(BasicBlock* block, GenTreePtr treeNode, RefPosi
             RegRecord* oldRegRecord = getRegisterRecord(oldAssignedReg);
             if (oldRegRecord->assignedInterval == interval)
             {
-#ifdef _TARGET_ARM_
                 updateAssignedInterval(oldRegRecord, nullptr, interval->registerType);
-#else
-                oldRegRecord->assignedInterval      = nullptr;
-#endif
             }
         }
     }
@@ -8327,22 +8317,14 @@ void LinearScan::resolveLocalRef(BasicBlock* block, GenTreePtr treeNode, RefPosi
         interval->assignedReg = nullptr;
         interval->physReg     = REG_NA;
 
-#ifdef _TARGET_ARM_
         updateAssignedInterval(physRegRecord, nullptr, interval->registerType);
-#else
-        physRegRecord->assignedInterval             = nullptr;
-#endif
     }
     else
     {
         interval->isActive    = true;
         interval->assignedReg = physRegRecord;
 
-#ifdef _TARGET_ARM_
         updateAssignedInterval(physRegRecord, interval, interval->registerType);
-#else
-        physRegRecord->assignedInterval             = interval;
-#endif
     }
 }
 
@@ -10107,7 +10089,7 @@ void LinearScan::resolveEdge(BasicBlock*      fromBlock,
             tempRegFlt = getTempRegForResolution(fromBlock, toBlock, TYP_FLOAT);
         }
 #else
-        tempRegFlt                                  = getTempRegForResolution(fromBlock, toBlock, TYP_FLOAT);
+        tempRegFlt = getTempRegForResolution(fromBlock, toBlock, TYP_FLOAT);
 #endif
     }
 

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -7006,7 +7006,8 @@ void LinearScan::processBlockStartLocations(BasicBlock* currentBlock, bool alloc
                 if (assignedInterval != nullptr)
                 {
 #ifdef _TARGET_ARM_
-                    if (assignedInterval->assignedReg == targetRegRecord || isSecondHalfReg(targetRegRecord, assignedInterval))
+                    if (assignedInterval->assignedReg == targetRegRecord ||
+                        isSecondHalfReg(targetRegRecord, assignedInterval))
 #else
                     if (assignedInterval->assignedReg == targetRegRecord)
 #endif
@@ -7028,6 +7029,13 @@ void LinearScan::processBlockStartLocations(BasicBlock* currentBlock, bool alloc
                     {
                         // This interval is no longer assigned to this register.
                         targetRegRecord->assignedInterval = nullptr;
+#ifdef _TARGET_ARM_
+                        if (assignedInterval->registerType == TYP_DOUBLE)
+                        {
+                            RegRecord* anotherHalfRegRec        = findAnotherHalfRegRec(targetRegRecord);
+                            anotherHalfRegRec->assignedInterval = nullptr;
+                        }
+#endif
                     }
                 }
                 assignPhysReg(targetRegRecord, interval);

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -697,8 +697,8 @@ private:
 #ifdef _TARGET_ARM_
     bool isSecondHalfReg(RegRecord* regRec, Interval* interval);
     RegRecord* findAnotherHalfRegRec(RegRecord* regRec);
-    void updateAssignedInterval(RegRecord* reg, Interval* interval, RegisterType regType);
 #endif
+    void updateAssignedInterval(RegRecord* reg, Interval* interval, RegisterType regType);
     bool canRestorePreviousInterval(RegRecord* regRec, Interval* assignedInterval);
     bool isAssignedToInterval(Interval* interval, RegRecord* regRec);
 

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -700,6 +700,7 @@ private:
     void updateAssignedInterval(RegRecord* reg, Interval* interval, RegisterType regType);
 #endif
     bool canRestorePreviousInterval(RegRecord* regRec, Interval* assignedInterval);
+    bool isAssignedToInterval(Interval* interval, RegRecord* regRec);
 
     RefType CheckBlockType(BasicBlock* block, BasicBlock* prevBlock);
 


### PR DESCRIPTION
Fix #12078 

When updating var locations at basic block entry,
we should un-assign double register properly for TYP_DOUBLE interval.


# Example

## Before
With `COMPlus_AltJit=* COMPlus_JitDump=test:Func` option, `JIT/Regression/CLR-x86-JIT/V1.2-M01/b16570/b16570` shows following allocation progress and raise assertion later.

```
Loc RP#  Name  Type  Action Reg  |f8   |f9   |f10  |f11  |
---------------------------------+-----+-----+-----+-----+
                                 |     |     |     |     |
  0.#0   BB1 PredBB0             |     |     |     |     |
  8.#1   C14   Def    Alloc r0   |     |     |     |     |
188.#253 V1    Def    Alloc f9   |V10 a|V1  a|C73 i|     |
...(omitted)...
209.#265 V10   Use *  Keep  f8   |V10 a|V1  a|V9  a|     |
---------------------------------+-----+-----+-----+-----+
Loc RP#  Name  Type  Action Reg  |f8   |f9   |f10  |f11  |
---------------------------------+-----+-----+-----+-----+
213.#266 BB2 PredBB1             |     |V1  a|V9  a|     |
...(omitted)...
230.#279 V8    Def    Alloc f8   |V8  a|V8  a|V9  i|     |// Interval V8 is TYP_DOUBLE.  f8 and f9 are allocated as double register (d4).
...(omitted)...
289.#337 V3    Use *  Keep  f0   |V8  i|V8  i|V9  i|     |
---------------------------------+-----+-----+-----+-----+
Loc RP#  Name  Type  Action Reg  |f8   |f9   |f10  |f11  |
---------------------------------+-----+-----+-----+-----+
291.#338 BB3 PredBB1             |V8  i|V1  a|V9  a|     |// Interval V1 is live-in at `f9` from BB1.
299.#339 V0    Use *  Keep  r4   |V8  i|V1  a|V9  a|     |
300.#340 I107  Def    Alloc r3   |V8  i|V1  a|V9  a|     |
```

BB3 has one pred BB1. BB2 returns at end, i.e.  no successor BB.

When interval `V1` is live-in at `f9` from BB1, we should unassign `f8` and `f9` together properly, because previously assigned interval `V8` is `TYP_DOUBLE`.


## After

`f8` and `f9` are un-assigned properly and interval `V1` reside in `f9` as expected.
And test is passed without problem.
```
---------------------------------+-----+-----+-----+-----+
Loc RP#  Name  Type  Action Reg  |f8   |f9   |f10  |f11  |
---------------------------------+-----+-----+-----+-----+
291.#338 BB3 PredBB1             |     |V1  a|V9  a|     |
299.#339 V0    Use *  Keep  r4   |     |V1  a|V9  a|     |
300.#340 I107  Def    Alloc r3   |     |V1  a|V9  a|     |
```


