### PR TITLE
Fix crossgen debug directory generation problems.

### DIFF
--- a/src/zap/zapheaders.cpp
+++ b/src/zap/zapheaders.cpp
@@ -282,6 +282,7 @@ void ZapDebugDirectory::SaveOriginalDebugDirectoryEntry(ZapWriter *pZapWriter)
 
 void ZapDebugDirectory::SaveNGenDebugDirectoryEntry(ZapWriter *pZapWriter)
 {
+#if !defined(NO_NGENPDB)
     _ASSERTE(pZapWriter);
 
     IMAGE_DEBUG_DIRECTORY debugDirectory = {0};
@@ -292,6 +293,10 @@ void ZapDebugDirectory::SaveNGenDebugDirectoryEntry(ZapWriter *pZapWriter)
     debugDirectory.Type = IMAGE_DEBUG_TYPE_CODEVIEW;
     debugDirectory.SizeOfData = m_pNGenPdbDebugData->GetSize();
     debugDirectory.AddressOfRawData = m_pNGenPdbDebugData->GetRVA();
+    // NGen PDBs are always Windows currently so make sure the "is portable pdb"
+    // indicator (0x504d) is clear since this debug directory is copied from
+    // an existing entry which could be a portable pdb.
+    debugDirectory.MinorVersion = 0;
     {
         ZapPhysicalSection *pPhysicalSection = ZapImage::GetImage(pZapWriter)->m_pTextSection;
         DWORD dwOffset = m_pNGenPdbDebugData->GetRVA() - pPhysicalSection->GetRVA();
@@ -299,6 +304,7 @@ void ZapDebugDirectory::SaveNGenDebugDirectoryEntry(ZapWriter *pZapWriter)
         debugDirectory.PointerToRawData = pPhysicalSection->GetFilePos() + dwOffset;
     }
     pZapWriter->Write(&debugDirectory, sizeof(debugDirectory));
+#endif // NO_NGENPDB
 }
 
 void ZapDebugDirectory::Save(ZapWriter * pZapWriter)

--- a/src/zap/zapheaders.cpp
+++ b/src/zap/zapheaders.cpp
@@ -293,9 +293,9 @@ void ZapDebugDirectory::SaveNGenDebugDirectoryEntry(ZapWriter *pZapWriter)
     debugDirectory.Type = IMAGE_DEBUG_TYPE_CODEVIEW;
     debugDirectory.SizeOfData = m_pNGenPdbDebugData->GetSize();
     debugDirectory.AddressOfRawData = m_pNGenPdbDebugData->GetRVA();
-    // NGen PDBs are always Windows currently so make sure the "is portable pdb"
-    // indicator (0x504d) is clear since this debug directory is copied from
-    // an existing entry which could be a portable pdb.
+    // Make sure the "is portable pdb" indicator (MinorVersion == 0x504d) is clear
+    // for the NGen debug directory entry since this debug directory is copied
+    // from an existing entry which could be a portable pdb.
     debugDirectory.MinorVersion = 0;
     {
         ZapPhysicalSection *pPhysicalSection = ZapImage::GetImage(pZapWriter)->m_pTextSection;

--- a/src/zap/zapheaders.h
+++ b/src/zap/zapheaders.h
@@ -249,7 +249,11 @@ public:
 
     virtual DWORD GetSize()
     {
+#if defined(NO_NGENPDB)
+        return sizeof(IMAGE_DEBUG_DIRECTORY) * m_nDebugDirectory;
+#else
         return sizeof(IMAGE_DEBUG_DIRECTORY) * (m_nDebugDirectory + 1);
+#endif // NO_NGENPDB
     }
 
     virtual UINT GetAlignment()

--- a/src/zap/zapheaders.h
+++ b/src/zap/zapheaders.h
@@ -252,6 +252,7 @@ public:
 #if defined(NO_NGENPDB)
         return sizeof(IMAGE_DEBUG_DIRECTORY) * m_nDebugDirectory;
 #else
+        // Add one for NGen PDB debug directory entry
         return sizeof(IMAGE_DEBUG_DIRECTORY) * (m_nDebugDirectory + 1);
 #endif // NO_NGENPDB
     }


### PR DESCRIPTION
The first problem was that when the existing/incoming PDB debug
directory entry was a portable PDB (MinorVersion == 0x504d), the
ngen/native PDB added had the same MinorVersion indicating that
it was a portable PDB (but it never can be).

This was fixed by setting MinorVersion to 0 when creating the
ngen PDB debug directory entry.

The second problem was that the ngen PDB entry was being created
even when crossgen was run on linux/mac, etc.

The fix was to ifdef NO_NGENPDB the save ngen PDB entry code.