### PR TITLE
[RyuJIT/ARM32] Unassign double register properly

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -5750,7 +5750,17 @@ regNumber LinearScan::tryAllocateFreeReg(Interval* currentInterval, RefPosition*
     {
         if (intervalToUnassign != nullptr)
         {
+#ifdef _TARGET_ARM_
+            RegRecord* unassignedPhysReg = availablePhysRegInterval;
+            // We should unassign a double register if availablePhysRegInterval is part of the double register
+            if (availablePhysRegInterval->assignedInterval->registerType == TYP_DOUBLE &&
+                !genIsValidDoubleReg(availablePhysRegInterval->regNum))
+                unassignedPhysReg = findAnotherHalfRegRec(availablePhysRegInterval);
+
+            unassignPhysReg(unassignedPhysReg, intervalToUnassign->recentRefPosition);
+#else
             unassignPhysReg(availablePhysRegInterval, intervalToUnassign->recentRefPosition);
+#endif
             if (bestScore & VALUE_AVAILABLE)
             {
                 assert(intervalToUnassign->isConstant);
@@ -5760,7 +5770,11 @@ regNumber LinearScan::tryAllocateFreeReg(Interval* currentInterval, RefPosition*
             // the next ref, remember it.
             else if ((bestScore & UNASSIGNED) != 0 && intervalToUnassign != nullptr)
             {
+#ifdef _TARGET_ARM_
+                updatePreviousInterval(unassignedPhysReg, intervalToUnassign, intervalToUnassign->registerType);
+#else
                 updatePreviousInterval(availablePhysRegInterval, intervalToUnassign, intervalToUnassign->registerType);
+#endif
             }
         }
         else

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -5750,17 +5750,14 @@ regNumber LinearScan::tryAllocateFreeReg(Interval* currentInterval, RefPosition*
     {
         if (intervalToUnassign != nullptr)
         {
+            RegRecord* physRegToUnassign = availablePhysRegInterval;
 #ifdef _TARGET_ARM_
-            RegRecord* unassignedPhysReg = availablePhysRegInterval;
             // We should unassign a double register if availablePhysRegInterval is part of the double register
             if (availablePhysRegInterval->assignedInterval->registerType == TYP_DOUBLE &&
                 !genIsValidDoubleReg(availablePhysRegInterval->regNum))
-                unassignedPhysReg = findAnotherHalfRegRec(availablePhysRegInterval);
-
-            unassignPhysReg(unassignedPhysReg, intervalToUnassign->recentRefPosition);
-#else
-            unassignPhysReg(availablePhysRegInterval, intervalToUnassign->recentRefPosition);
+                physRegToUnassign = findAnotherHalfRegRec(availablePhysRegInterval);
 #endif
+            unassignPhysReg(physRegToUnassign, intervalToUnassign->recentRefPosition);
             if (bestScore & VALUE_AVAILABLE)
             {
                 assert(intervalToUnassign->isConstant);
@@ -5770,11 +5767,7 @@ regNumber LinearScan::tryAllocateFreeReg(Interval* currentInterval, RefPosition*
             // the next ref, remember it.
             else if ((bestScore & UNASSIGNED) != 0 && intervalToUnassign != nullptr)
             {
-#ifdef _TARGET_ARM_
-                updatePreviousInterval(unassignedPhysReg, intervalToUnassign, intervalToUnassign->registerType);
-#else
-                updatePreviousInterval(availablePhysRegInterval, intervalToUnassign, intervalToUnassign->registerType);
-#endif
+                updatePreviousInterval(physRegToUnassign, intervalToUnassign, intervalToUnassign->registerType);
             }
         }
         else


### PR DESCRIPTION
Fix #12615 
In LinearScan::tryAllocateFreeReg(), unassign a double register properly
when a found float register is a part of a double register.

After applying this PR, all assertions of RA phase reported at #12615 are resolved and blocked by  another assertions which can be fixed by #12621.

With this PR and PR #12621, 15 tests from issue #12615 is passed.
Remaining 3 tests are blocked by other known issues.

