### PR TITLE
Mark shift helpers that produce an unused value as such.

### DIFF
--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -1426,6 +1426,11 @@ GenTree* DecomposeLongs::DecomposeShift(LIR::Use& use)
         GenTree* call = m_compiler->gtNewHelperCallNode(helper, TYP_LONG, 0, argList);
         call->gtFlags |= shift->gtFlags & GTF_ALL_EFFECT;
 
+        if ((shift->gtLIRFlags & LIR::Flags::IsUnusedValue) != 0)
+        {
+            call->gtLIRFlags |= LIR::Flags::IsUnusedValue;
+        }
+
         GenTreeCall*    callNode    = call->AsCall();
         ReturnTypeDesc* retTypeDesc = callNode->GetReturnTypeDesc();
         retTypeDesc->InitializeLongReturnType(m_compiler);

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_462274/DevDiv_462274.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_462274/DevDiv_462274.il
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib{}
+.assembly ILGEN_MODULE{}
+.class ILGEN_CLASS
+{
+    .method static int64 ILGEN_METHOD(unsigned int32, float32, unsigned int8, char, int64, float64)
+    {
+       .maxstack  65535
+       .locals init (float64, unsigned int32, int64, int32, unsigned int16, unsigned int64, char, int8, unsigned int32, bool, bool)
+
+        ldc.i8 0xfc7246b593d3e823
+        not
+        neg
+        ldarg 0x0005
+        conv.i2
+        conv.r.un
+        ldarg.s 0x05
+        conv.r4
+        cgt.un
+        nop
+        ldc.i8 0xb230872abaf2c301
+        conv.ovf.i
+        or
+        ldarg.s 0x02
+        conv.r.un
+        conv.ovf.i8.un
+        conv.ovf.u1.un
+        add.ovf.un
+        shl
+        ldloc 0x0004
+        dup
+        ldloc.s 0x08
+        not
+        ceq
+        clt
+        conv.r4
+        pop
+        ldarg.s 0x05
+        conv.ovf.i8.un
+        conv.ovf.i8
+        bgt skip
+        nop
+skip:
+        ldarg 0x0004
+        conv.u8
+        ret
+    }
+
+    .method static int32 Main()
+    {
+        .entrypoint
+
+        .try
+        {
+            ldc.i4 0
+            ldc.r4 0
+            ldc.i4 0
+            dup
+            ldc.i8 0
+            ldc.r8 0
+            call int64 ILGEN_CLASS::ILGEN_METHOD(unsigned int32, float32, unsigned int8, char, int64, float64)
+            pop
+            leave.s done
+        }
+        catch [mscorlib]System.Exception
+        {
+            leave.s done
+        }
+
+    done:
+        ldc.i4 100
+        ret
+    }
+
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_462274/DevDiv_462274.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_462274/DevDiv_462274.ilproj
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_462274.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
Fixes VSO 462274.