### PR TITLE
JIT: Fix calculation of opcodeOffsets in Compiler::impImportBlockCode

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -9972,9 +9972,9 @@ void Compiler::impImportBlockCode(BasicBlock* block)
             } cval;
 
             case CEE_PREFIX1:
-                opcode = (OPCODE)(getU1LittleEndian(codeAddr) + 256);
-                codeAddr += sizeof(__int8);
+                opcode     = (OPCODE)(getU1LittleEndian(codeAddr) + 256);
                 opcodeOffs = (IL_OFFSET)(codeAddr - info.compCode);
+                codeAddr += sizeof(__int8);
                 goto DECODE_OPCODE;
 
             SPILL_APPEND:
@@ -12448,9 +12448,9 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 impValidateMemoryAccessOpcode(codeAddr, codeEndp, false);
 
             PREFIX:
-                opcode = (OPCODE)getU1LittleEndian(codeAddr);
-                codeAddr += sizeof(__int8);
+                opcode     = (OPCODE)getU1LittleEndian(codeAddr);
                 opcodeOffs = (IL_OFFSET)(codeAddr - info.compCode);
+                codeAddr += sizeof(__int8);
                 goto DECODE_OPCODE;
 
             case CEE_VOLATILE:


### PR DESCRIPTION
In some cases offset of opcode is calculated incorrectly (https://github.com/dotnet/coreclr/issues/12663). For example for following IL code (method `Template::GetHashCode()` in [test.cs](https://gist.github.com/kbaladurin/e20eeda294dd36ab916b7ba9ad7b272b)):
```
IL to import:
IL_0000  00                nop         
IL_0001  02                ldarg.0     
IL_0002  7c 0c 00 00 0a    ldflda       0xA00000C
IL_0007  fe 16 02 00 00 1b constrained. 0x1B000002
IL_000d  6f 0d 00 00 0a    callvirt     0xA00000D
IL_0012  0a                stloc.0     
IL_0013  2b 00             br.s         0 (IL_0015)
IL_0015  06                ldloc.0     
IL_0016  2a                ret  
```
We  got following mapping:
```
IP mapping count : 9
IL offs PROLOG : 0x00000000 ( STACK_EMPTY )
IL offs NO_MAP : 0x00000016 ( STACK_EMPTY )
IL offs 0x0000 : 0x0000002A ( STACK_EMPTY )
IL offs 0x0001 : 0x0000002B ( STACK_EMPTY )
IL offs 0x000E : 0x00000039 ( CALL_INSTRUCTION )
IL offs 0x0012 : 0x00000041
IL offs 0x0013 : 0x00000047 ( STACK_EMPTY )
IL offs 0x0015 : 0x0000004A ( STACK_EMPTY )
IL offs EPILOG : 0x0000004D ( STACK_EMPTY )
```

`CALL_INSTRUCTION` opcode has offset 0xE instead of 0xD.

This patch fixes it.