### PR TITLE
Add ELF program and section headers to core dump.

### DIFF
--- a/src/debug/createdump/crashinfo.h
+++ b/src/debug/createdump/crashinfo.h
@@ -66,7 +66,10 @@ private:
     bool GetAuxvEntries();
     bool EnumerateModuleMappings();
     bool GetDSOInfo();
+    bool GetELFInfo(uint64_t baseAddress);
     bool EnumerateMemoryRegionsWithDAC(const char* programPath, MINIDUMP_TYPE minidumpType);
+    bool EnumerateManagedModules(IXCLRDataProcess* clrDataProcess);
+    void ReplaceModuleMapping(CLRDATA_ADDRESS baseAddress, char* pszName);
     bool ReadMemory(void* address, void* buffer, size_t size);
     void InsertMemoryRegion(uint64_t address, size_t size);
     void InsertMemoryRegion(const MemoryRegion& region);

--- a/src/debug/createdump/createdump.h
+++ b/src/debug/createdump/createdump.h
@@ -33,6 +33,8 @@ extern bool g_diagnostics;
 #include <xcordebug.h>
 #include <mscoree.h>
 #include <dumpcommon.h>
+typedef int T_CONTEXT;
+#include <dacprivate.h>
 #include <arrayholder.h>
 #include <releaseholder.h>
 #include <unistd.h>

--- a/src/debug/createdump/memoryregion.h
+++ b/src/debug/createdump/memoryregion.h
@@ -41,7 +41,7 @@ public:
     const uint64_t EndAddress() const { return m_endAddress; }
     const uint64_t Size() const { return m_endAddress - m_startAddress; }
     const uint64_t Offset() const { return m_offset; }
-    const char* FileName() const { return m_fileName; }
+    char* FileName() const { return m_fileName; }
 
     bool operator<(const MemoryRegion& rhs) const
     {


### PR DESCRIPTION
Issue #12341

This allows the build id for the modules be extracted properly.

Add .eh_frame and .eh_frame_hdr sections to core dump.

Add managed module info to core dump.