### PR TITLE
Disable default BuildNumberMajor

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -146,7 +146,6 @@
          pulling in different packaging dependencies.
      -->
     <PackagingTaskDir Condition="'$(TargetsWindows)' == 'true'">$(ToolsDir)net46/</PackagingTaskDir>
-    <BuildNumberMajor Condition="'$(BuildNumberMajor)' == ''">00001</BuildNumberMajor>
     <!-- defined in buildtools packaging.targets, but we need this before targets are imported -->
     <PackagePlatform Condition="'$(PackagePlatform)' == ''">$(Platform)</PackagePlatform>
     <PackagePlatform Condition="'$(PackagePlatform)' == 'amd64'">x64</PackagePlatform>


### PR DESCRIPTION
For https://github.com/dotnet/coreclr/issues/13395

@weshaggard is this all that is required?