### PR TITLE
Use CreateFile2FromApp if available (#13410)

### DIFF
--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -610,7 +610,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(BclSourcesRoot)\Microsoft\Win32\SafeHandles\SafeFindHandle.cs" />
-    <Compile Include="$(BclSourcesRoot)\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs" />
     <Compile Include="$(BclSourcesRoot)\Microsoft\Win32\SafeHandles\SafeWaitHandle.cs" />
     <Compile Condition="'$(FeatureWin32Registry)' == 'true'" Include="$(BclSourcesRoot)\Microsoft\Win32\SafeHandles\SafeRegistryHandle.cs" />
   </ItemGroup>

--- a/src/mscorlib/shared/Interop/Windows/FileApiInterop/Interop.CreateFile2FromApp.cs
+++ b/src/mscorlib/shared/Interop/Windows/FileApiInterop/Interop.CreateFile2FromApp.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System.IO;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class FileApiInterop
+    {
+#pragma warning disable BCL0015 // Not part of our whitelist
+        [DllImport("FileApiInterop.dll", EntryPoint = "CreateFile2FromApp", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern SafeFileHandle CreateFile2FromAppPrivate(
+            string lpFileName,
+            int dwDesiredAccess,
+            FileShare dwShareMode,
+            FileMode dwCreationDisposition,
+            ref Kernel32.CREATEFILE2_EXTENDED_PARAMETERS pCreateExParams);
+#pragma warning restore BCL0015
+
+        internal static SafeFileHandle CreateFile2FromApp(
+            string lpFileName,
+            int dwDesiredAccess,
+            FileShare dwShareMode,
+            FileMode dwCreationDisposition,
+            ref Kernel32.CREATEFILE2_EXTENDED_PARAMETERS pCreateExParams)
+        {
+            lpFileName = PathInternal.EnsureExtendedPrefixOverMaxPath(lpFileName);
+            return CreateFile2FromAppPrivate(lpFileName, dwDesiredAccess, dwShareMode, dwCreationDisposition, ref pCreateExParams);
+        }
+    }
+}

--- a/src/mscorlib/shared/Interop/Windows/Kernel32/Interop.CREATEFILE2_EXTENDED_PARAMETERS.cs
+++ b/src/mscorlib/shared/Interop/Windows/Kernel32/Interop.CREATEFILE2_EXTENDED_PARAMETERS.cs
@@ -1,23 +1,16 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Win32.SafeHandles;
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, EntryPoint = "CreateFile2", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
-        internal static extern unsafe SafeFileHandle CreateFile2(
-            string lpFileName,
-            int dwDesiredAccess,
-            System.IO.FileShare dwShareMode,
-            System.IO.FileMode dwCreationDisposition,
-            CREATEFILE2_EXTENDED_PARAMETERS* pCreateExParams);
-
         internal unsafe struct CREATEFILE2_EXTENDED_PARAMETERS
         {
             internal uint dwSize;

--- a/src/mscorlib/shared/Interop/Windows/Kernel32/Interop.FreeLibrary.cs
+++ b/src/mscorlib/shared/Interop/Windows/Kernel32/Interop.FreeLibrary.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
+        internal static extern bool FreeLibrary(IntPtr hModule);
+    }
+}

--- a/src/mscorlib/shared/Interop/Windows/Kernel32/Interop.LoadLibraryExW.cs
+++ b/src/mscorlib/shared/Interop/Windows/Kernel32/Interop.LoadLibraryExW.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        internal const int LOAD_LIBRARY_AS_DATAFILE = 0x00000002;
+
+        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
+        internal static extern SafeLibraryHandle LoadLibraryExW(string libFilename, IntPtr reserved, int flags);
+    }
+}

--- a/src/mscorlib/shared/Interop/Windows/User32/Interop.LoadStringW.cs
+++ b/src/mscorlib/shared/Interop/Windows/User32/Interop.LoadStringW.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Win32.SafeHandles;
+
+internal partial class Interop
+{
+    internal partial class User32
+    {
+        [DllImport(Libraries.User32, SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        internal static extern int LoadStringW(SafeLibraryHandle handle, int id, [Out] StringBuilder buffer, int bufferLength);
+    }
+}

--- a/src/mscorlib/shared/Microsoft/Win32/SafeHandles/SafeLibraryHandle.cs
+++ b/src/mscorlib/shared/Microsoft/Win32/SafeHandles/SafeLibraryHandle.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Win32.SafeHandles;
-
-namespace Microsoft.Win32
+namespace Microsoft.Win32.SafeHandles
 {
     sealed internal class SafeLibraryHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
@@ -12,7 +10,7 @@ namespace Microsoft.Win32
 
         override protected bool ReleaseHandle()
         {
-            return UnsafeNativeMethods.FreeLibrary(handle);
+            return Interop.Kernel32.FreeLibrary(handle);
         }
     }
 }

--- a/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
@@ -394,7 +394,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\StringBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\UnicodeEncoding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\UTF32Encoding.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Text\UTF7Encoding.cs" />   
+    <Compile Include="$(MSBuildThisFileDirectory)System\Text\UTF7Encoding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\UTF8Encoding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\TimeSpan.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\ThreadAttributes.cs" />
@@ -495,8 +495,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Interop.Libraries.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.CancelIoEx.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.CloseHandle.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.CreateFile.cs" Condition="'$(EnableWinRT)' != 'true'" />
-    <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.CreateFile2.cs" Condition="'$(EnableWinRT)' == 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.FileAttributes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.FILE_INFO_BY_HANDLE_CLASS.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.FileTypes.cs" />
@@ -531,24 +529,36 @@
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\OleAut32\Interop.SysAllocStringLen.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\OleAut32\Interop.SysFreeString.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\OleAut32\Interop.SysStringLen.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\User32\Interop.Constants.cs"  Condition="'$(EnableWinRT)' != 'true'" />
-    <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\User32\Interop.SendMessageTimeout.cs" Condition="'$(EnableWinRT)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeFileHandle.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\HijriCalendar.Win32.cs" Condition="'$(EnableWinRT)' != 'true' and '$(EnableDummyGlobalizationImplementation)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\HijriCalendar.WinRT.cs" Condition="'$(EnableWinRT)' == 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\JapaneseCalendar.Win32.cs" Condition="'$(EnableWinRT)' != 'true' and '$(EnableDummyGlobalizationImplementation)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\JapaneseCalendar.WinRT.cs" Condition="'$(EnableWinRT)' == 'true'" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\IO\FileStream.Win32.cs" Condition="'$(EnableWinRT)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\FileStream.Windows.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\IO\FileStream.WinRT.cs" Condition="'$(EnableWinRT)' == 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\FileStreamCompletionSource.Win32.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\Path.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\PathHelper.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\PathInternal.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\PathInternal.Windows.StringBuffer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\Win32Marshal.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IO\DisableMediaInsertionPrompt.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Security\SafeBSTRHandle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Security\SecureString.Windows.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="$(TargetsWindows) and '$(EnableWinRT)' != 'true'">
+    <Compile Include="$(MSBuildThisFileDirectory)System\IO\FileStream.Win32.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.LoadLibraryExW.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.FreeLibrary.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.CreateFile.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\User32\Interop.Constants.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\User32\Interop.SendMessageTimeout.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\User32\Interop.LoadStringW.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="$(TargetsWindows) and ('$(ClrProduct)' == 'core_clr' or '$(EnableWinRT)' == 'true')">
+    <Compile Include="$(MSBuildThisFileDirectory)System\IO\FileStream.WinRT.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\FileApiInterop\Interop.CreateFile2FromApp.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.CREATEFILE2_EXTENDED_PARAMETERS.cs" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetsUnix)">
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Unix\Interop.Errors.cs" />

--- a/src/mscorlib/shared/System/IO/DisableMediaInsertionPrompt.cs
+++ b/src/mscorlib/shared/System/IO/DisableMediaInsertionPrompt.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO
+{
+    /// <summary>
+    /// Simple wrapper to safely disable the normal media insertion prompt for
+    /// removable media (floppies, cds, memory cards, etc.)
+    /// </summary>
+    /// <remarks>
+    /// Note that removable media file systems lazily load. After starting the OS
+    /// they won't be loaded until you have media in the drive- and as such the
+    /// prompt won't happen. You have to have had media in at least once to get
+    /// the file system to load and then have removed it.
+    /// </remarks>
+    internal struct DisableMediaInsertionPrompt : IDisposable
+    {
+        private bool _disableSuccess;
+        private uint _oldMode;
+
+        public static DisableMediaInsertionPrompt Create()
+        {
+            DisableMediaInsertionPrompt prompt = new DisableMediaInsertionPrompt();
+            prompt._disableSuccess = Interop.Kernel32.SetThreadErrorMode(Interop.Kernel32.SEM_FAILCRITICALERRORS, out prompt._oldMode);
+            return prompt;
+        }
+
+        public void Dispose()
+        {
+            uint ignore;
+            if (_disableSuccess)
+                Interop.Kernel32.SetThreadErrorMode(_oldMode, out ignore);
+        }
+    }
+}

--- a/src/mscorlib/shared/System/IO/FileStream.Win32.cs
+++ b/src/mscorlib/shared/System/IO/FileStream.Win32.cs
@@ -3,13 +3,21 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Win32.SafeHandles;
-using System.Runtime.InteropServices;
 
 namespace System.IO
 {
     public partial class FileStream : Stream
     {
         private SafeFileHandle OpenHandle(FileMode mode, FileShare share, FileOptions options)
+        {
+#if CORECLR
+            if (AppDomain.IsAppXModel())
+                return CreateFile2OpenHandle(mode, share, options);
+#endif
+            return CreateFileOpenHandle(mode, share, options);
+        }
+
+        private unsafe SafeFileHandle CreateFileOpenHandle(FileMode mode, FileShare share, FileOptions options)
         {
             Interop.Kernel32.SECURITY_ATTRIBUTES secAttrs = GetSecAttrs(share);
 
@@ -30,44 +38,13 @@ namespace System.IO
             // For mitigating local elevation of privilege attack through named pipes
             // make sure we always call CreateFile with SECURITY_ANONYMOUS so that the
             // named pipe server can't impersonate a high privileged client security context
+            // (note that this is the effective default on CreateFile2)
             flagsAndAttributes |= (Interop.Kernel32.SecurityOptions.SECURITY_SQOS_PRESENT | Interop.Kernel32.SecurityOptions.SECURITY_ANONYMOUS);
 
-            // Don't pop up a dialog for reading from an empty floppy drive
-            uint oldMode;
-            bool success = Interop.Kernel32.SetThreadErrorMode(Interop.Kernel32.SEM_FAILCRITICALERRORS, out oldMode);
-            try
+            using (DisableMediaInsertionPrompt.Create())
             {
-                SafeFileHandle fileHandle = Interop.Kernel32.CreateFile(_path, fAccess, share, ref secAttrs, mode, flagsAndAttributes, IntPtr.Zero);
-                fileHandle.IsAsync = _useAsyncIO;
-
-                if (fileHandle.IsInvalid)
-                {
-                    // Return a meaningful exception with the full path.
-
-                    // NT5 oddity - when trying to open "C:\" as a Win32FileStream,
-                    // we usually get ERROR_PATH_NOT_FOUND from the OS.  We should
-                    // probably be consistent w/ every other directory.
-                    int errorCode = Marshal.GetLastWin32Error();
-
-                    if (errorCode == Interop.Errors.ERROR_PATH_NOT_FOUND && _path.Length == PathInternal.GetRootLength(_path))
-                        errorCode = Interop.Errors.ERROR_ACCESS_DENIED;
-
-                    throw Win32Marshal.GetExceptionForWin32Error(errorCode, _path);
-                }
-                
-                int fileType = Interop.Kernel32.GetFileType(fileHandle);
-                if (fileType != Interop.Kernel32.FileTypes.FILE_TYPE_DISK)
-                {
-                    fileHandle.Dispose();
-                    throw new NotSupportedException(SR.NotSupported_FileStreamOnNonFiles);
-                }
-
-                return fileHandle;
-            }
-            finally
-            {
-                if (success)
-                    Interop.Kernel32.SetThreadErrorMode(oldMode, out oldMode);
+                return ValidateFileHandle(
+                    Interop.Kernel32.CreateFile(_path, fAccess, share, ref secAttrs, mode, flagsAndAttributes, IntPtr.Zero));
             }
         }
     }

--- a/src/mscorlib/shared/System/IO/FileStream.WinRT.cs
+++ b/src/mscorlib/shared/System/IO/FileStream.WinRT.cs
@@ -9,11 +9,18 @@ namespace System.IO
 {
     public partial class FileStream : Stream
     {
+#if !CORECLR
         private unsafe SafeFileHandle OpenHandle(FileMode mode, FileShare share, FileOptions options)
+        {
+            return CreateFile2OpenHandle(mode, share, options);
+        }
+#endif
+
+        private unsafe SafeFileHandle CreateFile2OpenHandle(FileMode mode, FileShare share, FileOptions options)
         {
             Interop.Kernel32.SECURITY_ATTRIBUTES secAttrs = GetSecAttrs(share);
 
-            int fAccess =
+            int access =
                 ((_access & FileAccess.Read) == FileAccess.Read ? GENERIC_READ : 0) |
                 ((_access & FileAccess.Write) == FileAccess.Write ? GENERIC_WRITE : 0);
 
@@ -30,31 +37,15 @@ namespace System.IO
             parameters.dwFileFlags = (uint)options;
             parameters.lpSecurityAttributes = &secAttrs;
 
-            SafeFileHandle fileHandle = Interop.Kernel32.CreateFile2(
-                lpFileName: _path,
-                dwDesiredAccess: fAccess,
-                dwShareMode: share,
-                dwCreationDisposition: mode,
-                pCreateExParams: &parameters);
-
-            fileHandle.IsAsync = _useAsyncIO;
-
-            if (fileHandle.IsInvalid)
+            using (DisableMediaInsertionPrompt.Create())
             {
-                // Return a meaningful exception with the full path.
-
-                // NT5 oddity - when trying to open "C:\" as a Win32FileStream,
-                // we usually get ERROR_PATH_NOT_FOUND from the OS.  We should
-                // probably be consistent w/ every other directory.
-                int errorCode = Marshal.GetLastWin32Error();
-
-                if (errorCode == Interop.Errors.ERROR_PATH_NOT_FOUND && _path.Length == PathInternal.GetRootLength(_path))
-                    errorCode = Interop.Errors.ERROR_ACCESS_DENIED;
-
-                throw Win32Marshal.GetExceptionForWin32Error(errorCode, _path);
+                return ValidateFileHandle(Interop.FileApiInterop.CreateFile2FromApp(
+                    lpFileName: _path,
+                    dwDesiredAccess: access,
+                    dwShareMode: share,
+                    dwCreationDisposition: mode,
+                    pCreateExParams: ref parameters));
             }
-
-            return fileHandle;
         }
     }
 }

--- a/src/mscorlib/src/Microsoft/Win32/UnsafeNativeMethods.cs
+++ b/src/mscorlib/src/Microsoft/Win32/UnsafeNativeMethods.cs
@@ -4,17 +4,12 @@
 
 namespace Microsoft.Win32
 {
-    using Microsoft.Win32;
     using Microsoft.Win32.SafeHandles;
     using System;
-    using System.Runtime.CompilerServices;
-    using System.Runtime.ConstrainedExecution;
+    using System.Diagnostics.Tracing;
     using System.Runtime.InteropServices;
-    using System.Runtime.Serialization;
-    using System.Runtime.Versioning;
     using System.Security;
     using System.Text;
-    using System.Diagnostics.Tracing;
 
     [SuppressUnmanagedCodeSecurityAttribute()]
     internal static class UnsafeNativeMethods
@@ -49,18 +44,6 @@ namespace Microsoft.Win32
                                      StringBuilder fileMuiPath,
                                      ref int fileMuiPathLength,
                                      ref Int64 enumerator);
-
-
-        [DllImport(Win32Native.USER32, EntryPoint = "LoadStringW", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true, CallingConvention = CallingConvention.StdCall)]
-        internal static extern int LoadString(SafeLibraryHandle handle, int id, [Out] StringBuilder buffer, int bufferLength);
-
-        [DllImport(Win32Native.KERNEL32, CharSet = System.Runtime.InteropServices.CharSet.Unicode, SetLastError = true)]
-        internal static extern SafeLibraryHandle LoadLibraryEx(string libFilename, IntPtr reserved, int flags);
-
-        [DllImport(Win32Native.KERNEL32, CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool FreeLibrary(IntPtr hModule);
-
 
         [SuppressUnmanagedCodeSecurityAttribute()]
         internal static unsafe class ManifestEtw
@@ -247,6 +230,7 @@ namespace Microsoft.Win32
                 int OutBufferSize,
                 ref int ReturnLength);
         }
+
 #if FEATURE_COMINTEROP
         [DllImport("combase.dll", PreserveSig = true)]
         internal static extern int RoGetActivationFactory(
@@ -254,6 +238,5 @@ namespace Microsoft.Win32
             [In] ref Guid iid,
             [Out, MarshalAs(UnmanagedType.IInspectable)] out Object factory);
 #endif
-
     }
 }

--- a/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
+++ b/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
@@ -170,7 +170,6 @@ namespace Microsoft.Win32
         internal const int MUI_LANG_NEUTRAL_PE_FILE = 0x100;
         internal const int MUI_NON_LANG_NEUTRAL_FILE = 0x200;
 
-        internal const int LOAD_LIBRARY_AS_DATAFILE = 0x00000002;
         internal const int LOAD_STRING_MAX_LENGTH = 500;
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/mscorlib/src/System/TimeZoneInfo.Win32.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.Win32.cs
@@ -10,6 +10,7 @@ using System.Security;
 using System.Text;
 using System.Threading;
 using Microsoft.Win32;
+using Microsoft.Win32.SafeHandles;
 
 namespace System
 {
@@ -851,14 +852,14 @@ namespace System
         private static string TryGetLocalizedNameByNativeResource(string filePath, int resource)
         {
             using (SafeLibraryHandle handle =
-                       UnsafeNativeMethods.LoadLibraryEx(filePath, IntPtr.Zero, Win32Native.LOAD_LIBRARY_AS_DATAFILE))
+                       Interop.Kernel32.LoadLibraryExW(filePath, IntPtr.Zero, Interop.Kernel32.LOAD_LIBRARY_AS_DATAFILE))
             {
                 if (!handle.IsInvalid)
                 {
                     StringBuilder localizedResource = StringBuilderCache.Acquire(Win32Native.LOAD_STRING_MAX_LENGTH);
                     localizedResource.Length = Win32Native.LOAD_STRING_MAX_LENGTH;
 
-                    int result = UnsafeNativeMethods.LoadString(handle, resource,
+                    int result = Interop.User32.LoadStringW(handle, resource,
                                      localizedResource, localizedResource.Length);
 
                     if (result != 0)


### PR DESCRIPTION
This is a port of #13410, which adds brokering support for FileStream.

cc: @joperezr 



* Use CreateFile2FromApp if available

This is needed for F5 UAP brokering scenarios.

Remove check for handle type. Overzealous, doesn't apply to UAP scenarios.

* Address feedback

- Use CreateFile2 if Win8 or higher
- Always use CreateFile2FromApp if Appx
- Make DisableMediaInsertionPrompt a struct
- Push CreateFile2FromApp down to avoid JIT

* More feedback

Always use FromApp for WinRT.

* Conditionalize IsWindows8OrAbove check

* Always use FromApp if in AppX

* Address more feedback

- Fix Unix build by moving LoadString to shared
- Break out CREATEFILE2 struct
- Condition CreateFile2FromApp usage

* Move include