### PR TITLE
Arm Containment Cleanup

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -7030,17 +7030,12 @@ GenTreePtr Compiler::gtNewPutArgReg(var_types type, GenTreePtr arg, regNumber ar
     assert(arg != nullptr);
 
     GenTreePtr node = nullptr;
-#if !defined(LEGACY_BACKEND) && defined(_TARGET_ARM_)
+#if !defined(LEGACY_BACKEND) && defined(ARM_SOFTFP)
     // A PUTARG_REG could be a MultiRegOp on armel since we could move a double register to two int registers.
-    if (opts.compUseSoftFP)
-    {
-        node = new (this, GT_PUTARG_REG) GenTreeMultiRegOp(GT_PUTARG_REG, type, arg, nullptr);
-    }
-    else
+    node = new (this, GT_PUTARG_REG) GenTreeMultiRegOp(GT_PUTARG_REG, type, arg, nullptr);
+#else
+    node            = gtNewOperNode(GT_PUTARG_REG, type, arg);
 #endif
-    {
-        node = gtNewOperNode(GT_PUTARG_REG, type, arg);
-    }
     node->gtRegNum = argReg;
 
     return node;
@@ -9975,7 +9970,7 @@ void Compiler::gtDispRegVal(GenTree* tree)
 #endif
 
 #if !defined(LEGACY_BACKEND) && defined(_TARGET_ARM_)
-    if (tree->IsMultiReg() && tree->AsMultiRegOp()->gtOtherReg != REG_NA)
+    if (tree->OperIsMultiRegOp() && tree->AsMultiRegOp()->gtOtherReg != REG_NA)
     {
         printf(",%s", compRegVarName(tree->AsMultiRegOp()->gtOtherReg));
     }

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -1333,7 +1333,11 @@ public:
     bool OperIsMultiRegOp() const
     {
 #if !defined(LEGACY_BACKEND) && defined(_TARGET_ARM_)
-        if (gtOper == GT_MUL_LONG || gtOper == GT_PUTARG_REG || gtOper == GT_COPY)
+        if (gtOper == GT_MUL_LONG ||
+#ifdef ARM_SOFTFP
+            gtOper == GT_PUTARG_REG ||
+#endif
+            gtOper == GT_COPY)
         {
             return true;
         }
@@ -1778,9 +1782,6 @@ public:
 
     // Returns true if it is a GT_COPY or GT_RELOAD of a multi-reg call node
     inline bool IsCopyOrReloadOfMultiRegCall() const;
-
-    // Returns true if it is a MultiRegOp
-    inline bool IsMultiReg() const;
 
     bool OperMayThrow();
 
@@ -5999,27 +6000,6 @@ inline bool GenTree::IsCopyOrReloadOfMultiRegCall() const
     }
 
     return false;
-}
-
-//-----------------------------------------------------------------------------------
-// IsMultiReg: whether this is a MultiReg node (i.e. GT_MUL_LONG or GT_PUTARG_REG)
-//
-// Arguments:
-//     None
-//
-// Return Value:
-//     Returns true if this GenTree is a MultiReg node
-inline bool GenTree::IsMultiReg() const
-{
-#if !defined(LEGACY_BACKEND) && defined(_TARGET_ARM_)
-#ifdef ARM_SOFTFP
-    return (gtOper == GT_MUL_LONG) || (gtOper == GT_PUTARG_REG);
-#else  // !ARM_SOFTFP
-    return gtOper == GT_MUL_LONG;
-#endif // !ARM_SOFTFP
-#else  // ! _TARGET_ARM_
-    return false;
-#endif // ! _TARGET_ARM_
 }
 
 inline bool GenTree::IsCnsIntOrI() const

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3517,6 +3517,15 @@ static int ComputeOperandDstCount(GenTree* operand)
         // pointers to argument setup stores.
         return 0;
     }
+#ifdef _TARGET_ARMARCH_
+    else if (operand->OperIsPutArgStk())
+    {
+        // A PUTARG_STK argument is an operand of a call, but is neither contained, nor does it produce
+        // a result.
+        assert(!operand->isContained());
+        return 0;
+    }
+#endif // _TARGET_ARMARCH_
     else
     {
         // If a field list or non-void-typed operand is not an unused value and does not have source registers,

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -639,7 +639,6 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
         case GT_STORE_BLK:
         case GT_STORE_OBJ:
         case GT_STORE_DYN_BLK:
-            LowerBlockStore(tree->AsBlk());
             TreeNodeInfoInitBlockStore(tree->AsBlk());
             break;
 

--- a/src/jit/lsraarm64.cpp
+++ b/src/jit/lsraarm64.cpp
@@ -421,7 +421,6 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
         case GT_STORE_BLK:
         case GT_STORE_OBJ:
         case GT_STORE_DYN_BLK:
-            LowerBlockStore(tree->AsBlk());
             TreeNodeInfoInitBlockStore(tree->AsBlk());
             break;
 

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -559,20 +559,18 @@ void Lowering::TreeNodeInfoInitCall(GenTreeCall* call)
         // Skip arguments that have been moved to the Late Arg list
         if (!(args->gtFlags & GTF_LATE_ARG))
         {
+#ifdef DEBUG
+            fgArgTabEntryPtr curArgTabEntry = compiler->gtArgEntryByNode(call, arg);
+            assert(curArgTabEntry);
+#endif
             if (arg->gtOper == GT_PUTARG_STK)
             {
-                fgArgTabEntryPtr curArgTabEntry = compiler->gtArgEntryByNode(call, arg);
-                assert(curArgTabEntry);
-
-                assert(curArgTabEntry->regNum == REG_STK);
+                INDEBUG(assert(curArgTabEntry->regNum == REG_STK));
             }
 #ifdef _TARGET_ARM_
             else if (arg->OperGet() == GT_PUTARG_SPLIT)
             {
-#ifdef DEBUG
-                fgArgTabEntryPtr curArgTabEntry = compiler->gtArgEntryByNode(call, arg);
-                assert(arg->AsPutArgSplit()->gtNumRegs == curArgTabEntry->numRegs);
-#endif
+                INDEBUG(assert(arg->AsPutArgSplit()->gtNumRegs == curArgTabEntry->numRegs));
                 info->srcCount += arg->gtLsraInfo.dstCount;
             }
 #endif

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -565,12 +565,12 @@ void Lowering::TreeNodeInfoInitCall(GenTreeCall* call)
 #endif
             if (arg->gtOper == GT_PUTARG_STK)
             {
-                INDEBUG(assert(curArgTabEntry->regNum == REG_STK));
+                assert(curArgTabEntry->regNum == REG_STK);
             }
 #ifdef _TARGET_ARM_
             else if (arg->OperGet() == GT_PUTARG_SPLIT)
             {
-                INDEBUG(assert(arg->AsPutArgSplit()->gtNumRegs == curArgTabEntry->numRegs));
+                assert(arg->AsPutArgSplit()->gtNumRegs == curArgTabEntry->numRegs);
                 info->srcCount += arg->gtLsraInfo.dstCount;
             }
 #endif


### PR DESCRIPTION
- Fix a couple of issues with TreeNodeInfoInit for struct arguments
- Remove duplicate calls to LowerBlockStore from TreeNodeInfoInit for arm and arm64
- Eliminate duplicative isMultiReg method from GenTree and fix condition for OperIsMultiRegOp()