### PR TITLE
Port of https://github.com/dotnet/coreclr/pull/13034 to release 2.0.0 -- Remove Ubuntu 16.10 as it's EOL

### DIFF
--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -397,7 +397,7 @@
             "HelixJobType": "test/functional/cli/",
             "TargetsWindows": "false",
             "Rid": "linux-x64",
-            "TargetQueues": "debian.82.amd64,fedora.25.amd64,redhat.72.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1610.amd64",
+            "TargetQueues": "debian.82.amd64,fedora.25.amd64,redhat.72.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64",
             "TestContainerSuffix": "linux",
             "TargetsNonWindowsArg": "TargetsNonWindows "
           },
@@ -414,7 +414,7 @@
             "HelixJobType": "test/functional/r2r/cli/",
             "TargetsWindows": "false",
             "Rid": "linux-x64",
-            "TargetQueues": "debian.82.amd64,fedora.25.amd64,redhat.72.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1610.amd64",
+            "TargetQueues": "debian.82.amd64,fedora.25.amd64,redhat.72.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64",
             "TestContainerSuffix": "linux-r2r",
             "CrossgenArg": "Crossgen ",
             "TargetsNonWindowsArg": "TargetsNonWindows "


### PR DESCRIPTION
Remove Ubuntu 16.10 as it's EOL