### PR TITLE
Avoid a large local in a recursive visitor.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2927,14 +2927,9 @@ protected:
                             IL_OFFSET          rawILOffset);
 
     void impDevirtualizeCall(GenTreeCall*            call,
-                             GenTreePtr              obj,
-                             CORINFO_CALL_INFO*      callInfo,
-                             CORINFO_CONTEXT_HANDLE* exactContextHnd);
-
-    void impDevirtualizeCall(GenTreeCall*            call,
                              GenTreePtr              thisObj,
                              CORINFO_METHOD_HANDLE*  method,
-                             unsigned*               methodAttribs,
+                             unsigned*               methodFlags,
                              CORINFO_CONTEXT_HANDLE* contextHandle,
                              CORINFO_CONTEXT_HANDLE* exactContextHandle);
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2931,6 +2931,13 @@ protected:
                              CORINFO_CALL_INFO*      callInfo,
                              CORINFO_CONTEXT_HANDLE* exactContextHnd);
 
+    void impDevirtualizeCall(GenTreeCall*            call,
+                             GenTreePtr              thisObj,
+                             CORINFO_METHOD_HANDLE*  method,
+                             unsigned*               methodAttribs,
+                             CORINFO_CONTEXT_HANDLE* contextHandle,
+                             CORINFO_CONTEXT_HANDLE* exactContextHandle);
+
     bool impMethodInfo_hasRetBuffArg(CORINFO_METHOD_INFO* methInfo);
 
     GenTreePtr impFixupCallStructReturn(GenTreeCall* call, CORINFO_CLASS_HANDLE retClsHnd);

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -21793,9 +21793,10 @@ Compiler::fgWalkResult Compiler::fgUpdateInlineReturnExpressionPlaceHolder(GenTr
                 }
 #endif // DEBUG
 
-                CORINFO_CALL_INFO x = {};
-                x.hMethod           = call->gtCallMethHnd;
-                comp->impDevirtualizeCall(call, tree, &x, nullptr);
+                CORINFO_METHOD_HANDLE method = call->gtCallMethHnd;
+                unsigned methodFlags = 0;
+                CORINFO_CONTEXT_HANDLE context = nullptr;
+                comp->impDevirtualizeCall(call, tree, &method, &methodFlags, &context, nullptr);
             }
         }
     }

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -21793,9 +21793,9 @@ Compiler::fgWalkResult Compiler::fgUpdateInlineReturnExpressionPlaceHolder(GenTr
                 }
 #endif // DEBUG
 
-                CORINFO_METHOD_HANDLE method = call->gtCallMethHnd;
-                unsigned methodFlags = 0;
-                CORINFO_CONTEXT_HANDLE context = nullptr;
+                CORINFO_METHOD_HANDLE  method      = call->gtCallMethHnd;
+                unsigned               methodFlags = 0;
+                CORINFO_CONTEXT_HANDLE context     = nullptr;
                 comp->impDevirtualizeCall(call, tree, &method, &methodFlags, &context, nullptr);
             }
         }

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -7495,7 +7495,8 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
             assert(obj->gtType == TYP_REF);
 
             // See if we can devirtualize.
-            impDevirtualizeCall(call->AsCall(), obj, &callInfo->hMethod, &callInfo->methodFlags, &callInfo->contextHandle, &exactContextHnd);
+            impDevirtualizeCall(call->AsCall(), obj, &callInfo->hMethod, &callInfo->methodFlags,
+                                &callInfo->contextHandle, &exactContextHnd);
         }
         else
         {


### PR DESCRIPTION
This local of type `CORINFO_CALL_INFO` bloats the frame size of its
caller when the function is inlined and ends up aggravating stack size
issues in deep recursion. This change refactors the offending method a
bit in order to avoid the local entirely.

Hopefully this fixes #12691.