### PR TITLE
Fix NullCheck register modeling

### DIFF
--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -663,7 +663,9 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
         break;
 
         case GT_NULLCHECK:
-            assert(info->dstCount == 0);
+            // Although NULLCHECK is defined as GTK_NOVALUE, it requires a target
+            // register on ARM, as it is implemented as a load.
+            info->dstCount      = 1;
             info->srcCount      = 1;
             info->isLocalDefUse = true;
             // null check is an indirection on an addr

--- a/src/jit/lsraarm64.cpp
+++ b/src/jit/lsraarm64.cpp
@@ -630,9 +630,10 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
         break;
 
         case GT_NULLCHECK:
+            // Unlike ARM, ARM64 implements NULLCHECK as a load to REG_ZR, so no target register
+            // is required, and it is not a localDefUse.
             assert(info->dstCount == 0);
-            info->srcCount      = 1;
-            info->isLocalDefUse = true;
+            info->srcCount = 1;
             // null check is an indirection on an addr
             TreeNodeInfoInitIndir(tree->AsIndir());
             break;

--- a/src/jit/lsraxarch.cpp
+++ b/src/jit/lsraxarch.cpp
@@ -587,8 +587,7 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
 
         case GT_NULLCHECK:
             assert(info->dstCount == 0);
-            info->srcCount      = 1;
-            info->isLocalDefUse = true;
+            info->srcCount = 1;
             break;
 
         case GT_IND:


### PR DESCRIPTION
NullCheck is currently tagged with `isLocalDefUse` on all targets. However, for XARCH it is implemented with a compare (no target), and for ARM64 it is implemented with a load to REG_ZR, so neither of those require a target register.
Only on ARM is a target register required, and it is a localDefUse because the result is not used.