### PR TITLE
Fix ARM32 spill temp allocation

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -5643,13 +5643,7 @@ void Compiler::lvaAssignVirtualFrameOffsetsToLocals()
 
     bool tempsAllocated = false;
 
-#ifdef _TARGET_ARM_
-    // On ARM, SP based offsets use smaller encoding. Since temps are relatively
-    // rarer than lcl usage, allocate them farther from SP.
-    if (!opts.MinOpts() && !compLocallocUsed)
-#else
     if (lvaTempsHaveLargerOffsetThanVars() && !codeGen->isFramePointerUsed())
-#endif
     {
         // Because we want the temps to have a larger offset than locals
         // and we're not using a frame pointer, we have to place the temps


### PR DESCRIPTION
For ARM32 only, lvaAssignVirtualFrameOffsetsToLocals() forced temps
to be allocated high in the frame, with the comment:

```
// On ARM, SP based offsets use smaller encoding. Since temps are relatively
// rarer than lcl usage, allocate them farther from SP.
```

However, lvaFrameAddress(), when estimating the maximum frame offset for a
temp before final frame layout, did not consider this: it always assumed
temps were low on the frame. In addition, lvaTempsHaveLargerOffsetThanVars()
always returns `false` for ARM.

This caused an asserts with JitStress when we had an SP frame with large
locals, and estimated a small offset to a TEMP before final frame layout
but required a very large offset after final frame layout -- an offset that
could not be encoded by the chosen instruction. (These very large non-FP
frames might also exist only because of stress, such as GS stress.)

To fix this, simply remove the optimization, for both RyuJIT and LEGACY_BACKEND.

There is a very small code size regression (242 bytes over 42M) in asm diffs on internal
framework assemblies.

Fixes #12903