### PR TITLE
Reduce excessive loop count in interlocked tests

### DIFF
--- a/tests/src/baseservices/threading/interlocked/add/InterlockedAddLongWithSubtract.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/InterlockedAddLongWithSubtract.csproj
@@ -12,7 +12,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
-    <CLRTestExecutionArguments>/loops:500000 /addVal:1</CLRTestExecutionArguments>
+    <CLRTestExecutionArguments>/loops:10000 /addVal:1</CLRTestExecutionArguments>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/interlocked/add/interlockedaddintwithsubtract.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/interlockedaddintwithsubtract.csproj
@@ -10,7 +10,7 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <CLRTestPriority>1</CLRTestPriority>
-    <CLRTestExecutionArguments>/loops:500000 /addVal:1</CLRTestExecutionArguments>
+    <CLRTestExecutionArguments>/loops:10000 /addVal:1</CLRTestExecutionArguments>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
Two interlocked threading tests are using a loop count of 500K.  Most of the tests in this category are using loop count of 100.

Theses tests each create 50 threads.  Each thread performs an atomic add followed by an atomic subtract to a variable shared by all threads.  In systems with high thread count there is a lot of contention on these atomic variables and each atomic op is slowed due to scalability issues.

Reducing loop count will allow these to run in more reasonable time.

I choose 10K rather as a balance between the 100 typically used and the 500K current.