### PR TITLE
Allow users to set the number of build processes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -312,19 +312,6 @@ build_native()
         exit 1
     fi
     
-    if [[ -z ${NumProc} ]]; then
-        # Get the number of processors available to the scheduler
-        # Other techniques such as `nproc` only get the number of
-        # processors available to a single process.
-        if [ `uname` = "FreeBSD" ]; then
-            NumProc=`sysctl hw.ncpu | awk '{ print $2+1 }'`
-        elif [ `uname` = "NetBSD" ]; then
-            NumProc=$(($(getconf NPROCESSORS_ONLN)+1))
-        else
-            NumProc=$(($(getconf _NPROCESSORS_ONLN)+1))
-        fi
-    fi
-
     # Build
     if [ $__ConfigureOnly == 1 ]; then
         echo "Finish configuration & skipping $message build."
@@ -821,7 +808,7 @@ while :; do
             ;;
         numproc)
             if [ -n "$2" ]; then
-              NumProc="$2"
+              __NumProc="$2"
               shift
             else
               echo "ERROR: 'numproc' requires a non-empty option argument"
@@ -919,6 +906,21 @@ if [ $__CrossBuild == 1 ]; then
     export CROSSCOMPILE=1
     if ! [[ -n "$ROOTFS_DIR" ]]; then
         export ROOTFS_DIR="$__ProjectRoot/cross/rootfs/$__BuildArch"
+    fi
+fi
+
+if [[ -n "$__NumProc" ]]; then
+    NumProc="$__NumProc"
+else
+    # Get the number of processors available to the scheduler
+    # Other techniques such as `nproc` only get the number of
+    # processors available to a single process.
+    if [ `uname` = "FreeBSD" ]; then
+        NumProc=`sysctl hw.ncpu | awk '{ print $2+1 }'`
+    elif [ `uname` = "NetBSD" ]; then
+        NumProc=$(($(getconf NPROCESSORS_ONLN)+1))
+    else
+        NumProc=$(($(getconf _NPROCESSORS_ONLN)+1))
     fi
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -321,9 +321,9 @@ build_native()
     # Check that the makefiles were created.
     pushd "$intermediatesForBuild"
 
-    echo "Executing $buildTool install -j $NumProc"
+    echo "Executing $buildTool install -j $__NumProc"
 
-    $buildTool install -j $NumProc
+    $buildTool install -j $__NumProc
     if [ $? != 0 ]; then
         echo "Failed to build $message."
         exit 1
@@ -617,6 +617,17 @@ __msbuildonunsupportedplatform=0
 __PgoOptDataVersion=""
 __IbcOptDataVersion=""
 
+# Get the number of processors available to the scheduler
+# Other techniques such as `nproc` only get the number of
+# processors available to a single process.
+if [ `uname` = "FreeBSD" ]; then
+  __NumProc=`sysctl hw.ncpu | awk '{ print $2+1 }'`
+elif [ `uname` = "NetBSD" ]; then
+  __NumProc=$(($(getconf NPROCESSORS_ONLN)+1))
+else
+  __NumProc=$(($(getconf _NPROCESSORS_ONLN)+1))
+fi
+
 while :; do
     if [ $# -le 0 ]; then
         break
@@ -906,21 +917,6 @@ if [ $__CrossBuild == 1 ]; then
     export CROSSCOMPILE=1
     if ! [[ -n "$ROOTFS_DIR" ]]; then
         export ROOTFS_DIR="$__ProjectRoot/cross/rootfs/$__BuildArch"
-    fi
-fi
-
-if [[ -n "$__NumProc" ]]; then
-    NumProc="$__NumProc"
-else
-    # Get the number of processors available to the scheduler
-    # Other techniques such as `nproc` only get the number of
-    # processors available to a single process.
-    if [ `uname` = "FreeBSD" ]; then
-        NumProc=`sysctl hw.ncpu | awk '{ print $2+1 }'`
-    elif [ `uname` = "NetBSD" ]; then
-        NumProc=$(($(getconf NPROCESSORS_ONLN)+1))
-    else
-        NumProc=$(($(getconf _NPROCESSORS_ONLN)+1))
     fi
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -311,15 +311,17 @@ build_native()
         exit 1
     fi
     
-    # Get the number of processors available to the scheduler
-    # Other techniques such as `nproc` only get the number of
-    # processors available to a single process.
-    if [ `uname` = "FreeBSD" ]; then
-        NumProc=`sysctl hw.ncpu | awk '{ print $2+1 }'`
-    elif [ `uname` = "NetBSD" ]; then
-        NumProc=$(($(getconf NPROCESSORS_ONLN)+1))
-    else
-        NumProc=$(($(getconf _NPROCESSORS_ONLN)+1))
+    if [[ -z ${NumProc} ]]; then
+        # Get the number of processors available to the scheduler
+        # Other techniques such as `nproc` only get the number of
+        # processors available to a single process.
+        if [ `uname` = "FreeBSD" ]; then
+            NumProc=`sysctl hw.ncpu | awk '{ print $2+1 }'`
+        elif [ `uname` = "NetBSD" ]; then
+            NumProc=$(($(getconf NPROCESSORS_ONLN)+1))
+        else
+            NumProc=$(($(getconf _NPROCESSORS_ONLN)+1))
+        fi
     fi
 
     # Build

--- a/build.sh
+++ b/build.sh
@@ -52,6 +52,7 @@ usage()
     echo "bindir - output directory (defaults to $__ProjectRoot/bin)"
     echo "buildstandalonegc - builds the GC in a standalone mode. Can't be used with \"cmakeargs\"."
     echo "msbuildonunsupportedplatform - build managed binaries even if distro is not officially supported."
+    echo "numproc - set the number of build processes."
     exit 1
 }
 
@@ -817,6 +818,15 @@ while :; do
             ;;
         msbuildonunsupportedplatform)
             __msbuildonunsupportedplatform=1
+            ;;
+        numproc)
+            if [ -n "$2" ]; then
+              NumProc="$2"
+              shift
+            else
+              echo "ERROR: 'numproc' requires a non-empty option argument"
+              exit 1
+            fi
             ;;
         *)
             __UnprocessedBuildArgs="$__UnprocessedBuildArgs $1"


### PR DESCRIPTION
This commit allows users to override the number of build process via setting NumProc environment variable.

There is no change in default behavior.