### PR TITLE
Fix double-indirect p/invoke call generation

### DIFF
--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -19209,6 +19209,10 @@ regMaskTP CodeGen::genCodeForCall(GenTreeCall* call, bool valUsed)
                             emitCallType = emitter::EC_INDIR_ARD;
 
 #endif // CPU_LOAD_STORE_ARCH
+
+                            // For a indirect calls, we don't want to pass the address (used below),
+                            // so set it to nullptr. (We've already used the address to load up the target register.)
+                            addr = nullptr;
                         }
                     }
 


### PR DESCRIPTION
When the signature to getAddressOfPInvokeTarget() was changed,
the double-indirect CT_USER_FUNC case was accidentally changed
to pass a non-null `addr` to emitIns_Call(). This leads to asserts
when ngen'ing (in my test, ngen of System.dll on desktop using `LEGACY_BACKEND`
cross-compiling arm32 altjit). For some reason, x86 is more permissive
in the emitIns_Call() assert for this case, but doesn't use the
non-null addr.

Fixes VSO 478352