### PR TITLE
[CoreCLR] Display the contents of init-tools.log

### DIFF
--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -19,7 +19,7 @@ if [%1]==[force] (
   if exist "%PACKAGES_DIR%Microsoft.DotNet.BuildTools" rmdir /S /Q "%PACKAGES_DIR%Microsoft.DotNet.BuildTools"
 )
 
-:: If sempahore exists do nothing
+:: If semaphore exists do nothing
 if exist "%BUILD_TOOLS_SEMAPHORE%" (
   echo Tools are already initialized.
   goto :EOF
@@ -46,8 +46,8 @@ set DOTNET_LOCAL_PATH=%DOTNET_PATH%%DOTNET_ZIP_NAME%
 echo Installing '%DOTNET_REMOTE_PATH%' to '%DOTNET_LOCAL_PATH%' >> "%INIT_TOOLS_LOG%"
 powershell -NoProfile -ExecutionPolicy unrestricted -Command "$retryCount = 0; $success = $false; do { try { (New-Object Net.WebClient).DownloadFile('%DOTNET_REMOTE_PATH%', '%DOTNET_LOCAL_PATH%'); $success = $true; } catch { if ($retryCount -ge 6) { throw; } else { $retryCount++; Start-Sleep -Seconds (5 * $retryCount); } } } while ($success -eq $false); Add-Type -Assembly 'System.IO.Compression.FileSystem' -ErrorVariable AddTypeErrors; if ($AddTypeErrors.Count -eq 0) { [System.IO.Compression.ZipFile]::ExtractToDirectory('%DOTNET_LOCAL_PATH%', '%DOTNET_PATH%') } else { (New-Object -com shell.application).namespace('%DOTNET_PATH%').CopyHere((new-object -com shell.application).namespace('%DOTNET_LOCAL_PATH%').Items(),16) }" >> "%INIT_TOOLS_LOG%"
 if NOT exist "%DOTNET_LOCAL_PATH%" (
-  echo ERROR: Could not install dotnet cli correctly. See '%INIT_TOOLS_LOG%' for more details. 1>&2
-  exit /b 1
+  echo ERROR: Could not install dotnet cli correctly. 1>&2
+  goto :error
 )
 
 :afterdotnetrestore
@@ -57,8 +57,8 @@ echo Restoring BuildTools version %BUILDTOOLS_VERSION%...
 echo Running: "%DOTNET_CMD%" restore "%INIT_TOOLS_RESTORE_PROJECT%" --no-cache --packages %PACKAGES_DIR% --source "%BUILDTOOLS_SOURCE%" /p:BuildToolsPackageVersion=%BUILDTOOLS_VERSION% >> "%INIT_TOOLS_LOG%"
 call "%DOTNET_CMD%" restore "%INIT_TOOLS_RESTORE_PROJECT%" --no-cache --packages %PACKAGES_DIR% --source "%BUILDTOOLS_SOURCE%" /p:BuildToolsPackageVersion=%BUILDTOOLS_VERSION% >> "%INIT_TOOLS_LOG%"
 if NOT exist "%BUILD_TOOLS_PATH%init-tools.cmd" (
-  echo ERROR: Could not restore build tools correctly. See '%INIT_TOOLS_LOG%' for more details. 1>&2
-  exit /b 1
+  echo ERROR: Could not restore build tools correctly. 1>&2
+  goto :error
 )
 
 :afterbuildtoolsrestore
@@ -68,14 +68,19 @@ echo Running: "%BUILD_TOOLS_PATH%init-tools.cmd" "%~dp0" "%DOTNET_CMD%" "%TOOLRU
 call "%BUILD_TOOLS_PATH%init-tools.cmd" "%~dp0" "%DOTNET_CMD%" "%TOOLRUNTIME_DIR%" >> "%INIT_TOOLS_LOG%"
 set INIT_TOOLS_ERRORLEVEL=%ERRORLEVEL%
 if not [%INIT_TOOLS_ERRORLEVEL%]==[0] (
-  echo ERROR: An error occured when trying to initialize the tools. Please check '%INIT_TOOLS_LOG%' for more details. 1>&2
-  exit /b %INIT_TOOLS_ERRORLEVEL%
+  echo ERROR: An error occured when trying to initialize the tools. 1>&2
+  goto :error
 )
 
-:: Create sempahore file
+:: Create semaphore file
 echo Done initializing tools.
 if NOT exist "%BUILD_TOOLS_SEMAPHORE_DIR%" (
 	mkdir "%BUILD_TOOLS_SEMAPHORE_DIR%"
 )
 echo Init-Tools.cmd completed for BuildTools Version: %BUILDTOOLS_VERSION% > "%BUILD_TOOLS_SEMAPHORE%"
 exit /b 0
+
+:error
+echo Please check the detailed log that follows. 1>&2
+type "%INIT_TOOLS_LOG%" 1>&2
+exit /b 1

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -40,6 +40,12 @@ OSName=$(uname -s)
   esac
 fi
 
+display_error_message()
+{
+    echo "Please check the detailed log that follows." 1>&2
+    cat "$__init_tools_log" 1>&2
+}
+
 if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
     __PATCH_CLI_NUGET_FRAMEWORKS=0
 
@@ -88,7 +94,10 @@ if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
             echo "Restoring BuildTools version $__BUILD_TOOLS_PACKAGE_VERSION..."
             echo "Running: $__DOTNET_CMD restore \"$__INIT_TOOLS_RESTORE_PROJECT\" --no-cache --packages $__PACKAGES_DIR --source $__BUILDTOOLS_SOURCE /p:BuildToolsPackageVersion=$__BUILD_TOOLS_PACKAGE_VERSION" >> $__init_tools_log
             $__DOTNET_CMD restore "$__INIT_TOOLS_RESTORE_PROJECT" --no-cache --packages $__PACKAGES_DIR --source $__BUILDTOOLS_SOURCE /p:BuildToolsPackageVersion=$__BUILD_TOOLS_PACKAGE_VERSION >> $__init_tools_log
-            if [ ! -e "$__BUILD_TOOLS_PATH/init-tools.sh" ]; then echo "ERROR: Could not restore build tools correctly. See '$__init_tools_log' for more details."1>&2; fi
+            if [ ! -e "$__BUILD_TOOLS_PATH/init-tools.sh" ]; then
+                echo "ERROR: Could not restore build tools correctly." 1>&2
+                display_error_message
+            fi
         fi
 
         echo "Initializing BuildTools..."
@@ -98,7 +107,8 @@ if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
         chmod +x $__BUILD_TOOLS_PATH/init-tools.sh
         $__BUILD_TOOLS_PATH/init-tools.sh $__scriptpath $__DOTNET_CMD $__TOOLRUNTIME_DIR >> $__init_tools_log
         if [ "$?" != "0" ]; then
-            echo "ERROR: An error occured when trying to initialize the tools. Please check '$__init_tools_log' for more details."1>&2
+            echo "ERROR: An error occurred when trying to initialize the tools." 1>&2
+            display_error_message
             exit 1
         fi
     fi

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -82,7 +82,6 @@ if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
         fi
     fi
 
-
     if [ -n "$BUILD_TOOLS_TOOLSET_DIR" ] && [ -d "$BUILD_TOOLS_TOOLSET_DIR/$__BUILD_TOOLS_PACKAGE_VERSION" ]; then
         echo "Copying $BUILD_TOOLS_TOOLSET_DIR/$__BUILD_TOOLS_PACKAGE_VERSION to $__TOOLRUNTIME_DIR" >> $__init_tools_log
         cp -r $BUILD_TOOLS_TOOLSET_DIR/$__BUILD_TOOLS_PACKAGE_VERSION/* $__TOOLRUNTIME_DIR

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -923,10 +923,13 @@ void GCToEEInterface::StompWriteBarrier(WriteBarrierParameters* args)
         VolatileStore(&g_highest_address, args->highest_address);
         ::StompWriteBarrierResize(true, false);
 
-        // g_ephemeral_low/high aren't needed for the write barrier stomp, but they
-        // are needed in other places.
+        // StompWriteBarrierResize does not necessarily bash g_ephemeral_low
+        // usages, so we must do so here. This is particularly true on x86,
+        // where StompWriteBarrierResize will not bash g_ephemeral_low when
+        // called with the parameters (true, false), as it is above.
         g_ephemeral_low = args->ephemeral_low;
         g_ephemeral_high = args->ephemeral_high;
+        ::StompWriteBarrierEphemeral(true);
         return;
     case WriteBarrierOp::SwitchToWriteWatch:
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP


### PR DESCRIPTION
Though `init-tools` command prepares a detailed log, the console output is minimal.  To investigate a failure of `init-tools`, content of the log will be helpful.  Hence this change attempts to display the content of `init-tools.log` to console.

https://github.com/dotnet/core-eng/issues/1195

@wtgodbe PTAL.