### PR TITLE
Fix IndexOutOfRangeException in PayloadNames property

### DIFF
--- a/src/mscorlib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -4942,10 +4942,10 @@ namespace System.Diagnostics.Tracing
             get
             {
                 // For contract based events we create the list lazily.
-                if (m_payloadNames == null)
+                // You can have m_payloadNames be null in the TraceLogging case (EventID < 0) so only
+                // do the lazy init if you know it is contract based (EventID >= 0)
+                if (EventId >= 0 && m_payloadNames == null)
                 {
-                    // Self described events are identified by id -1.
-                    Debug.Assert(EventId != -1);
 
                     var names = new List<string>();
                     foreach (var parameter in m_eventSource.m_eventData[EventId].Parameters)


### PR DESCRIPTION
If you pass an null payload using Write<T>, and in the EventListener then call PayloadNames, it
will throw an IndexOutOfRangeException.   It should just return null.   This fixes this.

@brianrob, @stephentoub 