### PR TITLE
Making int.Parse("") faster

### DIFF
--- a/src/mscorlib/shared/System/Int32.cs
+++ b/src/mscorlib/shared/System/Int32.cs
@@ -119,7 +119,7 @@ namespace System
         public static int Parse(String s)
         {
             if (s == null) ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
-            return Number.ParseInt32(s.AsReadOnlySpan(), NumberStyles.Integer, NumberFormatInfo.CurrentInfo);
+            return Number.ParseInt32Fast(s.AsReadOnlySpan(), NumberFormatInfo.CurrentInfo);
         }
 
         [Pure]


### PR DESCRIPTION
This is a PoC to to make int.Parse() faster for 99%? cases.
The fast path only handles the `NumberStyles.Integer` style (sign, leading and trailing whitespaces)
This is a draft version. I will polish it if there's interest to have it in CLR. It reuses two functions `MatchChars` and `IsWhite`. I believe it's possible to make it faster (some magic with the loop and conditions, get rid of unsafe code and `MatchChars` function). It also possible to improve [all cases where `NumberStyles.Integer` used](https://github.com/dotnet/coreclr/search?l=C%23&p=2&q=NumberStyles.Integer&type=&utf8=%E2%9C%93)
I pushed initial benchmarks to [a separate repo](https://github.com/alexandrnikitin/MakingIntParseFaster.NET) (I didn't manage to do them in the coreclr repos 😕 )

Benchmark results:

 |            Method |      Mean |     Error |    StdDev |
 |------------------ |----------:|----------:|----------:|
 |          OneDigit |  60.28 ns | 1.5539 ns | 0.4036 ns |
 |          MaxValue | 105.17 ns | 3.4847 ns | 0.9051 ns |
 |              Sign | 109.57 ns | 4.4545 ns | 1.1570 ns |
 |       Whitespaces | 136.43 ns | 4.3078 ns | 1.1189 ns |
 |    FasterOneDigit |  18.97 ns | 0.6642 ns | 0.1725 ns |
 |    FasterMaxValue |  30.68 ns | 2.4894 ns | 0.6466 ns |
 |        FasterSign |  41.97 ns | 0.9735 ns | 0.2529 ns |
 | FasterWhitespaces | 208.79 ns | 6.2361 ns | 1.6198 ns |

_Not sure what's wrong with the Whitespaces case_ 😊 

Related issues: https://github.com/dotnet/coreclr/pull/3995 https://github.com/dotnet/corefx/issues/13293 https://github.com/dotnet/coreclr/pull/3163
cc who participated in previous discussions @jkotas @varocarbas @hughbe @danmosemsft @jakobbotsch @mikedn