### PR TITLE
Fixed misconception between FP register allocator and RyuJIT's CSE phase

### DIFF
--- a/src/jit/stackfp.cpp
+++ b/src/jit/stackfp.cpp
@@ -911,7 +911,18 @@ void CodeGen::genLoadStackFP(GenTreePtr tree, regNumber reg)
     }
     else
     {
-        FlatFPX87_PushVirtual(&compCurFPState, reg);
+        // Since FP register allocator doesn't work well with
+        // RyuJIT CSE optimizer it makes possible situation when
+        // CSE'ed value gets mapped many times.
+        if (compCurFPState.Mapped(reg))
+        {
+            assert(tree->OperGet() == GT_LCL_VAR);
+            assert(compiler->lclNumIsTrueCSE(tree->gtLclVarCommon.gtLclNum));
+        }
+        else
+        {
+            FlatFPX87_PushVirtual(&compCurFPState, reg);
+        }
         inst_FS_TT(INS_fld, tree);
     }
 }


### PR DESCRIPTION
Fixed issue #12469.

For CSE'ed values possible situation when it get mapped many times. 