### PR TITLE
Improve performance of string.IndexOfAny for 2 & 3 char searches

### DIFF
--- a/src/classlibnative/bcltype/stringnative.cpp
+++ b/src/classlibnative/bcltype/stringnative.cpp
@@ -327,8 +327,6 @@ FCIMPL4(INT32, COMString::IndexOfCharArray, StringObject* thisRef, CHARArray* va
 
     if (thisRef == NULL)
         FCThrow(kNullReferenceException);
-    if (valueRef == NULL)
-        FCThrowArgumentNull(W("anyOf"));
 
     WCHAR *thisChars;
     WCHAR *valueChars;
@@ -336,14 +334,6 @@ FCIMPL4(INT32, COMString::IndexOfCharArray, StringObject* thisRef, CHARArray* va
     int thisLength;
 
     thisRef->RefInterpretGetStringValuesDangerousForGC(&thisChars, &thisLength);
-
-    if (startIndex < 0 || startIndex > thisLength) {
-        FCThrowArgumentOutOfRange(W("startIndex"), W("ArgumentOutOfRange_Index"));
-    }
-
-    if (count < 0 || count > thisLength - startIndex) {
-        FCThrowArgumentOutOfRange(W("count"), W("ArgumentOutOfRange_Count"));
-    }
 
     int endIndex = startIndex + count;
 
@@ -494,19 +484,30 @@ void InitializeProbabilisticMap(int* charMap, __in_ecount(length) const WCHAR* c
     _ASSERTE(charArray != NULL);
     _ASSERTE(length >= 0);
 
+    bool hasAscii = false;
+
     for(int i = 0; i < length; ++i) {
         int hi,lo;
 
-        WCHAR c = charArray[i];
+        int c = charArray[i];
 
-        hi = (c >> 8) & 0xFF;
         lo = c & 0xFF;
+        hi = (c >> 8) & 0xFF;
 
         int* value = &charMap[lo & PROBABILISTICMAP_BLOCK_INDEX_MASK];
         SetBit(value, lo >> PROBABILISTICMAP_BLOCK_INDEX_SHIFT);
 
-        value = &charMap[hi & PROBABILISTICMAP_BLOCK_INDEX_MASK];
-        SetBit(value, hi >> PROBABILISTICMAP_BLOCK_INDEX_SHIFT);
+        if (hi > 0) {
+            value = &charMap[hi & PROBABILISTICMAP_BLOCK_INDEX_MASK];
+            SetBit(value, hi >> PROBABILISTICMAP_BLOCK_INDEX_SHIFT);
+        }
+        else {
+            hasAscii = true;
+        }
+    }
+
+    if (hasAscii) {
+        charMap[0] |= 1;
     }
 }
 

--- a/src/classlibnative/bcltype/stringnative.cpp
+++ b/src/classlibnative/bcltype/stringnative.cpp
@@ -507,6 +507,7 @@ void InitializeProbabilisticMap(int* charMap, __in_ecount(length) const WCHAR* c
     }
 
     if (hasAscii) {
+        // Common to search for ASCII symbols. Just the high value once.
         charMap[0] |= 1;
     }
 }

--- a/src/mscorlib/src/System/String.Searching.cs
+++ b/src/mscorlib/src/System/String.Searching.cs
@@ -122,8 +122,18 @@ namespace System
             {
                 return IndexOfAny(anyOf[0], anyOf[1], anyOf[2], startIndex, count);
             }
-
-            return IndexOfCharArray(anyOf, startIndex, count);
+            else if (anyOf.Length > 3)
+            {
+                return IndexOfCharArray(anyOf, startIndex, count);
+            }
+            else if (anyOf.Length == 1)
+            {
+                return IndexOf(anyOf[0], startIndex, count);
+            }
+            else // anyOf.Length == 0
+            {
+                return -1;
+            }
         }
 
         private unsafe int IndexOfAny(char value1, char value2, int startIndex, int count)

--- a/src/mscorlib/src/System/String.Searching.cs
+++ b/src/mscorlib/src/System/String.Searching.cs
@@ -134,18 +134,22 @@ namespace System
 
                 while (count > 0)
                 {
-                    if (*pCh == value1)
+                    char c = *pCh;
+
+                    if (c == value1)
                         goto ReturnIndex;
 
-                    if (*pCh == value2)
+                    if (c == value2)
                         goto ReturnIndex;
 
                     // Possibly reads outside of count and can include null terminator
                     // Handled in the return logic
-                    if (*(pCh + 1) == value1)
+                    c = *(pCh + 1);
+
+                    if (c == value1)
                         goto ReturnIndex1;
 
-                    if (*(pCh + 1) == value2)
+                    if (c == value2)
                         goto ReturnIndex1;
 
                     pCh += 2;

--- a/src/mscorlib/src/System/String.Searching.cs
+++ b/src/mscorlib/src/System/String.Searching.cs
@@ -136,20 +136,14 @@ namespace System
                 {
                     char c = *pCh;
 
-                    if (c == value1)
-                        goto ReturnIndex;
-
-                    if (c == value2)
+                    if (c == value1 || c == value2)
                         goto ReturnIndex;
 
                     // Possibly reads outside of count and can include null terminator
                     // Handled in the return logic
                     c = *(pCh + 1);
 
-                    if (c == value1)
-                        goto ReturnIndex1;
-
-                    if (c == value2)
+                    if (c == value1 || c == value2)
                         goto ReturnIndex1;
 
                     pCh += 2;

--- a/src/mscorlib/src/System/String.Searching.cs
+++ b/src/mscorlib/src/System/String.Searching.cs
@@ -96,8 +96,98 @@ namespace System
         }
 
         [Pure]
+        public int IndexOfAny(char[] anyOf, int startIndex, int count)
+        {
+            if (anyOf == null)
+            {
+                throw new ArgumentNullException(nameof(anyOf));
+            }
+
+            if ((uint)startIndex > (uint)Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
+            }
+
+            if ((uint)count > (uint)(Length - startIndex))
+            {
+                throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_Count);
+            }
+
+            if (anyOf.Length == 2)
+            {
+                // Very common optimization for directory separators (/, \), quotes (", '), brackets, etc
+                return IndexOfAny(anyOf[0], anyOf[1], startIndex, count);
+            }
+            else if (anyOf.Length == 3)
+            {
+                return IndexOfAny(anyOf[0], anyOf[1], anyOf[2], startIndex, count);
+            }
+
+            return IndexOfCharArray(anyOf, startIndex, count);
+        }
+
+        private unsafe int IndexOfAny(char value1, char value2, int startIndex, int count)
+        {
+            fixed (char* pChars = &_firstChar)
+            {
+                char* pCh = pChars + startIndex;
+
+                while (count > 0)
+                {
+                    if (*pCh == value1)
+                        goto ReturnIndex;
+
+                    if (*pCh == value2)
+                        goto ReturnIndex;
+
+                    // Possibly reads outside of count and can include null terminator
+                    // Handled in the return logic
+                    if (*(pCh + 1) == value1)
+                        goto ReturnIndex1;
+
+                    if (*(pCh + 1) == value2)
+                        goto ReturnIndex1;
+
+                    pCh += 2;
+                    count -= 2;
+                }
+
+                return -1;
+
+            ReturnIndex:
+                return (int)(pCh - pChars);
+
+            ReturnIndex1:
+                return (count == 1 ? -1 : (int)(pCh - pChars) + 1);
+            }
+        }
+
+        private unsafe int IndexOfAny(char value1, char value2, char value3, int startIndex, int count)
+        {
+            fixed (char* pChars = &_firstChar)
+            {
+                char* pCh = pChars + startIndex;
+
+                while (count > 0)
+                {
+                    char c = *pCh;
+
+                    if (c == value1 || c == value2 || c == value3)
+                        goto ReturnIndex;
+
+                    pCh++;
+                    count--;
+                }
+
+                return -1;
+
+            ReturnIndex:
+                return (int)(pCh - pChars);
+            }
+        }
+
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        public extern int IndexOfAny(char[] anyOf, int startIndex, int count);
+        private extern int IndexOfCharArray(char[] anyOf, int startIndex, int count);
 
 
         // Determines the position within this string of the first occurrence of the specified

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -119,7 +119,7 @@ FCFuncStart(gStringFuncs)
     FCIntrinsic("get_Chars", COMString::GetCharAt, CORINFO_INTRINSIC_StringGetChar)
     FCFuncElement("IsAscii", COMString::IsAscii)
     FCFuncElement("CompareOrdinalHelper", COMString::CompareOrdinalEx)
-    FCFuncElement("IndexOfAny", COMString::IndexOfCharArray)
+    FCFuncElement("IndexOfCharArray", COMString::IndexOfCharArray)
     FCFuncElement("LastIndexOfAny", COMString::LastIndexOfCharArray)
     FCFuncElementSig("ReplaceInternal", &gsig_IM_Str_Str_RetStr, COMString::ReplaceString)
 #ifdef FEATURE_COMINTEROP


### PR DESCRIPTION
Improves the performance of `string.IndexOfAny`, special casing common 2 and 3 character searches.

**2 char search**
Beats a minimal hard coded loop after 3rd string character.
Small string (22chars) - 67% faster than existing
Large string (366 chars) - 56% faster than existing

**3 char search**
Beats a minimal hard coded loop after 8th string character.
Small string (22chars)  - 49% faster than existing
Large string (366 chars) - 28% faster than existing

**InitializeProbabilisticMap**
Very common to search for ASCII symbols. The high map always writes the same value to the same location. Only doing that once gives a 13% improvement (isolated, 10 char array).

Issues
https://github.com/dotnet/corefx/issues/22771
https://github.com/aspnet/Mvc/issues/5362
https://github.com/NuGet/NuGet.Client/pull/1590#discussion_r130262373
https://github.com/dotnet/coreclr/issues/7017

cc @davkean @benaadams 