### PR TITLE
Remove empty try's

### DIFF
--- a/src/mscorlib/shared/System/DateTime.cs
+++ b/src/mscorlib/shared/System/DateTime.cs
@@ -1025,9 +1025,7 @@ namespace System
         }
 
         // Returns a DateTime representing the current date and time. The
-        // resolution of the returned value depends on the system timer. For
-        // Windows NT 3.5 and later the timer resolution is approximately 10ms.
-        //
+        // resolution of the returned value depends on the system timer.
         public static DateTime Now
         {
             get

--- a/src/mscorlib/shared/System/DateTime.cs
+++ b/src/mscorlib/shared/System/DateTime.cs
@@ -1026,9 +1026,7 @@ namespace System
 
         // Returns a DateTime representing the current date and time. The
         // resolution of the returned value depends on the system timer. For
-        // Windows NT 3.5 and later the timer resolution is approximately 10ms,
-        // for Windows NT 3.1 it is approximately 16ms, and for Windows 95 and 98
-        // it is approximately 55ms.
+        // Windows NT 3.5 and later the timer resolution is approximately 10ms.
         //
         public static DateTime Now
         {

--- a/src/mscorlib/shared/System/DateTimeOffset.cs
+++ b/src/mscorlib/shared/System/DateTimeOffset.cs
@@ -129,9 +129,7 @@ namespace System
         }
 
         // Returns a DateTimeOffset representing the current date and time. The
-        // resolution of the returned value depends on the system timer. For
-        // Windows NT 3.5 and later the timer resolution is approximately 10ms.
-        //
+        // resolution of the returned value depends on the system timer.
         public static DateTimeOffset Now
         {
             get

--- a/src/mscorlib/shared/System/DateTimeOffset.cs
+++ b/src/mscorlib/shared/System/DateTimeOffset.cs
@@ -130,9 +130,7 @@ namespace System
 
         // Returns a DateTimeOffset representing the current date and time. The
         // resolution of the returned value depends on the system timer. For
-        // Windows NT 3.5 and later the timer resolution is approximately 10ms,
-        // for Windows NT 3.1 it is approximately 16ms, and for Windows 95 and 98
-        // it is approximately 55ms.
+        // Windows NT 3.5 and later the timer resolution is approximately 10ms.
         //
         public static DateTimeOffset Now
         {

--- a/src/mscorlib/shared/System/IO/FileStream.Windows.cs
+++ b/src/mscorlib/shared/System/IO/FileStream.Windows.cs
@@ -742,9 +742,8 @@ namespace System.IO
                 else
                 {
                     // ERROR_INVALID_PARAMETER may be returned for writes
-                    // where the position is too large (i.e. writing at Int64.MaxValue 
-                    // on Win9x) OR for synchronous writes to a handle opened 
-                    // asynchronously.
+                    // where the position is too large or for synchronous writes 
+                    // to a handle opened asynchronously.
                     if (errorCode == ERROR_INVALID_PARAMETER)
                         throw new IOException(SR.IO_FileTooLongOrHandleNotSync);
                     throw Win32Marshal.GetExceptionForWin32Error(errorCode);

--- a/src/mscorlib/src/Microsoft/Win32/RegistryKey.cs
+++ b/src/mscorlib/src/Microsoft/Win32/RegistryKey.cs
@@ -458,9 +458,7 @@ namespace Microsoft.Win32
          * Note that <var>name</var> can be null or "", at which point the
          * unnamed or default value of this Registry key is returned, if any.
          * The default values for RegistryKeys are OS-dependent.  NT doesn't
-         * have them by default, but they can exist and be of any type.  On
-         * Win95, the default value is always an empty key of type REG_SZ.
-         * Win98 supports default values of any type, but defaults to REG_SZ.
+         * have them by default, but they can exist and be of any type. 
          *
          * @param name Name of value to retrieve.
          * @param defaultValue Value to return if <i>name</i> doesn't exist.

--- a/src/mscorlib/src/System/Diagnostics/Stacktrace.cs
+++ b/src/mscorlib/src/System/Diagnostics/Stacktrace.cs
@@ -247,9 +247,6 @@ namespace System.Diagnostics
 
     // Class which represents a description of a stack trace
     // There is no good reason for the methods of this class to be virtual.  
-    // In order to ensure trusted code can trust the data it gets from a 
-    // StackTrace, we use an InheritanceDemand to prevent partially-trusted
-    // subclasses.
     public class StackTrace
     {
         private StackFrame[] frames;

--- a/src/mscorlib/src/System/Reflection/RuntimeConstructorInfo.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimeConstructorInfo.cs
@@ -57,8 +57,7 @@ namespace System.Reflection
                         // this should be an invocable method, determine the other flags that participate in invocation
                         invocationFlags |= RuntimeMethodHandle.GetSecurityFlags(this);
 
-                        // Check for attempt to create a delegate class, we demand unmanaged
-                        // code permission for this since it's hard to validate the target address.
+                        // Check for attempt to create a delegate class.
                         if (typeof(Delegate).IsAssignableFrom(DeclaringType))
                             invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_IS_DELEGATE_CTOR;
                     }

--- a/src/mscorlib/src/System/Runtime/InteropServices/CriticalHandle.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/CriticalHandle.cs
@@ -130,13 +130,7 @@ using System.IO;
 
 namespace System.Runtime.InteropServices
 {
-    // This class should not be serializable - it's a handle.  We require unmanaged
-    // code permission to subclass CriticalHandle to prevent people from writing a 
-    // subclass and suddenly being able to run arbitrary native code with the
-    // same signature as CloseHandle.  This is technically a little redundant, but
-    // we'll do this to ensure we've cut off all attack vectors.  Similarly, all
-    // methods have a link demand to ensure untrusted code cannot directly edit
-    // or alter a handle.
+    // This class should not be serializable - it's a handle
     public abstract class CriticalHandle : CriticalFinalizerObject, IDisposable
     {
         // ! Do not add or rearrange fields as the EE depends on this layout.

--- a/src/mscorlib/src/System/Runtime/InteropServices/SafeBuffer.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/SafeBuffer.cs
@@ -173,15 +173,10 @@ namespace System.Runtime.InteropServices
 
             pointer = null;
             RuntimeHelpers.PrepareConstrainedRegions();
-            try
-            {
-            }
-            finally
-            {
-                bool junk = false;
-                DangerousAddRef(ref junk);
-                pointer = (byte*)handle;
-            }
+
+            bool junk = false;
+            DangerousAddRef(ref junk);
+            pointer = (byte*)handle;
         }
 
         public void ReleasePointer()

--- a/src/mscorlib/src/System/Runtime/Reliability/CriticalFinalizerObject.cs
+++ b/src/mscorlib/src/System/Runtime/Reliability/CriticalFinalizerObject.cs
@@ -11,7 +11,6 @@
 ** (i.e. the finalizer is guaranteed to run, won't be aborted by the host and is
 ** run after the finalizers of other objects collected at the same time).
 **
-** You must possess UnmanagedCode permission in order to derive from this class.
 **
 ** 
 ===========================================================*/

--- a/src/mscorlib/src/System/Threading/ThreadPool.cs
+++ b/src/mscorlib/src/System/Threading/ThreadPool.cs
@@ -756,16 +756,11 @@ namespace System.Threading
         {
             // needed for DangerousAddRef
             RuntimeHelpers.PrepareConstrainedRegions();
-            try
+
+            m_internalWaitObject = waitObject;
+            if (waitObject != null)
             {
-            }
-            finally
-            {
-                m_internalWaitObject = waitObject;
-                if (waitObject != null)
-                {
-                    m_internalWaitObject.SafeWaitHandle.DangerousAddRef(ref bReleaseNeeded);
-                }
+                m_internalWaitObject.SafeWaitHandle.DangerousAddRef(ref bReleaseNeeded);
             }
         }
 
@@ -776,47 +771,43 @@ namespace System.Threading
             bool result = false;
             // needed for DangerousRelease
             RuntimeHelpers.PrepareConstrainedRegions();
-            try
+
+            // lock(this) cannot be used reliably in Cer since thin lock could be
+            // promoted to syncblock and that is not a guaranteed operation
+            bool bLockTaken = false;
+            do
             {
-            }
-            finally
-            {
-                // lock(this) cannot be used reliably in Cer since thin lock could be
-                // promoted to syncblock and that is not a guaranteed operation
-                bool bLockTaken = false;
-                do
+                if (Interlocked.CompareExchange(ref m_lock, 1, 0) == 0)
                 {
-                    if (Interlocked.CompareExchange(ref m_lock, 1, 0) == 0)
+                    bLockTaken = true;
+                    try
                     {
-                        bLockTaken = true;
-                        try
+                        if (ValidHandle())
                         {
-                            if (ValidHandle())
+                            result = UnregisterWaitNative(GetHandle(), waitObject == null ? null : waitObject.SafeWaitHandle);
+                            if (result == true)
                             {
-                                result = UnregisterWaitNative(GetHandle(), waitObject == null ? null : waitObject.SafeWaitHandle);
-                                if (result == true)
+                                if (bReleaseNeeded)
                                 {
-                                    if (bReleaseNeeded)
-                                    {
-                                        m_internalWaitObject.SafeWaitHandle.DangerousRelease();
-                                        bReleaseNeeded = false;
-                                    }
-                                    // if result not true don't release/suppress here so finalizer can make another attempt
-                                    SetHandle(InvalidHandle);
-                                    m_internalWaitObject = null;
-                                    GC.SuppressFinalize(this);
+                                    m_internalWaitObject.SafeWaitHandle.DangerousRelease();
+                                    bReleaseNeeded = false;
                                 }
+                                // if result not true don't release/suppress here so finalizer can make another attempt
+                                SetHandle(InvalidHandle);
+                                m_internalWaitObject = null;
+                                GC.SuppressFinalize(this);
                             }
                         }
-                        finally
-                        {
-                            m_lock = 0;
-                        }
                     }
-                    Thread.SpinWait(1);     // yield to processor
+                    finally
+                    {
+                        m_lock = 0;
+                    }
                 }
-                while (!bLockTaken);
+                Thread.SpinWait(1);     // yield to processor
             }
+            while (!bLockTaken);
+
             return result;
         }
 


### PR DESCRIPTION
Just remove cases where we still had empty try's.

This isn't very interesting, but what is the status of CER's in CoreCLR? What does `RuntimeHelpers.PrepareConstrainedRegions();` do? Is there cleanup possible?