### PR TITLE
Add a generic operand visitor to `GenTree`.

### DIFF
--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -4754,7 +4754,7 @@ void GenTree::VisitOperands(TVisitor visitor)
         case GT_IL_OFFSET:
             return;
 
-        // Standard unary operators
+        // Unary operators with an optional operand
         case GT_NOP:
         case GT_RETURN:
         case GT_RETFILT:
@@ -4764,6 +4764,7 @@ void GenTree::VisitOperands(TVisitor visitor)
             }
             __fallthrough;
 
+        // Standard unary operators
         case GT_STORE_LCL_VAR:
         case GT_STORE_LCL_FLD:
         case GT_NOT:

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -4928,7 +4928,8 @@ void GenTree::VisitOperands(TVisitor visitor)
             {
                 return;
             }
-            if ((call->gtCallLateArgs != nullptr) && (call->gtCallLateArgs->VisitListOperands(visitor)) == VisitResult::Abort)
+            if ((call->gtCallLateArgs != nullptr) &&
+                (call->gtCallLateArgs->VisitListOperands(visitor)) == VisitResult::Abort)
             {
                 return;
             }

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -2148,7 +2148,12 @@ public:
     //     });
     //
     // This function is generally more efficient that the operand iterator and should be preferred over that API for
-    // hot code.
+    // hot code, as it affords better opportunities for inlining and acheives shorter dynamic path lengths when
+    // deciding how operands need to be accessed.
+    //
+    // Note that this function does not respect `GTF_REVERSE_OPS` and `gtEvalSizeFirst`. This is always safe in LIR,
+    // but may be dangerous in HIR if for some reason you need to visit operands in the order in which they will
+    // execute.
     template <typename TVisitor>
     void VisitOperands(TVisitor visitor);
 

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -2133,7 +2133,7 @@ public:
 
     enum class VisitResult
     {
-        Abort = false,
+        Abort    = false,
         Continue = true
     };
 

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -2131,6 +2131,35 @@ public:
     // Returns a range that will produce the operands of this node in use order.
     IteratorPair<GenTreeOperandIterator> Operands();
 
+    enum class VisitResult
+    {
+        Abort = false,
+        Continue = true
+    };
+
+    // Visits each operand of this node. The operand must be either a lambda, function, or functor with the signature
+    // `GenTree::VisitResult VisitorFunction(GenTree* operand)`. Here is a simple example:
+    //
+    //     unsigned operandCount = 0;
+    //     node->VisitOperands([&](GenTree* operand) -> GenTree::VisitResult)
+    //     {
+    //         operandCount++;
+    //         return GenTree::VisitResult::Continue;
+    //     });
+    //
+    // This function is generally more efficient that the operand iterator and should be preferred over that API for
+    // hot code.
+    template <typename TVisitor>
+    void VisitOperands(TVisitor visitor);
+
+private:
+    template <typename TVisitor>
+    VisitResult VisitListOperands(TVisitor visitor);
+
+    template <typename TVisitor>
+    void VisitBinOpOperands(TVisitor visitor);
+
+public:
     bool Precedes(GenTree* other);
 
     // The maximum possible # of children of any node.

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -2278,10 +2278,10 @@ bool Compiler::fgTryRemoveDeadLIRStore(LIR::Range& blockRange, GenTree* node, Ge
         // If the range of the operands contains unrelated code or if it contains any side effects,
         // do not remove it. Instead, just remove the store.
 
-        for (GenTree* operand : node->Operands())
-        {
+        node->VisitOperands([](GenTree* operand) -> GenTree::VisitResult {
             operand->gtLIRFlags |= LIR::Flags::IsUnusedValue;
-        }
+            return GenTree::VisitResult::Continue;
+        });
 
         *next = node->gtPrev;
     }

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -3591,10 +3591,10 @@ void Lowering::AddrModeCleanupHelper(GenTreeAddrMode* addrMode, GenTree* node)
     }
 
     // TODO-LIR: change this to use the LIR mark bit and iterate instead of recursing
-    for (GenTree* operand : node->Operands())
-    {
+    node->VisitOperands([this, addrMode](GenTree* operand) -> GenTree::VisitResult {
         AddrModeCleanupHelper(addrMode, operand);
-    }
+        return GenTree::VisitResult::Continue;
+    });
 
     BlockRange().Remove(node);
 }

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -711,12 +711,12 @@ bool Lowering::IsRMWIndirCandidate(GenTree* operand, GenTree* storeInd)
                 return false;
             }
 
-            for (GenTree* nodeOperand : node->Operands())
-            {
+            node->VisitOperands([&markCount](GenTree* nodeOperand) -> GenTree::VisitResult {
                 assert((nodeOperand->gtLIRFlags & LIR::Flags::Mark) == 0);
                 nodeOperand->gtLIRFlags |= LIR::Flags::Mark;
                 markCount++;
-            }
+                return GenTree::VisitResult::Continue;
+            });
         }
     }
 

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3943,12 +3943,13 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
         // if tree nodes are eventually allowed to be multiply-used), then the removal is only
         // correct at the last use.
         LocationInfoList operandDefs;
-        bool removed = operandToLocationInfoMap.TryRemove(operand, &operandDefs);
+        bool             removed = operandToLocationInfoMap.TryRemove(operand, &operandDefs);
         assert(removed);
         assert(!operandDefs.IsEmpty());
 
         LocationInfoListNode* const operandDefsEnd = operandDefs.End();
-        for (LocationInfoListNode* operandDefsIterator = operandDefs.Begin(); operandDefsIterator != operandDefsEnd; operandDefsIterator = operandDefsIterator->Next())
+        for (LocationInfoListNode* operandDefsIterator = operandDefs.Begin(); operandDefsIterator != operandDefsEnd;
+             operandDefsIterator                       = operandDefsIterator->Next())
         {
             LocationInfo& locInfo = *static_cast<LocationInfo*>(operandDefsIterator);
 
@@ -4047,7 +4048,8 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
                     // Explicitly insert a FixedRefPosition and fake the candidates, because otherwise newRefPosition
                     // will complain about the types not matching.
                     regNumber    physicalReg = genRegNumFromMask(fixedAssignment);
-                    RefPosition* pos = newRefPosition(physicalReg, currentLoc, RefTypeFixedReg, nullptr, fixedAssignment);
+                    RefPosition* pos =
+                        newRefPosition(physicalReg, currentLoc, RefTypeFixedReg, nullptr, fixedAssignment);
                 }
                 pos = newRefPosition(i, currentLoc, RefTypeUse, useNode, allRegs(i->registerType),
                                      multiRegIdx DEBUG_ARG(minRegCountForUsePos));

--- a/src/jit/sideeffects.cpp
+++ b/src/jit/sideeffects.cpp
@@ -252,8 +252,7 @@ void AliasSet::AddNode(Compiler* compiler, GenTree* node)
 {
     // First, add all lclVar uses associated with the node to the set. This is necessary because the lclVar reads occur
     // at the position of the user, not at the position of the GenTreeLclVar node.
-    for (GenTree* operand : node->Operands())
-    {
+    node->VisitOperands([compiler, this](GenTree* operand) -> GenTree::VisitResult {
         if (operand->OperIsLocalRead())
         {
             const unsigned lclNum = operand->AsLclVarCommon()->GetLclNum();
@@ -264,7 +263,8 @@ void AliasSet::AddNode(Compiler* compiler, GenTree* node)
 
             m_lclVarReads.Add(compiler, lclNum);
         }
-    }
+        return GenTree::VisitResult::Continue;
+    });
 
     NodeInfo nodeInfo(compiler, node);
     if (nodeInfo.ReadsAddressableLocation())


### PR DESCRIPTION
This visitor accepts any invokable argument (e.g. lambdas, functors,
etc.) with the following signature:

    `GenTree::VisitResult Visitor(GenTree* operand)`

This visitor is typically more efficient than the operand iterator
due to better opportunities for inlining and shorter dynamic path
lengths when deciding which operands need to be visited.

As noted below, these changes give about a .6% decrease in instructions retired as reported by callgrind S.P.C.dll on Linux/x64/Release.