### PR TITLE
Small cleanup to Char.IsWhiteSpaceLatin1

### DIFF
--- a/src/mscorlib/shared/System/Char.cs
+++ b/src/mscorlib/shared/System/Char.cs
@@ -274,11 +274,7 @@ namespace System
             // U+000d = <control> CARRIAGE RETURN
             // U+0085 = <control> NEXT LINE
             // U+00a0 = NO-BREAK SPACE
-            if ((c == ' ') || (c >= '\x0009' && c <= '\x000d') || c == '\x00a0' || c == '\x0085')
-            {
-                return (true);
-            }
-            return (false);
+            return c == ' ' || (c >= '\x0009' && c <= '\x000d') || c == '\x00a0' || c == '\x0085';
         }
 
         /*===============================ISWHITESPACE===================================


### PR DESCRIPTION
For some reason this is resulting in measurably better throughput, in particular for non-whitespace chars, so much so that it's visible in microbenchmarks against string.IsNullOrWhiteSpace.

If nothing else, it's cleaner.

Related to https://github.com/dotnet/coreclr/issues/12306