### PR TITLE
Reduce size of array enumerators for x86

### DIFF
--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -2418,13 +2418,14 @@ namespace System
 
         private sealed class SZArrayEnumerator : IEnumerator, ICloneable
         {
-            private Array _array;
+            private readonly Array _array;
             private int _index;
-            private int _endIndex; // cache array length, since it's a little slow.
+            private int _endIndex; // Cache Array.Length, since it's a little slow.
 
             internal SZArrayEnumerator(Array array)
             {
                 Debug.Assert(array.Rank == 1 && array.GetLowerBound(0) == 0, "SZArrayEnumerator only works on single dimension arrays w/ a lower bound of zero.");
+
                 _array = array;
                 _index = -1;
                 _endIndex = array.Length;

--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -2738,7 +2738,7 @@ namespace System
                 _array = array;
                 _index = -1;
             }
-    
+
             public bool MoveNext()
             {
                 int index = _index + 1;

--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -2612,8 +2612,7 @@ namespace System
             //! Warning: "this" is an array, not an SZArrayHelper. See comments above
             //! or you may introduce a security hole!
             T[] _this = JitHelpers.UnsafeCast<T[]>(this);
-            int length = _this.Length;
-            return length == 0 ? SZGenericArrayEnumerator<T>.Empty : new SZGenericArrayEnumerator<T>(_this, length);
+            return _this.Length == 0 ? SZGenericArrayEnumerator<T>.Empty : new SZGenericArrayEnumerator<T>(_this);
         }
 
         // -----------------------------------------------------------
@@ -2724,54 +2723,53 @@ namespace System
         //
         private sealed class SZGenericArrayEnumerator<T> : IEnumerator<T>
         {
-            private T[] _array;
+            private readonly T[] _array;
             private int _index;
-            private int _endIndex; // cache array length, since it's a little slow.
 
-            // Passing -1 for endIndex so that MoveNext always returns false without mutating _index
-            internal static readonly SZGenericArrayEnumerator<T> Empty = new SZGenericArrayEnumerator<T>(null, -1);
+            // Array.Empty is intentionally omitted here, since we don't want to pay for generic instantiations that
+            // wouldn't have otherwise been used.
+            internal static readonly SZGenericArrayEnumerator<T> Empty = new SZGenericArrayEnumerator<T>(new T[0]);
 
-            internal SZGenericArrayEnumerator(T[] array, int endIndex)
+            internal SZGenericArrayEnumerator(T[] array)
             {
-                // We allow passing null array in case of empty enumerator. 
-                Debug.Assert(array != null || endIndex == -1, "endIndex should be -1 in the case of a null array (for the empty enumerator).");
+                Debug.Assert(array != null);
+
                 _array = array;
                 _index = -1;
-                _endIndex = endIndex;
             }
-
+    
             public bool MoveNext()
             {
-                if (_index < _endIndex)
+                int index = _index + 1;
+                bool result = index < _array.Length;
+                
+                if (result)
                 {
-                    _index++;
-                    return (_index < _endIndex);
+                    _index = index;
                 }
-                return false;
-            }
 
+                return result;
+            }
+    
             public T Current
             {
                 get
                 {
-                    if (_index < 0) ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumNotStarted();
-                    if (_index >= _endIndex) ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumEnded();
-                    return _array[_index];
+                    int index = _index;
+                    T[] array = _array;
+
+                    if ((uint)index >= (uint)array.Length)
+                    {
+                        ThrowHelper.ThrowInvalidOperationException_EnumCurrent(index);
+                    }
+
+                    return array[index];
                 }
             }
+    
+            object IEnumerator.Current => Current;
 
-            object IEnumerator.Current
-            {
-                get
-                {
-                    return Current;
-                }
-            }
-
-            void IEnumerator.Reset()
-            {
-                _index = -1;
-            }
+            void IEnumerator.Reset() => _index = -1;
 
             public void Dispose()
             {

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -274,7 +274,8 @@ namespace System
             return GetArgumentException(ExceptionResource.Argument_InvalidOffLen);
         }
 
-        private static ArgumentException GetArgumentException(ExceptionResource resource) {
+        private static ArgumentException GetArgumentException(ExceptionResource resource)
+        {
             return new ArgumentException(GetResourceString(resource));
         }
 
@@ -308,10 +309,12 @@ namespace System
             return new ArgumentOutOfRangeException(GetArgumentName(argument) + "[" + paramNumber.ToString() + "]", GetResourceString(resource));
         }
 
-        private static InvalidOperationException GetInvalidOperationException_EnumCurrent(int index) {
-            if (index < 0)
-                return GetInvalidOperationException(ExceptionResource.InvalidOperation_EnumNotStarted);
-            return GetInvalidOperationException(ExceptionResource.InvalidOperation_EnumEnded);
+        private static InvalidOperationException GetInvalidOperationException_EnumCurrent(int index)
+        {
+            return GetInvalidOperationException(
+                index < 0 ?
+                ExceptionResource.InvalidOperation_EnumNotStarted :
+                ExceptionResource.InvalidOperation_EnumEnded);
         }
 
         // Allow nulls for reference types and Nullable<U>, but not for value types.

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -241,6 +241,11 @@ namespace System
             throw GetInvalidOperationException(ExceptionResource.InvalidOperation_EnumEnded);
         }
 
+        internal static void ThrowInvalidOperationException_EnumCurrent(int index)
+        {
+            throw GetInvalidOperationException_EnumCurrent(index);
+        }
+
         internal static void ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion()
         {
             throw GetInvalidOperationException(ExceptionResource.InvalidOperation_EnumFailedVersion);
@@ -269,8 +274,7 @@ namespace System
             return GetArgumentException(ExceptionResource.Argument_InvalidOffLen);
         }
 
-        private static ArgumentException GetArgumentException(ExceptionResource resource)
-        {
+        private static ArgumentException GetArgumentException(ExceptionResource resource) {
             return new ArgumentException(GetResourceString(resource));
         }
 
@@ -302,6 +306,12 @@ namespace System
         private static ArgumentOutOfRangeException GetArgumentOutOfRangeException(ExceptionArgument argument, int paramNumber, ExceptionResource resource)
         {
             return new ArgumentOutOfRangeException(GetArgumentName(argument) + "[" + paramNumber.ToString() + "]", GetResourceString(resource));
+        }
+
+        private static InvalidOperationException GetInvalidOperationException_EnumCurrent(int index) {
+            if (index < 0)
+                return GetInvalidOperationException(ExceptionResource.InvalidOperation_EnumNotStarted);
+            return GetInvalidOperationException(ExceptionResource.InvalidOperation_EnumEnded);
         }
 
         // Allow nulls for reference types and Nullable<U>, but not for value types.


### PR DESCRIPTION
This is just a revived version of an old PR: https://github.com/dotnet/coreclr/pull/9524. In there, TLDR I closed it because removing an `int` field from the enumerator wasn't making a difference for x64, and I was unsure how to test it with x86 because I only have x64 machines.

I was recently able to get around to testing on x86 via running [this program](https://gist.github.com/jamesqo/540268a41a54214033b24ee047a2093f), and verified that commenting out the `int j` field indeed causes the allocated memory to decrease by 20%. So I'm reopening a PR to eliminate the field.

/cc @benaadams, @jkotas