### PR TITLE
Remove -sequential build-flag

### DIFF
--- a/build-test.cmd
+++ b/build-test.cmd
@@ -444,8 +444,6 @@ echo -priority=^<N^> : specify a set of test that will be built and run, with pr
 echo     0: Build only priority 0 cases as essential testcases (default)
 echo     1: Build all tests with priority 0 and 1
 echo     666: Build all tests with priority 0, 1 ... 666
-echo -sequential: force a non-parallel build ^(default is to build in parallel
-echo     using all processors^).
 echo -verbose: enables detailed file logging for the msbuild tasks into the msbuild log file.
 exit /b 1
 

--- a/build.cmd
+++ b/build.cmd
@@ -639,8 +639,6 @@ echo buildstandalonegc: builds the GC in a standalone mode.
 echo -skiprestore: skip restoring packages ^(default: packages are restored during build^).
 echo -disableoss: Disable Open Source Signing for System.Private.CoreLib.
 echo -priority=^<N^> : specify a set of test that will be built and run, with priority N.
-echo -sequential: force a non-parallel build ^(default is to build in parallel
-echo     using all processors^).
 echo -officialbuildid=^<ID^>: specify the official build ID to be used by this build.
 echo -Rebuild: passes /t:rebuild to the build projects.
 echo portable : build for portable RID.

--- a/build.sh
+++ b/build.sh
@@ -43,8 +43,6 @@ usage()
     echo "verbose - optional argument to enable verbose build output."
     echo "-skiprestore: skip restoring packages ^(default: packages are restored during build^)."
 	echo "-disableoss: Disable Open Source Signing for System.Private.CoreLib."
-	echo "-sequential: force a non-parallel build ^(default is to build in parallel"
-	echo "   using all processors^)."
 	echo "-officialbuildid=^<ID^>: specify the official build ID to be used by this build."
 	echo "-Rebuild: passes /t:rebuild to the build projects."
     echo "stripSymbols - Optional argument to strip native symbols during the build."


### PR DESCRIPTION
The flag is not implemented anywhere and is completely ignored. Remove it form various help notices too.

Resolves https://github.com/dotnet/coreclr/issues/12035