### PR TITLE
Binary serialization unused methods and attributes cleanup and misc code cleanup

### DIFF
--- a/src/mscorlib/src/System/Collections/Concurrent/ConcurrentQueue.cs
+++ b/src/mscorlib/src/System/Collections/Concurrent/ConcurrentQueue.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Runtime.Serialization;
 using System.Threading;
 
 namespace System.Collections.Concurrent
@@ -53,16 +52,11 @@ namespace System.Collections.Concurrent
         /// Lock used to protect cross-segment operations, including any updates to <see cref="_tail"/> or <see cref="_head"/>
         /// and any operations that need to get a consistent view of them.
         /// </summary>
-        [NonSerialized]
         private object _crossSegmentLock;
         /// <summary>The current tail segment.</summary>
-        [NonSerialized]
         private volatile Segment _tail;
         /// <summary>The current head segment.</summary>
-        [NonSerialized]
         private volatile Segment _head;
-        /// <summary>Field used to temporarily store the contents of the queue for serialization.</summary>
-        private T[] _serializationArray;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConcurrentQueue{T}"/> class.
@@ -71,29 +65,6 @@ namespace System.Collections.Concurrent
         {
             _crossSegmentLock = new object();
             _tail = _head = new Segment(InitialSegmentLength);
-        }
-
-        /// <summary>Set the data array to be serialized.</summary>
-        [OnSerializing]
-        private void OnSerializing(StreamingContext context)
-        {
-            _serializationArray = ToArray();
-        }
-
-        /// <summary>Clear the data array that was serialized.</summary>
-        [OnSerialized]
-        private void OnSerialized(StreamingContext context)
-        {
-            _serializationArray = null;
-        }
-
-        /// <summary>Construct the queue from the deserialized <see cref="_serializationArray"/>.</summary>
-        [OnDeserialized]
-        private void OnDeserialized(StreamingContext context)
-        {
-            Debug.Assert(_serializationArray != null);
-            InitializeFromCollection(_serializationArray);
-            _serializationArray = null;
         }
 
         /// <summary>

--- a/src/mscorlib/src/System/Globalization/TextInfo.Unix.cs
+++ b/src/mscorlib/src/System/Globalization/TextInfo.Unix.cs
@@ -11,7 +11,6 @@ namespace System.Globalization
 {
     public partial class TextInfo
     {
-        [NonSerialized]
         private Tristate _needsTurkishCasing = Tristate.NotInitialized;
 
         private void FinishInitialization(string textInfoName)

--- a/src/mscorlib/src/System/Globalization/TextInfo.cs
+++ b/src/mscorlib/src/System/Globalization/TextInfo.cs
@@ -21,10 +21,6 @@ namespace System.Globalization
 {
     public partial class TextInfo : ICloneable, IDeserializationCallback
     {
-        ////--------------------------------------------------------------------//
-        ////                        Internal Information                        //
-        ////--------------------------------------------------------------------//
-
         private enum Tristate : byte
         {
             NotInitialized,
@@ -32,36 +28,22 @@ namespace System.Globalization
             False,
         }
 
-        ////
-        ////  Variables.
-        ////
-
-        [OptionalField(VersionAdded = 2)]
-        private String _listSeparator;
-        [OptionalField(VersionAdded = 2)]
+        private string _listSeparator;
         private bool _isReadOnly = false;
 
-        ////      _cultureName is the name of the creating culture.  Note that we consider this authoritative,
-        ////              if the culture's textinfo changes when deserializing, then behavior may change.
-        ////              (ala Whidbey behavior).  This is the only string Arrowhead needs to serialize.
-        ////      _cultureData is the data that backs this class.
-        ////      _textInfoName is the actual name of the textInfo (from cultureData.STEXTINFO)
-        ////              this can be the same as _cultureName on Silverlight since the OS knows
-        ////              how to do the sorting. However in the desktop, when we call the sorting dll, it doesn't
-        ////              know how to resolve custom locale names to sort ids so we have to have already resolved this.
-        ////      
+        /*    _cultureName is the name of the creating culture.
+              _cultureData is the data that backs this class.
+              _textInfoName is the actual name of the textInfo (from cultureData.STEXTINFO)
+                      In the desktop, when we call the sorting dll, it doesn't
+                      know how to resolve custom locle names to sort ids so we have to have already resolved this.
+        */
 
-        [OptionalField(VersionAdded = 3)]
         private String _cultureName;      // Name of the culture that created this text info
-        [NonSerialized]
         private CultureData _cultureData;      // Data record for the culture that made us, not for this textinfo
-        [NonSerialized]
         private String _textInfoName;     // Name of the text info we're using (ie: _cultureData.STEXTINFO)
-        [NonSerialized]
         private Tristate _isAsciiCasingSameAsInvariant = Tristate.NotInitialized;
 
         // _invariantMode is defined for the perf reason as accessing the instance field is faster than access the static property GlobalizationMode.Invariant
-        [NonSerialized] 
         private readonly bool _invariantMode = GlobalizationMode.Invariant;
 
         // Invariant text info

--- a/src/mscorlib/src/System/IO/MemoryStream.cs
+++ b/src/mscorlib/src/System/IO/MemoryStream.cs
@@ -49,7 +49,6 @@ namespace System.IO
         private bool _exposable;   // Whether the array can be returned to the user.
         private bool _isOpen;      // Is this stream open or closed?
 
-        [NonSerialized]
         private Task<int> _lastReadTask; // The last successful task returned from ReadAsync
 
         private const int MemStreamMaxLength = Int32.MaxValue;

--- a/src/mscorlib/src/System/IO/Stream.cs
+++ b/src/mscorlib/src/System/IO/Stream.cs
@@ -41,9 +41,7 @@ namespace System.IO
 
         // To implement Async IO operations on streams that don't support async IO
 
-        [NonSerialized]
         private ReadWriteTask _activeReadWriteTask;
-        [NonSerialized]
         private SemaphoreSlim _asyncActiveSemaphore;
 
         internal SemaphoreSlim EnsureAsyncActiveSemaphoreInitialized()

--- a/src/mscorlib/src/System/Reflection/Emit/ModuleBuilderData.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/ModuleBuilderData.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////
-// 
-
 using System;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
@@ -55,9 +51,7 @@ namespace System.Reflection.Emit
         internal String m_strFileName;
         internal bool m_fGlobalBeenCreated;
         internal bool m_fHasGlobal;
-        [NonSerialized]
         internal TypeBuilder m_globalTypeBuilder;
-        [NonSerialized]
         internal ModuleBuilder m_module;
 
         private int m_tkFile;
@@ -65,5 +59,5 @@ namespace System.Reflection.Emit
         internal const String MULTI_BYTE_VALUE_CLASS = "$ArrayType$";
         internal String m_strResourceFileName;
         internal byte[] m_resourceBytes;
-    } // class ModuleBuilderData
+    }
 }

--- a/src/mscorlib/src/System/Reflection/RuntimeParameterInfo.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimeParameterInfo.cs
@@ -118,20 +118,12 @@ namespace System.Reflection
         #endregion
 
         #region Private Data Members
-        // These are new in Whidbey, so we cannot serialize them directly or we break backwards compatibility.
-        [NonSerialized]
         private int m_tkParamDef;
-        [NonSerialized]
         private MetadataImport m_scope;
-        [NonSerialized]
         private Signature m_signature;
-        [NonSerialized]
         private volatile bool m_nameIsCached = false;
-        [NonSerialized]
         private readonly bool m_noMetadata = false;
-        [NonSerialized]
         private bool m_noDefaultValue = false;
-        [NonSerialized]
         private MethodBase m_originalMember = null;
         #endregion
 

--- a/src/mscorlib/src/System/Resources/ResourceSet.cs
+++ b/src/mscorlib/src/System/Resources/ResourceSet.cs
@@ -13,16 +13,10 @@
 ** 
 ===========================================================*/
 
-using System;
 using System.Collections;
 using System.IO;
-using System.Globalization;
-using System.Runtime.InteropServices;
 using System.Reflection;
-using System.Runtime.Serialization;
-using System.Runtime.Versioning;
 using System.Diagnostics.Contracts;
-using System.Collections.Generic;
 
 namespace System.Resources
 {
@@ -34,7 +28,7 @@ namespace System.Resources
     //
     public class ResourceSet : IDisposable, IEnumerable
     {
-        [NonSerialized] protected IResourceReader Reader;
+        protected IResourceReader Reader;
         internal Hashtable Table;
 
         private Hashtable _caseInsensitiveTable;  // For case-insensitive lookups.


### PR DESCRIPTION
Not sure about:
- https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/Diagnostics/Stacktrace.cs If I remove the serialization methods, `rgMethodHandle` will never be set but its value is used in `GetMethodBase(int)`. So is the whole StackFrameHelper type maybe tied to serialization?

Also did some other misc code cleanup / comment cleanup for serialization