### PR TITLE
Add regression test for issue #12224

### DIFF
--- a/tests/src/Regressions/coreclr/GitHub_12224/Test12224.csproj
+++ b/tests/src/Regressions/coreclr/GitHub_12224/Test12224.csproj
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{9CBB2BDE-E9EF-4F0A-840C-0F80380D4513}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="test12224.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/Regressions/coreclr/GitHub_12224/test12224.cs
+++ b/tests/src/Regressions/coreclr/GitHub_12224/test12224.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+using System.Threading;
+
+public class Test12224
+{    
+    // Regression test for EH getting stuck in an infinite loop when NullReferenceException
+    // happens inside a handler of another NullReferenceException.
+    static void ExecuteTest(object context)
+    {
+        string s = null;
+        try
+        {
+            try
+            {
+                int x = s.Length;
+            }
+            catch (NullReferenceException)
+            {
+                int x = s.Length;
+            }
+        }
+        catch (NullReferenceException)
+        {
+
+        }
+    }
+
+    public static int Main()
+    {
+        Thread thread = new Thread(new ParameterizedThreadStart(Test12224.ExecuteTest));
+        thread.IsBackground = true;
+        thread.Start(null);
+
+        // Give the thread 30 seconds to complete (it should be immediate). If it fails
+        // to complete within that timeout, it has hung.
+        bool terminated = thread.Join(new TimeSpan(0, 0, 30));
+
+        return terminated ? 100 : -1;
+    }
+}


### PR DESCRIPTION
This change adds regression test for EH getting stuck in an infinite
loop when NullReferenceException happens inside a handler of another
NullReferenceException.