### PR TITLE
Fixed arith operations with 'native int' and 'long' according to ECMA-335

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3098,6 +3098,7 @@ public:
     static bool IsTargetIntrinsic(CorInfoIntrinsics intrinsicId);
     static bool IsMathIntrinsic(CorInfoIntrinsics intrinsicId);
     static bool IsMathIntrinsic(GenTreePtr tree);
+    static bool IsOperArithmetic(genTreeOps oper);
 
 private:
     //----------------- Importing the method ----------------------------------

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -4142,6 +4142,12 @@ inline bool Compiler::IsGcSafePoint(GenTreePtr tree)
     return false;
 }
 
+inline bool Compiler::IsOperArithmetic(genTreeOps oper)
+{
+    return oper == GT_ADD || oper == GT_SUB || oper == GT_MUL || oper == GT_DIV || oper == GT_MOD || oper == GT_UDIV ||
+           oper == GT_UMOD || oper == GT_AND || oper == GT_OR || oper == GT_XOR;
+}
+
 //
 // Note that we want to have two special FIELD_HANDLES that will both
 // be considered non-Data Offset handles

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -11280,6 +11280,19 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 op2 = impPopStack().val;
                 op1 = impPopStack().val;
 
+#ifdef FEATURE_CORECLR
+                if (IsOperArithmetic(oper))
+                {
+                    const var_types tiOp1 = op1->TypeGet();
+                    const var_types tiOp2 = op2->TypeGet();
+
+                    if (tiOp1 == TYP_BYREF && (tiOp2 != TYP_BYREF && tiOp2 != TYP_INT))
+                    {
+                        BADCODE("Address plus non-int32 is not allowed. See ECMA-335 @ Table III.2");
+                    }
+                }
+#endif // FEATURE_CORECLR
+
 #if !CPU_HAS_FP_SUPPORT
                 if (varTypeIsFloating(op1->gtType))
                 {

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -6893,8 +6893,13 @@ bool getILIntrinsicImplementationForUnsafe(MethodDesc * ftn,
     }
     else if (tk == MscorlibBinder::GetMethod(METHOD__UNSAFE__BYREF_ADD_BYTE_OFFSET)->GetMemberDef())
     {
+#if defined(_TARGET_ARM_) || defined(_TARGET_X86_)
+        // 32 bit
         static BYTE ilcode[] = { CEE_LDARG_0, CEE_LDARG_1, CEE_ADD, CEE_RET };
-
+#else
+        // 64 bit
+        static BYTE ilcode[] = { CEE_LDARG_0, CEE_CONV_U8, CEE_LDARG_1, CEE_ADD, CEE_CONV_I, CEE_RET };
+#endif // _TARGET_ARM_ || _TARGET_X86_
         methInfo->ILCode = const_cast<BYTE*>(ilcode);
         methInfo->ILCodeSize = sizeof(ilcode);
         methInfo->maxStack = 2;

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -210,9 +210,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_255294\DevDiv_255294\DevDiv_255294.cmd">
             <Issue>11469, The test causes OutOfMemory exception in crossgen mode.</Issue> 
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_278523\DevDiv_278523\DevDiv_278523.cmd">
-            <Issue>11476, fails on both jit32 and RyuJit x86</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- The following are ARM32 failures -->

--- a/tests/src/JIT/Methodical/Boxing/morph/sin3double.il
+++ b/tests/src/JIT/Methodical/Boxing/morph/sin3double.il
@@ -379,6 +379,7 @@
   IL_01bd:  br         IL_023a
 
   IL_01c2:  ldloca.s   V_11
+            conv.i8
   IL_01c4:  ldloc.0
   IL_01c5:  conv.i8
   IL_01c6:  ldc.i4.4
@@ -401,6 +402,7 @@
   IL_01f0:  br.s       IL_023a
 
   IL_01f2:  ldloca.s   V_11
+            conv.i8
   IL_01f4:  ldloc.0
   IL_01f5:  conv.i8
   IL_01f6:  ldc.i4.4

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b147147/samabo.il
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b147147/samabo.il
@@ -68,7 +68,7 @@
     IL_0019:  ldflda     valuetype MyStruct/buffer__FixedBufferImpl MyStruct::buffer
     IL_001e:  ldflda     char MyStruct/buffer__FixedBufferImpl::FixedElementField
     IL_0023:  ldc.i4.2
-    IL_0024:  conv.i
+    IL_0024:  nop
     IL_0025:  add
     IL_0026:  ldc.i4.s   69
     IL_0028:  stind.i2
@@ -76,7 +76,7 @@
     IL_002b:  ldflda     valuetype MyStruct/buffer__FixedBufferImpl MyStruct::buffer
     IL_0030:  ldflda     char MyStruct/buffer__FixedBufferImpl::FixedElementField
     IL_0035:  ldc.i4.4
-    IL_0036:  conv.i
+    IL_0036:  nop
     IL_0037:  add
     IL_0038:  ldc.i4.s   76
     IL_003a:  stind.i2
@@ -84,7 +84,7 @@
     IL_003d:  ldflda     valuetype MyStruct/buffer__FixedBufferImpl MyStruct::buffer
     IL_0042:  ldflda     char MyStruct/buffer__FixedBufferImpl::FixedElementField
     IL_0047:  ldc.i4.6
-    IL_0048:  conv.i
+    IL_0048:  nop
     IL_0049:  add
     IL_004a:  ldc.i4.s   76
     IL_004c:  stind.i2
@@ -92,7 +92,7 @@
     IL_004f:  ldflda     valuetype MyStruct/buffer__FixedBufferImpl MyStruct::buffer
     IL_0054:  ldflda     char MyStruct/buffer__FixedBufferImpl::FixedElementField
     IL_0059:  ldc.i4.8
-    IL_005a:  conv.i
+    IL_005a:  nop
     IL_005b:  add
     IL_005c:  ldc.i4.s   79
     IL_005e:  stind.i2
@@ -104,7 +104,7 @@
     IL_0065:  ldflda     valuetype MyStruct/buffer__FixedBufferImpl MyStruct::buffer
     IL_006a:  ldflda     char MyStruct/buffer__FixedBufferImpl::FixedElementField
     IL_006f:  ldloc.1
-    IL_0070:  conv.i
+    IL_0070:  nop
     IL_0071:  ldc.i4.2
     IL_0072:  mul
     IL_0073:  add

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523.il
@@ -87,25 +87,31 @@
         .entrypoint
         .locals init (int32 V_0)
 
-        ldc.i4 100
-        dup
-
         sizeof [mscorlib]System.IntPtr
         ldc.i4 8
         beq.s _64bit
 
+        ldc.i4 100
+        dup
         call int32 C::Test32Bit(int32)
-        bne.un.s fail
-        br.s success
-
-_64bit:
-        call int32 C::Test64Bit(int32)
         bne.un.s fail
 
 success:
         ldc.i4 100
         ret
 
+_64bit:
+        .try
+        {
+            ldc.i4 100
+            call int32 C::Test64Bit(int32)
+            pop
+            leave.s fail
+        }
+        catch [mscorlib]System.InvalidProgramException
+        {
+            leave.s success
+        }
 fail:
         ldc.i4 101
         ret


### PR DESCRIPTION
Changes to fix the issue #11476 