### PR TITLE
Enable SuperPMI asm diffs using CoreDisTools

### DIFF
--- a/src/ToolBox/superpmi/superpmi/CMakeLists.txt
+++ b/src/ToolBox/superpmi/superpmi/CMakeLists.txt
@@ -5,6 +5,7 @@ remove_definitions(-D_UNICODE)
 
 add_definitions(-DFEATURE_NO_HOST)
 add_definitions(-DSELF_NO_HOST)
+add_definitions(-DUSE_COREDISTOOLS)
 
 if(WIN32)
   #use static crt
@@ -13,10 +14,6 @@ endif(WIN32)
 
 include_directories(.)
 include_directories(../superpmi-shared)
-
-# When it is ready (the build works on all platforms, referencing the coredistools
-# package), define this:
-# add_definitions(-DUSE_COREDISTOOLS)
 
 set(SUPERPMI_SOURCES
     commandline.cpp

--- a/src/ToolBox/superpmi/superpmi/commandline.cpp
+++ b/src/ToolBox/superpmi/superpmi/commandline.cpp
@@ -108,11 +108,16 @@ void CommandLine::DumpHelp(const char* program)
     printf("     Used by the assembly differences calculator. This specifies the target\n");
     printf("     architecture for cross-compilation. Currently allowed <target> value: arm64\n");
     printf("\n");
-#ifdef USE_COREDISTOOLS
     printf(" -coredistools\n");
     printf("     Use disassembly tools from the CoreDisTools library\n");
+#if defined(USE_MSVCDIS)
+    printf("     Default: use MSVCDIS.\n");
+#elif defined(USE_COREDISTOOLS)
+    printf("     Ignored: MSVCDIS is not available, so CoreDisTools will be used.\n");
+#else
+    printf("     Ignored: neither MSVCDIS nor CoreDisTools is available.\n");
+#endif
     printf("\n");
-#endif // USE_COREDISTOOLS
     printf("Inputs are case sensitive.\n");
     printf("\n");
     printf("SuperPMI method contexts are stored in files with extension .MC, implying\n");
@@ -353,12 +358,12 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
 
                 o->compileList = argv[i]; // Save this in case we need it for -parallel.
             }
-#ifdef USE_COREDISTOOLS
             else if ((_strnicmp(&argv[i][1], "coredistools", argLen) == 0))
             {
+#ifndef USE_COREDISTOOLS // If USE_COREDISTOOLS is not defined, then allow the switch, but ignore it.
                 o->useCoreDisTools = true;
-            }
 #endif // USE_COREDISTOOLS
+            }
             else if ((_strnicmp(&argv[i][1], "matchHash", argLen) == 0))
             {
                 if (++i >= argc)

--- a/src/ToolBox/superpmi/superpmi/commandline.h
+++ b/src/ToolBox/superpmi/superpmi/commandline.h
@@ -25,7 +25,11 @@ public:
             , breakOnAssert(false)
             , applyDiff(false)
             , parallel(false)
-            , useCoreDisTools(false)
+#if !defined(USE_MSVCDIS) && defined(USE_COREDISTOOLS)
+            , useCoreDisTools(true)     // if CoreDisTools is available (but MSVCDIS is not), use it.
+#else
+            , useCoreDisTools(false)    // Otherwise, use MSVCDIS if that is available (else no diffs are available).
+#endif
             , skipCleanup(false)
             , workerCount(-1)
             , indexCount(-1)

--- a/src/ToolBox/superpmi/superpmi/neardiffer.h
+++ b/src/ToolBox/superpmi/superpmi/neardiffer.h
@@ -26,7 +26,7 @@ public:
 
     ~NearDiffer();
 
-    void InitAsmDiff();
+    bool InitAsmDiff();
 
     bool compare(MethodContext* mc, CompileResult* cr1, CompileResult* cr2);
 
@@ -74,7 +74,12 @@ private:
         const void* payload, size_t blockOffset, size_t instrLen, uint64_t offset1, uint64_t offset2);
 
 #ifdef USE_COREDISTOOLS
+
+    static bool __cdecl CoreDisCompareOffsetsCallback(
+        const void* payload, size_t blockOffset, size_t instrLen, uint64_t offset1, uint64_t offset2);
+
     CorAsmDiff* corAsmDiff;
+
 #endif // USE_COREDISTOOLS
 
 #ifdef USE_MSVCDIS

--- a/src/ToolBox/superpmi/superpmi/superpmi.cpp
+++ b/src/ToolBox/superpmi/superpmi/superpmi.cpp
@@ -240,7 +240,10 @@ int __cdecl main(int argc, char* argv[])
 
     if (o.applyDiff)
     {
-        nearDiffer.InitAsmDiff();
+        if (!nearDiffer.InitAsmDiff())
+        {
+            return -1;
+        }
     }
 
     while (true)


### PR DESCRIPTION
Also, change SuperPMI to dynamically load coredistools.dll on demand,
and fix the "-coredistools" option to default to coredistools if msvcdis
support is not (also) enabled (only true for internal builds).