### PR TITLE
Fix a bug in LIR dead store removal.

### DIFF
--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -2278,7 +2278,7 @@ bool Compiler::fgTryRemoveDeadLIRStore(LIR::Range& blockRange, GenTree* node, Ge
         // If the range of the operands contains unrelated code or if it contains any side effects,
         // do not remove it. Instead, just remove the store.
 
-        node->VisitOperands([](GenTree* operand) -> GenTree::VisitResult {
+        store->VisitOperands([](GenTree* operand) -> GenTree::VisitResult {
             operand->gtLIRFlags |= LIR::Flags::IsUnusedValue;
             return GenTree::VisitResult::Continue;
         });


### PR DESCRIPTION
This came in with the recent operand visitor changes: instead of marking
the operands of a dead indirect store unused, DSE would mark the operands
of its address unsued.