### PR TITLE
Fix bad range check in TextInfo.IndexOfStringOrdinalIgnoreCase

### DIFF
--- a/src/mscorlib/src/System/Globalization/TextInfo.cs
+++ b/src/mscorlib/src/System/Globalization/TextInfo.cs
@@ -111,7 +111,7 @@ namespace System.Globalization
         // Currently we don't have native functions to do this, so we do it the hard way
         internal static int IndexOfStringOrdinalIgnoreCase(String source, String value, int startIndex, int count)
         {
-            if (count > source.Length || count < 0 || startIndex < 0 || startIndex >= source.Length || startIndex + count > source.Length)
+            if (count > source.Length || count < 0 || startIndex < 0 || startIndex > source.Length - count)
             {
                 return -1;
             }


### PR DESCRIPTION
Breaks:

   int idx = "\uabcd".IndexOf("", 1, StringComparison.OrdinalIgnoreCase);

should return 1, returns -1 instead.

(propagated fix from CoreRT)