### PR TITLE
Enable RedHat 6 in coreclr master

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -211,7 +211,7 @@ generate_event_logging_sources()
         __PythonWarningFlags="$__PythonWarningFlags -Werror"
     fi
 
-    
+
     if [[ $__SkipCoreCLR == 0 || $__ConfigureOnly == 1 ]]; then
         echo "Laying out dynamically generated files consumed by the build system "
         echo "Laying out dynamically generated Event Logging Test files"
@@ -360,8 +360,8 @@ build_cross_arch_component()
     else
         # not supported
         return
-    fi    
-    
+    fi
+
     export __CMakeBinDir="$__CrossComponentBinDir"
     export CROSSCOMPONENT=1
     __IncludeTests=
@@ -377,8 +377,8 @@ build_cross_arch_component()
 
     __ExtraCmakeArgs="-DCLR_CMAKE_TARGET_ARCH=$__BuildArch -DCLR_CMAKE_TARGET_OS=$__BuildOS -DCLR_CMAKE_PACKAGES_DIR=$__PackagesDir -DCLR_CMAKE_PGO_INSTRUMENT=$__PgoInstrument -DCLR_CMAKE_OPTDATA_VERSION=$__PgoOptDataVersion -DCLR_CMAKE_PGO_OPTIMIZE=$__PgoOptimize"
     build_native $__SkipCrossArchBuild "$__CrossArch" "$__CrossCompIntermediatesDir" "$__ExtraCmakeArgs" "cross-architecture component"
-   
-    # restore ROOTFS_DIR, CROSSCOMPONENT, and CROSSCOMPILE 
+
+    # restore ROOTFS_DIR, CROSSCOMPONENT, and CROSSCOMPILE
     if [ -n "$TARGET_ROOTFS" ]; then
         export ROOTFS_DIR="$TARGET_ROOTFS"
     fi
@@ -398,7 +398,7 @@ isMSBuildOnNETCoreSupported()
         if [ "$__HostOS" == "Linux" ]; then
             __isMSBuildOnNETCoreSupported=1
             # note: the RIDs below can use globbing patterns
-            UNSUPPORTED_RIDS=("debian.9-x64" "ubuntu.17.04-x64" "alpine.3.6.*-x64" "rhel.6-x64" "")
+            UNSUPPORTED_RIDS=("debian.9-x64" "ubuntu.17.04-x64" "alpine.3.6.*-x64" "")
             for UNSUPPORTED_RID in "${UNSUPPORTED_RIDS[@]}"
             do
                 if [[ $__HostDistroRid == $UNSUPPORTED_RID ]]; then
@@ -476,10 +476,10 @@ build_CoreLib()
            build_CoreLib_ni
        elif [[ ( "$__HostArch" == "arm64" ) && ( "$__BuildArch" == "arm" ) ]]; then
            build_CoreLib_ni
-       else 
+       else
            exit 1
        fi
-    fi 
+    fi
 }
 
 generate_NugetPackages()
@@ -699,7 +699,7 @@ while :; do
         cross)
             __CrossBuild=1
             ;;
-            
+
         -portablebuild=false)
             __PortableBuild=0
             ;;

--- a/build.sh
+++ b/build.sh
@@ -398,7 +398,7 @@ isMSBuildOnNETCoreSupported()
         if [ "$__HostOS" == "Linux" ]; then
             __isMSBuildOnNETCoreSupported=1
             # note: the RIDs below can use globbing patterns
-            UNSUPPORTED_RIDS=("debian.9-x64" "ubuntu.17.04-x64" "alpine.3.6.*-x64" "")
+            UNSUPPORTED_RIDS=("debian.9-x64" "ubuntu.17.04-x64" "alpine.3.6.*-x64")
             for UNSUPPORTED_RID in "${UNSUPPORTED_RIDS[@]}"
             do
                 if [[ $__HostDistroRid == $UNSUPPORTED_RID ]]; then

--- a/buildpipeline/DotNet-CoreClr-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Linux.json
@@ -121,7 +121,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs) ./build.sh $(PB_BuildType) $(Architecture) skipnuget -skiprestore stripSymbols -OfficialBuildId=$(OfficialBuildId) -- /flp:\"v=diag\"",
+        "arguments": "run --rm $(DockerCommonRunArgs) ./build.sh $(PB_BuildType) $(Architecture) skipnuget -skiprestore stripSymbols -OfficialBuildId=$(OfficialBuildId) $(PB_AdditionalBuildArgs) -- /flp:\"v=diag\"",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -139,7 +139,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs) ./build-packages.sh -BuildType=$(PB_BuildType) -BuildArch=$(Architecture) -- /p:OfficialBuildId=$(OfficialBuildId)",
+        "arguments": "run --rm $(DockerCommonRunArgs) ./build-packages.sh -BuildType=$(PB_BuildType) -BuildArch=$(Architecture) $(PB_AdditionalBuildArgs) -- /p:OfficialBuildId=$(OfficialBuildId)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -369,6 +369,9 @@
     },
     "PB_CleanAgent": {
       "value": "true"
+    },
+    "PB_AdditionalBuildArgs": {
+      "value":""
     }
   },
   "demands": [

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -27,7 +27,7 @@
           "Name": "DotNet-CoreClr-Trusted-Linux",
           "Parameters": {
             "DockerTag": "centos-6-783abde-20171304101322",
-            "Rid": "rhel6"
+            "Rid": "rhel.6"
           },
           "ReportingParameters": {
             "OperatingSystem": "RedHat6",
@@ -479,7 +479,7 @@
           "Parameters": {
             "HelixJobType": "test/functional/cli/",
             "TargetsWindows": "false",
-            "Rid": "rhel6-x64",
+            "Rid": "rhel.6-x64",
             "TargetQueues": "redhat.69.amd64",
             "TestContainerSuffix": "rhel6",
             "TargetsNonWindowsArg": "TargetsNonWindows "
@@ -496,7 +496,7 @@
           "Parameters": {
             "HelixJobType": "test/functional/r2r/cli/",
             "TargetsWindows": "false",
-            "Rid": "rhel6-x64",
+            "Rid": "rhel.6-x64",
             "TargetQueues": "redhat.69.amd64",
             "TestContainerSuffix": "rhel6-r2r",
             "CrossgenArg": "Crossgen ",

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -24,6 +24,19 @@
           }
         },
         {
+          "Name": "DotNet-CoreClr-Trusted-Linux",
+          "Parameters": {
+            "DockerTag": "centos-6-783abde-20171304101322",
+            "Rid": "rhel6"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "RedHat6",
+            "Type": "build/product/",
+            "Architecture": "x64",
+            "PB_BuildType": null
+          }
+        },		
+        {
           "Name": "DotNet-CoreClr-Trusted-Mac",
           "Parameters": {
             "Rid": "osx"
@@ -460,7 +473,42 @@
             "Type": "build/product/",
             "PB_BuildType": "Release"
           }
-        }
+        },
+        {
+          "Name": "Dotnet-CoreClr-Trusted-BuildTests",
+          "Parameters": {
+            "HelixJobType": "test/functional/cli/",
+            "TargetsWindows": "false",
+            "Rid": "rhel6-x64",
+            "TargetQueues": "redhat.69.amd64",
+            "TestContainerSuffix": "rhel6",
+            "TargetsNonWindowsArg": "TargetsNonWindows "
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "RedHat6",
+            "SubType":  "Build-Tests",
+            "Type": "build/product/",
+            "PB_BuildType": "Release"
+          }
+        },
+        {
+          "Name": "Dotnet-CoreClr-Trusted-BuildTests",
+          "Parameters": {
+            "HelixJobType": "test/functional/r2r/cli/",
+            "TargetsWindows": "false",
+            "Rid": "rhel6-x64",
+            "TargetQueues": "redhat.69.amd64",
+            "TestContainerSuffix": "rhel6-r2r",
+            "CrossgenArg": "Crossgen ",
+            "TargetsNonWindowsArg": "TargetsNonWindows "
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "RedHat6",
+            "SubType":  "Build-Tests-R2R",
+            "Type": "build/product/",
+            "PB_BuildType": "Release"
+          }
+        }		
       ],
       "DependsOn": [
         "Trusted-All-Release"

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -27,7 +27,8 @@
           "Name": "DotNet-CoreClr-Trusted-Linux",
           "Parameters": {
             "DockerTag": "centos-6-c8c9b08-20174310104313",
-            "Rid": "rhel.6"
+            "Rid": "rhel.6",
+			"PB_AdditionalBuildArgs": "-portablebuild=false"
           },
           "ReportingParameters": {
             "OperatingSystem": "RedHat6",

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -26,7 +26,7 @@
         {
           "Name": "DotNet-CoreClr-Trusted-Linux",
           "Parameters": {
-            "DockerTag": "centos-6-783abde-20171304101322",
+            "DockerTag": "centos-6-c8c9b08-20174310104313",
             "Rid": "rhel.6"
           },
           "ReportingParameters": {

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -37,6 +37,14 @@ if [ -z "$__DOTNET_PKG" ]; then
         Linux)
             __DOTNET_PKG=dotnet-dev-linux-x64
             OS=Linux
+
+            if [ -e /etc/redhat-release ]; then
+                redhatRelease=$(</etc/redhat-release)
+                if [[ $redhatRelease == "CentOS release 6."* || $redhatRelease == "Red Hat Enterprise Linux Server release 6."* ]]; then
+                    __DOTNET_PKG=dotnet-dev-rhel.6-x64
+                fi
+            fi
+
             ;;
 
         *)

--- a/tests/src/Common/build_against_pkg_dependencies/build_against_pkg_dependencies.csproj
+++ b/tests/src/Common/build_against_pkg_dependencies/build_against_pkg_dependencies.csproj
@@ -28,11 +28,11 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8</PackageTargetFallback>
-    <RuntimeIdentifiers>win-arm;win-x64;win-x86;win7-x86;win7-x64;win10-arm64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;osx.10.12-x64;osx-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-arm;win-x64;win-x86;win7-x86;win7-x64;win10-arm64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;osx.10.12-x64;osx-x64;centos.7-x64;rhel.6-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64;linux-x64</RuntimeIdentifiers>
     <ContainsPackageReferences>true</ContainsPackageReferences>
     <PrereleaseResolveNuGetPackages>false</PrereleaseResolveNuGetPackages>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <Target Name="Build"
-     DependsOnTargets="ResolveReferences" /> 
+     DependsOnTargets="ResolveReferences" />
 </Project>

--- a/tests/src/Common/targeting_pack_ref/targeting_pack_ref.csproj
+++ b/tests/src/Common/targeting_pack_ref/targeting_pack_ref.csproj
@@ -16,11 +16,11 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
-    <RuntimeIdentifiers>win-arm;win7-x86;win7-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;osx.10.12-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-arm;win7-x86;win7-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;osx.10.12-x64;centos.7-x64;rhel.6-x64;rhel.7-x64;debian.8-x64;fedora.24-x64</RuntimeIdentifiers>
     <ContainsPackageReferences>true</ContainsPackageReferences>
     <PrereleaseResolveNuGetPackages>false</PrereleaseResolveNuGetPackages>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <Target Name="Build"
-     DependsOnTargets="ResolveReferences" /> 
+     DependsOnTargets="ResolveReferences" />
 </Project>

--- a/tests/src/Common/test_dependencies/test_dependencies.csproj
+++ b/tests/src/Common/test_dependencies/test_dependencies.csproj
@@ -27,7 +27,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;netcoreapp1.1;portable-net45+win8</PackageTargetFallback>
-    <RuntimeIdentifiers>win-arm;win-x64;win-x86;win7-x86;win7-x64;win-arm64;win-arm;win7-arm64;win7-arm;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;osx.10.12-x64;osx-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-arm;win-x64;win-x86;win7-x86;win7-x64;win-arm64;win-arm;win7-arm64;win7-arm;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;osx.10.12-x64;osx-x64;centos.7-x64;rhel.6-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;linux-x64</RuntimeIdentifiers>
     <ContainsPackageReferences>true</ContainsPackageReferences>
     <PrereleaseResolveNuGetPackages>false</PrereleaseResolveNuGetPackages>
   </PropertyGroup>

--- a/tests/src/Common/test_runtime/test_runtime.csproj
+++ b/tests/src/Common/test_runtime/test_runtime.csproj
@@ -30,7 +30,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
-    <RuntimeIdentifiers>win-arm;win-x64;win-x86;win7-x86;win7-x64;win-arm64;win-arm;win7-arm64;win7-arm;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;osx.10.12-x64;osx-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-arm;win-x64;win-x86;win7-x86;win7-x64;win-arm64;win-arm;win7-arm64;win7-arm;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;osx.10.12-x64;osx-x64;centos.7-x64;rhel.6-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;linux-x64</RuntimeIdentifiers>
     <ContainsPackageReferences>true</ContainsPackageReferences>
     <PrereleaseResolveNuGetPackages>false</PrereleaseResolveNuGetPackages>
   </PropertyGroup>


### PR DESCRIPTION
Enable RedHat 6 in coreclr master.

This is identical as the approved PR to enable RedHat 6 in coreclr
release/2.0.0:
https://github.com/dotnet/coreclr/pull/13301