### PR TITLE
Ignore specified signal when using perf

### DIFF
--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -836,6 +836,7 @@ RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_ProfAPI_ValidateNGENInstrumentation, W("Pro
 
 #ifdef FEATURE_PERFMAP
 RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_PerfMapEnabled, W("PerfMapEnabled"), 0, "This flag is used on Linux to enable writing /tmp/perf-$pid.map. It is disabled by default", CLRConfig::REGUTIL_default)
+RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_PerfMapIgnoreSignal, W("PerfMapIgnoreSignal"), 0, "When perf map is enabled, this option will configure the specified signal to be accepeted and ignored as a marker in the perf logs.  It is disabled by default", CLRConfig::REGUTIL_default)
 #endif
 
 //

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -503,7 +503,7 @@ PAL_InitializeDebug(
 PALIMPORT
 void
 PALAPI
-PAL_IgnoreProfileSignal(void);
+PAL_IgnoreProfileSignal(int signalNum);
 
 PALIMPORT
 HINSTANCE

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -501,6 +501,11 @@ PAL_InitializeDebug(
     void);
 
 PALIMPORT
+void
+PALAPI
+PAL_IgnoreProfileSignal(void);
+
+PALIMPORT
 HINSTANCE
 PALAPI
 PAL_RegisterModule(

--- a/src/pal/src/exception/signal.cpp
+++ b/src/pal/src/exception/signal.cpp
@@ -711,22 +711,22 @@ static void signal_ignore_handler(int code, siginfo_t *siginfo, void *context)
 }
 
 
-void PAL_IgnoreProfileSignal(void)
+void PAL_IgnoreProfileSignal(int signalNum)
 {
-#if !HAVE_MACH_EXCEPTIONS && defined(SIGRTMAX)
+#if !HAVE_MACH_EXCEPTIONS
     // Add a signal handler which will ignore signals
     // This will allow signal to be used as a marker in perf recording.
     // This will be used as an aid to synchromize recorded profile with
     // test cases
     //
-    // signal(SIGRTMAX, SGN_IGN) can not be used here.  It will ignore
+    // signal(signalNum, SGN_IGN) can not be used here.  It will ignore
     // the signal in kernel space and therefore generate no recordable
     // event for profiling. Preventing it being used for profile
     // synchronization
     //
     // Since this is only used in rare circumstances no attempt to
     // restore the old handler will be made
-    handle_signal(SIGRTMAX, signal_ignore_handler, 0);
+    handle_signal(signalNum, signal_ignore_handler, 0);
 #endif
 }
 

--- a/src/pal/src/exception/signal.cpp
+++ b/src/pal/src/exception/signal.cpp
@@ -697,6 +697,42 @@ PAL_ERROR InjectActivationInternal(CorUnix::CPalThread* pThread)
 
 /*++
 Function :
+    signal_ignore_handler
+
+    Simple signal handler which does nothing
+
+Parameters :
+    POSIX signal handler parameter list ("man sigaction" for details)
+
+(no return value)
+--*/
+static void signal_ignore_handler(int code, siginfo_t *siginfo, void *context)
+{
+}
+
+
+void PAL_IgnoreProfileSignal(void)
+{
+#if !HAVE_MACH_EXCEPTIONS && defined(SIGRTMAX)
+    // Add a signal handler which will ignore signals
+    // This will allow signal to be used as a marker in perf recording.
+    // This will be used as an aid to synchromize recorded profile with
+    // test cases
+    //
+    // signal(SIGRTMAX, SGN_IGN) can not be used here.  It will ignore
+    // the signal in kernel space and therefore generate no recordable
+    // event for profiling. Preventing it being used for profile
+    // synchronization
+    //
+    // Since this is only used in rare circumstances no attempt to
+    // restore the old handler will be made
+    handle_signal(SIGRTMAX, signal_ignore_handler, 0);
+#endif
+}
+
+
+/*++
+Function :
     SEHSetSafeState
 
     specify whether the current thread is in a state where exception handling 

--- a/src/pal/src/exception/signal.cpp
+++ b/src/pal/src/exception/signal.cpp
@@ -716,7 +716,7 @@ void PAL_IgnoreProfileSignal(int signalNum)
 #if !HAVE_MACH_EXCEPTIONS
     // Add a signal handler which will ignore signals
     // This will allow signal to be used as a marker in perf recording.
-    // This will be used as an aid to synchromize recorded profile with
+    // This will be used as an aid to synchronize recorded profile with
     // test cases
     //
     // signal(signalNum, SGN_IGN) can not be used here.  It will ignore

--- a/src/vm/perfmap.cpp
+++ b/src/vm/perfmap.cpp
@@ -30,7 +30,7 @@ void PerfMap::Initialize()
 
         int signalNum = (int) CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_PerfMapIgnoreSignal);
 
-        if(signalNum > 0)
+        if (signalNum > 0)
         {
             PAL_IgnoreProfileSignal(signalNum);
         }

--- a/src/vm/perfmap.cpp
+++ b/src/vm/perfmap.cpp
@@ -28,7 +28,12 @@ void PerfMap::Initialize()
         // Create the map.
         s_Current = new PerfMap(currentPid);
 
-        PAL_IgnoreProfileSignal();
+        int signalNum = (int) CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_PerfMapIgnoreSignal);
+
+        if(signalNum > 0)
+        {
+            PAL_IgnoreProfileSignal(signalNum);
+        }
     }
 }
 

--- a/src/vm/perfmap.cpp
+++ b/src/vm/perfmap.cpp
@@ -27,6 +27,8 @@ void PerfMap::Initialize()
 
         // Create the map.
         s_Current = new PerfMap(currentPid);
+
+        PAL_IgnoreProfileSignal();
     }
 }
 


### PR DESCRIPTION
Add a do nothing signal handler to SIGRTMAX for profiling purposes.  Allows synchronization point injection into the profile