### PR TITLE
[ARM/Linux] Validate memory using ldrb instead of ldr

### DIFF
--- a/src/vm/arm/memcpy.S
+++ b/src/vm/arm/memcpy.S
@@ -22,8 +22,8 @@
         PROLOG_PUSH  "{r7, lr}"
         PROLOG_STACK_SAVE r7
         
-        ldr r3, [r0]
-        ldr r3, [r1]
+        ldrb r3, [r0]
+        ldrb r3, [r1]
         
         blx C_FUNC(memcpy)
 


### PR DESCRIPTION
Segmentation fault happens in FCallMemcpy when it takes unaligned addresses as src/dst.

This commit revises FCallMemcpy to use ldrb (instead of ldr) when it validates src/dst.

