### PR TITLE
Remove uses of the {RO}Span ctor that takes an array and offset

### DIFF
--- a/src/mscorlib/shared/System/IO/FileStream.Unix.cs
+++ b/src/mscorlib/shared/System/IO/FileStream.Unix.cs
@@ -581,13 +581,13 @@ namespace System.IO
                 int spaceRemaining = _bufferLength - _writePos;
                 if (spaceRemaining >= source.Length)
                 {
-                    source.CopyTo(new Span<byte>(GetBuffer(), _writePos));
+                    source.CopyTo(new Span<byte>(GetBuffer()).Slice(_writePos));
                     _writePos += source.Length;
                     return;
                 }
                 else if (spaceRemaining > 0)
                 {
-                    source.Slice(0, spaceRemaining).CopyTo(new Span<byte>(GetBuffer(), _writePos));
+                    source.Slice(0, spaceRemaining).CopyTo(new Span<byte>(GetBuffer()).Slice(_writePos));
                     _writePos += spaceRemaining;
                     source = source.Slice(spaceRemaining);
                 }

--- a/src/mscorlib/shared/System/IO/FileStream.Windows.cs
+++ b/src/mscorlib/shared/System/IO/FileStream.Windows.cs
@@ -681,13 +681,13 @@ namespace System.IO
                 {
                     if (numBytes >= source.Length)
                     {
-                        source.CopyTo(new Span<byte>(GetBuffer(), _writePos));
+                        source.CopyTo(new Span<byte>(GetBuffer()).Slice(_writePos));
                         _writePos += source.Length;
                         return;
                     }
                     else
                     {
-                        source.Slice(0, numBytes).CopyTo(new Span<byte>(GetBuffer(), _writePos));
+                        source.Slice(0, numBytes).CopyTo(new Span<byte>(GetBuffer()).Slice(_writePos));
                         _writePos += numBytes;
                         source = source.Slice(numBytes);
                     }
@@ -712,7 +712,7 @@ namespace System.IO
             }
 
             // Copy remaining bytes into buffer, to write at a later date.
-            source.CopyTo(new Span<byte>(GetBuffer(), _writePos));
+            source.CopyTo(new Span<byte>(GetBuffer()).Slice(_writePos));
             _writePos = source.Length;
             return;
         }

--- a/src/mscorlib/shared/System/Text/StringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.cs
@@ -833,7 +833,7 @@ namespace System.Text
             }
             Contract.EndContractBlock();
 
-            CopyTo(sourceIndex, new Span<char>(destination, destinationIndex), count);
+            CopyTo(sourceIndex, new Span<char>(destination).Slice(destinationIndex), count);
         }
 
         public void CopyTo(int sourceIndex, Span<char> destination, int count)

--- a/tests/src/CoreMangLib/system/span/BasicSpanTest.cs
+++ b/tests/src/CoreMangLib/system/span/BasicSpanTest.cs
@@ -41,10 +41,8 @@ class My
         int failedTestsCount = 0;
 
         Test(CanAccessItemsViaIndexer, "CanAccessItemsViaIndexer", ref failedTestsCount);
-        Test(CanAccessItemsViaIndexerStartCtor, "CanAccessItemsViaIndexerStartCtor", ref failedTestsCount);
         Test(CanAccessItemsViaIndexerStartLengthCtor, "CanAccessItemsViaIndexerStartLengthCtor", ref failedTestsCount);
 
-        Test(TestBoundaryEmptySpanStartCtor, "TestBoundaryEmptySpanStartCtor", ref failedTestsCount);
         Test(TestBoundaryEmptySpanStartLengthCtor, "TestBoundaryEmptySpanStartLengthCtor", ref failedTestsCount);
 
         Test(ReferenceTypesAreSupported, "ReferenceTypesAreSupported", ref failedTestsCount);
@@ -54,7 +52,6 @@ class My
         Test(MustNotMoveGcTypesToUnmanagedMemory, "MustNotMoveGcTypesToUnmanagedMemory", ref failedTestsCount);
 
         Test(TestArrayCoVariance, "TestArrayCoVariance", ref failedTestsCount);
-        Test(TestArrayCoVarianceStartCtor, "TestArrayCoVarianceStartCtor", ref failedTestsCount);
         Test(TestArrayCoVarianceStartLengthCtor, "TestArrayCoVarianceStartLengthCtor", ref failedTestsCount);
 
         Test(TestArrayCoVarianceReadOnly, "TestArrayCoVarianceReadOnly", ref failedTestsCount);
@@ -83,7 +80,6 @@ class My
         Test(WhenSourceTypeLargerThanTargetAndOverflowsInt32ThrowsException, "WhenSourceTypeLargerThanTargetAndOverflowsInt32ThrowsException", ref failedTestsCount);
         Test(CanCreateSpanFromString, "CanCreateSpanFromString", ref failedTestsCount);
 
-        Test(WhenStartLargerThanLengthThrowsExceptionStartCtor, "WhenStartLargerThanLengthThrowsExceptionStartCtor", ref failedTestsCount);
         Test(WhenStartLargerThanLengthThrowsExceptionStartLengthCtor, "WhenStartLargerThanLengthThrowsExceptionStartLengthCtor", ref failedTestsCount);
         Test(WhenStartAndLengthLargerThanLengthThrowsExceptionStartLengthCtor, "WhenStartAndLengthLargerThanLengthThrowsExceptionStartLengthCtor", ref failedTestsCount);
 
@@ -101,26 +97,11 @@ class My
         AssertTrue(Sum(subslice) == 5, "Failed to sum subslice");
     }
 
-    static void CanAccessItemsViaIndexerStartCtor()
-    {
-        int[] a = new int[] { 1, 2, 3 };
-        Span<int> slice = new Span<int>(a, start: 1);
-        AssertTrue(Sum(slice) == 5, "Failed to sum slice");
-    }
-
     static void CanAccessItemsViaIndexerStartLengthCtor()
     {
         int[] a = new int[] { 1, 2, 3 };
         Span<int> slice = new Span<int>(a, start: 1, length: 1);
         AssertTrue(Sum(slice) == 2, "Failed to sum slice");
-    }
-
-    static void TestBoundaryEmptySpanStartCtor()
-    {
-        int[] a = new int[5];
-
-        Span<int> slice = new Span<int>(a, start: a.Length);
-        AssertEqual(slice.Length, 0);
     }
 
     static void TestBoundaryEmptySpanStartLengthCtor()
@@ -190,30 +171,6 @@ class My
         try
         {
             new Span<object>(objEmptyArray);
-            AssertTrue(false, "Expected exception not thrown");
-        }
-        catch (ArrayTypeMismatchException)
-        {
-        }
-    }
-
-    static void TestArrayCoVarianceStartCtor()
-    {
-        var array = new ReferenceType[1];
-        var objArray = (object[])array;
-        try
-        {
-            new Span<object>(objArray, start: 0);
-            AssertTrue(false, "Expected exception not thrown");
-        }
-        catch (ArrayTypeMismatchException)
-        {
-        }
-
-        var objEmptyArray = Array.Empty<ReferenceType>();
-        try
-        {
-            new Span<object>(objEmptyArray, start: 0);
             AssertTrue(false, "Expected exception not thrown");
         }
         catch (ArrayTypeMismatchException)
@@ -715,19 +672,6 @@ class My
         string secondHalfOfString = fullText.Substring(fullText.Length / 2);
         var spanFromSecondHalf = fullText.Slice(fullText.Length / 2);
         AssertEqualContent(secondHalfOfString, spanFromSecondHalf);
-    }
-
-    static void WhenStartLargerThanLengthThrowsExceptionStartCtor()
-    {
-        try
-        {
-            var data = new byte[10];
-            var slice = new Span<byte>(data, start: 11);
-            AssertTrue(false, "Expected exception for Argument Out of Range not thrown");
-        }
-        catch (System.ArgumentOutOfRangeException)
-        {
-        }
     }
     
     static void WhenStartLargerThanLengthThrowsExceptionStartLengthCtor()


### PR DESCRIPTION
As per https://github.com/dotnet/coreclr/pull/13575#issuecomment-324786748, splitting the PR into two:
- This PR removes the uses of {RO}Span ctor from the tests
- https://github.com/dotnet/coreclr/pull/13575 removes the API

cc @jkotas, @stephentoub, @shiftylogic 