### PR TITLE
Add fail-fast check after lvaGrabTemp in impImportBlockCode

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -12730,6 +12730,8 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     lclNum = lvaGrabTemp(true DEBUGARG("NewObj constructor temp"));
                     if (compDonotInline())
                     {
+                        // Fail fast if lvaGrabTemp fails with CALLSITE_TOO_MANY_LOCALS.
+                        assert(compInlineResult->GetObservation() == InlineObservation::CALLSITE_TOO_MANY_LOCALS);
                         return;
                     }
 

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -12728,6 +12728,10 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
                     /* get a temporary for the new object */
                     lclNum = lvaGrabTemp(true DEBUGARG("NewObj constructor temp"));
+                    if (compDonotInline())
+                    {
+                        return;
+                    }
 
                     // In the value class case we only need clsHnd for size calcs.
                     //


### PR DESCRIPTION
Fix #13231.
PTAL @dotnet/jit-contrib 