### PR TITLE
Fix GetHashCode for ordinal comparer

### DIFF
--- a/src/mscorlib/shared/System/StringComparer.cs
+++ b/src/mscorlib/shared/System/StringComparer.cs
@@ -332,7 +332,7 @@ namespace System
                 throw new ArgumentNullException(nameof(obj));
 #endif
             }
-            return TextInfo.GetHashCodeOrdinalIgnoreCase(obj);
+            return obj.GetHashCode();
         }
 
         public void GetObjectData(SerializationInfo info, StreamingContext context)


### PR DESCRIPTION
Fixes regression introduced here: https://github.com/dotnet/coreclr/pull/12215