### PR TITLE
Avoid unnecessary intermediate Version allocation

### DIFF
--- a/src/mscorlib/src/System/AppContext/AppContextDefaultValues.cs
+++ b/src/mscorlib/src/System/AppContext/AppContextDefaultValues.cs
@@ -114,7 +114,7 @@ namespace System
                     {
                         value = value.Substring(1);
                     }
-                    Version realVersion = new Version(value);
+                    Version realVersion = Version.Parse(value);
                     // The version class will represent some unset values as -1 internally (instead of 0).
                     version = realVersion.Major * 10000;
                     if (realVersion.Minor > 0)


### PR DESCRIPTION
Just a minor nit: `Version..ctor(string)` is [implemented](https://github.com/dotnet/coreclr/blob/a6045809b3720833459c9247aeb4aafe281d7841/src/mscorlib/shared/System/Version.cs#L81-L88) by calling `Version.Parse`, which allocates an intermediate `Version` instance. Avoid the unnecessary intermediate allocation by using `Version.Parse` directly.

cc: @AlexGhiondea