### PR TITLE
Maintain sorted preds part 1 [WIP]

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4300,6 +4300,8 @@ public:
 
     void fgReplacePred(BasicBlock* block, BasicBlock* oldPred, BasicBlock* newPred);
 
+    void fgExpensiveSortedPredCheck();
+
     flowList* fgAddRefPred(BasicBlock* block,
                            BasicBlock* blockPred,
                            flowList*   oldEdge           = nullptr,


### PR DESCRIPTION
This adds asserts to enforce sorted pred lists and changes fgReplacePred
to correctly maintain sorted order when replacing a pred in the list.

**Note** there are other areas that will break the sorted order of the Pred list. Therefore, this change should not yet be merged. However, it is worth starting a review for what it already fixes.

ptal @BruceForstall @CarolEidt 
/cc @RussKeldorph