### PR TITLE
Print zapper stats on verbose mode

### DIFF
--- a/src/zap/zapimage.cpp
+++ b/src/zap/zapimage.cpp
@@ -1107,6 +1107,10 @@ HANDLE ZapImage::SaveImage(LPCWSTR wszOutputFileName, CORCOMPILE_NGEN_SIGNATURE 
 
     HANDLE hFile = GenerateFile(wszOutputFileName, pNativeImageSig);
 
+    if (m_zapper->m_pOpt->m_verbose)
+    {
+        PrintStats(wszOutputFileName);
+    }
 
     return hFile;
 }


### PR DESCRIPTION
As we discussed in https://github.com/dotnet/coreclr/pull/13742#issuecomment-326613852, I added `PrintStats()` when verbose mode.

cc: @jkotas 