### PR TITLE
Add full URL to the FileVersion information created a build time

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01903-01
+2.0.0-prerelease-01914-02

--- a/dir.props
+++ b/dir.props
@@ -61,6 +61,9 @@
     <SourceDir>$(__SourceDir)\</SourceDir>
     <SourceDir Condition="'$(__SourceDir)'==''">$(ProjectDir)src\</SourceDir>
 
+    <!-- This name is used to create a GIT reposiitory URL https://github.com/dotnet/$(GitHubRepositoryName) used to find source code for debugging -->
+    <GitHubRepositoryName Condition="'$(GitHubRepositoryName)' == ''">coreclr</GitHubRepositoryName>
+
     <PackagesDir>$(__PackagesDir)\</PackagesDir>
     <PackagesDir Condition="'$(__PackagesDir)'==''">$(ProjectDir)packages\</PackagesDir>
 

--- a/dir.props
+++ b/dir.props
@@ -182,7 +182,7 @@
     <PackageIndex Include="$(PackageIndexFile)" />
   </ItemGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(OfficialBuildId)' != ''">
     <BuildVersionFile>$(BaseIntermediateOutputPath)BuildVersion-$(OfficialBuildId).props</BuildVersionFile>
   </PropertyGroup>
 


### PR DESCRIPTION
It is useful to unambiguously find the source code for a given DLL.    Today we add the commit hash
to the FileVersion information information that a filever -v will show 
```
FileVersion     4.6.25302.01 built by: dlab-DDVSOWINAGE018. Commit Hash: ea50f78e431f325c4382c21e9b91c3e76898ba1e
```
This change augments the hash with the URL of the github so that you have a completely unambiguous identifier of the source code.  
```
FileVersion     4.6.25610.0 built by: vancem-VANCEM1. SrcCode: https://github.com/dotnet/coreclr/tree/59c978542dc085b8fd1756426dfbf3b0c883ae14
```
Note that the work to do this was checked into the tools code a while ago, this simply turns it on for coreclr by defining the 'GitHubRepositoryName' variable. 

@dagood @brianrob @lt72 