### PR TITLE
Revert "Fixed misconception between FP register allocator and RyuJIT's CSE phase"

### DIFF
--- a/src/jit/stackfp.cpp
+++ b/src/jit/stackfp.cpp
@@ -911,18 +911,7 @@ void CodeGen::genLoadStackFP(GenTreePtr tree, regNumber reg)
     }
     else
     {
-        // Since FP register allocator doesn't work well with
-        // RyuJIT CSE optimizer it makes possible situation when
-        // CSE'ed value gets mapped many times.
-        if (compCurFPState.Mapped(reg))
-        {
-            assert(tree->OperGet() == GT_LCL_VAR);
-            assert(compiler->lclNumIsTrueCSE(tree->gtLclVarCommon.gtLclNum));
-        }
-        else
-        {
-            FlatFPX87_PushVirtual(&compCurFPState, reg);
-        }
+        FlatFPX87_PushVirtual(&compCurFPState, reg);
         inst_FS_TT(INS_fld, tree);
     }
 }


### PR DESCRIPTION
This reverts commit 3f4ee3bed52291e592d7ab67da1fc0e39ee8a3b7.

#13535 is more generic fix for this problem. 