### PR TITLE
Re-import RHEL 6 test support from release/2.0.0 to master

### DIFF
--- a/tests/src/Common/build_against_pkg_dependencies/build_against_pkg_dependencies.csproj
+++ b/tests/src/Common/build_against_pkg_dependencies/build_against_pkg_dependencies.csproj
@@ -28,7 +28,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8</PackageTargetFallback>
-    <RuntimeIdentifiers>win-arm;win-x64;win-x86;win7-x86;win7-x64;win10-arm64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;osx.10.12-x64;osx-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-arm;win-x64;win-x86;win7-x86;win7-x64;win10-arm64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;osx.10.12-x64;osx-x64;centos.7-x64;rhel.6-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64;linux-x64</RuntimeIdentifiers>
     <ContainsPackageReferences>true</ContainsPackageReferences>
     <PrereleaseResolveNuGetPackages>false</PrereleaseResolveNuGetPackages>
   </PropertyGroup>


### PR DESCRIPTION
Re-import RHEL 6 test support from release/2.0.0 to master