### PR TITLE
Improve DCE in LIR liveness.

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -6097,10 +6097,11 @@ void CodeGen::genCompareInt(GenTreePtr treeNode)
     // it was spilled after producing its result in a register.
     // Spill code too will not modify the flags set by op1.
     GenTree* realOp1 = op1->gtSkipReloadOrCopy();
-    if (realOp1->gtSetFlags())
+    if ((tree->gtFlags & GTF_USE_FLAGS) != 0)
     {
         // op1 must set ZF and SF flags
         assert(realOp1->gtSetZSFlags());
+        assert(realOp1->gtSetFlags());
 
         // Must be (in)equality against zero.
         assert(tree->OperIs(GT_EQ, GT_NE));

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -9288,10 +9288,6 @@ int cTreeFlagsIR(Compiler* comp, GenTree* tree)
                 {
                     chars += printf("[IND_VOLATILE]");
                 }
-                if (tree->gtFlags & GTF_IND_REFARR_LAYOUT)
-                {
-                    chars += printf("[IND_REFARR_LAYOUT]");
-                }
                 if (tree->gtFlags & GTF_IND_TGTANYWHERE)
                 {
                     chars += printf("[IND_TGTANYWHERE]");

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3780,6 +3780,9 @@ public:
 
     void fgComputeLifeCall(VARSET_TP& life, GenTreeCall* call);
 
+    void fgComputeLifeTrackedLocalUse(VARSET_TP& life, LclVarDsc& varDsc, GenTreeLclVarCommon* node);
+    bool fgComputeLifeTrackedLocalDef(VARSET_TP& life, VARSET_VALARG_TP keepAliveVars, LclVarDsc& varDsc, GenTreeLclVarCommon* node);
+    void fgComputeLifeUntrackedLocal(VARSET_TP& life, VARSET_VALARG_TP keepAliveVars, LclVarDsc& varDsc, GenTreeLclVarCommon* lclVarNode, GenTree* node);
     bool fgComputeLifeLocal(VARSET_TP& life, VARSET_VALARG_TP keepAliveVars, GenTree* lclVarNode, GenTree* node);
 
     void fgComputeLife(VARSET_TP&       life,

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3781,8 +3781,15 @@ public:
     void fgComputeLifeCall(VARSET_TP& life, GenTreeCall* call);
 
     void fgComputeLifeTrackedLocalUse(VARSET_TP& life, LclVarDsc& varDsc, GenTreeLclVarCommon* node);
-    bool fgComputeLifeTrackedLocalDef(VARSET_TP& life, VARSET_VALARG_TP keepAliveVars, LclVarDsc& varDsc, GenTreeLclVarCommon* node);
-    void fgComputeLifeUntrackedLocal(VARSET_TP& life, VARSET_VALARG_TP keepAliveVars, LclVarDsc& varDsc, GenTreeLclVarCommon* lclVarNode, GenTree* node);
+    bool fgComputeLifeTrackedLocalDef(VARSET_TP&           life,
+                                      VARSET_VALARG_TP     keepAliveVars,
+                                      LclVarDsc&           varDsc,
+                                      GenTreeLclVarCommon* node);
+    void fgComputeLifeUntrackedLocal(VARSET_TP&           life,
+                                     VARSET_VALARG_TP     keepAliveVars,
+                                     LclVarDsc&           varDsc,
+                                     GenTreeLclVarCommon* lclVarNode,
+                                     GenTree*             node);
     bool fgComputeLifeLocal(VARSET_TP& life, VARSET_VALARG_TP keepAliveVars, GenTree* lclVarNode, GenTree* node);
 
     void fgComputeLife(VARSET_TP&       life,
@@ -3798,8 +3805,6 @@ public:
                            VARSET_VALARG_TP life,
                            bool*            doAgain,
                            bool* pStmtInfoDirty DEBUGARG(bool* treeModf));
-
-    bool fgTryRemoveDeadLIRStore(LIR::Range& blockRange, GenTree* node, GenTree** next);
 
     // For updating liveset during traversal AFTER fgComputeLife has completed
     VARSET_VALRET_TP fgGetVarBits(GenTreePtr tree);

--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -992,10 +992,13 @@ GenTree* DecomposeLongs::DecomposeArith(LIR::Use& use)
 
     if ((oper == GT_ADD) || (oper == GT_SUB))
     {
+        loResult->gtFlags |= GTF_SET_FLAGS;
+        hiResult->gtFlags |= GTF_USE_FLAGS;
+
         if (loResult->gtOverflow())
         {
-            hiResult->gtFlags |= GTF_OVERFLOW;
-            loResult->gtFlags &= ~GTF_OVERFLOW;
+            hiResult->gtFlags |= GTF_OVERFLOW | GTF_EXCEPT;
+            loResult->gtFlags &= ~(GTF_OVERFLOW | GTF_EXCEPT);
         }
         if (loResult->gtFlags & GTF_UNSIGNED)
         {

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -862,6 +862,7 @@ public:
 
 #define GTF_ZSF_SET     0x00000400 // the zero(ZF) and sign(SF) flags set to the operand
 #define GTF_SET_FLAGS   0x00000800 // Requires that codegen for this node set the flags. Use gtSetFlags() to check this flag.
+#define GTF_USE_FLAGS   0x00001000 // Indicates that this node uses the flags bits.
 
 #define GTF_MAKE_CSE    0x00002000 // Hoisted expression: try hard to make this into CSE (see optPerformHoistExpr)
 #define GTF_DONT_CSE    0x00004000 // Don't bother CSE'ing this expr
@@ -942,9 +943,10 @@ public:
 #define GTF_INX_REFARR_LAYOUT       0x20000000 // GT_INDEX -- same as GTF_IND_REFARR_LAYOUT
 #define GTF_INX_STRING_LAYOUT       0x40000000 // GT_INDEX -- this uses the special string array layout
 
-#define GTF_IND_NONFAULTING      GTF_SET_FLAGS // GT_IND   -- An indir that cannot fault. GTF_SET_FLAGS is not used on indirs.
+#define GTF_IND_ARR_LEN             0x80000000 // GT_IND   -- the indirection represents an array length (of the REF
+                                               //             contribution to its argument).
 #define GTF_IND_VOLATILE            0x40000000 // GT_IND   -- the load or store must use volatile sematics (this is a nop on X86)
-#define GTF_IND_REFARR_LAYOUT       0x20000000 // GT_IND   -- the array holds object refs (only affects layout of Arrays)
+#define GTF_IND_NONFAULTING         0x20000000 // GT_IND   -- An indir that cannot fault.
 #define GTF_IND_TGTANYWHERE         0x10000000 // GT_IND   -- the target could be anywhere
 #define GTF_IND_TLS_REF             0x08000000 // GT_IND   -- the target is accessed via TLS
 #define GTF_IND_ASG_LHS             0x04000000 // GT_IND   -- this GT_IND node is (the effective val) of the LHS of an
@@ -958,12 +960,10 @@ public:
 #define GTF_IND_UNALIGNED           0x02000000 // GT_IND   -- the load or store is unaligned (we assume worst case
                                                //             alignment of 1 byte)
 #define GTF_IND_INVARIANT           0x01000000 // GT_IND   -- the target is invariant (a prejit indirection)
-#define GTF_IND_ARR_LEN             0x80000000 // GT_IND   -- the indirection represents an array length (of the REF
-                                               //             contribution to its argument).
 #define GTF_IND_ARR_INDEX           0x00800000 // GT_IND   -- the indirection represents an (SZ) array index
 
 #define GTF_IND_FLAGS \
-    (GTF_IND_VOLATILE | GTF_IND_REFARR_LAYOUT | GTF_IND_TGTANYWHERE | GTF_IND_NONFAULTING | GTF_IND_TLS_REF |          \
+    (GTF_IND_VOLATILE | GTF_IND_TGTANYWHERE | GTF_IND_NONFAULTING | GTF_IND_TLS_REF |          \
      GTF_IND_UNALIGNED | GTF_IND_INVARIANT | GTF_IND_ARR_INDEX)
 
 #define GTF_CLS_VAR_VOLATILE        0x40000000 // GT_FIELD/GT_CLS_VAR -- same as GTF_IND_VOLATILE
@@ -3828,6 +3828,8 @@ struct GenTreeCall final : public GenTree
     }
 
     bool IsPure(Compiler* compiler) const;
+
+    bool HasSideEffects(Compiler* compiler, bool ignoreExceptions = false, bool ignoreCctors = false) const;
 
     void ClearFatPointerCandidate()
     {

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -1687,6 +1687,14 @@ void Compiler::fgComputeLifeCall(VARSET_TP& life, GenTreeCall* call)
     }
 }
 
+//------------------------------------------------------------------------
+// Compiler::fgComputeLifeTrackedLocalUse:
+//    Compute the changes to local var liveness due to a use of a tracked local var.
+//
+// Arguments:
+//    life          - The live set that is being computed.
+//    varDsc        - The LclVar descriptor for the variable being used or defined.
+//    node          - The node that is defining the lclVar.
 void Compiler::fgComputeLifeTrackedLocalUse(VARSET_TP& life, LclVarDsc& varDsc, GenTreeLclVarCommon* node)
 {
     assert(node != nullptr);
@@ -1722,7 +1730,23 @@ void Compiler::fgComputeLifeTrackedLocalUse(VARSET_TP& life, LclVarDsc& varDsc, 
     fgMarkIntf(life, varIndex);
 }
 
-bool Compiler::fgComputeLifeTrackedLocalDef(VARSET_TP& life, VARSET_VALARG_TP keepAliveVars, LclVarDsc& varDsc, GenTreeLclVarCommon* node)
+//------------------------------------------------------------------------
+// Compiler::fgComputeLifeTrackedLocalDef:
+//    Compute the changes to local var liveness due to a def of a tracked local var and return `true` if the def is a
+//    dead store.
+//
+// Arguments:
+//    life          - The live set that is being computed.
+//    keepAliveVars - The current set of variables to keep alive regardless of their actual lifetime.
+//    varDsc        - The LclVar descriptor for the variable being used or defined.
+//    node          - The node that is defining the lclVar.
+//
+// Returns:
+//    `true` if the def is a dead store; `false` otherwise.
+bool Compiler::fgComputeLifeTrackedLocalDef(VARSET_TP&           life,
+                                            VARSET_VALARG_TP     keepAliveVars,
+                                            LclVarDsc&           varDsc,
+                                            GenTreeLclVarCommon* node)
 {
     assert(node != nullptr);
     assert((node->gtFlags & GTF_VAR_DEF) != 0);
@@ -1731,12 +1755,10 @@ bool Compiler::fgComputeLifeTrackedLocalDef(VARSET_TP& life, VARSET_VALARG_TP ke
     const unsigned varIndex = varDsc.lvVarIndex;
     if (VarSetOps::IsMember(this, life, varIndex))
     {
-        /* The variable is live */
-
+        // The variable is live
         if ((node->gtFlags & GTF_VAR_USEASG) == 0)
         {
-            /* Mark variable as dead from here to its closest use */
-
+            // Remove the variable from the live set if it is not in the keepalive set.
             if (!VarSetOps::IsMember(this, keepAliveVars, varIndex))
             {
                 VarSetOps::RemoveElemD(this, life, varIndex);
@@ -1747,8 +1769,8 @@ bool Compiler::fgComputeLifeTrackedLocalDef(VARSET_TP& life, VARSET_VALARG_TP ke
                 printf("Def V%02u,T%02u at ", node->gtLclNum, varIndex);
                 printTreeID(node);
                 printf(" life %s -> %s\n",
-                       VarSetOps::ToString(this, VarSetOps::Union(this, life,
-                                                                  VarSetOps::MakeSingleton(this, varIndex))),
+                       VarSetOps::ToString(this,
+                                           VarSetOps::Union(this, life, VarSetOps::MakeSingleton(this, varIndex))),
                        VarSetOps::ToString(this, life));
             }
 #endif // DEBUG
@@ -1756,7 +1778,7 @@ bool Compiler::fgComputeLifeTrackedLocalDef(VARSET_TP& life, VARSET_VALARG_TP ke
     }
     else
     {
-        /* Dead assignment to the variable */
+        // Dead store
         node->gtFlags |= GTF_VAR_DEATH;
 
         if (!opts.MinOpts())
@@ -1769,15 +1791,32 @@ bool Compiler::fgComputeLifeTrackedLocalDef(VARSET_TP& life, VARSET_VALARG_TP ke
             // of the variable has been exposed. Improved alias analysis could allow
             // stores to these sorts of variables to be removed at the cost of compile
             // time.
-            return !varDsc.lvAddrExposed &&
-                   !(varDsc.lvIsStructField && lvaTable[varDsc.lvParentLcl].lvAddrExposed);
+            return !varDsc.lvAddrExposed && !(varDsc.lvIsStructField && lvaTable[varDsc.lvParentLcl].lvAddrExposed);
         }
     }
 
     return false;
 }
 
-void Compiler::fgComputeLifeUntrackedLocal(VARSET_TP& life, VARSET_VALARG_TP keepAliveVars, LclVarDsc& varDsc, GenTreeLclVarCommon* lclVarNode, GenTree* node)
+//------------------------------------------------------------------------
+// Compiler::fgComputeLifeUntrackedLocal:
+//    Compute the changes to local var liveness due to a use or a def of an untracked local var.
+//
+// Note:
+//    It may seem a bit counter-intuitive that a change to an untracked lclVar could affect the liveness of tracked
+//    lclVars. In theory, this could happen with promoted (especially dependently-promoted) structs: in these cases,
+//    a use or def of the untracked struct var is treated as a use or def of any of its component fields that are
+//    tracked.
+//
+// Arguments:
+//    life          - The live set that is being computed.
+//    keepAliveVars - The current set of variables to keep alive regardless of their actual lifetime.
+//    varDsc        - The LclVar descriptor for the variable being used or defined.
+//    lclVarNode    - The node that corresponds to the local var def or use. Only differs from `node` when targeting
+//                    the legacy backend.
+//    node          - The actual tree node being processed.
+void Compiler::fgComputeLifeUntrackedLocal(
+    VARSET_TP& life, VARSET_VALARG_TP keepAliveVars, LclVarDsc& varDsc, GenTreeLclVarCommon* lclVarNode, GenTree* node)
 {
     assert(lclVarNode != nullptr);
     assert(node != nullptr);
@@ -1844,24 +1883,19 @@ void Compiler::fgComputeLifeUntrackedLocal(VARSET_TP& life, VARSET_VALARG_TP kee
 }
 
 //------------------------------------------------------------------------
-// Compiler::fgComputeLifeLocal: compute the changes to local var liveness
-//                               due to a use or a def of a local var and
-//                               indicates wither the use/def is a dead
-//                               store.
+// Compiler::fgComputeLifeLocal:
+//    Compute the changes to local var liveness due to a use or a def of a local var and indicates whether the use/def
+//    is a dead store.
 //
 // Arguments:
 //    life          - The live set that is being computed.
-//    keepAliveVars - The currents set of variables to keep alive
-//                    regardless of their actual lifetime.
-//    lclVarNode    - The node that corresponds to the local var def or
-//                    use. Only differs from `node` when targeting the
-//                    legacy backend.
+//    keepAliveVars - The current set of variables to keep alive regardless of their actual lifetime.
+//    lclVarNode    - The node that corresponds to the local var def or use. Only differs from `node` when targeting
+//                    the legacy backend.
 //    node          - The actual tree node being processed.
 //
 // Returns:
-//    `true` if the local var node corresponds to a dead store; `false`
-//    otherwise.
-//
+//    `true` if the local var node corresponds to a dead store; `false` otherwise.
 bool Compiler::fgComputeLifeLocal(VARSET_TP& life, VARSET_VALARG_TP keepAliveVars, GenTree* lclVarNode, GenTree* node)
 {
     unsigned lclNum = lclVarNode->gtLclVarCommon.gtLclNum;
@@ -1964,17 +1998,230 @@ void Compiler::fgComputeLifeLIR(VARSET_TP& life, BasicBlock* block, VARSET_VALAR
     {
         next = node->gtPrev;
 
-        if (node->OperGet() == GT_CALL)
+        bool isDeadStore;
+        switch (node->OperGet())
         {
-            fgComputeLifeCall(life, node->AsCall());
-        }
-        else if (node->OperIsNonPhiLocal() || node->OperIsLocalAddr())
-        {
-            bool isDeadStore = fgComputeLifeLocal(life, keepAliveVars, node, node);
-            if (isDeadStore && fgTryRemoveDeadLIRStore(blockRange, node, &next))
+            case GT_CALL:
             {
-                fgStmtRemoved = true;
+                GenTreeCall* const call = node->AsCall();
+                if (((call->TypeGet() == TYP_VOID) || call->IsUnusedValue()) && !call->HasSideEffects(this))
+                {
+                    JITDUMP("Removing dead call:\n");
+                    DISPNODE(call);
+
+                    node->VisitOperands([](GenTree* operand) -> GenTree::VisitResult {
+                        if (operand->IsValue())
+                        {
+                            operand->SetUnusedValue();
+                        }
+
+                        // Special-case PUTARG_STK: since this operator is not considered a value, DCE will not remove
+                        // these nodes.
+                        if (operand->OperIs(GT_PUTARG_STK))
+                        {
+                            operand->AsPutArgStk()->gtOp1->SetUnusedValue();
+                            operand->gtBashToNOP();
+                        }
+
+                        return GenTree::VisitResult::Continue;
+                    });
+
+                    blockRange.Remove(node);
+
+                    // Removing a call does not affect liveness unless it is a tail call in a nethod with P/Invokes or
+                    // is itself a P/Invoke, in which case it may affect the liveness of the frame root variable.
+                    fgStmtRemoved = !opts.MinOpts() && !opts.ShouldUsePInvokeHelpers() &&
+                                    ((call->IsTailCall() && info.compCallUnmanaged) || call->IsUnmanaged()) &&
+                                    lvaTable[info.compLvFrameListRoot].lvTracked;
+                }
+                else
+                {
+                    fgComputeLifeCall(life, call);
+                }
+                break;
             }
+
+            case GT_LCL_VAR:
+            case GT_LCL_FLD:
+            {
+                GenTreeLclVarCommon* const lclVarNode = node->AsLclVarCommon();
+                LclVarDsc&                 varDsc     = lvaTable[lclVarNode->gtLclNum];
+
+                if (node->IsUnusedValue())
+                {
+                    JITDUMP("Removing dead LclVar use:\n");
+                    DISPNODE(lclVarNode);
+
+                    blockRange.Delete(this, block, node);
+                    fgStmtRemoved = varDsc.lvTracked && !opts.MinOpts();
+                }
+                else if (varDsc.lvTracked)
+                {
+                    fgComputeLifeTrackedLocalUse(life, varDsc, lclVarNode);
+                }
+                else
+                {
+                    fgComputeLifeUntrackedLocal(life, keepAliveVars, varDsc, lclVarNode, node);
+                }
+                break;
+            }
+
+            case GT_LCL_VAR_ADDR:
+            case GT_LCL_FLD_ADDR:
+                if (node->IsUnusedValue())
+                {
+                    JITDUMP("Removing dead LclVar address:\n");
+                    DISPNODE(node);
+
+                    const bool isTracked = lvaTable[node->AsLclVarCommon()->gtLclNum].lvTracked;
+                    blockRange.Delete(this, block, node);
+                    fgStmtRemoved = isTracked && !opts.MinOpts();
+                }
+                else
+                {
+                    isDeadStore = fgComputeLifeLocal(life, keepAliveVars, node, node);
+                    if (isDeadStore)
+                    {
+                        LIR::Use addrUse;
+                        if (blockRange.TryGetUse(node, &addrUse) && (addrUse.User()->OperGet() == GT_STOREIND))
+                        {
+                            // Remove the store. DCE will iteratively clean up any ununsed operands.
+                            GenTreeStoreInd* const store = addrUse.User()->AsStoreInd();
+
+                            JITDUMP("Removing dead indirect store:\n");
+                            DISPNODE(store);
+
+                            assert(store->Addr() == node);
+                            blockRange.Delete(this, block, node);
+
+                            store->Data()->SetUnusedValue();
+
+                            blockRange.Remove(store);
+
+                            assert(!opts.MinOpts());
+                            fgStmtRemoved = true;
+                        }
+                    }
+                }
+                break;
+
+            case GT_STORE_LCL_VAR:
+            case GT_STORE_LCL_FLD:
+            {
+                GenTreeLclVarCommon* const lclVarNode = node->AsLclVarCommon();
+
+                LclVarDsc& varDsc = lvaTable[lclVarNode->gtLclNum];
+                if (varDsc.lvTracked)
+                {
+                    isDeadStore = fgComputeLifeTrackedLocalDef(life, keepAliveVars, varDsc, lclVarNode);
+                    if (isDeadStore)
+                    {
+                        JITDUMP("Removing dead store:\n");
+                        DISPNODE(lclVarNode);
+
+                        // Remove the store. DCE will iteratively clean up any ununsed operands.
+                        lclVarNode->gtOp1->SetUnusedValue();
+
+                        lvaDecRefCnts(block, node);
+
+                        // If the store is marked as a late argument, it is referenced by a call. Instead of removing
+                        // it, bash
+                        // it to a NOP.
+                        if ((node->gtFlags & GTF_LATE_ARG) != 0)
+                        {
+                            node->gtBashToNOP();
+                        }
+                        else
+                        {
+                            blockRange.Remove(node);
+                        }
+
+                        assert(!opts.MinOpts());
+                        fgStmtRemoved = true;
+                    }
+                }
+                else
+                {
+                    fgComputeLifeUntrackedLocal(life, keepAliveVars, varDsc, lclVarNode, node);
+                }
+                break;
+            }
+
+            case GT_LABEL:
+            case GT_FTN_ADDR:
+            case GT_CNS_INT:
+            case GT_CNS_LNG:
+            case GT_CNS_DBL:
+            case GT_CNS_STR:
+            case GT_CLS_VAR_ADDR:
+            case GT_PHYSREG:
+                // These are all side-effect-free leaf nodes.
+                if (node->IsUnusedValue())
+                {
+                    JITDUMP("Removing dead node:\n");
+                    DISPNODE(node);
+
+                    blockRange.Remove(node);
+                }
+                break;
+
+            case GT_LOCKADD:
+            case GT_XADD:
+            case GT_XCHG:
+            case GT_CMPXCHG:
+            case GT_MEMORYBARRIER:
+            case GT_JMP:
+            case GT_STOREIND:
+            case GT_ARR_BOUNDS_CHECK:
+            case GT_STORE_OBJ:
+            case GT_STORE_BLK:
+            case GT_STORE_DYN_BLK:
+#if defined(FEATURE_SIMD)
+            case GT_SIMD_CHK:
+#endif // FEATURE_SIMD
+            case GT_CMP:
+            case GT_JCC:
+            case GT_JTRUE:
+            case GT_RETURN:
+            case GT_SWITCH:
+            case GT_RETFILT:
+            case GT_START_NONGC:
+            case GT_PROF_HOOK:
+#if !FEATURE_EH_FUNCLETS
+            case GT_END_LFIN:
+#endif // !FEATURE_EH_FUNCLETS
+            case GT_SWITCH_TABLE:
+            case GT_PINVOKE_PROLOG:
+            case GT_PINVOKE_EPILOG:
+            case GT_RETURNTRAP:
+            case GT_PUTARG_STK:
+            case GT_IL_OFFSET:
+                // Never remove these nodes, as they are always side-effecting.
+                //
+                // NOTE: the only side-effect of some of these nodes (GT_CMP, GT_SUB_HI) is a write to the flags
+                // register.
+                // Properly modeling this would allow these nodes to be removed.
+                break;
+
+            default:
+                assert(!node->OperIsLocal());
+                if (!node->IsValue() || node->IsUnusedValue())
+                {
+                    unsigned sideEffects = node->gtFlags & (GTF_SIDE_EFFECT | GTF_SET_FLAGS);
+                    if ((sideEffects == 0) || ((sideEffects == GTF_EXCEPT) && !node->OperMayThrow()))
+                    {
+                        JITDUMP("Removing dead node:\n");
+                        DISPNODE(node);
+
+                        node->VisitOperands([](GenTree* operand) -> GenTree::VisitResult {
+                            operand->SetUnusedValue();
+                            return GenTree::VisitResult::Continue;
+                        });
+
+                        blockRange.Remove(node);
+                    }
+                }
+                break;
         }
     }
 }
@@ -2322,96 +2569,6 @@ void Compiler::fgComputeLife(VARSET_TP&       life,
 #endif
 
 #endif // !LEGACY_BACKEND
-
-bool Compiler::fgTryRemoveDeadLIRStore(LIR::Range& blockRange, GenTree* node, GenTree** next)
-{
-    assert(node != nullptr);
-    assert(next != nullptr);
-
-    assert(node->OperIsLocalStore() || node->OperIsLocalAddr());
-
-    GenTree* store = nullptr;
-    GenTree* value = nullptr;
-    if (node->OperIsLocalStore())
-    {
-        store = node;
-        value = store->gtGetOp1();
-    }
-    else if (node->OperIsLocalAddr())
-    {
-        LIR::Use addrUse;
-        if (!blockRange.TryGetUse(node, &addrUse) || (addrUse.User()->OperGet() != GT_STOREIND))
-        {
-            *next = node->gtPrev;
-            return false;
-        }
-
-        store = addrUse.User();
-        value = store->gtGetOp2();
-    }
-    JITDUMP("Liveness is removing a dead store:\n");
-    DISPNODE(store);
-
-    bool               isClosed      = false;
-    unsigned           sideEffects   = 0;
-    LIR::ReadOnlyRange operandsRange = blockRange.GetRangeOfOperandTrees(store, &isClosed, &sideEffects);
-    if (!isClosed || ((sideEffects & GTF_SIDE_EFFECT) != 0) ||
-        (((sideEffects & GTF_ORDER_SIDEEFF) != 0) && (value->OperGet() == GT_CATCH_ARG)))
-    {
-        // If the range of the operands contains unrelated code or if it contains any side effects,
-        // do not remove it. Instead, just remove the store.
-        JITDUMP("  Marking operands as unused:\n");
-        DISPRANGE(operandsRange);
-
-        store->VisitOperands([](GenTree* operand) -> GenTree::VisitResult {
-            operand->SetUnusedValue();
-            return GenTree::VisitResult::Continue;
-        });
-
-        *next = node->gtPrev;
-    }
-    else
-    {
-        // Okay, the operands to the store form a contiguous range that has no side effects. Remove the
-        // range containing the operands and decrement the local var ref counts appropriately.
-
-        // Compute the next node to process. Note that we must be careful not to set the next node to
-        // process to a node that we are about to remove.
-        JITDUMP("  Deleting operands:\n");
-        DISPRANGE(operandsRange);
-        if (node->OperIsLocalStore())
-        {
-            assert(node == store);
-            *next = (operandsRange.LastNode()->gtNext == store) ? operandsRange.FirstNode()->gtPrev : node->gtPrev;
-        }
-        else
-        {
-            assert(operandsRange.Contains(node));
-            *next = operandsRange.FirstNode()->gtPrev;
-        }
-
-        blockRange.Delete(this, compCurBB, std::move(operandsRange));
-    }
-    JITDUMP("\n");
-
-    // If the store is marked as a late argument, it is referenced by a call. Instead of removing it,
-    // bash it to a NOP.
-    if ((store->gtFlags & GTF_LATE_ARG) != 0)
-    {
-        if (store->IsLocal())
-        {
-            lvaDecRefCnts(compCurBB, store);
-        }
-
-        store->gtBashToNOP();
-    }
-    else
-    {
-        blockRange.Delete(this, compCurBB, store);
-    }
-
-    return true;
-}
 
 // fgRemoveDeadStore - remove a store to a local which has no exposed uses.
 //

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -1938,6 +1938,7 @@ void Lowering::ContainCheckCompare(GenTreeOp* cmp)
                 // Require codegen of op1 to set the flags.
                 assert(!op1->gtSetFlags());
                 op1->gtFlags |= GTF_SET_FLAGS;
+                cmp->gtFlags |= GTF_USE_FLAGS;
             }
             else
             {


### PR DESCRIPTION
In particular:
- Rather than only removing dead code as part of dead store removal,
  remove all side-effect-free nodes that either do not produce a value
  or produce a value that is unused.
- When optimizing, set `fgStmtRemoved` in order to indicate that tracked
  lclVar uses or defs have been removed and liveness may need to be
  recalculated. Previously this flag was only set upon eliminating a
  dead store.