### PR TITLE
Use https when getting sources from github.

### DIFF
--- a/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
@@ -345,7 +345,7 @@
       "value": "Release"
     },
     "GitHubRepo": {
-      "value": "http://github.com/dotnet/coreclr.git"
+      "value": "https://github.com/dotnet/coreclr.git"
     },
     "GitHubDirectory": {
       "value": "/root/coreclr"

--- a/buildpipeline/DotNet-CoreClr-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Linux.json
@@ -309,7 +309,7 @@
       "value": "Release"
     },
     "GitHubRepo": {
-      "value": "http://github.com/dotnet/coreclr.git"
+      "value": "https://github.com/dotnet/coreclr.git"
     },
     "GitHubDirectory": {
       "value": "/root/coreclr"


### PR DESCRIPTION
https://github.com/dotnet/core-eng/issues/1438
Switching over to `https` to improve the reliability of `git clone` task.
