### PR TITLE
Put back HResults needed by System.Runtime.WindowsRuntime

### DIFF
--- a/src/mscorlib/src/System/HResults.cs
+++ b/src/mscorlib/src/System/HResults.cs
@@ -124,6 +124,9 @@ namespace System
         internal const int E_CHANGED_STATE = unchecked((int)0x8000000C);
         internal const int E_FAIL = unchecked((int)0x80004005);
         internal const int E_HANDLE = unchecked((int)0x80070006);
+        internal const int E_ILLEGAL_DELEGATE_ASSIGNMENT = unchecked((int)0x80000018);
+        internal const int E_ILLEGAL_METHOD_CALL = unchecked((int)0x8000000E);
+        internal const int E_ILLEGAL_STATE_CHANGE = unchecked((int)0x8000000D);
         internal const int E_INVALIDARG = unchecked((int)0x80070057);
         internal const int E_NOTIMPL = unchecked((int)0x80004001);
         internal const int E_POINTER = unchecked((int)0x80004003);


### PR DESCRIPTION
https://github.com/dotnet/coreclr/pull/13611 broke the corefx build by removing three HResult values System.Runtime.WindowsRuntime depends on:
```
System\Threading\Tasks\TaskToAsyncInfoAdapter.cs(80,38): error CS0117: 'HResults' does not contain a definition for 'E_ILLEGAL_METHOD_CALL' [D:\j\workspace\windows-TGrou---0d2c9ac4\src\System.Runtime.WindowsRuntime\src\System.Runtime.WindowsRuntime.csproj]
System\Threading\Tasks\TaskToAsyncInfoAdapter.cs(400,38): error CS0117: 'HResults' does not contain a definition for 'E_ILLEGAL_METHOD_CALL' [D:\j\workspace\windows-TGrou---0d2c9ac4\src\System.Runtime.WindowsRuntime\src\System.Runtime.WindowsRuntime.csproj]
System\Threading\Tasks\TaskToAsyncInfoAdapter.cs(860,46): error CS0117: 'HResults' does not contain a definition for 'E_ILLEGAL_DELEGATE_ASSIGNMENT' [D:\j\workspace\windows-TGrou---0d2c9ac4\src\System.Runtime.WindowsRuntime\src\System.Runtime.WindowsRuntime.csproj]
System\Threading\Tasks\TaskToAsyncInfoAdapter.cs(943,46): error CS0117: 'HResults' does not contain a definition for 'E_ILLEGAL_STATE_CHANGE' [D:\j\workspace\windows-TGrou---0d2c9ac4\src\System.Runtime.WindowsRuntime\src\System.Runtime.WindowsRuntime.csproj]
System\IO\NetFxToWinRtStreamAdapter.cs(415,46): error CS0117: 'HResults' does not contain a definition for 'E_ILLEGAL_METHOD_CALL' [D:\j\workspace\windows-TGrou---0d2c9ac4\src\System.Runtime.WindowsRuntime\src\System.Runtime.WindowsRuntime.csproj]
```
This puts them back.
cc: @danmosemsft, @jkotas 