### PR TITLE
[WIP] Spin Wait tuning

### DIFF
--- a/src/vm/comsynchronizable.cpp
+++ b/src/vm/comsynchronizable.cpp
@@ -1624,6 +1624,9 @@ FCIMPL1(FC_BOOL_RET, ThreadNative::IsThreadpoolThread, ThreadBaseObject* thread)
 }
 FCIMPLEND
 
+#if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
+extern "C" ptrdiff_t get_cycle_count();
+#endif
 
 FCIMPL1(void, ThreadNative::SpinWait, int iterations)
 {
@@ -1638,7 +1641,12 @@ FCIMPL1(void, ThreadNative::SpinWait, int iterations)
     //
     if (iterations <= 1000000)
     {
+#if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
+        ptrdiff_t endTime = get_cycle_count() + iterations * 10;
+        while (get_cycle_count() < endTime)
+#else
         for(int i = 0; i < iterations; i++)
+#endif
             YieldProcessor();
         return;
     }
@@ -1649,7 +1657,12 @@ FCIMPL1(void, ThreadNative::SpinWait, int iterations)
     HELPER_METHOD_FRAME_BEGIN_NOPOLL();
     GCX_PREEMP();
 
+#if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
+    ptrdiff_t endTime = get_cycle_count() + iterations * 10;
+    while (get_cycle_count() < endTime)
+#else
     for(int i = 0; i < iterations; i++)
+#endif
         YieldProcessor();
 
     HELPER_METHOD_FRAME_END();


### PR DESCRIPTION
Work in progress.  https://github.com/dotnet/coreclr/issues/13388

This PR tries to tune the Spin Wait on AMD64 and X86 platforms. Because "The latency of PAUSE instruction in prior generation microarchitecture is about 10 cycles, whereas on Skylake microarchitecture it has been extended to as many as 140 cycles." 

Assume `YieldProcessor()` took 10 cycles when the original code was written and tuned. `get_cycle_count()` is defined as `rdtsc`.

Use the similar method, which is suggested by the example shown at https://software.intel.com/sites/default/files/managed/9e/bc/64-ia-32-architectures-optimization-manual.pdf

![capture-example](https://user-images.githubusercontent.com/18431130/29585901-9e424aea-873d-11e7-83c5-f2da54a1a8f5.PNG)
