### PR TITLE
Fix JitMinOptsTrackGCrefs for legacy x86 back-end

### DIFF
--- a/src/jit/gcencode.cpp
+++ b/src/jit/gcencode.cpp
@@ -4134,8 +4134,11 @@ void GCInfo::gcMakeRegPtrTable(
     GCENCODER_WITH_LOGGING(gcInfoEncoderWithLog, gcInfoEncoder);
 
     const bool noTrackedGCSlots =
-        (compiler->opts.MinOpts() && !compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PREJIT) &&
-         !JitConfig.JitMinOptsTrackGCrefs());
+        (compiler->opts.MinOpts() && !compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PREJIT)
+#if !defined(JIT32_GCENCODER) || !defined(LEGACY_BACKEND)
+         && !JitConfig.JitMinOptsTrackGCrefs()
+#endif // !defined(JIT32_GCENCODER) || !defined(LEGACY_BACKEND)
+             );
 
     if (mode == MAKE_REG_PTR_MODE_ASSIGN_SLOTS)
     {

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -218,14 +218,15 @@ CONFIG_INTEGER(JitEnableNoWayAssert, W("JitEnableNoWayAssert"), 0)
 CONFIG_INTEGER(JitEnableNoWayAssert, W("JitEnableNoWayAssert"), 1)
 #endif // !defined(DEBUG) && !defined(_DEBUG)
 
-#if !defined(JIT32_GCENCODER)
-#if defined(_TARGET_AMD64_) && defined(FEATURE_CORECLR)
+// It was originally intended that JitMinOptsTrackGCrefs only be enabled for amd6 on CoreCLR. A mistake was
+// made, and it was enabled for x86 as well. However, it doesn't currently work with x86 legacy back-end, so
+// disable it for that. Whether it should continue to be enabled for x86 non-legacy-backend should be investigated.
+#if (defined(_TARGET_AMD64_) && defined(FEATURE_CORECLR)) || (defined(_TARGET_X86_) && !defined(LEGACY_BACKEND))
 #define JitMinOptsTrackGCrefs_Default 0 // Not tracking GC refs in MinOpts is new behavior
 #else
 #define JitMinOptsTrackGCrefs_Default 1
 #endif
 CONFIG_INTEGER(JitMinOptsTrackGCrefs, W("JitMinOptsTrackGCrefs"), JitMinOptsTrackGCrefs_Default) // Track GC roots
-#endif // !defined(JIT32_GCENCODER)
 
 // The following should be wrapped inside "#if MEASURE_MEM_ALLOC / #endif", but
 // some files include this one without bringing in the definitions from "jit.h"

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -218,9 +218,10 @@ CONFIG_INTEGER(JitEnableNoWayAssert, W("JitEnableNoWayAssert"), 0)
 CONFIG_INTEGER(JitEnableNoWayAssert, W("JitEnableNoWayAssert"), 1)
 #endif // !defined(DEBUG) && !defined(_DEBUG)
 
-// It was originally intended that JitMinOptsTrackGCrefs only be enabled for amd6 on CoreCLR. A mistake was
+// It was originally intended that JitMinOptsTrackGCrefs only be enabled for amd64 on CoreCLR. A mistake was
 // made, and it was enabled for x86 as well. However, it doesn't currently work with x86 legacy back-end, so
 // disable it for that. Whether it should continue to be enabled for x86 non-legacy-backend should be investigated.
+// This is tracked by issue https://github.com/dotnet/coreclr/issues/12415.
 #if (defined(_TARGET_AMD64_) && defined(FEATURE_CORECLR)) || (defined(_TARGET_X86_) && !defined(LEGACY_BACKEND))
 #define JitMinOptsTrackGCrefs_Default 0 // Not tracking GC refs in MinOpts is new behavior
 #else

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -3289,10 +3289,12 @@ void Compiler::lvaSortByRefCount()
             lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_PinningRef));
 #endif
         }
+#if !defined(JIT32_GCENCODER) || !defined(LEGACY_BACKEND)
         else if (opts.MinOpts() && !JitConfig.JitMinOptsTrackGCrefs() && varTypeIsGC(varDsc->TypeGet()))
         {
             varDsc->lvTracked = 0;
         }
+#endif // !defined(JIT32_GCENCODER) || !defined(LEGACY_BACKEND)
 #if defined(JIT32_GCENCODER) && defined(WIN64EXCEPTIONS)
         else if (lvaIsOriginalThisArg(lclNum) && (info.compMethodInfo->options & CORINFO_GENERICS_CTXT_FROM_THIS) != 0)
         {


### PR DESCRIPTION
Addresses #12415