### PR TITLE
Add reboot step to end of perf runs

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -14,7 +14,7 @@ def static addRebootPostStep(def job) {
             flexiblePublish {
                 conditionalAction {
                     condition {
-                        status('ABORTED', 'FAILURE', 'SUCCESS')
+                        status('ABORTED', 'SUCCESS')
                     }
                     steps {
                         shell('echo hello!')

--- a/perf.groovy
+++ b/perf.groovy
@@ -7,6 +7,23 @@ def branch = GithubBranchName
 def projectName = Utilities.getFolderName(project)
 def projectFolder = projectName + '/' + Utilities.getFolderName(branch)
 
+
+def static addRebootPostStep(def job) {
+    job.with {
+        publishers {
+            flexiblePublish {
+                conditionalAction {
+                    condition {
+                        status('ABORTED', 'FAILURE', 'SUCCESS')
+                    }
+                    steps {
+                        shell('echo hello!')
+                    }
+                }
+            }
+        }
+    }
+}
 def static getOSGroup(def os) {
     def osGroupMap = ['Ubuntu14.04':'Linux',
         'RHEL7.2': 'Linux',
@@ -123,7 +140,8 @@ def static getOSGroup(def os) {
 
                         Utilities.addArchival(newJob, archiveSettings)
                         Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
-
+                        addRebootPostStep(newJob)
+                        
                         newJob.with {
                             logRotator {
                                 artifactDaysToKeep(30)


### PR DESCRIPTION
We are seeing machines get into bad states and corrupt other runs.  To fix this we are just going to introduce a reboot at the end of each run.