### PR TITLE
Enable BuildTest in Windows Server Core

### DIFF
--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -366,7 +366,6 @@
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
-            "Architecture": "arm64",
             "SubType":  "Build-Tests",
             "Type": "build/product/",
             "PB_BuildType": "Release"
@@ -385,7 +384,41 @@
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
-            "Architecture": "arm64",
+            "SubType":  "Build-Tests-R2R",
+            "Type": "build/product/",
+            "PB_BuildType": "Release"
+          }
+        },
+		{
+          "Name": "Dotnet-CoreClr-Trusted-BuildTests",
+          "Parameters": {
+            "Architecture": "arm",
+            "HelixJobType": "test/functional/cli/",
+            "TargetsWindows": "true",
+            "Rid": "win-arm",
+            "TargetQueues": "Windows.10.Arm64.Core",
+            "TestContainerSuffix": "windows",
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "SubType":  "Build-Tests",
+            "Type": "build/product/",
+            "PB_BuildType": "Release"
+          }
+        },
+        {
+          "Name": "Dotnet-CoreClr-Trusted-BuildTests",
+          "Parameters": {
+            "Architecture": "arm",
+            "HelixJobType": "test/functional/r2r/cli/",
+            "TargetsWindows": "true",
+            "Rid": "win-arm",
+            "TargetQueues": "Windows.10.Arm64.Core",
+            "TestContainerSuffix": "windows-r2r",
+            "CrossgenArg": "Crossgen "
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
             "SubType":  "Build-Tests-R2R",
             "Type": "build/product/",
             "PB_BuildType": "Release"

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -349,6 +349,7 @@
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
+            "Architecture": "arm64",
             "SubType":  "Build-Tests-R2R",
             "Type": "build/product/",
             "PB_BuildType": "Release"
@@ -366,6 +367,7 @@
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
+            "Architecture": "arm64",
             "SubType":  "Build-Tests",
             "Type": "build/product/",
             "PB_BuildType": "Release"
@@ -384,6 +386,7 @@
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
+            "Architecture": "arm64",
             "SubType":  "Build-Tests-R2R",
             "Type": "build/product/",
             "PB_BuildType": "Release"
@@ -401,6 +404,7 @@
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
+            "Architecture": "arm64",
             "SubType":  "Build-Tests",
             "Type": "build/product/",
             "PB_BuildType": "Release"


### PR DESCRIPTION
Windows Server Core was just created so now enabling work to be processed in this image

/cc: @karajas @MattGal @danmosemsft 