### PR TITLE
Revert incorrect change from commit 16fc300

### DIFF
--- a/src/vm/clrex.cpp
+++ b/src/vm/clrex.cpp
@@ -1224,7 +1224,7 @@ OBJECTREF EEException::CreateThrowable()
 #endif
 }
 
-RuntimeExceptionKind EEException::GetKindFromHR(HRESULT hr, bool fIsWinRtMode)
+RuntimeExceptionKind EEException::GetKindFromHR(HRESULT hr, bool fIsWinRtMode /*= false*/)
 {
     LIMITED_METHOD_CONTRACT;
 

--- a/src/vm/clrex.h
+++ b/src/vm/clrex.h
@@ -1095,7 +1095,7 @@ inline EEMessageException::EEMessageException(HRESULT hr)
 }
 
 inline EEMessageException::EEMessageException(HRESULT hr, bool fUseCOMException)
-  : EEException(GetKindFromHR(hr, fUseCOMException)),
+  : EEException(GetKindFromHR(hr, !fUseCOMException)),
     m_hr(hr),
     m_resID(0)
 {

--- a/src/vm/stubhelpers.cpp
+++ b/src/vm/stubhelpers.cpp
@@ -1690,7 +1690,7 @@ FCIMPL4(Object*, StubHelpers::GetCOMHRExceptionObject, HRESULT hr, MethodDesc *p
             }
         }
 
-        GetExceptionForHR(hr, pErrInfo, fForWinRT, &oThrowable, pResErrorInfo, bHasNonCLRLanguageErrorObject);
+        GetExceptionForHR(hr, pErrInfo, !fForWinRT, &oThrowable, pResErrorInfo, bHasNonCLRLanguageErrorObject);
     }
     HELPER_METHOD_FRAME_END();    
 


### PR DESCRIPTION
The PR was trying to fix an incorrect test , we should be passing
in !fForWinRT.See https://github.com/dotnet/coreclr/issues/13460#issuecomment-324456870
for more info.