### PR TITLE
fixed incorrect reading a GC config

### DIFF
--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1031,7 +1031,7 @@ bool GCToEEInterface::GetBooleanConfigValue(const char* key, bool* value)
 
     if (strcmp(key, "gcConcurrent") == 0)
     {
-        *value = g_IGCconcurrent != 0;
+        *value = !!g_pConfig->GetGCconcurrent();
         return true;
     }
 


### PR DESCRIPTION
gcconcurrent config should be obtained from g_pConfig which takes env vars/reg values into consideration as well. @swgillespie PTAL.