### PR TITLE
Move JIT_TrialAlloc declaration into jitinterfacex86.cpp

### DIFF
--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -34,6 +34,39 @@
 #define MON_DEBUG 1
 #endif
 
+#ifdef _TARGET_X86_
+class JIT_TrialAlloc
+{
+public:
+    enum Flags
+    {
+        NORMAL       = 0x0,
+        MP_ALLOCATOR = 0x1,
+        SIZE_IN_EAX  = 0x2,
+        OBJ_ARRAY    = 0x4,
+        ALIGN8       = 0x8,     // insert a dummy object to insure 8 byte alignment (until the next GC)
+        ALIGN8OBJ    = 0x10,
+        NO_FRAME     = 0x20,    // call is from unmanaged code - don't try to put up a frame
+    };
+
+    static void *GenAllocSFast(Flags flags);
+    static void *GenBox(Flags flags);
+    static void *GenAllocArray(Flags flags);
+    static void *GenAllocString(Flags flags);
+
+private:
+    static void EmitAlignmentRoundup(CPUSTUBLINKER *psl,X86Reg regTestAlign, X86Reg regToAdj, Flags flags);
+    static void EmitDummyObject(CPUSTUBLINKER *psl, X86Reg regTestAlign, Flags flags);
+    static void EmitCore(CPUSTUBLINKER *psl, CodeLabel *noLock, CodeLabel *noAlloc, Flags flags);
+    static void EmitNoAllocCode(CPUSTUBLINKER *psl, Flags flags);
+
+#if CHECK_APP_DOMAIN_LEAKS
+    static void EmitSetAppDomain(CPUSTUBLINKER *psl);
+    static void EmitCheckRestore(CPUSTUBLINKER *psl);
+#endif
+};
+#endif // _TARGET_X86_
+
 extern "C" LONG g_global_alloc_lock;
 
 extern "C" void STDCALL JIT_WriteBarrierReg_PreGrow();// JIThelp.asm/JIThelp.s

--- a/src/vm/jitinterface.h
+++ b/src/vm/jitinterface.h
@@ -1546,41 +1546,6 @@ EXTERN_C void JIT_TailCallHelperStub_ReturnAddress();
 
 #endif // _TARGET_AMD64_ || _TARGET_ARM_
 
-
-#ifdef _TARGET_X86_
-
-class JIT_TrialAlloc
-{
-public:
-    enum Flags
-    {
-        NORMAL       = 0x0,
-        MP_ALLOCATOR = 0x1,
-        SIZE_IN_EAX  = 0x2,
-        OBJ_ARRAY    = 0x4,
-        ALIGN8       = 0x8,     // insert a dummy object to insure 8 byte alignment (until the next GC)
-        ALIGN8OBJ    = 0x10,
-        NO_FRAME     = 0x20,    // call is from unmanaged code - don't try to put up a frame
-    };
-
-    static void *GenAllocSFast(Flags flags);
-    static void *GenBox(Flags flags);
-    static void *GenAllocArray(Flags flags);
-    static void *GenAllocString(Flags flags);
-
-private:
-    static void EmitAlignmentRoundup(CPUSTUBLINKER *psl,X86Reg regTestAlign, X86Reg regToAdj, Flags flags);
-    static void EmitDummyObject(CPUSTUBLINKER *psl, X86Reg regTestAlign, Flags flags);
-    static void EmitCore(CPUSTUBLINKER *psl, CodeLabel *noLock, CodeLabel *noAlloc, Flags flags);
-    static void EmitNoAllocCode(CPUSTUBLINKER *psl, Flags flags);
-
-#if CHECK_APP_DOMAIN_LEAKS
-    static void EmitSetAppDomain(CPUSTUBLINKER *psl);
-    static void EmitCheckRestore(CPUSTUBLINKER *psl);
-#endif
-};
-#endif // _TARGET_X86_
-
 void *GenFastGetSharedStaticBase(bool bCheckCCtor);
 
 #ifdef HAVE_GCCOVER


### PR DESCRIPTION
It would be better to move JIT_TrialAlloc declaration int jitinterfacex86.cpp as JIT_TrialAlloc is referenced only inside jitinterfacex86.cpp.