### PR TITLE
Change identifier for EventProviders from GUID to string name

### DIFF
--- a/src/mscorlib/shared/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/EventProvider.cs
@@ -87,7 +87,7 @@ namespace System.Diagnostics.Tracing
         private long m_allKeywordMask;                   // Match all keyword
         private List<SessionInfo> m_liveSessions;        // current live sessions (Tuple<sessionIdBit, etwSessionId>)
         private bool m_enabled;                          // Enabled flag from Trace callback
-        private Guid m_providerId;                       // Control Guid 
+        private Guid m_providerName;                     // Control name
         internal bool m_disposed;                        // when true provider has unregistered
 
         [ThreadStatic]
@@ -140,13 +140,13 @@ namespace System.Diagnostics.Tracing
         // <SatisfiesLinkDemand Name="Win32Exception..ctor(System.Int32)" />
         // <ReferencesCritical Name="Method: EtwEnableCallBack(Guid&, Int32, Byte, Int64, Int64, Void*, Void*):Void" Ring="1" />
         // </SecurityKernel>
-        internal unsafe void Register(Guid providerGuid)
+        internal unsafe void Register(string providerName)
         {
-            m_providerId = providerGuid;
+            m_providerName = providerName;
             uint status;
             m_etwCallback = new UnsafeNativeMethods.ManifestEtw.EtwEnableCallback(EtwEnableCallBack);
 
-            status = EventRegister(ref m_providerId, m_etwCallback);
+            status = EventRegister(ref m_providerName, m_etwCallback);
             if (status != 0)
             {
                 throw new ArgumentException(Win32Native.GetMessage(unchecked((int)status)));
@@ -447,7 +447,7 @@ namespace System.Diagnostics.Tracing
                 buffer = space;
                 var hr = 0;
 
-                fixed (Guid* provider = &m_providerId)
+                fixed (string* provider = &m_providerName)
                 {
                     hr = UnsafeNativeMethods.ManifestEtw.EnumerateTraceGuidsEx(UnsafeNativeMethods.ManifestEtw.TRACE_QUERY_INFO_CLASS.TraceGuidQueryInfo,
                         provider, sizeof(Guid), buffer, buffSize, ref buffSize);
@@ -488,7 +488,7 @@ namespace System.Diagnostics.Tracing
             // at least some of the time.  
 
             // Determine our session from what is in the registry.  
-            string regKey = @"\Microsoft\Windows\CurrentVersion\Winevt\Publishers\{" + m_providerId + "}";
+            string regKey = @"\Microsoft\Windows\CurrentVersion\Winevt\Publishers\{" + m_providerName + "}";
             if (System.Runtime.InteropServices.Marshal.SizeOf(typeof(IntPtr)) == 8)
                 regKey = @"Software" + @"\Wow6432Node" + regKey;
             else
@@ -563,7 +563,7 @@ namespace System.Diagnostics.Tracing
             if (filterData == null)
             {
 #if (!ES_BUILD_PCL && !ES_BUILD_PN && PLATFORM_WINDOWS)
-                string regKey = @"\Microsoft\Windows\CurrentVersion\Winevt\Publishers\{" + m_providerId + "}";
+                string regKey = @"\Microsoft\Windows\CurrentVersion\Winevt\Publishers\{" + m_providerName + "}";
                 if (System.Runtime.InteropServices.Marshal.SizeOf(typeof(IntPtr)) == 8)
                     regKey = @"HKEY_LOCAL_MACHINE\Software" + @"\Wow6432Node" + regKey;
                 else
@@ -1184,11 +1184,11 @@ namespace System.Diagnostics.Tracing
 
         // These are look-alikes to the Manifest based ETW OS APIs that have been shimmed to work
         // either with Manifest ETW or Classic ETW (if Manifest based ETW is not available).  
-        private unsafe uint EventRegister(ref Guid providerId, UnsafeNativeMethods.ManifestEtw.EtwEnableCallback enableCallback)
+        private unsafe uint EventRegister(ref string providerName, UnsafeNativeMethods.ManifestEtw.EtwEnableCallback enableCallback)
         {
-            m_providerId = providerId;
+            m_providerName = providerName;
             m_etwCallback = enableCallback;
-            return m_eventProvider.EventRegister(ref providerId, enableCallback, null, ref m_regHandle);
+            return m_eventProvider.EventRegister(ref m_providerName, enableCallback, null, ref m_regHandle);
         }
 
         private uint EventUnregister(long registrationHandle)
@@ -1221,13 +1221,14 @@ namespace System.Diagnostics.Tracing
     {
         // Register an event provider.
         unsafe uint IEventProvider.EventRegister(
-            ref Guid providerId,
+            ref string providerName,
             UnsafeNativeMethods.ManifestEtw.EtwEnableCallback enableCallback,
             void* callbackContext,
             ref long registrationHandle)
         {
+            Guid fakeProviderId = 0; // Is it ok to not provide a provider Id here?
             return UnsafeNativeMethods.ManifestEtw.EventRegister(
-                ref providerId,
+                ref fakeProviderId,
                 enableCallback,
                 callbackContext,
                 ref registrationHandle);
@@ -1278,7 +1279,7 @@ namespace System.Diagnostics.Tracing
     internal sealed class NoOpEventProvider : IEventProvider
     {
         unsafe uint IEventProvider.EventRegister(
-            ref Guid providerId,
+            ref string providerName,
             UnsafeNativeMethods.ManifestEtw.EtwEnableCallback enableCallback,
             void* callbackContext,
             ref long registrationHandle)

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/EventProvider.cs
@@ -1226,7 +1226,8 @@ namespace System.Diagnostics.Tracing
             void* callbackContext,
             ref long registrationHandle)
         {
-            Guid fakeProviderId = 0; // Is it ok to not provide a provider Id here?
+            byte[] zeroes = new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+            Guid fakeProviderId(zeroes); // Is it ok to not provide a provider Id here?
             return UnsafeNativeMethods.ManifestEtw.EventRegister(
                 ref fakeProviderId,
                 enableCallback,

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/EventProvider.cs
@@ -87,7 +87,7 @@ namespace System.Diagnostics.Tracing
         private long m_allKeywordMask;                   // Match all keyword
         private List<SessionInfo> m_liveSessions;        // current live sessions (Tuple<sessionIdBit, etwSessionId>)
         private bool m_enabled;                          // Enabled flag from Trace callback
-        private Guid m_providerName;                     // Control name
+        private string m_providerName;                     // Control name
         internal bool m_disposed;                        // when true provider has unregistered
 
         [ThreadStatic]

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -1560,7 +1560,7 @@ namespace System.Diagnostics.Tracing
 
                 // Register the provider with ETW
                 var provider = new OverideEventProvider(this);
-                provider.Register(ref this);
+                provider.Register(this);
 #endif
                 // Add the eventSource to the global (weak) list.  
                 // This also sets m_id, which is the index in the list. 

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -1560,7 +1560,7 @@ namespace System.Diagnostics.Tracing
 
                 // Register the provider with ETW
                 var provider = new OverideEventProvider(this);
-                provider.Register(eventSourceName);
+                provider.Register(ref this);
 #endif
                 // Add the eventSource to the global (weak) list.  
                 // This also sets m_id, which is the index in the list. 

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -1560,7 +1560,7 @@ namespace System.Diagnostics.Tracing
 
                 // Register the provider with ETW
                 var provider = new OverideEventProvider(this);
-                provider.Register(eventSourceGuid);
+                provider.Register(eventSourceName);
 #endif
                 // Add the eventSource to the global (weak) list.  
                 // This also sets m_id, which is the index in the list. 

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/IEventProvider.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/IEventProvider.cs
@@ -15,7 +15,7 @@ namespace System.Diagnostics.Tracing
     {
         // Register an event provider.
         unsafe uint EventRegister(
-            ref Guid providerId,
+            ref string providerName,
             UnsafeNativeMethods.ManifestEtw.EtwEnableCallback enableCallback,
             void* callbackContext,
             ref long registrationHandle);

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/IEventProvider.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/IEventProvider.cs
@@ -15,7 +15,7 @@ namespace System.Diagnostics.Tracing
     {
         // Register an event provider.
         unsafe uint EventRegister(
-            ref string providerName,
+            ref EventSource eventSource,
             UnsafeNativeMethods.ManifestEtw.EtwEnableCallback enableCallback,
             void* callbackContext,
             ref long registrationHandle);

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/IEventProvider.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/IEventProvider.cs
@@ -15,7 +15,7 @@ namespace System.Diagnostics.Tracing
     {
         // Register an event provider.
         unsafe uint EventRegister(
-            ref EventSource eventSource,
+            EventSource eventSource,
             UnsafeNativeMethods.ManifestEtw.EtwEnableCallback enableCallback,
             void* callbackContext,
             ref long registrationHandle);

--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventPipe.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventPipe.cs
@@ -158,7 +158,7 @@ namespace System.Diagnostics.Tracing
         //
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
         [SuppressUnmanagedCodeSecurity]
-        internal static extern IntPtr CreateProvider(Guid providerID, UnsafeNativeMethods.ManifestEtw.EtwEnableCallback callbackFunc);
+        internal static extern IntPtr CreateProvider(string providerName, UnsafeNativeMethods.ManifestEtw.EtwEnableCallback callbackFunc);
 
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
         [SuppressUnmanagedCodeSecurity]

--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventPipeEventProvider.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventPipeEventProvider.cs
@@ -18,13 +18,13 @@ namespace System.Diagnostics.Tracing
 
         // Register an event provider.
         unsafe uint IEventProvider.EventRegister(
-            ref Guid providerId,
+            ref string providerName,
             UnsafeNativeMethods.ManifestEtw.EtwEnableCallback enableCallback,
             void* callbackContext,
             ref long registrationHandle)
         {
             uint returnStatus = 0;
-            m_provHandle = EventPipeInternal.CreateProvider(providerId, enableCallback);
+            m_provHandle = EventPipeInternal.CreateProvider(providerName, enableCallback);
             if(m_provHandle != IntPtr.Zero)
             {
                 // Fixed registration handle because a new EventPipeEventProvider

--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventPipeEventProvider.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventPipeEventProvider.cs
@@ -18,13 +18,13 @@ namespace System.Diagnostics.Tracing
 
         // Register an event provider.
         unsafe uint IEventProvider.EventRegister(
-            ref string providerName,
+            EventSource eventSource,
             UnsafeNativeMethods.ManifestEtw.EtwEnableCallback enableCallback,
             void* callbackContext,
             ref long registrationHandle)
         {
             uint returnStatus = 0;
-            m_provHandle = EventPipeInternal.CreateProvider(providerName, enableCallback);
+            m_provHandle = EventPipeInternal.CreateProvider(eventSource.Name, enableCallback);
             if(m_provHandle != IntPtr.Zero)
             {
                 // Fixed registration handle because a new EventPipeEventProvider

--- a/src/scripts/genEventPipe.py
+++ b/src/scripts/genEventPipe.py
@@ -403,7 +403,7 @@ bool WriteToBuffer(const T &value, char *&buffer, unsigned int& offset, unsigned
         eventpipeImpl.write(
             "const WCHAR* %sName = W(\"%s\");\n" % (
                 providerPrettyName,
-                providerPrettyName
+                providerName
             )
         )
         eventpipeImpl.write(

--- a/src/scripts/genEventPipe.py
+++ b/src/scripts/genEventPipe.py
@@ -401,15 +401,16 @@ bool WriteToBuffer(const T &value, char *&buffer, unsigned int& offset, unsigned
 
         eventpipeImpl.write(header)
         eventpipeImpl.write(
-            "SString const " +
-            providerPrettyName +
-            "Name = \"" +
-            providerPrettyName +
-            "\";\n")
+            "SString const %sName = SString(u\"%s\");\n" % (
+                providerPrettyName,
+                providerPrettyName
+            )
+        )
         eventpipeImpl.write(
-            "EventPipeProvider *EventPipeProvider" +
-            providerPrettyName +
-            " = nullptr;\n")
+            "EventPipeProvider *EventPipeProvider%s = nullptr;\n" % (
+                providerPrettyName,
+            )
+        )
         templateNodes = providerNode.getElementsByTagName('template')
         allTemplates = parseTemplateNodes(templateNodes)
         eventNodes = providerNode.getElementsByTagName('event')

--- a/src/scripts/genEventPipe.py
+++ b/src/scripts/genEventPipe.py
@@ -122,9 +122,9 @@ def generateClrEventPipeWriteEventsImpl(
     WriteEventImpl.append(
         "    EventPipeProvider" +
         providerPrettyName +
-        " = EventPipe::CreateProvider(" +
+        " = EventPipe::CreateProvider(SL(" +
         providerPrettyName +
-        "Name);\n")
+        "Name));\n")
     for eventNode in eventNodes:
         eventName = eventNode.getAttribute('symbol')
         templateName = eventNode.getAttribute('template')
@@ -401,7 +401,7 @@ bool WriteToBuffer(const T &value, char *&buffer, unsigned int& offset, unsigned
 
         eventpipeImpl.write(header)
         eventpipeImpl.write(
-            "SString const %sName = SString(u\"%s\");\n" % (
+            "const WCHAR* %sName = W(\"%s\");\n" % (
                 providerPrettyName,
                 providerPrettyName
             )

--- a/src/scripts/genEventPipe.py
+++ b/src/scripts/genEventPipe.py
@@ -124,7 +124,7 @@ def generateClrEventPipeWriteEventsImpl(
         providerPrettyName +
         " = EventPipe::CreateProvider(" +
         providerPrettyName +
-        "GUID);\n")
+        "Name);\n")
     for eventNode in eventNodes:
         eventName = eventNode.getAttribute('symbol')
         templateName = eventNode.getAttribute('template')
@@ -207,22 +207,8 @@ def generateWriteEventBody(template, providerName, eventName):
 
     return header + code + checking + body + footer
 
-providerGUIDMap = {}
-providerGUIDMap[
-    "{e13c0d23-ccbc-4e12-931b-d9cc2eee27e4}"] = "{0xe13c0d23,0xccbc,0x4e12,{0x93,0x1b,0xd9,0xcc,0x2e,0xee,0x27,0xe4}}"
-providerGUIDMap[
-    "{A669021C-C450-4609-A035-5AF59AF4DF18}"] = "{0xA669021C,0xC450,0x4609,{0xA0,0x35,0x5A,0xF5,0x9A,0xF4,0xDF,0x18}}"
-providerGUIDMap[
-    "{CC2BCBBA-16B6-4cf3-8990-D74C2E8AF500}"] = "{0xCC2BCBBA,0x16B6,0x4cf3,{0x89,0x90,0xD7,0x4C,0x2E,0x8A,0xF5,0x00}}"
-providerGUIDMap[
-    "{763FD754-7086-4dfe-95EB-C01A46FAF4CA}"] = "{0x763FD754,0x7086,0x4dfe,{0x95,0xEB,0xC0,0x1A,0x46,0xFA,0xF4,0xCA}}"
-
-
-def generateGUID(tmpGUID):
-    return providerGUIDMap[tmpGUID]
 
 keywordMap = {}
-
 
 def generateEventKeywords(eventKeywords):
     mask = 0
@@ -375,8 +361,6 @@ def generateEventPipeImplFiles(
     tree = DOM.parse(etwmanifest)
     coreclrRoot = os.getcwd()
     for providerNode in tree.getElementsByTagName('provider'):
-        providerGUID = providerNode.getAttribute('guid')
-        providerGUID = generateGUID(providerGUID)
         providerName = providerNode.getAttribute('name')
 
         providerPrettyName = providerName.replace("Windows-", '')
@@ -417,11 +401,11 @@ bool WriteToBuffer(const T &value, char *&buffer, unsigned int& offset, unsigned
 
         eventpipeImpl.write(header)
         eventpipeImpl.write(
-            "GUID const " +
+            "SString const " +
             providerPrettyName +
-            "GUID = " +
-            providerGUID +
-            ";\n")
+            "Name = \"" +
+            providerPrettyName +
+            "\";\n")
         eventpipeImpl.write(
             "EventPipeProvider *EventPipeProvider" +
             providerPrettyName +

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -380,7 +380,7 @@ bool EventPipe::Enabled()
     return enabled;
 }
 
-EventPipeProvider* EventPipe::CreateProvider(const GUID &providerID, EventPipeCallback pCallbackFunction, void *pCallbackData)
+EventPipeProvider* EventPipe::CreateProvider(const SString &providerName, EventPipeCallback pCallbackFunction, void *pCallbackData)
 {
     CONTRACTL
     {
@@ -390,7 +390,7 @@ EventPipeProvider* EventPipe::CreateProvider(const GUID &providerID, EventPipeCa
     }
     CONTRACTL_END;
 
-    return new EventPipeProvider(providerID, pCallbackFunction, pCallbackData);
+    return new EventPipeProvider(providerName, pCallbackFunction, pCallbackData);
 }
 
 void EventPipe::DeleteProvider(EventPipeProvider *pProvider)
@@ -700,7 +700,7 @@ void QCALLTYPE EventPipeInternal::Disable()
 }
 
 INT_PTR QCALLTYPE EventPipeInternal::CreateProvider(
-    GUID providerID,
+    SString providerName,
     EventPipeCallback pCallbackFunc)
 {
     QCALL_CONTRACT;
@@ -709,7 +709,7 @@ INT_PTR QCALLTYPE EventPipeInternal::CreateProvider(
 
     BEGIN_QCALL;
 
-    pProvider = EventPipe::CreateProvider(providerID, pCallbackFunc, NULL);
+    pProvider = EventPipe::CreateProvider(providerName, pCallbackFunc, NULL);
 
     END_QCALL;
 

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -700,7 +700,7 @@ void QCALLTYPE EventPipeInternal::Disable()
 }
 
 INT_PTR QCALLTYPE EventPipeInternal::CreateProvider(
-    SString providerName,
+    __in_z LPCWSTR providerName,
     EventPipeCallback pCallbackFunc)
 {
     QCALL_CONTRACT;
@@ -709,7 +709,7 @@ INT_PTR QCALLTYPE EventPipeInternal::CreateProvider(
 
     BEGIN_QCALL;
 
-    pProvider = EventPipe::CreateProvider(providerName, pCallbackFunc, NULL);
+    pProvider = EventPipe::CreateProvider(SL(providerName), pCallbackFunc, NULL);
 
     END_QCALL;
 

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -244,7 +244,7 @@ class EventPipe
         static bool Enabled();
 
         // Create a provider.
-        static EventPipeProvider* CreateProvider(const GUID &providerID, EventPipeCallback pCallbackFunction = NULL, void *pCallbackData = NULL);
+        static EventPipeProvider* CreateProvider(const SString &providerName, EventPipeCallback pCallbackFunction = NULL, void *pCallbackData = NULL);
 
         // Delete a provider.
         static void DeleteProvider(EventPipeProvider *pProvider);
@@ -358,7 +358,7 @@ public:
     static void QCALLTYPE Disable();
 
     static INT_PTR QCALLTYPE CreateProvider(
-        GUID providerID,
+        SString providerName,
         EventPipeCallback pCallbackFunc);
 
     static INT_PTR QCALLTYPE DefineEvent(

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -358,7 +358,7 @@ public:
     static void QCALLTYPE Disable();
 
     static INT_PTR QCALLTYPE CreateProvider(
-        SString providerName,
+        __in_z LPCWSTR providerName,
         EventPipeCallback pCallbackFunc);
 
     static INT_PTR QCALLTYPE DefineEvent(

--- a/src/vm/eventpipeconfiguration.cpp
+++ b/src/vm/eventpipeconfiguration.cpp
@@ -303,8 +303,8 @@ void EventPipeConfiguration::EnableRundown()
     _ASSERTE(m_pEnabledProviderList == NULL);
     const unsigned int numRundownProviders = 2;
     EventPipeProviderConfiguration rundownProviders[numRundownProviders];
-    rundownProviders[0] = EventPipeProviderConfiguration(W("DotNETRuntime"), 0x80020138, static_cast<unsigned int>(EventPipeEventLevel::Verbose)); // Public provider.
-    rundownProviders[1] = EventPipeProviderConfiguration(W("DotNETRuntimeRundown"), 0x80020138, static_cast<unsigned int>(EventPipeEventLevel::Verbose)); // Rundown provider.
+    rundownProviders[0] = EventPipeProviderConfiguration(W("Microsoft-Windows-DotNETRuntime"), 0x80020138, static_cast<unsigned int>(EventPipeEventLevel::Verbose)); // Public provider.
+    rundownProviders[1] = EventPipeProviderConfiguration(W("Microsoft-Windows-DotNETRuntimeRundown"), 0x80020138, static_cast<unsigned int>(EventPipeEventLevel::Verbose)); // Rundown provider.
 
     // Enable rundown.
     m_rundownEnabled = true;

--- a/src/vm/eventpipeconfiguration.cpp
+++ b/src/vm/eventpipeconfiguration.cpp
@@ -303,8 +303,8 @@ void EventPipeConfiguration::EnableRundown()
     _ASSERTE(m_pEnabledProviderList == NULL);
     const unsigned int numRundownProviders = 2;
     EventPipeProviderConfiguration rundownProviders[numRundownProviders];
-    rundownProviders[0] = EventPipeProviderConfiguration(W("e13c0d23-ccbc-4e12-931b-d9cc2eee27e4"), 0x80020138, static_cast<unsigned int>(EventPipeEventLevel::Verbose)); // Public provider.
-    rundownProviders[1] = EventPipeProviderConfiguration(W("a669021c-c450-4609-a035-5af59af4df18"), 0x80020138, static_cast<unsigned int>(EventPipeEventLevel::Verbose)); // Rundown provider.
+    rundownProviders[0] = EventPipeProviderConfiguration(W("DotNETRuntime"), 0x80020138, static_cast<unsigned int>(EventPipeEventLevel::Verbose)); // Public provider.
+    rundownProviders[1] = EventPipeProviderConfiguration(W("DotNETRuntimeRundown"), 0x80020138, static_cast<unsigned int>(EventPipeEventLevel::Verbose)); // Rundown provider.
 
     // Enable rundown.
     m_rundownEnabled = true;

--- a/src/vm/eventpipeconfiguration.cpp
+++ b/src/vm/eventpipeconfiguration.cpp
@@ -10,7 +10,7 @@
 
 #ifdef FEATURE_PERFTRACING
 
-const SString EventPipeConfiguration::s_configurationProviderName = SString(u"EventPipeConfigurationProvider");
+const SString EventPipeConfiguration::s_configurationProviderName = W("EventPipeConfigurationProvider");
 
 EventPipeConfiguration::EventPipeConfiguration()
 {

--- a/src/vm/eventpipeconfiguration.cpp
+++ b/src/vm/eventpipeconfiguration.cpp
@@ -10,7 +10,7 @@
 
 #ifdef FEATURE_PERFTRACING
 
-const WCHAR* EventPipeConfiguration::s_configurationProviderName = W("EventPipeConfigurationProvider");
+const WCHAR* EventPipeConfiguration::s_configurationProviderName = W("Microsoft-DotNETCore-EventPipeConfiguration");
 
 EventPipeConfiguration::EventPipeConfiguration()
 {
@@ -349,7 +349,7 @@ EventPipeEventInstance* EventPipeConfiguration::BuildEventMetadataEvent(EventPip
     memcpy(currentPtr, (BYTE*)providerName.GetUnicode(), providerNameLength);
     currentPtr += providerNameLength;
 
-    // Write the event ID.
+    // Write the event name as null-terminated unicode.
     memcpy(currentPtr, &eventID, sizeof(eventID));
     currentPtr += sizeof(eventID);
 

--- a/src/vm/eventpipeconfiguration.cpp
+++ b/src/vm/eventpipeconfiguration.cpp
@@ -10,9 +10,7 @@
 
 #ifdef FEATURE_PERFTRACING
 
-// {5291C09C-2660-4D6A-83A3-C383FD020DEC}
-const GUID EventPipeConfiguration::s_configurationProviderID =
-    { 0x5291c09c, 0x2660, 0x4d6a, { 0x83, 0xa3, 0xc3, 0x83, 0xfd, 0x2, 0xd, 0xec } };
+const SString EventPipeConfiguration::s_configurationProviderName = SString(u"EventPipeConfigurationProvider");
 
 EventPipeConfiguration::EventPipeConfiguration()
 {
@@ -59,7 +57,7 @@ void EventPipeConfiguration::Initialize()
     CONTRACTL_END;
 
     // Create the configuration provider.
-    m_pConfigProvider = EventPipe::CreateProvider(s_configurationProviderID);
+    m_pConfigProvider = EventPipe::CreateProvider(s_configurationProviderName);
 
     // Create the metadata event.
     m_pMetadataEvent = m_pConfigProvider->AddEvent(
@@ -178,7 +176,7 @@ EventPipeProvider* EventPipeConfiguration::GetProviderNoLock(const SString &prov
     while(pElem != NULL)
     {
         EventPipeProvider *pProvider = pElem->GetValue();
-        if(pProvider->GetProviderName() == providerName)
+        if(pProvider->GetProviderName().Equals(providerName))
         {
             return pProvider;
         }
@@ -348,7 +346,7 @@ EventPipeEventInstance* EventPipeConfiguration::BuildEventMetadataEvent(EventPip
     BYTE *currentPtr = pInstancePayload;
 
     // Write the provider ID.
-    memcpy(currentPtr, (BYTE*)&providerName.GetUnicode(), providerNameLength);
+    memcpy(currentPtr, (BYTE*)providerName.GetUnicode(), providerNameLength);
     currentPtr += providerNameLength;
 
     // Write the event ID.
@@ -495,7 +493,7 @@ EventPipeEnabledProvider* EventPipeEnabledProviderList::GetEnabledProvider(
         return NULL;
     }
 
-    SString providerNameStr pProvider->GetProviderName();
+    SString providerNameStr = pProvider->GetProviderName();
     LPCWSTR providerName = providerNameStr.GetUnicode();
 
     EventPipeEnabledProvider *pEnabledProvider = NULL;

--- a/src/vm/eventpipeconfiguration.cpp
+++ b/src/vm/eventpipeconfiguration.cpp
@@ -10,7 +10,7 @@
 
 #ifdef FEATURE_PERFTRACING
 
-const SString EventPipeConfiguration::s_configurationProviderName = W("EventPipeConfigurationProvider");
+const WCHAR* EventPipeConfiguration::s_configurationProviderName = W("EventPipeConfigurationProvider");
 
 EventPipeConfiguration::EventPipeConfiguration()
 {
@@ -57,7 +57,7 @@ void EventPipeConfiguration::Initialize()
     CONTRACTL_END;
 
     // Create the configuration provider.
-    m_pConfigProvider = EventPipe::CreateProvider(s_configurationProviderName);
+    m_pConfigProvider = EventPipe::CreateProvider(SL(s_configurationProviderName));
 
     // Create the metadata event.
     m_pMetadataEvent = m_pConfigProvider->AddEvent(

--- a/src/vm/eventpipeconfiguration.h
+++ b/src/vm/eventpipeconfiguration.h
@@ -100,7 +100,7 @@ private:
 
     // The provider name for the configuration event pipe provider.
     // This provider is used to emit configuration events.
-    static const SString s_configurationProviderName;
+    const static WCHAR* s_configurationProviderName;
 
     // True if rundown is enabled.
     Volatile<bool> m_rundownEnabled;

--- a/src/vm/eventpipeconfiguration.h
+++ b/src/vm/eventpipeconfiguration.h
@@ -42,7 +42,7 @@ public:
     bool UnregisterProvider(EventPipeProvider &provider);
 
     // Get the provider with the specified provider ID if it exists.
-    EventPipeProvider* GetProvider(const GUID &providerID);
+    EventPipeProvider* GetProvider(const SString &providerID);
 
     // Get the configured size of the circular buffer.
     size_t GetCircularBufferSize() const;
@@ -77,7 +77,7 @@ public:
 private:
 
     // Get the provider without taking the lock.
-    EventPipeProvider* GetProviderNoLock(const GUID &providerID);
+    EventPipeProvider* GetProviderNoLock(const SString &providerID);
 
     // Determines whether or not the event pipe is enabled.
     Volatile<bool> m_enabled;
@@ -98,9 +98,9 @@ private:
     // The event used to write event information to the event stream.
     EventPipeEvent *m_pMetadataEvent;
 
-    // The provider ID for the configuration event pipe provider.
+    // The provider name for the configuration event pipe provider.
     // This provider is used to emit configuration events.
-    static const GUID s_configurationProviderID;
+    static const SString s_configurationProviderName;
 
     // True if rundown is enabled.
     Volatile<bool> m_rundownEnabled;

--- a/src/vm/eventpipeeventinstance.cpp
+++ b/src/vm/eventpipeeventinstance.cpp
@@ -183,7 +183,7 @@ void EventPipeEventInstance::SerializeToJsonFile(EventPipeJsonFile *pFile)
     EX_TRY
     {
         StackScratchBuffer scratch;
-        providerName = m_pEvent->GetProvider()->GetProviderName();
+        SString providerName = m_pEvent->GetProvider()->GetProviderName();
 
         SString message;
         message.Printf("Provider=%s/EventID=%d/Version=%d", providerName.GetANSI(scratch), m_pEvent->GetEventID(), m_pEvent->GetEventVersion());

--- a/src/vm/eventpipeeventinstance.cpp
+++ b/src/vm/eventpipeeventinstance.cpp
@@ -182,19 +182,11 @@ void EventPipeEventInstance::SerializeToJsonFile(EventPipeJsonFile *pFile)
 
     EX_TRY
     {
-        const unsigned int guidSize = 39;
-        WCHAR wszProviderID[guidSize];
-        if(!StringFromGUID2(m_pEvent->GetProvider()->GetProviderID(), wszProviderID, guidSize))
-        {
-            wszProviderID[0] = '\0';
-        }
-
-        // Strip off the {}.
         StackScratchBuffer scratch;
-        SString guidStr(&wszProviderID[1], guidSize-3);
+        providerName = m_pEvent->GetProvider()->GetProviderName();
 
         SString message;
-        message.Printf("Provider=%s/EventID=%d/Version=%d", guidStr.GetANSI(scratch), m_pEvent->GetEventID(), m_pEvent->GetEventVersion());
+        message.Printf("Provider=%s/EventID=%d/Version=%d", providerName.GetANSI(scratch), m_pEvent->GetEventID(), m_pEvent->GetEventVersion());
         pFile->WriteEvent(m_timeStamp, m_threadID, message, m_stackContents);
     }
     EX_CATCH{} EX_END_CATCH(SwallowAllExceptions);

--- a/src/vm/eventpipefile.cpp
+++ b/src/vm/eventpipefile.cpp
@@ -25,6 +25,9 @@ EventPipeFile::EventPipeFile(
     }
     CONTRACTL_END;
 
+    m_objectVersion = 2;
+    m_minReaderVersion = 0;
+
     m_pSerializer = new FastSerializer(outputFilePath, *this);
     m_serializationLock.Init(LOCK_TYPE_DEFAULT);
     m_pMetadataLabels = new MapSHashWithRemove<EventPipeEvent*, StreamLabel>();

--- a/src/vm/eventpipefile.cpp
+++ b/src/vm/eventpipefile.cpp
@@ -25,8 +25,8 @@ EventPipeFile::EventPipeFile(
     }
     CONTRACTL_END;
 
-    m_objectVersion = 2;
-    m_minReaderVersion = 0;
+    SetObjectVersion(2);
+    SetMinReaderVersion(0);
 
     m_pSerializer = new FastSerializer(outputFilePath, *this);
     m_serializationLock.Init(LOCK_TYPE_DEFAULT);

--- a/src/vm/eventpipeprovider.cpp
+++ b/src/vm/eventpipeprovider.cpp
@@ -81,9 +81,9 @@ const GUID& EventPipeProvider::GenerateGuidFromName()
 {
     LIMITED_METHOD_CONTRACT;
 
-    unsigned int providerNameLength = (providerName.GetCount() + 1) * sizeof(WCHAR);
+    unsigned int providerNameLength = (m_providerName.GetCount() + 1) * sizeof(WCHAR);
 
-    SHA1hash hasher;
+    SHA1Hash hasher;
     hasher.AddData((BYTE *)m_providerName.GetUnicode(), providerNameLength); //There may be an issue with Endian-ness
     BYTE *hash = hasher.GetHash();
     hash[7] = (hash[7] & 0x0F) | 0x50;   // Set high 4 bits of octet 7 to 5, as per RFC 4122
@@ -93,18 +93,18 @@ const GUID& EventPipeProvider::GenerateGuidFromName()
     return m_providerID;
 }
 
-const GUID& EventPipeProvider::GetProviderName() const
-{
-    LIMITED_METHOD_CONTRACT;
-
-    return m_providerName;
-}
-
 const GUID& EventPipeProvider::GetProviderID() const
 {
     LIMITED_METHOD_CONTRACT;
 
     return m_providerID;
+}
+
+const SString& EventPipeProvider::GetProviderName() const
+{
+    LIMITED_METHOD_CONTRACT;
+
+    return m_providerName;
 }
 
 bool EventPipeProvider::Enabled() const

--- a/src/vm/eventpipeprovider.h
+++ b/src/vm/eventpipeprovider.h
@@ -76,6 +76,9 @@ public:
     // Get the provider ID.
     const GUID& GetProviderID() const;
 
+    // Get the provider Name.
+    const SString& GetProviderName() const;
+
     // Determine if the provider is enabled.
     bool Enabled() const;
 

--- a/src/vm/eventpipeprovider.h
+++ b/src/vm/eventpipeprovider.h
@@ -63,18 +63,12 @@ private:
     // has been deferred until tracing is stopped.
     bool m_deleteDeferred;
 
-    // Using the name of the provider, create a GUID identifier and save it
-    const GUID& GenerateGuidFromName();
-
     // Private constructor because all providers are created through EventPipe::CreateProvider.
     EventPipeProvider(const SString &providerName, EventPipeCallback pCallbackFunction = NULL, void *pCallbackData = NULL);
 
 public:
 
     ~EventPipeProvider();
-
-    // Get the provider ID.
-    const GUID& GetProviderID() const;
 
     // Get the provider Name.
     const SString& GetProviderName() const;

--- a/src/vm/eventpipeprovider.h
+++ b/src/vm/eventpipeprovider.h
@@ -34,6 +34,9 @@ private:
     // The GUID of the provider.
     GUID m_providerID;
 
+    // The name of the provider.
+    SString m_providerName;
+
     // True if the provider is enabled.
     bool m_enabled;
 
@@ -60,8 +63,11 @@ private:
     // has been deferred until tracing is stopped.
     bool m_deleteDeferred;
 
+    // Using the name of the provider, create a GUID identifier and save it
+    const GUID& GenerateGuidFromName();
+
     // Private constructor because all providers are created through EventPipe::CreateProvider.
-    EventPipeProvider(const GUID &providerID, EventPipeCallback pCallbackFunction = NULL, void *pCallbackData = NULL);
+    EventPipeProvider(const SString &providerName, EventPipeCallback pCallbackFunction = NULL, void *pCallbackData = NULL);
 
 public:
 

--- a/src/vm/fastserializableobject.h
+++ b/src/vm/fastserializableobject.h
@@ -26,10 +26,37 @@ public:
     // Get the type name for the current object.
     virtual const char* GetTypeName() = 0;
 
-    int GetObjectVersion() const { return m_objectVersion; }
-    int GetMinReaderVersion() const { return m_minReaderVersion; }
+    int GetObjectVersion() const
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        return m_objectVersion;
+    }
+
+    int GetMinReaderVersion() const
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        return m_minReaderVersion;
+    }
 
 protected:
+
+    void SetObjectVersion(int version)
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        m_objectVersion = version;
+    }
+
+    void SetMinReaderVersion(int version)
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        m_minReaderVersion = version;
+    }
+
+private:
 
     int m_objectVersion = 1;
     int m_minReaderVersion = 0;

--- a/src/vm/fastserializableobject.h
+++ b/src/vm/fastserializableobject.h
@@ -25,6 +25,14 @@ public:
 
     // Get the type name for the current object.
     virtual const char* GetTypeName() = 0;
+
+    int GetObjectVersion() const { return m_objectVersion; }
+    int GetMinReaderVersion() const { return m_minReaderVersion; }
+
+protected:
+
+    int m_objectVersion = 1;
+    int m_minReaderVersion = 0;
 };
 
 #endif // FEATURE_PERFTRACING

--- a/src/vm/fastserializer.cpp
+++ b/src/vm/fastserializer.cpp
@@ -226,8 +226,8 @@ void FastSerializer::WriteSerializationType(FastSerializableObject *pObject)
 
     // Write the SerializationType version fields.
     int serializationType[2];
-    serializationType[0] = 1; // Object Version.
-    serializationType[1] = 0; // Minimum Reader Version.
+    serializationType[0] = pObject->GetObjectVersion();
+    serializationType[1] = pObject->GetMinReaderVersion();
     WriteBuffer((BYTE*) &serializationType, sizeof(serializationType));
 
     // Write the SerializationType TypeName field.

--- a/src/vm/sampleprofiler.cpp
+++ b/src/vm/sampleprofiler.cpp
@@ -13,7 +13,7 @@
 
 Volatile<BOOL> SampleProfiler::s_profilingEnabled = false;
 Thread* SampleProfiler::s_pSamplingThread = NULL;
-const GUID SampleProfiler::s_providerID = {0x3c530d44,0x97ae,0x513a,{0x1e,0x6d,0x78,0x3e,0x8f,0x8e,0x03,0xa9}}; // {3c530d44-97ae-513a-1e6d-783e8f8e03a9}
+const SString SampleProfiler::s_providerName = SString(u"SampleProfilerProvider");
 EventPipeProvider* SampleProfiler::s_pEventPipeProvider = NULL;
 EventPipeEvent* SampleProfiler::s_pThreadTimeEvent = NULL;
 BYTE* SampleProfiler::s_pPayloadExternal = NULL;
@@ -36,7 +36,7 @@ void SampleProfiler::Enable()
 
     if(s_pEventPipeProvider == NULL)
     {
-        s_pEventPipeProvider = EventPipe::CreateProvider(s_providerID);
+        s_pEventPipeProvider = EventPipe::CreateProvider(s_providerName);
         s_pThreadTimeEvent = s_pEventPipeProvider->AddEvent(
             0, /* eventID */
             0, /* keywords */

--- a/src/vm/sampleprofiler.cpp
+++ b/src/vm/sampleprofiler.cpp
@@ -13,7 +13,7 @@
 
 Volatile<BOOL> SampleProfiler::s_profilingEnabled = false;
 Thread* SampleProfiler::s_pSamplingThread = NULL;
-const SString SampleProfiler::s_providerName = SString(u"SampleProfilerProvider");
+const WCHAR* SampleProfiler::s_providerName = W("SampleProfilerProvider");
 EventPipeProvider* SampleProfiler::s_pEventPipeProvider = NULL;
 EventPipeEvent* SampleProfiler::s_pThreadTimeEvent = NULL;
 BYTE* SampleProfiler::s_pPayloadExternal = NULL;
@@ -36,7 +36,7 @@ void SampleProfiler::Enable()
 
     if(s_pEventPipeProvider == NULL)
     {
-        s_pEventPipeProvider = EventPipe::CreateProvider(s_providerName);
+        s_pEventPipeProvider = EventPipe::CreateProvider(SL(s_providerName));
         s_pThreadTimeEvent = s_pEventPipeProvider->AddEvent(
             0, /* eventID */
             0, /* keywords */

--- a/src/vm/sampleprofiler.cpp
+++ b/src/vm/sampleprofiler.cpp
@@ -13,7 +13,7 @@
 
 Volatile<BOOL> SampleProfiler::s_profilingEnabled = false;
 Thread* SampleProfiler::s_pSamplingThread = NULL;
-const WCHAR* SampleProfiler::s_providerName = W("SampleProfilerProvider");
+const WCHAR* SampleProfiler::s_providerName = W("Microsoft-DotNETCore-SampleProfiler");
 EventPipeProvider* SampleProfiler::s_pEventPipeProvider = NULL;
 EventPipeEvent* SampleProfiler::s_pThreadTimeEvent = NULL;
 BYTE* SampleProfiler::s_pPayloadExternal = NULL;

--- a/src/vm/sampleprofiler.h
+++ b/src/vm/sampleprofiler.h
@@ -50,7 +50,7 @@ class SampleProfiler
         static Thread *s_pSamplingThread;
 
         // The provider and event emitted by the profiler.
-        static const GUID s_providerID;
+        static const SString s_providerName;
         static EventPipeProvider *s_pEventPipeProvider;
         static EventPipeEvent *s_pThreadTimeEvent;
 

--- a/src/vm/sampleprofiler.h
+++ b/src/vm/sampleprofiler.h
@@ -50,7 +50,7 @@ class SampleProfiler
         static Thread *s_pSamplingThread;
 
         // The provider and event emitted by the profiler.
-        static const SString s_providerName;
+        static const WCHAR* s_providerName;
         static EventPipeProvider *s_pEventPipeProvider;
         static EventPipeEvent *s_pThreadTimeEvent;
 

--- a/tests/src/tracing/common/TraceControl.cs
+++ b/tests/src/tracing/common/TraceControl.cs
@@ -40,7 +40,7 @@ namespace Tracing.Tests.Common
 
             // Enable the provider.
             config.EnableProvider(providerName, keywords, level);
-            //
+
             // Sample profiler.
             providerName = "SampleProfileProvider";
             keywords = 0x0;

--- a/tests/src/tracing/common/TraceControl.cs
+++ b/tests/src/tracing/common/TraceControl.cs
@@ -28,21 +28,21 @@ namespace Tracing.Tests.Common
             TraceConfiguration config = new TraceConfiguration(outputFile, circularBufferMB);
             // Setup the provider values.
             // Public provider.
-            string providerName = "DotNETRuntime";
+            string providerName = "Microsoft-Windows-DotNETRuntime";
             UInt64 keywords = 0x4c14fccbd;
 
             // Enable the provider.
             config.EnableProvider(providerName, keywords, level);
 
             // Private provider.
-            providerName = "DotNETRuntimePrivate";
+            providerName = "Microsoft-Windows-DotNETRuntimePrivate";
             keywords = 0x4002000b;
 
             // Enable the provider.
             config.EnableProvider(providerName, keywords, level);
 
             // Sample profiler.
-            providerName = "SampleProfileProvider";
+            providerName = "Microsoft-DotNETCore-SampleProfiler";
             keywords = 0x0;
 
             // Enable the provider.

--- a/tests/src/tracing/common/TraceControl.cs
+++ b/tests/src/tracing/common/TraceControl.cs
@@ -28,21 +28,21 @@ namespace Tracing.Tests.Common
             TraceConfiguration config = new TraceConfiguration(outputFile, circularBufferMB);
             // Setup the provider values.
             // Public provider.
-            string providerName = "e13c0d23-ccbc-4e12-931b-d9cc2eee27e4";
+            string providerName = "DotNETRuntime";
             UInt64 keywords = 0x4c14fccbd;
 
             // Enable the provider.
             config.EnableProvider(providerName, keywords, level);
 
             // Private provider.
-            providerName = "763fd754-7086-4dfe-95eb-c01a46faf4ca";
+            providerName = "DotNETRuntimePrivate";
             keywords = 0x4002000b;
 
             // Enable the provider.
             config.EnableProvider(providerName, keywords, level);
-
+            //
             // Sample profiler.
-            providerName = "3c530d44-97ae-513a-1e6d-783e8f8e03a9";
+            providerName = "SampleProfileProvider";
             keywords = 0x0;
 
             // Enable the provider.

--- a/tests/src/tracing/eventpipesmoke/EventPipeSmoke.cs
+++ b/tests/src/tracing/eventpipesmoke/EventPipeSmoke.cs
@@ -57,7 +57,7 @@ namespace Tracing.Tests
                 System.IO.File.Delete(outputFilename);
             }
 
-            return pass ? 100 : -1;
+            return pass ? 100 : 0;
         }
     }
 }

--- a/tests/src/tracing/eventsourcesmoke/EventSourceSmoke.cs
+++ b/tests/src/tracing/eventsourcesmoke/EventSourceSmoke.cs
@@ -32,7 +32,7 @@ namespace Tracing.Tests
             TraceConfiguration config = new TraceConfiguration(outputFile, circularBufferMB);
             // Setup the provider values.
             // Public provider.
-            string providerName = eventSource.Guid.ToString("D");
+            string providerName = eventSource.Name;
             UInt64 keywords = 0xffffffffffffffff;
 
             // Enable the provider.


### PR DESCRIPTION
This PR changes the standard identifier for an event provider from being a GUID to be a string, which is the name of the provider

Connected: #11551