### PR TITLE
[RyuJIT/armel] Introduce GetRegCount() for MultiRegOp

### DIFF
--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -1037,7 +1037,7 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
         else if (unspillTree->OperIsMultiRegOp())
         {
             GenTreeMultiRegOp* multiReg = unspillTree->AsMultiRegOp();
-            unsigned           regCount = multiReg->gtOtherReg == REG_NA ? 1 : 2;
+            unsigned           regCount = multiReg->GetRegCount();
 
             // In case of split struct argument node, GTF_SPILLED flag on it indicates that
             // one or more of its result regs are spilled.  Call node needs to be
@@ -1685,7 +1685,7 @@ void CodeGen::genProduceReg(GenTree* tree)
             else if (tree->OperIsMultiRegOp())
             {
                 GenTreeMultiRegOp* multiReg = tree->AsMultiRegOp();
-                unsigned           regCount = multiReg->gtOtherReg == REG_NA ? 1 : 2;
+                unsigned           regCount = multiReg->GetRegCount();
 
                 for (unsigned i = 0; i < regCount; ++i)
                 {

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -3921,6 +3921,15 @@ struct GenTreeMultiRegOp : public GenTreeOp
         ClearOtherRegFlags();
     }
 
+    unsigned GetRegCount() const
+    {
+        if (gtRegNum == REG_NA || gtRegNum == REG_STK)
+        {
+            return 0;
+        }
+        return (gtOtherReg == REG_NA || gtOtherReg == REG_STK) ? 1 : 2;
+    }
+
     //---------------------------------------------------------------------------
     // GetRegNumByIdx: get ith register allocated to this struct argument.
     //


### PR DESCRIPTION
Abstract getting reg count with method GetRegCount()
Added the case when the reg count is 0.