### PR TITLE
Add fallback addresses if ghprbPullAuthorEmail is empty

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -61,7 +61,7 @@ def static getOSGroup(def os) {
                             if (isPR) {
                                 parameters {
                                     stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
-                                    stringParam('BenchviewCommitUser', '\${ghprbPullAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
+                                    stringParam('BenchviewCommitUser', '\${ghprbPullAuthorEmail ?: (ghprbPullAuthorLogin ?: "anonymous") + "@github.usr"}', 'The email that will be used to build the alias of a run in Benchview')
                                 }
                             }
                             if (isSmoketest) {
@@ -206,7 +206,7 @@ def static getOSGroup(def os) {
                         if (isPR) {
                             parameters {
                                 stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that will be used to build the full title of a run in Benchview.')
-                                stringParam('BenchviewCommitUser', '\${ghprbPullAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
+                                stringParam('BenchviewCommitUser', '\${ghprbPullAuthorEmail ?: (ghprbPullAuthorLogin ?: "anonymous") + "@github.usr"}', 'The email that will be used to build the alias of a run in Benchview')
                             }
                         }
 
@@ -309,7 +309,7 @@ def static getFullPerfJobName(def project, def os, def isPR) {
             if (isPR) {
                 parameters {
                     stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
-                    stringParam('BenchviewCommitUser', '\${ghprbPullAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
+                    stringParam('BenchviewCommitUser', '\${ghprbPullAuthorEmail ?: (ghprbPullAuthorLogin ?: "anonymous") + "@github.usr"}', 'The email that will be used to build the alias of a run in Benchview')
                 }
             }
 
@@ -383,7 +383,7 @@ def static getFullPerfJobName(def project, def os, def isPR) {
         if (isPR) {
             parameters {
                 stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
-                stringParam('BenchviewCommitUser', '\${ghprbPullAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
+                stringParam('BenchviewCommitUser', '\${ghprbPullAuthorEmail ?: (ghprbPullAuthorLogin ?: "anonymous") + "@github.usr"}', 'The email that will be used to build the alias of a run in Benchview')
             }
         }
         buildFlow("""
@@ -464,7 +464,7 @@ def static getFullThroughputJobName(def project, def os, def isPR) {
                 if (isPR) {
                     parameters {
                         stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that will be used to build the full title of a run in Benchview.')
-                        stringParam('BenchviewCommitUser', '\${ghprbPullAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
+                        stringParam('BenchviewCommitUser', '\${ghprbPullAuthorEmail ?: (ghprbPullAuthorLogin ?: "anonymous") + "@github.usr"}', 'The email that will be used to build the alias of a run in Benchview')
                     }
                 }
 
@@ -529,7 +529,7 @@ def static getFullThroughputJobName(def project, def os, def isPR) {
         if (isPR) {
             parameters {
                 stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
-                stringParam('BenchviewCommitUser', '\${ghprbPullAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
+                stringParam('BenchviewCommitUser', '\${ghprbPullAuthorEmail ?: (ghprbPullAuthorLogin ?: "anonymous") + "@github.usr"}', 'The email that will be used to build the alias of a run in Benchview')
             }
         }
         buildFlow("""
@@ -592,7 +592,7 @@ parallel(
                         if (isPR) {
                             parameters {
                                 stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
-                                stringParam('BenchviewCommitUser', '\${ghprbPullAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
+                                stringParam('BenchviewCommitUser', '\${ghprbPullAuthorEmail ?: (ghprbPullAuthorLogin ?: "anonymous") + "@github.usr"}', 'The email that will be used to build the alias of a run in Benchview')
                             }
                         }
 


### PR DESCRIPTION
For perf jobs, not all users have `ghprbPullAuthorEmail` defined in their pull request builds (contributors' e-mail addresses may not be published/marked as public on their GitHub profiles). To avoid breaking perf smoke tests for these users' PRs, add fallback e-mail addresses:
* If the user's Login alias (github profile handle) is available, fall back to a pseudo-email created from that handle
* If the profile handle is also not available, fall back to just "anonymous@github.usr" as a last resort
