### PR TITLE
Port #13598 to release/2.0.0 - Delete superfluous check in funceval.cpp

### DIFF
--- a/src/debug/ee/funceval.cpp
+++ b/src/debug/ee/funceval.cpp
@@ -1559,22 +1559,7 @@ void ResolveFuncEvalGenericArgInfo(DebuggerEval *pDE)
     
     // We better have a MethodDesc at this point.
     _ASSERTE(pDE->m_md != NULL);
-    
-    IMDInternalImport *pInternalImport = pDE->m_md->GetMDImport();
-    DWORD dwAttr;
-    if (FAILED(pInternalImport->GetMethodDefProps(pDE->m_methodToken, &dwAttr)))
-    {
-        COMPlusThrow(kArgumentException, W("Argument_InvalidGenericArg"));
-    }
-    
-    if (dwAttr & mdRequireSecObject)
-    {
-        // command window cannot evaluate a function with mdRequireSecObject is turned on because
-        // this is expecting to put a security object into caller's frame which we don't have.
-        //
-        COMPlusThrow(kArgumentException,W("Argument_CantCallSecObjFunc"));
-    }
-    
+
     ValidateFuncEvalReturnType(pDE->m_evalType , pDE->m_md->GetMethodTable());
     
     // If this is a new object operation, then we should have a .ctor.

--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -868,9 +868,6 @@
   <data name="Argument_CannotSetParentToInterface" xml:space="preserve">
     <value>Cannot set parent to an interface.</value>
   </data>
-  <data name="Argument_CantCallSecObjFunc" xml:space="preserve">
-    <value>Cannot evaluate a security function.</value>
-  </data>
   <data name="Argument_CodepageNotSupported" xml:space="preserve">
     <value>{0} is not a supported code page.</value>
   </data>


### PR DESCRIPTION
Func-eval'ing BCL methods with the DynamicSecurityMethod attribute causes an ArgumentException.

Port #13598 to release/2.0.0