### PR TITLE
[RyuJIT/armel] Fix MultiRegOp definition

### DIFF
--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -1333,11 +1333,11 @@ public:
     bool OperIsMultiRegOp() const
     {
 #if !defined(LEGACY_BACKEND) && defined(_TARGET_ARM_)
-        if (gtOper == GT_MUL_LONG ||
 #ifdef ARM_SOFTFP
-            gtOper == GT_PUTARG_REG ||
+        if (gtOper == GT_MUL_LONG || gtOper == GT_PUTARG_REG)
+#else
+        if (gtOper == GT_MUL_LONG)
 #endif
-            gtOper == GT_COPY)
         {
             return true;
         }

--- a/src/jit/gtstructs.h
+++ b/src/jit/gtstructs.h
@@ -108,9 +108,9 @@ GTSTRUCT_1(AllocObj    , GT_ALLOCOBJ)
 GTSTRUCT_2(CC          , GT_JCC, GT_SETCC)
 #if !defined(LEGACY_BACKEND) && defined(_TARGET_ARM_)
 #ifdef ARM_SOFTFP
-GTSTRUCT_3(MultiRegOp  , GT_MUL_LONG, GT_PUTARG_REG, GT_COPY)
+GTSTRUCT_2(MultiRegOp  , GT_MUL_LONG, GT_PUTARG_REG)
 #else
-GTSTRUCT_2(MultiRegOp  , GT_MUL_LONG, GT_COPY)
+GTSTRUCT_1(MultiRegOp  , GT_MUL_LONG)
 #endif
 #endif
 /*****************************************************************************/

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -4141,7 +4141,7 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
         }
 #ifdef ARM_SOFTFP
         // If oper is GT_PUTARG_REG, set bits in useCandidates must be in sequential order.
-        else if (tree->OperIsMultiRegOp())
+        else if (tree->OperIsMultiRegOp() || tree->OperGet() == GT_COPY)
         {
             useCandidates = genFindLowestReg(remainingUseCandidates);
             remainingUseCandidates &= ~useCandidates;


### PR DESCRIPTION
GT_COPY should not be MultiRegOp since it is CopyOrReload.