### PR TITLE
Fix alignment of MD5Transform reads

### DIFF
--- a/src/utilcode/md5.cpp
+++ b/src/utilcode/md5.cpp
@@ -10,6 +10,7 @@
 #include "stdafx.h"
 
 #include <stdlib.h>
+#include "stdmacros.h"
 #include "md5.h"
 #include "contract.h"
 
@@ -76,7 +77,16 @@ void MD5::HashMore(const void* pvInput, ULONG cbInput)
         // Hash the data in 64-byte runs, starting just after what we've copied
         while (cbInput >= 64)
             {
-            MD5Transform(m_state, (ULONG*)pbInput);
+            if (IS_ALIGNED(pbInput, sizeof(ULONG)))
+                {
+                MD5Transform(m_state, (ULONG*)pbInput);
+                }
+            else
+                {
+                ULONG inputCopy[64 / sizeof(ULONG)];
+                memcpy(inputCopy, pbInput, sizeof(inputCopy));
+                MD5Transform(m_state, inputCopy);
+                }
             pbInput += 64;
             cbInput -= 64;
             }
@@ -212,6 +222,8 @@ void MD5::GetHashValue(MD5HASHDATA* phash)
         {
         STATIC_CONTRACT_NOTHROW;
         STATIC_CONTRACT_GC_NOTRIGGER;
+
+        _ASSERTE(IS_ALIGNED(data, sizeof(ULONG)));
 
         ULONG a=state[0];
         ULONG b=state[1];


### PR DESCRIPTION
This fixes misaligned access on ARMv7 during calculation of MD5 hash for Zap writer.

The following is the backtrace for SIGBUS due to the misaligned access, which is fixed by these changes:
```
0 MD5Transform (state=0xfffef4ac, data=0x79df5e) at src/utilcode/md5.cpp:223
1 MD5::HashMore at src/utilcode/md5.cpp:79
2 ZapFileStream::Write (this=0xfffef4a4, pv=0x79df1e, ...) at zap/zapimage.cpp:843
3 ZapWriter::Write (... p=0x79df1e ...) at src/zap/zapwriter.cpp:357
4 ZapWriter::Write (... pv=0x79c010, cb=174472 ...) at src/zap/zapwriter.cpp:413
```