### PR TITLE
Fix Region DisplayName

### DIFF
--- a/src/mscorlib/src/System/Globalization/CultureData.Windows.cs
+++ b/src/mscorlib/src/System/Globalization/CultureData.Windows.cs
@@ -326,20 +326,14 @@ namespace System.Globalization
 #if ENABLE_WINRT
             return WinRTInterop.Callbacks.GetRegionDisplayName(isoCountryCode);
 #else
-            // Usually the UI culture shouldn't be different than what we got from WinRT except
-            // if DefaultThreadCurrentUICulture was set
-            CultureInfo ci;
-
-            if (CultureInfo.DefaultThreadCurrentUICulture != null &&
-                ((ci = GetUserDefaultCulture()) != null) &&
-                !CultureInfo.DefaultThreadCurrentUICulture.Name.Equals(ci.Name))
-            {
-                return SNATIVECOUNTRY;
-            }
-            else
+            // If the current UI culture matching the OS UI language, we'll get the display name from the OS. 
+            // otherwise, we use the native name as we don't carry resources for the region display names anyway.
+            if (CultureInfo.CurrentUICulture.Name.Equals(CultureInfo.UserDefaultUICulture.Name))
             {
                 return GetLocaleInfo(LocaleStringData.LocalizedCountryName);
             }
+
+            return SNATIVECOUNTRY;
 #endif // ENABLE_WINRT
         }
 

--- a/src/mscorlib/src/System/Globalization/CultureInfo.cs
+++ b/src/mscorlib/src/System/Globalization/CultureInfo.cs
@@ -458,15 +458,23 @@ namespace System.Globalization
                 return ci;
             }
 
-            // if s_userDefaultUICulture == null means CultureInfo statics didn't get initialized yet. this can happen if there early static 
-            // method get executed which eventually hit the cultureInfo code while CultureInfo statics didn’t get chance to initialize
-            if (s_userDefaultUICulture == null)
-            {
-                Init();
-            }
+            return UserDefaultUICulture;
+        }
 
-            Debug.Assert(s_userDefaultUICulture != null);
-            return s_userDefaultUICulture;
+        internal static CultureInfo UserDefaultUICulture
+        {
+            get
+            {
+                // if s_userDefaultUICulture == null means CultureInfo statics didn't get initialized yet. this can happen if there early static
+                // method get executed which eventually hit the cultureInfo code while CultureInfo statics didn’t get chance to initialize
+                if (s_userDefaultUICulture == null)
+                {
+                    Init();
+                }
+
+                Debug.Assert(s_userDefaultUICulture != null);
+                return s_userDefaultUICulture;
+            }
         }
 
         public static CultureInfo InstalledUICulture


### PR DESCRIPTION
This change fixes the logic when getting the display name from the OS and when we use the native name instead.

Fixes https://github.com/dotnet/corefx/issues/22964