### PR TITLE
JIT: allow inlines of methods with calli

### DIFF
--- a/tests/src/JIT/opt/Inline/tests/calli.il
+++ b/tests/src/JIT/opt/Inline/tests/calli.il
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Test that inliner can now inline g1 and g2
+
+.assembly extern legacy library mscorlib {}
+
+.assembly legacy library calli_inline {}
+.class private auto ansi beforefieldinit calli_test
+       extends [mscorlib]System.Object
+{
+  .field private static int32 a
+  .field private static int32 b
+  .method public static int32 f1()
+  {
+    ldsfld     int32 calli_test::a
+    ret
+  }
+  .method public static int32 f2()
+  {
+    ldsfld     int32 calli_test::b
+    ret
+  }
+  .method public static int32 g1()
+  {
+    ldftn int32 calli_test::f1()
+    calli int32 ()
+    ret
+  }
+  .method public static int32 g2()
+  {
+    ldftn int32 calli_test::f2()
+    calli int32 ()
+    ret
+  }
+  .method public hidebysig static int32 Main() cil managed
+  {
+    .entrypoint
+    .maxstack  2
+    call int32 calli_test::g1()
+    call int32 calli_test::g2()
+    beq.s      GOOD
+    ldc.i4 0
+    br.s       DONE
+    GOOD: 
+    ldc.i4 100
+    DONE:
+    ret
+  }
+}

--- a/tests/src/JIT/opt/Inline/tests/calli.ilproj
+++ b/tests/src/JIT/opt/Inline/tests/calli.ilproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="calli.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Provided call sig has default callling convention. Added test case.
Continuation of #12714.