### PR TITLE
Fix `getTargetOfCall` for ARM.

### DIFF
--- a/src/vm/gccover.cpp
+++ b/src/vm/gccover.cpp
@@ -1035,6 +1035,10 @@ static SLOT getTargetOfCall(SLOT instrPtr, PCONTEXT regs, SLOT*nextInstr) {
         unsigned int regnum = (instrPtr[0] & 0x78) >> 3;
         return (BYTE *)getRegVal(regnum, regs);
     }
+    else
+    {
+        return 0; // Not a call.
+    }
 #elif defined(_TARGET_ARM64_)
    if (((*reinterpret_cast<DWORD*>(instrPtr)) & 0xFC000000) == 0x94000000)
    {


### PR DESCRIPTION
If the instruction we're decoding is not a call, don't attempt to decode
it as if it were an x86 instruction. Instead, just return 0 as on ARM64.