### PR TITLE
Fixes issue #13093

### DIFF
--- a/src/jit/alloc.cpp
+++ b/src/jit/alloc.cpp
@@ -310,7 +310,7 @@ void ArenaAllocator::freeHostMemory(void* block)
 
 #if defined(DEBUG)
 //------------------------------------------------------------------------
-// ArenaAllocator::alloateMemory:
+// ArenaAllocator::allocateMemory:
 //    Allocates memory using an `ArenaAllocator`.
 //
 // Arguments:
@@ -326,10 +326,11 @@ void ArenaAllocator::freeHostMemory(void* block)
 //    version does not: it may inject faults into the allocator and
 //    seeds all allocations with a specified pattern to help catch
 //    use-before-init problems.
+//
 void* ArenaAllocator::allocateMemory(size_t size)
 {
     assert(isInitialized());
-    assert(size != 0 && (size & (sizeof(int) - 1)) == 0);
+    assert(size != 0);
 
     // Ensure that we always allocate in pointer sized increments.
     size = (size_t)roundUp(size, sizeof(size_t));

--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -524,7 +524,7 @@ ASSERT_TP& Compiler::GetAssertionDep(unsigned lclNum)
 
 void Compiler::optAssertionTraitsInit(AssertionIndex assertionCount)
 {
-    apTraits = new (getAllocator()) BitVecTraits(assertionCount, this);
+    apTraits = new (this, CMK_AssertionProp) BitVecTraits(assertionCount, this);
     apFull   = BitVecOps::MakeFull(apTraits);
 }
 
@@ -547,9 +547,9 @@ void Compiler::optAssertionInit(bool isLocalProp)
     optMaxAssertionCount                    = countFunc[isLocalProp ? lowerBound : min(upperBound, codeSize)];
 
     optLocalAssertionProp  = isLocalProp;
-    optAssertionTabPrivate = new (getAllocator()) AssertionDsc[optMaxAssertionCount];
+    optAssertionTabPrivate = new (this, CMK_AssertionProp) AssertionDsc[optMaxAssertionCount];
     optComplementaryAssertionMap =
-        new (getAllocator()) AssertionIndex[optMaxAssertionCount](); // zero-inited (NO_ASSERTION_INDEX.)
+        new (this, CMK_AssertionProp) AssertionIndex[optMaxAssertionCount + 1](); // zero-inited (NO_ASSERTION_INDEX)
     assert(NO_ASSERTION_INDEX == 0);
 
     if (!isLocalProp)
@@ -559,7 +559,7 @@ void Compiler::optAssertionInit(bool isLocalProp)
 
     if (optAssertionDep == nullptr)
     {
-        optAssertionDep = new (getAllocator()) ExpandArray<ASSERT_TP>(getAllocator(), max(1, lvaCount));
+        optAssertionDep = new (this, CMK_AssertionProp) ExpandArray<ASSERT_TP>(getAllocator(), max(1, lvaCount));
     }
 
     optAssertionTraitsInit(optMaxAssertionCount);
@@ -2150,6 +2150,10 @@ void Compiler::optMapComplementary(AssertionIndex assertionIndex, AssertionIndex
     {
         return;
     }
+
+    assert(assertionIndex <= optMaxAssertionCount);
+    assert(index <= optMaxAssertionCount);
+
     optComplementaryAssertionMap[assertionIndex] = index;
     optComplementaryAssertionMap[index]          = assertionIndex;
 }

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -5029,20 +5029,15 @@ void GenTree::VisitBinOpOperands(TVisitor visitor)
  *
  *  Note that compGetMem is an arena allocator that returns memory that is
  *  not zero-initialized and can contain data from a prior allocation lifetime.
- *  it also requires that 'sz' be aligned to a multiple of sizeof(int)
  */
 
 inline void* __cdecl operator new(size_t sz, Compiler* context, CompMemKind cmk)
 {
-    sz = AlignUp(sz, sizeof(int));
-    assert(sz != 0 && (sz & (sizeof(int) - 1)) == 0);
     return context->compGetMem(sz, cmk);
 }
 
 inline void* __cdecl operator new[](size_t sz, Compiler* context, CompMemKind cmk)
 {
-    sz = AlignUp(sz, sizeof(int));
-    assert(sz != 0 && (sz & (sizeof(int) - 1)) == 0);
     return context->compGetMem(sz, cmk);
 }
 


### PR DESCRIPTION
Removed the legacy JIT32 assert regarding 4-byte alignment inArenaAllocator::allocateMemory
Immediately after this assert we roundUp to an pointer size allocation amount.

Fixed a couple of allocations in assertionprop to use CMF_AssertionProp so that we correctly
attribute which phase uses the memory being allocated.
Added range check for the array writes in Compiler::optMapComplementary

Removed the AlignUp to 4-byte in operator new and new[] in compiler.hpp