### PR TITLE
Fix ARM issues with Containment

### DIFF
--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -40,8 +40,6 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 //
 void Lowering::TreeNodeInfoInitReturn(GenTree* tree)
 {
-    ContainCheckRet(tree->AsOp());
-
     TreeNodeInfo* info     = &(tree->gtLsraInfo);
     LinearScan*   l        = m_lsra;
     Compiler*     compiler = comp;
@@ -107,8 +105,6 @@ void Lowering::TreeNodeInfoInitReturn(GenTree* tree)
 
 void Lowering::TreeNodeInfoInitLclHeap(GenTree* tree)
 {
-    ContainCheckLclHeap(tree->AsOp());
-
     TreeNodeInfo* info     = &(tree->gtLsraInfo);
     LinearScan*   l        = m_lsra;
     Compiler*     compiler = comp;
@@ -276,7 +272,6 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
 
         case GT_CAST:
         {
-            ContainCheckCast(tree->AsCast());
             info->srcCount = 1;
             assert(info->dstCount == 1);
 
@@ -419,7 +414,6 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
         case GT_AND:
         case GT_OR:
         case GT_XOR:
-            ContainCheckBinary(tree->AsOp());
             info->srcCount = tree->gtOp.gtOp2->isContained() ? 1 : 2;
             assert(info->dstCount == 1);
             break;
@@ -548,7 +542,6 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             break;
 
         case GT_ARR_OFFSET:
-            ContainCheckArrOffset(tree->AsArrOffs());
             // This consumes the offset, if any, the arrObj and the effective index,
             // and produces the flattened offset for this dimension.
             assert(info->dstCount == 1);

--- a/src/jit/lsraarm64.cpp
+++ b/src/jit/lsraarm64.cpp
@@ -384,7 +384,6 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             break;
 
         case GT_LOCKADD:
-            ContainCheckBinary(tree->AsOp());
             info->srcCount = tree->gtOp.gtOp2->isContained() ? 1 : 2;
             assert(info->dstCount == 1);
             break;
@@ -433,7 +432,6 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
 
         case GT_LCLHEAP:
         {
-            ContainCheckLclHeap(tree->AsOp());
             assert(info->dstCount == 1);
 
             // Need a variable number of temp regs (see genLclHeap() in codegenamd64.cpp):
@@ -575,7 +573,6 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             break;
 
         case GT_ARR_OFFSET:
-            ContainCheckArrOffset(tree->AsArrOffs());
             // This consumes the offset, if any, the arrObj and the effective index,
             // and produces the flattened offset for this dimension.
             info->srcCount = tree->gtArrOffs.gtOffset->isContained() ? 2 : 3;
@@ -685,8 +682,6 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
 //
 void Lowering::TreeNodeInfoInitReturn(GenTree* tree)
 {
-    ContainCheckRet(tree->AsOp());
-
     TreeNodeInfo* info     = &(tree->gtLsraInfo);
     LinearScan*   l        = m_lsra;
     Compiler*     compiler = comp;

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -236,8 +236,6 @@ void Lowering::TreeNodeInfoInitIndir(GenTreeIndir* indirTree)
 //
 void Lowering::TreeNodeInfoInitShiftRotate(GenTree* tree)
 {
-    ContainCheckShiftRotate(tree->AsOp());
-
     TreeNodeInfo* info = &(tree->gtLsraInfo);
     LinearScan*   l    = m_lsra;
 
@@ -534,6 +532,7 @@ void Lowering::TreeNodeInfoInitCall(GenTreeCall* call)
         else if (argNode->OperGet() == GT_PUTARG_SPLIT)
         {
             fgArgTabEntryPtr curArgTabEntry = compiler->gtArgEntryByNode(call, argNode);
+            info->srcCount += argNode->AsPutArgSplit()->gtNumRegs;
         }
 #endif
         else
@@ -665,7 +664,7 @@ void Lowering::TreeNodeInfoInitPutArgStk(GenTreePutArgStk* argNode)
                 }
             }
 
-            // We will generate all of the code for the GT_PUTARG_STK and it's child node
+            // We will generate all of the code for the GT_PUTARG_STK and its child node
             // as one contained operation
             //
             argNode->gtLsraInfo.srcCount = putArgChild->gtLsraInfo.srcCount;
@@ -928,7 +927,7 @@ void Lowering::TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode)
                 {
                     // The block size argument is a third argument to GT_STORE_DYN_BLK
                     assert(blkNode->gtOper == GT_STORE_DYN_BLK);
-                    blkNode->gtLsraInfo.setSrcCount(3);
+                    blkNode->gtLsraInfo.srcCount++;
                     GenTree* blockSize = blkNode->AsDynBlk()->gtDynamicSize;
                     blockSize->gtLsraInfo.setSrcCandidates(l, RBM_ARG_2);
                 }


### PR DESCRIPTION
These are changes that should have been part of PR #13198:
- Correctly contain struct arguments
- Correctly get number of source registers
- Allow `GT_FIELD_LIST` to have registers, even if contained
- Remove now-redundant `ContainCheck` methods for armarch targets.

Fix #13451