### PR TITLE
[Linux] Create crash dump (minidump) on unhandled SIGILL, SIGFPE, SIGSEGV, SIGTRAP, SIGBUS

### DIFF
--- a/src/pal/src/exception/signal.cpp
+++ b/src/pal/src/exception/signal.cpp
@@ -357,6 +357,7 @@ static void sigill_handler(int code, siginfo_t *siginfo, void *context)
     }
 
     PROCNotifyProcessShutdown();
+    PROCCreateCrashDumpIfEnabled();
 }
 
 /*++
@@ -391,6 +392,7 @@ static void sigfpe_handler(int code, siginfo_t *siginfo, void *context)
     }
 
     PROCNotifyProcessShutdown();
+    PROCCreateCrashDumpIfEnabled();
 }
 
 /*++
@@ -498,6 +500,7 @@ static void sigsegv_handler(int code, siginfo_t *siginfo, void *context)
     }
 
     PROCNotifyProcessShutdown();
+    PROCCreateCrashDumpIfEnabled();
 }
 
 /*++
@@ -533,6 +536,7 @@ static void sigtrap_handler(int code, siginfo_t *siginfo, void *context)
     }
 
     PROCNotifyProcessShutdown();
+    PROCCreateCrashDumpIfEnabled();
 }
 
 /*++
@@ -570,6 +574,7 @@ static void sigbus_handler(int code, siginfo_t *siginfo, void *context)
     }
 
     PROCNotifyProcessShutdown();
+    PROCCreateCrashDumpIfEnabled();
 }
 
 /*++

--- a/src/pal/src/include/pal/process.h
+++ b/src/pal/src/include/pal/process.h
@@ -160,6 +160,17 @@ VOID PROCNotifyProcessShutdown();
 
 /*++
 Function:
+  PROCCreateCrashDumpIfEnabled
+
+  Creates crash dump of the process (if enabled). Can be
+  called from the unhandled native exception handler.
+
+(no return value)
+--*/
+VOID PROCCreateCrashDumpIfEnabled();
+
+/*++
+Function:
   InitializeFlushProcessWriteBuffers
 
 Abstract


### PR DESCRIPTION
According to https://github.com/dotnet/coreclr/blob/master/Documentation/botr/xplat-minidump-generation.md a crash dump file should be created because of unhandled h/w signal (if requested with `COMPlus_CreateDumpDiagnostics=1`).
However, handlers for the signals only call `PROCNotifyProcessShutdown()` function which does not generate the crash dump.

This PR enables creation of minidump on unhandled SIGILL, SIGFPE, SIGSEGV, SIGTRAP, SIGBUS.

@mikem8361 PTAL

CC: @Dmitri-Botcharnikov, @kbaladurin 
