### PR TITLE
Fix bug where whitespace breaks arg proccessing

### DIFF
--- a/build-test.cmd
+++ b/build-test.cmd
@@ -86,9 +86,12 @@ if /i "%1" == "targetsNonWindows"     (set __TargetsWindows=0&set processedArgs=
 if /i "%1" == "Exclude"               (set __Exclude=%2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)
 
 if [!processedArgs!]==[] (
-  call set __UnprocessedBuildArgs=!__args!
+  set __UnprocessedBuildArgs=%__args%
 ) else (
-  call set __UnprocessedBuildArgs=%%__args:*!processedArgs!=%%
+  set __UnprocessedBuildArgs=%__args%
+  for %%t in (!processedArgs!) do (
+    set __UnprocessedBuildArgs=!__UnprocessedBuildArgs:*%%t=!
+  )
 )
 
 :ArgsDone

--- a/build.cmd
+++ b/build.cmd
@@ -155,9 +155,12 @@ if /i "%1" == "buildstandalonegc"   (
 if /i "%1" == "altjitcrossgen"      (set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 
 if [!processedArgs!]==[] (
-  call set __UnprocessedBuildArgs=!__args!
+  set __UnprocessedBuildArgs=%__args%
 ) else (
-  call set __UnprocessedBuildArgs=%%__args:*!processedArgs!=%%
+  set __UnprocessedBuildArgs=%__args%
+  for %%t in (!processedArgs!) do (
+    set __UnprocessedBuildArgs=!__UnprocessedBuildArgs:*%%t=!
+  )
 )
 
 :ArgsDone


### PR DESCRIPTION
Prior to this commit there is an issue where adding extra whitespace between args processable by build.cmd will causes all args (including those meant for build.cmd) to be passed down to run.exe. 

This commit removes processed args in a way which ensures whitespace does not effect the processing of args by build.cmd and processed args are removed correctly. 

Closes: #13317