### PR TITLE
[RyuJIT/ARM32] Assign 2 numslots to gtLsraInfo.srcCount in TYP_DOUBLE

### DIFF
--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -711,12 +711,13 @@ void Lowering::TreeNodeInfoInitPutArgStk(GenTreePutArgStk* argNode, fgArgTabEntr
             MakeSrcContained(argNode, putArgChild);
         }
     }
+#ifdef _TARGET_ARM_
     else if (putArgChild->TypeGet() == TYP_DOUBLE) {
-        // We consume all of the items in the TYP_DOUBLE
-        // TYP_DOUBLE uses 2 numSlots
-        argNode->gtLsraInfo.srcCount = info->numSlots;
+        // Even though TYP_DOUBLE uses 2 numSlots, we consume 1 srcCount in TYP_DOUBLE
+        argNode->gtLsraInfo.srcCount = 1;
         putArgChild->SetContained();
     }
+#endif
     else
     {
         // We must not have a multi-reg struct

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -711,17 +711,15 @@ void Lowering::TreeNodeInfoInitPutArgStk(GenTreePutArgStk* argNode, fgArgTabEntr
             MakeSrcContained(argNode, putArgChild);
         }
     }
-#ifdef _TARGET_ARM_
-    else if (putArgChild->TypeGet() == TYP_DOUBLE) {
-        // Even though TYP_DOUBLE uses 2 numSlots, we consume 1 srcCount in TYP_DOUBLE
-        argNode->gtLsraInfo.srcCount = 1;
-        putArgChild->SetContained();
-    }
-#endif
     else
     {
+#ifdef _TARGET_ARM_
+        // We must not have a multi-reg strcut; double uses 2 slots and isn't a multi-reg struct
+        assert((info->numSlots == 1) || ((info->numSlots == 2) && (putArgChild->TypeGet() == TYP_DOUBLE)));
+#else // !_TARGET_ARM_
         // We must not have a multi-reg struct
         assert(info->numSlots == 1);
+#endif // !_TARGET_ARM_
     }
 }
 

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -711,6 +711,12 @@ void Lowering::TreeNodeInfoInitPutArgStk(GenTreePutArgStk* argNode, fgArgTabEntr
             MakeSrcContained(argNode, putArgChild);
         }
     }
+    else if (putArgChild->TypeGet() == TYP_DOUBLE) {
+        // We consume all of the items in the TYP_DOUBLE
+        // TYP_DOUBLE uses 2 numSlots
+        argNode->gtLsraInfo.srcCount = info->numSlots;
+        putArgChild->SetContained();
+    }
     else
     {
         // We must not have a multi-reg struct

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -714,9 +714,9 @@ void Lowering::TreeNodeInfoInitPutArgStk(GenTreePutArgStk* argNode, fgArgTabEntr
     else
     {
 #ifdef _TARGET_ARM_
-        // We must not have a multi-reg strcut; double uses 2 slots and isn't a multi-reg struct
+        // We must not have a multi-reg struct; double uses 2 slots and isn't a multi-reg struct
         assert((info->numSlots == 1) || ((info->numSlots == 2) && (putArgChild->TypeGet() == TYP_DOUBLE)));
-#else // !_TARGET_ARM_
+#else  // !_TARGET_ARM_
         // We must not have a multi-reg struct
         assert(info->numSlots == 1);
 #endif // !_TARGET_ARM_


### PR DESCRIPTION
Fixed #11849 issue

This issue is related to passing more than 8 double arguments as function.
The double argument uses 2 numSlots but this assersion always requires only one numSlots except TYP_STRUCT and GT_FIELD_LIST.

Tracing with gdb:
```
#10 0x70de8944 in Lowering::TreeNodeInfoInitPutArgStk (this=0x7effc290, argNode=0xe5a38, info=0xc1c3c)
    at /opt/code/src/jit/lsraarmarch.cpp:694
694	in /opt/code/src/jit/lsraarmarch.cpp
(gdb) p info->numSlots 
$4 = 2
(gdb) p *putArgChild
$8 = {_vptr$GenTree = 0x70fdf194 <vtable for GenTreeDblCon+8>, gtOper = genTreeOps::GT_CNS_DBL, gtType = var_types::TYP_DOUBLE, 
  gtOperSave = genTreeOps::GT_NONE, gtCSEnum = 0 '\000', gtLIRFlags = 0 '\000', gtAssertionInfo = {m_isNextEdgeAssertion = 0, 
    m_assertionIndex = 0}, gtCostsInitialized = true, _gtCostEx = 3 '\003', _gtCostSz = 4 '\004', 
  gtRegTag = GenTree::GT_REGTAG_REG, {_gtRegNum = 49 '1', _gtRegPair = 49}, gtFlags = 0, gtDebugFlags = 2, gtVNPair = {
    m_liberal = 256, m_conservative = 256}, gtRsvdRegs = 0, gtLsraInfo = {loc = 5, srcCandsIndex = 1 '\001', 
    dstCandsIndex = 1 '\001', internalCandsIndex = 0 '\000', _srcCount = 0 '\000', _dstCount = 1 '\001', 
    _internalIntCount = 2 '\002', _internalFloatCount = 0 '\000', isLocalDefUse = 0 '\000', isLsraAdded = 0 '\000', 
    isDelayFree = 0 '\000', hasDelayFreeSrc = 0 '\000', isTgtPref = 0 '\000', regOptional = 0 '\000', 
```

But even though this patch is merged, it still occurs a below assersion. This issue will be traced with new issue.
```
Assert failure(PID 19461 [0x00004c05], Thread: 19461 [0x4c05]): Assertion failed '((consume == 0) && (produce == 0)) || (ComputeAvailableSrcCount(tree) == consume)' in 'ldarg_s_r8:test_float64():int' (IL size 2310)

    File: /opt/code/src/jit/lsra.cpp Line: 3599
    Image: /home/pi3/Downloads/ryujit/overlay-0615-fixed/corerun
```

/cc @hqueue @hseok-oh @wateret @sjsinju 