### PR TITLE
[ARM/Linux] Fix inconsistency between GetHasCode and Equals

### DIFF
--- a/src/mscorlib/src/System/MulticastDelegate.cs
+++ b/src/mscorlib/src/System/MulticastDelegate.cs
@@ -452,6 +452,17 @@ namespace System
             if (IsUnmanagedFunctionPtr())
                 return ValueType.GetHashCodeOfPtr(_methodPtr) ^ ValueType.GetHashCodeOfPtr(_methodPtrAux);
 
+            if (_invocationCount != (IntPtr)0)
+            {
+                var t = _invocationList as Delegate;
+
+                if (t != null)
+                {
+                    // this is a secure/wrapper delegate so we need to unwrap and check the inner one
+                    return t.GetHashCode();
+                }
+            }
+
             Object[] invocationList = _invocationList as Object[];
             if (invocationList == null)
             {


### PR DESCRIPTION
MulticastDelegate.Equals considers Secure/Wrapper delegates (when _invocationList is Delegate), but the corresponding GetHashCode does not take into account Secure/Wrapper delegates.

This inconsistency results in #13160.

This commit revises the implementation of GetHashCode to fix #13160.