### PR TITLE
Fix VSO 471670.

### DIFF
--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -731,6 +731,7 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, ArrayStack<G
             {
                 use.ReplaceWith(comp, node->gtGetOp1());
                 BlockRange().Remove(node);
+                node = node->gtGetOp1();
             }
             break;
 

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_471670/DevDiv_471670.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_471670/DevDiv_471670.il
@@ -1,0 +1,107 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib{}
+.assembly ILGEN_MODULE{}
+.class ILGEN_CLASS
+{
+    .method static bool ILGEN_METHOD(float64, char, unsigned int32)
+    {
+        .maxstack  65535
+        .locals init (float64, native unsigned int, unsigned int16, native int, unsigned int16, unsigned int8, int64, float64)
+
+        ldarg.s 0x00
+        conv.ovf.u2
+        ldc.i8 0x5674a8efc99eac21
+        pop
+        ldloc.s 0x02
+        conv.ovf.u1.un
+        conv.ovf.u8.un
+        conv.u8
+        conv.r4
+        pop
+        ldarg.s 0x02
+        bgt IL_0037
+        ldloc.s 0x06
+        conv.ovf.u8.un
+        ldloc 0x0006
+        clt.un
+        neg
+        brtrue IL_002b
+        nop
+        
+    IL_002b:
+        nop
+        ldloc 0x0003
+        ldloc 0x0005
+        clt
+        pop
+
+    IL_0037:
+        ldloc.s 0x04
+        brtrue IL_003f
+        nop
+
+    IL_003f:
+        ldloc 0x0003
+        conv.ovf.i2.un
+        ldarg.s 0x01
+        conv.r8
+        ldloc.s 0x00
+        ckfinite
+        mul
+        conv.r4
+        ldloc.s 0x00
+        conv.ovf.u8.un
+        conv.r.un
+        clt
+        conv.i8
+        conv.i4
+        add.ovf
+        starg.s 0x02
+        ldc.i8 0x953f9661d4ec7f53
+        neg
+        neg
+        ldloc.s 0x06
+        or
+        neg
+        conv.r.un
+        ldc.i4 0x2f6100eb
+        conv.r.un
+        neg
+        stloc 0x0000
+        ldarg 0x0000
+        neg
+        neg
+        ldloc.s 0x07
+        neg
+        conv.r.un
+        add
+        cgt
+        ret
+    }
+
+    .method static int32 Main()
+    {
+        .entrypoint
+
+        .try
+        {
+            ldc.r8 0
+            ldc.i4 0
+            dup
+            call bool ILGEN_CLASS::ILGEN_METHOD(float64, char, unsigned int32)
+            pop
+            leave.s done
+        }
+        catch [mscorlib]System.Exception
+        {
+            leave.s done
+        }
+
+    done:
+        ldc.i4 100
+        ret
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_471670/DevDiv_471670.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_471670/DevDiv_471670.ilproj
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_471670.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
If we remove a NOP during rationalize that is unused, we need to ensure
that its operand is also marked as an unused value.