### PR TITLE
callsignalhandlerwrapper: improve unwinding

### DIFF
--- a/src/pal/inc/unixasmmacrosarm.inc
+++ b/src/pal/inc/unixasmmacrosarm.inc
@@ -72,7 +72,6 @@ C_FUNC(\Name\()_End):
 
 .macro free_stack Size
         add sp, sp, (\Size)
-        .pad #-(\Size)
 .endm
 
 .macro POP_CALLEE_SAVED_REGISTERS

--- a/src/pal/src/arch/arm/callsignalhandlerwrapper.S
+++ b/src/pal/src/arch/arm/callsignalhandlerwrapper.S
@@ -18,13 +18,27 @@ C_FUNC(SignalHandlerWorkerReturnOffset\Alignment):
 // address set to SignalHandlerWorkerReturn during SIGSEGV handling.
 // It enables the unwinder to unwind stack from the handling code to the actual failure site.
 NESTED_ENTRY CallSignalHandlerWrapper\Alignment, _TEXT, NoHandler
-    alloc_stack     (8 + \Alignment) // red zone + alignment
-    PROLOG_PUSH  "{r7, lr}"
+#ifndef __linux__
+__StackAllocationSize = (8 + 4 + \Alignment) // red zone + alignment
+    alloc_stack __StackAllocationSize
+    PROLOG_PUSH "{r7, r11, lr}"
     bl      EXTERNAL_C_FUNC(signal_handler_worker)
 LOCAL_LABEL(SignalHandlerWorkerReturn\Alignment):
-    EPILOG_POP "{r7, lr}"
-    free_stack (8 + \Alignment)    
+    EPILOG_POP "{r7, r11, lr}"
+    free_stack __StackAllocationSize
     bx      lr
+#else
+    // This unwind information is needed for lldb gdb doesn't use it and tries
+    // to read all registers from $sp + 12
+    .save {r0-r15}
+    .pad #12
+    bl      EXTERNAL_C_FUNC(signal_handler_worker)
+LOCAL_LABEL(SignalHandlerWorkerReturn\Alignment):
+    // Following instruction are needed to say gdb that this frame is SIGTRAMP_FRAME
+    // and it can restore all registers from stack
+    mov.w r7, #119
+    svc 0
+#endif
 NESTED_END CallSignalHandlerWrapper\Alignment, _TEXT
 
 .endm


### PR DESCRIPTION
For linux:
make CallSignalHandlerWrapper's frame sigtramp frame for gdb and lldb:
- Save all registers on stack
- Add sigreturn syscall after call of signal_handler_worker

It provides ability for gdb and lldb unwind frame with invalid pc (due to jump to invalid addresss).

For non linux:
- Save r11 on stack as it also can be used as frame pointer
- Set instruction set flag (thumb / arm) for saved pc. It is necessary for gdb because it uses lr's lsb to determine function mode