### PR TITLE
Type `lea [this + delegateObject]` as `TYP_BYREF`.

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2795,7 +2795,7 @@ GenTree* Lowering::LowerDelegateInvoke(GenTreeCall* call)
     // [originalThis + offsetOfDelegateInstance]
 
     GenTree* newThisAddr = new (comp, GT_LEA)
-        GenTreeAddrMode(TYP_REF, thisExpr, nullptr, 0, comp->eeGetEEInfo()->offsetOfDelegateInstance);
+        GenTreeAddrMode(TYP_BYREF, thisExpr, nullptr, 0, comp->eeGetEEInfo()->offsetOfDelegateInstance);
 
     GenTree* newThis = comp->gtNewOperNode(GT_IND, TYP_REF, newThisAddr);
 


### PR DESCRIPTION
This node was incorrectly typed as `TYP_GCREF`, which was causing an
assertion during GC stress in internal testing.

Fixes VSO 482577.