### PR TITLE
Update BuildTools to 2.0.0-prerelease-01721-01.

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01702-02
+2.0.0-prerelease-01721-01


### PR DESCRIPTION
This should fix the Maestro builds failing on the BuildTools "A file with that name already exists" error (like https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=818953&_a=summary).