### PR TITLE
Fixed misprint in legacy backend that led to assert failure

### DIFF
--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -19067,7 +19067,7 @@ regMaskTP CodeGen::genCodeForCall(GenTreeCall* call, bool valUsed)
                         CORINFO_CONST_LOOKUP lookup;
                         compiler->info.compCompHnd->getAddressOfPInvokeTarget(methHnd, &lookup);
 
-                        void* addr = lookup.addr;
+                        addr = lookup.addr;
 
                         assert(addr != NULL);
 


### PR DESCRIPTION
Was found during legacy backend performance testing work