### PR TITLE
Fix bad cast morphing

### DIFF
--- a/tests/src/JIT/Regression/JitBlue/GitHub_13404/GitHub_13404.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_13404/GitHub_13404.il
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib {auto}
+.assembly extern System.Console {auto}
+.assembly GitHub_13404 {}
+
+.class Program
+{
+    .field static int8 s8;
+
+    .method static void Test() noinlining
+    {
+        ldsfld int8 Program::s8
+        conv.ovf.i2.un
+        pop
+        ret
+    }
+
+    .method static int32 Main() 
+    {
+        .entrypoint
+        .maxstack 1
+
+        ldc.i4 -1
+        stsfld int8 Program::s8
+
+        .try
+        {
+            call void Program::Test()
+            leave FAIL
+        }
+        catch [mscorlib]System.OverflowException
+        {
+            pop
+            leave PASS
+        }
+    FAIL:
+        ldstr "FAIL"
+        call void [System.Console]System.Console::WriteLine(string)
+        ldc.i4 1
+        ret
+    PASS: 
+        ldstr "PASS"
+        call void [System.Console]System.Console::WriteLine(string)
+        ldc.i4 100
+        ret
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_13404/GitHub_13404.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_13404/GitHub_13404.ilproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_13404.il" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
`fgMorphCast` thinks that casting a `i1` value to `i2` via `conv.ovf.i2.un` is a widening conversion and removes the overflow check. But this is in fact a narrowing conversion because `i1` is implicitly sign extended to `i4` and then `i4` is treated as `u4`. Going from `i4` to `u4` overflows for negative values so we can't treat the source type of the cast as `i1`, it has to be `u4`.

Of course, the existing code works fine if the source type is unsigned. Going from `u1` to `i4` and then to `u4` never overflows so it's safe to treat the source type as `u1`.

Fixes #13404