### PR TITLE
[ARM/Linux] Set R2R_INDIRECT_PARAM before R2R call

### DIFF
--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -19475,7 +19475,6 @@ regMaskTP CodeGen::genCodeForCall(GenTreeCall* call, bool valUsed)
                                                        REG_NA, 0, 0, // xreg, xmul, disp
                                                        false,        /* isJump */
                                                        emitter::emitNoGChelper(helperNum));
-
                         }
                         break;
 

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -19449,7 +19449,7 @@ regMaskTP CodeGen::genCodeForCall(GenTreeCall* call, bool valUsed)
                             instGen_Set_Reg_To_Imm(EA_HANDLE_CNS_RELOC, indCallReg, (ssize_t)addr);
 
 #ifdef FEATURE_READYTORUN_COMPILER
-                            regNumber spillReg = REG_NA;
+                            regNumber indSpillReg = REG_NA;
 
                             if (call->IsR2RRelativeIndir())
                             {
@@ -19457,8 +19457,8 @@ regMaskTP CodeGen::genCodeForCall(GenTreeCall* call, bool valUsed)
                                 {
                                     regMaskTP spillMask =
                                         RBM_INT_CALLEE_SAVED & ~RBM_R2R_INDIRECT_PARAM & ~genRegMask(indCallReg);
-                                    spillReg = regSet.rsPickReg(spillMask);
-                                    getEmitter()->emitIns_R_R(INS_mov, EA_PTRSIZE, spillReg, REG_R2R_INDIRECT_PARAM);
+                                    indSpillReg = regSet.rsPickReg(spillMask);
+                                    getEmitter()->emitIns_R_R(INS_mov, EA_PTRSIZE, indSpillReg, REG_R2R_INDIRECT_PARAM);
                                 }
                                 getEmitter()->emitIns_R_R(INS_mov, EA_PTRSIZE, REG_R2R_INDIRECT_PARAM, indCallReg);
                             }
@@ -19485,9 +19485,9 @@ regMaskTP CodeGen::genCodeForCall(GenTreeCall* call, bool valUsed)
                                                        emitter::emitNoGChelper(helperNum));
 
 #ifdef FEATURE_READYTORUN_COMPILER
-                            if (spillReg != REG_NA)
+                            if (indSpillReg != REG_NA)
                             {
-                                getEmitter()->emitIns_R_R(INS_mov, EA_PTRSIZE, REG_R2R_INDIRECT_PARAM, spillReg);
+                                getEmitter()->emitIns_R_R(INS_mov, EA_PTRSIZE, REG_R2R_INDIRECT_PARAM, indSpillReg);
                             }
 #endif // FEATURE_READYTORUN_COMPILER
                         }

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -19443,8 +19443,8 @@ regMaskTP CodeGen::genCodeForCall(GenTreeCall* call, bool valUsed)
                             }
 #endif // FEATURE_READYTORUN_COMPILER
 
-                            indCallReg = regSet.rsGrabReg(indCallMask); // Grab an available register to use for the CALL
-                                                                        // indirection
+                            // Grab an available register to use for the CALL indirection
+                            indCallReg = regSet.rsGrabReg(indCallMask);
 
                             instGen_Set_Reg_To_Imm(EA_HANDLE_CNS_RELOC, indCallReg, (ssize_t)addr);
 #ifdef FEATURE_READYTORUN_COMPILER

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -19455,7 +19455,8 @@ regMaskTP CodeGen::genCodeForCall(GenTreeCall* call, bool valUsed)
                             {
                                 if ((regSet.rsRegMaskCanGrab() & RBM_R2R_INDIRECT_PARAM) == 0)
                                 {
-                                    regMaskTP spillMask = RBM_INT_CALLEE_SAVED & ~RBM_R2R_INDIRECT_PARAM & ~genRegMask(indCallReg);
+                                    regMaskTP spillMask =
+                                        RBM_INT_CALLEE_SAVED & ~RBM_R2R_INDIRECT_PARAM & ~genRegMask(indCallReg);
                                     spillReg = regSet.rsPickReg(spillMask);
                                     getEmitter()->emitIns_R_R(INS_mov, EA_PTRSIZE, spillReg, REG_R2R_INDIRECT_PARAM);
                                 }

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -19484,12 +19484,14 @@ regMaskTP CodeGen::genCodeForCall(GenTreeCall* call, bool valUsed)
                                                        false,        /* isJump */
                                                        emitter::emitNoGChelper(helperNum));
 
+#if CPU_LOAD_STORE_ARCH
 #ifdef FEATURE_READYTORUN_COMPILER
                             if (indSpillReg != REG_NA)
                             {
                                 getEmitter()->emitIns_R_R(INS_mov, EA_PTRSIZE, REG_R2R_INDIRECT_PARAM, indSpillReg);
                             }
 #endif // FEATURE_READYTORUN_COMPILER
+#endif // CPU_LOAD_STORE_ARCH
                         }
                         break;
 

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -19449,17 +19449,9 @@ regMaskTP CodeGen::genCodeForCall(GenTreeCall* call, bool valUsed)
                             instGen_Set_Reg_To_Imm(EA_HANDLE_CNS_RELOC, indCallReg, (ssize_t)addr);
 
 #ifdef FEATURE_READYTORUN_COMPILER
-                            regNumber indSpillReg = REG_NA;
-
                             if (call->IsR2RRelativeIndir())
                             {
-                                if ((regSet.rsRegMaskCanGrab() & RBM_R2R_INDIRECT_PARAM) == 0)
-                                {
-                                    regMaskTP spillMask =
-                                        RBM_INT_CALLEE_SAVED & ~RBM_R2R_INDIRECT_PARAM & ~genRegMask(indCallReg);
-                                    indSpillReg = regSet.rsPickReg(spillMask);
-                                    getEmitter()->emitIns_R_R(INS_mov, EA_PTRSIZE, indSpillReg, REG_R2R_INDIRECT_PARAM);
-                                }
+                                noway_assert(regSet.rsRegMaskCanGrab() & RBM_R2R_INDIRECT_PARAM);
                                 getEmitter()->emitIns_R_R(INS_mov, EA_PTRSIZE, REG_R2R_INDIRECT_PARAM, indCallReg);
                             }
 #endif // FEATURE_READYTORUN_COMPILER
@@ -19484,14 +19476,6 @@ regMaskTP CodeGen::genCodeForCall(GenTreeCall* call, bool valUsed)
                                                        false,        /* isJump */
                                                        emitter::emitNoGChelper(helperNum));
 
-#if CPU_LOAD_STORE_ARCH
-#ifdef FEATURE_READYTORUN_COMPILER
-                            if (indSpillReg != REG_NA)
-                            {
-                                getEmitter()->emitIns_R_R(INS_mov, EA_PTRSIZE, REG_R2R_INDIRECT_PARAM, indSpillReg);
-                            }
-#endif // FEATURE_READYTORUN_COMPILER
-#endif // CPU_LOAD_STORE_ARCH
                         }
                         break;
 

--- a/src/jit/regalloc.cpp
+++ b/src/jit/regalloc.cpp
@@ -4835,6 +4835,17 @@ regMaskTP Compiler::rpPredictTreeRegUse(GenTreePtr   tree,
             }
             assert(list == NULL);
 
+#ifdef LEGACY_BACKEND
+#if CPU_LOAD_STORE_ARCH
+#ifdef FEATURE_READYTORUN_COMPILER
+            if (tree->gtCall.IsR2RRelativeIndir())
+            {
+                tree->gtUsedRegs |= RBM_R2R_INDIRECT_PARAM;
+            }
+#endif // FEATURE_READYTORUN_COMPILER
+#endif // CPU_LOAD_STORE_ARCH
+#endif // LEGACY_BACKEND
+
             regMaskTP callAddrMask;
             callAddrMask = RBM_NONE;
 #if CPU_LOAD_STORE_ARCH


### PR DESCRIPTION
Ryu JIT currently inserts R2R_INDIRECT_PARAM  load while lowering. Unfortunately, Legacy JIT has no corresponding implementation, which results in #12660.

This commit attempts to set R2R_INDIRECT_PARAM (R4 for ARM) before R2R call to fix #12660.



