### PR TITLE
Fix AssemblyName(string) constructor's version parsing

### DIFF
--- a/src/binder/assemblybinder.cpp
+++ b/src/binder/assemblybinder.cpp
@@ -89,38 +89,66 @@ namespace BINDER_SPACE
             AssemblyVersion *pRequestedVersion = pRequestedName->GetVersion();
             AssemblyVersion *pFoundVersion = pFoundName->GetVersion();
 
-            //
-            // If the AssemblyRef has no version, we can treat it as requesting the most accommodating version (0.0.0.0). In
-            // that case, skip version checking and allow the bind.
-            //
-            if (!pRequestedName->HaveAssemblyVersion())
+            do
             {
-                return hr;
-            }
+                if (!pRequestedVersion->HasMajor())
+                {
+                    // An unspecified requested version component matches any value for the same component in the found version,
+                    // regardless of lesser-order version components
+                    break;
+                }
+                if (!pFoundVersion->HasMajor() || pRequestedVersion->GetMajor() > pFoundVersion->GetMajor())
+                {
+                    // - A specific requested version component does not match an unspecified value for the same component in
+                    //   the found version, regardless of lesser-order version components
+                    // - Or, the requested version is greater than the found version
+                    hr = FUSION_E_APP_DOMAIN_LOCKED;
+                    break;
+                }
+                if (pRequestedVersion->GetMajor() < pFoundVersion->GetMajor())
+                {
+                    // The requested version is less than the found version
+                    break;
+                }
 
-            //
-            // This if condition is paired with the one above that checks for pRequestedName
-            // not having an assembly version.  If we didn't exit in the above if condition,
-            // and satisfy this one's requirements, we're in a situation where the assembly
-            // Ref has a version, but the Def doesn't, which cannot succeed a bind
-            //
-            _ASSERTE(pRequestedName->HaveAssemblyVersion());
-            if (!pFoundName->HaveAssemblyVersion())
-            {
-                hr = FUSION_E_APP_DOMAIN_LOCKED;
-            }
-            else if (pRequestedVersion->IsEqualFeatureVersion(pFoundVersion))
-            {
-                // Now service version matters
-                if (pRequestedVersion->IsLargerServiceVersion(pFoundVersion))
+                if (!pRequestedVersion->HasMinor())
+                {
+                    break;
+                }
+                if (!pFoundVersion->HasMinor() || pRequestedVersion->GetMinor() > pFoundVersion->GetMinor())
                 {
                     hr = FUSION_E_APP_DOMAIN_LOCKED;
+                    break;
                 }
-            }
-            else if (pRequestedVersion->IsLargerFeatureVersion(pFoundVersion))
-            {
-                hr = FUSION_E_APP_DOMAIN_LOCKED;
-            }
+                if (pRequestedVersion->GetMinor() < pFoundVersion->GetMinor())
+                {
+                    break;
+                }
+
+                if (!pRequestedVersion->HasBuild())
+                {
+                    break;
+                }
+                if (!pFoundVersion->HasBuild() || pRequestedVersion->GetBuild() > pFoundVersion->GetBuild())
+                {
+                    hr = FUSION_E_APP_DOMAIN_LOCKED;
+                    break;
+                }
+                if (pRequestedVersion->GetBuild() < pFoundVersion->GetBuild())
+                {
+                    break;
+                }
+
+                if (!pRequestedVersion->HasRevision())
+                {
+                    break;
+                }
+                if (!pFoundVersion->HasRevision() || pRequestedVersion->GetRevision() > pFoundVersion->GetRevision())
+                {
+                    hr = FUSION_E_APP_DOMAIN_LOCKED;
+                    break;
+                }
+            } while (false);
 
             if (pApplicationContext->IsTpaListProvided() && hr == FUSION_E_APP_DOMAIN_LOCKED)
             {

--- a/src/binder/inc/assemblyname.inl
+++ b/src/binder/inc/assemblyname.inl
@@ -133,7 +133,7 @@ void AssemblyName::SetHave(DWORD dwIdentityFlags)
 
 BOOL AssemblyName::HaveAssemblyVersion()
 {
-    return (m_version.GetMajor() != static_cast<DWORD>(-1));
+    return m_version.HasMajor();
 }
 
 BOOL AssemblyName::HaveNeutralCulture()

--- a/src/binder/inc/assemblyversion.hpp
+++ b/src/binder/inc/assemblyversion.hpp
@@ -22,9 +22,18 @@ namespace BINDER_SPACE
 {
     class AssemblyVersion
     {
+    private:
+        static const DWORD Unspecified = (DWORD)-1;
+        static const USHORT UnspecifiedShort = (USHORT)-1;
+
     public:
         inline AssemblyVersion();
         inline ~AssemblyVersion();
+
+        inline BOOL HasMajor();
+        inline BOOL HasMinor();
+        inline BOOL HasBuild();
+        inline BOOL HasRevision();
 
         inline DWORD GetMajor();
         inline DWORD GetMinor();
@@ -35,19 +44,10 @@ namespace BINDER_SPACE
                                       /* in */ DWORD dwMinor);
         inline void SetServiceVersion(/* in */ DWORD dwBuild,
                                       /* in */ DWORD dwRevision);
-        inline BOOL SetServiceVersion(/* in */ LPCWSTR pwzVersionStr);
-        inline BOOL SetVersion(/* in */ LPCWSTR pwzVersionStr);
         inline void SetVersion(AssemblyVersion *pAssemblyVersion);
 
-        inline BOOL IsLargerFeatureVersion(/* in */ AssemblyVersion *pAssemblyVersion);
-        inline BOOL IsEqualFeatureVersion(/* in */ AssemblyVersion *pAssemblyVersion);
-        inline BOOL IsSmallerFeatureVersion(/* in */ AssemblyVersion *pAssemblyVersion);
-        inline BOOL IsEqualServiceVersion(/* in */ AssemblyVersion *pAssemblyVersion);
-        inline BOOL IsLargerServiceVersion(/* in */ AssemblyVersion *pAssemblyVersion);
         inline BOOL Equals(AssemblyVersion *pAssemblyVersion);
-        inline BOOL IsSmallerOrEqual(AssemblyVersion *pAssemblyVersion);
-        inline BOOL IsLargerOrEqual(AssemblyVersion *pAssemblyVersion);
-    protected:
+    private:
         DWORD m_dwMajor;
         DWORD m_dwMinor;
         DWORD m_dwBuild;

--- a/src/vm/assemblyspec.cpp
+++ b/src/vm/assemblyspec.cpp
@@ -494,18 +494,68 @@ void AssemblySpec::AssemblyNameInit(ASSEMBLYNAMEREF* pAsmName, PEImage* pImageIn
         // version
         gc.Version = AllocateObject(pVersion);
 
-
-        MethodDescCallSite ctorMethod(METHOD__VERSION__CTOR);
-            
-        ARG_SLOT VersionArgs[5] =
+        // BaseAssemblySpec and AssemblyName properties store uint16 components for the version. Version and AssemblyVersion
+        // store int32 or uint32. When the former are initialized from the latter, the components are truncated to uint16 size.
+        // When the latter are initialized from the former, they are zero-extended to int32 size. For uint16 components, the max
+        // value is used to indicate an unspecified component. For int32 components, -1 is used. Since we're initializing a
+        // Version from an assembly version, map the uint16 unspecified value to the int32 size.
+        int componentCount = 2;
+        if (m_context.usBuildNumber != (USHORT)-1)
         {
-            ObjToArgSlot(gc.Version),
-            (ARG_SLOT) m_context.usMajorVersion,      
-            (ARG_SLOT) m_context.usMinorVersion,
-            (ARG_SLOT) m_context.usBuildNumber,
-            (ARG_SLOT) m_context.usRevisionNumber,
-        };
-        ctorMethod.Call(VersionArgs);
+            ++componentCount;
+            if (m_context.usRevisionNumber != (USHORT)-1)
+            {
+                ++componentCount;
+            }
+        }
+        switch (componentCount)
+        {
+            case 2:
+            {
+                // Call Version(int, int) because Version(int, int, int, int) does not allow passing the unspecified value -1
+                MethodDescCallSite ctorMethod(METHOD__VERSION__CTOR_Ix2);
+                ARG_SLOT VersionArgs[] =
+                {
+                    ObjToArgSlot(gc.Version),
+                    (ARG_SLOT) m_context.usMajorVersion,
+                    (ARG_SLOT) m_context.usMinorVersion
+                };
+                ctorMethod.Call(VersionArgs);
+                break;
+            }
+
+            case 3:
+            {
+                // Call Version(int, int, int) because Version(int, int, int, int) does not allow passing the unspecified value -1
+                MethodDescCallSite ctorMethod(METHOD__VERSION__CTOR_Ix3);
+                ARG_SLOT VersionArgs[] =
+                {
+                    ObjToArgSlot(gc.Version),
+                    (ARG_SLOT) m_context.usMajorVersion,
+                    (ARG_SLOT) m_context.usMinorVersion,
+                    (ARG_SLOT) m_context.usBuildNumber
+                };
+                ctorMethod.Call(VersionArgs);
+                break;
+            }
+
+            default:
+            {
+                // Call Version(int, int, int, int)
+                _ASSERTE(componentCount == 4);
+                MethodDescCallSite ctorMethod(METHOD__VERSION__CTOR_Ix4);
+                ARG_SLOT VersionArgs[] =
+                {
+                    ObjToArgSlot(gc.Version),
+                    (ARG_SLOT) m_context.usMajorVersion,
+                    (ARG_SLOT) m_context.usMinorVersion,
+                    (ARG_SLOT) m_context.usBuildNumber,
+                    (ARG_SLOT) m_context.usRevisionNumber
+                };
+                ctorMethod.Call(VersionArgs);
+                break;
+            }
+        }
     }
     
     // cultureinfo

--- a/src/vm/metasig.h
+++ b/src/vm/metasig.h
@@ -412,6 +412,8 @@ DEFINE_METASIG(IM(Int_RefIntPtr_RefIntPtr_RefIntPtr_RetVoid, i r(I) r(I) r(I), v
 DEFINE_METASIG(IM(Int_RetStr, i, s))
 DEFINE_METASIG(IM(Int_RetVoid, i, v))
 DEFINE_METASIG(IM(Int_RetBool, i, F))
+DEFINE_METASIG(IM(Int_Int_RetVoid, i i, v))
+DEFINE_METASIG(IM(Int_Int_Int_RetVoid, i i i, v))
 DEFINE_METASIG(IM(Int_Int_Int_Int_RetVoid, i i i i, v))
 DEFINE_METASIG_T(IM(Obj_EventArgs_RetVoid, j C(EVENT_ARGS), v))
 DEFINE_METASIG_T(IM(Obj_UnhandledExceptionEventArgs_RetVoid, j C(UNHANDLED_EVENTARGS), v))

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -163,7 +163,9 @@ DEFINE_FIELD_U(_Minor,                     VersionBaseObject,    m_Minor)
 DEFINE_FIELD_U(_Build,                     VersionBaseObject,    m_Build)
 DEFINE_FIELD_U(_Revision,                  VersionBaseObject,    m_Revision)
 DEFINE_CLASS(VERSION,               System,                 Version)
-DEFINE_METHOD(VERSION,              CTOR,                   .ctor,                      IM_Int_Int_Int_Int_RetVoid)
+DEFINE_METHOD(VERSION,              CTOR_Ix2,               .ctor,                      IM_Int_Int_RetVoid)
+DEFINE_METHOD(VERSION,              CTOR_Ix3,               .ctor,                      IM_Int_Int_Int_RetVoid)
+DEFINE_METHOD(VERSION,              CTOR_Ix4,               .ctor,                      IM_Int_Int_Int_Int_RetVoid)
 
 DEFINE_CLASS(ASSEMBLY_VERSION_COMPATIBILITY, Assemblies,    AssemblyVersionCompatibility)
 


### PR DESCRIPTION
Functional fix for https://github.com/dotnet/corefx/issues/22663
- Allow fewer version components
- Match .NET Framework behavior in several cases. Major and minor version must be specified for the version to be used.
- Used zero for unspecified build/revision. This is different from .NET Framework but the loader also behaves differently. Details are in code comments, not sure if this is what we want to do though.