### PR TITLE
Do not devirtualize indirect calls

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -21802,8 +21802,8 @@ Compiler::fgWalkResult Compiler::fgUpdateInlineReturnExpressionPlaceHolder(GenTr
 
         if ((parentTree != nullptr) && (parentTree->gtOper == GT_CALL))
         {
-            GenTreeCall* call          = parentTree->AsCall();
-            bool         tryLateDevirt = call->IsVirtual() && (call->gtCallObjp == tree) && (call->gtCallType == CT_USER_FUNC);
+            GenTreeCall* call  = parentTree->AsCall();
+            bool tryLateDevirt = call->IsVirtual() && (call->gtCallObjp == tree) && (call->gtCallType == CT_USER_FUNC);
 
 #ifdef DEBUG
             tryLateDevirt = tryLateDevirt && (JitConfig.JitEnableLateDevirtualization() == 1);

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -21803,7 +21803,7 @@ Compiler::fgWalkResult Compiler::fgUpdateInlineReturnExpressionPlaceHolder(GenTr
         if ((parentTree != nullptr) && (parentTree->gtOper == GT_CALL))
         {
             GenTreeCall* call          = parentTree->AsCall();
-            bool         tryLateDevirt = call->IsVirtual() && (call->gtCallObjp == tree);
+            bool         tryLateDevirt = call->IsVirtual() && (call->gtCallObjp == tree) && (call->gtCallType == CT_USER_FUNC);
 
 #ifdef DEBUG
             tryLateDevirt = tryLateDevirt && (JitConfig.JitEnableLateDevirtualization() == 1);

--- a/tests/src/JIT/Regression/JitBlue/GitHub_13561/GitHub_13561.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_13561/GitHub_13561.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+internal static class Program
+{
+    class MemberInfo { }
+
+    class PropertyInfo : MemberInfo {  }
+
+    class CustomAttributeData
+    {
+        public Attribute Instantiate() => new CLSCompliantAttribute(false);
+    }
+
+    private static IEnumerable<CustomAttributeData> GetMatchingCustomAttributes(this MemberInfo element, Type optionalAttributeTypeFilter, bool inherit, bool skipTypeValidation = false)
+    {
+        {
+            PropertyInfo propertyInfo = element as PropertyInfo;
+            if (propertyInfo != null)
+                yield return new CustomAttributeData();
+        }
+
+        if (element == null)
+            throw new ArgumentNullException();
+
+        throw new NotSupportedException(); // Shouldn't get here.
+    }
+
+    private static IEnumerable<TOut> Select<TIn, TOut>(this IEnumerable<TIn> source, Func<TIn, TOut> transform)
+    {
+        foreach (var s in source)
+            yield return transform(s);
+    }
+
+    private static IEnumerable<T> GetCustomAttributes<T>(this MemberInfo element, bool inherit) where T : Attribute
+    {
+        IEnumerable<CustomAttributeData> matches = element.GetMatchingCustomAttributes(typeof(T), inherit, skipTypeValidation: true);
+        return matches.Select(m => (T)(m.Instantiate()));
+    }
+
+    private static AttributeType GetCustomAttribute<AttributeType>(PropertyInfo propInfo)
+        where AttributeType : Attribute
+    {
+        AttributeType result = null;
+        foreach (var attrib in propInfo.GetCustomAttributes<AttributeType>(false))
+        {
+            result = attrib;
+            break;
+        }
+        return result;
+    }
+
+    private static int Main(string[] args)
+    {
+        return GetCustomAttribute<Attribute>(new PropertyInfo()) != null ? 100 : -1;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_13561/GitHub_13561.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_13561/GitHub_13561.csproj
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>False</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_13561/GitHub_13561.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_13561/GitHub_13561.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <DebugType></DebugType>
-    <Optimize>False</Optimize>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
Not sure if this is the right fix but it makes my problem go away.

I'm seeing the affected code take the `impDevirtualizeCall` code path
with CT_INDIRECT calls. `gtCallMethHnd` is a `GenTreePtr` in that case
(it's a union) and passing that as as `CORINFO_METHOD_HANDLE` leads
to bad things.