### PR TITLE
Remove redundant call to TimeSpan.TotalMilliseconds

### DIFF
--- a/src/mscorlib/src/System/Threading/SpinWait.cs
+++ b/src/mscorlib/src/System/Threading/SpinWait.cs
@@ -210,15 +210,15 @@ namespace System.Threading
         public static bool SpinUntil(Func<bool> condition, TimeSpan timeout)
         {
             // Validate the timeout
-            Int64 totalMilliseconds = (Int64)timeout.TotalMilliseconds;
-            if (totalMilliseconds < -1 || totalMilliseconds > Int32.MaxValue)
+            long totalMilliseconds = (long)timeout.TotalMilliseconds;
+            if (totalMilliseconds < -1 || totalMilliseconds > int.MaxValue)
             {
                 throw new System.ArgumentOutOfRangeException(
                     nameof(timeout), timeout, SR.SpinWait_SpinUntil_TimeoutWrong);
             }
 
             // Call wait with the timeout milliseconds
-            return SpinUntil(condition, (int)timeout.TotalMilliseconds);
+            return SpinUntil(condition, (int)totalMilliseconds);
         }
 
         /// <summary>


### PR DESCRIPTION
`SpinWait.SpinUntil` was calling `TimeSpan.TotalMilliseconds` twice. The result of the first invocation is used for nothing but argument validation, which seems odd, so it looks like the second invocation wasn't intentional.

/cc @jkotas, @stephentoub 