### PR TITLE
For LEGACY_BACKEND ARM32 do not overwrite 1 element HFA type

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -1003,9 +1003,14 @@ var_types Compiler::getReturnTypeForStruct(CORINFO_CLASS_HANDLE clsHnd,
     //
     if (structSize <= sizeof(double))
     {
-        // We set the "primitive" useType based upon the structSize
-        // and also examine the clsHnd to see if it is an HFA of count one
-        useType = getPrimitiveTypeForStruct(structSize, clsHnd);
+#if defined LEGACY_BACKEND
+        if (!IsHfa(clsHnd))
+#endif
+        {
+            // We set the "primitive" useType based upon the structSize
+            // and also examine the clsHnd to see if it is an HFA of count one
+            useType = getPrimitiveTypeForStruct(structSize, clsHnd);
+        }
     }
 
 #endif // FEATURE_UNIX_AMD64_STRUCT_PASSING
@@ -1043,8 +1048,10 @@ var_types Compiler::getReturnTypeForStruct(CORINFO_CLASS_HANDLE clsHnd,
             // Structs that are HFA's are returned in multiple registers
             if (IsHfa(clsHnd))
             {
+#if !defined(LEGACY_BACKEND)
                 // HFA's of count one should have been handled by getPrimitiveTypeForStruct
                 assert(GetHfaCount(clsHnd) >= 2);
+#endif // !defined(LEGACY_BACKEND)
 
                 // setup wbPassType and useType indicate that this is returned by value as an HFA
                 //  using multiple registers

--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -8993,7 +8993,7 @@ RelativePath=JIT\Directed\StructABI\StructABI\StructABI.cmd
 WorkingDir=JIT\Directed\StructABI\StructABI
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;8093
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Ackermann.cmd_1125]


### PR DESCRIPTION
On arm64 we will treat 1 element HFA types as the primitive
type that is contained. On Legacy Backend codegenlegacy will
incorrectly assign these two types. Instead keep the struct
type through the IR correctly to do a blockop.

Fixes #8093 