### PR TITLE
Handle error case when looking for reg pair

### DIFF
--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -14672,7 +14672,7 @@ void CodeGen::genCodeForTreeLng(GenTreePtr tree, regMaskTP needReg, regMaskTP av
                             if (!genMaxOneBit(needReg))
                             {
                                 regPair = regSet.rsFindRegPairNo(needReg);
-                                if (needReg != genRegPairMask(regPair))
+                                if ((regPair == REG_PAIR_NONE) || (needReg != genRegPairMask(regPair)))
                                     goto ANY_FREE_REG_UNSIGNED;
                                 loRegMask = genRegMask(genRegPairLo(regPair));
                                 if ((loRegMask & regSet.rsRegMaskCanGrab()) == 0)


### PR DESCRIPTION
When performing unsigned up-cast to long, if needReg was computed
with exactly 2 bits, then rsFindRegPairNo() is called to find the
corresponding reg pair. This can fail if one of the needReg bits
is in the reserved set (rsMaskResvd), as was the case in this test
on ARM for R10.

Add logic to handle this error return. The same logic already existed
in the signed cast case.

Fixes #12886