### PR TITLE
Implement a /verbose flag to show the verbose output from crossgen

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -455,6 +455,7 @@ if %__BuildNativeCoreLib% EQU 1 (
         type %__CrossGenCoreLibLog%
         goto CrossgenFailure
     )
+    echo "%__CrossgenExe%" /Platform_Assemblies_Paths "%__BinDir%" /CreatePdb "%__BinDir%\PDB" "%__BinDir%\System.Private.CoreLib.dll"
     "%__CrossgenExe%" /Platform_Assemblies_Paths "%__BinDir%" /CreatePdb "%__BinDir%\PDB" "%__BinDir%\System.Private.CoreLib.dll" >> "%__CrossGenCoreLibLog%" 2>&1
     if NOT !errorlevel! == 0 (
         echo %__MsgPrefix%Error: CrossGen /CreatePdb System.Private.CoreLib build failed. Refer to %__CrossGenCoreLibLog%

--- a/src/inc/coregen.h
+++ b/src/inc/coregen.h
@@ -19,5 +19,6 @@
 #define NGENWORKER_FLAGS_READYTORUN              0x2000
 #define NGENWORKER_FLAGS_NO_METADATA             0x4000
 #define NGENWORKER_FLAGS_SILENT                  0x8000
+#define NGENWORKER_FLAGS_VERBOSE                0x10000
 
 #endif // _NGENCOMMON_H_

--- a/src/tools/crossgen/crossgen.cpp
+++ b/src/tools/crossgen/crossgen.cpp
@@ -109,6 +109,7 @@ void PrintUsageHelper()
        W("    /? or /help          - Display this screen\n")
        W("    /nologo              - Prevents displaying the logo\n")
        W("    /silent              - Do not display completion message\n")
+       W("    /verbose             - Display verbose information\n")
        W("    @response.rsp        - Process command line arguments from specified\n")
        W("                           response file\n")
        W("    /partialtrust        - Assembly will be run in a partial trust domain.\n")
@@ -484,6 +485,10 @@ int _cdecl wmain(int argc, __in_ecount(argc) WCHAR **argv)
         {
             dwFlags |= NGENWORKER_FLAGS_SILENT;
         }
+        else if (MatchParameter(*argv, W("verbose")))
+        {
+            dwFlags |= NGENWORKER_FLAGS_VERBOSE;
+        }
         else if (MatchParameter(*argv, W("Tuning")))
         {
             dwFlags |= NGENWORKER_FLAGS_TUNING;
@@ -620,7 +625,7 @@ int _cdecl wmain(int argc, __in_ecount(argc) WCHAR **argv)
             argv++;
             argc--;
 
-            // Clear the /fulltrust flag - /CreatePDB does not work with any other flags.
+            // Clear any extra flags - using /CreatePDB fails if any of these are set.
             dwFlags = dwFlags & ~(NGENWORKER_FLAGS_FULLTRUSTDOMAIN | NGENWORKER_FLAGS_READYTORUN);
 
             // Parse: <directory to store PDB>

--- a/src/vm/methodtable.cpp
+++ b/src/vm/methodtable.cpp
@@ -4470,18 +4470,20 @@ BOOL MethodTable::ComputeNeedsRestoreWorker(DataImage *image, TypeHandleList *pV
 
     if (g_CorCompileVerboseLevel == CORCOMPILE_VERBOSE)
     {
-        DefineFullyQualifiedNameForClass();
-        LPCUTF8 name = GetFullyQualifiedNameForClass(this);
-        printf ("MethodTable %s needs restore? ", name);
+        DefineFullyQualifiedNameForClassW();
+        LPCWSTR name = GetFullyQualifiedNameForClassW(this);
+        WszOutputDebugString(W("MethodTable "));
+        WszOutputDebugString(name);
+        WszOutputDebugString(W(" needs restore? "));
     }
     if (g_CorCompileVerboseLevel >= CORCOMPILE_STATS && GetModule()->GetNgenStats())
         GetModule()->GetNgenStats()->MethodTableRestoreNumReasons[TotalMethodTables]++;
 
-    #define UPDATE_RESTORE_REASON(c)                         \
-        if (g_CorCompileVerboseLevel == CORCOMPILE_VERBOSE)  \
-            printf ("Yes, " #c " \n");                       \
-        if (g_CorCompileVerboseLevel >= CORCOMPILE_STATS && GetModule()->GetNgenStats())    \
-            GetModule()->GetNgenStats()->MethodTableRestoreNumReasons[c]++;
+    #define UPDATE_RESTORE_REASON(ARG)                                                    \
+        if (g_CorCompileVerboseLevel == CORCOMPILE_VERBOSE)                               \
+            { WszOutputDebugString(W("Yes, ")); WszOutputDebugString(W(#ARG "\n")); }          \
+        if (g_CorCompileVerboseLevel >= CORCOMPILE_STATS && GetModule()->GetNgenStats())  \
+            GetModule()->GetNgenStats()->MethodTableRestoreNumReasons[ARG]++;
 
     // The special method table for IL stubs has to be prerestored. Restore is not able to handle it
     // because of it does not have a token. In particular, this is a problem for /profiling native images.
@@ -4570,7 +4572,9 @@ BOOL MethodTable::ComputeNeedsRestoreWorker(DataImage *image, TypeHandleList *pV
     }
 
     if (g_CorCompileVerboseLevel == CORCOMPILE_VERBOSE)
-        printf ("No \n");
+    {
+        WszOutputDebugString(W("No\n"));
+    }
     return FALSE;
 }
 

--- a/src/zap/zapper.cpp
+++ b/src/zap/zapper.cpp
@@ -125,7 +125,7 @@ STDAPI NGenWorker(LPCWSTR pwzFilename, DWORD dwFlags, LPCWSTR pwzPlatformAssembl
         ngo.fEmitFixups = false;
         ngo.fFatHeaders = false;
 
-        ngo.fVerbose = false;
+        ngo.fVerbose = (dwFlags & NGENWORKER_FLAGS_VERBOSE) != 0;
         ngo.uStats = false;
 
         ngo.fNgenLastRetry = false;


### PR DESCRIPTION
Crossgen generates lots of extra output that is logged using:
` Zapper::Info(LPCWSTR format, ...)`

But it can't be displayed unless m_verbose is true
```
    case CORZAP_LOGLEVEL_INFO:
        if (!m_pOpt->m_verbose)
            return;
        break;
```
This  commit allows us to see this output from crossgen by using a new /verbose option
