### PR TITLE
don't use r2r images when the profiler requests that ngen images are disabled

### DIFF
--- a/src/vm/readytoruninfo.cpp
+++ b/src/vm/readytoruninfo.cpp
@@ -483,6 +483,12 @@ PTR_ReadyToRunInfo ReadyToRunInfo::Initialize(Module * pModule, AllocMemTracker 
         return NULL;
     }
 
+    if (CORProfilerDisableAllNGenImages() || CORProfilerUseProfileImages())
+    {
+        DoLog("Ready to Run disabled - profiler disabled native images");
+        return NULL;
+    }
+
     if (g_pConfig->ExcludeReadyToRun(pModule->GetSimpleName()))
     {
         DoLog("Ready to Run disabled - module on exclusion list");


### PR DESCRIPTION
This changes so that ready to run images are not loaded when a profiler requests that NGEN images are not used, or when a profiler requests that profiled NGEN images are used.
Conceptually profilers don't care if pre-generated images are NGEN or R2R. When they request that native images are not loaded, it is because the profiler wants to have all functions be instrumentable.