### PR TITLE
[release/2.0.0] Port fix of #12207

### DIFF
--- a/src/vm/object.cpp
+++ b/src/vm/object.cpp
@@ -2954,8 +2954,9 @@ void __fastcall ZeroMemoryInGCHeap(void* mem, size_t size)
         *memBytes++ = 0;
 
     // now write pointer sized pieces
+    // volatile ensures that this doesn't get optimized back into a memset call (see #12207)
     size_t nPtrs = (endBytes - memBytes) / sizeof(PTR_PTR_VOID);
-    PTR_PTR_VOID memPtr = (PTR_PTR_VOID) memBytes;
+    volatile PTR_PTR_VOID memPtr = (PTR_PTR_VOID) memBytes;
     for (size_t i = 0; i < nPtrs; i++)
         *memPtr++ = 0;
 


### PR DESCRIPTION
Ensure that ZeroMemoryInGCHeap writes in pointer-sized increments
by adding the volatile keyword (which disables memset optimization).
Fixes #12700