### PR TITLE
[RyuJIT/ARM32] Fix failures related to explicit containedness

### DIFF
--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -59,10 +59,17 @@ void Lowering::TreeNodeInfoInitStoreLoc(GenTreeLclVarCommon* storeLoc)
         // Call node srcCandidates = Bitwise-OR(allregs(GetReturnRegType(i))) for all i=0..RetRegCount-1
         regMaskTP srcCandidates = m_lsra->allMultiRegCallNodeRegs(call);
         op1->gtLsraInfo.setSrcCandidates(m_lsra, srcCandidates);
-        return;
     }
-
-    CheckImmedAndMakeContained(storeLoc, op1);
+#if defined(_TARGET_ARM_)
+    else if (op1->OperGet() == GT_LONG)
+    {
+        op1->SetContained();
+    }
+#endif // _TARGET_ARM_
+    else
+    {
+        CheckImmedAndMakeContained(storeLoc, op1);
+    }
 }
 
 //------------------------------------------------------------------------
@@ -674,6 +681,7 @@ void Lowering::TreeNodeInfoInitPutArgStk(GenTreePutArgStk* argNode, fgArgTabEntr
         {
             // We consume all of the items in the GT_FIELD_LIST
             argNode->gtLsraInfo.srcCount = info->numSlots;
+            putArgChild->SetContained();
         }
         else
         {


### PR DESCRIPTION
Fixes assertion failures appeared after #11901 was merged:
```
Assert failure(PID 15623 [0x00003d07], Thread: 15623 [0x3d07]): Assertion failed 'source->isContained()' in 'System.IO.FileStream:Init(int,int):this' (IL size 169)

    File: /home/mskvortsov/git/coreclr/src/jit/codegenarmarch.cpp Line: 558
    Image: /home/mskvortsov/clr-checked/corerun

Assert failure(PID 15201 [0x00003b61], Thread: 15201 [0x3b61]): Assertion failed 'isMarkedContained || (gtGetParent(nullptr) == nullptr)' in 'System.Reflection.RuntimeAssembly:GetManifestResourceStream(ref,byref,bool):ref:this' (IL size 65)

    File: /home/mskvortsov/git/coreclr/src/jit/gentree.cpp Line: 15506
    Image: /home/mskvortsov/clr-checked/corerun
```
cc @dotnet/arm32-contrib 