### PR TITLE
[JIT] Fix comment in optimizer.cpp:optOptimizeBools

### DIFF
--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -8285,7 +8285,7 @@ void Compiler::optOptimizeBools()
                         B2: brtrue(t2, BX)
                         B3:
                    we will try to fold it to :
-                        B1: brtrue((!t1)&&t2, B3)
+                        B1: brtrue((!t1)&&t2, BX)
                         B3:
                 */
 


### PR DESCRIPTION
Only comments are modified.

Before:

``` text
/* Given the following sequence of blocks :
        B1: brtrue(t1, B3)
        B2: brtrue(t2, BX)
        B3:
   we will try to fold it to :
        B1: brtrue((!t1)&&t2, B3)
        B3:
*/
```

after:

``` text
/* Given the following sequence of blocks :
        B1: brtrue(t1, B3)
        B2: brtrue(t2, BX)
        B3:
   we will try to fold it to :
        B1: brtrue((!t1)&&t2, BX)
        B3:
*/
```