### PR TITLE
Undo a few JIT layout workarounds

### DIFF
--- a/src/mscorlib/src/System/String.Comparison.cs
+++ b/src/mscorlib/src/System/String.Comparison.cs
@@ -44,7 +44,7 @@ namespace System
 
                     //Return the (case-insensitive) difference between them.
                     if (charA != charB)
-                        goto ReturnCharAMinusCharB; // TODO: Workaround for https://github.com/dotnet/coreclr/issues/9692
+                        return charA - charB;
 
                     // Next char
                     a++; b++;
@@ -52,9 +52,6 @@ namespace System
                 }
 
                 return strA.Length - strB.Length;
-
-                ReturnCharAMinusCharB:
-                return charA - charB;
             }
         }
 
@@ -168,14 +165,11 @@ namespace System
                     }
                     else
                     {
-                        goto ReturnFalse;
+                        return false;
                     }
                 }
 
                 return true;
-
-            ReturnFalse:
-                return false;
             }
         }
 

--- a/src/mscorlib/src/System/String.Searching.cs
+++ b/src/mscorlib/src/System/String.Searching.cs
@@ -147,26 +147,20 @@ namespace System
                     char c = *pCh;
 
                     if (c == value1 || c == value2)
-                        goto ReturnIndex;
+                        return (int)(pCh - pChars);
 
                     // Possibly reads outside of count and can include null terminator
                     // Handled in the return logic
                     c = *(pCh + 1);
 
                     if (c == value1 || c == value2)
-                        goto ReturnIndex1;
+                        return (count == 1 ? -1 : (int)(pCh - pChars) + 1);
 
                     pCh += 2;
                     count -= 2;
                 }
 
                 return -1;
-
-            ReturnIndex:
-                return (int)(pCh - pChars);
-
-            ReturnIndex1:
-                return (count == 1 ? -1 : (int)(pCh - pChars) + 1);
             }
         }
 
@@ -181,16 +175,13 @@ namespace System
                     char c = *pCh;
 
                     if (c == value1 || c == value2 || c == value3)
-                        goto ReturnIndex;
+                        return (int)(pCh - pChars);
 
                     pCh++;
                     count--;
                 }
 
                 return -1;
-
-            ReturnIndex:
-                return (int)(pCh - pChars);
             }
         }
 


### PR DESCRIPTION
Remove some `goto`s that were added to work around #9692 (poor code
layout for loop exit paths) -- the JIT's layout decisions were improved
in #13314, and these particular `goto`s are no longer needed; crossgen
of System.Private.CoreLib now produces the same machine code with or
without this change.

Part of #13466.