### PR TITLE
[Local GC] No longer need to initialize SVR dacvars separately

### DIFF
--- a/src/debug/daccess/enummem.cpp
+++ b/src/debug/daccess/enummem.cpp
@@ -221,9 +221,6 @@ HRESULT ClrDataAccess::EnumMemCLRStatic(IN CLRDataEnumMemoryFlags flags)
 #define DEFINE_DACVAR(id_type, size_type, id, var) \
     ReportMem(m_globalBase + g_dacGlobals.id, sizeof(size_type));
 
-#define DEFINE_DACVAR_SVR(id_type, size_type, id, var) \
-    ReportMem(m_globalBase + g_dacGlobals.id, sizeof(size_type));
-
 #ifdef FEATURE_PAL
     // Add the dac table memory in coreclr
     CATCH_ALL_EXCEPT_RETHROW_COR_E_OPERATIONCANCELLED ( ReportMem(m_globalBase + DAC_TABLE_RVA, sizeof(g_dacGlobals)); )

--- a/src/debug/ee/dactable.cpp
+++ b/src/debug/ee/dactable.cpp
@@ -42,9 +42,6 @@ void DacGlobals::Initialize()
 {
     TADDR baseAddress = PTR_TO_TADDR(PAL_GetSymbolModuleBase((void *)DacGlobals::Initialize));
     g_dacTable.InitializeEntries(baseAddress);
-#ifdef FEATURE_SVR_GC
-    g_dacTable.InitializeSVREntries(baseAddress);
-#endif
 }
 
 // Initializes the non-SVR table entries

--- a/src/debug/ee/dactable.cpp
+++ b/src/debug/ee/dactable.cpp
@@ -48,7 +48,6 @@ void DacGlobals::Initialize()
 void DacGlobals::InitializeEntries(TADDR baseAddress)
 {
 #define DEFINE_DACVAR(id_type, size, id, var)                   id = PTR_TO_TADDR(&var) - baseAddress;
-#define DEFINE_DACVAR_SVR(id_type, size, id, var) 
 #define DEFINE_DACVAR_NO_DUMP(id_type, size, id, var)           id = PTR_TO_TADDR(&var) - baseAddress;
 #include "dacvars.h"
 

--- a/src/gc/gceesvr.cpp
+++ b/src/gc/gceesvr.cpp
@@ -22,15 +22,4 @@ namespace SVR {
 #include "gcee.cpp"
 }
 
-#if defined(FEATURE_PAL) && !defined(DACCESS_COMPILE)
- 
-// Initializes the SVR DAC table entries
-void DacGlobals::InitializeSVREntries(TADDR baseAddress)
-{
-#define DEFINE_DACVAR_SVR(id_type, size, id, var)   id = PTR_TO_TADDR(&var) - baseAddress;
-#include "dacvars.h"
-}
-
-#endif // FEATURE_PAL && !DACCESS_COMPILE
-
 #endif // FEATURE_SVR_GC

--- a/src/inc/daccess.h
+++ b/src/inc/daccess.h
@@ -606,7 +606,6 @@ typedef struct _DacGlobals
 
 // These will define all of the dac related mscorwks static and global variables    
 #define DEFINE_DACVAR(id_type, size, id, var)                 id_type id;
-#define DEFINE_DACVAR_SVR(id_type, size, id, var)             id_type id;
 #define DEFINE_DACVAR_NO_DUMP(id_type, size, id, var)         id_type id;
 #include "dacvars.h"
 

--- a/src/inc/daccess.h
+++ b/src/inc/daccess.h
@@ -602,9 +602,6 @@ typedef struct _DacGlobals
 #ifdef FEATURE_PAL
     static void Initialize();
     void InitializeEntries(TADDR baseAddress);
-#ifdef FEATURE_SVR_GC
-    void InitializeSVREntries(TADDR baseAddress);
-#endif // FEATURE_SVR_GC
 #endif // FEATURE_PAL
 
 // These will define all of the dac related mscorwks static and global variables    

--- a/src/inc/dacvars.h
+++ b/src/inc/dacvars.h
@@ -64,11 +64,6 @@
 #define DEFINE_DACVAR(type, true_type, id, var)
 #endif
 
-// Use this macro for any server (namespace SVR) variables
-#ifndef DEFINE_DACVAR_SVR
-#define DEFINE_DACVAR_SVR(type, true_type, id, var)
-#endif
-
 // Use this macro to define a static var that is known to DAC, but not captured in a dump.                         
 #ifndef DEFINE_DACVAR_NO_DUMP
 #define DEFINE_DACVAR_NO_DUMP(type, true_type, id, var)
@@ -279,5 +274,4 @@ DEFINE_DACVAR(ULONG, TADDR, dac__g_MiniMetaDataBuffAddress, ::g_MiniMetaDataBuff
 DEFINE_DACVAR(ULONG, SIZE_T, dac__g_clrNotificationArguments, ::g_clrNotificationArguments)
 
 #undef DEFINE_DACVAR
-#undef DEFINE_DACVAR_SVR
 #undef DEFINE_DACVAR_NO_DUMP


### PR DESCRIPTION
Now that all server dacvars go through the `GcDacVars` struct (https://github.com/dotnet/coreclr/pull/9255 - despite the name this also includes Server GC), we don't need to initialize them here. Furthermore, since there are no `DEFINE_DACVAR_SVR` macros in `dacvars.h` anymore, this function has no effect anyway today.