### PR TITLE
[RyuJIT/ARM32] Fix assertion failed 'gcPtrCount == 0'

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -665,7 +665,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
                 gcPtrCount = varDsc->lvStructGcCount;
                 for (unsigned i = 0; i < gcPtrCount; ++i)
                     gcPtrs[i]   = varDsc->lvGcLayout[i];
-#else // _TARGET_ARM_
+#else  // _TARGET_ARM_
                 gcPtrs     = treeNode->gtGcPtrs;
                 gcPtrCount = treeNode->gtNumberReferenceSlots;
 #endif // _TARGET_ARM_

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -667,7 +667,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
                     gcPtrs[i]   = varDsc->lvGcLayout[i];
 #else // _TARGET_ARM_
                 gcPtrs     = treeNode->gtGcPtrs;
-                gcPtrCount = treeNode->gtNumSlots;
+                gcPtrCount = treeNode->gtNumberReferenceSlots;
 #endif // _TARGET_ARM_
             }
             else // addrNode is used


### PR DESCRIPTION
Change wrong `gcPtrCount`'s value from `gtNumSlots` to `gtNumberReferenceSlots` of `GenTreePutArgStk`