### PR TITLE
[RyuJIT/ARM32] Add NYI_ARM for handling promoted struct

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -954,6 +954,13 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
     {
         srcVarNum = varNode->gtLclNum;
         assert(srcVarNum < compiler->lvaCount);
+
+        // handle promote situation
+        LclVarDsc* varDsc = compiler->lvaTable + srcVarNum;
+        if (varDsc->lvPromoted)
+        {
+            NYI_ARM("CodeGen::genPutArgSplit - promoted struct");
+        }
     }
     else // addrNode is used
     {


### PR DESCRIPTION
- In RyuJIT/ARM32, promoted struct on stack can't be handled like splitted struct arg's one.
- Until implementing handling it, make it entering the NYI_ARM.