### PR TITLE
Tag the GitHub_11408 test with its bug number.

### DIFF
--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -33737,7 +33737,7 @@ RelativePath=JIT\Regression\JitBlue\GitHub_11408\GitHub_11408\GitHub_11408.cmd
 WorkingDir=JIT\Regression\JitBlue\GitHub_11408\GitHub_11408
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=EXPECTED_FAIL;11408
 HostStyle=0
 
 [Generated762.cmd_4218]


### PR DESCRIPTION
This tests sets `COMPlus_TailCallStress` to `1` before running, which is
not compatible with the ARM32 legacy backend. Tag it with its bug number
for tracking.

Contributes to #12918.