### PR TITLE
[RyuJIT/ARM32] Add block copy for 3bytes struct

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -3660,6 +3660,13 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
 #endif
                             }
                         }
+
+#if !defined(LEGACY_BACKEND)
+                        if (structSize < TARGET_POINTER_SIZE)
+                        {
+                            copyBlkClass = objClass;
+                        }
+#endif
 #endif // _TARGET_ARM_
                     }
 #ifndef FEATURE_UNIX_AMD64_STRUCT_PASSING


### PR DESCRIPTION
- Block copy for 3bytes struct(byte,byte,byte)
- Similar to x64's one

/cc @dotnet/arm32-contrib 

Fix https://github.com/dotnet/coreclr/issues/12895