### PR TITLE
Ensure that ZeroMemoryInGCHeap writes in pointer-sized increments

### DIFF
--- a/src/vm/object.cpp
+++ b/src/vm/object.cpp
@@ -2978,8 +2978,9 @@ void __fastcall ZeroMemoryInGCHeap(void* mem, size_t size)
         *memBytes++ = 0;
 
     // now write pointer sized pieces
+    // volatile ensures that this doesn't get optimized back into a memset call (see #12207)
     size_t nPtrs = (endBytes - memBytes) / sizeof(PTR_PTR_VOID);
-    PTR_PTR_VOID memPtr = (PTR_PTR_VOID) memBytes;
+    volatile PTR_PTR_VOID memPtr = (PTR_PTR_VOID) memBytes;
     for (size_t i = 0; i < nPtrs; i++)
         *memPtr++ = 0;
 


### PR DESCRIPTION
Enabling PGO optimizations exposed a latent but in the `ZeroMemoryInGCHeap` function: it assumed that writing a constant (`0`) to a pointer-sized location in memory was inherently atomic. This is not, in fact, the case: the compiler can freely turn the write into a non-atomic sequence of smaller writes. This leads to a race condition with the GC running in another thread, as discovered by the test failure tracked by #12207.

The fix is essentially the same as for #4341, and corroborated by advice from compiler devs: mark the buffer being cleared as volatile. This prevents the compiler from performing read/write optimizations against the buffer, and thus, that the store of a pointer-sized integer constant (given that the buffer access is aligned) remains a single, atomic store.
