### PR TITLE
Fix lclVar move node type inserted on lsra resolve phase 

### DIFF
--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -735,7 +735,7 @@ void CodeGen::genSpillVar(GenTreePtr tree)
             restoreRegVar = true;
         }
 
-        instruction storeIns = ins_Store(tree->TypeGet(), compiler->isSIMDTypeLocalAligned(varNum));
+        instruction storeIns = ins_Store(lclTyp, compiler->isSIMDTypeLocalAligned(varNum));
 #if CPU_LONG_USES_REGPAIR
         if (varTypeIsMultiReg(tree))
         {

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -9209,11 +9209,6 @@ void LinearScan::insertMove(
     GenTreePtr src              = compiler->gtNewLclvNode(lclNum, varDsc->TypeGet());
     src->gtLsraInfo.isLsraAdded = true;
 
-    if (varDsc->lvNormalizeOnStore())
-    {
-        src->gtType = TYP_INT;
-    }
-
     // There are three cases we need to handle:
     // - We are loading a lclVar from the stack.
     // - We are storing a lclVar to the stack.

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -9209,6 +9209,11 @@ void LinearScan::insertMove(
     GenTreePtr src              = compiler->gtNewLclvNode(lclNum, varDsc->TypeGet());
     src->gtLsraInfo.isLsraAdded = true;
 
+    if (varDsc->lvNormalizeOnStore())
+    {
+        src->gtType = TYP_INT;
+    }
+
     // There are three cases we need to handle:
     // - We are loading a lclVar from the stack.
     // - We are storing a lclVar to the stack.


### PR DESCRIPTION
When we try to insert lclVal move node (load, store) on lsra resolve phase,
fix type as TYP_INT if size is smaller than TYP_INT.

Related issue: #13156