### PR TITLE
Crossgen - Disable the Target-dependent SIMD vector types warning

### DIFF
--- a/src/inc/corcompile.h
+++ b/src/inc/corcompile.h
@@ -1378,9 +1378,12 @@ class ICorCompileDataStore
     // Returns ZapImage
     virtual ZapImage * GetZapImage() = 0;
 
-    // Reports an error during preloading.  Return the error code to propagate,
-    // or S_OK to ignore the error
-    virtual void Error(mdToken token, HRESULT hr, LPCWSTR description) = 0;
+    // Report an error during preloading:
+    // 'token' is the metadata token that triggered the error
+    // hr is the HRESULT from the thrown Exception, or S_OK if we don't have an thrown exception
+    // resID is the resourceID with additional information from the thrown Exception, or 0
+    //
+    virtual void Error(mdToken token, HRESULT hr, UINT _resID, LPCWSTR description) = 0;
 };
 
 

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -6838,10 +6838,20 @@ void CEEPreloader::Error(mdToken token, Exception * pException)
 {
     STANDARD_VM_CONTRACT;
 
+    HRESULT hr = pException->GetHR();
+    UINT    resID = 0;
+
     StackSString msg;
 
 #ifdef CROSSGEN_COMPILE
     pException->GetMessage(msg);
+
+    // Do we have an EEException with a resID?
+    if (EEMessageException::IsEEMessageException(pException))
+    {
+        EEMessageException * pEEMessageException = (EEMessageException *) pException;
+        resID = pEEMessageException->GetResID();
+    }
 #else
     {
         GCX_COOP();
@@ -6860,7 +6870,7 @@ void CEEPreloader::Error(mdToken token, Exception * pException)
     }
 #endif
     
-    m_pData->Error(token, pException->GetHR(), msg.GetUnicode());
+    m_pData->Error(token, hr, resID, msg.GetUnicode());
 }
 
 CEEInfo *g_pCEEInfo = NULL;

--- a/src/zap/zapcode.cpp
+++ b/src/zap/zapcode.cpp
@@ -983,7 +983,7 @@ void ZapMethodEntryPoint::Resolve(ZapImage * pImage)
     {
         mdMethodDef token;
         pImage->GetCompileInfo()->GetMethodDef(GetHandle(), &token);
-        pImage->Error(token, S_OK, W("MapMethodEntryPoint failed"));
+        pImage->Error(token, S_OK, 0, W("MapMethodEntryPoint failed"));
     }
     else
 #endif

--- a/src/zap/zapimage.cpp
+++ b/src/zap/zapimage.cpp
@@ -3553,7 +3553,7 @@ void ZapImage::FileNotFoundError(LPCWSTR pszMessage)
     fileNotFoundErrorsTable.Append(message);
 }
 
-void ZapImage::Error(mdToken token, HRESULT hr, LPCWSTR message)
+void ZapImage::Error(mdToken token, HRESULT hr, UINT resID,  LPCWSTR message)
 {
     // Missing dependencies are reported as fatal errors in code:CompilationDomain::BindAssemblySpec.
     // Avoid printing redundant error message for them.
@@ -3562,12 +3562,21 @@ void ZapImage::Error(mdToken token, HRESULT hr, LPCWSTR message)
 
     CorZapLogLevel level = CORZAP_LOGLEVEL_ERROR;
 
+    // Some warnings are demoted to informational level
+    if (resID == IDS_EE_SIMD_NGEN_DISALLOWED)
+    {
+        // Supress printing of "Target-dependent SIMD vector types may not be used with ngen."
+        level = CORZAP_LOGLEVEL_INFO;
+    }
+
     if (m_zapper->m_pOpt->m_ignoreErrors)
     {
 #ifdef CROSSGEN_COMPILE
         // Warnings should not go to stderr during crossgen
         if (level == CORZAP_LOGLEVEL_ERROR)
+        {
             level = CORZAP_LOGLEVEL_WARNING;
+        }
 #endif
         m_zapper->Print(level, W("Warning: "));
     }

--- a/src/zap/zapimage.h
+++ b/src/zap/zapimage.h
@@ -829,7 +829,7 @@ public:
 
     // Returns ZapImage
     virtual ZapImage * GetZapImage();
-    void Error(mdToken token, HRESULT error, LPCWSTR message);
+    void Error(mdToken token, HRESULT error, UINT resID, LPCWSTR message);
 
     // Returns virtual section for EE datastructures
     ZapVirtualSection * GetSection(CorCompileSection section)


### PR DESCRIPTION
When a SIMD type is referenced during CEEPreloader instead of loading it
we throw a type load exception with a unique resource ID and message.
This commit changed the ICorCompileDataStore interface to allow us to pass
the unique resource ID over to the zapper from the VM.

The Zapper can then demote certain resource ID warnings down to the
lowest informational level, so that they aren't printed out during crossgen.
With this commit we currently are demoting IDS_EE_SIMD_NGEN_DISALLOWED