### PR TITLE
LoadFromResolve event handler should return null 

### DIFF
--- a/src/mscorlib/src/System/Reflection/Assembly.CoreCLR.cs
+++ b/src/mscorlib/src/System/Reflection/Assembly.CoreCLR.cs
@@ -51,7 +51,19 @@ namespace System.Reflection
             string requestedAssemblyPath = Path.Combine(Path.GetDirectoryName(requestorPath), requestedAssemblyName.Name+".dll");
 
             // Load the dependency via LoadFrom so that it goes through the same path of being in the LoadFrom list.
-            return Assembly.LoadFrom(requestedAssemblyPath);
+            Assembly resolvedAssembly = null;
+
+            try
+            {
+                resolvedAssembly = Assembly.LoadFrom(requestedAssemblyPath);
+            }
+            catch(FileNotFoundException)
+            {
+                // Catch FileNotFoundException when attempting to resolve assemblies via this handler to account for missing assemblies.
+                resolvedAssembly = null;
+            }
+
+            return resolvedAssembly;
         }
 
         public static Assembly LoadFrom(String assemblyFile)


### PR DESCRIPTION
Since LoadFromResolve event handler is wired upto AppDomain.AssemblyResolve event, it should return null when an assembly cannot be found for any reason as AssemblyResolve event expects that (See https://msdn.microsoft.com/en-us/library/system.appdomain.assemblyresolve(v=vs.110).aspx).

Fixes dotnet/corefx#21095

@jkotas @tarekgh PTAL