### PR TITLE
Fix generic context passed to resolved constrained method calls

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -7467,7 +7467,8 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
                 // because pResolvedToken is an interface method and interface types make a poor generic context.
                 if (pConstrainedResolvedToken)
                 {
-                    instParam = impTokenToHandle(pConstrainedResolvedToken, &runtimeLookup, TRUE /*mustRestoreHandle*/, FALSE /* importParent */);
+                    instParam = impTokenToHandle(pConstrainedResolvedToken, &runtimeLookup, TRUE /*mustRestoreHandle*/,
+                                                 FALSE /* importParent */);
                 }
                 else
                 {

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -7462,7 +7462,18 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
             }
             else
             {
-                instParam = impParentClassTokenToHandle(pResolvedToken, &runtimeLookup, TRUE /*mustRestoreHandle*/);
+                // If the EE was able to resolve a constrained call, the instantiating parameter to use is the type
+                // by which the call was constrained with. We embed pConstrainedResolvedToken as the extra argument
+                // because pResolvedToken is an interface method and interface types make a poor generic context.
+                if (pConstrainedResolvedToken)
+                {
+                    instParam = impTokenToHandle(pConstrainedResolvedToken, &runtimeLookup, TRUE /*mustRestoreHandle*/, FALSE /* importParent */);
+                }
+                else
+                {
+                    instParam = impParentClassTokenToHandle(pResolvedToken, &runtimeLookup, TRUE /*mustRestoreHandle*/);
+                }
+
                 if (instParam == nullptr)
                 {
                     return callRetTyp;


### PR DESCRIPTION
If the EE was able to resolve a constrained call, the instantiating
parameter to use is the type by which the call was constrained with. We
embed pConstrainedResolvedToken as the extra argument because
pResolvedToken is an interface method and interface types make a poor
generic context.

The CLR doesn't hit this path because these types of constrained method
calls go through an instantiating stub. We don't do instantiating stubs
in CoreRT.

Contributes to fixing dotnet/corert#3608 (we'll need to clean up a couple workarounds).