### PR TITLE
Fix missing references in FEATURE_MERGE_JIT_AND_ENGINE

### DIFF
--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -212,6 +212,35 @@ endif()
 
 add_custom_target(jit_exports DEPENDS ${JIT_EXPORTS_FILE})
 
+set(RYUJIT_LINK_LIBRARIES
+   utilcodestaticnohost
+   gcinfo
+)
+
+if(CLR_CMAKE_PLATFORM_UNIX)
+    list(APPEND RYUJIT_LINK_LIBRARIES
+       mscorrc_debug
+       coreclrpal
+       palrt
+    )
+else()
+    list(APPEND RYUJIT_LINK_LIBRARIES
+       ${STATIC_MT_CRT_LIB}
+       ${STATIC_MT_VCRT_LIB}
+       kernel32.lib
+       advapi32.lib
+       ole32.lib
+       oleaut32.lib
+       uuid.lib
+       user32.lib
+       version.lib
+       shlwapi.lib
+       bcrypt.lib
+       crypt32.lib
+       RuntimeObject.lib
+    )
+endif(CLR_CMAKE_PLATFORM_UNIX)
+
 if (FEATURE_MERGE_JIT_AND_ENGINE)
   # Despite the directory being named "dll", it creates a static library "clrjit_static" to link into the VM.
   add_subdirectory(dll)

--- a/src/jit/crossgen/CMakeLists.txt
+++ b/src/jit/crossgen/CMakeLists.txt
@@ -5,3 +5,6 @@ if(CLR_CMAKE_TARGET_ARCH_ARM)
 endif()
 
 add_library_clr(clrjit_crossgen ${SOURCES} ${JIT_ARCH_SOURCES})
+if(FEATURE_MERGE_JIT_AND_ENGINE)
+  target_link_libraries(clrjit_crossgen ${RYUJIT_LINK_LIBRARIES})
+endif(FEATURE_MERGE_JIT_AND_ENGINE)

--- a/src/jit/standalone/CMakeLists.txt
+++ b/src/jit/standalone/CMakeLists.txt
@@ -27,35 +27,6 @@ add_dependencies(clrjit jit_exports)
 set_property(TARGET clrjit APPEND_STRING PROPERTY LINK_FLAGS ${JIT_EXPORTS_LINKER_OPTION})
 set_property(TARGET clrjit APPEND_STRING PROPERTY LINK_DEPENDS ${JIT_EXPORTS_FILE})
 
-set(RYUJIT_LINK_LIBRARIES
-   utilcodestaticnohost
-   gcinfo
-)
-
-if(CLR_CMAKE_PLATFORM_UNIX)
-    list(APPEND RYUJIT_LINK_LIBRARIES
-       mscorrc_debug
-       coreclrpal
-       palrt
-    )
-else()
-    list(APPEND RYUJIT_LINK_LIBRARIES
-       ${STATIC_MT_CRT_LIB}
-       ${STATIC_MT_VCRT_LIB}
-       kernel32.lib
-       advapi32.lib
-       ole32.lib
-       oleaut32.lib
-       uuid.lib
-       user32.lib
-       version.lib
-       shlwapi.lib
-       bcrypt.lib
-       crypt32.lib
-       RuntimeObject.lib
-    )
-endif(CLR_CMAKE_PLATFORM_UNIX)
-
 target_link_libraries(clrjit
    ${RYUJIT_LINK_LIBRARIES}
 )

--- a/src/zap/crossgen/CMakeLists.txt
+++ b/src/zap/crossgen/CMakeLists.txt
@@ -26,3 +26,6 @@ endif (FEATURE_READYTORUN)
 
 add_precompiled_header(common.h ../common.cpp ZAP_SOURCES)
 add_library_clr(corzap_crossgen STATIC ${ZAP_SOURCES})
+if(FEATURE_MERGE_JIT_AND_ENGINE)
+  target_link_libraries(corzap_crossgen clrjit_crossgen)
+endif(FEATURE_MERGE_JIT_AND_ENGINE)


### PR DESCRIPTION
This commit allows uses to enable FEATURE_MERGE_JIT_AND_ENGINE via command-line. 

Note that this commit does NOT change the default build.