### PR TITLE
Fix the race condition in mutex test using another manual reset event

### DIFF
--- a/tests/src/baseservices/threading/mutex/openexisting/openmutexpos4.cs
+++ b/tests/src/baseservices/threading/mutex/openexisting/openmutexpos4.cs
@@ -41,6 +41,7 @@ public class Test
 
         Mutex mutex = new Mutex(true, mutexName, out exists);
         
+        reuseBeforeReleaseEvent.Set();
         if (exists)
         {
             Console.WriteLine("Error, created new mutex!");
@@ -48,7 +49,6 @@ public class Test
         }
         else
         {
-            reuseBeforeReleaseEvent.Set();
             mutex.WaitOne();
         }
 

--- a/tests/src/baseservices/threading/mutex/openexisting/openmutexpos4.cs
+++ b/tests/src/baseservices/threading/mutex/openexisting/openmutexpos4.cs
@@ -13,6 +13,7 @@ public class Test
     const string mutexName = "MySharedMutex";
     static ManualResetEvent manualEvent = new ManualResetEvent(false);
     static ManualResetEvent exitEvent = new ManualResetEvent(false);
+    static ManualResetEvent reuseBeforeReleaseEvent = new ManualResetEvent(false);
     int success = 100;
 
 
@@ -26,10 +27,10 @@ public class Test
         Console.WriteLine("Mutex created");
         
         manualEvent.Set();
+        reuseBeforeReleaseEvent.WaitOne();
         mutex.ReleaseMutex();
         
         exitEvent.WaitOne();
-        GC.KeepAlive(mutex);
     }
 
     public void ReuseMutexThread()
@@ -47,6 +48,7 @@ public class Test
         }
         else
         {
+            reuseBeforeReleaseEvent.Set();
             mutex.WaitOne();
         }
 


### PR DESCRIPTION
Related to this PR: https://github.com/dotnet/coreclr/pull/5713

Fix the race condition by using another manual reset event so that the mutex is only released after the boolean `exists` is set in the ReuseMutexThread(). We force t1 to wait before calling ReleaseMutex.

This seems to me like a cleaner solution than the GC.KeepAlive().
Thoughts?

cc @sergiy-k, @RussKeldorph, @wtgodbe 