### PR TITLE
Fix resources lookup to use satellite assembly resouce lookup inside AppX when the assembly is Private.Corelib

### DIFF
--- a/src/mscorlib/src/System/Resources/ResourceManager.cs
+++ b/src/mscorlib/src/System/Resources/ResourceManager.cs
@@ -889,7 +889,7 @@ namespace System.Resources
         //       contains the PRI resources.
         private bool ShouldUseSatelliteAssemblyResourceLookupUnderAppX(RuntimeAssembly resourcesAssembly)
         {
-            bool fUseSatelliteAssemblyResourceLookupUnderAppX = true; // TODO: https://github.com/dotnet/coreclr/issues/12178 once we fix our uap testhost
+            bool fUseSatelliteAssemblyResourceLookupUnderAppX = typeof(Object).Assembly == resourcesAssembly;
 
             if (!fUseSatelliteAssemblyResourceLookupUnderAppX)
             {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/coreclr/issues/12178

Infrastructure changes in corefx are in PR so we can bring back whenever that PR is merged to not block CI.

cc: @jkotas @tarekgh 