### PR TITLE
[RyuJIT/arm32] Add support for tailcall via helper

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1937,7 +1937,7 @@ void Lowering::LowerFastTailCall(GenTreeCall* call)
 // has already inserted tailcall helper special arguments. This function
 // inserts actual data for some placeholders.
 //
-// For AMD64, lower
+// For ARM32, AMD64, lower
 //      tail.call(void* copyRoutine, void* dummyArg, ...)
 // as
 //      Jit_TailCall(void* copyRoutine, void* callTarget, ...)
@@ -2006,9 +2006,9 @@ GenTree* Lowering::LowerTailCallViaHelper(GenTreeCall* call, GenTree* callTarget
 
     fgArgTabEntry* argEntry;
 
-#if defined(_TARGET_AMD64_)
+#if defined(_TARGET_AMD64_) || defined(_TARGET_ARM_)
 
-// For AMD64, first argument is CopyRoutine and second argument is a place holder node.
+// For ARM32 and AMD64, first argument is CopyRoutine and second argument is a place holder node.
 
 #ifdef DEBUG
     argEntry = comp->gtArgEntryByArgNum(call, 0);

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7671,11 +7671,11 @@ void Compiler::fgMorphTailCall(GenTreeCall* call)
         call->gtFlags |= GTF_EXCEPT;
     }
 
-    // Now inject a placeholder for the real call target that codegen will generate
+// Now inject a placeholder for the real call target that codegen will generate
 #ifdef LEGACY_BACKEND
     GenTreePtr arg = new (this, GT_NOP) GenTreeOp(GT_NOP, TYP_I_IMPL);
     codeGen->genMarkTreeInReg(arg, REG_TAILCALL_ADDR);
-#else // !LEGACY_BACKEND
+#else  // !LEGACY_BACKEND
     GenTreePtr arg = gtNewIconNode(0, TYP_I_IMPL);
 #endif // !LEGACY_BACKEND
     call->gtCallArgs = gtNewListNode(arg, call->gtCallArgs);
@@ -7686,10 +7686,10 @@ void Compiler::fgMorphTailCall(GenTreeCall* call)
     arg               = gtNewIconHandleNode(ssize_t(pfnCopyArgs), GTF_ICON_FTN_ADDR);
     call->gtCallArgs  = gtNewListNode(arg, call->gtCallArgs);
 
-    // It is now a varargs tail call
+// It is now a varargs tail call
 #ifdef LEGACY_BACKEND
     call->gtCallMoreFlags = GTF_CALL_M_VARARGS | GTF_CALL_M_TAILCALL;
-#else // !LEGACY_BACKEND
+#else  // !LEGACY_BACKEND
     call->gtCallMoreFlags |= GTF_CALL_M_VARARGS | GTF_CALL_M_TAILCALL | GTF_CALL_M_TAILCALL_VIA_HELPER;
 #endif // !LEGACY_BACKEND
     call->gtFlags &= ~GTF_CALL_POP_ARGS;

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7671,12 +7671,13 @@ void Compiler::fgMorphTailCall(GenTreeCall* call)
         call->gtFlags |= GTF_EXCEPT;
     }
 
-    // Now inject a placeholder for the real call target that codegen
-    // will generate
-    GenTreePtr arg = new (this, GT_NOP) GenTreeOp(GT_NOP, TYP_I_IMPL);
+    // Now inject a placeholder for the real call target that codegen will generate
 #ifdef LEGACY_BACKEND
+    GenTreePtr arg = new (this, GT_NOP) GenTreeOp(GT_NOP, TYP_I_IMPL);
     codeGen->genMarkTreeInReg(arg, REG_TAILCALL_ADDR);
-#endif
+#else // !LEGACY_BACKEND
+    GenTreePtr arg = gtNewIconNode(0, TYP_I_IMPL);
+#endif // !LEGACY_BACKEND
     call->gtCallArgs = gtNewListNode(arg, call->gtCallArgs);
 
     // Lastly inject the pointer for the copy routine
@@ -7686,7 +7687,11 @@ void Compiler::fgMorphTailCall(GenTreeCall* call)
     call->gtCallArgs  = gtNewListNode(arg, call->gtCallArgs);
 
     // It is now a varargs tail call
+#ifdef LEGACY_BACKEND
     call->gtCallMoreFlags = GTF_CALL_M_VARARGS | GTF_CALL_M_TAILCALL;
+#else // !LEGACY_BACKEND
+    call->gtCallMoreFlags |= GTF_CALL_M_VARARGS | GTF_CALL_M_TAILCALL | GTF_CALL_M_TAILCALL_VIA_HELPER;
+#endif // !LEGACY_BACKEND
     call->gtFlags &= ~GTF_CALL_POP_ARGS;
 
 #elif defined(_TARGET_XARCH_) && !defined(LEGACY_BACKEND)


### PR DESCRIPTION
Essentially, just do what AMD64 was doing in fgMorphTailCall()
and LowerTailCallViaHelper(). All the VM support for tailcall
via helper is already there (and used by legacy backend).

Fixes #11844, #11836