### PR TITLE
Update BuildTools version to latest

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01805-01
+2.0.0-prerelease-01811-02


### PR DESCRIPTION
This will fix errors like "E:\A\_work\0\a\MicroBuild\Plugins\MicroBuild.Plugins.Signing.1.0.321\build\MicroBuild.Plugins.Signing.targets(0,0): error : File E:\A\_work\0\b\pipelineRepository\bin\obj\SymbolsCatalog\9\signatures.cat is not in one of the expected output locations and cannot be signed. [E:\A\_work\0\b\pipelineRepository\build.proj]" being tracked by https://github.com/dotnet/core-eng/issues/1173