### PR TITLE
[RyuJIT/ARM32] Register for multiple-add operation in codegenarmarch

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -1615,9 +1615,9 @@ void CodeGen::genCodeForIndexAddr(GenTreeIndexAddr* node)
             // tmp = scale
             CodeGen::genSetRegToIcon(tmpReg, (ssize_t)node->gtElemSize, TYP_INT);
 
-            // dest = base + index * tmp
-            getEmitter()->emitIns_R_R_R_R(INS_MULADD, emitTypeSize(node), node->gtRegNum, node->gtRegNum,
-                                          index->gtRegNum, tmpReg);
+            // dest = index * tmp + base
+            getEmitter()->emitIns_R_R_R_R(INS_MULADD, emitTypeSize(node), node->gtRegNum, index->gtRegNum, tmpReg,
+                                          base->gtRegNum);
             break;
         }
     }


### PR DESCRIPTION
Fix bug: register multiple-add operation
wrong: dest = dest x index + temp
fix: dest = index x temp + base