### PR TITLE
[RyuJIT/ARM32] Implement CreateDictionaryLookupHelper only via helper

### DIFF
--- a/src/vm/arm/stubs.cpp
+++ b/src/vm/arm/stubs.cpp
@@ -3604,10 +3604,8 @@ PCODE DynamicHelpers::CreateHelper(LoaderAllocator * pAllocator, TADDR arg, PCOD
     END_DYNAMIC_HELPER_EMIT();
 }
 
-PCODE DynamicHelpers::CreateHelperWithArg(LoaderAllocator * pAllocator, TADDR arg, PCODE target)
+void DynamicHelpers::EmitHelperWithArg(BYTE*& p, LoaderAllocator * pAllocator, TADDR arg, PCODE target)
 {
-    BEGIN_DYNAMIC_HELPER_EMIT(18);
-
     // mov r1, arg
     MovRegImm(p, 1, arg);
     p += 8;
@@ -3619,6 +3617,13 @@ PCODE DynamicHelpers::CreateHelperWithArg(LoaderAllocator * pAllocator, TADDR ar
     // bx r12
     *(WORD *)p = 0x4760;
     p += 2;
+}
+
+PCODE DynamicHelpers::CreateHelperWithArg(LoaderAllocator * pAllocator, TADDR arg, PCODE target)
+{
+    BEGIN_DYNAMIC_HELPER_EMIT(18);
+
+    EmitHelperWithArg(p, pAllocator, arg, target);
 
     END_DYNAMIC_HELPER_EMIT();
 }
@@ -3767,8 +3772,23 @@ PCODE DynamicHelpers::CreateDictionaryLookupHelper(LoaderAllocator * pAllocator,
 {
     STANDARD_VM_CONTRACT;
 
-    // TODO (NYI)
-    ThrowHR(E_NOTIMPL);
+    PCODE helperAddress = (pLookup->helper == CORINFO_HELP_RUNTIMEHANDLE_METHOD ?
+        GetEEFuncEntryPoint(JIT_GenericHandleMethodWithSlotAndModule) :
+        GetEEFuncEntryPoint(JIT_GenericHandleClassWithSlotAndModule));
+
+    GenericHandleArgs * pArgs = (GenericHandleArgs *)(void *)pAllocator->GetDynamicHelpersHeap()->AllocAlignedMem(sizeof(GenericHandleArgs), DYNAMIC_HELPER_ALIGNMENT);
+    pArgs->dictionaryIndexAndSlot = dictionaryIndexAndSlot;
+    pArgs->signature = pLookup->signature;
+    pArgs->module = (CORINFO_MODULE_HANDLE)pModule;
+
+    // It's available only via the run-time helper function
+    BEGIN_DYNAMIC_HELPER_EMIT(18);
+
+    EmitHelperWithArg(p, pAllocator, (TADDR)pArgs, helperAddress);
+
+    END_DYNAMIC_HELPER_EMIT();
+
+    // @TODO : Additional implementation is required for optimization cases.
 }
 #endif // FEATURE_READYTORUN
 

--- a/src/vm/arm/stubs.cpp
+++ b/src/vm/arm/stubs.cpp
@@ -3781,7 +3781,10 @@ PCODE DynamicHelpers::CreateDictionaryLookupHelper(LoaderAllocator * pAllocator,
     pArgs->signature = pLookup->signature;
     pArgs->module = (CORINFO_MODULE_HANDLE)pModule;
 
-    // It's available only via the run-time helper function
+    // It's available only via the run-time helper function,
+    // since optimization cases are not yet implemented.
+    assert(pLookup->indirections == CORINFO_USEHELPER);
+
     BEGIN_DYNAMIC_HELPER_EMIT(18);
 
     EmitHelperWithArg(p, pAllocator, (TADDR)pArgs, helperAddress);

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -3132,9 +3132,6 @@ void CEEInfo::ComputeRuntimeLookupForSharedGenericToken(DictionaryEntryKind entr
 #ifdef FEATURE_READYTORUN_COMPILER
     if (IsReadyToRunCompilation())
     {
-#if defined(_TARGET_ARM_)
-        ThrowHR(E_NOTIMPL); /* TODO - NYI */
-#endif
         pResultLookup->lookupKind.runtimeLookupArgs = NULL;
 
         switch (entryKind)

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -2586,6 +2586,9 @@ void ProcessDynamicDictionaryLookup(TransitionBlock *           pTransitionBlock
     //
     // Optimization cases
     //
+    // TODO-ARM : If the optimization cases are implemented in CreateDictionaryLookupHelper,
+    //            It's ifndef for ARM will be removed.
+#ifndef _TARGET_ARM_
     if (signatureKind == ENCODE_TYPE_HANDLE)
     {
         SigPointer sigptr(pBlob, -1);
@@ -2628,6 +2631,7 @@ void ProcessDynamicDictionaryLookup(TransitionBlock *           pTransitionBlock
             return;
         }
     }
+#endif // !_TARGET_ARM_
 
     if (pContextMT != NULL && pContextMT->GetNumDicts() > 0xFFFF)
         ThrowHR(COR_E_BADIMAGEFORMAT);


### PR DESCRIPTION
#13653 

I've implemented the CreateDictionaryLookupHelper used only via the run-time helper simply.
It seems to work well but does not consider the optimization case.