### PR TITLE
[WIP][ARM/Linux] Use Helper Lookup for Core CLR

### DIFF
--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -19216,7 +19216,7 @@ regMaskTP CodeGen::genCodeForCall(GenTreeCall* call, bool valUsed)
                     noway_assert(helperNum != CORINFO_HELP_UNDEF);
 
 #ifdef FEATURE_READYTORUN_COMPILER
-                    if (call->gtEntryPoint.addr != NULL)
+                    if (call->gtEntryPoint.addr != NULL && compiler->IsTargetAbi(CORINFO_CORERT_ABI))
                     {
                         accessType = call->gtEntryPoint.accessType;
                         addr       = call->gtEntryPoint.addr;


### PR DESCRIPTION
#12104 revises legacy JIT not to use helper lookup if entry point is known,which results in #12660.

This commit enforces CLR to always use helper lookup to fix #12660.