### PR TITLE
Do not use GT_INDEX in impInitializeArrayIntrinsic

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -3257,18 +3257,18 @@ GenTreePtr Compiler::impInitializeArrayIntrinsic(CORINFO_SIG_INFO* sig)
     impPopStack();
 
     const unsigned blkSize = size.Value();
-    GenTreePtr     dst;
+    unsigned       dataOffset;
 
     if (isMDArray)
     {
-        unsigned dataOffset = eeGetMDArrayDataOffset(elementType, rank);
-
-        dst = gtNewOperNode(GT_ADD, TYP_BYREF, arrayLocalNode, gtNewIconNode(dataOffset, TYP_I_IMPL));
+        dataOffset = eeGetMDArrayDataOffset(elementType, rank);
     }
     else
     {
-        dst = gtNewOperNode(GT_ADDR, TYP_BYREF, gtNewIndexRef(elementType, arrayLocalNode, gtNewIconNode(0)));
+        dataOffset = eeGetArrayDataOffset(elementType);
     }
+
+    GenTreePtr dst     = gtNewOperNode(GT_ADD, TYP_BYREF, arrayLocalNode, gtNewIconNode(dataOffset, TYP_I_IMPL));
     GenTreePtr blk     = gtNewBlockVal(dst, blkSize);
     GenTreePtr srcAddr = gtNewIconHandleNode((size_t)initData, GTF_ICON_STATIC_HDL);
     GenTreePtr src     = gtNewOperNode(GT_IND, TYP_STRUCT, srcAddr);


### PR DESCRIPTION
We know that array size is larger than 0 so we do not need a range check.  This range check survives until the RangeCheck phase so it creates more work of the phases before it. It is also very unlikely to enable other optimizations, subsequent `a[0]` range checks can still be eliminated because the array length is known and constant.