### PR TITLE
Use Live built ILAsm for building tests

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -13,19 +13,19 @@
   
   <!-- Source of truth for dependency tooling: the commit hash of the dotnet/versions master branch as of the last auto-upgrade. -->
   <PropertyGroup>
-    <CoreFxCurrentRef>8c5e29c80651aff43c981375d9ae935d96f9d637</CoreFxCurrentRef>
-    <CoreClrCurrentRef>8c5e29c80651aff43c981375d9ae935d96f9d637</CoreClrCurrentRef>
+    <CoreFxCurrentRef>a97bcb7231471554cf5cf9b685e60ccbaf505d1f</CoreFxCurrentRef>
+    <CoreClrCurrentRef>a97bcb7231471554cf5cf9b685e60ccbaf505d1f</CoreClrCurrentRef>
   </PropertyGroup>
 
   <!-- Auto-upgraded properties for each build info dependency. -->
   <PropertyGroup>
-    <CoreFxPackageVersion>4.5.0-preview2-25518-02</CoreFxPackageVersion>
+    <CoreFxPackageVersion>4.5.0-preview2-25526-52</CoreFxPackageVersion>
     <PlatformPackageVersion>2.1.0-preview1-25324-02</PlatformPackageVersion>
   </PropertyGroup>
 
   <!-- Full package version strings that are used in other parts of the build. -->
   <PropertyGroup>
-    <CoreClrPackageVersion>2.1.0-preview2-25518-01</CoreClrPackageVersion>
+    <CoreClrPackageVersion>2.1.0-dev-di-25528-01</CoreClrPackageVersion>
     <XunitPackageVersion>2.2.0-beta2-build3300</XunitPackageVersion>
     <XUnitConsoleNetCoreVersion>1.0.2-prerelease-00177</XUnitConsoleNetCoreVersion>
     <XUnitPerformanceApiVersion>1.0.0-beta-build0007</XUnitPerformanceApiVersion>
@@ -36,7 +36,7 @@
   <!-- Package dependency verification/auto-upgrade configuration. -->
   <PropertyGroup>
     <BaseDotNetBuildInfo>build-info/dotnet/</BaseDotNetBuildInfo>
-    <DependencyBranch>master</DependencyBranch>
+    <DependencyBranch>dev/defaultintf</DependencyBranch>
     <CurrentRefXmlPath>$(MSBuildThisFileFullPath)</CurrentRefXmlPath>
   </PropertyGroup>
 

--- a/src/ilasm/typar.hpp
+++ b/src/ilasm/typar.hpp
@@ -51,17 +51,27 @@ private:
 
 class TyParList {
 public:
-	TyParList(DWORD a, BinStr* b, LPCUTF8 n, TyParList* nx = NULL) 
+    TyParList(DWORD a, BinStr* b, LPCUTF8 n, TyParList* nx = NULL) 
     { 
         bound  = (b == NULL) ? new BinStr() : b;
         bound->appendInt32(0); // zero terminator
-		attrs = a; name = n; next = nx;
-	};
-	~TyParList() 
-    { 
-        if(bound) delete bound;
-		if (next) delete next; 
-	};
+        attrs = a; name = n; next = nx;
+    };
+    ~TyParList() 
+    {         
+        if( bound) delete bound;
+
+        // To avoid excessive stack usage (especially in debug builds), we break the next chain
+        // and delete as we traverse the link list
+        TyParList *pCur = next;
+        while (pCur != NULL)
+        {
+            TyParList *pTmp = pCur->next;
+            pCur->next = NULL;
+            delete pCur;
+            pCur = pTmp;
+        }
+    };
     int Count()
     {
         TyParList* tp = this;
@@ -154,7 +164,7 @@ public:
     TyParList* Next() { return next; };
     BinStr* Bound() { return bound; };
 private:
-	BinStr* bound;
+    BinStr* bound;
     LPCUTF8 name;
     TyParList* next;
     DWORD   attrs;

--- a/tests/src/IL.targets
+++ b/tests/src/IL.targets
@@ -13,8 +13,7 @@
     <PropertyGroup>
       <_ShellKeyMarker Condition="'$(RunningOnUnix)' == 'true'">-</_ShellKeyMarker>  <!-- Work around ilasm comandline parser bugs... -->
       <_ShellKeyMarker Condition="'$(RunningOnUnix)' != 'true'">/</_ShellKeyMarker>
-      <_ilasm>ilasm</_ilasm>
-      <_ilasm Condition="'$(RunningOnUnix)' == 'true'">$(CoreCLRBinDir)ilasm</_ilasm>
+      <_ilasm>$(CoreCLRBinDir)ilasm</_ilasm>
       <_OutputTypeArgument Condition="'$(OutputType)' == 'Library'">$(_ShellKeyMarker)DLL</_OutputTypeArgument>
       <_OutputTypeArgument Condition="'$(OutputType)' == 'Exe'">$(_ShellKeyMarker)EXE</_OutputTypeArgument>
       <_IlasmSwitches>-QUIET -NOLOGO</_IlasmSwitches>
@@ -24,12 +23,9 @@
       <_IlasmSwitches Condition="'$(DebugType)' == 'Impl'">$(_IlasmSwitches) -DEBUG=IMPL</_IlasmSwitches>
       <_IlasmSwitches Condition="'$(DebugType)' == 'PdbOnly'">$(_IlasmSwitches) -DEBUG=OPT</_IlasmSwitches>
       <_IlasmSwitches Condition="'$(Optimize)' == 'True'">$(_IlasmSwitches) -OPTIMIZE</_IlasmSwitches>
-      <ILAsmExe>ilasm</ILAsmExe>
-      <!-- Unfortunately not every IL test is compatible with CoreCLR ilasm. We are only opt-in those that really requires it -->
-      <ILAsmExe Condition="'$(UseCustomILAsm)'=='True'">$(__BinDir)\$(ILAsmExe)</ILAsmExe>
     </PropertyGroup>
 
-    <Exec Command="$(ILAsmExe) $(_OutputTypeArgument) $(_ShellKeyMarker)OUTPUT=@(IntermediateAssembly) $(_IlasmSwitches) @(Compile)">
+    <Exec Command="$(_ilasm) $(_OutputTypeArgument) $(_ShellKeyMarker)OUTPUT=@(IntermediateAssembly) $(_IlasmSwitches) @(Compile)">
       <Output TaskParameter="ExitCode" PropertyName="_ILAsmExitCode" />
     </Exec>
     <Error Text="ILAsm failed" Condition="'$(_ILAsmExitCode)' != '0'" />


### PR DESCRIPTION
* Update dependencies.prop to use an official build from dev/defaultintf that has a ILAsm with proper fixes which can build tests
* Fix ILAsm so that it doesn't delete ->next type parameter pointers recursively - this demands excessive stack space in one of the crazy generic tests with tons of generic parameters
* Update IL.targets to use live ILAsm or ILAsm from package