### PR TITLE
Fix remove in list

### DIFF
--- a/src/jit/jitstd/list.h
+++ b/src/jit/jitstd/list.h
@@ -639,11 +639,15 @@ typename list<T, Allocator>::const_reverse_iterator
 template <typename T, typename Allocator>
 void list<T, Allocator>::remove(const T& val)
 {
-    for (iterator i = begin(); i != end(); ++i)
+    for (iterator i = begin(); i != end();)
     {
         if (*i == val)
         {
             i = erase(i);
+        }
+        else
+        {
+            ++i;
         }
     }
 }
@@ -652,11 +656,15 @@ template <typename T, typename Allocator>
 template <class Predicate>
 void list<T, Allocator>::remove_if(Predicate pred)
 {
-    for (iterator i = begin(); i != end(); ++i)
+    for (iterator i = begin(); i != end();)
     {
         if (pred(*i))
         {
             i = erase(i);
+        }
+        else
+        {
+            ++i;
         }
     }
 }


### PR DESCRIPTION
`remove` uses `erase` to delete the entry in list.
Since `erase` returns the next iterator, the iterator shouldn't be increased
when the entry is found and deleted.