### PR TITLE
Add path to exception messages

### DIFF
--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -1384,8 +1384,8 @@
   <data name="Argument_PathEmpty" xml:space="preserve">
     <value>Path cannot be the empty string or all whitespace.</value>
   </data>
-  <data name="Argument_PathFormatNotSupported" xml:space="preserve">
-    <value>The given path's format is not supported.</value>
+  <data name="Argument_PathFormatNotSupported_Path" xml:space="preserve">
+    <value>The format of the path '{0}' is not supported.</value>
   </data>
   <data name="Argument_PreAllocatedAlreadyAllocated" xml:space="preserve">
     <value>'preAllocated' is already in use.</value>

--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -88,9 +88,6 @@
   <data name="Acc_ReadOnly" xml:space="preserve">
     <value>Cannot set a constant field.</value>
   </data>
-  <data name="Acc_RvaStatic" xml:space="preserve">
-    <value>SkipVerification permission is needed to modify an image-based (RVA) static field.</value>
-  </data>
   <data name="Access_Void" xml:space="preserve">
     <value>Cannot create an instance of void.</value>
   </data>
@@ -2703,7 +2700,7 @@
     <value>Could not find file '{0}'.</value>
   </data>
   <data name="IO_AlreadyExists_Name" xml:space="preserve">
-    <value>Cannot create "{0}" because a file or directory with the same name already exists.</value>
+    <value>Cannot create '{0}' because a file or directory with the same name already exists.</value>
   </data>
   <data name="IO_BindHandleFailed" xml:space="preserve">
     <value>BindHandle for ThreadPool failed on this handle.</value>
@@ -2725,9 +2722,6 @@
   </data>
   <data name="IO_InvalidStringLen_Len" xml:space="preserve">
     <value>BinaryReader encountered an invalid string length of {0} characters.</value>
-  </data>
-  <data name="IO_NoPermissionToDirectoryName" xml:space="preserve">
-    <value>&lt;Path discovery permission to the specified directory was denied.&gt;</value>
   </data>
   <data name="IO_SeekAppendOverwrite" xml:space="preserve">
     <value>Unable seek backward to overwrite data that previously existed in a file opened in Append mode.</value>

--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -592,8 +592,8 @@
   <data name="Arg_PathEmpty" xml:space="preserve">
     <value>The path is empty.</value>
   </data>
-  <data name="Arg_PathIllegalUNC" xml:space="preserve">
-    <value>The UNC path should be of the form \\\\server\\share.</value>
+  <data name="Arg_PathIllegalUNC_Path" xml:space="preserve">
+    <value>The UNC path '{0}' should be of the form \\\\server\\share.</value>
   </data>
   <data name="Arg_PlatformNotSupported" xml:space="preserve">
     <value>Operation is not supported on this platform.</value>

--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -2756,6 +2756,9 @@
   <data name="IO_PathTooLong" xml:space="preserve">
     <value>The specified file name or path is too long, or a component of the specified path is too long.</value>
   </data>
+  <data name="IO_PathTooLong_Path" xml:space="preserve">
+    <value>The path '{0}' is too long, or a component of the specified path is too long.</value>
+  </data>
   <data name="IO_UnknownFileName" xml:space="preserve">
     <value>[Unknown]</value>
   </data>

--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -589,8 +589,8 @@
   <data name="Arg_ParmCnt" xml:space="preserve">
     <value>Parameter count mismatch.</value>
   </data>
-  <data name="Arg_PathIllegal" xml:space="preserve">
-    <value>The path is not of a legal form.</value>
+  <data name="Arg_PathEmpty" xml:space="preserve">
+    <value>The path is empty.</value>
   </data>
   <data name="Arg_PathIllegalUNC" xml:space="preserve">
     <value>The UNC path should be of the form \\\\server\\share.</value>

--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -353,7 +353,7 @@
     <value>Operation is not valid due to the current state of the object.</value>
   </data>
   <data name="Arg_InvalidSearchPattern" xml:space="preserve">
-    <value>Search pattern cannot contain ".." to move up directories and can be contained only internally in file/directory names, as in "a..b".</value>
+    <value>Search pattern '{0}' cannot contain ".." to move up directories and can be contained only internally in file/directory names, as in "a..b".</value>
   </data>
   <data name="Arg_InvalidTypeInRetType" xml:space="preserve">
     <value>The return Type contains some invalid type (i.e. null, ByRef)</value>

--- a/src/mscorlib/shared/Interop/Unix/Interop.IOErrors.cs
+++ b/src/mscorlib/shared/Interop/Unix/Interop.IOErrors.cs
@@ -138,7 +138,9 @@ internal static partial class Interop
                     new UnauthorizedAccessException(SR.UnauthorizedAccess_IODenied_NoPathName, inner);
 
             case Error.ENAMETOOLONG:
-                return new PathTooLongException(SR.IO_PathTooLong);
+                return !string.IsNullOrEmpty(path) ?
+                    new PathTooLongException(SR.Format(SR.IO_PathTooLong_Path, path)) :
+                    new PathTooLongException(SR.IO_PathTooLong);
 
             case Error.EWOULDBLOCK:
                 return !string.IsNullOrEmpty(path) ?

--- a/src/mscorlib/shared/System/IO/Path.Unix.cs
+++ b/src/mscorlib/shared/System/IO/Path.Unix.cs
@@ -23,7 +23,7 @@ namespace System.IO
                 throw new ArgumentNullException(nameof(path));
 
             if (path.Length == 0)
-                throw new ArgumentException(SR.Arg_PathIllegal, nameof(path));
+                throw new ArgumentException(SR.Arg_PathEmpty, nameof(path));
 
             PathInternal.CheckInvalidPathChars(path);
 
@@ -199,7 +199,7 @@ namespace System.IO
         {
             if (path == null) return null;
 			if (string.IsNullOrWhiteSpace(path))
-                throw new ArgumentException(SR.Arg_PathIllegal, nameof(path));
+                throw new ArgumentException(SR.Arg_PathEmpty, nameof(path));
 
 			return IsPathRooted(path) ? PathInternal.DirectorySeparatorCharAsString : String.Empty;
         }

--- a/src/mscorlib/shared/System/IO/Path.Unix.cs
+++ b/src/mscorlib/shared/System/IO/Path.Unix.cs
@@ -42,7 +42,7 @@ namespace System.IO
 
             if (collapsedString.Length > Interop.Sys.MaxPath)
             {
-                throw new PathTooLongException(SR.IO_PathTooLong);
+                throw new PathTooLongException(SR.Format(SR.IO_PathTooLong_Path, path));
             }
 
             string result = collapsedString.Length == 0 ? PathInternal.DirectorySeparatorCharAsString : collapsedString;
@@ -120,7 +120,7 @@ namespace System.IO
 
                 if (++componentCharCount > Interop.Sys.MaxName)
                 {
-                    throw new PathTooLongException(SR.IO_PathTooLong);
+                    throw new PathTooLongException(SR.Format(SR.IO_PathTooLong_Path, path));
                 }
 
                 // Normalize the directory separator if needed

--- a/src/mscorlib/shared/System/IO/Path.Windows.cs
+++ b/src/mscorlib/shared/System/IO/Path.Windows.cs
@@ -76,7 +76,7 @@ namespace System.IO
 
             // Technically this doesn't matter but we used to throw for this case
             if (string.IsNullOrWhiteSpace(path))
-                throw new ArgumentException(SR.Arg_PathIllegal);
+                throw new ArgumentException(SR.Arg_PathEmpty);
 
             // We don't want to check invalid characters for device format- see comments for extended above
             string fullPath = PathHelper.Normalize(path, checkInvalidCharacters: !isDevice, expandShortPaths: true);
@@ -142,7 +142,7 @@ namespace System.IO
         {
             if (path == null) return null;
             if (string.IsNullOrWhiteSpace(path)) 
-                throw new ArgumentException(SR.Arg_PathIllegal, nameof(path));
+                throw new ArgumentException(SR.Arg_PathEmpty, nameof(path));
 
             PathInternal.CheckInvalidPathChars(path);
 

--- a/src/mscorlib/shared/System/IO/Path.Windows.cs
+++ b/src/mscorlib/shared/System/IO/Path.Windows.cs
@@ -70,7 +70,7 @@ namespace System.IO
                     || (path.Length >= startIndex && path[startIndex - 1] == PathInternal.VolumeSeparatorChar && !PathInternal.IsValidDriveChar(path[startIndex - 2]))
                     || (path.Length > startIndex && path.IndexOf(PathInternal.VolumeSeparatorChar, startIndex) != -1))
                 {
-                    throw new NotSupportedException(SR.Argument_PathFormatNotSupported);
+                    throw new NotSupportedException(SR.Format(SR.Argument_PathFormatNotSupported_Path, path));
                 }
             }
 

--- a/src/mscorlib/shared/System/IO/Path.Windows.cs
+++ b/src/mscorlib/shared/System/IO/Path.Windows.cs
@@ -76,7 +76,7 @@ namespace System.IO
 
             // Technically this doesn't matter but we used to throw for this case
             if (string.IsNullOrWhiteSpace(path))
-                throw new ArgumentException(SR.Arg_PathEmpty);
+                throw new ArgumentException(SR.Arg_PathEmpty, nameof(path));
 
             // We don't want to check invalid characters for device format- see comments for extended above
             string fullPath = PathHelper.Normalize(path, checkInvalidCharacters: !isDevice, expandShortPaths: true);

--- a/src/mscorlib/shared/System/IO/Path.cs
+++ b/src/mscorlib/shared/System/IO/Path.cs
@@ -79,7 +79,7 @@ namespace System.IO
             if (string.IsNullOrWhiteSpace(path))
             {
                 if (path == null) return null;
-                throw new ArgumentException(SR.Arg_PathIllegal, nameof(path));
+                throw new ArgumentException(SR.Arg_PathEmpty, nameof(path));
             }
 
             PathInternal.CheckInvalidPathChars(path);

--- a/src/mscorlib/shared/System/IO/PathHelper.Windows.cs
+++ b/src/mscorlib/shared/System/IO/PathHelper.Windows.cs
@@ -128,7 +128,7 @@ namespace System.IO
                                     // If we're at the end of the path and this is the first separator, we're missing the share.
                                     // Otherwise we're good, so ignore UNC tracking from here.
                                     if (index == fullPath.Length - 1)
-                                        throw new ArgumentException(SR.Arg_PathIllegalUNC);
+                                        throw new ArgumentException(SR.Format(SR.Arg_PathIllegalUNC_Path, fullPath.ToString()));
                                     else
                                         possibleBadUnc = false;
                                 }
@@ -145,7 +145,7 @@ namespace System.IO
                 }
 
                 if (possibleBadUnc)
-                    throw new ArgumentException(SR.Arg_PathIllegalUNC);
+                    throw new ArgumentException(SR.Format(SR.Arg_PathIllegalUNC_Path, fullPath.ToString()));
 
                 segmentLength = fullPath.Length - lastSeparator - 1;
                 if (segmentLength > PathInternal.MaxComponentLength)

--- a/src/mscorlib/shared/System/IO/PathHelper.Windows.cs
+++ b/src/mscorlib/shared/System/IO/PathHelper.Windows.cs
@@ -53,7 +53,7 @@ namespace System.IO
                 if (fullPath.Length >= PathInternal.MaxLongPath)
                 {
                     // Fullpath is genuinely too long
-                    throw new PathTooLongException(SR.IO_PathTooLong);
+                    throw new PathTooLongException(SR.Format(SR.IO_PathTooLong_Path, fullPath.ToString()));
                 }
 
                 // Checking path validity used to happen before getting the full path name. To avoid additional input allocation
@@ -109,7 +109,7 @@ namespace System.IO
                             case '\\':
                                 segmentLength = index - lastSeparator - 1;
                                 if (segmentLength > PathInternal.MaxComponentLength)
-                                    throw new PathTooLongException(SR.IO_PathTooLong + fullPath.ToString());
+                                    throw new PathTooLongException(SR.Format(SR.IO_PathTooLong_Path, fullPath.ToString()));
                                 lastSeparator = index;
 
                                 if (foundTilde)
@@ -149,7 +149,7 @@ namespace System.IO
 
                 segmentLength = fullPath.Length - lastSeparator - 1;
                 if (segmentLength > PathInternal.MaxComponentLength)
-                    throw new PathTooLongException(SR.IO_PathTooLong);
+                    throw new PathTooLongException(SR.Format(SR.IO_PathTooLong_Path, fullPath.ToString()));
 
                 if (foundTilde && segmentLength <= MaxShortName)
                     possibleShortPath = true;

--- a/src/mscorlib/shared/System/IO/PathInternal.cs
+++ b/src/mscorlib/shared/System/IO/PathInternal.cs
@@ -162,7 +162,7 @@ namespace System.IO
                 // Terminal ".." . Files names cannot end in ".."
                 if (index + 2 == searchPattern.Length
                     || IsDirectorySeparator(searchPattern[index + 2]))
-                    throw new ArgumentException(SR.Arg_InvalidSearchPattern);
+                    throw new ArgumentException(SR.Format(SR.Arg_InvalidSearchPattern, searchPattern));
 
                 searchPattern = searchPattern.Substring(index + 2);
             }

--- a/src/mscorlib/shared/System/IO/Win32Marshal.cs
+++ b/src/mscorlib/shared/System/IO/Win32Marshal.cs
@@ -63,7 +63,7 @@ namespace System.IO
                     return new IOException(SR.Format(SR.IO_AlreadyExists_Name, path), MakeHRFromErrorCode(errorCode));
 
                 case Interop.Errors.ERROR_FILENAME_EXCED_RANGE:
-                    return new PathTooLongException(SR.IO_PathTooLong);
+                    return new PathTooLongException(SR.Format(SR.IO_PathTooLong_Path, path));
 
                 case Interop.Errors.ERROR_INVALID_PARAMETER:
                     return new IOException(GetMessage(errorCode), MakeHRFromErrorCode(errorCode));

--- a/src/mscorlib/src/System/IO/__Error.cs
+++ b/src/mscorlib/src/System/IO/__Error.cs
@@ -75,40 +75,6 @@ namespace System.IO
             throw new ArgumentException(SR.InvalidOperation_EndWriteCalledMultiple);
         }
 
-        // Given a possible fully qualified path, ensure that we have path
-        // discovery permission to that path.  If we do not, return just the 
-        // file name.  If we know it is a directory, then don't return the 
-        // directory name.
-        internal static String GetDisplayablePath(String path, bool isInvalidPath)
-        {
-            if (String.IsNullOrEmpty(path))
-                return String.Empty;
-
-            // Is it a fully qualified path?
-            bool isFullyQualified = false;
-            if (path.Length < 2)
-                return path;
-            if (PathInternal.IsDirectorySeparator(path[0]) && PathInternal.IsDirectorySeparator(path[1]))
-                isFullyQualified = true;
-            else if (path[1] == Path.VolumeSeparatorChar)
-            {
-                isFullyQualified = true;
-            }
-
-            if (!isFullyQualified && !isInvalidPath)
-                return path;
-
-            if (isInvalidPath)
-            {
-                if (PathInternal.IsDirectorySeparator(path[path.Length - 1]))
-                    path = SR.IO_NoPermissionToDirectoryName;
-                else
-                    path = Path.GetFileName(path);
-            }
-
-            return path;
-        }
-
         internal static void WinIOError()
         {
             int errorCode = Marshal.GetLastWin32Error();
@@ -120,12 +86,8 @@ namespace System.IO
         // will determine the appropriate exception to throw dependent on your 
         // error, and depending on the error, insert a string into the message 
         // gotten from the ResourceManager.
-        internal static void WinIOError(int errorCode, String maybeFullPath)
+        internal static void WinIOError(int errorCode, String str)
         {
-            // This doesn't have to be perfect, but is a perf optimization.
-            bool isInvalidPath = errorCode == Win32Native.ERROR_INVALID_NAME || errorCode == Win32Native.ERROR_BAD_PATHNAME;
-            String str = GetDisplayablePath(maybeFullPath, isInvalidPath);
-
             switch (errorCode)
             {
                 case Win32Native.ERROR_FILE_NOT_FOUND:
@@ -149,7 +111,7 @@ namespace System.IO
                 case Win32Native.ERROR_ALREADY_EXISTS:
                     if (str.Length == 0)
                         goto default;
-                    throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, str), Win32Native.MakeHRFromErrorCode(errorCode), maybeFullPath);
+                    throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, str), Win32Native.MakeHRFromErrorCode(errorCode), str);
 
                 case Win32Native.ERROR_FILENAME_EXCED_RANGE:
                     throw new PathTooLongException(SR.Format(SR.IO_PathTooLong_Path, str));
@@ -158,24 +120,24 @@ namespace System.IO
                     throw new DriveNotFoundException(SR.Format(SR.IO_DriveNotFound_Drive, str));
 
                 case Win32Native.ERROR_INVALID_PARAMETER:
-                    throw new IOException(Win32Native.GetMessage(errorCode), Win32Native.MakeHRFromErrorCode(errorCode), maybeFullPath);
+                    throw new IOException(Win32Native.GetMessage(errorCode), Win32Native.MakeHRFromErrorCode(errorCode), str);
 
                 case Win32Native.ERROR_SHARING_VIOLATION:
                     if (str.Length == 0)
-                        throw new IOException(SR.IO_SharingViolation_NoFileName, Win32Native.MakeHRFromErrorCode(errorCode), maybeFullPath);
+                        throw new IOException(SR.IO_SharingViolation_NoFileName, Win32Native.MakeHRFromErrorCode(errorCode), str);
                     else
-                        throw new IOException(SR.Format(SR.IO_SharingViolation_File, str), Win32Native.MakeHRFromErrorCode(errorCode), maybeFullPath);
+                        throw new IOException(SR.Format(SR.IO_SharingViolation_File, str), Win32Native.MakeHRFromErrorCode(errorCode), str);
 
                 case Win32Native.ERROR_FILE_EXISTS:
                     if (str.Length == 0)
                         goto default;
-                    throw new IOException(SR.Format(SR.IO_FileExists_Name, str), Win32Native.MakeHRFromErrorCode(errorCode), maybeFullPath);
+                    throw new IOException(SR.Format(SR.IO_FileExists_Name, str), Win32Native.MakeHRFromErrorCode(errorCode), str);
 
                 case Win32Native.ERROR_OPERATION_ABORTED:
                     throw new OperationCanceledException();
 
                 default:
-                    throw new IOException(Win32Native.GetMessage(errorCode), Win32Native.MakeHRFromErrorCode(errorCode), maybeFullPath);
+                    throw new IOException(Win32Native.GetMessage(errorCode), Win32Native.MakeHRFromErrorCode(errorCode), str);
             }
         }
 

--- a/src/mscorlib/src/System/IO/__Error.cs
+++ b/src/mscorlib/src/System/IO/__Error.cs
@@ -152,7 +152,7 @@ namespace System.IO
                     throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, str), Win32Native.MakeHRFromErrorCode(errorCode), maybeFullPath);
 
                 case Win32Native.ERROR_FILENAME_EXCED_RANGE:
-                    throw new PathTooLongException(SR.IO_PathTooLong);
+                    throw new PathTooLongException(SR.Format(SR.IO_PathTooLong_Path, str));
 
                 case Win32Native.ERROR_INVALID_DRIVE:
                     throw new DriveNotFoundException(SR.Format(SR.IO_DriveNotFound_Drive, str));

--- a/src/mscorlib/src/System/IO/__Error.cs
+++ b/src/mscorlib/src/System/IO/__Error.cs
@@ -98,30 +98,7 @@ namespace System.IO
             if (!isFullyQualified && !isInvalidPath)
                 return path;
 
-            bool safeToReturn = false;
-            try
-            {
-                if (!isInvalidPath)
-                {
-                    safeToReturn = true;
-                }
-            }
-            catch (SecurityException)
-            {
-            }
-            catch (ArgumentException)
-            {
-                // ? and * characters cause ArgumentException to be thrown from HasIllegalCharacters
-                // inside FileIOPermission.AddPathList
-            }
-            catch (NotSupportedException)
-            {
-                // paths like "!Bogus\\dir:with/junk_.in it" can cause NotSupportedException to be thrown
-                // from Security.Util.StringExpressionSet.CanonicalizePath when ':' is found in the path
-                // beyond string index position 1.  
-            }
-
-            if (!safeToReturn)
+            if (isInvalidPath)
             {
                 if (PathInternal.IsDirectorySeparator(path[path.Length - 1]))
                     path = SR.IO_NoPermissionToDirectoryName;


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/19033

Add path to some common exception messages where it would be helpful but previously was missing because of CAS reasons.