### PR TITLE
Avoid StringBuilder allocation in ResourceManager

### DIFF
--- a/src/mscorlib/src/System/Resources/ResourceManager.cs
+++ b/src/mscorlib/src/System/Resources/ResourceManager.cs
@@ -525,17 +525,16 @@ namespace System.Resources
         // such as ".ResX", or a completely different format for naming files.
         protected virtual String GetResourceFileName(CultureInfo culture)
         {
-            StringBuilder sb = new StringBuilder(255);
-            sb.Append(BaseNameField);
-            // If this is the neutral culture, don't append culture name.
-            if (!culture.HasInvariantCultureName)
+            // If this is the neutral culture, don't include the culture name.
+            if (culture.HasInvariantCultureName)
             {
-                CultureInfo.VerifyCultureName(culture.Name, true);
-                sb.Append('.');
-                sb.Append(culture.Name);
+                return BaseNameField + ResFileExtension;
             }
-            sb.Append(ResFileExtension);
-            return sb.ToString();
+            else
+            {
+                CultureInfo.VerifyCultureName(culture.Name, throwException: true);
+                return BaseNameField + "." + culture.Name + ResFileExtension;
+            }
         }
 
         // WARNING: This function must be kept in sync with ResourceFallbackManager.GetEnumerator()


### PR DESCRIPTION
Minor nit: Avoid the unnecessary `StringBuilder` allocation in `ResourceManager` in favor of a more efficient `String.Concat`.