### PR TITLE
Compact the size of GenTreeCall nodes

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -1769,7 +1769,7 @@ regMaskTP GenTreeCall::GetOtherRegMask() const
     {
         if (gtOtherRegs[i] != REG_NA)
         {
-            resultMask |= genRegMask(gtOtherRegs[i]);
+            resultMask |= genRegMask((regNumber)gtOtherRegs[i]);
             continue;
         }
         break;


### PR DESCRIPTION
The data stored in GenTreeCall under `#ifdef FEATURE_MULTIREG_RET`
(defined for x86 (RyuJIT), amd64/Linux, arm32, arm64) was poorly
packed. Improving this reduces x86 GenTreeCall node size from 124 to 112 bytes.
Since GenTreeCall is the largest node, it also reduces the size of all
"large" nodes.