### PR TITLE
[WIP] Encapsulate parts of fgComputeLife in a helper class.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -85,6 +85,8 @@ class CSE_DataFlow; // defined in OptCSE.cpp
 struct IndentStack;
 #endif
 
+class ComputeLifeHelper;
+
 #ifndef LEGACY_BACKEND
 class Lowering; // defined in lower.h
 #endif
@@ -3768,17 +3770,12 @@ public:
 
     void fgUpdateRefCntForExtract(GenTreePtr wholeTree, GenTreePtr keptTree);
 
-    void fgComputeLifeCall(VARSET_TP& life, GenTreeCall* call);
-
-    bool fgComputeLifeLocal(VARSET_TP& life, VARSET_VALARG_TP keepAliveVars, GenTree* lclVarNode, GenTree* node);
-
-    void fgComputeLife(VARSET_TP&       life,
-                       GenTreePtr       startNode,
-                       GenTreePtr       endNode,
-                       VARSET_VALARG_TP volatileVars,
+    void fgComputeLife(ComputeLifeHelper& helper,
+                       GenTree*           startNode,
+                       GenTree*           endNode,
                        bool* pStmtInfoDirty DEBUGARG(bool* treeModf));
 
-    void fgComputeLifeLIR(VARSET_TP& life, BasicBlock* block, VARSET_VALARG_TP volatileVars);
+    void fgComputeLifeLIR(ComputeLifeHelper& helper, BasicBlock* block);
 
     bool fgRemoveDeadStore(GenTree**        pTree,
                            LclVarDsc*       varDsc,

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -2218,7 +2218,7 @@ void Compiler::fgComputeLife(ComputeLifeHelper& helper,
             /* Variables in the two branches that are live at the split
              * must interfere with each other */
 
-            fgMarkIntf(life, gtColonLiveSet);
+            fgMarkIntf(helper.LiveVars(), gtColonLiveSet);
 
             /* The live set at the split is the union of the two branches */
 


### PR DESCRIPTION
This avoids the passing around of bitsets and helps clarify the per-node
liveness logic somewhat. This is in preparation for some further minor
refactoring of local var liveness.