### PR TITLE
DateTime serialization fixed, added attention labels to serialized fields

### DIFF
--- a/src/mscorlib/shared/System/Collections/DictionaryEntry.cs
+++ b/src/mscorlib/shared/System/Collections/DictionaryEntry.cs
@@ -12,8 +12,8 @@ namespace System.Collections
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public struct DictionaryEntry
     {
-        private Object _key;
-        private Object _value;
+        private Object _key; // Do not rename (binary serialization)
+        private Object _value; // Do not rename (binary serialization)
 
         // Constructs a new DictionaryEnumerator by setting the Key
         // and Value fields appropriately.

--- a/src/mscorlib/shared/System/Collections/Generic/KeyValuePair.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/KeyValuePair.cs
@@ -49,8 +49,8 @@ namespace System.Collections.Generic
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public struct KeyValuePair<TKey, TValue>
     {
-        private TKey key;       // DO NOT change the field name, it's required for compatibility with desktop .NET as it appears in serialization payload.
-        private TValue value;   // DO NOT change the field name, it's required for compatibility with desktop .NET as it appears in serialization payload.
+        private TKey key; // Do not rename (binary serialization)
+        private TValue value; // Do not rename (binary serialization)
 
         public KeyValuePair(TKey key, TValue value)
         {

--- a/src/mscorlib/shared/System/DateTime.cs
+++ b/src/mscorlib/shared/System/DateTime.cs
@@ -126,8 +126,8 @@ namespace System
         private const UInt64 KindLocalAmbiguousDst = 0xC000000000000000;
         private const Int32 KindShift = 62;
 
-        private const String TicksField = "ticks";
-        private const String DateDataField = "_dateData";
+        private const String TicksField = "ticks"; // Do not rename (binary serialization)
+        private const String DateDataField = "dateData"; // Do not rename (binary serialization)
 
         // The data is stored as an unsigned 64-bit integeter
         //   Bits 01-62: The value of 100-nanosecond ticks where 0 represents 1/1/0001 12:00am, up until the value

--- a/src/mscorlib/shared/System/DateTimeOffset.cs
+++ b/src/mscorlib/shared/System/DateTimeOffset.cs
@@ -574,8 +574,8 @@ namespace System
                 throw new ArgumentNullException(nameof(info));
             }
 
-            info.AddValue("DateTime", _dateTime);
-            info.AddValue("OffsetMinutes", _offsetMinutes);
+            info.AddValue("DateTime", _dateTime); // Do not rename (binary serialization)
+            info.AddValue("OffsetMinutes", _offsetMinutes); // Do not rename (binary serialization)
         }
 
 
@@ -586,8 +586,8 @@ namespace System
                 throw new ArgumentNullException(nameof(info));
             }
 
-            _dateTime = (DateTime)info.GetValue("DateTime", typeof(DateTime));
-            _offsetMinutes = (Int16)info.GetValue("OffsetMinutes", typeof(Int16));
+            _dateTime = (DateTime)info.GetValue("DateTime", typeof(DateTime)); // Do not rename (binary serialization)
+            _offsetMinutes = (Int16)info.GetValue("OffsetMinutes", typeof(Int16)); // Do not rename (binary serialization)
         }
 
         // Returns the hash code for this DateTimeOffset.

--- a/src/mscorlib/shared/System/StringComparer.cs
+++ b/src/mscorlib/shared/System/StringComparer.cs
@@ -177,13 +177,13 @@ namespace System
         private readonly CompareInfo _compareInfo; // Do not rename (binary serialization)
         private readonly bool _ignoreCase; // Do not rename (binary serialization)
 
-        private CompareOptions Options => _ignoreCase ? CompareOptions.IgnoreCase : CompareOptions.None;
-
         internal CultureAwareComparer(CultureInfo culture, bool ignoreCase)
         {
             _compareInfo = culture.CompareInfo;
             _ignoreCase = ignoreCase;
         }
+
+        private CompareOptions Options => _ignoreCase ? CompareOptions.IgnoreCase : CompareOptions.None;
 
         public override int Compare(string x, string y)
         {

--- a/src/mscorlib/shared/System/StringComparer.cs
+++ b/src/mscorlib/shared/System/StringComparer.cs
@@ -175,12 +175,14 @@ namespace System
     internal sealed class CultureAwareComparer : StringComparer
     {
         private readonly CompareInfo _compareInfo; // Do not rename (binary serialization)
-        private readonly CompareOptions _options; // Do not rename (binary serialization)
+        private readonly bool _ignoreCase; // Do not rename (binary serialization)
+
+        private CompareOptions Options => _ignoreCase ? CompareOptions.IgnoreCase : CompareOptions.None;
 
         internal CultureAwareComparer(CultureInfo culture, bool ignoreCase)
         {
             _compareInfo = culture.CompareInfo;
-            _options = ignoreCase ? CompareOptions.IgnoreCase : CompareOptions.None;
+            _ignoreCase = ignoreCase;
         }
 
         public override int Compare(string x, string y)
@@ -188,14 +190,14 @@ namespace System
             if (object.ReferenceEquals(x, y)) return 0;
             if (x == null) return -1;
             if (y == null) return 1;
-            return _compareInfo.Compare(x, y, _options);
+            return _compareInfo.Compare(x, y, Options);
         }
 
         public override bool Equals(string x, string y)
         {
             if (object.ReferenceEquals(x, y)) return true;
             if (x == null || y == null) return false;
-            return _compareInfo.Compare(x, y, _options) == 0;
+            return _compareInfo.Compare(x, y, Options) == 0;
         }
 
         public override int GetHashCode(string obj)
@@ -204,7 +206,7 @@ namespace System
             {
                 throw new ArgumentNullException(nameof(obj));
             }
-            return _compareInfo.GetHashCodeOfString(obj, _options);
+            return _compareInfo.GetHashCodeOfString(obj, Options);
         }
 
         // Equals method for the comparer itself.
@@ -213,14 +215,14 @@ namespace System
             CultureAwareComparer comparer = obj as CultureAwareComparer;
             return
                 comparer != null &&
-                _options == comparer._options &&
+                _ignoreCase == comparer._ignoreCase &&
                 _compareInfo.Equals(comparer._compareInfo);
         }
 
         public override int GetHashCode()
         {
             int hashCode = _compareInfo.GetHashCode();
-            return _options == CompareOptions.None ? hashCode : ~hashCode;
+            return _ignoreCase ? ~hashCode : hashCode;
         }
     }
 

--- a/src/mscorlib/shared/System/StringComparer.cs
+++ b/src/mscorlib/shared/System/StringComparer.cs
@@ -174,8 +174,8 @@ namespace System
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     internal sealed class CultureAwareComparer : StringComparer
     {
-        private readonly CompareInfo _compareInfo;
-        private readonly CompareOptions _options;
+        private readonly CompareInfo _compareInfo; // Do not rename (binary serialization)
+        private readonly CompareOptions _options; // Do not rename (binary serialization)
 
         internal CultureAwareComparer(CultureInfo culture, bool ignoreCase)
         {

--- a/src/mscorlib/shared/System/Text/StringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.cs
@@ -59,10 +59,11 @@ namespace System.Text
         //
         //
         internal const int DefaultCapacity = 16;
-        private const String CapacityField = "Capacity";
-        private const String MaxCapacityField = "m_MaxCapacity";
-        private const String StringValueField = "m_StringValue";
-        private const String ThreadIDField = "m_currentThread";
+        private const String CapacityField = "Capacity"; // Do not rename (binary serialization)
+        private const String MaxCapacityField = "m_MaxCapacity"; // Do not rename (binary serialization)
+        private const String StringValueField = "m_StringValue"; // Do not rename (binary serialization)
+        private const String ThreadIDField = "m_currentThread"; // Do not rename (binary serialization)
+
         // We want to keep chunk arrays out of large object heap (< 85K bytes ~ 40K chars) to be sure.
         // Making the maximum chunk size big means less allocation code called, but also more waste
         // in unused characters and slower inserts / replaces (since you do need to slide characters over

--- a/src/mscorlib/shared/System/Version.cs
+++ b/src/mscorlib/shared/System/Version.cs
@@ -21,10 +21,10 @@ namespace System
         , IComparable<Version>, IEquatable<Version>
     {
         // AssemblyName depends on the order staying the same
-        private readonly int _Major;
-        private readonly int _Minor;
-        private readonly int _Build = -1;
-        private readonly int _Revision = -1;
+        private readonly int _Major; // Do not rename (binary serialization)
+        private readonly int _Minor; // Do not rename (binary serialization)
+        private readonly int _Build = -1; // Do not rename (binary serialization)
+        private readonly int _Revision = -1; // Do not rename (binary serialization)
 
         public Version(int major, int minor, int build, int revision)
         {

--- a/src/mscorlib/src/System/AggregateException.cs
+++ b/src/mscorlib/src/System/AggregateException.cs
@@ -33,7 +33,7 @@ namespace System
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class AggregateException : Exception
     {
-        private ReadOnlyCollection<Exception> m_innerExceptions; // Complete set of exceptions.
+        private ReadOnlyCollection<Exception> m_innerExceptions; // Complete set of exceptions. Do not rename (binary serialization)
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AggregateException"/> class.

--- a/src/mscorlib/src/System/ArraySegment.cs
+++ b/src/mscorlib/src/System/ArraySegment.cs
@@ -33,9 +33,9 @@ namespace System
         // instantiating another generic type in addition to ArraySegment<T> for new type parameters.
         public static ArraySegment<T> Empty { get; } = new ArraySegment<T>(new T[0]);
 
-        private readonly T[] _array;
-        private readonly int _offset;
-        private readonly int _count;
+        private readonly T[] _array; // Do not rename (binary serialization)
+        private readonly int _offset; // Do not rename (binary serialization)
+        private readonly int _count; // Do not rename (binary serialization)
 
         public ArraySegment(T[] array)
         {

--- a/src/mscorlib/src/System/Collections/Comparer.cs
+++ b/src/mscorlib/src/System/Collections/Comparer.cs
@@ -13,20 +13,16 @@
 ** 
 ===========================================================*/
 
-using System;
 using System.Globalization;
-using System.Runtime.Serialization;
 using System.Diagnostics.Contracts;
 
 namespace System.Collections
 {
-    internal sealed class Comparer : IComparer, ISerializable
+    internal sealed class Comparer : IComparer
     {
         private CompareInfo m_compareInfo;
         public static readonly Comparer Default = new Comparer(CultureInfo.CurrentCulture);
         public static readonly Comparer DefaultInvariant = new Comparer(CultureInfo.InvariantCulture);
-
-        private const String CompareInfoName = "CompareInfo";
 
         private Comparer()
         {
@@ -72,11 +68,6 @@ namespace System.Collections
                 return -ib.CompareTo(a);
 
             throw new ArgumentException(SR.Argument_ImplementIComparable);
-        }
-
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            throw new PlatformNotSupportedException();
         }
     }
 }

--- a/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
@@ -75,10 +75,10 @@ namespace System.Collections.Generic
         private Object _syncRoot;
 
         // constants for serialization
-        private const String VersionName = "Version";
-        private const String HashSizeName = "HashSize";  // Must save buckets.Length
-        private const String KeyValuePairsName = "KeyValuePairs";
-        private const String ComparerName = "Comparer";
+        private const String VersionName = "Version"; // Do not rename (binary serialization)
+        private const String HashSizeName = "HashSize"; // Do not rename (binary serialization). Must save buckets.Length
+        private const String KeyValuePairsName = "KeyValuePairs"; // Do not rename (binary serialization)
+        private const String ComparerName = "Comparer"; // Do not rename (binary serialization)
 
         public Dictionary() : this(0, null) { }
 

--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -35,10 +35,10 @@ namespace System.Collections.Generic
     {
         private const int _defaultCapacity = 4;
 
-        private T[] _items;
+        private T[] _items; // Do not rename (binary serialization)
         [ContractPublicPropertyName("Count")]
-        private int _size;
-        private int _version;
+        private int _size; // Do not rename (binary serialization)
+        private int _version; // Do not rename (binary serialization)
         [NonSerialized]
         private Object _syncRoot;
 

--- a/src/mscorlib/src/System/Collections/ListDictionaryInternal.cs
+++ b/src/mscorlib/src/System/Collections/ListDictionaryInternal.cs
@@ -23,9 +23,9 @@ namespace System.Collections
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
     internal class ListDictionaryInternal : IDictionary
     {
-        private DictionaryNode head;
-        private int version;
-        private int count;
+        private DictionaryNode head; // Do not rename (binary serialization)
+        private int version; // Do not rename (binary serialization)
+        private int count; // Do not rename (binary serialization)
         [NonSerialized]
         private Object _syncRoot;
 

--- a/src/mscorlib/src/System/Collections/ObjectModel/Collection.cs
+++ b/src/mscorlib/src/System/Collections/ObjectModel/Collection.cs
@@ -18,7 +18,7 @@ namespace System.Collections.ObjectModel
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Collection<T> : IList<T>, IList, IReadOnlyList<T>
     {
-        private IList<T> items;
+        private IList<T> items; // Do not rename (binary serialization)
         [NonSerialized]
         private Object _syncRoot;
 

--- a/src/mscorlib/src/System/Collections/ObjectModel/ReadOnlyCollection.cs
+++ b/src/mscorlib/src/System/Collections/ObjectModel/ReadOnlyCollection.cs
@@ -18,7 +18,7 @@ namespace System.Collections.ObjectModel
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class ReadOnlyCollection<T> : IList<T>, IList, IReadOnlyList<T>
     {
-        private IList<T> list;
+        private IList<T> list; // Do not rename (binary serialization)
         [NonSerialized]
         private Object _syncRoot;
 

--- a/src/mscorlib/src/System/Decimal.cs
+++ b/src/mscorlib/src/System/Decimal.cs
@@ -133,7 +133,8 @@ namespace System
         // positive and 1 meaning negative.
         //
         // NOTE: Do not change the order in which these fields are declared. The
-        // native methods in this class rely on this particular order.
+        // native methods in this class rely on this particular order. 
+        // Do not rename (binary serialization).
         private int flags;
         private int hi;
         private int lo;

--- a/src/mscorlib/src/System/Exception.cs
+++ b/src/mscorlib/src/System/Exception.cs
@@ -76,17 +76,17 @@ namespace System
                 throw new ArgumentNullException(nameof(info));
             Contract.EndContractBlock();
 
-            _className = info.GetString("ClassName");
-            _message = info.GetString("Message");
-            _data = (IDictionary)(info.GetValueNoThrow("Data", typeof(IDictionary)));
-            _innerException = (Exception)(info.GetValue("InnerException", typeof(Exception)));
-            _helpURL = info.GetString("HelpURL");
-            _stackTraceString = info.GetString("StackTraceString");
-            _remoteStackTraceString = info.GetString("RemoteStackTraceString");
-            _remoteStackIndex = info.GetInt32("RemoteStackIndex");
-            
-            HResult = info.GetInt32("HResult");
-            _source = info.GetString("Source");
+            _className = info.GetString("ClassName"); // Do not rename (binary serialization)
+            _message = info.GetString("Message"); // Do not rename (binary serialization)
+            _data = (IDictionary)(info.GetValueNoThrow("Data", typeof(IDictionary))); // Do not rename (binary serialization)
+            _innerException = (Exception)(info.GetValue("InnerException", typeof(Exception))); // Do not rename (binary serialization)
+            _helpURL = info.GetString("HelpURL"); // Do not rename (binary serialization)
+            _stackTraceString = info.GetString("StackTraceString"); // Do not rename (binary serialization)
+            _remoteStackTraceString = info.GetString("RemoteStackTraceString"); // Do not rename (binary serialization)
+            _remoteStackIndex = info.GetInt32("RemoteStackIndex"); // Do not rename (binary serialization)
+
+            HResult = info.GetInt32("HResult"); // Do not rename (binary serialization)
+            _source = info.GetString("Source"); // Do not rename (binary serialization)
 
             // Get the WatsonBuckets that were serialized - this is particularly
             // done to support exceptions going across AD transitions.
@@ -94,7 +94,7 @@ namespace System
             // We use the no throw version since we could be deserializing a pre-V4
             // exception object that may not have this entry. In such a case, we would
             // get null.
-            _watsonBuckets = (Object)info.GetValueNoThrow("WatsonBuckets", typeof(byte[]));
+            _watsonBuckets = (Object)info.GetValueNoThrow("WatsonBuckets", typeof(byte[])); // Do not rename (binary serialization)
 
 
             if (_className == null || HResult == 0)
@@ -460,20 +460,20 @@ namespace System
                 _source = Source; // Set the Source information correctly before serialization
             }
 
-            info.AddValue("ClassName", GetClassName(), typeof(String));
-            info.AddValue("Message", _message, typeof(String));
-            info.AddValue("Data", _data, typeof(IDictionary));
-            info.AddValue("InnerException", _innerException, typeof(Exception));
-            info.AddValue("HelpURL", _helpURL, typeof(String));
-            info.AddValue("StackTraceString", tempStackTraceString, typeof(String));
-            info.AddValue("RemoteStackTraceString", _remoteStackTraceString, typeof(String));
-            info.AddValue("RemoteStackIndex", _remoteStackIndex, typeof(Int32));
-            info.AddValue("ExceptionMethod", null, typeof(String));
-            info.AddValue("HResult", HResult);
-            info.AddValue("Source", _source, typeof(String));
+            info.AddValue("ClassName", GetClassName(), typeof(String)); // Do not rename (binary serialization)
+            info.AddValue("Message", _message, typeof(String)); // Do not rename (binary serialization)
+            info.AddValue("Data", _data, typeof(IDictionary)); // Do not rename (binary serialization)
+            info.AddValue("InnerException", _innerException, typeof(Exception)); // Do not rename (binary serialization)
+            info.AddValue("HelpURL", _helpURL, typeof(String)); // Do not rename (binary serialization)
+            info.AddValue("StackTraceString", tempStackTraceString, typeof(String)); // Do not rename (binary serialization)
+            info.AddValue("RemoteStackTraceString", _remoteStackTraceString, typeof(String)); // Do not rename (binary serialization)
+            info.AddValue("RemoteStackIndex", _remoteStackIndex, typeof(Int32)); // Do not rename (binary serialization)
+            info.AddValue("ExceptionMethod", null, typeof(String)); // Do not rename (binary serialization)
+            info.AddValue("HResult", HResult); // Do not rename (binary serialization)
+            info.AddValue("Source", _source, typeof(String)); // Do not rename (binary serialization)
 
             // Serialize the Watson bucket details as well
-            info.AddValue("WatsonBuckets", _watsonBuckets, typeof(byte[]));
+            info.AddValue("WatsonBuckets", _watsonBuckets, typeof(byte[])); // Do not rename (binary serialization)
         }
 
         // This method will clear the _stackTrace of the exception object upon deserialization

--- a/src/mscorlib/src/System/Guid.cs
+++ b/src/mscorlib/src/System/Guid.cs
@@ -26,17 +26,17 @@ namespace System
         ////////////////////////////////////////////////////////////////////////////////
         //  Member variables
         ////////////////////////////////////////////////////////////////////////////////
-        private int _a;
-        private short _b;
-        private short _c;
-        private byte _d;
-        private byte _e;
-        private byte _f;
-        private byte _g;
-        private byte _h;
-        private byte _i;
-        private byte _j;
-        private byte _k;
+        private int _a; // Do not rename (binary serialization)
+        private short _b; // Do not rename (binary serialization)
+        private short _c; // Do not rename (binary serialization)
+        private byte _d; // Do not rename (binary serialization)
+        private byte _e; // Do not rename (binary serialization)
+        private byte _f; // Do not rename (binary serialization)
+        private byte _g; // Do not rename (binary serialization)
+        private byte _h; // Do not rename (binary serialization)
+        private byte _i; // Do not rename (binary serialization)
+        private byte _j; // Do not rename (binary serialization)
+        private byte _k; // Do not rename (binary serialization)
 
 
 

--- a/src/mscorlib/src/System/IntPtr.cs
+++ b/src/mscorlib/src/System/IntPtr.cs
@@ -26,7 +26,7 @@ namespace System
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public struct IntPtr : IEquatable<IntPtr>, ISerializable
     {
-        unsafe private void* _value; // The compiler treats void* closest to uint hence explicit casts are required to preserve int behavior
+        unsafe private void* _value; // The compiler treats void* closest to uint hence explicit casts are required to preserve int behavior. Do not rename (binary serialization)
 
         public static readonly IntPtr Zero;
 

--- a/src/mscorlib/src/System/Nullable.cs
+++ b/src/mscorlib/src/System/Nullable.cs
@@ -26,8 +26,8 @@ namespace System
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public struct Nullable<T> where T : struct
     {
-        private bool hasValue;
-        internal T value;
+        private bool hasValue; // Do not rename (binary serialization)
+        internal T value; // Do not rename (binary serialization)
 
         [System.Runtime.Versioning.NonVersionable]
         public Nullable(T value)

--- a/src/mscorlib/src/System/TimeSpan.cs
+++ b/src/mscorlib/src/System/TimeSpan.cs
@@ -68,7 +68,7 @@ namespace System
 
         // internal so that DateTime doesn't have to call an extra get
         // method for some arithmetic operations.
-        internal long _ticks;
+        internal long _ticks; // Do not rename (binary serialization)
 
         //public TimeSpan() {
         //    _ticks = 0;

--- a/src/mscorlib/src/System/TimeZoneInfo.AdjustmentRule.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.AdjustmentRule.cs
@@ -212,13 +212,13 @@ namespace System
                 }
                 Contract.EndContractBlock();
 
-                info.AddValue("DateStart", _dateStart);
-                info.AddValue("DateEnd", _dateEnd);
-                info.AddValue("DaylightDelta", _daylightDelta);
-                info.AddValue("DaylightTransitionStart", _daylightTransitionStart);
-                info.AddValue("DaylightTransitionEnd", _daylightTransitionEnd);
-                info.AddValue("BaseUtcOffsetDelta", _baseUtcOffsetDelta);
-                info.AddValue("NoDaylightTransitions", _noDaylightTransitions);
+                info.AddValue("DateStart", _dateStart); // Do not rename (binary serialization)
+                info.AddValue("DateEnd", _dateEnd); // Do not rename (binary serialization)
+                info.AddValue("DaylightDelta", _daylightDelta); // Do not rename (binary serialization)
+                info.AddValue("DaylightTransitionStart", _daylightTransitionStart); // Do not rename (binary serialization)
+                info.AddValue("DaylightTransitionEnd", _daylightTransitionEnd); // Do not rename (binary serialization)
+                info.AddValue("BaseUtcOffsetDelta", _baseUtcOffsetDelta); // Do not rename (binary serialization)
+                info.AddValue("NoDaylightTransitions", _noDaylightTransitions); // Do not rename (binary serialization)
             }
 
             private AdjustmentRule(SerializationInfo info, StreamingContext context)
@@ -228,19 +228,19 @@ namespace System
                     throw new ArgumentNullException(nameof(info));
                 }
 
-                _dateStart = (DateTime)info.GetValue("DateStart", typeof(DateTime));
-                _dateEnd = (DateTime)info.GetValue("DateEnd", typeof(DateTime));
-                _daylightDelta = (TimeSpan)info.GetValue("DaylightDelta", typeof(TimeSpan));
-                _daylightTransitionStart = (TransitionTime)info.GetValue("DaylightTransitionStart", typeof(TransitionTime));
-                _daylightTransitionEnd = (TransitionTime)info.GetValue("DaylightTransitionEnd", typeof(TransitionTime));
+                _dateStart = (DateTime)info.GetValue("DateStart", typeof(DateTime)); // Do not rename (binary serialization)
+                _dateEnd = (DateTime)info.GetValue("DateEnd", typeof(DateTime)); // Do not rename (binary serialization)
+                _daylightDelta = (TimeSpan)info.GetValue("DaylightDelta", typeof(TimeSpan)); // Do not rename (binary serialization)
+                _daylightTransitionStart = (TransitionTime)info.GetValue("DaylightTransitionStart", typeof(TransitionTime)); // Do not rename (binary serialization)
+                _daylightTransitionEnd = (TransitionTime)info.GetValue("DaylightTransitionEnd", typeof(TransitionTime)); // Do not rename (binary serialization)
 
-                object o = info.GetValueNoThrow("BaseUtcOffsetDelta", typeof(TimeSpan));
+                object o = info.GetValueNoThrow("BaseUtcOffsetDelta", typeof(TimeSpan)); // Do not rename (binary serialization)
                 if (o != null)
                 {
                     _baseUtcOffsetDelta = (TimeSpan)o;
                 }
 
-                o = info.GetValueNoThrow("NoDaylightTransitions", typeof(bool));
+                o = info.GetValueNoThrow("NoDaylightTransitions", typeof(bool)); // Do not rename (binary serialization)
                 if (o != null)
                 {
                     _noDaylightTransitions = (bool)o;

--- a/src/mscorlib/src/System/TimeZoneInfo.TransitionTime.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.TransitionTime.cs
@@ -132,12 +132,12 @@ namespace System
                 }
                 Contract.EndContractBlock();
 
-                info.AddValue("TimeOfDay", _timeOfDay);
-                info.AddValue("Month", _month);
-                info.AddValue("Week", _week);
-                info.AddValue("Day", _day);
-                info.AddValue("DayOfWeek", _dayOfWeek);
-                info.AddValue("IsFixedDateRule", _isFixedDateRule);
+                info.AddValue("TimeOfDay", _timeOfDay); // Do not rename (binary serialization)
+                info.AddValue("Month", _month); // Do not rename (binary serialization)
+                info.AddValue("Week", _week); // Do not rename (binary serialization)
+                info.AddValue("Day", _day); // Do not rename (binary serialization)
+                info.AddValue("DayOfWeek", _dayOfWeek); // Do not rename (binary serialization)
+                info.AddValue("IsFixedDateRule", _isFixedDateRule); // Do not rename (binary serialization)
             }
 
             private TransitionTime(SerializationInfo info, StreamingContext context)
@@ -147,12 +147,12 @@ namespace System
                     throw new ArgumentNullException(nameof(info));
                 }
 
-                _timeOfDay = (DateTime)info.GetValue("TimeOfDay", typeof(DateTime));
-                _month = (byte)info.GetValue("Month", typeof(byte));
-                _week = (byte)info.GetValue("Week", typeof(byte));
-                _day = (byte)info.GetValue("Day", typeof(byte));
-                _dayOfWeek = (DayOfWeek)info.GetValue("DayOfWeek", typeof(DayOfWeek));
-                _isFixedDateRule = (bool)info.GetValue("IsFixedDateRule", typeof(bool));
+                _timeOfDay = (DateTime)info.GetValue("TimeOfDay", typeof(DateTime)); // Do not rename (binary serialization)
+                _month = (byte)info.GetValue("Month", typeof(byte)); // Do not rename (binary serialization)
+                _week = (byte)info.GetValue("Week", typeof(byte)); // Do not rename (binary serialization)
+                _day = (byte)info.GetValue("Day", typeof(byte)); // Do not rename (binary serialization)
+                _dayOfWeek = (DayOfWeek)info.GetValue("DayOfWeek", typeof(DayOfWeek)); // Do not rename (binary serialization)
+                _isFixedDateRule = (bool)info.GetValue("IsFixedDateRule", typeof(bool)); // Do not rename (binary serialization)
             }
         }
     }

--- a/src/mscorlib/src/System/TimeZoneInfo.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.cs
@@ -1041,13 +1041,13 @@ namespace System
             }
             Contract.EndContractBlock();
 
-            info.AddValue("Id", _id);
-            info.AddValue("DisplayName", _displayName);
-            info.AddValue("StandardName", _standardDisplayName);
-            info.AddValue("DaylightName", _daylightDisplayName);
-            info.AddValue("BaseUtcOffset", _baseUtcOffset);
-            info.AddValue("AdjustmentRules", _adjustmentRules);
-            info.AddValue("SupportsDaylightSavingTime", _supportsDaylightSavingTime);
+            info.AddValue("Id", _id); // Do not rename (binary serialization)
+            info.AddValue("DisplayName", _displayName); // Do not rename (binary serialization)
+            info.AddValue("StandardName", _standardDisplayName); // Do not rename (binary serialization)
+            info.AddValue("DaylightName", _daylightDisplayName); // Do not rename (binary serialization)
+            info.AddValue("BaseUtcOffset", _baseUtcOffset); // Do not rename (binary serialization)
+            info.AddValue("AdjustmentRules", _adjustmentRules); // Do not rename (binary serialization)
+            info.AddValue("SupportsDaylightSavingTime", _supportsDaylightSavingTime); // Do not rename (binary serialization)
         }
 
         private TimeZoneInfo(SerializationInfo info, StreamingContext context)
@@ -1057,13 +1057,13 @@ namespace System
                 throw new ArgumentNullException(nameof(info));
             }
 
-            _id = (string)info.GetValue("Id", typeof(string));
-            _displayName = (string)info.GetValue("DisplayName", typeof(string));
-            _standardDisplayName = (string)info.GetValue("StandardName", typeof(string));
-            _daylightDisplayName = (string)info.GetValue("DaylightName", typeof(string));
-            _baseUtcOffset = (TimeSpan)info.GetValue("BaseUtcOffset", typeof(TimeSpan));
-            _adjustmentRules = (AdjustmentRule[])info.GetValue("AdjustmentRules", typeof(AdjustmentRule[]));
-            _supportsDaylightSavingTime = (bool)info.GetValue("SupportsDaylightSavingTime", typeof(bool));
+            _id = (string)info.GetValue("Id", typeof(string)); // Do not rename (binary serialization)
+            _displayName = (string)info.GetValue("DisplayName", typeof(string)); // Do not rename (binary serialization)
+            _standardDisplayName = (string)info.GetValue("StandardName", typeof(string)); // Do not rename (binary serialization)
+            _daylightDisplayName = (string)info.GetValue("DaylightName", typeof(string)); // Do not rename (binary serialization)
+            _baseUtcOffset = (TimeSpan)info.GetValue("BaseUtcOffset", typeof(TimeSpan)); // Do not rename (binary serialization)
+            _adjustmentRules = (AdjustmentRule[])info.GetValue("AdjustmentRules", typeof(AdjustmentRule[])); // Do not rename (binary serialization)
+            _supportsDaylightSavingTime = (bool)info.GetValue("SupportsDaylightSavingTime", typeof(bool)); // Do not rename (binary serialization)
         }
 
         private AdjustmentRule GetAdjustmentRuleForTime(DateTime dateTime, out int? ruleIndex)

--- a/src/mscorlib/src/System/Tuple.cs
+++ b/src/mscorlib/src/System/Tuple.cs
@@ -108,7 +108,7 @@ namespace System
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Tuple<T1> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
-        private readonly T1 m_Item1;
+        private readonly T1 m_Item1; // Do not rename (binary serialization)
 
         public T1 Item1 { get { return m_Item1; } }
 
@@ -208,8 +208,8 @@ namespace System
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Tuple<T1, T2> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
-        private readonly T1 m_Item1;
-        private readonly T2 m_Item2;
+        private readonly T1 m_Item1; // Do not rename (binary serialization)
+        private readonly T2 m_Item2; // Do not rename (binary serialization)
 
         public T1 Item1 { get { return m_Item1; } }
         public T2 Item2 { get { return m_Item2; } }
@@ -323,9 +323,9 @@ namespace System
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Tuple<T1, T2, T3> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
-        private readonly T1 m_Item1;
-        private readonly T2 m_Item2;
-        private readonly T3 m_Item3;
+        private readonly T1 m_Item1; // Do not rename (binary serialization)
+        private readonly T2 m_Item2; // Do not rename (binary serialization)
+        private readonly T3 m_Item3; // Do not rename (binary serialization)
 
         public T1 Item1 { get { return m_Item1; } }
         public T2 Item2 { get { return m_Item2; } }
@@ -449,10 +449,10 @@ namespace System
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Tuple<T1, T2, T3, T4> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
-        private readonly T1 m_Item1;
-        private readonly T2 m_Item2;
-        private readonly T3 m_Item3;
-        private readonly T4 m_Item4;
+        private readonly T1 m_Item1; // Do not rename (binary serialization)
+        private readonly T2 m_Item2; // Do not rename (binary serialization)
+        private readonly T3 m_Item3; // Do not rename (binary serialization)
+        private readonly T4 m_Item4; // Do not rename (binary serialization)
 
         public T1 Item1 { get { return m_Item1; } }
         public T2 Item2 { get { return m_Item2; } }
@@ -586,11 +586,11 @@ namespace System
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Tuple<T1, T2, T3, T4, T5> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
-        private readonly T1 m_Item1;
-        private readonly T2 m_Item2;
-        private readonly T3 m_Item3;
-        private readonly T4 m_Item4;
-        private readonly T5 m_Item5;
+        private readonly T1 m_Item1; // Do not rename (binary serialization)
+        private readonly T2 m_Item2; // Do not rename (binary serialization)
+        private readonly T3 m_Item3; // Do not rename (binary serialization)
+        private readonly T4 m_Item4; // Do not rename (binary serialization)
+        private readonly T5 m_Item5; // Do not rename (binary serialization)
 
         public T1 Item1 { get { return m_Item1; } }
         public T2 Item2 { get { return m_Item2; } }
@@ -734,12 +734,12 @@ namespace System
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Tuple<T1, T2, T3, T4, T5, T6> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
-        private readonly T1 m_Item1;
-        private readonly T2 m_Item2;
-        private readonly T3 m_Item3;
-        private readonly T4 m_Item4;
-        private readonly T5 m_Item5;
-        private readonly T6 m_Item6;
+        private readonly T1 m_Item1; // Do not rename (binary serialization)
+        private readonly T2 m_Item2; // Do not rename (binary serialization)
+        private readonly T3 m_Item3; // Do not rename (binary serialization)
+        private readonly T4 m_Item4; // Do not rename (binary serialization)
+        private readonly T5 m_Item5; // Do not rename (binary serialization)
+        private readonly T6 m_Item6; // Do not rename (binary serialization)
 
         public T1 Item1 { get { return m_Item1; } }
         public T2 Item2 { get { return m_Item2; } }
@@ -893,13 +893,13 @@ namespace System
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Tuple<T1, T2, T3, T4, T5, T6, T7> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
-        private readonly T1 m_Item1;
-        private readonly T2 m_Item2;
-        private readonly T3 m_Item3;
-        private readonly T4 m_Item4;
-        private readonly T5 m_Item5;
-        private readonly T6 m_Item6;
-        private readonly T7 m_Item7;
+        private readonly T1 m_Item1; // Do not rename (binary serialization)
+        private readonly T2 m_Item2; // Do not rename (binary serialization)
+        private readonly T3 m_Item3; // Do not rename (binary serialization)
+        private readonly T4 m_Item4; // Do not rename (binary serialization)
+        private readonly T5 m_Item5; // Do not rename (binary serialization)
+        private readonly T6 m_Item6; // Do not rename (binary serialization)
+        private readonly T7 m_Item7; // Do not rename (binary serialization)
 
         public T1 Item1 { get { return m_Item1; } }
         public T2 Item2 { get { return m_Item2; } }
@@ -1063,14 +1063,14 @@ namespace System
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Tuple<T1, T2, T3, T4, T5, T6, T7, TRest> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
-        private readonly T1 m_Item1;
-        private readonly T2 m_Item2;
-        private readonly T3 m_Item3;
-        private readonly T4 m_Item4;
-        private readonly T5 m_Item5;
-        private readonly T6 m_Item6;
-        private readonly T7 m_Item7;
-        private readonly TRest m_Rest;
+        private readonly T1 m_Item1; // Do not rename (binary serialization)
+        private readonly T2 m_Item2; // Do not rename (binary serialization)
+        private readonly T3 m_Item3; // Do not rename (binary serialization)
+        private readonly T4 m_Item4; // Do not rename (binary serialization)
+        private readonly T5 m_Item5; // Do not rename (binary serialization)
+        private readonly T6 m_Item6; // Do not rename (binary serialization)
+        private readonly T7 m_Item7; // Do not rename (binary serialization)
+        private readonly TRest m_Rest; // Do not rename (binary serialization)
 
         public T1 Item1 { get { return m_Item1; } }
         public T2 Item2 { get { return m_Item2; } }

--- a/src/mscorlib/src/System/UIntPtr.cs
+++ b/src/mscorlib/src/System/UIntPtr.cs
@@ -24,7 +24,7 @@ namespace System
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
     public struct UIntPtr : IEquatable<UIntPtr>, ISerializable
     {
-        unsafe private void* _value;
+        unsafe private void* _value; // Do not rename (binary serialization)
 
         public static readonly UIntPtr Zero;
 

--- a/src/mscorlib/src/System/WeakReference.cs
+++ b/src/mscorlib/src/System/WeakReference.cs
@@ -58,8 +58,8 @@ namespace System
             }
             Contract.EndContractBlock();
 
-            Object target = info.GetValue("TrackedObject", typeof(Object));
-            bool trackResurrection = info.GetBoolean("TrackResurrection");
+            Object target = info.GetValue("TrackedObject", typeof(Object)); // Do not rename (binary serialization)
+            bool trackResurrection = info.GetBoolean("TrackResurrection"); // Do not rename (binary serialization)
 
             Create(target, trackResurrection);
         }
@@ -109,8 +109,8 @@ namespace System
                 throw new ArgumentNullException(nameof(info));
             }
             Contract.EndContractBlock();
-            info.AddValue("TrackedObject", Target, typeof(Object));
-            info.AddValue("TrackResurrection", IsTrackResurrection());
+            info.AddValue("TrackedObject", Target, typeof(Object)); // Do not rename (binary serialization)
+            info.AddValue("TrackResurrection", IsTrackResurrection()); // Do not rename (binary serialization)
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]

--- a/src/mscorlib/src/System/WeakReferenceOfT.cs
+++ b/src/mscorlib/src/System/WeakReferenceOfT.cs
@@ -53,8 +53,8 @@ namespace System
             }
             Contract.EndContractBlock();
 
-            T target = (T)info.GetValue("TrackedObject", typeof(T));
-            bool trackResurrection = info.GetBoolean("TrackResurrection");
+            T target = (T)info.GetValue("TrackedObject", typeof(T)); // Do not rename (binary serialization)
+            bool trackResurrection = info.GetBoolean("TrackResurrection"); // Do not rename (binary serialization)
 
             Create(target, trackResurrection);
         }
@@ -106,8 +106,8 @@ namespace System
             }
             Contract.EndContractBlock();
 
-            info.AddValue("TrackedObject", this.Target, typeof(T));
-            info.AddValue("TrackResurrection", IsTrackResurrection());
+            info.AddValue("TrackedObject", this.Target, typeof(T)); // Do not rename (binary serialization)
+            info.AddValue("TrackResurrection", IsTrackResurrection()); // Do not rename (binary serialization)
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]


### PR DESCRIPTION
I went through all serializable types in coreclr again and double-checked all variables and typeforwards with netfx. I noticed that DateTime serialization was partially broken because in the ISerializable routine a different name was used. I fixed that and also added attention labels to not rename serialized fields. Also removed unnecessary ISerializable implementation in Comparer.

**CultureAwareComparer serialization is partially broken because implementation is different.**
Netfx: https://referencesource.microsoft.com/#mscorlib/system/stringcomparer.cs,137 
Core: https://github.com/dotnet/coreclr/blob/master/src/mscorlib/shared/System/StringComparer.cs#L178

Should we just ignore it or write a custom deserialization logic with ISerializable? The mapping would be easy from the Boolean value to the enum value (1 = IgnoreCase, 0 = None).

cc @stephentoub @danmosemsft @morganbr