### PR TITLE
Adding FileApiInterop.dll to runtime package

### DIFF
--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/FileApiInteropRestore.depproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/FileApiInteropRestore.depproj
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <RestoreOutputPath>$(MSBuildThisFileDirectory)obj</RestoreOutputPath>
+    <OutputPath>$(BinDir)</OutputPath>
+    <Language>C#</Language>
+    <ContainsPackageReferences>true</ContainsPackageReferences>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <NuGetTargetMoniker>.NETCoreApp,Version=v1.1</NuGetTargetMoniker>
+    <NugetTargetMonikerShort>netcoreapp1.1</NugetTargetMonikerShort>
+    <NugetRuntimeIdentifier>win10-$(Platform)</NugetRuntimeIdentifier>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm</RuntimeIdentifiers>
+    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FileApiInterop">
+      <Version>1.0.0-preview-01</Version>
+    </PackageReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup>
+    <ProjectAssetsFile>$(RestoreOutputPath)\project.assets.json</ProjectAssetsFile>
+  </PropertyGroup>
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.builds
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.builds
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Project Include="$(MSBuildThisFileDirectory)FileApiInteropRestore.depproj" Condition="'$(BuildOS)' == 'Windows_NT' And '$(BuildArch)' != 'arm64'" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <SerializeProjects>true</SerializeProjects>
+  </PropertyGroup>
 
   <ItemGroup>
     <!-- identity project, runtime specific projects are included by props above -->

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Windows_NT.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Windows_NT.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -19,6 +19,7 @@
     <NativeBinary Include="$(BinDir)mscorrc.debug.dll" />
     <NativeBinary Include="$(BinDir)mscorrc.dll" />
     <NativeBinary Include="$(BinDir)sos.dll" />
+    <NativeBinary Include="$(BinDir)FileApiInterop.dll" Condition="'$(BuildArch)' != 'arm64'" />
     <NativeBinary Include="$(UniversalCRTSDKDir)Redist\ucrt\DLLs\$(BuildArch)\*.dll" Condition="'$(BuildType)'=='Release' AND '$(BuildArch)' != 'arm64'" />
     <NativeBinary Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />


### PR DESCRIPTION
cc: @weshaggard @JeremyKuhne @danmosemsft @ericstj @joshfree 

Adding FileApiInterop.dll restore project so that we can add it to the runtime package. This is required since we will PInvoke to this dll when running in AppContainer to get brokered file access.