### PR TITLE
Use SUB instead of XOR to clear fat pointer bit

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -24947,7 +24947,7 @@ private:
         {
             GenTreePtr fptrAddressCopy = compiler->gtCloneExpr(fptrAddress);
             GenTreePtr fatPointerMask  = new (compiler, GT_CNS_INT) GenTreeIntCon(TYP_I_IMPL, FAT_POINTER_MASK);
-            return compiler->gtNewOperNode(GT_XOR, pointerType, fptrAddressCopy, fatPointerMask);
+            return compiler->gtNewOperNode(GT_SUB, pointerType, fptrAddressCopy, fatPointerMask);
         }
 
         //------------------------------------------------------------------------


### PR DESCRIPTION
This makes the code generated for fat calli smaller because of the clearing of the fat pointer bit gets fused into address mode.