### PR TITLE
Enable ARM test runs in Helix

### DIFF
--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -354,6 +354,41 @@
         {
           "Name": "Dotnet-CoreClr-Trusted-BuildTests",
           "Parameters": {
+            "Architecture": "arm",
+            "HelixJobType": "test/functional/cli/",
+            "TargetsWindows": "true",
+            "Rid": "win-arm",
+            "TargetQueues": "windows.10.arm64",
+            "TestContainerSuffix": "windows",
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "SubType":  "Build-Tests",
+            "Type": "build/product/",
+            "PB_BuildType": "Release"
+          }
+        },
+        {
+          "Name": "Dotnet-CoreClr-Trusted-BuildTests",
+          "Parameters": {
+            "Architecture": "arm",
+            "HelixJobType": "test/functional/r2r/cli/",
+            "TargetsWindows": "true",
+            "Rid": "win-arm",
+            "TargetQueues": "windows.10.arm64",
+            "TestContainerSuffix": "windows-r2r",
+            "CrossgenArg": "Crossgen "
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "SubType":  "Build-Tests-R2R",
+            "Type": "build/product/",
+            "PB_BuildType": "Release"
+          }
+        },
+        {
+          "Name": "Dotnet-CoreClr-Trusted-BuildTests",
+          "Parameters": {
             "HelixJobType": "test/functional/cli/",
             "TargetsWindows": "false",
             "Rid": "osx-x64",


### PR DESCRIPTION
This will enable ARM tests for IL & Ready-to-run in Helix.

CC @RussKeldorph @danmosemsft @MattGal