### PR TITLE
Increase timeout and log the result for a couple of WaitAny tests tha…

### DIFF
--- a/tests/src/baseservices/threading/waithandle/waitany/waitanyex2.cs
+++ b/tests/src/baseservices/threading/waithandle/waitany/waitanyex2.cs
@@ -36,8 +36,8 @@ class WaitAnyEx
         {
             Console.WriteLine("Waiting...");
             int i = WaitHandle.WaitAny(
-                new WaitHandle[]{myMutex, myMRE}, 5000);
-            Console.WriteLine("WaitAny did not throw AbandonedMutexException");
+                new WaitHandle[]{myMutex, myMRE}, 30000);
+            Console.WriteLine("WaitAny did not throw AbandonedMutexException. Result: {0}", i);
         }
         catch(AbandonedMutexException)
         {

--- a/tests/src/baseservices/threading/waithandle/waitany/waitanyex2a.cs
+++ b/tests/src/baseservices/threading/waithandle/waitany/waitanyex2a.cs
@@ -37,7 +37,7 @@ class WaitAnyEx
             Console.WriteLine("Waiting...");
             int i = WaitHandle.WaitAny(
                 new WaitHandle[]{myMutex, myMRE});
-            Console.WriteLine("WaitAny did not throw AbandonedMutexException");
+            Console.WriteLine("WaitAny did not throw AbandonedMutexException. Result: {0}", i);
         }
         catch(AbandonedMutexException)
         {


### PR DESCRIPTION
…t expect AbandonedMutexException

Close #10514

There are a whole bunch of such tests and they should be cleaned up / moved to CoreFX. Of the set, these two tests are the ones that fail in the CI most often for this reason. Added some logging to help figure out why they are failing. Once the issue is understood, the tests can be moved and cleaned up.