### PR TITLE
Disable TalcallVerifyWithPrefix test for ARM

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -221,6 +221,9 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall_v4\hijacking\hijacking.cmd">
             <Issue>6217</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Tailcall\TailcallVerifyWithPrefix\TailcallVerifyWithPrefix.cmd">
+            <Issue>2420</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- Tests that need to be triaged for vararg usage as that is not supported -->


### PR DESCRIPTION
For issue https://github.com/dotnet/coreclr/issues/12490

CC @BruceForstall 