### PR TITLE
Update compLongUsed in rationalize.

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -4460,7 +4460,10 @@ void Lowering::DoPhase()
 
 #if !defined(_TARGET_64BIT_)
     DecomposeLongs decomp(comp); // Initialize the long decomposition class.
-    decomp.PrepareForDecomposition();
+    if (comp->compLongUsed)
+    {
+        decomp.PrepareForDecomposition();
+    }
 #endif // !defined(_TARGET_64BIT_)
 
     for (BasicBlock* block = comp->fgFirstBB; block; block = block->bbNext)
@@ -4469,7 +4472,10 @@ void Lowering::DoPhase()
         comp->compCurBB = block;
 
 #if !defined(_TARGET_64BIT_)
-        decomp.DecomposeBlock(block);
+        if (comp->compLongUsed)
+        {
+            decomp.DecomposeBlock(block);
+        }
 #endif //!_TARGET_64BIT_
 
         LowerBlock(block);

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -983,6 +983,11 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, ArrayStack<G
             // Clear the GTF_CALL flag for all nodes but calls
             node->gtFlags &= ~GTF_CALL;
         }
+
+        if (node->TypeGet() == TYP_LONG)
+        {
+            comp->compLongUsed = true;
+        }
     }
 
     assert(isLateArg == ((use.Def()->gtFlags & GTF_LATE_ARG) != 0));


### PR DESCRIPTION
This allows us to skip decompisition if long-typed values are not used by a method.