### PR TITLE
Lay out loop bodies contiguously

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5360,7 +5360,7 @@ protected:
                                 GenTreePtr* ppTest,
                                 GenTreePtr* ppIncr);
 
-    void optRecordLoop(BasicBlock*   head,
+    bool optRecordLoop(BasicBlock*   head,
                        BasicBlock*   first,
                        BasicBlock*   top,
                        BasicBlock*   entry,

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4115,11 +4115,11 @@ public:
     void vnPrint(ValueNum vn, unsigned level);
 #endif
 
+    bool fgDominate(BasicBlock* b1, BasicBlock* b2); // Return true if b1 dominates b2
+
     // Dominator computation member functions
     // Not exposed outside Compiler
 protected:
-    bool fgDominate(BasicBlock* b1, BasicBlock* b2); // Return true if b1 dominates b2
-
     bool fgReachable(BasicBlock* b1, BasicBlock* b2); // Returns true if block b1 can reach block b2
 
     void fgComputeDoms(); // Computes the immediate dominators for each basic block in the
@@ -5317,6 +5317,14 @@ public:
     LoopDsc       optLoopTable[MAX_LOOP_NUM]; // loop descriptor table
     unsigned char optLoopCount;               // number of tracked loops
 
+    bool optRecordLoop(BasicBlock*   head,
+                       BasicBlock*   first,
+                       BasicBlock*   top,
+                       BasicBlock*   entry,
+                       BasicBlock*   bottom,
+                       BasicBlock*   exit,
+                       unsigned char exitCnt);
+
 protected:
     unsigned optCallCount;         // number of calls made in the method
     unsigned optIndirectCallCount; // number of virtual, interface and indirect calls made in the method
@@ -5359,14 +5367,6 @@ protected:
                                 GenTreePtr* ppInit,
                                 GenTreePtr* ppTest,
                                 GenTreePtr* ppIncr);
-
-    bool optRecordLoop(BasicBlock*   head,
-                       BasicBlock*   first,
-                       BasicBlock*   top,
-                       BasicBlock*   entry,
-                       BasicBlock*   bottom,
-                       BasicBlock*   exit,
-                       unsigned char exitCnt);
 
     void optFindNaturalLoops();
 

--- a/tests/src/JIT/Performance/CodeQuality/Layout/SearchLoops.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Layout/SearchLoops.cs
@@ -1,0 +1,120 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Xunit.Performance;
+using Microsoft.Xunit.Performance.Api;
+using System;
+using System.Reflection;
+using Xunit;
+
+[assembly: OptimizeForBenchmarks]
+
+// Test code taken directly from GitHub issue #9692 (https://github.com/dotnet/coreclr/issues/9692)
+// Laying the loop's early return path in-line can cost 30% on this micro-benchmark.
+
+namespace Layout
+{
+    public unsafe class SearchLoops
+    {
+        public static int Main(string[] args)
+        {
+            // Make sure equal strings compare as such
+            if (!LoopReturn("hello", "hello") || !LoopGoto("goodbye", "goodbye"))
+            {
+                return -1;
+            }
+
+            // Make sure not-equal strings compare as such
+            if (LoopReturn("hello", "goodbye") || LoopGoto("goodbye", "hello"))
+            {
+                return -1;
+            }
+
+            // Success
+            return 100;
+        }
+
+        public int length = 100;
+
+        private string test1;
+        private string test2;
+
+        public SearchLoops()
+        {
+            test1 = new string('A', length);
+            test2 = new string('A', length);
+        }
+
+        [Benchmark]
+        public void LoopReturn()
+        {
+            Benchmark.Iterate(() => LoopReturn(test1, test2));
+        }
+
+        [Benchmark]
+        public void LoopGoto()
+        {
+            Benchmark.Iterate(() => LoopGoto(test1, test2));
+        }
+
+        // Variant with code written naturally -- need JIT to lay this out
+        // with return path out of loop for best performance.
+        public static bool LoopReturn(String strA, String strB)
+        {
+            int length = strA.Length;
+
+            fixed (char* ap = strA) fixed (char* bp = strB)
+            {
+                char* a = ap;
+                char* b = bp;
+
+                while (length != 0)
+                {
+                    int charA = *a;
+                    int charB = *b;
+
+                    if (charA != charB)
+                        return false;  // placement of prolog for this return is the issue
+
+                    a++;
+                    b++;
+                    length--;
+                }
+
+                return true;
+            }
+        }
+
+        // Variant with code written awkwardly but which acheives the desired
+        // performance if JIT simply lays out code in source order.
+        public static bool LoopGoto(String strA, String strB)
+        {
+            int length = strA.Length;
+
+            fixed (char* ap = strA) fixed (char* bp = strB)
+            {
+                char* a = ap;
+                char* b = bp;
+
+                while (length != 0)
+                {
+                    int charA = *a;
+                    int charB = *b;
+
+                    if (charA != charB)
+                        goto ReturnFalse;  // placement of prolog for this return is the issue
+
+                    a++;
+                    b++;
+                    length--;
+                }
+
+                return true;
+
+                ReturnFalse:
+                return false;
+            }
+        }
+    }
+}

--- a/tests/src/JIT/Performance/CodeQuality/Layout/SearchLoops.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/Layout/SearchLoops.csproj
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{C1BFD48A-A83F-4767-8EB2-3E2C50906681}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="SearchLoops.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+  <PropertyGroup>
+    <ProjectAssetsFile>$(JitPackagesConfigFileDirectory)benchmark\obj\project.assets.json</ProjectAssetsFile>
+  </PropertyGroup>
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_9692/GitHub_9692.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_9692/GitHub_9692.cs
@@ -1,0 +1,411 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+// Tests for moving exits out of loops and ensuring that doing so doesn't
+// violate EH clause nesting rules.
+
+namespace N
+{
+    class C
+    {
+        // Simple search loop: should move the "return true" out of the loop
+        static bool Simple(int[] values)
+        {
+            foreach (int value in values)
+            {
+                if (value == 5)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // Nested loop with return that exits both: should move exit out of both.
+        static bool Nested(int[][] values)
+        {
+            foreach (int[] innerValues in values)
+            {
+                foreach(int value in innerValues)
+                {
+                    if (value == 5)
+                    {
+                        CallSomeMethod();
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void CallSomeMethod(int n = 0) { }
+
+        static int SharedTop(int n, int a, int b, int x, int y)
+        {
+            int result = 0;
+
+            do
+            {
+                do
+                {
+                    result += x * y + x * x + y * y;
+                } while ((--n & 3) != 1);
+                ++x;
+                result += a * b + a * a + b * b;
+            } while ((--n) != 0);
+
+            return result;
+        }
+
+        class Node
+        {
+            public int value;
+            public Node next;
+        }
+
+        // Entire loop is enclosed in a try block: should still be able to move
+        // exit path out of loop.
+        static bool InTry(Node node)
+        {
+            try
+            {
+                while (node != null)
+                {
+                    if (node.value == 5)
+                    {
+                        return (node.next.value == 7);
+                    }
+                    node = node.next;
+                }
+            }
+            catch (NullReferenceException) { }
+            return false;
+        }
+
+        // Nested loop again, make sure throws are recognized as exits -- throw should
+        // be moved out of loop
+        static bool NestedThrows(int[][] values)
+        {
+            try
+            {
+                foreach (int[] innerValues in values)
+                {
+                    foreach (int value in innerValues)
+                    {
+                        if (value == 5)
+                        {
+                            throw new System.Exception("foo");
+                        }
+                    }
+                }
+                return false;
+            }
+            catch
+            {
+                return true;
+            }
+        }
+
+        // Can't move out of loop without crossing try region boundary; should leave in loop.
+        // Loop should still be recognized, and invariant multiplication hoisted out of it.
+        static bool CrossTry(Node node, int x, int y)
+        {
+            int r = 0;
+            while (node != null)
+            {
+                r += x * y * x * y * x * y * x * y * x * y * x * y;
+                try
+                {
+                    if (node.value == 5)
+                    {
+                        return (node.next.value == 7);
+                    }
+                }
+                catch (NullReferenceException) { return true; }
+                node = node.next;
+            }
+            return (r < 13);
+        }
+
+        // Example where we move a branch out to its target and so should make
+        // it fall through.
+        static bool MoveToTarget(int n, int j)
+        {
+            CallSomeMethod();
+
+            do // Loop 1 starts here
+            {
+                if (n == 1)
+                {
+                    // This path exits Loop 1, so should get moved out.
+                    CallSomeMethod(1);
+                    goto One;
+                }
+                n = ((n & 1) == 0 ? n / 2 : 3 * n + 1);
+            } while (n != 0);
+            // Exit when n == 0 falls through here, so we'll move Call(1) farther down
+            CallSomeMethod(2);
+            return false;
+            // No fallthrough here, so we'll move CallSomeMethod(1) here.
+            // But that means the 'goto One' will become a goto-next that we should
+            // clean up.
+            One:
+            // Making the block at 'One' a loop head prompts an assertion failure
+            // analyzing that loop (wasn't expecting branch-to-next since it runs
+            // after flow opts) if we don't clean up the branch-to-next.
+            do
+            {
+                CallSomeMethod(3);
+            } while (--j != 0);
+
+            return true;
+        }
+
+        // Example where we move a run of blocks that a goto in the loop
+        // branches around.
+        static bool ContractGoto(int n, int j)
+        {
+            CallSomeMethod();
+
+            do  // Loop 1
+            {
+                CallSomeMethod(1);
+                goto StillInLoop;  // this goto will become goto-next when Call(2) gets moved
+
+                EarlyReturn:   // this should get moved out-of-line
+                CallSomeMethod(2);
+                return false;
+
+                StillInLoop:  // make this the top of a loop so assertion would fire if goto left
+                do  // Loop 2
+                {
+                    n = ((n & 1) == 0 ? n / 2 : 3 * n + 1);
+                } while (n == 0);
+
+                if (j < 0)
+                {
+                    goto EarlyReturn;
+                }
+
+            } while (n != 1);
+
+            return true;
+        }
+
+        // Example where we move a label to just after a goto targeting it and so should
+        // changethat goto-next to fall through.
+        static bool MoveAfterGoto(int n, int j)
+        {
+            CallSomeMethod();
+
+            do // Loop 1 starts here
+            {
+                if (j > 0)
+                {
+                    // This path exits Loop 1, so should get moved out.
+                    CallSomeMethod(1);
+                    goto MovingLabel;
+                }
+                // This block stays in the loop.
+                n = ((n & 1) == 0 ? n / 2 : 3 * n + 1);
+                continue;
+                MovingLabel: // This gets moved out, just after its goto, requring cleanup
+                do  // Loop 2 (gets moved out of Loop 1)
+                {
+                    CallSomeMethod(3);
+                } while (--j != 0);
+                return true;
+            } while (n != 1);
+            // Exit when n == 0 falls through here, so we'll move Call(1) farther down
+            CallSomeMethod(2);
+            return false;
+        }
+
+        // Test to make sure we check for exits on fall-through edges.
+        static bool FallThroughExit(int n, int j, int k, int l)
+        {
+            CallSomeMethod(1);
+
+            do
+            {
+                CallSomeMethod(2);
+                if (n == 1)  // There is an exit here but it's fall-through
+                {
+                    CallSomeMethod(3);
+                    break;
+                }
+                // This is not an articulated block, but missing the first exit
+                // would make us think it is and we might hoist this big expression.
+                CallSomeMethod(k * j + k * k + j * j + k * l + j * l + l * l);
+                n = ((n & 1) == 0 ? n / 2 : 3 * n + 1);
+            } while (n > 1);  // This will be the only exit we see if we miss the other
+            CallSomeMethod(4);
+            return true;
+        }
+
+
+        // Test to make sure we can safely handle single-exit loops when the
+        // algorithm to compact loops decrements the exit count from two back
+        // to one and leaves it there.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void MaybeThrow(int n)
+        {
+            if (n == 21)
+            {
+                throw new Exception("Twenty-One");
+            }
+        }
+        static bool InnerInfiniteLoop(int n, int j, int k, int l)
+        {
+            CallSomeMethod();
+
+            do
+            {
+                CallSomeMethod(1);
+
+                if (n == 1)  // This is the first exit
+                {
+                    break;
+                }
+
+                // This is not an articulated block, but missing the first exit
+                // would make us think it is and we might hoist this big expression.
+                CallSomeMethod(k * j + k * k + j * j + k * l + j * l + l * l);
+
+                try
+                {
+                    if (n == 23)  // This is the second exit, but the exit path
+                    {             // cannot be moved out due to the try block.
+                        CallSomeMethod(3);
+                        do
+                        {
+                            MaybeThrow(--n);
+                        } while (true);
+                    }
+                }
+                catch
+                {
+                    return false;
+                }
+                n = ((n & 1) == 0 ? n / 2 : 3 * n + 1);
+            } while (true);
+
+            CallSomeMethod(4);
+
+            if (j < 0)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        class Box
+        {
+            public int Data;
+        }
+
+        // Test to make sure we don't record a loop and then
+        // move some of its blocks out.
+        static bool InOut(int n, Box box)
+        {
+            int value = box.Data;
+            int target = 0;
+            int result = 0;
+
+            do  // Outer loop starts here
+            {
+                result += box.Data;  // Hoisting this is illegal due to the write in the inner loop
+                goto enterInnerLoop; // branch around 'continueOuterLoop'
+
+                continueOuterLoop:  // Target for lexically-backward exit from inner loop that
+                ++result;           // is not an exit from the outer loop
+                continue;
+
+                enterInnerLoop:
+                --result;
+                do  // Inner loop starts here
+                {
+                    if (target == 0)  // Conditional exit from inner loop that we'll want to move out
+                    {                 // but need to be careful not to move it out of the outer loop
+                        box.Data = value + 1;  // ValueNumbering needs to see that this store is part of
+                        target = value * n;    // the outer loop, else we'll think the load above is invariant.
+                        goto continueOuterLoop;
+                    }
+                } while (box.Data < 0);
+            } while (--n > 0);
+
+            return (result == target);
+        }
+
+        public static int Main(string[] args)
+        {
+            int[] has5 = new int[] { 1, 2, 3, 4, 5 };
+            int[] no5 = new int[] { 6, 7, 8, 9 };
+            int[][] has5jagged = new int[][] { no5, has5 };
+            int[][] no5jagged = new int[][] { no5, no5 };
+            Node faultHead = new Node { value = 6, next = new Node { value = 13, next = new Node { value = 5, next = null } } };
+            Node trueHead = new Node { value = 23, next = new Node { value = 5, next = new Node { value = 7, next = null } } };
+            Node falseHead = new Node { value = 5, next = new Node { value = 8, next = null } };
+
+            int result = 100; // 100 indicates success; increment for errors.
+
+            if (!Simple(has5) || Simple(no5))
+            {
+                ++result;
+            }
+            if (!Nested(has5jagged) || Nested(no5jagged))
+            {
+                ++result;
+            }
+            if (SharedTop(17, 2, 3, 4, 5) != 1145)
+            {
+                ++result;
+            }
+            if (!InTry(trueHead) || InTry(falseHead) || InTry(faultHead))
+            {
+                ++result;
+            }
+            if (!NestedThrows(has5jagged) || NestedThrows(no5jagged))
+            {
+                ++result;
+            }
+            if (!CrossTry(trueHead, 8, 4) || CrossTry(falseHead, 8, 4) || !CrossTry(faultHead, 8, 4))
+            {
+                ++result;
+            }
+
+            if (!MoveToTarget(7, 2))
+            {
+                ++result;
+            }
+            if (!ContractGoto(23, 5) || ContractGoto(42, -5))
+            {
+                ++result;
+            }
+            if (!MoveAfterGoto(23, 5) || MoveAfterGoto(42, -5))
+            {
+                ++result;
+            }
+
+            if (!FallThroughExit(8, 5, 7, 22))
+            {
+                ++result;
+            }
+            if (!InnerInfiniteLoop(8, 5, 3, 18) || InnerInfiniteLoop(16, -5, 2, 4) || InnerInfiniteLoop(23, 7, 6, 5) || !InnerInfiniteLoop(1, 0, 11, 22))
+            {
+                ++result;
+            }
+
+            if (!InOut(17, new Box() { Data = 5 }))
+            {
+                ++result;
+            }
+
+            return result;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_9692/GitHub_9692.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_9692/GitHub_9692.csproj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{9711BC9D-A24D-458D-8357-007D6423C212}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
Rearrange basic blocks during loop identification so that loop bodies
are kept contiguous when possible.  Blocks in the lexical range of the
loop which do not participate in the flow cycle (which typically
correspond to code associated with early exits using `break` or
`return`) are moved out below the loop when possible without breaking EH
region nesting.  The target insertion point, when possible, is chosen to
be the first spot below the loop that will not break up fall-through.

Layout can significantly affect the performance of loops, particularly
small search loops, by avoiding the taken branch on the hot path,
improving the locality of the code fetched while iterating the loop, and
potentially aiding loop stream detection.

Resolves #9692.
