### PR TITLE
Remove ThrowExceptionIfDisposedCancellationTokenSource switch

### DIFF
--- a/src/mscorlib/src/System/AppContext/AppContextDefaultValues.Defaults.cs
+++ b/src/mscorlib/src/System/AppContext/AppContextDefaultValues.Defaults.cs
@@ -9,7 +9,6 @@ namespace System
     internal static partial class AppContextDefaultValues
     {
         internal static readonly string SwitchNoAsyncCurrentCulture = "Switch.System.Globalization.NoAsyncCurrentCulture";
-        internal static readonly string SwitchThrowExceptionIfDisposedCancellationTokenSource = "Switch.System.Threading.ThrowExceptionIfDisposedCancellationTokenSource";
         internal static readonly string SwitchPreserveEventListnerObjectIdentity = "Switch.System.Diagnostics.EventSource.PreserveEventListnerObjectIdentity";
 
         // This is a partial method. Platforms can provide an implementation of it that will set override values
@@ -36,7 +35,6 @@ namespace System
                         if (version <= 40502)
                         {
                             AppContext.DefineSwitchDefault(SwitchNoAsyncCurrentCulture, true);
-                            AppContext.DefineSwitchDefault(SwitchThrowExceptionIfDisposedCancellationTokenSource, true);
                         }
 
                         break;
@@ -47,7 +45,6 @@ namespace System
                         if (version <= 80100)
                         {
                             AppContext.DefineSwitchDefault(SwitchNoAsyncCurrentCulture, true);
-                            AppContext.DefineSwitchDefault(SwitchThrowExceptionIfDisposedCancellationTokenSource, true);
                         }
                         break;
                     }

--- a/src/mscorlib/src/System/AppContext/AppContextSwitches.cs
+++ b/src/mscorlib/src/System/AppContext/AppContextSwitches.cs
@@ -19,16 +19,6 @@ namespace System
             }
         }
 
-        private static int _throwExceptionIfDisposedCancellationTokenSource;
-        public static bool ThrowExceptionIfDisposedCancellationTokenSource
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                return GetCachedSwitchValue(AppContextDefaultValues.SwitchThrowExceptionIfDisposedCancellationTokenSource, ref _throwExceptionIfDisposedCancellationTokenSource);
-            }
-        }
-
         private static int _preserveEventListnerObjectIdentity;
         public static bool PreserveEventListnerObjectIdentity
         {

--- a/src/mscorlib/src/System/Threading/CancellationToken.cs
+++ b/src/mscorlib/src/System/Threading/CancellationToken.cs
@@ -459,13 +459,6 @@ namespace System.Threading
                 ThrowOperationCanceledException();
         }
 
-        // Throw an ODE if this CancellationToken's source is disposed.
-        internal void ThrowIfSourceDisposed()
-        {
-            if ((m_source != null) && m_source.IsDisposed)
-                ThrowObjectDisposedException();
-        }
-
         // Throws an OCE; separated out to enable better inlining of ThrowIfCancellationRequested
         private void ThrowOperationCanceledException()
         {

--- a/src/mscorlib/src/System/Threading/CancellationTokenSource.cs
+++ b/src/mscorlib/src/System/Threading/CancellationTokenSource.cs
@@ -620,11 +620,6 @@ namespace System.Threading
         internal CancellationTokenRegistration InternalRegister(
             Action<object> callback, object stateForCallback, SynchronizationContext targetSyncContext, ExecutionContext executionContext)
         {
-            if (AppContextSwitches.ThrowExceptionIfDisposedCancellationTokenSource)
-            {
-                ThrowIfDisposed();
-            }
-
             // the CancellationToken has already checked that the token is cancelable before calling this method.
             Debug.Assert(CanBeCanceled, "Cannot register for uncancelable token src");
 
@@ -646,7 +641,7 @@ namespace System.Threading
                 // comes in after this line, we simply run the minor risk of having m_registeredCallbacksLists reinitialized
                 // (after it was cleared to null during Dispose).
 
-                if (m_disposed && !AppContextSwitches.ThrowExceptionIfDisposedCancellationTokenSource)
+                if (m_disposed)
                     return new CancellationTokenRegistration();
 
                 int myIndex = Thread.CurrentThread.ManagedThreadId % s_nLists;

--- a/src/mscorlib/src/System/Threading/Tasks/Task.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/Task.cs
@@ -624,11 +624,6 @@ namespace System.Threading.Tasks
 
             try
             {
-                if (AppContextSwitches.ThrowExceptionIfDisposedCancellationTokenSource)
-                {
-                    cancellationToken.ThrowIfSourceDisposed();
-                }
-
                 // If an unstarted task has a valid CancellationToken that gets signalled while the task is still not queued
                 // we need to proactively cancel it, because it may never execute to transition itself. 
                 // The only way to accomplish this is to register a callback on the CT.
@@ -5238,11 +5233,6 @@ namespace System.Threading.Tasks
             if (function == null) ThrowHelper.ThrowArgumentNullException(ExceptionArgument.function);
             Contract.EndContractBlock();
 
-            if (AppContextSwitches.ThrowExceptionIfDisposedCancellationTokenSource)
-            {
-                cancellationToken.ThrowIfSourceDisposed();
-            }
-
             // Short-circuit if we are given a pre-canceled token
             if (cancellationToken.IsCancellationRequested)
                 return Task.FromCanceled(cancellationToken);
@@ -5288,11 +5278,6 @@ namespace System.Threading.Tasks
             // Check arguments
             if (function == null) ThrowHelper.ThrowArgumentNullException(ExceptionArgument.function);
             Contract.EndContractBlock();
-
-            if (AppContextSwitches.ThrowExceptionIfDisposedCancellationTokenSource)
-            {
-                cancellationToken.ThrowIfSourceDisposed();
-            }
 
             // Short-circuit if we are given a pre-canceled token
             if (cancellationToken.IsCancellationRequested)


### PR DESCRIPTION
This is a legacy switch from desktop; we used to throw exceptions in certain cases, now we don't, and for whatever reason it was deemed an app compat issue on desktop, so a switch was added to continue throwing that exception if the switch was set.  This was all then inherited into coreclr. But there's no reason anyone would want to opt-in to the behavior on core, and the checks for it are actually measurable in scenarios that stress registering/unregistering cancellation tokens.

I'm simply deleting the switch.

cc: @AlexGhiondea, @kouvel 