### PR TITLE
Pin GC threads to corresponding processors on Linux

### DIFF
--- a/src/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/dlls/mscoree/mscorwks_unixexports.src
@@ -109,6 +109,7 @@ WideCharToMultiByte
 WriteFile
 GetLogicalProcessorInformationEx
 SetThreadGroupAffinity
+SetThreadAffinityMask
 GetThreadGroupAffinity
 GetCurrentProcessorNumberEx
 

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -4990,6 +4990,14 @@ GetLogicalProcessorInformationEx(
 );
 
 PALIMPORT
+DWORD_PTR
+PALAPI
+SetThreadAffinityMask(
+  IN HANDLE hThread,
+  IN DWORD_PTR dwThreadAffinityMask
+);
+
+PALIMPORT
 BOOL
 PALAPI
 SetThreadGroupAffinity(

--- a/src/pal/src/numa/numa.cpp
+++ b/src/pal/src/numa/numa.cpp
@@ -595,7 +595,7 @@ SetThreadAffinityMask(
 
     if (st == 0)
     {
-        for (int i = 0; i < g_possibleCpuCount; i++)
+        for (int i = 0; i < min(8 * sizeof(KAFFINITY), g_possibleCpuCount); i++)
         {
             if (CPU_ISSET(i, &prevCpuSet))
             {
@@ -620,17 +620,17 @@ SetThreadAffinityMask(
 
     st = pthread_setaffinity_np(thread, sizeof(cpu_set_t), &cpuSet);
 
-    if (st == -1)
+    if (st != 0)
     {
-        switch (errno)
+        switch (st)
         {
         case EINVAL:
             // There is no processor in the mask that is allowed to execute the
             // process
             SetLastError(ERROR_INVALID_PARAMETER);
             break;
-        case EPERM:
-            SetLastError(ERROR_ACCESS_DENIED);
+        case ESRCH:
+            SetLastError(ERROR_INVALID_HANDLE);
             break;
         default:
             SetLastError(ERROR_GEN_FAILURE);

--- a/src/pal/src/numa/numa.cpp
+++ b/src/pal/src/numa/numa.cpp
@@ -438,11 +438,24 @@ GetThreadGroupAffinity(
 {
     PERF_ENTRY(GetThreadGroupAffinity);
     ENTRY("GetThreadGroupAffinity(hThread=%p, GroupAffinity=%p)\n", hThread, GroupAffinity);
+    CPalThread *pCurrentThread = InternalGetCurrentThread();
+    CPalThread *pTargetThread = NULL;
+    IPalObject *pTargetThreadObject = NULL;
 
-    CPalThread *palThread = InternalGetCurrentThread();
+    PAL_ERROR palErr =
+        InternalGetThreadDataFromHandle(pCurrentThread, hThread,
+                                        0, // THREAD_SET_CONTEXT
+                                        &pTargetThread, &pTargetThreadObject);
 
-    BOOL success = GetThreadGroupAffinityInternal(palThread->GetPThreadSelf(), GroupAffinity);
+    if (NO_ERROR != palErr)
+    {
+        ERROR("Unable to obtain thread data for handle %p (error %x)!\n", hThread,
+              palErr);
+        return FALSE;
+    }
 
+    BOOL success = GetThreadGroupAffinityInternal(
+        pTargetThread->GetPThreadSelf(), GroupAffinity);
     LOGEXIT("GetThreadGroupAffinity returns BOOL %d\n", success);
     PERF_EXIT(GetThreadGroupAffinity);
 
@@ -467,9 +480,23 @@ SetThreadGroupAffinity(
     PERF_ENTRY(SetThreadGroupAffinity);
     ENTRY("SetThreadGroupAffinity(hThread=%p, GroupAffinity=%p, PreviousGroupAffinity=%p)\n", hThread, GroupAffinity, PreviousGroupAffinity);
 
-    CPalThread *palThread = InternalGetCurrentThread();
+    CPalThread *pCurrentThread = InternalGetCurrentThread();
+    CPalThread *pTargetThread = NULL;
+    IPalObject *pTargetThreadObject = NULL;
 
-    pthread_t thread = palThread->GetPThreadSelf();
+    PAL_ERROR palErr =
+        InternalGetThreadDataFromHandle(pCurrentThread, hThread,
+                                        0, // THREAD_SET_CONTEXT
+                                        &pTargetThread, &pTargetThreadObject);
+
+    if (NO_ERROR != palErr)
+    {
+        ERROR("Unable to obtain thread data for handle %p (error %x)!\n", hThread,
+              palErr);
+        return FALSE;
+    }
+
+    pthread_t thread = pTargetThread->GetPThreadSelf();
 
     if (PreviousGroupAffinity != NULL)
     {
@@ -523,6 +550,103 @@ SetThreadGroupAffinity(
     PERF_EXIT(SetThreadGroupAffinity);
 
     return success;
+}
+
+/*++
+Function:
+  SetThreadAffinityMask
+
+See MSDN doc.
+--*/
+DWORD_PTR
+PALAPI
+SetThreadAffinityMask(
+  IN HANDLE hThread,
+  IN DWORD_PTR dwThreadAffinityMask
+)
+{
+    PERF_ENTRY(SetThreadAffinityMask);
+    ENTRY("SetThreadAffinityMask(hThread=%p, dwThreadAffinityMask=%p)\n", hThread, dwThreadAffinityMask);
+
+    CPalThread *pCurrentThread = InternalGetCurrentThread();
+    CPalThread *pTargetThread = NULL;
+    IPalObject *pTargetThreadObject = NULL;
+
+    PAL_ERROR palErr =
+        InternalGetThreadDataFromHandle(pCurrentThread, hThread,
+                                        0, // THREAD_SET_CONTEXT
+                                        &pTargetThread, &pTargetThreadObject);
+
+    if (NO_ERROR != palErr)
+    {
+        ERROR("Unable to obtain thread data for handle %p (error %x)!\n", hThread,
+              palErr);
+        return 0;
+    }
+
+    pthread_t thread = pTargetThread->GetPThreadSelf();
+
+#if HAVE_PTHREAD_GETAFFINITY_NP
+    cpu_set_t prevCpuSet;
+    CPU_ZERO(&prevCpuSet);
+    KAFFINITY prevMask = 0;
+
+    int st = pthread_getaffinity_np(thread, sizeof(cpu_set_t), &prevCpuSet);
+
+    if (st == 0)
+    {
+        for (int i = 0; i < g_possibleCpuCount; i++)
+        {
+            if (CPU_ISSET(i, &prevCpuSet))
+            {
+                prevMask |= ((KAFFINITY)1) << i;
+            }
+        }
+    }
+
+    cpu_set_t cpuSet;
+    CPU_ZERO(&cpuSet);
+
+    int cpu = 0;
+    while (dwThreadAffinityMask)
+    {
+        if (dwThreadAffinityMask & 1)
+        {
+            CPU_SET(cpu, &cpuSet);
+        }
+        cpu++;
+        dwThreadAffinityMask >>= 1;
+    }
+
+    st = pthread_setaffinity_np(thread, sizeof(cpu_set_t), &cpuSet);
+
+    if (st == -1)
+    {
+        switch (errno)
+        {
+        case EINVAL:
+            // There is no processor in the mask that is allowed to execute the
+            // process
+            SetLastError(ERROR_INVALID_PARAMETER);
+            break;
+        case EPERM:
+            SetLastError(ERROR_ACCESS_DENIED);
+            break;
+        default:
+            SetLastError(ERROR_GEN_FAILURE);
+            break;
+        }
+    }
+
+    DWORD_PTR ret = (st == 0) ? prevMask : 0;
+#else  // HAVE_PTHREAD_GETAFFINITY_NP
+    // There is no API to manage thread affinity, so let's ignore the request
+    DWORD_PTR ret = 0;
+#endif // HAVE_PTHREAD_GETAFFINITY_NP
+    LOGEXIT("SetThreadAffinityMask returns  %lu\n", ret);
+    PERF_EXIT(SetThreadAffinityMask);
+
+    return ret;
 }
 
 /*++

--- a/src/vm/gcenv.os.cpp
+++ b/src/vm/gcenv.os.cpp
@@ -659,7 +659,6 @@ bool GCToOSInterface::CreateThread(GCThreadFunction function, void* param, GCThr
 
     SetThreadPriority(gc_thread, /* THREAD_PRIORITY_ABOVE_NORMAL );*/ THREAD_PRIORITY_HIGHEST );
 
-#ifndef FEATURE_PAL
     if (affinity->Group != GCThreadAffinity::None)
     {
         _ASSERTE(affinity->Processor != GCThreadAffinity::None);
@@ -676,7 +675,6 @@ bool GCToOSInterface::CreateThread(GCThreadFunction function, void* param, GCThr
     {
         SetThreadAffinityMask(gc_thread, (DWORD_PTR)1 << affinity->Processor);
     }
-#endif // !FEATURE_PAL
 
     ResumeThread(gc_thread);
     CloseHandle(gc_thread);


### PR DESCRIPTION
This PR fixes `GetThreadGroupAffinity` and `SetThreadGroupAffinity`, adds `SetThreadAffinityMask` API and pins GC threads to corresponding processors on Linux.