### PR TITLE
Throw ArgumentNullException on Unix calling Marshal.IsComObject(null)

### DIFF
--- a/src/mscorlib/src/System/Runtime/InteropServices/NonPortable.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/NonPortable.cs
@@ -153,7 +153,12 @@ namespace System.Runtime.InteropServices
         }
 
         public static bool IsComObject(object o)
-        { 
+        {
+            if (o == null)
+            {
+                throw new ArgumentNullException(nameof(o));
+            }
+
             return false;
         }
 


### PR DESCRIPTION
Contributes to #21168 (will be fixed when I add tests in corefx)