### PR TITLE
Fix build.sh from break by poorly timed dotnet first time experience

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -164,8 +164,8 @@ restore_optdata()
             fi
         fi
         local OptDataProjectFilePath="$__ProjectRoot/src/.nuget/optdata/optdata.csproj"
-        __PgoOptDataVersion=$($DotNetCli msbuild $OptDataProjectFilePath /t:DumpPgoDataPackageVersion /nologo | sed 's/^\s*//')
-        __IbcOptDataVersion=$($DotNetCli msbuild $OptDataProjectFilePath /t:DumpIbcDataPackageVersion /nologo | sed 's/^\s*//')
+        __PgoOptDataVersion=$(DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 $DotNetCli msbuild $OptDataProjectFilePath /t:DumpPgoDataPackageVersion /nologo | sed 's/^\s*//')
+        __IbcOptDataVersion=$(DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 $DotNetCli msbuild $OptDataProjectFilePath /t:DumpIbcDataPackageVersion /nologo | sed 's/^\s*//')
     fi
 }
 


### PR DESCRIPTION
Depending on machine state, calling `dotnet` to dump the PGO and IBC package version might trigger the first time experience message. This breaks build.sh where it tries to parse the package version from `dotnet msbuild`'s output. The fix is to disable the first time experience path in these two invocations of `dotnet`.