### PR TITLE
Update BuildTools to fix output path for signing.

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01805-01
+2.0.0-prerelease-01811-02


### PR DESCRIPTION
This takes dotnet/buildtools#1603 which fixes the IntermediateOutputPath -
this is required by MicroBuild for signing.