### PR TITLE
Add unwind info to core dumps.

### DIFF
--- a/src/debug/createdump/datatarget.cpp
+++ b/src/debug/createdump/datatarget.cpp
@@ -251,12 +251,3 @@ DumpDataTarget::Request(
     assert(false);
     return E_NOTIMPL;
 }
-
-HRESULT STDMETHODCALLTYPE 
-DumpDataTarget::VirtualUnwind(
-    /* [in] */ DWORD threadId,
-    /* [in] */ ULONG32 contextSize,
-    /* [in, out, size_is(contextSize)] */ PBYTE context)
-{
-    return E_NOTIMPL;
-}

--- a/src/debug/createdump/datatarget.h
+++ b/src/debug/createdump/datatarget.h
@@ -4,7 +4,7 @@
 
 class CrashInfo;
 
-class DumpDataTarget : public ICLRDataTarget, ICorDebugDataTarget4
+class DumpDataTarget : public ICLRDataTarget
 {
 private:
     LONG m_ref;                         // reference count
@@ -79,12 +79,4 @@ public:
         /* [size_is][in] */ BYTE *inBuffer,
         /* [in] */ ULONG32 outBufferSize,
         /* [size_is][out] */ BYTE *outBuffer);
-
-    //
-    // ICorDebugDataTarget4
-    //
-    virtual HRESULT STDMETHODCALLTYPE VirtualUnwind(
-        /* [in] */ DWORD threadId,
-        /* [in] */ ULONG32 contextSize,
-        /* [in, out, size_is(contextSize)] */ PBYTE context);
 };

--- a/src/debug/createdump/memoryregion.h
+++ b/src/debug/createdump/memoryregion.h
@@ -58,6 +58,18 @@ public:
         assert((end & ~PAGE_MASK) == 0);
     }
 
+    // This is a special constructor for the module base address
+    // set where the start/end are not page aligned and "offset"
+    // is reused as the module base address.
+    MemoryRegion(uint32_t flags, uint64_t start, uint64_t end, uint64_t baseAddress) : 
+        m_flags(flags),
+        m_startAddress(start),
+        m_endAddress(end),
+        m_offset(baseAddress),
+        m_fileName(nullptr)
+    {
+    }
+
     // copy with new file name constructor
     MemoryRegion(const MemoryRegion& region, const char* fileName) : 
         m_flags(region.m_flags),

--- a/src/debug/createdump/threadinfo.h
+++ b/src/debug/createdump/threadinfo.h
@@ -35,25 +35,26 @@ private:
 public:
     ThreadInfo(pid_t tid);
     ~ThreadInfo();
-    bool Initialize(ICLRDataTarget* dataTarget);
+    bool Initialize(ICLRDataTarget* pDataTarget);
     void ResumeThread();
-    void GetThreadStack(const CrashInfo& crashInfo, uint64_t* startAddress, size_t* size) const;
-    void GetThreadCode(uint64_t* startAddress, size_t* size) const;
+    bool UnwindThread(CrashInfo& crashInfo, IXCLRDataProcess* pClrDataProcess);
+    void GetThreadStack(CrashInfo& crashInfo);
     void GetThreadContext(uint32_t flags, CONTEXT* context) const;
 
-    const pid_t Tid() const { return m_tid; }
-    const pid_t Ppid() const { return m_ppid; }
-    const pid_t Tgid() const { return m_tgid; }
+    inline const pid_t Tid() const { return m_tid; }
+    inline const pid_t Ppid() const { return m_ppid; }
+    inline const pid_t Tgid() const { return m_tgid; }
 
-    const user_regs_struct* GPRegisters() const { return &m_gpRegisters; }
-    const user_fpregs_struct* FPRegisters() const { return &m_fpRegisters; }
+    inline const user_regs_struct* GPRegisters() const { return &m_gpRegisters; }
+    inline const user_fpregs_struct* FPRegisters() const { return &m_fpRegisters; }
 #if defined(__i386__)
-    const user_fpxregs_struct* FPXRegisters() const { return &m_fpxRegisters; }
+    inline const user_fpxregs_struct* FPXRegisters() const { return &m_fpxRegisters; }
 #elif defined(__arm__) && defined(__VFP_FP__) && !defined(__SOFTFP__)
-    const user_vfpregs_struct* VFPRegisters() const { return &m_vfpRegisters; }
+    inline const user_vfpregs_struct* VFPRegisters() const { return &m_vfpRegisters; }
 #endif
 
 private:
+    void UnwindNativeFrames(CrashInfo& crashInfo, CONTEXT* pContext);
     bool GetRegistersWithPTrace();
     bool GetRegistersWithDataTarget(ICLRDataTarget* dataTarget);
 };

--- a/src/debug/daccess/dacimpl.h
+++ b/src/debug/daccess/dacimpl.h
@@ -125,6 +125,7 @@ enum DAC_USAGE_TYPE
     DAC_VPTR,
     DAC_STRA,
     DAC_STRW,
+    DAC_PAL,
 };
 
 // mscordacwks's module handle 


### PR DESCRIPTION
The createdump utility now enumerates all the native stack frames (with
some help from the managed stack walker) for all the threads adding all
the ELF unwind info needed.

On a different machine and without any of the native modules loaded when
the crashdump was generated all the thread stacks can still be unwound
with lldb/gdb.

Change the PAL_VirtualUnwindOutOfProc read memory adapter in DAC
to add the memory to instances manager.

Some misc. cleanup.