### PR TITLE
[RyuJIT/ARM32] Fix register type setting for split struct arg

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -878,7 +878,7 @@ GenTreePtr Lowering::NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntryP
             GenTreeFieldList* fieldListPtr = arg->AsFieldList();
             for (unsigned index = 0; index < info->numRegs; fieldListPtr = fieldListPtr->Rest(), index++)
             {
-                var_types regType          = fieldListPtr->TypeGet();
+                var_types regType          = fieldListPtr->gtGetOp1()->TypeGet();
                 argSplit->m_regType[index] = regType;
             }
         }


### PR DESCRIPTION
Fix register type setting for split struct argument using GT_FIELD_LIST node

Related PR: #11815
cc/ @dotnet/arm32-contrib @CarolEidt 