### PR TITLE
[x86/Linux] Restore PTR_MethodTable in FastPrimitiveArrayAllocator

### DIFF
--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -923,9 +923,9 @@ HCIMPL2_RAW(Object*, UnframedAllocatePrimitiveArray, CorElementType type, DWORD 
 }
 HCIMPLEND_RAW
 
-HCIMPL1_RAW(PTR_MethodTable, UnframedGetTemplateMethodTable, ArrayTypeDesc *arrayDesc)
+HCIMPL1_RAW(PTR_MethodTable, UnframedGetMethodTable, ArrayTypeDesc *arrayDesc)
 {
-    return arrayDesc->GetTemplateMethodTable();
+    return arrayDesc->GetMethodTable();
 }
 HCIMPLEND_RAW
 
@@ -968,7 +968,7 @@ void *JIT_TrialAlloc::GenAllocArray(Flags flags)
             // je noLock
             sl.X86EmitCondJump(noLock, X86CondCode::kJZ);
 
-            sl.X86EmitCall(sl.NewExternalCodeLabel((LPVOID)UnframedGetTemplateMethodTable), 0);
+            sl.X86EmitCall(sl.NewExternalCodeLabel((LPVOID)UnframedGetMethodTable), 0);
             sl.X86EmitMovRegReg(kECX, kEAX);
         }
     }

--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -34,7 +34,6 @@
 #define MON_DEBUG 1
 #endif
 
-#ifdef _TARGET_X86_
 class JIT_TrialAlloc
 {
 public:
@@ -65,7 +64,6 @@ private:
     static void EmitCheckRestore(CPUSTUBLINKER *psl);
 #endif
 };
-#endif // _TARGET_X86_
 
 extern "C" LONG g_global_alloc_lock;
 
@@ -925,6 +923,11 @@ HCIMPL2_RAW(Object*, UnframedAllocatePrimitiveArray, CorElementType type, DWORD 
 }
 HCIMPLEND_RAW
 
+HCIMPL1_RAW(PTR_MethodTable, UnframedGetTemplateMethodTable, ArrayTypeDesc *arrayDesc)
+{
+    return arrayDesc->GetTemplateMethodTable();
+}
+HCIMPLEND_RAW
 
 void *JIT_TrialAlloc::GenAllocArray(Flags flags)
 {
@@ -964,6 +967,9 @@ void *JIT_TrialAlloc::GenAllocArray(Flags flags)
 
             // je noLock
             sl.X86EmitCondJump(noLock, X86CondCode::kJZ);
+
+            sl.X86EmitCall(sl.NewExternalCodeLabel((LPVOID)UnframedGetTemplateMethodTable), 0);
+            sl.X86EmitMovRegReg(kECX, kEAX);
         }
     }
     else

--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -923,9 +923,9 @@ HCIMPL2_RAW(Object*, UnframedAllocatePrimitiveArray, CorElementType type, DWORD 
 }
 HCIMPLEND_RAW
 
-HCIMPL1_RAW(PTR_MethodTable, UnframedGetMethodTable, ArrayTypeDesc *arrayDesc)
+HCIMPL1_RAW(PTR_MethodTable, UnframedGetTemplateMethodTable, ArrayTypeDesc *arrayDesc)
 {
-    return arrayDesc->GetMethodTable();
+    return arrayDesc->GetTemplateMethodTable();
 }
 HCIMPLEND_RAW
 
@@ -968,7 +968,10 @@ void *JIT_TrialAlloc::GenAllocArray(Flags flags)
             // je noLock
             sl.X86EmitCondJump(noLock, X86CondCode::kJZ);
 
-            sl.X86EmitCall(sl.NewExternalCodeLabel((LPVOID)UnframedGetMethodTable), 0);
+            sl.X86EmitPushReg(kEDX);
+            sl.X86EmitCall(sl.NewExternalCodeLabel((LPVOID)UnframedGetTemplateMethodTable), 0);
+            sl.X86EmitPopReg(kEDX);
+
             sl.X86EmitMovRegReg(kECX, kEAX);
         }
     }


### PR DESCRIPTION
FastPrimitiveArrayAllocator (that JIT_TrialAlloc::GenAllocArray generates) should pass PTR_MethodTable, but currently passes RelativeFixupPointer<PTR_MethodTable>.

This bug results in #12545.

This commit revises JIT_TrialAlloc::GenAllocArray) to generate FastPrimitiveArrayAllocator that restores PTR_MethodTable from RelativeFixupPointer<PTR_MethodTable>.

In addition, this PR removes unnecessary ifdef introduces in #12562.