### PR TITLE
Set Register Requirements for Mod/Div

### DIFF
--- a/src/jit/lsraxarch.cpp
+++ b/src/jit/lsraxarch.cpp
@@ -2068,7 +2068,7 @@ void Lowering::TreeNodeInfoInitModDiv(GenTree* tree)
         op1->gtLsraInfo.setSrcCandidates(l, RBM_RAX);
     }
 
-    if (op2->IsRegOptional())
+    if (!op2->isContained())
     {
         op2->gtLsraInfo.setSrcCandidates(l, l->allRegs(TYP_INT) & ~(RBM_RAX | RBM_RDX));
     }


### PR DESCRIPTION
If a Mod/Div is not contained (whether or not it is RegOptional) we should set preferred registers on op2. This omission was discovered when doing diffs for moving containment analysis to the first phase of `Lowering`. It results in exactly one diff, a reduction of 11 bytes in JIT\Regression\Dev11\External\dev11_239804\ShowLocallocAlignment\ShowLocallocAlignment.exe