### PR TITLE
[RyuJIT/ARM32] GT_PUTARG_REG code generation for one-filed structures.

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1000,6 +1000,15 @@ GenTreePtr Lowering::NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntryP
 #endif // FEATURE_MULTIREG_ARGS
 #endif // not defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
             {
+                if ((info->numRegs == 1) && (arg->OperGet() == GT_FIELD_LIST))
+                {
+                    // One-field structures are being wrapped to the GT_PUTARG_REG
+                    GenTreeFieldList* fieldListPtr = arg->AsFieldList();
+                    type                           = fieldListPtr->gtOp.gtOp1->TypeGet();
+
+                    noway_assert(fieldListPtr->Rest() == NULL);
+                }
+
                 putArg = comp->gtNewPutArgReg(type, arg);
             }
         }


### PR DESCRIPTION
Fix for #11783
One-field structures are being wrapped to GT_PUTARG_REG before passing to
GT_CALL instruction. Despite that they have only one field such structs still
contain GT_FIELD_LIST which doesn't being handled proper way in lowering and
code generation.

```C#
namespace HFATest
{
    public struct HFA01
    {
        public float f1;
    }

    public class TestMan
    {
        [MethodImplAttribute(MethodImplOptions.NoInlining)]
        public static float Sum5_HFA01(HFA01 hfa)
        {
            return hfa.f1;
        }

    }

    public class TestCase
    {
        static int Main()
        {
            HFA01 hfa01;
            hfa01.f1 = 1;
            TestMan.Sum5_HFA01(hfa01);

            return 100;
        }
    }
}
```

In example above `hfa01` struct inside method `Main()` will be morphed to the:
```C#
    ▌  PUTARG_REG void   REG NA
    └──▌  FIELD_LIST void   float at offset 0 REG NA $181
    └──▌  LCL_FLD   float  V00 loc0         [+0] NA
    └──▌    float  V00.f1 (offs=0x00) -> V01 tmp0          REG NA $1c0

```
before `TestMan.Sum5_HFA01()` invocation, which cause assertions on codegeneration.

cc @dotnet/arm32-contrib 