### PR TITLE
Automatic build runtime layout when skipping tests

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -501,7 +501,17 @@ if %__BuildTests% EQU 1 (
         REM buildtest.cmd has already emitted an error message and mentioned the build log file to examine.
         exit /b 1
     )
-)
+) else (
+    echo %__MsgPrefix%Skipping test build. Proceeding to building runtime layout for %__BuildOS%.%__BuildArch%.%__BuildType%
+
+    echo "%__ProjectDir%\tests\runtest.cmd %__BuildArch% %__BuildType% %__UnprocessedBuildArgs% GenerateLayoutOnly"
+    @call %__ProjectDir%\tests\runtest.cmd %__BuildArch% %__BuildType% %__UnprocessedBuildArgs% GenerateLayoutOnly
+
+    if not !errorlevel! == 0 (
+        REM runtest.cmd has already emitted an error message and mentioned the build log file to examine.
+        exit /b 1
+    )    
+) 
 
 REM =========================================================================================
 REM ===


### PR DESCRIPTION
When you are iterating on a fix/feature to make a test pass, it's nice to avoid build all the tests (which takes forever) but you still want your runtime changes to go into the runtime layout directory bin\tests\Windows_NT.x64.Debug\Tests\Core_Root. This makes it so that we would build runtime layout even when you specify skiptests.