### PR TITLE
[RyuJIT/ARM32] Kill the R4 register on exit if the call is the stub

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -2897,13 +2897,14 @@ regMaskTP LinearScan::getKillSetForNode(GenTree* tree)
                 {
 #ifdef _TARGET_ARM_
                     // On ARM, There is the case that the argument of a virtual stub call is transferred by R4 register.
-                    // And then if the virtual stub is called, 
+                    // And then if the virtual stub is called,
                     // R4 register would be the busy status to avoid losing the argument data.
                     // It means R4 register must not be assigned to anywhere until the next kill.
                     // But the R4 register has to be killed in case of after virtual stub call to escape the busy state.
                     if (tree->AsCall()->IsVirtualStub())
                     {
-                        killMask = RBM_INT_CALLEE_TRASH | RBM_ARG_4;
+                        regMaskTP virtualStubParamMask = compiler->virtualStubParamInfo->GetRegMask();
+                        killMask = RBM_INT_CALLEE_TRASH | virtualStubParamMask;
                     }
                     else
 #endif // _TARGET_ARM_

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -2897,7 +2897,8 @@ regMaskTP LinearScan::getKillSetForNode(GenTree* tree)
                 {
 #ifdef _TARGET_ARM_
                     // On ARM, There is the case that the argument of a virtual stub call is transferred by R4 register.
-                    // And then if the virtual stub is called, R4 register would be the busy status to avoid losing the argument data.
+                    // And then if the virtual stub is called, 
+                    // R4 register would be the busy status to avoid losing the argument data.
                     // It means R4 register must not be assigned to anywhere until the next kill.
                     // But the R4 register has to be killed in case of after virtual stub call to escape the busy state.
                     if (tree->AsCall()->IsVirtualStub())

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -2895,7 +2895,18 @@ regMaskTP LinearScan::getKillSetForNode(GenTree* tree)
                 }
                 else
                 {
-                    killMask = RBM_INT_CALLEE_TRASH;
+#ifdef _TARGET_ARM_
+                    // On ARM, There is the case that the argument of a virtual stub call is transferred by R4 register.
+                    // And then if the virtual stub is called, R4 register would be the busy status to avoid losing the argument data.
+                    // It means R4 register must not be assigned to anywhere until the next kill.
+                    // But the R4 register has to be killed in case of after virtual stub call to escape the busy state.
+                    if (tree->AsCall()->IsVirtualStub())
+                    {
+                        killMask = RBM_INT_CALLEE_TRASH | RBM_ARG_4;
+                    }
+                    else
+#endif // _TARGET_ARM_
+                        killMask = RBM_INT_CALLEE_TRASH;
                 }
             }
             break;

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -2904,7 +2904,7 @@ regMaskTP LinearScan::getKillSetForNode(GenTree* tree)
                     if (tree->AsCall()->IsVirtualStub())
                     {
                         regMaskTP virtualStubParamMask = compiler->virtualStubParamInfo->GetRegMask();
-                        killMask = RBM_INT_CALLEE_TRASH | virtualStubParamMask;
+                        killMask                       = RBM_INT_CALLEE_TRASH | virtualStubParamMask;
                     }
                     else
 #endif // _TARGET_ARM_

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -2895,6 +2895,7 @@ regMaskTP LinearScan::getKillSetForNode(GenTree* tree)
                 }
                 else
                 {
+                    killMask = RBM_INT_CALLEE_TRASH;
 #ifdef _TARGET_ARM_
                     // On ARM, There is the case that the argument of a virtual stub call is transferred by R4 register.
                     // And then if the virtual stub is called,
@@ -2904,11 +2905,9 @@ regMaskTP LinearScan::getKillSetForNode(GenTree* tree)
                     if (tree->AsCall()->IsVirtualStub())
                     {
                         regMaskTP virtualStubParamMask = compiler->virtualStubParamInfo->GetRegMask();
-                        killMask                       = RBM_INT_CALLEE_TRASH | virtualStubParamMask;
+                        killMask |= virtualStubParamMask;
                     }
-                    else
 #endif // _TARGET_ARM_
-                        killMask = RBM_INT_CALLEE_TRASH;
                 }
             }
             break;

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -1462,6 +1462,7 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define REG_ARG_1                REG_R1
   #define REG_ARG_2                REG_R2
   #define REG_ARG_3                REG_R3
+  #define REG_ARG_4                REG_R4             // Special case for virtual stub.
 
   SELECTANY const regNumber intArgRegs [] = {REG_R0, REG_R1, REG_R2, REG_R3};
   SELECTANY const regMaskTP intArgMasks[] = {RBM_R0, RBM_R1, RBM_R2, RBM_R3};
@@ -1470,6 +1471,7 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define RBM_ARG_1                RBM_R1
   #define RBM_ARG_2                RBM_R2
   #define RBM_ARG_3                RBM_R3
+  #define RBM_ARG_4                RBM_R4             // Special case for virtual stub.
 
   #define RBM_ARG_REGS            (RBM_ARG_0|RBM_ARG_1|RBM_ARG_2|RBM_ARG_3)
   #define RBM_FLTARG_REGS         (RBM_F0|RBM_F1|RBM_F2|RBM_F3|RBM_F4|RBM_F5|RBM_F6|RBM_F7|RBM_F8|RBM_F9|RBM_F10|RBM_F11|RBM_F12|RBM_F13|RBM_F14|RBM_F15)

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -1462,7 +1462,6 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define REG_ARG_1                REG_R1
   #define REG_ARG_2                REG_R2
   #define REG_ARG_3                REG_R3
-  #define REG_ARG_4                REG_R4             // Special case for virtual stub.
 
   SELECTANY const regNumber intArgRegs [] = {REG_R0, REG_R1, REG_R2, REG_R3};
   SELECTANY const regMaskTP intArgMasks[] = {RBM_R0, RBM_R1, RBM_R2, RBM_R3};
@@ -1471,7 +1470,6 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define RBM_ARG_1                RBM_R1
   #define RBM_ARG_2                RBM_R2
   #define RBM_ARG_3                RBM_R3
-  #define RBM_ARG_4                RBM_R4             // Special case for virtual stub.
 
   #define RBM_ARG_REGS            (RBM_ARG_0|RBM_ARG_1|RBM_ARG_2|RBM_ARG_3)
   #define RBM_FLTARG_REGS         (RBM_F0|RBM_F1|RBM_F2|RBM_F3|RBM_F4|RBM_F5|RBM_F6|RBM_F7|RBM_F8|RBM_F9|RBM_F10|RBM_F11|RBM_F12|RBM_F13|RBM_F14|RBM_F15)


### PR DESCRIPTION
Related #11838

In this issue, farthestRefPhysRegRecord was nullptr in the end of allocateBusyReg(). That's because R4 register had been busy since the before allocation of R4 Register.
It was caused that the R4 register was not killed on exit of the stub call.

On ARM, There is the case that the argument of a virtual stub call is transferred by R4 register.
And then if the virtual stub is called, R4 register would be the busy status to avoid losing the argument data. It means R4 register must not be assigned to anywhere until the next kill.
So the R4 register has to be killed in case of after virtual stub call to escape the busy state.

## Before
```
---------------------------------+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+
Loc RP#  Name  Type  Action Reg  |r0   |r1   |r2   |r3   |r4   |r5   |r6   |r7   |r8   |r9   |r10  |r11  |r12  |sp   |lr   |
---------------------------------+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+
159.#169 V12   Use    Keep  r4   |I52 a|     |     |     |V12 a|V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
160.#170 r4    Fixd   Keep  r4   |I52 a|     |     |     |V12 a|V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
160.#171 I53   Def    PtArg r4   |I52 a|     |     |     |V12 a|V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
163.#172 V12   Use *  Keep  r4   |I52 a|     |     |     |V12 a|V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
164.#173 I54   Def    Alloc r3   |I52 a|     |     |I54 a|Busy |V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
165.#174 r0    Fixd   Keep  r0   |I52 a|     |     |I54 a|Busy |V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
165.#175 I52   Use *  Keep  r0   |I52 a|     |     |I54 a|Busy |V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
165.#176 r4    Fixd   Keep  r4   |I52 a|     |     |I54 a|Busy |V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
165.#177 I53   Use *  PtArg r4   |I52 a|     |     |I54 a|Busy |V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
165.#178 I54   Use *  Keep  r3   |I52 a|     |     |I54 a|Busy |V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
166.#179 r0    Kill   Keep  r0   |     |     |     |     |Busy |V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
.......
...
...
475.#443 BB15 PredBB13           |     |     |V15 a|V14 a|Busy |V0  a|V3  a|V29 i|V25 i|V2  a|---- |---- |     |---- |     |
479.#444 r0    Fixd   Keep  r0   |     |     |V15 a|V14 a|Busy |V0  a|V3  a|V29 i|V25 i|V2  a|---- |---- |     |---- |     |
479.#445 V2    Use *  Copy  r0   |V2  a|     |V15 a|V14 a|Busy |V0  a|V3  a|V29 i|V25 i|V2  a|---- |---- |     |---- |     |
480.#446 r0    Fixd   Keep  r0   |     |     |V15 a|V14 a|Busy |V0  a|V3  a|V29 i|V25 i|     |---- |---- |     |---- |     |
480.#447 I109  Def    Alloc r0   |I109a|     |V15 a|V14 a|Busy |V0  a|V3  a|V29 i|V25 i|     |---- |---- |     |---- |     |
483.#448 r4    Fixd   Keep  r4   |I109a|     |V15 a|V14 a|Busy |V0  a|V3  a|V29 i|V25 i|     |---- |---- |     |---- |     |
483.#449 V15   Use<<<<<<<<<<<<<<<< Assertion
```

## After
```
---------------------------------+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+
Loc RP#  Name  Type  Action Reg  |r0   |r1   |r2   |r3   |r4   |r5   |r6   |r7   |r8   |r9   |r10  |r11  |r12  |sp   |lr   |
---------------------------------+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+
159.#171 r4    Fixd   Keep  r4   |I52 a|     |     |     |V12 a|V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
159.#172 V12   Use    Keep  r4   |I52 a|     |     |     |V12 a|V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
160.#173 r4    Fixd   Keep  r4   |I52 a|     |     |     |V12 a|V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
160.#174 I53   Def    PtArg r4   |I52 a|     |     |     |V12 a|V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
163.#175 V12   Use *  Keep  r4   |I52 a|     |     |     |V12 a|V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
164.#176 I54   Def    Alloc r3   |I52 a|     |     |I54 a|Busy |V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
165.#177 r0    Fixd   Keep  r0   |I52 a|     |     |I54 a|Busy |V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
165.#178 I52   Use *  Keep  r0   |I52 a|     |     |I54 a|Busy |V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
165.#179 r4    Fixd   Keep  r4   |I52 a|     |     |I54 a|Busy |V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
165.#180 I53   Use *  PtArg r4   |I52 a|     |     |I54 a|Busy |V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
165.#181 I54   Use *  Keep  r3   |I52 a|     |     |I54 a|Busy |V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
166.#182 r0    Kill   Keep  r0   |     |     |     |     |Busy |V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
166.#183 r1    Kill   Keep  r1   |     |     |     |     |Busy |V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
166.#184 r2    Kill   Keep  r2   |     |     |     |     |Busy |V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
166.#185 r3    Kill   Keep  r3   |     |     |     |     |Busy |V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
166.#186 r4    Kill   Keep  r4   |     |     |     |     |     |V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
166.#187 r12   Kill   Keep  r12  |     |     |     |     |     |V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
166.#188 lr    Kill   Keep  lr   |     |     |     |     |     |V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
166.#189 r0    Fixd   Keep  r0   |     |     |     |     |     |V0  a|V1  i|V29 a|V25 a|V2  a|---- |---- |     |---- |     |
....
...
.
```
