### PR TITLE
Fixed issue #13282: dbgshim fails with E_ACCESSDENIED on Windows.

### DIFF
--- a/src/utilcode/securityutil.cpp
+++ b/src/utilcode/securityutil.cpp
@@ -336,7 +336,7 @@ HRESULT SecurityUtil::GetMandatoryLabelFromProcess(HANDLE hProcess, LPBYTE * ppb
     HandleHolder hToken;
     DWORD err = 0;
 
-    if(!OpenProcessToken(hProcess, TOKEN_READ, &hToken))
+    if(!OpenProcessToken(hProcess, TOKEN_QUERY, &hToken))
     {
         return HRESULT_FROM_GetLastError();
     }


### PR DESCRIPTION
Changed the open process token from TOKEN_READ to TOKEN_QUERY.

Fixes #13282 in release/2.0.0 branch.
Port of #13291