### PR TITLE
Assert that Nullcheck child is not contained

### DIFF
--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -666,6 +666,7 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
         case GT_NULLCHECK:
             // It requires a internal register on ARM, as it is implemented as a load
             assert(info->dstCount == 0);
+            assert(!tree->gtGetOp1()->isContained());
             info->srcCount         = 1;
             info->internalIntCount = 1;
             break;

--- a/src/jit/lsraarm64.cpp
+++ b/src/jit/lsraarm64.cpp
@@ -633,6 +633,7 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
             // Unlike ARM, ARM64 implements NULLCHECK as a load to REG_ZR, so no internal register
             // is required, and it is not a localDefUse.
             assert(info->dstCount == 0);
+            assert(!tree->gtGetOp1()->isContained());
             info->srcCount = 1;
             break;
 


### PR DESCRIPTION
TreeNodeInfoInit doesn't call `TreeNodeInfoInitIndir on `GT_NULLCHECK`, though it does an indirection, because we never create an LEA for these. Assert that the child is not contained.