### PR TITLE
Add Helix jobs for Nano, Win7, Win8

### DIFF
--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -327,7 +327,7 @@
             "HelixJobType": "test/functional/cli/",
             "TargetsWindows": "true",
             "Rid": "win-x64",
-            "TargetQueues": "windows.10.amd64,Windows.10.Amd64.Core",
+            "TargetQueues": "Windows.10.Amd64,Windows.10.Nano.Amd64,Windows.10.Amd64.Core,Windows.7.Amd64,Windows.81.Amd64",
             "TestContainerSuffix": "windows",
           },
           "ReportingParameters": {
@@ -343,7 +343,7 @@
             "HelixJobType": "test/functional/r2r/cli/",
             "TargetsWindows": "true",
             "Rid": "win-x64",
-            "TargetQueues": "windows.10.amd64,Windows.10.Amd64.Core",
+            "TargetQueues": "Windows.10.Amd64,Windows.10.Nano.Amd64,Windows.10.Amd64.Core,Windows.7.Amd64,Windows.81.Amd64",
             "TestContainerSuffix": "windows-r2r",
             "CrossgenArg": "Crossgen "
           },


### PR DESCRIPTION
I have a test run for these jobs here - https://mc.dot.net/#/user/wtgodbe/pr~2Fcoreclr~2Fmaster~2F/test~2Ffunctional~2Fcli~2F/20170725.5308. Seems to be mostly passing.

CC @MattGal 