### PR TITLE
need casting for size calculation

### DIFF
--- a/tests/src/GC/API/NoGCRegion/NoGC.cs
+++ b/tests/src/GC/API/NoGCRegion/NoGC.cs
@@ -57,8 +57,8 @@ public class Test
             
         DoAlloc();
 
-        long size = sizeMB * 1024 * 1024;
-        long sizeLOH = ((sizeMBLOH == -1) ? 0 : (sizeMBLOH * 1024 * 1024));
+        long size = (long)sizeMB * (long)1024 * (long)1024;
+        long sizeLOH = ((sizeMBLOH == -1) ? 0 : ((long)sizeMBLOH * (long)1024 * (long)1024));
         try
         {
             Console.WriteLine("\nCalling TryStartNoGCRegion(..) with totalSize = {0:N0} MB",


### PR DESCRIPTION
@swgillespie PTAL. Let's unblock the CI first. GCInterface::StartNoGCRegion should do some arg validation and we can add a test case for that in the test.