### PR TITLE
Move containment analysis to 1st phase of Lowering

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -265,7 +265,8 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
         case GT_LIST:
         case GT_FIELD_LIST:
         case GT_ARGPLACE:
-            // Nothing to do
+            // Should always be marked contained.
+            assert(!"LIST, FIELD_LIST and ARGPLACE nodes should always be marked contained.");
             break;
 
         case GT_PUTARG_STK:

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -1851,7 +1851,8 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
         case GT_LIST:
         case GT_FIELD_LIST:
         case GT_ARGPLACE:
-            // Nothing to do
+            // Should always be marked contained.
+            assert(!"LIST, FIELD_LIST and ARGPLACE nodes should always be marked contained.");
             break;
 
         case GT_SWAP:

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2028,7 +2028,7 @@ public:
 
     GenTree* gtNewBlkOpNode(GenTreePtr dst, GenTreePtr srcOrFillVal, unsigned size, bool isVolatile, bool isCopyBlock);
 
-    GenTree* gtNewPutArgReg(var_types type, GenTreePtr arg);
+    GenTree* gtNewPutArgReg(var_types type, GenTreePtr arg, regNumber argReg);
 
 protected:
     void gtBlockOpInit(GenTreePtr result, GenTreePtr dst, GenTreePtr srcOrFillVal, bool isVolatile);
@@ -2444,6 +2444,9 @@ public:
         DNER_DepField,    // It is a field of a dependently promoted struct
         DNER_NoRegVars,   // opts.compFlags & CLFLG_REGVAR is not set
         DNER_MinOptsGC,   // It is a GC Ref and we are compiling MinOpts
+#if !defined(LEGACY_BACKEND) && !defined(_TARGET_64BIT_)
+        DNER_LongParamField, // It is a decomposed field of a long parameter.
+#endif
 #ifdef JIT32_GCENCODER
         DNER_PinningRef,
 #endif

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -17,6 +17,9 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #endif
 
 #include "allocacheck.h" // for alloca
+#ifndef LEGACY_BACKEND
+#include "lower.h" // for LowerRange()
+#endif
 
 /*****************************************************************************/
 
@@ -13477,6 +13480,10 @@ bool Compiler::fgOptimizeEmptyBlock(BasicBlock* block)
                         if (block->IsLIR())
                         {
                             LIR::AsRange(block).InsertAtEnd(nop);
+#ifndef LEGACY_BACKEND
+                            LIR::ReadOnlyRange range(nop, nop);
+                            m_pLowering->LowerRange(block, range);
+#endif
                         }
                         else
                         {
@@ -13796,6 +13803,10 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
         if (block->IsLIR())
         {
             blockRange->InsertAfter(switchVal, zeroConstNode, condNode);
+#ifndef LEGACY_BACKEND
+            LIR::ReadOnlyRange range(zeroConstNode, switchTree);
+            m_pLowering->LowerRange(block, range);
+#endif // !LEGACY_BACKEND
         }
         else
         {

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -2035,7 +2035,12 @@ void Compiler::lvaPromoteLongVars()
             fieldVarDsc->lvFldOffset     = (unsigned char)(index * genTypeSize(TYP_INT));
             fieldVarDsc->lvFldOrdinal    = (unsigned char)index;
             fieldVarDsc->lvParentLcl     = lclNum;
-            fieldVarDsc->lvIsParam       = isParam;
+            // Currently we do not support enregistering incoming promoted aggregates with more than one field.
+            if (isParam)
+            {
+                fieldVarDsc->lvIsParam = true;
+                lvaSetVarDoNotEnregister(varNum DEBUGARG(DNER_LongParamField));
+            }
         }
     }
 
@@ -2168,6 +2173,11 @@ void Compiler::lvaSetVarDoNotEnregister(unsigned varNum DEBUGARG(DoNotEnregister
         case DNER_PinningRef:
             JITDUMP("pinning ref\n");
             assert(varDsc->lvPinned);
+            break;
+#endif
+#if !defined(LEGACY_BACKEND) && !defined(_TARGET_64BIT_)
+        case DNER_LongParamField:
+            JITDUMP("it is a decomposed field of a long parameter\n");
             break;
 #endif
         default:

--- a/src/jit/lir.h
+++ b/src/jit/lir.h
@@ -112,12 +112,12 @@ public:
         GenTree* m_firstNode;
         GenTree* m_lastNode;
 
-        ReadOnlyRange(GenTree* firstNode, GenTree* lastNode);
-
         ReadOnlyRange(const ReadOnlyRange& other) = delete;
         ReadOnlyRange& operator=(const ReadOnlyRange& other) = delete;
 
     public:
+        ReadOnlyRange(GenTree* firstNode, GenTree* lastNode);
+
         class Iterator
         {
             friend class ReadOnlyRange;
@@ -312,6 +312,9 @@ public:
 inline void GenTree::SetUnusedValue()
 {
     gtLIRFlags |= LIR::Flags::UnusedValue;
+#ifndef LEGACY_BACKEND
+    ClearContained();
+#endif
 }
 
 inline void GenTree::ClearUnusedValue()

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -44,7 +44,6 @@ void Lowering::MakeSrcContained(GenTreePtr parentNode, GenTreePtr childNode)
     assert(!parentNode->OperIsLeaf());
     assert(childNode->canBeContained());
     childNode->SetContained();
-    m_lsra->clearOperandCounts(childNode);
 }
 
 //------------------------------------------------------------------------
@@ -103,7 +102,6 @@ bool Lowering::IsSafeToContainMem(GenTree* parentNode, GenTree* childNode)
 //
 // Arguments:
 //    node        - the node of interest.
-//    useTracked  - true if this is being called after liveness so lvTracked is correct
 //
 // Return value:
 //    True if this will definitely be a memory reference that could be contained.
@@ -113,11 +111,11 @@ bool Lowering::IsSafeToContainMem(GenTree* parentNode, GenTree* childNode)
 //    the case of doNotEnregister local. This won't include locals that
 //    for some other reason do not become register candidates, nor those that get
 //    spilled.
-//    Also, if we call this before we redo liveness analysis, any new lclVars
+//    Also, because we usually call this before we redo dataflow, any new lclVars
 //    introduced after the last dataflow analysis will not yet be marked lvTracked,
 //    so we don't use that.
 //
-bool Lowering::IsContainableMemoryOp(GenTree* node, bool useTracked)
+bool Lowering::IsContainableMemoryOp(GenTree* node)
 {
 #ifdef _TARGET_XARCH_
     if (node->isMemoryOp())
@@ -131,7 +129,7 @@ bool Lowering::IsContainableMemoryOp(GenTree* node, bool useTracked)
             return true;
         }
         LclVarDsc* varDsc = &comp->lvaTable[node->AsLclVar()->gtLclNum];
-        return (varDsc->lvDoNotEnregister || (useTracked && !varDsc->lvTracked));
+        return varDsc->lvDoNotEnregister;
     }
 #endif // _TARGET_XARCH_
     return false;
@@ -147,18 +145,64 @@ GenTree* Lowering::LowerNode(GenTree* node)
     {
         case GT_IND:
             TryCreateAddrMode(LIR::Use(BlockRange(), &node->gtOp.gtOp1, node), true);
+            ContainCheckIndir(node->AsIndir());
             break;
 
         case GT_STOREIND:
-            LowerStoreInd(node);
+            TryCreateAddrMode(LIR::Use(BlockRange(), &node->gtOp.gtOp1, node), true);
+            if (!comp->codeGen->gcInfo.gcIsWriteBarrierAsgNode(node))
+            {
+                LowerStoreIndir(node->AsIndir());
+            }
             break;
 
         case GT_ADD:
-            return LowerAdd(node);
+        {
+            GenTree* afterTransform = LowerAdd(node);
+            if (afterTransform != nullptr)
+            {
+                return afterTransform;
+            }
+            __fallthrough;
+        }
+
+#if !defined(_TARGET_64BIT_)
+        case GT_ADD_LO:
+        case GT_ADD_HI:
+        case GT_SUB_LO:
+        case GT_SUB_HI:
+#endif
+        case GT_SUB:
+        case GT_AND:
+        case GT_OR:
+        case GT_XOR:
+            ContainCheckBinary(node->AsOp());
+            break;
+
+#ifdef _TARGET_XARCH_
+        case GT_NEG:
+            // Codegen of this tree node sets ZF and SF flags.
+            if (!varTypeIsFloating(node))
+            {
+                node->gtFlags |= GTF_ZSF_SET;
+            }
+            break;
+#endif // _TARGET_XARCH_
+
+        case GT_MUL:
+        case GT_MULHI:
+#if defined(_TARGET_X86_) && !defined(LEGACY_BACKEND)
+        case GT_MUL_LONG:
+#endif
+            ContainCheckMul(node->AsOp());
+            break;
 
         case GT_UDIV:
         case GT_UMOD:
-            return LowerUnsignedDivOrMod(node->AsOp());
+            if (!LowerUnsignedDivOrMod(node->AsOp()))
+            {
+                ContainCheckDivOrMod(node->AsOp());
+            }
             break;
 
         case GT_DIV:
@@ -178,7 +222,14 @@ GenTree* Lowering::LowerNode(GenTree* node)
         case GT_GE:
         case GT_EQ:
         case GT_NE:
+        case GT_TEST_EQ:
+        case GT_TEST_NE:
+        case GT_CMP:
             LowerCompare(node);
+            break;
+
+        case GT_JTRUE:
+            ContainCheckJTrue(node->AsOp());
             break;
 
         case GT_JMP:
@@ -189,68 +240,76 @@ GenTree* Lowering::LowerNode(GenTree* node)
             LowerRet(node);
             break;
 
+        case GT_RETURNTRAP:
+            ContainCheckReturnTrap(node->AsOp());
+            break;
+
         case GT_CAST:
             LowerCast(node);
             break;
 
+#ifdef _TARGET_XARCH_
+        case GT_ARR_BOUNDS_CHECK:
+#ifdef FEATURE_SIMD
+        case GT_SIMD_CHK:
+#endif // FEATURE_SIMD
+            ContainCheckBoundsChk(node->AsBoundsChk());
+            break;
+#endif // _TARGET_XARCH_
         case GT_ARR_ELEM:
             return LowerArrElem(node);
+
+        case GT_ARR_OFFSET:
+            ContainCheckArrOffset(node->AsArrOffs());
+            break;
 
         case GT_ROL:
         case GT_ROR:
             LowerRotate(node);
             break;
 
-#ifdef _TARGET_XARCH_
+#ifndef _TARGET_64BIT_
+        case GT_LSH_HI:
+        case GT_RSH_LO:
+            ContainCheckShiftRotate(node->AsOp());
+            break;
+#endif // !_TARGET_64BIT_
+
         case GT_LSH:
         case GT_RSH:
         case GT_RSZ:
+#ifdef _TARGET_XARCH_
             LowerShift(node->AsOp());
-            break;
+#else
+            ContainCheckShiftRotate(node->AsOp());
 #endif
+            break;
 
         case GT_STORE_BLK:
         case GT_STORE_OBJ:
         case GT_STORE_DYN_BLK:
         {
-            // TODO-Cleanup: Consider moving this code to LowerBlockStore, which is currently
-            // called from TreeNodeInfoInitBlockStore, and calling that method here.
             GenTreeBlk* blkNode = node->AsBlk();
             TryCreateAddrMode(LIR::Use(BlockRange(), &blkNode->Addr(), blkNode), false);
+            LowerBlockStore(blkNode);
         }
         break;
 
-#ifdef FEATURE_SIMD
-        case GT_SIMD:
-            if (node->TypeGet() == TYP_SIMD12)
-            {
-                // GT_SIMD node requiring to produce TYP_SIMD12 in fact
-                // produces a TYP_SIMD16 result
-                node->gtType = TYP_SIMD16;
-            }
+        case GT_LCLHEAP:
+            ContainCheckLclHeap(node->AsOp());
+            break;
 
 #ifdef _TARGET_XARCH_
-            if ((node->AsSIMD()->gtSIMDIntrinsicID == SIMDIntrinsicGetItem) && (node->gtGetOp1()->OperGet() == GT_IND))
-            {
-                // If SIMD vector is already in memory, we force its
-                // addr to be evaluated into a reg.  This would allow
-                // us to generate [regBase] or [regBase+offset] or
-                // [regBase+sizeOf(SIMD vector baseType)*regIndex]
-                // to access the required SIMD vector element directly
-                // from memory.
-                //
-                // TODO-CQ-XARCH: If addr of GT_IND is GT_LEA, we
-                // might be able update GT_LEA to fold the regIndex
-                // or offset in some cases.  Instead with this
-                // approach we always evaluate GT_LEA into a reg.
-                // Ideally, we should be able to lower GetItem intrinsic
-                // into GT_IND(newAddr) where newAddr combines
-                // the addr of SIMD vector with the given index.
-                node->gtOp.gtOp1->gtFlags |= GTF_IND_REQ_ADDR_IN_REG;
-            }
-#endif
+        case GT_INTRINSIC:
+            ContainCheckIntrinsic(node->AsOp());
             break;
-#endif // FEATURE_SIMD
+#endif // _TARGET_XARCH_
+
+#ifdef FEATURE_SIMD
+        case GT_SIMD:
+            LowerSIMD(node->AsSIMD());
+            break;
+#endif //
 
         case GT_LCL_VAR:
             WidenSIMD12IfNecessary(node->AsLclVarCommon());
@@ -266,7 +325,6 @@ GenTree* Lowering::LowerNode(GenTree* node)
                     new (comp, GT_BITCAST) GenTreeOp(GT_BITCAST, store->TypeGet(), store->gtOp1, nullptr);
                 store->gtOp1 = bitcast;
                 BlockRange().InsertBefore(store, bitcast);
-                break;
             }
         }
 #endif // _TARGET_AMD64_
@@ -287,6 +345,10 @@ GenTree* Lowering::LowerNode(GenTree* node)
 #endif // !FEATURE_MULTIREG_RET
             }
             LowerStoreLoc(node->AsLclVarCommon());
+            break;
+
+        case GT_LOCKADD:
+            CheckImmedAndMakeContained(node, node->gtOp.gtOp2);
             break;
 
         default:
@@ -445,7 +507,7 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
     unsigned blockWeight = originalSwitchBB->getBBWeight(comp);
 
     LIR::Use use(switchBBRange, &(node->gtOp.gtOp1), node);
-    use.ReplaceWithLclVar(comp, blockWeight);
+    ReplaceWithLclVar(use);
 
     // GT_SWITCH(indexExpression) is now two statements:
     //   1. a statement containing 'asg' (for temp = indexExpression)
@@ -907,7 +969,7 @@ GenTreePtr Lowering::NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntryP
                     //
                     // clang-format on
 
-                    putArg = comp->gtNewPutArgReg(type, arg);
+                    putArg = comp->gtNewPutArgReg(type, arg, info->regNum);
                 }
                 else if (info->structDesc.eightByteCount == 2)
                 {
@@ -953,10 +1015,13 @@ GenTreePtr Lowering::NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntryP
                         GenTreePtr newOper = comp->gtNewPutArgReg(
                             comp->GetTypeFromClassificationAndSizes(info->structDesc.eightByteClassifications[ctr],
                                                                     info->structDesc.eightByteSizes[ctr]),
-                            fieldListPtr->gtOp.gtOp1);
+                            fieldListPtr->gtOp.gtOp1, (ctr == 0) ? info->regNum : info->otherRegNum);
 
                         // Splice in the new GT_PUTARG_REG node in the GT_FIELD_LIST
                         ReplaceArgWithPutArgOrCopy(&fieldListPtr->gtOp.gtOp1, newOper);
+
+                        // Initialize all the gtRegNum's since the list won't be traversed in an LIR traversal.
+                        fieldListPtr->gtRegNum = REG_NA;
                     }
 
                     // Just return arg. The GT_FIELD_LIST is not replaced.
@@ -979,16 +1044,31 @@ GenTreePtr Lowering::NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntryP
                 GenTreeFieldList* fieldListPtr = arg->AsFieldList();
                 assert(fieldListPtr->IsFieldListHead());
 
+                // There could be up to 2-4 PUTARG_REGs in the list (3 or 4 can only occur for HFAs)
+                regNumber argReg = info->regNum;
                 for (unsigned ctr = 0; fieldListPtr != nullptr; fieldListPtr = fieldListPtr->Rest(), ctr++)
                 {
                     GenTreePtr curOp  = fieldListPtr->gtOp.gtOp1;
                     var_types  curTyp = curOp->TypeGet();
 
                     // Create a new GT_PUTARG_REG node with op1
-                    GenTreePtr newOper = comp->gtNewPutArgReg(curTyp, curOp);
+                    GenTreePtr newOper = comp->gtNewPutArgReg(curTyp, curOp, argReg);
 
                     // Splice in the new GT_PUTARG_REG node in the GT_FIELD_LIST
                     ReplaceArgWithPutArgOrCopy(&fieldListPtr->gtOp.gtOp1, newOper);
+
+                    // Update argReg for the next putarg_reg (if any)
+                    argReg = genRegArgNext(argReg);
+
+#if defined(_TARGET_ARM_)
+                    // A double register is modelled as an even-numbered single one
+                    if (fieldListPtr->Current()->TypeGet() == TYP_DOUBLE)
+                    {
+                        argReg = genRegArgNext(argReg);
+                    }
+#endif // _TARGET_ARM_
+                    // Initialize all the gtRegNum's since the list won't be traversed in an LIR traversal.
+                    fieldListPtr->gtRegNum = REG_NA;
                 }
 
                 // Just return arg. The GT_FIELD_LIST is not replaced.
@@ -999,7 +1079,7 @@ GenTreePtr Lowering::NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntryP
 #endif // FEATURE_MULTIREG_ARGS
 #endif // not defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
             {
-                putArg = comp->gtNewPutArgReg(type, arg);
+                putArg = comp->gtNewPutArgReg(type, arg, info->regNum);
             }
         }
         else
@@ -1195,7 +1275,8 @@ void Lowering::LowerArg(GenTreeCall* call, GenTreePtr* ppArg)
             GenTreeFieldList* fieldList = new (comp, GT_FIELD_LIST) GenTreeFieldList(argLo, 0, TYP_INT, nullptr);
             (void)new (comp, GT_FIELD_LIST) GenTreeFieldList(argHi, 4, TYP_INT, fieldList);
 
-            putArg = NewPutArg(call, fieldList, info, TYP_VOID);
+            putArg           = NewPutArg(call, fieldList, info, TYP_VOID);
+            putArg->gtRegNum = info->regNum;
 
             BlockRange().InsertBefore(arg, putArg);
             BlockRange().Remove(arg);
@@ -1214,7 +1295,8 @@ void Lowering::LowerArg(GenTreeCall* call, GenTreePtr* ppArg)
             GenTreeFieldList* fieldList = new (comp, GT_FIELD_LIST) GenTreeFieldList(argLo, 0, TYP_INT, nullptr);
             // Only the first fieldList node (GTF_FIELD_LIST_HEAD) is in the instruction sequence.
             (void)new (comp, GT_FIELD_LIST) GenTreeFieldList(argHi, 4, TYP_INT, fieldList);
-            putArg = NewPutArg(call, fieldList, info, TYP_VOID);
+            putArg           = NewPutArg(call, fieldList, info, TYP_VOID);
+            putArg->gtRegNum = info->regNum;
 
             // We can't call ReplaceArgWithPutArgOrCopy here because it presumes that we are keeping the original arg.
             BlockRange().InsertBefore(arg, fieldList, putArg);
@@ -1318,6 +1400,7 @@ void Lowering::LowerCall(GenTree* node)
     DISPTREERANGE(BlockRange(), call);
     JITDUMP("\n");
 
+    call->ClearOtherRegs();
     LowerArgsForCall(call);
 
     // note that everything generated from this point on runs AFTER the outgoing args are placed
@@ -1420,6 +1503,7 @@ void Lowering::LowerCall(GenTree* node)
             }
         }
 
+        ContainCheckRange(resultRange);
         BlockRange().InsertBefore(insertionPoint, std::move(resultRange));
 
         call->gtControlExpr = result;
@@ -1430,6 +1514,7 @@ void Lowering::LowerCall(GenTree* node)
         CheckVSQuirkStackPaddingNeeded(call);
     }
 
+    ContainCheckCallOperands(call);
     JITDUMP("lowering call (after):\n");
     DISPTREERANGE(BlockRange(), call);
     JITDUMP("\n");
@@ -1817,6 +1902,7 @@ void Lowering::LowerFastTailCall(GenTreeCall* call)
             GenTreeLclVar* local =
                 new (comp, GT_LCL_VAR) GenTreeLclVar(GT_LCL_VAR, tmpType, callerArgLclNum, BAD_IL_OFFSET);
             GenTree* assignExpr = comp->gtNewTempAssign(tmpLclNum, local);
+            ContainCheckRange(local, assignExpr);
             BlockRange().InsertBefore(firstPutArgStk, LIR::SeqTree(comp, assignExpr));
         }
     }
@@ -1959,6 +2045,7 @@ GenTree* Lowering::LowerTailCallViaHelper(GenTreeCall* call, GenTree* callTarget
     assert(argEntry->node->gtOper == GT_PUTARG_REG);
     GenTree* secondArg = argEntry->node->gtOp.gtOp1;
 
+    ContainCheckRange(callTargetRange);
     BlockRange().InsertAfter(secondArg, std::move(callTargetRange));
 
     bool               isClosed;
@@ -1987,6 +2074,7 @@ GenTree* Lowering::LowerTailCallViaHelper(GenTreeCall* call, GenTree* callTarget
     assert(argEntry->node->gtOper == GT_PUTARG_STK);
     GenTree* arg0 = argEntry->node->gtOp.gtOp1;
 
+    ContainCheckRange(callTargetRange);
     BlockRange().InsertAfter(arg0, std::move(callTargetRange));
 
     bool               isClosed;
@@ -2116,6 +2204,7 @@ void Lowering::LowerCompare(GenTree* cmp)
             {
                 loCmp = comp->gtNewOperNode(GT_XOR, TYP_INT, loSrc1, loSrc2);
                 BlockRange().InsertBefore(cmp, loCmp);
+                ContainCheckBinary(loCmp->AsOp());
             }
 
             if (hiSrc1->OperIs(GT_CNS_INT))
@@ -2132,10 +2221,12 @@ void Lowering::LowerCompare(GenTree* cmp)
             {
                 hiCmp = comp->gtNewOperNode(GT_XOR, TYP_INT, hiSrc1, hiSrc2);
                 BlockRange().InsertBefore(cmp, hiCmp);
+                ContainCheckBinary(hiCmp->AsOp());
             }
 
             hiCmp = comp->gtNewOperNode(GT_OR, TYP_INT, loCmp, hiCmp);
             BlockRange().InsertBefore(cmp, hiCmp);
+            ContainCheckBinary(hiCmp->AsOp());
         }
         else
         {
@@ -2220,12 +2311,15 @@ void Lowering::LowerCompare(GenTree* cmp)
 
                 hiCmp = comp->gtNewOperNode(GT_CMP, TYP_VOID, hiSrc1, hiSrc2);
                 BlockRange().InsertBefore(cmp, hiCmp);
+                ContainCheckCompare(hiCmp->AsOp());
             }
             else
             {
                 loCmp = comp->gtNewOperNode(GT_CMP, TYP_VOID, loSrc1, loSrc2);
                 hiCmp = comp->gtNewOperNode(GT_SUB_HI, TYP_INT, hiSrc1, hiSrc2);
                 BlockRange().InsertBefore(cmp, loCmp, hiCmp);
+                ContainCheckCompare(loCmp->AsOp());
+                ContainCheckBinary(hiCmp->AsOp());
 
                 //
                 // Try to move the first SUB_HI operands right in front of it, this allows using
@@ -2311,6 +2405,7 @@ void Lowering::LowerCompare(GenTree* cmp)
                 GenTree* cast = comp->gtNewCastNode(TYP_LONG, *smallerOpUse, TYP_LONG);
                 *smallerOpUse = cast;
                 BlockRange().InsertAfter(cast->gtGetOp1(), cast);
+                ContainCheckCast(cast->AsCast());
             }
         }
     }
@@ -2323,7 +2418,7 @@ void Lowering::LowerCompare(GenTree* cmp)
         GenTreeIntCon* op2      = cmp->gtGetOp2()->AsIntCon();
         ssize_t        op2Value = op2->IconValue();
 
-        if (IsContainableMemoryOp(op1, false) && varTypeIsSmall(op1Type) && genTypeCanRepresentValue(op1Type, op2Value))
+        if (IsContainableMemoryOp(op1) && varTypeIsSmall(op1Type) && genTypeCanRepresentValue(op1Type, op2Value))
         {
             //
             // If op1's type is small then try to narrow op2 so it has the same type as op1.
@@ -2353,12 +2448,25 @@ void Lowering::LowerCompare(GenTree* cmp)
                 // the result of bool returning calls.
                 //
 
-                if (castOp->OperIs(GT_CALL, GT_LCL_VAR) || castOp->OperIsLogical() ||
-                    IsContainableMemoryOp(castOp, false))
+                if (castOp->OperIs(GT_CALL, GT_LCL_VAR) || castOp->OperIsLogical() || IsContainableMemoryOp(castOp))
                 {
                     assert(!castOp->gtOverflowEx()); // Must not be an overflow checking operation
 
-                    castOp->gtType  = castToType;
+                    castOp->gtType = castToType;
+                    // If we have any contained memory ops on castOp, they must now not be contained.
+                    if (castOp->OperIsLogical())
+                    {
+                        GenTree* op1 = castOp->gtGetOp1();
+                        if ((op1 != nullptr) && !op1->IsCnsIntOrI())
+                        {
+                            op1->ClearContained();
+                        }
+                        GenTree* op2 = castOp->gtGetOp2();
+                        if ((op2 != nullptr) && !op2->IsCnsIntOrI())
+                        {
+                            op2->ClearContained();
+                        }
+                    }
                     cmp->gtOp.gtOp1 = castOp;
                     op2->gtType     = castToType;
 
@@ -2398,8 +2506,11 @@ void Lowering::LowerCompare(GenTree* cmp)
                 cmp->SetOperRaw(cmp->OperIs(GT_EQ) ? GT_TEST_EQ : GT_TEST_NE);
                 cmp->gtOp.gtOp1 = andOp1;
                 cmp->gtOp.gtOp2 = andOp2;
+                // We will re-evaluate containment below
+                andOp1->ClearContained();
+                andOp2->ClearContained();
 
-                if (IsContainableMemoryOp(andOp1, false) && andOp2->IsIntegralConst())
+                if (IsContainableMemoryOp(andOp1) && andOp2->IsIntegralConst())
                 {
                     //
                     // For "test" we only care about the bits that are set in the second operand (mask).
@@ -2450,6 +2561,7 @@ void Lowering::LowerCompare(GenTree* cmp)
         }
     }
 #endif // _TARGET_XARCH_
+    ContainCheckCompare(cmp->AsOp());
 }
 
 // Lower "jmp <method>" tail call to insert PInvoke method epilog if required.
@@ -2493,6 +2605,7 @@ void Lowering::LowerRet(GenTree* ret)
     {
         InsertPInvokeMethodEpilog(comp->compCurBB DEBUGARG(ret));
     }
+    ContainCheckRet(ret->AsOp());
 }
 
 GenTree* Lowering::LowerDirectCall(GenTreeCall* call)
@@ -2648,6 +2761,7 @@ GenTree* Lowering::LowerDelegateInvoke(GenTreeCall* call)
 
     assert(thisArgNode->gtOper == GT_PUTARG_REG);
     GenTree* originalThisExpr = thisArgNode->gtOp.gtOp1;
+    GenTree* thisExpr         = originalThisExpr;
 
     // We're going to use the 'this' expression multiple times, so make a local to copy it.
 
@@ -2670,21 +2784,21 @@ GenTree* Lowering::LowerDelegateInvoke(GenTreeCall* call)
         unsigned delegateInvokeTmp = comp->lvaGrabTemp(true DEBUGARG("delegate invoke call"));
 
         LIR::Use thisExprUse(BlockRange(), &thisArgNode->gtOp.gtOp1, thisArgNode);
-        thisExprUse.ReplaceWithLclVar(comp, m_block->getBBWeight(comp), delegateInvokeTmp);
+        ReplaceWithLclVar(thisExprUse, delegateInvokeTmp);
 
-        originalThisExpr = thisExprUse.Def(); // it's changed; reload it.
-        lclNum           = delegateInvokeTmp;
+        thisExpr = thisExprUse.Def(); // it's changed; reload it.
+        lclNum   = delegateInvokeTmp;
     }
 
     // replace original expression feeding into thisPtr with
     // [originalThis + offsetOfDelegateInstance]
 
     GenTree* newThisAddr = new (comp, GT_LEA)
-        GenTreeAddrMode(TYP_REF, originalThisExpr, nullptr, 0, comp->eeGetEEInfo()->offsetOfDelegateInstance);
+        GenTreeAddrMode(TYP_REF, thisExpr, nullptr, 0, comp->eeGetEEInfo()->offsetOfDelegateInstance);
 
     GenTree* newThis = comp->gtNewOperNode(GT_IND, TYP_REF, newThisAddr);
 
-    BlockRange().InsertAfter(originalThisExpr, newThisAddr, newThis);
+    BlockRange().InsertAfter(thisExpr, newThisAddr, newThis);
 
     thisArgNode->gtOp.gtOp1 = newThis;
 
@@ -2779,11 +2893,9 @@ GenTree* Lowering::SetGCState(int state)
 
     GenTree* base = new (comp, GT_LCL_VAR) GenTreeLclVar(TYP_I_IMPL, comp->info.compLvFrameListRoot, -1);
 
-    GenTree* storeGcState = new (comp, GT_STOREIND)
-        GenTreeStoreInd(TYP_BYTE,
-                        new (comp, GT_LEA) GenTreeAddrMode(TYP_I_IMPL, base, nullptr, 1, pInfo->offsetOfGCState),
-                        new (comp, GT_CNS_INT) GenTreeIntCon(TYP_BYTE, state));
-
+    GenTree* stateNode    = new (comp, GT_CNS_INT) GenTreeIntCon(TYP_BYTE, state);
+    GenTree* addr         = new (comp, GT_LEA) GenTreeAddrMode(TYP_I_IMPL, base, nullptr, 1, pInfo->offsetOfGCState);
+    GenTree* storeGcState = new (comp, GT_STOREIND) GenTreeStoreInd(TYP_BYTE, addr, stateNode);
     return storeGcState;
 }
 
@@ -2966,6 +3078,7 @@ void Lowering::InsertPInvokeMethodProlog()
         // The init routine sets InlinedCallFrame's m_pNext, so we just set the thead's top-of-stack
         GenTree* frameUpd = CreateFrameLinkUpdate(PushFrame);
         firstBlockRange.InsertBefore(insertionPoint, LIR::SeqTree(comp, frameUpd));
+        ContainCheckStoreIndir(frameUpd->AsIndir());
         DISPTREERANGE(firstBlockRange, frameUpd);
     }
 #endif // _TARGET_64BIT_
@@ -3030,6 +3143,7 @@ void Lowering::InsertPInvokeMethodEpilog(BasicBlock* returnBB DEBUGARG(GenTreePt
     // That is [tcb + offsetOfGcState] = 1
     GenTree* storeGCState = SetGCState(1);
     returnBlockRange.InsertBefore(insertionPoint, LIR::SeqTree(comp, storeGCState));
+    ContainCheckStoreIndir(storeGCState->AsIndir());
 
     // Pop the frame if necessary. This always happens in the epilog on 32-bit targets. For 64-bit targets, we only do
     // this in the epilog for IL stubs; for non-IL stubs the frame is popped after every PInvoke call.
@@ -3041,6 +3155,7 @@ void Lowering::InsertPInvokeMethodEpilog(BasicBlock* returnBB DEBUGARG(GenTreePt
     {
         GenTree* frameUpd = CreateFrameLinkUpdate(PopFrame);
         returnBlockRange.InsertBefore(insertionPoint, LIR::SeqTree(comp, frameUpd));
+        ContainCheckStoreIndir(frameUpd->AsIndir());
     }
 }
 
@@ -3148,7 +3263,7 @@ void Lowering::InsertPInvokeCallProlog(GenTreeCall* call)
                                                        callFrameInfo.offsetOfCallTarget);
         store->gtOp1 = src;
 
-        BlockRange().InsertBefore(insertBefore, LIR::SeqTree(comp, store));
+        InsertTreeBeforeAndContainCheck(insertBefore, store);
     }
 
 #ifdef _TARGET_X86_
@@ -3161,7 +3276,7 @@ void Lowering::InsertPInvokeCallProlog(GenTreeCall* call)
 
     storeCallSiteSP->gtOp1 = PhysReg(REG_SPBASE);
 
-    BlockRange().InsertBefore(insertBefore, LIR::SeqTree(comp, storeCallSiteSP));
+    InsertTreeBeforeAndContainCheck(insertBefore, storeCallSiteSP);
 
 #endif
 
@@ -3178,7 +3293,7 @@ void Lowering::InsertPInvokeCallProlog(GenTreeCall* call)
     labelRef->gtType       = TYP_I_IMPL;
     storeLab->gtOp1        = labelRef;
 
-    BlockRange().InsertBefore(insertBefore, LIR::SeqTree(comp, storeLab));
+    InsertTreeBeforeAndContainCheck(insertBefore, storeLab);
 
     // Push the PInvoke frame if necessary. On 32-bit targets this only happens in the method prolog if a method
     // contains PInvokes; on 64-bit targets this is necessary in non-stubs.
@@ -3194,6 +3309,7 @@ void Lowering::InsertPInvokeCallProlog(GenTreeCall* call)
         // Stubs do this once per stub, not once per call.
         GenTree* frameUpd = CreateFrameLinkUpdate(PushFrame);
         BlockRange().InsertBefore(insertBefore, LIR::SeqTree(comp, frameUpd));
+        ContainCheckStoreIndir(frameUpd->AsIndir());
     }
 #endif // _TARGET_64BIT_
 
@@ -3204,6 +3320,7 @@ void Lowering::InsertPInvokeCallProlog(GenTreeCall* call)
 
     GenTree* storeGCState = SetGCState(0);
     BlockRange().InsertBefore(insertBefore, LIR::SeqTree(comp, storeGCState));
+    ContainCheckStoreIndir(storeGCState->AsIndir());
 }
 
 //------------------------------------------------------------------------
@@ -3229,11 +3346,12 @@ void Lowering::InsertPInvokeCallEpilog(GenTreeCall* call)
         frameAddr->SetOperRaw(GT_LCL_VAR_ADDR);
 
         // Insert call to CORINFO_HELP_JIT_PINVOKE_END
-        GenTree* helperCall =
+        GenTreeCall* helperCall =
             comp->gtNewHelperCallNode(CORINFO_HELP_JIT_PINVOKE_END, TYP_VOID, 0, comp->gtNewArgList(frameAddr));
 
         comp->fgMorphTree(helperCall);
         BlockRange().InsertAfter(call, LIR::SeqTree(comp, helperCall));
+        ContainCheckCallOperands(helperCall);
         return;
     }
 
@@ -3242,9 +3360,11 @@ void Lowering::InsertPInvokeCallEpilog(GenTreeCall* call)
 
     GenTree* tree = SetGCState(1);
     BlockRange().InsertBefore(insertionPoint, LIR::SeqTree(comp, tree));
+    ContainCheckStoreIndir(tree->AsIndir());
 
     tree = CreateReturnTrapSeq();
     BlockRange().InsertBefore(insertionPoint, LIR::SeqTree(comp, tree));
+    ContainCheckReturnTrap(tree->AsOp());
 
     // Pop the frame if necessary. On 32-bit targets this only happens in the method epilog; on 64-bit targets thi
     // happens after every PInvoke call in non-stubs. 32-bit targets instead mark the frame as inactive.
@@ -3255,6 +3375,7 @@ void Lowering::InsertPInvokeCallEpilog(GenTreeCall* call)
     {
         tree = CreateFrameLinkUpdate(PopFrame);
         BlockRange().InsertBefore(insertionPoint, LIR::SeqTree(comp, tree));
+        ContainCheckStoreIndir(tree->AsIndir());
     }
 #else
     const CORINFO_EE_INFO::InlinedCallFrameInfo& callFrameInfo = comp->eeGetEEInfo()->inlinedCallFrameInfo;
@@ -3271,6 +3392,7 @@ void Lowering::InsertPInvokeCallEpilog(GenTreeCall* call)
     storeCallSiteTracker->gtOp1 = constantZero;
 
     BlockRange().InsertBefore(insertionPoint, constantZero, storeCallSiteTracker);
+    ContainCheckStoreLoc(storeCallSiteTracker);
 #endif // _TARGET_64BIT_
 }
 
@@ -3438,7 +3560,7 @@ GenTree* Lowering::LowerVirtualVtableCall(GenTreeCall* call)
         }
 
         LIR::Use thisPtrUse(BlockRange(), &(argEntry->node->gtOp.gtOp1), argEntry->node);
-        thisPtrUse.ReplaceWithLclVar(comp, m_block->getBBWeight(comp), vtableCallTemp);
+        ReplaceWithLclVar(thisPtrUse, vtableCallTemp);
 
         lclNum = vtableCallTemp;
     }
@@ -3582,6 +3704,7 @@ GenTree* Lowering::LowerVirtualStubCall(GenTreeCall* call)
         ind->gtFlags |= GTF_IND_REQ_ADDR_IN_REG;
 
         BlockRange().InsertAfter(call->gtCallAddr, ind);
+        ContainCheckIndir(ind->AsIndir());
         call->gtCallAddr = ind;
     }
     else
@@ -3845,6 +3968,15 @@ GenTree* Lowering::TryCreateAddrMode(LIR::Use&& use, bool isIndir)
 
     GenTreeAddrMode* addrMode = new (comp, GT_LEA) GenTreeAddrMode(addrModeType, base, index, scale, offset);
 
+    // Neither the base nor the index should now be contained.
+    if (base != nullptr)
+    {
+        base->ClearContained();
+    }
+    if (index != nullptr)
+    {
+        index->ClearContained();
+    }
     addrMode->gtRsvdRegs = addr->gtRsvdRegs;
     addrMode->gtFlags |= (addr->gtFlags & GTF_IND_FLAGS);
     addrMode->gtFlags &= ~GTF_ALL_EFFECT; // LEAs are side-effect-free.
@@ -3871,44 +4003,34 @@ GenTree* Lowering::TryCreateAddrMode(LIR::Use&& use, bool isIndir)
 //    node - the node we care about
 //
 // Returns:
-//    The next node to lower.
+//    The next node to lower if we have transformed the ADD; nullptr otherwise.
 //
 GenTree* Lowering::LowerAdd(GenTree* node)
 {
     GenTree* next = node->gtNext;
 
-#ifdef _TARGET_ARMARCH_
-    // For ARM architectures we don't have the LEA instruction
-    // therefore we won't get much benefit from doing this.
-    return next;
-#else  // _TARGET_ARMARCH_
-    if (!varTypeIsIntegralOrI(node))
+#ifndef _TARGET_ARMARCH_
+    if (varTypeIsIntegralOrI(node))
     {
-        return next;
+        LIR::Use use;
+        if (BlockRange().TryGetUse(node, &use))
+        {
+            // If this is a child of an indir, let the parent handle it.
+            // If there is a chain of adds, only look at the topmost one.
+            GenTree* parent = use.User();
+            if (!parent->OperIsIndir() && (parent->gtOper != GT_ADD))
+            {
+                GenTree* addr = TryCreateAddrMode(std::move(use), false);
+                if (addr != node)
+                {
+                    return addr->gtNext;
+                }
+            }
+        }
     }
-
-    LIR::Use use;
-    if (!BlockRange().TryGetUse(node, &use))
-    {
-        return next;
-    }
-
-    // if this is a child of an indir, let the parent handle it.
-    GenTree* parent = use.User();
-    if (parent->OperIsIndir())
-    {
-        return next;
-    }
-
-    // if there is a chain of adds, only look at the topmost one
-    if (parent->gtOper == GT_ADD)
-    {
-        return next;
-    }
-
-    GenTree* addr = TryCreateAddrMode(std::move(use), false);
-    return addr->gtNext;
 #endif // !_TARGET_ARMARCH_
+
+    return nullptr;
 }
 
 //------------------------------------------------------------------------
@@ -3917,12 +4039,16 @@ GenTree* Lowering::LowerAdd(GenTree* node)
 // Arguments:
 //    divMod - pointer to the GT_UDIV/GT_UMOD node to be lowered
 //
+// Return Value:
+//    Returns a boolean indicating whether the node was transformed.
+//
 // Notes:
 //    - Transform UDIV/UMOD by power of 2 into RSZ/AND
 //    - Transform UDIV by constant >= 2^(N-1) into GE
 //    - Transform UDIV/UMOD by constant >= 3 into "magic division"
+//
 
-GenTree* Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
+bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
 {
     assert(divMod->OperIs(GT_UDIV, GT_UMOD));
 
@@ -3933,13 +4059,13 @@ GenTree* Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
 #if !defined(_TARGET_64BIT_)
     if (dividend->OperIs(GT_LONG))
     {
-        return next;
+        return false;
     }
 #endif
 
     if (!divisor->IsCnsIntOrI())
     {
-        return next;
+        return false;
     }
 
     if (dividend->IsCnsIntOrI())
@@ -3947,7 +4073,7 @@ GenTree* Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
         // We shouldn't see a divmod with constant operands here but if we do then it's likely
         // because optimizations are disabled or it's a case that's supposed to throw an exception.
         // Don't optimize this.
-        return next;
+        return false;
     }
 
     const var_types type = divMod->TypeGet();
@@ -3964,7 +4090,7 @@ GenTree* Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
 
     if (divisorValue == 0)
     {
-        return next;
+        return false;
     }
 
     const bool isDiv = divMod->OperIs(GT_UDIV);
@@ -3985,11 +4111,10 @@ GenTree* Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
         }
 
         divMod->SetOper(newOper);
-        divisor->AsIntCon()->SetIconValue(divisorValue);
-
-        return next;
+        divisor->gtIntCon.SetIconValue(divisorValue);
+        ContainCheckNode(divMod);
+        return true;
     }
-
     if (isDiv)
     {
         // If the divisor is greater or equal than 2^(N - 1) then the result is 1
@@ -3999,7 +4124,8 @@ GenTree* Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
         {
             divMod->SetOper(GT_GE);
             divMod->gtFlags |= GTF_UNSIGNED;
-            return next;
+            ContainCheckNode(divMod);
+            return true;
         }
     }
 
@@ -4038,7 +4164,7 @@ GenTree* Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
         if (requiresDividendMultiuse)
         {
             LIR::Use dividendUse(BlockRange(), &divMod->gtOp1, divMod);
-            dividendLclNum = dividendUse.ReplaceWithLclVar(comp, curBBWeight);
+            dividendLclNum = ReplaceWithLclVar(dividendUse);
             dividend       = divMod->gtGetOp1();
         }
 
@@ -4050,6 +4176,7 @@ GenTree* Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
         mulhi->gtFlags |= GTF_UNSIGNED;
         divisor->AsIntCon()->SetIconValue(magic);
         BlockRange().InsertBefore(divMod, mulhi);
+        GenTree* firstNode = mulhi;
 
         if (requiresAdjustment)
         {
@@ -4063,7 +4190,7 @@ GenTree* Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
             BlockRange().InsertBefore(divMod, one, rsz);
 
             LIR::Use mulhiUse(BlockRange(), &sub->gtOp.gtOp2, sub);
-            unsigned mulhiLclNum = mulhiUse.ReplaceWithLclVar(comp, curBBWeight);
+            unsigned mulhiLclNum = ReplaceWithLclVar(mulhiUse);
 
             GenTree* mulhiCopy = comp->gtNewLclvNode(mulhiLclNum, type);
             GenTree* add       = comp->gtNewOperNode(GT_ADD, type, rsz, mulhiCopy);
@@ -4099,31 +4226,30 @@ GenTree* Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
             BlockRange().InsertBefore(divMod, div, divisor, mul, dividend);
             comp->lvaTable[dividendLclNum].incRefCnts(curBBWeight, comp);
         }
+        ContainCheckRange(firstNode, divMod);
 
-        return mulhi;
+        return true;
     }
 #endif
-
-    return next;
+    return false;
 }
 
-//------------------------------------------------------------------------
-// LowerSignedDivOrMod: transform integer GT_DIV/GT_MOD nodes with a power of 2
-// const divisor into equivalent but faster sequences.
+// LowerConstIntDivOrMod: Transform integer GT_DIV/GT_MOD nodes with a power of 2
+//     const divisor into equivalent but faster sequences.
 //
 // Arguments:
-//    node - pointer to node we care about
+//    node - pointer to the DIV or MOD node
 //
 // Returns:
 //    The next node to lower.
 //
-GenTree* Lowering::LowerSignedDivOrMod(GenTreePtr node)
+GenTree* Lowering::LowerConstIntDivOrMod(GenTree* node)
 {
     assert((node->OperGet() == GT_DIV) || (node->OperGet() == GT_MOD));
-
-    GenTree* next    = node->gtNext;
-    GenTree* divMod  = node;
-    GenTree* divisor = divMod->gtGetOp2();
+    GenTree* next     = node->gtNext;
+    GenTree* divMod   = node;
+    GenTree* dividend = divMod->gtGetOp1();
+    GenTree* divisor  = divMod->gtGetOp2();
 
     if (!divisor->IsCnsIntOrI())
     {
@@ -4132,8 +4258,6 @@ GenTree* Lowering::LowerSignedDivOrMod(GenTreePtr node)
 
     const var_types type = divMod->TypeGet();
     assert((type == TYP_INT) || (type == TYP_LONG));
-
-    GenTree* dividend = divMod->gtGetOp1();
 
     if (dividend->IsCnsIntOrI())
     {
@@ -4168,6 +4292,7 @@ GenTree* Lowering::LowerSignedDivOrMod(GenTreePtr node)
             // If the divisor is the minimum representable integer value then we can use a compare,
             // the result is 1 iff the dividend equals divisor.
             divMod->SetOper(GT_EQ);
+            ContainCheckCompare(divMod->AsOp());
             return next;
         }
     }
@@ -4229,7 +4354,7 @@ GenTree* Lowering::LowerSignedDivOrMod(GenTreePtr node)
         if (requiresDividendMultiuse)
         {
             LIR::Use dividendUse(BlockRange(), &mulhi->gtOp.gtOp2, mulhi);
-            dividendLclNum = dividendUse.ReplaceWithLclVar(comp, curBBWeight);
+            dividendLclNum = ReplaceWithLclVar(dividendUse);
         }
 
         GenTree* adjusted;
@@ -4252,7 +4377,7 @@ GenTree* Lowering::LowerSignedDivOrMod(GenTreePtr node)
         BlockRange().InsertBefore(divMod, shiftBy, signBit);
 
         LIR::Use adjustedUse(BlockRange(), &signBit->gtOp.gtOp1, signBit);
-        unsigned adjustedLclNum = adjustedUse.ReplaceWithLclVar(comp, curBBWeight);
+        unsigned adjustedLclNum = ReplaceWithLclVar(adjustedUse);
         adjusted                = comp->gtNewLclvNode(adjustedLclNum, type);
         comp->lvaTable[adjustedLclNum].incRefCnts(curBBWeight, comp);
         BlockRange().InsertBefore(divMod, adjusted);
@@ -4307,7 +4432,7 @@ GenTree* Lowering::LowerSignedDivOrMod(GenTreePtr node)
     unsigned curBBWeight = comp->compCurBB->getBBWeight(comp);
 
     LIR::Use opDividend(BlockRange(), &divMod->gtOp.gtOp1, divMod);
-    opDividend.ReplaceWithLclVar(comp, curBBWeight);
+    ReplaceWithLclVar(opDividend);
 
     dividend = divMod->gtGetOp1();
     assert(dividend->OperGet() == GT_LCL_VAR);
@@ -4340,11 +4465,13 @@ GenTree* Lowering::LowerSignedDivOrMod(GenTreePtr node)
         divisor->gtIntCon.SetIconValue(genLog2(absDivisorValue));
 
         newDivMod = comp->gtNewOperNode(GT_RSH, type, adjustedDividend, divisor);
+        ContainCheckShiftRotate(newDivMod->AsOp());
 
         if (divisorValue < 0)
         {
             // negate the result if the divisor is negative
             newDivMod = comp->gtNewOperNode(GT_NEG, type, newDivMod);
+            ContainCheckNode(newDivMod);
         }
     }
     else
@@ -4356,6 +4483,7 @@ GenTree* Lowering::LowerSignedDivOrMod(GenTreePtr node)
 
         newDivMod = comp->gtNewOperNode(GT_SUB, type, comp->gtNewLclvNode(dividendLclNum, type),
                                         comp->gtNewOperNode(GT_AND, type, adjustedDividend, divisor));
+        ContainCheckBinary(newDivMod->AsOp());
 
         comp->lvaTable[dividendLclNum].incRefCnts(curBBWeight, comp);
     }
@@ -4366,7 +4494,7 @@ GenTree* Lowering::LowerSignedDivOrMod(GenTreePtr node)
     BlockRange().Remove(dividend);
 
     // linearize and insert the new tree before the original divMod node
-    BlockRange().InsertBefore(divMod, LIR::SeqTree(comp, newDivMod));
+    InsertTreeBeforeAndContainCheck(divMod, newDivMod);
     BlockRange().Remove(divMod);
 
     // replace the original divmod node with the new divmod tree
@@ -4374,24 +4502,37 @@ GenTree* Lowering::LowerSignedDivOrMod(GenTreePtr node)
 
     return newDivMod->gtNext;
 }
-
 //------------------------------------------------------------------------
-// LowerStoreInd: attempt to transform an indirect store to use an
-//    addressing mode
+// LowerSignedDivOrMod: transform integer GT_DIV/GT_MOD nodes with a power of 2
+// const divisor into equivalent but faster sequences.
 //
 // Arguments:
-//    node - the node we care about
+//    node - the DIV or MOD node
 //
-void Lowering::LowerStoreInd(GenTree* node)
+// Returns:
+//    The next node to lower.
+//
+GenTree* Lowering::LowerSignedDivOrMod(GenTreePtr node)
 {
-    assert(node != nullptr);
-    assert(node->OperGet() == GT_STOREIND);
+    assert((node->OperGet() == GT_DIV) || (node->OperGet() == GT_MOD));
+    GenTree* next     = node->gtNext;
+    GenTree* divMod   = node;
+    GenTree* dividend = divMod->gtGetOp1();
+    GenTree* divisor  = divMod->gtGetOp2();
 
-    TryCreateAddrMode(LIR::Use(BlockRange(), &node->gtOp.gtOp1, node), true);
+#ifdef _TARGET_XARCH_
+    if (!varTypeIsFloating(node->TypeGet()))
+#endif // _TARGET_XARCH_
+    {
+        next = LowerConstIntDivOrMod(node);
+    }
 
-    // Mark all GT_STOREIND nodes to indicate that it is not known
-    // whether it represents a RMW memory op.
-    node->AsStoreInd()->SetRMWStatusDefault();
+    if ((node->OperGet() == GT_DIV) || (node->OperGet() == GT_MOD))
+    {
+        ContainCheckDivOrMod(node->AsOp());
+    }
+
+    return next;
 }
 
 void Lowering::WidenSIMD12IfNecessary(GenTreeLclVarCommon* node)
@@ -4503,7 +4644,7 @@ GenTree* Lowering::LowerArrElem(GenTree* node)
     if (!arrElem->gtArrObj->IsLocal())
     {
         LIR::Use arrObjUse(BlockRange(), &arrElem->gtArrObj, arrElem);
-        arrObjUse.ReplaceWithLclVar(comp, blockWeight);
+        ReplaceWithLclVar(arrObjUse);
     }
 
     GenTree* arrObjNode = arrElem->gtArrObj;
@@ -4514,6 +4655,7 @@ GenTree* Lowering::LowerArrElem(GenTree* node)
     // The first ArrOffs node will have 0 for the offset of the previous dimension.
     GenTree* prevArrOffs = new (comp, GT_CNS_INT) GenTreeIntCon(TYP_I_IMPL, 0);
     BlockRange().InsertBefore(insertionPoint, prevArrOffs);
+    GenTree* nextToLower = prevArrOffs;
 
     for (unsigned char dim = 0; dim < rank; dim++)
     {
@@ -4589,7 +4731,7 @@ GenTree* Lowering::LowerArrElem(GenTree* node)
     DISPTREERANGE(BlockRange(), leaNode);
     JITDUMP("\n\n");
 
-    return leaNode;
+    return nextToLower;
 }
 
 void Lowering::DoPhase()
@@ -4711,10 +4853,13 @@ void Lowering::DoPhase()
 
 #ifdef DEBUG
             node->gtSeqNum = currentLoc;
+            // In DEBUG, we want to set the gtRegTag to GT_REGTAG_REG, so that subsequent dumps will so the register
+            // value.
+            // Although this looks like a no-op it sets the tag.
+            node->gtRegNum = node->gtRegNum;
 #endif
 
             node->gtLsraInfo.Initialize(m_lsra, node, currentLoc);
-            node->gtClearReg(comp);
 
             currentLoc += 2;
 
@@ -4771,6 +4916,7 @@ void Lowering::CheckCallArg(GenTree* arg)
         case GT_FIELD_LIST:
         {
             GenTreeFieldList* list = arg->AsFieldList();
+            assert(list->isContained());
             assert(list->IsFieldListHead());
 
             for (; list != nullptr; list = list->Rest())
@@ -5133,6 +5279,122 @@ void Lowering::getCastDescription(GenTreePtr treeNode, CastInfo* castInfo)
 }
 
 //------------------------------------------------------------------------
+// Containment Analysis
+//------------------------------------------------------------------------
+void Lowering::ContainCheckNode(GenTree* node)
+{
+    switch (node->gtOper)
+    {
+        case GT_STORE_LCL_VAR:
+        case GT_STORE_LCL_FLD:
+            ContainCheckStoreLoc(node->AsLclVarCommon());
+            break;
+
+        case GT_EQ:
+        case GT_NE:
+        case GT_LT:
+        case GT_LE:
+        case GT_GE:
+        case GT_GT:
+        case GT_TEST_EQ:
+        case GT_TEST_NE:
+        case GT_CMP:
+            ContainCheckCompare(node->AsOp());
+            break;
+
+        case GT_JTRUE:
+            ContainCheckJTrue(node->AsOp());
+            break;
+
+        case GT_ADD:
+        case GT_SUB:
+#if !defined(_TARGET_64BIT_)
+        case GT_ADD_LO:
+        case GT_ADD_HI:
+        case GT_SUB_LO:
+        case GT_SUB_HI:
+#endif
+        case GT_AND:
+        case GT_OR:
+        case GT_XOR:
+            ContainCheckBinary(node->AsOp());
+            break;
+
+#ifdef _TARGET_XARCH_
+        case GT_NEG:
+            // Codegen of this tree node sets ZF and SF flags.
+            if (!varTypeIsFloating(node))
+            {
+                node->gtFlags |= GTF_ZSF_SET;
+            }
+            break;
+#endif // _TARGET_XARCH_
+
+#if defined(_TARGET_X86_)
+        case GT_MUL_LONG:
+#endif
+        case GT_MUL:
+        case GT_MULHI:
+            ContainCheckMul(node->AsOp());
+            break;
+        case GT_DIV:
+        case GT_MOD:
+        case GT_UDIV:
+        case GT_UMOD:
+            ContainCheckDivOrMod(node->AsOp());
+            break;
+        case GT_LSH:
+        case GT_RSH:
+        case GT_RSZ:
+        case GT_ROL:
+        case GT_ROR:
+#ifndef _TARGET_64BIT_
+        case GT_LSH_HI:
+        case GT_RSH_LO:
+#endif
+            ContainCheckShiftRotate(node->AsOp());
+            break;
+        case GT_ARR_OFFSET:
+            ContainCheckArrOffset(node->AsArrOffs());
+            break;
+        case GT_LCLHEAP:
+            ContainCheckLclHeap(node->AsOp());
+            break;
+        case GT_RETURN:
+            ContainCheckRet(node->AsOp());
+            break;
+        case GT_RETURNTRAP:
+            ContainCheckReturnTrap(node->AsOp());
+            break;
+        case GT_STOREIND:
+            ContainCheckStoreIndir(node->AsIndir());
+        case GT_IND:
+            ContainCheckIndir(node->AsIndir());
+            break;
+        case GT_PUTARG_REG:
+        case GT_PUTARG_STK:
+#ifdef _TARGET_ARM_
+        case GT_PUTARG_SPLIT:
+#endif
+            // The regNum must have been set by the lowering of the call.
+            assert(node->gtRegNum != REG_NA);
+            break;
+#ifdef _TARGET_XARCH_
+        case GT_INTRINSIC:
+            ContainCheckIntrinsic(node->AsOp());
+            break;
+#endif // _TARGET_XARCH_
+#ifdef FEATURE_SIMD
+        case GT_SIMD:
+            ContainCheckSIMD(node->AsSIMD());
+            break;
+#endif // FEATURE_SIMD
+        default:
+            break;
+    }
+}
+
+//------------------------------------------------------------------------
 // GetIndirSourceCount: Get the source registers for an indirection that might be contained.
 //
 // Arguments:
@@ -5189,7 +5451,7 @@ void Lowering::ContainCheckDivOrMod(GenTreeOp* node)
         // everything is made explicit by adding casts.
         assert(dividend->TypeGet() == divisor->TypeGet());
 
-        if (IsContainableMemoryOp(divisor, true) || divisor->IsCnsNonZeroFltOrDbl())
+        if (IsContainableMemoryOp(divisor) || divisor->IsCnsNonZeroFltOrDbl())
         {
             MakeSrcContained(node, divisor);
         }
@@ -5211,7 +5473,7 @@ void Lowering::ContainCheckDivOrMod(GenTreeOp* node)
 #endif
 
     // divisor can be an r/m, but the memory indirection must be of the same size as the divide
-    if (IsContainableMemoryOp(divisor, true) && (divisor->TypeGet() == node->TypeGet()))
+    if (IsContainableMemoryOp(divisor) && (divisor->TypeGet() == node->TypeGet()))
     {
         MakeSrcContained(node, divisor);
     }
@@ -5232,12 +5494,14 @@ void Lowering::ContainCheckDivOrMod(GenTreeOp* node)
 //
 void Lowering::ContainCheckReturnTrap(GenTreeOp* node)
 {
+#ifdef _TARGET_XARCH_
     assert(node->OperIs(GT_RETURNTRAP));
     // This just turns into a compare of its child with an int + a conditional call
     if (node->gtOp1->isIndir())
     {
         MakeSrcContained(node, node->gtOp1);
     }
+#endif // _TARGET_XARCH_
 }
 
 //------------------------------------------------------------------------
@@ -5311,7 +5575,6 @@ void Lowering::ContainCheckRet(GenTreeOp* ret)
 #endif // FEATURE_MULTIREG_RET
 }
 
-#ifdef FEATURE_SIMD
 //------------------------------------------------------------------------
 // ContainCheckJTrue: determine whether the source of a JTRUE should be contained.
 //
@@ -5320,6 +5583,11 @@ void Lowering::ContainCheckRet(GenTreeOp* ret)
 //
 void Lowering::ContainCheckJTrue(GenTreeOp* node)
 {
+    // The compare does not need to be generated into a register.
+    GenTree* cmp                   = node->gtGetOp1();
+    cmp->gtLsraInfo.isNoRegCompare = true;
+
+#ifdef FEATURE_SIMD
     assert(node->OperIs(GT_JTRUE));
 
     // Say we have the following IR
@@ -5329,7 +5597,6 @@ void Lowering::ContainCheckJTrue(GenTreeOp* node)
     //
     // In this case we don't need to generate code for GT_EQ_/NE, since SIMD (In)Equality
     // intrinsic will set or clear the Zero flag.
-    GenTree*   cmp     = node->gtGetOp1();
     genTreeOps cmpOper = cmp->OperGet();
     if (cmpOper == GT_EQ || cmpOper == GT_NE)
     {
@@ -5340,12 +5607,36 @@ void Lowering::ContainCheckJTrue(GenTreeOp* node)
         {
             // We always generate code for a SIMD equality comparison, though it produces no value.
             // Neither the GT_JTRUE nor the immediate need to be evaluated.
-            m_lsra->clearOperandCounts(cmp);
             MakeSrcContained(cmp, cmpOp2);
+            cmpOp1->gtLsraInfo.isNoRegCompare = true;
+            // We have to reverse compare oper in the following cases:
+            // 1) SIMD Equality: Sets Zero flag on equal otherwise clears it.
+            //    Therefore, if compare oper is == or != against false(0), we will
+            //    be checking opposite of what is required.
+            //
+            // 2) SIMD inEquality: Clears Zero flag on true otherwise sets it.
+            //    Therefore, if compare oper is == or != against true(1), we will
+            //    be checking opposite of what is required.
+            GenTreeSIMD* simdNode = cmpOp1->AsSIMD();
+            if (simdNode->gtSIMDIntrinsicID == SIMDIntrinsicOpEquality)
+            {
+                if (cmpOp2->IsIntegralConst(0))
+                {
+                    cmp->SetOper(GenTree::ReverseRelop(cmpOper));
+                }
+            }
+            else
+            {
+                assert(simdNode->gtSIMDIntrinsicID == SIMDIntrinsicOpInEquality);
+                if (cmpOp2->IsIntegralConst(1))
+                {
+                    cmp->SetOper(GenTree::ReverseRelop(cmpOper));
+                }
+            }
         }
     }
-}
 #endif // FEATURE_SIMD
+}
 
 #ifdef DEBUG
 void Lowering::DumpNodeInfoMap()

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -10600,7 +10600,11 @@ void TreeNodeInfo::Initialize(LinearScan* lsra, GenTree* node, LsraLocation loca
     // if there is a reg indicated on the tree node, use that for dstCandidates
     // the exception is the NOP, which sometimes show up around late args.
     // TODO-Cleanup: get rid of those NOPs.
-    if (node->gtRegNum == REG_NA || node->gtOper == GT_NOP)
+    if (node->gtRegNum == REG_STK)
+    {
+        dstCandidates = RBM_NONE;
+    }
+    else if (node->gtRegNum == REG_NA || node->gtOper == GT_NOP)
     {
 #ifdef ARM_SOFTFP
         if (node->OperGet() == GT_PUTARG_REG)

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -749,29 +749,6 @@ private:
     // Update reg state for an incoming register argument
     void updateRegStateForArg(LclVarDsc* argDsc);
 
-    inline void setTreeNodeInfo(GenTree* tree, TreeNodeInfo info)
-    {
-        tree->gtLsraInfo = info;
-        tree->gtClearReg(compiler);
-
-        DBEXEC(VERBOSE, info.dump(this));
-    }
-
-    inline void clearDstCount(GenTree* tree)
-    {
-        tree->gtLsraInfo.dstCount = 0;
-    }
-
-    inline void clearOperandCounts(GenTree* tree)
-    {
-        TreeNodeInfo& info = tree->gtLsraInfo;
-        info.srcCount      = 0;
-        info.dstCount      = 0;
-
-        info.internalIntCount   = 0;
-        info.internalFloatCount = 0;
-    }
-
     inline bool isLocalDefUse(GenTree* tree)
     {
         return tree->gtLsraInfo.isLocalDefUse;

--- a/src/jit/nodeinfo.h
+++ b/src/jit/nodeinfo.h
@@ -32,6 +32,7 @@ public:
         regOptional            = false;
         definesAnyRegisters    = false;
         isInternalRegDelayFree = false;
+        isNoRegCompare         = false;
 #ifdef DEBUG
         isInitialized = false;
 #endif
@@ -143,6 +144,9 @@ public:
     // Whether internal register needs to be different from targetReg
     // in which result is produced.
     unsigned char isInternalRegDelayFree : 1;
+
+    // True if this is a compare feeding a JTRUE that doesn't need to be generated into a register.
+    unsigned char isNoRegCompare : 1;
 
 #ifdef DEBUG
     // isInitialized is set when the tree node is handled.

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -516,6 +516,7 @@ void Rationalizer::RewriteAssignment(LIR::Use& use)
             location->gtType = TYP_BYREF;
 
             assignment->SetOper(GT_STOREIND);
+            assignment->AsStoreInd()->SetRMWStatusDefault();
 
             // TODO: JIT dump
         }


### PR DESCRIPTION
- Ensure that the only changes to child nodes are the specification of srcCandidates (i.e. the register requirements of the parent/consumer)
  - Set the register numbers on the PutArg nodes during call Lowering
    - This means that we don't want to call `gtClearReg()` prior to `TreeNodeInfoInit()`.
      - Since it is not tractable to ensure that it is called on all new nodes, use an alternate method, `gtCheckReg()` which checks whether a register has been assigned, and only clears it if it has not.
  - If a node is known to be contained, don't bother handling it in `TreeNodeInfoInit()`.
- This now occurs before dataflow analysis so we don't have complete information on what lclVars will be register candidates
  - This is mitigated by the fact that they are usually marked RegOptional if they could be contained as lclVars
    - Note that issue #12398 means that these are not always handled consistently
    - Also, this means that we sometimes choose different registers in `PreferredRegOptionalOperand()`, which has both positive and negative impact on code generation, since it is an estimate. See issue 6361.
  - In addition, mark decomposed/promoted fields of long params as `lvDoNotEnregister` on x86 so that they will be known not to be register candidates.
- Ensure that any new code added after `Lowering` is handled by calling `LowerRange()`