### PR TITLE
Replace System.Private.CoreLib with new version in TP jobs

### DIFF
--- a/tests/scripts/run-throughput-perf.py
+++ b/tests/scripts/run-throughput-perf.py
@@ -301,6 +301,9 @@ def main(args):
     crossgen_path = os.path.join(bin_path,crossgen)
     jit_path = os.path.join(bin_path, jit)
 
+    # Replace assembly_root's System.Private.CoreLib with built System.Private.CoreLib.
+    shutil.copyfile(os.path.join(bin_path, 'System.Private.CoreLib.dll'), os.path.join(assembly_root, 'System.Private.CoreLib.dll'))
+
     iterations = 6
 
     python_exe = python_exe_list[os_group]


### PR DESCRIPTION
SPC and the jit/coreclr are tightly coupled. With the changes to
crossgen into the dll, rather than the ni.dll, the throughput jobs are
now using the non-crossgen'd version of SPC on TP runs, which led to a
regression in TP on Linux because our comparison was not the same. This
change updates testing to replace the System.Private.CoreLib in the
throughput directory with the System.Private.CoreLib built by the
coreclr build.