### PR TITLE
Improvements in the Zapper to VM interface, no longer throw exceptions across the interface.

### DIFF
--- a/src/dlls/mscorrc/mscorrc.rc
+++ b/src/dlls/mscorrc/mscorrc.rc
@@ -851,6 +851,8 @@ BEGIN
     IDS_EE_PROC_NOT_FOUND                   "A procedure imported by '%1' could not be loaded."
     IDS_EE_SIMD_NGEN_DISALLOWED             "Target-dependent SIMD vector types may not be used with ngen."
     IDS_EE_SIMD_PARTIAL_TRUST_DISALLOWED    "SIMD intrinsics may not be used by partial trust applications."
+    IDS_IBC_MISSING_EXTERNAL_TYPE           "The generic type specified by the IBC data is not available to this assembly"
+    IDS_IBC_MISSING_EXTERNAL_METHOD         "The generic method specified by the IBC data is not available to this assembly"
 
     IDS_INET_E_CANNOT_CONNECT               "Cannot connect to URL for '%1'."
     IDS_INET_E_RESOURCE_NOT_FOUND           "The server or proxy was not found for '%1'."
@@ -2037,11 +2039,6 @@ BEGIN
         BFA_ONLY_VOID_PTR_IN_ARGS               "Only pointer to void allowed in function arguments."
         BFA_TYPEDBYREFCANNOTHAVEBYREF           "An ELEMENT_TYPE_TYPEDBYREF cannot have a ELEMENT_TYPE_BYREF modifier."
         BFA_REFERENCE_ASSEMBLY                  "Cannot load a reference assembly for execution."
-
-#ifdef FEATURE_PREJIT
-        BFA_MISSING_IBC_EXTERNAL_TYPE           "The type specified by the IBC data is no longer present in the assembly's metadata"
-        BFA_MISSING_IBC_EXTERNAL_METHOD         "The method specified by the IBC data is no longer present in the assembly's metadata"
-#endif
 
 #ifdef FEATURE_COMINTEROP
         BFA_WINRT_INVALID_NAMESPACE_FOR_TYPE    "Windows Runtime type '%1' has invalid namespace that does not begin with the file name in assembly '%2'."

--- a/src/dlls/mscorrc/resource.h
+++ b/src/dlls/mscorrc/resource.h
@@ -611,6 +611,8 @@
 
 #define IDS_EE_SIMD_NGEN_DISALLOWED             0x1ac3
 #define IDS_EE_SIMD_PARTIAL_TRUST_DISALLOWED    0x1ac4
+#define IDS_IBC_MISSING_EXTERNAL_TYPE           0x1ac5
+#define IDS_IBC_MISSING_EXTERNAL_METHOD         0x1ac6
 
 #define BFA_INVALID_FILE_TOKEN                  0x2000
 #define BFA_INVALID_TOKEN_TYPE                  0x2001
@@ -825,11 +827,6 @@
 #define IDS_ACCESS_EXCEPTION_CONTEXT_PT_TRANSPARENT     0x2203
 
 #define IDS_E_LOADFROM_REMOTE_SOURCE_MOTW       0x2204
-
-#ifdef FEATURE_PREJIT
-#define BFA_MISSING_IBC_EXTERNAL_TYPE           0x2400
-#define BFA_MISSING_IBC_EXTERNAL_METHOD         0x2401
-#endif
 
 // Profiler error messages for event log
 #define IDS_E_PROF_NO_CLSID                     0x2500

--- a/src/inc/corcompile.h
+++ b/src/inc/corcompile.h
@@ -1156,11 +1156,11 @@ class ICorCompilePreloader
     // If the class or method is generic, instantiate all parameters with <object>
     virtual CORINFO_METHOD_HANDLE LookupMethodDef(mdMethodDef token) = 0;
 
+    // For the given ftnHnd fill in the methInfo structure and return true if successful.
+    virtual bool GetMethodInfo(mdMethodDef token, CORINFO_METHOD_HANDLE ftnHnd, CORINFO_METHOD_INFO * methInfo) = 0;
+
     // Returns region that the IL should be emitted in
     virtual CorCompileILRegion GetILRegion(mdMethodDef token) = 0;
-
-    // Find the (parameterized) type for the given blob from the profile data
-    virtual CORINFO_CLASS_HANDLE FindTypeForProfileEntry(CORBBTPROF_BLOB_PARAM_SIG_ENTRY * profileBlobEntry) = 0;
 
     // Find the (parameterized) method for the given blob from the profile data
     virtual CORINFO_METHOD_HANDLE FindMethodForProfileEntry(CORBBTPROF_BLOB_PARAM_SIG_ENTRY * profileBlobEntry) = 0;

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -7374,7 +7374,9 @@ mdMethodDef Module::LookupIbcMethodToken(TypeHandle enclosingType, mdToken ibcTo
     ibcName.tkEnclosingClass = LookupIbcTypeToken(pExternalModule, ibcName.tkIbcNestedClass, optionalFullNameOut);
        
     if (IsNilToken(ibcName.tkEnclosingClass))
-        THROW_BAD_FORMAT(BFA_MISSING_IBC_EXTERNAL_TYPE, this);
+    {
+        COMPlusThrow(kTypeLoadException, IDS_IBC_MISSING_EXTERNAL_TYPE);
+    }
 
     if (optionalFullNameOut != NULL)
     {
@@ -7434,100 +7436,7 @@ mdMethodDef Module::LookupIbcMethodToken(TypeHandle enclosingType, mdToken ibcTo
     return mdResult;
 }
 
-void Module::IBCTypeLoadFailed(CORBBTPROF_BLOB_PARAM_SIG_ENTRY *pBlobSigEntry, 
-                               SString& exceptionMessage, SString* typeNameError)
-{
-    CONTRACTL
-    {
-        THROWS;
-        GC_TRIGGERS;
-        MODE_ANY;
-        INJECT_FAULT(COMPlusThrowOM());
-        PRECONDITION(CheckPointer(pBlobSigEntry));
-    }
-    CONTRACTL_END
-
-    //
-    // Print an error message for the type load failure
-    // 
-    StackSString msg(W("Failed to load type token "));
-    SString typeName;
-
-    char buff[16];
-    sprintf_s(buff, COUNTOF(buff), "%08x", pBlobSigEntry->blob.token); 
-    StackSString szToken(SString::Ascii, &buff[0]);
-    msg += szToken;
-
-    if (!exceptionMessage.IsEmpty())
-    {
-        if ((typeNameError != NULL) && !typeNameError->IsEmpty())
-        {
-            msg += W(" for the profile data in ");
-            msg.Append(exceptionMessage);
-            msg += W(".");
-
-            msg += W("  The type was ");
-            msg.Append(*typeNameError);
-            msg += W(".");
-        }
-        else
-        {
-            msg += W(" from profile data. The error is ");
-            msg.Append(exceptionMessage);
-        }
-    }
-    msg += W("\n");
-
-    GetSvcLogger()->Log(msg, LogLevel_Info);
-}
-
-void Module::IBCMethodLoadFailed(CORBBTPROF_BLOB_PARAM_SIG_ENTRY *pBlobSigEntry, 
-                                 SString& exceptionMessage, SString* methodNameError)
-{
-    CONTRACTL
-    {
-        THROWS;
-        GC_TRIGGERS;
-        MODE_ANY;
-        INJECT_FAULT(COMPlusThrowOM());
-        PRECONDITION(CheckPointer(pBlobSigEntry));
-    }
-    CONTRACTL_END
-
-    //
-    // Print an error message for the type load failure
-    // 
-    StackSString msg(W("Failed to load method token "));
-
-    char buff[16];
-    sprintf_s(buff, COUNTOF(buff), "%08x", pBlobSigEntry->blob.token); 
-    StackSString szToken(SString::Ascii, &buff[0]);
-    msg += szToken;
-
-    if (!exceptionMessage.IsEmpty())
-    {
-        if ((methodNameError != NULL) && !methodNameError->IsEmpty())
-        {
-            msg += W(" for the profile data in ");
-            msg.Append(exceptionMessage);
-            msg += W(".");
-
-            msg += W("  The method was ");
-            msg.Append(*methodNameError);
-            msg += W(".\n");
-        }
-        else
-        {
-            msg += W(" from profile data. The error is ");
-            msg.Append(exceptionMessage);
-        }
-    }
-    msg += W("\n");
-
-    GetSvcLogger()->Log(msg, LogLevel_Info);
-}
-
-TypeHandle Module::LoadIBCTypeHelper(CORBBTPROF_BLOB_PARAM_SIG_ENTRY *pBlobSigEntry)
+TypeHandle Module::LoadIBCTypeHelper(DataImage *image, CORBBTPROF_BLOB_PARAM_SIG_ENTRY *pBlobSigEntry)
 {
     CONTRACT(TypeHandle)
     {
@@ -7568,11 +7477,7 @@ TypeHandle Module::LoadIBCTypeHelper(CORBBTPROF_BLOB_PARAM_SIG_ENTRY *pBlobSigEn
     }
     EX_CATCH
     {
-        CONTRACT_VIOLATION(ThrowsViolation);
-
-        StackSString exceptionMessage;
-        GET_EXCEPTION()->GetMessage(exceptionMessage);
-        IBCTypeLoadFailed(pBlobSigEntry, exceptionMessage, nullptr);
+        image->GetPreloader()->Error(pBlobSigEntry->blob.token, GET_EXCEPTION());
         loadedType = TypeHandle();
     }
     EX_END_CATCH(SwallowAllExceptions)
@@ -7582,7 +7487,7 @@ TypeHandle Module::LoadIBCTypeHelper(CORBBTPROF_BLOB_PARAM_SIG_ENTRY *pBlobSigEn
 
 //---------------------------------------------------------------------------------------
 // 
-MethodDesc* Module::LoadIBCMethodHelper(CORBBTPROF_BLOB_PARAM_SIG_ENTRY * pBlobSigEntry)
+MethodDesc* Module::LoadIBCMethodHelper(DataImage *image, CORBBTPROF_BLOB_PARAM_SIG_ENTRY * pBlobSigEntry)
 {
     CONTRACT(MethodDesc*)
     {
@@ -7629,11 +7534,7 @@ MethodDesc* Module::LoadIBCMethodHelper(CORBBTPROF_BLOB_PARAM_SIG_ENTRY * pBlobS
     }
     EX_CATCH
     {
-        CONTRACT_VIOLATION(ThrowsViolation);
-
-        StackSString exceptionMessage;
-        GET_EXCEPTION()->GetMessage(exceptionMessage);
-        IBCTypeLoadFailed(pBlobSigEntry, exceptionMessage, nullptr);
+        image->GetPreloader()->Error(pBlobSigEntry->blob.token, GET_EXCEPTION());
         enclosingType = TypeHandle();
     }
     EX_END_CATCH(SwallowAllExceptions)
@@ -7697,10 +7598,9 @@ MethodDesc* Module::LoadIBCMethodHelper(CORBBTPROF_BLOB_PARAM_SIG_ENTRY * pBlobS
 
                 if (IsNilToken(methodToken))
                 {
-                    THROW_BAD_FORMAT(BFA_MISSING_IBC_EXTERNAL_METHOD, this);
+                    COMPlusThrow(kTypeLoadException, IDS_IBC_MISSING_EXTERNAL_METHOD);
                 }
             }
-
 
             SigTypeContext methodTypeContext( enclosingType );
             pMethod = MemberLoader::GetMethodDescFromMemberDefOrRefOrSpec(
@@ -7727,13 +7627,23 @@ MethodDesc* Module::LoadIBCMethodHelper(CORBBTPROF_BLOB_PARAM_SIG_ENTRY * pBlobS
 
             for (DWORD i = 0; i < nargs; i++)
             {
-                pInst[i] = p.GetTypeHandleThrowing( this,
+                TypeHandle curInst;
+
+                curInst = p.GetTypeHandleThrowing( this,
                               &typeContext,
                               ClassLoader::LoadTypes,
                               CLASS_LOADED,
                               FALSE,
                               NULL,
                               pZapSigContext);
+
+                // curInst will be nullptr when the type fails the versioning bubble check
+                if (curInst.IsNull() && IsReadyToRunCompilation())
+                {
+                    COMPlusThrow(kTypeLoadException, IDS_IBC_MISSING_EXTERNAL_TYPE);
+                }
+
+                pInst[i] = curInst;
                 IfFailThrow(p.SkipExactlyOne());
             }
 
@@ -7744,26 +7654,26 @@ MethodDesc* Module::LoadIBCMethodHelper(CORBBTPROF_BLOB_PARAM_SIG_ENTRY * pBlobS
             inst = pMethod->LoadMethodInstantiation();
         }
 
+        // We should now be able to create an instantiation for this generic method
+
         // This must be called even if nargs == 0, in order to create an instantiating
         // stub for static methods in generic classees if needed, also for BoxedEntryPointStubs
         // in non-generic structs.
+        const bool allowInstParam = !(isInstantiatingStub || isUnboxingStub);
+
         pMethod = MethodDesc::FindOrCreateAssociatedMethodDesc(pMethod, pOwnerMT,
-                                                               isUnboxingStub,
-                                                               inst,
-                                                               !(isInstantiatingStub || isUnboxingStub));
+                                                               isUnboxingStub, 
+                                                               inst, allowInstParam);
 
 #if defined(_DEBUG) && !defined(DACCESS_COMPILE)
         g_pConfig->DebugCheckAndForceIBCFailure(EEConfig::CallSite_3);
 #endif
-
     }
     EX_CATCH
     {
-        CONTRACT_VIOLATION(ThrowsViolation);
-
-        StackSString exceptionMessage;
-        GET_EXCEPTION()->GetMessage(exceptionMessage);
-        IBCMethodLoadFailed(pBlobSigEntry, exceptionMessage, nullptr);
+        // Catch any kTypeLoadException that we may have thrown above
+        //
+        image->GetPreloader()->Error(pBlobSigEntry->blob.token, GET_EXCEPTION());
         pMethod = NULL;
     }
     EX_END_CATCH(SwallowAllExceptions)
@@ -8066,7 +7976,8 @@ void Module::ExpandAll(DataImage *image)
     //
     // Load all the reported parameterized types and methods
     //
-    CORBBTPROF_BLOB_ENTRY *pBlobEntry = GetProfileData()->GetBlobStream();
+    CorProfileData *  profileData = this->GetProfileData();
+    CORBBTPROF_BLOB_ENTRY *pBlobEntry = profileData->GetBlobStream();
     
     if (pBlobEntry != NULL)
     {
@@ -8077,7 +7988,8 @@ void Module::ExpandAll(DataImage *image)
                 _ASSERTE(pBlobEntry->type == ParamTypeSpec);
                 CORBBTPROF_BLOB_PARAM_SIG_ENTRY *pBlobSigEntry = (CORBBTPROF_BLOB_PARAM_SIG_ENTRY *) pBlobEntry;
 
-                TypeHandle th = LoadIBCTypeHelper(pBlobSigEntry);
+                TypeHandle th = LoadIBCTypeHelper(image, pBlobSigEntry);
+
                 if (!th.IsNull())
                 {
                     image->GetPreloader()->TriageTypeForZap(th, TRUE);
@@ -8088,17 +8000,13 @@ void Module::ExpandAll(DataImage *image)
                 _ASSERTE(pBlobEntry->type == ParamMethodSpec);
                 CORBBTPROF_BLOB_PARAM_SIG_ENTRY *pBlobSigEntry = (CORBBTPROF_BLOB_PARAM_SIG_ENTRY *) pBlobEntry;
                 
-                MethodDesc *pMD = LoadIBCMethodHelper(pBlobSigEntry);
-                if (pMD != NULL)
-                {
-                    image->GetPreloader()->TriageMethodForZap(pMD, TRUE);
-                }
+                MethodDesc *pMD = LoadIBCMethodHelper(image, pBlobSigEntry);
             }
             pBlobEntry = pBlobEntry->GetNextEntry();
         }
         _ASSERTE(pBlobEntry->type == EndOfBlobStream);
     }
-    
+
     {
         //
         // Fill out MemberRef RID map and va sig cookies for
@@ -8715,7 +8623,7 @@ void Module::Save(DataImage *image)
                             if (pBlobEntry->token == token)
                             {
                                 CORBBTPROF_BLOB_PARAM_SIG_ENTRY *pBlobSigEntry = (CORBBTPROF_BLOB_PARAM_SIG_ENTRY *) pBlobEntry;
-                                TypeHandle th = LoadIBCTypeHelper(pBlobSigEntry);
+                                TypeHandle th = LoadIBCTypeHelper(image, pBlobSigEntry);
                                 
                                 if (!th.IsNull())
                                 {
@@ -9474,7 +9382,7 @@ void Module::Arrange(DataImage *image)
                     //
                     // decode generic type signature
                     //
-                    TypeHandle th = LoadIBCTypeHelper(pBlobSigEntry);
+                    TypeHandle th = LoadIBCTypeHelper(image, pBlobSigEntry);
 
                     //
                     // Place a hot instantiated type and it's data
@@ -9542,7 +9450,7 @@ void Module::Arrange(DataImage *image)
                 else // (pBlobSigEntry  != NULL)
                 {
                     _ASSERTE(pBlobSigEntry->blob.token == token);
-                    MethodDesc * pMD = LoadIBCMethodHelper(pBlobSigEntry);
+                    MethodDesc * pMD = LoadIBCMethodHelper(image, pBlobSigEntry);
                     
                     if (pMD != NULL)
                     {

--- a/src/vm/ceeload.h
+++ b/src/vm/ceeload.h
@@ -2936,17 +2936,11 @@ public:
     void SetProfileData(CorProfileData * profileData);
     CorProfileData *GetProfileData();
 
-
     mdTypeDef     LookupIbcTypeToken(  Module *   pExternalModule, mdToken ibcToken, SString* optionalFullNameOut = NULL);
     mdMethodDef   LookupIbcMethodToken(TypeHandle enclosingType,   mdToken ibcToken, SString* optionalFullNameOut = NULL);
 
-    void          IBCTypeLoadFailed(  CORBBTPROF_BLOB_PARAM_SIG_ENTRY *pBlobSigEntry, 
-                                      SString& exceptionMessage, SString* typeNameError);
-    void          IBCMethodLoadFailed(CORBBTPROF_BLOB_PARAM_SIG_ENTRY *pBlobSigEntry, 
-                                      SString& exceptionMessage, SString* typeNameError);
-
-    TypeHandle    LoadIBCTypeHelper(  CORBBTPROF_BLOB_PARAM_SIG_ENTRY *pBlobSigEntry);
-    MethodDesc *  LoadIBCMethodHelper(CORBBTPROF_BLOB_PARAM_SIG_ENTRY *pBlobSigEntry);
+    TypeHandle    LoadIBCTypeHelper(DataImage *image, CORBBTPROF_BLOB_PARAM_SIG_ENTRY *pBlobSigEntry);
+    MethodDesc *  LoadIBCMethodHelper(DataImage *image, CORBBTPROF_BLOB_PARAM_SIG_ENTRY *pBlobSigEntry);
  
 
     void ExpandAll(DataImage *image);

--- a/src/vm/compile.h
+++ b/src/vm/compile.h
@@ -637,10 +637,10 @@ public:
     void NoteDeduplicatedCode(CORINFO_METHOD_HANDLE method, CORINFO_METHOD_HANDLE duplicateMethod);
 
     CORINFO_METHOD_HANDLE LookupMethodDef(mdMethodDef token);
+    bool GetMethodInfo(mdMethodDef token, CORINFO_METHOD_HANDLE ftnHnd, CORINFO_METHOD_INFO * methInfo);
 
     CorCompileILRegion GetILRegion(mdMethodDef token);
 
-    CORINFO_CLASS_HANDLE  FindTypeForProfileEntry(CORBBTPROF_BLOB_PARAM_SIG_ENTRY * profileBlobEntry);
     CORINFO_METHOD_HANDLE FindMethodForProfileEntry(CORBBTPROF_BLOB_PARAM_SIG_ENTRY * profileBlobEntry);
 
     void ReportInlining(CORINFO_METHOD_HANDLE inliner, CORINFO_METHOD_HANDLE inlinee);

--- a/src/vm/siginfo.cpp
+++ b/src/vm/siginfo.cpp
@@ -1200,8 +1200,6 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
             PREFIX_ASSUME(pZapSigContext != NULL);
             pModule = pZapSigContext->GetZapSigModule()->GetModuleFromIndex(ix);
 
-            // For ReadyToRunCompilation we return a null TypeHandle when we reference a non-local module
-            //
             if ((pModule != NULL) && pModule->IsInCurrentVersionBubble())
             {
                 thRet = psig.GetTypeHandleThrowing(pModule, 
@@ -1211,6 +1209,12 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
                                                    dropGenericArgumentLevel,
                                                    pSubst, 
                                                    pZapSigContext);
+            }
+            else
+            {
+                // For ReadyToRunCompilation we return a null TypeHandle when we reference a non-local module
+                //
+                thRet = TypeHandle();
             }
 #else
             DacNotImpl();
@@ -1466,7 +1470,7 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
                
                 if (IsNilToken(typeToken))
                 {
-                    THROW_BAD_FORMAT(BFA_MISSING_IBC_EXTERNAL_TYPE, pOrigModule);
+                    COMPlusThrow(kTypeLoadException, IDS_IBC_MISSING_EXTERNAL_TYPE);
                 }
             }
 #endif
@@ -1768,7 +1772,7 @@ TypeHandle SigPointer::GetGenericInstType(Module *        pModule,
 
             if (IsNilToken(typeToken))
             {
-                THROW_BAD_FORMAT(BFA_MISSING_IBC_EXTERNAL_TYPE, pOrigModule);
+                COMPlusThrow(kTypeLoadException, IDS_IBC_MISSING_EXTERNAL_TYPE);
             }
         }
 #endif

--- a/src/vm/typehash.cpp
+++ b/src/vm/typehash.cpp
@@ -716,7 +716,7 @@ void EETypeHashTable::Save(DataImage *image, Module *module, CorProfileData *pro
                     {
                         if (flags & (1<<ReadTypeHashTable))
                         {
-                            TypeHandle th = GetModule()->LoadIBCTypeHelper(pBlobSigEntry);
+                            TypeHandle th = GetModule()->LoadIBCTypeHelper(image, pBlobSigEntry);
 #if defined(_DEBUG) && !defined(DACCESS_COMPILE)
                             g_pConfig->DebugCheckAndForceIBCFailure(EEConfig::CallSite_8);
 #endif

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -3586,7 +3586,7 @@ void ZapInfo::getMethodSig(CORINFO_METHOD_HANDLE ftn, CORINFO_SIG_INFO *sig,CORI
 
 bool ZapInfo::getMethodInfo(CORINFO_METHOD_HANDLE ftn,CORINFO_METHOD_INFO* info)
 {
-    bool result = m_pEEJitInfo->getMethodInfo(ftn, info);
+    bool result = m_pImage->m_pPreloader->GetMethodInfo(m_currentMethodToken, ftn, info);
     info->regionKind = m_pImage->GetCurrentRegionKind();
     return result;
 }


### PR DESCRIPTION
Catch any exception on the VM side of the interface call and report the error to the zapper using an Error() function call rather than throwing exceptions across the interface call.

The interface methods LoadIBCTypeHelper and LoadIBCMethodHelper no longer need a ThrowsViolation in their contracts.

Instead of using BAD_FORMAT exceptions for a failures to load IBC data type and methods, we now
throw TypeLoad exception.