### PR TITLE
Speed up fgLocalVarLiveness in minopts.

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -5519,16 +5519,13 @@ void CodeGen::genCheckUseBlockInit()
             continue;
         }
 
-#if CAN_DISABLE_DFA
         /* If we don't know lifetimes of variables, must be conservative */
-
-        if (compiler->opts.MinOpts())
+        if (!compiler->backendRequiresLocalVarLifetimes())
         {
             varDsc->lvMustInit = true;
             noway_assert(!varDsc->lvRegister);
         }
         else
-#endif // CAN_DISABLE_DFA
         {
             if (!varDsc->lvTracked)
             {

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -910,6 +910,7 @@ class LinearScanInterface
 public:
     virtual void doLinearScan()                                = 0;
     virtual void recordVarLocationsAtStartOfBB(BasicBlock* bb) = 0;
+    virtual bool willEnregisterLocalVars() const               = 0;
 };
 
 LinearScanInterface* getLinearScanAllocator(Compiler* comp);
@@ -3723,6 +3724,15 @@ public:
     GenTreeCall* fgGetStaticsCCtorHelper(CORINFO_CLASS_HANDLE cls, CorInfoHelpFunc helper);
 
     GenTreeCall* fgGetSharedCCtor(CORINFO_CLASS_HANDLE cls);
+
+    inline bool backendRequiresLocalVarLifetimes()
+    {
+#if defined(LEGACY_BACKEND)
+        return true;
+#else
+        return !opts.MinOpts() || m_pLinearScan->willEnregisterLocalVars();
+#endif
+    }
 
     void fgLocalVarLiveness();
 

--- a/src/jit/jit.h
+++ b/src/jit/jit.h
@@ -407,8 +407,6 @@ typedef ptrdiff_t ssize_t;
 
 #define CSE_INTO_HANDLERS 0
 
-#define CAN_DISABLE_DFA 1 // disable data flow for minopts
-
 #define LARGE_EXPSET 1   // Track 64 or 32 assertions/copies/consts/rangechecks
 #define ASSERTION_PROP 1 // Enable value/assertion propagation
 

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -4588,7 +4588,7 @@ void Lowering::DoPhase()
     // For now we'll take the throughput hit of recomputing local liveness but in the long term
     // we're striving to use the unified liveness computation (fgLocalVarLiveness) and stop
     // computing it separately in LSRA.
-    if (comp->lvaCount != 0)
+    if ((comp->lvaCount != 0) && !comp->opts.MinOpts())
     {
         comp->lvaSortAgain = true;
     }

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -4588,7 +4588,7 @@ void Lowering::DoPhase()
     // For now we'll take the throughput hit of recomputing local liveness but in the long term
     // we're striving to use the unified liveness computation (fgLocalVarLiveness) and stop
     // computing it separately in LSRA.
-    if ((comp->lvaCount != 0) && !comp->backendRequiresLocalVarLifetimes())
+    if ((comp->lvaCount != 0) && comp->backendRequiresLocalVarLifetimes())
     {
         comp->lvaSortAgain = true;
     }

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -4588,7 +4588,7 @@ void Lowering::DoPhase()
     // For now we'll take the throughput hit of recomputing local liveness but in the long term
     // we're striving to use the unified liveness computation (fgLocalVarLiveness) and stop
     // computing it separately in LSRA.
-    if ((comp->lvaCount != 0) && !comp->opts.MinOpts())
+    if ((comp->lvaCount != 0) && !comp->backendRequiresLocalVarLifetimes())
     {
         comp->lvaSortAgain = true;
     }

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -1171,6 +1171,11 @@ private:
     // True if there are any register candidate lclVars available for allocation.
     bool enregisterLocalVars;
 
+    virtual bool willEnregisterLocalVars() const
+    {
+        return enregisterLocalVars;
+    }
+
     // Ordered list of RefPositions
     RefPositionList refPositions;
 


### PR DESCRIPTION
In particular:
- Do not re-sort lclVars
- Do not run LVA
- Do not set `mustInit`
- Do not set last uses
- Do not perform DSE