### PR TITLE
Enable overriding default stack size on Unix

### DIFF
--- a/Documentation/project-docs/clr-complus-conf-docgen.sh
+++ b/Documentation/project-docs/clr-complus-conf-docgen.sh
@@ -69,6 +69,25 @@ Name | Description | Type | Class | Default Value | Flags
 EOF
 
 #################################
+# PAL section of the document
+#
+# This section contains a table of COMPlus configurations that are
+# used in the PAL on Unix
+#################################
+read -r -d '' PALCONFIGSECTIONCONTENTS << "EOF"
+## PAL Configuration Knobs
+All the names below need to be prefixed by `COMPlus_`.
+
+Name | Description | Type | Default Value
+-----|-------------|------|---------------
+`DefaultStackSize` | Overrides the default stack size for secondary threads | STRING | 0
+`DbgEnableMiniDump` | If set to 1, enables this core dump generation. The default is NOT to generate a dump | DWORD | 0
+`DbgMiniDumpName` | If set, use as the template to create the dump path and file name. The pid can be placed in the name with %d. | STRING | _/tmp/coredump.%d_
+`DbgMiniDumpType` | If set to 1 generates _MiniDumpNormal_, 2 _MiniDumpWithPrivateReadWriteMemory_, 3 _MiniDumpFilterTriage_, 4 _MiniDumpWithFullMemory_ | DWORD | 1
+`CreateDumpDiagnostics` | If set to 1, enables the _createdump_ utilities diagnostic messages (TRACE macro) | DWORD | 0
+EOF
+
+#################################
 # M4 script for processing macros
 #################################
 
@@ -103,3 +122,6 @@ cat <(echo "$INTROSECTION") <(echo)\
 cat <(echo "$M4SCRIPT") \
     <(echo "$CLRCONFIGSECTIONCONTENTS") <(cat "$1" | sed "/^\/\//d" | sed "/^#/d" | sed "s/\\\\\"/'/g" | sed "/^$/d"  ) \
     | m4 | sed "s/;$//" >> "$2";
+
+cat <(echo "$PALCONFIGSECTIONCONTENTS") >> "$2";
+	

--- a/src/pal/src/include/pal/init.h
+++ b/src/pal/src/include/pal/init.h
@@ -39,6 +39,8 @@ void PALCommonCleanup();
 
 extern Volatile<INT> init_count;
 
+extern SIZE_T g_defaultStackSize;
+
 /*++
 MACRO:
   PALIsInitialized

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -99,6 +99,9 @@ Volatile<LONG> g_coreclrInitialized = 0;
 static BOOL g_fThreadDataAvailable = FALSE;
 static pthread_mutex_t init_critsec_mutex = PTHREAD_MUTEX_INITIALIZER;
 
+// The default minimum stack size
+SIZE_T g_defaultStackSize = 0;
+
 /* critical section to protect access to init_count. This is allocated on the
    very first PAL_Initialize call, and is freed afterward. */
 static PCRITICAL_SECTION init_critsec = NULL;
@@ -167,6 +170,66 @@ PALAPI
 PAL_InitializeDLL()
 {
     return Initialize(0, NULL, PAL_INITIALIZE_DLL);
+}
+
+#ifndef __GLIBC__
+/*++
+Function:
+  EnsureStackSize
+
+Abstract:
+  This fixes a problem on MUSL where the initial stack size reported by the
+  pthread_attr_getstack is about 128kB, but this limit is not fixed and
+  the stack can grow dynamically. The problem is that it makes the 
+  functions ReflectionInvocation::[Try]EnsureSufficientExecutionStack 
+  to fail for real life scenarios like e.g. compilation of corefx.
+  Since there is no real fixed limit for the stack, the code below
+  ensures moving the stack limit to a value that makes reasonable
+  real life scenarios work.
+
+--*/
+__attribute__((noinline,optnone))
+void
+EnsureStackSize(SIZE_T stackSize)
+{
+    volatile uint8_t *s = (uint8_t *)_alloca(stackSize);
+    *s = 0;
+}
+#endif // __GLIBC__
+
+/*++
+Function:
+  InitializeDefaultStackSize
+
+Abstract:
+  Initializes the default stack size. 
+
+--*/
+void
+InitializeDefaultStackSize()
+{
+    char* defaultStackSizeStr = getenv("COMPlus_DefaultStackSize");
+    if (defaultStackSizeStr != NULL)
+    {
+        errno = 0;
+        // Like all numeric values specific by the COMPlus_xxx variables, it is a 
+        // hexadecimal string without any prefix.
+        long int size = strtol(defaultStackSizeStr, NULL, 16);
+
+        if (errno == 0)
+        {
+            g_defaultStackSize = max(size, PTHREAD_STACK_MIN);
+        }
+    }
+
+#ifndef __GLIBC__
+    if (g_defaultStackSize == 0)
+    {
+        // Set the default minimum stack size for MUSL to the same value as we
+        // use on Windows.
+        g_defaultStackSize = 1536 * 1024;
+    }
+#endif // __GLIBC__
 }
 
 /*++
@@ -244,6 +307,12 @@ Initialize(
         gSID = getsid(gPID);
 
         fFirstTimeInit = true;
+
+        InitializeDefaultStackSize();
+
+#ifndef __GLIBC__
+        EnsureStackSize(g_defaultStackSize);
+#endif // __GLIBC__
 
         // Initialize the TLS lookaside cache
         if (FALSE == TLSInitialize())

--- a/src/pal/src/thread/thread.cpp
+++ b/src/pal/src/thread/thread.cpp
@@ -636,15 +636,21 @@ CorUnix::InternalCreateThread(
 
     fAttributesInitialized = TRUE;
 
+    if (alignedStackSize == 0)
+    {
+        // The thread is to be created with default stack size. Use the default stack size
+        // override that was determined during the PAL initialization.
+        alignedStackSize = g_defaultStackSize;
+    }
+
     /* adjust the stack size if necessary */
     if (alignedStackSize != 0)
     {
 #ifdef PTHREAD_STACK_MIN
-        const size_t MinStackSize = PTHREAD_STACK_MIN;
+        size_t MinStackSize = ALIGN_UP(PTHREAD_STACK_MIN, GetVirtualPageSize());
 #else // !PTHREAD_STACK_MIN
-        const size_t MinStackSize = 64 * 1024; // this value is typically accepted by pthread_attr_setstacksize()
+        size_t MinStackSize = 64 * 1024; // this value is typically accepted by pthread_attr_setstacksize()
 #endif // PTHREAD_STACK_MIN
-        _ASSERTE(IS_ALIGNED(MinStackSize, GetVirtualPageSize()));
         if (alignedStackSize < MinStackSize)
         {
             // Adjust the stack size to a minimum value that is likely to be accepted by pthread_attr_setstacksize(). If this


### PR DESCRIPTION
Alpine Linux has a very small default stack size limit, about 80kB.
This is not enough for running coreclr apps.

This change enables overriding the default stack size using the
COMPlus_DefaultStackSize env variable. For Alpine, it also sets
the default stack size to the same value we use for Windows, which
is 1.5MB.

I have also added documentation for this env variable and also the other pre-existing env variables used by the crashdump to the Documentation/project-docs/clr-configuration-knobs.md. Since that file is generated by the Documentation/project-docs/clr-complus-conf-docgen.sh, I have modified that script and added the new resulting clr-configuration-knobs.md. The script was ran more than a year ago and so there were some stale and some new configuration knobs.
