### PR TITLE
[ARM/Linux] Use 'udf 0xff' instead of 'bkpt 0xbe' as a poison

### DIFF
--- a/src/vm/arm/stubs.cpp
+++ b/src/vm/arm/stubs.cpp
@@ -2524,8 +2524,8 @@ void UMEntryThunkCode::Encode(BYTE* pTargetCode, void* pvSecretParam)
 
 void UMEntryThunkCode::Poison()
 {
-    // Insert 'bkpt 0x00be' at the entry point
-    m_code[0] = 0xbebe;
+    // Insert 'udf 0xff' at the entry point
+    m_code[0] = 0xdeff;
 }
 
 ///////////////////////////// UNIMPLEMENTED //////////////////////////////////


### PR DESCRIPTION
This commit replaces the current trapping poison 'bkpt 0xbe' with 'udf 0xff'.  
It turns out that GDB gets stuck when it encounters 'bkpt 0xbe' (while LLDB doesn't). 
This change allows GDB not to get stuck.