### PR TITLE
Change FinalizerThreadCreate location to after profiler is initialized

### DIFF
--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -901,7 +901,6 @@ void EEStartupHelper(COINITIEE fFlags)
 
         // This isn't done as part of InitializeGarbageCollector() above because thread
         // creation requires AppDomains to have been set up.
-        FinalizerThread::FinalizerThreadCreate();
 
 #ifndef FEATURE_PAL
         // Watson initialization must precede InitializeDebugger() and InstallUnhandledExceptionFilter() 
@@ -955,6 +954,8 @@ void EEStartupHelper(COINITIEE fFlags)
 
         // throws on error
         SetupThread();
+
+        FinalizerThread::FinalizerThreadCreate();
 
 #ifdef DEBUGGING_SUPPORTED
         // Notify debugger once the first thread is created to finish initialization.

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -952,10 +952,6 @@ void EEStartupHelper(COINITIEE fFlags)
         // throws on error
         SetupThread();
 
-        // This isn't done as part of InitializeGarbageCollector() above because thread
-        // creation requires AppDomains to have been set up.
-        FinalizerThread::FinalizerThreadCreate();
-
 #ifdef DEBUGGING_SUPPORTED
         // Notify debugger once the first thread is created to finish initialization.
         if (g_pDebugInterface != NULL)
@@ -1008,6 +1004,10 @@ void EEStartupHelper(COINITIEE fFlags)
         // of InitJITHelpers1.
         hr = g_pGCHeap->Initialize();
         IfFailGo(hr);
+
+        // This isn't done as part of InitializeGarbageCollector() above because thread
+        // creation requires AppDomains to have been set up.
+        FinalizerThread::FinalizerThreadCreate();
 
         // Now we really have fully initialized the garbage collector
         SetGarbageCollectorFullyInitialized();

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -899,9 +899,6 @@ void EEStartupHelper(COINITIEE fFlags)
 
 #ifndef CROSSGEN_COMPILE
 
-        // This isn't done as part of InitializeGarbageCollector() above because thread
-        // creation requires AppDomains to have been set up.
-
 #ifndef FEATURE_PAL
         // Watson initialization must precede InitializeDebugger() and InstallUnhandledExceptionFilter() 
         // because on CoreCLR when Waston is enabled, debugging service needs to be enabled and UEF will be used.
@@ -955,6 +952,8 @@ void EEStartupHelper(COINITIEE fFlags)
         // throws on error
         SetupThread();
 
+        // This isn't done as part of InitializeGarbageCollector() above because thread
+        // creation requires AppDomains to have been set up.
         FinalizerThread::FinalizerThreadCreate();
 
 #ifdef DEBUGGING_SUPPORTED


### PR DESCRIPTION
Changed FinalizeThreadCreate to be called after ProfilerAPI is initialized to ensure finalizer creation notification to profilerAPI.

Fix issue #13499