### PR TITLE
[RyuJIT/armel] Make RefPosition arg regs fixed

### DIFF
--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -1034,6 +1034,32 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
 
             unspillTree->gtFlags &= ~GTF_SPILLED;
         }
+        else if (unspillTree->OperIsMultiRegOp())
+        {
+            GenTreeMultiRegOp* multiReg = unspillTree->AsMultiRegOp();
+            unsigned           regCount = multiReg->gtOtherReg == REG_NA ? 1 : 2;
+
+            // In case of split struct argument node, GTF_SPILLED flag on it indicates that
+            // one or more of its result regs are spilled.  Call node needs to be
+            // queried to know which specific result regs to be unspilled.
+            for (unsigned i = 0; i < regCount; ++i)
+            {
+                unsigned flags = multiReg->GetRegSpillFlagByIdx(i);
+                if ((flags & GTF_SPILLED) != 0)
+                {
+                    var_types dstType = multiReg->GetRegType(i);
+                    regNumber dstReg  = multiReg->GetRegNumByIdx(i);
+
+                    TempDsc* t = regSet.rsUnspillInPlace(multiReg, dstReg, i);
+                    getEmitter()->emitIns_R_S(ins_Load(dstType), emitActualTypeSize(dstType), dstReg, t->tdTempNum(),
+                                              0);
+                    compiler->tmpRlsTemp(t);
+                    gcInfo.gcMarkRegPtrVal(dstReg, dstType);
+                }
+            }
+
+            unspillTree->gtFlags &= ~GTF_SPILLED;
+        }
 #endif
         else
         {
@@ -1652,6 +1678,22 @@ void CodeGen::genProduceReg(GenTree* tree)
                     {
                         regNumber reg = argSplit->GetRegNumByIdx(i);
                         regSet.rsSpillTree(reg, argSplit, i);
+                        gcInfo.gcMarkRegSetNpt(genRegMask(reg));
+                    }
+                }
+            }
+            else if (tree->OperIsMultiRegOp())
+            {
+                GenTreeMultiRegOp* multiReg = tree->AsMultiRegOp();
+                unsigned           regCount = multiReg->gtOtherReg == REG_NA ? 1 : 2;
+
+                for (unsigned i = 0; i < regCount; ++i)
+                {
+                    unsigned flags = multiReg->GetRegSpillFlagByIdx(i);
+                    if ((flags & GTF_SPILL) != 0)
+                    {
+                        regNumber reg = multiReg->GetRegNumByIdx(i);
+                        regSet.rsSpillTree(reg, multiReg, i);
                         gcInfo.gcMarkRegSetNpt(genRegMask(reg));
                     }
                 }

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -8839,6 +8839,13 @@ void LinearScan::recordMaxSpill()
         maxSpill[TYP_FLOAT] += 1;
     }
 #endif // _TARGET_X86_
+
+    if (compiler->opts.compUseSoftFP)
+    {
+        JITDUMP("Adding a spill temp for moving target address to a register.\n");
+        maxSpill[TYP_INT] += 1;
+    }
+
     for (int i = 0; i < TYP_COUNT; i++)
     {
         if (var_types(i) != compiler->tmpNormalizeType(var_types(i)))

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3985,6 +3985,15 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
 #endif // DEBUG
 
             regMaskTP candidates = getUseCandidates(useNode);
+#ifdef ARM_SOFTFP
+            // If oper is GT_PUTARG_REG, set bits in useCandidates must be in sequential order.
+            if (useNode->OperGet() == GT_PUTARG_REG || useNode->OperGet() == GT_COPY)
+            {
+                regMaskTP candidate = genFindLowestReg(candidates);
+                useNode->gtLsraInfo.setSrcCandidates(this, candidates & ~candidate);
+                candidates = candidate;
+            }
+#endif // ARM_SOFTFP
             assert((candidates & allRegs(i->registerType)) != 0);
 
             // For non-localVar uses we record nothing, as nothing needs to be written back to the tree.

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3987,7 +3987,7 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
             regMaskTP candidates = getUseCandidates(useNode);
 #ifdef ARM_SOFTFP
             // If oper is GT_PUTARG_REG, set bits in useCandidates must be in sequential order.
-            if (useNode->OperGet() == GT_PUTARG_REG || useNode->OperGet() == GT_COPY)
+            if (useNode->OperIsMultiRegOp())
             {
                 regMaskTP candidate = genFindLowestReg(candidates);
                 useNode->gtLsraInfo.setSrcCandidates(this, candidates & ~candidate);
@@ -9238,6 +9238,11 @@ void LinearScan::resolveRegisters()
                             {
                                 GenTreePutArgSplit* splitArg = treeNode->AsPutArgSplit();
                                 splitArg->SetRegSpillFlagByIdx(GTF_SPILL, currentRefPosition->getMultiRegIdx());
+                            }
+                            else if (treeNode->OperIsMultiRegOp())
+                            {
+                                GenTreeMultiRegOp* multiReg = treeNode->AsMultiRegOp();
+                                multiReg->SetRegSpillFlagByIdx(GTF_SPILL, currentRefPosition->getMultiRegIdx());
                             }
 #endif
                         }

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -8916,15 +8916,15 @@ void LinearScan::updateMaxSpill(RefPosition* refPosition)
                     ReturnTypeDesc* retTypeDesc = treeNode->AsCall()->GetReturnTypeDesc();
                     typ                         = retTypeDesc->GetReturnRegType(refPosition->getMultiRegIdx());
                 }
-#ifdef _TARGET_ARM_
+#ifdef ARM_SOFTFP
                 else if (treeNode->OperIsPutArgReg())
                 {
                     // For double arg regs, the type is changed to long since they must be passed via `r0-r3`.
                     // However when they get spilled, they should be treated as separated int registers.
                     var_types typNode = treeNode->TypeGet();
-                    typ = (typNode == TYP_LONG) ? TYP_INT : typNode;
+                    typ               = (typNode == TYP_LONG) ? TYP_INT : typNode;
                 }
-#endif // _TARGET_ARM_
+#endif // ARM_SOFTFP
                 else
                 {
                     typ = treeNode->TypeGet();

--- a/src/jit/regset.cpp
+++ b/src/jit/regset.cpp
@@ -1533,6 +1533,7 @@ void RegSet::rsSpillTree(regNumber reg, GenTreePtr tree, unsigned regIdx /* =0 *
     var_types    treeType;
 #if !defined(LEGACY_BACKEND) && defined(_TARGET_ARM_)
     GenTreePutArgSplit* splitArg = nullptr;
+    GenTreeMultiRegOp*  multiReg = nullptr;
 #endif
 
 #ifndef LEGACY_BACKEND
@@ -1547,6 +1548,11 @@ void RegSet::rsSpillTree(regNumber reg, GenTreePtr tree, unsigned regIdx /* =0 *
     {
         splitArg = tree->AsPutArgSplit();
         treeType = splitArg->GetRegType(regIdx);
+    }
+    else if (tree->OperIsMultiRegOp())
+    {
+        multiReg = tree->AsMultiRegOp();
+        treeType = multiReg->GetRegType(regIdx); // XXX check
     }
 #endif // _TARGET_ARM_
     else
@@ -1605,10 +1611,16 @@ void RegSet::rsSpillTree(regNumber reg, GenTreePtr tree, unsigned regIdx /* =0 *
         assert((regFlags & GTF_SPILL) != 0);
         regFlags &= ~GTF_SPILL;
     }
+    else if (multiReg != nullptr)
+    {
+        regFlags = multiReg->GetRegSpillFlagByIdx(regIdx);
+        assert((regFlags & GTF_SPILL) != 0);
+        regFlags &= ~GTF_SPILL;
+    }
 #endif // _TARGET_ARM_
     else
     {
-        assert(!varTypeIsMultiReg(tree) || (m_rsCompiler->opts.compUseSoftFP && treeType == TYP_LONG));
+        assert(!varTypeIsMultiReg(tree));
         tree->gtFlags &= ~GTF_SPILL;
     }
 #endif // !LEGACY_BACKEND
@@ -1758,6 +1770,11 @@ void RegSet::rsSpillTree(regNumber reg, GenTreePtr tree, unsigned regIdx /* =0 *
     {
         regFlags |= GTF_SPILLED;
         splitArg->SetRegSpillFlagByIdx(regFlags, regIdx);
+    }
+    else if (multiReg != nullptr)
+    {
+        regFlags |= GTF_SPILLED;
+        multiReg->SetRegSpillFlagByIdx(regFlags, regIdx);
     }
 #endif // _TARGET_ARM_
 #endif //! LEGACY_BACKEND
@@ -2400,6 +2417,13 @@ TempDsc* RegSet::rsUnspillInPlace(GenTreePtr tree, regNumber oldReg, unsigned re
         unsigned            flags    = splitArg->GetRegSpillFlagByIdx(regIdx);
         flags &= ~GTF_SPILLED;
         splitArg->SetRegSpillFlagByIdx(flags, regIdx);
+    }
+    else if (tree->OperIsMultiRegOp())
+    {
+        GenTreeMultiRegOp* multiReg = tree->AsMultiRegOp();
+        unsigned           flags    = multiReg->GetRegSpillFlagByIdx(regIdx);
+        flags &= ~GTF_SPILLED;
+        multiReg->SetRegSpillFlagByIdx(flags, regIdx);
     }
 #endif // !LEGACY_BACKEND && _TARGET_ARM_
     else

--- a/src/jit/regset.cpp
+++ b/src/jit/regset.cpp
@@ -1608,7 +1608,7 @@ void RegSet::rsSpillTree(regNumber reg, GenTreePtr tree, unsigned regIdx /* =0 *
 #endif // _TARGET_ARM_
     else
     {
-        assert(!varTypeIsMultiReg(tree));
+        assert(!varTypeIsMultiReg(tree) || (m_rsCompiler->opts.compUseSoftFP && treeType == TYP_LONG));
         tree->gtFlags &= ~GTF_SPILL;
     }
 #endif // !LEGACY_BACKEND


### PR DESCRIPTION
Passing double arg regs via `r0:r1` or `r2:r3`,
each RefPosition's RegMask should have only one exact register
so the candidate register can be fixed.

e.g.)

```
<RefPosition #4099 @2625 RefTypeUse <Ivl:1237> BB35 regmask=[r0-r1] last>
<RefPosition #4100 @2625 RefTypeUse <Ivl:1238> BB35 regmask=[r0-r1] last>
```

to be:

```
<RefPosition #4099 @2625 RefTypeUse <Ivl:1237> BB35 regmask=[r0] last fixed>
<RefPosition #4100 @2625 RefTypeUse <Ivl:1238> BB35 regmask=[r1] last fixed>
```

Fix #12994