### PR TITLE
Spmi third cleaning

### DIFF
--- a/src/ToolBox/superpmi/mcs/CMakeLists.txt
+++ b/src/ToolBox/superpmi/mcs/CMakeLists.txt
@@ -41,6 +41,7 @@ set(MCS_SOURCES
     ../superpmi-shared/spmiutil.cpp
     ../superpmi-shared/tocfile.cpp
     ../superpmi-shared/typeutils.cpp
+    ../superpmi-shared/spmidumphelper.cpp
 )
 
 add_precompiled_header(

--- a/src/ToolBox/superpmi/superpmi-shared/compileresult.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/compileresult.cpp
@@ -101,7 +101,7 @@ void CompileResult::AddCall(const char* name)
     if (CallLog == nullptr)
         CallLog = new DenseLightWeightMap<DWORD>();
     // if(name[0] != '+')
-     //CallLog->Append(CallLog->AddBuffer((const unsigned char *)name, (DWORD)strlen(name)+1));
+    // CallLog->Append(CallLog->AddBuffer((const unsigned char *)name, (DWORD)strlen(name)+1));
 }
 unsigned int CompileResult::CallLog_GetCount()
 {
@@ -131,7 +131,7 @@ void CompileResult::dumpToConsole()
 }
 
 // Note - EE allocates these blocks (and the exception blocks) in a single linear region.
- //Note - EE assures that RoBlock is 8 byte aligned
+// Note - EE assures that RoBlock is 8 byte aligned
 void CompileResult::recAllocMem(ULONG              hotCodeSize,
                                 ULONG              coldCodeSize,
                                 ULONG              roDataSize,
@@ -977,7 +977,7 @@ void CompileResult::dmpRecordCallSite(DWORD key, const Agnostic_RecordCallSite& 
            key, value.callSig.callConv, value.callSig.retTypeClass, value.callSig.retTypeSigClass,
            value.callSig.retType, value.callSig.flags, value.callSig.numArgs, value.callSig.sigInst_classInstCount,
            value.callSig.sigInst_classInst_Index, value.callSig.sigInst_methInstCount,
-           value.callSig.sigInst_methInst_Index, value.callSig.cbSig, value.callSig.pSig, value.callSig.scope,
+           value.callSig.sigInst_methInst_Index, value.callSig.cbSig, value.callSig.pSig_Index, value.callSig.scope,
            value.callSig.token, value.methodHandle);
 }
 
@@ -1005,11 +1005,11 @@ void CompileResult::repRecordCallSite(ULONG instrOffset, CORINFO_SIG_INFO* callS
         value.callSig.sigInst_methInst_Index =
             RecordCallSite->AddBuffer((unsigned char*)callSig->sigInst.methInst,
                                       callSig->sigInst.methInstCount * 8); // porting issue
-        value.callSig.args  = (DWORDLONG)callSig->args;
-        value.callSig.cbSig = (DWORD)callSig->cbSig;
-        value.callSig.pSig  = (DWORD)RecordCallSite->AddBuffer((unsigned char*)callSig->pSig, callSig->cbSig);
-        value.callSig.scope = (DWORDLONG)callSig->scope;
-        value.callSig.token = (DWORD)callSig->token;
+        value.callSig.args       = (DWORDLONG)callSig->args;
+        value.callSig.cbSig      = (DWORD)callSig->cbSig;
+        value.callSig.pSig_Index = (DWORD)RecordCallSite->AddBuffer((unsigned char*)callSig->pSig, callSig->cbSig);
+        value.callSig.scope      = (DWORDLONG)callSig->scope;
+        value.callSig.token      = (DWORD)callSig->token;
     }
     else
     {
@@ -1025,7 +1025,7 @@ void CompileResult::repRecordCallSite(ULONG instrOffset, CORINFO_SIG_INFO* callS
         value.callSig.sigInst_methInst_Index  = (DWORD)-1;
         value.callSig.args                    = (DWORDLONG)-1;
         value.callSig.cbSig                   = (DWORD)-1;
-        value.callSig.pSig                    = (DWORD)-1;
+        value.callSig.pSig_Index              = (DWORD)-1;
         value.callSig.scope                   = (DWORDLONG)-1;
         value.callSig.token                   = (DWORD)-1;
     }
@@ -1061,7 +1061,7 @@ bool CompileResult::fndRecordCallSiteSigInfo(ULONG instrOffset, CORINFO_SIG_INFO
     pCallSig->sigInst.methInst = (CORINFO_CLASS_HANDLE*)RecordCallSite->GetBuffer(value.callSig.sigInst_methInst_Index);
     pCallSig->args             = (CORINFO_ARG_LIST_HANDLE)value.callSig.args;
     pCallSig->cbSig            = (unsigned int)value.callSig.cbSig;
-    pCallSig->pSig             = (PCCOR_SIGNATURE)RecordCallSite->GetBuffer(value.callSig.pSig);
+    pCallSig->pSig             = (PCCOR_SIGNATURE)RecordCallSite->GetBuffer(value.callSig.pSig_Index);
     pCallSig->scope            = (CORINFO_MODULE_HANDLE)value.callSig.scope;
     pCallSig->token            = (mdToken)value.callSig.token;
 

--- a/src/ToolBox/superpmi/superpmi-shared/compileresult.h
+++ b/src/ToolBox/superpmi/superpmi-shared/compileresult.h
@@ -140,7 +140,7 @@ public:
         DWORD     sigInst_methInstCount;
         DWORD     sigInst_methInst_Index;
         DWORDLONG args;
-        DWORD     pSig;
+        DWORD     pSig_Index;
         DWORD     cbSig;
         DWORDLONG scope;
         DWORD     token;

--- a/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -15,6 +15,7 @@
 #include "lightweightmap.h"
 #include "callutils.h"
 #include "spmirecordhelper.h"
+#include "spmidumphelper.h"
 
 struct
 {
@@ -1294,11 +1295,9 @@ void MethodContext::recResolveToken(CORINFO_RESOLVED_TOKEN* pResolvedToken, DWOR
 }
 void MethodContext::dmpResolveToken(const Agnostic_CORINFO_RESOLVED_TOKENin& key, const ResolveTokenValue& value)
 {
-    printf("ResolveToken key tc-%016llX ts-%016llX tok-%08X tt-%u", key.tokenContext, key.tokenScope, key.token,
-           key.tokenType);
-    printf(", value cls-%016llX meth-%016llX fld-%016llX ti-%u ts-%u mi-%u ms-%u excp-%08X", value.tokenOut.hClass,
-           value.tokenOut.hMethod, value.tokenOut.hField, value.tokenOut.pTypeSpec_Index, value.tokenOut.cbTypeSpec,
-           value.tokenOut.pMethodSpec_Index, value.tokenOut.cbMethodSpec, value.exceptionCode);
+    printf("ResolveToken key: %s\n", SpmiDumpHelper::DumpAgnostic_CORINFO_RESOLVED_TOKENin(key).c_str());
+    printf(", value: %s excp-%08X", SpmiDumpHelper::DumpAgnostic_CORINFO_RESOLVED_TOKENout(value.tokenOut).c_str(),
+           value.exceptionCode);
 }
 void MethodContext::repResolveToken(CORINFO_RESOLVED_TOKEN* pResolvedToken, DWORD* exceptionCode)
 {
@@ -1337,11 +1336,9 @@ void MethodContext::recTryResolveToken(CORINFO_RESOLVED_TOKEN* pResolvedToken, b
 }
 void MethodContext::dmpTryResolveToken(const Agnostic_CORINFO_RESOLVED_TOKENin& key, const TryResolveTokenValue& value)
 {
-    printf("TryResolveToken key tc-%016llX ts-%016llX tok-%08X tt-%u", key.tokenContext, key.tokenScope, key.token,
-           key.tokenType);
-    printf(", value cls-%016llX meth-%016llX fld-%016llX ti-%u ts-%u mi-%u ms-%u failed-%u", value.tokenOut.hClass,
-           value.tokenOut.hMethod, value.tokenOut.hField, value.tokenOut.pTypeSpec_Index, value.tokenOut.cbTypeSpec,
-           value.tokenOut.pMethodSpec_Index, value.tokenOut.cbMethodSpec, value.success);
+    printf("TryResolveToken key: %s\n", SpmiDumpHelper::DumpAgnostic_CORINFO_RESOLVED_TOKENin(key).c_str());
+    printf(", value: %s failed-%u", SpmiDumpHelper::DumpAgnostic_CORINFO_RESOLVED_TOKENout(value.tokenOut).c_str(),
+           value.success);
 }
 bool MethodContext::repTryResolveToken(CORINFO_RESOLVED_TOKEN* pResolvedToken)
 {
@@ -1459,21 +1456,10 @@ void MethodContext::recGetCallInfo(CORINFO_RESOLVED_TOKEN* pResolvedToken,
 }
 void MethodContext::dmpGetCallInfo(const Agnostic_GetCallInfo& key, const Agnostic_CORINFO_CALL_INFO& value)
 {
-    printf("GetCallInfo key"
-           " rt{tc-%016llX ts-%016llX tok-%08X tt-%u cls-%016llX meth-%016llX fld-%016llX ti-%u ts-%u mi-%u ms-%u}"
-           " crt{tc-%016llX ts-%016llX tok-%08X tt-%u cls-%016llX meth-%016llX fld-%016llX ti-%u ts-%u mi-%u ms-%u}"
-           " ch-%016llX flg-%08X",
-           key.ResolvedToken.inValue.tokenContext, key.ResolvedToken.inValue.tokenScope,
-           key.ResolvedToken.inValue.token, key.ResolvedToken.inValue.tokenType, key.ResolvedToken.outValue.hClass,
-           key.ResolvedToken.outValue.hMethod, key.ResolvedToken.outValue.hField,
-           key.ResolvedToken.outValue.pTypeSpec_Index, key.ResolvedToken.outValue.cbTypeSpec,
-           key.ResolvedToken.outValue.pMethodSpec_Index, key.ResolvedToken.outValue.cbMethodSpec,
-           key.ConstrainedResolvedToken.inValue.tokenContext, key.ConstrainedResolvedToken.inValue.tokenScope,
-           key.ConstrainedResolvedToken.inValue.token, key.ConstrainedResolvedToken.inValue.tokenType,
-           key.ConstrainedResolvedToken.outValue.hClass, key.ConstrainedResolvedToken.outValue.hMethod,
-           key.ConstrainedResolvedToken.outValue.hField, key.ConstrainedResolvedToken.outValue.pTypeSpec_Index,
-           key.ConstrainedResolvedToken.outValue.cbTypeSpec, key.ConstrainedResolvedToken.outValue.pMethodSpec_Index,
-           key.ConstrainedResolvedToken.outValue.cbMethodSpec, key.callerHandle, key.flags);
+    printf("GetCallInfo key rt{%s} crt{%s} ch-%016llX flg-%08X\n",
+           SpmiDumpHelper::DumpAgnostic_CORINFO_RESOLVED_TOKEN(key.ResolvedToken).c_str(),
+           SpmiDumpHelper::DumpAgnostic_CORINFO_RESOLVED_TOKEN(key.ConstrainedResolvedToken).c_str(), key.callerHandle,
+           key.flags);
     printf(", value mth-%016llX, mf-%08X cf-%08X"
            " sig{flg-%08X na-%u cc-%u ci-%u mc-%u mi-%u args-%016llX scp-%016llX tok-%08X}"
            " vsig{flg-%08X na-%u cc-%u ci-%u mc-%u mi-%u args-%016llX scp-%016llX tok-%08X}"
@@ -2926,13 +2912,8 @@ void MethodContext::recEmbedGenericHandle(CORINFO_RESOLVED_TOKEN*       pResolve
 void MethodContext::dmpEmbedGenericHandle(const Agnostic_EmbedGenericHandle&           key,
                                           const Agnostic_CORINFO_GENERICHANDLE_RESULT& value)
 {
-    printf("EmbedGenericHandle key rt{tokCon-%016llX tokScp-%016llX tok-%08X tokTyp-%08X cls-%016llX ftn-%016llX "
-           "fld-%016llX tsi-%u cbts-%u msi-%u cbms-%u} emb-%u",
-           key.ResolvedToken.inValue.tokenContext, key.ResolvedToken.inValue.tokenScope,
-           key.ResolvedToken.inValue.token, key.ResolvedToken.inValue.tokenType, key.ResolvedToken.outValue.hClass,
-           key.ResolvedToken.outValue.hMethod, key.ResolvedToken.outValue.hField,
-           key.ResolvedToken.outValue.pTypeSpec_Index, key.ResolvedToken.outValue.cbTypeSpec,
-           key.ResolvedToken.outValue.pMethodSpec_Index, key.ResolvedToken.outValue.cbMethodSpec, key.fEmbedParent);
+    printf("EmbedGenericHandle key rt{%s} emb-%u\n",
+           SpmiDumpHelper::DumpAgnostic_CORINFO_RESOLVED_TOKEN(key.ResolvedToken).c_str(), key.fEmbedParent);
     printf(", value nrl-%u rlk-%u", value.lookup.lookupKind.needsRuntimeLookup,
            value.lookup.lookupKind.runtimeLookupKind);
     if (value.lookup.lookupKind.needsRuntimeLookup)
@@ -3186,13 +3167,8 @@ void MethodContext::recGetFieldInfo(CORINFO_RESOLVED_TOKEN* pResolvedToken,
 }
 void MethodContext::dmpGetFieldInfo(const Agnostic_GetFieldInfo& key, const Agnostic_CORINFO_FIELD_INFO& value)
 {
-    printf("GetFieldInfo key ch-%016llX flg-%08X rt{tc-%016llX ts-%016llX tok-%08X tt-%u cls-%016llX meth-%016llX "
-           "fld-%016llX tsi-%u cbts-%u msi-%u cbms-%u}",
-           key.callerHandle, key.flags, key.ResolvedToken.inValue.tokenContext, key.ResolvedToken.inValue.tokenScope,
-           key.ResolvedToken.inValue.token, key.ResolvedToken.inValue.tokenType, key.ResolvedToken.outValue.hClass,
-           key.ResolvedToken.outValue.hMethod, key.ResolvedToken.outValue.hField,
-           key.ResolvedToken.outValue.pTypeSpec_Index, key.ResolvedToken.outValue.cbTypeSpec,
-           key.ResolvedToken.outValue.pMethodSpec_Index, key.ResolvedToken.outValue.cbMethodSpec);
+    printf("GetFieldInfo key ch-%016llX flg-%08X rt{%s}\n", key.callerHandle, key.flags,
+           SpmiDumpHelper::DumpAgnostic_CORINFO_RESOLVED_TOKEN(key.ResolvedToken).c_str());
 
     printf(", value fa-%u fflg-%08X hlp-%u off-%u fT-%u(%s) sT-%016llX aa-%u hnum-%u na-%u {", value.fieldAccessor,
            value.fieldFlags, value.helper, value.offset, value.fieldType, toString((CorInfoType)value.fieldType),
@@ -3535,13 +3511,8 @@ void MethodContext::recCanAccessClass(CORINFO_RESOLVED_TOKEN*      pResolvedToke
 }
 void MethodContext::dmpCanAccessClass(const Agnostic_CanAccessClassIn& key, const Agnostic_CanAccessClassOut& value)
 {
-    printf("CanAccessClass key tc-%016llX ts-%016llX tok-%08X tt-%u cls-%016llX meth-%016llX fld-%016llX ti-%u ts-%u "
-           "mi-%u ms-%u",
-           key.ResolvedToken.inValue.tokenContext, key.ResolvedToken.inValue.tokenScope,
-           key.ResolvedToken.inValue.token, key.ResolvedToken.inValue.tokenType, key.ResolvedToken.outValue.hClass,
-           key.ResolvedToken.outValue.hMethod, key.ResolvedToken.outValue.hField,
-           key.ResolvedToken.outValue.pTypeSpec_Index, key.ResolvedToken.outValue.cbTypeSpec,
-           key.ResolvedToken.outValue.pMethodSpec_Index, key.ResolvedToken.outValue.cbMethodSpec);
+    printf("CanAccessClass key rt{%s}, callerHandle %016llX\n",
+           SpmiDumpHelper::DumpAgnostic_CORINFO_RESOLVED_TOKEN(key.ResolvedToken).c_str(), key.callerHandle);
     printf(", value hnum-%u na-%u {", value.AccessHelper.helperNum, value.AccessHelper.numArgs);
     for (int i = 0; i < CORINFO_ACCESS_ALLOWED_MAX_ARGS; i++)
     {
@@ -4007,7 +3978,7 @@ void MethodContext::recGetInlinedCallFrameVptr(void** ppIndirection, const void*
 }
 void MethodContext::dmpGetInlinedCallFrameVptr(DWORD key, DLDL value)
 {
-    printf("GetInlinedCallFrameVptr key 0, value ppIndirection-%016llX result-%016llX\n", value.A, value.B);
+    printf("GetInlinedCallFrameVptr key 0, value ppIndirection-%016llX result-%016llX", value.A, value.B);
 }
 const void* MethodContext::repGetInlinedCallFrameVptr(void** ppIndirection)
 {

--- a/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -1311,14 +1311,8 @@ void MethodContext::repResolveToken(CORINFO_RESOLVED_TOKEN* pResolvedToken, DWOR
 
     ResolveTokenValue value = ResolveToken->Get(key);
 
-    pResolvedToken->hClass       = (CORINFO_CLASS_HANDLE)value.tokenOut.hClass;
-    pResolvedToken->hMethod      = (CORINFO_METHOD_HANDLE)value.tokenOut.hMethod;
-    pResolvedToken->hField       = (CORINFO_FIELD_HANDLE)value.tokenOut.hField;
-    pResolvedToken->pTypeSpec    = (PCCOR_SIGNATURE)ResolveToken->GetBuffer(value.tokenOut.pTypeSpec_Index);
-    pResolvedToken->cbTypeSpec   = (ULONG)value.tokenOut.cbTypeSpec;
-    pResolvedToken->pMethodSpec  = (PCCOR_SIGNATURE)ResolveToken->GetBuffer(value.tokenOut.pMethodSpec_Index);
-    pResolvedToken->cbMethodSpec = (ULONG)value.tokenOut.cbMethodSpec;
-    *exceptionCode               = (DWORD)value.exceptionCode;
+    SpmiRecordsHelper::Restore_CORINFO_RESOLVED_TOKENout(pResolvedToken, value.tokenOut, ResolveToken);
+    *exceptionCode  = (DWORD)value.exceptionCode;
 
     DEBUG_REP(dmpResolveToken(key, value));
 }
@@ -1359,13 +1353,7 @@ bool MethodContext::repTryResolveToken(CORINFO_RESOLVED_TOKEN* pResolvedToken)
 
     TryResolveTokenValue value = TryResolveToken->Get(key);
 
-    pResolvedToken->hClass       = (CORINFO_CLASS_HANDLE)value.tokenOut.hClass;
-    pResolvedToken->hMethod      = (CORINFO_METHOD_HANDLE)value.tokenOut.hMethod;
-    pResolvedToken->hField       = (CORINFO_FIELD_HANDLE)value.tokenOut.hField;
-    pResolvedToken->pTypeSpec    = (PCCOR_SIGNATURE)ResolveToken->GetBuffer(value.tokenOut.pTypeSpec_Index);
-    pResolvedToken->cbTypeSpec   = (ULONG)value.tokenOut.cbTypeSpec;
-    pResolvedToken->pMethodSpec  = (PCCOR_SIGNATURE)ResolveToken->GetBuffer(value.tokenOut.pMethodSpec_Index);
-    pResolvedToken->cbMethodSpec = (ULONG)value.tokenOut.cbMethodSpec;
+    SpmiRecordsHelper::Restore_CORINFO_RESOLVED_TOKENout(pResolvedToken, value.tokenOut, ResolveToken);
 
     DEBUG_REP(dmpTryResolveToken(key, value));
     return (DWORD)value.success == 0;

--- a/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -769,7 +769,7 @@ void MethodContext::recCompileMethod(CORINFO_METHOD_INFO* info, unsigned flags)
                                  info->args.sigInst.methInstCount * 8); // porting issue
     value.info.args.args           = (DWORDLONG)info->args.args;
     value.info.args.cbSig          = (DWORD)info->args.cbSig;
-    value.info.args.pSig           = (DWORD)CompileMethod->AddBuffer((unsigned char*)info->args.pSig, info->args.cbSig);
+    value.info.args.pSig_Index     = (DWORD)CompileMethod->AddBuffer((unsigned char*)info->args.pSig, info->args.cbSig);
     value.info.args.scope          = (DWORDLONG)info->args.scope;
     value.info.args.token          = (DWORD)info->args.token;
     value.info.locals.callConv     = (DWORD)info->locals.callConv;
@@ -788,7 +788,8 @@ void MethodContext::recCompileMethod(CORINFO_METHOD_INFO* info, unsigned flags)
                                  info->locals.sigInst.methInstCount * 8); // porting issue
     value.info.locals.args  = (DWORDLONG)info->locals.args;
     value.info.locals.cbSig = (DWORD)info->locals.cbSig;
-    value.info.locals.pSig  = (DWORD)CompileMethod->AddBuffer((unsigned char*)info->locals.pSig, info->locals.cbSig);
+    value.info.locals.pSig_Index =
+        (DWORD)CompileMethod->AddBuffer((unsigned char*)info->locals.pSig, info->locals.cbSig);
     value.info.locals.scope = (DWORDLONG)info->locals.scope;
     value.info.locals.token = (DWORD)info->locals.token;
     value.flags             = (DWORD)flags;
@@ -800,9 +801,9 @@ void MethodContext::dmpCompileMethod(DWORD key, const Agnostic_CompileMethod& va
 {
     printf("CompiledMethod key %u, value ftn-%016llX scp-%016llX ilo-%u ils-%u ms-%u ehc-%u opt-%u rk-%u "
            "args{cc-%u rc-%016llX rts-%016llX rt-%u(%s) flg-%08X nA-%u cc-%u ci-%u mc-%u mi-%u arg-%016llX cb-%u "
-           "pSig-%u scp-%016llX tok-%08X} "
+           "pSig_Index-%u scp-%016llX tok-%08X} "
            "locals{cc-%u rc-%016llX rts-%016llX rt-%u(%s) flg-%08X nA-%u cc-%u ci-%u mc-%u mi-%u arg-%016llX cb-%u "
-           "pSig-%u scp-%016llX tok-%08X} "
+           "pSig_Index-%u scp-%016llX tok-%08X} "
            "flg-%08X",
            key, value.info.ftn, value.info.scope, value.info.ILCode_offset, value.info.ILCodeSize, value.info.maxStack,
            value.info.EHcount, value.info.options, value.info.regionKind, value.info.args.callConv,
@@ -810,13 +811,13 @@ void MethodContext::dmpCompileMethod(DWORD key, const Agnostic_CompileMethod& va
            toString((CorInfoType)value.info.args.retType), value.info.args.flags, value.info.args.numArgs,
            value.info.args.sigInst_classInstCount, value.info.args.sigInst_classInst_Index,
            value.info.args.sigInst_methInstCount, value.info.args.sigInst_methInst_Index, value.info.args.args,
-           value.info.args.cbSig, value.info.args.pSig, value.info.args.scope, value.info.args.token,
+           value.info.args.cbSig, value.info.args.pSig_Index, value.info.args.scope, value.info.args.token,
            value.info.locals.callConv, value.info.locals.retTypeClass, value.info.locals.retTypeSigClass,
            value.info.locals.retType, toString((CorInfoType)value.info.locals.retType), value.info.locals.flags,
            value.info.locals.numArgs, value.info.locals.sigInst_classInstCount,
            value.info.locals.sigInst_classInst_Index, value.info.locals.sigInst_methInstCount,
            value.info.locals.sigInst_methInst_Index, value.info.locals.args, value.info.locals.cbSig,
-           value.info.locals.pSig, value.info.locals.scope, value.info.locals.token, value.flags);
+           value.info.locals.pSig_Index, value.info.locals.scope, value.info.locals.token, value.flags);
 }
 void MethodContext::repCompileMethod(CORINFO_METHOD_INFO* info, unsigned* flags)
 {
@@ -847,7 +848,7 @@ void MethodContext::repCompileMethod(CORINFO_METHOD_INFO* info, unsigned* flags)
         (CORINFO_CLASS_HANDLE*)CompileMethod->GetBuffer(value.info.args.sigInst_methInst_Index);
     info->args.args                     = (CORINFO_ARG_LIST_HANDLE)value.info.args.args;
     info->args.cbSig                    = (unsigned int)value.info.args.cbSig;
-    info->args.pSig                     = (PCCOR_SIGNATURE)CompileMethod->GetBuffer(value.info.args.pSig);
+    info->args.pSig                     = (PCCOR_SIGNATURE)CompileMethod->GetBuffer(value.info.args.pSig_Index);
     info->args.scope                    = (CORINFO_MODULE_HANDLE)value.info.args.scope;
     info->args.token                    = (mdToken)value.info.args.token;
     info->locals.callConv               = (CorInfoCallConv)value.info.locals.callConv;
@@ -864,7 +865,7 @@ void MethodContext::repCompileMethod(CORINFO_METHOD_INFO* info, unsigned* flags)
         (CORINFO_CLASS_HANDLE*)CompileMethod->GetBuffer(value.info.locals.sigInst_methInst_Index);
     info->locals.args  = (CORINFO_ARG_LIST_HANDLE)value.info.locals.args;
     info->locals.cbSig = (unsigned int)value.info.locals.cbSig;
-    info->locals.pSig  = (PCCOR_SIGNATURE)CompileMethod->GetBuffer(value.info.locals.pSig);
+    info->locals.pSig  = (PCCOR_SIGNATURE)CompileMethod->GetBuffer(value.info.locals.pSig_Index);
     info->locals.scope = (CORINFO_MODULE_HANDLE)value.info.locals.scope;
     info->locals.token = (mdToken)value.info.locals.token;
     *flags             = (unsigned)value.flags;
@@ -1395,72 +1396,18 @@ void MethodContext::recGetCallInfo(CORINFO_RESOLVED_TOKEN* pResolvedToken,
     key.flags        = (DWORD)flags;
 
     Agnostic_CORINFO_CALL_INFO value;
+    ZeroMemory(&value, sizeof(Agnostic_CORINFO_CALL_INFO)); // init verSig with 0.
+
     if (exceptionCode == 0)
     {
-        value.hMethod                    = (DWORDLONG)pResult->hMethod;
-        value.methodFlags                = (DWORD)pResult->methodFlags;
-        value.classFlags                 = (DWORD)pResult->classFlags;
-        value.sig.callConv               = (DWORD)pResult->sig.callConv;
-        value.sig.retTypeClass           = (DWORDLONG)pResult->sig.retTypeClass;
-        value.sig.retTypeSigClass        = (DWORDLONG)pResult->sig.retTypeSigClass;
-        value.sig.retType                = (DWORD)pResult->sig.retType;
-        value.sig.flags                  = (DWORD)pResult->sig.flags;
-        value.sig.numArgs                = (DWORD)pResult->sig.numArgs;
-        value.sig.sigInst_classInstCount = (DWORD)pResult->sig.sigInst.classInstCount;
-        value.sig.sigInst_classInst_Index =
-            GetCallInfo->AddBuffer((unsigned char*)pResult->sig.sigInst.classInst,
-                                   pResult->sig.sigInst.classInstCount * 8); // porting issue
-        value.sig.sigInst_methInstCount = (DWORD)pResult->sig.sigInst.methInstCount;
-        value.sig.sigInst_methInst_Index =
-            GetCallInfo->AddBuffer((unsigned char*)pResult->sig.sigInst.methInst,
-                                   pResult->sig.sigInst.methInstCount * 8); // porting issue
-        value.sig.args  = (DWORDLONG)pResult->sig.args;
-        value.sig.cbSig = (DWORD)pResult->sig.cbSig;
-        value.sig.pSig  = (DWORD)GetCallInfo->AddBuffer((unsigned char*)pResult->sig.pSig, pResult->sig.cbSig);
-        value.sig.scope = (DWORDLONG)pResult->sig.scope;
-        value.sig.token = (DWORD)pResult->sig.token;
+        value.hMethod     = (DWORDLONG)pResult->hMethod;
+        value.methodFlags = (DWORD)pResult->methodFlags;
+        value.classFlags  = (DWORD)pResult->classFlags;
+        value.sig         = SpmiRecordsHelper::StoreAgnostic_CORINFO_SIG_INFO(pResult->sig, GetCallInfo);
         if (flags & CORINFO_CALLINFO_VERIFICATION)
         {
-            value.verMethodFlags                = (DWORD)pResult->verMethodFlags;
-            value.verSig.callConv               = (DWORD)pResult->verSig.callConv;
-            value.verSig.retTypeClass           = (DWORDLONG)pResult->verSig.retTypeClass;
-            value.verSig.retTypeSigClass        = (DWORDLONG)pResult->verSig.retTypeSigClass;
-            value.verSig.retType                = (DWORD)pResult->verSig.retType;
-            value.verSig.flags                  = (DWORD)pResult->verSig.flags;
-            value.verSig.numArgs                = (DWORD)pResult->verSig.numArgs;
-            value.verSig.sigInst_classInstCount = (DWORD)pResult->verSig.sigInst.classInstCount;
-            value.verSig.sigInst_classInst_Index =
-                GetCallInfo->AddBuffer((unsigned char*)pResult->verSig.sigInst.classInst,
-                                       pResult->verSig.sigInst.classInstCount * 8); // porting issue
-            value.verSig.sigInst_methInstCount = (DWORD)pResult->verSig.sigInst.methInstCount;
-            value.verSig.sigInst_methInst_Index =
-                GetCallInfo->AddBuffer((unsigned char*)pResult->verSig.sigInst.methInst,
-                                       pResult->verSig.sigInst.methInstCount * 8); // porting issue
-            value.verSig.args  = (DWORDLONG)pResult->verSig.args;
-            value.verSig.cbSig = (DWORD)pResult->verSig.cbSig;
-            value.verSig.pSig =
-                (DWORD)GetCallInfo->AddBuffer((unsigned char*)pResult->verSig.pSig, pResult->verSig.cbSig);
-            value.verSig.scope = (DWORDLONG)pResult->verSig.scope;
-            value.verSig.token = (DWORD)pResult->verSig.token;
-        }
-        else
-        {
-            value.verMethodFlags                 = (DWORD)0;
-            value.verSig.callConv                = (DWORD)0;
-            value.verSig.retTypeClass            = (DWORDLONG)0;
-            value.verSig.retTypeSigClass         = (DWORDLONG)0;
-            value.verSig.retType                 = (DWORD)0;
-            value.verSig.flags                   = (DWORD)0;
-            value.verSig.numArgs                 = (DWORD)0;
-            value.verSig.sigInst_classInstCount  = (DWORD)0;
-            value.verSig.sigInst_classInst_Index = (DWORD)0;
-            value.verSig.sigInst_methInstCount   = (DWORD)0;
-            value.verSig.sigInst_methInst_Index  = (DWORD)0;
-            value.verSig.args                    = (DWORDLONG)0;
-            value.verSig.cbSig                   = (DWORD)0;
-            value.verSig.pSig                    = (DWORD)0;
-            value.verSig.scope                   = (DWORDLONG)0;
-            value.verSig.token                   = (DWORD)0;
+            value.verMethodFlags = (DWORD)pResult->verMethodFlags;
+            value.verSig         = SpmiRecordsHelper::StoreAgnostic_CORINFO_SIG_INFO(pResult->verSig, GetCallInfo);
         }
 
         value.accessAllowed                   = (DWORD)pResult->accessAllowed;
@@ -1580,44 +1527,14 @@ void MethodContext::repGetCallInfo(CORINFO_RESOLVED_TOKEN* pResolvedToken,
 
     value = GetCallInfo->Get(key);
 
-    pResult->hMethod                    = (CORINFO_METHOD_HANDLE)value.hMethod;
-    pResult->methodFlags                = (unsigned)value.methodFlags;
-    pResult->classFlags                 = (unsigned)value.classFlags;
-    pResult->sig.callConv               = (CorInfoCallConv)value.sig.callConv;
-    pResult->sig.retTypeClass           = (CORINFO_CLASS_HANDLE)value.sig.retTypeClass;
-    pResult->sig.retTypeSigClass        = (CORINFO_CLASS_HANDLE)value.sig.retTypeSigClass;
-    pResult->sig.retType                = (CorInfoType)value.sig.retType;
-    pResult->sig.flags                  = (unsigned)value.sig.flags;
-    pResult->sig.numArgs                = (unsigned)value.sig.numArgs;
-    pResult->sig.sigInst.classInstCount = (unsigned)value.sig.sigInst_classInstCount;
-    pResult->sig.sigInst.classInst = (CORINFO_CLASS_HANDLE*)GetCallInfo->GetBuffer(value.sig.sigInst_classInst_Index);
-    pResult->sig.sigInst.methInstCount = (unsigned)value.sig.sigInst_methInstCount;
-    pResult->sig.sigInst.methInst = (CORINFO_CLASS_HANDLE*)GetCallInfo->GetBuffer(value.sig.sigInst_methInst_Index);
-    pResult->sig.args             = (CORINFO_ARG_LIST_HANDLE)value.sig.args;
-    pResult->sig.cbSig            = (unsigned int)value.sig.cbSig;
-    pResult->sig.pSig             = (PCCOR_SIGNATURE)GetCallInfo->GetBuffer(value.sig.pSig);
-    pResult->sig.scope            = (CORINFO_MODULE_HANDLE)value.sig.scope;
-    pResult->sig.token            = (mdToken)value.sig.token;
+    pResult->hMethod     = (CORINFO_METHOD_HANDLE)value.hMethod;
+    pResult->methodFlags = (unsigned)value.methodFlags;
+    pResult->classFlags  = (unsigned)value.classFlags;
+    pResult->sig         = SpmiRecordsHelper::Restore_CORINFO_SIG_INFO(value.sig, GetCallInfo);
     if (flags & CORINFO_CALLINFO_VERIFICATION)
     {
-        pResult->verMethodFlags                = (unsigned)value.verMethodFlags;
-        pResult->verSig.callConv               = (CorInfoCallConv)value.verSig.callConv;
-        pResult->verSig.retTypeClass           = (CORINFO_CLASS_HANDLE)value.verSig.retTypeClass;
-        pResult->verSig.retTypeSigClass        = (CORINFO_CLASS_HANDLE)value.verSig.retTypeSigClass;
-        pResult->verSig.retType                = (CorInfoType)value.verSig.retType;
-        pResult->verSig.flags                  = (unsigned)value.verSig.flags;
-        pResult->verSig.numArgs                = (unsigned)value.verSig.numArgs;
-        pResult->verSig.sigInst.classInstCount = (unsigned)value.verSig.sigInst_classInstCount;
-        pResult->verSig.sigInst.classInst =
-            (CORINFO_CLASS_HANDLE*)GetCallInfo->GetBuffer(value.verSig.sigInst_classInst_Index);
-        pResult->verSig.sigInst.methInstCount = (unsigned)value.verSig.sigInst_methInstCount;
-        pResult->verSig.sigInst.methInst =
-            (CORINFO_CLASS_HANDLE*)GetCallInfo->GetBuffer(value.verSig.sigInst_methInst_Index);
-        pResult->verSig.args  = (CORINFO_ARG_LIST_HANDLE)value.verSig.args;
-        pResult->verSig.cbSig = (unsigned int)value.verSig.cbSig;
-        pResult->verSig.pSig  = (PCCOR_SIGNATURE)GetCallInfo->GetBuffer(value.verSig.pSig);
-        pResult->verSig.scope = (CORINFO_MODULE_HANDLE)value.verSig.scope;
-        pResult->verSig.token = (mdToken)value.verSig.token;
+        pResult->verMethodFlags = (unsigned)value.verMethodFlags;
+        pResult->verSig         = SpmiRecordsHelper::Restore_CORINFO_SIG_INFO(value.verSig, GetCallInfo);
     }
     pResult->accessAllowed                   = (CorInfoIsAccessAllowedResult)value.accessAllowed;
     pResult->callsiteCalloutHelper.helperNum = (CorInfoHelpFunc)value.callsiteCalloutHelper.helperNum;
@@ -2655,28 +2572,10 @@ void MethodContext::recGetMethodSig(CORINFO_METHOD_HANDLE ftn, CORINFO_SIG_INFO*
     DLDL key;
     ZeroMemory(&key, sizeof(DLDL)); // We use the input structs as a key and use memcmp to compare.. so we need to zero
                                     // out padding too
-    Agnostic_CORINFO_SIG_INFO value;
-
     key.A = (DWORDLONG)ftn;
     key.B = (DWORDLONG)memberParent;
 
-    value.callConv                = (DWORD)sig->callConv;
-    value.retTypeClass            = (DWORDLONG)sig->retTypeClass;
-    value.retTypeSigClass         = (DWORDLONG)sig->retTypeSigClass;
-    value.retType                 = (DWORD)sig->retType;
-    value.flags                   = (DWORD)sig->flags;
-    value.numArgs                 = (DWORD)sig->numArgs;
-    value.sigInst_classInstCount  = (DWORD)sig->sigInst.classInstCount;
-    value.sigInst_classInst_Index = GetMethodSig->AddBuffer((unsigned char*)sig->sigInst.classInst,
-                                                            sig->sigInst.classInstCount * 8); // porting issue
-    value.sigInst_methInstCount = (DWORD)sig->sigInst.methInstCount;
-    value.sigInst_methInst_Index =
-        GetMethodSig->AddBuffer((unsigned char*)sig->sigInst.methInst, sig->sigInst.methInstCount * 8); // porting issue
-    value.args  = (DWORDLONG)sig->args;
-    value.cbSig = (DWORD)sig->cbSig;
-    value.pSig  = (DWORD)GetMethodSig->AddBuffer((unsigned char*)sig->pSig, sig->cbSig);
-    value.scope = (DWORDLONG)sig->scope;
-    value.token = (DWORD)sig->token;
+    Agnostic_CORINFO_SIG_INFO value = SpmiRecordsHelper::StoreAgnostic_CORINFO_SIG_INFO(*sig, GetMethodSig);
 
     GetMethodSig->Add(key, value);
     DEBUG_REC(dmpGetMethodSig(key, value));
@@ -2684,11 +2583,11 @@ void MethodContext::recGetMethodSig(CORINFO_METHOD_HANDLE ftn, CORINFO_SIG_INFO*
 void MethodContext::dmpGetMethodSig(DLDL key, const Agnostic_CORINFO_SIG_INFO& value)
 {
     printf("GetMethodSig key ftn-%016llX prt-%016llX, value cc-%u rtc-%016llX rts-%016llX rt-%u(%s) flg-%08X na-%u "
-           "cc-%u ci-%u mc-%u mi-%u args-%016llX sig-%u pSig-%u scp-%016llX tok-%08X",
+           "cc-%u ci-%u mc-%u mi-%u args-%016llX sig-%u pSig_Index-%u scp-%016llX tok-%08X",
            key.A, key.B, value.callConv, value.retTypeClass, value.retTypeSigClass, value.retType,
            toString((CorInfoType)value.retType), value.flags, value.numArgs, value.sigInst_classInstCount,
            value.sigInst_classInst_Index, value.sigInst_methInstCount, value.sigInst_methInst_Index, value.args,
-           value.cbSig, value.pSig, value.scope, value.token);
+           value.cbSig, value.pSig_Index, value.scope, value.token);
 }
 void MethodContext::repGetMethodSig(CORINFO_METHOD_HANDLE ftn, CORINFO_SIG_INFO* sig, CORINFO_CLASS_HANDLE memberParent)
 {
@@ -2702,21 +2601,7 @@ void MethodContext::repGetMethodSig(CORINFO_METHOD_HANDLE ftn, CORINFO_SIG_INFO*
 
     value = GetMethodSig->Get(key);
 
-    sig->callConv               = (CorInfoCallConv)value.callConv;
-    sig->retTypeClass           = (CORINFO_CLASS_HANDLE)value.retTypeClass;
-    sig->retTypeSigClass        = (CORINFO_CLASS_HANDLE)value.retTypeSigClass;
-    sig->retType                = (CorInfoType)value.retType;
-    sig->flags                  = (unsigned)value.flags;
-    sig->numArgs                = (unsigned)value.numArgs;
-    sig->sigInst.classInstCount = (unsigned)value.sigInst_classInstCount;
-    sig->sigInst.classInst      = (CORINFO_CLASS_HANDLE*)GetMethodSig->GetBuffer(value.sigInst_classInst_Index);
-    sig->sigInst.methInstCount  = (unsigned)value.sigInst_methInstCount;
-    sig->sigInst.methInst       = (CORINFO_CLASS_HANDLE*)GetMethodSig->GetBuffer(value.sigInst_methInst_Index);
-    sig->args                   = (CORINFO_ARG_LIST_HANDLE)value.args;
-    sig->cbSig                  = (unsigned int)value.cbSig;
-    sig->pSig                   = (PCCOR_SIGNATURE)GetMethodSig->GetBuffer(value.pSig);
-    sig->scope                  = (CORINFO_MODULE_HANDLE)value.scope;
-    sig->token                  = (mdToken)value.token;
+    *sig = SpmiRecordsHelper::Restore_CORINFO_SIG_INFO(value, GetMethodSig);
 
     DEBUG_REP(dmpGetMethodSig(key, value));
 }
@@ -2851,7 +2736,7 @@ void MethodContext::recGetMethodInfo(CORINFO_METHOD_HANDLE ftn,
                                             info->args.sigInst.methInstCount * 8); // porting issue
         value.info.args.args       = (DWORDLONG)info->args.args;
         value.info.args.cbSig      = (DWORD)info->args.cbSig;
-        value.info.args.pSig       = (DWORD)GetMethodInfo->AddBuffer((unsigned char*)info->args.pSig, info->args.cbSig);
+        value.info.args.pSig_Index = (DWORD)GetMethodInfo->AddBuffer((unsigned char*)info->args.pSig, info->args.cbSig);
         value.info.args.scope      = (DWORDLONG)info->args.scope;
         value.info.args.token      = (DWORD)info->args.token;
         value.info.locals.callConv = (DWORD)info->locals.callConv;
@@ -2870,7 +2755,8 @@ void MethodContext::recGetMethodInfo(CORINFO_METHOD_HANDLE ftn,
                                             info->locals.sigInst.methInstCount * 8); // porting issue
         value.info.locals.args  = (DWORDLONG)info->locals.args;
         value.info.locals.cbSig = (DWORD)info->locals.cbSig;
-        value.info.locals.pSig = (DWORD)GetMethodInfo->AddBuffer((unsigned char*)info->locals.pSig, info->locals.cbSig);
+        value.info.locals.pSig_Index =
+            (DWORD)GetMethodInfo->AddBuffer((unsigned char*)info->locals.pSig, info->locals.cbSig);
         value.info.locals.scope = (DWORDLONG)info->locals.scope;
         value.info.locals.token = (DWORD)info->locals.token;
     }
@@ -2885,9 +2771,9 @@ void MethodContext::dmpGetMethodInfo(DWORDLONG key, const Agnostic_GetMethodInfo
     printf("GetMethodInfo key ftn-%016llX", key);
     printf(", value res-%u ftn-%016llX scp-%016llX ilo-%u ils-%u ms-%u ehc-%u opt-%08X rk-%u "
            "args{cc-%u rc-%016llX rts-%016llX rt-%u(%s) flg-%08X nA-%u cc-%u ci-%u mc-%u mi-%u arg-%016llX cb-%u "
-           "pSig-%u scp-%016llX tok-%08X} "
+           "pSig_Index-%u scp-%016llX tok-%08X} "
            "locals{cc-%u rc-%016llX rts-%016llX rt-%u(%s) flg-%08X nA-%u cc-%u ci-%u mc-%u mi-%u arg-%016llX cb-%u "
-           "pSig-%u scp-%016llX tok-%08X} "
+           "pSig_Index-%u scp-%016llX tok-%08X} "
            "excp-%08X",
            value.result, value.info.ftn, value.info.scope, value.info.ILCode_offset, value.info.ILCodeSize,
            value.info.maxStack, value.info.EHcount, value.info.options, value.info.regionKind, value.info.args.callConv,
@@ -2895,13 +2781,13 @@ void MethodContext::dmpGetMethodInfo(DWORDLONG key, const Agnostic_GetMethodInfo
            toString((CorInfoType)value.info.args.retType), value.info.args.flags, value.info.args.numArgs,
            value.info.args.sigInst_classInstCount, value.info.args.sigInst_classInst_Index,
            value.info.args.sigInst_methInstCount, value.info.args.sigInst_methInst_Index, value.info.args.args,
-           value.info.args.cbSig, value.info.args.pSig, value.info.args.scope, value.info.args.token,
+           value.info.args.cbSig, value.info.args.pSig_Index, value.info.args.scope, value.info.args.token,
            value.info.locals.callConv, value.info.locals.retTypeClass, value.info.locals.retTypeSigClass,
            value.info.locals.retType, toString((CorInfoType)value.info.locals.retType), value.info.locals.flags,
            value.info.locals.numArgs, value.info.locals.sigInst_classInstCount,
            value.info.locals.sigInst_classInst_Index, value.info.locals.sigInst_methInstCount,
            value.info.locals.sigInst_methInst_Index, value.info.locals.args, value.info.locals.cbSig,
-           value.info.locals.pSig, value.info.locals.scope, value.info.locals.token, value.exceptionCode);
+           value.info.locals.pSig_Index, value.info.locals.scope, value.info.locals.token, value.exceptionCode);
 }
 bool MethodContext::repGetMethodInfo(CORINFO_METHOD_HANDLE ftn, CORINFO_METHOD_INFO* info, DWORD* exceptionCode)
 {
@@ -2936,7 +2822,7 @@ bool MethodContext::repGetMethodInfo(CORINFO_METHOD_HANDLE ftn, CORINFO_METHOD_I
             (CORINFO_CLASS_HANDLE*)GetMethodInfo->GetBuffer(value.info.args.sigInst_methInst_Index);
         info->args.args                     = (CORINFO_ARG_LIST_HANDLE)value.info.args.args;
         info->args.cbSig                    = (unsigned int)value.info.args.cbSig;
-        info->args.pSig                     = (PCCOR_SIGNATURE)GetMethodInfo->GetBuffer(value.info.args.pSig);
+        info->args.pSig                     = (PCCOR_SIGNATURE)GetMethodInfo->GetBuffer(value.info.args.pSig_Index);
         info->args.scope                    = (CORINFO_MODULE_HANDLE)value.info.args.scope;
         info->args.token                    = (mdToken)value.info.args.token;
         info->locals.callConv               = (CorInfoCallConv)value.info.locals.callConv;
@@ -2953,7 +2839,7 @@ bool MethodContext::repGetMethodInfo(CORINFO_METHOD_HANDLE ftn, CORINFO_METHOD_I
             (CORINFO_CLASS_HANDLE*)GetMethodInfo->GetBuffer(value.info.locals.sigInst_methInst_Index);
         info->locals.args  = (CORINFO_ARG_LIST_HANDLE)value.info.locals.args;
         info->locals.cbSig = (unsigned int)value.info.locals.cbSig;
-        info->locals.pSig  = (PCCOR_SIGNATURE)GetMethodInfo->GetBuffer(value.info.locals.pSig);
+        info->locals.pSig  = (PCCOR_SIGNATURE)GetMethodInfo->GetBuffer(value.info.locals.pSig_Index);
         info->locals.scope = (CORINFO_MODULE_HANDLE)value.info.locals.scope;
         info->locals.token = (mdToken)value.info.locals.token;
     }
@@ -3644,7 +3530,7 @@ void MethodContext::recCanAccessClass(CORINFO_RESOLVED_TOKEN*      pResolvedToke
     ZeroMemory(&key, sizeof(Agnostic_CanAccessClassIn)); // We use the input structs as a key and use memcmp to
                                                          // compare.. so we need to zero out padding too
     key.ResolvedToken = SpmiRecordsHelper::StoreAgnostic_CORINFO_RESOLVED_TOKEN(pResolvedToken, CanAccessClass);
-    key.callerHandle = (DWORDLONG)callerHandle;
+    key.callerHandle  = (DWORDLONG)callerHandle;
 
     Agnostic_CanAccessClassOut value;
     value.AccessHelper.helperNum = (DWORD)pAccessHelper->helperNum;
@@ -3809,10 +3695,10 @@ void MethodContext::recPInvokeMarshalingRequired(CORINFO_METHOD_HANDLE method,
     ZeroMemory(&key, sizeof(PInvokeMarshalingRequiredValue)); // We use the input structs as a key and use memcmp to
                                                               // compare.. so we need to zero out padding too
 
-    key.method = (DWORDLONG)method;
-    key.pSig   = (DWORD)PInvokeMarshalingRequired->AddBuffer((unsigned char*)callSiteSig->pSig, callSiteSig->cbSig);
-    key.cbSig  = (DWORD)callSiteSig->cbSig;
-    key.scope  = (DWORDLONG)callSiteSig->scope;
+    key.method     = (DWORDLONG)method;
+    key.pSig_Index = (DWORD)PInvokeMarshalingRequired->AddBuffer((unsigned char*)callSiteSig->pSig, callSiteSig->cbSig);
+    key.cbSig      = (DWORD)callSiteSig->cbSig;
+    key.scope      = (DWORDLONG)callSiteSig->scope;
 
     PInvokeMarshalingRequired->Add(key, (DWORD)result);
     DEBUG_REC(dmpPInvokeMarshalingRequired(key, (DWORD)result));
@@ -3820,7 +3706,7 @@ void MethodContext::recPInvokeMarshalingRequired(CORINFO_METHOD_HANDLE method,
 void MethodContext::dmpPInvokeMarshalingRequired(const PInvokeMarshalingRequiredValue& key, DWORD value)
 {
     printf("PInvokeMarshalingRequired key mth-%016llX scp-%016llX sig-%u, value res-%u", key.method, key.scope,
-           key.pSig, value);
+           key.pSig_Index, value);
 }
 // Note the jit interface implementation seems to only care about scope and pSig from callSiteSig
 BOOL MethodContext::repPInvokeMarshalingRequired(CORINFO_METHOD_HANDLE method, CORINFO_SIG_INFO* callSiteSig)
@@ -3832,10 +3718,10 @@ BOOL MethodContext::repPInvokeMarshalingRequired(CORINFO_METHOD_HANDLE method, C
     ZeroMemory(&key, sizeof(PInvokeMarshalingRequiredValue)); // We use the input structs as a key and use memcmp to
                                                               // compare.. so we need to zero out padding too
 
-    key.method = (DWORDLONG)method;
-    key.pSig   = (DWORD)PInvokeMarshalingRequired->Contains((unsigned char*)callSiteSig->pSig, callSiteSig->cbSig);
-    key.cbSig  = (DWORD)callSiteSig->cbSig;
-    key.scope  = (DWORDLONG)callSiteSig->scope;
+    key.method     = (DWORDLONG)method;
+    key.pSig_Index = (DWORD)PInvokeMarshalingRequired->Contains((unsigned char*)callSiteSig->pSig, callSiteSig->cbSig);
+    key.cbSig      = (DWORD)callSiteSig->cbSig;
+    key.scope      = (DWORDLONG)callSiteSig->scope;
 
     DWORD value = PInvokeMarshalingRequired->Get(key);
     DEBUG_REP(dmpPInvokeMarshalingRequired(key, value));
@@ -3853,29 +3739,11 @@ void MethodContext::recFindSig(CORINFO_MODULE_HANDLE  module,
     Agnostic_FindSig key;
     ZeroMemory(&key, sizeof(Agnostic_FindSig)); // We use the input structs as a key and use memcmp to compare.. so we
                                                 // need to zero out padding too
-    Agnostic_CORINFO_SIG_INFO value;
-
     key.module  = (DWORDLONG)module;
     key.sigTOK  = (DWORD)sigTOK;
     key.context = (DWORDLONG)context;
 
-    value.callConv               = (DWORD)sig->callConv;
-    value.retTypeClass           = (DWORDLONG)sig->retTypeClass;
-    value.retTypeSigClass        = (DWORDLONG)sig->retTypeSigClass;
-    value.retType                = (DWORD)sig->retType;
-    value.flags                  = (DWORD)sig->flags;
-    value.numArgs                = (DWORD)sig->numArgs;
-    value.sigInst_classInstCount = (DWORD)sig->sigInst.classInstCount;
-    value.sigInst_classInst_Index =
-        FindSig->AddBuffer((unsigned char*)sig->sigInst.classInst, sig->sigInst.classInstCount * 8); // porting issue
-    value.sigInst_methInstCount = (DWORD)sig->sigInst.methInstCount;
-    value.sigInst_methInst_Index =
-        FindSig->AddBuffer((unsigned char*)sig->sigInst.methInst, sig->sigInst.methInstCount * 8); // porting issue
-    value.args  = (DWORDLONG)sig->args;
-    value.cbSig = (DWORD)sig->cbSig;
-    value.pSig  = (DWORD)FindSig->AddBuffer((unsigned char*)sig->pSig, sig->cbSig);
-    value.scope = (DWORDLONG)sig->scope;
-    value.token = (DWORD)sig->token;
+    Agnostic_CORINFO_SIG_INFO value = SpmiRecordsHelper::StoreAgnostic_CORINFO_SIG_INFO(*sig, FindSig);
 
     FindSig->Add(key, value);
     DEBUG_REC(dmpFindSig(key, value));
@@ -3885,11 +3753,11 @@ void MethodContext::dmpFindSig(const Agnostic_FindSig& key, const Agnostic_CORIN
     printf("FindSig key module-%016llX sigTOK-%08X context-%016llX", key.module, key.sigTOK, key.context);
     printf(", value callConv-%08X retTypeClass-%016llX retTypeSigClass-%016llX retType-%u(%s) flags-%08X numArgs-%08X "
            "classInstCount-%08X classInd-%08X "
-           "methInstCount-%08X methInd-%08X args-%016llX cbSig-%08X pSig-%08X scope-%016llX token-%08X",
+           "methInstCount-%08X methInd-%08X args-%016llX cbSig-%08X pSig_Index-%08X scope-%016llX token-%08X",
            value.callConv, value.retTypeClass, value.retTypeSigClass, value.retType,
            toString((CorInfoType)value.retType), value.flags, value.numArgs, value.sigInst_classInstCount,
            value.sigInst_classInst_Index, value.sigInst_methInstCount, value.sigInst_methInst_Index, value.args,
-           value.cbSig, value.pSig, value.scope, value.token);
+           value.cbSig, value.pSig_Index, value.scope, value.token);
 }
 void MethodContext::repFindSig(CORINFO_MODULE_HANDLE  module,
                                unsigned               sigTOK,
@@ -3907,21 +3775,7 @@ void MethodContext::repFindSig(CORINFO_MODULE_HANDLE  module,
 
     value = FindSig->Get(key);
 
-    sig->callConv               = (CorInfoCallConv)value.callConv;
-    sig->retTypeClass           = (CORINFO_CLASS_HANDLE)value.retTypeClass;
-    sig->retTypeSigClass        = (CORINFO_CLASS_HANDLE)value.retTypeSigClass;
-    sig->retType                = (CorInfoType)value.retType;
-    sig->flags                  = (unsigned)value.flags;
-    sig->numArgs                = (unsigned)value.numArgs;
-    sig->sigInst.classInstCount = (unsigned)value.sigInst_classInstCount;
-    sig->sigInst.classInst      = (CORINFO_CLASS_HANDLE*)FindSig->GetBuffer(value.sigInst_classInst_Index);
-    sig->sigInst.methInstCount  = (unsigned)value.sigInst_methInstCount;
-    sig->sigInst.methInst       = (CORINFO_CLASS_HANDLE*)FindSig->GetBuffer(value.sigInst_methInst_Index);
-    sig->args                   = (CORINFO_ARG_LIST_HANDLE)value.args;
-    sig->cbSig                  = (unsigned int)value.cbSig;
-    sig->pSig                   = (PCCOR_SIGNATURE)FindSig->GetBuffer(value.pSig);
-    sig->scope                  = (CORINFO_MODULE_HANDLE)value.scope;
-    sig->token                  = (mdToken)value.token;
+    *sig = SpmiRecordsHelper::Restore_CORINFO_SIG_INFO(value, FindSig);
     DEBUG_REP(dmpFindSig(key, value));
 }
 
@@ -5061,29 +4915,11 @@ void MethodContext::recFindCallSiteSig(CORINFO_MODULE_HANDLE  module,
     Agnostic_FindCallSiteSig key;
     ZeroMemory(&key, sizeof(Agnostic_FindCallSiteSig)); // We use the input structs as a key and use memcmp to compare..
                                                         // so we need to zero out padding too
-    Agnostic_CORINFO_SIG_INFO value;
-
     key.module  = (DWORDLONG)module;
     key.methTok = (DWORD)methTOK;
     key.context = (DWORDLONG)context;
 
-    value.callConv                = (DWORD)sig->callConv;
-    value.retTypeClass            = (DWORDLONG)sig->retTypeClass;
-    value.retTypeSigClass         = (DWORDLONG)sig->retTypeSigClass;
-    value.retType                 = (DWORD)sig->retType;
-    value.flags                   = (DWORD)sig->flags;
-    value.numArgs                 = (DWORD)sig->numArgs;
-    value.sigInst_classInstCount  = (DWORD)sig->sigInst.classInstCount;
-    value.sigInst_classInst_Index = FindCallSiteSig->AddBuffer((unsigned char*)sig->sigInst.classInst,
-                                                               sig->sigInst.classInstCount * 8); // porting issue
-    value.sigInst_methInstCount  = (DWORD)sig->sigInst.methInstCount;
-    value.sigInst_methInst_Index = FindCallSiteSig->AddBuffer((unsigned char*)sig->sigInst.methInst,
-                                                              sig->sigInst.methInstCount * 8); // porting issue
-    value.args  = (DWORDLONG)sig->args;
-    value.cbSig = (DWORD)sig->cbSig;
-    value.pSig  = (DWORD)FindCallSiteSig->AddBuffer((unsigned char*)sig->pSig, sig->cbSig);
-    value.scope = (DWORDLONG)sig->scope;
-    value.token = (DWORD)sig->token;
+    Agnostic_CORINFO_SIG_INFO value = SpmiRecordsHelper::StoreAgnostic_CORINFO_SIG_INFO(*sig, FindCallSiteSig);
 
     FindCallSiteSig->Add(key, value);
     DEBUG_REC(dmpFindCallSiteSig(key, value));
@@ -5093,11 +4929,11 @@ void MethodContext::dmpFindCallSiteSig(const Agnostic_FindCallSiteSig& key, cons
     printf("dmpFindCallSiteSig key module-%016llX methTok-%08X context-%016llX", key.module, key.methTok, key.context);
     printf(", value callConv-%08X retTypeClass-%016llX retTypeSigClass-%016llX retType-%u(%s) flags-%08X numArgs-%08X "
            "classInstCount-%08X classInd-%08X "
-           "methInstCount-%08X methInd-%08X args-%016llX cbSig-%08X pSig-%08X scope-%016llX token-%08X",
+           "methInstCount-%08X methInd-%08X args-%016llX cbSig-%08X pSig_Index-%08X scope-%016llX token-%08X",
            value.callConv, value.retTypeClass, value.retTypeSigClass, value.retType,
            toString((CorInfoType)value.retType), value.flags, value.numArgs, value.sigInst_classInstCount,
            value.sigInst_classInst_Index, value.sigInst_methInstCount, value.sigInst_methInst_Index, value.args,
-           value.cbSig, value.pSig, value.scope, value.token);
+           value.cbSig, value.pSig_Index, value.scope, value.token);
 }
 void MethodContext::repFindCallSiteSig(CORINFO_MODULE_HANDLE  module,
                                        unsigned               methTOK,
@@ -5117,21 +4953,8 @@ void MethodContext::repFindCallSiteSig(CORINFO_MODULE_HANDLE  module,
     AssertCodeMsg(FindCallSiteSig->GetIndex(key) != -1, EXCEPTIONCODE_MC, "Didn't find %08X", (DWORD)key.methTok);
     value = FindCallSiteSig->Get(key);
 
-    sig->callConv               = (CorInfoCallConv)value.callConv;
-    sig->retTypeClass           = (CORINFO_CLASS_HANDLE)value.retTypeClass;
-    sig->retTypeSigClass        = (CORINFO_CLASS_HANDLE)value.retTypeSigClass;
-    sig->retType                = (CorInfoType)value.retType;
-    sig->flags                  = (unsigned)value.flags;
-    sig->numArgs                = (unsigned)value.numArgs;
-    sig->sigInst.classInstCount = (unsigned)value.sigInst_classInstCount;
-    sig->sigInst.classInst      = (CORINFO_CLASS_HANDLE*)FindCallSiteSig->GetBuffer(value.sigInst_classInst_Index);
-    sig->sigInst.methInstCount  = (unsigned)value.sigInst_methInstCount;
-    sig->sigInst.methInst       = (CORINFO_CLASS_HANDLE*)FindCallSiteSig->GetBuffer(value.sigInst_methInst_Index);
-    sig->args                   = (CORINFO_ARG_LIST_HANDLE)value.args;
-    sig->cbSig                  = (unsigned int)value.cbSig;
-    sig->pSig                   = (PCCOR_SIGNATURE)FindCallSiteSig->GetBuffer(value.pSig);
-    sig->scope                  = (CORINFO_MODULE_HANDLE)value.scope;
-    sig->token                  = (mdToken)value.token;
+    *sig = SpmiRecordsHelper::Restore_CORINFO_SIG_INFO(value, FindCallSiteSig);
+
     DEBUG_REP(dmpFindCallSiteSig(key, value));
 }
 
@@ -5194,10 +5017,10 @@ void MethodContext::recGetVarArgsHandle(CORINFO_SIG_INFO* pSig, void** ppIndirec
     GetVarArgsHandleValue key;
     ZeroMemory(&key, sizeof(GetVarArgsHandleValue)); // We use the input structs as a key and use memcmp to
                                                      // compare.. so we need to zero out padding too
-    key.cbSig = (DWORD)pSig->cbSig;
-    key.pSig  = (DWORD)GetVarArgsHandle->AddBuffer((unsigned char*)pSig->pSig, pSig->cbSig);
-    key.scope = (DWORDLONG)pSig->scope;
-    key.token = (DWORD)pSig->token;
+    key.cbSig      = (DWORD)pSig->cbSig;
+    key.pSig_Index = (DWORD)GetVarArgsHandle->AddBuffer((unsigned char*)pSig->pSig, pSig->cbSig);
+    key.scope      = (DWORDLONG)pSig->scope;
+    key.token      = (DWORD)pSig->token;
 
     DLDL value;
     if (ppIndirection != nullptr)
@@ -5210,8 +5033,8 @@ void MethodContext::recGetVarArgsHandle(CORINFO_SIG_INFO* pSig, void** ppIndirec
 }
 void MethodContext::dmpGetVarArgsHandle(const GetVarArgsHandleValue& key, DLDL value)
 {
-    printf("GetVarArgsHandle key cbSig-%08X pSig-%08X scope-%016llX token-%08X", key.cbSig, key.pSig, key.scope,
-           key.token);
+    printf("GetVarArgsHandle key cbSig-%08X pSig_Index-%08X scope-%016llX token-%08X", key.cbSig, key.pSig_Index,
+           key.scope, key.token);
     printf(", value ppIndirection-%016llX result-%016llX", value.A, value.B);
 }
 CORINFO_VARARGS_HANDLE MethodContext::repGetVarArgsHandle(CORINFO_SIG_INFO* pSig, void** ppIndirection)
@@ -5220,10 +5043,10 @@ CORINFO_VARARGS_HANDLE MethodContext::repGetVarArgsHandle(CORINFO_SIG_INFO* pSig
     ZeroMemory(&key, sizeof(GetVarArgsHandleValue)); // We use the input structs as a key and use memcmp to
                                                      // compare.. so we need to zero out padding too
 
-    key.cbSig = (DWORD)pSig->cbSig;
-    key.pSig  = (DWORD)GetVarArgsHandle->Contains((unsigned char*)pSig->pSig, pSig->cbSig);
-    key.scope = (DWORDLONG)pSig->scope;
-    key.token = (DWORD)pSig->token;
+    key.cbSig      = (DWORD)pSig->cbSig;
+    key.pSig_Index = (DWORD)GetVarArgsHandle->Contains((unsigned char*)pSig->pSig, pSig->cbSig);
+    key.scope      = (DWORDLONG)pSig->scope;
+    key.token      = (DWORD)pSig->token;
 
     DLDL value = (DLDL)GetVarArgsHandle->Get(key);
 
@@ -5387,10 +5210,10 @@ void MethodContext::recGetCookieForPInvokeCalliSig(CORINFO_SIG_INFO* szMetaSig, 
     GetCookieForPInvokeCalliSigValue key;
     ZeroMemory(&key, sizeof(GetCookieForPInvokeCalliSigValue)); // We use the input structs as a key and use memcmp to
                                                                 // compare.. so we need to zero out padding too
-    key.cbSig = (DWORD)szMetaSig->cbSig;
-    key.pSig  = (DWORD)GetCookieForPInvokeCalliSig->AddBuffer((unsigned char*)szMetaSig->pSig, szMetaSig->cbSig);
-    key.scope = (DWORDLONG)szMetaSig->scope;
-    key.token = (DWORD)szMetaSig->token;
+    key.cbSig      = (DWORD)szMetaSig->cbSig;
+    key.pSig_Index = (DWORD)GetCookieForPInvokeCalliSig->AddBuffer((unsigned char*)szMetaSig->pSig, szMetaSig->cbSig);
+    key.scope      = (DWORDLONG)szMetaSig->scope;
+    key.token      = (DWORD)szMetaSig->token;
 
     DLDL value;
     if (ppIndirection != nullptr)
@@ -5410,10 +5233,10 @@ LPVOID MethodContext::repGetCookieForPInvokeCalliSig(CORINFO_SIG_INFO* szMetaSig
     GetCookieForPInvokeCalliSigValue key;
     ZeroMemory(&key, sizeof(GetCookieForPInvokeCalliSigValue)); // We use the input structs as a key and use memcmp to
                                                                 // compare.. so we need to zero out padding too
-    key.cbSig = (DWORD)szMetaSig->cbSig;
-    key.pSig  = (DWORD)GetCookieForPInvokeCalliSig->Contains((unsigned char*)szMetaSig->pSig, szMetaSig->cbSig);
-    key.scope = (DWORDLONG)szMetaSig->scope;
-    key.token = (DWORD)szMetaSig->token;
+    key.cbSig      = (DWORD)szMetaSig->cbSig;
+    key.pSig_Index = (DWORD)GetCookieForPInvokeCalliSig->Contains((unsigned char*)szMetaSig->pSig, szMetaSig->cbSig);
+    key.scope      = (DWORDLONG)szMetaSig->scope;
+    key.token      = (DWORD)szMetaSig->token;
 
     DLDL value = (DLDL)GetCookieForPInvokeCalliSig->Get(key);
     if (ppIndirection != nullptr)
@@ -5918,27 +5741,8 @@ void MethodContext::recGetTailCallCopyArgsThunk(CORINFO_SIG_INFO*               
     Agnostic_GetTailCallCopyArgsThunk key;
     ZeroMemory(&key, sizeof(Agnostic_GetTailCallCopyArgsThunk)); // We use the input structs as a key and use memcmp to
                                                                  // compare.. so we need to zero out padding too
-
-    key.Sig.callConv               = (DWORD)pSig->callConv;
-    key.Sig.retTypeClass           = (DWORDLONG)pSig->retTypeClass;
-    key.Sig.retTypeSigClass        = (DWORDLONG)pSig->retTypeSigClass;
-    key.Sig.retType                = (DWORD)pSig->retType;
-    key.Sig.flags                  = (DWORD)pSig->flags;
-    key.Sig.numArgs                = (DWORD)pSig->numArgs;
-    key.Sig.sigInst_classInstCount = (DWORD)pSig->sigInst.classInstCount;
-    key.Sig.sigInst_classInst_Index =
-        (DWORD)GetTailCallCopyArgsThunk->AddBuffer((unsigned char*)pSig->sigInst.classInst,
-                                                   pSig->sigInst.classInstCount * 8); // porting issue
-    key.Sig.sigInst_methInstCount = (DWORD)pSig->sigInst.methInstCount;
-    key.Sig.sigInst_methInst_Index =
-        (DWORD)GetTailCallCopyArgsThunk->AddBuffer((unsigned char*)pSig->sigInst.methInst,
-                                                   pSig->sigInst.methInstCount * 8); // porting issue
-    key.Sig.args  = (DWORDLONG)pSig->args;
-    key.Sig.cbSig = (DWORD)pSig->cbSig;
-    key.Sig.pSig  = (DWORD)GetTailCallCopyArgsThunk->AddBuffer((unsigned char*)pSig->pSig, pSig->cbSig);
-    key.Sig.scope = (DWORDLONG)pSig->scope;
-    key.Sig.token = (DWORD)pSig->token;
-    key.flags     = (DWORD)flags;
+    key.Sig   = SpmiRecordsHelper::StoreAgnostic_CORINFO_SIG_INFO(*pSig, GetTailCallCopyArgsThunk);
+    key.flags = (DWORD)flags;
 
     GetTailCallCopyArgsThunk->Add(key, (DWORDLONG)result);
     DEBUG_REC(dmpGetTailCallCopyArgsThunk(key, (DWORDLONG)result));
@@ -5946,40 +5750,22 @@ void MethodContext::recGetTailCallCopyArgsThunk(CORINFO_SIG_INFO*               
 void MethodContext::dmpGetTailCallCopyArgsThunk(const Agnostic_GetTailCallCopyArgsThunk& key, DWORDLONG value)
 {
     printf("GetTailCallCopyArgsThunk key sig{cc-%u rtc-%016llX rts-%016llX rt-%u flg-%08X na-%u cc-%u ci-%u mc-%u "
-           "mi-%u sig-%u pSig-%u scp-%016llX tok-%08X} flg-%08X",
+           "mi-%u sig-%u pSig_Index-%u scp-%016llX tok-%08X} flg-%08X",
            key.Sig.callConv, key.Sig.retTypeClass, key.Sig.retTypeSigClass, key.Sig.retType, key.Sig.flags,
            key.Sig.numArgs, key.Sig.sigInst_classInstCount, key.Sig.sigInst_classInst_Index,
-           key.Sig.sigInst_methInstCount, key.Sig.sigInst_methInst_Index, key.Sig.cbSig, key.Sig.pSig, key.Sig.scope,
-           key.Sig.token, key.flags);
+           key.Sig.sigInst_methInstCount, key.Sig.sigInst_methInst_Index, key.Sig.cbSig, key.Sig.pSig_Index,
+           key.Sig.scope, key.Sig.token, key.flags);
     printf(", value res-%016llX", value);
 }
 void* MethodContext::repGetTailCallCopyArgsThunk(CORINFO_SIG_INFO* pSig, CorInfoHelperTailCallSpecialHandling flags)
 {
+    AssertCodeMsg(GetTailCallCopyArgsThunk != nullptr, EXCEPTIONCODE_MC, "Didn't find anything for ...");
+
     Agnostic_GetTailCallCopyArgsThunk key;
     ZeroMemory(&key, sizeof(Agnostic_GetTailCallCopyArgsThunk)); // We use the input structs as a key and use memcmp to
                                                                  // compare.. so we need to zero out padding too
-
-    AssertCodeMsg(GetTailCallCopyArgsThunk != nullptr, EXCEPTIONCODE_MC, "Didn't find anything for ...");
-    key.Sig.callConv               = (DWORD)pSig->callConv;
-    key.Sig.retTypeClass           = (DWORDLONG)pSig->retTypeClass;
-    key.Sig.retTypeSigClass        = (DWORDLONG)pSig->retTypeSigClass;
-    key.Sig.retType                = (DWORD)pSig->retType;
-    key.Sig.flags                  = (DWORD)pSig->flags;
-    key.Sig.numArgs                = (DWORD)pSig->numArgs;
-    key.Sig.sigInst_classInstCount = (DWORD)pSig->sigInst.classInstCount;
-    key.Sig.sigInst_classInst_Index =
-        (DWORD)GetTailCallCopyArgsThunk->Contains((unsigned char*)pSig->sigInst.classInst,
-                                                  pSig->sigInst.classInstCount * 8); // porting issue
-    key.Sig.sigInst_methInstCount = (DWORD)pSig->sigInst.methInstCount;
-    key.Sig.sigInst_methInst_Index =
-        (DWORD)GetTailCallCopyArgsThunk->Contains((unsigned char*)pSig->sigInst.methInst,
-                                                  pSig->sigInst.methInstCount * 8); // porting issue
-    key.Sig.args  = (DWORDLONG)pSig->args;
-    key.Sig.cbSig = (DWORD)pSig->cbSig;
-    key.Sig.pSig  = (DWORD)GetTailCallCopyArgsThunk->Contains((unsigned char*)pSig->pSig, pSig->cbSig);
-    key.Sig.scope = (DWORDLONG)pSig->scope;
-    key.Sig.token = (DWORD)pSig->token;
-    key.flags     = (DWORD)flags;
+    key.Sig   = SpmiRecordsHelper::RestoreAgnostic_CORINFO_SIG_INFO(*pSig, GetTailCallCopyArgsThunk);
+    key.flags = (DWORD)flags;
 
     AssertCodeMsg(GetTailCallCopyArgsThunk->GetIndex(key) != -1, EXCEPTIONCODE_MC, "Didn't find %016llX",
                   (DWORDLONG)key.Sig.retTypeClass);

--- a/src/ToolBox/superpmi/superpmi-shared/methodcontext.h
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontext.h
@@ -37,7 +37,7 @@ public:
         DWORD     sigInst_methInstCount;
         DWORD     sigInst_methInst_Index;
         DWORDLONG args;
-        DWORD     pSig;
+        DWORD     pSig_Index;
         DWORD     cbSig;
         DWORDLONG scope;
         DWORD     token;
@@ -114,7 +114,7 @@ public:
         DWORD     sigInst_classInst_Index;
         DWORD     sigInst_methInstCount;
         DWORD     sigInst_methInst_Index;
-        DWORDLONG     scope;
+        DWORDLONG scope;
         DWORDLONG args;
     };
     struct GetArgClassValue
@@ -290,7 +290,7 @@ public:
     struct PInvokeMarshalingRequiredValue
     {
         DWORDLONG method;
-        DWORD     pSig;
+        DWORD     pSig_Index;
         DWORD     cbSig;
         DWORDLONG scope;
     };
@@ -474,7 +474,7 @@ public:
     struct GetVarArgsHandleValue
     {
         DWORD     cbSig;
-        DWORD     pSig;
+        DWORD     pSig_Index;
         DWORDLONG scope;
         DWORD     token;
     };
@@ -488,7 +488,7 @@ public:
     struct GetCookieForPInvokeCalliSigValue
     {
         DWORD     cbSig;
-        DWORD     pSig;
+        DWORD     pSig_Index;
         DWORDLONG scope;
         DWORD     token;
     };

--- a/src/ToolBox/superpmi/superpmi-shared/spmidumphelper.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/spmidumphelper.cpp
@@ -1,0 +1,37 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+//----------------------------------------------------------
+// SpmiDumpHelper.cpp - a helper to dump structs that are used in JitEEInterface calls and spmi collections.
+//----------------------------------------------------------
+
+#include "standardpch.h"
+#include "spmidumphelper.h"
+
+std::string SpmiDumpHelper::DumpAgnostic_CORINFO_RESOLVED_TOKENin(
+    const MethodContext::Agnostic_CORINFO_RESOLVED_TOKENin& tokenIn)
+{
+    char buffer[MAX_BUFFER_SIZE];
+    sprintf_s(buffer, MAX_BUFFER_SIZE, "tc-%016llX ts-%016llX tok - %08X tt-%u", tokenIn.tokenContext, tokenIn.tokenScope,
+            tokenIn.token, tokenIn.tokenType);
+    return std::string(buffer);
+}
+
+std::string SpmiDumpHelper::DumpAgnostic_CORINFO_RESOLVED_TOKENout(
+    const MethodContext::Agnostic_CORINFO_RESOLVED_TOKENout& tokenOut)
+{
+    char buffer[MAX_BUFFER_SIZE];
+    sprintf_s(buffer, MAX_BUFFER_SIZE, "cls-%016llX meth-%016llX fld-%016llX ti-%u ts-%u mi-%u ms-%u", tokenOut.hClass,
+            tokenOut.hMethod, tokenOut.hField, tokenOut.pTypeSpec_Index, tokenOut.cbTypeSpec,
+            tokenOut.pMethodSpec_Index, tokenOut.cbMethodSpec);
+    return std::string(buffer);
+}
+
+std::string SpmiDumpHelper::DumpAgnostic_CORINFO_RESOLVED_TOKEN(
+    const MethodContext::Agnostic_CORINFO_RESOLVED_TOKEN& token)
+{
+    return DumpAgnostic_CORINFO_RESOLVED_TOKENin(token.inValue) + std::string(" ") +
+           DumpAgnostic_CORINFO_RESOLVED_TOKENout(token.outValue);
+}

--- a/src/ToolBox/superpmi/superpmi-shared/spmidumphelper.h
+++ b/src/ToolBox/superpmi/superpmi-shared/spmidumphelper.h
@@ -1,0 +1,28 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+//----------------------------------------------------------
+// SpmiDumpHelper.h - a helper to dump structs that are used in JitEEInterface calls and spmi collections.
+//----------------------------------------------------------
+
+#ifndef _SpmiDumpHelper
+#define _SpmiDumpHelper
+
+#include "methodcontext.h"
+
+class SpmiDumpHelper
+{
+public:
+    static std::string DumpAgnostic_CORINFO_RESOLVED_TOKENin(
+        const MethodContext::Agnostic_CORINFO_RESOLVED_TOKENin& tokenIn);
+    static std::string DumpAgnostic_CORINFO_RESOLVED_TOKENout(
+        const MethodContext::Agnostic_CORINFO_RESOLVED_TOKENout& tokenOut);
+    static std::string DumpAgnostic_CORINFO_RESOLVED_TOKEN(const MethodContext::Agnostic_CORINFO_RESOLVED_TOKEN& token);
+
+private:
+    static const int MAX_BUFFER_SIZE = 1000;
+};
+
+#endif

--- a/src/ToolBox/superpmi/superpmi-shared/spmirecordhelper.h
+++ b/src/ToolBox/superpmi/superpmi-shared/spmirecordhelper.h
@@ -12,61 +12,80 @@
 class SpmiRecordsHelper
 {
 public:
-    static MethodContext::Agnostic_CORINFO_RESOLVED_TOKENin CreateAgnostic_CORINFO_RESOLVED_TOKENin
-    (CORINFO_RESOLVED_TOKEN* pResolvedToken);
+    static MethodContext::Agnostic_CORINFO_RESOLVED_TOKENin CreateAgnostic_CORINFO_RESOLVED_TOKENin(
+        CORINFO_RESOLVED_TOKEN* pResolvedToken);
 
-    static MethodContext::Agnostic_CORINFO_RESOLVED_TOKENout CreateAgnostic_CORINFO_RESOLVED_TOKENout_without_buffers
-    (CORINFO_RESOLVED_TOKEN* pResolvedToken);
+    static MethodContext::Agnostic_CORINFO_RESOLVED_TOKENout CreateAgnostic_CORINFO_RESOLVED_TOKENout_without_buffers(
+        CORINFO_RESOLVED_TOKEN* pResolvedToken);
 
-    template<typename key, typename value>
-    static MethodContext::Agnostic_CORINFO_RESOLVED_TOKENout StoreAgnostic_CORINFO_RESOLVED_TOKENout
-    (CORINFO_RESOLVED_TOKEN* pResolvedToken, LightWeightMap<key, value>* buffers);
+    template <typename key, typename value>
+    static MethodContext::Agnostic_CORINFO_RESOLVED_TOKENout StoreAgnostic_CORINFO_RESOLVED_TOKENout(
+        CORINFO_RESOLVED_TOKEN* pResolvedToken, LightWeightMap<key, value>* buffers);
 
-    template<typename key, typename value>
-    static MethodContext::Agnostic_CORINFO_RESOLVED_TOKENout RestoreAgnostic_CORINFO_RESOLVED_TOKENout
-    (CORINFO_RESOLVED_TOKEN* pResolvedToken, LightWeightMap<key, value>* buffers);
+    template <typename key, typename value>
+    static MethodContext::Agnostic_CORINFO_RESOLVED_TOKENout RestoreAgnostic_CORINFO_RESOLVED_TOKENout(
+        CORINFO_RESOLVED_TOKEN* pResolvedToken, LightWeightMap<key, value>* buffers);
 
-    template<typename key, typename value>
-    static MethodContext::Agnostic_CORINFO_RESOLVED_TOKEN StoreAgnostic_CORINFO_RESOLVED_TOKEN
-    (CORINFO_RESOLVED_TOKEN* pResolvedToken, LightWeightMap<key, value>* buffers);
+    template <typename key, typename value>
+    static MethodContext::Agnostic_CORINFO_RESOLVED_TOKEN StoreAgnostic_CORINFO_RESOLVED_TOKEN(
+        CORINFO_RESOLVED_TOKEN* pResolvedToken, LightWeightMap<key, value>* buffers);
 
-    template<typename key, typename value>
-    static MethodContext::Agnostic_CORINFO_RESOLVED_TOKEN RestoreAgnostic_CORINFO_RESOLVED_TOKEN
-    (CORINFO_RESOLVED_TOKEN* pResolvedToken, LightWeightMap<key, value>* buffers);
+    template <typename key, typename value>
+    static MethodContext::Agnostic_CORINFO_RESOLVED_TOKEN RestoreAgnostic_CORINFO_RESOLVED_TOKEN(
+        CORINFO_RESOLVED_TOKEN* pResolvedToken, LightWeightMap<key, value>* buffers);
+
+    static MethodContext::Agnostic_CORINFO_SIG_INFO CreateAgnostic_CORINFO_SIG_INFO_without_buffers(
+        CORINFO_SIG_INFO& sigInfo);
+
+    template <typename key, typename value>
+    static MethodContext::Agnostic_CORINFO_SIG_INFO StoreAgnostic_CORINFO_SIG_INFO(CORINFO_SIG_INFO& sigInfo,
+                                                                                   LightWeightMap<key, value>* buffers);
+
+    template <typename key, typename value>
+    static MethodContext::Agnostic_CORINFO_SIG_INFO RestoreAgnostic_CORINFO_SIG_INFO(
+        CORINFO_SIG_INFO& sigInfo, LightWeightMap<key, value>* buffers);
+
+    template <typename key, typename value>
+    static CORINFO_SIG_INFO Restore_CORINFO_SIG_INFO(MethodContext::Agnostic_CORINFO_SIG_INFO& sigInfo,
+                                                     LightWeightMap<key, value>* buffers);
 };
 
-inline MethodContext::Agnostic_CORINFO_RESOLVED_TOKENin SpmiRecordsHelper::CreateAgnostic_CORINFO_RESOLVED_TOKENin(CORINFO_RESOLVED_TOKEN * pResolvedToken)
+inline MethodContext::Agnostic_CORINFO_RESOLVED_TOKENin SpmiRecordsHelper::CreateAgnostic_CORINFO_RESOLVED_TOKENin(
+    CORINFO_RESOLVED_TOKEN* pResolvedToken)
 {
     MethodContext::Agnostic_CORINFO_RESOLVED_TOKENin tokenIn;
     ZeroMemory(&tokenIn, sizeof(tokenIn));
     tokenIn.tokenContext = (DWORDLONG)pResolvedToken->tokenContext;
-    tokenIn.tokenScope = (DWORDLONG)pResolvedToken->tokenScope;
-    tokenIn.token = (DWORD)pResolvedToken->token;
-    tokenIn.tokenType = (DWORD)pResolvedToken->tokenType;
+    tokenIn.tokenScope   = (DWORDLONG)pResolvedToken->tokenScope;
+    tokenIn.token        = (DWORD)pResolvedToken->token;
+    tokenIn.tokenType    = (DWORD)pResolvedToken->tokenType;
     return tokenIn;
 }
 
-inline MethodContext::Agnostic_CORINFO_RESOLVED_TOKENout SpmiRecordsHelper::CreateAgnostic_CORINFO_RESOLVED_TOKENout_without_buffers(CORINFO_RESOLVED_TOKEN * pResolvedToken)
+inline MethodContext::Agnostic_CORINFO_RESOLVED_TOKENout SpmiRecordsHelper::
+    CreateAgnostic_CORINFO_RESOLVED_TOKENout_without_buffers(CORINFO_RESOLVED_TOKEN* pResolvedToken)
 {
     MethodContext::Agnostic_CORINFO_RESOLVED_TOKENout tokenOut;
     ZeroMemory(&tokenOut, sizeof(tokenOut));
-    tokenOut.hClass = (DWORDLONG)pResolvedToken->hClass;
+    tokenOut.hClass  = (DWORDLONG)pResolvedToken->hClass;
     tokenOut.hMethod = (DWORDLONG)pResolvedToken->hMethod;
-    tokenOut.hField = (DWORDLONG)pResolvedToken->hField;
+    tokenOut.hField  = (DWORDLONG)pResolvedToken->hField;
 
-    tokenOut.cbTypeSpec = (DWORD)pResolvedToken->cbTypeSpec;
+    tokenOut.cbTypeSpec   = (DWORD)pResolvedToken->cbTypeSpec;
     tokenOut.cbMethodSpec = (DWORD)pResolvedToken->cbMethodSpec;
 
-    tokenOut.pTypeSpec_Index = -1;
+    tokenOut.pTypeSpec_Index   = -1;
     tokenOut.pMethodSpec_Index = -1;
 
     return tokenOut;
 }
 
-template<typename key, typename value>
-inline MethodContext::Agnostic_CORINFO_RESOLVED_TOKENout SpmiRecordsHelper::StoreAgnostic_CORINFO_RESOLVED_TOKENout(CORINFO_RESOLVED_TOKEN * pResolvedToken, LightWeightMap<key, value>* buffers)
+template <typename key, typename value>
+inline MethodContext::Agnostic_CORINFO_RESOLVED_TOKENout SpmiRecordsHelper::StoreAgnostic_CORINFO_RESOLVED_TOKENout(
+    CORINFO_RESOLVED_TOKEN* pResolvedToken, LightWeightMap<key, value>* buffers)
 {
-    MethodContext::Agnostic_CORINFO_RESOLVED_TOKENout tokenOut(CreateAgnostic_CORINFO_RESOLVED_TOKENout_without_buffers(pResolvedToken));
+    MethodContext::Agnostic_CORINFO_RESOLVED_TOKENout tokenOut(
+        CreateAgnostic_CORINFO_RESOLVED_TOKENout_without_buffers(pResolvedToken));
 
     tokenOut.pTypeSpec_Index =
         (DWORD)buffers->AddBuffer((unsigned char*)pResolvedToken->pTypeSpec, pResolvedToken->cbTypeSpec);
@@ -76,10 +95,12 @@ inline MethodContext::Agnostic_CORINFO_RESOLVED_TOKENout SpmiRecordsHelper::Stor
     return tokenOut;
 }
 
-template<typename key, typename value>
-inline MethodContext::Agnostic_CORINFO_RESOLVED_TOKENout SpmiRecordsHelper::RestoreAgnostic_CORINFO_RESOLVED_TOKENout(CORINFO_RESOLVED_TOKEN * pResolvedToken, LightWeightMap<key, value>* buffers)
+template <typename key, typename value>
+inline MethodContext::Agnostic_CORINFO_RESOLVED_TOKENout SpmiRecordsHelper::RestoreAgnostic_CORINFO_RESOLVED_TOKENout(
+    CORINFO_RESOLVED_TOKEN* pResolvedToken, LightWeightMap<key, value>* buffers)
 {
-    MethodContext::Agnostic_CORINFO_RESOLVED_TOKENout tokenOut(CreateAgnostic_CORINFO_RESOLVED_TOKENout_without_buffers(pResolvedToken));
+    MethodContext::Agnostic_CORINFO_RESOLVED_TOKENout tokenOut(
+        CreateAgnostic_CORINFO_RESOLVED_TOKENout_without_buffers(pResolvedToken));
     tokenOut.pTypeSpec_Index =
         (DWORD)buffers->Contains((unsigned char*)pResolvedToken->pTypeSpec, pResolvedToken->cbTypeSpec);
     tokenOut.pMethodSpec_Index =
@@ -87,21 +108,92 @@ inline MethodContext::Agnostic_CORINFO_RESOLVED_TOKENout SpmiRecordsHelper::Rest
     return tokenOut;
 }
 
-template<typename key, typename value>
-inline MethodContext::Agnostic_CORINFO_RESOLVED_TOKEN SpmiRecordsHelper::StoreAgnostic_CORINFO_RESOLVED_TOKEN(CORINFO_RESOLVED_TOKEN * pResolvedToken, LightWeightMap<key, value>* buffers)
+template <typename key, typename value>
+inline MethodContext::Agnostic_CORINFO_RESOLVED_TOKEN SpmiRecordsHelper::StoreAgnostic_CORINFO_RESOLVED_TOKEN(
+    CORINFO_RESOLVED_TOKEN* pResolvedToken, LightWeightMap<key, value>* buffers)
 {
     MethodContext::Agnostic_CORINFO_RESOLVED_TOKEN token;
-    token.inValue = CreateAgnostic_CORINFO_RESOLVED_TOKENin(pResolvedToken);
+    token.inValue  = CreateAgnostic_CORINFO_RESOLVED_TOKENin(pResolvedToken);
     token.outValue = StoreAgnostic_CORINFO_RESOLVED_TOKENout(pResolvedToken, buffers);
     return token;
 }
 
-template<typename key, typename value>
-inline MethodContext::Agnostic_CORINFO_RESOLVED_TOKEN SpmiRecordsHelper::RestoreAgnostic_CORINFO_RESOLVED_TOKEN(CORINFO_RESOLVED_TOKEN * pResolvedToken, LightWeightMap<key, value>* buffers)
+template <typename key, typename value>
+inline MethodContext::Agnostic_CORINFO_RESOLVED_TOKEN SpmiRecordsHelper::RestoreAgnostic_CORINFO_RESOLVED_TOKEN(
+    CORINFO_RESOLVED_TOKEN* pResolvedToken, LightWeightMap<key, value>* buffers)
 {
     MethodContext::Agnostic_CORINFO_RESOLVED_TOKEN token;
     ZeroMemory(&token, sizeof(token));
-    token.inValue = CreateAgnostic_CORINFO_RESOLVED_TOKENin(pResolvedToken);
+    token.inValue  = CreateAgnostic_CORINFO_RESOLVED_TOKENin(pResolvedToken);
     token.outValue = RestoreAgnostic_CORINFO_RESOLVED_TOKENout(pResolvedToken, buffers);
     return token;
+}
+
+inline MethodContext::Agnostic_CORINFO_SIG_INFO SpmiRecordsHelper::CreateAgnostic_CORINFO_SIG_INFO_without_buffers(
+    CORINFO_SIG_INFO& sigInfo)
+{
+    MethodContext::Agnostic_CORINFO_SIG_INFO sig;
+    ZeroMemory(&sig, sizeof(sig));
+    sig.callConv               = (DWORD)sigInfo.callConv;
+    sig.retTypeClass           = (DWORDLONG)sigInfo.retTypeClass;
+    sig.retTypeSigClass        = (DWORDLONG)sigInfo.retTypeSigClass;
+    sig.retType                = (DWORD)sigInfo.retType;
+    sig.flags                  = (DWORD)sigInfo.flags;
+    sig.numArgs                = (DWORD)sigInfo.numArgs;
+    sig.sigInst_classInstCount = (DWORD)sigInfo.sigInst.classInstCount;
+    sig.sigInst_methInstCount  = (DWORD)sigInfo.sigInst.methInstCount;
+    sig.args                   = (DWORDLONG)sigInfo.args;
+    sig.cbSig                  = (DWORD)sigInfo.cbSig;
+    sig.scope                  = (DWORDLONG)sigInfo.scope;
+    sig.token                  = (DWORD)sigInfo.token;
+    return sig;
+}
+
+template <typename key, typename value>
+inline MethodContext::Agnostic_CORINFO_SIG_INFO SpmiRecordsHelper::StoreAgnostic_CORINFO_SIG_INFO(
+    CORINFO_SIG_INFO& sigInfo, LightWeightMap<key, value>* buffers)
+{
+    MethodContext::Agnostic_CORINFO_SIG_INFO sig(CreateAgnostic_CORINFO_SIG_INFO_without_buffers(sigInfo));
+    sig.sigInst_classInst_Index =
+        buffers->AddBuffer((unsigned char*)sigInfo.sigInst.classInst, sigInfo.sigInst.classInstCount * 8);
+    sig.sigInst_methInst_Index =
+        buffers->AddBuffer((unsigned char*)sigInfo.sigInst.methInst, sigInfo.sigInst.methInstCount * 8);
+    sig.pSig_Index = (DWORD)buffers->AddBuffer((unsigned char*)sigInfo.pSig, sigInfo.cbSig);
+    return sig;
+}
+
+template <typename key, typename value>
+inline MethodContext::Agnostic_CORINFO_SIG_INFO SpmiRecordsHelper::RestoreAgnostic_CORINFO_SIG_INFO(
+    CORINFO_SIG_INFO& sigInfo, LightWeightMap<key, value>* buffers)
+{
+    MethodContext::Agnostic_CORINFO_SIG_INFO sig(CreateAgnostic_CORINFO_SIG_INFO_without_buffers(sigInfo));
+    sig.sigInst_classInst_Index =
+        buffers->Contains((unsigned char*)sigInfo.sigInst.classInst, sigInfo.sigInst.classInstCount * 8);
+    sig.sigInst_methInst_Index =
+        buffers->Contains((unsigned char*)sigInfo.sigInst.methInst, sigInfo.sigInst.methInstCount * 8);
+    sig.pSig_Index = (DWORD)buffers->Contains((unsigned char*)sigInfo.pSig, sigInfo.cbSig);
+    return sig;
+}
+
+template <typename key, typename value>
+inline CORINFO_SIG_INFO SpmiRecordsHelper::Restore_CORINFO_SIG_INFO(MethodContext::Agnostic_CORINFO_SIG_INFO& sigInfo,
+                                                                    LightWeightMap<key, value>* buffers)
+{
+    CORINFO_SIG_INFO sig;
+    sig.callConv               = (CorInfoCallConv)sigInfo.callConv;
+    sig.retTypeClass           = (CORINFO_CLASS_HANDLE)sigInfo.retTypeClass;
+    sig.retTypeSigClass        = (CORINFO_CLASS_HANDLE)sigInfo.retTypeSigClass;
+    sig.retType                = (CorInfoType)sigInfo.retType;
+    sig.flags                  = (unsigned)sigInfo.flags;
+    sig.numArgs                = (unsigned)sigInfo.numArgs;
+    sig.sigInst.classInstCount = (unsigned)sigInfo.sigInst_classInstCount;
+    sig.sigInst.classInst      = (CORINFO_CLASS_HANDLE*)buffers->GetBuffer(sigInfo.sigInst_classInst_Index);
+    sig.sigInst.methInstCount  = (unsigned)sigInfo.sigInst_methInstCount;
+    sig.sigInst.methInst       = (CORINFO_CLASS_HANDLE*)buffers->GetBuffer(sigInfo.sigInst_methInst_Index);
+    sig.args                   = (CORINFO_ARG_LIST_HANDLE)sigInfo.args;
+    sig.cbSig                  = (unsigned int)sigInfo.cbSig;
+    sig.pSig                   = (PCCOR_SIGNATURE)buffers->GetBuffer(sigInfo.pSig_Index);
+    sig.scope                  = (CORINFO_MODULE_HANDLE)sigInfo.scope;
+    sig.token                  = (mdToken)sigInfo.token;
+    return sig;
 }

--- a/src/ToolBox/superpmi/superpmi-shared/spmirecordhelper.h
+++ b/src/ToolBox/superpmi/superpmi-shared/spmirecordhelper.h
@@ -4,8 +4,10 @@
 //
 
 //----------------------------------------------------------
-// SpmiRecordHelper.h - Helpers to copy data between agnostic/non-agnostic types and dump them.
+// SpmiRecordHelper.h - a helper to copy data between agnostic/non-agnostic types.
 //----------------------------------------------------------
+#ifndef _SpmiRecordsHelper
+#define _SpmiRecordsHelper
 
 #include "methodcontext.h"
 
@@ -33,6 +35,13 @@ public:
     template <typename key, typename value>
     static MethodContext::Agnostic_CORINFO_RESOLVED_TOKEN RestoreAgnostic_CORINFO_RESOLVED_TOKEN(
         CORINFO_RESOLVED_TOKEN* pResolvedToken, LightWeightMap<key, value>* buffers);
+
+
+    // Restore the out values in the first argument from the second.
+    // Can't just return whole CORINFO_RESOLVED_TOKEN because [in] values in it are important too.
+    template <typename key, typename value>
+    static void Restore_CORINFO_RESOLVED_TOKENout(CORINFO_RESOLVED_TOKEN* pResolvedToken,
+        MethodContext::Agnostic_CORINFO_RESOLVED_TOKENout& token, LightWeightMap<key, value>* buffers);
 
     static MethodContext::Agnostic_CORINFO_SIG_INFO CreateAgnostic_CORINFO_SIG_INFO_without_buffers(
         CORINFO_SIG_INFO& sigInfo);
@@ -129,6 +138,19 @@ inline MethodContext::Agnostic_CORINFO_RESOLVED_TOKEN SpmiRecordsHelper::Restore
     return token;
 }
 
+template <typename key, typename value>
+inline void SpmiRecordsHelper::Restore_CORINFO_RESOLVED_TOKENout(CORINFO_RESOLVED_TOKEN* pResolvedToken,
+    MethodContext::Agnostic_CORINFO_RESOLVED_TOKENout& tokenOut, LightWeightMap<key, value>* buffers)
+{
+    pResolvedToken->hClass       = (CORINFO_CLASS_HANDLE)tokenOut.hClass;
+    pResolvedToken->hMethod      = (CORINFO_METHOD_HANDLE)tokenOut.hMethod;
+    pResolvedToken->hField       = (CORINFO_FIELD_HANDLE)tokenOut.hField;
+    pResolvedToken->pTypeSpec    = (PCCOR_SIGNATURE)buffers->GetBuffer(tokenOut.pTypeSpec_Index);
+    pResolvedToken->cbTypeSpec   = (ULONG)tokenOut.cbTypeSpec;
+    pResolvedToken->pMethodSpec  = (PCCOR_SIGNATURE)buffers->GetBuffer(tokenOut.pMethodSpec_Index);
+    pResolvedToken->cbMethodSpec = (ULONG)tokenOut.cbMethodSpec;
+}
+
 inline MethodContext::Agnostic_CORINFO_SIG_INFO SpmiRecordsHelper::CreateAgnostic_CORINFO_SIG_INFO_without_buffers(
     CORINFO_SIG_INFO& sigInfo)
 {
@@ -197,3 +219,5 @@ inline CORINFO_SIG_INFO SpmiRecordsHelper::Restore_CORINFO_SIG_INFO(MethodContex
     sig.token                  = (mdToken)sigInfo.token;
     return sig;
 }
+
+#endif

--- a/src/ToolBox/superpmi/superpmi-shim-collector/CMakeLists.txt
+++ b/src/ToolBox/superpmi/superpmi-shim-collector/CMakeLists.txt
@@ -33,6 +33,7 @@ set(SUPERPMI_SHIM_COLLECTOR_SOURCES
     ../superpmi-shared/spmiutil.cpp
     ../superpmi-shared/tocfile.cpp
     ../superpmi-shared/typeutils.cpp
+    ../superpmi-shared/spmidumphelper.cpp
 )
 
 add_precompiled_header(

--- a/src/ToolBox/superpmi/superpmi-shim-counter/CMakeLists.txt
+++ b/src/ToolBox/superpmi/superpmi-shim-counter/CMakeLists.txt
@@ -34,6 +34,7 @@ set(SUPERPMI_SHIM_COUNTER_SOURCES
     ../superpmi-shared/spmiutil.cpp
     ../superpmi-shared/tocfile.cpp
     ../superpmi-shared/typeutils.cpp
+    ../superpmi-shared/spmidumphelper.cpp
 )
 
 add_precompiled_header(

--- a/src/ToolBox/superpmi/superpmi-shim-simple/CMakeLists.txt
+++ b/src/ToolBox/superpmi/superpmi-shim-simple/CMakeLists.txt
@@ -33,6 +33,7 @@ set(SUPERPMI_SHIM_SIMPLE_SOURCES
     ../superpmi-shared/spmiutil.cpp
     ../superpmi-shared/tocfile.cpp
     ../superpmi-shared/typeutils.cpp
+    ../superpmi-shared/spmidumphelper.cpp
 )
 
 add_precompiled_header(

--- a/src/ToolBox/superpmi/superpmi/CMakeLists.txt
+++ b/src/ToolBox/superpmi/superpmi/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SUPERPMI_SOURCES
     ../superpmi-shared/spmiutil.cpp
     ../superpmi-shared/tocfile.cpp
     ../superpmi-shared/typeutils.cpp
+    ../superpmi-shared/spmidumphelper.cpp
 )
 
 add_precompiled_header(


### PR DESCRIPTION
1. delete duplicate code for sigInfo;
2. fix the names for pSig that should be pSig_Index when it is the index of the buffer;
3. create dump class, that returns string representation of most popular structs, allows to delete duplicates. 
4. dump helper also shows some forgotten fields in dmp functions, fixed.