### PR TITLE
[RyuJIT/armel] Cleanup with OperIsMultiRegOp()

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -4090,7 +4090,7 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
         }
 #ifdef ARM_SOFTFP
         // If oper is GT_PUTARG_REG, set bits in useCandidates must be in sequential order.
-        else if (tree->OperGet() == GT_PUTARG_REG || tree->OperGet() == GT_COPY)
+        else if (tree->OperIsMultiRegOp())
         {
             useCandidates = genFindLowestReg(remainingUseCandidates);
             remainingUseCandidates &= ~useCandidates;


### PR DESCRIPTION
Use OperIsMultiRegOp() instead of separated conditions

cc: @dotnet/arm32-contrib 