### PR TITLE
Remove unnecessary update of RegRecord in LSRA

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -6480,6 +6480,9 @@ void LinearScan::unassignPhysReg(RegRecord* regRec, RefPosition* spillRefPositio
     {
         // This must have been a temporary copy reg, but we can't assert that because there
         // may have been intervening RefPositions that were not copyRegs.
+
+        // reg->assignedInterval has already been set to nullptr by checkAndClearInterval()
+        assert(regRec->assignedInterval == nullptr);
         return;
     }
 

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -6480,7 +6480,6 @@ void LinearScan::unassignPhysReg(RegRecord* regRec, RefPosition* spillRefPositio
     {
         // This must have been a temporary copy reg, but we can't assert that because there
         // may have been intervening RefPositions that were not copyRegs.
-        regRec->assignedInterval = nullptr;
         return;
     }
 


### PR DESCRIPTION
We don't need to clear assignedInterval of regRec here,
because it was already cleared by checkAndClearInterval() above at https://github.com/dotnet/coreclr/pull/12474/files#diff-93fb9832a03a9783e2a415b581fcb45cR6453.
