### PR TITLE
[ARM32/RyuJIT] Use regtype instead of node's type in PUTARG_SPLIT case

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -1797,8 +1797,11 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
 
         GenTreePtr argNode = list->Current();
 
-        fgArgTabEntryPtr curArgTabEntry = compiler->gtArgEntryByNode(call, argNode->gtSkipReloadOrCopy());
+        fgArgTabEntryPtr curArgTabEntry = compiler->gtArgEntryByNode(call, argNode);
         assert(curArgTabEntry);
+
+        // GT_RELOAD/GT_COPY use the child node
+        argNode = argNode->gtSkipReloadOrCopy();
 
         if (curArgTabEntry->regNum == REG_STK)
             continue;

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -8916,6 +8916,12 @@ void LinearScan::updateMaxSpill(RefPosition* refPosition)
                     ReturnTypeDesc* retTypeDesc = treeNode->AsCall()->GetReturnTypeDesc();
                     typ                         = retTypeDesc->GetReturnRegType(refPosition->getMultiRegIdx());
                 }
+#ifdef _TARGET_ARM_
+                else if (treeNode->OperIsPutArgSplit())
+                {
+                    typ = treeNode->AsPutArgSplit()->GetRegType(refPosition->getMultiRegIdx());
+                }
+#endif
 #ifdef ARM_SOFTFP
                 else if (treeNode->OperIsPutArgReg())
                 {
@@ -9247,11 +9253,6 @@ void LinearScan::resolveRegisters()
                             {
                                 GenTreePutArgSplit* splitArg = treeNode->AsPutArgSplit();
                                 splitArg->SetRegSpillFlagByIdx(GTF_SPILL, currentRefPosition->getMultiRegIdx());
-                            }
-                            else if (treeNode->OperIsMultiRegOp())
-                            {
-                                GenTreeMultiRegOp* multiReg = treeNode->AsMultiRegOp();
-                                multiReg->SetRegSpillFlagByIdx(GTF_SPILL, currentRefPosition->getMultiRegIdx());
                             }
 #endif
                         }

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -684,6 +684,7 @@ void Lowering::TreeNodeInfoInitPutArgSplit(GenTreePutArgSplit* argNode, TreeNode
         argMask |= genRegMask((regNumber)((unsigned)argReg + i));
     }
     argNode->gtLsraInfo.setDstCandidates(m_lsra, argMask);
+    argNode->gtLsraInfo.setSrcCandidates(m_lsra, argMask);
 
     if (putArgChild->OperGet() == GT_FIELD_LIST)
     {


### PR DESCRIPTION
The size of TYP_STRUCT in definition is 1 and it is lower than sizeof(int).
It means TYP_STRUCT should use the node's type instead of its type.
In PUTARG_SPLIT case, it wil use its regtype of child nodes.

Related issue: #12990 

/cc @dotnet/arm32-contrib 