### PR TITLE
[RyuJIT/ARM32] Fix using fgMorphMultiregStructArg for mkrefany

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -3816,7 +3816,8 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                     hasMultiregStructArgs = true;
                 }
 #elif defined(_TARGET_ARM_)
-                if (size > 1)
+                // Build the mkrefany as a GT_FIELD_LIST in this function
+                if (size > 1 && argx->gtOper != GT_MKREFANY)
                 {
                     hasMultiregStructArgs = true;
                 }


### PR DESCRIPTION
Block using fgMorphMultiregStructArg function for mkrefany.
Morphing for mkrefany struct is already done in fgMorphArgs function.

Related issue: #11781 
cc/ @dotnet/arm32-contrib 