### PR TITLE
Add ELF program and section headers to core dump. (#12425)

### DIFF
--- a/src/debug/createdump/createdump.h
+++ b/src/debug/createdump/createdump.h
@@ -33,6 +33,8 @@ extern bool g_diagnostics;
 #include <xcordebug.h>
 #include <mscoree.h>
 #include <dumpcommon.h>
+typedef int T_CONTEXT;
+#include <dacprivate.h>
 #include <arrayholder.h>
 #include <releaseholder.h>
 #include <unistd.h>

--- a/src/debug/createdump/dumpwriter.h
+++ b/src/debug/createdump/dumpwriter.h
@@ -69,9 +69,3 @@ private:
         );
     }
 };
-
-static inline int sex()
-{
-  int probe = 1;
-  return !*(char *)&probe;
-}

--- a/src/debug/createdump/memoryregion.h
+++ b/src/debug/createdump/memoryregion.h
@@ -2,20 +2,31 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+enum MEMORY_REGION_FLAGS : uint32_t
+{
+    // PF_X        = 0x01,      // Execute
+    // PF_W        = 0x02,      // Write
+    // PF_R        = 0x04,      // Read
+    MEMORY_REGION_FLAG_PERMISSIONS_MASK = 0x0f,
+    MEMORY_REGION_FLAG_SHARED = 0x10,
+    MEMORY_REGION_FLAG_PRIVATE = 0x20,
+    MEMORY_REGION_FLAG_MEMORY_BACKED = 0x40
+};
+
 struct MemoryRegion 
 {
 private:
-    uint32_t m_permissions;
+    uint32_t m_flags;
     uint64_t m_startAddress;
     uint64_t m_endAddress;
     uint64_t m_offset;
 
     // The name used for NT_FILE output
-    char* m_fileName;
+    const char* m_fileName;
 
 public:
-    MemoryRegion(uint64_t start, uint64_t end) : 
-        m_permissions(PF_R | PF_W | PF_X),
+    MemoryRegion(uint32_t flags, uint64_t start, uint64_t end) : 
+        m_flags(flags),
         m_startAddress(start),
         m_endAddress(end),
         m_offset(0),
@@ -25,8 +36,8 @@ public:
         assert((end & ~PAGE_MASK) == 0);
     }
 
-    MemoryRegion(uint32_t permissions, uint64_t start, uint64_t end, uint64_t offset, char* filename) : 
-        m_permissions(permissions),
+    MemoryRegion(uint32_t flags, uint64_t start, uint64_t end, uint64_t offset, const char* filename) : 
+        m_flags(flags),
         m_startAddress(start),
         m_endAddress(end),
         m_offset(offset),
@@ -36,7 +47,39 @@ public:
         assert((end & ~PAGE_MASK) == 0);
     }
 
-    const uint32_t Permissions() const { return m_permissions; }
+    // copy with new file name constructor
+    MemoryRegion(const MemoryRegion& region, const char* fileName) : 
+        m_flags(region.m_flags),
+        m_startAddress(region.m_startAddress),
+        m_endAddress(region.m_endAddress),
+        m_offset(region.m_offset),
+        m_fileName(fileName)
+    {
+    }
+
+    // copy with new flags constructor. The file name is not copied.
+    MemoryRegion(const MemoryRegion& region, uint32_t flags) : 
+        m_flags(flags),
+        m_startAddress(region.m_startAddress),
+        m_endAddress(region.m_endAddress),
+        m_offset(region.m_offset),
+        m_fileName(nullptr)
+    {
+    }
+
+    // copy constructor
+    MemoryRegion(const MemoryRegion& region) : 
+        m_flags(region.m_flags),
+        m_startAddress(region.m_startAddress),
+        m_endAddress(region.m_endAddress),
+        m_offset(region.m_offset),
+        m_fileName(region.m_fileName)
+    {
+    }
+
+    const uint32_t Permissions() const { return m_flags & MEMORY_REGION_FLAG_PERMISSIONS_MASK; }
+    const uint32_t Flags() const { return m_flags; }
+    const bool IsBackedByMemory() const { return (m_flags & MEMORY_REGION_FLAG_MEMORY_BACKED) != 0; }
     const uint64_t StartAddress() const { return m_startAddress; }
     const uint64_t EndAddress() const { return m_endAddress; }
     const uint64_t Size() const { return m_endAddress - m_startAddress; }
@@ -48,27 +91,25 @@ public:
         return (m_startAddress < rhs.m_startAddress) && (m_endAddress <= rhs.m_startAddress);
     }
 
+    // Returns true if "rhs" is wholly contained in this one
     bool Contains(const MemoryRegion& rhs) const
     {
         return (m_startAddress <= rhs.m_startAddress) && (m_endAddress >= rhs.m_endAddress);
     }
 
+    // Free the file name memory
     void Cleanup()
     {
         if (m_fileName != nullptr)
         {
-            free(m_fileName);
+            free((void*)m_fileName);
             m_fileName = nullptr;
         }
     }
 
-    void Print() const
+    void Trace() const
     {
-        if (m_fileName != nullptr) {
-            TRACE("%016lx - %016lx (%06ld) %016lx %x %s\n", m_startAddress, m_endAddress, (Size() >> PAGE_SHIFT), m_offset, m_permissions, m_fileName);
-        }
-        else {
-            TRACE("%016lx - %016lx (%06ld) %x\n", m_startAddress, m_endAddress, (Size() >> PAGE_SHIFT), m_permissions);
-        }
+        TRACE("%s%016lx - %016lx (%06ld) %016lx %02x %s\n", IsBackedByMemory() ? "*" : " ", m_startAddress, m_endAddress, 
+            (Size() >> PAGE_SHIFT), m_offset, m_flags, m_fileName != nullptr ? m_fileName : "");
     }
 };

--- a/src/debug/createdump/threadinfo.cpp
+++ b/src/debug/createdump/threadinfo.cpp
@@ -145,21 +145,19 @@ ThreadInfo::GetThreadStack(const CrashInfo& crashInfo, uint64_t* startAddress, s
     *startAddress = m_gpRegisters.rsp & PAGE_MASK;
     *size = 4 * PAGE_SIZE;
 
-    for (const MemoryRegion& mapping : crashInfo.OtherMappings())
-    {
-        if (*startAddress >= mapping.StartAddress() && *startAddress < mapping.EndAddress())
-        {
-            // Use the mapping found for the size of the thread's stack
-            *size = mapping.EndAddress() - *startAddress;
+    const MemoryRegion* region = CrashInfo::SearchMemoryRegions(crashInfo.OtherMappings(), *startAddress);
+    if (region != nullptr) {
 
-            if (g_diagnostics)
-            {
-                TRACE("Thread %04x stack found in other mapping (size %08lx): ", m_tid, *size);
-                mapping.Print();
-            }
-            break;
+        // Use the mapping found for the size of the thread's stack
+        *size = region->EndAddress() - *startAddress;
+
+        if (g_diagnostics)
+        {
+            TRACE("Thread %04x stack found in other mapping (size %08lx): ", m_tid, *size);
+            region->Trace();
         }
     }
+    
 }
 
 void

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -2951,6 +2951,10 @@ PROCAbortInitialize()
             {
                 *argv++ = "--triage";
             }
+            else if (strcmp(envvar, "4") == 0)
+            {
+                *argv++ = "--full";
+            }
         }
 
         envvar = getenv("COMPlus_CreateDumpDiagnostics");


### PR DESCRIPTION
Add ELF program and section headers to core dump.

Issue #12341

This allows the build id for the modules be extracted properly.

Add .eh_frame, .eh_frame_hdr and some other important sections to core dump.

Add managed module names to core dump so the symbol acquisition
tool can get symbol store keys for them.

Add the non memory/file backed memory regions to core dump so debuggers
like lldb can check if an address is "code" or not. Unwinding doesn't
work when there isn't a module/.so file present.