### PR TITLE
Add symbol signing to published packages.

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01714-04
+2.0.0-prerelease-01805-01

--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -20,6 +20,24 @@
       }
     },
     {
+        "enabled": true,
+        "continueOnError": false,
+        "alwaysRun": false,
+        "displayName": "Install Signing Plugin",
+        "timeoutInMinutes": 0,
+        "task": {
+            "id": "30666190-6959-11e5-9f96-f56098202fef",
+            "versionSpec": "1.*",
+            "definitionType": "task"
+        },
+        "inputs": {
+            "signType": "real",
+            "zipSources": "true",
+            "version": "",
+            "feedSource": "https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json"
+        }
+    },
+    {
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
@@ -78,6 +96,26 @@
         "workingFolder": "$(Pipeline.SourcesDirectory)",
         "failOnStandardError": "false"
       }
+    },
+    {
+        "enabled": true,
+        "continueOnError": false,
+        "alwaysRun": false,
+        "displayName": "Inject signed symbol catalogs",
+        "timeoutInMinutes": 0,
+        "task": {
+            "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+            "versionSpec": "1.*",
+            "definitionType": "task"
+        },
+        "inputs": {
+            "scriptType": "inlineScript",
+            "scriptName": "",
+            "arguments": "-ConfigGroup $(ConfigurationGroup) -SymPkgGlob $(AzureContainerSymbolPackageGlob) -PipelineSrcDir $(Pipeline.SourcesDirectory)",
+            "workingFolder": "$(Pipeline.SourcesDirectory)",
+            "inlineScript": "param($ConfigGroup, $SymPkgGlob, $PipelineSrcDir)\nmsbuild build.proj /t:InjectSignedSymbolCatalogIntoSymbolPackages /p:SymbolPackagesToPublishGlob=$PipelineSrcDir\\packages\\AzureTransfer\\$ConfigGroup\\$env:AzureContainerSymbolPackageGlob /p:SymbolCatalogCertificateId=400",
+            "failOnStandardError": "true"
+        }
     },
     {
       "enabled": true,
@@ -321,6 +359,19 @@
         "ArtifactType": "Container",
         "TargetPath": "\\\\my\\share\\$(Build.DefinitionName)\\$(Build.BuildNumber)"
       }
+    },
+    {
+        "enabled": true,
+        "continueOnError": false,
+        "alwaysRun": false,
+        "displayName": "Send Telemetry",
+        "timeoutInMinutes": 0,
+        "task": {
+            "id": "521a94ea-9e68-468a-8167-6dcf361ea776",
+            "versionSpec": "1.*",
+            "definitionType": "task"
+        },
+        "inputs": {}
     }
   ],
   "options": [
@@ -498,7 +549,7 @@
       "allowOverride": true
     },
     "AzureContainerSymbolPackageGlob": {
-      "value": "symbols\\*.nupkg",
+      "value": "symbolpkg\\*.nupkg",
       "allowOverride": true
     },
     "GitHubRepositoryName": {

--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -98,24 +98,22 @@
       }
     },
     {
-        "enabled": true,
-        "continueOnError": false,
-        "alwaysRun": false,
-        "displayName": "Inject signed symbol catalogs",
-        "timeoutInMinutes": 0,
-        "task": {
-            "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
-            "versionSpec": "1.*",
-            "definitionType": "task"
-        },
-        "inputs": {
-            "scriptType": "inlineScript",
-            "scriptName": "",
-            "arguments": "-ConfigGroup $(ConfigurationGroup) -SymPkgGlob $(AzureContainerSymbolPackageGlob) -PipelineSrcDir $(Pipeline.SourcesDirectory)",
-            "workingFolder": "$(Pipeline.SourcesDirectory)",
-            "inlineScript": "param($ConfigGroup, $SymPkgGlob, $PipelineSrcDir)\nmsbuild build.proj /t:InjectSignedSymbolCatalogIntoSymbolPackages /p:SymbolPackagesToPublishGlob=$PipelineSrcDir\\packages\\AzureTransfer\\$ConfigGroup\\$env:AzureContainerSymbolPackageGlob /p:SymbolCatalogCertificateId=400",
-            "failOnStandardError": "true"
-        }
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Inject signed symbol catalogs",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "msbuild",
+        "arguments": "/t:InjectSignedSymbolCatalogIntoSymbolPackages /p:SymbolPackagesToPublishGlob=$(Pipeline.SourcesDirectory)\\packages\\AzureTransfer\\$(ConfigurationGroup)\\$(AzureContainerSymbolPackageGlob) /p:SymbolCatalogCertificateId=400",
+        "workingFolder": "$(Pipeline.SourcesDirectory)",
+        "failOnStandardError": "true"
+      }
     },
     {
       "enabled": true,

--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -543,7 +543,7 @@
       "allowOverride": true
     },
     "AzureContainerPackageGlob": {
-      "value": "*.nupkg",
+      "value": "pkg\\*.nupkg",
       "allowOverride": true
     },
     "AzureContainerSymbolPackageGlob": {

--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -110,7 +110,7 @@
       },
       "inputs": {
         "filename": "msbuild",
-        "arguments": "/t:InjectSignedSymbolCatalogIntoSymbolPackages /p:SymbolPackagesToPublishGlob=$(Pipeline.SourcesDirectory)\\packages\\AzureTransfer\\$(ConfigurationGroup)\\$(AzureContainerSymbolPackageGlob) /p:SymbolCatalogCertificateId=400",
+        "arguments": "/t:InjectSignedSymbolCatalogIntoSymbolPackages /p:SymbolPackagesToPublishGlob=$(Pipeline.SourcesDirectory)\\packages\\AzureTransfer\\$(ConfigurationGroup)\\$(AzureContainerSymbolPackageGlob) /p:SymbolCatalogCertificateId=$(PB_SymbolCatalogCertificateId)",
         "workingFolder": "$(Pipeline.SourcesDirectory)",
         "failOnStandardError": "true"
       }
@@ -557,6 +557,9 @@
     "UseLegacyBuildScripts": {
       "value": "false",
       "allowOverride": true
+    },
+    "PB_SymbolCatalogCertificateId": {
+      "value": "400"
     }
   },
   "retentionRules": [

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -216,9 +216,7 @@
           "SkipBranchAndVersionOverrides": "true",
           "Parameters": {
             "VstsRepositoryName": "DotNet-CoreCLR-Trusted",
-            "GitHubRepositoryName": "coreclr",
-            "AzureContainerPackageGlob": "pkg\\*.nupkg",
-            "AzureContainerSymbolPackageGlob": "symbolpkg\\*.nupkg"
+            "GitHubRepositoryName": "coreclr"
           },
           "ReportingParameters": {
             "TaskName":  "Publish",


### PR DESCRIPTION
- Enable MicroBuild signing steps.
- Update build to call new BuildTools symbol signing targets.