### PR TITLE
Check for TestEnv before running test

### DIFF
--- a/tests/src/CLRTest.Execute.Batch.targets
+++ b/tests/src/CLRTest.Execute.Batch.targets
@@ -364,7 +364,14 @@ $(BatchCLRTestArgPrep)
 $(BatchCLRTestExitCodePrep)
 
 REM The __TestEnv variable may be used to specify something to run before the test.
-IF NOT "%__TestEnv%"=="" call %__TestEnv%
+IF NOT "%__TestEnv%"=="" (
+    if exist %__TestEnv% (
+        call %__TestEnv%
+    ) else (
+        echo "Error unable to find TestEnv."
+        exit /b -1
+    )
+)
 
 REM Environment Variables
 $(BatchEnvironmentVariables)


### PR DESCRIPTION
This handles the case that an incorrect path was passed for the TestEnv
location. Instead of running something possibly undesired, return an error
and warn that the TestEnv was incorrectly passed.