### PR TITLE
don't use r2r images when the profiler requests that ngen images are disabled

### DIFF
--- a/src/vm/readytoruninfo.cpp
+++ b/src/vm/readytoruninfo.cpp
@@ -348,9 +348,7 @@ BOOL ReadyToRunInfo::IsReadyToRunEnabled()
     WRAPPER_NO_CONTRACT;
 
     static ConfigDWORD configReadyToRun;
-    return configReadyToRun.val(CLRConfig::EXTERNAL_ReadyToRun) && 
-            !(CORProfilerDisableAllNGenImages()) && 
-            !(CORProfilerUseProfileImages());
+    return configReadyToRun.val(CLRConfig::EXTERNAL_ReadyToRun);
 }
 
 // A log file to record success/failure of R2R loads. s_r2rLogFile can have the following values:
@@ -482,6 +480,12 @@ PTR_ReadyToRunInfo ReadyToRunInfo::Initialize(Module * pModule, AllocMemTracker 
     {
         // Log message is ignored in this case.
         DoLog(NULL);
+        return NULL;
+    }
+
+    if (CORProfilerDisableAllNGenImages() || CORProfilerUseProfileImages())
+    {
+        DoLog("Ready to Run disabled - profiler disabled native images");
         return NULL;
     }
 

--- a/src/vm/readytoruninfo.cpp
+++ b/src/vm/readytoruninfo.cpp
@@ -348,7 +348,9 @@ BOOL ReadyToRunInfo::IsReadyToRunEnabled()
     WRAPPER_NO_CONTRACT;
 
     static ConfigDWORD configReadyToRun;
-    return configReadyToRun.val(CLRConfig::EXTERNAL_ReadyToRun);
+    return configReadyToRun.val(CLRConfig::EXTERNAL_ReadyToRun) && 
+            !(CORProfilerDisableAllNGenImages()) && 
+            !(CORProfilerUseProfileImages());
 }
 
 // A log file to record success/failure of R2R loads. s_r2rLogFile can have the following values:


### PR DESCRIPTION
Fix for #13021
This changes so that ready to run images are not loaded when a profiler requests that NGEN images are not used, or when a profiler requests that profiled NGEN images are used.

Conceptually profilers don't care if pre-generated images are NGEN or R2R. When they request that native images are not loaded, it is because the profiler wants to have all functions be instrumentable.

@jkotas @kouvel I don't know if you're the right people to review r2r changes, but you're the ones I can see that have dealt with it in the past.

/CC @noahfalk 