### PR TITLE
Port "git clone" fixes to release 2.0.0

### DIFF
--- a/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
@@ -439,7 +439,7 @@
     },
     "VsoRepositoryName": {
       "value": "DotNet-CoreCLR-Trusted",
-	  "allowOverride": true
+      "allowOverride": true
     }
   },
   "demands": [

--- a/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
@@ -49,7 +49,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs) git clone $(GitHubRepo) $(GitHubDirectory)",
+        "arguments": "run --rm $(DockerCommonRunArgs) git clone $(VsoCoreClrGitUrl) $(GitHubDirectory)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -426,6 +426,20 @@
     },
     "PB_CleanAgent": {
       "value": "true"
+    },
+    "VsoAccountName": {
+      "value": "dn-bot"
+    },
+    "VsoCoreClrGitUrl": {
+      "value": "https://$(VsoAccountName):$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/$(VsoRepositoryName)/"
+    },
+    "VsoPassword": {
+      "value": null,
+      "isSecret": true
+    },
+    "VsoRepositoryName": {
+      "value": "DotNet-CoreCLR-Trusted",
+	  "allowOverride": true
     }
   },
   "demands": [

--- a/buildpipeline/DotNet-CoreClr-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Linux.json
@@ -49,7 +49,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs) git clone $(GitHubRepo) $(GitHubDirectory)",
+        "arguments": "run --rm $(DockerCommonRunArgs) git clone $(VsoCoreClrGitUrl) $(GitHubDirectory)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -390,6 +390,20 @@
     },
     "PB_AdditionalBuildArgs": {
       "value":""
+    },
+    "VsoAccountName": {
+      "value": "dn-bot"
+    },
+    "VsoCoreClrGitUrl": {
+      "value": "https://$(VsoAccountName):$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/$(VsoRepositoryName)/"
+    },
+    "VsoPassword": {
+      "value": null,
+      "isSecret": true
+    },
+    "VsoRepositoryName": {
+      "value": "DotNet-CoreCLR-Trusted",
+	  "allowOverride": true
     }
   },
   "demands": [

--- a/buildpipeline/DotNet-CoreClr-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Linux.json
@@ -403,7 +403,7 @@
     },
     "VsoRepositoryName": {
       "value": "DotNet-CoreCLR-Trusted",
-	  "allowOverride": true
+      "allowOverride": true
     }
   },
   "demands": [


### PR DESCRIPTION
It migrates "git clone" from unstable github to VSO. The ported commits
are:
1.
https://github.com/dotnet/coreclr/commit/66d0fed853589e19336b6486f05f9218019ca4c9
2.
https://github.com/dotnet/coreclr/commit/3ab8def1e9692f3d620c92be415cd54572dd7f67