### PR TITLE
Copy additional GenTreeBoundsChk fields in gtCloneExpr

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -7737,6 +7737,8 @@ GenTreePtr Compiler::gtCloneExpr(
                                  gtCloneExpr(tree->gtBoundsChk.gtIndex, addFlags, deepVarNum, deepVarVal),
                                  gtCloneExpr(tree->gtBoundsChk.gtArrLen, addFlags, deepVarNum, deepVarVal),
                                  tree->gtBoundsChk.gtThrowKind);
+            copy->gtBoundsChk.gtIndRngFailBB = tree->gtBoundsChk.gtIndRngFailBB;
+            copy->gtBoundsChk.gtStkDepth     = tree->gtBoundsChk.gtStkDepth;
             break;
 
         case GT_STORE_DYN_BLK:


### PR DESCRIPTION
We were previously losing the gtStkDepth field, which led to
an assert with the STRESS_CLONE_EXPR stress mode with array
bounds checks in function argument lists that had already
pushed stack arguments. This assert could happen in any case
where such calls + call arguments are cloned, perhaps due to
an optimization such as loop cloning or unrolling.

Fixes VSO 471672
