### PR TITLE
Fix running corefx tests

### DIFF
--- a/tests/scripts/run-corefx-tests.py
+++ b/tests/scripts/run-corefx-tests.py
@@ -270,7 +270,7 @@ def main(args):
     if Is_windows:
         command = 'build-tests.cmd'
         if env_script is not None:
-            command = ('cmd /c %s&&' % env_script) + command
+            command = ('cmd /c \"%s&&' % env_script) + command + '\"'
     else:
         command = './build-tests.sh'
         if env_script is not None:


### PR DESCRIPTION
Running CoreFX tests was supposed to use a batch file (env_script) to run CoreFX tests under different environment configurations. However due to subtlties in how the command line is parsed none of the environment variables set by this script would actually persist for the execution of the tests. As best I can tell prior to this fix specifying a env_script had no effect whatsoever on windows, and our CI corefx test stress scenarios weren't actually testing the scenario they claimed to be testing.

cmd /c "Set.bat&&Check.bat" will propagate env vars set in Set.bat so that they are visible in Check.bat because both batch files execute within the context of the newly invoked cmd.exe process. However cmd /c Set.bat&&Check.bat (no quotes) will run Set.bat in its own cmd.exe process, then exit that process and run Check.bat in the parent shell process. The parent process does not have any environment variable changes that were made by Set.bat.