### PR TITLE
Loosen an assertion in the emitter re: byrefs.

### DIFF
--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -8012,48 +8012,8 @@ DONE:
                 break;
 
             case IF_RRW_ARD:
-                assert(id->idGCref() == GCT_BYREF);
-
-#ifdef DEBUG
-                regMaskTP regMask;
-                regMask = genRegMask(id->idReg1());
-
-                // <BUGNUM> VSW 335101 </BUGNUM>
-                // Either id->idReg1(), id->idAddr()->iiaAddrMode.amBaseReg, or id->idAddr()->iiaAddrMode.amIndxReg
-                // could be a BYREF.
-                // For example in the following case:
-                //     mov     EDX, bword ptr [EBP-78H] ; EDX becomes BYREF after this instr.
-                //     add     EAX, bword ptr [EDX+8]   ; It is the EDX that's causing id->idGCref to be GCT_BYREF.
-                //                                      ; EAX becomes BYREF after this instr.
-                // <BUGNUM> DD 273707 </BUGNUM>
-                //     add     EDX, bword ptr [036464E0H] ; int + static field (technically a GCREF)=BYREF
-                regMaskTP baseRegMask;
-                if (reg == REG_NA)
-                {
-                    baseRegMask = RBM_NONE;
-                }
-                else
-                {
-                    baseRegMask = genRegMask(reg);
-                }
-                regMaskTP indexRegMask;
-                if (rgx == REG_NA)
-                {
-                    indexRegMask = RBM_NONE;
-                }
-                else
-                {
-                    indexRegMask = genRegMask(rgx);
-                }
-
-                // r1 could have been a GCREF as GCREF + int=BYREF
-                //                            or BYREF+/-int=BYREF
-                assert(((reg == REG_NA) && (rgx == REG_NA) && (ins == INS_add || ins == INS_sub)) ||
-                       (((regMask | baseRegMask | indexRegMask) & emitThisGCrefRegs) && (ins == INS_add)) ||
-                       (((regMask | baseRegMask | indexRegMask) & emitThisByrefRegs) &&
-                        (ins == INS_add || ins == INS_sub)));
-#endif
-                // Mark it as holding a GCT_BYREF
+                // Mark the destination register as holding a GCT_BYREF
+                assert(id->idGCref() == GCT_BYREF && (ins == INS_add || ins == INS_sub));
                 emitGCregLiveUpd(GCT_BYREF, id->idReg1(), dst);
                 break;
 


### PR DESCRIPTION
This assertion was attempting to ensure that one of the sources of an
instruction with a particular format that produced a byref was itself a
gcref or a byref. Its attempt to do so was overly strong, however, as it
rejected IR of the following form (specifically, the `add r, m`
generated by `t8 = ADD byref REG rdx`).

```
Generating: N005 (  3, 10) [000005] ------------        t5 =    CNS_INT(h) long   0x1c348f05a78 static Fseq[??_7type_info@@6B@] REG rax
IN0001:        mov      rax, 0x1C348F05A78
                                                             /--*  t5     long
Generating: N007 (  5, 12) [000006] -c----------        t6 = *  IND       ref    REG NA
Generating: N009 (  1,  1) [000009] ------------        t9 =    CNS_INT   int    8 REG rdx
IN0002:        mov      edx, 8
                                                             /--*  t9     int
Generating: N011 (  2,  3) [000010] ------------       t10 = *  CAST      long <- int REG rdx
IN0003:        movsxd   rdx, edx
                                                             /--*  t6     ref
                                                             +--*  t10    long
Generating: N013 (  8, 16) [000008] ------------        t8 = *  ADD       byref  REG rdx
IN0004:        add      rdx, bword ptr [rax]
							Byref regs: 00000000 {} => 00000004 {rdx}
```

This changes loosens the assertion s.t. it merely ensures that the
instrution is either an add or a sub that produces a byref.