### PR TITLE
Update to master prerelease2 tag

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -8,7 +8,7 @@
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <StableVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == ''">$(PackageVersion)</StableVersion>
 
-    <PreReleaseLabel>preview1</PreReleaseLabel>
+    <PreReleaseLabel>preview2</PreReleaseLabel>
   </PropertyGroup>
   
   <!-- Source of truth for dependency tooling: the commit hash of the dotnet/versions master branch as of the last auto-upgrade. -->


### PR DESCRIPTION
release/uwp6.0 is going to use preview1 and we don't want to publish
different versions of the package with the same package identity