### PR TITLE
[RyuJIT/armel] Fix PutArgReg BuildRefPositions

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3990,22 +3990,12 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
 
             regMaskTP candidates = getUseCandidates(useNode);
 #ifdef _TARGET_ARM_
-            // If oper is GT_PUTARG_SPLIT, set bits in useCandidates must be in sequential order.
-            if (useNode->OperIsPutArgSplit())
+            if (useNode->OperIsPutArgSplit() || (compiler->opts.compUseSoftFP && useNode->OperIsPutArgReg()))
             {
-                // get i-th candidate
+                // get i-th candidate, set bits in useCandidates must be in sequential order.
                 candidates = genFindLowestReg(candidates & ~currCandidates);
                 currCandidates |= candidates;
             }
-#ifdef ARM_SOFTFP
-            // If oper is GT_PUTARG_REG, set bits in useCandidates must be in sequential order.
-            if (useNode->OperIsMultiRegOp())
-            {
-                regMaskTP candidate = genFindLowestReg(candidates);
-                useNode->gtLsraInfo.setSrcCandidates(this, candidates & ~candidate);
-                candidates = candidate;
-            }
-#endif // ARM_SOFTFP
 #endif // _TARGET_ARM_
 
             assert((candidates & allRegs(i->registerType)) != 0);


### PR DESCRIPTION
We should fix registers for GT_PUTARG_REG, not GT_COPY or GT_MUL_LONG.
And merge the `if` statement with GT_PUTARG_SPLIT case.

cc: @dotnet/arm32-contrib 