### PR TITLE
Reduce the verbosity of optdata sync on stdout

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -25,7 +25,8 @@
   </Target>
 
   <Target Name="RestoreOptData">
-    <Exec Command="$(DotnetRestoreCommand) $(SourceDir).nuget/optdata/optdata.csproj" />
+    <Exec Command="$(DotnetRestoreCommand) $(SourceDir).nuget/optdata/optdata.csproj"
+          StandardOutputImportance="Low" />
   </Target>
 
   <!--


### PR DESCRIPTION
Set the "StandardOutputImportance" attribute on the RestoreOptData target to low, matching the "RestoreNETCorePlatforms" target. Logging to sync.log remains verbose, but stdout on the console is made much less verbose.

Fixes #12127 