### PR TITLE
Fix package download path.

### DIFF
--- a/tests/dir.props
+++ b/tests/dir.props
@@ -66,7 +66,7 @@
 
    <ItemGroup> 
      <!-- Need to escape double forward slash (%2F) or MSBuild will normalize to one slash on Unix. -->
-     <DotnetSourceList Include="$(PackagesDir)AzureTransfer\$(__BuildType)\pkg\" Condition="'$(OverwriteCoreClrPackageVersion)' == 'true'" />
+     <DotnetSourceList Include="$(PackagesDir)AzureTransfer\" Condition="'$(OverwriteCoreClrPackageVersion)' == 'true'" />
      <DotnetSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
      <DotnetSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-core/api/v3/index.json" /> 
      <DotnetSourceList Include="https:%2F%2Fapi.nuget.org/v3/index.json" /> 


### PR DESCRIPTION
This was a BuildTools change that leaves the $BuildConfiguration/pkg part off of the package download path.