### PR TITLE
Fix VSO 475427.

### DIFF
--- a/src/jit/regalloc.cpp
+++ b/src/jit/regalloc.cpp
@@ -6469,7 +6469,7 @@ void Compiler::rpPredictRegUse()
             allAcceptableRegs &= ~RBM_OPT_RSVD;
             if ((regUsed & RBM_OPT_RSVD) != 0)
             {
-                mustPredict = true;
+                mustPredict              = true;
                 rpBestRecordedPrediction = nullptr;
             }
         }

--- a/src/jit/regalloc.cpp
+++ b/src/jit/regalloc.cpp
@@ -6462,12 +6462,16 @@ void Compiler::rpPredictRegUse()
 
 #ifdef _TARGET_ARM_
         // The spill count may be now high enough that we now need to reserve r10. If this is the case, we'll need to
-        // reserve r10, and if it was used, repredict.
+        // reserve r10, and if it was used, throw out the last prediction and repredict.
         if (((codeGen->regSet.rsMaskResvd & RBM_OPT_RSVD) == 0) && compRsvdRegCheck(REGALLOC_FRAME_LAYOUT))
         {
             codeGen->regSet.rsMaskResvd |= RBM_OPT_RSVD;
             allAcceptableRegs &= ~RBM_OPT_RSVD;
-            mustPredict = (regUsed & RBM_OPT_RSVD) != 0;
+            if ((regUsed & RBM_OPT_RSVD) != 0)
+            {
+                mustPredict = true;
+                rpBestRecordedPrediction = nullptr;
+            }
         }
 #endif
 


### PR DESCRIPTION
In addition to repredicting if the frame size is large enough to require
that we reserve `r10`, we also need to throw out any previous
prediction. If we do not, we may decide to reuse it if uses less stack
space than the reprediction.