### PR TITLE
Further improve perf of Char.IsWhiteSpace

### DIFF
--- a/src/mscorlib/shared/System/Char.cs
+++ b/src/mscorlib/shared/System/Char.cs
@@ -274,7 +274,11 @@ namespace System
             // U+000d = <control> CARRIAGE RETURN
             // U+0085 = <control> NEXT LINE
             // U+00a0 = NO-BREAK SPACE
-            return c == ' ' || (c >= '\x0009' && c <= '\x000d') || c == '\x00a0' || c == '\x0085';
+            return
+                c == ' ' ||
+                (uint)(c - '\x0009') <= ('\x000d' - '\x0009') || // (c >= '\x0009' && c <= '\x000d')
+                c == '\x00a0' ||
+                c == '\x0085';
         }
 
         /*===============================ISWHITESPACE===================================


### PR DESCRIPTION
IsWhiteSpaceLatin1 is not being inlined.  By changing a range check done with two comparison operations to instead be done with a subtraction and a single comparison (per a suggestion from @mikedn), the code is shortened to not only be less expensive but also then get inlined into Char.IsWhiteSpace and then further into String.IsNullOrWhiteSpace.  The net result is a measurable throughput improvement for IsNullOrWhiteSpace.  A microbenchmark for String.IsNullOrWhiteSpace("a") improves on my machine by ~15%.  A microbenchmark for String.IsNullOrWhiteSpace(" \r\n\ta") improves on my machine by ~45%.