### PR TITLE
Add enforcepgo for release Windows_NT default release build

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1442,6 +1442,11 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                         buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${arch} ${buildOpts}"
                     }
 
+                    // If it is a release build for windows, ensure PGO is used, else fail the build
+                    if ((lowerConfiguration == 'release') && (scenario == 'default')) {
+                        buildOpts += 'enforcepgo'
+                    }
+
                     // For Pri 1 tests, we must shorten the output test binary path names.
                     // if __TestIntermediateDir is already set, build-test.cmd will
                     // output test binaries to that directory. If it is not set, the

--- a/netci.groovy
+++ b/netci.groovy
@@ -1443,8 +1443,8 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                     }
 
                     // If it is a release build for windows, ensure PGO is used, else fail the build
-                    if ((lowerConfiguration == 'release') && (scenario == 'default') && (architecture != 'x86lb')) {
-                        buildOpts += 'enforcepgo'
+                    if ((lowerConfiguration == 'release') && (scenario in Constants.basicScenarios) && (architecture != 'x86lb')) {
+                        buildOpts += ' enforcepgo'
                     }
 
                     // For Pri 1 tests, we must shorten the output test binary path names.

--- a/netci.groovy
+++ b/netci.groovy
@@ -1443,7 +1443,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                     }
 
                     // If it is a release build for windows, ensure PGO is used, else fail the build
-                    if ((lowerConfiguration == 'release') && (scenario == 'default')) {
+                    if ((lowerConfiguration == 'release') && (scenario == 'default') && (architecture != 'x86lb')) {
                         buildOpts += 'enforcepgo'
                     }
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -1431,6 +1431,11 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                         buildCommands += "tests\\scripts\\build_illink.cmd clone ${arch}"
                     }
 
+                    // If it is a release build for windows, ensure PGO is used, else fail the build
+                    if ((lowerConfiguration == 'release') && (scenario in Constants.basicScenarios) && (architecture != 'x86lb')) {
+                        buildOpts += ' enforcepgo'
+                    }
+
                     if (Constants.jitStressModeScenarios.containsKey(scenario) ||
                             scenario == 'default' ||
                             scenario == 'r2r' ||
@@ -1440,11 +1445,6 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                             Constants.r2rJitStressScenarios.indexOf(scenario) != -1) {
                         buildOpts += enableCorefxTesting ? ' skiptests' : ''
                         buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${arch} ${buildOpts}"
-                    }
-
-                    // If it is a release build for windows, ensure PGO is used, else fail the build
-                    if ((lowerConfiguration == 'release') && (scenario in Constants.basicScenarios) && (architecture != 'x86lb')) {
-                        buildOpts += ' enforcepgo'
                     }
 
                     // For Pri 1 tests, we must shorten the output test binary path names.


### PR DESCRIPTION
This PR adds a step in the process for the windows release build scenario to enforce that PGO is used in compilation of coreclr.dll and clrjit.dll. The intention is to prevent merging any code which would break PGO

This is my first time looking at this system, so I'd like to confirm my change does what I expect. Mainly, what I am unsure of is whether or not I am correct to limit the additional of 'enforcepgo' to default scenario builds, or if I should add it to all release builds.

@jashook @mmitche I added you two because you are top contributors on this file recently, let me know if there is someone else I should ask to review this change instead

Follow-up to #13258 
Connect #12863 