### PR TITLE
fix JitConfig initialize and destoy

### DIFF
--- a/src/jit/jitconfig.cpp
+++ b/src/jit/jitconfig.cpp
@@ -14,6 +14,7 @@ JitConfigValues JitConfig;
 void JitConfigValues::MethodSet::initialize(const wchar_t* list, ICorJitHost* host)
 {
     assert(m_list == nullptr);
+    assert(m_names == nullptr);
 
     enum State
     {

--- a/src/jit/jitconfig.cpp
+++ b/src/jit/jitconfig.cpp
@@ -45,7 +45,7 @@ void JitConfigValues::MethodSet::initialize(const wchar_t* list, ICorJitHost* ho
     {
         // Failed to convert the list. Free the memory and ignore the list.
         host->freeMemory(reinterpret_cast<void*>(const_cast<char*>(m_list)));
-        m_list = "";
+        m_list = nullptr;
         return;
     }
 
@@ -230,11 +230,12 @@ void JitConfigValues::MethodSet::destroy(ICorJitHost* host)
         next = name->m_next;
         host->freeMemory(reinterpret_cast<void*>(const_cast<MethodName*>(name)));
     }
-
-    host->freeMemory(reinterpret_cast<void*>(const_cast<char*>(m_list)));
-
+    if (m_list != nullptr)
+    {
+        host->freeMemory(reinterpret_cast<void*>(const_cast<char*>(m_list)));
+        m_list = nullptr;
+    }
     m_names = nullptr;
-    m_list  = nullptr;
 }
 
 static bool matchesName(const char* const name, int nameLen, const char* const s2)


### PR DESCRIPTION
We don't use "destroy" nowadays, but if we want, it will not work.
It is part of spmi collection with different environment sets.