### PR TITLE
Fix for checking enregisterLocalVars to display fpCalleeSaveCandidateVars

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -2335,7 +2335,7 @@ void LinearScan::identifyCandidates()
     if (VERBOSE)
     {
         printf("\nFP callee save candidate vars: ");
-        if (!VarSetOps::IsEmpty(compiler, fpCalleeSaveCandidateVars))
+        if (enregisterLocalVars && !VarSetOps::IsEmpty(compiler, fpCalleeSaveCandidateVars))
         {
             dumpConvertedVarSet(compiler, fpCalleeSaveCandidateVars);
             printf("\n");


### PR DESCRIPTION

fpCalleeSaveCandidateVars should be used under enregisterLocalVars.
Or it contains garbage value.
