### PR TITLE
Don't dump an uninitialized bitset in LSRA.

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -2341,7 +2341,7 @@ void LinearScan::identifyCandidates()
     if (VERBOSE)
     {
         printf("\nFP callee save candidate vars: ");
-        if (!VarSetOps::IsEmpty(compiler, fpCalleeSaveCandidateVars))
+        if (enregisterLocalVars && !VarSetOps::IsEmpty(compiler, fpCalleeSaveCandidateVars))
         {
             dumpConvertedVarSet(compiler, fpCalleeSaveCandidateVars);
             printf("\n");


### PR DESCRIPTION
LSRA was unconditionally dumping `fpCalleeSaveCandidateVars`, which is
not initialized if we are not enregistering any lclVars. This was
causing an assertion with dumping enabled.