### PR TITLE
Enable Ubuntu's 1710 BuilsTests

### DIFF
--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -366,6 +366,7 @@
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
+            "Architecture": "arm64",
             "SubType":  "Build-Tests",
             "Type": "build/product/",
             "PB_BuildType": "Release"
@@ -384,6 +385,7 @@
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
+            "Architecture": "arm64",
             "SubType":  "Build-Tests-R2R",
             "Type": "build/product/",
             "PB_BuildType": "Release"

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -327,7 +327,7 @@
             "HelixJobType": "test/functional/cli/",
             "TargetsWindows": "true",
             "Rid": "win-x64",
-            "TargetQueues": "windows.10.amd64,Windows.10.Amd64.Core",
+            "TargetQueues": "windows.10.amd64",
             "TestContainerSuffix": "windows",
           },
           "ReportingParameters": {
@@ -343,7 +343,7 @@
             "HelixJobType": "test/functional/r2r/cli/",
             "TargetsWindows": "true",
             "Rid": "win-x64",
-            "TargetQueues": "windows.10.amd64,Windows.10.Amd64.Core",
+            "TargetQueues": "windows.10.amd64",
             "TestContainerSuffix": "windows-r2r",
             "CrossgenArg": "Crossgen "
           },
@@ -366,7 +366,6 @@
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
-            "Architecture": "arm64",
             "SubType":  "Build-Tests",
             "Type": "build/product/",
             "PB_BuildType": "Release"
@@ -385,7 +384,6 @@
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
-            "Architecture": "arm64",
             "SubType":  "Build-Tests-R2R",
             "Type": "build/product/",
             "PB_BuildType": "Release"
@@ -432,7 +430,7 @@
             "HelixJobType": "test/functional/cli/",
             "TargetsWindows": "false",
             "Rid": "linux-x64",
-            "TargetQueues": "debian.82.amd64,fedora.25.amd64,redhat.72.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1610.amd64",
+            "TargetQueues": "debian.82.amd64,fedora.25.amd64,redhat.72.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1710.amd64",
             "TestContainerSuffix": "linux",
             "TargetsNonWindowsArg": "TargetsNonWindows "
           },
@@ -449,7 +447,7 @@
             "HelixJobType": "test/functional/r2r/cli/",
             "TargetsWindows": "false",
             "Rid": "linux-x64",
-            "TargetQueues": "debian.82.amd64,fedora.25.amd64,redhat.72.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1610.amd64",
+            "TargetQueues": "debian.82.amd64,fedora.25.amd64,redhat.72.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1710.amd64",
             "TestContainerSuffix": "linux-r2r",
             "CrossgenArg": "Crossgen ",
             "TargetsNonWindowsArg": "TargetsNonWindows "


### PR DESCRIPTION
After adding Helix Queue for Ubuntu1710 we are enabling BuildTest for this SKU.

This completes: https://github.com/dotnet/core-eng/issues/1307