### PR TITLE
[ARM/Linux] Trash REG_R2R_INDIRECT_PARAM properly

### DIFF
--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -19547,6 +19547,7 @@ regMaskTP CodeGen::genCodeForCall(GenTreeCall* call, bool valUsed)
                             {
                                 noway_assert(regSet.rsRegMaskCanGrab() & RBM_R2R_INDIRECT_PARAM);
                                 getEmitter()->emitIns_R_R(INS_mov, EA_PTRSIZE, REG_R2R_INDIRECT_PARAM, indCallReg);
+                                regTracker.rsTrackRegTrash(REG_R2R_INDIRECT_PARAM);
                             }
 #endif // FEATURE_READYTORUN_COMPILER
 


### PR DESCRIPTION
Both readytorun.mainv1 and readytorun.mainv2 failed as REG_R2R_INDIRECT_PARAM is not trashed after loading R2R indirection thunk.