### PR TITLE
Add help statement for perf.groovy

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -486,3 +486,7 @@ def static getOSGroup(def os) {
         }
     }
 }
+
+Utilities.createHelperJob(this, project, branch,
+    "Welcome to the ${project} Perf help",
+    "Have a nice day!")


### PR DESCRIPTION
When you use the help from dotnet bot you do not get any of the
performance runs in the help.  This should add those in.