### PR TITLE
Treat byref-typed uses of int-typed lclVars as type int in LB.

### DIFF
--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -207,6 +207,12 @@ bool CodeGenInterface::genMarkLclVar(GenTreePtr tree)
     assert(varNum < compiler->lvaCount);
     varDsc = compiler->lvaTable + varNum;
 
+    // Retype byref-typed appearances of intptr-typed lclVars as type intptr.
+    if ((varDsc->TypeGet() == TYP_I_IMPL) && (tree->TypeGet() == TYP_BYREF))
+    {
+        tree->gtType = TYP_I_IMPL;
+    }
+
     if (varDsc->lvRegister)
     {
         genBashLclVar(tree, varNum, varDsc);

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_468732/DevDiv_468732.cs
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_468732/DevDiv_468732.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Repro case for a bug involving byref-typed appearances of int-typed lclVars.
+
+using System.Runtime.CompilerServices;
+
+struct S
+{
+    int i;
+
+    void N()
+    {
+        i = 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static unsafe S* Test(S* s)
+    {
+        s->N();
+        return s;
+    }
+
+    static unsafe int Main()
+    {
+        S s;
+        return Test(&s)->i;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_468732/DevDiv_468732.csproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_468732/DevDiv_468732.csproj
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{1D93D1C3-458A-44ED-ABCC-7D0739B28C92}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_468732.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
This is consistent with the behvaior of both JIT32 and RyuJIT. This
resolves an assertion originating from the following scenario:

1. The input IL contains a lclVar of type `Foo*`, which the JIT imports as
   `TYP_I_IMPL` (which is `TYP_INT` in this case).
2. This lclVar is used as the `this` argument to a number of method calls.
   This is legal as per ECMA-335 section III.3.19 ("Correct CIL also allows
   a native int to be passed as a byref (&); in which case following the
   store the value will be tracked by garbage collection.")
3. All of the method calls to which this lclVar is passed as a byref are
   inlined. This produces many uses of the lclVar as a byref (i.e. we see
   nodes like `lclVar V06 byref` even though V06's varDsc has type int).
4. The lclVar is assigned a register `r`. At its first appearance--which is
   the first occasion in which it is loaded into this register--it is used
   as `TYP_BYREF`. When the code generator processes this appearance, it
   first sets the appropriate bit for `r` in `gcInfo.gcRegByrefSetCur`
   (`gcInfo.gcMarkRegPtrVal`, called by `genCodeForTree_REG_VAR1`) and then
   sets the appropriate bit for `r` in `regSet.rsMaskVars`
   (`genUpdateLife`).
5. The lclVar is used as `TYP_INT` as the operand to a `GT_RETURN` node.
   When the code generator processes this appearance, it attempts to update
   the GC-ness of `r` by calling `gcInfo.gcMarkRegPtrVal` (again via
   `genCodeForTree_REG_VAR1`). This function, though, explicitly excludes
   registers that contain live variables from its update, so `r` remains in
   `gcInfo.gcRegByrefSetCur` after this call. After calling
   `gcMarkRegPtrVal`, `genCodeForTree_REG_VAR1` calls `genUpdateLife`,
   which removes the the lclVar from `regSet.rsMaskVars`.
6. An assertion intended to verify that the only registers that are live
   after processing a statement are registers that contain lclVars fires,
   as `gcRegByrefSetCur` still contains `r`.

Fixes VSO 468732.