### PR TITLE
First step for enabling ARM test runs

### DIFF
--- a/tests/helixpublish.proj
+++ b/tests/helixpublish.proj
@@ -1,4 +1,9 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <__BuildArch>$(Platform)</__BuildArch>
+  </PropertyGroup>
+  
   <Import Project="..\dir.props" />
   <!-- CoreClr-Specific Helix test submission project. -->
 

--- a/tests/src/Common/build_against_pkg_dependencies/build_against_pkg_dependencies.csproj
+++ b/tests/src/Common/build_against_pkg_dependencies/build_against_pkg_dependencies.csproj
@@ -28,7 +28,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8</PackageTargetFallback>
-    <RuntimeIdentifiers>win-x64;win-x86;win7-x86;win7-x64;win10-arm64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;osx.10.12-x64;osx-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-arm;win-x64;win-x86;win7-x86;win7-x64;win10-arm64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;osx.10.12-x64;osx-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64;linux-x64</RuntimeIdentifiers>
     <ContainsPackageReferences>true</ContainsPackageReferences>
     <PrereleaseResolveNuGetPackages>false</PrereleaseResolveNuGetPackages>
   </PropertyGroup>

--- a/tests/src/Common/targeting_pack_ref/targeting_pack_ref.csproj
+++ b/tests/src/Common/targeting_pack_ref/targeting_pack_ref.csproj
@@ -16,7 +16,7 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
-    <RuntimeIdentifiers>win7-x86;win7-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;osx.10.12-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-arm;win7-x86;win7-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;osx.10.12-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64</RuntimeIdentifiers>
     <ContainsPackageReferences>true</ContainsPackageReferences>
     <PrereleaseResolveNuGetPackages>false</PrereleaseResolveNuGetPackages>
   </PropertyGroup>

--- a/tests/src/Common/test_dependencies/test_dependencies.csproj
+++ b/tests/src/Common/test_dependencies/test_dependencies.csproj
@@ -27,7 +27,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;netcoreapp1.1;portable-net45+win8</PackageTargetFallback>
-    <RuntimeIdentifiers>win-x64;win-x86;win7-x86;win7-x64;win-arm64;win-arm;win7-arm64;win7-arm;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;osx.10.12-x64;osx-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-arm;win-x64;win-x86;win7-x86;win7-x64;win-arm64;win-arm;win7-arm64;win7-arm;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;osx.10.12-x64;osx-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;linux-x64</RuntimeIdentifiers>
     <ContainsPackageReferences>true</ContainsPackageReferences>
     <PrereleaseResolveNuGetPackages>false</PrereleaseResolveNuGetPackages>
   </PropertyGroup>

--- a/tests/src/Common/test_runtime/test_runtime.csproj
+++ b/tests/src/Common/test_runtime/test_runtime.csproj
@@ -30,7 +30,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
-    <RuntimeIdentifiers>win-x64;win-x86;win7-x86;win7-x64;win-arm64;win-arm;win7-arm64;win7-arm;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;osx.10.12-x64;osx-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-arm;win-x64;win-x86;win7-x86;win7-x64;win-arm64;win-arm;win7-arm64;win7-arm;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;osx.10.12-x64;osx-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;linux-x64</RuntimeIdentifiers>
     <ContainsPackageReferences>true</ContainsPackageReferences>
     <PrereleaseResolveNuGetPackages>false</PrereleaseResolveNuGetPackages>
   </PropertyGroup>


### PR DESCRIPTION
Enable restoring win-arm packages, and fix a bug in helixpublish.proj (Platform variable wasn't getting translated into BuildArch).

CC @RussKeldorph @danmosemsft @MattGal 