### PR TITLE
Fix NullReferenceException thrown when using CurrentCulture

### DIFF
--- a/src/mscorlib/src/System/Globalization/CultureInfo.cs
+++ b/src/mscorlib/src/System/Globalization/CultureInfo.cs
@@ -967,7 +967,7 @@ namespace System.Globalization
 
         public void ClearCachedData()
         {
-            s_userDefaultCulture = null;
+            Init(); // reset the default culture values
 
             RegionInfo.s_currentRegionInfo = null;
             #pragma warning disable 0618 // disable the obsolete warning 


### PR DESCRIPTION
CurrentCulture used the static field s_userDefaultCulture which used to store the current culture. We always ensure this field is initialized all the time. When we introduced the v2.0 added APIs, we have added ClearCachedData(). This method was setting s_userDefaultCulture to null which can cause any other thread to throw this NullReferenceException if it is using s_userDefaultCulture. Here is example of such stack

System.NullReferenceException : Object reference not set to an instance of an object.
Stack Trace :
   at System.Globalization.NumberFormatInfo.get_CurrentInfo()
   at System.Double.ToString(String format, IFormatProvider provider)