### PR TITLE
Fix issue #13161.

### DIFF
--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -19547,6 +19547,7 @@ regMaskTP CodeGen::genCodeForCall(GenTreeCall* call, bool valUsed)
                             {
                                 noway_assert(regSet.rsRegMaskCanGrab() & RBM_R2R_INDIRECT_PARAM);
                                 getEmitter()->emitIns_R_R(INS_mov, EA_PTRSIZE, REG_R2R_INDIRECT_PARAM, indCallReg);
+                                regTracker.rsTrackRegTrash(REG_R2R_INDIRECT_PARAM);
                             }
 #endif // FEATURE_READYTORUN_COMPILER
 

--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -633,7 +633,7 @@ RelativePath=readytorun\tests\mainv1\mainv1.cmd
 WorkingDir=readytorun\tests\mainv1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [ComparerCompare2.cmd_80]
@@ -85505,7 +85505,7 @@ RelativePath=readytorun\tests\mainv2\mainv2.cmd
 WorkingDir=readytorun\tests\mainv2
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1463.cmd_10690]


### PR DESCRIPTION
This issue was a crash when calling R2R-compiled code from JITted code
on Windows/ARM32. The caller had a live value in `r4` that was scribbled
over by the callee. This change adds the necessary call to
`regSet.rsTrackRegTrash` which ensures that `r4` is saved/restored in
the prolog/epilog when it is used for R2R indirect calls.