### PR TITLE
Enable RHEL6 official builds and tests in coreclr release/2.0.0

### DIFF
--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -27,7 +27,7 @@
           "Name": "DotNet-CoreClr-Trusted-Linux",
           "Parameters": {
             "DockerTag": "centos-6-783abde-20171304101322",
-            "Rid": "rhel6"
+            "Rid": "rhel.6"
           },
           "ReportingParameters": {
             "OperatingSystem": "RedHat6",
@@ -444,7 +444,7 @@
           "Parameters": {
             "HelixJobType": "test/functional/cli/",
             "TargetsWindows": "false",
-            "Rid": "rhel6-x64",
+            "Rid": "rhel.6-x64",
             "TargetQueues": "redhat.69.amd64",
             "TestContainerSuffix": "rhel6",
             "TargetsNonWindowsArg": "TargetsNonWindows "
@@ -461,7 +461,7 @@
           "Parameters": {
             "HelixJobType": "test/functional/r2r/cli/",
             "TargetsWindows": "false",
-            "Rid": "rhel6-x64",
+            "Rid": "rhel.6-x64",
             "TargetQueues": "redhat.69.amd64",
             "TestContainerSuffix": "rhel6-r2r",
             "CrossgenArg": "Crossgen ",

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -27,7 +27,7 @@
           "Name": "DotNet-CoreClr-Trusted-Linux",
           "Parameters": {
             "DockerTag": "centos-6-783abde-20171304101322",
-            "Rid": "linux"
+            "Rid": "rhel6"
           },
           "ReportingParameters": {
             "OperatingSystem": "RedHat6",
@@ -444,9 +444,9 @@
           "Parameters": {
             "HelixJobType": "test/functional/cli/",
             "TargetsWindows": "false",
-            "Rid": "linux-x64",
+            "Rid": "rhel6-x64",
             "TargetQueues": "redhat.69.amd64",
-            "TestContainerSuffix": "linux",
+            "TestContainerSuffix": "rhel6",
             "TargetsNonWindowsArg": "TargetsNonWindows "
           },
           "ReportingParameters": {
@@ -461,9 +461,9 @@
           "Parameters": {
             "HelixJobType": "test/functional/r2r/cli/",
             "TargetsWindows": "false",
-            "Rid": "linux-x64",
+            "Rid": "rhel6-x64",
             "TargetQueues": "redhat.69.amd64",
-            "TestContainerSuffix": "linux-r2r",
+            "TestContainerSuffix": "rhel6-r2r",
             "CrossgenArg": "Crossgen ",
             "TargetsNonWindowsArg": "TargetsNonWindows "
           },

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -24,6 +24,19 @@
           }
         },
         {
+          "Name": "DotNet-CoreClr-Trusted-Linux",
+          "Parameters": {
+            "DockerTag": "centos-6-783abde-20171304101322",
+            "Rid": "linux"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "RedHat6",
+            "Type": "build/product/",
+            "Architecture": "x64",
+            "PB_BuildType": null
+          }
+        },		
+        {
           "Name": "DotNet-CoreClr-Trusted-Mac",
           "Parameters": {
             "Rid": "osx"
@@ -425,7 +438,42 @@
             "Type": "build/product/",
             "PB_BuildType": "Release"
           }
-        }
+        },
+        {
+          "Name": "Dotnet-CoreClr-Trusted-BuildTests",
+          "Parameters": {
+            "HelixJobType": "test/functional/cli/",
+            "TargetsWindows": "false",
+            "Rid": "linux-x64",
+            "TargetQueues": "redhat.69.amd64",
+            "TestContainerSuffix": "linux",
+            "TargetsNonWindowsArg": "TargetsNonWindows "
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "RedHat6",
+            "SubType":  "Build-Tests",
+            "Type": "build/product/",
+            "PB_BuildType": "Release"
+          }
+        },
+        {
+          "Name": "Dotnet-CoreClr-Trusted-BuildTests",
+          "Parameters": {
+            "HelixJobType": "test/functional/r2r/cli/",
+            "TargetsWindows": "false",
+            "Rid": "linux-x64",
+            "TargetQueues": "redhat.69.amd64",
+            "TestContainerSuffix": "linux-r2r",
+            "CrossgenArg": "Crossgen ",
+            "TargetsNonWindowsArg": "TargetsNonWindows "
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "RedHat6",
+            "SubType":  "Build-Tests-R2R",
+            "Type": "build/product/",
+            "PB_BuildType": "Release"
+          }
+        }		
       ],
       "DependsOn": [
         "Trusted-All-Release"


### PR DESCRIPTION
Enable RHEL6 official builds and tests in coreclr release/2.0.0.

This is the coreclr effort to resolve https://github.com/dotnet/core-eng/issues/1427.

For the reference, the corefx part of this change was merged into corefx release/2.0.0 as
https://github.com/dotnet/corefx/commit/204cdd7479afdf46b118fd3bd70e5c47df419a95