### PR TITLE
Fix errors in MSBuild properties initialization in System.Private.CoreLib.csproj

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
+  <Import Condition="Exists('..\dir.props')" Project="..\dir.props" />
+  
   <!--
     $(OS) is set to Unix/Windows_NT. This comes from an environment variable on Windows and MSBuild on Unix.
   -->

--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -1,10 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- Always use latest Roslyn compiler -->
-  <Import Project="..\..\Tools\net46\roslyn\build\Microsoft.Net.Compilers.props" Condition="'$(OS)'=='Windows_NT'" />
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+   <!-- Include common build properties -->
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <!-- Include common build properties -->
-  <Import Project="..\..\dir.props" />
   <!-- Compilation options -->
   <PropertyGroup>
     <AvailablePlatforms>amd64,x86,arm,armel,arm64</AvailablePlatforms>


### PR DESCRIPTION

Fixes issue #12355

Project System.Private.CoreLib.csproj imports directly Microsoft.Net.Compilers.props
at line# 4 before including dir.props from repo root. $(RepoRoot)/dir.props imports
Microsoft.Net.Compilers.props at line# 186. As a result of this sequence of duplicated
project imports and lack of safeguards against importing the same .props file twice
MSBuild reports that Microsoft.Net.Compilers.props file is included twice with warning
that second import will be ignored - in this case not evaluated. This results
in initialization of Microsoft.Net.Compilers.props values to defaults because MSBuild
evaluates Microsoft.Net.Compilers.props only once before $(RepoRoot)/dir.props are included.
Removing import of Microsoft.Net.Compilers.props from System.Private.CoreLib.csproj
and moving $(RepoRoot)/dir.props file import to top of System.Private.CoreLib.csproj
solves these problems by ensuring expected order of evaluation of Microsoft.Net.Compilers.props
file by MSBuild after all project wide values are initialized in $(RepoRoot)/dir.props.

Above described configuration problems affect only builds with Visual Studio 2017 both from developer command prompt and from IDE.