### PR TITLE
Fix GitHub_3449 test

### DIFF
--- a/tests/src/JIT/Regression/JitBlue/GitHub_3449/GitHub_3449.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_3449/GitHub_3449.cs
@@ -15,26 +15,19 @@ public class Program
     // 43e08b2a2c280291, which is different from what the codegen produces. To fix this inconsistency,
     // the constant folding is forced to have the same behavior as the codegen, and the result
     // must be always 43e08b2a2c280290.
+    // 
+    // We don't have a good way to tell if the CLR is compiled by clang or VC++, so we simply allow
+    // both answers.
+
     public static int Main(string[] args)
     {
-        //Check if the test is being executed on ARMARCH
-        bool isProcessorArmArch = false;        
-        string processorArchEnvVar = null;
-        processorArchEnvVar = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
-        
-        if ((processorArchEnvVar != null)
-            && (processorArchEnvVar.Equals("ARM", StringComparison.CurrentCultureIgnoreCase)
-                || processorArchEnvVar.Equals("ARM64", StringComparison.CurrentCultureIgnoreCase)))
-        {
-            isProcessorArmArch = true;
-        }        
-        
         ulong u64 = 0x84595161401484A0UL;
         double f64 = (double)u64;        
         long h64 = BitConverter.DoubleToInt64Bits(f64);            
-        long expected_h64 = isProcessorArmArch ? 0x43e08b2a2c280291L : 0x43e08b2a2c280290L;
-        if (h64 != expected_h64) {
-            Console.WriteLine(String.Format("Expected: 0x{0:x}\nActual: 0x{1:x}", expected_h64, h64));
+        long expected_h64_1 = 0x43e08b2a2c280291L;
+        long expected_h64_2 = 0x43e08b2a2c280290L;
+        if ((h64 != expected_h64_1) && (h64 != expected_h64_2)) {
+            Console.WriteLine(String.Format("Expected: 0x{0:x} or 0x{1:x}\nActual: 0x{2:x}", expected_h64_1, expected_h64_2, h64));
             return -1;
         }
         return 100;

--- a/tests/src/JIT/Regression/JitBlue/GitHub_3449/GitHub_3449.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_3449/GitHub_3449.cs
@@ -6,15 +6,13 @@ using System;
 
 public class Program
 {
-    // RyuJIT codegen and clang (or gcc) may produce different results for casting uint64 to 
-    // double, and the clang result is more accurate. For example,
+    // RyuJIT codegen, VC++, clang and gcc may produce different results for casting uint64 to 
+    // double.
     //    1) (double)0x84595161401484A0UL --> 43e08b2a2c280290  (RyuJIT codegen or VC++)
     //    2) (double)0x84595161401484A0UL --> 43e08b2a2c280291  (clang or gcc)
     // Constant folding in RyuJIT simply does (double)0x84595161401484A0UL in its C++ implementation.
-    // If it is compiled by clang, the example unsigned value and cast tree node are folded into 
-    // 43e08b2a2c280291, which is different from what the codegen produces. To fix this inconsistency,
-    // the constant folding is forced to have the same behavior as the codegen, and the result
-    // must be always 43e08b2a2c280290.
+    // If it is compiled by clang or gcc, the example unsigned value and cast tree node are folded into 
+    // 43e08b2a2c280291, which is different from what RyuJIT codegen or VC++ produces.
     // 
     // We don't have a good way to tell if the CLR is compiled by clang or VC++, so we simply allow
     // both answers.


### PR DESCRIPTION
This test was looking for one answer for ARM and ARM64 but another
for other architectures. This didn't work for ARM32 on Windows
(compared to ARM32 on Linux).

Instead, simply allow either answer. This doesn't seem like a
terrible loss of precision, since we already allowed different
answers based on the platform.