### PR TITLE
Removed the unused vararg version of String Concat

### DIFF
--- a/src/mscorlib/src/System/String.Manipulation.cs
+++ b/src/mscorlib/src/System/String.Manipulation.cs
@@ -83,37 +83,6 @@ namespace System
             return Concat(arg0.ToString(), arg1.ToString(), arg2.ToString());
         }
 
-        [CLSCompliant(false)]
-        public static String Concat(Object arg0, Object arg1, Object arg2, Object arg3, __arglist)
-        {
-            Contract.Ensures(Contract.Result<String>() != null);
-            Contract.EndContractBlock();
-
-            Object[] objArgs;
-            int argCount;
-
-            ArgIterator args = new ArgIterator(__arglist);
-
-            //+4 to account for the 4 hard-coded arguments at the beginning of the list.
-            argCount = args.GetRemainingCount() + 4;
-
-            objArgs = new Object[argCount];
-
-            //Handle the hard-coded arguments
-            objArgs[0] = arg0;
-            objArgs[1] = arg1;
-            objArgs[2] = arg2;
-            objArgs[3] = arg3;
-
-            //Walk all of the args in the variable part of the argument list.
-            for (int i = 4; i < argCount; i++)
-            {
-                objArgs[i] = TypedReference.ToObject(args.GetNextArg());
-            }
-
-            return Concat(objArgs);
-        }
-
         public static string Concat(params object[] args)
         {
             if (args == null)

--- a/tests/src/JIT/Directed/Misc/Concat/ConcatTest.cs
+++ b/tests/src/JIT/Directed/Misc/Concat/ConcatTest.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal class ConcatTest
+{
+    static string strA = "A";
+    static string strB = "B";
+    static string strC = "C";
+    static string strD = "D";
+    static string strE = "E";
+
+    static string strAB      = "AB";
+    static string strABC     = "ABC";
+    static string strABCD    = "ABCD";
+    static string strABCDE   = "ABCDE";
+    static string strABCDx2  = "ABCDABCD";
+
+    static int iReturn = 100;
+
+    static public int Main()
+    {
+        iReturn = 100;
+        try
+        {
+            string result;
+
+            result = string.Concat(strA, strB);
+            CheckResult(result, strAB);
+
+            result = string.Concat(strA, strB, strC);
+            CheckResult(result, strABC);
+
+            result = string.Concat(strA, strB, strC, strD);
+            CheckResult(result, strABCD);
+
+            result = string.Concat(strA, strB, strC, strD, strE);
+            CheckResult(result, strABCDE);
+
+            result = string.Concat(strA, strB, strC, strD, strA, strB, strC, strD);
+            CheckResult(result, strABCDx2);
+
+            Console.WriteLine("Passed all tests.");
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("Failed {0}", e.StackTrace);
+
+            iReturn = 99;
+        }
+
+        return iReturn;
+    }
+
+    static void CheckResult(string result, string expected)
+    {
+        if (result != expected)
+        {
+            Console.WriteLine("FAILED: result was '" + result +
+                              "', expected was '" + expected + "'");
+            iReturn++;
+        }
+    }
+}

--- a/tests/src/JIT/Directed/Misc/Concat/ConcatTest.csproj
+++ b/tests/src/JIT/Directed/Misc/Concat/ConcatTest.csproj
@@ -29,7 +29,7 @@
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gettypetypeofmatrix.cs" />
+    <Compile Include="ConcatTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />


### PR DESCRIPTION
The __arglist version of varargs is not supported on CoreCLR

Fixes issue #12146 - crossgen warning - Vararg calling convention not supported.

Added a new test case for String Concat