### PR TITLE
[RyuJIT/ARMARCH] TreeNodeInfoInit for GT_NULLCHECK

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -1272,7 +1272,7 @@ void CodeGen::genCodeForNullCheck(GenTreeOp* tree)
 #ifdef _TARGET_ARM64_
     regNumber targetReg = REG_ZR;
 #else
-    regNumber targetReg = tree->gtRegNum;
+    regNumber targetReg = tree->GetSingleTempReg();
 #endif
 
     getEmitter()->emitIns_R_R_I(INS_ldr, EA_4BYTE, targetReg, addrReg, 0);

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -664,13 +664,10 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
         break;
 
         case GT_NULLCHECK:
-            // Although NULLCHECK is defined as GTK_NOVALUE, it requires a target
-            // register on ARM, as it is implemented as a load.
-            info->dstCount      = 1;
-            info->srcCount      = 1;
-            info->isLocalDefUse = true;
-            // null check is an indirection on an addr
-            TreeNodeInfoInitIndir(tree->AsIndir());
+            // It requires a internal register on ARM, as it is implemented as a load
+            assert(info->dstCount == 0);
+            info->srcCount         = 1;
+            info->internalIntCount = 1;
             break;
 
         case GT_IND:

--- a/src/jit/lsraarm64.cpp
+++ b/src/jit/lsraarm64.cpp
@@ -630,12 +630,10 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
         break;
 
         case GT_NULLCHECK:
-            // Unlike ARM, ARM64 implements NULLCHECK as a load to REG_ZR, so no target register
+            // Unlike ARM, ARM64 implements NULLCHECK as a load to REG_ZR, so no internal register
             // is required, and it is not a localDefUse.
             assert(info->dstCount == 0);
             info->srcCount = 1;
-            // null check is an indirection on an addr
-            TreeNodeInfoInitIndir(tree->AsIndir());
             break;
 
         case GT_IND:

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -159,7 +159,7 @@ void LinearScan::TreeNodeInfoInitGCWriteBarrier(GenTree* tree)
 //                       of an indirection operation.
 //
 // Arguments:
-//    indirTree - GT_IND, GT_STOREIND, block node or GT_NULLCHECK gentree node
+//    indirTree - GT_IND, GT_STOREIND or block gentree node
 //
 void LinearScan::TreeNodeInfoInitIndir(GenTreeIndir* indirTree)
 {


### PR DESCRIPTION
Change dstCount, internalCount for GT_NULLCHECK on ARM32
Remove calling TreeNodeInfoInitIndir() for GT_NULLCHECK on ARM32, ARM64

Fix #13675

cc/ @dotnet/arm32-contrib @dotnet/jit-contrib 