### PR TITLE
Restrict alignment assert to only if volatile

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -1554,11 +1554,13 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
     emitAttr    attr       = emitTypeSize(tree);
     instruction ins        = ins_Load(targetType);
 
-    assert((attr != EA_1BYTE) || !(tree->gtFlags & GTF_IND_UNALIGNED));
-
     genConsumeAddress(tree->Addr());
-    if (tree->gtFlags & GTF_IND_VOLATILE)
+    if ((tree->gtFlags & GTF_IND_VOLATILE) != 0)
     {
+        bool isAligned = ((tree->gtFlags & GTF_IND_UNALIGNED) == 0);
+
+        assert((attr != EA_1BYTE) || isAligned);
+
 #ifdef _TARGET_ARM64_
         GenTree* addr           = tree->Addr();
         bool     useLoadAcquire = genIsValidIntReg(targetReg) && !addr->isContained() &&


### PR DESCRIPTION
Seems like an unaligned byte access should be valid and that the assert is too restrictive. I kept the assert in the volatile path, as it makes sense why alignment would want to be preserved for the volatile case.

PTAL @sdmaclea @briansull 