### PR TITLE
JIT: allow nulls in gtCanOptimizeTypeEquality

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -14761,7 +14761,16 @@ void Compiler::gtCheckQuirkAddrExposedLclVar(GenTreePtr tree, GenTreeStack* pare
 //    the operands is:
 //    1) The result of Object::GetType
 //    2) The result of typeof(...)
-//    3) Is otherwise known to have type RuntimeType
+//    3) Is a null reference
+//    4) Is otherwise known to have type RuntimeType
+//
+//    The null reference case is surprisingly common because operator
+//    overloading turns the otherwise innocuous
+//
+//        Type t = ....;
+//        if (t == null)
+//
+//    into a method call.
 
 bool Compiler::gtCanOptimizeTypeEquality(GenTreePtr tree)
 {
@@ -14783,6 +14792,10 @@ bool Compiler::gtCanOptimizeTypeEquality(GenTreePtr tree)
         }
     }
     else if ((tree->gtOper == GT_INTRINSIC) && (tree->gtIntrinsic.gtIntrinsicId == CORINFO_INTRINSIC_Object_GetType))
+    {
+        return true;
+    }
+    else if ((tree->gtOper == GT_CNS_INT) && (tree->gtIntCon.gtIconVal == 0))
     {
         return true;
     }


### PR DESCRIPTION
This is a follow-on to #13657. I looked at the remaining calls to
`Type::op_Equality` in the jit-diffs output and saw many of the calls had a
null pointer argument. This pattern comes about from explicit null checks in
the sources, often as part of argument validation.

Such calls can also be optimized into simple pointer equality checks, so
add another clause to `gtCanOptimizeTypeEquality` to look for nulls.