### PR TITLE
Fix warnings when building SOS.NETCore.csproj

### DIFF
--- a/src/ToolBox/SOS/NETCore/SOS.NETCore.csproj
+++ b/src/ToolBox/SOS/NETCore/SOS.NETCore.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
@@ -48,14 +48,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Platforms">
-      <Version>$(RuntimeIdGraphDefinitionVersion)</Version>
-    </PackageReference>
     <PackageReference Include="System.IO.FileSystem">
-      <Version>4.0.1</Version>
+      <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime.InteropServices">
-      <Version>4.1.0</Version>
+      <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.Reflection.Metadata">
       <Version>1.4.1</Version>


### PR DESCRIPTION
These warnings have been bugging me for a while, so I took a few moments to fix them.