### PR TITLE
Fix resources lookup to use satellite assembly resouce lookup inside AppX when the assembly is Private.Corelib

### DIFF
--- a/src/mscorlib/src/System/Resources/ResourceManager.cs
+++ b/src/mscorlib/src/System/Resources/ResourceManager.cs
@@ -889,7 +889,7 @@ namespace System.Resources
         //       contains the PRI resources.
         private bool ShouldUseSatelliteAssemblyResourceLookupUnderAppX(RuntimeAssembly resourcesAssembly)
         {
-            bool fUseSatelliteAssemblyResourceLookupUnderAppX = true; // TODO: https://github.com/dotnet/coreclr/issues/12178 once we fix our uap testhost
+            bool fUseSatelliteAssemblyResourceLookupUnderAppX = typeof(Object).Assembly == resourcesAssembly;
 
             if (!fUseSatelliteAssemblyResourceLookupUnderAppX)
             {
@@ -1038,6 +1038,11 @@ namespace System.Resources
                                         if (e.HResult != __HResults.ERROR_MRM_MAP_NOT_FOUND)
                                             throw; // Unexpected exception code. Bubble it up to the caller.
                                     }
+
+                                    if (!_PRIonAppXInitialized)
+                                    {
+                                        _bUsingModernResourceManagement = false;
+                                    }
                                     // Allow all other exception types to bubble up to the caller.
 
                                     // Yes, this causes us to potentially throw exception types that are not documented.
@@ -1122,7 +1127,7 @@ namespace System.Resources
                 {
                     // When running inside AppX we want to ignore the languages list when trying to come up with our CurrentUICulture.
                     // This line behaves the same way as CultureInfo.CurrentUICulture would have in .NET 4
-                    culture = CultureInfo.GetCurrentUICultureNoAppX();
+                    culture = CultureInfo.CurrentUICulture;
                 }
 
                 ResourceSet last = GetFirstResourceSet(culture);


### PR DESCRIPTION
Necessary changes in CoreFX are in. 

cc: @tarekgh @jkotas 