### PR TITLE
Fix CompareInfo.Version on Windows

### DIFF
--- a/src/mscorlib/src/System/Globalization/CompareInfo.Windows.cs
+++ b/src/mscorlib/src/System/Globalization/CompareInfo.Windows.cs
@@ -469,6 +469,7 @@ namespace System.Globalization
             Debug.Assert(!_invariantMode);
 
             Interop.Kernel32.NlsVersionInfoEx nlsVersion = new Interop.Kernel32.NlsVersionInfoEx();
+            nlsVersion.dwNLSVersionInfoSize = Marshal.SizeOf(typeof(Interop.Kernel32.NlsVersionInfoEx));
             Interop.Kernel32.GetNLSVersionEx(Interop.Kernel32.COMPARE_STRING, _sortName, &nlsVersion);
             return new SortVersion(
                         nlsVersion.dwNLSVersion,


### PR DESCRIPTION
We call Windows to get the sort version. We call Windows passing the structure NlsVersionInfoEx but Windows expect we have to initialize the size of this structure which we are missing.