### PR TITLE
Implement a new approach for SIMD8/LONG interactions.

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -1708,6 +1708,41 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             genCodeForCast(treeNode->AsOp());
             break;
 
+        case GT_REINTERPRET:
+        {
+            GenTree* const op1 = treeNode->AsOp()->gtOp1;
+            genConsumeReg(op1);
+
+            const bool srcFltReg = varTypeIsFloating(op1) || varTypeIsSIMD(op1);
+            const bool dstFltReg = varTypeIsFloating(treeNode) || varTypeIsSIMD(treeNode);
+            if (srcFltReg != dstFltReg)
+            {
+                instruction ins;
+                regNumber   fltReg;
+                regNumber   intReg;
+                if (dstFltReg)
+                {
+                    ins    = ins_CopyIntToFloat(op1->TypeGet(), treeNode->TypeGet());
+                    fltReg = treeNode->gtRegNum;
+                    intReg = op1->gtRegNum;
+                }
+                else
+                {
+                    ins    = ins_CopyFloatToInt(op1->TypeGet(), treeNode->TypeGet());
+                    intReg = treeNode->gtRegNum;
+                    fltReg = op1->gtRegNum;
+                }
+                inst_RV_RV(ins, fltReg, intReg, treeNode->TypeGet());
+            }
+            else if (treeNode->gtRegNum != op1->gtRegNum)
+            {
+                inst_RV_RV(ins_Copy(treeNode->TypeGet()), treeNode->gtRegNum, op1->gtRegNum, treeNode->TypeGet());
+            }
+
+            genProduceReg(treeNode);
+            break;
+        }
+
         case GT_LCL_FLD_ADDR:
         case GT_LCL_VAR_ADDR:
             genCodeForLclAddr(treeNode);

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -1708,7 +1708,7 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             genCodeForCast(treeNode->AsOp());
             break;
 
-        case GT_REINTERPRET:
+        case GT_BITCAST:
         {
             GenTree* const op1 = treeNode->AsOp()->gtOp1;
             genConsumeReg(op1);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -9599,7 +9599,7 @@ public:
             case GT_RELOAD:
             case GT_ARR_LENGTH:
             case GT_CAST:
-            case GT_REINTERPRET:
+            case GT_BITCAST:
             case GT_CKFINITE:
             case GT_LCLHEAP:
             case GT_ADDR:

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -9599,6 +9599,7 @@ public:
             case GT_RELOAD:
             case GT_ARR_LENGTH:
             case GT_CAST:
+            case GT_REINTERPRET:
             case GT_CKFINITE:
             case GT_LCLHEAP:
             case GT_ADDR:

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -4771,6 +4771,7 @@ void GenTree::VisitOperands(TVisitor visitor)
         case GT_RELOAD:
         case GT_ARR_LENGTH:
         case GT_CAST:
+        case GT_REINTERPRET:
         case GT_CKFINITE:
         case GT_LCLHEAP:
         case GT_ADDR:

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -4771,7 +4771,7 @@ void GenTree::VisitOperands(TVisitor visitor)
         case GT_RELOAD:
         case GT_ARR_LENGTH:
         case GT_CAST:
-        case GT_REINTERPRET:
+        case GT_BITCAST:
         case GT_CKFINITE:
         case GT_LCLHEAP:
         case GT_ADDR:

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -5377,7 +5377,7 @@ bool GenTree::TryGetUse(GenTree* def, GenTree*** use)
         case GT_RELOAD:
         case GT_ARR_LENGTH:
         case GT_CAST:
-        case GT_REINTERPRET:
+        case GT_BITCAST:
         case GT_CKFINITE:
         case GT_LCLHEAP:
         case GT_ADDR:
@@ -8645,7 +8645,7 @@ GenTreeUseEdgeIterator::GenTreeUseEdgeIterator(GenTree* node)
         case GT_RELOAD:
         case GT_ARR_LENGTH:
         case GT_CAST:
-        case GT_REINTERPRET:
+        case GT_BITCAST:
         case GT_CKFINITE:
         case GT_LCLHEAP:
         case GT_ADDR:

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -5377,6 +5377,7 @@ bool GenTree::TryGetUse(GenTree* def, GenTree*** use)
         case GT_RELOAD:
         case GT_ARR_LENGTH:
         case GT_CAST:
+        case GT_REINTERPRET:
         case GT_CKFINITE:
         case GT_LCLHEAP:
         case GT_ADDR:
@@ -8644,6 +8645,7 @@ GenTreeUseEdgeIterator::GenTreeUseEdgeIterator(GenTree* node)
         case GT_RELOAD:
         case GT_ARR_LENGTH:
         case GT_CAST:
+        case GT_REINTERPRET:
         case GT_CKFINITE:
         case GT_LCLHEAP:
         case GT_ADDR:

--- a/src/jit/gtlist.h
+++ b/src/jit/gtlist.h
@@ -64,7 +64,7 @@ GTNODE(CMPXCHG          , GenTreeCmpXchg     ,0,GTK_SPECIAL)
 GTNODE(MEMORYBARRIER    , GenTree            ,0,GTK_LEAF|GTK_NOVALUE)
 
 GTNODE(CAST             , GenTreeCast        ,0,GTK_UNOP|GTK_EXOP)      // conversion to another type
-GTNODE(REINTERPRET      , GenTreeUnOp        ,0,GTK_UNOP)               // reinterpretation of bits as another type
+GTNODE(BITCAST          , GenTreeUnOp        ,0,GTK_UNOP)               // reinterpretation of bits as another type
 GTNODE(CKFINITE         , GenTreeOp          ,0,GTK_UNOP|GTK_NOCONTAIN) // Check for NaN
 GTNODE(LCLHEAP          , GenTreeOp          ,0,GTK_UNOP|GTK_NOCONTAIN) // alloca()
 GTNODE(JMP              , GenTreeVal         ,0,GTK_LEAF|GTK_NOVALUE)   // Jump to another function

--- a/src/jit/gtlist.h
+++ b/src/jit/gtlist.h
@@ -64,6 +64,7 @@ GTNODE(CMPXCHG          , GenTreeCmpXchg     ,0,GTK_SPECIAL)
 GTNODE(MEMORYBARRIER    , GenTree            ,0,GTK_LEAF|GTK_NOVALUE)
 
 GTNODE(CAST             , GenTreeCast        ,0,GTK_UNOP|GTK_EXOP)      // conversion to another type
+GTNODE(REINTERPRET      , GenTreeUnOp        ,0,GTK_UNOP)               // reinterpretation of bits as another type
 GTNODE(CKFINITE         , GenTreeOp          ,0,GTK_UNOP|GTK_NOCONTAIN) // Check for NaN
 GTNODE(LCLHEAP          , GenTreeOp          ,0,GTK_UNOP|GTK_NOCONTAIN) // alloca()
 GTNODE(JMP              , GenTreeVal         ,0,GTK_LEAF|GTK_NOVALUE)   // Jump to another function

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -268,9 +268,9 @@ GenTree* Lowering::LowerNode(GenTree* node)
                 GenTreeLclVarCommon* const store = node->AsLclVarCommon();
                 if ((store->TypeGet() == TYP_SIMD8) != (store->gtOp1->TypeGet() == TYP_SIMD8))
                 {
-                    GenTreeUnOp* reinterpret = new (comp, GT_REINTERPRET) GenTreeOp(GT_REINTERPRET, store->TypeGet(), store->gtOp1, nullptr);
-                    store->gtOp1 = reinterpret;
-                    BlockRange().InsertBefore(store, reinterpret);
+                    GenTreeUnOp* bitcast = new (comp, GT_BITCAST) GenTreeOp(GT_BITCAST, store->TypeGet(), store->gtOp1, nullptr);
+                    store->gtOp1 = bitcast;
+                    BlockRange().InsertBefore(store, bitcast);
                     break;
                 }
             }
@@ -1173,10 +1173,10 @@ void Lowering::LowerArg(GenTreeCall* call, GenTreePtr* ppArg)
     // TYP_SIMD8 parameters that are passed as longs 
     if (type == TYP_SIMD8 && genIsValidIntReg(info->regNum))
     {
-        GenTreeUnOp* reinterpret = new (comp, GT_REINTERPRET) GenTreeOp(GT_REINTERPRET, TYP_LONG, arg, nullptr);
-        BlockRange().InsertAfter(arg, reinterpret);
+        GenTreeUnOp* bitcast = new (comp, GT_BITCAST) GenTreeOp(GT_BITCAST, TYP_LONG, arg, nullptr);
+        BlockRange().InsertAfter(arg, bitcast);
 
-        info->node = *ppArg = arg = reinterpret;
+        info->node = *ppArg = arg = bitcast;
         type = TYP_LONG;
     }
 #endif // defined(_TARGET_X86_)
@@ -2483,9 +2483,9 @@ void Lowering::LowerRet(GenTree* ret)
     GenTreeUnOp* const unOp = ret->AsUnOp();
     if ((unOp->TypeGet() == TYP_LONG) && (unOp->gtOp1->TypeGet() == TYP_SIMD8))
     {
-        GenTreeUnOp* reinterpret = new (comp, GT_REINTERPRET) GenTreeOp(GT_REINTERPRET, TYP_LONG, unOp->gtOp1, nullptr);
-        unOp->gtOp1 = reinterpret;
-        BlockRange().InsertBefore(unOp, reinterpret);
+        GenTreeUnOp* bitcast = new (comp, GT_BITCAST) GenTreeOp(GT_BITCAST, TYP_LONG, unOp->gtOp1, nullptr);
+        unOp->gtOp1 = bitcast;
+        BlockRange().InsertBefore(unOp, bitcast);
     }
 #endif // _TARGET_AMD64_
 

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -263,6 +263,18 @@ GenTree* Lowering::LowerNode(GenTree* node)
             break;
 
         case GT_STORE_LCL_VAR:
+#if defined(_TARGET_AMD64_)
+            {
+                GenTreeLclVarCommon* const store = node->AsLclVarCommon();
+                if ((store->TypeGet() == TYP_SIMD8) != (store->gtOp1->TypeGet() == TYP_SIMD8))
+                {
+                    GenTreeUnOp* reinterpret = new (comp, GT_REINTERPRET) GenTreeOp(GT_REINTERPRET, store->TypeGet(), store->gtOp1, nullptr);
+                    store->gtOp1 = reinterpret;
+                    BlockRange().InsertBefore(store, reinterpret);
+                    break;
+                }
+            }
+#endif // _TARGET_AMD64_
             WidenSIMD12IfNecessary(node->AsLclVarCommon());
             __fallthrough;
 
@@ -851,14 +863,6 @@ GenTreePtr Lowering::NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntryP
     {
         if (!isOnStack)
         {
-#ifdef FEATURE_SIMD
-            // TYP_SIMD8 is passed in an integer register.  We need the putArg node to be of the int type.
-            if (type == TYP_SIMD8 && genIsValidIntReg(info->regNum))
-            {
-                type = TYP_LONG;
-            }
-#endif // FEATURE_SIMD
-
 #if defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
             if (info->isStruct)
             {
@@ -1141,7 +1145,8 @@ void Lowering::LowerArg(GenTreeCall* call, GenTreePtr* ppArg)
         type = TYP_INT;
     }
 
-#if defined(FEATURE_SIMD) && defined(_TARGET_X86_)
+#if defined(FEATURE_SIMD)
+#if defined(_TARGET_X86_)
     // Non-param TYP_SIMD12 local var nodes are massaged in Lower to TYP_SIMD16 to match their
     // allocated size (see lvSize()). However, when passing the variables as arguments, and
     // storing the variables to the outgoing argument area on the stack, we must use their
@@ -1164,7 +1169,18 @@ void Lowering::LowerArg(GenTreeCall* call, GenTreePtr* ppArg)
             }
         }
     }
-#endif // defined(FEATURE_SIMD) && defined(_TARGET_X86_)
+#elif defined(_TARGET_AMD64_)
+    // TYP_SIMD8 parameters that are passed as longs 
+    if (type == TYP_SIMD8 && genIsValidIntReg(info->regNum))
+    {
+        GenTreeUnOp* reinterpret = new (comp, GT_REINTERPRET) GenTreeOp(GT_REINTERPRET, TYP_LONG, arg, nullptr);
+        BlockRange().InsertAfter(arg, reinterpret);
+
+        info->node = *ppArg = arg = reinterpret;
+        type = TYP_LONG;
+    }
+#endif // defined(_TARGET_X86_)
+#endif // defined(FEATURE_SIMD)
 
     GenTreePtr putArg;
 
@@ -2462,6 +2478,16 @@ void Lowering::LowerRet(GenTree* ret)
     JITDUMP("lowering GT_RETURN\n");
     DISPNODE(ret);
     JITDUMP("============");
+
+#ifdef _TARGET_AMD64_
+    GenTreeUnOp* const unOp = ret->AsUnOp();
+    if ((unOp->TypeGet() == TYP_LONG) && (unOp->gtOp1->TypeGet() == TYP_SIMD8))
+    {
+        GenTreeUnOp* reinterpret = new (comp, GT_REINTERPRET) GenTreeOp(GT_REINTERPRET, TYP_LONG, unOp->gtOp1, nullptr);
+        unOp->gtOp1 = reinterpret;
+        BlockRange().InsertBefore(unOp, reinterpret);
+    }
+#endif // _TARGET_AMD64_
 
     // Method doing PInvokes has exactly one return block unless it has tail calls.
     if (comp->info.compCallUnmanaged && (comp->compCurBB == comp->genReturnBB))

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -2242,6 +2242,7 @@ void LinearScan::identifyCandidates()
                     varDsc->lvLRACandidate = 0;
                 }
                 break;
+
             // TODO-1stClassStructs: Move TYP_SIMD8 up with the other SIMD types, after handling the param issue
             // (passing & returning as TYP_LONG).
             case TYP_SIMD8:
@@ -3749,10 +3750,13 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
     assert(!tree->OperIsAssignment());
     if (tree->OperIsLocalStore())
     {
-        if (isCandidateLocalRef(tree))
+        GenTreeLclVarCommon* const store = tree->AsLclVarCommon();
+        assert((consume > 1) || (regType(store->gtOp1->TypeGet()) == regType(store->TypeGet())));
+
+        LclVarDsc* varDsc = &compiler->lvaTable[store->gtLclNum];
+        if (isCandidateVar(varDsc))
         {
             // We always push the tracked lclVar intervals
-            LclVarDsc* varDsc = &compiler->lvaTable[tree->gtLclVarCommon.gtLclNum];
             assert(varDsc->lvTracked);
             unsigned varIndex = varDsc->lvVarIndex;
             varDefInterval    = getIntervalForLocalVar(varIndex);
@@ -3794,24 +3798,37 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
                     // Preference the source to dest, if src is not a local var.
                     srcInterval->assignRelatedInterval(varDefInterval);
                 }
-
-                // We can have a case where the source of the store has a different register type,
-                // e.g. when the store is of a return value temp, and op1 is a Vector2
-                // (TYP_SIMD8).  We will need to set the
-                // src candidates accordingly on op1 so that LSRA will generate a copy.
-                // We could do this during Lowering, but at that point we don't know whether
-                // this lclVar will be a register candidate, and if not, we would prefer to leave
-                // the type alone.
-                if (regType(tree->gtGetOp1()->TypeGet()) != regType(tree->TypeGet()))
-                {
-                    tree->gtGetOp1()->gtLsraInfo.setSrcCandidates(this, allRegs(tree->TypeGet()));
-                }
             }
 
             if ((tree->gtFlags & GTF_VAR_DEATH) == 0)
             {
                 VarSetOps::AddElemD(compiler, currentLiveVars, varIndex);
             }
+        }
+        else if (store->gtOp1->OperIs(GT_REINTERPRET))
+        {
+            store->gtType = store->gtOp1->gtType = store->gtOp1->AsUnOp()->gtOp1->TypeGet();
+
+            // Get the location info for the register defined by the first operand.
+            LocationInfoList operandDefs;
+            bool             found = operandToLocationInfoMap.TryGetValue(GetFirstOperand(store), &operandDefs);
+            assert(found);
+
+            // Since we only expect to consume one register, we should only have a single register to consume.
+            assert(operandDefs.Begin()->Next() == operandDefs.End());
+
+            LocationInfo& operandInfo = *static_cast<LocationInfo*>(operandDefs.Begin());
+
+            Interval* srcInterval = operandInfo.interval;
+            srcInterval->registerType = regType(store->TypeGet());
+
+            RefPosition* srcDefPosition = srcInterval->firstRefPosition;
+            assert(srcDefPosition != nullptr);
+            assert(srcDefPosition->refType == RefTypeDef);
+            assert(srcDefPosition->treeNode == store->gtOp1);
+
+            srcDefPosition->registerAssignment = allRegs(store->TypeGet());
+            store->gtOp1->gtLsraInfo.setSrcCandidates(this, allRegs(store->TypeGet()));
         }
     }
     else if (noAdd && produce == 0)
@@ -3974,26 +3991,6 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
             Interval* i           = locInfo.interval;
             unsigned  multiRegIdx = locInfo.multiRegIdx;
 
-#ifdef FEATURE_SIMD
-            // In case of multi-reg call store to a local, there won't be any mismatch of
-            // use candidates with the type of the tree node.
-            if (tree->OperIsLocalStore() && varDefInterval == nullptr && !useNode->IsMultiRegCall())
-            {
-                // This is a non-candidate store.  If this is a SIMD type, the use candidates
-                // may not match the type of the tree node.  If that is the case, change the
-                // type of the tree node to match, so that we do the right kind of store.
-                if ((candidates & allRegs(tree->gtType)) == RBM_NONE)
-                {
-                    noway_assert((candidates & allRegs(useNode->gtType)) != RBM_NONE);
-                    // Currently, the only case where this should happen is for a TYP_LONG
-                    // source and a TYP_SIMD8 target.
-                    assert((useNode->gtType == TYP_LONG && tree->gtType == TYP_SIMD8) ||
-                           (useNode->gtType == TYP_SIMD8 && tree->gtType == TYP_LONG));
-                    tree->gtType = useNode->gtType;
-                }
-            }
-#endif // FEATURE_SIMD
-
             if (useNode->gtLsraInfo.isTgtPref)
             {
                 prefSrcInterval = i;
@@ -4047,29 +4044,9 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
             }
 #endif // DEBUG
 
-            RefPosition* pos;
-            if ((candidates & allRegs(i->registerType)) == 0)
-            {
-                // This should only occur where we've got a type mismatch due to SIMD
-                // pointer-size types that are passed & returned as longs.
-                i->hasConflictingDefUse = true;
-                if (fixedAssignment != RBM_NONE)
-                {
-                    // Explicitly insert a FixedRefPosition and fake the candidates, because otherwise newRefPosition
-                    // will complain about the types not matching.
-                    regNumber    physicalReg = genRegNumFromMask(fixedAssignment);
-                    RefPosition* pos =
-                        newRefPosition(physicalReg, currentLoc, RefTypeFixedReg, nullptr, fixedAssignment);
-                }
-                pos = newRefPosition(i, currentLoc, RefTypeUse, useNode, allRegs(i->registerType),
-                                     multiRegIdx DEBUG_ARG(minRegCountForUsePos));
-                pos->registerAssignment = candidates;
-            }
-            else
-            {
-                pos = newRefPosition(i, currentLoc, RefTypeUse, useNode, candidates,
-                                     multiRegIdx DEBUG_ARG(minRegCountForUsePos));
-            }
+            assert((candidates & allRegs(i->registerType)) != 0);
+            RefPosition* pos = newRefPosition(i, currentLoc, RefTypeUse, useNode, candidates,
+                                              multiRegIdx DEBUG_ARG(minRegCountForUsePos));
 
             if (delayRegFree)
             {
@@ -5277,16 +5254,8 @@ RegisterType LinearScan::getRegisterType(Interval* currentInterval, RefPosition*
     assert(refPosition->getInterval() == currentInterval);
     RegisterType regType    = currentInterval->registerType;
     regMaskTP    candidates = refPosition->registerAssignment;
-#if defined(FEATURE_SIMD) && defined(_TARGET_AMD64_)
-    if ((candidates & allRegs(regType)) == RBM_NONE)
-    {
-        assert((regType == TYP_SIMD8) && (refPosition->refType == RefTypeUse) &&
-               ((candidates & allRegs(TYP_INT)) != RBM_NONE));
-        regType = TYP_INT;
-    }
-#else  // !(defined(FEATURE_SIMD) && defined(_TARGET_AMD64_))
+
     assert((candidates & allRegs(regType)) != RBM_NONE);
-#endif // !(defined(FEATURE_SIMD) && defined(_TARGET_AMD64_))
     return regType;
 }
 
@@ -8462,20 +8431,6 @@ void LinearScan::insertCopyOrReload(BasicBlock* block, GenTreePtr tree, unsigned
     {
         // Create the new node, with "tree" as its only child.
         var_types treeType = tree->TypeGet();
-
-#ifdef FEATURE_SIMD
-        // Check to see whether we need to move to a different register set.
-        // This currently only happens in the case of SIMD vector types that are small enough (pointer size)
-        // that they must be passed & returned in integer registers.
-        // 'treeType' is the type of the register we are moving FROM,
-        // and refPosition->registerAssignment is the mask for the register we are moving TO.
-        // If they don't match, we need to reverse the type for the "move" node.
-
-        if ((allRegs(treeType) & refPosition->registerAssignment) == 0)
-        {
-            treeType = (useFloatReg(treeType)) ? TYP_I_IMPL : TYP_SIMD8;
-        }
-#endif // FEATURE_SIMD
 
         GenTreeCopyOrReload* newNode = new (compiler, oper) GenTreeCopyOrReload(oper, treeType, tree);
         assert(refPosition->registerAssignment != RBM_NONE);

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3819,7 +3819,7 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
 
             LocationInfo& operandInfo = *static_cast<LocationInfo*>(operandDefs.Begin());
 
-            Interval* srcInterval = operandInfo.interval;
+            Interval* srcInterval     = operandInfo.interval;
             srcInterval->registerType = regType(store->TypeGet());
 
             RefPosition* srcDefPosition = srcInterval->firstRefPosition;
@@ -10080,7 +10080,7 @@ void LinearScan::resolveEdge(BasicBlock*      fromBlock,
             tempRegFlt = getTempRegForResolution(fromBlock, toBlock, TYP_FLOAT);
         }
 #else
-        tempRegFlt = getTempRegForResolution(fromBlock, toBlock, TYP_FLOAT);
+        tempRegFlt                   = getTempRegForResolution(fromBlock, toBlock, TYP_FLOAT);
 #endif
     }
 

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3805,7 +3805,7 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
                 VarSetOps::AddElemD(compiler, currentLiveVars, varIndex);
             }
         }
-        else if (store->gtOp1->OperIs(GT_REINTERPRET))
+        else if (store->gtOp1->OperIs(GT_BITCAST))
         {
             store->gtType = store->gtOp1->gtType = store->gtOp1->AsUnOp()->gtOp1->TypeGet();
 

--- a/src/jit/lsraxarch.cpp
+++ b/src/jit/lsraxarch.cpp
@@ -471,6 +471,12 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             TreeNodeInfoInitCast(tree);
             break;
 
+        case GT_REINTERPRET:
+            info->srcCount = 1;
+            info->dstCount = 1;
+            tree->AsUnOp()->gtOp1->gtLsraInfo.isTgtPref = true;
+            break;
+
         case GT_NEG:
             info->srcCount = 1;
             info->dstCount = 1;

--- a/src/jit/lsraxarch.cpp
+++ b/src/jit/lsraxarch.cpp
@@ -471,7 +471,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             TreeNodeInfoInitCast(tree);
             break;
 
-        case GT_REINTERPRET:
+        case GT_BITCAST:
             info->srcCount = 1;
             info->dstCount = 1;
             tree->AsUnOp()->gtOp1->gtLsraInfo.isTgtPref = true;

--- a/src/jit/lsraxarch.cpp
+++ b/src/jit/lsraxarch.cpp
@@ -472,8 +472,8 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             break;
 
         case GT_BITCAST:
-            info->srcCount = 1;
-            info->dstCount = 1;
+            info->srcCount                              = 1;
+            info->dstCount                              = 1;
             tree->AsUnOp()->gtOp1->gtLsraInfo.isTgtPref = true;
             break;
 


### PR DESCRIPTION
SIMD8 values need to be converted to longs under a small number of
situations on x64/Windows:
- SIMD8 values are passed and returned as LONGs
- SIMD8 values may be stored to a LONG lclVar

Currently, LSRA performs some gymnastics when building use positions in
order to ensure that registers are properly allocated. This change is a
stab at a different approach: rather than pushing this work onto the RA,
lowering inserts `GT_BITCAST` nodes where necessary to indicate
that the source long- or SIMD8-typed value should be retinterpreted as
a SIMD8- or long-typed value as necessary. The RA performs one specific
optimization wherein it retypes stores of `GT_BITCAST` nodes to
non-register-candidate local vars with the type of the cast's operand
and preferences the cast to its source interval.

This approach trades slightly larger IR for some functions that
manipulate SIMD8 values for tighter code in buildRefPositions.