### PR TITLE
Fix issues with early dumps of multi-reg-returning calls.

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -9915,7 +9915,7 @@ void Compiler::gtDispRegVal(GenTree* tree)
         // 0th reg is gtRegNum, which is already printed above.
         // Print the remaining regs of a multi-reg call node.
         GenTreeCall* call     = tree->AsCall();
-        unsigned     regCount = call->GetReturnTypeDesc()->GetReturnRegCount();
+        unsigned     regCount = call->GetReturnTypeDesc()->TryGetReturnRegCount();
         for (unsigned i = 1; i < regCount; ++i)
         {
             printf(",%s", compRegVarName(call->GetRegNumByIdx(i)));
@@ -9925,7 +9925,7 @@ void Compiler::gtDispRegVal(GenTree* tree)
     {
         GenTreeCopyOrReload* copyOrReload = tree->AsCopyOrReload();
         GenTreeCall*         call         = tree->gtGetOp1()->AsCall();
-        unsigned             regCount     = call->GetReturnTypeDesc()->GetReturnRegCount();
+        unsigned             regCount     = call->GetReturnTypeDesc()->TryGetReturnRegCount();
         for (unsigned i = 1; i < regCount; ++i)
         {
             printf(",%s", compRegVarName(copyOrReload->GetRegNumByIdx(i)));

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -3171,6 +3171,13 @@ public:
 #endif
     }
 
+#ifdef DEBUG
+    unsigned TryGetReturnRegCount() const
+    {
+        return m_inited ? GetReturnRegCount() : 0;
+    }
+#endif //DEBUG
+
     //--------------------------------------------------------------------------------------------
     // GetReturnRegCount:  Get the count of return registers in which the return value is returned.
     //

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -3172,6 +3172,8 @@ public:
     }
 
 #ifdef DEBUG
+    // NOTE: we only use this function when writing out IR dumps. These dumps may take place before the ReturnTypeDesc
+    // has been initialized.
     unsigned TryGetReturnRegCount() const
     {
         return m_inited ? GetReturnRegCount() : 0;

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -3176,7 +3176,7 @@ public:
     {
         return m_inited ? GetReturnRegCount() : 0;
     }
-#endif //DEBUG
+#endif // DEBUG
 
     //--------------------------------------------------------------------------------------------
     // GetReturnRegCount:  Get the count of return registers in which the return value is returned.


### PR DESCRIPTION
The tree dump code was calling `GetReturnRegCount` before the return type
descriptor was initialized, which lead to an assert. This change introduces
a new debug-only method that simply returns `0` if the return type desc
has not been initialized.