### PR TITLE
Fix for a bug in tail recursion elimination.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7529,6 +7529,39 @@ void Compiler::fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCa
         fgInsertStmtBefore(block, paramAssignmentInsertionPoint, arg0AssignmentStmt);
     }
 
+    // If compInitMem is set, we may need to zero-initialize some locals. Normally it's done in the prolog
+    // but this loop can't include the prolog. Since we don't have liveness information, we insert zero-initialization
+    // for all non-parameter non-temp locals. Liveness phase will remove unnecessary initializations.
+    if (info.compInitMem)
+    {
+        unsigned   varNum;
+        LclVarDsc* varDsc;
+        for (varNum = 0, varDsc = lvaTable; varNum < info.compLocalsCount; varNum++, varDsc++)
+        {
+            if (!varDsc->lvIsParam)
+            {
+                assert(!varDsc->lvIsTemp);
+                var_types  lclType = varDsc->TypeGet();
+                GenTreePtr lcl     = gtNewLclvNode(varNum, lclType);
+                GenTreePtr init    = nullptr;
+                if (lclType == TYP_STRUCT)
+                {
+                    const bool isVolatile  = false;
+                    const bool isCopyBlock = false;
+                    init = gtNewBlkOpNode(lcl, gtNewIconNode(0), varDsc->lvSize(), isVolatile, isCopyBlock);
+                    init = fgMorphInitBlock(init);
+                }
+                else
+                {
+                    GenTreePtr zero = gtNewZeroConNode(genActualType(lclType));
+                    init            = gtNewAssignNode(lcl, zero);
+                }
+                GenTreePtr initStmt = gtNewStmt(init, callILOffset);
+                fgInsertStmtBefore(block, last, initStmt);
+            }
+        }
+    }
+
     // Remove the call
     fgRemoveStmt(block, last);
 

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_461649/DevDiv_461649.cs
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_461649/DevDiv_461649.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Xml;
+using System.Xml.XPath;
+using System.Xml.Xsl;
+
+
+namespace XSLTest
+{
+    class Program
+    {
+        // In this test a dynamic method with tail-prefixed call is created.
+        // One of the locals is not explicitly initialized but a flag to init locals is set.
+        // (That never happens in normal C# methods due to C# definite assignment rules.)
+        // The jit performs an optimization transforming the tail call into a loop.
+        // The bug was that the local was only zero-initialized for the first iteration of the loop.
+
+        static int Main(string[] args)
+        {
+            string inputXml = "Input.xml";
+            string inputXsl = "Transform.xsl";
+
+            return DotNetXslCompiledTransform(inputXml, inputXsl);
+        }
+
+        private static int DotNetXslCompiledTransform(string inputXml, string inputXsl)
+        {
+            XslCompiledTransform transform = new XslCompiledTransform();
+            transform.Load(inputXsl);
+
+            StringWriter stringWriter = new StringWriter();
+            XmlWriter writer = new XmlTextWriter(stringWriter);
+
+            transform.Transform(inputXml, null, writer);
+
+            string transformResult = stringWriter.ToString();
+            if (transformResult == "<!--20.0 20.0 20.0 20.0 20.0--> 40 40 40 40 40")
+            {
+                Console.WriteLine("SUCCESS");
+                return 100;
+            }
+            else
+            {
+                Console.WriteLine("FAILURE");
+                return 0;
+            }
+        }
+    }
+}
+

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_461649/DevDiv_461649.csproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_461649/DevDiv_461649.csproj
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <Reference Include="System.Private.Xml" />
+    <Content Include="Input.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Transform.xsl">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_461649/Input.xml
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_461649/Input.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+	<bla test="20.0 20.0 20.0 20.0 20.0"/>
+</root>

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_461649/Transform.xsl
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_461649/Transform.xsl
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:l="http://www.schema.de/XSL/ST4DocuManagerlang" version="1.0">
+	<xsl:template match="/">
+		<xsl:for-each select="/root/bla">
+			<xsl:comment>
+				<xsl:value-of select="@test"/>
+			</xsl:comment>
+			<xsl:call-template name="duplicate">
+				<xsl:with-param name="value" select="@test" />
+			</xsl:call-template>
+		</xsl:for-each>
+	</xsl:template>
+
+	<xsl:template name="duplicate">
+		<xsl:param name="value" />
+		<xsl:param name="result" />
+		<xsl:choose>
+			<xsl:when test="contains($value, ' ')">
+				<xsl:call-template name="duplicate">
+					<xsl:with-param name="value" select="substring-after($value, ' ')" />
+					<xsl:with-param name="result" select="concat($result,' ', substring-before($value, ' ') * 2)" />
+				</xsl:call-template>
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:value-of select="concat($result,' ', $value * 2)" />
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
Tail recursion elimination transforms a tail call into a loop.
If compInitMem is set, we may need to zero-initialize some locals. Normally it's done in the prolog
but the loop we are creating can't include the prolog. The fix is to insert zero-initialization
for all non-parameter non-temp locals in the loop. Liveness phase will remove unnecessary initializations.

We never hit this case with normal C# code since C# definite assignment rules ensure that there are
no uninitialized locals in the generated msil. In the repro the method with tail recursion is a dynamic method
and it has an uninitialized local.