### PR TITLE
Fix corefx break due to missing internal method

### DIFF
--- a/src/mscorlib/src/System/Threading/CancellationTokenRegistration.cs
+++ b/src/mscorlib/src/System/Threading/CancellationTokenRegistration.cs
@@ -36,6 +36,16 @@ namespace System.Threading
             }
         }
 
+        /// <summary>
+        /// Disposes of the registration and unregisters the target callback from the associated 
+        /// <see cref="T:System.Threading.CancellationToken">CancellationToken</see>.
+        /// </summary>
+        internal bool TryDeregister() // corefx currently has an InternalsVisibleTo dependency on this
+        {
+            CancellationTokenSource.CallbackNode node = _node;
+            return node != null && node.Partition.Unregister(_id, node);
+        }
+
         private void WaitForCallbackIfNecessary()
         {
             // We're a valid registration but we were unable to unregister, which means the callback wasn't in the list,


### PR DESCRIPTION
System.Runtime.WindowsRuntime uses CancellationTokenRegistration.TryDeregister instead of Dispose to avoid a potential deadlock due to blocking waiting for an in-progress cancellation to complete.  Putting back TryDeregister to unblock corefx until a corresponding public API is exposed for this.

cc: @joperezr 