### PR TITLE
Update trusted RHEL build Dockertag to support LTO

### DIFF
--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -12,7 +12,7 @@
         {
           "Name": "DotNet-CoreClr-Trusted-Linux",
           "Parameters": {
-            "DockerTag": "rhel7_prereqs_2",
+            "DockerTag": "rhel-7-dd8aa64-20170320090348",
             "Rid": "linux"
           },
           "ReportingParameters": {


### PR DESCRIPTION
The new RHEL image was generated using the same Dockerfile as the previous, but has LLVM recompiled with gold support enabled, which is required to do a build with -flto (a prerequisite for PGO).

Note: the fixes in this image update were already introduced in Jenkins. This change ensures that we use the same compiler optimizations and the same linker on VSTS as we already do on Jenkins CI (including correctness and performance testing).
