### PR TITLE
Don't call AssemblyResolve event for CoreLib resources

### DIFF
--- a/src/mscorlib/src/System/Reflection/Assembly.CoreCLR.cs
+++ b/src/mscorlib/src/System/Reflection/Assembly.CoreCLR.cs
@@ -23,7 +23,11 @@ namespace System.Reflection
         private static Assembly LoadFromResolveHandler(object sender, ResolveEventArgs args)
         {
             Assembly requestingAssembly = args.RequestingAssembly;
-            
+            if (requestingAssembly == null)
+            {
+                return null;
+            }
+
             // Requesting assembly for LoadFrom is always loaded in defaultContext - proceed only if that
             // is the case.
             if (AssemblyLoadContext.Default != AssemblyLoadContext.GetLoadContext(requestingAssembly))

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -7220,18 +7220,26 @@ EndTry2:;
                     }
                     else if (!fIsWellKnown)
                     {
-                        // Trigger the resolve event also for non-throw situation.
-                        // However, this code path will behave as if the resolve handler has thrown,
-                        // that is, not trigger an MDA.
                         _ASSERTE(fThrowOnFileNotFound == FALSE);
 
-                        AssemblySpec NewSpec(this);
-                        AssemblySpec *pFailedSpec = NULL;
+                        // Don't trigger the resolve event for the CoreLib satellite assembly. A misbehaving resolve event may
+                        // return an assembly that does not match, and this can cause recursive resource lookups during error
+                        // reporting. The CoreLib satellite assembly is loaded from relative locations based on the culture, see
+                        // AssemblySpec::Bind().
+                        if (!pSpec->IsMscorlibSatellite())
+                        {
+                            // Trigger the resolve event also for non-throw situation.
+                            // However, this code path will behave as if the resolve handler has thrown,
+                            // that is, not trigger an MDA.
 
-                        fForceReThrow = TRUE; // Managed resolve event handler can throw
+                            AssemblySpec NewSpec(this);
+                            AssemblySpec *pFailedSpec = NULL;
 
-                        // Purposly ignore return value
-                        PostBindResolveAssembly(pSpec, &NewSpec, hrBindResult, &pFailedSpec);
+                            fForceReThrow = TRUE; // Managed resolve event handler can throw
+
+                            // Purposly ignore return value
+                            PostBindResolveAssembly(pSpec, &NewSpec, hrBindResult, &pFailedSpec);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Port of https://github.com/dotnet/coreclr/pull/12999 to release/2.0.0

Part of fix for #12668:
- CoreLib resource lookup should not raise the AssemblyResolve event because a misbehaving handler could cause an infinite recursion check and fail-fast to be triggered when the resource is not found, as the issue would repeat when reporting that error
- A handler could misbehave by returning an assembly that does not match the requested identity or by throwing