### PR TITLE
Fix build of native CoreCLR components on Alpine Linux

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -390,10 +390,11 @@ isMSBuildOnNETCoreSupported()
     if [ "$__HostArch" == "x64" ]; then
         if [ "$__HostOS" == "Linux" ]; then
             __isMSBuildOnNETCoreSupported=1
-            UNSUPPORTED_RIDS=("debian.9-x64" "ubuntu.17.04-x64")
+            # note: the RIDs below can use globbing patterns
+            UNSUPPORTED_RIDS=("debian.9-x64" "ubuntu.17.04-x64" "alpine.3.6.*-x64")
             for UNSUPPORTED_RID in "${UNSUPPORTED_RIDS[@]}"
             do
-                if [ "$__HostDistroRid" == "$UNSUPPORTED_RID" ]; then
+                if [[ $__HostDistroRid == $UNSUPPORTED_RID ]]; then
                     __isMSBuildOnNETCoreSupported=0
                     break
                 fi

--- a/src/debug/createdump/threadinfo.cpp
+++ b/src/debug/createdump/threadinfo.cpp
@@ -5,6 +5,10 @@
 #include "createdump.h"
 #include <asm/ptrace.h>
 
+#ifndef __GLIBC__
+typedef int __ptrace_request;
+#endif
+
 #define FPREG_ErrorOffset(fpregs) *(DWORD*)&((fpregs).rip)
 #define FPREG_ErrorSelector(fpregs) *(((WORD*)&((fpregs).rip)) + 2)
 #define FPREG_DataOffset(fpregs) *(DWORD*)&((fpregs).rdp)


### PR DESCRIPTION
The src/debug/createdump/threadinfo.cpp was including asm/ptrace.h while it should include sys/ptrace.h instead. That removes the need for the cast of constants to __ptrace_request which doesn't exist on Alpine.

Also, I've added Alpine to the list of distros that don't support msbuild to make sure the build won't fail when trying to download dotnet tools that don't exist on Alpine yet. Since the version we get from /etc/os-release contains even the minor version number (third part of the version), I've also modified the script so that globbing is supported in the list of unsupported distros.