### PR TITLE
Add CGroup CFS CPU limit support

### DIFF
--- a/src/classlibnative/bcltype/system.cpp
+++ b/src/classlibnative/bcltype/system.cpp
@@ -369,6 +369,13 @@ INT32 QCALLTYPE SystemNative::GetProcessorCount()
         processorCount = systemInfo.dwNumberOfProcessors;
     }
 
+#ifdef FEATURE_PAL
+    uint32_t cpuLimit;
+
+    if (PAL_GetCpuLimit(&cpuLimit) && cpuLimit < processorCount)
+        processorCount = cpuLimit;
+#endif
+
     END_QCALL;
 
     return processorCount;

--- a/src/dlls/mscordac/mscordac_unixexports.src
+++ b/src/dlls/mscordac/mscordac_unixexports.src
@@ -22,6 +22,7 @@ PAL_GetResourceString
 PAL_get_stdout
 PAL_get_stderr
 PAL_GetCurrentThread
+PAL_GetCpuLimit
 PAL_GetSymbolModuleBase
 PAL_GetTransportPipeName
 PAL_InitializeDLL

--- a/src/gc/unix/gcenv.unix.cpp
+++ b/src/gc/unix/gcenv.unix.cpp
@@ -66,6 +66,7 @@ static pthread_mutex_t g_flushProcessWriteBuffersMutex;
 
 size_t GetRestrictedPhysicalMemoryLimit();
 bool GetWorkingSetSize(size_t* val);
+bool GetCpuLimit(uint32_t* val);
 
 static size_t g_RestrictedPhysicalMemoryLimit = 0;
 
@@ -507,6 +508,7 @@ bool GCToOSInterface::GetCurrentProcessAffinityMask(uintptr_t* processAffinityMa
 uint32_t GCToOSInterface::GetCurrentProcessCpuCount()
 {
     uintptr_t pmask, smask;
+    uint32_t cpuLimit;
 
     if (!GetCurrentProcessAffinityMask(&pmask, &smask))
         return 1;
@@ -529,6 +531,9 @@ uint32_t GCToOSInterface::GetCurrentProcessCpuCount()
     // maximum of 64 here.
     if (count == 0 || count > 64)
         count = 64;
+
+    if (GetCpuLimit(&cpuLimit) && cpuLimit < count)
+        count = cpuLimit;
 
     return count;
 }

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -2569,6 +2569,11 @@ PALAPI
 PAL_GetWorkingSetSize(size_t* val);
 
 PALIMPORT
+BOOL
+PALAPI
+PAL_GetCpuLimit(UINT* val);
+
+PALIMPORT
 size_t
 PALAPI
 PAL_GetLogicalProcessorCacheSizeFromOS(VOID);

--- a/src/utilcode/util.cpp
+++ b/src/utilcode/util.cpp
@@ -1269,32 +1269,43 @@ int GetCurrentProcessCpuCount()
     if (cCPUs != 0)
         return cCPUs;
 
+    int count = 0;
     DWORD_PTR pmask, smask;
 
     if (!GetProcessAffinityMask(GetCurrentProcess(), &pmask, &smask))
-        return 1;
-
-    pmask &= smask;
-
-    int count = 0;
-    while (pmask)
     {
-        pmask &= (pmask - 1);
-        count++;
+        count = 1;
+    }
+    else
+    {
+        pmask &= smask;
+
+        while (pmask)
+        {
+            pmask &= (pmask - 1);
+            count++;
+        }
+
+        // GetProcessAffinityMask can return pmask=0 and smask=0 on systems with more
+        // than 64 processors, which would leave us with a count of 0.  Since the GC
+        // expects there to be at least one processor to run on (and thus at least one
+        // heap), we'll return 64 here if count is 0, since there are likely a ton of
+        // processors available in that case.  The GC also cannot (currently) handle
+        // the case where there are more than 64 processors, so we will return a
+        // maximum of 64 here.
+        if (count == 0 || count > 64)
+            count = 64;
     }
 
-    // GetProcessAffinityMask can return pmask=0 and smask=0 on systems with more
-    // than 64 processors, which would leave us with a count of 0.  Since the GC
-    // expects there to be at least one processor to run on (and thus at least one
-    // heap), we'll return 64 here if count is 0, since there are likely a ton of
-    // processors available in that case.  The GC also cannot (currently) handle
-    // the case where there are more than 64 processors, so we will return a
-    // maximum of 64 here.
-    if (count == 0 || count > 64)
-        count = 64;
+#ifdef FEATURE_PAL
+    uint32_t cpuLimit;
+
+    if (PAL_GetCpuLimit(&cpuLimit) && cpuLimit < count)
+        count = cpuLimit;
+#endif
 
     cCPUs = count;
-            
+
     return count;
 }
 


### PR DESCRIPTION
Virtualization containers systems (such as Docker, Mesos, Kubernetes...) often relies on cgroup cpu to limit resources.

Currently "Environment.ProcessorCount" in such systems return the physical number of processors. The problem is that this variable is used to properly scale the thread pool.

In our case the cpu limit in Mesos was set to 2 while the machine had 24 processors. Then the application (running a Kestrel HTTP Server) performed very badly and was often irresponsive.

Memory limit was already correctly implemented. Thus it makes sense to do the same for CPU.