### PR TITLE
Missed one empty case in GetPathRoot

### DIFF
--- a/src/mscorlib/shared/System/IO/Path.Windows.cs
+++ b/src/mscorlib/shared/System/IO/Path.Windows.cs
@@ -141,7 +141,7 @@ namespace System.IO
         public static string GetPathRoot(string path)
         {
             if (path == null) return null;
-            if (string.IsNullOrEmpty(path))
+            if (PathInternal.IsEffectivelyEmpty(path))
                 throw new ArgumentException(SR.Arg_PathEmpty, nameof(path));
 
             PathInternal.CheckInvalidPathChars(path);

--- a/src/mscorlib/shared/System/IO/Path.cs
+++ b/src/mscorlib/shared/System/IO/Path.cs
@@ -76,11 +76,11 @@ namespace System.IO
         // "\\server\share").
         public static string GetDirectoryName(string path)
         {
+            if (path == null)
+                return null;
+
             if (PathInternal.IsEffectivelyEmpty(path))
-            {
-                if (path == null) return null;
                 throw new ArgumentException(SR.Arg_PathEmpty, nameof(path));
-            }
 
             PathInternal.CheckInvalidPathChars(path);
             path = PathInternal.NormalizeDirectorySeparators(path);


### PR DESCRIPTION
This matches our new behavior with whitespace paths