### PR TITLE
Add benchmarks mandelbrot and fannkuch

### DIFF
--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/fannkuch-redux/fannkuch-redux.csharp.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/fannkuch-redux/fannkuch-redux.csharp.cs
@@ -1,0 +1,103 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+/* The Computer Language Benchmarks Game
+   http://benchmarksgame.alioth.debian.org/
+
+   contributed by Isaac Gouy, transliterated from Mike Pall's Lua program
+
+   modified for use with xunit-performance
+*/
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Microsoft.Xunit.Performance;
+using Microsoft.Xunit.Performance.Api;
+using Xunit;
+
+namespace BenchmarksGame
+{
+    public class FannkuchRedux
+    {
+        private const int Iterations = 1;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static int[] Bench(int n, bool verbose = false)
+        {
+            int[] p = new int[n], q = new int[n], s = new int[n];
+            int sign = 1, maxflips = 0, sum = 0, m = n - 1;
+            for (int i = 0; i < n; i++) { p[i] = i; q[i] = i; s[i] = i; }
+            do
+            {
+                // Copy and flip.
+                var q0 = p[0];                                     // Cache 0th element.
+                if (q0 != 0)
+                {
+                    for (int i = 1; i < n; i++) q[i] = p[i];             // Work on a copy.
+                    var flips = 1;
+                    do
+                    {
+                        var qq = q[q0];
+                        if (qq == 0)
+                        {                                // ... until 0th element is 0.
+                            sum += sign * flips;
+                            if (flips > maxflips) maxflips = flips;   // New maximum?
+                            break;
+                        }
+                        q[q0] = q0;
+                        if (q0 >= 3)
+                        {
+                            int i = 1, j = q0 - 1, t;
+                            do { t = q[i]; q[i] = q[j]; q[j] = t; i++; j--; } while (i < j);
+                        }
+                        q0 = qq; flips++;
+                    } while (true);
+                }
+                // Permute.
+                if (sign == 1)
+                {
+                    var t = p[1]; p[1] = p[0]; p[0] = t; sign = -1; // Rotate 0<-1.
+                }
+                else
+                {
+                    var t = p[1]; p[1] = p[2]; p[2] = t; sign = 1;  // Rotate 0<-1 and 0<-1<-2.
+                    for (int i = 2; i < n; i++)
+                    {
+                        var sx = s[i];
+                        if (sx != 0) { s[i] = sx - 1; break; }
+                        if (i == m) return new int[] { sum, maxflips };  // Out of permutations.
+                        s[i] = i;
+                        // Rotate 0<-...<-i+1.
+                        t = p[0]; for (int j = 0; j <= i; j++) { p[j] = p[j + 1]; }
+                        p[i + 1] = t;
+                    }
+                }
+            } while (true);
+        }
+
+        [Benchmark]
+        [InlineData(10)]
+        public static void Test(int n)
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Iterations; i++)
+                    {
+                        Bench(n);
+                    }
+                }
+            }
+        }
+
+        public static int Main(string[] args)
+        {
+            using (var ph = new XunitPerformanceHarness(args))
+            {
+                ph.RunBenchmarks(Assembly.GetEntryAssembly().Location);
+            }
+            return 0;
+        }
+    }
+}

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/fannkuch-redux/fannkuch-redux.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/fannkuch-redux/fannkuch-redux.csproj
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetTargetMoniker>.NETStandard,Version=v2.0</NuGetTargetMoniker>
+    <NuGetTargetMonikerShort>netstandard2.0</NuGetTargetMonikerShort>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <PropertyGroup>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="fannkuch-redux.csharp.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+  <PropertyGroup>
+    <ProjectAssetsFile>$(JitPackagesConfigFileDirectory)benchmark\obj\project.assets.json</ProjectAssetsFile>
+  </PropertyGroup>
+</Project>

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/mandelbrot/mandelbrot.csharp.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/mandelbrot/mandelbrot.csharp.cs
@@ -1,0 +1,120 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+/* The Computer Language Benchmarks Game
+   http://benchmarksgame.alioth.debian.org/
+
+   started with Java #2 program (Krause/Whipkey/Bennet/AhnTran/Enotus/Stalcup)
+   adapted for C# by Jan de Vaan
+   simplified and optimised to use TPL by Anthony Lloyd
+
+   modified for use with xunit-performance
+*/
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Microsoft.Xunit.Performance;
+using Microsoft.Xunit.Performance.Api;
+using Xunit;
+
+namespace BenchmarksGame
+{
+    public class Mandelbrot
+    {
+        private const int Iterations = 1;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static byte getByte(double[] Crb, double Ciby, int x, int y)
+        {
+            int res = 0;
+            for (int i = 0; i < 8; i += 2)
+            {
+                double Crbx = Crb[x + i], Crbx1 = Crb[x + i + 1];
+                double Zr1 = Crbx, Zr2 = Crbx1;
+                double Zi1 = Ciby, Zi2 = Ciby;
+
+                int b = 0;
+                int j = 49;
+                do
+                {
+                    double nZr1 = Zr1 * Zr1 - Zi1 * Zi1 + Crbx;
+                    Zi1 = Zr1 * Zi1 + Zr1 * Zi1 + Ciby;
+                    Zr1 = nZr1;
+
+                    double nZr2 = Zr2 * Zr2 - Zi2 * Zi2 + Crbx1;
+                    Zi2 = Zr2 * Zi2 + Zr2 * Zi2 + Ciby;
+                    Zr2 = nZr2;
+
+                    if (Zr1 * Zr1 + Zi1 * Zi1 > 4)
+                    {
+                        b |= 2;
+                        if (b == 3)
+                            break;
+                    }
+                    if (Zr2 * Zr2 + Zi2 * Zi2 > 4)
+                    {
+                        b |= 1;
+                        if (b == 3)
+                            break;
+                    }
+                } while (--j > 0);
+                res = (res << 2) + b;
+            }
+            return (byte)(res ^ -1);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static byte[] Bench(int n, bool verbose = false)
+        {
+            double invN = 2.0 / n;
+            var Crb = new double[n + 7];
+            for (int i = 0; i < n; i++)
+            {
+                Crb[i] = i * invN - 1.5;
+            }
+            int lineLen = (n - 1) / 8 + 1;
+            var data = new byte[n * lineLen];
+            for (int i = 0; i < n; i++)
+            {
+                var Cibi = i * invN - 1.0;
+                var offset = i * lineLen;
+                for (int x = 0; x < lineLen; x++)
+                    data[offset + x] = getByte(Crb, Cibi, x * 8, i);
+            };
+
+            if (verbose)
+            {
+                Console.Out.WriteLine("P4\n{0} {0}", n);
+                Console.OpenStandardOutput().Write(data, 0, data.Length);
+            }
+
+            return data;
+        }
+
+        [Benchmark]
+        [InlineData(4000)]
+        public static void Test(int n)
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Iterations; i++)
+                    {
+                        Bench(n);
+                    }
+                }
+            }
+        }
+
+        public static int Main(string[] args)
+        {
+            using (var ph = new XunitPerformanceHarness(args))
+            {
+                ph.RunBenchmarks(Assembly.GetEntryAssembly().Location);
+            }
+            return 0;
+        }
+    }
+}

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/mandelbrot/mandelbrot.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/mandelbrot/mandelbrot.csproj
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetTargetMoniker>.NETStandard,Version=v2.0</NuGetTargetMoniker>
+    <NuGetTargetMonikerShort>netstandard2.0</NuGetTargetMonikerShort>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <PropertyGroup>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="mandelbrot.csharp.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+  <PropertyGroup>
+    <ProjectAssetsFile>$(JitPackagesConfigFileDirectory)benchmark\obj\project.assets.json</ProjectAssetsFile>
+  </PropertyGroup>
+</Project>

--- a/tests/src/JIT/config/benchmark/benchmark.csproj
+++ b/tests/src/JIT/config/benchmark/benchmark.csproj
@@ -2,8 +2,8 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <NugetTargetMoniker>.NETStandard,Version=v1.4</NugetTargetMoniker>
-    <NugetTargetMonikerShort>netstandard1.4</NugetTargetMonikerShort>
+    <NugetTargetMoniker>.NETStandard,Version=v1.5</NugetTargetMoniker>
+    <NugetTargetMonikerShort>netstandard1.5</NugetTargetMonikerShort>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
@@ -102,7 +102,7 @@
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard1.5</TargetFramework>
     <TargetFrameworkIdentifier>.NETStandard</TargetFrameworkIdentifier>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
     <ContainsPackageReferences>true</ContainsPackageReferences>


### PR DESCRIPTION
Adding mandelbrot and fankuch-redux from Benchmarks Game to
complete the representation of benchmarks from this list
[Benchmarks Game C# Benchmarks](http://benchmarksgame.alioth.debian.org/u64q/csharp.html)

@dotnet/rap-team