### PR TITLE
Delete test that tests pinning of System.Object

### DIFF
--- a/tests/src/GC/Features/Pinning/PinningOther/PinnedObject.cs
+++ b/tests/src/GC/Features/Pinning/PinningOther/PinnedObject.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 // Tests Pinning of objects
-// Cannot pin objects or array of objects
+// Cannot pin array of objects
 
 using System;
 using System.Runtime.InteropServices;
@@ -13,10 +13,6 @@ public class Test
     public static int Main()
     {
         Object[] arr = new Object[100];
-        Object obj = new Object();
-        int exceptionCount = 0;
-
-        Console.WriteLine("This test should throw 2 exceptions");
 
         try
         {
@@ -25,21 +21,6 @@ public class Test
         catch (Exception e)
         {
             Console.WriteLine("Caught: {0}", e);
-            exceptionCount++;
-        }
-
-        try
-        {
-            GCHandle handle2 = GCUtil.Alloc(obj, GCHandleType.Pinned);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine("Caught: {0}", e);
-            exceptionCount++;
-        }
-
-        if (exceptionCount == 2)
-        {
             Console.WriteLine("Test passed");
             return 100;
         }


### PR DESCRIPTION
See dotnet/corefx#21673 for motivation. This test fails on CoreRT.