### PR TITLE
Only lock unlocked registers in `rsUnspillRegPair`.

### DIFF
--- a/src/jit/regset.cpp
+++ b/src/jit/regset.cpp
@@ -2669,7 +2669,7 @@ void RegSet::rsUnspillRegPair(GenTreePtr tree, regMaskTP needReg, KeepReg keepRe
             // Temporarily lock the high part if necessary. If this register is a multi-use register that is shared
             // with another tree, the register may already be locked.
             const regMaskTP regHiMask = genRegMask(regHi);
-            const bool lockReg = (rsMaskLock & regHiMask) == 0;
+            const bool      lockReg   = (rsMaskLock & regHiMask) == 0;
             if (lockReg)
             {
                 rsLockUsedReg(regHiMask);
@@ -2710,7 +2710,7 @@ void RegSet::rsUnspillRegPair(GenTreePtr tree, regMaskTP needReg, KeepReg keepRe
             // Temporarily lock the low part if necessary. If this register is a multi-use register that is shared
             // with another tree, the register may already be locked.
             const regMaskTP regLoMask = genRegMask(regLo);
-            const bool lockReg = (rsMaskLock & regLoMask) == 0;
+            const bool      lockReg   = (rsMaskLock & regLoMask) == 0;
             if (lockReg)
             {
                 rsLockReg(regLoMask, &regLoUsed);


### PR DESCRIPTION
`rsUnspillRegPair` needs to lock the hi/lo part of the reg pair when
unspilling the lo/hi part in order to ensure that the two parts of the
pair do not end up in the same register. However, the register to be
locked may already be locked if it is a multi-use register. In this case
`rsUnspillRegPair` does not need to re-lock the register.