### PR TITLE
[ARM/Linux] Enable clrstack -f

### DIFF
--- a/src/ToolBox/SOS/Strike/util.h
+++ b/src/ToolBox/SOS/Strike/util.h
@@ -2519,8 +2519,8 @@ typedef struct{
 
 /// ARM Context
 #define ARM_MAX_BREAKPOINTS_CONST     8
-#define ARM_MAX_WATCHPOINTS_CONST     4
-typedef struct {
+#define ARM_MAX_WATCHPOINTS_CONST     1
+typedef DECLSPEC_ALIGN(8) struct {
 
     DWORD ContextFlags;
 
@@ -2544,6 +2544,7 @@ typedef struct {
     DWORD Cpsr;
 
     DWORD Fpscr;
+    DWORD Padding;
     union {
         M128A_XPLAT Q[16];
         ULONGLONG D[32];
@@ -2554,6 +2555,8 @@ typedef struct {
     DWORD Bcr[ARM_MAX_BREAKPOINTS_CONST];
     DWORD Wvr[ARM_MAX_WATCHPOINTS_CONST];
     DWORD Wcr[ARM_MAX_WATCHPOINTS_CONST];
+
+    DWORD Padding2[2];
 
 } ARM_CONTEXT;
 


### PR DESCRIPTION
This commit enables clrstack -f on ARM/Linux. 

To enable clrstack -f, this commit first revises GetContextStackTrace to use ARM_CONTEXT as a context for ARM (the code is not changed for other architectures), and then fixes the inconsistency between ARM_CONTEXT and DT_CONTEXT definition.