### PR TITLE
Fix `INDEX_ADDR` codegen on ARM for large element sizes.

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -1616,8 +1616,8 @@ void CodeGen::genCodeForIndexAddr(GenTreeIndexAddr* node)
             CodeGen::genSetRegToIcon(tmpReg, (ssize_t)node->gtElemSize, TYP_INT);
 
             // dest = index * tmp + base
-            getEmitter()->emitIns_R_R_R_R(INS_MULADD, emitTypeSize(node), node->gtRegNum, index->gtRegNum,
-                                          tmpReg, base->gtRegNum);
+            getEmitter()->emitIns_R_R_R_R(INS_MULADD, emitTypeSize(node), node->gtRegNum, index->gtRegNum, tmpReg,
+                                          base->gtRegNum);
             break;
         }
     }

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -1615,9 +1615,9 @@ void CodeGen::genCodeForIndexAddr(GenTreeIndexAddr* node)
             // tmp = scale
             CodeGen::genSetRegToIcon(tmpReg, (ssize_t)node->gtElemSize, TYP_INT);
 
-            // dest = base + index * tmp
-            getEmitter()->emitIns_R_R_R_R(INS_MULADD, emitTypeSize(node), node->gtRegNum, node->gtRegNum,
-                                          index->gtRegNum, tmpReg);
+            // dest = index * tmp + base
+            getEmitter()->emitIns_R_R_R_R(INS_MULADD, emitTypeSize(node), node->gtRegNum, index->gtRegNum,
+                                          tmpReg, base->gtRegNum);
             break;
         }
     }


### PR DESCRIPTION
We were attempting to generate `base + index * size` using `MADD`, but
had the registers in the wrong order and were generating
`base * index + size`. This change fixes the register order s.t. the
expected instruction is generated.

Fixes #13593.