### PR TITLE
[ARM32] Remove useless code: struct split using float registers

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -999,7 +999,6 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
         BYTE*    gcPtrs     = treeNode->gtGcPtrs;
         unsigned gcPtrCount = treeNode->gtNumberReferenceSlots; // The count of GC pointers in the struct
         int      structSize = treeNode->getArgSize();
-        bool     isHfa      = treeNode->gtIsHfa;
 
         // This is the varNum for our load operations,
         // only used when we have a struct with a LclVar source
@@ -1016,6 +1015,9 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
             {
                 NYI_ARM("CodeGen::genPutArgSplit - promoted struct");
             }
+
+            // We don't split HFA struct
+            assert(!varDsc->lvIsHfa());
         }
         else // addrNode is used
         {
@@ -1029,13 +1031,9 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
             // Because the candidate mask for the internal baseReg does not include any of the target register,
             // we can ensure that baseReg, addrReg, and the last target register are not all same.
             assert(baseReg != addrReg);
-        }
 
-        // If we have an HFA we can't have any GC pointers,
-        // if not then the max size for the the struct is 16 bytes
-        if (isHfa)
-        {
-            assert(gcPtrCount == 0);
+            // We don't split HFA struct
+            assert(!compiler->IsHfa(source->gtObj.gtClass));
         }
 
         // Put on stack first

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -4970,9 +4970,6 @@ struct GenTreePutArgStk : public GenTreeUnOp
     unsigned gtNumSlots;             // Number of slots for the argument to be passed on stack
     unsigned gtNumberReferenceSlots; // Number of reference slots.
     BYTE*    gtGcPtrs;               // gcPointers
-#ifdef _TARGET_ARM_
-    bool gtIsHfa;
-#endif
 
 #endif // FEATURE_PUT_STRUCT_ARG_STK
 
@@ -4996,7 +4993,6 @@ struct GenTreePutArgSplit : public GenTreePutArgStk
     GenTreePutArgSplit(GenTreePtr op1,
                        unsigned slotNum PUT_STRUCT_ARG_STK_ONLY_ARG(unsigned numSlots),
                        unsigned     numRegs,
-                       bool         isHfa,
                        bool         putIncomingArgArea = false,
                        GenTreeCall* callNode           = nullptr)
         : GenTreePutArgStk(GT_PUTARG_SPLIT,
@@ -5007,7 +5003,6 @@ struct GenTreePutArgSplit : public GenTreePutArgStk
                            callNode)
         , gtNumRegs(numRegs)
     {
-        gtIsHfa = isHfa;
         ClearOtherRegs();
         ClearOtherRegFlags();
     }
@@ -5017,7 +5012,6 @@ struct GenTreePutArgSplit : public GenTreePutArgStk
 
     // First reg of struct is always given by gtRegNum.
     // gtOtherRegs holds the other reg numbers of struct.
-    // HFA args is not yet handled.
     regNumberSmall gtOtherRegs[MAX_REG_ARG - 1];
 
     // GTF_SPILL or GTF_SPILLED flag on a multi-reg struct node indicates that one or

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -810,7 +810,7 @@ GenTreePtr Lowering::NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntryP
 
         putArg = new (comp, GT_PUTARG_SPLIT)
             GenTreePutArgSplit(arg, info->slotNum PUT_STRUCT_ARG_STK_ONLY_ARG(info->numSlots), info->numRegs,
-                               info->isHfaRegArg, call->IsFastTailCall(), call);
+                               call->IsFastTailCall(), call);
 
         // If struct argument is morphed to GT_FIELD_LIST node(s),
         // we can know GC info by type of each GT_FIELD_LIST node.

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -4108,17 +4108,9 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                         // we skip the corresponding floating point register argument
                         intArgRegNum = min(intArgRegNum + size, MAX_REG_ARG);
 #endif // WINDOWS_AMD64_ABI
-#ifdef _TARGET_ARM_
-                        if (fltArgRegNum > MAX_FLOAT_REG_ARG)
-                        {
-                            // This indicates a partial enregistration of a struct type
-                            assert(varTypeIsStruct(argx));
-                            unsigned numRegsPartial = size - (fltArgRegNum - MAX_FLOAT_REG_ARG);
-                            assert((unsigned char)numRegsPartial == numRegsPartial);
-                            call->fgArgInfo->SplitArg(argIndex, numRegsPartial, size - numRegsPartial);
-                            fltArgRegNum = MAX_FLOAT_REG_ARG;
-                        }
-#endif // _TARGET_ARM_
+                        // There is no partial struct using float registers
+                        // on all supported architectures
+                        assert(fltArgRegNum <= MAX_FLOAT_REG_ARG);
                     }
                     else
                     {
@@ -4766,12 +4758,7 @@ GenTreePtr Compiler::fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr f
 #ifdef _TARGET_ARM_
     if (fgEntryPtr->isSplit)
     {
-        if (fgEntryPtr->isHfaRegArg)
-        {
-            // We cannot handle HFA split struct morphed to GT_FIELD_LIST yet
-            NYI_ARM("Struct split between float registers and stack");
-        }
-        else if (fgEntryPtr->numSlots + fgEntryPtr->numRegs > 4)
+        if (fgEntryPtr->numSlots + fgEntryPtr->numRegs > 4)
         {
             return arg;
         }


### PR DESCRIPTION
On ARM32, the split struct is using only integer registers.
If float registers for argument passing remain but not enough to pass entire HFA struct value,
the HFA struct is passed using stack only.
So we can remove useless code in morph.cpp and `GenTreePutArgSplit` that is split struct using float registers on ARM32.

This commit doesn't change ARM32 ABI.

cc/ @dotnet/arm32-contrib