### PR TITLE
Align Linux TP benchmarks with Windows TP benchmarks

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -439,7 +439,7 @@ def static getFullThroughputJobName(def project, def os, def isPR) {
                 -os \"${os}\" \\
                 -configuration \"${configuration}\" \\
                 -clr_root \"\${WORKSPACE}\" \\
-                -assembly_root \"\${WORKSPACE}/_/fx/bin/runtime/netcoreapp-${osGroup}-${configuration}-${architecture}\" \\
+                -assembly_root \"\${WORKSPACE}/Microsoft.Benchview.ThroughputBenchmarks.${architecture}.Windows_NT/lib\" \\
                 -run_type \"${runType}\" \\
                 -benchview_path \"\${WORKSPACE}/tests/scripts/Microsoft.BenchView.JSONFormat/tools\"""")
             }

--- a/tests/scripts/perf-prep.sh
+++ b/tests/scripts/perf-prep.sh
@@ -64,19 +64,17 @@ python3.5 --version
 python3.5 ./tests/scripts/Microsoft.BenchView.JSONFormat/tools/machinedata.py
 
 if [ $throughput -eq 1 ]; then
-    # Clone corefx
-    if [ -d "_" ]; then
-        rm -r -f _
+    # Download throughput benchmarks
+    if [ -d "Microsoft.Benchview.ThroughputBenchmarks.x64.Windows_NT" ]; then
+        rm -r -f Microsoft.Benchview.ThroughputBenchmarks.x64.Windows_NT
     fi
-    mkdir _
-    git clone https://github.com/dotnet/corefx.git _/fx
-    cd _/fx
+    mkdir Microsoft.Benchview.ThroughputBenchmarks.x64.Windows_NT
+    cd Microsoft.Benchview.ThroughputBenchmarks.x64.Windows_NT
 
-    # Checkout the specific commit we want
-    git checkout f0b9e238c08f62a1db90ef0378980ac771204d35
+    curl -OL https://dotnet.myget.org/F/dotnet-core/api/v2/package/Microsoft.Benchview.ThroughputBenchmarks.x64.Windows_NT/1.0.0
+    mv 1.0.0 1.0.0.zip
+    unzip -q 1.0.0.zip
 
-    # Build
-    ./build.sh -release
 else
     # Set up the copies
     # Coreclr build containing the tests and mscorlib


### PR DESCRIPTION
On Windows, we download a set of assemblies that we have uploaded to
MyGet. On Linux, we were building corefx each run to get the benchmarks.
This change updates Linux to pull down the same benchmarks Windows uses,
using curl to grab the nuget package from MyGet.

Note: after this commit, we will have data for fewer assemblies on
Linux, but we will now have the same set for both Windows and Linux.
Some data in Benchview may be affected.