### PR TITLE
Remove macro definition checks that aren't useful and cause unnecessa…

### DIFF
--- a/src/gc/env/gcenv.base.h
+++ b/src/gc/env/gcenv.base.h
@@ -209,14 +209,6 @@ typedef DWORD (WINAPI *PTHREAD_START_ROUTINE)(void* lpThreadParameter);
 
 #endif // _MSC_VER
 
-#ifndef YieldProcessor
- #error "Don't know how to YieldProcessor on this architecture"
-#endif
-
-#ifndef MemoryBarrier
- #error "Don't know how to MemoryBarrier on this architecture"
-#endif
-
 #ifdef _MSC_VER
 #pragma intrinsic(_BitScanForward)
 #if WIN64


### PR DESCRIPTION
…ry build breaks.

These checks are checking for macro definitions of these identifiers, which is not particularly useful since on some platforms these functions are not macros at all but inline functions. This code only affects the GCSample (which builds by default) and standalone GC (which does not build by default).

Fixes the arm/arm64 build break. cc @AndyAyersMS 