### PR TITLE
Remove unnecessary SkipVerification CAS attribute that is not supported in CoreCLR

### DIFF
--- a/tests/src/baseservices/exceptions/regressions/V1/SEH/asm/Except.il
+++ b/tests/src/baseservices/exceptions/regressions/V1/SEH/asm/Except.il
@@ -14,11 +14,7 @@
   .ver 4:0:0:0
 }
 
-.assembly Except.exe{
- //This byte field requests that this assembly not be verified at run time and corresponds to this C# declaration:
-  //[assembly:System.Security.Permissions.SecurityPermissionAttribute( [mscorlib]System.Security.Permissions.SecurityAction.RequestMinimum, Flags=System.Security.Permissions.SecurityPermissionFlag.SkipVerification )]
-  .permission reqmin ['mscorlib']System.Security.Permissions.SecurityPermissionAttribute ( "SkipVerification" = true )
-}
+.assembly Except.exe {}
 
 .class		Except {
 

--- a/tests/src/baseservices/exceptions/regressions/V1/SEH/asm/FiltCatch.il
+++ b/tests/src/baseservices/exceptions/regressions/V1/SEH/asm/FiltCatch.il
@@ -16,10 +16,7 @@
   .ver 4:0:0:0
 }
 
-.assembly FiltCatch.exe{
-  //This byte field requests that this assembly not be verified at run time and corresponds to this C# declaration:
-  //[assembly:System.Security.Permissions.SecurityPermissionAttribute( [mscorlib]System.Security.Permissions.SecurityAction.RequestMinimum, Flags=System.Security.Permissions.SecurityPermissionFlag.SkipVerification )]
-  .permission reqmin ['mscorlib']System.Security.Permissions.SecurityPermissionAttribute ( "SkipVerification" = true )}
+.assembly FiltCatch.exe{}
 
 .class		FiltCatch {
 

--- a/tests/src/baseservices/exceptions/regressions/V1/SEH/asm/FiltFallThru.il
+++ b/tests/src/baseservices/exceptions/regressions/V1/SEH/asm/FiltFallThru.il
@@ -16,10 +16,7 @@
   .ver 4:0:0:0
 }
 
-.assembly FiltFallThru{
-//This byte field requests that this assembly not be verified at run time and corresponds to this C# declaration:
-  //[assembly:System.Security.Permissions.SecurityPermissionAttribute( [mscorlib]System.Security.Permissions.SecurityAction.RequestMinimum, Flags=System.Security.Permissions.SecurityPermissionFlag.SkipVerification )]
-  .permission reqmin ['mscorlib']System.Security.Permissions.SecurityPermissionAttribute ( "SkipVerification" = true )}
+.assembly FiltFallThru{}
 
 .class		FiltFallThru {
 

--- a/tests/src/baseservices/exceptions/regressions/V1/SEH/asm/Finally.il
+++ b/tests/src/baseservices/exceptions/regressions/V1/SEH/asm/Finally.il
@@ -14,11 +14,7 @@
   .ver 4:0:0:0
 }
 
-.assembly Finally.exe{
-//This byte field requests that this assembly not be verified at run time and corresponds to this C# declaration:
-  //[assembly:System.Security.Permissions.SecurityPermissionAttribute( [mscorlib]System.Security.Permissions.SecurityAction.RequestMinimum, Flags=System.Security.Permissions.SecurityPermissionFlag.SkipVerification )]
-  .permission reqmin ['mscorlib']System.Security.Permissions.SecurityPermissionAttribute ( "SkipVerification" = true )}
-
+.assembly Finally.exe{}
 
 .class		Finally {
 .field static int32 iResult


### PR DESCRIPTION
Without this, using CoreCLR version of ILAsm would fail to emit the attribute because the support for CAS isn't there. 