### PR TITLE
Fix contributing workflow commit message link

### DIFF
--- a/Documentation/project-docs/contributing-workflow.md
+++ b/Documentation/project-docs/contributing-workflow.md
@@ -10,7 +10,7 @@ We use and recommend the following workflow:
 1. Create an issue for your work. 
     - You can skip this step for trivial changes.
     - Reuse an existing issue on the topic, if there is one.
-    - Use [CODE_OWNERS.TXT](https://github.com/dotnet/coreclr/blob/master/CODE_OWNERS.TXT) to find relevant maintainers and @ mention them to ask for feedback on your issue.
+    - Use [CODE_OWNERS.TXT](../../CODE_OWNERS.TXT) to find relevant maintainers and @ mention them to ask for feedback on your issue.
     - Get agreement from the team and the community that your proposed change is a good one.
     - If your change adds a new API, follow the [API Review Process](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/api-review-process.md). 
     - Clearly state that you are going to take on implementing it, if that's the case. You can request that the issue be assigned to you. Note: The issue filer and the implementer don't have to be the same person.
@@ -19,7 +19,7 @@ We use and recommend the following workflow:
     - Name the branch so that it clearly communicates your intentions, such as issue-123 or githubhandle-issue. 
     - Branches are useful since they isolate your changes from incoming changes from upstream. They also enable you to create multiple PRs from the same fork.
 4. Make and commit your changes.
-    - Please follow our [Commit Messages](https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/contributing-workflow.md#commit-messages) guidance.
+    - Please follow our [Commit Messages](contributing.md#commit-messages) guidance.
 5. Add new tests corresponding to your change, if applicable.
 6. Build the repository with your changes.
     - Make sure that the builds are clean.


### PR DESCRIPTION
A recent change moved the Commit Messages section to a different
markdown file.  This change fixes that link, and provides relative
paths for links where appropiate.  This keeps people in their own
fork of the repo when browsing on github.