### PR TITLE
Get rid of redundant spinning on non-Windows machines

### DIFF
--- a/src/vm/syncblk.cpp
+++ b/src/vm/syncblk.cpp
@@ -3337,7 +3337,8 @@ bool AwareLock::Contention(INT32 timeOut)
                     bKeepGoing = false;
                     break;
                 }
-                
+
+#ifdef PLATFORM_WINDOWS
                 // Spin for i iterations, and make sure to never go more than 20000 iterations between
                 // checking if we should SwitchToThread
                 int remainingDelay = i;
@@ -3376,7 +3377,7 @@ bool AwareLock::Contention(INT32 timeOut)
                         __SwitchToThread(0, CALLER_LIMITS_SPINNING);
                     }
                 }
-
+#endif // PLATFORM_WINDOWS
                 // exponential backoff: wait a factor longer in the next iteration
                 i *= g_SpinConstants.dwBackoffFactor;
             }

--- a/src/vm/syncblk.inl
+++ b/src/vm/syncblk.inl
@@ -133,6 +133,7 @@ inline AwareLock::EnterHelperResult ObjHeader::EnterObjMonitorHelperSpin(Thread*
         return AwareLock::EnterHelperResult_Contention;
     }
 
+#ifdef PLATFORM_WINDOWS
     DWORD spincount = g_SpinConstants.dwInitialDuration;
 
     for (;;)
@@ -159,6 +160,17 @@ inline AwareLock::EnterHelperResult ObjHeader::EnterObjMonitorHelperSpin(Thread*
     }
 
     return AwareLock::EnterHelperResult_Contention;
+#else
+    // non-Windows
+    for (;;)
+    {
+        AwareLock::EnterHelperResult result = EnterObjMonitorHelper(pCurThread);
+        if (result != AwareLock::EnterHelperResult_Contention)
+        {
+            return result;
+        }
+    }
+#endif // PLATFORM_WINDOWS
 }
 
 // Helper encapsulating the core logic for releasing monitor. Returns what kind of 


### PR DESCRIPTION
Attempt to fix Linux issue discovered during investigation low performance of building tests. 