### PR TITLE
Refactor large Task NoOptimization bodies into own methods

### DIFF
--- a/src/mscorlib/src/System/Threading/Tasks/Task.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/Task.cs
@@ -4463,7 +4463,7 @@ namespace System.Threading.Tasks
 #if DEBUG
             bool waitResult =
 #endif
-            WaitAll(tasks, Timeout.Infinite);
+            WaitAllCore(tasks, Timeout.Infinite, default(CancellationToken));
 
 #if DEBUG
             Debug.Assert(waitResult, "expected wait to succeed");
@@ -4508,7 +4508,7 @@ namespace System.Threading.Tasks
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.timeout);
             }
 
-            return WaitAll(tasks, (int)totalMilliseconds);
+            return WaitAllCore(tasks, (int)totalMilliseconds, default(CancellationToken));
         }
 
         /// <summary>
@@ -4540,7 +4540,7 @@ namespace System.Threading.Tasks
         [MethodImpl(MethodImplOptions.NoOptimization)]  // this is needed for the parallel debugger
         public static bool WaitAll(Task[] tasks, int millisecondsTimeout)
         {
-            return WaitAll(tasks, millisecondsTimeout, default(CancellationToken));
+            return WaitAllCore(tasks, millisecondsTimeout, default(CancellationToken));
         }
 
         /// <summary>
@@ -4572,7 +4572,7 @@ namespace System.Threading.Tasks
         [MethodImpl(MethodImplOptions.NoOptimization)]  // this is needed for the parallel debugger
         public static void WaitAll(Task[] tasks, CancellationToken cancellationToken)
         {
-            WaitAll(tasks, Timeout.Infinite, cancellationToken);
+            WaitAllCore(tasks, Timeout.Infinite, cancellationToken);
         }
 
         /// <summary>
@@ -4857,7 +4857,7 @@ namespace System.Threading.Tasks
         [MethodImpl(MethodImplOptions.NoOptimization)]  // this is needed for the parallel debugger
         public static int WaitAny(params Task[] tasks)
         {
-            int waitResult = WaitAny(tasks, Timeout.Infinite);
+            int waitResult = WaitAnyCore(tasks, Timeout.Infinite, default(CancellationToken));
             Debug.Assert(tasks.Length == 0 || waitResult != -1, "expected wait to succeed");
             return waitResult;
         }
@@ -4896,7 +4896,7 @@ namespace System.Threading.Tasks
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.timeout);
             }
 
-            return WaitAny(tasks, (int)totalMilliseconds);
+            return WaitAnyCore(tasks, (int)totalMilliseconds, default(CancellationToken));
         }
 
         /// <summary>
@@ -4923,7 +4923,7 @@ namespace System.Threading.Tasks
         [MethodImpl(MethodImplOptions.NoOptimization)]  // this is needed for the parallel debugger
         public static int WaitAny(Task[] tasks, CancellationToken cancellationToken)
         {
-            return WaitAny(tasks, Timeout.Infinite, cancellationToken);
+            return WaitAnyCore(tasks, Timeout.Infinite, cancellationToken);
         }
 
         /// <summary>
@@ -4953,7 +4953,7 @@ namespace System.Threading.Tasks
         [MethodImpl(MethodImplOptions.NoOptimization)]  // this is needed for the parallel debugger
         public static int WaitAny(Task[] tasks, int millisecondsTimeout)
         {
-            return WaitAny(tasks, millisecondsTimeout, default(CancellationToken));
+            return WaitAnyCore(tasks, millisecondsTimeout, default(CancellationToken));
         }
 
         /// <summary>

--- a/src/mscorlib/src/System/Threading/Tasks/Task.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/Task.cs
@@ -2831,7 +2831,12 @@ namespace System.Threading.Tasks
         /// the current context is known or cached.
         /// </summary>
         [MethodImpl(MethodImplOptions.NoOptimization)]  // this is needed for the parallel debugger
-        internal bool InternalWait(int millisecondsTimeout, CancellationToken cancellationToken)
+        internal bool InternalWait(int millisecondsTimeout, CancellationToken cancellationToken) =>
+            InternalWaitCore(millisecondsTimeout, cancellationToken);
+
+        // Separated out to allow it to be optimized (caller is marked NoOptimization for VS parallel debugger
+        // to be able to see the method on the stack and inspect arguments).
+        private bool InternalWaitCore(int millisecondsTimeout, CancellationToken cancellationToken)
         {
             // ETW event for Task Wait Begin
             var etwLog = TplEtwProvider.Log;
@@ -4605,7 +4610,12 @@ namespace System.Threading.Tasks
         /// The <paramref name="cancellationToken"/> was canceled.
         /// </exception>
         [MethodImpl(MethodImplOptions.NoOptimization)]  // this is needed for the parallel debugger
-        public static bool WaitAll(Task[] tasks, int millisecondsTimeout, CancellationToken cancellationToken)
+        public static bool WaitAll(Task[] tasks, int millisecondsTimeout, CancellationToken cancellationToken) =>
+            WaitAllCore(tasks, millisecondsTimeout, cancellationToken);
+
+        // Separated out to allow it to be optimized (caller is marked NoOptimization for VS parallel debugger
+        // to be able to see the method on the stack and inspect arguments).
+        private static bool WaitAllCore(Task[] tasks, int millisecondsTimeout, CancellationToken cancellationToken)
         {
             if (tasks == null)
             {
@@ -4977,7 +4987,12 @@ namespace System.Threading.Tasks
         /// The <paramref name="cancellationToken"/> was canceled.
         /// </exception>
         [MethodImpl(MethodImplOptions.NoOptimization)]  // this is needed for the parallel debugger
-        public static int WaitAny(Task[] tasks, int millisecondsTimeout, CancellationToken cancellationToken)
+        public static int WaitAny(Task[] tasks, int millisecondsTimeout, CancellationToken cancellationToken) =>
+            WaitAnyCore(tasks, millisecondsTimeout, cancellationToken);
+
+        // Separated out to allow it to be optimized (caller is marked NoOptimization for VS parallel debugger
+        // to be able to inspect arguments).
+        private static int WaitAnyCore(Task[] tasks, int millisecondsTimeout, CancellationToken cancellationToken)
         {
             if (tasks == null)
             {


### PR DESCRIPTION
The methods apparently need to be marked as [MethodImpl(MethodImplOptions.NoOptimization)] to aid the Visual Studio debugger in picking out these methods and their arguments, but it's causing a few chunky functions to have no optimizations on the whole body.  Separating these bodies out.

cc: @gregg-miskelly, @AndyAyersMS 