### PR TITLE
[RyuJIT/ARM32] Removed int <-> float casts related NYIs.

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -1528,7 +1528,7 @@ void CodeGen::genLongToIntCast(GenTree* cast)
 }
 
 //------------------------------------------------------------------------
-// genIntToFloatCast: Generate code to cast an int/long to float/double
+// genIntToFloatCast: Generate code to cast an int to float/double
 //
 // Arguments:
 //    treeNode - The GT_CAST node
@@ -1564,40 +1564,26 @@ void CodeGen::genIntToFloatCast(GenTreePtr treeNode)
         srcType = genUnsignedType(srcType);
     }
 
-    // We should never see a srcType whose size is neither EA_4BYTE or EA_8BYTE
+    // We only expect a srcType whose size is EA_4BYTE.
     // For conversions from small types (byte/sbyte/int16/uint16) to float/double,
     // we expect the front-end or lowering phase to have generated two levels of cast.
     //
     emitAttr srcSize = EA_ATTR(genTypeSize(srcType));
-    noway_assert((srcSize == EA_4BYTE) || (srcSize == EA_8BYTE));
+    noway_assert(srcSize == EA_4BYTE);
 
     instruction insVcvt = INS_invalid;
 
     if (dstType == TYP_DOUBLE)
     {
-        if (srcSize == EA_4BYTE)
-        {
-            insVcvt = (varTypeIsUnsigned(srcType)) ? INS_vcvt_u2d : INS_vcvt_i2d;
-        }
-        else
-        {
-            assert(srcSize == EA_8BYTE);
-            NYI_ARM("Casting int64/uint64 to double in genIntToFloatCast");
-        }
+        insVcvt = (varTypeIsUnsigned(srcType)) ? INS_vcvt_u2d : INS_vcvt_i2d;
     }
     else
     {
         assert(dstType == TYP_FLOAT);
-        if (srcSize == EA_4BYTE)
-        {
-            insVcvt = (varTypeIsUnsigned(srcType)) ? INS_vcvt_u2f : INS_vcvt_i2f;
-        }
-        else
-        {
-            assert(srcSize == EA_8BYTE);
-            NYI_ARM("Casting int64/uint64 to float in genIntToFloatCast");
-        }
+        insVcvt = (varTypeIsUnsigned(srcType)) ? INS_vcvt_u2f : INS_vcvt_i2f;
     }
+    // All other cast are implemented by different CORINFO_HELP_XX2XX
+    // Look to Compiler::fgMorphCast()
 
     genConsumeOperands(treeNode->AsOp());
 
@@ -1609,7 +1595,7 @@ void CodeGen::genIntToFloatCast(GenTreePtr treeNode)
 }
 
 //------------------------------------------------------------------------
-// genFloatToIntCast: Generate code to cast float/double to int/long
+// genFloatToIntCast: Generate code to cast float/double to int
 //
 // Arguments:
 //    treeNode - The GT_CAST node
@@ -1640,40 +1626,26 @@ void CodeGen::genFloatToIntCast(GenTreePtr treeNode)
     var_types srcType = op1->TypeGet();
     assert(varTypeIsFloating(srcType) && !varTypeIsFloating(dstType));
 
-    // We should never see a dstType whose size is neither EA_4BYTE or EA_8BYTE
+    // We only expect a dstType whose size is EA_4BYTE.
     // For conversions to small types (byte/sbyte/int16/uint16) from float/double,
     // we expect the front-end or lowering phase to have generated two levels of cast.
     //
     emitAttr dstSize = EA_ATTR(genTypeSize(dstType));
-    noway_assert((dstSize == EA_4BYTE) || (dstSize == EA_8BYTE));
+    noway_assert(dstSize == EA_4BYTE);
 
     instruction insVcvt = INS_invalid;
 
     if (srcType == TYP_DOUBLE)
     {
-        if (dstSize == EA_4BYTE)
-        {
-            insVcvt = (varTypeIsUnsigned(dstType)) ? INS_vcvt_d2u : INS_vcvt_d2i;
-        }
-        else
-        {
-            assert(dstSize == EA_8BYTE);
-            NYI_ARM("Casting double to int64/uint64 in genIntToFloatCast");
-        }
+        insVcvt = (varTypeIsUnsigned(dstType)) ? INS_vcvt_d2u : INS_vcvt_d2i;
     }
     else
     {
         assert(srcType == TYP_FLOAT);
-        if (dstSize == EA_4BYTE)
-        {
-            insVcvt = (varTypeIsUnsigned(dstType)) ? INS_vcvt_f2u : INS_vcvt_f2i;
-        }
-        else
-        {
-            assert(dstSize == EA_8BYTE);
-            NYI_ARM("Casting float to int64/uint64 in genIntToFloatCast");
-        }
+        insVcvt = (varTypeIsUnsigned(dstType)) ? INS_vcvt_f2u : INS_vcvt_f2i;
     }
+    // All other cast are implemented by different CORINFO_HELP_XX2XX
+    // Look to Compiler::fgMorphCast()
 
     genConsumeOperands(treeNode->AsOp());
 


### PR DESCRIPTION
Fix for #12958
This casts are already implemented by different `CORINFO_HELP_XX2XX`. Transformation logic is in `Compiler::fgMorphCast()`

cc @dotnet/arm32-contrib 