### PR TITLE
Pull CoreCLR build from RHEL7.2 in perf runs

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -339,6 +339,11 @@ def static getFullPerfJobName(def project, def os, def isPR) {
         "{ build(params + [PRODUCT_BUILD: b.build.number], '${getFullPerfJobName(project, os, isPR)}') }"
     }
     def newFlowJob = buildFlowJob(Utilities.getFullJobName(project, "perf_linux_flow", isPR, '')) {
+        if (isPR) {
+            parameters {
+                stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
+            }
+        }
         buildFlow("""
 // First, build the bits on RHEL7.2
 b = build(params, '${fullBuildJobName}')
@@ -466,6 +471,11 @@ def static getFullThroughputJobName(def project, def os, def isPR) {
         "{ build(params + [PRODUCT_BUILD: b.build.number], '${getFullThroughputJobName(project, os, isPR)}') }"
     }
     def newFlowJob = buildFlowJob(Utilities.getFullJobName(project, "perf_throughput_linux_flow", isPR, '')) {
+        if (isPR) {
+            parameters {
+                stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
+            }
+        }
         buildFlow("""
 // First, build the bits on RHEL7.2
 b = build(params, '${fullBuildJobName}')

--- a/perf.groovy
+++ b/perf.groovy
@@ -247,7 +247,7 @@ def static getFullPerfJobName(def project, def os, def isPR) {
     ['RHEL7.2'].each { os ->
         def newBuildJob = job(fullBuildJobName) {
             steps {
-                shell("./build.sh ${architecture} ${configuration}")
+                shell("./build.sh verbose ${architecture} ${configuration}")
             }
         }
         Utilities.setMachineAffinity(newBuildJob, os, 'latest-or-auto')
@@ -381,7 +381,7 @@ def static getFullThroughputJobName(def project, def os, def isPR) {
     ['RHEL7.2'].each { os ->
         def newBuildJob = job(fullBuildJobName) {
             steps {
-                shell("./build.sh ${architecture} ${configuration}")
+                shell("./build.sh verbose ${architecture} ${configuration}")
             }
         }
         Utilities.setMachineAffinity(newBuildJob, os, 'latest-or-auto')

--- a/perf.groovy
+++ b/perf.groovy
@@ -245,11 +245,9 @@ def static getFullPerfJobName(def project, def os, def isPR) {
 
     // Build has to happen on RHEL7.2 (that's where we produce the bits we ship)
     ['RHEL7.2'].each { os ->
-        def osGroup = getOSGroup(os)
         def newBuildJob = job(fullBuildJobName) {
             steps {
                 shell("./build.sh verbose ${architecture} ${configuration}")
-                shell("src/pal/tests/palsuite/runpaltests.sh \${WORKSPACE}/bin/obj/${osGroup}.${architecture}.${configuration} \${WORKSPACE}/bin/paltestout")
             }
         }
         Utilities.setMachineAffinity(newBuildJob, os, 'latest-or-auto')

--- a/perf.groovy
+++ b/perf.groovy
@@ -233,8 +233,8 @@ def static getOSGroup(def os) {
     }
 }
 
-def static getFullPerfJobName(def os) {
-    return "perf_${os}"
+def static getFullPerfJobName(def os, def isPR) {
+    return Utilities.getFullJobName(project, "perf_${os}", isPR)
 }
 
 // Create the Linux/OSX/CentOS coreclr test leg for debug and release and each scenario
@@ -258,7 +258,7 @@ def static getFullPerfJobName(def os) {
     // Actual perf testing on the following OSes
     def perfOSList = ['Ubuntu14.04']
     perfOSList.each { os ->
-        def newJob = job(Utilities.getFullJobName(project, getFullPerfJobName(os), isPR)) {
+        def newJob = job(getFullPerfJobName(os, isPR)) {
 
             label('linux_clr_perf')
             wrappers {
@@ -334,7 +334,7 @@ def static getFullPerfJobName(def os) {
     } // os
 
     def flowJobPerfRunList = perfOSList.collect { os ->
-        "{ build(params + [PRODUCT_BUILD: b.build.number], '${getFullPerfJobName(os)}') }"
+        "{ build(params + [PRODUCT_BUILD: b.build.number], '${getFullPerfJobName(os, isPR)}') }"
     }
     def newFlowJob = buildFlowJob(Utilities.getFullJobName(project, "perf_linux_flow", isPR, '')) {
         buildFlow("""
@@ -367,8 +367,8 @@ parallel(
 
 } // isPR
 
-def static getFullThroughputJobName(def os) {
-    return "perf_throughput_${os}"
+def static getFullThroughputJobName(def os, def isPR) {
+    return Utilities.getFullJobName(project, "perf_throughput_${os}", isPR)
 }
 
 // Create the Linux/OSX/CentOS coreclr test leg for debug and release and each scenario
@@ -392,7 +392,7 @@ def static getFullThroughputJobName(def os) {
     // Actual perf testing on the following OSes
     def throughputOSList = ['Ubuntu14.04']
     throughputOSList.each { os ->
-        def newJob = job(Utilities.getFullJobName(project, getFullThroughputJobName(os), isPR)) {
+        def newJob = job(getFullThroughputJobName(os, isPR)) {
 
             label('linux_clr_perf')
                 wrappers {
@@ -461,7 +461,7 @@ def static getFullThroughputJobName(def os) {
     } // os
 
     def flowJobTPRunList = throughputOSList.collect { os ->
-        "{ build(params + [PRODUCT_BUILD: b.build.number], '${getFullThroughputJobName(os)}') }"
+        "{ build(params + [PRODUCT_BUILD: b.build.number], '${getFullThroughputJobName(os, isPR)}') }"
     }
     def newFlowJob = buildFlowJob(Utilities.getFullJobName(project, "perf_throughput_linux_flow", isPR, '')) {
         buildFlow("""

--- a/perf.groovy
+++ b/perf.groovy
@@ -233,7 +233,7 @@ def static getOSGroup(def os) {
     }
 }
 
-def getFullPerfJobName(def os, def isPR) {
+def static getFullPerfJobName(def project, def os, def isPR) {
     return Utilities.getFullJobName(project, "perf_${os}", isPR)
 }
 
@@ -258,7 +258,7 @@ def getFullPerfJobName(def os, def isPR) {
     // Actual perf testing on the following OSes
     def perfOSList = ['Ubuntu14.04']
     perfOSList.each { os ->
-        def newJob = job(getFullPerfJobName(os, isPR)) {
+        def newJob = job(getFullPerfJobName(project, os, isPR)) {
 
             label('linux_clr_perf')
             wrappers {
@@ -334,7 +334,7 @@ def getFullPerfJobName(def os, def isPR) {
     } // os
 
     def flowJobPerfRunList = perfOSList.collect { os ->
-        "{ build(params + [PRODUCT_BUILD: b.build.number], '${getFullPerfJobName(os, isPR)}') }"
+        "{ build(params + [PRODUCT_BUILD: b.build.number], '${getFullPerfJobName(project, os, isPR)}') }"
     }
     def newFlowJob = buildFlowJob(Utilities.getFullJobName(project, "perf_linux_flow", isPR, '')) {
         buildFlow("""
@@ -367,7 +367,7 @@ parallel(
 
 } // isPR
 
-def getFullThroughputJobName(def os, def isPR) {
+def static getFullThroughputJobName(def project, def os, def isPR) {
     return Utilities.getFullJobName(project, "perf_throughput_${os}", isPR)
 }
 
@@ -392,7 +392,7 @@ def getFullThroughputJobName(def os, def isPR) {
     // Actual perf testing on the following OSes
     def throughputOSList = ['Ubuntu14.04']
     throughputOSList.each { os ->
-        def newJob = job(getFullThroughputJobName(os, isPR)) {
+        def newJob = job(getFullThroughputJobName(project, os, isPR)) {
 
             label('linux_clr_perf')
                 wrappers {
@@ -461,7 +461,7 @@ def getFullThroughputJobName(def os, def isPR) {
     } // os
 
     def flowJobTPRunList = throughputOSList.collect { os ->
-        "{ build(params + [PRODUCT_BUILD: b.build.number], '${getFullThroughputJobName(os, isPR)}') }"
+        "{ build(params + [PRODUCT_BUILD: b.build.number], '${getFullThroughputJobName(project, os, isPR)}') }"
     }
     def newFlowJob = buildFlowJob(Utilities.getFullJobName(project, "perf_throughput_linux_flow", isPR, '')) {
         buildFlow("""

--- a/perf.groovy
+++ b/perf.groovy
@@ -233,7 +233,7 @@ def static getOSGroup(def os) {
     }
 }
 
-def static getFullPerfJobName(def os, def isPR) {
+def getFullPerfJobName(def os, def isPR) {
     return Utilities.getFullJobName(project, "perf_${os}", isPR)
 }
 
@@ -367,7 +367,7 @@ parallel(
 
 } // isPR
 
-def static getFullThroughputJobName(def os, def isPR) {
+def getFullThroughputJobName(def os, def isPR) {
     return Utilities.getFullJobName(project, "perf_throughput_${os}", isPR)
 }
 


### PR DESCRIPTION
Our Ubuntu perf testing has been creating Linux CoreCLR builds by creating the build locally. This fits the local developer scenario, but doesn't actually test the bits that ship; the 'official' product configuration is generated by building on RHEL 7.2 and packaging those bits for various distros, including Ubuntu.

In order to more accurately measure end-user-perceived performance, we should do the same thing official builds do: build on RHEL7.2, then copy those bits onto other OSes to test perf on those OSes.

This PR makes that happen by structuring Linux perf and throughput jobs as flow jobs, with builds up front on a RHEL VM, before the bits are dropped onto Ubuntu perf test machines.