### PR TITLE
Update PGO counts to version 20170609-1125

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -23,7 +23,7 @@
 
   <!-- Profile-based optimization data package versions -->
   <PropertyGroup>
-    <PgoDataPackageVersion>99.99.99-master-20170531-3000</PgoDataPackageVersion>
+    <PgoDataPackageVersion>99.99.99-master-20170609-1125</PgoDataPackageVersion>
     <!--<IbcDataPackageVersion></IbcDataPackageVersion>-->
   </PropertyGroup>
 

--- a/pgosupport.cmake
+++ b/pgosupport.cmake
@@ -11,8 +11,7 @@ function(add_pgo TargetName)
     if(WIN32)
         set(ProfileFileName "${TargetName}.pgd")
     else(WIN32)
-        # Clang/LLVM uses one profdata file for the entire repo
-        set(ProfileFileName "coreclr.profdata")
+        set(ProfileFileName "${TargetName}.profdata")
     endif(WIN32)
 
     set(CLR_CMAKE_OPTDATA_PACKAGEWITHRID "optimization.${CLR_CMAKE_TARGET_OS}-${CLR_CMAKE_TARGET_ARCH}.PGO.CoreCLR")


### PR DESCRIPTION
Update PGO optdata package version to 20170609-1125.
Update how Linux PGO consumes counts to reflect change in optdata format.

