### PR TITLE
Create Windows PDBs from Portable PDBs during symbol archive

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01811-02
+2.0.0-prerelease-01812-02

--- a/buildpipeline/DotNet-Trusted-Publish-Symbols.json
+++ b/buildpipeline/DotNet-Trusted-Publish-Symbols.json
@@ -56,7 +56,7 @@
         "scriptName": "",
         "arguments": "-BuildType $(PB_BuildType) -SymPkgGlob $(PB_AzureContainerSymbolPackageGlob) -Branch $(SourceBranch)",
         "workingFolder": "$(Pipeline.SourcesDirectory)",
-        "inlineScript": "param($BuildType, $SymPkgGlob, $Branch)\nif ($BuildType -ne \"Release\") { exit }\n$archive = $Branch.StartsWith(\"release/\")\n\n$target = \"UnzipSymbolPackagesForPublish\"\nif ($archive) { $target = \"SubmitSymbolsRequest\" }\n\n.\\run.cmd build -- `\n/t:$target `\n/p:SymbolPackagesToPublishGlob=$SymPkgGlob `\n/p:ArchiveSymbols=$archive `\n/v:D",
+        "inlineScript": "param($BuildType, $SymPkgGlob, $Branch)\nif ($BuildType -ne \"Release\") { exit }\n$archive = $Branch.StartsWith(\"release/\")\n\n$target = \"GetAllSymbolFilesToPublish\"\nif ($archive) { $target = \"SubmitSymbolsRequest\" }\n\n.\\run.cmd build -- `\n/t:$target `\n/p:SymbolPackagesToPublishGlob=$SymPkgGlob `\n/p:ArchiveSymbols=$archive `\n/v:D",
         "failOnStandardError": "true"
       }
     },


### PR DESCRIPTION
Update buildtools to get https://github.com/dotnet/buildtools/pull/1605, which automatically creates converted Windows PDBs for any Portable PDBs in the symbol archive build leg.

I changed the target used for master branch builds to `GetAllSymbolFilesToPublish` rather than `UnzipSymbolPackagesForPublish` so that we create converted symbols even if we aren't going to archive them. (We index them on symweb using VSTS Symbol.)

I tried this out on a CoreCLR package set--it made converted copies of SOS.NETCore.pdb and System.Private.CoreLib.pdb for linux-arm, linux-x64, and osx-x64.

See https://github.com/dotnet/corefx/pull/22169

This is part of https://github.com/dotnet/core-eng/issues/698.
Note: the converted symbols won't be put on MyGet yet. https://github.com/dotnet/core-eng/issues/1132 tracks that.