### PR TITLE
Fix dir.props BuildVersionFile override

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -104,6 +104,11 @@
     <OutputPath Condition="'$(OutputPath)' == ''">$(BinDir)</OutputPath>
   </PropertyGroup>
 
+  <!-- Explicitly set BuildVersionFile before importing common. This is used by BuildVersion.targets. -->
+  <PropertyGroup Condition="'$(OfficialBuildId)' != ''">
+    <BuildVersionFile>$(BaseIntermediateOutputPath)BuildVersion-$(OfficialBuildId).props</BuildVersionFile>
+  </PropertyGroup>
+
   <!-- Import Build tools common props file where repo-independent properties are found -->
   <Import Condition="Exists('$(ToolsDir)Build.Common.props')" Project="$(ToolsDir)Build.Common.props" />
 
@@ -180,10 +185,6 @@
     </File>
     <PackageIndex Include="$(PackageIndexFile)" />
   </ItemGroup>
-
-  <PropertyGroup Condition="'$(OfficialBuildId)' != ''">
-    <BuildVersionFile>$(BaseIntermediateOutputPath)BuildVersion-$(OfficialBuildId).props</BuildVersionFile>
-  </PropertyGroup>
 
   <!-- Use Roslyn Compilers to build -->
   <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'!='true' and Exists('$(RoslynPropsFile)') and '$(UseRoslynCompilers)'!='false'" />


### PR DESCRIPTION
The override needs to be before the Build.Common.props import, because BuildVersion.targets is in Build.Common.props and it's what's responsible for importing BuildVersionFile if it exists.

This fixes https://github.com/dotnet/coreclr/issues/13601 on my machine.

@wtgodbe do you mind taking charge of this PR in case I don't have time to come back to it?

cc @mikem8361 