### PR TITLE
WIP: Rematerialize constants in LSRA.

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -59,6 +59,12 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
         return;
     }
 #endif // _TARGET_ARM64_
+    if (treeNode->IsRematerialize())
+    {
+        assert(treeNode->OperIsConst());
+        JITDUMP("  Node is markes Rematerialize\n");
+        return;
+    }
 
     // contained nodes are part of their parents for codegen purposes
     // ex : immediates, most LEAs

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -1124,6 +1124,11 @@ regNumber CodeGen::genConsumeReg(GenTree* tree)
     {
         genRegCopy(tree);
     }
+    else if (tree->IsRematerialize())
+    {
+        tree->ResetRematerialize();
+        genCodeForTreeNode(tree);
+    }
 
     // Handle the case where we have a lclVar that needs to be copied before use (i.e. because it
     // interferes with one of the other sources (or the target, if it's a "delayed use" register)).

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -1607,6 +1607,12 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
         JITDUMP("  TreeNode is marked ReuseReg\n");
         return;
     }
+    if (treeNode->IsRematerialize())
+    {
+        assert(treeNode->OperIsConst());
+        JITDUMP("  Node is markes Rematerialize\n");
+        return;
+    }
 
     // contained nodes are part of their parents for codegen purposes
     // ex : immediates, most LEAs

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -878,6 +878,9 @@ public:
                                      // It CANNOT be set on var (GT_LCL*) nodes, or on indir (GT_IND or GT_STOREIND) nodes, since
                                      // it is not needed for lclVars and is highly unlikely to be useful for indir nodes.
 
+#define GTF_REMATERIALIZE_VAL 0x01000000 // Rematerialize this value at the point at which it is used rather than generating its code
+                                         // where it appears it execution order. Currently only valid for constant nodes.
+
 //---------------------------------------------------------------------
 //  The following flags can be used only with a small set of nodes, and
 //  thus their values need not be distinct (other than within the set
@@ -2139,6 +2142,21 @@ public:
     {
         assert(OperIsConst());
         gtFlags &= ~GTF_REUSE_REG_VAL;
+    }
+
+    bool IsRematerialize() const
+    {
+        return OperIsConst() && ((gtFlags & GTF_REMATERIALIZE_VAL) != 0);
+    }
+    void SetRematerialize()
+    {
+        assert(OperIsConst());
+        gtFlags |= GTF_REMATERIALIZE_VAL;
+    }
+    void ResetRematerialize()
+    {
+        assert(OperIsConst());
+        gtFlags &= ~GTF_REMATERIALIZE_VAL;
     }
 
 #if MEASURE_NODE_SIZE


### PR DESCRIPTION
Rather than reloading spilled constants LSRA, rematerialize them at the
point of use. This avoids the need to insert spill and reload code.

This change also tweaks the allocator's heuristics slightly:
- constant intervals are only allocated a register at the point of def
  if there is an appropriate register available; otherwise, they are
  spilled and rematerialized at the point of use
- ref positions that are freely rematerializable are assigned the lowest
  possible weight.