### PR TITLE
Add new Span-based virtual sync Read/Write Stream methods

### DIFF
--- a/src/mscorlib/shared/System/IO/PinnedBufferMemoryStream.cs
+++ b/src/mscorlib/shared/System/IO/PinnedBufferMemoryStream.cs
@@ -46,6 +46,10 @@ namespace System.IO
                 Initialize(ptr, len, len, FileAccess.Read);
         }
 
+        public override int Read(Span<byte> destination) => ReadCore(destination);
+
+        public override void Write(ReadOnlySpan<byte> source) => WriteCore(source);
+
         ~PinnedBufferMemoryStream()
         {
             Dispose(false);

--- a/src/mscorlib/shared/System/IO/UnmanagedMemoryStream.cs
+++ b/src/mscorlib/shared/System/IO/UnmanagedMemoryStream.cs
@@ -361,8 +361,27 @@ namespace System.IO
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
             if (buffer.Length - offset < count)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
-            Contract.EndContractBlock();  // Keep this in sync with contract validation in ReadAsync
 
+            return ReadCore(new Span<byte>(buffer, offset, count));
+        }
+
+        public override int Read(Span<byte> destination)
+        {
+            if (GetType() == typeof(UnmanagedMemoryStream))
+            {
+                return ReadCore(destination);
+            }
+            else
+            {
+                // UnmanagedMemoryStream is not sealed, and a derived type may have overridden Read(byte[], int, int) prior
+                // to this Read(Span<byte>) overload being introduced.  In that case, this Read(Span<byte>) overload
+                // should use the behavior of Read(byte[],int,int) overload.
+                return base.Read(destination);
+            }
+        }
+
+        private int ReadCore(Span<byte> destination)
+        {
             if (!_isOpen) throw Error.GetStreamIsClosed();
             if (!CanRead) throw Error.GetReadNotSupported();
 
@@ -370,20 +389,22 @@ namespace System.IO
             // changes our position after we decide we can read some bytes.
             long pos = Interlocked.Read(ref _position);
             long len = Interlocked.Read(ref _length);
-            long n = len - pos;
-            if (n > count)
-                n = count;
+            long n = Math.Min(len - pos, destination.Length);
             if (n <= 0)
+            {
                 return 0;
+            }
 
             int nInt = (int)n; // Safe because n <= count, which is an Int32
             if (nInt < 0)
+            {
                 return 0;  // _position could be beyond EOF
+            }
             Debug.Assert(pos + nInt >= 0, "_position + n >= 0");  // len is less than 2^63 -1.
 
             unsafe
             {
-                fixed (byte* pBuffer = buffer)
+                fixed (byte* pBuffer = &destination.DangerousGetPinnableReference())
                 {
                     if (_buffer != null)
                     {
@@ -393,7 +414,7 @@ namespace System.IO
                         try
                         {
                             _buffer.AcquirePointer(ref pointer);
-                            Buffer.Memcpy(pBuffer + offset, pointer + pos + _offset, nInt);
+                            Buffer.Memcpy(pBuffer, pointer + pos + _offset, nInt);
                         }
                         finally
                         {
@@ -405,7 +426,7 @@ namespace System.IO
                     }
                     else
                     {
-                        Buffer.Memcpy(pBuffer + offset, _mem + pos, nInt);
+                        Buffer.Memcpy(pBuffer, _mem + pos, nInt);
                     }
                 }
             }
@@ -583,17 +604,40 @@ namespace System.IO
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
             if (buffer.Length - offset < count)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
-            Contract.EndContractBlock();  // Keep contract validation in sync with WriteAsync(..)
 
-            if (!_isOpen) throw Error.GetStreamIsClosed();
-            if (!CanWrite) throw Error.GetWriteNotSupported();
+            WriteCore(new Span<byte>(buffer, offset, count));
+        }
+
+        public override void Write(ReadOnlySpan<byte> source)
+        {
+            if (GetType() == typeof(UnmanagedMemoryStream))
+            {
+                WriteCore(source);
+            }
+            else
+            {
+                // UnmanagedMemoryStream is not sealed, and a derived type may have overridden Write(byte[], int, int) prior
+                // to this Write(Span<byte>) overload being introduced.  In that case, this Write(Span<byte>) overload
+                // should use the behavior of Write(byte[],int,int) overload.
+                base.Write(source);
+            }
+        }
+
+        private unsafe void WriteCore(ReadOnlySpan<byte> source)
+        {
+            if (!_isOpen)
+                throw Error.GetStreamIsClosed();
+            if (!CanWrite)
+                throw Error.GetWriteNotSupported();
 
             long pos = Interlocked.Read(ref _position);  // Use a local to avoid a race condition
             long len = Interlocked.Read(ref _length);
-            long n = pos + count;
+            long n = pos + source.Length;
             // Check for overflow
             if (n < 0)
+            {
                 throw new IOException(SR.IO_StreamTooLong);
+            }
 
             if (n > _capacity)
             {
@@ -606,10 +650,7 @@ namespace System.IO
                 // zero any memory in the middle.
                 if (pos > len)
                 {
-                    unsafe
-                    {
-                        Buffer.ZeroMemory(_mem + len, pos - len);
-                    }
+                    Buffer.ZeroMemory(_mem + len, pos - len);
                 }
 
                 // set length after zeroing memory to avoid race condition of accessing unzeroed memory
@@ -619,39 +660,37 @@ namespace System.IO
                 }
             }
 
-            unsafe
+            fixed (byte* pBuffer = &source.DangerousGetPinnableReference())
             {
-                fixed (byte* pBuffer = buffer)
+                if (_buffer != null)
                 {
-                    if (_buffer != null)
+                    long bytesLeft = _capacity - pos;
+                    if (bytesLeft < source.Length)
                     {
-                        long bytesLeft = _capacity - pos;
-                        if (bytesLeft < count)
-                        {
-                            throw new ArgumentException(SR.Arg_BufferTooSmall);
-                        }
-
-                        byte* pointer = null;
-                        RuntimeHelpers.PrepareConstrainedRegions();
-                        try
-                        {
-                            _buffer.AcquirePointer(ref pointer);
-                            Buffer.Memcpy(pointer + pos + _offset, pBuffer + offset, count);
-                        }
-                        finally
-                        {
-                            if (pointer != null)
-                            {
-                                _buffer.ReleasePointer();
-                            }
-                        }
+                        throw new ArgumentException(SR.Arg_BufferTooSmall);
                     }
-                    else
+
+                    byte* pointer = null;
+                    RuntimeHelpers.PrepareConstrainedRegions();
+                    try
                     {
-                        Buffer.Memcpy(_mem + pos, pBuffer + offset, count);
+                        _buffer.AcquirePointer(ref pointer);
+                        Buffer.Memcpy(pointer + pos + _offset, pBuffer, source.Length);
+                    }
+                    finally
+                    {
+                        if (pointer != null)
+                        {
+                            _buffer.ReleasePointer();
+                        }
                     }
                 }
+                else
+                {
+                    Buffer.Memcpy(_mem + pos, pBuffer, source.Length);
+                }
             }
+
             Interlocked.Exchange(ref _position, n);
             return;
         }

--- a/src/mscorlib/shared/System/IO/UnmanagedMemoryStream.cs
+++ b/src/mscorlib/shared/System/IO/UnmanagedMemoryStream.cs
@@ -380,7 +380,7 @@ namespace System.IO
             }
         }
 
-        private int ReadCore(Span<byte> destination)
+        internal int ReadCore(Span<byte> destination)
         {
             if (!_isOpen) throw Error.GetStreamIsClosed();
             if (!CanRead) throw Error.GetReadNotSupported();
@@ -623,12 +623,10 @@ namespace System.IO
             }
         }
 
-        private unsafe void WriteCore(ReadOnlySpan<byte> source)
+        internal unsafe void WriteCore(ReadOnlySpan<byte> source)
         {
-            if (!_isOpen)
-                throw Error.GetStreamIsClosed();
-            if (!CanWrite)
-                throw Error.GetWriteNotSupported();
+            if (!_isOpen) throw Error.GetStreamIsClosed();
+            if (!CanWrite) throw Error.GetWriteNotSupported();
 
             long pos = Interlocked.Read(ref _position);  // Use a local to avoid a race condition
             long len = Interlocked.Read(ref _length);

--- a/src/mscorlib/shared/System/IO/UnmanagedMemoryStreamWrapper.cs
+++ b/src/mscorlib/shared/System/IO/UnmanagedMemoryStreamWrapper.cs
@@ -114,6 +114,11 @@ namespace System.IO
             return _unmanagedStream.Read(buffer, offset, count);
         }
 
+        public override int Read(Span<byte> destination)
+        {
+            return _unmanagedStream.Read(destination);
+        }
+
         public override int ReadByte()
         {
             return _unmanagedStream.ReadByte();
@@ -134,6 +139,11 @@ namespace System.IO
         public override void Write(byte[] buffer, int offset, int count)
         {
             _unmanagedStream.Write(buffer, offset, count);
+        }
+
+        public override void Write(ReadOnlySpan<byte> source)
+        {
+            _unmanagedStream.Write(source);
         }
 
         public override void WriteByte(byte value)

--- a/src/mscorlib/src/System/IO/MemoryStream.cs
+++ b/src/mscorlib/src/System/IO/MemoryStream.cs
@@ -412,9 +412,10 @@ namespace System.IO
                 return 0;
             }
 
-            // TODO: Read(byte[], int, int) has an n <= 8 optimization, presumably
-            // based on benchmarking.  Determine if/where such a cut-off is here and
-            // add an equivalent optimization if necessary.
+            // TODO https://github.com/dotnet/corefx/issues/22388:
+            // Read(byte[], int, int) has an n <= 8 optimization, presumably based
+            // on benchmarking.  Determine if/where such a cut-off is here and add
+            // an equivalent optimization if necessary.
             new Span<byte>(_buffer, _position, n).CopyTo(destination);
 
             _position += n;

--- a/src/mscorlib/src/System/IO/MemoryStream.cs
+++ b/src/mscorlib/src/System/IO/MemoryStream.cs
@@ -391,6 +391,36 @@ namespace System.IO
             return n;
         }
 
+        public override int Read(Span<byte> destination)
+        {
+            if (GetType() != typeof(MemoryStream))
+            {
+                // MemoryStream is not sealed, and a derived type may have overridden Read(byte[], int, int) prior
+                // to this Read(Span<byte>) overload being introduced.  In that case, this Read(Span<byte>) overload
+                // should use the behavior of Read(byte[],int,int) overload.
+                return base.Read(destination);
+            }
+
+            if (!_isOpen)
+            {
+                __Error.StreamIsClosed();
+            }
+
+            int n = Math.Min(_length - _position, destination.Length);
+            if (n <= 0)
+            {
+                return 0;
+            }
+
+            // TODO: Read(byte[], int, int) has an n <= 8 optimization, presumably
+            // based on benchmarking.  Determine if/where such a cut-off is here and
+            // add an equivalent optimization if necessary.
+            new Span<byte>(_buffer, _position, n).CopyTo(destination);
+
+            _position += n;
+            return n;
+        }
+
         public override Task<int> ReadAsync(Byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             if (buffer == null)
@@ -631,6 +661,52 @@ namespace System.IO
             }
             else
                 Buffer.InternalBlockCopy(buffer, offset, _buffer, _position, count);
+            _position = i;
+        }
+
+        public override void Write(ReadOnlySpan<byte> source)
+        {
+            if (GetType() != typeof(MemoryStream))
+            {
+                // MemoryStream is not sealed, and a derived type may have overridden Write(byte[], int, int) prior
+                // to this Write(Span<byte>) overload being introduced.  In that case, this Write(Span<byte>) overload
+                // should use the behavior of Write(byte[],int,int) overload.
+                base.Write(source);
+                return;
+            }
+
+            if (!_isOpen)
+            {
+                __Error.StreamIsClosed();
+            }
+            EnsureWriteable();
+
+            // Check for overflow
+            int i = _position + source.Length;
+            if (i < 0)
+            {
+                throw new IOException(SR.IO_StreamTooLong);
+            }
+
+            if (i > _length)
+            {
+                bool mustZero = _position > _length;
+                if (i > _capacity)
+                {
+                    bool allocatedNewArray = EnsureCapacity(i);
+                    if (allocatedNewArray)
+                    {
+                        mustZero = false;
+                    }
+                }
+                if (mustZero)
+                {
+                    Array.Clear(_buffer, _length, i - _length);
+                }
+                _length = i;
+            }
+
+            source.CopyTo(new Span<byte>(_buffer, _position, source.Length));
             _position = i;
         }
 

--- a/src/mscorlib/src/System/IO/Stream.cs
+++ b/src/mscorlib/src/System/IO/Stream.cs
@@ -741,8 +741,7 @@ namespace System.IO
                 return 0;
             }
 
-            ArrayPool<byte> pool = ArrayPool<byte>.Shared;
-            byte[] buffer = pool.Rent(destination.Length);
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(destination.Length);
             try
             {
                 int numRead = Read(buffer, 0, destination.Length);
@@ -753,7 +752,7 @@ namespace System.IO
                 new Span<byte>(buffer, 0, numRead).CopyTo(destination);
                 return numRead;
             }
-            finally { pool.Return(buffer); }
+            finally { ArrayPool<byte>.Shared.Return(buffer); }
         }
 
         // Reads one byte from the stream by calling Read(byte[], int, int). 
@@ -783,14 +782,13 @@ namespace System.IO
                 return;
             }
 
-            ArrayPool<byte> pool = ArrayPool<byte>.Shared;
-            byte[] buffer = pool.Rent(source.Length);
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(source.Length);
             try
             {
                 source.CopyTo(buffer);
                 Write(buffer, 0, source.Length);
             }
-            finally { pool.Return(buffer); }
+            finally { ArrayPool<byte>.Shared.Return(buffer); }
         }
 
         // Writes one byte from the stream by calling Write(byte[], int, int).

--- a/src/mscorlib/src/System/IO/Stream.cs
+++ b/src/mscorlib/src/System/IO/Stream.cs
@@ -734,6 +734,28 @@ namespace System.IO
 
         public abstract int Read([In, Out] byte[] buffer, int offset, int count);
 
+        public virtual int Read(Span<byte> destination)
+        {
+            if (destination.Length == 0)
+            {
+                return 0;
+            }
+
+            ArrayPool<byte> pool = ArrayPool<byte>.Shared;
+            byte[] buffer = pool.Rent(destination.Length);
+            try
+            {
+                int numRead = Read(buffer, 0, destination.Length);
+                if ((uint)numRead > destination.Length)
+                {
+                    throw new IOException(SR.IO_StreamTooLong);
+                }
+                new Span<byte>(buffer, 0, numRead).CopyTo(destination);
+                return numRead;
+            }
+            finally { pool.Return(buffer); }
+        }
+
         // Reads one byte from the stream by calling Read(byte[], int, int). 
         // Will return an unsigned byte cast to an int or -1 on end of stream.
         // This implementation does not perform well because it allocates a new
@@ -753,6 +775,23 @@ namespace System.IO
         }
 
         public abstract void Write(byte[] buffer, int offset, int count);
+
+        public virtual void Write(ReadOnlySpan<byte> source)
+        {
+            if (source.Length == 0)
+            {
+                return;
+            }
+
+            ArrayPool<byte> pool = ArrayPool<byte>.Shared;
+            byte[] buffer = pool.Rent(source.Length);
+            try
+            {
+                source.CopyTo(buffer);
+                Write(buffer, 0, source.Length);
+            }
+            finally { pool.Return(buffer); }
+        }
 
         // Writes one byte from the stream by calling Write(byte[], int, int).
         // This implementation does not perform well because it allocates a new
@@ -957,6 +996,11 @@ namespace System.IO
                 return 0;
             }
 
+            public override int Read(Span<byte> destination)
+            {
+                return 0;
+            }
+
             public override Task<int> ReadAsync(Byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
                 var nullReadTask = s_nullReadTask;
@@ -972,6 +1016,10 @@ namespace System.IO
             }
 
             public override void Write(byte[] buffer, int offset, int count)
+            {
+            }
+
+            public override void Write(ReadOnlySpan<byte> source)
             {
             }
 
@@ -1229,6 +1277,12 @@ namespace System.IO
                     return _stream.Read(bytes, offset, count);
             }
 
+            public override int Read(Span<byte> destination)
+            {
+                lock (_stream)
+                    return _stream.Read(destination);
+            }
+
             public override int ReadByte()
             {
                 lock (_stream)
@@ -1280,6 +1334,12 @@ namespace System.IO
             {
                 lock (_stream)
                     _stream.Write(bytes, offset, count);
+            }
+
+            public override void Write(ReadOnlySpan<byte> source)
+            {
+                lock (_stream)
+                    _stream.Write(source);
             }
 
             public override void WriteByte(byte b)


### PR DESCRIPTION
- Add the new Read/Write virtuals to Stream (contributes to https://github.com/dotnet/corefx/issues/22381). Base implementations defer to the array-based implementations, getting an array from the shared array pool.
- Override on MemoryStream (contributes to https://github.com/dotnet/corefx/issues/22388).  Overrides defer to the base implementation if the instance is actually a derived type and thus might override the existing Read/Write methods.  I chose to duplicate the code for reading/writing rather than have the existing array-based overload layered on top of the span one as the array-based have some optimizations that suggest low-level perf tuning was done, and I don't want to derail that.  We can subsequently revisit these to tune them.
- Override on UnmanagedMemoryStream (contributes to https://github.com/dotnet/corefx/issues/22389).  Overrides defer to the base implementation if the instance is actually a derived type and thus might override the existing Read/Write methods.

cc: @jkotas, @JeremyKuhne, @KrzysztofCwalina 