### PR TITLE
[Local GC] Remove a number of inclusions of handle table private headers from the VM

### DIFF
--- a/src/debug/daccess/dacimpl.h
+++ b/src/debug/daccess/dacimpl.h
@@ -14,6 +14,11 @@
 #ifndef __DACIMPL_H__
 #define __DACIMPL_H__
 
+// This header include will need to be removed as part of GitHub#12170.
+// The only reason it's here now is that this header references the GC-private
+// structure "HandleTableMap".
+#include "../../gc/objecthandle.h"
+
 #if defined(_TARGET_ARM_) || defined(FEATURE_CORESYSTEM) // @ARMTODO: STL breaks the build with current VC headers
 //---------------------------------------------------------------------------------------
 // Setting DAC_HASHTABLE tells the DAC to use the hand rolled hashtable for

--- a/src/debug/ee/dactable.cpp
+++ b/src/debug/ee/dactable.cpp
@@ -12,6 +12,11 @@
 
 #include "stdafx.h"
 #include <daccess.h>
+
+// This header include will need to be rmeoved as part of GitHub#12170.
+// The only reason it's here now is that this file references the GC-private
+// variable g_HandleTableMap.
+#include "../../gc/objecthandle.h"
 #include "../../vm/virtualcallstub.h"
 #include "../../vm/win32threadpool.h"
 #include "../../vm/hillclimbing.h"

--- a/src/gc/gchandletable.cpp
+++ b/src/gc/gchandletable.cpp
@@ -187,3 +187,8 @@ HandleType GCHandleManager::HandleFetchType(OBJECTHANDLE handle)
     return static_cast<HandleType>(type);
 }
 
+void GCHandleManager::TraceRefCountedHandles(HANDLESCANPROC callback, uintptr_t param1, uintptr_t param2)
+{
+    ::Ref_TraceRefCountHandles(callback, param1, param2);
+}
+

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -72,6 +72,8 @@ public:
     virtual Object* InterlockedCompareExchangeObjectInHandle(OBJECTHANDLE handle, Object* object, Object* comparandObject);
 
     virtual HandleType HandleFetchType(OBJECTHANDLE handle);
+
+    virtual void TraceRefCountedHandles(HANDLESCANPROC callback, uintptr_t param1, uintptr_t param2);
 };
 
 #endif  // GCHANDLETABLE_H_

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -466,6 +466,8 @@ public:
     virtual Object* InterlockedCompareExchangeObjectInHandle(OBJECTHANDLE handle, Object* object, Object* comparandObject) = 0;
 
     virtual HandleType HandleFetchType(OBJECTHANDLE handle) = 0;
+
+    virtual void TraceRefCountedHandles(HANDLESCANPROC callback, uintptr_t param1, uintptr_t param2) = 0;
 };
 
 // IGCHeap is the interface that the VM will use when interacting with the GC.

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -820,6 +820,14 @@ void updateGCShadow(Object** ptr, Object* val);
 #define GC_ALLOC_ALIGN8_BIAS 0x4
 #define GC_ALLOC_ALIGN8 0x8
 
+#if defined(USE_CHECKED_OBJECTREFS) && !defined(_NOVM)
+#define OBJECTREF_TO_UNCHECKED_OBJECTREF(objref)    (*((_UNCHECKED_OBJECTREF*)&(objref)))
+#define UNCHECKED_OBJECTREF_TO_OBJECTREF(obj)       (OBJECTREF(obj))
+#else
+#define OBJECTREF_TO_UNCHECKED_OBJECTREF(objref)    (objref)
+#define UNCHECKED_OBJECTREF_TO_OBJECTREF(obj)       (obj)
+#endif
+
 struct ScanContext
 {
     Thread* thread_under_crawl;

--- a/src/gc/gcsvr.cpp
+++ b/src/gc/gcsvr.cpp
@@ -14,6 +14,8 @@
 #include "gcscan.h"
 #include "gcdesc.h"
 #include "softwarewritewatch.h"
+#include "handletable.h"
+#include "handletable.inl"
 
 #define SERVER_GC 1
 

--- a/src/gc/gcwks.cpp
+++ b/src/gc/gcwks.cpp
@@ -12,6 +12,8 @@
 #include "gcscan.h"
 #include "gcdesc.h"
 #include "softwarewritewatch.h"
+#include "handletable.h"
+#include "handletable.inl"
 
 #ifdef SERVER_GC
 #undef SERVER_GC

--- a/src/gc/handletable.h
+++ b/src/gc/handletable.h
@@ -144,14 +144,6 @@ uint32_t        HndCountAllHandles(BOOL fUseLocks);
 /*--------------------------------------------------------------------------*/
 
 
-#if defined(USE_CHECKED_OBJECTREFS) && !defined(_NOVM)
-#define OBJECTREF_TO_UNCHECKED_OBJECTREF(objref)    (*((_UNCHECKED_OBJECTREF*)&(objref)))
-#define UNCHECKED_OBJECTREF_TO_OBJECTREF(obj)       (OBJECTREF(obj))
-#else
-#define OBJECTREF_TO_UNCHECKED_OBJECTREF(objref)    (objref)
-#define UNCHECKED_OBJECTREF_TO_OBJECTREF(obj)       (obj)
-#endif
-
 #ifdef _DEBUG_IMPL
 void ValidateAssignObjrefForHandle(OBJECTREF, ADIndex appDomainIndex);
 void ValidateFetchObjrefForHandle(OBJECTREF, ADIndex appDomainIndex);

--- a/src/gc/objecthandle.cpp
+++ b/src/gc/objecthandle.cpp
@@ -1162,10 +1162,10 @@ void Ref_TraceNormalRoots(uint32_t condemned, uint32_t maxgen, ScanContext* sc, 
 #endif // FEATURE_COMINTEROP || FEATURE_REDHAWK
 }
 
-#ifdef FEATURE_COMINTEROP
 
 void Ref_TraceRefCountHandles(HANDLESCANPROC callback, uintptr_t lParam1, uintptr_t lParam2)
 {
+#ifdef FEATURE_COMINTEROP
     int max_slots = getNumberOfSlots();
     uint32_t handleType = HNDTYPE_REFCOUNTED;
 
@@ -1186,9 +1186,13 @@ void Ref_TraceRefCountHandles(HANDLESCANPROC callback, uintptr_t lParam1, uintpt
         }
         walk = walk->pNext;
     }
+#else
+    UNREFERENCED_PARAMETER(callback);
+    UNREFERENCED_PARAMETER(lParam1);
+    UNREFERENCED_PARAMETER(lParam2);
+#endif // FEATURE_COMINTEROP
 }
 
-#endif
 
 
 

--- a/src/gc/objecthandle.h
+++ b/src/gc/objecthandle.h
@@ -72,8 +72,6 @@ uint32_t     GetVariableHandleType(OBJECTHANDLE handle);
 void         UpdateVariableHandleType(OBJECTHANDLE handle, uint32_t type);
 uint32_t     CompareExchangeVariableHandleType(OBJECTHANDLE handle, uint32_t oldType, uint32_t newType);
 
-void GCHandleValidatePinnedObject(OBJECTREF obj);
-
 /*
  * Convenience prototypes for using the global handles
  */

--- a/src/strongname/api/common.h
+++ b/src/strongname/api/common.h
@@ -304,7 +304,6 @@ namespace Loader
 #include "eeconfig.h"
 
 #include "spinlock.h"
-#include "objecthandle.h"
 #include "cgensys.h"
 #include "declsec.h"
 
@@ -319,7 +318,6 @@ namespace Loader
 
 #include "eehash.h"
 
-#include "handletable.h"
 #include "vars.hpp"
 #include "eventstore.hpp"
 
@@ -392,7 +390,6 @@ extern DummyGlobalContract ___contract;
 #include "ceeload.inl"
 #include "clsload.inl"
 #include "domainfile.inl"
-#include "handletable.inl"
 #include "clsload.inl"
 #include "method.inl"
 #include "stackprobe.inl"

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -130,7 +130,6 @@
 #include "syncblk.h"
 #include "eeconfig.h"
 #include "stublink.h"
-#include "handletable.h"
 #include "method.hpp"
 #include "codeman.h"
 #include "frames.h"

--- a/src/vm/class.h
+++ b/src/vm/class.h
@@ -43,7 +43,6 @@
 #include "clrex.h"
 #include "hash.h"
 #include "crst.h"
-#include "objecthandle.h"
 #include "cgensys.h"
 #include "declsec.h"
 #ifdef FEATURE_COMINTEROP

--- a/src/vm/classcompat.h
+++ b/src/vm/classcompat.h
@@ -19,7 +19,6 @@
 #include "clrex.h"
 #include "hash.h"
 #include "crst.h"
-#include "objecthandle.h"
 #include "cgensys.h"
 #include "declsec.h"
 #include "stdinterfaces.h"

--- a/src/vm/clrex.h
+++ b/src/vm/clrex.h
@@ -14,7 +14,6 @@
 
 #include <ex.h>
 
-#include "objecthandle.h"
 #include "runtimeexceptionkind.h"
 #include "interoputil.h"
 

--- a/src/vm/comcallablewrapper.cpp
+++ b/src/vm/comcallablewrapper.cpp
@@ -31,7 +31,6 @@
 #include "cgensys.h"
 #include "comtoclrcall.h"
 #include "clrtocomcall.h"
-#include "objecthandle.h"
 #include "comutilnative.h"
 #include "eeconfig.h"
 #include "interoputil.h"

--- a/src/vm/comcallablewrapper.h
+++ b/src/vm/comcallablewrapper.h
@@ -17,7 +17,6 @@
 #include "vars.hpp"
 #include "stdinterfaces.h"
 #include "threads.h"
-#include "objecthandle.h"
 #include "comutilnative.h"
 #include "spinlock.h"
 #include "comtoclrcall.h"

--- a/src/vm/common.h
+++ b/src/vm/common.h
@@ -320,7 +320,6 @@ namespace Loader
 #include "eeconfig.h"
 
 #include "spinlock.h"
-#include "objecthandle.h"
 #include "declsec.h"
 
 #ifdef FEATURE_COMINTEROP 
@@ -334,7 +333,6 @@ namespace Loader
 
 #include "eehash.h"
 
-#include "handletable.h"
 #include "vars.hpp"
 #include "eventstore.hpp"
 
@@ -472,7 +470,6 @@ extern DummyGlobalContract ___contract;
 #include "object.inl"
 #include "clsload.inl"
 #include "domainfile.inl"
-#include "handletable.inl"
 #include "method.inl"
 #include "stackprobe.inl"
 #include "syncblk.inl"

--- a/src/vm/dispatchinfo.cpp
+++ b/src/vm/dispatchinfo.cpp
@@ -22,7 +22,6 @@
 #include "comcallablewrapper.h"
 #include "threads.h"
 #include "excep.h"
-#include "objecthandle.h"
 #include "comutilnative.h"
 #include "eeconfig.h"
 #include "interoputil.h"

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -1343,7 +1343,7 @@ void BulkComLogger::LogAllComObjects()
     // We need to do work in HandleWalkCallback which may trigger a GC.  We cannot do this while
     // enumerating the handle table.  Instead, we will build a list of RefCount handles we found
     // during the handle table enumeration first (m_enumResult) during this enumeration:
-    Ref_TraceRefCountHandles(BulkComLogger::HandleWalkCallback, uintptr_t(this), 0);
+    GCHandleUtilities::GetGCHandleManager()->TraceRefCountedHandles(BulkComLogger::HandleWalkCallback, uintptr_t(this), 0);
 
     // Now that we have all of the object handles, we will walk all of the handles and write the
     // etw events.

--- a/src/vm/field.h
+++ b/src/vm/field.h
@@ -10,7 +10,6 @@
 #ifndef _FIELD_H_
 #define _FIELD_H_
 
-#include "objecthandle.h"
 #include "excep.h"
 
 // Temporary values stored in FieldDesc m_dwOffset during loading

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -16,7 +16,6 @@
 #include "security.h"
 #include "stublink.h"
 #include "fieldmarshaler.h"
-#include "objecthandle.h"
 #include "siginfo.hpp"
 #include "gcheaputilities.h"
 #include "dllimportcallback.h"

--- a/src/vm/frames.h
+++ b/src/vm/frames.h
@@ -276,7 +276,6 @@ FRAME_TYPE_NAME(AssumeByrefFromJITStack)
 #include "vars.hpp"
 #include "regdisp.h"
 #include "object.h"
-#include "objecthandle.h"
 #include <stddef.h>
 #include "siginfo.hpp"
 // context headers

--- a/src/vm/gchandleutilities.h
+++ b/src/vm/gchandleutilities.h
@@ -33,6 +33,10 @@ private:
 void ValidateObjectAndAppDomain(OBJECTREF objRef, ADIndex appDomainIndex);
 void ValidateHandleAssignment(OBJECTHANDLE handle, OBJECTREF objRef);
 
+// Check that the supplied object is valid to put in a pinned handle,
+// throwing an exception if not.
+void ValidatePinnedObject(OBJECTREF obj);
+
 // Given a handle, returns an OBJECTREF for the object it refers to.
 inline OBJECTREF ObjectFromHandle(OBJECTHANDLE handle)
 {

--- a/src/vm/gchandleutilities.h
+++ b/src/vm/gchandleutilities.h
@@ -33,10 +33,6 @@ private:
 void ValidateObjectAndAppDomain(OBJECTREF objRef, ADIndex appDomainIndex);
 void ValidateHandleAssignment(OBJECTHANDLE handle, OBJECTREF objRef);
 
-// Check that the supplied object is valid to put in a pinned handle,
-// throwing an exception if not.
-void ValidatePinnedObject(OBJECTREF obj);
-
 // Given a handle, returns an OBJECTREF for the object it refers to.
 inline OBJECTREF ObjectFromHandle(OBJECTHANDLE handle)
 {

--- a/src/vm/handletable.h
+++ b/src/vm/handletable.h
@@ -1,5 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-#include "../gc/handletable.h"

--- a/src/vm/handletable.inl
+++ b/src/vm/handletable.inl
@@ -1,5 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-#include "../gc/handletable.inl"

--- a/src/vm/marshalnative.cpp
+++ b/src/vm/marshalnative.cpp
@@ -30,7 +30,6 @@
 #include "gcheaputilities.h"
 #include "security.h"
 #include "dbginterface.h"
-#include "objecthandle.h"
 #include "marshalnative.h"
 #include "fcall.h"
 #include "dllimportcallback.h"
@@ -592,7 +591,7 @@ FCIMPLEND
 
  // Check that the supplied object is valid to put in a pinned handle.
 // Throw an exception if not.
-void GCHandleValidatePinnedObject(OBJECTREF obj)
+void ValidatePinnedObject(OBJECTREF obj)
 {
     CONTRACTL
     {
@@ -642,7 +641,7 @@ FCIMPL2(LPVOID, MarshalNative::GCHandleInternalAlloc, Object *obj, int type)
 
     // If it is a pinned handle, check the object type.
     if (type == HNDTYPE_PINNED)
-        GCHandleValidatePinnedObject(objRef);
+        ValidatePinnedObject(objRef);
 
     assert(type >= HNDTYPE_WEAK_SHORT && type <= HNDTYPE_WEAK_WINRT);
     // Create the handle.
@@ -701,7 +700,7 @@ FCIMPL3(VOID, MarshalNative::GCHandleInternalSet, OBJECTHANDLE handle, Object *o
     //<TODO>@todo: If the handle is pinned check the object type.</TODO>
     if (isPinned)
     {
-        GCHandleValidatePinnedObject(objRef);
+        ValidatePinnedObject(objRef);
     }
 
     // Update the stored object reference.
@@ -722,7 +721,7 @@ FCIMPL4(Object*, MarshalNative::GCHandleInternalCompareExchange, OBJECTHANDLE ha
 
     //<TODO>@todo: If the handle is pinned check the object type.</TODO>
     if (isPinned)
-        GCHandleValidatePinnedObject(newObjref);
+        ValidatePinnedObject(newObjref);
 
     // Update the stored object reference.
     ret = InterlockedCompareExchangeObjectInHandle(handle, newObjref, oldObjref);
@@ -785,7 +784,7 @@ FCIMPL1(INT32, MarshalNative::CalculateCount, ArrayWithOffsetData* pArrayWithOff
         if (arrayObj->GetMethodTable()->IsMultiDimArray())
             COMPlusThrow(kArgumentException, IDS_EE_NOTISOMORPHIC);
 
-        GCHandleValidatePinnedObject(arrayObj);
+        ValidatePinnedObject(arrayObj);
     }
 
     if (arrayObj == NULL)

--- a/src/vm/marshalnative.h
+++ b/src/vm/marshalnative.h
@@ -239,4 +239,8 @@ private:
 #endif // FEATURE_COMINTEROP
 };
 
+// Check that the supplied object is valid to put in a pinned handle,
+// throwing an exception if not.
+void ValidatePinnedObject(OBJECTREF obj);
+
 #endif

--- a/src/vm/methodtable.h
+++ b/src/vm/methodtable.h
@@ -21,7 +21,6 @@
 #include "cor.h"
 #include "hash.h"
 #include "crst.h"
-#include "objecthandle.h"
 #include "cgensys.h"
 #include "declsec.h"
 #ifdef FEATURE_COMINTEROP

--- a/src/vm/nativeoverlapped.cpp
+++ b/src/vm/nativeoverlapped.cpp
@@ -137,7 +137,7 @@ FCIMPL1(void*, AllocateNativeOverlapped, OverlappedDataObject* overlappedUNSAFE)
             SIZE_T i;
             for (i = 0; i < num; i ++)
             {
-                GCHandleValidatePinnedObject(pObj[i]);
+                ValidatePinnedObject(pObj[i]);
             }
             for (i = 0; i < num; i ++)
             {
@@ -147,7 +147,7 @@ FCIMPL1(void*, AllocateNativeOverlapped, OverlappedDataObject* overlappedUNSAFE)
         }
         else
         {
-            GCHandleValidatePinnedObject(userObject);
+            ValidatePinnedObject(userObject);
             AddMTForPinHandle(userObject);
         }
         

--- a/src/vm/nativeoverlapped.cpp
+++ b/src/vm/nativeoverlapped.cpp
@@ -20,6 +20,7 @@
 #include "mdaassistants.h"
 #include "comsynchronizable.h"
 #include "comthreadpool.h"
+#include "marshalnative.h"
 
 LONG OverlappedDataObject::s_CleanupRequestCount = 0;
 BOOL OverlappedDataObject::s_CleanupInProgress = FALSE;

--- a/src/vm/objecthandle.h
+++ b/src/vm/objecthandle.h
@@ -1,5 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-#include "../gc/objecthandle.h"

--- a/src/vm/rcwrefcache.cpp
+++ b/src/vm/rcwrefcache.cpp
@@ -17,7 +17,6 @@
 
 #include "common.h"
 
-#include "objecthandle.h"
 #include "rcwrefcache.h"
 #include "comcallablewrapper.h"
 #include "runtimecallablewrapper.h"

--- a/src/vm/runtimecallablewrapper.h
+++ b/src/vm/runtimecallablewrapper.h
@@ -61,7 +61,6 @@
 
 #include "utilcode.h"
 #include "vars.hpp"
-#include "objecthandle.h"
 #include "spinlock.h"
 #include "interoputil.h"
 #include "mngstdinterfaces.h"

--- a/src/vm/runtimehandles.cpp
+++ b/src/vm/runtimehandles.cpp
@@ -22,7 +22,6 @@
 #include "stackprobe.h"
 #include "eeconfig.h"
 #include "eehash.h"
-#include "objecthandle.h"
 #include "interoputil.h"
 #include "typedesc.h"
 #include "virtualcallstub.h"

--- a/src/vm/syncblk.h
+++ b/src/vm/syncblk.h
@@ -16,7 +16,6 @@
 #include "util.hpp"
 #include "slist.h"
 #include "crst.h"
-#include "handletable.h"
 #include "vars.hpp"
 
 // #SyncBlockOverview


### PR DESCRIPTION
This PR removes a number of occurrences where the VM was including GC headers. In most cases, nothing from these headers were being used. For the things that were being used from these headers:
* Uses of `Ref_TraceRefCountedHandles` were refactored to go through `IGCHandleManager::TraceRefCountedHandles`, which I added to the `IGCHandleManager` interface. This was not detected earlier because it only is used when `FEATURE_EVENT_TRACE` is defined.
* The `OBJECTREF_TO_UNCHECKED_OBJECTREF` and `UNCHECKED_OBJECTREF_TO_OBJECTREF` macros were moved to `gcinterface.h`, because they are used by both the VM and the GC. I don't think this is ideal. It seems like we should be moving away from using `OBJECTREF` when inside the GC.
* `GCHandleValidatePinnedObject` was renamed to `ValidatePinnedObject` and its prototype was moved out of `objecthandle.h` and onto `gchandleutilities.h`. It's implementation still lives in `marshalnative.cpp` [here](https://github.com/dotnet/coreclr/blob/master/src/vm/marshalnative.cpp#L595). Once https://github.com/dotnet/coreclr/pull/12314 lands, I think `gchandleutilities.cpp` would be a much better place for it.
