### PR TITLE
Rename System.Threading.Thread.m_ManagedThreadId to System.Threading.…

### DIFF
--- a/src/mscorlib/MembersMustExist.AnalyzerData
+++ b/src/mscorlib/MembersMustExist.AnalyzerData
@@ -1,0 +1,3 @@
+# Visual Studio
+private int System.Threading.Thread._managedThreadId
+

--- a/src/mscorlib/src/System/Threading/Thread.cs
+++ b/src/mscorlib/src/System/Threading/Thread.cs
@@ -128,7 +128,12 @@ namespace System.Threading
 
         private IntPtr DONT_USE_InternalThread;        // Pointer
         private int m_Priority;                     // INT32
-        private int m_ManagedThreadId;              // INT32
+
+        // The following field is required for interop with the VS Debugger
+        // Prior to making any changes to this field, please reach out to the VS Debugger 
+        // team to make sure that your changes are not going to prevent the debugger
+        // from working.
+        private int _managedThreadId;              // INT32
 
 #pragma warning restore 414
 #pragma warning restore 169
@@ -200,7 +205,7 @@ namespace System.Threading
 
         public override int GetHashCode()
         {
-            return m_ManagedThreadId;
+            return _managedThreadId;
         }
 
         extern public new int ManagedThreadId


### PR DESCRIPTION
…Thread._ManagedThreadId to align with CoreRT implementation (#13473)

Rename System.Threading.Thread.m_ManagedThreadId to System.Threading.Thread._ManagedThreadId to align with CoreRT implementation