### PR TITLE
LinkBench: Fix Roslyn job

### DIFF
--- a/tests/src/performance/linkbench/linkbench.cs
+++ b/tests/src/performance/linkbench/linkbench.cs
@@ -384,7 +384,6 @@ namespace LinkBench
             Environment.SetEnvironmentVariable("LinkBenchRoot", LinkBenchRoot);
             Environment.SetEnvironmentVariable("__dotnet", LinkBenchRoot + "\\.Net\\dotnet.exe");
             Environment.SetEnvironmentVariable("__dotnet1", LinkBenchRoot + "\\.Net1\\dotnet.exe");
-            Environment.SetEnvironmentVariable("__dotnet2", LinkBenchRoot + "\\.Net2\\dotnet.exe");
 
             // Update the build files to facilitate the link step
             if (doSetup)

--- a/tests/src/performance/linkbench/scripts/build.cmd
+++ b/tests/src/performance/linkbench/scripts/build.cmd
@@ -132,11 +132,12 @@ cd ..
 
 REM Build CscCore
 call Restore.cmd
-cd src\Compilers\CSharp\CscCore
-call %__dotnet2% publish -c Release -r win7-x64
+REM Fetch the appropriate version of MSBuild to build and publish CscCore 
+for /f "delims=`" %%i in ('powershell -noprofile -executionPolicy RemoteSigned -command "& { . build\scripts\build-utils.ps1;Ensure-MSBuild }"') do set MSBUILD=%%i
+REM publish CscCore for win7-x64
+"%MSBUILD%" src\Compilers\CSharp\CscCore\CscCore.csproj /t:Publish /p:RuntimeIdentifier=win7-x64 /p:Configuration=Release /p:TreatWarningsAsErrors=true /warnaserror /nologo /nodeReuse:false /m 
 if errorlevel 1 set ExitCode=1&& echo Roslyn: publish failed 
 REM Published CscCore to Binaries\Release\Exes\CscCore\win7-x64\publish
-cd ..\..\..\..
 
 REM Create Linker Directory
 cd Binaries\Release\Exes\CscCore\win7-x64\

--- a/tests/src/performance/linkbench/scripts/clone.cmd
+++ b/tests/src/performance/linkbench/scripts/clone.cmd
@@ -17,7 +17,7 @@ popd
 exit /b %EXITCODE%
 
 :DotNet
-REM We clone three different versions of .Net CLI in order to cope with 
+REM We clone different versions of .Net CLI in order to cope with 
 REM different runtimes that the benchmarks target, and certain limitations 
 REM in the ILLink/CLI integration and packaging.
 REM
@@ -27,26 +27,16 @@ REM      We use this specific version instead of the latest available from
 REM      the master branch, because the latest CLI generates R2R images for 
 REM      system binaries, while ILLink cannot yet. We need pure MSIL images
 REM      in the unlinked version in order to be able to do a fair dir-size comparison.
-REM .Net2 => This is the latest CLI for .Net 2.0.0
-REM      Roslyn build needs the latest Roslyn 15.3 compilers which are only available   
-REM      with the latest CLI. But Roslyn targets netcoreapp v1, so the latest .Net CLI
-REM      does not output R2R images in this case.
 REM .Net1 => This is .Net CLI v 1.1.0
 REM      Since Roslyn targets netcoreapp v1, it cannot use the IlLink.Tasks package.
 REM      We use the ILLink package to get the linker and run it manually.
 REM      Since IlLink.exe from this package only runs on .Net v1
-REM
-REM HelloWorld, WebAPI, and MusicStore use .Net
-REM Roslyn uses .Net1 and .Net2
-REM CoreFX downloads its own .Net CLI in its build.
 
 powershell -noprofile -executionPolicy RemoteSigned wget  https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1 -OutFile dotnet-install.ps1
 if not exist %__dotnet%  mkdir .Net  && powershell -noprofile -executionPolicy RemoteSigned -file dotnet-install.ps1 -Channel master -InstallDir .Net -version 2.0.0-preview2-005905
 if not exist %__dotnet1% mkdir .Net1 && powershell -noprofile -executionPolicy RemoteSigned -file dotnet-install.ps1 -InstallDir .Net1
-if not exist %__dotnet2% mkdir .Net2 && powershell -noprofile -executionPolicy RemoteSigned -file dotnet-install.ps1 -Channel master -InstallDir .Net2
 if not exist %__dotnet% set EXITCODE=1&& echo DotNet not installed
 if not exist %__dotnet1% set EXITCODE=1&& echo DotNet.1 not installed
-if not exist %__dotnet2% set EXITCODE=1&& echo DotNet.2 not installed
 exit /b 
 
 :HelloWorld


### PR DESCRIPTION
This change fixes a build-break in the LinkBench job, because
of a failure in the Roslyn Build.
With this change, Roslyn Benchmark is built using MsBuild (similar to
Roslyn's Build.cmd) instead of directly calling dotnet publish.