### PR TITLE
Fix a case where a reg is spilled before being freed, leading to assert

### DIFF
--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -2001,16 +2001,16 @@ void CodeGen::genRangeCheck(GenTreePtr oper)
     // Free the registers that were used.
     if (!index->IsCnsIntOrI())
     {
-        regSet.rsMarkRegFree(index->gtRegNum, index);
+        genReleaseReg(index);
     }
 
     if (arrRef != NULL)
     {
-        regSet.rsMarkRegFree(arrRef->gtRegNum, arrRef);
+        genReleaseReg(arrRef);
     }
     else if (!arrLen->IsCnsIntOrI())
     {
-        regSet.rsMarkRegFree(arrLen->gtRegNum, arrLen);
+        genReleaseReg(arrLen);
     }
 }
 


### PR DESCRIPTION
In genRangeCheck(), under stress, the call to the range check helper
might spill the index register. This leads to an assert in rsMarkRegFree():
`rsIsTreeInReg(reg, tree)`. So, instead of calling rsMarkRegFree,
call genReleaseReg(), which handles this case.

This unfortunately reloads the spilled tree, which seems unnecessary, but it
otherwise frees the register fine.

One subtlety that is not obvious to me: the current code calls
`rsMarkRegFree(node->gtRegNum, node)` but `genRangeCheck()`
calls `rsMarkRegFree(genRegMask(node->gtRegNum))`. I'm not 100% sure
these are equivalent.

Fixes #12904.