### PR TITLE
Remove empty span check from Stream.Read/Write

### DIFF
--- a/src/mscorlib/src/System/IO/Stream.cs
+++ b/src/mscorlib/src/System/IO/Stream.cs
@@ -736,11 +736,6 @@ namespace System.IO
 
         public virtual int Read(Span<byte> destination)
         {
-            if (destination.Length == 0)
-            {
-                return 0;
-            }
-
             byte[] buffer = ArrayPool<byte>.Shared.Rent(destination.Length);
             try
             {
@@ -777,11 +772,6 @@ namespace System.IO
 
         public virtual void Write(ReadOnlySpan<byte> source)
         {
-            if (source.Length == 0)
-            {
-                return;
-            }
-
             byte[] buffer = ArrayPool<byte>.Shared.Rent(source.Length);
             try
             {


### PR DESCRIPTION
When I added the base Stream.Read/Write(span) default implementations, I added a special-case check for if the span is empty, in which case it made the operation a nop.  But various streams want to impose behavior even in the 0-byte case, e.g. throwing an ObjectDisposedException if the stream has been closed.  This commit just removes the check and allows Read/Write to delegate for all sized spans.

cc: @danmosemsft 