### PR TITLE
Added SetThreadDescription to set the unmanaged thread name

### DIFF
--- a/src/inc/utilcode.h
+++ b/src/inc/utilcode.h
@@ -4687,6 +4687,8 @@ inline void ClrFlsClearThreadType (TlsThreadTypeFlag flag)
 #define CLEAR_THREAD_TYPE_STACKWALKER() ClrFlsSetValue(TlsIdx_StackWalkerWalkingThread, NULL)
 #endif  // DACCESS_COMPILE
 
+HRESULT SetThreadName(HANDLE hThread, PCWSTR lpThreadDescription);
+
 inline BOOL IsStackWalkerThread()
 {
     STATIC_CONTRACT_NOTHROW;

--- a/src/utilcode/winfix.cpp
+++ b/src/utilcode/winfix.cpp
@@ -426,6 +426,38 @@ lExit:
     
 }
 
+typedef HRESULT(WINAPI *pfnSetThreadDescription)(HANDLE hThread, PCWSTR lpThreadDescription);
+extern pfnSetThreadDescription g_pfnSetThreadDescription;
+
+// Dummy method if windows version does not support it
+HRESULT SetThreadDescriptionDummy(HANDLE hThread, PCWSTR lpThreadDescription)
+{
+    return NOERROR;
+}
+
+HRESULT WINAPI InitializeSetThreadDescription(HANDLE hThread, PCWSTR lpThreadDescription)
+{
+    HMODULE hKernel32 = WszLoadLibrary(W("kernel32.dll"));
+    if (hKernel32 != NULL)
+    {
+        g_pfnSetThreadDescription = (pfnSetThreadDescription)GetProcAddress(hKernel32, "SetThreadDescription");
+    }
+
+    if (g_pfnSetThreadDescription == NULL) // method is only available with Windows 10 Creators Update or later
+    {
+        g_pfnSetThreadDescription = SetThreadDescriptionDummy;
+    }
+
+    return g_pfnSetThreadDescription(hThread, lpThreadDescription);
+}
+
+pfnSetThreadDescription g_pfnSetThreadDescription = &InitializeSetThreadDescription;
+
+// Set unmanaged thread name which will show up in ETW and Debuggers which know how to read this data.
+HRESULT SetThreadName(HANDLE hThread, PCWSTR lpThreadDescription)
+{
+    return g_pfnSetThreadDescription(hThread, lpThreadDescription);
+}
 
 DWORD
 WszGetWorkingSet()

--- a/src/vm/comsynchronizable.cpp
+++ b/src/vm/comsynchronizable.cpp
@@ -1584,7 +1584,7 @@ void QCALLTYPE ThreadNative::InformThreadNameChange(QCall::ThreadHandle thread, 
         {
 
             auto last = ::GetLastError();
-            wprintf(L"\r\nSetThreadName failed for string %s and returned: %lx, lastError: %llx, Thread Handle: %llx. This should not happen unless the thread handle is invalid or the API call itself has a problem.", name, lret, last, pThread->GetThreadHandle());
+            printf("\r\nSetThreadName failed and returned: %llx, lastError: %llx, Thread Handle: %llx. This should not happen unless the thread handle is invalid or the API call itself has a problem.", lret, last, pThread->GetThreadHandle());
         }
 #endif
     }

--- a/src/vm/comsynchronizable.cpp
+++ b/src/vm/comsynchronizable.cpp
@@ -1547,7 +1547,6 @@ void QCALLTYPE ThreadNative::InformThreadNameChange(QCall::ThreadHandle thread, 
     QCALL_CONTRACT;
 
     BEGIN_QCALL;
-
     
     Thread* pThread = &(*thread);
 

--- a/src/vm/finalizerthread.cpp
+++ b/src/vm/finalizerthread.cpp
@@ -909,7 +909,7 @@ void FinalizerThread::FinalizerThreadCreate()
     // actual thread terminates.
     GetFinalizerThread()->IncExternalCount();
 
-    if (GetFinalizerThread()->CreateNewThread(0, &FinalizerThreadStart, NULL))
+    if (GetFinalizerThread()->CreateNewThread(0, &FinalizerThreadStart, NULL, L"Finalizer"))
     {
         DWORD dwRet = GetFinalizerThread()->StartThread();
 

--- a/src/vm/finalizerthread.cpp
+++ b/src/vm/finalizerthread.cpp
@@ -909,7 +909,7 @@ void FinalizerThread::FinalizerThreadCreate()
     // actual thread terminates.
     GetFinalizerThread()->IncExternalCount();
 
-    if (GetFinalizerThread()->CreateNewThread(0, &FinalizerThreadStart, NULL, L"Finalizer"))
+    if (GetFinalizerThread()->CreateNewThread(0, &FinalizerThreadStart, NULL, W("Finalizer")) )
     {
         DWORD dwRet = GetFinalizerThread()->StartThread();
 

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -445,7 +445,7 @@ Thread* GCToEEInterface::CreateBackgroundThread(GCBackgroundThreadFunction threa
         return NULL;
     }
 
-    if (threadStubArgs.thread->CreateNewThread(0, (LPTHREAD_START_ROUTINE)BackgroundThreadStub, &threadStubArgs))
+    if (threadStubArgs.thread->CreateNewThread(0, (LPTHREAD_START_ROUTINE)BackgroundThreadStub, &threadStubArgs, L"Background GC"))
     {
         threadStubArgs.thread->SetBackground (TRUE, FALSE);
         threadStubArgs.thread->StartThread();

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -445,7 +445,7 @@ Thread* GCToEEInterface::CreateBackgroundThread(GCBackgroundThreadFunction threa
         return NULL;
     }
 
-    if (threadStubArgs.thread->CreateNewThread(0, (LPTHREAD_START_ROUTINE)BackgroundThreadStub, &threadStubArgs, L"Background GC"))
+    if (threadStubArgs.thread->CreateNewThread(0, (LPTHREAD_START_ROUTINE)BackgroundThreadStub, &threadStubArgs, W("Background GC")))
     {
         threadStubArgs.thread->SetBackground (TRUE, FALSE);
         threadStubArgs.thread->StartThread();

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -2530,7 +2530,7 @@ void UndoRevert(BOOL bReverted, HANDLE hToken)
 // We don't want ::CreateThread() calls scattered throughout the source.  So gather
 // them all here.
 
-BOOL Thread::CreateNewThread(SIZE_T stackSize, LPTHREAD_START_ROUTINE start, void *args)
+BOOL Thread::CreateNewThread(SIZE_T stackSize, LPTHREAD_START_ROUTINE start, void *args, LPCWSTR pName)
 {
     CONTRACTL {
         NOTHROW;
@@ -2557,6 +2557,7 @@ BOOL Thread::CreateNewThread(SIZE_T stackSize, LPTHREAD_START_ROUTINE start, voi
     bRet = CreateNewOSThread(stackSize, start, args);
 #ifndef FEATURE_PAL
     UndoRevert(bReverted, token);
+    SetThreadName(m_ThreadHandle, pName);
 #endif // !FEATURE_PAL
 
     return bRet;

--- a/src/vm/threads.h
+++ b/src/vm/threads.h
@@ -1944,7 +1944,7 @@ public:
     // Create all new threads here.  The thread is created as suspended, so
     // you must ::ResumeThread to kick it off.  It is guaranteed to create the
     // thread, or throw.
-    BOOL CreateNewThread(SIZE_T stackSize, LPTHREAD_START_ROUTINE start, void *args);
+    BOOL CreateNewThread(SIZE_T stackSize, LPTHREAD_START_ROUTINE start, void *args, LPCWSTR pName=NULL);
 
 
     enum StackSizeBucket

--- a/src/vm/win32threadpool.cpp
+++ b/src/vm/win32threadpool.cpp
@@ -1816,7 +1816,7 @@ Thread* ThreadpoolMgr::CreateUnimpersonatedThread(LPTHREAD_START_ROUTINE lpStart
         bOK = pThread->CreateNewThread(0,               // default stack size
                                        lpStartAddress,
                                        lpArgs,           //arguments
-                                       W("ThreadPool"));
+                                       W(".NET Core ThreadPool"));
     }
     else {
 #ifndef FEATURE_PAL

--- a/src/vm/win32threadpool.cpp
+++ b/src/vm/win32threadpool.cpp
@@ -1816,7 +1816,7 @@ Thread* ThreadpoolMgr::CreateUnimpersonatedThread(LPTHREAD_START_ROUTINE lpStart
         bOK = pThread->CreateNewThread(0,               // default stack size
                                        lpStartAddress,
                                        lpArgs,           //arguments
-                                       L"ThreadPool");
+                                       W("ThreadPool"));
     }
     else {
 #ifndef FEATURE_PAL

--- a/src/vm/win32threadpool.cpp
+++ b/src/vm/win32threadpool.cpp
@@ -1815,8 +1815,8 @@ Thread* ThreadpoolMgr::CreateUnimpersonatedThread(LPTHREAD_START_ROUTINE lpStart
         // CreateNewThread takes care of reverting any impersonation - so dont do anything here.
         bOK = pThread->CreateNewThread(0,               // default stack size
                                        lpStartAddress,
-                                       lpArgs           //arguments
-                                       );
+                                       lpArgs,           //arguments
+                                       L"ThreadPool");
     }
     else {
 #ifndef FEATURE_PAL


### PR DESCRIPTION
This will show up in future debuggers which know how to read that information or in ETW traces in the Thread Name column.

Not sure if I have adhered to all coding guidelines. If the GC and finalizer should also get a name the code should be put into a more global file. Is there a good location for it or is it ok for now to get at least for managed thread names in ETW their names?