### PR TITLE
[RyuJIT/ARM32] Change the 3bytes struct to int on morph phase.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2262,17 +2262,17 @@ void fgArgInfo::EvalArgsToTemps()
                     if (setupArg->OperIsCopyBlkOp())
                     {
                         setupArg = compiler->fgMorphCopyBlock(setupArg);
-#ifdef _TARGET_ARM64_
-                        // This scalar LclVar widening step is only performed for ARM64
+#if defined(_TARGET_ARM64_) || (!defined(LEGACY_BACKEND) && defined(_TARGET_ARM_))
+                        // This scalar LclVar widening step is only performed for ARM architectures.
                         //
                         CORINFO_CLASS_HANDLE clsHnd     = compiler->lvaGetStruct(tmpVarNum);
                         unsigned             structSize = varDsc->lvExactSize;
 
                         scalarType = compiler->getPrimitiveTypeForStruct(structSize, clsHnd);
-#endif // _TARGET_ARM64_
+#endif // _TARGET_ARM*_
                     }
 
-                    // scalarType can be set to a wider type for ARM64: (3 => 4)  or (5,6,7 => 8)
+                    // scalarType can be set to a wider type for ARM architectures: (3 => 4)  or (5,6,7 => 8)
                     if ((scalarType != TYP_UNKNOWN) && (scalarType != lclVarType))
                     {
                         // Create a GT_LCL_FLD using the wider type to go to the late argument list


### PR DESCRIPTION
It is necessary that the 3bytes struct which is a local var copy block to int on morph phase.

Related Issue : #12290 (Assertion failed 'emitTypeSizes[TypeGet(type)] > 0')

TC
```c#
using System;

#pragma warning disable 169 
struct MyStruct
{
    byte a, b, c;
}
#pragma warning restore 169 

class My
{
    static void foo<T>(T[,] s)
    {   
        s[0, 1] = s[1, 0]; 
    }   

    static int Main()
    {   
        try
        {
            Object o1 = new Object();
            Object o2 = new Object();
            Object o3 = new Object();
            Object o4 = new Object();

            foo(new MyStruct[2, 2]); //corrupts registry

            o1.ToString();
            o2.ToString();
            o3.ToString();
            o4.ToString();
        }
        catch (Exception e)
        {
            Console.WriteLine("Unexpected exception: " + e); 
            return 102;
        }

        Console.WriteLine("Pass");
        return 100;
    }   
}
```
Before the patch (foo)
```
               [000131] --CXG+-------             *  CALL      void   MyStruct[,].Set
     ( 21, 14) [000132] ---XG--N-----             |  /--*  IND       struct
   ( 15, 10) [000129] ---X---------               |  |  \--*  ARR_ELEM[,] byref
   (  3,  2) [000126] -------------               |  |     +--*  LCL_VAR   ref    V12 tmp6
   (  1,  1) [000127] -------------               |  |     +--*  CNS_INT   int    1
   (  1,  1) [000128] -------------               |  |     \--*  CNS_INT   int    0
               [000161] -A-XG---R--L- arg3 SETUP  +--*  ASG       struct (copy)
               [000159] D------N-----             |  \--*  LCL_VAR   struct V14 tmp8
               [000162] ------------- arg3 in r3  +--*  LCL_VAR   struct V14 tmp8
               [000123] -----+------- this in r0  +--*  LCL_VAR   ref    V12 tmp6
               [000124] -----+------- arg1 in r1  +--*  CNS_INT   int    0
               [000125] -----+------- arg2 in r2  \--*  CNS_INT   int    1
```

After the patch (foo)
```
fgMorphTree BB01, stmt 14 (after)
               [000131] --CXG+-------             *  CALL      void   MyStruct[,].Set
     ( 21, 14) [000132] ---XG--N-----             |  /--*  IND       struct    
     ( 15, 10) [000129] ---X---------             |  |  \--*  ARR_ELEM[,] byref 
     (  3,  2) [000126] -------------             |  |     +--*  LCL_VAR   ref    V12 tmp6
     (  1,  1) [000127] -------------             |  |     +--*  CNS_INT   int    1     
     (  1,  1) [000128] -------------             |  |     \--*  CNS_INT   int    0
               [000161] -A-XG---R--L- arg3 SETUP  +--*  ASG       struct (copy)
               [000159] D------N-----             |  \--*  LCL_VAR   struct V14 tmp8
               [000162] ------------- arg3 in r3  +--*  LCL_FLD   int    V14 tmp8         [+0]
               [000123] -----+------- this in r0  +--*  LCL_VAR   ref    V12 tmp6
               [000124] -----+------- arg1 in r1  +--*  CNS_INT   int    0
               [000125] -----+------- arg2 in r2  \--*  CNS_INT   int    1
```
