### PR TITLE
Added explicit cast float -> double for arguments

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -10905,9 +10905,7 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
 
         if (fgGlobalMorph)
         {
-#if !FEATURE_STACK_FP_X87
             tree = fgMorphForRegisterFP(tree);
-#endif
         }
 
         genTreeOps oper = tree->OperGet();


### PR DESCRIPTION
Change to fix #12465 and #12466 

Original IL code causes the problem looks like

```
    IL_0127:  ldc.r8     3.1090543741470467e-094
    IL_0130:  ldsfld     float32 ILGEN_0x65088b5c::field_0x8$PST04000009
    IL_0135:  ceq
```