### PR TITLE
Revert PR: https://github.com/dotnet/coreclr/pull/12830

### DIFF
--- a/src/mscorlib/src/System/Resources/ResourceManager.cs
+++ b/src/mscorlib/src/System/Resources/ResourceManager.cs
@@ -889,7 +889,7 @@ namespace System.Resources
         //       contains the PRI resources.
         private bool ShouldUseSatelliteAssemblyResourceLookupUnderAppX(RuntimeAssembly resourcesAssembly)
         {
-            bool fUseSatelliteAssemblyResourceLookupUnderAppX = typeof(Object).Assembly == resourcesAssembly;
+            bool fUseSatelliteAssemblyResourceLookupUnderAppX = true; // TODO: https://github.com/dotnet/coreclr/issues/12178 once we fix our uap testhost
 
             if (!fUseSatelliteAssemblyResourceLookupUnderAppX)
             {


### PR DESCRIPTION
Reverting this PR to unblock coreclr ingestion in corefx. I will open another PR to bring this change back once the infrastructure changes are merged into buildtools and consumed by corefx.

See: https://github.com/dotnet/corefx/pull/22295#issuecomment-315574780

cc: @stephentoub