### PR TITLE
[release/2.0.0] Update trusted RHEL build Dockertag to support LTO (Port #12396)

### DIFF
--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -13,7 +13,7 @@
         {
           "Name": "DotNet-CoreClr-Trusted-Linux",
           "Parameters": {
-            "DockerTag": "rhel7_prereqs_2",
+            "DockerTag": "rhel-7-dd8aa64-20170320090348",
             "Rid": "linux"
           },
           "ReportingParameters": {


### PR DESCRIPTION
The new RHEL image was generated using the same Dockerfile as the previous, but has LLVM recompiled with gold support enabled, which is required to do a build with -flto (a prerequisite for PGO).

Cherry-pick bed557d59ab60ede4204d6186ca7daf57eb7869c from master
