### PR TITLE
Clean up the code that builds uses a bit in LSRA.

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -4016,7 +4016,7 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
 
             // For non-localVar uses we record nothing, as nothing needs to be written back to the tree.
             GenTree* const refPosNode = i->isLocalVar ? useNode : nullptr;
-            RefPosition* pos = newRefPosition(i, currentLoc, RefTypeUse, refPosNode, candidates,
+            RefPosition*   pos        = newRefPosition(i, currentLoc, RefTypeUse, refPosNode, candidates,
                                               locInfo.multiRegIdx DEBUG_ARG(minRegCountForUsePos));
 
             if (delayRegFree)

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3968,30 +3968,17 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
 
             JITDUMP("t%u ", locInfo.loc);
 
-            // for interstitial tree temps, a use is always last and end;
-            // this is  set by default in newRefPosition
-            GenTree* useNode = locInfo.treeNode;
+            // for interstitial tree temps, a use is always last and end; this is set by default in newRefPosition
+            GenTree* const useNode = locInfo.treeNode;
             assert(useNode != nullptr);
-            var_types type        = useNode->TypeGet();
-            regMaskTP candidates  = getUseCandidates(useNode);
-            Interval* i           = locInfo.interval;
-            unsigned  multiRegIdx = locInfo.multiRegIdx;
 
+            Interval* const i = locInfo.interval;
             if (useNode->gtLsraInfo.isTgtPref)
             {
                 prefSrcInterval = i;
             }
 
-            const bool regOptionalAtUse = useNode->IsRegOptional();
-            const bool delayRegFree     = (hasDelayFreeSrc && useNode->gtLsraInfo.isDelayFree);
-
-            assert(isCandidateLocalRef(useNode) == i->isLocalVar);
-            if (!i->isLocalVar)
-            {
-                // For non-localVar uses we record nothing,
-                // as nothing needs to be written back to the tree.
-                useNode = nullptr;
-            }
+            const bool delayRegFree = (hasDelayFreeSrc && useNode->gtLsraInfo.isDelayFree);
 
 #ifdef DEBUG
             // If delayRegFree, then Use will interfere with the destination of
@@ -4024,17 +4011,20 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
             }
 #endif // DEBUG
 
+            regMaskTP candidates = getUseCandidates(useNode);
             assert((candidates & allRegs(i->registerType)) != 0);
-            RefPosition* pos = newRefPosition(i, currentLoc, RefTypeUse, useNode, candidates,
-                                              multiRegIdx DEBUG_ARG(minRegCountForUsePos));
+
+            // For non-localVar uses we record nothing, as nothing needs to be written back to the tree.
+            GenTree* const refPosNode = i->isLocalVar ? useNode : nullptr;
+            RefPosition* pos = newRefPosition(i, currentLoc, RefTypeUse, refPosNode, candidates,
+                                              locInfo.multiRegIdx DEBUG_ARG(minRegCountForUsePos));
 
             if (delayRegFree)
             {
-                hasDelayFreeSrc   = true;
                 pos->delayRegFree = true;
             }
 
-            if (regOptionalAtUse)
+            if (useNode->IsRegOptional())
             {
                 pos->setAllocateIfProfitable(true);
             }


### PR DESCRIPTION
These cleanups are enabled by the recent changes to SIMD8 handling and
the removal of `fixedCandidateMask`.