### PR TITLE
Fixed round-trip bug of double.ToString("R").

### DIFF
--- a/src/classlibnative/bcltype/number.cpp
+++ b/src/classlibnative/bcltype/number.cpp
@@ -2109,30 +2109,7 @@ FCIMPL3_VII(Object*, COMNumber::FormatDouble, double value, StringObject* format
     int precision = DOUBLE_PRECISION;
     switch (val) {
     case 'R':
-        //In order to give numbers that are both friendly to display and round-trippable,
-        //we parse the number using 15 digits and then determine if it round trips to the same
-        //value.  If it does, we convert that NUMBER to a string, otherwise we reparse using 17 digits
-        //and display that.
-
-        DoubleToNumber(value, DOUBLE_PRECISION, &number);
-
-        if (number.scale == (int) SCALE_NAN) {
-            gc.refRetVal = gc.numfmt->sNaN;
-            goto lExit;
-        }
-
-        if (number.scale == SCALE_INF) {
-            gc.refRetVal = (number.sign? gc.numfmt->sNegativeInfinity: gc.numfmt->sPositiveInfinity);
-            goto lExit;
-        }
-
-        NumberToDouble(&number, &dTest);
-
-        if (dTest == value) {
-            gc.refRetVal = NumberToString(&number, 'G', DOUBLE_PRECISION, gc.numfmt);
-            goto lExit;
-        }
-
+        // Per IEEE double-precision floating-point format, double number in 17 digits precision should be round-trippable.
         DoubleToNumber(value, 17, &number);
         gc.refRetVal = NumberToString(&number, 'G', 17, gc.numfmt);
         goto lExit;

--- a/src/classlibnative/bcltype/number.cpp
+++ b/src/classlibnative/bcltype/number.cpp
@@ -2111,6 +2111,16 @@ FCIMPL3_VII(Object*, COMNumber::FormatDouble, double value, StringObject* format
     case 'R':
         // Per IEEE double-precision floating-point format, double number in 17 digits precision should be round-trippable.
         DoubleToNumber(value, 17, &number);
+        if (number.scale == (int) SCALE_NAN) {
+            gc.refRetVal = gc.numfmt->sNaN;
+            goto lExit;
+        }
+
+        if (number.scale == SCALE_INF) {
+            gc.refRetVal = (number.sign? gc.numfmt->sNegativeInfinity: gc.numfmt->sPositiveInfinity);
+            goto lExit;
+        }
+
         gc.refRetVal = NumberToString(&number, 'G', 17, gc.numfmt);
         goto lExit;
         break;


### PR DESCRIPTION
Removed the "15 digits precision first, then 17 digits precision" converting logic in double.ToString("R"). This change fixes https://stackoverflow.com/questions/24299692/why-is-a-round-trip-conversion-via-a-string-not-safe-for-a-double

Fix #13106