### PR TITLE
Don't multiply YieldProcessor count by proc count

### DIFF
--- a/src/mscorlib/src/System/Threading/ManualResetEventSlim.cs
+++ b/src/mscorlib/src/System/Threading/ManualResetEventSlim.cs
@@ -584,7 +584,7 @@ namespace System.Threading
                         }
                         else
                         {
-                            Thread.SpinWait(PlatformHelper.ProcessorCount * (4 << i));
+                            Thread.SpinWait(4 << i);
                         }
                     }
                     else if (i % HOW_MANY_YIELD_EVERY_SLEEP_1 == 0)

--- a/src/mscorlib/src/System/Threading/Tasks/Task.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/Task.cs
@@ -2986,7 +2986,7 @@ namespace System.Threading.Tasks
                 }
                 else
                 {
-                    Thread.SpinWait(PlatformHelper.ProcessorCount * (4 << i));
+                    Thread.SpinWait(4 << i);
                 }
             }
 


### PR DESCRIPTION
Related to issue mentioned in https://github.com/dotnet/coreclr/issues/13388
- Multipying the YieldProcessor count by proc count can cause excessive delays that are not fruitful on machines with a large number of procs. Even on a 12-proc machine (6-core), the heuristics as they are without the multiply seem to perform much better.
- The issue above also mentions that the delay of PAUSE on Intel Skylake+ processors have a significantly larger delay (140 cycles vs 10 cycles). Simulating that by multiplying the YieldProcessor count by 14 shows that in both tests tested, it begins crawling at low thread counts.
- I did most of the testing on ManualResetEventSlim, and since Task is using the same spin heuristics, applied the same change there as well.

I used two perf tests to verify the change. The first test is sort of a latency test, one thread is constantly setting the event and resetting the event in a loop (with slight modifications to add different types of delays in certain places, which are not in the code below), and a bunch of wait threads are constantly waiting on the event and incrementing a counter on each success. The test measures how frequently the signal is seen by other threads before the event is reset, and so favors scenarios that do a light amount of spinning with little delay between iterations. Code:

```c#
    private static void Main(string[] args)
    {
        int processorCount = Environment.ProcessorCount;
        int threadCount = args.Length == 0 ? processorCount : (int)uint.Parse(args[0]);

        var sw = new Stopwatch();
        var startTest = new ManualResetEvent(false);
        int waiterWaitCount = 0;
        var e = new ManualResetEventSlim(false);

        ThreadStart waitThreadStart = () =>
        {
            startTest.WaitOne();
            while (true)
            {
                e.Wait();
                Interlocked.Increment(ref waiterWaitCount);
            }
        };
        var waitThreads = new Thread[threadCount];
        for (int i = 0; i < waitThreads.Length; ++i)
        {
            var t = new Thread(waitThreadStart);
            t.IsBackground = true;
            t.Start();
            waitThreads[i] = t;
        }

        var signalThread = new Thread(() =>
        {
            startTest.WaitOne();
            while (true)
            {
                e.Set();
                e.Reset();
            }
        });
        signalThread.IsBackground = true;
        signalThread.Start();

        startTest.Set();

        // Warmup

        Thread.Sleep(100);

        Interlocked.Exchange(ref waiterWaitCount, 0);

        // Measure

        sw.Restart();
        Thread.Sleep(500);
        sw.Stop();

        int waitCount = waiterWaitCount;

        long elapsedMs = sw.ElapsedMilliseconds;
        double score = (double)waitCount / elapsedMs;

        Console.WriteLine("Score: {0:0.000000}", score);
    }
```

The second test measures how long it takes for all waiting threads to see the signal. One thread signals the event and all threads wait until all waiting threads see the signal. Then the former thread signals the event again, and so on. This test favors longer-duration spin loops that don't enter a wait state before succeeding, for instance too-early waiting (disabling spinning for instance) causes excessive context switching that causes this test to crawl, that's mainly what I was looking for. Code:

```c#
    private static void Main(string[] args)
    {
        int processorCount = Environment.ProcessorCount;
        int threadCount = args.Length == 0 ? processorCount : (int)uint.Parse(args[0]);

        var sw = new Stopwatch();
        var startTest = new ManualResetEvent(false);
        var allWaitersWoken0 = new ManualResetEvent(false);
        var allWaitersWoken1 = new ManualResetEvent(false);
        int waiterWaitCount = 0;
        int waiterWokenCount = 0;
        var e = new ManualResetEventSlim(false);

        ThreadStart waitThreadStart = () =>
        {
            startTest.WaitOne();
            var allWaitersWoken = allWaitersWoken0;
            while (true)
            {
                e.Wait();
                if (Interlocked.Increment(ref waiterWokenCount) == threadCount)
                {
                    waiterWaitCount += threadCount;
                    waiterWokenCount = 0;
                    e.Reset();
                    (allWaitersWoken == allWaitersWoken0 ? allWaitersWoken1 : allWaitersWoken0).Reset();
                    allWaitersWoken.Set();
                }
                else
                    allWaitersWoken.WaitOne();
                allWaitersWoken = allWaitersWoken == allWaitersWoken0 ? allWaitersWoken1 : allWaitersWoken0;
            }
        };
        var waitThreads = new Thread[threadCount];
        for (int i = 0; i < waitThreads.Length; ++i)
        {
            var t = new Thread(waitThreadStart);
            t.IsBackground = true;
            t.Start();
            waitThreads[i] = t;
        }

        var signalThread = new Thread(() =>
        {
            startTest.WaitOne();
            var allWaitersWoken = allWaitersWoken0;
            while (true)
            {
                e.Set();
                allWaitersWoken.WaitOne();
                allWaitersWoken = allWaitersWoken == allWaitersWoken0 ? allWaitersWoken1 : allWaitersWoken0;
            }
        });
        signalThread.IsBackground = true;
        signalThread.Start();

        startTest.Set();

        // Warmup

        Thread.Sleep(100);

        Interlocked.Exchange(ref waiterWaitCount, 0);

        // Measure

        sw.Restart();
        Thread.Sleep(500);
        sw.Stop();

        int waitCount = waiterWaitCount;

        long elapsedMs = sw.ElapsedMilliseconds;
        double score = (double)waitCount / elapsedMs;

        Console.WriteLine("Score: {0:0.000000}", score);
    }
```

I saw that simulating a longer PAUSE by multiplying the YieldProcessor by 14 (including the multiply by proc count) caused especially the second test to crawl even at proc count threads. In both tests, removing the multiply significantly improved the score.