### PR TITLE
Restore missing native *.ni.pdb file from the Microsoft.NETCore.Runtime.CoreCLR

### DIFF
--- a/src/.nuget/dir.targets
+++ b/src/.nuget/dir.targets
@@ -51,6 +51,8 @@
       <WindowsNativeFile Include="@(NativeWithSymbolFile)"
                          Condition="'%(NativeWithSymbolFile.Extension)'=='.dll' OR '%(NativeWithSymbolFile.Extension)'=='.exe'" />
       <WindowsSymbolFile Include="@(WindowsNativeFile -> '%(RootDir)%(Directory)PDB\%(Filename).pdb')" />
+      <!-- Crossgened files (on windows) have both a *.pdb and a *.ni.pdb symbol file.  Include the *.ni.pdb file as well if it exists. -->
+      <WindowsSymbolFile Include="@(WindowsNativeFile -> '%(RootDir)%(Directory)PDB\%(Filename).ni.pdb')" />
 
       <!--
         Search for all xplat symbol file extensions on every xplat native binary. Some binaries have


### PR DESCRIPTION
Issue #13545

Restore missing native *.ni.pdb file from the Microsoft.NETCore.Runtime.CoreCLR package

DLLs that have native code, need both the *.pdb (for IL information) and the *.ni.pdb (for
native information).

When System.Private.Corlib was renamed from System.Private.Corlib.ni.pdb to System.Private.Corlib,
the logic that decides what goes into the  Microsoft.NETCore.Runtime.CoreCLR package lost
the *.ni.pdb for System.Private.Corlib.

This change basically causes this logic to search both for *.ni.pdb as well as the *.pdb file and
thus fixes this issue.