### PR TITLE
Fix optdata bootstrap test script & Linux skiprestoreoptdata behavior

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -140,24 +140,27 @@ check_prereqs()
 
 restore_optdata()
 {
-    # if msbuild is not supported, then set __SkipRestoreOptData to 1
-    if [ $__isMSBuildOnNETCoreSupported == 0 ]; then __SkipRestoreOptData=1; fi
     # we only need optdata on a Release build
     if [[ "$__BuildType" != "Release" ]]; then __SkipRestoreOptData=1; fi
 
-    if [ $__SkipRestoreOptData == 0 ]; then
+    if [[ ( $__SkipRestoreOptData == 0 ) && ( $__isMSBuildOnNETCoreSupported == 1 ) ]]; then
         echo "Restoring the OptimizationData package"
         "$__ProjectRoot/run.sh" sync -optdata
         if [ $? != 0 ]; then
             echo "Failed to restore the optimization data package."
             exit 1
         fi
+    fi
 
+    if [ $__isMSBuildOnNETCoreSupported == 1 ]; then
         # Parse the optdata package versions out of msbuild so that we can pass them on to CMake
         local DotNetCli="$__ProjectRoot/Tools/dotnetcli/dotnet"
         if [ ! -f $DotNetCli ]; then
-            echo "Assertion failed: dotnet CLI not found at '$DotNetCli'"
-            exit 1
+            "$__ProjectRoot/init-tools.sh"
+            if [ $? != 0 ]; then
+                echo "Failed to restore buildtools."
+                exit 1
+            fi
         fi
         local OptDataProjectFilePath="$__ProjectRoot/src/.nuget/optdata/optdata.csproj"
         __PgoOptDataVersion=$($DotNetCli msbuild $OptDataProjectFilePath /t:DumpPgoDataPackageVersion /nologo | sed 's/^\s*//')

--- a/tests/scripts/optdata/bootstrap.py
+++ b/tests/scripts/optdata/bootstrap.py
@@ -51,7 +51,7 @@ def get_optdata_dir(tool, arch):
     """Returns an absolute path to the directory that should contain optdata given a tool,arch"""
     package_name = 'optimization.%s-%s.%s.CoreCLR' % (get_buildos(), arch, tool)
     package_version = get_optdata_version(tool)
-    return path.join(REPO_ROOT, 'packages', package_name, package_version, 'data')
+    return path.join(REPO_ROOT, 'packages', package_name.lower(), package_version.lower(), 'data')
 
 def check_for_unstaged_changes(file_path):
     """Returns whether a file in git has untracked changes."""


### PR DESCRIPTION
Fixes #12171.
* bootstrap.py was printing an improperly-cased path to put PGO/IBC training data, which breaks on case-sensitive file systems, i.e., on Linux.
* On Linux, `skiprestoreoptdata` was improperly skipping PGO even if optdata was already present due to some of the conditional checks in build.sh. This cleans that up to better match the intent of the switch, and to fix Linux behavior to better match Windows.
