### PR TITLE
Fixing bug in PAL's wcsstr function

### DIFF
--- a/src/pal/src/cruntime/wchar.cpp
+++ b/src/pal/src/cruntime/wchar.cpp
@@ -1194,16 +1194,22 @@ PAL_wcsstr(
         i = 0;
         while (1)
         {
-            if (*(string + i) == 0 || *(strCharSet + i) == 0)
+            if (*(strCharSet + i) == 0)
             {
                 ret = (wchar_16 *) string;
                 goto leave;
             }
-            if (*(string + i) != *(strCharSet + i))
+            else if (*(string + i) == 0)
+            {
+                ret = NULL;
+                goto leave;
+            }
+            else if (*(string + i) != *(strCharSet + i))
             {
                 break;
             }
-        i++;
+
+            i++;
         }
         string++;
     }

--- a/src/pal/tests/palsuite/c_runtime/wcsstr/test1/test1.cpp
+++ b/src/pal/tests/palsuite/c_runtime/wcsstr/test1/test1.cpp
@@ -21,6 +21,7 @@ int __cdecl main(int argc, char *argv[])
     WCHAR *key1;
     WCHAR *key2;
     WCHAR key3[] = { 0 };
+    WCHAR *key4;
     WCHAR *result;
         
     if (PAL_Initialize(argc, argv))
@@ -31,6 +32,7 @@ int __cdecl main(int argc, char *argv[])
     string = convert("foo bar baz bar");
     key1 = convert("bar");
     key2 = convert("Bar");
+    key4 = convert("arggggh!");
 
     result = wcsstr(string, key1);
     if (result != string + 4)
@@ -55,6 +57,14 @@ int __cdecl main(int argc, char *argv[])
         Fail("ERROR: Got incorrect result in scanning \"%s\" for \"%s\".\n"
             "Expected to get pointer to %#p, got %#p\n", convertC(string),
             convertC(key3), string, result);
+    }
+
+    result = wcsstr(string, key4);
+    if (result != nullptr)
+    {
+        Fail("ERROR: Got incorrect result in scanning \"%s\" for \"%s\".\n"
+            "Expected to get pointer to null, got %#p\n", convertC(string),
+            convertC(key4), result);
     }
 
     PAL_Terminate();


### PR DESCRIPTION
PAL's wcsstr was returning incorrect result

PAL's wcsstr function would return an incorrect result when the search string
was longer than the remaining target string.  E.g., it would return the string
`"bc"` when  `wcsstr("abc", "bcXX")` was called.  Fixed the bug & added a 
regression case to wchar's pal tests.
