### PR TITLE
Fix race condition for some threading tests using GC.KeepAlive

### DIFF
--- a/tests/src/baseservices/threading/mutex/openexisting/openmutexneg7.cs
+++ b/tests/src/baseservices/threading/mutex/openexisting/openmutexneg7.cs
@@ -46,6 +46,8 @@ class OpenMutexNeg
                 e.ToString());
         }
 
+        GC.KeepAlive(mut);
+
         Console.WriteLine(100 == iRet ? "Test Passed" : "Test Failed");
         return iRet;
     }

--- a/tests/src/baseservices/threading/waithandle/waitany/nullarray.cs
+++ b/tests/src/baseservices/threading/waithandle/waitany/nullarray.cs
@@ -31,7 +31,6 @@ class Duplicates
 			retCode = 98;			
 		}
 
-		GC.KeepAlive(waitHandles);
 
 		if (retCode ==100)
 			Console.WriteLine("Test Passed");

--- a/tests/src/baseservices/threading/waithandle/waitany/nullarray.cs
+++ b/tests/src/baseservices/threading/waithandle/waitany/nullarray.cs
@@ -31,6 +31,8 @@ class Duplicates
 			retCode = 98;			
 		}
 
+		GC.KeepAlive(waitHandles);
+
 		if (retCode ==100)
 			Console.WriteLine("Test Passed");
 		else

--- a/tests/src/baseservices/threading/waithandle/waitany/nullarray.cs
+++ b/tests/src/baseservices/threading/waithandle/waitany/nullarray.cs
@@ -31,7 +31,6 @@ class Duplicates
 			retCode = 98;			
 		}
 
-
 		if (retCode ==100)
 			Console.WriteLine("Test Passed");
 		else


### PR DESCRIPTION
cc @sergiy-k, @jkotas @RussKeldorph 

I observed that these tests were failing in .NET Native under GC stress.