### PR TITLE
Preemptively adding a resource string.

### DIFF
--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -3593,4 +3593,7 @@
   <data name="SynchronizationLockException_MisMatchedWrite" xml:space="preserve">
     <value>The write lock is being released without being held.</value>
   </data>
+  <data name="NotSupported_SignatureType" xml:space="preserve">
+    <value>This method is not supported on signature types.</value>
+  </data>
 </root>


### PR DESCRIPTION
Adding this now to save time later as
the CoreCLR/CoreRT bot will soon be
porting over a big feature change
and the only thing blocking the bot
from a green CI is this one new error string.