### PR TITLE
[RyuJIT/ARM32] Block copy for promoted struct argument assign

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -3655,6 +3655,9 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                                 {
                                     fgAddSkippedRegsInPromotedStructArg(varDsc, intArgRegNum, &argSkippedRegMask);
                                 }
+#if !defined(LEGACY_BACKEND)
+                                copyBlkClass = objClass;
+#endif
                             }
                         }
 #endif // _TARGET_ARM_


### PR DESCRIPTION
Block copy for promoted struct
Similar implementation as x64 with FEATURE_UNIX_AMD64_STRUCT_PASSING

Related issue: #12810