### PR TITLE
create GetAssertionIndex to convert from unsigned to AssertionIndex

### DIFF
--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -151,6 +151,18 @@ typedef unsigned short AssertionIndex;
 
 static const AssertionIndex NO_ASSERTION_INDEX = 0;
 
+//------------------------------------------------------------------------
+// GetAssertionIndex: return 1-based AssertionIndex from 0-based int index.
+//
+// Arguments:
+//    index - 0-based index
+// Return Value:
+//    1-based AssertionIndex.
+inline AssertionIndex GetAssertionIndex(unsigned index)
+{
+    return (AssertionIndex)(index + 1);
+}
+
 class AssertionInfo
 {
     // true if the assertion holds on the bbNext edge instead of the bbJumpDest edge (for GT_JTRUE nodes)

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -496,9 +496,9 @@ void RangeCheck::MergeEdgeAssertions(GenTreePtr tree, ASSERT_VALARG_TP assertion
     unsigned        index = 0;
     while (iter.NextElem(&index))
     {
-        index++;
+        AssertionIndex assertionIndex = GetAssertionIndex(index);
 
-        Compiler::AssertionDsc* curAssertion = m_pCompiler->optGetAssertion((AssertionIndex)index);
+        Compiler::AssertionDsc* curAssertion = m_pCompiler->optGetAssertion(assertionIndex);
 
         // Current assertion is about compare against constant or checked bound.
         if (!curAssertion->IsCheckedBoundArithBound() && !curAssertion->IsCheckedBoundBound() &&
@@ -510,7 +510,7 @@ void RangeCheck::MergeEdgeAssertions(GenTreePtr tree, ASSERT_VALARG_TP assertion
 #ifdef DEBUG
         if (m_pCompiler->verbose)
         {
-            m_pCompiler->optPrintAssertion(curAssertion, (AssertionIndex)index);
+            m_pCompiler->optPrintAssertion(curAssertion, assertionIndex);
         }
 #endif
 
@@ -610,7 +610,7 @@ void RangeCheck::MergeEdgeAssertions(GenTreePtr tree, ASSERT_VALARG_TP assertion
 #ifdef DEBUG
         if (m_pCompiler->verbose)
         {
-            m_pCompiler->optPrintAssertion(curAssertion, (AssertionIndex)index);
+            m_pCompiler->optPrintAssertion(curAssertion, assertionIndex);
         }
 #endif
 


### PR DESCRIPTION
It was strange that we increase iterator twice, if you don't know that iter.NextElem(&index)) doesn't use the index value.
This change allows to delete many casts and make code a bit more straightforward.

It is useful part of #11945.
