### PR TITLE
[GDBJIT] Use placement new to initialize ELF Header (instead of memcpy)

### DIFF
--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -407,7 +407,6 @@ private:
     static void OnMethodCompiled(MethodDesc* methodDescPtr);
 
     static int GetSectionIndex(const char *sectName);
-    static bool BuildELFHeader(MemBuf& buf);
     static void BuildSectionTables(MemBuf& sectBuf, MemBuf& strBuf, FunctionMemberPtrArrayHolder &method,
                                    int symbolCount);
     static bool BuildSymbolTableSection(MemBuf& buf, PCODE addr, TADDR codeSize, FunctionMemberPtrArrayHolder &method,


### PR DESCRIPTION
This commit reduces memory allocation cost (very slightly) via using placement new instead of using  new & memcpy.