### PR TITLE
Test change to induce a test failure to test new infrastructure.

### DIFF
--- a/tests/src/GC/API/GC/Finalize.cs
+++ b/tests/src/GC/API/GC/Finalize.cs
@@ -43,6 +43,7 @@ public class Test
         temp.RunTest();
 
 
+	visited = false;
         if (visited)
         {
             Console.WriteLine("Test for Finalize() & WaitForPendingFinalizers() passed!");


### PR DESCRIPTION
This should not be checked in.  Testing the PR infrastructure. 