### PR TITLE
spmi add R2R field to getFieldInfo

### DIFF
--- a/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -3102,6 +3102,7 @@ void MethodContext::recGetFieldInfo(CORINFO_RESOLVED_TOKEN* pResolvedToken,
     value.accessAllowed                 = (DWORD)pResult->accessAllowed;
     value.accessCalloutHelper.helperNum = (DWORD)pResult->accessCalloutHelper.helperNum;
     value.accessCalloutHelper.numArgs   = (DWORD)pResult->accessCalloutHelper.numArgs;
+    value.fieldLookup                   = SpmiRecordsHelper::StoreAgnostic_CORINFO_CONST_LOOKUP(&pResult->fieldLookup);
     for (int i = 0; i < CORINFO_ACCESS_ALLOWED_MAX_ARGS; i++)
     {
         value.accessCalloutHelper.args[i].constant = (DWORDLONG)pResult->accessCalloutHelper.args[i].constant;
@@ -3144,7 +3145,7 @@ void MethodContext::dmpGetFieldInfo(const Agnostic_GetFieldInfo& key, const Agno
                 break;
         }
     }
-    printf("}");
+    printf(" fl %s}", SpmiDumpHelper::DumpAgnostic_CORINFO_CONST_LOOKUP(value.fieldLookup).c_str());
 }
 void MethodContext::repGetFieldInfo(CORINFO_RESOLVED_TOKEN* pResolvedToken,
                                     CORINFO_METHOD_HANDLE   callerHandle,
@@ -3207,6 +3208,7 @@ void MethodContext::repGetFieldInfo(CORINFO_RESOLVED_TOKEN* pResolvedToken,
     pResult->accessAllowed                 = (CorInfoIsAccessAllowedResult)value.accessAllowed;
     pResult->accessCalloutHelper.helperNum = (CorInfoHelpFunc)value.accessCalloutHelper.helperNum;
     pResult->accessCalloutHelper.numArgs   = (unsigned)value.accessCalloutHelper.numArgs;
+    pResult->fieldLookup                   = SpmiRecordsHelper::RestoreCORINFO_CONST_LOOKUP(value.fieldLookup);
     for (int i = 0; i < CORINFO_ACCESS_ALLOWED_MAX_ARGS; i++)
     {
         pResult->accessCalloutHelper.args[i].constant = (size_t)value.accessCalloutHelper.args[i].constant;

--- a/src/ToolBox/superpmi/superpmi-shared/methodcontext.h
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontext.h
@@ -191,16 +191,45 @@ public:
         DWORD                       numArgs;
         Agnostic_CORINFO_HELPER_ARG args[CORINFO_ACCESS_ALLOWED_MAX_ARGS];
     };
+    struct Agnostic_CORINFO_CONST_LOOKUP
+    {
+        DWORD     accessType;
+        DWORDLONG handle; // actually a union of two pointer sized things
+    };
+    struct Agnostic_CORINFO_LOOKUP_KIND
+    {
+        DWORD needsRuntimeLookup;
+        DWORD runtimeLookupKind;
+        WORD  runtimeLookupFlags;
+    };
+    struct Agnostic_CORINFO_RUNTIME_LOOKUP
+    {
+        DWORDLONG signature;
+        DWORD     helper;
+        DWORD     indirections;
+        DWORD     testForNull;
+        DWORD     testForFixup;
+        DWORDLONG offsets[CORINFO_MAXINDIRECTIONS];
+        DWORD     indirectFirstOffset;
+    };
+    struct Agnostic_CORINFO_LOOKUP
+    {
+        Agnostic_CORINFO_LOOKUP_KIND    lookupKind;
+        Agnostic_CORINFO_RUNTIME_LOOKUP runtimeLookup; // This and constLookup actually a union, but with different
+                                                       // layouts.. :-| copy the right one based on lookupKinds value
+        Agnostic_CORINFO_CONST_LOOKUP constLookup;
+    };
     struct Agnostic_CORINFO_FIELD_INFO
     {
-        DWORD                        fieldAccessor;
-        DWORD                        fieldFlags;
-        DWORD                        helper;
-        DWORD                        offset;
-        DWORD                        fieldType;
-        DWORDLONG                    structType;
-        DWORD                        accessAllowed;
-        Agnostic_CORINFO_HELPER_DESC accessCalloutHelper;
+        DWORD                         fieldAccessor;
+        DWORD                         fieldFlags;
+        DWORD                         helper;
+        DWORD                         offset;
+        DWORD                         fieldType;
+        DWORDLONG                     structType;
+        DWORD                         accessAllowed;
+        Agnostic_CORINFO_HELPER_DESC  accessCalloutHelper;
+        Agnostic_CORINFO_CONST_LOOKUP fieldLookup;
     };
     struct DD
     {
@@ -227,34 +256,7 @@ public:
         DWORDLONG                       callerHandle;
         DWORD                           flags;
     };
-    struct Agnostic_CORINFO_LOOKUP_KIND
-    {
-        DWORD needsRuntimeLookup;
-        DWORD runtimeLookupKind;
-        WORD  runtimeLookupFlags;
-    };
-    struct Agnostic_CORINFO_RUNTIME_LOOKUP
-    {
-        DWORDLONG signature;
-        DWORD     helper;
-        DWORD     indirections;
-        DWORD     testForNull;
-        DWORD     testForFixup;
-        DWORDLONG offsets[CORINFO_MAXINDIRECTIONS];
-        DWORD     indirectFirstOffset;
-    };
-    struct Agnostic_CORINFO_CONST_LOOKUP
-    {
-        DWORD     accessType;
-        DWORDLONG handle; // actually a union of two pointer sized things
-    };
-    struct Agnostic_CORINFO_LOOKUP
-    {
-        Agnostic_CORINFO_LOOKUP_KIND    lookupKind;
-        Agnostic_CORINFO_RUNTIME_LOOKUP runtimeLookup; // This and constLookup actually a union, but with different
-                                                       // layouts.. :-| copy the right one based on lookupKinds value
-        Agnostic_CORINFO_CONST_LOOKUP constLookup;
-    };
+
     struct Agnostic_CORINFO_CALL_INFO
     {
         DWORDLONG                     hMethod;


### PR DESCRIPTION
There was a missed field with R2R data in Agnostic_GetFieldInfo.
The fix decreases number of failed methods during a replay from 1612 to 162.
162 is the number that we were not able to crossgen, maybe in this case we should not create an mc file for such methods in the future.
