### PR TITLE
Enable SourceBranch to be passed from the pipeline parameters

### DIFF
--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -3,7 +3,8 @@
   "Definitions": {
     "Path": ".",
     "Type": "VSTS",
-    "BaseUrl":  "https://devdiv.visualstudio.com/DefaultCollection"
+    "BaseUrl":  "https://devdiv.visualstudio.com/DefaultCollection",
+    "SkipBranchAndVersionOverrides": "false"
   },
   "DefinitionGroups": [
     {
@@ -212,6 +213,7 @@
       "Definitions": [
         {
           "Name": "DotNet-Trusted-Publish",
+          "SkipBranchAndVersionOverrides": "true",
           "Parameters": {
             "VstsRepositoryName": "DotNet-CoreCLR-Trusted",
             "GitHubRepositoryName": "coreclr",
@@ -241,6 +243,7 @@
       "Definitions": [
         {
           "Name": "DotNet-Trusted-Publish",
+          "SkipBranchAndVersionOverrides": "true",
           "Parameters": {
             "VstsRepositoryName": "DotNet-CoreCLR-Trusted",
             "GitHubRepositoryName": "coreclr"
@@ -268,6 +271,7 @@
       "Definitions": [
         {
           "Name": "DotNet-Trusted-Publish-Symbols",
+          "SkipBranchAndVersionOverrides": "true",
           "Parameters": {
           },
           "ReportingParameters": {
@@ -293,6 +297,7 @@
       "Definitions": [
         {
           "Name": "DotNet-Trusted-Publish",
+          "SkipBranchAndVersionOverrides": "true",
           "Parameters": {
             "VstsRepositoryName": "DotNet-CoreCLR-Trusted",
             "GitHubRepositoryName": "coreclr"


### PR DESCRIPTION
sets SkipBranchAndVersionOverrides=false so SourceBranch and SourceVersion
are correctly passed through the pipeline file.

set SkipBranchAndVersionOverrides=true for the publish definitions as
they don't build from the SourceBranch and instead use a different
tools branch to do their work.