### PR TITLE
JIT: fix CHK/REL diff from fgRetypeImplicitByRefArgs

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -18112,17 +18112,17 @@ void Compiler::fgRetypeImplicitByRefArgs()
             //
             varDsc->lvOverlappingFields = 0; // This flag could have been set, clear it.
 
-#ifdef DEBUG
-            // This should not be converted to a double in stress mode,
-            // because it is really a pointer
-            varDsc->lvKeepType = 1;
-
             // The struct parameter may have had its address taken, but the pointer parameter
             // cannot -- any uses of the struct parameter's address are uses of the pointer
             // parameter's value, and there's no way for the MSIL to reference the pointer
             // parameter's address.  So clear the address-taken bit for the parameter.
             varDsc->lvAddrExposed     = 0;
             varDsc->lvDoNotEnregister = 0;
+
+#ifdef DEBUG
+            // This should not be converted to a double in stress mode,
+            // because it is really a pointer
+            varDsc->lvKeepType = 1;
 
             if (verbose)
             {


### PR DESCRIPTION
Make sure some important code is not under DEBUG.

Fixes #13358.