### PR TITLE
Temporarily block core dump printing on arm64

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -576,6 +576,14 @@ function set_up_core_dump_generation {
 }
 
 function print_info_from_core_file {
+
+    #### temporary
+    if [ "$ARCH" == "arm64" ]; then
+        echo "Not inspecting core dumps on arm64 at the moment."
+        return
+    fi
+    ####
+
     local core_file_name=$1
     local executable_name=$2
 


### PR DESCRIPTION
I see a bunch of Ubuntu arm64 Cross Debug Build jobs are stalling and then failing. Looking at the logs, I see things like this:

https://ci.dot.net/job/dotnet_coreclr/job/master/job/arm64_debug_small_page_size_tst_prtest/94/consoleText

It appears gdb gets lost while taking a backtrace and ends up in an infinite loop printing the same frame over and over until the job times out. While we figure out what to do, I think it's reasonable to temporarily stop printing info from dumps on arm64.