### PR TITLE
[x86/Linux] Adjust SP in throwing helper block

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -1650,7 +1650,7 @@ void CodeGen::genAdjustStackLevel(BasicBlock* block)
         // x86/Linux requires stack frames to be 16-byte aligned, but SP may be unaligned
         // at this point if a jump to this block is made in the middle of pushing arugments.
         //
-        // Here we restore SP to prevent potential stack alignment issue.
+        // Here we restore SP to prevent potential stack alignment issues.
         getEmitter()->emitIns_R_AR(INS_lea, EA_PTRSIZE, REG_SPBASE, REG_FPBASE, -genSPtoFPdelta());
     }
 #endif

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2712,7 +2712,7 @@ void CodeGen::genJumpToThrowHlpBlk(emitJumpKind jumpKind, SpecialCodeKind codeKi
 
 #if defined(UNIX_X86_ABI) && FEATURE_EH_FUNCLETS
     // Inline exception-throwing code in funclet to make it possible to unwind funclet frames.
-    useThrowHlpBlk = useThrowHlpBlk && !siInFuncletRegion;
+    useThrowHlpBlk = useThrowHlpBlk && (compiler->funCurrentFunc()->funKind == FUNC_ROOT);
 #endif // UNIX_X86_ABI && FEATURE_EH_FUNCLETS
 
     if (useThrowHlpBlk)

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -1642,6 +1642,8 @@ void CodeGen::genAdjustStackLevel(BasicBlock* block)
 {
 #if !FEATURE_FIXED_OUT_ARGS
     // Check for inserted throw blocks and adjust genStackLevel.
+    CLANG_FORMAT_COMMENT_ANCHOR;
+
 #if defined(UNIX_X86_ABI)
     if (isFramePointerUsed() && compiler->fgIsThrowHlpBlk(block))
     {

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -17776,10 +17776,6 @@ BasicBlock* Compiler::fgAddCodeRef(BasicBlock* srcBlk, unsigned refData, Special
 #if defined(UNIX_X86_ABI)
         codeGen->setFrameRequired(true);
         codeGen->setFramePointerRequiredGCInfo(true);
-        add->acdStkLvl = 0;
-#ifdef DEBUG
-        add->acdDstBlk->bbTgtStkDepth = 0;
-#endif
 #else  // !defined(UNIX_X86_ABI)
         if (add->acdStkLvl != stkDepth)
         {

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -17776,6 +17776,10 @@ BasicBlock* Compiler::fgAddCodeRef(BasicBlock* srcBlk, unsigned refData, Special
 #if defined(UNIX_X86_ABI)
         codeGen->setFrameRequired(true);
         codeGen->setFramePointerRequiredGCInfo(true);
+        add->acdStkLvl = 0;
+#ifdef DEBUG
+        add->acdDstBlk->bbTgtStkDepth = 0;
+#endif
 #else  // !defined(UNIX_X86_ABI)
         if (add->acdStkLvl != stkDepth)
         {


### PR DESCRIPTION
CodeGen::genAdjustStackLevel currently adjusts SP only for throwing helper blocks in ESP-framed methods, which results in #11820 for EBP-framed methods.

This PR revises CodeGen::genAdjustStackLevel to adjust SP even for throwing helper blocks in EBP-framed methods in order to fix #11820.

This PR also enforces JIT to inline exception throwing calls inside funclet region to prevent potential unwind issues.