### PR TITLE
[RyuJIT/ARM32] Implement storing multi-reg/HFA return value at caller

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -904,7 +904,7 @@ void CodeGen::genMultiRegCallStoreToLocal(GenTreePtr treeNode)
 
 #if defined(_TARGET_ARM_)
     // Longs are returned in two return registers on Arm32.
-    // TODO-Cleanup: Structs are returned in four return registers on ARM32 and HFAs(?)
+    // Structs are returned in four registers on ARM32 and HFAs.
     assert(varTypeIsLong(treeNode) || varTypeIsStruct(treeNode));
 #elif defined(_TARGET_ARM64_)
     // Structs of size >=9 and <=16 are returned in two return registers on ARM64 and HFAs.

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -904,7 +904,8 @@ void CodeGen::genMultiRegCallStoreToLocal(GenTreePtr treeNode)
 
 #if defined(_TARGET_ARM_)
     // Longs are returned in two return registers on Arm32.
-    assert(varTypeIsLong(treeNode));
+    // TODO-Cleanup: Structs are returned in four return registers on ARM32 and HFAs(?)
+    assert(varTypeIsLong(treeNode) || varTypeIsStruct(treeNode));
 #elif defined(_TARGET_ARM64_)
     // Structs of size >=9 and <=16 are returned in two return registers on ARM64 and HFAs.
     assert(varTypeIsStruct(treeNode));

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -16928,11 +16928,9 @@ void ReturnTypeDesc::InitializeLongReturnType(Compiler* comp)
 //     Returns ith return register as per target ABI.
 //
 // Notes:
-//     Right now this is implemented only for x64 Unix and Arm32.
-//     and yet to be implemented for other multi-reg return
-//     targets (Arm64/x86).
+//     x86 and ARM return long in multiple registers.
+//     ARM and ARM64 return HFA struct in multiple registers.
 //
-// TODO-X86:   Implement this routine to support long returns.
 regNumber ReturnTypeDesc::GetABIReturnReg(unsigned idx)
 {
     unsigned count = GetReturnRegCount();
@@ -17020,7 +17018,7 @@ regNumber ReturnTypeDesc::GetABIReturnReg(unsigned idx)
         assert(idx < MAX_RET_REG_COUNT); // Up to 4 return registers for HFA's
         if (regType == TYP_DOUBLE)
         {
-            resultReg = (regNumber)((unsigned)(REG_FLOATRET) + idx*2); // d0, d1, d2 or d3
+            resultReg = (regNumber)((unsigned)(REG_FLOATRET) + idx * 2); // d0, d1, d2 or d3
         }
         else
         {
@@ -17058,15 +17056,8 @@ regNumber ReturnTypeDesc::GetABIReturnReg(unsigned idx)
 //    reg mask of return registers in which the return type is returned.
 //
 // Note:
-//    For now this is implemented only for x64 Unix and yet to be implemented
-//    for other multi-reg return targets (Arm64/Arm32x86).
-//
 //    This routine can be used when the caller is not particular about the order
 //    of return registers and wants to know the set of return registers.
-//
-// TODO-ARM:   Implement this routine to support HFA returns.
-// TODO-ARM64: Implement this routine to support HFA returns.
-// TODO-X86:   Implement this routine to support long returns.
 //
 // static
 regMaskTP ReturnTypeDesc::GetABIReturnRegs()

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -16986,7 +16986,7 @@ regNumber ReturnTypeDesc::GetABIReturnReg(unsigned idx)
         }
     }
 
-#elif defined(_TARGET_X86_) || defined(_TARGET_ARM_)
+#elif defined(_TARGET_X86_)
 
     if (idx == 0)
     {
@@ -16996,6 +16996,35 @@ regNumber ReturnTypeDesc::GetABIReturnReg(unsigned idx)
     {
         resultReg = REG_LNGRET_HI;
     }
+
+#elif defined(_TARGET_ARM_)
+
+    var_types regType = GetReturnRegType(idx);
+    if (varTypeIsIntegralOrI(regType))
+    {
+        if (idx == 0)
+        {
+            resultReg = REG_LNGRET_LO;
+        }
+        else if (idx == 1)
+        {
+            resultReg = REG_LNGRET_HI;
+        }
+#if FEATURE_MULTIREG_RET
+        else
+        {
+            assert(idx < MAX_RET_REG_COUNT);          // Up to 4 return registers for 16-byte structs
+            resultReg = (idx == 2) ? REG_R2 : REG_R3; // r2 or r3
+        }
+#endif
+    }
+#if FEATURE_MULTIREG_RET
+    else
+    {
+        assert(idx < MAX_RET_REG_COUNT);                         // Up to 4 return registers for HFA's
+        resultReg = (regNumber)((unsigned)(REG_FLOATRET) + idx); // f0, f1, f2 or f3
+    }
+#endif
 
 #elif defined(_TARGET_ARM64_)
 


### PR DESCRIPTION
Fixes #12289

This PR implements `FEATURE_MULTIREG_RET` and `FEATURE_HFA` for struct in RyuJIT/ARM32.

All 34 tests reported in #12289 are passed.