### PR TITLE
Add regression tests for #12761.

### DIFF
--- a/tests/src/JIT/Regression/JitBlue/GitHub_12761/GitHub_12761.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_12761/GitHub_12761.il
@@ -1,0 +1,165 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib {}
+
+.assembly GitHub_12761
+{
+}
+
+// =============== CLASS MEMBERS DECLARATION ===================
+
+.class public auto ansi beforefieldinit Test
+       extends [mscorlib]System.Object
+{
+  .class sequential ansi sealed nested public beforefieldinit IntWrapper
+         extends [mscorlib]System.ValueType
+  {
+    .field public int32 i
+  } // end of class IntWrapper
+
+  // Sum1 and Sum2 are have tail-recursive calls that the jit turns into loops.
+  // Both methods access locals that are not initialized by msil instructions; instead,
+  // the methods have .locals init directives. The jit has to initialize the locals on each iteration
+  // of the loop. The first test has a scalar local, the second test has a struct local.
+
+  .method public hidebysig static int32  Main() cil managed
+  {
+    .entrypoint
+    .maxstack  8
+              ldc.i4.0
+              ldc.i4.s   10
+              call       int32 Test::Sum1(int32,
+                                          int32)
+              ldc.i4.s   55
+              beq      TEST2
+
+              ldc.i4.m1
+              ret
+
+    TEST2:    ldc.i4.0
+              ldc.i4.s   10
+              call       int32 Test::Sum2(int32,
+                                          int32)
+              ldc.i4.s   55
+              beq.s      SUCCESS
+
+              ldc.i4.m1
+              ret
+
+    SUCCESS:  ldc.i4.s   100
+              ret
+  } // end of method Test::Main
+
+  .method public hidebysig static int32  Sum1(int32 cur,
+                                              int32 n) cil managed
+  {
+    .maxstack  3
+    .locals init (int32 V_0)
+
+              ldloc.0
+              brfalse.s  L1
+
+              ldc.i4     0x7d0
+              ret
+
+    L1:       ldarg.1
+              brtrue.s   L2
+
+              ldarg.0
+              ret
+
+    L2:       ldloc.0
+              call       int32 Test::AddTwo(int32)
+              stloc.0
+              ldarg.0
+              ldarg.1
+              add
+              ldarg.1
+              ldc.i4.1
+              sub
+              call       int32 Test::Sum1(int32,
+                                          int32)
+              ret
+  } // end of method Test::Sum1
+
+  .method public hidebysig static int32  Sum2(int32 cur,
+                                              int32 n) cil managed
+  {
+    .maxstack  3
+    .locals init (valuetype Test/IntWrapper V_0)
+
+              ldloc.0
+              call       bool Test::CheckZero(valuetype Test/IntWrapper)
+              brtrue.s   L1
+
+              ldc.i4     0x7d0
+              ret
+
+    L1:       ldarg.1
+              brtrue.s   L2
+
+              ldarg.0
+              ret
+
+    L2:  ldloc.0
+              call       valuetype Test/IntWrapper Test::AddTwo(valuetype Test/IntWrapper)
+              stloc.0
+              ldarg.0
+              ldarg.1
+              add
+              ldarg.1
+              ldc.i4.1
+              sub
+              call       int32 Test::Sum2(int32,
+                                          int32)
+              ret
+  } // end of method Test::Sum2
+
+  .method public hidebysig static int32  AddTwo(int32 i) cil managed noinlining
+  {
+    .maxstack  8
+              ldarg.0
+              ldc.i4.2
+              add
+              ret
+  } // end of method Test::AddTwo
+
+  .method public hidebysig static valuetype Test/IntWrapper 
+          AddTwo(valuetype Test/IntWrapper wrapper) cil managed noinlining
+  {
+    .maxstack  8
+              ldarga.s   wrapper
+              ldflda     int32 Test/IntWrapper::i
+              dup
+              ldind.i4
+              ldc.i4.2
+              add
+              stind.i4
+              ldarg.0
+              ret
+  } // end of method Test::AddTwo
+
+  .method public hidebysig static bool  CheckZero(valuetype Test/IntWrapper wrapper) cil managed noinlining
+  {
+    .maxstack  8
+              ldarg.0
+              ldfld      int32 Test/IntWrapper::i
+              ldc.i4.0
+              ceq
+              ret
+  } // end of method Test::CheckZero
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    .maxstack  8
+              ldarg.0
+              call       instance void [mscorlib]System.Object::.ctor()
+              ret
+  } // end of method Test::.ctor
+
+} // end of class Test
+
+// =============================================================

--- a/tests/src/JIT/Regression/JitBlue/GitHub_12761/GitHub_12761.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_12761/GitHub_12761.ilproj
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_12761.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
#12761 was fixed by #12735.
The bug was repro-ing on a dynamic method produced by Reflection::Emit.

It's not possible to repro the bug on normal C# code because of
C# definite assignment rules.

This change adds a simple il regression test.