### PR TITLE
[Ryujit/ARM32] Update allocateBusyReg() in LSRA for ARM32

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -5800,9 +5800,9 @@ bool LinearScan::canSpillDoubleReg(RegRecord*   physRegRecord,
 //
 bool LinearScan::checkActiveInterval(Interval* interval, LsraLocation refLocation)
 {
-    RefPosition* recentAssignedRef = interval->recentRefPosition;
     if (!interval->isActive)
     {
+        RefPosition* recentAssignedRef = interval->recentRefPosition;
         // Note that we may or may not have actually handled the reference yet, so it could either
         // be recentAssignedRef, or the next reference.
         assert(recentAssignedRef != nullptr);
@@ -6276,10 +6276,16 @@ regNumber LinearScan::allocateBusyReg(Interval* current, RefPosition* refPositio
             RefPosition* nextRefPosition2 =
                 (assignedInterval2 == nullptr) ? nullptr : assignedInterval2->getNextRefPosition();
             if (nextRefPosition != nullptr)
+            {
                 if (nextRefPosition2 != nullptr)
+                {
                     assert(!nextRefPosition->RequiresRegister() || !nextRefPosition2->RequiresRegister());
+                }
                 else
+                {
                     assert(!nextRefPosition->RequiresRegister());
+                }
+            }
             else
             {
                 assert(nextRefPosition2 != nullptr && !nextRefPosition2->RequiresRegister());
@@ -6309,7 +6315,9 @@ regNumber LinearScan::allocateBusyReg(Interval* current, RefPosition* refPositio
         }
         else
 #endif
+        {
             unassignPhysReg(farthestRefPhysRegRecord, farthestRefPhysRegRecord->assignedInterval->recentRefPosition);
+        }
 
         assignPhysReg(farthestRefPhysRegRecord, current);
         refPosition->registerAssignment = genRegMask(foundReg);

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -5953,8 +5953,9 @@ regNumber LinearScan::allocateBusyReg(Interval* current, RefPosition* refPositio
         RegRecord* physRegRecord2 = nullptr;
         // For ARM32, let's consider two float registers consisting a double reg together,
         // when allocaing a double register.
-        if (current->registerType == TYP_DOUBLE && genIsValidDoubleReg(regNum))
+        if (current->registerType == TYP_DOUBLE)
         {
+            assert(genIsValidDoubleReg(regNum));
             physRegRecord2 = findAnotherHalfRegRec(physRegRecord);
         }
 #endif
@@ -6042,7 +6043,7 @@ regNumber LinearScan::allocateBusyReg(Interval* current, RefPosition* refPositio
         RefPosition* recentAssignedRef = (assignedInterval == nullptr) ? nullptr : assignedInterval->recentRefPosition;
         RefPosition* recentAssignedRef2 =
             (assignedInterval2 == nullptr) ? nullptr : assignedInterval2->recentRefPosition;
-        // There are four cases for ARM32 when we are trying to allocation a double register for TYP_DOUBLE
+        // There are four cases for ARM32 when we are trying to allocate a double register for TYP_DOUBLE
         // Case 1: LoReg->assignedInterval != nullptr && HiReg->assignedInterval != nullptr
         // Case 2: LoReg->assignedInterval != nullptr && HiReg->assignedInterval == nullptr
         // Case 3: LoReg->assignedInterval == nullptr && HiReg->assignedInterval != nullptr

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -704,12 +704,13 @@ private:
                                      LsraLocation refLocation,
                                      unsigned*    recentAssignedRefWeight,
                                      unsigned     farthestRefPosWeight);
-    void LinearScan::checkReferenceAt(RefPosition* recentAssignedRef, LsraLocation refLocation);
 #endif
     void updateAssignedInterval(RegRecord* reg, Interval* interval, RegisterType regType);
     void updatePreviousInterval(RegRecord* reg, Interval* interval, RegisterType regType);
     bool canRestorePreviousInterval(RegRecord* regRec, Interval* assignedInterval);
     bool isAssignedToInterval(Interval* interval, RegRecord* regRec);
+    bool checkActiveInterval(Interval* interval, LsraLocation refLocation);
+    bool checkActiveIntervals(RegRecord* physRegRecord, LsraLocation refLocation, RegisterType registerType);
 
     RefType CheckBlockType(BasicBlock* block, BasicBlock* prevBlock);
 

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -701,6 +701,7 @@ private:
                            LsraLocation refLocation,
                            unsigned*    recentAssignedRefWeight,
                            unsigned     farthestRefPosWeight);
+    void unassignDoublePhysReg(RegRecord* doubleRegRecord);
 #endif
     void updateAssignedInterval(RegRecord* reg, Interval* interval, RegisterType regType);
     void updatePreviousInterval(RegRecord* reg, Interval* interval, RegisterType regType);

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -697,6 +697,14 @@ private:
 #ifdef _TARGET_ARM_
     bool isSecondHalfReg(RegRecord* regRec, Interval* interval);
     RegRecord* findAnotherHalfRegRec(RegRecord* regRec);
+    bool LinearScan::canSpillThisReg(RegRecord*   physRegRecord,
+                                     RefPosition* recentAssignedRef,
+                                     RegRecord*   anotherPhysRegRecord,
+                                     RefPosition* anotherRecentAssignedRef,
+                                     LsraLocation refLocation,
+                                     unsigned*    recentAssignedRefWeight,
+                                     unsigned     farthestRefPosWeight);
+    void LinearScan::checkReferenceAt(RefPosition* recentAssignedRef, LsraLocation refLocation);
 #endif
     void updateAssignedInterval(RegRecord* reg, Interval* interval, RegisterType regType);
     void updatePreviousInterval(RegRecord* reg, Interval* interval, RegisterType regType);

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -697,13 +697,10 @@ private:
 #ifdef _TARGET_ARM_
     bool isSecondHalfReg(RegRecord* regRec, Interval* interval);
     RegRecord* findAnotherHalfRegRec(RegRecord* regRec);
-    bool LinearScan::canSpillThisReg(RegRecord*   physRegRecord,
-                                     RefPosition* recentAssignedRef,
-                                     RegRecord*   anotherPhysRegRecord,
-                                     RefPosition* anotherRecentAssignedRef,
-                                     LsraLocation refLocation,
-                                     unsigned*    recentAssignedRefWeight,
-                                     unsigned     farthestRefPosWeight);
+    bool canSpillDoubleReg(RegRecord*   physRegRecord,
+                           LsraLocation refLocation,
+                           unsigned*    recentAssignedRefWeight,
+                           unsigned     farthestRefPosWeight);
 #endif
     void updateAssignedInterval(RegRecord* reg, Interval* interval, RegisterType regType);
     void updatePreviousInterval(RegRecord* reg, Interval* interval, RegisterType regType);
@@ -711,6 +708,10 @@ private:
     bool isAssignedToInterval(Interval* interval, RegRecord* regRec);
     bool checkActiveInterval(Interval* interval, LsraLocation refLocation);
     bool checkActiveIntervals(RegRecord* physRegRecord, LsraLocation refLocation, RegisterType registerType);
+    bool canSpillReg(RegRecord*   physRegRecord,
+                     LsraLocation refLocation,
+                     unsigned*    recentAssignedRefWeight,
+                     unsigned     farthestRefPosWeight);
 
     RefType CheckBlockType(BasicBlock* block, BasicBlock* prevBlock);
 

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -713,6 +713,7 @@ private:
                      LsraLocation refLocation,
                      unsigned*    recentAssignedRefWeight,
                      unsigned     farthestRefPosWeight);
+    bool isRegInUse(RegRecord* regRec, RefPosition* refPosition, LsraLocation* nextLocation);
 
     RefType CheckBlockType(BasicBlock* block, BasicBlock* prevBlock);
 


### PR DESCRIPTION
Fix #13118 

- Add two helper functions. `canSpillThisReg()` and `checkReferenceAt()`
- Update allocateBusyReg() to spill and allocate a double register properly