### PR TITLE
Revert #13647 and #13638

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -61,7 +61,7 @@ def static getOSGroup(def os) {
                             if (isPR) {
                                 parameters {
                                     stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
-                                    stringParam('BenchviewCommitUser', '\${ghprbPullAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
+                                    stringParam('BenchviewCommitUser', '\${ghprbTriggerAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
                                 }
                             }
                             if (isSmoketest) {
@@ -206,7 +206,7 @@ def static getOSGroup(def os) {
                         if (isPR) {
                             parameters {
                                 stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that will be used to build the full title of a run in Benchview.')
-                                stringParam('BenchviewCommitUser', '\${ghprbPullAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
+                                stringParam('BenchviewCommitUser', '\${ghprbTriggerAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
                             }
                         }
 
@@ -309,7 +309,7 @@ def static getFullPerfJobName(def project, def os, def isPR) {
             if (isPR) {
                 parameters {
                     stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
-                    stringParam('BenchviewCommitUser', '\${ghprbPullAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
+                    stringParam('BenchviewCommitUser', '\${ghprbTriggerAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
                 }
             }
 
@@ -383,7 +383,7 @@ def static getFullPerfJobName(def project, def os, def isPR) {
         if (isPR) {
             parameters {
                 stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
-                stringParam('BenchviewCommitUser', '\${ghprbPullAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
+                stringParam('BenchviewCommitUser', '\${ghprbTriggerAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
             }
         }
         buildFlow("""
@@ -464,7 +464,7 @@ def static getFullThroughputJobName(def project, def os, def isPR) {
                 if (isPR) {
                     parameters {
                         stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that will be used to build the full title of a run in Benchview.')
-                        stringParam('BenchviewCommitUser', '\${ghprbPullAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
+                        stringParam('BenchviewCommitUser', '\${ghprbTriggerAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
                     }
                 }
 
@@ -529,7 +529,7 @@ def static getFullThroughputJobName(def project, def os, def isPR) {
         if (isPR) {
             parameters {
                 stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
-                stringParam('BenchviewCommitUser', '\${ghprbPullAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
+                stringParam('BenchviewCommitUser', '\${ghprbTriggerAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
             }
         }
         buildFlow("""
@@ -592,7 +592,7 @@ parallel(
                         if (isPR) {
                             parameters {
                                 stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
-                                stringParam('BenchviewCommitUser', '\${ghprbPullAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
+                                stringParam('BenchviewCommitUser', '\${ghprbTriggerAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
                             }
                         }
 

--- a/perf.groovy
+++ b/perf.groovy
@@ -61,7 +61,6 @@ def static getOSGroup(def os) {
                             if (isPR) {
                                 parameters {
                                     stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
-                                    stringParam('BenchviewCommitUser', '\${ghprbTriggerAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
                                 }
                             }
                             if (isSmoketest) {
@@ -80,7 +79,6 @@ def static getOSGroup(def os) {
                             def configuration = 'Release'
                             def runType = isPR ? 'private' : 'rolling'
                             def benchViewName = isPR ? 'coreclr private %BenchviewCommitName%' : 'coreclr rolling %GIT_BRANCH_WITHOUT_ORIGIN% %GIT_COMMIT%'
-                            def benchViewUser = isPR ? '%BenchviewCommitUser%' : 'dotnet-bot@microsoft.com'
                             def uploadString = isSmoketest ? '' : '-uploadToBenchview'
 
                             steps {
@@ -94,7 +92,7 @@ def static getOSGroup(def os) {
                                 batchFile("if \"%GIT_BRANCH:~0,7%\" == \"origin/\" (set \"GIT_BRANCH_WITHOUT_ORIGIN=%GIT_BRANCH:origin/=%\") else (set \"GIT_BRANCH_WITHOUT_ORIGIN=%GIT_BRANCH%\")\n" +
                                 "set \"BENCHVIEWNAME=${benchViewName}\"\n" +
                                 "set \"BENCHVIEWNAME=%BENCHVIEWNAME:\"=%\"\n" +
-                                "py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\submission-metadata.py\" --name \"%BENCHVIEWNAME%\" --user \"${benchViewUser}\"\n" +
+                                "py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\submission-metadata.py\" --name \"%BENCHVIEWNAME%\" --user \"dotnet-bot@microsoft.com\"\n" +
                                 "py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\build.py\" git --branch %GIT_BRANCH_WITHOUT_ORIGIN% --type ${runType}")
                                 batchFile("py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\machinedata.py\"")
                                 batchFile("set __TestIntermediateDir=int&&build.cmd ${configuration} ${architecture}")
@@ -206,14 +204,12 @@ def static getOSGroup(def os) {
                         if (isPR) {
                             parameters {
                                 stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that will be used to build the full title of a run in Benchview.')
-                                stringParam('BenchviewCommitUser', '\${ghprbTriggerAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
                             }
                         }
 
                         def configuration = 'Release'
                         def runType = isPR ? 'private' : 'rolling'
                         def benchViewName = isPR ? 'coreclr-throughput private %BenchviewCommitName%' : 'coreclr-throughput rolling %GIT_BRANCH_WITHOUT_ORIGIN% %GIT_COMMIT%'
-                        def benchViewUser = isPR ? '%BenchviewCommitUser%' : 'dotnet-bot@microsoft.com'
 
                         steps {
                             // Batch
@@ -226,7 +222,7 @@ def static getOSGroup(def os) {
                             batchFile("if \"%GIT_BRANCH:~0,7%\" == \"origin/\" (set \"GIT_BRANCH_WITHOUT_ORIGIN=%GIT_BRANCH:origin/=%\") else (set \"GIT_BRANCH_WITHOUT_ORIGIN=%GIT_BRANCH%\")\n" +
                             "set \"BENCHVIEWNAME=${benchViewName}\"\n" +
                             "set \"BENCHVIEWNAME=%BENCHVIEWNAME:\"=%\"\n" +
-                            "py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\submission-metadata.py\" --name \"${benchViewName}\" --user \"${benchViewUser}\"\n" +
+                            "py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\submission-metadata.py\" --name \"${benchViewName}\" --user \"dotnet-bot@microsoft.com\"\n" +
                             "py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\build.py\" git --branch %GIT_BRANCH_WITHOUT_ORIGIN% --type ${runType}")
                             batchFile("py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\machinedata.py\"")
                             batchFile("set __TestIntermediateDir=int&&build.cmd ${configuration} ${architecture} skiptests")
@@ -308,8 +304,7 @@ def static getFullPerfJobName(def project, def os, def isPR) {
 
             if (isPR) {
                 parameters {
-                    stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
-                    stringParam('BenchviewCommitUser', '\${ghprbTriggerAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
+                    stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
                 }
             }
 
@@ -323,7 +318,6 @@ def static getFullPerfJobName(def project, def os, def isPR) {
             def osGroup = getOSGroup(os)
             def runType = isPR ? 'private' : 'rolling'
             def benchViewName = isPR ? 'coreclr private \$BenchviewCommitName' : 'coreclr rolling \$GIT_BRANCH_WITHOUT_ORIGIN \$GIT_COMMIT'
-            def benchViewUser = isPR ? '\$BenchviewCommitUser' : 'dotnet-bot@microsoft.com'
 
             steps {
                 shell("./tests/scripts/perf-prep.sh")
@@ -335,7 +329,7 @@ def static getFullPerfJobName(def project, def os, def isPR) {
                     }
                 }
                 shell("GIT_BRANCH_WITHOUT_ORIGIN=\$(echo \$GIT_BRANCH | sed \"s/[^/]*\\/\\(.*\\)/\\1 /\")\n" +
-                "python3.5 \"\${WORKSPACE}/tests/scripts/Microsoft.BenchView.JSONFormat/tools/submission-metadata.py\" --name \" ${benchViewName} \" --user \"${benchViewUser}\"\n" +
+                "python3.5 \"\${WORKSPACE}/tests/scripts/Microsoft.BenchView.JSONFormat/tools/submission-metadata.py\" --name \" ${benchViewName} \" --user \"dotnet-bot@microsoft.com\"\n" +
                 "python3.5 \"\${WORKSPACE}/tests/scripts/Microsoft.BenchView.JSONFormat/tools/build.py\" git --branch \$GIT_BRANCH_WITHOUT_ORIGIN --type ${runType}")
                 shell("""./tests/scripts/run-xunit-perf.sh \\
                 --testRootDir=\"\${WORKSPACE}/bin/tests/Windows_NT.${architecture}.${configuration}\" \\
@@ -383,7 +377,6 @@ def static getFullPerfJobName(def project, def os, def isPR) {
         if (isPR) {
             parameters {
                 stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
-                stringParam('BenchviewCommitUser', '\${ghprbTriggerAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
             }
         }
         buildFlow("""
@@ -464,7 +457,6 @@ def static getFullThroughputJobName(def project, def os, def isPR) {
                 if (isPR) {
                     parameters {
                         stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that will be used to build the full title of a run in Benchview.')
-                        stringParam('BenchviewCommitUser', '\${ghprbTriggerAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
                     }
                 }
 
@@ -475,7 +467,6 @@ def static getFullThroughputJobName(def project, def os, def isPR) {
                 def osGroup = getOSGroup(os)
                 def runType = isPR ? 'private' : 'rolling'
                 def benchViewName = isPR ? 'coreclr-throughput private \$BenchviewCommitName' : 'coreclr-throughput rolling \$GIT_BRANCH_WITHOUT_ORIGIN \$GIT_COMMIT'
-                def benchViewUser = isPR ? '\$BenchviewCommitUser' : 'dotnet-bot@microsoft.com'
 
                 steps {
                     shell("bash ./tests/scripts/perf-prep.sh --throughput")
@@ -487,7 +478,7 @@ def static getFullThroughputJobName(def project, def os, def isPR) {
                         }
                     }
                     shell("GIT_BRANCH_WITHOUT_ORIGIN=\$(echo \$GIT_BRANCH | sed \"s/[^/]*\\/\\(.*\\)/\\1 /\")\n" +
-                    "python3.5 \"\${WORKSPACE}/tests/scripts/Microsoft.BenchView.JSONFormat/tools/submission-metadata.py\" --name \" ${benchViewName} \" --user \"${benchViewUser}\"\n" +
+                    "python3.5 \"\${WORKSPACE}/tests/scripts/Microsoft.BenchView.JSONFormat/tools/submission-metadata.py\" --name \" ${benchViewName} \" --user \"dotnet-bot@microsoft.com\"\n" +
                     "python3.5 \"\${WORKSPACE}/tests/scripts/Microsoft.BenchView.JSONFormat/tools/build.py\" git --branch \$GIT_BRANCH_WITHOUT_ORIGIN --type ${runType}")
                     shell("""python3.5 ./tests/scripts/run-throughput-perf.py \\
                     -arch \"${architecture}\" \\
@@ -529,7 +520,6 @@ def static getFullThroughputJobName(def project, def os, def isPR) {
         if (isPR) {
             parameters {
                 stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
-                stringParam('BenchviewCommitUser', '\${ghprbTriggerAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
             }
         }
         buildFlow("""
@@ -592,7 +582,6 @@ parallel(
                         if (isPR) {
                             parameters {
                                 stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
-                                stringParam('BenchviewCommitUser', '\${ghprbTriggerAuthorEmail}', 'The email that will be used to build the alias of a run in Benchview')
                             }
                         }
 
@@ -604,7 +593,6 @@ parallel(
                         def configuration = 'Release'
                         def runType = isPR ? 'private' : 'rolling'
                         def benchViewName = isPR ? 'CoreCLR-Scenarios private %BenchviewCommitName%' : 'CoreCLR-Scenarios rolling %GIT_BRANCH_WITHOUT_ORIGIN% %GIT_COMMIT%'
-                        def benchViewUser = isPR ? '%BenchviewCommitUser%' : 'dotnet-bot@microsoft.com'
                         def uploadString = '-uploadToBenchview'
 
                         steps {
@@ -618,7 +606,7 @@ parallel(
                             batchFile("if \"%GIT_BRANCH:~0,7%\" == \"origin/\" (set \"GIT_BRANCH_WITHOUT_ORIGIN=%GIT_BRANCH:origin/=%\") else (set \"GIT_BRANCH_WITHOUT_ORIGIN=%GIT_BRANCH%\")\n" +
                             "set \"BENCHVIEWNAME=${benchViewName}\"\n" +
                             "set \"BENCHVIEWNAME=%BENCHVIEWNAME:\"=%\"\n" +
-                            "py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\submission-metadata.py\" --name \"%BENCHVIEWNAME%\" --user \"${benchViewUser}\"\n" +
+                            "py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\submission-metadata.py\" --name \"%BENCHVIEWNAME%\" --user \"dotnet-bot@microsoft.com\"\n" +
                             "py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\build.py\" git --branch %GIT_BRANCH_WITHOUT_ORIGIN% --type ${runType}")
                             batchFile("py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\machinedata.py\"")
                             batchFile("set __TestIntermediateDir=int&&build.cmd ${configuration} ${architecture}")


### PR DESCRIPTION
#13638 and #13647 attempted to replace the generic 'dotnet-bot' e-mail address with PR authors' e-mail addresses when uploading perf data to BenchView. Unfortunately, these changes are still broken for some users (specifically, if a user's e-mail address is not published/visible on their GitHub profile).

There is no clean way to implement the proper fix, and the right fix will change once pipeline support is available. Rather than putting in something hacky now, I'm reverting these changes to unblock PRs. We should revisit these changes after pipeline jobs are available.
