### PR TITLE
Fix switch unsigned cast

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -767,6 +767,7 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
         {
             // Note that the switch value is unsigned so the cast should be unsigned as well.
             switchValue = comp->gtNewCastNode(TYP_I_IMPL, switchValue, TYP_U_IMPL);
+            switchValue->gtFlags |= GTF_UNSIGNED;
         }
 #endif
         GenTreePtr gtTableSwitch =


### PR DESCRIPTION
In #9398 I forgot to set the `GTF_UNSIGNED` flag on the cast. This issue is hidden by a weird piece of code in `CodeGen::genIntToIntCast` (see #13501) that generates a zero extending cast as if the flag was set.

No diffs on x64. On ARM64 `mov` is now generated instead of `sxtw`, as intended.