### PR TITLE
Fixes for issue 12982 Android cross-build fails when compiling cee_wks

### DIFF
--- a/cross/android/arm64/toolchain.cmake
+++ b/cross/android/arm64/toolchain.cmake
@@ -21,6 +21,7 @@ find_program(CMAKE_OBJDUMP ${TOOLCHAIN_PREFIX}objdump)
 
 add_compile_options(--sysroot=${CROSS_ROOTFS})
 add_compile_options(-fPIE)
+add_compile_options(-D__ANDROID__)
 
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -B ${CROSS_ROOTFS}/usr/lib/gcc/${TOOLCHAIN}")
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -L${CROSS_ROOTFS}/lib/${TOOLCHAIN}")

--- a/cross/android/arm64/toolchain.cmake
+++ b/cross/android/arm64/toolchain.cmake
@@ -21,7 +21,6 @@ find_program(CMAKE_OBJDUMP ${TOOLCHAIN_PREFIX}objdump)
 
 add_compile_options(--sysroot=${CROSS_ROOTFS})
 add_compile_options(-fPIE)
-add_compile_options(-D__ANDROID__)
 
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -B ${CROSS_ROOTFS}/usr/lib/gcc/${TOOLCHAIN}")
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -L${CROSS_ROOTFS}/lib/${TOOLCHAIN}")

--- a/src/inc/volatile.h
+++ b/src/inc/volatile.h
@@ -120,7 +120,7 @@ T VolatileLoad(T const * pt)
     STATIC_CONTRACT_SUPPORTS_DAC_HOST_ONLY;
 
 #ifndef DACCESS_COMPILE
-#if defined(_ARM64_) && defined(__GNUC__) && defined(__CLANG__) && __has_builtin(__atomic_load)
+#if defined(_ARM64_) && defined(__GNUC__) && defined(__clang__) && __has_builtin(__atomic_load)
     T val;
     static const unsigned lockFreeAtomicSizeMask = (1 << 1) | (1 << 2) | (1 << 4) | (1 << 8);
     if((1 << sizeof(T)) & lockFreeAtomicSizeMask)

--- a/src/inc/volatile.h
+++ b/src/inc/volatile.h
@@ -120,7 +120,7 @@ T VolatileLoad(T const * pt)
     STATIC_CONTRACT_SUPPORTS_DAC_HOST_ONLY;
 
 #ifndef DACCESS_COMPILE
-#if defined(_ARM64_) && defined(__GNUC__) && !(defined(__ANDROID__))
+#if defined(_ARM64_) && defined(__GNUC__) && defined(__CLANG__) && __has_builtin(__atomic_load)
     T val;
     static const unsigned lockFreeAtomicSizeMask = (1 << 1) | (1 << 2) | (1 << 4) | (1 << 8);
     if((1 << sizeof(T)) & lockFreeAtomicSizeMask)

--- a/src/inc/volatile.h
+++ b/src/inc/volatile.h
@@ -120,7 +120,7 @@ T VolatileLoad(T const * pt)
     STATIC_CONTRACT_SUPPORTS_DAC_HOST_ONLY;
 
 #ifndef DACCESS_COMPILE
-#if defined(_ARM64_) && defined(__GNUC__)
+#if defined(_ARM64_) && defined(__GNUC__) && !(defined(__ANDROID__))
     T val;
     static const unsigned lockFreeAtomicSizeMask = (1 << 1) | (1 << 2) | (1 << 4) | (1 << 8);
     if((1 << sizeof(T)) & lockFreeAtomicSizeMask)

--- a/src/inc/volatile.h
+++ b/src/inc/volatile.h
@@ -120,13 +120,15 @@ T VolatileLoad(T const * pt)
     STATIC_CONTRACT_SUPPORTS_DAC_HOST_ONLY;
 
 #ifndef DACCESS_COMPILE
-#if defined(_ARM64_) && defined(__clang__) && __has_builtin(__atomic_load)
+#if defined(_ARM64_) && defined(__clang__)
     T val;
     static const unsigned lockFreeAtomicSizeMask = (1 << 1) | (1 << 2) | (1 << 4) | (1 << 8);
+#if __has_builtin(__atomic_load)
     if((1 << sizeof(T)) & lockFreeAtomicSizeMask)
     {
         __atomic_load((T volatile const *)pt, &val, __ATOMIC_ACQUIRE);
     }
+#endif
     else
     {
         val = *(T volatile const *)pt;

--- a/src/inc/volatile.h
+++ b/src/inc/volatile.h
@@ -120,7 +120,7 @@ T VolatileLoad(T const * pt)
     STATIC_CONTRACT_SUPPORTS_DAC_HOST_ONLY;
 
 #ifndef DACCESS_COMPILE
-#if defined(_ARM64_) && defined(__GNUC__) && defined(__clang__) && __has_builtin(__atomic_load)
+#if defined(_ARM64_) && defined(__clang__) && __has_builtin(__atomic_load)
     T val;
     static const unsigned lockFreeAtomicSizeMask = (1 << 1) | (1 << 2) | (1 << 4) | (1 << 8);
     if((1 << sizeof(T)) & lockFreeAtomicSizeMask)


### PR DESCRIPTION
The cross build script needs to be updated with the correct supporting package versions or download and build will fail.

Copying @qmfrederik and @jkotas  @sdmaclea 