### PR TITLE
CoreCLR - Remove preemptive checks for path being too long

### DIFF
--- a/src/mscorlib/shared/System/IO/Path.Unix.cs
+++ b/src/mscorlib/shared/System/IO/Path.Unix.cs
@@ -40,11 +40,6 @@ namespace System.IO
             Debug.Assert(collapsedString.Length < path.Length || collapsedString.ToString() == path,
                 "Either we've removed characters, or the string should be unmodified from the input path.");
 
-            if (collapsedString.Length > Interop.Sys.MaxPath)
-            {
-                throw new PathTooLongException(SR.Format(SR.IO_PathTooLong_Path, path));
-            }
-
             string result = collapsedString.Length == 0 ? PathInternal.DirectorySeparatorCharAsString : collapsedString;
 
             return result;
@@ -116,11 +111,6 @@ namespace System.IO
                         i += 2;
                         continue;
                     }
-                }
-
-                if (++componentCharCount > Interop.Sys.MaxName)
-                {
-                    throw new PathTooLongException(SR.Format(SR.IO_PathTooLong_Path, path));
                 }
 
                 // Normalize the directory separator if needed

--- a/src/mscorlib/shared/System/IO/PathHelper.Windows.cs
+++ b/src/mscorlib/shared/System/IO/PathHelper.Windows.cs
@@ -50,12 +50,6 @@ namespace System.IO
                 // Trim whitespace off the end of the string. Win32 normalization trims only U+0020.
                 fullPath.TrimEnd(PathInternal.s_trimEndChars);
 
-                if (fullPath.Length >= PathInternal.MaxLongPath)
-                {
-                    // Fullpath is genuinely too long
-                    throw new PathTooLongException(SR.Format(SR.IO_PathTooLong_Path, fullPath.ToString()));
-                }
-
                 // Checking path validity used to happen before getting the full path name. To avoid additional input allocation
                 // (to trim trailing whitespace) we now do it after the Win32 call. This will allow legitimate paths through that
                 // used to get kicked back (notably segments with invalid characters might get removed via "..").
@@ -67,7 +61,6 @@ namespace System.IO
                 //
                 //  - Illegal path characters.
                 //  - Invalid UNC paths like \\, \\server, \\server\.
-                //  - Segments that are too long (over MaxComponentLength)
 
                 // As the path could be > 30K, we'll combine the validity scan. None of these checks are performed by the Win32
                 // GetFullPathName() API.
@@ -108,8 +101,6 @@ namespace System.IO
                                 break;
                             case '\\':
                                 segmentLength = index - lastSeparator - 1;
-                                if (segmentLength > PathInternal.MaxComponentLength)
-                                    throw new PathTooLongException(SR.Format(SR.IO_PathTooLong_Path, fullPath.ToString()));
                                 lastSeparator = index;
 
                                 if (foundTilde)
@@ -148,8 +139,6 @@ namespace System.IO
                     throw new ArgumentException(SR.Format(SR.Arg_PathIllegalUNC_Path, fullPath.ToString()));
 
                 segmentLength = fullPath.Length - lastSeparator - 1;
-                if (segmentLength > PathInternal.MaxComponentLength)
-                    throw new PathTooLongException(SR.Format(SR.IO_PathTooLong_Path, fullPath.ToString()));
 
                 if (foundTilde && segmentLength <= MaxShortName)
                     possibleShortPath = true;

--- a/src/mscorlib/shared/System/IO/PathInternal.Windows.cs
+++ b/src/mscorlib/shared/System/IO/PathInternal.Windows.cs
@@ -56,14 +56,12 @@ namespace System.IO
 
         internal const int MaxShortPath = 260;
         internal const int MaxShortDirectoryPath = 248;
-        internal const int MaxLongPath = short.MaxValue;
         // \\?\, \\.\, \??\
         internal const int DevicePrefixLength = 4;
         // \\
         internal const int UncPrefixLength = 2;
         // \\?\UNC\, \\.\UNC\
         internal const int UncExtendedPrefixLength = 8;
-        internal const int MaxComponentLength = 255;
 
         /// <summary>
         /// Returns true if the given character is a valid drive letter


### PR DESCRIPTION
Don't preemptively validate path length as it may very well be wrong. Instead let the native interop handle it. See dotnet/corefx#8655

After this, I will be working on any CoreFX tests that need to be fixed up.

cc @JeremyKuhne 