### PR TITLE
Fix print message in runtest.sh

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -1200,7 +1200,7 @@ precompile_overlay_assemblies
 
 if [ "$buildOverlayOnly" == "ON" ];
 then
-    echo "Build overlay directory \'$coreOverlayDir\' complete."
+    echo "Build overlay directory '$coreOverlayDir' complete."
     exit 0
 fi
 


### PR DESCRIPTION
A nit. Remove unncessary character `\`.

The current output message is:

```
Build overlay directory \'/home/hanjoung/ws/dotnet/ut/170727/Tests/coreoverlay\' complete.
```

To be:

```
Build overlay directory '/home/hanjoung/ws/dotnet/ut/170727/Tests/coreoverlay' complete.
```