### PR TITLE
Remove FreeBSD 10.1/OpenSuSE 13.2 and Fedora 23

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -17,7 +17,6 @@ def static getOSGroup(def os) {
         'Fedora23':'Linux',
         'OSX':'OSX',
         'Windows_NT':'Windows_NT',
-        'FreeBSD':'FreeBSD',
         'CentOS7.1': 'Linux',
         'OpenSUSE13.2': 'Linux',
         'LinuxARMEmulator': 'Linux']
@@ -32,7 +31,7 @@ class Constants {
     // The Windows_NT_BuildOnly OS is a way to speed up the Non-NT builds temporarily by avoiding
     // test execution in the build flow runs.  It generates the exact same build
     // as Windows_NT but without the tests.
-    def static osList = ['Ubuntu', 'Debian8.2', 'OSX', 'Windows_NT', 'Windows_NT_BuildOnly', 'FreeBSD', 'CentOS7.1', 'OpenSUSE13.2', 'RHEL7.2', 'LinuxARMEmulator', 'Ubuntu16.04', 'Fedora23']
+    def static osList = ['Ubuntu', 'Debian8.2', 'OSX', 'Windows_NT', 'Windows_NT_BuildOnly', 'CentOS7.1', 'OpenSUSE13.2', 'RHEL7.2', 'LinuxARMEmulator', 'Ubuntu16.04', 'Fedora23']
     def static crossList = ['Ubuntu', 'OSX', 'CentOS7.1', 'RHEL7.2', 'Debian8.2', 'OpenSUSE13.2']
     // This is a set of JIT stress modes combined with the set of variables that
     // need to be set to actually enable that stress mode.  The key of the map is the stress mode and
@@ -260,7 +259,7 @@ def static getJobName(def configuration, def architecture, def os, def scenario,
 
 // **************************
 // Define the basic inner loop builds for PR and commit.  This is basically just the set
-// of coreclr builds over linux/osx/freebsd/windows and debug/release/checked.  In addition, the windows
+// of coreclr builds over linux/osx/windows and debug/release/checked.  In addition, the windows
 // builds will do a couple extra steps.
 // **************************
 
@@ -982,12 +981,6 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                             break
                     }
                     break
-                case 'FreeBSD':
-                    assert scenario == 'default'
-                    if (configuration == 'Checked') {
-                        Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build")
-                    }
-                    break
                 default:
                     println("Unknown os: ${os}");
                     assert false
@@ -1543,7 +1536,6 @@ combinedScenarios.each { scenario ->
                                         // Run the rest of the build    
                                         // Build the mscorlib for the other OS's
                                         buildCommands += "build.cmd ${lowerConfiguration} ${arch} linuxmscorlib"
-                                        buildCommands += "build.cmd ${lowerConfiguration} ${arch} freebsdmscorlib"
                                         buildCommands += "build.cmd ${lowerConfiguration} ${arch} osxmscorlib"
                                     
                                         // Zip up the tests directory so that we don't use so much space/time copying
@@ -1604,7 +1596,6 @@ combinedScenarios.each { scenario ->
                         case 'Ubuntu16.04':
                         case 'Debian8.2':
                         case 'OSX':
-                        case 'FreeBSD':
                         case 'CentOS7.1':
                         case 'RHEL7.2':
                         case 'OpenSUSE13.2':
@@ -1621,7 +1612,7 @@ combinedScenarios.each { scenario ->
                                     if (!enableCorefxTesting) {
                                         // We run pal tests on all OS but generate mscorlib (and thus, nuget packages)
                                         // only on supported OS platforms.
-                                        if ((os == 'FreeBSD') || (os == 'OpenSUSE13.2'))
+                                        if (os == 'OpenSUSE13.2')
                                         {
                                             buildCommands += "./build.sh skipmscorlib verbose ${lowerConfiguration} ${arch}"
                                         }

--- a/netci.groovy
+++ b/netci.groovy
@@ -14,11 +14,9 @@ def static getOSGroup(def os) {
         'RHEL7.2': 'Linux',
         'Ubuntu16.04': 'Linux',
         'Debian8.2':'Linux',
-        'Fedora23':'Linux',
         'OSX':'OSX',
         'Windows_NT':'Windows_NT',
         'CentOS7.1': 'Linux',
-        'OpenSUSE13.2': 'Linux',
         'LinuxARMEmulator': 'Linux']
     def osGroup = osGroupMap.get(os, null) 
     assert osGroup != null : "Could not find os group for ${os}"
@@ -31,8 +29,8 @@ class Constants {
     // The Windows_NT_BuildOnly OS is a way to speed up the Non-NT builds temporarily by avoiding
     // test execution in the build flow runs.  It generates the exact same build
     // as Windows_NT but without the tests.
-    def static osList = ['Ubuntu', 'Debian8.2', 'OSX', 'Windows_NT', 'Windows_NT_BuildOnly', 'CentOS7.1', 'OpenSUSE13.2', 'RHEL7.2', 'LinuxARMEmulator', 'Ubuntu16.04', 'Fedora23']
-    def static crossList = ['Ubuntu', 'OSX', 'CentOS7.1', 'RHEL7.2', 'Debian8.2', 'OpenSUSE13.2']
+    def static osList = ['Ubuntu', 'Debian8.2', 'OSX', 'Windows_NT', 'Windows_NT_BuildOnly', 'CentOS7.1', 'RHEL7.2', 'LinuxARMEmulator', 'Ubuntu16.04']
+    def static crossList = ['Ubuntu', 'OSX', 'CentOS7.1', 'RHEL7.2', 'Debian8.2']
     // This is a set of JIT stress modes combined with the set of variables that
     // need to be set to actually enable that stress mode.  The key of the map is the stress mode and
     // the values are the environment variables
@@ -272,7 +270,7 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
         return
     }
     
-    def bidailyCrossList = ['RHEL7.2', 'Debian8.2', 'OpenSUSE13.2']
+    def bidailyCrossList = ['RHEL7.2', 'Debian8.2']
     // Non pull request builds.
     if (!isPR) {
         // Check scenario.
@@ -481,8 +479,7 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                 break
             }
             switch (os) {
-                // OpenSUSE, Debian & RedHat get trigger phrases for pri 0 build, and pri 1 build & test
-                case 'OpenSUSE13.2':
+                // Debian & RedHat get trigger phrases for pri 0 build, and pri 1 build & test
                 case 'Debian8.2':
                 case 'RHEL7.2':
                     if (scenario == 'default') {
@@ -494,7 +491,6 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                         Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Pri 1 Build & Test", "(?i).*test\\W+${os}\\W+${scenario}.*")
                     }
                     break
-                case 'Fedora23':
                 case 'Ubuntu16.04':
                     assert !isFlowJob
                     assert scenario == 'default'
@@ -1598,8 +1594,6 @@ combinedScenarios.each { scenario ->
                         case 'OSX':
                         case 'CentOS7.1':
                         case 'RHEL7.2':
-                        case 'OpenSUSE13.2':
-                        case 'Fedora23':
                             switch (architecture) {
                                 case 'x64':
                                 case 'x86ryujit':
@@ -1612,11 +1606,7 @@ combinedScenarios.each { scenario ->
                                     if (!enableCorefxTesting) {
                                         // We run pal tests on all OS but generate mscorlib (and thus, nuget packages)
                                         // only on supported OS platforms.
-                                        if (os == 'OpenSUSE13.2')
-                                        {
-                                            buildCommands += "./build.sh skipmscorlib verbose ${lowerConfiguration} ${arch}"
-                                        }
-                                        else if (scenario == 'coverage')
+                                        if (scenario == 'coverage')
                                         {
                                             assert os == 'Ubuntu'
                                             assert lowerConfiguration == 'release'
@@ -1769,7 +1759,7 @@ combinedScenarios.each { scenario ->
                             return
                         }
                         //Skip stress modes for these scenarios
-                        if (os == 'RHEL7.2' || os == 'Debian8.2' || os == 'OpenSUSE13.2') {
+                        if (os == 'RHEL7.2' || os == 'Debian8.2') {
                             return
                         }
                     }
@@ -1791,8 +1781,8 @@ combinedScenarios.each { scenario ->
                             return
                         }
                     }
-                    // For RedHat, Debian, and OpenSUSE, we only do Release pri1 builds.
-                    else if (os == 'RHEL7.2' || os == 'Debian8.2' || os == 'OpenSUSE13.2') {
+                    // For RedHat and Debian, we only do Release pri1 builds.
+                    else if (os == 'RHEL7.2' || os == 'Debian8.2') {
                         if (scenario != 'pri1') {
                             return
                         }


### PR DESCRIPTION
10.1 has been EOL'd, and the image is not upgradeable.  This image will become unusable in newer versions of Jenkins.  Eliminating from CI.  If needed, new versions of BSD could be prepped and re-added to CI.