### PR TITLE
Use NuGetPush target from BuildTools

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01702-02
+2.0.0-prerelease-01708-02

--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -151,9 +151,9 @@
       "inputs": {
         "scriptType": "inlineScript",
         "scriptName": "",
-        "arguments": "$(MyGetApiKey) $(ConfigurationGroup)",
-        "inlineScript": "param($ApiKey, $ConfigurationGroup)\nif ($ConfigurationGroup -ne \"Release\") { exit }\n& $env:CustomNuGetPath push $env:Pipeline_SourcesDirectory\\packages\\AzureTransfer\\$env:ConfigurationGroup\\$env:AzureContainerPackageGlob $ApiKey -Source $env:MyGetFeedUrl -Timeout 3600",
-        "workingFolder": "",
+        "arguments": "-ApiKey $(MyGetApiKey) -ConfigurationGroup $(ConfigurationGroup) -PackagesGlob $(Pipeline.SourcesDirectory)\\packages\\AzureTransfer\\$(ConfigurationGroup)\\$(AzureContainerPackageGlob) -MyGetFeedUrl $(MyGetFeedUrl)",
+        "workingFolder": "$(Pipeline.SourcesDirectory)",
+        "inlineScript": "param($ApiKey, $ConfigurationGroup, $PackagesGlob, $MyGetFeedUrl)\n\nif ($ConfigurationGroup -ne \"Release\") { exit }\n\nmsbuild /t:NuGetPush /v:Normal `\n/p:NuGetExePath=$env:CustomNuGetPath `\n/p:NuGetApiKey=$ApiKey `\n/p:NuGetSource=$MyGetFeedUrl `\n/p:PackagesGlob=$PackagesGlob",
         "failOnStandardError": "true"
       }
     },
@@ -171,9 +171,9 @@
       "inputs": {
         "scriptType": "inlineScript",
         "scriptName": "",
-        "arguments": "$(MyGetApiKey) $(ConfigurationGroup)",
-        "inlineScript": "param($ApiKey, $ConfigurationGroup)\nif ($ConfigurationGroup -ne \"Release\") { exit }\nif ($env:SourceBranch.StartsWith(\"release/\")) { exit }\n& $env:CustomNuGetPath push $env:Build_StagingDirectory\\IndexedSymbolPackages\\*.nupkg $ApiKey -Source $env:MyGetFeedUrl -Timeout 3600",
-        "workingFolder": "",
+        "arguments": "-ApiKey $(MyGetApiKey) -ConfigurationGroup $(ConfigurationGroup) -PackagesGlob $(Build.StagingDirectory)\\IndexedSymbolPackages\\*.nupkg -MyGetFeedUrl $(MyGetFeedUrl)",
+        "workingFolder": "$(Pipeline.SourcesDirectory)",
+        "inlineScript": "param($ApiKey, $ConfigurationGroup, $PackagesGlob, $MyGetFeedUrl)\n\nif ($ConfigurationGroup -ne \"Release\") { exit }\nif ($env:SourceBranch.StartsWith(\"release/\")) { exit }\n\nmsbuild /t:NuGetPush /v:Normal `\n/p:NuGetExePath=$env:CustomNuGetPath `\n/p:NuGetApiKey=$ApiKey `\n/p:NuGetSource=$MyGetFeedUrl `\n/p:PackagesGlob=$PackagesGlob",
         "failOnStandardError": "true"
       }
     },


### PR DESCRIPTION
skip ci please

Use `NuGetPush` target added to BuildTools in https://github.com/dotnet/buildtools/pull/1543. This includes per-package retries, to fix the NuGet push hang (https://github.com/dotnet/core-eng/issues/434) in CoreCLR master.

With these changes, a test push (using VSTS infra) took 10 minutes. The push of the same set of packages during the real build was 12 minutes. It's likely that the reduced time is just variance, but it seems safe to say `NuGetPush` won't make the publish take longer.

I pulled out a decoded diff of the json to make it easier to read:

```diff
 === packages -> dotnet.myget.org ===
 --- Arguments ---
-$(MyGetApiKey) $(ConfigurationGroup)
+-ApiKey $(MyGetApiKey) -ConfigurationGroup $(ConfigurationGroup) -PackagesGlob $(Pipeline.SourcesDirectory)\packages\AzureTransfer\$(ConfigurationGroup)\$(AzureContainerPackageGlob) -MyGetFeedUrl $(MyGetFeedUrl)
 --- Inline Script ---
-param($ApiKey, $ConfigurationGroup)
+param($ApiKey, $ConfigurationGroup, $PackagesGlob, $MyGetFeedUrl)
+
 if ($ConfigurationGroup -ne "Release") { exit }
-& $env:CustomNuGetPath push $env:Pipeline_SourcesDirectory\packages\AzureTransfer\$env:ConfigurationGroup\$env:AzureContainerPackageGlob $ApiKey -Source $env:MyGetFeedUrl -Timeout 3600
+
+msbuild /t:NuGetPush /v:Normal `
+/p:NuGetExePath=$env:CustomNuGetPath `
+/p:NuGetApiKey=$ApiKey `
+/p:NuGetSource=$MyGetFeedUrl `
+/p:PackagesGlob=$PackagesGlob
 
 === symbol packages -> dotnet.myget.org ===
 --- Arguments ---
-$(MyGetApiKey) $(ConfigurationGroup)
+-ApiKey $(MyGetApiKey) -ConfigurationGroup $(ConfigurationGroup) -PackagesGlob $(Build.StagingDirectory)\IndexedSymbolPackages\*.nupkg -MyGetFeedUrl $(MyGetFeedUrl)
 --- Inline Script ---
-param($ApiKey, $ConfigurationGroup)
+param($ApiKey, $ConfigurationGroup, $PackagesGlob, $MyGetFeedUrl)
+
 if ($ConfigurationGroup -ne "Release") { exit }
 if ($env:SourceBranch.StartsWith("release/")) { exit }
-& $env:CustomNuGetPath push $env:Build_StagingDirectory\IndexedSymbolPackages\*.nupkg $ApiKey -Source $env:MyGetFeedUrl -Timeout 3600
+
+msbuild /t:NuGetPush /v:Normal `
+/p:NuGetExePath=$env:CustomNuGetPath `
+/p:NuGetApiKey=$ApiKey `
+/p:NuGetSource=$MyGetFeedUrl `
+/p:PackagesGlob=$PackagesGlob
```

There are a few unnecessary changes in there, but they bring CoreCLR's publish step closer to CoreFX's. Here's the PR to use `NuGetPush` in CoreFX: https://github.com/dotnet/corefx/pull/20882.