### PR TITLE
Add Memory-based Stream overloads to coreclr

### DIFF
--- a/src/mscorlib/shared/System/IO/FileStream.Unix.cs
+++ b/src/mscorlib/shared/System/IO/FileStream.Unix.cs
@@ -472,84 +472,79 @@ namespace System.IO
         /// Asynchronously reads a sequence of bytes from the current stream and advances
         /// the position within the stream by the number of bytes read.
         /// </summary>
-        /// <param name="buffer">The buffer to write the data into.</param>
-        /// <param name="offset">The byte offset in buffer at which to begin writing data from the stream.</param>
-        /// <param name="count">The maximum number of bytes to read.</param>
+        /// <param name="destination">The buffer to write the data into.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <param name="synchronousResult">If the operation completes synchronously, the number of bytes read.</param>
         /// <returns>A task that represents the asynchronous read operation.</returns>
-        private Task<int> ReadAsyncInternal(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        private Task<int> ReadAsyncInternal(Memory<byte> destination, CancellationToken cancellationToken, out int synchronousResult)
         {
-            if (_useAsyncIO)
+            Debug.Assert(_useAsyncIO);
+
+            if (!CanRead) // match Windows behavior; this gets thrown synchronously
             {
-                if (!CanRead) // match Windows behavior; this gets thrown synchronously
+                throw Error.GetReadNotSupported();
+            }
+
+            // Serialize operations using the semaphore.
+            Task waitTask = _asyncState.WaitAsync();
+
+            // If we got ownership immediately, and if there's enough data in our buffer
+            // to satisfy the full request of the caller, hand back the buffered data.
+            // While it would be a legal implementation of the Read contract, we don't
+            // hand back here less than the amount requested so as to match the behavior
+            // in ReadCore that will make a native call to try to fulfill the remainder
+            // of the request.
+            if (waitTask.Status == TaskStatus.RanToCompletion)
+            {
+                int numBytesAvailable = _readLength - _readPos;
+                if (numBytesAvailable >= destination.Length)
                 {
-                    throw Error.GetReadNotSupported();
-                }
-
-                // Serialize operations using the semaphore.
-                Task waitTask = _asyncState.WaitAsync();
-
-                // If we got ownership immediately, and if there's enough data in our buffer
-                // to satisfy the full request of the caller, hand back the buffered data.
-                // While it would be a legal implementation of the Read contract, we don't
-                // hand back here less than the amount requested so as to match the behavior
-                // in ReadCore that will make a native call to try to fulfill the remainder
-                // of the request.
-                if (waitTask.Status == TaskStatus.RanToCompletion)
-                {
-                    int numBytesAvailable = _readLength - _readPos;
-                    if (numBytesAvailable >= count)
-                    {
-                        try
-                        {
-                            PrepareForReading();
-
-                            Buffer.BlockCopy(GetBuffer(), _readPos, buffer, offset, count);
-                            _readPos += count;
-
-                            return _asyncState._lastSuccessfulReadTask != null && _asyncState._lastSuccessfulReadTask.Result == count ?
-                                _asyncState._lastSuccessfulReadTask :
-                                (_asyncState._lastSuccessfulReadTask = Task.FromResult(count));
-                        }
-                        catch (Exception exc)
-                        {
-                            return Task.FromException<int>(exc);
-                        }
-                        finally
-                        {
-                            _asyncState.Release();
-                        }
-                    }
-                }
-
-                // Otherwise, issue the whole request asynchronously.
-                _asyncState.Update(buffer, offset, count);
-                return waitTask.ContinueWith((t, s) =>
-                {
-                    // The options available on Unix for writing asynchronously to an arbitrary file 
-                    // handle typically amount to just using another thread to do the synchronous write, 
-                    // which is exactly  what this implementation does. This does mean there are subtle
-                    // differences in certain FileStream behaviors between Windows and Unix when multiple 
-                    // asynchronous operations are issued against the stream to execute concurrently; on 
-                    // Unix the operations will be serialized due to the usage of a semaphore, but the 
-                    // position /length information won't be updated until after the write has completed, 
-                    // whereas on Windows it may happen before the write has completed.
-
-                    Debug.Assert(t.Status == TaskStatus.RanToCompletion);
-                    var thisRef = (FileStream)s;
                     try
                     {
-                        byte[] b = thisRef._asyncState._buffer;
-                        thisRef._asyncState._buffer = null; // remove reference to user's buffer
-                        return thisRef.ReadSpan(new Span<byte>(b, thisRef._asyncState._offset, thisRef._asyncState._count));
+                        PrepareForReading();
+
+                        new Span<byte>(GetBuffer(), _readPos, destination.Length).CopyTo(destination.Span);
+                        _readPos += destination.Length;
+
+                        synchronousResult = destination.Length;
+                        return null;
                     }
-                    finally { thisRef._asyncState.Release(); }
-                }, this, CancellationToken.None, TaskContinuationOptions.DenyChildAttach, TaskScheduler.Default);
+                    catch (Exception exc)
+                    {
+                        synchronousResult = 0;
+                        return Task.FromException<int>(exc);
+                    }
+                    finally
+                    {
+                        _asyncState.Release();
+                    }
+                }
             }
-            else
+
+            // Otherwise, issue the whole request asynchronously.
+            synchronousResult = 0;
+            _asyncState.Memory = destination;
+            return waitTask.ContinueWith((t, s) =>
             {
-                return base.ReadAsync(buffer, offset, count, cancellationToken);
-            }
+                // The options available on Unix for writing asynchronously to an arbitrary file 
+                // handle typically amount to just using another thread to do the synchronous write, 
+                // which is exactly  what this implementation does. This does mean there are subtle
+                // differences in certain FileStream behaviors between Windows and Unix when multiple 
+                // asynchronous operations are issued against the stream to execute concurrently; on 
+                // Unix the operations will be serialized due to the usage of a semaphore, but the 
+                // position /length information won't be updated until after the write has completed, 
+                // whereas on Windows it may happen before the write has completed.
+
+                Debug.Assert(t.Status == TaskStatus.RanToCompletion);
+                var thisRef = (FileStream)s;
+                try
+                {
+                    Memory<byte> memory = thisRef._asyncState.Memory;
+                    thisRef._asyncState.Memory = default(Memory<byte>);
+                    return thisRef.ReadSpan(memory.Span);
+                }
+                finally { thisRef._asyncState.Release(); }
+            }, this, CancellationToken.None, TaskContinuationOptions.DenyChildAttach, TaskScheduler.Default);
         }
 
         /// <summary>Reads from the file handle into the buffer, overwriting anything in it.</summary>
@@ -636,84 +631,77 @@ namespace System.IO
         /// the current position within this stream by the number of bytes written, and
         /// monitors cancellation requests.
         /// </summary>
-        /// <param name="buffer">The buffer to write data from.</param>
-        /// <param name="offset">The zero-based byte offset in buffer from which to begin copying bytes to the stream.</param>
-        /// <param name="count">The maximum number of bytes to write.</param>
+        /// <param name="source">The buffer to write data from.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private Task WriteAsyncInternal(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        private Task WriteAsyncInternal(ReadOnlyMemory<byte> source, CancellationToken cancellationToken)
         {
+            Debug.Assert(_useAsyncIO);
+
             if (cancellationToken.IsCancellationRequested)
                 return Task.FromCanceled(cancellationToken);
 
             if (_fileHandle.IsClosed)
                 throw Error.GetFileNotOpen();
 
-            if (_useAsyncIO)
+            if (!CanWrite) // match Windows behavior; this gets thrown synchronously
             {
-                if (!CanWrite) // match Windows behavior; this gets thrown synchronously
+                throw Error.GetWriteNotSupported();
+            }
+
+            // Serialize operations using the semaphore.
+            Task waitTask = _asyncState.WaitAsync();
+
+            // If we got ownership immediately, and if there's enough space in our buffer
+            // to buffer the entire write request, then do so and we're done.
+            if (waitTask.Status == TaskStatus.RanToCompletion)
+            {
+                int spaceRemaining = _bufferLength - _writePos;
+                if (spaceRemaining >= source.Length)
                 {
-                    throw Error.GetWriteNotSupported();
-                }
-
-                // Serialize operations using the semaphore.
-                Task waitTask = _asyncState.WaitAsync();
-
-                // If we got ownership immediately, and if there's enough space in our buffer
-                // to buffer the entire write request, then do so and we're done.
-                if (waitTask.Status == TaskStatus.RanToCompletion)
-                {
-                    int spaceRemaining = _bufferLength - _writePos;
-                    if (spaceRemaining >= count)
-                    {
-                        try
-                        {
-                            PrepareForWriting();
-
-                            Buffer.BlockCopy(buffer, offset, GetBuffer(), _writePos, count);
-                            _writePos += count;
-
-                            return Task.CompletedTask;
-                        }
-                        catch (Exception exc)
-                        {
-                            return Task.FromException(exc);
-                        }
-                        finally
-                        {
-                            _asyncState.Release();
-                        }
-                    }
-                }
-
-                // Otherwise, issue the whole request asynchronously.
-                _asyncState.Update(buffer, offset, count);
-                return waitTask.ContinueWith((t, s) =>
-                {
-                    // The options available on Unix for writing asynchronously to an arbitrary file 
-                    // handle typically amount to just using another thread to do the synchronous write, 
-                    // which is exactly  what this implementation does. This does mean there are subtle
-                    // differences in certain FileStream behaviors between Windows and Unix when multiple 
-                    // asynchronous operations are issued against the stream to execute concurrently; on 
-                    // Unix the operations will be serialized due to the usage of a semaphore, but the 
-                    // position/length information won't be updated until after the write has completed, 
-                    // whereas on Windows it may happen before the write has completed.
-
-                    Debug.Assert(t.Status == TaskStatus.RanToCompletion);
-                    var thisRef = (FileStream)s;
                     try
                     {
-                        byte[] b = thisRef._asyncState._buffer;
-                        thisRef._asyncState._buffer = null; // remove reference to user's buffer
-                        thisRef.WriteSpan(new ReadOnlySpan<byte>(b, thisRef._asyncState._offset, thisRef._asyncState._count));
+                        PrepareForWriting();
+
+                        source.Span.CopyTo(new Span<byte>(GetBuffer(), _writePos, source.Length));
+                        _writePos += source.Length;
+
+                        return Task.CompletedTask;
                     }
-                    finally { thisRef._asyncState.Release(); }
-                }, this, CancellationToken.None, TaskContinuationOptions.DenyChildAttach, TaskScheduler.Default);
+                    catch (Exception exc)
+                    {
+                        return Task.FromException(exc);
+                    }
+                    finally
+                    {
+                        _asyncState.Release();
+                    }
+                }
             }
-            else
+
+            // Otherwise, issue the whole request asynchronously.
+            _asyncState.ReadOnlyMemory = source;
+            return waitTask.ContinueWith((t, s) =>
             {
-                return base.WriteAsync(buffer, offset, count, cancellationToken);
-            }
+                // The options available on Unix for writing asynchronously to an arbitrary file 
+                // handle typically amount to just using another thread to do the synchronous write, 
+                // which is exactly  what this implementation does. This does mean there are subtle
+                // differences in certain FileStream behaviors between Windows and Unix when multiple 
+                // asynchronous operations are issued against the stream to execute concurrently; on 
+                // Unix the operations will be serialized due to the usage of a semaphore, but the 
+                // position/length information won't be updated until after the write has completed, 
+                // whereas on Windows it may happen before the write has completed.
+
+                Debug.Assert(t.Status == TaskStatus.RanToCompletion);
+                var thisRef = (FileStream)s;
+                try
+                {
+                    ReadOnlyMemory<byte> readOnlyMemory = thisRef._asyncState.ReadOnlyMemory;
+                    thisRef._asyncState.ReadOnlyMemory = default(ReadOnlyMemory<byte>);
+                    thisRef.WriteSpan(readOnlyMemory.Span);
+                }
+                finally { thisRef._asyncState.Release(); }
+            }, this, CancellationToken.None, TaskContinuationOptions.DenyChildAttach, TaskScheduler.Default);
         }
 
         /// <summary>Sets the current position of this stream to the given value.</summary>
@@ -814,25 +802,11 @@ namespace System.IO
         /// <summary>State used when the stream is in async mode.</summary>
         private sealed class AsyncState : SemaphoreSlim
         {
-            /// <summary>The caller's buffer currently being used by the active async operation.</summary>
-            internal byte[] _buffer;
-            /// <summary>The caller's offset currently being used by the active async operation.</summary>
-            internal int _offset;
-            /// <summary>The caller's count currently being used by the active async operation.</summary>
-            internal int _count;
-            /// <summary>The last task successfully, synchronously returned task from ReadAsync.</summary>
-            internal Task<int> _lastSuccessfulReadTask;
+            internal ReadOnlyMemory<byte> ReadOnlyMemory;
+            internal Memory<byte> Memory;
 
             /// <summary>Initialize the AsyncState.</summary>
             internal AsyncState() : base(initialCount: 1, maxCount: 1) { }
-
-            /// <summary>Sets the active buffer, offset, and count.</summary>
-            internal void Update(byte[] buffer, int offset, int count)
-            {
-                _buffer = buffer;
-                _offset = offset;
-                _count = count;
-            }
         }
     }
 }

--- a/src/mscorlib/shared/System/IO/FileStreamCompletionSource.Win32.cs
+++ b/src/mscorlib/shared/System/IO/FileStreamCompletionSource.Win32.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Security;
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Runtime.InteropServices;
-using System.Diagnostics;
 
 namespace System.IO
 {
@@ -15,7 +15,7 @@ namespace System.IO
         // This is an internal object extending TaskCompletionSource with fields
         // for all of the relevant data necessary to complete the IO operation.
         // This is used by IOCallback and all of the async methods.
-        unsafe private sealed class FileStreamCompletionSource : TaskCompletionSource<int>
+        private unsafe class FileStreamCompletionSource : TaskCompletionSource<int>
         {
             private const long NoResult = 0;
             private const long ResultSuccess = (long)1 << 32;
@@ -28,7 +28,6 @@ namespace System.IO
 
             private readonly FileStream _stream;
             private readonly int _numBufferedBytes;
-            private readonly CancellationToken _cancellationToken;
             private CancellationTokenRegistration _cancellationRegistration;
 #if DEBUG
             private bool _cancellationHasBeenRegistered;
@@ -37,20 +36,19 @@ namespace System.IO
             private long _result; // Using long since this needs to be used in Interlocked APIs
 
             // Using RunContinuationsAsynchronously for compat reasons (old API used Task.Factory.StartNew for continuations)
-            internal FileStreamCompletionSource(FileStream stream, int numBufferedBytes, byte[] bytes, CancellationToken cancellationToken)
+            internal FileStreamCompletionSource(FileStream stream, int numBufferedBytes, byte[] bytes)
                 : base(TaskCreationOptions.RunContinuationsAsynchronously)
             {
                 _numBufferedBytes = numBufferedBytes;
                 _stream = stream;
                 _result = NoResult;
-                _cancellationToken = cancellationToken;
 
-                // Create the native overlapped. We try to use the preallocated overlapped if possible: 
-                // it's possible if the byte buffer is the same one that's associated with the preallocated overlapped 
-                // and if no one else is currently using the preallocated overlapped.  This is the fast-path for cases 
-                // where the user-provided buffer is smaller than the FileStream's buffer (such that the FileStream's 
+                // Create the native overlapped. We try to use the preallocated overlapped if possible: it's possible if the byte
+                // buffer is null (there's nothing to pin) or the same one that's associated with the preallocated overlapped (and
+                // thus is already pinned) and if no one else is currently using the preallocated overlapped.  This is the fast-path
+                // for cases where the user-provided buffer is smaller than the FileStream's buffer (such that the FileStream's
                 // buffer is used) and where operations on the FileStream are not being performed concurrently.
-                _overlapped = ReferenceEquals(bytes, _stream._buffer) && _stream.CompareExchangeCurrentOverlappedOwner(this, null) == null ?
+                _overlapped = (bytes == null || ReferenceEquals(bytes, _stream._buffer)) && _stream.CompareExchangeCurrentOverlappedOwner(this, null) == null ?
                     _stream._fileHandle.ThreadPoolBinding.AllocateNativeOverlapped(_stream._preallocatedOverlapped) :
                     _stream._fileHandle.ThreadPoolBinding.AllocateNativeOverlapped(s_ioCallback, this, bytes);
                 Debug.Assert(_overlapped != null, "AllocateNativeOverlapped returned null");
@@ -67,15 +65,16 @@ namespace System.IO
                 TrySetResult(numBytes + _numBufferedBytes);
             }
 
-            public void RegisterForCancellation()
+            public void RegisterForCancellation(CancellationToken cancellationToken)
             {
 #if DEBUG
+                Debug.Assert(cancellationToken.CanBeCanceled);
                 Debug.Assert(!_cancellationHasBeenRegistered, "Cannot register for cancellation twice");
                 _cancellationHasBeenRegistered = true;
 #endif
 
-                // Quick check to make sure that the cancellation token supports cancellation, and that the IO hasn't completed
-                if ((_cancellationToken.CanBeCanceled) && (_overlapped != null))
+                // Quick check to make sure the IO hasn't completed
+                if (_overlapped != null)
                 {
                     var cancelCallback = s_cancelCallback;
                     if (cancelCallback == null) s_cancelCallback = cancelCallback = Cancel;
@@ -84,7 +83,7 @@ namespace System.IO
                     long packedResult = Interlocked.CompareExchange(ref _result, RegisteringCancellation, NoResult);
                     if (packedResult == NoResult)
                     {
-                        _cancellationRegistration = _cancellationToken.Register(cancelCallback, this);
+                        _cancellationRegistration = cancellationToken.Register(cancelCallback, this);
 
                         // Switch the result, just in case IO completed while we were setting the registration
                         packedResult = Interlocked.Exchange(ref _result, NoResult);
@@ -104,7 +103,7 @@ namespace System.IO
                 }
             }
 
-            internal void ReleaseNativeResource()
+            internal virtual void ReleaseNativeResource()
             {
                 // Ensure that cancellation has been completed and cleaned up.
                 _cancellationRegistration.Dispose();
@@ -172,6 +171,7 @@ namespace System.IO
             private void CompleteCallback(ulong packedResult)
             {
                 // Free up the native resource and cancellation registration
+                CancellationToken cancellationToken = _cancellationRegistration.Token; // access before disposing registration
                 ReleaseNativeResource();
 
                 // Unpack the result and send it to the user
@@ -181,7 +181,7 @@ namespace System.IO
                     int errorCode = unchecked((int)(packedResult & uint.MaxValue));
                     if (errorCode == Interop.Errors.ERROR_OPERATION_ABORTED)
                     {
-                        TrySetCanceled(_cancellationToken.IsCancellationRequested ? _cancellationToken : new CancellationToken(true));
+                        TrySetCanceled(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
                     }
                     else
                     {
@@ -216,6 +216,29 @@ namespace System.IO
                         throw Win32Marshal.GetExceptionForWin32Error(errorCode);
                     }
                 }
+            }
+        }
+
+        /// <summary>
+        /// Extends <see cref="FileStreamCompletionSource"/> with to support disposing of a
+        /// <see cref="MemoryHandle"/> when the operation has completed.  This should only be used
+        /// when memory doesn't wrap a byte[].
+        /// </summary>
+        private sealed class MemoryFileStreamCompletionSource : FileStreamCompletionSource
+        {
+            private MemoryHandle _handle; // mutable struct; do not make this readonly
+
+            internal MemoryFileStreamCompletionSource(FileStream stream, int numBufferedBytes, ReadOnlyMemory<byte> memory) :
+                base(stream, numBufferedBytes, bytes: null) // this type handles the pinning, so null is passed for bytes
+            {
+                Debug.Assert(!memory.DangerousTryGetArray(out ArraySegment<byte> array), "The base should be used directly if we can get the array.");
+                _handle = memory.Retain(pin: true);
+            }
+
+            internal override void ReleaseNativeResource()
+            {
+                _handle.Dispose();
+                base.ReleaseNativeResource();
             }
         }
     }

--- a/src/mscorlib/shared/System/IO/UnmanagedMemoryStream.cs
+++ b/src/mscorlib/shared/System/IO/UnmanagedMemoryStream.cs
@@ -471,6 +471,28 @@ namespace System.IO
         }
 
         /// <summary>
+        /// Reads bytes from stream and puts them into the buffer
+        /// </summary>
+        /// <param name="destination">Buffer to read the bytes to.</param>
+        /// <param name="cancellationToken">Token that can be used to cancel this operation.</param>
+        public override ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return new ValueTask<int>(Task.FromCanceled<int>(cancellationToken));
+            }
+
+            try
+            {
+                return new ValueTask<int>(Read(destination.Span));
+            }
+            catch (Exception ex)
+            {
+                return new ValueTask<int>(Task.FromException<int>(ex));
+            }
+        }
+
+        /// <summary>
         /// Returns the byte at the stream current Position and advances the Position.
         /// </summary>
         /// <returns></returns>
@@ -724,6 +746,29 @@ namespace System.IO
             catch (Exception ex)
             {
                 Debug.Assert(!(ex is OperationCanceledException));
+                return Task.FromException(ex);
+            }
+        }
+
+        /// <summary>
+        /// Writes buffer into the stream. The operation completes synchronously.
+        /// </summary>
+        /// <param name="buffer">Buffer that will be written.</param>
+        /// <param name="cancellationToken">Token that can be used to cancel the operation.</param>
+        public override Task WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled(cancellationToken);
+            }
+
+            try
+            {
+                Write(source.Span);
+                return Task.CompletedTask;
+            }
+            catch (Exception ex)
+            {
                 return Task.FromException(ex);
             }
         }

--- a/src/mscorlib/shared/System/IO/UnmanagedMemoryStreamWrapper.cs
+++ b/src/mscorlib/shared/System/IO/UnmanagedMemoryStreamWrapper.cs
@@ -210,10 +210,20 @@ namespace System.IO
             return _unmanagedStream.ReadAsync(buffer, offset, count, cancellationToken);
         }
 
+        public override ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return _unmanagedStream.ReadAsync(destination, cancellationToken);
+        }
+
 
         public override Task WriteAsync(Byte[] buffer, Int32 offset, Int32 count, CancellationToken cancellationToken)
         {
             return _unmanagedStream.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override Task WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return _unmanagedStream.WriteAsync(source, cancellationToken);
         }
     }  // class UnmanagedMemoryStreamWrapper
 }  // namespace

--- a/src/mscorlib/src/System/Threading/CancellationTokenRegistration.cs
+++ b/src/mscorlib/src/System/Threading/CancellationTokenRegistration.cs
@@ -37,6 +37,13 @@ namespace System.Threading
         }
 
         /// <summary>
+        /// Gets the <see cref="CancellationToken"/> with which this registration is associated.  If the
+        /// registration isn't associated with a token (such as after the registration has been disposed),
+        /// this will return a default token.
+        /// </summary>
+        internal CancellationToken Token => _node?.Partition.Source.Token ?? default(CancellationToken);
+
+        /// <summary>
         /// Disposes of the registration and unregisters the target callback from the associated 
         /// <see cref="T:System.Threading.CancellationToken">CancellationToken</see>.
         /// </summary>


### PR DESCRIPTION
Includes adding the virtuals to Stream and then overriding on the various streams implemented in coreclr.

cc: @JeremyKuhne, @pjanotti, @ahsonkhan, @KrzysztofCwalina 