### PR TITLE
Maintain `LIR::IsUnusedValue` in the backend.

### DIFF
--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -1765,17 +1765,17 @@ GenTree* DecomposeLongs::DecomposeSimdGetItem(LIR::Use& use)
         index = simdTree->gtOp.gtOp2->gtIntCon.gtIconVal;
     }
 
-    GenTree* simdTmpVar = RepresentOpAsLocalVar(simdTree->gtOp.gtOp1, simdTree, &simdTree->gtOp.gtOp1);
+    GenTree* simdTmpVar    = RepresentOpAsLocalVar(simdTree->gtOp.gtOp1, simdTree, &simdTree->gtOp.gtOp1);
     unsigned simdTmpVarNum = simdTmpVar->AsLclVarCommon()->gtLclNum;
     JITDUMP("[DecomposeSimdGetItem]: Saving op1 tree to a temp var:\n");
     DISPTREERANGE(Range(), simdTmpVar);
     Range().Remove(simdTmpVar);
 
-    GenTree* indexTmpVar = nullptr;
+    GenTree* indexTmpVar    = nullptr;
     unsigned indexTmpVarNum = 0;
     if (!indexIsConst)
     {
-        indexTmpVar = RepresentOpAsLocalVar(simdTree->gtOp.gtOp2, simdTree, &simdTree->gtOp.gtOp2);
+        indexTmpVar    = RepresentOpAsLocalVar(simdTree->gtOp.gtOp2, simdTree, &simdTree->gtOp.gtOp2);
         indexTmpVarNum = indexTmpVar->AsLclVarCommon()->gtLclNum;
         JITDUMP("[DecomposeSimdGetItem]: Saving op2 tree to a temp var:\n");
         DISPTREERANGE(Range(), indexTmpVar);

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -10298,7 +10298,7 @@ void Compiler::fgRemoveConditionalJump(BasicBlock* block)
         else
         {
             // Otherwise, just remove the jump node itself.
-            blockRange.Remove(test);
+            blockRange.Remove(test, true);
         }
     }
     else
@@ -14070,7 +14070,7 @@ bool Compiler::fgOptimizeBranchToNext(BasicBlock* block, BasicBlock* bNext, Basi
             else
             {
                 // Otherwise, just remove the jump node itself.
-                blockRange.Remove(jmp);
+                blockRange.Remove(jmp, true);
             }
         }
         else

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -972,10 +972,18 @@ void LIR::Range::InsertAtEnd(Range&& range)
 // Arguments:
 //    node - The node to remove. Must be part of this range.
 //
-void LIR::Range::Remove(GenTree* node)
+void LIR::Range::Remove(GenTree* node, bool markOperandsUnused)
 {
     assert(node != nullptr);
     assert(Contains(node));
+
+    if (markOperandsUnused)
+    {
+        for (GenTree* operand : node->Operands())
+        {
+            operand->gtLIRFlags |= Flags::IsUnusedValue;
+        }
+    }
 
     GenTree* prev = node->gtPrev;
     GenTree* next = node->gtNext;

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -1188,7 +1188,7 @@ bool LIR::Range::TryGetUse(GenTree* node, Use* use)
     // Don't bother looking for uses of nodes that are not values.
     // If the node is the last node, we won't find a use (and we would
     // end up creating an illegal range if we tried).
-    if (node->IsValue() && (node != LastNode()))
+    if (node->IsValue() && ((node->gtLIRFlags & Flags::IsUnusedValue) == 0) && (node != LastNode()))
     {
         for (GenTree* n : ReadOnlyRange(node->gtNext, m_lastNode))
         {

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -971,6 +971,7 @@ void LIR::Range::InsertAtEnd(Range&& range)
 //
 // Arguments:
 //    node - The node to remove. Must be part of this range.
+//    markOperandsUnused - If true, marks the node's operands as unused.
 //
 void LIR::Range::Remove(GenTree* node, bool markOperandsUnused)
 {

--- a/src/jit/lir.h
+++ b/src/jit/lir.h
@@ -279,7 +279,7 @@ public:
         void InsertAtBeginning(Range&& range);
         void InsertAtEnd(Range&& range);
 
-        void Remove(GenTree* node);
+        void Remove(GenTree* node, bool markOperandsUnused = false);
         Range Remove(GenTree* firstNode, GenTree* lastNode);
         Range Remove(ReadOnlyRange&& range);
 

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -2278,6 +2278,11 @@ bool Compiler::fgTryRemoveDeadLIRStore(LIR::Range& blockRange, GenTree* node, Ge
         // If the range of the operands contains unrelated code or if it contains any side effects,
         // do not remove it. Instead, just remove the store.
 
+        for (GenTree* operand : node->Operands())
+        {
+            operand->gtLIRFlags |= LIR::Flags::IsUnusedValue;
+        }
+
         *next = node->gtPrev;
     }
     else

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -4533,9 +4533,12 @@ void Lowering::DoPhase()
     {
         comp->fgDispBasicBlocks(true);
     }
-#endif
 
-    assert(BlockRange().CheckLIR(comp, true));
+    for (BasicBlock* block = comp->fgFirstBB; block; block = block->bbNext)
+    {
+        assert(LIR::AsRange(block).CheckLIR(comp, true));
+    }
+#endif
 
     // The initialization code for the TreeNodeInfo map was initially part of a single full IR
     // traversal and it has been split because the order of traversal performed by fgWalkTreePost
@@ -4581,23 +4584,8 @@ void Lowering::DoPhase()
             node->gtLsraInfo.Initialize(m_lsra, node, currentLoc);
             node->gtClearReg(comp);
 
-            // Mark the node's operands as used
-            for (GenTree* operand : node->Operands())
-            {
-                operand->gtLIRFlags &= ~LIR::Flags::IsUnusedValue;
-            }
-
-            // If the node produces a value, mark it as unused.
-            if (node->IsValue())
-            {
-                node->gtLIRFlags |= LIR::Flags::IsUnusedValue;
-            }
-
             currentLoc += 2;
-        }
 
-        for (GenTree* node : BlockRange().NonPhiNodes())
-        {
             TreeNodeInfoInit(node);
 
             // Only nodes that produce values should have a non-zero dstCount.

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2155,6 +2155,10 @@ void Lowering::LowerCompare(GenTree* cmp)
                         comp->lvaDecRefCnts(m_block, loSrc1);
                     }
                 }
+                else
+                {
+                    loSrc1->gtLIRFlags |= LIR::Flags::IsUnusedValue;
+                }
 
                 hiCmp = comp->gtNewOperNode(GT_CMP, TYP_VOID, hiSrc1, hiSrc2);
                 BlockRange().InsertBefore(cmp, hiCmp);
@@ -2182,6 +2186,10 @@ void Lowering::LowerCompare(GenTree* cmp)
         }
 
         hiCmp->gtFlags |= GTF_SET_FLAGS;
+        if (hiCmp->IsValue())
+        {
+            hiCmp->gtLIRFlags |= LIR::Flags::IsUnusedValue;
+        }
 
         LIR::Use cmpUse;
         if (BlockRange().TryGetUse(cmp, &cmpUse) && cmpUse.User()->OperIs(GT_JTRUE))
@@ -4410,6 +4418,10 @@ GenTree* Lowering::LowerArrElem(GenTree* node)
     {
         arrElemUse.ReplaceWith(comp, leaNode);
     }
+    else
+    {
+        leaNode->gtLIRFlags |= LIR::Flags::IsUnusedValue;
+    }
 
     BlockRange().Remove(arrElem);
 
@@ -4513,6 +4525,7 @@ void Lowering::DoPhase()
             comp->fgLocalVarLiveness();
         }
     }
+
 #ifdef DEBUG
     JITDUMP("Liveness pass finished after lowering, IR:\n");
     JITDUMP("lvasortagain = %d\n", comp->lvaSortAgain);
@@ -4521,6 +4534,8 @@ void Lowering::DoPhase()
         comp->fgDispBasicBlocks(true);
     }
 #endif
+
+    assert(BlockRange().CheckLIR(comp, true));
 
     // The initialization code for the TreeNodeInfo map was initially part of a single full IR
     // traversal and it has been split because the order of traversal performed by fgWalkTreePost
@@ -4589,7 +4604,7 @@ void Lowering::DoPhase()
             assert((node->gtLsraInfo.dstCount == 0) || node->IsValue());
 
             // If the node produces an unused value, mark it as a local def-use
-            if ((node->gtLIRFlags & LIR::Flags::IsUnusedValue) != 0)
+            if (node->IsValue() && ((node->gtLIRFlags & LIR::Flags::IsUnusedValue) != 0))
             {
                 node->gtLsraInfo.isLocalDefUse = true;
                 node->gtLsraInfo.dstCount      = 0;
@@ -4726,7 +4741,7 @@ bool Lowering::CheckBlock(Compiler* compiler, BasicBlock* block)
         CheckNode(node);
     }
 
-    assert(blockRange.CheckLIR(compiler));
+    assert(blockRange.CheckLIR(compiler, true));
     return true;
 }
 #endif

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -4770,7 +4770,7 @@ void LinearScan::buildIntervals()
         for (GenTree* node : blockRange.NonPhiNodes())
         {
             assert(node->gtLsraInfo.loc >= currentLoc);
-            assert(((node->gtLIRFlags & LIR::Flags::IsUnusedValue) == 0) || node->gtLsraInfo.isLocalDefUse);
+            assert(!node->IsValue() || ((node->gtLIRFlags & LIR::Flags::IsUnusedValue) == 0) || node->gtLsraInfo.isLocalDefUse);
 
             currentLoc = node->gtLsraInfo.loc;
             buildRefPositionsForNode(node, block, listNodePool, operandToLocationInfoMap, currentLoc);

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -4770,7 +4770,8 @@ void LinearScan::buildIntervals()
         for (GenTree* node : blockRange.NonPhiNodes())
         {
             assert(node->gtLsraInfo.loc >= currentLoc);
-            assert(!node->IsValue() || ((node->gtLIRFlags & LIR::Flags::IsUnusedValue) == 0) || node->gtLsraInfo.isLocalDefUse);
+            assert(!node->IsValue() || ((node->gtLIRFlags & LIR::Flags::IsUnusedValue) == 0) ||
+                   node->gtLsraInfo.isLocalDefUse);
 
             currentLoc = node->gtLsraInfo.loc;
             buildRefPositionsForNode(node, block, listNodePool, operandToLocationInfoMap, currentLoc);


### PR DESCRIPTION
This flag indicates whether or not the SDSU temp produced by a node is
ever read. This information is needed by the register allocator, but is
also useful in other parts of the compiler (for example, `TryGetUse` can
return immediately if this flag is set). Setting this flag properly in
rationalize and maintaining it through decomposition and lowering allows
us to remove an IR walk immediately prior to LSRA.