### PR TITLE
[ARM/Linux] Fix DacStackWalk

### DIFF
--- a/src/unwinder/arm/unwinder_arm.cpp
+++ b/src/unwinder/arm/unwinder_arm.cpp
@@ -647,7 +647,7 @@ Return Value:
 HRESULT
 RtlpUnwindFunctionCompact(
     __in ULONG ControlPcRva,
-    __in PIMAGE_ARM_RUNTIME_FUNCTION_ENTRY FunctionEntry,
+    __in PT_RUNTIME_FUNCTION FunctionEntry,
     __inout PT_CONTEXT ContextRecord,
     __out PULONG EstablisherFrame,
     __deref_opt_out_opt PEXCEPTION_ROUTINE *HandlerRoutine,
@@ -917,7 +917,7 @@ HRESULT
 RtlpUnwindFunctionFull(
     __in ULONG ControlPcRva,
     __in ULONG ImageBase,
-    __in PIMAGE_ARM_RUNTIME_FUNCTION_ENTRY FunctionEntry,
+    __in PT_RUNTIME_FUNCTION FunctionEntry,
     __inout PT_CONTEXT ContextRecord,
     __out PULONG EstablisherFrame,
     __deref_opt_out_opt PEXCEPTION_ROUTINE *HandlerRoutine,
@@ -1444,7 +1444,7 @@ BOOL OOPStackUnwinderArm::Unwind(T_CONTEXT * pContext)
     DWORD startingPc = pContext->Pc;
     DWORD startingSp = pContext->Sp;
     
-    IMAGE_ARM_RUNTIME_FUNCTION_ENTRY Rfe;
+    T_RUNTIME_FUNCTION Rfe;
     if (FAILED(GetFunctionEntry(DBS_EXTEND64(pContext->Pc), &Rfe, sizeof(Rfe))))
         return FALSE;
 
@@ -1511,17 +1511,13 @@ PEXCEPTION_ROUTINE RtlVirtualUnwind(
     PEXCEPTION_ROUTINE handlerRoutine;
     HRESULT res;
     
-    IMAGE_ARM_RUNTIME_FUNCTION_ENTRY rfe;
-    rfe.BeginAddress = FunctionEntry->BeginAddress;
-    rfe.UnwindData = FunctionEntry->UnwindData;
-    
     ARM_UNWIND_PARAMS unwindParams;
     unwindParams.ContextPointers = ContextPointers;
     
     if ((FunctionEntry->UnwindData & 3) != 0) 
     {
         res = RtlpUnwindFunctionCompact(ControlPc - ImageBase,
-                                        &rfe,
+                                        FunctionEntry,
                                         ContextRecord,
                                         EstablisherFrame,
                                         &handlerRoutine,
@@ -1533,7 +1529,7 @@ PEXCEPTION_ROUTINE RtlVirtualUnwind(
     {
         res = RtlpUnwindFunctionFull(ControlPc - ImageBase,
                                     ImageBase,
-                                    &rfe,
+                                    FunctionEntry,
                                     ContextRecord,
                                     EstablisherFrame,
                                     &handlerRoutine,


### PR DESCRIPTION
For ARM/Linux, DacUnwindStackFrame failed to unwind stack frame due to
the mismatch between RUNTIME_FUNCTION and IMAGE_ARM_RUNTIME_FUNCTION_ENTRY.

ClrStack SOS command currently does not work due to this bug.

This commit fixes this mismatch and re-enables ClrStack SOS command.