### PR TITLE
Resolve FEATURE_GDBJIT/FEATURE_INTERPRETER conflict

### DIFF
--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -795,9 +795,13 @@ PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, J
     }
 #endif // PROFILING_SUPPORTED
 
+#ifdef FEATURE_INTERPRETER
+    bool isJittedMethod = (Interpreter::InterpretationStubToMethodInfo(pCode) == NULL);
+#endif
+
     // Interpretted methods skip this notification
 #ifdef FEATURE_INTERPRETER
-    if (Interpreter::InterpretationStubToMethodInfo(pCode) == NULL)
+    if (isJittedMethod)
 #endif
     {
 #ifdef FEATURE_PERFMAP
@@ -822,8 +826,13 @@ PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, J
     }
 #endif
 
-    // The notification will only occur if someone has registered for this method.
-    DACNotifyCompilationFinished(this);
+#ifdef FEATURE_INTERPRETER
+    if (isJittedMethod)
+#endif
+    {
+        // The notification will only occur if someone has registered for this method.
+        DACNotifyCompilationFinished(this);
+    }
 
     return pCode;
 }


### PR DESCRIPTION
Currently, there are 2 conflicts between FEATURE_GDBJIT and FEATURE_INTERPRETER.

First, GDBJIT assumes that an entry point that invokeCompileMethodHelper provides always points to a jitted code, and attempts to retrieve CodeHeader from it.
Unfortunately, this assumption does not hold if FEATURE_INTERPRETER is turned on, and thus segmentation fault occurs while retrieving CodeHeader.

Second, GDBJIT assumes that DACNotifyCompilationFinished is invoked only when a method of interest is jitted. The current implementation, however, invokes DACNotifyCompilationFinished  even when the method is not jitted.

This commit resolves these two conflicts between FEATURE_GDBJIT and FEATURE_INTERPRETER.