### PR TITLE
Use logf() instead of JitDump()

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -3661,14 +3661,6 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
 
 #ifdef DEBUG
 
-void JitDump(const char* pcFormat, ...)
-{
-    va_list lst;
-    va_start(lst, pcFormat);
-    vflogf(jitstdout, pcFormat, lst);
-    va_end(lst);
-}
-
 bool Compiler::compJitHaltMethod()
 {
     /* This method returns true when we use an INS_BREAKPOINT to allow us to step into the generated native code */

--- a/src/jit/jit.h
+++ b/src/jit/jit.h
@@ -514,11 +514,10 @@ const bool dspGCtbls = true;
 #endif // !DEBUG
 
 #ifdef DEBUG
-void JitDump(const char* pcFormat, ...);
 #define JITDUMP(...)                                                                                                   \
     {                                                                                                                  \
         if (JitTls::GetCompiler()->verbose)                                                                            \
-            JitDump(__VA_ARGS__);                                                                                      \
+            logf(__VA_ARGS__);                                                                                         \
     }
 #define JITLOG(x)                                                                                                      \
     {                                                                                                                  \

--- a/src/jit/ssaconfig.h
+++ b/src/jit/ssaconfig.h
@@ -24,7 +24,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #ifdef DEBUG
 #define DBG_SSA_JITDUMP(...)                                                                                           \
     if (JitTls::GetCompiler()->verboseSsa)                                                                             \
-        logf(__VA_ARGS__)
+    logf(__VA_ARGS__)
 #else
 #define DBG_SSA_JITDUMP(...)
 #endif

--- a/src/jit/ssaconfig.h
+++ b/src/jit/ssaconfig.h
@@ -24,7 +24,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #ifdef DEBUG
 #define DBG_SSA_JITDUMP(...)                                                                                           \
     if (JitTls::GetCompiler()->verboseSsa)                                                                             \
-    JitDump(__VA_ARGS__)
+        logf(__VA_ARGS__)
 #else
 #define DBG_SSA_JITDUMP(...)
 #endif


### PR DESCRIPTION
This allows more JitDump output to get routed through the CLR
logging facility.