### PR TITLE
Add StringBuilder Span-based APIs

### DIFF
--- a/src/mscorlib/shared/System/Text/StringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.cs
@@ -822,11 +822,6 @@ namespace System.Text
                 throw new ArgumentNullException(nameof(destination));
             }
 
-            if (count < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(count), SR.Arg_NegativeArgCount);
-            }
-
             if (destinationIndex < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(destinationIndex), SR.Format(SR.ArgumentOutOfRange_MustBeNonNegNum, nameof(destinationIndex)));
@@ -835,6 +830,17 @@ namespace System.Text
             if (destinationIndex > destination.Length - count)
             {
                 throw new ArgumentException(SR.ArgumentOutOfRange_OffsetOut);
+            }
+            Contract.EndContractBlock();
+
+            CopyTo(sourceIndex, new Span<char>(destination, destinationIndex), count);
+        }
+
+        public void CopyTo(int sourceIndex, Span<char> destination, int count)
+        {
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count), SR.Arg_NegativeArgCount);
             }
 
             if ((uint)sourceIndex > (uint)Length)
@@ -852,7 +858,7 @@ namespace System.Text
 
             StringBuilder chunk = this;
             int sourceEndIndex = sourceIndex + count;
-            int curDestIndex = destinationIndex + count;
+            int curDestIndex = count;
             while (count > 0)
             {
                 int chunkEndIndex = sourceEndIndex - chunk.m_ChunkOffset;
@@ -1025,6 +1031,21 @@ namespace System.Text
                 unsafe
                 {
                     fixed (char* valueChars = &value[0])
+                    {
+                        Append(valueChars, value.Length);
+                    }
+                }
+            }
+            return this;
+        }
+
+        public StringBuilder Append(ReadOnlySpan<char> value)
+        {
+            if (value.Length > 0)
+            {
+                unsafe
+                {
+                    fixed (char* valueChars = &value.DangerousGetPinnableReference())
                     {
                         Append(valueChars, value.Length);
                     }
@@ -1262,6 +1283,27 @@ namespace System.Text
         public StringBuilder Insert(int index, ulong value) => Insert(index, value.ToString(), 1);
 
         public StringBuilder Insert(int index, Object value) => (value == null) ? this : Insert(index, value.ToString(), 1);
+
+        public StringBuilder Insert(int index, ReadOnlySpan<char> value)
+        {
+            Contract.Ensures(Contract.Result<StringBuilder>() != null);
+            Contract.EndContractBlock();
+
+            if ((uint)index > (uint)Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
+            }
+
+            if (value.Length > 0)
+            {
+                unsafe
+                {
+                    fixed (char* sourcePtr = &value.DangerousGetPinnableReference())
+                        Insert(index, sourcePtr, value.Length);
+                }
+            }
+            return this;
+        }
 
         public StringBuilder AppendFormat(String format, Object arg0) => AppendFormatHelper(null, format, new ParamsArray(arg0));
 
@@ -2001,6 +2043,22 @@ namespace System.Text
             }
         }
 
+        private static unsafe void ThreadSafeCopy(char* sourcePtr, Span<char> destination, int destinationIndex, int count)
+        {
+            if (count > 0)
+            {
+                if ((uint)destinationIndex <= (uint)destination.Length && (destinationIndex + count) <= destination.Length)
+                {
+                    fixed (char* destinationPtr = &destination.DangerousGetPinnableReference())
+                        string.wstrcpy(destinationPtr + destinationIndex, sourcePtr, count);
+                }
+                else
+                {
+                    throw new ArgumentOutOfRangeException(nameof(destinationIndex), SR.ArgumentOutOfRange_Index);
+                }
+            }
+        }
+
         private static void ThreadSafeCopy(char[] source, int sourceIndex, char[] destination, int destinationIndex, int count)
         {
             if (count > 0)
@@ -2019,6 +2077,26 @@ namespace System.Text
                 }
             }
         }
+
+        private static void ThreadSafeCopy(char[] source, int sourceIndex, Span<char> destination, int destinationIndex, int count)
+        {
+            if (count > 0)
+            {
+                if ((uint)sourceIndex <= (uint)source.Length && (sourceIndex + count) <= source.Length)
+                {
+                    unsafe
+                    {
+                        fixed (char* sourcePtr = &source[sourceIndex])
+                            ThreadSafeCopy(sourcePtr, destination, destinationIndex, count);
+                    }
+                }
+                else
+                {
+                    throw new ArgumentOutOfRangeException(nameof(sourceIndex), SR.ArgumentOutOfRange_Index);
+                }
+            }
+        }
+
 
         /// <summary>
         /// Gets the chunk corresponding to the logical index in this builder.

--- a/src/mscorlib/shared/System/Text/StringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.cs
@@ -2043,60 +2043,25 @@ namespace System.Text
             }
         }
 
-        private static unsafe void ThreadSafeCopy(char* sourcePtr, Span<char> destination, int destinationIndex, int count)
+        private static unsafe void ThreadSafeCopy(char[] source, int sourceIndex, Span<char> destination, int destinationIndex, int count)
         {
             if (count > 0)
             {
-                if ((uint)destinationIndex <= (uint)destination.Length && (destinationIndex + count) <= destination.Length)
+                if ((uint)sourceIndex > (uint)source.Length || (sourceIndex + count) > source.Length)
                 {
-                    fixed (char* destinationPtr = &destination.DangerousGetPinnableReference())
-                        string.wstrcpy(destinationPtr + destinationIndex, sourcePtr, count);
+                    throw new ArgumentOutOfRangeException(nameof(sourceIndex), SR.ArgumentOutOfRange_Index);
                 }
-                else
+
+                if ((uint)destinationIndex > (uint)destination.Length || (destinationIndex + count) > destination.Length)
                 {
                     throw new ArgumentOutOfRangeException(nameof(destinationIndex), SR.ArgumentOutOfRange_Index);
                 }
+
+                fixed (char* sourcePtr = &source[sourceIndex])
+                    fixed (char* destinationPtr = &destination.DangerousGetPinnableReference())
+                        string.wstrcpy(destinationPtr + destinationIndex, sourcePtr, count);
             }
         }
-
-        private static void ThreadSafeCopy(char[] source, int sourceIndex, char[] destination, int destinationIndex, int count)
-        {
-            if (count > 0)
-            {
-                if ((uint)sourceIndex <= (uint)source.Length && (sourceIndex + count) <= source.Length)
-                {
-                    unsafe
-                    {
-                        fixed (char* sourcePtr = &source[sourceIndex])
-                            ThreadSafeCopy(sourcePtr, destination, destinationIndex, count);
-                    }
-                }
-                else
-                {
-                    throw new ArgumentOutOfRangeException(nameof(sourceIndex), SR.ArgumentOutOfRange_Index);
-                }
-            }
-        }
-
-        private static void ThreadSafeCopy(char[] source, int sourceIndex, Span<char> destination, int destinationIndex, int count)
-        {
-            if (count > 0)
-            {
-                if ((uint)sourceIndex <= (uint)source.Length && (sourceIndex + count) <= source.Length)
-                {
-                    unsafe
-                    {
-                        fixed (char* sourcePtr = &source[sourceIndex])
-                            ThreadSafeCopy(sourcePtr, destination, destinationIndex, count);
-                    }
-                }
-                else
-                {
-                    throw new ArgumentOutOfRangeException(nameof(sourceIndex), SR.ArgumentOutOfRange_Index);
-                }
-            }
-        }
-
 
         /// <summary>
         /// Gets the chunk corresponding to the logical index in this builder.

--- a/src/mscorlib/shared/System/Text/StringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.cs
@@ -2047,12 +2047,12 @@ namespace System.Text
         {
             if (count > 0)
             {
-                if ((uint)sourceIndex > (uint)source.Length || (sourceIndex + count) > source.Length)
+                if ((uint)sourceIndex > (uint)source.Length || count > source.Length - sourceIndex)
                 {
                     throw new ArgumentOutOfRangeException(nameof(sourceIndex), SR.ArgumentOutOfRange_Index);
                 }
 
-                if ((uint)destinationIndex > (uint)destination.Length || (destinationIndex + count) > destination.Length)
+                if ((uint)destinationIndex > (uint)destination.Length || count > destination.Length - destinationIndex)
                 {
                     throw new ArgumentOutOfRangeException(nameof(destinationIndex), SR.ArgumentOutOfRange_Index);
                 }


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/22430

- Add span-based Append/Insert/CopyTo methods to StringBuilder
- Rewrote the existing CopyTo method into an overload of the span-based version, to reduce code duplication