### PR TITLE
Move CoreRT fat calli transformation after fgInline.

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4385,11 +4385,6 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
         fgRemovePreds();
     }
 
-    if (IsTargetAbi(CORINFO_CORERT_ABI) && doesMethodHaveFatPointer())
-    {
-        fgTransformFatCalli();
-    }
-
     EndPhase(PHASE_IMPORTATION);
 
     if (compIsForInlining())

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17422,6 +17422,12 @@ void Compiler::fgMorph()
 
     EndPhase(PHASE_MORPH_INLINE);
 
+    if (IsTargetAbi(CORINFO_CORERT_ABI) && doesMethodHaveFatPointer())
+    {
+        /* Add CoreRT fat pointers blocks/trees. */
+        fgTransformFatCalli();
+    }
+
     /* Add any internal blocks/trees we may need */
 
     fgAddInternal();


### PR DESCRIPTION
Fix #9422 and dotnet/corert#4251.
The problem is described in #13435.
We can't move it after fgMarkImplicitByRefArgs (actually can move it, but inside global morph). However, I am not morph expert.

PTAL @dotnet/jit-contrib 
cc @MichalStrehovsky 