### PR TITLE
Improve performance of CancellationToken.Register / CancellationTokenRegistration.Dispose

### DIFF
--- a/src/mscorlib/src/System/Threading/CancellationTokenSource.cs
+++ b/src/mscorlib/src/System/Threading/CancellationTokenSource.cs
@@ -1,94 +1,72 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-#pragma warning disable 0420
 
-//
-////////////////////////////////////////////////////////////////////////////////
-
-using System;
-using System.Security;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
-using System.Runtime;
 
 namespace System.Threading
 {
-    /// <summary>
-    /// Signals to a <see cref="System.Threading.CancellationToken"/> that it should be canceled.
-    /// </summary>
+    /// <summary>Signals to a <see cref="CancellationToken"/> that it should be canceled.</summary>
     /// <remarks>
     /// <para>
-    /// <see cref="T:System.Threading.CancellationTokenSource"/> is used to instantiate a <see
-    /// cref="T:System.Threading.CancellationToken"/>
-    /// (via the source's <see cref="System.Threading.CancellationTokenSource.Token">Token</see> property)
-    /// that can be handed to operations that wish to be notified of cancellation or that can be used to
-    /// register asynchronous operations for cancellation. That token may have cancellation requested by
-    /// calling to the source's <see cref="System.Threading.CancellationTokenSource.Cancel()">Cancel</see>
-    /// method.
+    /// <see cref="CancellationTokenSource"/> is used to instantiate a <see cref="CancellationToken"/> (via
+    /// the source's <see cref="Token">Token</see> property) that can be handed to operations that wish to be
+    /// notified of cancellation or that can be used to register asynchronous operations for cancellation. That
+    /// token may have cancellation requested by calling to the source's <see cref="Cancel()"/> method.
     /// </para>
     /// <para>
-    /// All members of this class, except <see cref="Dispose">Dispose</see>, are thread-safe and may be used
+    /// All members of this class, except <see cref="Dispose"/>, are thread-safe and may be used
     /// concurrently from multiple threads.
     /// </para>
     /// </remarks>
-
     public class CancellationTokenSource : IDisposable
     {
-        //static sources that can be used as the backing source for 'fixed' CancellationTokens that never change state.
-        private static readonly CancellationTokenSource _staticSource_Set = new CancellationTokenSource(true);
-        private static readonly CancellationTokenSource _staticSource_NotCancelable = new CancellationTokenSource(false);
+        /// <summary>A <see cref="CancellationTokenSource"/> that's already canceled.</summary>
+        internal static readonly CancellationTokenSource s_canceledSource = new CancellationTokenSource() { _state = NotifyingCompleteState };
+        /// <summary>A <see cref="CancellationTokenSource"/> that's never canceled.  This isn't enforced programmatically, only by usage.  Do not cancel!</summary>
+        internal static readonly CancellationTokenSource s_neverCanceledSource = new CancellationTokenSource();
 
-        //Note: the callback lists array is only created on first registration.
-        //      the actual callback lists are only created on demand.
-        //      Storing a registered callback costs around >60bytes, hence some overhead for the lists array is OK
-        // At most 24 lists seems reasonable, and caps the cost of the listsArray to 96bytes(32-bit,24-way) or 192bytes(64-bit,24-way).
-        private static readonly int s_nLists = (PlatformHelper.ProcessorCount > 24) ? 24 : PlatformHelper.ProcessorCount;
+        /// <summary>Delegate used with <see cref="Timer"/> to trigger cancellation of a <see cref="CancellationTokenSource"/>.</summary>
+        private static readonly TimerCallback s_timerCallback = obj =>
+            ((CancellationTokenSource)obj).NotifyCancellation(throwOnFirstException: false); // skip ThrowIfDisposed() check in Cancel()
 
-        private volatile ManualResetEvent m_kernelEvent; //lazily initialized if required.
+        /// <summary>The number of callback partitions to use in a <see cref="CancellationTokenSource"/>. Must be a power of 2.</summary>
+        private static readonly int s_numPartitions = GetPartitionCount();
+        /// <summary><see cref="s_numPartitions"/> - 1, used to quickly mod into <see cref="_callbackPartitions"/>.</summary>
+        private static readonly int s_numPartitionsMask = s_numPartitions - 1;
 
-        private volatile SparselyPopulatedArray<CancellationCallbackInfo>[] m_registeredCallbacksLists;
+        /// <summary>The current state of the CancellationTokenSource.</summary>
+        private volatile int _state;
+        /// <summary>The ID of the thread currently executing the main body of CTS.Cancel()</summary>
+        /// <remarks>
+        /// This helps us to know if a call to ctr.Dispose() is running 'within' a cancellation callback.
+        /// This is updated as we move between the main thread calling cts.Cancel() and any syncContexts
+        /// that are used to actually run the callbacks.
+        /// </remarks>
+        private volatile int _threadIDExecutingCallbacks = -1;
+        /// <summary>Tracks the running callback to assist ctr.Dispose() to wait for the target callback to complete.</summary>
+        private long _executingCallbackId;
+        /// <summary>Partitions of callbacks.  Split into multiple partitions to help with scalability of registering/unregistering; each is protected by its own lock.</summary>
+        private volatile CallbackPartition[] _callbackPartitions;
+        /// <summary>Timer used by CancelAfter and Timer-related ctors.</summary>
+        private volatile Timer _timer;
+        /// <summary><see cref="System.Threading.WaitHandle"/> lazily initialized and returned from <see cref="WaitHandle"/>.</summary>
+        private volatile ManualResetEvent _kernelEvent;
+        /// <summary>Whether this <see cref="CancellationTokenSource"/> has been disposed.</summary>
+        private bool _disposed;
 
-        // legal values for m_state
-        private const int CANNOT_BE_CANCELED = 0;
-        private const int NOT_CANCELED = 1;
-        private const int NOTIFYING = 2;
-        private const int NOTIFYINGCOMPLETE = 3;
+        // legal values for _state
+        private const int NotCanceledState = 1;
+        private const int NotifyingState = 2;
+        private const int NotifyingCompleteState = 3;
 
-        //m_state uses the pattern "volatile int32 reads, with cmpxch writes" which is safe for updates and cannot suffer torn reads.
-        private volatile int m_state;
-
-
-        /// The ID of the thread currently executing the main body of CTS.Cancel()
-        /// this helps us to know if a call to ctr.Dispose() is running 'within' a cancellation callback.
-        /// This is updated as we move between the main thread calling cts.Cancel() and any syncContexts that are used to 
-        /// actually run the callbacks.
-        private volatile int m_threadIDExecutingCallbacks = -1;
-
-        private bool m_disposed;
-
-        // we track the running callback to assist ctr.Dispose() to wait for the target callback to complete.
-        private volatile CancellationCallbackInfo m_executingCallback;
-
-        // provided for CancelAfter and timer-related constructors
-        private volatile Timer m_timer;
-
-        // ---------------------- 
-        // ** public properties
-
-        /// <summary>
-        /// Gets whether cancellation has been requested for this <see
-        /// cref="System.Threading.CancellationTokenSource">CancellationTokenSource</see>.
-        /// </summary>
-        /// <value>Whether cancellation has been requested for this <see
-        /// cref="System.Threading.CancellationTokenSource">CancellationTokenSource</see>.</value>
+        /// <summary>Gets whether cancellation has been requested for this <see cref="CancellationTokenSource" />.</summary>
+        /// <value>Whether cancellation has been requested for this <see cref="CancellationTokenSource" />.</value>
         /// <remarks>
         /// <para>
         /// This property indicates whether cancellation has been requested for this token source, such as
-        /// due to a call to its
-        /// <see cref="System.Threading.CancellationTokenSource.Cancel()">Cancel</see> method.
+        /// due to a call to its <see cref="Cancel()"/> method.
         /// </para>
         /// <para>
         /// If this property returns true, it only guarantees that cancellation has been requested. It does not
@@ -98,44 +76,24 @@ namespace System.Threading
         /// canceled concurrently.
         /// </para>
         /// </remarks>
-        public bool IsCancellationRequested
-        {
-            get { return m_state >= NOTIFYING; }
-        }
+        public bool IsCancellationRequested => _state >= NotifyingState;
 
-        /// <summary>
-        /// A simple helper to determine whether cancellation has finished.
-        /// </summary>
-        internal bool IsCancellationCompleted
-        {
-            get { return m_state == NOTIFYINGCOMPLETE; }
-        }
+        /// <summary>A simple helper to determine whether cancellation has finished.</summary>
+        internal bool IsCancellationCompleted => _state == NotifyingCompleteState;
 
-        /// <summary>
-        /// A simple helper to determine whether disposal has occurred.
-        /// </summary>
-        internal bool IsDisposed
-        {
-            get { return m_disposed; }
-        }
+        /// <summary>A simple helper to determine whether disposal has occurred.</summary>
+        internal bool IsDisposed => _disposed;
 
-        /// <summary>
-        /// The ID of the thread that is running callbacks.
-        /// </summary>
+        /// <summary>The ID of the thread that is running callbacks.</summary>
         internal int ThreadIDExecutingCallbacks
         {
-            set { m_threadIDExecutingCallbacks = value; }
-            get { return m_threadIDExecutingCallbacks; }
+            get => _threadIDExecutingCallbacks;
+            set => _threadIDExecutingCallbacks = value;
         }
 
-        /// <summary>
-        /// Gets the <see cref="System.Threading.CancellationToken">CancellationToken</see>
-        /// associated with this <see cref="CancellationTokenSource"/>.
-        /// </summary>
-        /// <value>The <see cref="System.Threading.CancellationToken">CancellationToken</see>
-        /// associated with this <see cref="CancellationTokenSource"/>.</value>
-        /// <exception cref="T:System.ObjectDisposedException">The token source has been
-        /// disposed.</exception>
+        /// <summary>Gets the <see cref="CancellationToken"/> associated with this <see cref="CancellationTokenSource"/>.</summary>
+        /// <value>The <see cref="CancellationToken"/> associated with this <see cref="CancellationTokenSource"/>.</value>
+        /// <exception cref="ObjectDisposedException">The token source has been disposed.</exception>
         public CancellationToken Token
         {
             get
@@ -145,35 +103,23 @@ namespace System.Threading
             }
         }
 
-        // ---------------------- 
-        // ** internal and private properties.
-
-        /// <summary>
-        ///
-        /// </summary>
-        internal bool CanBeCanceled
-        {
-            get { return m_state != CANNOT_BE_CANCELED; }
-        }
-
-        /// <summary>
-        ///
-        /// </summary>
         internal WaitHandle WaitHandle
         {
             get
             {
                 ThrowIfDisposed();
 
-                // fast path if already allocated.
-                if (m_kernelEvent != null)
-                    return m_kernelEvent;
-
-                // lazy-init the mre.
-                ManualResetEvent mre = new ManualResetEvent(false);
-                if (Interlocked.CompareExchange(ref m_kernelEvent, mre, null) != null)
+                // Return the handle if it was already allocated.
+                if (_kernelEvent != null)
                 {
-                    ((IDisposable)mre).Dispose();
+                    return _kernelEvent;
+                }
+
+                // Lazily-initialize the handle.
+                var mre = new ManualResetEvent(false);
+                if (Interlocked.CompareExchange(ref _kernelEvent, mre, null) != null)
+                {
+                    mre.Dispose();
                 }
 
                 // There is a race condition between checking IsCancellationRequested and setting the event.
@@ -181,97 +127,44 @@ namespace System.Threading
                 //   1. if IsCancellationRequested = true, then we will call Set()
                 //   2. if IsCancellationRequested = false, then NotifyCancellation will see that the event exists, and will call Set().
                 if (IsCancellationRequested)
-                    m_kernelEvent.Set();
-
-                return m_kernelEvent;
-            }
-        }
-
-
-        /// <summary>
-        /// The currently executing callback
-        /// </summary>
-        internal CancellationCallbackInfo ExecutingCallback
-        {
-            get { return m_executingCallback; }
-        }
-
-#if DEBUG
-        /// <summary>
-        /// Used by the dev unit tests to check the number of outstanding registrations.
-        /// They use private reflection to gain access.  Because this would be dead retail
-        /// code, however, it is ifdef'd out to work only in debug builds.
-        /// </summary>
-        private int CallbackCount
-        {
-            get
-            {
-                SparselyPopulatedArray<CancellationCallbackInfo>[] callbackLists = m_registeredCallbacksLists;
-                if (callbackLists == null)
-                    return 0;
-
-                int count = 0;
-                foreach (SparselyPopulatedArray<CancellationCallbackInfo> sparseArray in callbackLists)
                 {
-                    if (sparseArray != null)
-                    {
-                        SparselyPopulatedArrayFragment<CancellationCallbackInfo> currCallbacks = sparseArray.Head;
-                        while (currCallbacks != null)
-                        {
-                            for (int i = 0; i < currCallbacks.Length; i++)
-                                if (currCallbacks[i] != null)
-                                    count++;
-
-                            currCallbacks = currCallbacks.Next;
-                        }
-                    }
+                    _kernelEvent.Set();
                 }
-                return count;
+
+                return _kernelEvent;
             }
         }
-#endif
 
-        // ** Public Constructors
 
-        /// <summary>
-        /// Initializes the <see cref="T:System.Threading.CancellationTokenSource"/>.
-        /// </summary>
-        public CancellationTokenSource()
-        {
-            m_state = NOT_CANCELED;
-        }
+        /// <summary>Gets the ID of the currently executing callback.</summary>
+        internal long ExecutingCallback => Volatile.Read(ref _executingCallbackId);
 
-        // ** Private constructors for static sources.
-        // set=false ==> cannot be canceled.
-        // set=true  ==> is canceled. 
-        private CancellationTokenSource(bool set)
-        {
-            m_state = set ? NOTIFYINGCOMPLETE : CANNOT_BE_CANCELED;
-        }
+        /// <summary>Initializes the <see cref="CancellationTokenSource"/>.</summary>
+        public CancellationTokenSource() => _state = NotCanceledState;
 
         /// <summary>
-        /// Constructs a <see cref="T:System.Threading.CancellationTokenSource"/> that will be canceled after a specified time span.
+        /// Constructs a <see cref="CancellationTokenSource"/> that will be canceled after a specified time span.
         /// </summary>
-        /// <param name="delay">The time span to wait before canceling this <see cref="T:System.Threading.CancellationTokenSource"/></param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        /// <param name="delay">The time span to wait before canceling this <see cref="CancellationTokenSource"/></param>
+        /// <exception cref="ArgumentOutOfRangeException">
         /// The exception that is thrown when <paramref name="delay"/> is less than -1 or greater than Int32.MaxValue.
         /// </exception>
         /// <remarks>
         /// <para>
         /// The countdown for the delay starts during the call to the constructor.  When the delay expires, 
-        /// the constructed <see cref="T:System.Threading.CancellationTokenSource"/> is canceled, if it has
+        /// the constructed <see cref="CancellationTokenSource"/> is canceled, if it has
         /// not been canceled already.
         /// </para>
         /// <para>
         /// Subsequent calls to CancelAfter will reset the delay for the constructed 
-        /// <see cref="T:System.Threading.CancellationTokenSource"/>, if it has not been
+        /// <see cref="CancellationTokenSource"/>, if it has not been
         /// canceled already.
         /// </para>
         /// </remarks>
         public CancellationTokenSource(TimeSpan delay)
         {
             long totalMilliseconds = (long)delay.TotalMilliseconds;
-            if (totalMilliseconds < -1 || totalMilliseconds > Int32.MaxValue)
+            if (totalMilliseconds < -1 || totalMilliseconds > int.MaxValue)
             {
                 throw new ArgumentOutOfRangeException(nameof(delay));
             }
@@ -280,25 +173,25 @@ namespace System.Threading
         }
 
         /// <summary>
-        /// Constructs a <see cref="T:System.Threading.CancellationTokenSource"/> that will be canceled after a specified time span.
+        /// Constructs a <see cref="CancellationTokenSource"/> that will be canceled after a specified time span.
         /// </summary>
-        /// <param name="millisecondsDelay">The time span to wait before canceling this <see cref="T:System.Threading.CancellationTokenSource"/></param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        /// <param name="millisecondsDelay">The time span to wait before canceling this <see cref="CancellationTokenSource"/></param>
+        /// <exception cref="ArgumentOutOfRangeException">
         /// The exception that is thrown when <paramref name="millisecondsDelay"/> is less than -1.
         /// </exception>
         /// <remarks>
         /// <para>
         /// The countdown for the millisecondsDelay starts during the call to the constructor.  When the millisecondsDelay expires, 
-        /// the constructed <see cref="T:System.Threading.CancellationTokenSource"/> is canceled (if it has
+        /// the constructed <see cref="CancellationTokenSource"/> is canceled (if it has
         /// not been canceled already).
         /// </para>
         /// <para>
         /// Subsequent calls to CancelAfter will reset the millisecondsDelay for the constructed 
-        /// <see cref="T:System.Threading.CancellationTokenSource"/>, if it has not been
+        /// <see cref="CancellationTokenSource"/>, if it has not been
         /// canceled already.
         /// </para>
         /// </remarks>
-        public CancellationTokenSource(Int32 millisecondsDelay)
+        public CancellationTokenSource(int millisecondsDelay)
         {
             if (millisecondsDelay < -1)
             {
@@ -308,109 +201,90 @@ namespace System.Threading
             InitializeWithTimer(millisecondsDelay);
         }
 
-        // Common initialization logic when constructing a CTS with a delay parameter
-        private void InitializeWithTimer(Int32 millisecondsDelay)
+        /// <summary>Common initialization logic when constructing a CTS with a delay parameter</summary>
+        private void InitializeWithTimer(int millisecondsDelay)
         {
-            m_state = NOT_CANCELED;
-            m_timer = new Timer(s_timerCallback, this, millisecondsDelay, -1);
+            _state = NotCanceledState;
+            _timer = new Timer(s_timerCallback, this, millisecondsDelay, -1);
         }
 
-        // ** Public Methods
-
-        /// <summary>
-        /// Communicates a request for cancellation.
-        /// </summary>
+        /// <summary>Communicates a request for cancellation.</summary>
         /// <remarks>
         /// <para>
-        /// The associated <see cref="T:System.Threading.CancellationToken" /> will be
-        /// notified of the cancellation and will transition to a state where 
-        /// <see cref="System.Threading.CancellationToken.IsCancellationRequested">IsCancellationRequested</see> returns true. 
-        /// Any callbacks or cancelable operations
-        /// registered with the <see cref="T:System.Threading.CancellationToken"/>  will be executed.
+        /// The associated <see cref="CancellationToken" /> will be notified of the cancellation
+        /// and will transition to a state where <see cref="CancellationToken.IsCancellationRequested"/> returns true. 
+        /// Any callbacks or cancelable operations registered with the <see cref="CancellationToken"/>  will be executed.
         /// </para>
         /// <para>
         /// Cancelable operations and callbacks registered with the token should not throw exceptions.
-        /// However, this overload of Cancel will aggregate any exceptions thrown into a <see cref="System.AggregateException"/>,
+        /// However, this overload of Cancel will aggregate any exceptions thrown into a <see cref="AggregateException"/>,
         /// such that one callback throwing an exception will not prevent other registered callbacks from being executed.
         /// </para>
         /// <para>
-        /// The <see cref="T:System.Threading.ExecutionContext"/> that was captured when each callback was registered
+        /// The <see cref="ExecutionContext"/> that was captured when each callback was registered
         /// will be reestablished when the callback is invoked.
         /// </para>
         /// </remarks>
-        /// <exception cref="T:System.AggregateException">An aggregate exception containing all the exceptions thrown
-        /// by the registered callbacks on the associated <see cref="T:System.Threading.CancellationToken"/>.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">This <see
-        /// cref="T:System.Threading.CancellationTokenSource"/> has been disposed.</exception> 
-        public void Cancel()
-        {
-            Cancel(false);
-        }
+        /// <exception cref="AggregateException">An aggregate exception containing all the exceptions thrown
+        /// by the registered callbacks on the associated <see cref="CancellationToken"/>.</exception>
+        /// <exception cref="ObjectDisposedException">This <see cref="CancellationTokenSource"/> has been disposed.</exception> 
+        public void Cancel() => Cancel(false);
 
-        /// <summary>
-        /// Communicates a request for cancellation.
-        /// </summary>
+        /// <summary>Communicates a request for cancellation.</summary>
         /// <remarks>
         /// <para>
-        /// The associated <see cref="T:System.Threading.CancellationToken" /> will be
-        /// notified of the cancellation and will transition to a state where 
-        /// <see cref="System.Threading.CancellationToken.IsCancellationRequested">IsCancellationRequested</see> returns true. 
-        /// Any callbacks or cancelable operations
-        /// registered with the <see cref="T:System.Threading.CancellationToken"/>  will be executed.
+        /// The associated <see cref="CancellationToken" /> will be notified of the cancellation and will transition to a state where 
+        /// <see cref="CancellationToken.IsCancellationRequested"/> returns true. Any callbacks or cancelable operationsregistered
+        /// with the <see cref="CancellationToken"/>  will be executed.
         /// </para>
         /// <para>
         /// Cancelable operations and callbacks registered with the token should not throw exceptions. 
         /// If <paramref name="throwOnFirstException"/> is true, an exception will immediately propagate out of the
         /// call to Cancel, preventing the remaining callbacks and cancelable operations from being processed.
         /// If <paramref name="throwOnFirstException"/> is false, this overload will aggregate any 
-        /// exceptions thrown into a <see cref="System.AggregateException"/>,
+        /// exceptions thrown into a <see cref="AggregateException"/>,
         /// such that one callback throwing an exception will not prevent other registered callbacks from being executed.
         /// </para>
         /// <para>
-        /// The <see cref="T:System.Threading.ExecutionContext"/> that was captured when each callback was registered
+        /// The <see cref="ExecutionContext"/> that was captured when each callback was registered
         /// will be reestablished when the callback is invoked.
         /// </para>
         /// </remarks>
         /// <param name="throwOnFirstException">Specifies whether exceptions should immediately propagate.</param>
-        /// <exception cref="T:System.AggregateException">An aggregate exception containing all the exceptions thrown
-        /// by the registered callbacks on the associated <see cref="T:System.Threading.CancellationToken"/>.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">This <see
-        /// cref="T:System.Threading.CancellationTokenSource"/> has been disposed.</exception> 
+        /// <exception cref="AggregateException">An aggregate exception containing all the exceptions thrown
+        /// by the registered callbacks on the associated <see cref="CancellationToken"/>.</exception>
+        /// <exception cref="ObjectDisposedException">This <see cref="CancellationTokenSource"/> has been disposed.</exception> 
         public void Cancel(bool throwOnFirstException)
         {
             ThrowIfDisposed();
             NotifyCancellation(throwOnFirstException);
         }
 
-        /// <summary>
-        /// Schedules a Cancel operation on this <see cref="T:System.Threading.CancellationTokenSource"/>.
-        /// </summary>
-        /// <param name="delay">The time span to wait before canceling this <see
-        /// cref="T:System.Threading.CancellationTokenSource"/>.
+        /// <summary>Schedules a Cancel operation on this <see cref="CancellationTokenSource"/>.</summary>
+        /// <param name="delay">The time span to wait before canceling this <see cref="CancellationTokenSource"/>.
         /// </param>
-        /// <exception cref="T:System.ObjectDisposedException">The exception thrown when this <see
-        /// cref="T:System.Threading.CancellationTokenSource"/> has been disposed.
+        /// <exception cref="ObjectDisposedException">The exception thrown when this <see
+        /// cref="CancellationTokenSource"/> has been disposed.
         /// </exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentOutOfRangeException">
         /// The exception thrown when <paramref name="delay"/> is less than -1 or 
         /// greater than Int32.MaxValue.
         /// </exception>
         /// <remarks>
         /// <para>
         /// The countdown for the delay starts during this call.  When the delay expires, 
-        /// this <see cref="T:System.Threading.CancellationTokenSource"/> is canceled, if it has
+        /// this <see cref="CancellationTokenSource"/> is canceled, if it has
         /// not been canceled already.
         /// </para>
         /// <para>
         /// Subsequent calls to CancelAfter will reset the delay for this  
-        /// <see cref="T:System.Threading.CancellationTokenSource"/>, if it has not been
-        /// canceled already.
+        /// <see cref="CancellationTokenSource"/>, if it has not been canceled already.
         /// </para>
         /// </remarks>
         public void CancelAfter(TimeSpan delay)
         {
             long totalMilliseconds = (long)delay.TotalMilliseconds;
-            if (totalMilliseconds < -1 || totalMilliseconds > Int32.MaxValue)
+            if (totalMilliseconds < -1 || totalMilliseconds > int.MaxValue)
             {
                 throw new ArgumentOutOfRangeException(nameof(delay));
             }
@@ -419,30 +293,30 @@ namespace System.Threading
         }
 
         /// <summary>
-        /// Schedules a Cancel operation on this <see cref="T:System.Threading.CancellationTokenSource"/>.
+        /// Schedules a Cancel operation on this <see cref="CancellationTokenSource"/>.
         /// </summary>
         /// <param name="millisecondsDelay">The time span to wait before canceling this <see
-        /// cref="T:System.Threading.CancellationTokenSource"/>.
+        /// cref="CancellationTokenSource"/>.
         /// </param>
-        /// <exception cref="T:System.ObjectDisposedException">The exception thrown when this <see
-        /// cref="T:System.Threading.CancellationTokenSource"/> has been disposed.
+        /// <exception cref="ObjectDisposedException">The exception thrown when this <see
+        /// cref="CancellationTokenSource"/> has been disposed.
         /// </exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentOutOfRangeException">
         /// The exception thrown when <paramref name="millisecondsDelay"/> is less than -1.
         /// </exception>
         /// <remarks>
         /// <para>
         /// The countdown for the millisecondsDelay starts during this call.  When the millisecondsDelay expires, 
-        /// this <see cref="T:System.Threading.CancellationTokenSource"/> is canceled, if it has
+        /// this <see cref="CancellationTokenSource"/> is canceled, if it has
         /// not been canceled already.
         /// </para>
         /// <para>
         /// Subsequent calls to CancelAfter will reset the millisecondsDelay for this  
-        /// <see cref="T:System.Threading.CancellationTokenSource"/>, if it has not been
+        /// <see cref="CancellationTokenSource"/>, if it has not been
         /// canceled already.
         /// </para>
         /// </remarks>
-        public void CancelAfter(Int32 millisecondsDelay)
+        public void CancelAfter(int millisecondsDelay)
         {
             ThrowIfDisposed();
 
@@ -451,7 +325,10 @@ namespace System.Threading
                 throw new ArgumentOutOfRangeException(nameof(millisecondsDelay));
             }
 
-            if (IsCancellationRequested) return;
+            if (IsCancellationRequested)
+            {
+                return;
+            }
 
             // There is a race condition here as a Cancel could occur between the check of
             // IsCancellationRequested and the creation of the timer.  This is benign; in the 
@@ -462,26 +339,25 @@ namespace System.Threading
             // expired and Disposed itself).  But this would be considered bad behavior, as
             // Dispose() is not thread-safe and should not be called concurrently with CancelAfter().
 
-            if (m_timer == null)
+            if (_timer == null)
             {
                 // Lazily initialize the timer in a thread-safe fashion.
                 // Initially set to "never go off" because we don't want to take a
                 // chance on a timer "losing" the initialization and then
                 // cancelling the token before it (the timer) can be disposed.
                 Timer newTimer = new Timer(s_timerCallback, this, -1, -1);
-                if (Interlocked.CompareExchange(ref m_timer, newTimer, null) != null)
+                if (Interlocked.CompareExchange(ref _timer, newTimer, null) != null)
                 {
                     // We did not initialize the timer.  Dispose the new timer.
                     newTimer.Dispose();
                 }
             }
 
-
             // It is possible that m_timer has already been disposed, so we must do
             // the following in a try/catch block.
             try
             {
-                m_timer.Change(millisecondsDelay, -1);
+                _timer.Change(millisecondsDelay, -1);
             }
             catch (ObjectDisposedException)
             {
@@ -492,37 +368,10 @@ namespace System.Threading
             }
         }
 
-        private static readonly TimerCallback s_timerCallback = new TimerCallback(TimerCallbackLogic);
 
-        // Common logic for a timer delegate
-        private static void TimerCallbackLogic(object obj)
-        {
-            CancellationTokenSource cts = (CancellationTokenSource)obj;
 
-            // Cancel the source; handle a race condition with cts.Dispose()
-            if (!cts.IsDisposed)
-            {
-                // There is a small window for a race condition where a cts.Dispose can sneak
-                // in right here.  I'll wrap the cts.Cancel() in a try/catch to proof us
-                // against this race condition.
-                try
-                {
-                    cts.Cancel(); // will take care of disposing of m_timer
-                }
-                catch (ObjectDisposedException)
-                {
-                    // If the ODE was not due to the target cts being disposed, then propagate the ODE.
-                    if (!cts.IsDisposed) throw;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Releases the resources used by this <see cref="T:System.Threading.CancellationTokenSource" />.
-        /// </summary>
-        /// <remarks>
-        /// This method is not thread-safe for any other concurrent calls.
-        /// </remarks>
+        /// <summary>Releases the resources used by this <see cref="CancellationTokenSource" />.</summary>
+        /// <remarks>This method is not thread-safe for any other concurrent calls.</remarks>
         public void Dispose()
         {
             Dispose(true);
@@ -530,192 +379,186 @@ namespace System.Threading
         }
 
         /// <summary>
-        /// Releases the unmanaged resources used by the <see cref="T:System.Threading.CancellationTokenSource" /> class and optionally releases the managed resources.
+        /// Releases the unmanaged resources used by the <see cref="CancellationTokenSource" /> class and optionally releases the managed resources.
         /// </summary>
         /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
         protected virtual void Dispose(bool disposing)
         {
-            // There is nothing to do if disposing=false because the CancellationTokenSource holds no unmanaged resources.
-
-            if (disposing && !m_disposed)
+            if (disposing && !_disposed)
             {
-                //NOTE: We specifically tolerate that a callback can be deregistered
-                //      after the CTS has been disposed and/or concurrently with cts.Dispose().
-                //      This is safe without locks because the reg.Dispose() only
-                //      mutates a sparseArrayFragment and then reads from properties of the CTS that are not
-                //      invalidated by cts.Dispose().
-                //     
-                //      We also tolerate that a callback can be registered after the CTS has been
-                //      disposed.  This is safe without locks because InternalRegister is tolerant
-                //      of m_registeredCallbacksLists becoming null during its execution.  However,
-                //      we run the acceptable risk of m_registeredCallbacksLists getting reinitialized
-                //      to non-null if there is a race between Dispose and Register, in which case this
-                //      instance may unnecessarily hold onto a registered callback.  But that's no worse
-                //      than if Dispose wasn't safe to use concurrently, as Dispose would never be called,
-                //      and thus no handlers would be dropped.
+                // We specifically tolerate that a callback can be deregistered
+                // after the CTS has been disposed and/or concurrently with cts.Dispose().
+                // This is safe without locks because Dispose doesn't interact with values
+                // in the callback partitions, only nulling out the ref to existing partitions.
+                // 
+                // We also tolerate that a callback can be registered after the CTS has been
+                // disposed.  This is safe because InternalRegister is tolerant
+                // of _callbackPartitions becoming null during its execution.  However,
+                // we run the acceptable risk of _callbackPartitions getting reinitialized
+                // to non-null if there is a race between Dispose and Register, in which case this
+                // instance may unnecessarily hold onto a registered callback.  But that's no worse
+                // than if Dispose wasn't safe to use concurrently, as Dispose would never be called,
+                // and thus no handlers would be dropped.
                 //
-                //      And, we tolerate Dispose being used concurrently with Cancel.  This is necessary
-                //      to properly support LinkedCancellationTokenSource, where, due to common usage patterns,
-                //      it's possible for this pairing to occur with valid usage (e.g. a component accepts
-                //      an external CancellationToken and uses CreateLinkedTokenSource to combine it with an
-                //      internal source of cancellation, then Disposes of that linked source, which could
-                //      happen at the same time the external entity is requesting cancellation).
+                // And, we tolerate Dispose being used concurrently with Cancel.  This is necessary
+                // to properly support, e.g., LinkedCancellationTokenSource, where, due to common usage patterns,
+                // it's possible for this pairing to occur with valid usage (e.g. a component accepts
+                // an external CancellationToken and uses CreateLinkedTokenSource to combine it with an
+                // internal source of cancellation, then Disposes of that linked source, which could
+                // happen at the same time the external entity is requesting cancellation).
 
-                m_timer?.Dispose(); // Timer.Dispose is thread-safe
+                _timer?.Dispose(); // Timer.Dispose is thread-safe
 
-                // registered callbacks are now either complete or will never run, due to guarantees made by ctr.Dispose()
-                // so we can now perform main disposal work without risk of linking callbacks trying to use this CTS.
-
-                m_registeredCallbacksLists = null; // free for GC; Cancel correctly handles a null field
+                _callbackPartitions = null; // free for GC; Cancel correctly handles a null field
 
                 // If a kernel event was created via WaitHandle, we'd like to Dispose of it.  However,
                 // we only want to do so if it's not being used by Cancel concurrently.  First, we
                 // interlocked exchange it to be null, and then we check whether cancellation is currently
                 // in progress.  NotifyCancellation will only try to set the event if it exists after it's
-                // transitioned to and while it's in the NOTIFYING state.
-                if (m_kernelEvent != null)
+                // transitioned to and while it's in the NotifyingState.
+                if (_kernelEvent != null)
                 {
-                    ManualResetEvent mre = Interlocked.Exchange(ref m_kernelEvent, null);
-                    if (mre != null && m_state != NOTIFYING)
+                    ManualResetEvent mre = Interlocked.Exchange(ref _kernelEvent, null);
+                    if (mre != null && _state != NotifyingState)
                     {
                         mre.Dispose();
                     }
                 }
 
-                m_disposed = true;
+                _disposed = true;
             }
         }
 
-        // -- Internal methods.
-
-        /// <summary>
-        /// Throws an exception if the source has been disposed.
-        /// </summary>
-        internal void ThrowIfDisposed()
+        /// <summary>Throws an exception if the source has been disposed.</summary>
+        private void ThrowIfDisposed()
         {
-            if (m_disposed)
+            if (_disposed)
+            {
                 ThrowObjectDisposedException();
+            }
         }
 
-        // separation enables inlining of ThrowIfDisposed
-        private static void ThrowObjectDisposedException()
-        {
+        /// <summary>Throws an <see cref="ObjectDisposedException"/>.  Separated out from ThrowIfDisposed to help with inlining.</summary>
+        private static void ThrowObjectDisposedException() =>
             throw new ObjectDisposedException(null, SR.CancellationTokenSource_Disposed);
-        }
-
-        /// <summary>
-        /// InternalGetStaticSource()
-        /// </summary>
-        /// <param name="set">Whether the source should be set.</param>
-        /// <returns>A static source to be shared among multiple tokens.</returns>
-        internal static CancellationTokenSource InternalGetStaticSource(bool set)
-        {
-            return set ? _staticSource_Set : _staticSource_NotCancelable;
-        }
 
         /// <summary>
         /// Registers a callback object. If cancellation has already occurred, the
         /// callback will have been run by the time this method returns.
         /// </summary>
         internal CancellationTokenRegistration InternalRegister(
-            Action<object> callback, object stateForCallback, SynchronizationContext targetSyncContext, ExecutionContext executionContext)
+            Action<object> callback, object stateForCallback, SynchronizationContext syncContext, ExecutionContext executionContext)
         {
-            // the CancellationToken has already checked that the token is cancelable before calling this method.
-            Debug.Assert(CanBeCanceled, "Cannot register for uncancelable token src");
+            Debug.Assert(this != s_neverCanceledSource, "This source should never be exposed via a CancellationToken.");
 
-            // if not canceled, register the event handlers
-            // if canceled already, run the callback synchronously
-            // Apart from the semantics of late-enlistment, this also ensures that during ExecuteCallbackHandlers() there
-            // will be no mutation of the _registeredCallbacks list
-
+            // If not canceled, register the handler; if canceled already, run the callback synchronously.
+            // This also ensures that during ExecuteCallbackHandlers() there will be no mutation of the _callbackPartitions.
             if (!IsCancellationRequested)
             {
                 // In order to enable code to not leak too many handlers, we allow Dispose to be called concurrently
                 // with Register.  While this is not a recommended practice, consumers can and do use it this way.
-                // We don't make any guarantees about whether the CTS will hold onto the supplied callback
-                // if the CTS has already been disposed when the callback is registered, but we try not to
-                // while at the same time not paying any non-negligible overhead.  The simple compromise
-                // is to check whether we're disposed (not volatile), and if we see we are, to return an empty
-                // registration, just as if CanBeCanceled was false for the check made in CancellationToken.Register.
-                // If there's a race and m_disposed is false even though it's been disposed, or if the disposal request
-                // comes in after this line, we simply run the minor risk of having m_registeredCallbacksLists reinitialized
-                // (after it was cleared to null during Dispose).
-
-                if (m_disposed)
+                // We don't make any guarantees about whether the CTS will hold onto the supplied callback if the CTS
+                // has already been disposed when the callback is registered, but we try not to while at the same time
+                // not paying any non-negligible overhead.  The simple compromise is to check whether we're disposed
+                // (not volatile), and if we see we are, to return an empty registration. If there's a race and _disposed
+                // is false even though it's been disposed, or if the disposal request comes in after this line, we simply
+                // run the minor risk of having _callbackPartitions reinitialized (after it was cleared to null during Dispose).
+                if (_disposed)
+                {
                     return new CancellationTokenRegistration();
-
-                int myIndex = Thread.CurrentThread.ManagedThreadId % s_nLists;
-
-                CancellationCallbackInfo callbackInfo = targetSyncContext != null ?
-                    new CancellationCallbackInfo.WithSyncContext(callback, stateForCallback, executionContext, this, targetSyncContext) :
-                    new CancellationCallbackInfo(callback, stateForCallback, executionContext, this);
-
-                //allocate the callback list array
-                var registeredCallbacksLists = m_registeredCallbacksLists;
-                if (registeredCallbacksLists == null)
-                {
-                    SparselyPopulatedArray<CancellationCallbackInfo>[] list = new SparselyPopulatedArray<CancellationCallbackInfo>[s_nLists];
-                    registeredCallbacksLists = Interlocked.CompareExchange(ref m_registeredCallbacksLists, list, null);
-                    if (registeredCallbacksLists == null) registeredCallbacksLists = list;
                 }
 
-                //allocate the actual lists on-demand to save mem in low-use situations, and to avoid false-sharing.
-                var callbacks = Volatile.Read<SparselyPopulatedArray<CancellationCallbackInfo>>(ref registeredCallbacksLists[myIndex]);
-                if (callbacks == null)
+                // Get the partitions...
+                CallbackPartition[] partitions = _callbackPartitions;
+                if (partitions == null)
                 {
-                    SparselyPopulatedArray<CancellationCallbackInfo> callBackArray = new SparselyPopulatedArray<CancellationCallbackInfo>(4);
-                    Interlocked.CompareExchange(ref (registeredCallbacksLists[myIndex]), callBackArray, null);
-                    callbacks = registeredCallbacksLists[myIndex];
+                    partitions = new CallbackPartition[s_numPartitions];
+                    partitions = Interlocked.CompareExchange(ref _callbackPartitions, partitions, null) ?? partitions;
                 }
 
-                // Now add the registration to the list.
-                SparselyPopulatedArrayAddInfo<CancellationCallbackInfo> addInfo = callbacks.Add(callbackInfo);
-                CancellationTokenRegistration registration = new CancellationTokenRegistration(callbackInfo, addInfo);
-
-                if (!IsCancellationRequested)
-                    return registration;
-
-                // If a cancellation has since come in, we will try to undo the registration and run the callback ourselves.
-                // (this avoids leaving the callback orphaned)
-                bool deregisterOccurred = registration.TryDeregister();
-
-                if (!deregisterOccurred)
+                // ...and determine which partition to use.
+                int partitionIndex = Environment.CurrentManagedThreadId & s_numPartitionsMask;
+                Debug.Assert(partitionIndex < partitions.Length, $"Expected {partitionIndex} to be less than {partitions.Length}");
+                CallbackPartition partition = partitions[partitionIndex];
+                if (partition == null)
                 {
-                    // The thread that is running Cancel() snagged our callback for execution.
-                    // So we don't need to run it, but we do return the registration so that 
-                    // ctr.Dispose() will wait for callback completion.
-                    return registration;
+                    partition = new CallbackPartition(this);
+                    partition = Interlocked.CompareExchange(ref partitions[partitionIndex], partition, null) ?? partition;
+                }
+
+                // Store the callback information into the callback arrays.
+                long id;
+                CallbackNode node;
+                bool lockTaken = false;
+                partition.Lock.Enter(ref lockTaken);
+                try
+                {
+                    // Assign the next available unique ID.
+                    id = partition.NextAvailableId++;
+
+                    // Get a node, from the free list if possible or else a new one.
+                    node = partition.FreeNodeList;
+                    if (node != null)
+                    {
+                        partition.FreeNodeList = node.Next;
+                        Debug.Assert(node.Prev == null, "Nodes in the free list should all have a null Prev");
+                        // node.Next will be overwritten below so no need to set it here.
+                    }
+                    else
+                    {
+                        node = new CallbackNode(partition);
+                    }
+
+                    // Configure the node.
+                    node.Id = id;
+                    node.Callback = callback;
+                    node.CallbackState = stateForCallback;
+                    node.ExecutionContext = executionContext;
+                    node.SynchronizationContext = syncContext;
+
+                    // Add it to the callbacks list.
+                    node.Next = partition.Callbacks;
+                    if (node.Next != null)
+                    {
+                        node.Next.Prev = node;
+                    }
+                    partition.Callbacks = node;
+                }
+                finally
+                {
+                    partition.Lock.Exit(useMemoryBarrier: false); // no check on lockTaken needed without thread aborts
+                }
+
+                // If cancellation hasn't been requested, return the registration.
+                // if cancellation has been requested, try to undo the registration and run the callback
+                // ourselves, but if we can't unregister it (e.g. the thread running Cancel snagged
+                // our callback for execution), return the registration so that the caller can wait
+                // for callback completion in ctr.Dispose().
+                var ctr = new CancellationTokenRegistration(id, node);
+                if (!IsCancellationRequested || !partition.Unregister(id, node))
+                {
+                    return ctr;
                 }
             }
 
-            // If cancellation already occurred, we run the callback on this thread and return an empty registration.
+            // Cancellation already occurred.  Run the callback on this thread and return an empty registration.
             callback(stateForCallback);
-            return new CancellationTokenRegistration();
+            return default(CancellationTokenRegistration);
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
         private void NotifyCancellation(bool throwOnFirstException)
         {
-            // fast-path test to check if Notify has been called previously
-            if (IsCancellationRequested)
-                return;
-
             // If we're the first to signal cancellation, do the main extra work.
-            if (Interlocked.CompareExchange(ref m_state, NOTIFYING, NOT_CANCELED) == NOT_CANCELED)
+            if (!IsCancellationRequested && Interlocked.CompareExchange(ref _state, NotifyingState, NotCanceledState) == NotCanceledState)
             {
                 // Dispose of the timer, if any.  Dispose may be running concurrently here, but Timer.Dispose is thread-safe.
-                m_timer?.Dispose();
-
-                // Record the threadID being used for running the callbacks.
-                ThreadIDExecutingCallbacks = Thread.CurrentThread.ManagedThreadId;
+                _timer?.Dispose();
 
                 // Set the event if it's been lazily initialized and hasn't yet been disposed of.  Dispose may
                 // be running concurrently, in which case either it'll have set m_kernelEvent back to null and
                 // we won't see it here, or it'll see that we've transitioned to NOTIFYING and will skip disposing it,
                 // leaving cleanup to finalization.
-                m_kernelEvent?.Set(); // update the MRE value.
+                _kernelEvent?.Set(); // update the MRE value.
 
                 // - late enlisters to the Canceled event will have their callbacks called immediately in the Register() methods.
                 // - Callbacks are not called inside a lock.
@@ -726,135 +569,118 @@ namespace System.Threading
             }
         }
 
-        /// <summary>
-        /// Invoke the Canceled event.
-        /// </summary>
-        /// <remarks>
-        /// The handlers are invoked synchronously in LIFO order.
-        /// </remarks>
+        /// <summary>Invoke all registered callbacks.</summary>
+        /// <remarks>The handlers are invoked synchronously in LIFO order.</remarks>
         private void ExecuteCallbackHandlers(bool throwOnFirstException)
         {
             Debug.Assert(IsCancellationRequested, "ExecuteCallbackHandlers should only be called after setting IsCancellationRequested->true");
-            Debug.Assert(ThreadIDExecutingCallbacks != -1, "ThreadIDExecutingCallbacks should have been set.");
 
-            // Design decision: call the delegates in LIFO order so that callbacks fire 'deepest first'.
-            // This is intended to help with nesting scenarios so that child enlisters cancel before their parents.
-            List<Exception> exceptionList = null;
-            SparselyPopulatedArray<CancellationCallbackInfo>[] callbackLists = m_registeredCallbacksLists;
+            // Record the threadID being used for running the callbacks.
+            ThreadIDExecutingCallbacks = Thread.CurrentThread.ManagedThreadId;
 
             // If there are no callbacks to run, we can safely exit.  Any race conditions to lazy initialize it
             // will see IsCancellationRequested and will then run the callback themselves.
-            if (callbackLists == null)
+            CallbackPartition[] partitions = Interlocked.Exchange(ref _callbackPartitions, null);
+            if (partitions == null)
             {
-                Interlocked.Exchange(ref m_state, NOTIFYINGCOMPLETE);
+                Interlocked.Exchange(ref _state, NotifyingCompleteState);
                 return;
             }
 
+            List<Exception> exceptionList = null;
             try
             {
-                for (int index = 0; index < callbackLists.Length; index++)
+                // For each partition, and each callback in that partition, execute the associated handler.
+                // We call the delegates in LIFO order on each partition so that callbacks fire 'deepest first'.
+                // This is intended to help with nesting scenarios so that child enlisters cancel before their parents.
+                foreach (CallbackPartition partition in partitions)
                 {
-                    SparselyPopulatedArray<CancellationCallbackInfo> list = Volatile.Read<SparselyPopulatedArray<CancellationCallbackInfo>>(ref callbackLists[index]);
-                    if (list != null)
+                    if (partition == null)
                     {
-                        SparselyPopulatedArrayFragment<CancellationCallbackInfo> currArrayFragment = list.Tail;
+                        // Uninitialized partition. Nothing to do.
+                        continue;
+                    }
 
-                        while (currArrayFragment != null)
+                    // Get the callbacks from the partition, substituting in null so that anyone
+                    // else coming along (e.g. CTR.Dispose) will find the callbacks gone.
+                    CallbackNode node;
+                    bool lockTaken = false;
+                    partition.Lock.Enter(ref lockTaken); // try/finally not needed without thread aborts
+                    {
+                        node = partition.Callbacks;
+                        partition.Callbacks = null;
+                    }
+                    partition.Lock.Exit(useMemoryBarrier: false);
+
+                    for (; node != null; node = node.Next)
+                    {
+                        // Publish the intended callback, to ensure ctr.Dispose can tell if a wait is necessary.
+                        Volatile.Write(ref _executingCallbackId, node.Id);
+
+                        // Invoke the callback on this thread if there's no sync context or on the
+                        // target sync context if there is one.
+                        try
                         {
-                            for (int i = currArrayFragment.Length - 1; i >= 0; i--)
+                            if (node.SynchronizationContext != null)
                             {
-                                // 1a. publish the indended callback, to ensure ctr.Dipose can tell if a wait is necessary.
-                                // 1b. transition to the target syncContext and continue there..
-                                //  On the target SyncContext.
-                                //   2. actually remove the callback
-                                //   3. execute the callback
-                                // re:#2 we do the remove on the syncCtx so that we can be sure we have control of the syncCtx before
-                                //        grabbing the callback.  This prevents a deadlock if ctr.Dispose() might run on the syncCtx too.
-                                m_executingCallback = currArrayFragment[i];
-                                if (m_executingCallback != null)
+                                // Transition to the target syncContext and continue there.
+                                node.SynchronizationContext.Send(s =>
                                 {
-                                    //Transition to the target sync context (if necessary), and continue our work there.
-                                    CancellationCallbackCoreWorkArguments args = new CancellationCallbackCoreWorkArguments(currArrayFragment, i);
-
-                                    // marshal exceptions: either aggregate or perform an immediate rethrow
-                                    // We assume that syncCtx.Send() has forwarded on user exceptions when appropriate.
-                                    try
-                                    {
-                                        var wsc = m_executingCallback as CancellationCallbackInfo.WithSyncContext;
-                                        if (wsc != null)
-                                        {
-                                            Debug.Assert(wsc.TargetSyncContext != null, "Should only have derived CCI if non-null SyncCtx");
-                                            wsc.TargetSyncContext.Send(CancellationCallbackCoreWork_OnSyncContext, args);
-                                            // CancellationCallbackCoreWork_OnSyncContext may have altered ThreadIDExecutingCallbacks, so reset it. 
-                                            ThreadIDExecutingCallbacks = Thread.CurrentThread.ManagedThreadId;
-                                        }
-                                        else
-                                        {
-                                            CancellationCallbackCoreWork(args);
-                                        }
-                                    }
-                                    catch (Exception ex)
-                                    {
-                                        if (throwOnFirstException)
-                                            throw;
-
-                                        // Otherwise, log it and proceed.
-                                        if (exceptionList == null)
-                                            exceptionList = new List<Exception>();
-                                        exceptionList.Add(ex);
-                                    }
-                                }
+                                    var n = (CallbackNode)s;
+                                    n.Partition.Source.ThreadIDExecutingCallbacks = Thread.CurrentThread.ManagedThreadId;
+                                    n.ExecuteCallback();
+                                }, node);
+                                ThreadIDExecutingCallbacks = Thread.CurrentThread.ManagedThreadId; // above may have altered ThreadIDExecutingCallbacks, so reset it
                             }
-
-                            currArrayFragment = currArrayFragment.Prev;
+                            else
+                            {
+                                node.ExecuteCallback();
+                            }
+                        }
+                        catch (Exception ex) when (!throwOnFirstException)
+                        {
+                            // Store the exception and continue
+                            (exceptionList ?? (exceptionList = new List<Exception>())).Add(ex);
                         }
                     }
                 }
             }
             finally
             {
-                m_state = NOTIFYINGCOMPLETE;
-                m_executingCallback = null;
+                _state = NotifyingCompleteState;
+                Volatile.Write(ref _executingCallbackId, 0);
                 Interlocked.MemoryBarrier(); // for safety, prevent reorderings crossing this point and seeing inconsistent state.
             }
 
             if (exceptionList != null)
             {
-                Debug.Assert(exceptionList.Count > 0, "Expected exception count > 0");
+                Debug.Assert(exceptionList.Count > 0, $"Expected {exceptionList.Count} > 0");
                 throw new AggregateException(exceptionList);
             }
         }
 
-        // The main callback work that executes on the target synchronization context
-        private void CancellationCallbackCoreWork_OnSyncContext(object obj)
+        /// <summary>Gets the number of callback partitions to use based on the number of cores.</summary>
+        /// <returns>A power of 2 representing the number of partitions to use.</returns>
+        private static int GetPartitionCount()
         {
-            CancellationCallbackCoreWork((CancellationCallbackCoreWorkArguments)obj);
+            int procs = PlatformHelper.ProcessorCount;
+            int count =
+                procs > 8 ? 16 : // capped at 16 to limit memory usage on larger machines
+                procs > 4 ? 8 :
+                procs > 2 ? 4 :
+                procs > 1 ? 2 :
+                1;
+            Debug.Assert(count > 0 && (count & (count - 1)) == 0, $"Got {count}, but expected a power of 2");
+            return count;
         }
-
-        private void CancellationCallbackCoreWork(CancellationCallbackCoreWorkArguments args)
-        {
-            // remove the intended callback..and ensure that it worked.
-            // otherwise the callback has disappeared in the interim and we can immediately return.
-            CancellationCallbackInfo callback = args.m_currArrayFragment.SafeAtomicRemove(args.m_currArrayIndex, m_executingCallback);
-            if (callback == m_executingCallback)
-            {
-                if (callback.TargetExecutionContext != null)
-                {
-                    // we are running via a custom sync context, so update the executing threadID
-                    callback.CancellationTokenSource.ThreadIDExecutingCallbacks = Thread.CurrentThread.ManagedThreadId;
-                }
-                callback.ExecuteCallback();
-            }
-        }
-
 
         /// <summary>
-        /// Creates a <see cref="T:System.Threading.CancellationTokenSource">CancellationTokenSource</see> that will be in the canceled state
+        /// Creates a <see cref="CancellationTokenSource"/> that will be in the canceled state
         /// when any of the source tokens are in the canceled state.
         /// </summary>
-        /// <param name="token1">The first <see cref="T:System.Threading.CancellationToken">CancellationToken</see> to observe.</param>
-        /// <param name="token2">The second <see cref="T:System.Threading.CancellationToken">CancellationToken</see> to observe.</param>
-        /// <returns>A <see cref="T:System.Threading.CancellationTokenSource">CancellationTokenSource</see> that is linked 
+        /// <param name="token1">The first <see cref="CancellationToken">CancellationToken</see> to observe.</param>
+        /// <param name="token2">The second <see cref="CancellationToken">CancellationToken</see> to observe.</param>
+        /// <returns>A <see cref="CancellationTokenSource"/> that is linked 
         /// to the source tokens.</returns>
         public static CancellationTokenSource CreateLinkedTokenSource(CancellationToken token1, CancellationToken token2) =>
             !token1.CanBeCanceled ? CreateLinkedTokenSource(token2) :
@@ -865,23 +691,24 @@ namespace System.Threading
         /// Creates a <see cref="CancellationTokenSource"/> that will be in the canceled state
         /// when any of the source tokens are in the canceled state.
         /// </summary>
-        /// <param name="token">The first <see cref="T:System.Threading.CancellationToken">CancellationToken</see> to observe.</param>
+        /// <param name="token">The first <see cref="CancellationToken">CancellationToken</see> to observe.</param>
         /// <returns>A <see cref="CancellationTokenSource"/> that is linked to the source tokens.</returns>
         internal static CancellationTokenSource CreateLinkedTokenSource(CancellationToken token) =>
             token.CanBeCanceled ? new Linked1CancellationTokenSource(token) : new CancellationTokenSource();
 
         /// <summary>
-        /// Creates a <see cref="T:System.Threading.CancellationTokenSource">CancellationTokenSource</see> that will be in the canceled state
+        /// Creates a <see cref="CancellationTokenSource"/> that will be in the canceled state
         /// when any of the source tokens are in the canceled state.
         /// </summary>
-        /// <param name="tokens">The <see cref="T:System.Threading.CancellationToken">CancellationToken</see> instances to observe.</param>
-        /// <returns>A <see cref="T:System.Threading.CancellationTokenSource">CancellationTokenSource</see> that is linked 
-        /// to the source tokens.</returns>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="tokens"/> is null.</exception>
+        /// <param name="tokens">The <see cref="CancellationToken">CancellationToken</see> instances to observe.</param>
+        /// <returns>A <see cref="CancellationTokenSource"/> that is linked to the source tokens.</returns>
+        /// <exception cref="System.ArgumentNullException"><paramref name="tokens"/> is null.</exception>
         public static CancellationTokenSource CreateLinkedTokenSource(params CancellationToken[] tokens)
         {
             if (tokens == null)
+            {
                 throw new ArgumentNullException(nameof(tokens));
+            }
 
             switch (tokens.Length)
             {
@@ -899,15 +726,18 @@ namespace System.Threading
         }
 
 
-        // Wait for a single callback to complete (or, more specifically, to not be running).
-        // It is ok to call this method if the callback has already finished.
-        // Calling this method before the target callback has been selected for execution would be an error.
-        internal void WaitForCallbackToComplete(CancellationCallbackInfo callbackInfo)
+
+        /// <summary>
+        /// Wait for a single callback to complete (or, more specifically, to not be running).
+        /// It is ok to call this method if the callback has already finished.
+        /// Calling this method before the target callback has been selected for execution would be an error.
+        /// </summary>
+        internal void WaitForCallbackToComplete(long id)
         {
-            SpinWait sw = new SpinWait();
-            while (ExecutingCallback == callbackInfo)
+            var sw = new SpinWait();
+            while (ExecutingCallback == id)
             {
-                sw.SpinOnce();  //spin as we assume callback execution is fast and that this situation is rare.
+                sw.SpinOnce();  // spin, as we assume callback execution is fast and that this situation is rare.
             }
         }
 
@@ -922,7 +752,11 @@ namespace System.Threading
 
             protected override void Dispose(bool disposing)
             {
-                if (!disposing || m_disposed) return;
+                if (!disposing || _disposed)
+                {
+                    return;
+                }
+
                 _reg1.Dispose();
                 base.Dispose(disposing);
             }
@@ -941,7 +775,11 @@ namespace System.Threading
 
             protected override void Dispose(bool disposing)
             {
-                if (!disposing || m_disposed) return;
+                if (!disposing || _disposed)
+                {
+                    return;
+                }
+
                 _reg1.Dispose();
                 _reg2.Dispose();
                 base.Dispose(disposing);
@@ -972,8 +810,10 @@ namespace System.Threading
 
             protected override void Dispose(bool disposing)
             {
-                if (!disposing || m_disposed)
+                if (!disposing || _disposed)
+                {
                     return;
+                }
 
                 CancellationTokenRegistration[] linkingRegistrations = m_linkingRegistrations;
                 if (linkingRegistrations != null)
@@ -988,296 +828,115 @@ namespace System.Threading
                 base.Dispose(disposing);
             }
         }
-    }
 
-    // ----------------------------------------------------------
-    // -- CancellationCallbackCoreWorkArguments --
-    // ----------------------------------------------------------
-    // Helper struct for passing data to the target sync context
-    internal struct CancellationCallbackCoreWorkArguments
-    {
-        internal SparselyPopulatedArrayFragment<CancellationCallbackInfo> m_currArrayFragment;
-        internal int m_currArrayIndex;
-
-        public CancellationCallbackCoreWorkArguments(SparselyPopulatedArrayFragment<CancellationCallbackInfo> currArrayFragment, int currArrayIndex)
+        internal sealed class CallbackPartition
         {
-            m_currArrayFragment = currArrayFragment;
-            m_currArrayIndex = currArrayIndex;
-        }
-    }
+            /// <summary>The associated source that owns this partition.</summary>
+            public readonly CancellationTokenSource Source;
+            /// <summary>Lock that protects all state in the partition.</summary>
+            public SpinLock Lock = new SpinLock(enableThreadOwnerTracking: false); // mutable struct; do not make this readonly
+            /// <summary>
+            /// The array of callbacks registered in the partition.  Slots may be empty, meaning a default value of the struct.
+            /// <see cref="NextCallbacksSlot"/> - 1 defines the last filled slot.
+            /// </summary>
+            /// <remarks>
+            /// Initialized to an array with at least 1 slot because a partition is only ever created if we're about
+            /// to store something into it.  And initialized with at most 1 slot to help optimize the common case where
+            /// there's only ever a single registration in a CTS (that and many registrations are the most common cases).
+            /// </remarks>
+            public CallbackNode Callbacks;
+            public CallbackNode FreeNodeList;
+            /// <summary>
+            /// Every callback is assigned a unique, never-reused ID.  This defines the next available ID.
+            /// </summary>
+            public long NextAvailableId = 1; // avoid using 0, as that's the default long value and used to represent an empty slot
 
-    // ----------------------------------------------------------
-    // -- CancellationCallbackInfo --
-    // ----------------------------------------------------------
-
-    /// <summary>
-    /// A helper class for collating the various bits of information required to execute 
-    /// cancellation callbacks.
-    /// </summary>
-    internal class CancellationCallbackInfo
-    {
-        internal readonly Action<object> Callback;
-        internal readonly object StateForCallback;
-        internal readonly ExecutionContext TargetExecutionContext;
-        internal readonly CancellationTokenSource CancellationTokenSource;
-
-        internal sealed class WithSyncContext : CancellationCallbackInfo
-        {
-            // Very rarely used, and as such it is separated out into a 
-            // a derived type so that the space for it is pay-for-play.
-            internal readonly SynchronizationContext TargetSyncContext;
-
-            internal WithSyncContext(
-                Action<object> callback, object stateForCallback, ExecutionContext targetExecutionContext, CancellationTokenSource cancellationTokenSource,
-                SynchronizationContext targetSyncContext) :
-                base(callback, stateForCallback, targetExecutionContext, cancellationTokenSource)
+            public CallbackPartition(CancellationTokenSource source)
             {
-                TargetSyncContext = targetSyncContext;
+                Debug.Assert(source != null, "Expected non-null source");
+                Source = source;
             }
-        }
 
-        internal CancellationCallbackInfo(
-            Action<object> callback, object stateForCallback, ExecutionContext targetExecutionContext, CancellationTokenSource cancellationTokenSource)
-        {
-            Callback = callback;
-            StateForCallback = stateForCallback;
-            TargetExecutionContext = targetExecutionContext;
-            CancellationTokenSource = cancellationTokenSource;
-        }
-
-        // Cached callback delegate that's lazily initialized due to ContextCallback being SecurityCritical
-        private static ContextCallback s_executionContextCallback;
-
-        /// <summary>
-        /// InternalExecuteCallbackSynchronously_GeneralPath
-        /// This will be called on the target synchronization context, however, we still need to restore the required execution context
-        /// </summary>
-        internal void ExecuteCallback()
-        {
-            if (TargetExecutionContext != null)
+            internal bool Unregister(long id, CallbackNode node)
             {
-                // Lazily initialize the callback delegate; benign race condition
-                var callback = s_executionContextCallback;
-                if (callback == null) s_executionContextCallback = callback = new ContextCallback(ExecutionContextCallback);
+                Debug.Assert(id != 0, "Expected non-zero id");
+                Debug.Assert(node != null, "Expected non-null node");
 
-                ExecutionContext.Run(
-                    TargetExecutionContext,
-                    callback,
-                    this);
-            }
-            else
-            {
-                //otherwise run directly
-                ExecutionContextCallback(this);
-            }
-        }
-
-        // the worker method to actually run the callback
-        // The signature is such that it can be used as a 'ContextCallback'
-        private static void ExecutionContextCallback(object obj)
-        {
-            CancellationCallbackInfo callbackInfo = obj as CancellationCallbackInfo;
-            Debug.Assert(callbackInfo != null);
-            callbackInfo.Callback(callbackInfo.StateForCallback);
-        }
-    }
-
-
-    // ----------------------------------------------------------
-    // -- SparselyPopulatedArray --
-    // ----------------------------------------------------------
-
-    /// <summary>
-    /// A sparsely populated array.  Elements can be sparse and some null, but this allows for
-    /// lock-free additions and growth, and also for constant time removal (by nulling out).
-    /// </summary>
-    /// <typeparam name="T">The kind of elements contained within.</typeparam>
-    internal class SparselyPopulatedArray<T> where T : class
-    {
-        private readonly SparselyPopulatedArrayFragment<T> m_head;
-        private volatile SparselyPopulatedArrayFragment<T> m_tail;
-
-        /// <summary>
-        /// Allocates a new array with the given initial size.
-        /// </summary>
-        /// <param name="initialSize">How many array slots to pre-allocate.</param>
-        internal SparselyPopulatedArray(int initialSize)
-        {
-            m_head = m_tail = new SparselyPopulatedArrayFragment<T>(initialSize);
-        }
-
-#if DEBUG
-        // Used in DEBUG mode by CancellationTokenSource.CallbackCount
-        /// <summary>
-        /// The head of the doubly linked list.
-        /// </summary>
-        internal SparselyPopulatedArrayFragment<T> Head
-        {
-            get { return m_head; }
-        }
-#endif
-
-        /// <summary>
-        /// The tail of the doubly linked list.
-        /// </summary>
-        internal SparselyPopulatedArrayFragment<T> Tail
-        {
-            get { return m_tail; }
-        }
-
-        /// <summary>
-        /// Adds an element in the first available slot, beginning the search from the tail-to-head.
-        /// If no slots are available, the array is grown.  The method doesn't return until successful.
-        /// </summary>
-        /// <param name="element">The element to add.</param>
-        /// <returns>Information about where the add happened, to enable O(1) deregistration.</returns>
-        internal SparselyPopulatedArrayAddInfo<T> Add(T element)
-        {
-            while (true)
-            {
-                // Get the tail, and ensure it's up to date.
-                SparselyPopulatedArrayFragment<T> tail = m_tail;
-                while (tail.m_next != null)
-                    m_tail = (tail = tail.m_next);
-
-                // Search for a free index, starting from the tail.
-                SparselyPopulatedArrayFragment<T> curr = tail;
-                while (curr != null)
+                bool lockTaken = false;
+                Lock.Enter(ref lockTaken);
+                try
                 {
-                    const int RE_SEARCH_THRESHOLD = -10; // Every 10 skips, force a search.
-                    if (curr.m_freeCount < 1)
-                        --curr.m_freeCount;
-
-                    if (curr.m_freeCount > 0 || curr.m_freeCount < RE_SEARCH_THRESHOLD)
+                    if (Callbacks == null || node.Id != id)
                     {
-                        int c = curr.Length;
-
-                        // We'll compute a start offset based on how many free slots we think there
-                        // are.  This optimizes for ordinary the LIFO deregistration pattern, and is
-                        // far from perfect due to the non-threadsafe ++ and -- of the free counter.
-                        int start = ((c - curr.m_freeCount) % c);
-                        if (start < 0)
-                        {
-                            start = 0;
-                            curr.m_freeCount--; // Too many free elements; fix up.
-                        }
-                        Debug.Assert(start >= 0 && start < c, "start is outside of bounds");
-
-                        // Now walk the array until we find a free slot (or reach the end).
-                        for (int i = 0; i < c; i++)
-                        {
-                            // If the slot is null, try to CAS our element into it.
-                            int tryIndex = (start + i) % c;
-                            Debug.Assert(tryIndex >= 0 && tryIndex < curr.m_elements.Length, "tryIndex is outside of bounds");
-
-                            if (curr.m_elements[tryIndex] == null && Interlocked.CompareExchange(ref curr.m_elements[tryIndex], element, null) == null)
-                            {
-                                // We adjust the free count by --. Note: if this drops to 0, we will skip
-                                // the fragment on the next search iteration.  Searching threads will -- the
-                                // count and force a search every so often, just in case fragmentation occurs.
-                                int newFreeCount = curr.m_freeCount - 1;
-                                curr.m_freeCount = newFreeCount > 0 ? newFreeCount : 0;
-                                return new SparselyPopulatedArrayAddInfo<T>(curr, tryIndex);
-                            }
-                        }
+                        // Cancellation was already requested or the callback was already disposed.
+                        // Even though we have the node itself, it's important to check Callbacks
+                        // in order to synchronize with callback execution.
+                        return false;
                     }
 
-                    curr = curr.m_prev;
-                }
+                    // Remove the registration from the list.
+                    if (node.Prev != null) node.Prev.Next = node.Next;
+                    if (node.Next != null) node.Next.Prev = node.Prev;
+                    if (Callbacks == node) Callbacks = node.Next;
 
-                // If we got here, we need to add a new chunk to the tail and try again.
-                SparselyPopulatedArrayFragment<T> newTail = new SparselyPopulatedArrayFragment<T>(
-                    tail.m_elements.Length == 4096 ? 4096 : tail.m_elements.Length * 2, tail);
-                if (Interlocked.CompareExchange(ref tail.m_next, newTail, null) == null)
+                    // Clear it out and put it on the free list
+                    node.Clear();
+                    node.Prev = null;
+                    node.Next = FreeNodeList;
+                    FreeNodeList = node;
+
+                    return true;
+                }
+                finally
                 {
-                    m_tail = newTail;
+                    Lock.Exit(useMemoryBarrier: false); // no check on lockTaken needed without thread aborts
                 }
             }
         }
-    }
 
-    /// <summary>
-    /// A struct to hold a link to the exact spot in an array an element was inserted, enabling
-    /// constant time removal later on.
-    /// </summary>
-    internal struct SparselyPopulatedArrayAddInfo<T> where T : class
-    {
-        private SparselyPopulatedArrayFragment<T> m_source;
-        private int m_index;
-
-        internal SparselyPopulatedArrayAddInfo(SparselyPopulatedArrayFragment<T> source, int index)
+        /// <summary>All of the state associated a registered callback, in a node that's part of a linked list of registered callbacks.</summary>
+        internal sealed class CallbackNode
         {
-            Debug.Assert(source != null);
-            Debug.Assert(index >= 0 && index < source.Length);
-            m_source = source;
-            m_index = index;
-        }
+            public readonly CallbackPartition Partition;
+            public CallbackNode Prev;
+            public CallbackNode Next;
 
-        internal SparselyPopulatedArrayFragment<T> Source
-        {
-            get { return m_source; }
-        }
+            public long Id;
+            public Action<object> Callback;
+            public object CallbackState;
+            public ExecutionContext ExecutionContext;
+            public SynchronizationContext SynchronizationContext;
+            
+            public CallbackNode(CallbackPartition partition)
+            {
+                Debug.Assert(partition != null, "Expected non-null partition");
+                Partition = partition;
+            }
 
-        internal int Index
-        {
-            get { return m_index; }
-        }
-    }
+            public void Clear()
+            {
+                Id = 0;
+                Callback = null;
+                CallbackState = null;
+                ExecutionContext = null;
+                SynchronizationContext = null;
+            }
 
-    /// <summary>
-    /// A fragment of a sparsely populated array, doubly linked.
-    /// </summary>
-    /// <typeparam name="T">The kind of elements contained within.</typeparam>
-    internal class SparselyPopulatedArrayFragment<T> where T : class
-    {
-        internal readonly T[] m_elements; // The contents, sparsely populated (with nulls).
-        internal volatile int m_freeCount; // A hint of the number of free elements.
-        internal volatile SparselyPopulatedArrayFragment<T> m_next; // The next fragment in the chain.
-        internal volatile SparselyPopulatedArrayFragment<T> m_prev; // The previous fragment in the chain.
-
-        internal SparselyPopulatedArrayFragment(int size) : this(size, null)
-        {
-        }
-
-        internal SparselyPopulatedArrayFragment(int size, SparselyPopulatedArrayFragment<T> prev)
-        {
-            m_elements = new T[size];
-            m_freeCount = size;
-            m_prev = prev;
-        }
-
-        internal T this[int index]
-        {
-            get { return Volatile.Read<T>(ref m_elements[index]); }
-        }
-
-        internal int Length
-        {
-            get { return m_elements.Length; }
-        }
-
-#if DEBUG
-        // Used in DEBUG mode by CancellationTokenSource.CallbackCount
-        internal SparselyPopulatedArrayFragment<T> Next
-        {
-            get { return m_next; }
-        }
-#endif
-        internal SparselyPopulatedArrayFragment<T> Prev
-        {
-            get { return m_prev; }
-        }
-
-        // only removes the item at the specified index if it is still the expected one.
-        // Returns the prevailing value.
-        // The remove occurred successfully if the return value == expected element
-        // otherwise the remove did not occur.
-        internal T SafeAtomicRemove(int index, T expectedElement)
-        {
-            T prevailingValue = Interlocked.CompareExchange(ref m_elements[index], null, expectedElement);
-            if (prevailingValue != null)
-                ++m_freeCount;
-            return prevailingValue;
+            public void ExecuteCallback()
+            {
+                if (ExecutionContext != null)
+                {
+                    ExecutionContext.Run(ExecutionContext, s =>
+                    {
+                        CallbackNode n = (CallbackNode)s;
+                        n.Callback(n.CallbackState);
+                    }, this);
+                }
+                else
+                {
+                    Callback(CallbackState);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
CancellationToken.Register currently allocates an object per call.  This PR makes it allocation-free (amortized).

The current implementation was optimized for scalability, using a lock-free algorithm to minimize contention when lots of threads are registering with a token concurrently.  Each registration allocates an object which is then stored into a lock-free sparse array data structure.  But the level of scalability enabled is unnecessary for the vast majority of CancellationToken usage, adds non-trivial complexity to the implementation, and adds costs to the most common usage scenarios, e.g. a single CancellationToken that registered with and the unregistered with repeatedly.

The new implementation strikes a (IMO) better balance between performance and scalability, retaining most of the latter while doing much better for the former in the most interesting use cases.  CancellationTokenSource now maintains an array of partition objects, each of which is lazily-initialized, contains a lock that protects that partition, and contains a linked list of registration objects.  The striped locking helps maintain most of the scalability and also enables node reuse due to not suffering from ABA problems.

(All numbers that follow are 64-bit.)

The size of CancellationTokenSource itself doesn't change (64 bytes), so allocating a CancellationTokenSource and then never registering with its token remains the same in both speed and space.

The size overhead associated with the first registration on a CancellationTokenSource improves.  With the old implementation, the first registration would result in 272 bytes allocated, whereas with the new implementation that shrinks to 218.

Each additional registration at the same time in the CancellationToken is now larger than in the old implementation, 80 bytes instead of ~56 bytes (it varies in the old implementation due to the details of the lock-free algorithm and when new segments are created), but these new node allocations are reusable.  So if you register 100 registrations with the same CancellationToken and don't unregister any of them, you'll incur ~8000 bytes of allocation instead of ~5600, but if you instead register and unregister them 100 times, you'll only incur ~80 bytes of allocation instead of ~5600, with objects reused for the former case but not the latter case.

Speed is also significantly improved.  A single thread registering and unregistering repeatedly from a token is now ~2x the old implementation in throughput.  Similarly with eight threads on eight logical cores all registering/unregistering concurrently.

Finally, the size of CancellationTokenRegistration also shrinks by a few bytes.  This struct is often contained in other classes that have registered with the token, and so will end up shrinking the size of those allocations as well.

cc: @kouvel, @alexperovich, @benaadams 