### PR TITLE
Mark lvDoNotEnregister lclVars as contained

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2435,6 +2435,9 @@ public:
         DNER_LiveAcrossUnmanagedCall,
         DNER_BlockOp,     // Is read or written via a block operation that explicitly takes the address.
         DNER_IsStructArg, // Is a struct passed as an argument in a way that requires a stack location.
+        DNER_DepField,    // It is a field of a dependently promoted struct
+        DNER_NoRegVars,   // opts.compFlags & CLFLG_REGVAR is not set
+        DNER_MinOptsGC,   // It is a GC Ref and we are compiling MinOpts
 #ifdef JIT32_GCENCODER
         DNER_PinningRef,
 #endif

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -134,6 +134,8 @@ private:
 
     void TreeNodeInfoInitCheckByteable(GenTree* tree);
 
+    void SetDelayFree(GenTree* delayUseSrc);
+
 #if defined(_TARGET_XARCH_)
     void TreeNodeInfoInitSimple(GenTree* tree);
 

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -279,7 +279,7 @@ private:
     bool IsContainableImmed(GenTree* parentNode, GenTree* childNode);
 
     // Return true if 'node' is a containable memory op.
-    bool IsContainableMemoryOp(GenTree* node);
+    bool IsContainableMemoryOp(GenTree* node, bool useTracked);
 
     // Makes 'childNode' contained in the 'parentNode'
     void MakeSrcContained(GenTreePtr parentNode, GenTreePtr childNode);

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -10839,6 +10839,14 @@ void TreeNodeInfo::dump(LinearScan* lsra)
     {
         printf(" P");
     }
+    if (regOptional)
+    {
+        printf(" O");
+    }
+    if (isInternalRegDelayFree)
+    {
+        printf(" ID");
+    }
     printf(">\n");
 }
 

--- a/src/jit/lsraxarch.cpp
+++ b/src/jit/lsraxarch.cpp
@@ -401,12 +401,13 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
                 info->srcCount = 2;
                 info->dstCount = 1;
 
-                if (IsContainableMemoryOp(op2) || op2->IsCnsNonZeroFltOrDbl())
+                if (IsContainableMemoryOp(op2, true) || op2->IsCnsNonZeroFltOrDbl())
                 {
                     MakeSrcContained(tree, op2);
                 }
                 else if (tree->OperIsCommutative() &&
-                         (op1->IsCnsNonZeroFltOrDbl() || (IsContainableMemoryOp(op1) && IsSafeToContainMem(tree, op1))))
+                         (op1->IsCnsNonZeroFltOrDbl() ||
+                          (IsContainableMemoryOp(op1, true) && IsSafeToContainMem(tree, op1))))
                 {
                     // Though we have GT_ADD(op1=memOp, op2=non-memOp, we try to reorder the operands
                     // as long as it is safe so that the following efficient code sequence is generated:
@@ -630,7 +631,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             {
                 other = node->gtIndex;
             }
-            else if (IsContainableMemoryOp(node->gtIndex))
+            else if (IsContainableMemoryOp(node->gtIndex, true))
             {
                 other = node->gtIndex;
             }
@@ -641,7 +642,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
 
             if (node->gtIndex->TypeGet() == node->gtArrLen->TypeGet())
             {
-                if (IsContainableMemoryOp(other))
+                if (IsContainableMemoryOp(other, true))
                 {
                     MakeSrcContained(tree, other);
                 }
@@ -845,8 +846,8 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
 
                 delayUseSrc = op1;
             }
-            else if ((op2 != nullptr) &&
-                     (!tree->OperIsCommutative() || (IsContainableMemoryOp(op2) && (op2->gtLsraInfo.srcCount == 0))))
+            else if ((op2 != nullptr) && (!tree->OperIsCommutative() ||
+                                          (IsContainableMemoryOp(op2, true) && (op2->gtLsraInfo.srcCount == 0))))
             {
                 delayUseSrc = op2;
             }
@@ -2118,7 +2119,8 @@ void Lowering::TreeNodeInfoInitLogicalOp(GenTree* tree)
         binOpInRMW = IsBinOpInRMWStoreInd(tree);
         if (!binOpInRMW)
         {
-            if (IsContainableMemoryOp(op2) && tree->TypeGet() == op2->TypeGet())
+            const unsigned operatorSize = genTypeSize(tree->TypeGet());
+            if (IsContainableMemoryOp(op2, true) && (genTypeSize(op2->TypeGet()) == operatorSize))
             {
                 directlyEncodable = true;
                 operand           = op2;
@@ -2126,7 +2128,8 @@ void Lowering::TreeNodeInfoInitLogicalOp(GenTree* tree)
             else if (tree->OperIsCommutative())
             {
                 if (IsContainableImmed(tree, op1) ||
-                    (IsContainableMemoryOp(op1) && tree->TypeGet() == op1->TypeGet() && IsSafeToContainMem(tree, op1)))
+                    (IsContainableMemoryOp(op1, true) && (genTypeSize(op1->TypeGet()) == operatorSize) &&
+                     IsSafeToContainMem(tree, op1)))
                 {
                     // If it is safe, we can reverse the order of operands of commutative operations for efficient
                     // codegen
@@ -2184,7 +2187,7 @@ void Lowering::TreeNodeInfoInitModDiv(GenTree* tree)
                 // everything is made explicit by adding casts.
                 assert(op1->TypeGet() == op2->TypeGet());
 
-                if (IsContainableMemoryOp(op2) || op2->IsCnsNonZeroFltOrDbl())
+                if (IsContainableMemoryOp(op2, true) || op2->IsCnsNonZeroFltOrDbl())
                 {
                     MakeSrcContained(tree, op2);
                 }
@@ -2251,7 +2254,7 @@ void Lowering::TreeNodeInfoInitModDiv(GenTree* tree)
     }
 
     // divisor can be an r/m, but the memory indirection must be of the same size as the divide
-    if (IsContainableMemoryOp(op2) && (op2->TypeGet() == tree->TypeGet()))
+    if (IsContainableMemoryOp(op2, true) && (op2->TypeGet() == tree->TypeGet()))
     {
         MakeSrcContained(tree, op2);
     }
@@ -2290,7 +2293,7 @@ void Lowering::TreeNodeInfoInitIntrinsic(GenTree* tree)
     switch (tree->gtIntrinsic.gtIntrinsicId)
     {
         case CORINFO_INTRINSIC_Sqrt:
-            if (IsContainableMemoryOp(op1) || op1->IsCnsNonZeroFltOrDbl())
+            if (IsContainableMemoryOp(op1, true) || op1->IsCnsNonZeroFltOrDbl())
             {
                 MakeSrcContained(tree, op1);
             }
@@ -2595,7 +2598,7 @@ void Lowering::TreeNodeInfoInitSIMD(GenTree* tree)
                 info->srcCount = 1;
             }
 
-            if (IsContainableMemoryOp(op1))
+            if (IsContainableMemoryOp(op1, true))
             {
                 MakeSrcContained(tree, op1);
 
@@ -2823,7 +2826,7 @@ void Lowering::TreeNodeInfoInitCast(GenTree* tree)
         // U8 -> R8 conversion requires that the operand be in a register.
         if (castOpType != TYP_ULONG)
         {
-            if (IsContainableMemoryOp(castOp) || castOp->IsCnsNonZeroFltOrDbl())
+            if (IsContainableMemoryOp(castOp, true) || castOp->IsCnsNonZeroFltOrDbl())
             {
                 MakeSrcContained(tree, castOp);
             }
@@ -3114,7 +3117,7 @@ void Lowering::TreeNodeInfoInitCmp(GenTreePtr tree)
         {
             MakeSrcContained(tree, otherOp);
         }
-        else if (IsContainableMemoryOp(otherOp) && ((otherOp == op2) || IsSafeToContainMem(tree, otherOp)))
+        else if (IsContainableMemoryOp(otherOp, true) && ((otherOp == op2) || IsSafeToContainMem(tree, otherOp)))
         {
             MakeSrcContained(tree, otherOp);
         }
@@ -3137,7 +3140,7 @@ void Lowering::TreeNodeInfoInitCmp(GenTreePtr tree)
         // we can treat the MemoryOp as contained.
         if (op1Type == op2Type)
         {
-            if (IsContainableMemoryOp(op1))
+            if (IsContainableMemoryOp(op1, true))
             {
                 MakeSrcContained(tree, op1);
             }
@@ -3186,11 +3189,11 @@ void Lowering::TreeNodeInfoInitCmp(GenTreePtr tree)
         // Note that TEST does not have a r,rm encoding like CMP has but we can still
         // contain the second operand because the emitter maps both r,rm and rm,r to
         // the same instruction code. This avoids the need to special case TEST here.
-        if (IsContainableMemoryOp(op2))
+        if (IsContainableMemoryOp(op2, true))
         {
             MakeSrcContained(tree, op2);
         }
-        else if (IsContainableMemoryOp(op1) && IsSafeToContainMem(tree, op1))
+        else if (IsContainableMemoryOp(op1, true) && IsSafeToContainMem(tree, op1))
         {
             MakeSrcContained(tree, op1);
         }
@@ -3281,7 +3284,7 @@ bool Lowering::TreeNodeInfoInitIfRMWMemOp(GenTreePtr storeInd)
         // On Xarch RMW operations require that the non-rmw operand be an immediate or in a register.
         // Therefore, if we have previously marked the indirOpSource as a contained memory op while lowering
         // the binary node, we need to reset that now.
-        if (IsContainableMemoryOp(indirOpSource))
+        if (IsContainableMemoryOp(indirOpSource, true))
         {
             indirOpSource->ClearContained();
         }
@@ -3400,11 +3403,11 @@ void Lowering::TreeNodeInfoInitMul(GenTreePtr tree)
     {
         assert(tree->OperGet() == GT_MUL);
 
-        if (IsContainableMemoryOp(op2) || op2->IsCnsNonZeroFltOrDbl())
+        if (IsContainableMemoryOp(op2, true) || op2->IsCnsNonZeroFltOrDbl())
         {
             MakeSrcContained(tree, op2);
         }
-        else if (op1->IsCnsNonZeroFltOrDbl() || (IsContainableMemoryOp(op1) && IsSafeToContainMem(tree, op1)))
+        else if (op1->IsCnsNonZeroFltOrDbl() || (IsContainableMemoryOp(op1, true) && IsSafeToContainMem(tree, op1)))
         {
             // Since  GT_MUL is commutative, we will try to re-order operands if it is safe to
             // generate more efficient code sequence for the case of GT_MUL(op1=memOp, op2=non-memOp)
@@ -3493,7 +3496,7 @@ void Lowering::TreeNodeInfoInitMul(GenTreePtr tree)
         }
 
         MakeSrcContained(tree, imm); // The imm is always contained
-        if (IsContainableMemoryOp(other))
+        if (IsContainableMemoryOp(other, true))
         {
             memOp = other; // memOp may be contained below
         }
@@ -3504,9 +3507,24 @@ void Lowering::TreeNodeInfoInitMul(GenTreePtr tree)
     // This is because during codegen we use 'tree' type to derive EmitTypeSize.
     // E.g op1 type = byte, op2 type = byte but GT_MUL tree type is int.
     //
-    if (memOp == nullptr && IsContainableMemoryOp(op2))
+    if (memOp == nullptr)
     {
-        memOp = op2;
+        if (IsContainableMemoryOp(op2, true) && (op2->TypeGet() == tree->TypeGet()) && IsSafeToContainMem(tree, op2))
+        {
+            memOp = op2;
+        }
+        else if (IsContainableMemoryOp(op1, true) && (op1->TypeGet() == tree->TypeGet()) &&
+                 IsSafeToContainMem(tree, op1))
+        {
+            memOp = op1;
+        }
+    }
+    else
+    {
+        if ((memOp->TypeGet() != tree->TypeGet()) || !IsSafeToContainMem(tree, memOp))
+        {
+            memOp = nullptr;
+        }
     }
 
     // To generate an LEA we need to force memOp into a register
@@ -3514,7 +3532,7 @@ void Lowering::TreeNodeInfoInitMul(GenTreePtr tree)
     //
     if (!useLeaEncoding)
     {
-        if ((memOp != nullptr) && (memOp->TypeGet() == tree->TypeGet()) && IsSafeToContainMem(tree, memOp))
+        if (memOp != nullptr)
         {
             MakeSrcContained(tree, memOp);
         }
@@ -3643,7 +3661,7 @@ bool Lowering::ExcludeNonByteableRegisters(GenTree* tree)
                 GenTree*  op1      = simdNode->gtGetOp1();
                 GenTree*  op2      = simdNode->gtGetOp2();
                 var_types baseType = simdNode->gtSIMDBaseType;
-                if (!IsContainableMemoryOp(op1) && op2->IsCnsIntOrI() && varTypeIsSmallInt(baseType))
+                if (!IsContainableMemoryOp(op1, true) && op2->IsCnsIntOrI() && varTypeIsSmallInt(baseType))
                 {
                     bool     ZeroOrSignExtnReqd = true;
                     unsigned baseSize           = genTypeSize(baseType);


### PR DESCRIPTION
Even if a lclVar is tracked, it may not be a register candidate. When determining whether a lclVar should be contained or RegOptional, take that into account.
In the interest of making this as accurate as possible, mark lclVars early as lvDoNotEnregister when they meet criteria that will later disqualify them from a register.