### PR TITLE
Make unit tests run clean with tiered compilation

### DIFF
--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -8103,7 +8103,7 @@ void AppDomain::Exit(BOOL fRunFinalizers, BOOL fAsyncExit)
     // have exited the domain.
     //
 #ifdef FEATURE_TIERED_COMPILATION
-    m_tieredCompilationManager.OnAppDomainShutdown();
+    m_tieredCompilationManager.Shutdown(FALSE);
 #endif
 
     //

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -1624,7 +1624,10 @@ void STDMETHODCALLTYPE EEShutDownHelper(BOOL fIsDllUnloading)
         g_fEEShutDown |= ShutDown_Start;
 
 #ifdef FEATURE_TIERED_COMPILATION
-        TieredCompilationManager::ShutdownAllDomains();
+        {
+            GCX_PREEMP();
+            TieredCompilationManager::ShutdownAllDomains();
+        }
 #endif
 
         fFinalizeOK = TRUE;

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -1623,6 +1623,10 @@ void STDMETHODCALLTYPE EEShutDownHelper(BOOL fIsDllUnloading)
         // Indicate the EE is the shut down phase.
         g_fEEShutDown |= ShutDown_Start;
 
+#ifdef FEATURE_TIERED_COMPILATION
+        TieredCompilationManager::ShutdownAllDomains();
+#endif
+
         fFinalizeOK = TRUE;
 
         // Terminate the BBSweep thread

--- a/src/vm/tieredcompilation.cpp
+++ b/src/vm/tieredcompilation.cpp
@@ -110,7 +110,7 @@ void TieredCompilationManager::Init(ADID appDomainId)
 
     SpinLockHolder holder(&m_lock);
     m_domainId = appDomainId;
-    m_asyncWorkDoneEvent.CreateManualEvent(TRUE);
+    m_asyncWorkDoneEvent.CreateManualEventNoThrow(TRUE);
 }
 
 // Called each time code in this AppDomain has been run. This is our sole entrypoint to begin

--- a/src/vm/tieredcompilation.cpp
+++ b/src/vm/tieredcompilation.cpp
@@ -110,8 +110,7 @@ void TieredCompilationManager::Init(ADID appDomainId)
 
     SpinLockHolder holder(&m_lock);
     m_domainId = appDomainId;
-    m_pAsyncWorkDoneEvent = new CLREvent();
-    m_pAsyncWorkDoneEvent->CreateManualEvent(TRUE);
+    m_asyncWorkDoneEvent.CreateManualEvent(TRUE);
 }
 
 // Called each time code in this AppDomain has been run. This is our sole entrypoint to begin
@@ -253,7 +252,7 @@ void TieredCompilationManager::Shutdown(BOOL fBlockUntilAsyncWorkIsComplete)
     }
     if (fBlockUntilAsyncWorkIsComplete)
     {
-        m_pAsyncWorkDoneEvent->Wait(INFINITE, FALSE);
+        m_asyncWorkDoneEvent.Wait(INFINITE, FALSE);
     }
 }
 
@@ -447,7 +446,7 @@ void TieredCompilationManager::IncrementWorkerThreadCount()
     //m_lock should be held
 
     m_countOptimizationThreadsRunning++;
-    m_pAsyncWorkDoneEvent->Reset();
+    m_asyncWorkDoneEvent.Reset();
 }
 
 void TieredCompilationManager::DecrementWorkerThreadCount()
@@ -458,7 +457,7 @@ void TieredCompilationManager::DecrementWorkerThreadCount()
     m_countOptimizationThreadsRunning--;
     if (m_countOptimizationThreadsRunning == 0)
     {
-        m_pAsyncWorkDoneEvent->Set();
+        m_asyncWorkDoneEvent.Set();
     }
 }
 

--- a/src/vm/tieredcompilation.h
+++ b/src/vm/tieredcompilation.h
@@ -50,7 +50,7 @@ private:
     DWORD m_countOptimizationThreadsRunning;
     DWORD m_callCountOptimizationThreshhold;
     DWORD m_optimizationQuantumMs;
-    CLREvent* m_pAsyncWorkDoneEvent;
+    CLREvent m_asyncWorkDoneEvent;
 };
 
 #endif // FEATURE_TIERED_COMPILATION

--- a/src/vm/tieredcompilation.h
+++ b/src/vm/tieredcompilation.h
@@ -27,7 +27,8 @@ public:
     void Init(ADID appDomainId);
     BOOL OnMethodCalled(MethodDesc* pMethodDesc, DWORD currentCallCount);
     void AsyncPromoteMethodToTier1(MethodDesc* pMethodDesc);
-    void OnAppDomainShutdown();
+    static void ShutdownAllDomains();
+    void Shutdown(BOOL fBlockUntilAsyncWorkIsComplete);
     static CORJIT_FLAGS GetJitFlags(NativeCodeVersion nativeCodeVersion);
 
 private:
@@ -39,6 +40,9 @@ private:
     BOOL CompileCodeVersion(NativeCodeVersion nativeCodeVersion);
     void ActivateCodeVersion(NativeCodeVersion nativeCodeVersion);
 
+    void IncrementWorkerThreadCount();
+    void DecrementWorkerThreadCount();
+
     SpinLock m_lock;
     SList<SListElem<NativeCodeVersion>> m_methodsToOptimize;
     ADID m_domainId;
@@ -46,6 +50,7 @@ private:
     DWORD m_countOptimizationThreadsRunning;
     DWORD m_callCountOptimizationThreshhold;
     DWORD m_optimizationQuantumMs;
+    CLREvent* m_pAsyncWorkDoneEvent;
 };
 
 #endif // FEATURE_TIERED_COMPILATION

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -85,6 +85,7 @@ if /i "%1" == "GenerateLayoutOnly"    (set __GenerateLayoutOnly=1&shift&goto Arg
 if /i "%1" == "PerfTests"             (set __PerfTests=true&shift&goto Arg_Loop)
 if /i "%1" == "runcrossgentests"      (set RunCrossGen=true&shift&goto Arg_Loop)
 if /i "%1" == "link"                  (set DoLink=true&set ILLINK=%2&shift&shift&goto Arg_Loop)
+if /i "%1" == "tieredcompilation"     (set COMPLUS_EXPERIMENTAL_TieredCompilation=1&shift&goto Arg_Loop)
 
 REM change it to COMPlus_GCStress when we stop using xunit harness
 if /i "%1" == "gcstresslevel"         (set __GCSTRESSLEVEL=%2&set __TestTimeout=1800000&shift&shift&goto Arg_Loop)
@@ -464,6 +465,7 @@ echo                               2: GC on transitions to preemptive GC
 echo                               4: GC on every allowable JITed instruction
 echo                               8: GC on every allowable NGEN instruction
 echo                              16: GC only on a unique stack trace
+echo tieredcompilation         - Run the tests with COMPlus_EXPERIMENTAL_TieredCompilation=1
 echo msbuildargs ^<args...^>     - Pass all subsequent args directly to msbuild invocations.
 echo ^<CORE_ROOT^>               - Path to the runtime to test (if specified).
 echo.

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -58,6 +58,7 @@ function print_usage {
     echo '    8: GC on every allowable NGEN instr   16: GC only on a unique stack trace'
     echo '  --long-gc                        : Runs the long GC tests'
     echo '  --gcsimulator                    : Runs the GCSimulator tests'
+    echo '  --tieredcompilation              : Runs the tests with COMPlus_EXPERIMENTAL_TieredCompilation=1'
     echo '  --link <ILlink>                  : Runs the tests after linking via ILlink'
     echo '  --show-time                      : Print execution sequence and running time for each test'
     echo '  --no-lf-conversion               : Do not execute LF conversion before running test script'
@@ -1018,6 +1019,9 @@ do
         --link=*)
             export ILLINK=${i#*=}
             export DoLink=true
+            ;;
+        --tieredcompilation)
+            export COMPlus_EXPERIMENTAL_TieredCompilation=1
             ;;
         --jitdisasm)
             jitdisasm=1

--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -83,9 +83,9 @@ fi
       ]]></BashCLRTestEnvironmentCompatibilityCheck>
       <BashCLRTestEnvironmentCompatibilityCheck Condition="'$(JitOptimizationSensitive)' == 'true'"><![CDATA[
 $(BashCLRTestEnvironmentCompatibilityCheck)
-if [[ ( ! -z "$COMPlus_JitStress" ) || ( ! -z "$COMPlus_JitStressRegs" ) || ( ! -z "$COMPlus_JITMinOpts" ) || ( ! -z "$COMPlus_TailcallStress" ) ]]
+if [[ ( ! -z "$COMPlus_JitStress" ) || ( ! -z "$COMPlus_JitStressRegs" ) || ( ! -z "$COMPlus_JITMinOpts" ) || ( ! -z "$COMPlus_TailcallStress" ) || ( ! -z "$COMPlus_EXPERIMENTAL_TieredCompilation" ) ]]
 then
-  echo "SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts, COMPlus_TailcallStress) IS SET"
+  echo "SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts, COMPlus_TailcallStress, COMPlus_EXPERIMENTAL_TieredCompilation) IS SET"
   exit $(GCBashScriptExitCode)
 fi
       ]]></BashCLRTestEnvironmentCompatibilityCheck>

--- a/tests/src/CLRTest.Execute.Batch.targets
+++ b/tests/src/CLRTest.Execute.Batch.targets
@@ -78,8 +78,8 @@ IF NOT "%COMPlus_GCStress%"=="" (
       ]]></BatchCLRTestEnvironmentCompatibilityCheck>
       <BatchCLRTestEnvironmentCompatibilityCheck Condition="'$(JitOptimizationSensitive)' == 'true'"><![CDATA[
 $(BatchCLRTestEnvironmentCompatibilityCheck)
-IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_JITMinOpts%"=="" IF "%COMPlus_TailcallStress%"=="" goto :Compatible1
-  ECHO SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts, COMPlus_TailcallStress) IS SET
+IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_JITMinOpts%"=="" IF "%COMPlus_TailcallStress%"=="" IF "%COMPlus_EXPERIMENTAL_TieredCompilation%"=="" goto :Compatible1
+  ECHO SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts, COMPlus_TailcallStress, COMPlus_EXPERIMENTAL_TieredCompilation) IS SET
   popd
   Exit /b 0
 :Compatible1


### PR DESCRIPTION
A handful of tests are optimization sensitive and needed to be disabled because tiered jitting doesn't optimize right away.
There was also a shutdown timing issue where the tiered jitting background compilation thread would continue calling into the JIT after the JIT was shutdown. This manifested as an error writing to the jit log after the stream had been closed.