### PR TITLE
Fix an issue where g_ephemeral_low would never get bashed into the write...

### DIFF
--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -923,10 +923,13 @@ void GCToEEInterface::StompWriteBarrier(WriteBarrierParameters* args)
         VolatileStore(&g_highest_address, args->highest_address);
         ::StompWriteBarrierResize(true, false);
 
-        // g_ephemeral_low/high aren't needed for the write barrier stomp, but they
-        // are needed in other places.
+        // StompWriteBarrierResize does not necessarily bash g_ephemeral_low
+        // usages, so we must do so here. This is particularly true on x86,
+        // where StompWriteBarrierResize will not bash g_ephemeral_low when
+        // called with the parameters (true, false), as it is above.
         g_ephemeral_low = args->ephemeral_low;
         g_ephemeral_high = args->ephemeral_high;
+        ::StompWriteBarrierEphemeral(true);
         return;
     case WriteBarrierOp::SwitchToWriteWatch:
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP


### PR DESCRIPTION
...barrier when starting up with Server GC (x86 only).

The problem is triggered by this bit of code:

```c++
void gc_heap::adjust_ephemeral_limits ()
{
    ephemeral_low = generation_allocation_start (generation_of (max_generation - 1));
    ephemeral_high = heap_segment_reserved (ephemeral_heap_segment);

    dprintf (3, ("new ephemeral low: %Ix new ephemeral high: %Ix",
                 (size_t)ephemeral_low, (size_t)ephemeral_high))

#ifndef MULTIPLE_HEAPS
    // This updates the write barrier helpers with the new info.
    stomp_write_barrier_ephemeral(ephemeral_low, ephemeral_high);
#endif // MULTIPLE_HEAPS
}
```

The change that triggered this problem added the `#ifndef MULTIPLE_HEAPS`. This is because, at the time, it was thought that `ephemeral_low` was not being used by any Server GC write barriers; since there is no single ephemeral generation, it does not make sense to check them all. amd64 does not makes use of `g_ephemeral_low` when using server GC at all, but x86 unfortunately does. Since `stomp_write_barrier_ephemeral` will not be called when running with Server GC, the GC will complete its initialization without ever calling `StompWriteBarrierEphemeral`, which is what signals the runtime to bash `g_ephemeral_low` (and possibly also `g_ephemeral_high`, if necessary) into the write barrier.

Previously, the runtime would be bashing `1` as `g_ephemeral_low`, so that all non-null pointers would have their card table bits set in the write barrier. However, since it was never initialized, the write barrier still has the sentinel value `0x0F0F0F0F` as `g_ephemeral_low` and will only set card table bits for pointers over that value. Windows rarely assigns virtual addresses as low as `0x0F0F0F0F` to managed heap segments, so this does not manifest when running on vanilla Windows. However, if the kernel does place managed heap segments below that virtual address, their card bits will never be set and the heap will be corrupted on the next GC.

This PR remedies the startup problem by explicitly calling `StompWriteBarrierEphemeral` from `GCToEEInterface::StompWriteBarrier`, as part of the `WriteBarrierOp
WriteBarrierOp::Initialize` code path, which is called once from `GCHeap::Initialize`. 

Fixes https://github.com/dotnet/coreclr/issues/12560.