### PR TITLE
Do not get the GC layout for small structs in legacy backend.

### DIFF
--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -17700,7 +17700,7 @@ void CodeGen::SetupLateArgs(GenTreeCall* call)
                     }
                     else
                     {
-                        gcLayout = new (compiler, CMK_Codegen) BYTE[1];
+                        gcLayout    = new (compiler, CMK_Codegen) BYTE[1];
                         gcLayout[0] = TYPE_GC_NONE;
                     }
                 }

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -17693,7 +17693,16 @@ void CodeGen::SetupLateArgs(GenTreeCall* call)
 
                     getEmitter()->emitIns_R_S(INS_lea, EA_PTRSIZE, regSrc, varNum, 0);
                     regTracker.rsTrackRegTrash(regSrc);
-                    gcLayout = compiler->lvaGetGcLayout(varNum);
+
+                    if (varDsc->lvExactSize >= TARGET_POINTER_SIZE)
+                    {
+                        gcLayout = compiler->lvaGetGcLayout(varNum);
+                    }
+                    else
+                    {
+                        gcLayout = new (compiler, CMK_Codegen) BYTE[1];
+                        gcLayout[0] = TYPE_GC_NONE;
+                    }
                 }
             }
             else if (arg->gtOper == GT_MKREFANY)


### PR DESCRIPTION
Such structs are too small to contain any GC pointers. Synthesize a GC
layout with a single slot of `TYPE_GC_NONE`.

Fixes VSO 469600.