### PR TITLE
Make ResourceManager netstandard 2.0 API behave correctly

### DIFF
--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -3182,9 +3182,6 @@
   <data name="PlatformNotSupported_OverlappedIO" xml:space="preserve">
     <value>This API is specific to the way in which Windows handles asynchronous I/O, and is not supported on this platform.</value>
   </data>
-  <data name="PlatformNotSupported_ResourceManager_ResWFileUnsupportedProperty" xml:space="preserve">
-    <value>ResourceManager property '{0}' is not supported when reading from .resw resource files.</value>
-  </data>  
   <data name="Policy_CannotLoadSemiTrustAssembliesDuringInit" xml:space="preserve">
     <value>All assemblies loaded as part of AppDomain initialization must be fully trusted.</value>
   </data>

--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -3182,6 +3182,9 @@
   <data name="PlatformNotSupported_OverlappedIO" xml:space="preserve">
     <value>This API is specific to the way in which Windows handles asynchronous I/O, and is not supported on this platform.</value>
   </data>
+  <data name="PlatformNotSupported_ResourceManager_ResWFileUnsupportedProperty" xml:space="preserve">
+    <value>ResourceManager property '{0}' is not supported when reading from .resw resource files.</value>
+  </data>  
   <data name="Policy_CannotLoadSemiTrustAssembliesDuringInit" xml:space="preserve">
     <value>All assemblies loaded as part of AppDomain initialization must be fully trusted.</value>
   </data>

--- a/src/mscorlib/src/System/Resources/ResourceManager.cs
+++ b/src/mscorlib/src/System/Resources/ResourceManager.cs
@@ -438,18 +438,16 @@ namespace System.Resources
         // security check in each constructor prevents it.
         private void CommonAssemblyInit()
         {
-            if (_bUsingModernResourceManagement == false)
-            {
-                UseManifest = true;
+            // Now we can use the managed resources even when using PRI's to support the APIs GetObject, GetStream...etc.
+            UseManifest = true;
 
-                _resourceSets = new Dictionary<String, ResourceSet>();
-                _lastUsedResourceCache = new CultureNameResourceSetPair();
+            _resourceSets = new Dictionary<String, ResourceSet>();
+            _lastUsedResourceCache = new CultureNameResourceSetPair();
 
-                _fallbackLoc = UltimateResourceFallbackLocation.MainAssembly;
+            _fallbackLoc = UltimateResourceFallbackLocation.MainAssembly;
 
-                ResourceManagerMediator mediator = new ResourceManagerMediator(this);
-                resourceGroveler = new ManifestBasedResourceGroveler(mediator);
-            }
+            ResourceManagerMediator mediator = new ResourceManagerMediator(this);
+            resourceGroveler = new ManifestBasedResourceGroveler(mediator);
 
             _neutralResourcesCulture = ManifestBasedResourceGroveler.GetNeutralResourcesLanguage(MainAssembly, ref _fallbackLoc);
         }
@@ -465,7 +463,15 @@ namespace System.Resources
         public virtual bool IgnoreCase
         {
             get { return _ignoreCase; }
-            set { _ignoreCase = value; }
+            set 
+            { 
+                if (_PRIonAppXInitialized && value)
+                {
+                    throw new PlatformNotSupportedException(SR.Format(SR.PlatformNotSupported_ResourceManager_ResWFileUnsupportedProperty, nameof(IgnoreCase)));
+                }
+
+                _ignoreCase = value; 
+            }
         }
 
         // Returns the Type of the ResourceSet the ResourceManager uses

--- a/src/mscorlib/src/System/Resources/ResourceManager.cs
+++ b/src/mscorlib/src/System/Resources/ResourceManager.cs
@@ -463,16 +463,7 @@ namespace System.Resources
         public virtual bool IgnoreCase
         {
             get { return _ignoreCase; }
-            set 
-            { 
-#if FEATURE_APPX
-                if (_PRIonAppXInitialized && value)
-                {
-                    throw new PlatformNotSupportedException(SR.Format(SR.PlatformNotSupported_ResourceManager_ResWFileUnsupportedProperty, nameof(IgnoreCase)));
-                }
-#endif // FEATURE_APPX
-                _ignoreCase = value; 
-            }
+            set { _ignoreCase = value; }
         }
 
         // Returns the Type of the ResourceSet the ResourceManager uses

--- a/src/mscorlib/src/System/Resources/ResourceManager.cs
+++ b/src/mscorlib/src/System/Resources/ResourceManager.cs
@@ -465,11 +465,12 @@ namespace System.Resources
             get { return _ignoreCase; }
             set 
             { 
+#if FEATURE_APPX
                 if (_PRIonAppXInitialized && value)
                 {
                     throw new PlatformNotSupportedException(SR.Format(SR.PlatformNotSupported_ResourceManager_ResWFileUnsupportedProperty, nameof(IgnoreCase)));
                 }
-
+#endif // FEATURE_APPX
                 _ignoreCase = value; 
             }
         }


### PR DESCRIPTION
In netstandard 2.0 we have enabled the APIs like GetObject, GetStream,..etc. these are not functioning correctly in UWP apps because was assuming we always uses PRI files. The changes here is to initialize the managed resources too and let these APIs behave as if we are running inside desktop app.