### PR TITLE
Remove unnecessary buffer copy from EventPipe::WriteEvent pipeline

### DIFF
--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventPipe.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventPipe.cs
@@ -174,6 +174,6 @@ namespace System.Diagnostics.Tracing
 
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
         [SuppressUnmanagedCodeSecurity]
-        internal static extern unsafe void WriteEvent(IntPtr eventHandle, uint eventID, EventProvider.EventData** pBlobs, uint blobCount, Guid* activityId, Guid* relatedActivityId);
+        internal static extern unsafe void WriteEventBlob(IntPtr eventHandle, uint eventID, EventProvider.EventData** pBlobs, uint blobCount, Guid* activityId, Guid* relatedActivityId);
     }
 }

--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventPipe.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventPipe.cs
@@ -171,5 +171,9 @@ namespace System.Diagnostics.Tracing
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
         [SuppressUnmanagedCodeSecurity]
         internal static extern unsafe void WriteEvent(IntPtr eventHandle, uint eventID, void* pData, uint length, Guid* activityId, Guid* relatedActivityId);
+
+        [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
+        [SuppressUnmanagedCodeSecurity]
+        internal static extern unsafe void WriteEvent(IntPtr eventHandle, uint eventID, void** pBlobs, uint blobCount, Guid* activityId, Guid* relatedActivityId);
     }
 }

--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventPipe.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventPipe.cs
@@ -174,6 +174,6 @@ namespace System.Diagnostics.Tracing
 
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
         [SuppressUnmanagedCodeSecurity]
-        internal static extern unsafe void WriteEventData(IntPtr eventHandle, uint eventID, EventProvider.EventData** pBlobs, uint blobCount, Guid* activityId, Guid* relatedActivityId);
+        internal static extern unsafe void WriteEventData(IntPtr eventHandle, uint eventID, EventProvider.EventData** pEventData, uint dataCount, Guid* activityId, Guid* relatedActivityId);
     }
 }

--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventPipe.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventPipe.cs
@@ -174,6 +174,6 @@ namespace System.Diagnostics.Tracing
 
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
         [SuppressUnmanagedCodeSecurity]
-        internal static extern unsafe void WriteEvent(IntPtr eventHandle, uint eventID, void** pBlobs, uint blobCount, Guid* activityId, Guid* relatedActivityId);
+        internal static extern unsafe void WriteEvent(IntPtr eventHandle, uint eventID, EventProvider.EventData** pBlobs, uint blobCount, Guid* activityId, Guid* relatedActivityId);
     }
 }

--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventPipe.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventPipe.cs
@@ -174,6 +174,6 @@ namespace System.Diagnostics.Tracing
 
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
         [SuppressUnmanagedCodeSecurity]
-        internal static extern unsafe void WriteEventBlob(IntPtr eventHandle, uint eventID, EventProvider.EventData** pBlobs, uint blobCount, Guid* activityId, Guid* relatedActivityId);
+        internal static extern unsafe void WriteEventData(IntPtr eventHandle, uint eventID, EventProvider.EventData** pBlobs, uint blobCount, Guid* activityId, Guid* relatedActivityId);
     }
 }

--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventPipeEventProvider.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventPipeEventProvider.cs
@@ -62,11 +62,11 @@ namespace System.Diagnostics.Tracing
             {
                 if (userDataCount == 0)
                 {
-                    EventPipeInternal.WriteEventBlob(eventHandle, eventID, null, 0, activityId, relatedActivityId);
+                    EventPipeInternal.WriteEventData(eventHandle, eventID, null, 0, activityId, relatedActivityId);
                     return 0;
                 }
 
-                EventPipeInternal.WriteEventBlob(eventHandle, eventID, &userData, (uint) userDataCount, activityId, relatedActivityId);
+                EventPipeInternal.WriteEventData(eventHandle, eventID, &userData, (uint) userDataCount, activityId, relatedActivityId);
             }
             return 0;
         }

--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventPipeEventProvider.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventPipeEventProvider.cs
@@ -66,23 +66,9 @@ namespace System.Diagnostics.Tracing
                     return 0;
                 }
 
-                uint length = 0;
-                for (int i = 0; i < userDataCount; i++)
+                fixed (EventProvider.EventData **pBlobs = &userData)
                 {
-                    length += userData[i].Size;
-                }
-
-                byte[] data = new byte[length];
-                fixed (byte *pData = data)
-                {
-                    uint offset = 0;
-                    for (int i = 0; i < userDataCount; i++)
-                    {
-                        byte * singleUserDataPtr = (byte *)(userData[i].Ptr);
-                        uint singleUserDataSize = userData[i].Size;
-                        WriteToBuffer(pData, length, ref offset, singleUserDataPtr, singleUserDataSize);
-                    }
-                    EventPipeInternal.WriteEvent(eventHandle, eventID, pData, length, activityId, relatedActivityId);
+                    EventPipeInternal.WriteEvent(eventHandle, eventID, pBlobs, userDataCount, activityId, relatedActivityId);
                 }
             }
             return 0;

--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventPipeEventProvider.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventPipeEventProvider.cs
@@ -66,10 +66,7 @@ namespace System.Diagnostics.Tracing
                     return 0;
                 }
 
-                fixed (EventProvider.EventData **pBlobs = &userData)
-                {
-                    EventPipeInternal.WriteEvent(eventHandle, eventID, pBlobs, userDataCount, activityId, relatedActivityId);
-                }
+                EventPipeInternal.WriteEvent(eventHandle, eventID, &userData, (uint) userDataCount, activityId, relatedActivityId);
             }
             return 0;
         }

--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventPipeEventProvider.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventPipeEventProvider.cs
@@ -62,11 +62,11 @@ namespace System.Diagnostics.Tracing
             {
                 if (userDataCount == 0)
                 {
-                    EventPipeInternal.WriteEvent(eventHandle, eventID, null, 0, activityId, relatedActivityId);
+                    EventPipeInternal.WriteEventBlob(eventHandle, eventID, null, 0, activityId, relatedActivityId);
                     return 0;
                 }
 
-                EventPipeInternal.WriteEvent(eventHandle, eventID, &userData, (uint) userDataCount, activityId, relatedActivityId);
+                EventPipeInternal.WriteEventBlob(eventHandle, eventID, &userData, (uint) userDataCount, activityId, relatedActivityId);
             }
             return 0;
         }

--- a/src/scripts/genEventPipe.py
+++ b/src/scripts/genEventPipe.py
@@ -110,7 +110,7 @@ def generateClrEventPipeWriteEventsImpl(
             WriteEventImpl.append(
                 "    EventPipe::WriteEvent(*EventPipeEvent" +
                 eventName +
-                ", nullptr, 0);\n")
+                ", (BYTE*) nullptr, 0);\n")
 
         WriteEventImpl.append("\n    return ERROR_SUCCESS;\n}\n\n")
 

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -1245,7 +1245,7 @@ FCFuncStart(gEventPipeInternalFuncs)
     QCFuncElement("DefineEvent", EventPipeInternal::DefineEvent)
     QCFuncElement("DeleteProvider", EventPipeInternal::DeleteProvider)
     QCFuncElement("WriteEvent", EventPipeInternal::WriteEvent)
-    QCFuncElement("WriteEventBlob", EventPipeInternal::WriteEvent)
+    QCFuncElement("WriteEventData", EventPipeInternal::WriteEventData)
 FCFuncEnd()
 #endif // FEATURE_PERFTRACING
 

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -1245,6 +1245,7 @@ FCFuncStart(gEventPipeInternalFuncs)
     QCFuncElement("DefineEvent", EventPipeInternal::DefineEvent)
     QCFuncElement("DeleteProvider", EventPipeInternal::DeleteProvider)
     QCFuncElement("WriteEvent", EventPipeInternal::WriteEvent)
+    QCFuncElement("WriteEventBlob", EventPipeInternal::WriteEvent)
 FCFuncEnd()
 #endif // FEATURE_PERFTRACING
 

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -368,6 +368,15 @@ void EventPipe::WriteEvent(EventPipeEvent &event, EventData **pBlobs, unsigned i
     }
     else if(s_pConfig->RundownEnabled())
     {
+        length = blobCount * sizeof(EventData);
+        BYTE *pData = (BYTE*)malloc(length);
+
+        unsigned int offset = 0;
+        for (int i=0; i<blobCount; i++){
+            memcpy(pData + offset; pBlobs[i]; i++);
+            offset += sizeof(EventData);
+        }
+
         // Write synchronously to the file.
         // We're under lock and blocking the disabling thread.
         EventPipeEventInstance instance(
@@ -382,6 +391,8 @@ void EventPipe::WriteEvent(EventPipeEvent &event, EventData **pBlobs, unsigned i
         {
             s_pFile->WriteEvent(instance);
         }
+
+        free(pData);
     }
 
 #ifdef _DEBUG

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -73,7 +73,12 @@ EventPipeEventPayload::EventPipeEventPayload(EventData **pBlobs, unsigned int bl
     m_blobCount = blobCount;
     m_performedAllocation = false;
 
-    S_UINT32 tmp_size = S_UINT32(blobCount) * S_UINT32(sizeof(EventData));
+    S_UINT32 tmp_size = S_UINT32(0);
+    for (unsigned int i=0; i<m_blobCount; i++)
+    {
+        tmp_size += S_UINT32(m_pBlobs[i]->Size);
+    }
+
     if (tmp_size.IsOverflow())
     {
         // If there is an overflow, drop the data and create an empty payload
@@ -148,10 +153,10 @@ void EventPipeEventPayload::CopyData(BYTE *pDst)
         else if(m_pBlobs != NULL)
         {
             unsigned int offset = 0;
-            for(int i=0; i<m_blobCount; i++)
+            for(unsigned int i=0; i<m_blobCount; i++)
             {
-                memcpy(pDst + offset, m_pBlobs[i], sizeof(EventData));
-                offset += sizeof(EventData);
+                memcpy(pDst + offset, (BYTE*)m_pBlobs[i]->Ptr, m_pBlobs[i]->Size);
+                offset += m_pBlobs[i]->Size;
             }
         }
     }

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -117,11 +117,12 @@ void EventPipeEventPayload::Flatten()
     {
         if (!this->IsFlattened())
         {
-            m_pData = new (nothrow) BYTE[m_size];
-            if (m_pData != NULL)
+            BYTE* tmp_pData = new (nothrow) BYTE[m_size];
+            if (tmp_pData != NULL)
             {
                 m_performedAllocation = true;
-                this->CopyData(m_pData);
+                this->CopyData(tmp_pData);
+                m_pData = tmp_pData;
             }
         }
     }
@@ -139,7 +140,7 @@ void EventPipeEventPayload::CopyData(BYTE *pDst)
 
     if(m_size > 0)
     {
-        if(m_pData != NULL)
+        if(this->IsFlattened())
         {
             memcpy(pDst, m_pData, m_size);
         }

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -41,6 +41,14 @@ extern "C" void InitProvidersAndEvents();
 
 EventPipeEventPayload::EventPipeEventPayload(byte *pData, unsigned int length)
 {
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGERS;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
+
     m_pData = pData;
     m_pBlobs = NULL;
     m_blobCount = 0;
@@ -51,6 +59,14 @@ EventPipeEventPayload::EventPipeEventPayload(byte *pData, unsigned int length)
 
 EventPipeEventPayload::EventPipeEventPayload(EventData **pBlobs, unsigned int blobCount)
 {
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGERS;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
+
     m_pData = NULL;
     m_pBlobs = pBlobs;
     m_blobCount = blobCount;
@@ -69,6 +85,14 @@ EventPipeEventPayload::EventPipeEventPayload(EventData **pBlobs, unsigned int bl
 
 void EventPipeEventPayload::~EventPipeEventPayload();
 {
+    CONTRACTL
+    {
+        THROWS;
+        GC_TRIGGERS;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
+
     if(m_performedAllocation){
         delete[] m_pData;
         m_pData = NULL;
@@ -77,6 +101,14 @@ void EventPipeEventPayload::~EventPipeEventPayload();
 
 void EventPipeEventPayload::Flatten();
 {
+    CONTRACTL
+    {
+        THROWS;
+        GC_TRIGGERS;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
+
     if(m_size > 0){
         if (!this->IsFlattened()){
             m_pData = new BYTE[m_size];
@@ -88,6 +120,14 @@ void EventPipeEventPayload::Flatten();
 
 void EventPipeEventPayload::CopyData(BYTE *pDst);
 {
+    CONTRACTL
+    {
+        THROWS;
+        GC_NOTRIGGER;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
+
     if(m_size > 0){
         if(this->IsFlattened()){
             memcpy(pDst, m_pData, m_size);
@@ -349,12 +389,27 @@ void EventPipe::DeleteProvider(EventPipeProvider *pProvider)
 
 static void EventPipe::WriteEvent(EventPipeEvent &event, BYTE *pData, unsigned int length, LPCGUID pActivityId, LPCGUID pRelatedActivityId)
 {
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
+    }
+
+    CONTRACTL_END;
     EventPipeEventPayload payload(pData, length);
     EventPipe::WriteEventInternal(event, payload, pActivityId, pRelatedActivityId)
 }
 
 static void EventPipe::WriteEvent(EventPipeEvent &event, EventData **pBlobs, unsigned int blobCount, LPCGUID pActivityId, LPCGUID pRelatedActivityId);
 {
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
+    }
+
     EventPipeEventPayload payload(pBlobs, blobCount);
     EventPipe::WriteEventInternal(event, payload, pActivityId, pRelatedActivityId)
 }

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -35,7 +35,7 @@ public:
     unsigned long ptr;
     unsigned int size;
     unsigned int reserved;
-}
+};
 
 class EventPipeEventPayload
 {
@@ -78,20 +78,20 @@ public:
         return m_size;
     }
 
-    unsigned int GetFlatData() const
+    BYTE* GetFlatData() const
     {
         LIMITED_METHOD_CONTRACT;
 
         return m_pData;
     }
 
-    unsigned int GetBlobData() const
+    EventData** GetBlobData() const
     {
         LIMITED_METHOD_CONTRACT;
 
         return m_pBlobs;
     }
-}
+};
 
 class StackContents
 {
@@ -256,7 +256,7 @@ class EventPipe
 
         // Write out an event.
         // Data is written as a serialized blob matching the ETW serialization conventions.
-        static void WriteEvent(EventPipeEvent &event, EventData **pBlobs, unsigned int blobCount, LPCGUID pActivityId = NULL, LPCGUID pRelatedActivityId = NULL);
+        static void WriteEventBlob(EventPipeEvent &event, EventData **pBlobs, unsigned int blobCount, LPCGUID pActivityId = NULL, LPCGUID pRelatedActivityId = NULL);
 
         // Write out a sample profile event.
         static void WriteSampleProfileEvent(Thread *pSamplingThread, EventPipeEvent *pEvent, Thread *pTargetThread, StackContents &stackContents, BYTE *pData = NULL, unsigned int length = 0);
@@ -268,6 +268,7 @@ class EventPipe
         static bool WalkManagedStackForThread(Thread *pThread, StackContents &stackContents);
 
     protected:
+
         // The counterpart to WriteEvent which after the payload is constructed
         static void WriteEventInternal(EventPipeEvent &event, EventPipeEventPayload &payload, LPCGUID pActivityId = NULL, LPCGUID pRelatedActivityId = NULL);
 
@@ -380,11 +381,11 @@ public:
         unsigned int length,
         LPCGUID pActivityId, LPCGUID pRelatedActivityId);
 
-    static void QCALLTYPE WriteEvent(
+    static void QCALLTYPE WriteEventBlob(
         INT_PTR eventHandle,
         unsigned int eventID,
-        EventData **pData,
-        unsigned int count,
+        EventData **pBlobs,
+        unsigned int blobCount,
         LPCGUID pActivityId, LPCGUID pRelatedActivityId);
 };
 

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -29,6 +29,14 @@ typedef void (*EventPipeCallback)(
     void *FilterData,
     void *CallbackContext);
 
+struct EventData
+{
+public:
+    unsigned long ptr;
+    unsigned int size;
+    unsigned int reserved;
+}
+
 class StackContents
 {
 private:
@@ -190,6 +198,10 @@ class EventPipe
         // Data is written as a serialized blob matching the ETW serialization conventions.
         static void WriteEvent(EventPipeEvent &event, BYTE *pData, unsigned int length, LPCGUID pActivityId = NULL, LPCGUID pRelatedActivityId = NULL);
 
+        // Write out an event.
+        // Data is written as a serialized blob matching the ETW serialization conventions.
+        static void WriteEvent(EventPipeEvent &event, EventData **pBlobs, unsigned int blobCount, LPCGUID pActivityId = NULL, LPCGUID pRelatedActivityId = NULL);
+
         // Write out a sample profile event.
         static void WriteSampleProfileEvent(Thread *pSamplingThread, EventPipeEvent *pEvent, Thread *pTargetThread, StackContents &stackContents, BYTE *pData = NULL, unsigned int length = 0);
         
@@ -306,6 +318,13 @@ public:
         unsigned int eventID,
         void *pData,
         unsigned int length,
+        LPCGUID pActivityId, LPCGUID pRelatedActivityId);
+
+    static void QCALLTYPE WriteEvent(
+        INT_PTR eventHandle,
+        unsigned int eventID,
+        void **pData,
+        unsigned int count,
         LPCGUID pActivityId, LPCGUID pRelatedActivityId);
 };
 

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -41,25 +41,25 @@ class EventPipeEventPayload
 {
 private:
     BYTE *m_pData;
-    EventData **m_pBlobs;
-    unsigned int m_blobCount;
+    EventData **m_pEventData;
+    unsigned int m_eventDataCount;
     unsigned int m_size;
-    bool m_performedAllocation;
+    bool m_allocatedData;
 
-    // If the data is stored only as an array of blobs, create a flat buffer and copy into it
+    // If the data is stored only as an array of EventData objects, create a flat buffer and copy into it
     void Flatten();
 
 public:
     // Build this payload with a flat buffer inside
     EventPipeEventPayload(BYTE *pData, unsigned int length);
 
-    // Build this payload to contain an array of EventData blobs
-    EventPipeEventPayload(EventData **pBlobs, unsigned int blobCount);
+    // Build this payload to contain an array of EventData objects
+    EventPipeEventPayload(EventData **pEventData, unsigned int eventDataCount);
 
     // If a buffer was allocated internally, delete it
     ~EventPipeEventPayload();
     
-    // Copy the data (whether flat or array of blobs) into a flat buffer at pDst
+    // Copy the data (whether flat or array of objects) into a flat buffer at pDst
     // Assumes that pDst points to an appropriatly sized buffer
     void CopyData(BYTE *pDst);
 
@@ -84,11 +84,11 @@ public:
         return m_size;
     }
 
-    EventData** GetBlobData() const
+    EventData** GetEventDataArray() const
     {
         LIMITED_METHOD_CONTRACT;
 
-        return m_pBlobs;
+        return m_pEventData;
     }
 };
 
@@ -249,13 +249,13 @@ class EventPipe
         // Delete a provider.
         static void DeleteProvider(EventPipeProvider *pProvider);
 
-        // Write out an event.
+        // Write out an event from a flat buffer.
         // Data is written as a serialized blob matching the ETW serialization conventions.
         static void WriteEvent(EventPipeEvent &event, BYTE *pData, unsigned int length, LPCGUID pActivityId = NULL, LPCGUID pRelatedActivityId = NULL);
 
-        // Write out an event.
+        // Write out an event from an EventData array.
         // Data is written as a serialized blob matching the ETW serialization conventions.
-        static void WriteEvent(EventPipeEvent &event, EventData **pBlobs, unsigned int blobCount, LPCGUID pActivityId = NULL, LPCGUID pRelatedActivityId = NULL);
+        static void WriteEvent(EventPipeEvent &event, EventData **pEventData, unsigned int eventDataCount, LPCGUID pActivityId = NULL, LPCGUID pRelatedActivityId = NULL);
 
         // Write out a sample profile event.
         static void WriteSampleProfileEvent(Thread *pSamplingThread, EventPipeEvent *pEvent, Thread *pTargetThread, StackContents &stackContents, BYTE *pData = NULL, unsigned int length = 0);
@@ -383,8 +383,8 @@ public:
     static void QCALLTYPE WriteEventData(
         INT_PTR eventHandle,
         unsigned int eventID,
-        EventData **pBlobs,
-        unsigned int blobCount,
+        EventData **pEventData,
+        unsigned int eventDataCount,
         LPCGUID pActivityId, LPCGUID pRelatedActivityId);
 };
 

--- a/src/vm/eventpipebuffer.cpp
+++ b/src/vm/eventpipebuffer.cpp
@@ -164,6 +164,7 @@ bool EventPipeBuffer::WriteEvent(Thread *pThread, EventPipeEvent &event, EventDa
             unsigned int offset = 0;
             for(int i=0; i<blobCount; i++){
                 memcpy(pDataDest + offset, pBlobs[i], sizeof(EventData));
+                offset += sizeof(EventData)
             }
         }
 

--- a/src/vm/eventpipebuffer.h
+++ b/src/vm/eventpipebuffer.h
@@ -82,8 +82,7 @@ public:
     // Returns:
     //  - true: The write succeeded.
     //  - false: The write failed.  In this case, the buffer should be considered full.
-    bool WriteEvent(Thread *pThread, EventPipeEvent &event, BYTE *pData, unsigned int dataLength, LPCGUID pActivityId, LPCGUID pRelatedActivityId, StackContents *pStack = NULL);
-    bool WriteEvent(Thread *pThread, EventPipeEvent &event, EventData **pBlobs, unsigned int blobCount, LPCGUID pActivityId, LPCGUID pRelatedActivityId, StackContents *pStack = NULL);
+    bool WriteEvent(Thread *pThread, EventPipeEvent &event, EventPipeEventPayload &payload, LPCGUID pActivityId, LPCGUID pRelatedActivityId, StackContents *pStack = NULL);
 
     // Get the timestamp of the most recent event in the buffer.
     LARGE_INTEGER GetMostRecentTimeStamp() const;

--- a/src/vm/eventpipebuffer.h
+++ b/src/vm/eventpipebuffer.h
@@ -7,6 +7,7 @@
 
 #ifdef FEATURE_PERFTRACING
 
+#include "eventpipe.h"
 #include "eventpipeevent.h"
 #include "eventpipeeventinstance.h"
 
@@ -82,6 +83,7 @@ public:
     //  - true: The write succeeded.
     //  - false: The write failed.  In this case, the buffer should be considered full.
     bool WriteEvent(Thread *pThread, EventPipeEvent &event, BYTE *pData, unsigned int dataLength, LPCGUID pActivityId, LPCGUID pRelatedActivityId, StackContents *pStack = NULL);
+    bool WriteEvent(Thread *pThread, EventPipeEvent &event, EventData **pBlobs, unsigned int blobCount, LPCGUID pActivityId, LPCGUID pRelatedActivityId, StackContents *pStack = NULL);
 
     // Get the timestamp of the most recent event in the buffer.
     LARGE_INTEGER GetMostRecentTimeStamp() const;

--- a/src/vm/eventpipebuffermanager.cpp
+++ b/src/vm/eventpipebuffermanager.cpp
@@ -291,7 +291,7 @@ bool EventPipeBufferManager::WriteEvent(Thread *pThread, EventPipeEvent &event, 
         // However, the GC is waiting on this call to return so that it can make forward progress.  Thus it is not safe
         // to switch to preemptive mode here.
 
-        unsigned int requestSize = sizeof(EventPipeEventInstance) + length;
+        unsigned int requestSize = sizeof(EventPipeEventInstance) + payload.GetSize();
         pBuffer = AllocateBufferForThread(pThread, requestSize);
     }
 
@@ -300,7 +300,7 @@ bool EventPipeBufferManager::WriteEvent(Thread *pThread, EventPipeEvent &event, 
     // This is the second time if this thread did have one or more buffers, but they were full.
     if(allocNewBuffer && pBuffer != NULL)
     {
-        allocNewBuffer = !pBuffer->WriteEvent(pEventThread, event, pData, length, pActivityId, pRelatedActivityId, pStack);
+        allocNewBuffer = !pBuffer->WriteEvent(pEventThread, event, payload, pActivityId, pRelatedActivityId, pStack);
     }
 
     // Mark that the thread is no longer writing an event.

--- a/src/vm/eventpipebuffermanager.cpp
+++ b/src/vm/eventpipebuffermanager.cpp
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "common.h"
+#include "eventpipe.h"
 #include "eventpipeconfiguration.h"
 #include "eventpipebuffer.h"
 #include "eventpipebuffermanager.h"
@@ -313,6 +314,106 @@ bool EventPipeBufferManager::WriteEvent(Thread *pThread, EventPipeEvent &event, 
 #endif // _DEBUG
     return !allocNewBuffer;
 }
+
+bool EventPipeBufferManager::WriteEvent(Thread *pThread, EventPipeEvent &event, EventData **pBlobs, unsigned int blobCount, LPCGUID pActivityId, LPCGUID pRelatedActivityId, Thread *pEventThread, StackContents *pStack)
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
+        // The input thread must match the current thread because no lock is taken on the buffer.
+        PRECONDITION(pThread == GetThread());
+    }
+    CONTRACTL_END;
+
+    _ASSERTE(pThread == GetThread());
+
+    // Check to see an event thread was specified.  If not, then use the current thread.
+    if(pEventThread == NULL)
+    {
+        pEventThread = pThread;
+    }
+
+    // Before we pick a buffer, make sure the event is enabled.
+    if(!event.IsEnabled())
+    {
+        return false;
+    }
+
+    // The event is still enabled.  Mark that the thread is now writing an event.
+    pThread->SetEventWriteInProgress(true);
+
+    // Check one more time to make sure that the event is still enabled.
+    // We do this because we might be trying to disable tracing and free buffers, so we
+    // must make sure that the event is enabled after we mark that we're writing to avoid
+    // races with the destructing thread.
+    if(!event.IsEnabled())
+    {
+        return false;
+    }
+
+    // See if the thread already has a buffer to try.
+    bool allocNewBuffer = false;
+    EventPipeBuffer *pBuffer = NULL;
+    EventPipeBufferList *pThreadBufferList = pThread->GetEventPipeBufferList();
+    if(pThreadBufferList == NULL)
+    {
+        allocNewBuffer = true;
+    }
+    else
+    {
+        // The thread already has a buffer list.  Select the newest buffer and attempt to write into it.
+        pBuffer = pThreadBufferList->GetTail();
+        if(pBuffer == NULL)
+        {
+            // This should never happen.  If the buffer list exists, it must contain at least one entry.
+            _ASSERT(!"Thread buffer list with zero entries encountered.");
+            return false;
+        }
+        else
+        {
+            for(int i=0; i<count; i++){
+                // Attempt to write the event to the buffer.  If this fails, we should allocate a new buffer.
+                allocNewBuffer = !pBuffer->WriteEvent(pEventThread, event, pBlobs, blobCount, pActivityId, pRelatedActivityId, pStack);
+            }
+        }
+    }
+
+    // Check to see if we need to allocate a new buffer, and if so, do it here.
+    if(allocNewBuffer)
+    {
+        // We previously switched to preemptive mode here, however, this is not safe and can cause deadlocks.
+        // When a GC is started, and background threads are created (for the first BGC), a thread creation event is fired.
+        // When control gets here the buffer is allocated, but then the thread hangs waiting for the GC to complete
+        // (it was marked as started before creating threads) so that it can switch back to cooperative mode.
+        // However, the GC is waiting on this call to return so that it can make forward progress.  Thus it is not safe
+        // to switch to preemptive mode here.
+
+        unsigned int requestSize = sizeof(EventPipeEventInstance) + (blobCount * sizeof(EventData));
+        pBuffer = AllocateBufferForThread(pThread, requestSize);
+    }
+
+    // Try to write the event after we allocated (or stole) a buffer.
+    // This is the first time if the thread had no buffers before the call to this function.
+    // This is the second time if this thread did have one or more buffers, but they were full.
+    if(allocNewBuffer && pBuffer != NULL)
+    {
+        allocNewBuffer = !pBuffer->WriteEvent(pEventThread, event, pBlobs, blobCount, pActivityId, pRelatedActivityId, pStack);
+    }
+
+    // Mark that the thread is no longer writing an event.
+     pThread->SetEventWriteInProgress(false);
+
+#ifdef _DEBUG
+    if(!allocNewBuffer)
+    {
+        InterlockedIncrement(&m_numEventsStored);
+    }
+#endif // _DEBUG
+    return !allocNewBuffer;
+}
+
 
 void EventPipeBufferManager::WriteAllBuffersToFile(EventPipeFile *pFile, LARGE_INTEGER stopTimeStamp)
 {

--- a/src/vm/eventpipebuffermanager.h
+++ b/src/vm/eventpipebuffermanager.h
@@ -7,6 +7,7 @@
 
 #ifdef FEATURE_PERFTRACING
 
+#include "eventpipe.h"
 #include "eventpipefile.h"
 #include "eventpipebuffer.h"
 #include "spinlock.h"
@@ -68,6 +69,7 @@ public:
     // An optional stack trace can be provided for sample profiler events.
     // Otherwise, if a stack trace is needed, one will be automatically collected.
     bool WriteEvent(Thread *pThread, EventPipeEvent &event, BYTE *pData, unsigned int length, LPCGUID pActivityId, LPCGUID pRelatedActivityId, Thread *pEventThread = NULL, StackContents *pStack = NULL);
+    bool WriteEvent(Thread *pThread, EventPipeEvent &event, EventData *pBlobs, unsigned int blobCount, LPCGUID pActivityId, LPCGUID pRelatedActivityId, Thread *pEventThread = NULL, StackContents *pStack = NULL);
 
     // Write the contents of the managed buffers to the specified file.
     // The stopTimeStamp is used to determine when tracing was stopped to ensure that we

--- a/src/vm/eventpipebuffermanager.h
+++ b/src/vm/eventpipebuffermanager.h
@@ -68,8 +68,7 @@ public:
     // This is because the thread that writes the events is not the same as the "event thread".
     // An optional stack trace can be provided for sample profiler events.
     // Otherwise, if a stack trace is needed, one will be automatically collected.
-    bool WriteEvent(Thread *pThread, EventPipeEvent &event, BYTE *pData, unsigned int length, LPCGUID pActivityId, LPCGUID pRelatedActivityId, Thread *pEventThread = NULL, StackContents *pStack = NULL);
-    bool WriteEvent(Thread *pThread, EventPipeEvent &event, EventData *pBlobs, unsigned int blobCount, LPCGUID pActivityId, LPCGUID pRelatedActivityId, Thread *pEventThread = NULL, StackContents *pStack = NULL);
+    bool WriteEvent(Thread *pThread, EventPipeEvent &event, EventPipeEventPayload &payload, LPCGUID pActivityId, LPCGUID pRelatedActivityId, Thread *pEventThread = NULL, StackContents *pStack = NULL);
 
     // Write the contents of the managed buffers to the specified file.
     // The stopTimeStamp is used to determine when tracing was stopped to ensure that we

--- a/tests/src/tracing/eventpipesmoke/EventPipeSmoke.cs
+++ b/tests/src/tracing/eventpipesmoke/EventPipeSmoke.cs
@@ -10,11 +10,19 @@ namespace Tracing.Tests
     {
         private static int allocIterations = 10000;
         private static int trivialSize = 0x100000;
-        private static bool keepOutput = false;
 
         static int Main(string[] args)
         {
-            string outputFilename = System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".netperf";
+            bool keepOutput = false;
+            // Use the first arg as an output filename if there is one
+            string outputFilename = null;
+            if (args.Length >= 1) {
+                outputFilename = args[0];
+                keepOutput = true;
+            }
+            else {
+                outputFilename = System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".netperf";
+            }
 
             Console.WriteLine("\tStart: Enable tracing.");
             TraceControl.EnableDefault(outputFilename);

--- a/tests/src/tracing/eventpipesmoke/EventPipeSmoke.cs
+++ b/tests/src/tracing/eventpipesmoke/EventPipeSmoke.cs
@@ -57,7 +57,7 @@ namespace Tracing.Tests
                 System.IO.File.Delete(outputFilename);
             }
 
-            return pass ? 100 : 0;
+            return pass ? 100 : -1;
         }
     }
 }

--- a/tests/src/tracing/eventsourcesmoke/EventSourceSmoke.cs
+++ b/tests/src/tracing/eventsourcesmoke/EventSourceSmoke.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Threading.Tasks;
+using System.IO;
+using System.Diagnostics.Tracing;
+
+using Tracing.Tests.Common;
+
+namespace Tracing.Tests
+{
+    [EventSource(Name = "SimpleEventSource")]
+    class SimpleEventSource : EventSource
+    {
+        public SimpleEventSource() : base(true) { }
+
+        [Event(1)]
+        internal void Message(string msg) { this.WriteEvent(1, msg); }
+    }
+
+    class EventPipeSmoke
+    {
+        private static int messageIterations = 10000;
+        private static int trivialSize = 0x100000;
+        private static bool keepOutput = true;
+
+        public static TraceConfiguration GetConfig(EventSource eventSource, string outputFile="default.netperf")
+        {
+            // Setup the configuration values.
+            uint circularBufferMB = 1024; // 1 GB
+            uint level = 5;//(uint)EventLevel.Informational;
+            TimeSpan profSampleDelay = TimeSpan.FromMilliseconds(1);
+
+            // Create a new instance of EventPipeConfiguration.
+            TraceConfiguration config = new TraceConfiguration(outputFile, circularBufferMB);
+            // Setup the provider values.
+            // Public provider.
+            string providerName = eventSource.Guid.ToString("D");
+            UInt64 keywords = 0xffffffffffffffff;
+
+            // Enable the provider.
+            config.EnableProvider(providerName, keywords, level);
+
+            // Set the sampling rate.
+            config.SetSamplingRate(profSampleDelay);
+
+            return config;
+        }
+
+        static int Main(string[] args)
+        {
+            string outputFilename = System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".netperf";
+            SimpleEventSource eventSource = new SimpleEventSource();
+
+            Console.WriteLine("\tStart: Enable tracing.");
+            TraceControl.Enable(GetConfig(eventSource, outputFilename));
+            Console.WriteLine("\tEnd: Enable tracing.\n");
+
+            Console.WriteLine("\tStart: Messaging.");
+            // Send messages
+            // Use random numbers and addition as a simple, human readble checksum
+            Random generator = new Random();
+            for(int i=0; i<messageIterations; i++)
+            {
+                int x = generator.Next(1,1000);
+                int y = generator.Next(1,1000);
+                string result = String.Format("{0} + {1} = {2}", x, y, x+y);
+                
+                eventSource.Message(result);
+            }
+            Console.WriteLine("\tEnd: Messaging.\n");
+
+            Console.WriteLine("\tStart: Disable tracing.");
+            TraceControl.Disable();
+            Console.WriteLine("\tEnd: Disable tracing.\n");
+
+            FileInfo outputMeta = new FileInfo(outputFilename);
+            Console.WriteLine("\tCreated {0} bytes of data", outputMeta.Length);
+
+            bool pass = false;
+            if (outputMeta.Length > trivialSize){
+                pass = true;
+            }
+
+            if (keepOutput)
+            {
+                Console.WriteLine(String.Format("\tOutput file: {0}", outputFilename));
+            }
+            else
+            {
+                System.IO.File.Delete(outputFilename);
+            }
+
+            return pass ? 100 : 0;
+        }
+    }
+}

--- a/tests/src/tracing/eventsourcesmoke/EventSourceSmoke.cs
+++ b/tests/src/tracing/eventsourcesmoke/EventSourceSmoke.cs
@@ -20,7 +20,6 @@ namespace Tracing.Tests
     {
         private static int messageIterations = 10000;
         private static int trivialSize = 0x100000;
-        private static bool keepOutput = true;
 
         public static TraceConfiguration GetConfig(EventSource eventSource, string outputFile="default.netperf")
         {
@@ -47,7 +46,17 @@ namespace Tracing.Tests
 
         static int Main(string[] args)
         {
-            string outputFilename = System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".netperf";
+            bool keepOutput = false;
+            // Use the first arg as an output filename if there is one
+            string outputFilename = null;
+            if (args.Length >= 1) {
+                outputFilename = args[0];
+                keepOutput = true;
+            }
+            else {
+                outputFilename = System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".netperf";
+            }
+
             SimpleEventSource eventSource = new SimpleEventSource();
 
             Console.WriteLine("\tStart: Enable tracing.");

--- a/tests/src/tracing/eventsourcesmoke/EventSourceSmoke.cs
+++ b/tests/src/tracing/eventsourcesmoke/EventSourceSmoke.cs
@@ -89,7 +89,7 @@ namespace Tracing.Tests
                 System.IO.File.Delete(outputFilename);
             }
 
-            return pass ? 100 : 0;
+            return pass ? 100 : -1;
         }
     }
 }

--- a/tests/src/tracing/eventsourcesmoke/eventsourcesmoke.csproj
+++ b/tests/src/tracing/eventsourcesmoke/eventsourcesmoke.csproj
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{8E3244CB-407F-4142-BAAB-E7A55901A5FA}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="EventSourceSmoke.cs" />
+    <ProjectReference Include="../common/common.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
This PR goes about removing an unnecessary buffer copy in the EventPipelineEventProvider by passing the data structures as an array of EventData blobs rather than requiring a flat buffer. To facilitate this alternate structuring in the current code path an encapsulation class, EventPipeEventPayload, is added to the native code

Connected: #13238