### PR TITLE
Simplify the `isContainedNode` check in LSRA.

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3699,9 +3699,11 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
     }
 #endif // DEBUG
 
-    const bool isContainedNode = !info.isLocalDefUse && consume == 0 && produce == 0 && tree->canBeContained();
-    if (isContainedNode)
+    if (tree->isContained())
     {
+        assert(!info.isLocalDefUse);
+        assert(consume == 0);
+        assert(produce == 0);
         assert(info.internalIntCount == 0);
         assert(info.internalFloatCount == 0);
 

--- a/src/jit/lsraxarch.cpp
+++ b/src/jit/lsraxarch.cpp
@@ -1694,9 +1694,11 @@ void Lowering::TreeNodeInfoInitPutArgStk(GenTreePutArgStk* putArgStk)
     LinearScan*   l    = m_lsra;
     info->srcCount     = 0;
 
-#ifdef _TARGET_X86_
     if (putArgStk->gtOp1->gtOper == GT_FIELD_LIST)
     {
+        putArgStk->gtOp1->SetContained();
+
+#ifdef _TARGET_X86_
         unsigned fieldCount    = 0;
         bool     needsByteTemp = false;
         bool     needsSimdTemp = false;
@@ -1805,8 +1807,8 @@ void Lowering::TreeNodeInfoInitPutArgStk(GenTreePutArgStk* putArgStk)
 #endif // defined(FEATURE_SIMD)
 
         return;
-    }
 #endif // _TARGET_X86_
+    }
 
 #if defined(FEATURE_SIMD) && defined(_TARGET_X86_)
     // For PutArgStk of a TYP_SIMD12, we need an extra register.


### PR DESCRIPTION
Now that containedness is explicit this can simply check `isContained`.