### PR TITLE
[RyuJIT/ARM32] Set carry bit: neg operation

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -823,7 +823,7 @@ void CodeGen::genCodeForNegNot(GenTree* tree)
     }
     else
     {
-        getEmitter()->emitIns_R_R_I(ins, emitTypeSize(tree), targetReg, operandReg, 0);
+        getEmitter()->emitIns_R_R_I(ins, emitTypeSize(tree), targetReg, operandReg, 0, INS_FLAGS_SET);
     }
 
     genProduceReg(tree);


### PR DESCRIPTION
Set carry bit when we generate ARM32 code for neg operation

Fix #13421 