### PR TITLE
Add InnerIterationCount to layout benchmarks

### DIFF
--- a/tests/src/JIT/Performance/CodeQuality/Layout/SearchLoops.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Layout/SearchLoops.cs
@@ -46,13 +46,13 @@ namespace Layout
             test2 = new string('A', length);
         }
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = 20000000)]
         public void LoopReturn()
         {
             Benchmark.Iterate(() => LoopReturn(test1, test2));
         }
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = 20000000)]
         public void LoopGoto()
         {
             Benchmark.Iterate(() => LoopGoto(test1, test2));


### PR DESCRIPTION
These tests were too short-running to measure effectively.  Add an inner
iteration count that makes the running time around 1 second (measured
locally).