### PR TITLE
Renaming one missing serialized field for Desktop compatibility

### DIFF
--- a/src/mscorlib/src/System/Globalization/CompareInfo.cs
+++ b/src/mscorlib/src/System/Globalization/CompareInfo.cs
@@ -70,7 +70,7 @@ namespace System.Globalization
         private string _sortName; // The name that defines our behavior.
 
         [OptionalField(VersionAdded = 3)]
-        private SortVersion m_sortVersion; // Do not rename (binary serialization)
+        private SortVersion m_SortVersion; // Do not rename (binary serialization)
 
         // _invariantMode is defined for the perf reason as accessing the instance field is faster than access the static property GlobalizationMode.Invariant
         [NonSerialized]
@@ -1209,11 +1209,11 @@ namespace System.Globalization
         {
             get
             {
-                if (m_sortVersion == null)
+                if (m_SortVersion == null)
                 {
                     if (_invariantMode)
                     {
-                        m_sortVersion = new SortVersion(0, CultureInfo.LOCALE_INVARIANT, new Guid(0, 0, 0, 0, 0, 0, 0,
+                        m_SortVersion = new SortVersion(0, CultureInfo.LOCALE_INVARIANT, new Guid(0, 0, 0, 0, 0, 0, 0,
                                                                         (byte) (CultureInfo.LOCALE_INVARIANT >> 24),
                                                                         (byte) ((CultureInfo.LOCALE_INVARIANT  & 0x00FF0000) >> 16),
                                                                         (byte) ((CultureInfo.LOCALE_INVARIANT  & 0x0000FF00) >> 8),
@@ -1221,11 +1221,11 @@ namespace System.Globalization
                     }
                     else
                     {
-                        m_sortVersion = GetSortVersion();
+                        m_SortVersion = GetSortVersion();
                     }
                 }
 
-                return m_sortVersion;
+                return m_SortVersion;
             }
         }
 


### PR DESCRIPTION
I missed this one... I didn't run the tests on a Unix machine, that's the reason why it slipped through till now...

cc @danmosemsft @stephentoub 
