### PR TITLE
[WIP] Enable cast operand containment

### DIFF
--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -781,7 +781,17 @@ protected:
 
     struct GenIntCastDesc
     {
-        enum CheckKind
+        enum LoadKind : unsigned
+        {
+            LOAD,
+            LOAD_ZERO_EXTEND_SMALL_INT,
+            LOAD_SIGN_EXTEND_SMALL_INT,
+#ifdef _TARGET_64BIT_
+            LOAD_SIGN_EXTEND_INT
+#endif
+        };
+
+        enum CheckKind : unsigned
         {
             CHECK_NONE,
             CHECK_SMALL_INT_RANGE,
@@ -793,7 +803,7 @@ protected:
 #endif
         };
 
-        enum ExtendKind
+        enum ExtendKind : unsigned
         {
             COPY,
             ZERO_EXTEND_SMALL_INT,
@@ -805,6 +815,8 @@ protected:
         };
 
     private:
+        LoadKind   m_loadKind;
+        unsigned   m_loadSrcSize;
         CheckKind  m_checkKind;
         unsigned   m_checkSrcSize;
         int        m_checkSmallIntMin;
@@ -814,6 +826,16 @@ protected:
 
     public:
         GenIntCastDesc(GenTreeCast* cast);
+
+        LoadKind LoadKind() const
+        {
+            return m_loadKind;
+        }
+
+        unsigned LoadSrcSize() const
+        {
+            return m_loadSrcSize;
+        }
 
         CheckKind CheckKind() const
         {

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -1288,7 +1288,7 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
             instGen_MemoryBarrier();
         }
 
-        getEmitter()->emitInsLoadStoreOp(ins_Store(type), emitTypeSize(type), data->gtRegNum, tree);
+        getEmitter()->emitInsLoadStoreOp(ins_Store(type), emitActualTypeSize(type), data->gtRegNum, tree);
     }
 }
 

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -1238,12 +1238,11 @@ void CodeGen::genCodeForReturnTrap(GenTreeOp* tree)
 //
 void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
 {
-    GenTree*  data       = tree->Data();
-    GenTree*  addr       = tree->Addr();
-    var_types targetType = tree->TypeGet();
-    emitter*  emit       = getEmitter();
+    GenTree*  data = tree->Data();
+    GenTree*  addr = tree->Addr();
+    var_types type = tree->TypeGet();
 
-    assert(!varTypeIsFloating(targetType) || (targetType == data->TypeGet()));
+    assert(!varTypeIsFloating(type) || (type == data->TypeGet()));
 
     GCInfo::WriteBarrierForm writeBarrierForm = gcInfo.gcIsWriteBarrierCandidate(tree, data);
     if (writeBarrierForm != GCInfo::WBF_NoBarrier)
@@ -1274,8 +1273,6 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
     }
     else // A normal store, not a WriteBarrier store
     {
-        bool dataIsUnary = false;
-
         // We must consume the operands in the proper execution order,
         // so that liveness is updated appropriately.
         genConsumeAddress(addr);
@@ -1285,13 +1282,13 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
             genConsumeRegs(data);
         }
 
-        if (tree->gtFlags & GTF_IND_VOLATILE)
+        if ((tree->gtFlags & GTF_IND_VOLATILE) != 0)
         {
             // issue a full memory barrier a before volatile StInd
             instGen_MemoryBarrier();
         }
 
-        emit->emitInsLoadStoreOp(ins_Store(targetType), emitTypeSize(tree), data->gtRegNum, tree);
+        getEmitter()->emitInsLoadStoreOp(ins_Store(type), emitTypeSize(type), data->gtRegNum, tree);
     }
 }
 

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -340,7 +340,7 @@ void CodeGen::genLclHeap(GenTree* tree)
 
         // Save a copy of PSPSym
         pspSymReg = tree->ExtractTempReg();
-        getEmitter()->emitIns_R_S(ins_Load(TYP_I_IMPL), EA_PTRSIZE, pspSymReg, compiler->lvaPSPSym, 0);
+        getEmitter()->emitIns_R_S(INS_ldr, EA_PTRSIZE, pspSymReg, compiler->lvaPSPSym, 0);
     }
 #endif
 
@@ -510,7 +510,7 @@ ALLOC_DONE:
         if (hasPspSym)
         {
             assert(genIsValidIntReg(pspSymReg));
-            getEmitter()->emitIns_S_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, pspSymReg, compiler->lvaPSPSym, 0);
+            getEmitter()->emitIns_S_R(INS_str, EA_PTRSIZE, pspSymReg, compiler->lvaPSPSym, 0);
         }
 #endif
         // Return the stackalloc'ed address in result register.
@@ -541,7 +541,7 @@ BAILOUT:
         noway_assert(compiler->lvaReturnEspCheck != 0xCCCCCCCC &&
                      compiler->lvaTable[compiler->lvaReturnEspCheck].lvDoNotEnregister &&
                      compiler->lvaTable[compiler->lvaReturnEspCheck].lvOnFrame);
-        getEmitter()->emitIns_S_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, regCnt, compiler->lvaReturnEspCheck, 0);
+        getEmitter()->emitIns_S_R(INS_str, EA_PTRSIZE, regCnt, compiler->lvaReturnEspCheck, 0);
     }
 #endif
 

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -1000,13 +1000,13 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
         // X2 is scratch when we have a large constant offset
 
         // Load the CallerSP of the main function (stored in the PSP of the dynamically containing funclet or function)
-        genInstrWithConstant(ins_Load(TYP_I_IMPL), EA_PTRSIZE, REG_R1, REG_R1,
-                             genFuncletInfo.fiCallerSP_to_PSP_slot_delta, REG_R2, false);
+        genInstrWithConstant(INS_ldr, EA_PTRSIZE, REG_R1, REG_R1, genFuncletInfo.fiCallerSP_to_PSP_slot_delta, REG_R2,
+                             false);
         regSet.verifyRegUsed(REG_R1);
 
         // Store the PSP value (aka CallerSP)
-        genInstrWithConstant(ins_Store(TYP_I_IMPL), EA_PTRSIZE, REG_R1, REG_SPBASE,
-                             genFuncletInfo.fiSP_to_PSP_slot_delta, REG_R2, false);
+        genInstrWithConstant(INS_str, EA_PTRSIZE, REG_R1, REG_SPBASE, genFuncletInfo.fiSP_to_PSP_slot_delta, REG_R2,
+                             false);
 
         // re-establish the frame pointer
         genInstrWithConstant(INS_add, EA_PTRSIZE, REG_FPBASE, REG_R1, genFuncletInfo.fiFunction_CallerSP_to_FP_delta,
@@ -1273,7 +1273,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
 
     if (compiler->lvaPSPSym != BAD_VAR_NUM)
     {
-        getEmitter()->emitIns_R_S(ins_Load(TYP_I_IMPL), EA_PTRSIZE, REG_R0, compiler->lvaPSPSym, 0);
+        getEmitter()->emitIns_R_S(INS_ldr, EA_PTRSIZE, REG_R0, compiler->lvaPSPSym, 0);
     }
     else
     {
@@ -1931,7 +1931,7 @@ void CodeGen::genLclHeap(GenTree* tree)
 
         // Save a copy of PSPSym
         pspSymReg = tree->ExtractTempReg();
-        getEmitter()->emitIns_R_S(ins_Load(TYP_I_IMPL), EA_PTRSIZE, pspSymReg, compiler->lvaPSPSym, 0);
+        getEmitter()->emitIns_R_S(INS_ldr, EA_PTRSIZE, pspSymReg, compiler->lvaPSPSym, 0);
     }
 #endif
 
@@ -2121,7 +2121,7 @@ ALLOC_DONE:
         if (hasPspSym)
         {
             assert(genIsValidIntReg(pspSymReg));
-            getEmitter()->emitIns_S_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, pspSymReg, compiler->lvaPSPSym, 0);
+            getEmitter()->emitIns_S_R(INS_str, EA_PTRSIZE, pspSymReg, compiler->lvaPSPSym, 0);
         }
 #endif
         // Return the stackalloc'ed address in result register.
@@ -2153,7 +2153,7 @@ BAILOUT:
         noway_assert(compiler->lvaReturnEspCheck != 0xCCCCCCCC &&
                      compiler->lvaTable[compiler->lvaReturnEspCheck].lvDoNotEnregister &&
                      compiler->lvaTable[compiler->lvaReturnEspCheck].lvOnFrame);
-        getEmitter()->emitIns_S_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, targetReg, compiler->lvaReturnEspCheck, 0);
+        getEmitter()->emitIns_S_R(INS_str, EA_PTRSIZE, targetReg, compiler->lvaReturnEspCheck, 0);
     }
 #endif
 
@@ -4866,7 +4866,7 @@ void CodeGen::genStoreIndTypeSIMD12(GenTree* treeNode)
     assert(tmpReg != addr->gtRegNum);
 
     // 8-byte write
-    getEmitter()->emitIns_R_R(ins_Store(TYP_DOUBLE), EA_8BYTE, data->gtRegNum, addr->gtRegNum);
+    getEmitter()->emitIns_R_R(INS_str, EA_8BYTE, data->gtRegNum, addr->gtRegNum);
 
     // Extract upper 4-bytes from data
     getEmitter()->emitIns_R_R_I(INS_mov, EA_4BYTE, tmpReg, data->gtRegNum, 2);
@@ -4902,7 +4902,7 @@ void CodeGen::genLoadIndTypeSIMD12(GenTree* treeNode)
     regNumber tmpReg = treeNode->GetSingleTempReg();
 
     // 8-byte read
-    getEmitter()->emitIns_R_R(ins_Load(TYP_DOUBLE), EA_8BYTE, targetReg, addr->gtRegNum);
+    getEmitter()->emitIns_R_R(INS_ldr, EA_8BYTE, targetReg, addr->gtRegNum);
 
     // 4-byte read
     getEmitter()->emitIns_R_R_I(INS_ldr, EA_4BYTE, tmpReg, addr->gtRegNum, 8);

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -1609,9 +1609,7 @@ void CodeGen::genCodeForLclVar(GenTreeLclVar* tree)
         assert(targetType != TYP_STRUCT);
 
         instruction ins  = ins_Load(targetType);
-        emitAttr    attr = emitTypeSize(targetType);
-
-        attr = varTypeIsFloating(targetType) ? attr : emit->emitInsAdjustLoadStoreAttr(ins, attr);
+        emitAttr    attr = emitActualTypeSize(targetType);
 
         emit->emitIns_R_S(ins, attr, tree->gtRegNum, varNum, 0);
         genProduceReg(tree);
@@ -1671,9 +1669,7 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
 
     instruction ins = ins_Store(targetType);
 
-    emitAttr attr = emitTypeSize(targetType);
-
-    attr = varTypeIsFloating(targetType) ? attr : emit->emitInsAdjustLoadStoreAttr(ins, attr);
+    emitAttr attr = emitActualTypeSize(targetType);
 
     emit->emitIns_S_R(ins, attr, dataReg, varNum, offset);
 
@@ -1750,9 +1746,7 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
             inst_set_SV_var(tree);
 
             instruction ins  = ins_Store(targetType);
-            emitAttr    attr = emitTypeSize(targetType);
-
-            attr = varTypeIsFloating(targetType) ? attr : emit->emitInsAdjustLoadStoreAttr(ins, attr);
+            emitAttr    attr = emitActualTypeSize(targetType);
 
             emit->emitIns_S_R(ins, attr, dataReg, varNum, /* offset */ 0);
 
@@ -3109,7 +3103,7 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
             }
         }
 
-        getEmitter()->emitInsLoadStoreOp(ins, emitTypeSize(type), dataReg, tree);
+        getEmitter()->emitInsLoadStoreOp(ins, emitActualTypeSize(type), dataReg, tree);
     }
 }
 
@@ -4552,9 +4546,6 @@ void CodeGen::genSIMDIntrinsicGetItem(GenTreeSIMD* simdNode)
             {
                 int         offset = (int)index * genTypeSize(baseType);
                 instruction ins    = ins_Load(baseType);
-                baseTypeSize       = varTypeIsFloating(baseType)
-                                   ? baseTypeSize
-                                   : getEmitter()->emitInsAdjustLoadStoreAttr(ins, baseTypeSize);
 
                 assert(!op1->isUsedFromReg());
 
@@ -4562,7 +4553,7 @@ void CodeGen::genSIMDIntrinsicGetItem(GenTreeSIMD* simdNode)
                 {
                     unsigned varNum = op1->gtLclVarCommon.gtLclNum;
 
-                    getEmitter()->emitIns_R_S(ins, baseTypeSize, targetReg, varNum, offset);
+                    getEmitter()->emitIns_R_S(ins, emitActualTypeSize(baseType), targetReg, varNum, offset);
                 }
                 else
                 {
@@ -4573,7 +4564,7 @@ void CodeGen::genSIMDIntrinsicGetItem(GenTreeSIMD* simdNode)
                     regNumber baseReg = addr->gtRegNum;
 
                     // ldr targetReg, [baseReg, #offset]
-                    getEmitter()->emitIns_R_R_I(ins, baseTypeSize, targetReg, baseReg, offset);
+                    getEmitter()->emitIns_R_R_I(ins, emitActualTypeSize(baseType), targetReg, baseReg, offset);
                 }
             }
             else

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -1473,11 +1473,11 @@ void CodeGen::genCodeForArrIndex(GenTreeArrIndex* arrIndex)
     unsigned  offset;
 
     offset = genOffsetOfMDArrayLowerBound(elemType, rank, dim);
-    emit->emitIns_R_R_I(ins_Load(TYP_INT), EA_PTRSIZE, tmpReg, arrReg, offset); // a 4 BYTE sign extending load
+    emit->emitIns_R_R_I(INS_ldr, EA_4BYTE, tmpReg, arrReg, offset);
     emit->emitIns_R_R_R(INS_sub, EA_4BYTE, tgtReg, indexReg, tmpReg);
 
     offset = genOffsetOfMDArrayDimensionSize(elemType, rank, dim);
-    emit->emitIns_R_R_I(ins_Load(TYP_INT), EA_PTRSIZE, tmpReg, arrReg, offset); // a 4 BYTE sign extending load
+    emit->emitIns_R_R_I(INS_ldr, EA_4BYTE, tmpReg, arrReg, offset);
     emit->emitIns_R_R(INS_cmp, EA_4BYTE, tgtReg, tmpReg);
 
     emitJumpKind jmpGEU = genJumpKindForOper(GT_GE, CK_UNSIGNED);
@@ -1529,7 +1529,7 @@ void CodeGen::genCodeForArrOffset(GenTreeArrOffs* arrOffset)
 
         // Load tmpReg with the dimension size and evaluate
         // tgtReg = offsetReg*tmpReg + indexReg.
-        emit->emitIns_R_R_I(ins_Load(TYP_INT), EA_PTRSIZE, tmpReg, arrReg, offset);
+        emit->emitIns_R_R_I(INS_ldr, EA_4BYTE, tmpReg, arrReg, offset);
         emit->emitIns_R_R_R_R(INS_MULADD, EA_PTRSIZE, tgtReg, tmpReg, offsetReg, indexReg);
     }
     else

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -1623,17 +1623,7 @@ void CodeGen::genCodeForLclFld(GenTreeLclFld* tree)
     unsigned varNum = tree->gtLclNum;
     assert(varNum < compiler->lvaCount);
 
-    if (varTypeIsFloating(targetType) || varTypeIsSIMD(targetType))
-    {
-        emit->emitIns_R_S(ins_Load(targetType), size, targetReg, varNum, offs);
-    }
-    else
-    {
-#ifdef _TARGET_ARM64_
-        size = EA_SET_SIZE(size, EA_8BYTE);
-#endif // _TARGET_ARM64_
-        emit->emitIns_R_S(ins_Move_Extend(targetType, false), size, targetReg, varNum, offs);
-    }
+    emit->emitIns_R_S(ins_Load(targetType), emitActualTypeSize(targetType), targetReg, varNum, offs);
 
     genProduceReg(tree);
 }
@@ -1753,7 +1743,7 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
         }
     }
 
-    getEmitter()->emitInsLoadStoreOp(ins, emitTypeSize(type), targetReg, tree);
+    getEmitter()->emitInsLoadStoreOp(ins, emitActualTypeSize(type), targetReg, tree);
 
     if (emitBarrier)
     {
@@ -1930,14 +1920,14 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* cpBlkNode)
     {
         if ((size & 2) != 0)
         {
-            genCodeForLoadOffset(INS_ldrh, EA_2BYTE, tmpReg, srcAddr, offset);
-            genCodeForStoreOffset(INS_strh, EA_2BYTE, tmpReg, dstAddr, offset);
+            genCodeForLoadOffset(INS_ldrh, EA_4BYTE, tmpReg, srcAddr, offset);
+            genCodeForStoreOffset(INS_strh, EA_4BYTE, tmpReg, dstAddr, offset);
             offset += 2;
         }
         if ((size & 1) != 0)
         {
-            genCodeForLoadOffset(INS_ldrb, EA_1BYTE, tmpReg, srcAddr, offset);
-            genCodeForStoreOffset(INS_strb, EA_1BYTE, tmpReg, dstAddr, offset);
+            genCodeForLoadOffset(INS_ldrb, EA_4BYTE, tmpReg, srcAddr, offset);
+            genCodeForStoreOffset(INS_strb, EA_4BYTE, tmpReg, dstAddr, offset);
         }
     }
 #endif // !_TARGET_ARM64_

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2607,12 +2607,12 @@ void CodeGen::genJmpMethod(GenTree* jmp)
         if (varDsc->TypeGet() == TYP_LONG)
         {
             // long - at least the low half must be enregistered
-            getEmitter()->emitIns_S_R(ins_Store(TYP_INT), EA_4BYTE, varDsc->lvRegNum, varNum, 0);
+            getEmitter()->emitIns_S_R(INS_str, EA_4BYTE, varDsc->lvRegNum, varNum, 0);
 
             // Is the upper half also enregistered?
             if (varDsc->lvOtherReg != REG_STK)
             {
-                getEmitter()->emitIns_S_R(ins_Store(TYP_INT), EA_4BYTE, varDsc->lvOtherReg, varNum, sizeof(int));
+                getEmitter()->emitIns_S_R(INS_str, EA_4BYTE, varDsc->lvOtherReg, varNum, sizeof(int));
             }
         }
         else

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -1892,10 +1892,10 @@ void CodeGen::genEmitGSCookieCheck(bool pushReg)
     {
         // Ngen case - GS cookie constant needs to be accessed through an indirection.
         instGen_Set_Reg_To_Imm(EA_HANDLE_CNS_RELOC, regGSConst, (ssize_t)compiler->gsGlobalSecurityCookieAddr);
-        getEmitter()->emitIns_R_R_I(ins_Load(TYP_I_IMPL), EA_PTRSIZE, regGSConst, regGSConst, 0);
+        getEmitter()->emitIns_R_R_I(INS_ldr, EA_PTRSIZE, regGSConst, regGSConst, 0);
     }
     // Load this method's GS value from the stack frame
-    getEmitter()->emitIns_R_S(ins_Load(TYP_I_IMPL), EA_PTRSIZE, regGSValue, compiler->lvaGSSecurityCookie, 0);
+    getEmitter()->emitIns_R_S(INS_ldr, EA_PTRSIZE, regGSValue, compiler->lvaGSSecurityCookie, 0);
     // Compare with the GC cookie constant
     getEmitter()->emitIns_R_R(INS_cmp, EA_PTRSIZE, regGSConst, regGSValue);
 
@@ -6664,7 +6664,7 @@ void CodeGen::genReportGenericContextArg(regNumber initReg, bool* pInitRegZeroed
     }
 
 #if CPU_LOAD_STORE_ARCH
-    getEmitter()->emitIns_R_R_I(ins_Store(TYP_I_IMPL), EA_PTRSIZE, reg, genFramePointerReg(),
+    getEmitter()->emitIns_R_R_I(INS_str, EA_PTRSIZE, reg, genFramePointerReg(),
                                 compiler->lvaCachedGenericContextArgOffset());
 #else  // CPU_LOAD_STORE_ARCH
     // mov [ebp-lvaCachedGenericContextArgOffset()], reg
@@ -6717,7 +6717,7 @@ void CodeGen::genSetGSSecurityCookie(regNumber initReg, bool* pInitRegZeroed)
 
 #if CPU_LOAD_STORE_ARCH
         instGen_Set_Reg_To_Imm(EA_PTR_DSP_RELOC, reg, (ssize_t)compiler->gsGlobalSecurityCookieAddr);
-        getEmitter()->emitIns_R_R_I(ins_Load(TYP_I_IMPL), EA_PTRSIZE, reg, reg, 0);
+        getEmitter()->emitIns_R_R_I(INS_ldr, EA_PTRSIZE, reg, reg, 0);
         regSet.verifyRegUsed(reg);
 #else
         //  mov   reg, dword ptr [compiler->gsGlobalSecurityCookieAddr]
@@ -8292,7 +8292,7 @@ void CodeGen::genFnProlog()
     if (compiler->info.compPublishStubParam)
     {
 #if CPU_LOAD_STORE_ARCH
-        getEmitter()->emitIns_R_R_I(ins_Store(TYP_I_IMPL), EA_PTRSIZE, REG_SECRET_STUB_PARAM, genFramePointerReg(),
+        getEmitter()->emitIns_R_R_I(INS_str, EA_PTRSIZE, REG_SECRET_STUB_PARAM, genFramePointerReg(),
                                     compiler->lvaTable[compiler->lvaStubArgumentVar].lvStkOffs);
 #else
         // mov [lvaStubArgumentVar], EAX
@@ -9380,11 +9380,9 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
     {
         // This is the first block of a filter
 
-        getEmitter()->emitIns_R_R_I(ins_Load(TYP_I_IMPL), EA_PTRSIZE, REG_R1, REG_R1,
-                                    genFuncletInfo.fiPSP_slot_CallerSP_offset);
+        getEmitter()->emitIns_R_R_I(INS_ldr, EA_PTRSIZE, REG_R1, REG_R1, genFuncletInfo.fiPSP_slot_CallerSP_offset);
         regSet.verifyRegUsed(REG_R1);
-        getEmitter()->emitIns_R_R_I(ins_Store(TYP_I_IMPL), EA_PTRSIZE, REG_R1, REG_SPBASE,
-                                    genFuncletInfo.fiPSP_slot_SP_offset);
+        getEmitter()->emitIns_R_R_I(INS_str, EA_PTRSIZE, REG_R1, REG_SPBASE, genFuncletInfo.fiPSP_slot_SP_offset);
         getEmitter()->emitIns_R_R_I(INS_sub, EA_PTRSIZE, REG_FPBASE, REG_R1,
                                     genFuncletInfo.fiFunctionCallerSPtoFPdelta);
     }
@@ -9394,8 +9392,7 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
         getEmitter()->emitIns_R_R_I(INS_add, EA_PTRSIZE, REG_R3, REG_FPBASE,
                                     genFuncletInfo.fiFunctionCallerSPtoFPdelta);
         regSet.verifyRegUsed(REG_R3);
-        getEmitter()->emitIns_R_R_I(ins_Store(TYP_I_IMPL), EA_PTRSIZE, REG_R3, REG_SPBASE,
-                                    genFuncletInfo.fiPSP_slot_SP_offset);
+        getEmitter()->emitIns_R_R_I(INS_str, EA_PTRSIZE, REG_R3, REG_SPBASE, genFuncletInfo.fiPSP_slot_SP_offset);
     }
 }
 
@@ -10055,7 +10052,7 @@ void CodeGen::genSetPSPSym(regNumber initReg, bool* pInitRegZeroed)
     *pInitRegZeroed  = false;
 
     getEmitter()->emitIns_R_R_I(INS_add, EA_PTRSIZE, regTmp, regBase, callerSPOffs);
-    getEmitter()->emitIns_S_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, regTmp, compiler->lvaPSPSym, 0);
+    getEmitter()->emitIns_S_R(INS_str, EA_PTRSIZE, regTmp, compiler->lvaPSPSym, 0);
 
 #elif defined(_TARGET_ARM64_)
 
@@ -10067,7 +10064,7 @@ void CodeGen::genSetPSPSym(regNumber initReg, bool* pInitRegZeroed)
     *pInitRegZeroed  = false;
 
     getEmitter()->emitIns_R_R_Imm(INS_add, EA_PTRSIZE, regTmp, REG_SPBASE, SPtoCallerSPdelta);
-    getEmitter()->emitIns_S_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, regTmp, compiler->lvaPSPSym, 0);
+    getEmitter()->emitIns_S_R(INS_str, EA_PTRSIZE, regTmp, compiler->lvaPSPSym, 0);
 
 #elif defined(_TARGET_AMD64_)
 

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -1275,7 +1275,6 @@ void CodeGen::genConsumeRegs(GenTree* tree)
         {
             genConsumeAddress(tree->AsIndir()->Addr());
         }
-#ifdef _TARGET_XARCH_
         else if (tree->OperIsLocalRead())
         {
             // A contained lcl var must be living on stack and marked as reg optional, or not be a
@@ -1289,7 +1288,6 @@ void CodeGen::genConsumeRegs(GenTree* tree)
             // Update the life of the lcl var.
             genUpdateLife(tree);
         }
-#endif // _TARGET_XARCH_
         else if (tree->OperIsInitVal())
         {
             genConsumeReg(tree->gtGetOp1());

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -893,11 +893,8 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
                 targetType = genActualType(varDsc->lvType);
             }
             instruction ins  = ins_Load(targetType, compiler->isSIMDTypeLocalAligned(lcl->gtLclNum));
-            emitAttr    attr = emitTypeSize(targetType);
+            emitAttr    attr = emitActualTypeSize(targetType);
             emitter*    emit = getEmitter();
-
-            // Fixes Issue #3326
-            attr = varTypeIsFloating(targetType) ? attr : emit->emitInsAdjustLoadStoreAttr(ins, attr);
 
             // Load local variable from its home location.
             inst_RV_TT(ins, dstReg, unspillTree, 0, attr);

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -2247,14 +2247,14 @@ void emitter::emitIns_R_R(
             break;
 
         case INS_tbb:
-            assert(size == EA_1BYTE);
+            assert(size == EA_4BYTE);
             assert(insDoesNotSetFlags(flags));
             fmt = IF_T2_C9;
             sf  = INS_FLAGS_NOT_SET;
             break;
 
         case INS_tbh:
-            assert(size == EA_2BYTE);
+            assert(size == EA_4BYTE);
             assert(insDoesNotSetFlags(flags));
             fmt = IF_T2_C9;
             sf  = INS_FLAGS_NOT_SET;
@@ -2268,7 +2268,7 @@ void emitter::emitIns_R_R(
 
         case INS_ldrexb:
         case INS_strexb:
-            assert(size == EA_1BYTE);
+            assert(size == EA_4BYTE);
             assert(insDoesNotSetFlags(flags));
             fmt = IF_T2_E1;
             sf  = INS_FLAGS_NOT_SET;
@@ -2276,7 +2276,7 @@ void emitter::emitIns_R_R(
 
         case INS_ldrexh:
         case INS_strexh:
-            assert(size == EA_2BYTE);
+            assert(size == EA_4BYTE);
             assert(insDoesNotSetFlags(flags));
             fmt = IF_T2_E1;
             sf  = INS_FLAGS_NOT_SET;
@@ -2701,7 +2701,7 @@ void emitter::emitIns_R_R_I(instruction ins,
 
         case INS_ldrb:
         case INS_strb:
-            assert(size == EA_1BYTE);
+            assert(size == EA_4BYTE);
             assert(insDoesNotSetFlags(flags));
 
             if (isLowRegister(reg1) && isLowRegister(reg2) && insOptsNone(opt) && ((imm & 0x001f) == imm))
@@ -2713,12 +2713,12 @@ void emitter::emitIns_R_R_I(instruction ins,
             goto COMMON_THUMB2_LDST;
 
         case INS_ldrsb:
-            assert(size == EA_1BYTE);
+            assert(size == EA_4BYTE);
             goto COMMON_THUMB2_LDST;
 
         case INS_ldrh:
         case INS_strh:
-            assert(size == EA_2BYTE);
+            assert(size == EA_4BYTE);
             assert(insDoesNotSetFlags(flags));
 
             if (isLowRegister(reg1) && isLowRegister(reg2) && insOptsNone(opt) && ((imm & 0x003e) == imm))
@@ -2730,7 +2730,7 @@ void emitter::emitIns_R_R_I(instruction ins,
             goto COMMON_THUMB2_LDST;
 
         case INS_ldrsh:
-            assert(size == EA_2BYTE);
+            assert(size == EA_4BYTE);
             goto COMMON_THUMB2_LDST;
 
         case INS_vldr:
@@ -3015,13 +3015,13 @@ void emitter::emitIns_R_R_R(instruction ins,
         case INS_ldrb:
         case INS_strb:
         case INS_ldrsb:
-            assert(size == EA_1BYTE);
+            assert(size == EA_4BYTE);
             goto COMMON_THUMB1_LDST;
 
         case INS_ldrsh:
         case INS_ldrh:
         case INS_strh:
-            assert(size == EA_2BYTE);
+            assert(size == EA_4BYTE);
             goto COMMON_THUMB1_LDST;
 
         case INS_ldr:
@@ -3269,13 +3269,13 @@ void emitter::emitIns_R_R_R_I(instruction ins,
         case INS_ldrb:
         case INS_ldrsb:
         case INS_strb:
-            assert(size == EA_1BYTE);
+            assert(size == EA_4BYTE);
             goto COMMON_THUMB2_LDST;
 
         case INS_ldrh:
         case INS_ldrsh:
         case INS_strh:
-            assert(size == EA_2BYTE);
+            assert(size == EA_4BYTE);
             goto COMMON_THUMB2_LDST;
 
         case INS_ldr:

--- a/src/jit/emitarm.h
+++ b/src/jit/emitarm.h
@@ -96,7 +96,7 @@ void emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataReg, GenTr
 static bool isModImmConst(int imm);
 static int encodeModImmConst(int imm);
 
-static int insUnscaleImm(int imm, emitAttr size);
+static int insUnscaleImm(instruction ins, insFormat fmt, int imm);
 
 /************************************************************************/
 /*           Public inline informational methods                        */

--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -960,34 +960,6 @@ bool emitter::emitInsMayWriteMultipleRegs(instrDesc* id)
     }
 }
 
-// For the small loads/store instruction we adjust the size 'attr'
-// depending upon whether we have a load or a store
-//
-emitAttr emitter::emitInsAdjustLoadStoreAttr(instruction ins, emitAttr attr)
-{
-    if (EA_SIZE(attr) < EA_4BYTE)
-    {
-        if (emitInsIsLoad(ins))
-        {
-            // The value of 'ins' encodes the size to load
-            // we use EA_8BYTE here because it is the size we will write (into dataReg)
-            //
-            attr = EA_8BYTE;
-        }
-        else
-        {
-            assert(emitInsIsStore(ins));
-
-            // The value of 'ins' encodes the size to store
-            // we use EA_4BYTE here because it is the size of the register
-            // that we want to display when storing small values
-            //
-            attr = EA_4BYTE;
-        }
-    }
-    return attr;
-}
-
 // Takes an instrDesc 'id' and uses the instruction 'ins' to determine the
 // size of the target register that is written or read by the instruction.
 // Note that even if EA_4BYTE is returned a load instruction will still
@@ -11590,8 +11562,6 @@ void emitter::emitDispFrameRef(int varx, int disp, int offs, bool asmfm)
 //
 void emitter::emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataReg, GenTreeIndir* indir)
 {
-    emitAttr ldstAttr = isVectorRegister(dataReg) ? attr : emitInsAdjustLoadStoreAttr(ins, attr);
-
     GenTree* addr = indir->Addr();
 
     if (addr->isContained())
@@ -11640,7 +11610,7 @@ void emitter::emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataR
                     noway_assert(emitInsIsLoad(ins) || (tmpReg != dataReg));
 
                     // Then load/store dataReg from/to [tmpReg + offset]
-                    emitIns_R_R_I(ins, ldstAttr, dataReg, tmpReg, offset);
+                    emitIns_R_R_I(ins, attr, dataReg, tmpReg, offset);
                 }
                 else // large offset
                 {
@@ -11654,7 +11624,7 @@ void emitter::emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataR
                     noway_assert(tmpReg != index->gtRegNum);
 
                     // Then load/store dataReg from/to [tmpReg + index*scale]
-                    emitIns_R_R_R_I(ins, ldstAttr, dataReg, tmpReg, index->gtRegNum, lsl, INS_OPTS_LSL);
+                    emitIns_R_R_R_I(ins, attr, dataReg, tmpReg, index->gtRegNum, lsl, INS_OPTS_LSL);
                 }
             }
             else // (offset == 0)
@@ -11662,21 +11632,21 @@ void emitter::emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataR
                 if (lsl > 0)
                 {
                     // Then load/store dataReg from/to [memBase + index*scale]
-                    emitIns_R_R_R_I(ins, ldstAttr, dataReg, memBase->gtRegNum, index->gtRegNum, lsl, INS_OPTS_LSL);
+                    emitIns_R_R_R_I(ins, attr, dataReg, memBase->gtRegNum, index->gtRegNum, lsl, INS_OPTS_LSL);
                 }
                 else // no scale
                 {
                     // Then load/store dataReg from/to [memBase + index]
-                    emitIns_R_R_R(ins, ldstAttr, dataReg, memBase->gtRegNum, index->gtRegNum);
+                    emitIns_R_R_R(ins, attr, dataReg, memBase->gtRegNum, index->gtRegNum);
                 }
             }
         }
         else // no Index register
         {
-            if (emitIns_valid_imm_for_ldst_offset(offset, EA_SIZE(attr)))
+            if (emitIns_valid_imm_for_ldst_offset(offset, emitTypeSize(indir->TypeGet())))
             {
                 // Then load/store dataReg from/to [memBase + offset]
-                emitIns_R_R_I(ins, ldstAttr, dataReg, memBase->gtRegNum, offset);
+                emitIns_R_R_I(ins, attr, dataReg, memBase->gtRegNum, offset);
             }
             else
             {
@@ -11687,14 +11657,14 @@ void emitter::emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataR
                 codeGen->instGen_Set_Reg_To_Imm(EA_PTRSIZE, tmpReg, offset);
 
                 // Then load/store dataReg from/to [memBase + tmpReg]
-                emitIns_R_R_R(ins, ldstAttr, dataReg, memBase->gtRegNum, tmpReg);
+                emitIns_R_R_R(ins, attr, dataReg, memBase->gtRegNum, tmpReg);
             }
         }
     }
     else // addr is not contained, so we evaluate it into a register
     {
         // Then load/store dataReg from/to [addrReg]
-        emitIns_R_R(ins, ldstAttr, dataReg, addr->gtRegNum);
+        emitIns_R_R(ins, attr, dataReg, addr->gtRegNum);
     }
 }
 

--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -965,13 +965,12 @@ bool emitter::emitInsMayWriteMultipleRegs(instrDesc* id)
 //
 emitAttr emitter::emitInsAdjustLoadStoreAttr(instruction ins, emitAttr attr)
 {
-    if (EA_SIZE(attr) <= EA_4BYTE)
+    if (EA_SIZE(attr) < EA_4BYTE)
     {
         if (emitInsIsLoad(ins))
         {
             // The value of 'ins' encodes the size to load
             // we use EA_8BYTE here because it is the size we will write (into dataReg)
-            // it is also required when ins is INS_ldrsw
             //
             attr = EA_8BYTE;
         }

--- a/src/jit/emitarm64.h
+++ b/src/jit/emitarm64.h
@@ -84,7 +84,6 @@ bool emitInsIsCompare(instruction ins);
 bool emitInsIsLoad(instruction ins);
 bool emitInsIsStore(instruction ins);
 bool emitInsIsLoadOrStore(instruction ins);
-emitAttr emitInsAdjustLoadStoreAttr(instruction ins, emitAttr attr);
 emitAttr emitInsTargetRegSize(instrDesc* id);
 emitAttr emitInsLoadStoreSize(instrDesc* id);
 

--- a/src/jit/instr.cpp
+++ b/src/jit/instr.cpp
@@ -1585,16 +1585,7 @@ instruction CodeGenInterface::ins_Load(var_types srcType, bool aligned /*=false*
 #elif defined(_TARGET_ARMARCH_)
     if (!varTypeIsSmall(srcType))
     {
-#if defined(_TARGET_ARM64_)
-        if (!varTypeIsI(srcType) && !varTypeIsUnsigned(srcType))
-        {
-            ins = INS_ldrsw;
-        }
-        else
-#endif // defined(_TARGET_ARM64_)
-        {
-            ins = INS_ldr;
-        }
+        ins = INS_ldr;
     }
     else if (varTypeIsByte(srcType))
     {

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2616,6 +2616,7 @@ GenTree* Lowering::OptimizeConstCompare(GenTree* cmp)
                 cmp->SetOperRaw(cmpEq ? GT_TEST_EQ : GT_TEST_NE);
                 op2->SetIconValue(0xff);
                 op2->gtType = castOp->gtType;
+                castOp->ClearContained();
 #else
                 castOp->gtType = castToType;
                 op2->gtType    = castToType;

--- a/src/jit/lowerarmarch.cpp
+++ b/src/jit/lowerarmarch.cpp
@@ -764,7 +764,7 @@ void Lowering::ContainCheckCast(GenTreeCast* node)
 
     if (varTypeIsIntegral(castToType) && varTypeIsIntegral(srcType))
     {
-        if (IsContainableMemoryOp(castOp))
+        if (IsContainableMemoryOp(castOp) && (!castOp->OperIsIndir() || !castOp->AsIndir()->Addr()->OperIsAddrMode()))
         {
             MakeSrcContained(node, castOp);
         }

--- a/src/jit/lowerarmarch.cpp
+++ b/src/jit/lowerarmarch.cpp
@@ -758,17 +758,28 @@ void Lowering::ContainCheckStoreLoc(GenTreeLclVarCommon* storeLoc)
 //
 void Lowering::ContainCheckCast(GenTreeCast* node)
 {
-#ifdef _TARGET_ARM_
     GenTree*  castOp     = node->CastOp();
     var_types castToType = node->CastToType();
     var_types srcType    = castOp->TypeGet();
 
-    if (varTypeIsLong(castOp))
+    if (varTypeIsIntegral(castToType) && varTypeIsIntegral(srcType))
     {
-        assert(castOp->OperGet() == GT_LONG);
-        MakeSrcContained(node, castOp);
+        if (IsContainableMemoryOp(castOp))
+        {
+            MakeSrcContained(node, castOp);
+        }
+#if !defined(_TARGET_64BIT_)
+        else if (varTypeIsLong(srcType))
+        {
+            noway_assert(castOp->OperGet() == GT_LONG);
+            castOp->SetContained();
+        }
+#endif
+        else
+        {
+            castOp->SetRegOptional();
+        }
     }
-#endif // _TARGET_ARM_
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -749,6 +749,13 @@ int LinearScan::BuildCast(GenTreeCast* cast)
     if (cast->gtOverflow() && varTypeIsLong(srcType) && !cast->IsUnsigned() && (castType == TYP_INT))
     {
         buildInternalIntRegisterDefForNode(cast);
+
+        // If the cast operand ends up being in memory then the value will be loaded directly
+        // into the destination register and thus the internal register has to be different.
+        if (src->isContained() || src->IsRegOptional())
+        {
+            setInternalRegsDelayFree = true;
+        }
     }
 #endif
 

--- a/src/jit/lsraxarch.cpp
+++ b/src/jit/lsraxarch.cpp
@@ -2699,9 +2699,14 @@ int LinearScan::BuildCast(GenTreeCast* cast)
     // register to extract the upper 32 bits of the 64 bit source register.
     if (cast->gtOverflow() && varTypeIsLong(srcType) && (castType == TYP_UINT))
     {
-        // Here we don't need internal register to be different from targetReg,
-        // rather require it to be different from operand's reg.
         buildInternalIntRegisterDefForNode(cast);
+
+        // If the cast operand ends up being in memory then the value will be loaded directly
+        // into the destination register and thus the internal register has to be different.
+        if (src->isContained() || src->IsRegOptional())
+        {
+            setInternalRegsDelayFree = true;
+        }
     }
 #endif
 


### PR DESCRIPTION
This improves code generation for (u)int -> (u)long casts without overflow when the cast operand is a GT_IND node. Currently this is a two step process - first load the value from memory (and widen it to TYP_INT if it's a small int value) and then widen to TYP_LONG. This can be avoided by containing the cast operand.

Fixes #12595