### PR TITLE
Move StoreLoc type widening to Lowering

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4815,8 +4815,8 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
     m_pLinearScan = getLinearScanAllocator(this);
 
     /* Lower */
-    Lowering lower(this, m_pLinearScan); // PHASE_LOWERING
-    lower.Run();
+    m_pLowering = new (this, CMK_LSRA) Lowering(this, m_pLinearScan); // PHASE_LOWERING
+    m_pLowering->Run();
 
     assert(lvaSortAgain == false); // We should have re-run fgLocalVarLiveness() in lower.Run()
     lvaTrackedFixed = true;        // We can not add any new tracked variables after this point.

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -85,6 +85,10 @@ class CSE_DataFlow; // defined in OptCSE.cpp
 struct IndentStack;
 #endif
 
+#ifndef LEGACY_BACKEND
+class Lowering; // defined in lower.h
+#endif
+
 // The following are defined in this file, Compiler.h
 
 class Compiler;
@@ -6240,6 +6244,7 @@ public:
 
 private:
 #ifndef LEGACY_BACKEND
+    Lowering*            m_pLowering;   // Lowering; needed to Lower IR that's added or modified after Lowering.
     LinearScanInterface* m_pLinearScan; // Linear Scan allocator
 #else                                   // LEGACY_BACKEND
     unsigned  raAvoidArgRegMask;       // Mask of incoming argument registers that we may need to avoid

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -14,6 +14,9 @@
 #if !defined(_TARGET_64BIT_)
 #include "decomposelongs.h"
 #endif
+#ifndef LEGACY_BACKEND
+#include "lower.h" // for LowerRange()
+#endif
 
 /*****************************************************************************
  *
@@ -1028,9 +1031,12 @@ void Compiler::fgExtendDbgLifetimes()
                     LIR::Range initRange = LIR::EmptyRange();
                     initRange.InsertBefore(nullptr, zero, store);
 
-#if !defined(_TARGET_64BIT_) && !defined(LEGACY_BACKEND)
+#ifndef LEGACY_BACKEND
+#if !defined(_TARGET_64BIT_)
                     DecomposeLongs::DecomposeRange(this, blockWeight, initRange);
-#endif // !defined(_TARGET_64BIT_) && !defined(LEGACY_BACKEND)
+#endif // !defined(_TARGET_64BIT_)
+                    m_pLowering->LowerRange(std::move(initRange));
+#endif // !LEGACY_BACKEND
 
                     // Naively inserting the initializer at the end of the block may add code after the block's
                     // terminator, in which case the inserted code will never be executed (and the IR for the

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -305,17 +305,21 @@ GenTree* Lowering::LowerNode(GenTree* node)
             __fallthrough;
 
         case GT_STORE_LCL_FLD:
-            // TODO-1stClassStructs: Once we remove the requirement that all struct stores
-            // are block stores (GT_STORE_BLK or GT_STORE_OBJ), here is where we would put the local
-            // store under a block store if codegen will require it.
-            if (node->OperIsStore() && (node->TypeGet() == TYP_STRUCT) && (node->gtGetOp1()->OperGet() != GT_PHI))
+            if (node->OperIsStore())
             {
+                // TODO-1stClassStructs: Once we remove the requirement that all struct stores
+                // are block stores (GT_STORE_BLK or GT_STORE_OBJ), here is where we would put the local
+                // store under a block store if codegen will require it.
+                if ((node->TypeGet() == TYP_STRUCT) && (node->gtGetOp1()->OperGet() != GT_PHI))
+                {
 #if FEATURE_MULTIREG_RET
-                GenTree* src = node->gtGetOp1();
-                assert((src->OperGet() == GT_CALL) && src->AsCall()->HasMultiRegRetVal());
+                    GenTree* src = node->gtGetOp1();
+                    assert((src->OperGet() == GT_CALL) && src->AsCall()->HasMultiRegRetVal());
 #else  // !FEATURE_MULTIREG_RET
-                assert(!"Unexpected struct local store in Lowering");
+                    assert(!"Unexpected struct local store in Lowering");
 #endif // !FEATURE_MULTIREG_RET
+                }
+                LowerStoreLoc(node->AsLclVarCommon());
             }
             break;
 

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -47,6 +47,15 @@ public:
 
     static void getCastDescription(GenTreePtr treeNode, CastInfo* castInfo);
 
+    // LowerRange handles new code that is introduced by or after Lowering.
+    void LowerRange(LIR::Range&& range)
+    {
+        for (GenTree* newNode : range)
+        {
+            LowerNode(newNode);
+        }
+    }
+
 private:
 #ifdef DEBUG
     static void CheckCallArg(GenTree* arg);
@@ -57,6 +66,7 @@ private:
 
     void LowerBlock(BasicBlock* block);
     GenTree* LowerNode(GenTree* node);
+
     void CheckVSQuirkStackPaddingNeeded(GenTreeCall* call);
 
     // ------------------------------

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -246,7 +246,6 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
                 info->srcCount = 1;
             }
             info->dstCount = 0;
-            LowerStoreLoc(tree->AsLclVarCommon());
             TreeNodeInfoInitStoreLoc(tree->AsLclVarCommon());
             break;
 

--- a/src/jit/lsraarm64.cpp
+++ b/src/jit/lsraarm64.cpp
@@ -89,7 +89,6 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
         case GT_STORE_LCL_VAR:
             info->srcCount = 1;
             info->dstCount = 0;
-            LowerStoreLoc(tree->AsLclVarCommon());
             TreeNodeInfoInitStoreLoc(tree->AsLclVarCommon());
             break;
 

--- a/src/jit/lsraxarch.cpp
+++ b/src/jit/lsraxarch.cpp
@@ -39,7 +39,6 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 //    - Setting the appropriate candidates for a store of a multi-reg call return value.
 //    - Requesting an internal register for SIMD12 stores.
 //    - Handling of contained immediates.
-//    - Widening operations of unsigneds. (TODO: Move to 1st phase of Lowering)
 
 void Lowering::TreeNodeInfoInitStoreLoc(GenTreeLclVarCommon* storeLoc)
 {
@@ -92,10 +91,6 @@ void Lowering::TreeNodeInfoInitStoreLoc(GenTreeLclVarCommon* storeLoc)
     {
         MakeSrcContained(storeLoc, op1);
     }
-
-    // TODO: This should be moved to Lowering, but it widens the types, which changes the behavior
-    // of the above condition.
-    LowerStoreLoc(storeLoc);
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
This has been a "TODO" item in the source code for some time. Doing the widening earlier results in more cases where we use an xor to clear a register intead of storing zero, which is smaller. This also helps with the refactoring of containment analysis in preparation for moving it to `Lowering`.
There are 395 bytes of improvement over all of tests & frameworks for x64, with no regressions. On x86 the net improvement is 6102 bytes, with 7 methods regressing due to issues with preferencing the target of the xor.