### PR TITLE
[RyuJIT/ARM32] Remove LEA[b+0]

### DIFF
--- a/tests/src/JIT/Regression/JitBlue/GitHub_13057/GitHub_13057.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_13057/GitHub_13057.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Collections;
+using System.Collections.Generic;
+using System.Resources;
+
+public class Program
+{
+    const int Pass = 100;
+    const int Fail = -1;
+
+    struct RetSt2 {
+        public Object _key;
+        public Object _value;
+
+        public RetSt2(Object value)
+        {
+            _key = "f";
+            _value = value;
+        }
+    }
+
+    class Test {
+        private Object lockObject;
+
+        internal Test(Object reader)
+        {
+            lockObject = reader;
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        Object FirstValue()
+        {
+            return "FirstValue";
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        Object SecondValue()
+        {
+            return "SecondValue";
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public RetSt2 foo(int d) {
+            Object value = null;
+            lock (lockObject)
+            {
+                lock (lockObject)
+                {
+                    if (d == -1) {
+                        value = FirstValue();
+                    } else {
+                        value = SecondValue();
+                    }
+                }
+            }
+            return new RetSt2(value);
+        }
+    }
+
+
+
+    public static int Main()
+    {
+        RetSt2 r = new Test("Lock").foo(-1);
+        Console.WriteLine("r._key: " + r._key);
+        Console.WriteLine("r._value: " + r._value);
+
+        r = new Test("Lock").foo(-2);
+        Console.WriteLine("r._key: " + r._key);
+        Console.WriteLine("r._value: " + r._value);
+
+        return Pass;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_13057/GitHub_13057.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_13057/GitHub_13057.csproj
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
Node `LEA[b+0]` can be removed since it can be reduced to simple move
from one register to another.

Fix for #13057 
cc @dotnet/arm32-contrib 