### PR TITLE
Add a missing case to GenTree::VisitOperands()

### DIFF
--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -4788,6 +4788,9 @@ void GenTree::VisitOperands(TVisitor visitor)
         case GT_PHYSREGDST:
         case GT_PUTARG_REG:
         case GT_PUTARG_STK:
+#if defined(_TARGET_ARM_) && !defined(LEGACY_BACKEND)
+        case GT_PUTARG_SPLIT:
+#endif
         case GT_RETURNTRAP:
             visitor(this->AsUnOp()->gtOp1);
             return;


### PR DESCRIPTION
Fixes failures of the arm32 leg:
```
Assertion failed 'this->OperIsBinary()' in 'NullableTest13:Run()' (IL size 79)

    File: /opt/git/coreclr/src/jit/compiler.hpp Line: 4957
    Image: /opt/clr-checked/corerun
```

cc @dotnet/arm32-contrib 