### PR TITLE
[RyuJIT/ARM32] Enable HasMultiRegRetVal() for struct

### DIFF
--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -3507,9 +3507,12 @@ struct GenTreeCall final : public GenTree
     //
     bool HasMultiRegRetVal() const
     {
-#if (defined(_TARGET_X86_) || defined(_TARGET_ARM_)) && !defined(LEGACY_BACKEND)
+#if defined(_TARGET_X86_) && !defined(LEGACY_BACKEND)
         // LEGACY_BACKEND does not use multi reg returns for calls with long return types
         return varTypeIsLong(gtType);
+#elif FEATURE_MULTIREG_RET && (defined(_TARGET_ARM_) && !defined(LEGACY_BACKEND))
+        // LEGACY_BACKEND does not use multi reg returns for calls with long return types
+        return varTypeIsLong(gtType) || (varTypeIsStruct(gtType) && !HasRetBufArg());
 #elif FEATURE_MULTIREG_RET
         return varTypeIsStruct(gtType) && !HasRetBufArg();
 #else


### PR DESCRIPTION
This partially fix #11842. 

Some tests are passed by triggering NYI assertions as expected.

This PR allow further implemenation for struct return.

Following tests from #11842 are passed by falling back to legacy jit with NYI assertion.
```
PASSED   - [   0][  19s]JIT/jit64/hfa/main/testE/hfa_nd0E_d/hfa_nd0E_d.sh
PASSED   - [   2][  20s]JIT/jit64/hfa/main/testE/hfa_nd1E_d/hfa_nd1E_d.sh
PASSED   - [   6][  19s]JIT/jit64/hfa/main/testE/hfa_nf0E_d/hfa_nf0E_d.sh
PASSED   - [   8][  19s]JIT/jit64/hfa/main/testE/hfa_nf1E_d/hfa_nf1E_d.sh
PASSED   - [  12][  17s]JIT/jit64/hfa/main/testE/hfa_sd0E_d/hfa_sd0E_d.sh
PASSED   - [  14][  18s]JIT/jit64/hfa/main/testE/hfa_sd1E_d/hfa_sd1E_d.sh
PASSED   - [  18][  19s]JIT/jit64/hfa/main/testE/hfa_sf0E_d/hfa_sf0E_d.sh
PASSED   - [  20][  19s]JIT/jit64/hfa/main/testE/hfa_sf1E_d/hfa_sf1E_d.sh
```
