### PR TITLE
[RyuJIT/Arm32] Support unaligned floating point loads/stores

### DIFF
--- a/src/jit/emitarm.h
+++ b/src/jit/emitarm.h
@@ -110,6 +110,7 @@ bool emitInsIsLoadOrStore(instruction ins);
 // Generate code for a load or store operation and handle the case
 // of contained GT_LEA op1 with [base + index<<scale + offset]
 void emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataReg, GenTreeIndir* indir);
+void emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataReg, GenTreeIndir* indir, int offset);
 
 /*****************************************************************************
 *


### PR DESCRIPTION
For unaligned accesses, instead of generating a direct vstr/vldr:
```
G_M4475_IG02:
000006  ED80 0B00      vstr    d0, [r0]
```
make an integer access and a conversion:
```
G_M4475_IG02:
000006  EC53 2B10      vmov.d2i r2, r3, d0
00000A  6002           str     r2, [r0]
00000C  6043           str     r3, [r0+4]
```

Fixes #12661.

cc @dotnet/arm32-contrib 