### PR TITLE
Update CoreFX and CoreCLR to match dotnet/versions

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -19,13 +19,13 @@
 
   <!-- Auto-upgraded properties for each build info dependency. -->
   <PropertyGroup>
-    <CoreFxPackageVersion>4.5.0-preview1-25421-02</CoreFxPackageVersion>
+    <CoreFxPackageVersion>4.5.0-preview1-25505-02</CoreFxPackageVersion>
     <PlatformPackageVersion>2.1.0-preview1-25324-02</PlatformPackageVersion>
   </PropertyGroup>
 
   <!-- Full package version strings that are used in other parts of the build. -->
   <PropertyGroup>
-    <CoreClrPackageVersion>2.1.0-preview1-25421-01</CoreClrPackageVersion>
+    <CoreClrPackageVersion>2.1.0-preview2-25505-01</CoreClrPackageVersion>
     <XunitPackageVersion>2.2.0-beta2-build3300</XunitPackageVersion>
     <XUnitConsoleNetCoreVersion>1.0.2-prerelease-00177</XUnitConsoleNetCoreVersion>
     <XUnitPerformanceApiVersion>1.0.0-beta-build0007</XUnitPerformanceApiVersion>


### PR DESCRIPTION
The uwp6.0 CoreCLR build is currently blocked because the CurrentRef doesn't match the package versions. This is just running `UpdateDependencies` to make them match.

https://github.com/dotnet/core-eng/issues/1271