### PR TITLE
Add IsPathFullyQualified() to Path Class

### DIFF
--- a/src/mscorlib/shared/System/IO/Path.cs
+++ b/src/mscorlib/shared/System/IO/Path.cs
@@ -166,6 +166,30 @@ namespace System.IO
             return new string(pRandomFileName, 0, RandomFileNameLength);
         }
 
+        /// <summary>
+        /// Returns true if the path is fixed to a specific drive or UNC path. This method does no
+        /// validation of the path (URIs will be returned as relative as a result).
+        /// Returns false if the path specified is relative to the current drive or working directory.
+        /// </summary>
+        /// <remarks>
+        /// Handles paths that use the alternate directory separator.  It is a frequent mistake to
+        /// assume that rooted paths <see cref="Path.IsPathRooted(string)"/> are not relative.  This isn't the case.
+        /// "C:a" is drive relative- meaning that it will be resolved against the current directory
+        /// for C: (rooted, but relative). "C:\a" is rooted and not relative (the current directory
+        /// will not be used to modify the path).
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="path"/> is null.
+        /// </exception>
+        public static bool IsPathFullyQualified(string path)
+        {
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+            return !PathInternal.IsPartiallyQualified(path);
+        }
+
         // Tests if a path includes a file extension. The result is
         // true if the characters that follow the last directory
         // separator ('\\' or '/') or volume separator (':') in the path include 


### PR DESCRIPTION
API change proposed in issue [#22345](https://github.com/dotnet/corefx/issues/22345). Added method to determine if a path is relative to the current working directory. Implementation already existed as an [internal method](https://github.com/dotnet/coreclr/blob/master/src/mscorlib/shared/System/IO/PathInternal.Windows.cs#L270-L306). 