### PR TITLE
Fix event, semaphore, mutex create/open to request the maximum allowe…

### DIFF
--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -1917,7 +1917,7 @@ HANDLE OpenStartupNotificationEvent()
     WCHAR szEventName[cchEventNameBufferSize];
     swprintf_s(szEventName, cchEventNameBufferSize, StartupNotifyEventNamePrefix W("%08x"), debuggeePID);
 
-    return WszOpenEvent(EVENT_ALL_ACCESS, FALSE, szEventName);
+    return WszOpenEvent(MAXIMUM_ALLOWED | SYNCHRONIZE | EVENT_MODIFY_STATE, FALSE, szEventName);
 }
 
 void NotifyDebuggerOfTelestoStartup()

--- a/src/dlls/mscordac/mscordac_unixexports.src
+++ b/src/dlls/mscordac/mscordac_unixexports.src
@@ -71,7 +71,9 @@ CreateFileMappingW
 CreateFileA
 CreateFileW
 CreateMutexW
+CreateMutexExW
 CreateEventW
+CreateEventExW
 CreateProcessW
 CreateSemaphoreExW
 CreateStreamOnHGlobal

--- a/src/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/dlls/mscoree/mscorwks_unixexports.src
@@ -29,9 +29,12 @@ CoTaskMemRealloc
 CoTaskMemFree
 CreateDirectoryW
 CreateEventW
+CreateEventExW
 CreateFileW
 CreateMutexW
+CreateMutexExW
 CreateSemaphoreW
+CreateSemaphoreExW
 DeleteFileW
 DuplicateHandle
 FindClose

--- a/src/inc/winwrap.h
+++ b/src/inc/winwrap.h
@@ -652,7 +652,7 @@
 
 // CoreSystem has CreateSemaphoreExW but not CreateSemaphoreW.
 #undef WszCreateSemaphore
-#define WszCreateSemaphore(_secattr, _count, _maxcount, _name) CreateSemaphoreExW((_secattr), (_count), (_maxcount), (_name), 0, SEMAPHORE_ALL_ACCESS)
+#define WszCreateSemaphore(_secattr, _count, _maxcount, _name) CreateSemaphoreExW((_secattr), (_count), (_maxcount), (_name), 0, MAXIMUM_ALLOWED | SYNCHRONIZE | SEMAPHORE_MODIFY_STATE)
 
 // Same deal as above for GetFileVersionInfo/GetFileVersionInfoSize.
 #undef GetFileVersionInfo

--- a/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
+++ b/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
@@ -327,6 +327,7 @@ namespace Microsoft.Win32
         // Win32 ACL-related constants:
         internal const int READ_CONTROL = 0x00020000;
         internal const int SYNCHRONIZE = 0x00100000;
+        internal const int MAXIMUM_ALLOWED = 0x02000000;
 
         internal const int STANDARD_RIGHTS_READ = READ_CONTROL;
         internal const int STANDARD_RIGHTS_WRITE = READ_CONTROL;
@@ -342,8 +343,13 @@ namespace Microsoft.Win32
         internal const int SEMAPHORE_MODIFY_STATE = 0x00000002;
         internal const int EVENT_MODIFY_STATE = 0x00000002;
         internal const int MUTEX_MODIFY_STATE = 0x00000001;
-        internal const int MUTEX_ALL_ACCESS = 0x001F0001;
 
+        // CreateEventEx: flags
+        internal const uint CREATE_EVENT_MANUAL_RESET = 0x1;
+        internal const uint CREATE_EVENT_INITIAL_SET = 0x2;
+
+        // CreateMutexEx: flags
+        internal const uint CREATE_MUTEX_INITIAL_OWNER = 0x1;
 
         internal const int LMEM_FIXED = 0x0000;
         internal const int LMEM_ZEROINIT = 0x0040;
@@ -554,16 +560,16 @@ namespace Microsoft.Win32
         internal static extern bool ResetEvent(SafeWaitHandle handle);
 
         [DllImport(KERNEL32, SetLastError = true, CharSet = CharSet.Auto, BestFitMapping = false)]
-        internal static extern SafeWaitHandle CreateEvent(SECURITY_ATTRIBUTES lpSecurityAttributes, bool isManualReset, bool initialState, String name);
+        internal static extern SafeWaitHandle CreateEventEx(SECURITY_ATTRIBUTES lpSecurityAttributes, string name, uint flags, uint desiredAccess);
 
         [DllImport(KERNEL32, SetLastError = true, CharSet = CharSet.Auto, BestFitMapping = false)]
-        internal static extern SafeWaitHandle OpenEvent(/* DWORD */ int desiredAccess, bool inheritHandle, String name);
+        internal static extern SafeWaitHandle OpenEvent(uint desiredAccess, bool inheritHandle, string name);
 
         [DllImport(KERNEL32, SetLastError = true, CharSet = CharSet.Auto, BestFitMapping = false)]
-        internal static extern SafeWaitHandle CreateMutex(SECURITY_ATTRIBUTES lpSecurityAttributes, bool initialOwner, String name);
+        internal static extern SafeWaitHandle CreateMutexEx(SECURITY_ATTRIBUTES lpSecurityAttributes, string name, uint flags, uint desiredAccess);
 
         [DllImport(KERNEL32, SetLastError = true, CharSet = CharSet.Auto, BestFitMapping = false)]
-        internal static extern SafeWaitHandle OpenMutex(/* DWORD */ int desiredAccess, bool inheritHandle, String name);
+        internal static extern SafeWaitHandle OpenMutex(uint desiredAccess, bool inheritHandle, string name);
 
         [DllImport(KERNEL32, SetLastError = true)]
         internal static extern bool ReleaseMutex(SafeWaitHandle handle);
@@ -575,14 +581,14 @@ namespace Microsoft.Win32
         internal static unsafe extern int WriteFile(SafeFileHandle handle, byte* bytes, int numBytesToWrite, out int numBytesWritten, IntPtr mustBeZero);
 
         [DllImport(KERNEL32, SetLastError = true, CharSet = CharSet.Auto, BestFitMapping = false)]
-        internal static extern SafeWaitHandle CreateSemaphore(SECURITY_ATTRIBUTES lpSecurityAttributes, int initialCount, int maximumCount, String name);
+        internal static extern SafeWaitHandle CreateSemaphoreEx(SECURITY_ATTRIBUTES lpSecurityAttributes, int initialCount, int maximumCount, string name, uint flags, uint desiredAccess);
 
         [DllImport(KERNEL32, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool ReleaseSemaphore(SafeWaitHandle handle, int releaseCount, out int previousCount);
 
         [DllImport(KERNEL32, SetLastError = true, CharSet = CharSet.Auto, BestFitMapping = false)]
-        internal static extern SafeWaitHandle OpenSemaphore(/* DWORD */ int desiredAccess, bool inheritHandle, String name);
+        internal static extern SafeWaitHandle OpenSemaphore(uint desiredAccess, bool inheritHandle, string name);
 
         // Will be in winnls.h
         internal const int FIND_STARTSWITH = 0x00100000; // see if value is at the beginning of source

--- a/src/mscorlib/src/System/Threading/EventWaitHandle.cs
+++ b/src/mscorlib/src/System/Threading/EventWaitHandle.cs
@@ -39,6 +39,9 @@ namespace System.Threading
     [ComVisibleAttribute(true)]
     public class EventWaitHandle : WaitHandle
     {
+        private const uint AccessRights =
+            (uint)Win32Native.MAXIMUM_ALLOWED | Win32Native.SYNCHRONIZE | Win32Native.EVENT_MODIFY_STATE;
+
         public EventWaitHandle(bool initialState, EventResetMode mode) : this(initialState, mode, null) { }
 
         public EventWaitHandle(bool initialState, EventResetMode mode, string name)
@@ -56,19 +59,21 @@ namespace System.Threading
             }
             Contract.EndContractBlock();
 
-            SafeWaitHandle _handle = null;
+            uint eventFlags = initialState ? Win32Native.CREATE_EVENT_INITIAL_SET : 0;
             switch (mode)
             {
                 case EventResetMode.ManualReset:
-                    _handle = Win32Native.CreateEvent(null, true, initialState, name);
+                    eventFlags |= Win32Native.CREATE_EVENT_MANUAL_RESET;
                     break;
+
                 case EventResetMode.AutoReset:
-                    _handle = Win32Native.CreateEvent(null, false, initialState, name);
                     break;
 
                 default:
                     throw new ArgumentException(SR.Format(SR.Argument_InvalidFlag, name));
             };
+
+            SafeWaitHandle _handle = Win32Native.CreateEventEx(null, name, eventFlags, AccessRights);
 
             if (_handle.IsInvalid)
             {
@@ -104,24 +109,23 @@ namespace System.Threading
             Contract.EndContractBlock();
             Win32Native.SECURITY_ATTRIBUTES secAttrs = null;
 
-            SafeWaitHandle _handle = null;
-            Boolean isManualReset;
+            uint eventFlags = initialState ? Win32Native.CREATE_EVENT_INITIAL_SET : 0;
             switch (mode)
             {
                 case EventResetMode.ManualReset:
-                    isManualReset = true;
+                    eventFlags |= Win32Native.CREATE_EVENT_MANUAL_RESET;
                     break;
+
                 case EventResetMode.AutoReset:
-                    isManualReset = false;
                     break;
 
                 default:
                     throw new ArgumentException(SR.Format(SR.Argument_InvalidFlag, name));
             };
 
-            _handle = Win32Native.CreateEvent(secAttrs, isManualReset, initialState, name);
-            int errorCode = Marshal.GetLastWin32Error();
+            SafeWaitHandle _handle = Win32Native.CreateEventEx(secAttrs, name, eventFlags, AccessRights);
 
+            int errorCode = Marshal.GetLastWin32Error();
             if (_handle.IsInvalid)
             {
                 _handle.SetHandleAsInvalid();
@@ -193,7 +197,7 @@ namespace System.Threading
 
             result = null;
 
-            SafeWaitHandle myHandle = Win32Native.OpenEvent(Win32Native.EVENT_MODIFY_STATE | Win32Native.SYNCHRONIZE, false, name);
+            SafeWaitHandle myHandle = Win32Native.OpenEvent(AccessRights, false, name);
 
             if (myHandle.IsInvalid)
             {

--- a/src/mscorlib/src/System/Threading/Mutex.cs
+++ b/src/mscorlib/src/System/Threading/Mutex.cs
@@ -21,7 +21,6 @@ namespace System.Threading
     using Microsoft.Win32;
     using Microsoft.Win32.SafeHandles;
     using System.Runtime.InteropServices;
-    using System.Runtime.ConstrainedExecution;
     using System.Runtime.Versioning;
     using System.Security;
     using System.Diagnostics;
@@ -29,6 +28,9 @@ namespace System.Threading
 
     public sealed class Mutex : WaitHandle
     {
+        private const uint AccessRights =
+            (uint)Win32Native.MAXIMUM_ALLOWED | Win32Native.SYNCHRONIZE | Win32Native.MUTEX_MODIFY_STATE;
+
         private static bool dummyBool;
 
         internal class MutexSecurity
@@ -94,30 +96,16 @@ namespace System.Threading
 
             internal void MutexTryCode(object userData)
             {
-                SafeWaitHandle mutexHandle = null;
                 // try block                
-                RuntimeHelpers.PrepareConstrainedRegions();
-                try
+                if (m_initiallyOwned)
                 {
-                }
-                finally
-                {
-                    if (m_initiallyOwned)
-                    {
-                        m_cleanupInfo.inCriticalRegion = true;
-                    }
+                    m_cleanupInfo.inCriticalRegion = true;
                 }
 
-                int errorCode = 0;
-                RuntimeHelpers.PrepareConstrainedRegions();
-                try
-                {
-                }
-                finally
-                {
-                    errorCode = CreateMutexHandle(m_initiallyOwned, m_name, m_secAttrs, out mutexHandle);
-                }
+                uint mutexFlags = m_initiallyOwned ? Win32Native.CREATE_MUTEX_INITIAL_OWNER : 0;
+                SafeWaitHandle mutexHandle = Win32Native.CreateMutexEx(m_secAttrs, m_name, mutexFlags, AccessRights);
 
+                int errorCode = Marshal.GetLastWin32Error();
                 if (mutexHandle.IsInvalid)
                 {
                     mutexHandle.SetHandleAsInvalid();
@@ -251,12 +239,11 @@ namespace System.Threading
             // with parameters to allow us to view & edit the ACL.  This will
             // fail if we don't have permission to view or edit the ACL's.  
             // If that happens, ask for less permissions.
-            SafeWaitHandle myHandle = Win32Native.OpenMutex(Win32Native.MUTEX_MODIFY_STATE | Win32Native.SYNCHRONIZE, false, name);
+            SafeWaitHandle myHandle = Win32Native.OpenMutex(AccessRights, false, name);
 
-            int errorCode = 0;
             if (myHandle.IsInvalid)
             {
-                errorCode = Marshal.GetLastWin32Error();
+                int errorCode = Marshal.GetLastWin32Error();
 
 #if PLATFORM_UNIX
                 if (name != null && errorCode == Win32Native.ERROR_FILENAME_EXCED_RANGE)
@@ -293,40 +280,6 @@ namespace System.Threading
             {
                 throw new ApplicationException(SR.Arg_SynchronizationLockException);
             }
-        }
-
-        private static int CreateMutexHandle(bool initiallyOwned, String name, Win32Native.SECURITY_ATTRIBUTES securityAttribute, out SafeWaitHandle mutexHandle)
-        {
-            int errorCode;
-
-            while (true)
-            {
-                mutexHandle = Win32Native.CreateMutex(securityAttribute, initiallyOwned, name);
-                errorCode = Marshal.GetLastWin32Error();
-                if (!mutexHandle.IsInvalid) break;
-
-                if (errorCode != Win32Native.ERROR_ACCESS_DENIED) break;
-
-                // If a mutex with the name already exists, OS will try to open it with FullAccess.
-                // It might fail if we don't have enough access. In that case, we try to open the mutex will modify and synchronize access.
-                RuntimeHelpers.PrepareConstrainedRegions();
-
-                mutexHandle = Win32Native.OpenMutex(
-                    Win32Native.MUTEX_MODIFY_STATE | Win32Native.SYNCHRONIZE,
-                    false,
-                    name);
-
-                errorCode = !mutexHandle.IsInvalid ? Win32Native.ERROR_ALREADY_EXISTS : Marshal.GetLastWin32Error();
-
-                // There could be a race condition here, the other owner of the mutex can free the mutex,
-                // We need to retry creation in that case.
-                if (errorCode != Win32Native.ERROR_FILE_NOT_FOUND)
-                {
-                    if (errorCode == Win32Native.ERROR_SUCCESS) errorCode = Win32Native.ERROR_ALREADY_EXISTS;
-                    break;
-                }
-            }
-            return errorCode;
         }
     }
 }

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -1345,6 +1345,19 @@ CreateEventW(
          IN BOOL bInitialState,
          IN LPCWSTR lpName);
 
+PALIMPORT
+HANDLE
+PALAPI
+CreateEventExW(
+         IN LPSECURITY_ATTRIBUTES lpEventAttributes,
+         IN LPCWSTR lpName,
+         IN DWORD dwFlags,
+         IN DWORD dwDesiredAccess);
+
+// CreateEventExW: dwFlags
+#define CREATE_EVENT_MANUAL_RESET ((DWORD)0x1)
+#define CREATE_EVENT_INITIAL_SET ((DWORD)0x2)
+
 #ifdef UNICODE
 #define CreateEvent CreateEventW
 #else
@@ -1383,10 +1396,22 @@ CreateMutexW(
     IN BOOL bInitialOwner,
     IN LPCWSTR lpName);
 
+PALIMPORT
+HANDLE
+PALAPI
+CreateMutexExW(
+    IN LPSECURITY_ATTRIBUTES lpMutexAttributes,
+    IN LPCWSTR lpName,
+    IN DWORD dwFlags,
+    IN DWORD dwDesiredAccess);
+
+// CreateMutexExW: dwFlags
+#define CREATE_MUTEX_INITIAL_OWNER ((DWORD)0x1)
+
 #ifdef UNICODE
-#define CreateMutex  CreateMutexW
+#define CreateMutex CreateMutexW
 #else
-#define CreateMutex  CreateMutexA
+#define CreateMutex CreateMutexA
 #endif
 
 PALIMPORT
@@ -3949,19 +3974,17 @@ typedef struct _RUNTIME_FUNCTION {
 #define STANDARD_RIGHTS_REQUIRED  (0x000F0000L)
 #define SYNCHRONIZE               (0x00100000L)
 #define READ_CONTROL              (0x00020000L)
+#define MAXIMUM_ALLOWED           (0x02000000L)
 
 #define EVENT_MODIFY_STATE        (0x0002)
-#define EVENT_ALL_ACCESS          (STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | \
-                                   0x3) 
+#define EVENT_ALL_ACCESS          (STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | 0x3) 
 
 #define MUTANT_QUERY_STATE        (0x0001)
-#define MUTANT_ALL_ACCESS         (STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | \
-                                   MUTANT_QUERY_STATE)
+#define MUTANT_ALL_ACCESS         (STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | MUTANT_QUERY_STATE)
 #define MUTEX_ALL_ACCESS          MUTANT_ALL_ACCESS
 
 #define SEMAPHORE_MODIFY_STATE    (0x0002)
-#define SEMAPHORE_ALL_ACCESS      (STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | \
-                                   0x3)
+#define SEMAPHORE_ALL_ACCESS      (STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | 0x3)
 
 #define PROCESS_TERMINATE         (0x0001)  
 #define PROCESS_CREATE_THREAD     (0x0002)  

--- a/src/pal/src/synchobj/event.cpp
+++ b/src/pal/src/synchobj/event.cpp
@@ -189,6 +189,36 @@ CreateEventW(
 
 /*++
 Function:
+  CreateEventExW
+
+Note:
+  lpEventAttributes and dwDesiredAccess are currently ignored:
+  -- Win32 object security not supported
+  -- handles to event objects are not inheritable
+  -- Access rights are not supported
+
+Parameters:  
+  See MSDN doc.
+--*/
+
+HANDLE
+PALAPI
+CreateEventExW(
+    IN LPSECURITY_ATTRIBUTES lpEventAttributes,
+    IN LPCWSTR lpName,
+    IN DWORD dwFlags,
+    IN DWORD dwDesiredAccess)
+{
+    return
+        CreateEventW(
+            lpEventAttributes,
+            (dwFlags & CREATE_EVENT_MANUAL_RESET) != 0,
+            (dwFlags & CREATE_EVENT_INITIAL_SET) != 0,
+            lpName);
+}
+
+/*++
+Function:
   InternalCreateEvent
 
 Note:

--- a/src/pal/src/synchobj/mutex.cpp
+++ b/src/pal/src/synchobj/mutex.cpp
@@ -215,6 +215,30 @@ CreateMutexWExit:
 
 /*++
 Function:
+CreateMutexW
+
+Note:
+lpMutexAttributes currentely ignored:
+-- Win32 object security not supported
+-- handles to mutex objects are not inheritable
+
+Parameters:
+See MSDN doc.
+--*/
+
+HANDLE
+PALAPI
+CreateMutexExW(
+    IN LPSECURITY_ATTRIBUTES lpMutexAttributes,
+    IN LPCWSTR lpName,
+    IN DWORD dwFlags,
+    IN DWORD dwDesiredAccess)
+{
+    return CreateMutexW(lpMutexAttributes, (dwFlags & CREATE_MUTEX_INITIAL_OWNER) != 0, lpName);
+}
+
+/*++
+Function:
   InternalCreateMutex
 
 Note:

--- a/src/pal/src/synchobj/semaphore.cpp
+++ b/src/pal/src/synchobj/semaphore.cpp
@@ -161,7 +161,6 @@ Parameters:
 See MSDN doc.
 --*/
 
-PALIMPORT
 HANDLE
 PALAPI
 CreateSemaphoreExW(
@@ -172,10 +171,7 @@ CreateSemaphoreExW(
         IN /*_Reserved_*/  DWORD dwFlags,
         IN DWORD dwDesiredAccess)
 {
-    // dwFlags is reserved and unused, and dwDesiredAccess is currently
-    // only ever used as SEMAPHORE_ALL_ACCESS.  The other parameters
-    // all map to CreateSemaphoreW.
-    _ASSERTE(SEMAPHORE_ALL_ACCESS == dwDesiredAccess);
+    // dwFlags is reserved and unused
 
     return CreateSemaphoreW(
         lpSemaphoreAttributes,


### PR DESCRIPTION
…d access

Functional fix for #11306
- Ported dotnet/corert@78fae17f5434839a8720603973ff53f27e27f916 to CoreCLR, see that commit for details on the hang during mutex creation that is also fixed by this change.
- Replaced all uses of the *_ALL_ACCESS flags relevant to events, semaphores, and mutexes