### PR TITLE
Revert "Fixes for issue 12982 Android cross-build fails when compiling cee_wks (#12986)"

### DIFF
--- a/src/inc/volatile.h
+++ b/src/inc/volatile.h
@@ -120,15 +120,13 @@ T VolatileLoad(T const * pt)
     STATIC_CONTRACT_SUPPORTS_DAC_HOST_ONLY;
 
 #ifndef DACCESS_COMPILE
-#if defined(_ARM64_) && defined(__clang__)
+#if defined(_ARM64_) && defined(__GNUC__)
     T val;
     static const unsigned lockFreeAtomicSizeMask = (1 << 1) | (1 << 2) | (1 << 4) | (1 << 8);
-#if __has_builtin(__atomic_load)
     if((1 << sizeof(T)) & lockFreeAtomicSizeMask)
     {
         __atomic_load((T volatile const *)pt, &val, __ATOMIC_ACQUIRE);
     }
-#endif
     else
     {
         val = *(T volatile const *)pt;


### PR DESCRIPTION


This reverts commit 2e7326df470bea696699cc7c812ee56dd0b470b9.