### PR TITLE
Cleanup unused DoDelegateInvokeForHostCheck declaration

### DIFF
--- a/src/vm/comdelegate.h
+++ b/src/vm/comdelegate.h
@@ -234,6 +234,4 @@ struct ShuffleEntry
 
 #include <poppack.h>
 
-void __stdcall DoDelegateInvokeForHostCheck(Object* pDelegate);
-
 #endif  // _COMDELEGATE_H_


### PR DESCRIPTION
DoDelegateInvokeForHostCheck has no implementation and no use.