### PR TITLE
Fix access order for double pointer

### DIFF
--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -76,7 +76,7 @@ EventPipeEventPayload::EventPipeEventPayload(EventData **pEventData, unsigned in
     S_UINT32 tmp_size = S_UINT32(0);
     for (unsigned int i=0; i<m_eventDataCount; i++)
     {
-        tmp_size += S_UINT32(m_pEventData[i]->Size);
+        tmp_size += S_UINT32((*m_pEventData)[i].Size);
     }
 
     if (tmp_size.IsOverflow())
@@ -156,8 +156,8 @@ void EventPipeEventPayload::CopyData(BYTE *pDst)
             unsigned int offset = 0;
             for(unsigned int i=0; i<m_eventDataCount; i++)
             {
-                memcpy(pDst + offset, (BYTE*)m_pEventData[i]->Ptr, m_pEventData[i]->Size);
-                offset += m_pEventData[i]->Size;
+                memcpy(pDst + offset, (BYTE*)(*m_pEventData)[i].Ptr, (*m_pEventData)[i].Size);
+                offset += (*m_pEventData)[i].Size;
             }
         }
     }

--- a/tests/src/tracing/eventsourcesmoke/EventSourceSmoke.cs
+++ b/tests/src/tracing/eventsourcesmoke/EventSourceSmoke.cs
@@ -13,7 +13,7 @@ namespace Tracing.Tests
         public SimpleEventSource() : base(true) { }
 
         [Event(1)]
-        internal void Message(string msg) { this.WriteEvent(1, msg); }
+        internal void MathResult(int x, int y, int z, string formula) { this.WriteEvent(1, x, y, z, formula); }
     }
 
     class EventPipeSmoke
@@ -71,9 +71,9 @@ namespace Tracing.Tests
             {
                 int x = generator.Next(1,1000);
                 int y = generator.Next(1,1000);
-                string result = String.Format("{0} + {1} = {2}", x, y, x+y);
+                string formula = String.Format("{0} + {1} = {2}", x, y, x+y);
                 
-                eventSource.Message(result);
+                eventSource.MathResult(x, y, x+y, formula);
             }
             Console.WriteLine("\tEnd: Messaging.\n");
 


### PR DESCRIPTION
In the EventPipeEventPayload, m_pEventData was being treated as an array of pointers, when it is actually a pointer to an array, as handed down from managed code.

This commit changes the order of dereferencing and indexing to fix this issue