### PR TITLE
Mask INJECT_ACTIVATION_SIGNAL while on alternate signal stack

### DIFF
--- a/src/pal/src/exception/signal.cpp
+++ b/src/pal/src/exception/signal.cpp
@@ -411,7 +411,27 @@ extern "C" void signal_handler_worker(int code, siginfo_t *siginfo, void *contex
     // TODO: First variable parameter says whether a read (0) or write (non-0) caused the
     // fault. We must disassemble the instruction at record.ExceptionAddress
     // to correctly fill in this value.
+
+    // Unmask the activation signal now that we are running on the original stack of the thread
+    sigset_t signal_set;
+    sigemptyset(&signal_set);
+    sigaddset(&signal_set, INJECT_ACTIVATION_SIGNAL);
+
+    int sigmaskRet = pthread_sigmask(SIG_UNBLOCK, &signal_set, NULL);
+    if (sigmaskRet != 0)
+    {
+        ASSERT("pthread_sigmask failed; error number is %d\n", sigmaskRet);
+    }
+
     returnPoint->returnFromHandler = common_signal_handler(code, siginfo, context, 2, (size_t)0, (size_t)siginfo->si_addr);
+
+    // We are going to return to the alternate stack, so block the activation signal again
+    sigmaskRet = pthread_sigmask(SIG_BLOCK, &signal_set, NULL);
+    if (sigmaskRet != 0)
+    {
+        ASSERT("pthread_sigmask failed; error number is %d\n", sigmaskRet);
+    }
+
     RtlRestoreContext(&returnPoint->context, NULL);
 }
 
@@ -855,6 +875,16 @@ void handle_signal(int signal_id, SIGFUNC sigfunc, struct sigaction *previousAct
     newAction.sa_handler = SIG_DFL;
 #endif  /* HAVE_SIGINFO_T */
     sigemptyset(&newAction.sa_mask);
+
+#ifdef INJECT_ACTIVATION_SIGNAL
+    if ((additionalFlags & SA_ONSTACK) != 0)
+    {
+        // A handler that runs on a separate stack should not be interrupted by the activation signal
+        // until it switches back to the regular stack, since that signal's handler would run on the
+        // limited separate stack and likely run into a stack overflow.
+        sigaddset(&newAction.sa_mask, INJECT_ACTIVATION_SIGNAL);
+    }
+#endif
 
     if (-1 == sigaction(signal_id, &newAction, previousAction))
     {


### PR DESCRIPTION
This prevents a rare crash where we get an activation signal while we're on the parts of the SIGSEGV handler that run on the alternate signal stack. If that happens, we run out of stack space in the code that handles the activation signal (to perform thread suspension) since the signal stack is [not very big](https://github.com/dotnet/coreclr/blob/master/src/pal/src/exception/signal.cpp#L155).

To prevent this from happening, this change does two things:
- During registration of signal handlers that run on the alternate signal handler stack, it sets a mask such that delivery of the activation signal is blocked while the handler is running.
- We also temporarily unmask and remask the activation signal for the duration of the part of the SIGSEGV signal handler that runs on the original stack.
  - This part of the change ensures that we minimize the window where signal handling behavior is altered to just the parts when we need it (namely, when we’re on the alternate stack).
  - Note: re-masking here may seem unnecessary because the restoration of the signal mask upon completion of the signal handler will override any changes made while we were in the handler, but it protects us against the possibility of getting an activation signal in the tiny window where we’re back on the alternate stack before completing the handling of the signal.

@jkotas @sergiy-k @Petermarcu @janvorli 