### PR TITLE
Fix VSO 469210.

### DIFF
--- a/src/jit/instr.cpp
+++ b/src/jit/instr.cpp
@@ -977,7 +977,7 @@ void CodeGen::sched_AM(instruction ins,
         // Setup regVal
         //
 
-        regVal = regSet.rsPickReg(RBM_ALLINT & ~avoidMask);
+        regVal = regSet.rsPickFreeReg(RBM_ALLINT & ~avoidMask);
         regTracker.rsTrackRegTrash(regVal);
         avoidMask |= genRegMask(regVal);
         var_types load_store_type;


### PR DESCRIPTION
This bug arises when ARM32/Legacy backend generates an RMW operator
whose source operand is an addressing mode. In that case, `sched_AM`
needs to choose a register to use for the value that will be loaded from
memory. Originally it was doing so via `rsPickReg`, but that function
may spill registers that are in use, including the register that is
supposed to be modified by the RMW operator. All other points in
`sched_AM` that need to allocate a register use `rsPickFreeReg` in order
to avoid issues like this. This change updates the use of `rsPickReg` to
instead use `rsPickFreeReg`.