### PR TITLE
Port fixes in DotNet-CoreClr-Trusted-Linux.json to unblock coreclr

### DIFF
--- a/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
@@ -49,7 +49,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs) git clone $(GitHubRepo) $(GitHubDirectory)",
+        "arguments": "run --rm $(DockerCommonRunArgs) git clone $(VsoCoreClrGitUrl) $(GitHubDirectory)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -408,6 +408,19 @@
     },
     "PB_CleanAgent": {
       "value": "true"
+    },
+    "VsoAccountName": {
+      "value": "dn-bot"
+    },
+    "VsoCoreClrGitUrl": {
+      "value": "https://$(VsoAccountName):$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/$(VsoRepositoryName)/"
+    },
+    "VsoPassword": {
+      "value": null,
+      "isSecret": true
+    },
+    "VsoRepositoryName": {
+      "value": "DotNet-CoreCLR-Trusted"
     }
   },
   "demands": [


### PR DESCRIPTION
Port fixes in DotNet-CoreClr-Trusted-Linux.json to unblock coreclr official run:

Port this commit:
https://github.com/dotnet/coreclr/commit/66d0fed853589e19336b6486f05f9218019ca4c9