### PR TITLE
ARM: Fix return of single element HFA

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -8215,7 +8215,7 @@ GenTreePtr Compiler::impFixupStructReturnType(GenTreePtr op, CORINFO_CLASS_HANDL
 
 #elif FEATURE_MULTIREG_RET && defined(_TARGET_ARM_)
 
-    if (varTypeIsStruct(info.compRetNativeType) && !info.compIsVarArgs && IsHfa(retClsHnd))
+    if (!info.compIsVarArgs && IsHfa(retClsHnd))
     {
         if (op->gtOper == GT_LCL_VAR)
         {


### PR DESCRIPTION
Remove a condition in impFixupStructReturnType() that prevented
single-element HFA returns from being handled properly. The
condition didn't exist in previous JITs.

Fixes #12684