### PR TITLE
Fix DevDiv_278523 test for r2r x86.

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -210,9 +210,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_255294\DevDiv_255294\DevDiv_255294.cmd">
             <Issue>11469, The test causes OutOfMemory exception in crossgen mode.</Issue> 
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_278523\DevDiv_278523\DevDiv_278523.cmd">
-            <Issue>11476, fails on both jit32 and RyuJit x86</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- The following are ARM32 failures -->

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523.ilproj
@@ -24,7 +24,11 @@
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(Platform)' == 'x64' ">
+    <Compile Include="DevDiv_278523_x64.il" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(Platform)' != 'x64' ">
+    <!-- It includes x86, arm32, arm64 and future architectures. -->
     <Compile Include="DevDiv_278523.il" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523.ilproj
@@ -24,12 +24,11 @@
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(Platform)' == 'x64' ">
-    <Compile Include="DevDiv_278523_x64.il" />
+  <ItemGroup Condition=" '$(PointerSize)' == '64' ">
+    <Compile Include="DevDiv_278523_64.il" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(Platform)' != 'x64' ">
-    <!-- It includes x86, arm32, arm64 and future architectures. -->
-    <Compile Include="DevDiv_278523.il" />
+  <ItemGroup Condition=" '$(PointerSize)' == '32' ">
+    <Compile Include="DevDiv_278523_32.il" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523_32.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523_32.il
@@ -35,7 +35,7 @@
 
 .class private abstract auto ansi sealed beforefieldinit C extends [mscorlib]System.Object
 {
-    .method private static int32 Test64Bit(int32 i) noinlining
+    .method private static int32 Test32Bit(int32 i) noinlining
     {
         .locals init (valuetype S V_0, valuetype T V_1)
 
@@ -44,12 +44,9 @@
         conv.u1
         stfld uint8 S::m_fld6
 
-        // This sequence of IL repros the issue. Note that the `ldc.i8` is necessary (rather than an `ldc.i4` that is
-        // implicitly converted to a long by the `add`).
-        // This sequence is incorrect IL, because it adds native int + long, that is BADCODE according to ECMA.
-        // However, 64bits jit can compile and execute it. See CoreCLR issue #11476.
+        // This sequence of IL repros the issue.
         ldloca.s V_1
-        ldc.i8 4
+        ldc.i4.4
         add
         ldloc.0
         stobj S
@@ -60,6 +57,7 @@
         conv.i4
         ret
     }
+
 
     .method private static int32 Main()
     {
@@ -73,12 +71,13 @@
         ldc.i4 8
         beq.s _64bit
 
-        // This file is for x64 only.
-        br.s fail
+        call int32 C::Test32Bit(int32)
+        bne.un.s fail
+        br.s success
 
 _64bit:
-        call int32 C::Test64Bit(int32)
-        bne.un.s fail
+        // This file is for 32bit-ness platforms only.
+        br.s fail
 
 success:
         ldc.i4 100

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523_64.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523_64.il
@@ -35,7 +35,7 @@
 
 .class private abstract auto ansi sealed beforefieldinit C extends [mscorlib]System.Object
 {
-    .method private static int32 Test32Bit(int32 i) noinlining
+    .method private static int32 Test64Bit(int32 i) noinlining
     {
         .locals init (valuetype S V_0, valuetype T V_1)
 
@@ -44,9 +44,12 @@
         conv.u1
         stfld uint8 S::m_fld6
 
-        // This sequence of IL repros the issue.
+        // This sequence of IL repros the issue. Note that the `ldc.i8` is necessary (rather than an `ldc.i4` that is
+        // implicitly converted to a long by the `add`).
+        // This sequence is incorrect IL, because it adds native int + long, that is BADCODE according to ECMA.
+        // However, 64bits jit can compile and execute it. See CoreCLR issue #11476.
         ldloca.s V_1
-        ldc.i4.4
+        ldc.i8 4
         add
         ldloc.0
         stobj S
@@ -57,7 +60,6 @@
         conv.i4
         ret
     }
-
 
     .method private static int32 Main()
     {
@@ -71,14 +73,11 @@
         ldc.i4 8
         beq.s _64bit
 
-        call int32 C::Test32Bit(int32)
-        bne.un.s fail
-        br.s success
+        // This file is for 64bit-ness platforms only.
+        br.s fail
 
 _64bit:
-        // This path can be reached when run on 64bits target, but not amd64.
-        // For example on arm64. There is no way to distinguish platform bitness in proj file.
-        call int32 C::Test32Bit(int32)
+        call int32 C::Test64Bit(int32)
         bne.un.s fail
 
 success:

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523_x64.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523_x64.il
@@ -35,7 +35,7 @@
 
 .class private abstract auto ansi sealed beforefieldinit C extends [mscorlib]System.Object
 {
-    .method private static int32 Test32Bit(int32 i) noinlining
+    .method private static int32 Test64Bit(int32 i) noinlining
     {
         .locals init (valuetype S V_0, valuetype T V_1)
 
@@ -44,9 +44,12 @@
         conv.u1
         stfld uint8 S::m_fld6
 
-        // This sequence of IL repros the issue.
+        // This sequence of IL repros the issue. Note that the `ldc.i8` is necessary (rather than an `ldc.i4` that is
+        // implicitly converted to a long by the `add`).
+        // This sequence is incorrect IL, because it adds native int + long, that is BADCODE according to ECMA.
+        // However, 64bits jit can compile and execute it. See CoreCLR issue #11476.
         ldloca.s V_1
-        ldc.i4.4
+        ldc.i8 4
         add
         ldloc.0
         stobj S
@@ -57,7 +60,6 @@
         conv.i4
         ret
     }
-
 
     .method private static int32 Main()
     {
@@ -71,14 +73,11 @@
         ldc.i4 8
         beq.s _64bit
 
-        call int32 C::Test32Bit(int32)
-        bne.un.s fail
-        br.s success
+        // This file is for x64 only.
+        br.s fail
 
 _64bit:
-        // This path can be reached when run on 64bits target, but not amd64.
-        // For example on arm64. There is no way to distinguish platform bitness in proj file.
-        call int32 C::Test32Bit(int32)
+        call int32 C::Test64Bit(int32)
         bne.un.s fail
 
 success:

--- a/tests/src/dir.common.props
+++ b/tests/src/dir.common.props
@@ -32,6 +32,14 @@
     <DebugType Condition="'$(DebugType)' == ''">full</DebugType>
     <DefineConstants>$(DefineConstants);DEBUG;TRACE;XUNIT_PERF</DefineConstants>
   </PropertyGroup>
+  
+  <!-- Setup target platform pointer size in bit-->
+  <PropertyGroup>
+    <PointerSize Condition="'$(Platform)'=='x64'">64</PointerSize>
+    <PointerSize Condition="'$(Platform)'=='arm64'">64</PointerSize>
+    <PointerSize Condition="'$(Platform)'=='x86'">32</PointerSize>
+    <PointerSize Condition="'$(Platform)'=='arm'">32</PointerSize>
+  </PropertyGroup>
 
 <!-- Setup the default output and intermediate paths -->
   <PropertyGroup>


### PR DESCRIPTION
Fix the issue #11476.
Separate test source file into 2: the first is for amd64, the second for the other targets.

I didn't find how to compile ilproj with several includes, so I was not able to avoid code duplication.
It would be nice to execute _x64 on all 64 bits platforms, but looks like there is no msbuild condition for it. 