### PR TITLE
Fix a build break when compiling with Standalone GC on non-Windows platforms

### DIFF
--- a/src/gc/unix/gcenv.unix.cpp
+++ b/src/gc/unix/gcenv.unix.cpp
@@ -78,7 +78,7 @@ bool GCToOSInterface::Initialize()
 {
     int pageSize = sysconf( _SC_PAGE_SIZE );
 
-    g_pageSizeUnixInl = uint32_t((pageSize > 0) pageSize : 0x1000);
+    g_pageSizeUnixInl = uint32_t((pageSize > 0) ? pageSize : 0x1000);
 
     // Calculate and cache the number of processors on this machine
     int cpuCount = sysconf(_SC_NPROCESSORS_ONLN);


### PR DESCRIPTION
Unfortunate that this one slipped through the cracks, but this should fix up the standalone GC CI jobs.