### PR TITLE
SuperPMI replay: fix enviroment variables initialization.

### DIFF
--- a/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -6061,3 +6061,46 @@ OnError:
 
 #endif // !FEATURE_PAL
 }
+
+DenseLightWeightMap<MethodContext::Agnostic_Environment>* MethodContext::prevEnviroment = nullptr;
+
+bool MethodContext::wasEnviromentChanged()
+{
+    bool changed = false;
+    if (prevEnviroment == nullptr)
+    {
+        changed = true;
+    }
+    else if (Environment->GetCount() != prevEnviroment->GetCount())
+    {
+        changed = true;
+    }
+    else
+    {
+        for (unsigned int i = 0; i < Environment->GetCount(); i++)
+        {
+            Agnostic_Environment currEnvValue = Environment->Get(i);
+            LPCSTR currKey = (LPCSTR)Environment->GetBuffer(currEnvValue.name_index);
+            LPCSTR currVal = (LPCSTR)Environment->GetBuffer(currEnvValue.val_index);
+
+            Agnostic_Environment prevEnvValue = prevEnviroment->Get(i);
+            LPCSTR prevKey = (LPCSTR)prevEnviroment->GetBuffer(prevEnvValue.name_index);
+            LPCSTR prevVal = (LPCSTR)prevEnviroment->GetBuffer(prevEnvValue.val_index);
+            if (strcmp(currKey, prevKey) != 0 || strcmp(currVal, prevVal) != 0)
+            {
+                changed = true;
+                break;
+            }
+        }
+    }
+    if (changed)
+    {
+        if (prevEnviroment == nullptr)
+        {
+            delete prevEnviroment;
+        }
+        prevEnviroment = new DenseLightWeightMap<Agnostic_Environment>(*Environment);
+        return true;
+    }
+    return false;
+}

--- a/src/ToolBox/superpmi/superpmi-shared/methodcontext.h
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontext.h
@@ -1233,6 +1233,9 @@ public:
     void dmpGetStringConfigValue(DWORD nameIndex, DWORD result);
     const wchar_t* repGetStringConfigValue(const wchar_t* name);
 
+    bool wasEnviromentChanged();
+    static DenseLightWeightMap<Agnostic_Environment>* prevEnviroment;
+
     CompileResult* cr;
     CompileResult* originalCR;
     int            index;

--- a/src/ToolBox/superpmi/superpmi-shared/methodcontextreader.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontextreader.cpp
@@ -121,6 +121,10 @@ MethodContextReader::MethodContextReader(
 
 MethodContextReader::~MethodContextReader()
 {
+    if (MethodContext::prevEnviroment != nullptr)
+    {
+        delete MethodContext::prevEnviroment;
+    }
     if (fileHandle != INVALID_HANDLE_VALUE)
     {
         CloseHandle(this->fileHandle);

--- a/src/ToolBox/superpmi/superpmi/jithost.h
+++ b/src/ToolBox/superpmi/superpmi/jithost.h
@@ -6,7 +6,7 @@
 #ifndef _JITHOST
 #define _JITHOST
 
-class JitHost : public ICorJitHost
+class JitHost final: public ICorJitHost
 {
 public:
     JitHost(JitInstance& jitInstance);

--- a/src/ToolBox/superpmi/superpmi/jitinstance.cpp
+++ b/src/ToolBox/superpmi/superpmi/jitinstance.cpp
@@ -438,7 +438,7 @@ bool JitInstance::resetConfig(MethodContext* firstContext)
         mc = firstContext;
         ICorJitHost* newHost = new JitHost(*this);
         pnjitStartup(newHost);
-        delete jitHost;
+        delete static_cast<JitHost*>(jitHost);
         jitHost = newHost;
         return true;
     }

--- a/src/ToolBox/superpmi/superpmi/jitinstance.cpp
+++ b/src/ToolBox/superpmi/superpmi/jitinstance.cpp
@@ -212,8 +212,7 @@ HRESULT JitInstance::StartUp(char*          PathToJit,
 
 bool JitInstance::reLoad(MethodContext* firstContext)
 {
-    // TODO: Memory leaks here, but CILJit::ProcessShutdownWork is very expensive.
-    FreeLibrary(hLib); 
+    FreeLibrary(hLib);
 
     // Load Library
     hLib = ::LoadLibraryA(PathToTempJit);
@@ -429,4 +428,19 @@ void JitInstance::freeArray(void* array)
 void JitInstance::freeLongLivedArray(void* array)
 {
     HeapFree(ourHeap, 0, array);
+}
+
+// Reset JitConfig, that stores Enviroment variables.
+bool JitInstance::resetConfig(MethodContext* firstContext)
+{
+    if (pnjitStartup != nullptr)
+    {
+        mc = firstContext;
+        ICorJitHost* newHost = new JitHost(*this);
+        pnjitStartup(newHost);
+        delete jitHost;
+        jitHost = newHost;
+        return true;
+    }
+    return false;
 }

--- a/src/ToolBox/superpmi/superpmi/jitinstance.cpp
+++ b/src/ToolBox/superpmi/superpmi/jitinstance.cpp
@@ -212,7 +212,8 @@ HRESULT JitInstance::StartUp(char*          PathToJit,
 
 bool JitInstance::reLoad(MethodContext* firstContext)
 {
-    FreeLibrary(hLib);
+    // TODO: Memory leaks here, but CILJit::ProcessShutdownWork is very expensive.
+    FreeLibrary(hLib); 
 
     // Load Library
     hLib = ::LoadLibraryA(PathToTempJit);

--- a/src/ToolBox/superpmi/superpmi/jitinstance.h
+++ b/src/ToolBox/superpmi/superpmi/jitinstance.h
@@ -46,6 +46,8 @@ public:
     HRESULT StartUp(char* PathToJit, bool copyJit, bool breakOnDebugBreakorAV, MethodContext* firstContext);
     bool reLoad(MethodContext* firstContext);
 
+    bool resetConfig(MethodContext* firstContext);
+
     Result CompileMethod(MethodContext* MethodToCompile, int mcIndex, bool collectThroughput);
 
     void* allocateArray(ULONG size);

--- a/src/ToolBox/superpmi/superpmi/superpmi.cpp
+++ b/src/ToolBox/superpmi/superpmi/superpmi.cpp
@@ -304,6 +304,19 @@ int __cdecl main(int argc, char* argv[])
             }
         }
 
+        if (mc->wasEnviromentChanged())
+        {
+            // Each MC can have the own set of enviroment variables set.
+            // Jit reads these variables only once in JitStartUp.
+            // We have to reload the jit, if we want to take enviroment changes.
+            jit->reLoad(mc);
+            if (o.nameOfJit2 != nullptr)
+            {
+                jit2->reLoad(mc);
+            }
+        }
+
+
         // I needed to reason about what crl contains at any point in time
         // Here is my guess based on reading the code so far
         // crl initially contains the CompileResult from the MCH file

--- a/src/ToolBox/superpmi/superpmi/superpmi.cpp
+++ b/src/ToolBox/superpmi/superpmi/superpmi.cpp
@@ -304,19 +304,6 @@ int __cdecl main(int argc, char* argv[])
             }
         }
 
-        if (mc->wasEnviromentChanged())
-        {
-            // Each MC can have the own set of enviroment variables set.
-            // Jit reads these variables only once in JitStartUp.
-            // We have to reload the jit, if we want to take enviroment changes.
-            jit->reLoad(mc);
-            if (o.nameOfJit2 != nullptr)
-            {
-                jit2->reLoad(mc);
-            }
-        }
-
-
         // I needed to reason about what crl contains at any point in time
         // Here is my guess based on reading the code so far
         // crl initially contains the CompileResult from the MCH file
@@ -325,6 +312,21 @@ int __cdecl main(int argc, char* argv[])
 
         mc->cr         = new CompileResult();
         mc->originalCR = crl;
+
+        if (mc->wasEnviromentChanged())
+        {
+            if (!jit->resetConfig(mc))
+            {
+                LogError("JIT can't reset enviroment");
+            }
+            if (o.nameOfJit2 != nullptr)
+            {
+                if (!jit2->resetConfig(mc))
+                {
+                    LogError("JIT2 can't reset enviroment");
+                }
+            }
+        }
 
         jittedCount++;
         st3.Start();


### PR DESCRIPTION
If we have MCH file, that contains MC files with different environment variables, we have to reload jit every time when these variables changes.

Allows to fix problem with x86 collection, when the first MC set jitdump and replay created 50GB dump.

Also I expect that MCH files become bigger, because we will strip less on the cleaning phase.

The replay time didn't change, because it happens ~7 times for 100 methods. 