### PR TITLE
Add an assert to getRegisterRecord() that regNum is legal

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -367,6 +367,7 @@ bool RegRecord::isFree()
  *****************************************************************************/
 RegRecord* LinearScan::getRegisterRecord(regNumber regNum)
 {
+    assert((unsigned)regNum < ArrLen(physRegs));
     return &physRegs[regNum];
 }
 


### PR DESCRIPTION
This turns crashes into asserts in a `COMPlus_JitStressRegs=8` scenario I'm investigating.