### PR TITLE
JIT: don't reuse box temps when optimizing

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -15978,6 +15978,21 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTreePtr tree, bool* isExact, 
             break;
         }
 
+        case GT_BOX:
+        {
+            // Box should just wrap a local var reference which has
+            // the type we're looking for. Also box only represents a
+            // non-nullable value type so result cannot be null.
+            GenTreeBox* box     = obj->AsBox();
+            GenTree*    boxTemp = box->BoxOp();
+            assert(boxTemp->IsLocal());
+            const unsigned boxTempLcl = boxTemp->AsLclVar()->GetLclNum();
+            objClass                  = lvaTable[boxTempLcl].lvClassHnd;
+            *isExact                  = lvaTable[boxTempLcl].lvClassIsExact;
+            *isNonNull                = true;
+            break;
+        }
+
         default:
         {
             break;


### PR DESCRIPTION
The importer reuses temps for different box operations that do not overlap.
This keeps the number of temps to a minimum and reduces prolog zeroing if the
temps end up untracked. But reuse prevents the importer from accurately typing
the temp.

So now, when optimizing, allocate a new temp for each box operation, and type
the temp with the type of the box.

This, along with a small update in `gtGetClassHandle` to obtain the box type,
enables some devirtualization of interface calls on boxes and will facilitate
future changes to optimize away boxes entirely (eg #5626).