### PR TITLE
Fix getCastDescription to use the actual source type

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -5163,7 +5163,7 @@ void Lowering::getCastDescription(GenTreePtr treeNode, CastInfo* castInfo)
     GenTreePtr castOp = treeNode->gtCast.CastOp();
 
     var_types dstType = treeNode->CastToType();
-    var_types srcType = castOp->TypeGet();
+    var_types srcType = genActualType(castOp->TypeGet());
 
     castInfo->unsignedDest   = varTypeIsUnsigned(dstType);
     castInfo->unsignedSource = varTypeIsUnsigned(srcType);


### PR DESCRIPTION
Fixes #12893

The test I added in #13429 fails on ARM64 due to this bug.

Code generated before the fix:
```asm
G_M47568_IG02:
        ...
        39800129          ldrsb   x9, [x9]
        53003D29          uxth    w9, w9
```
After the fix:
```asm
G_M47568_IG02:
        ...
        39800129          ldrsb   x9, [x9]
        7211413F          tst     w9, #0xffff8000
        54000061          bne     G_M47568_IG04
```