### PR TITLE
Fix Linux PGO optdata consumption + PGO count update

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -23,7 +23,7 @@
 
   <!-- Profile-based optimization data package versions -->
   <PropertyGroup>
-    <PgoDataPackageVersion>99.99.99-master-20170609-1125</PgoDataPackageVersion>
+    <PgoDataPackageVersion>99.99.99-master-20170612-1411</PgoDataPackageVersion>
     <!--<IbcDataPackageVersion></IbcDataPackageVersion>-->
   </PropertyGroup>
 

--- a/pgosupport.cmake
+++ b/pgosupport.cmake
@@ -15,12 +15,14 @@ function(add_pgo TargetName)
     endif(WIN32)
 
     set(CLR_CMAKE_OPTDATA_PACKAGEWITHRID "optimization.${CLR_CMAKE_TARGET_OS}-${CLR_CMAKE_TARGET_ARCH}.PGO.CoreCLR")
+
+    # On case-sensitive file systems, NuGet packages are restored to lowercase paths
+    string(TOLOWER "${CLR_CMAKE_OPTDATA_PACKAGEWITHRID}/${CLR_CMAKE_OPTDATA_VERSION}" OptDataVersionedSubPath)
+
     file(TO_NATIVE_PATH
-        "${CLR_CMAKE_PACKAGES_DIR}/${CLR_CMAKE_OPTDATA_PACKAGEWITHRID}/${CLR_CMAKE_OPTDATA_VERSION}/data/${ProfileFileName}"
+        "${CLR_CMAKE_PACKAGES_DIR}/${OptDataVersionedSubPath}/data/${ProfileFileName}"
         ProfilePath
     )
-    # NuGet packages are restored to lowercase paths
-    string(TOLOWER "${ProfilePath}" ProfilePath)
 
     if(CLR_CMAKE_PGO_INSTRUMENT)
         if(WIN32)


### PR DESCRIPTION
Linux_PGO had a path casing bug that caused builds on certain machines to skip optimizing with PGO data altogether. The problem is that we were calling `string(TOLOWER ...)` on the profile data file's absolute path. This doesn't work if the build root (to where the repo is cloned) has any uppercase characters in the path leading up to it. The fix is to only lowercase the NuGet package name/version part of the path.

This PR also includes an updated optdata package with newer counts on Windows, and a lot more counts for Linux (due to fixes in training runs).