### PR TITLE
Fixed NaN's GetHashCode and Equals invariant issue.

### DIFF
--- a/src/mscorlib/shared/System/Double.cs
+++ b/src/mscorlib/shared/System/Double.cs
@@ -238,6 +238,13 @@ namespace System
                 // Ensure that 0 and -0 have the same hash code
                 return 0;
             }
+
+            if (IsNaN(d))
+            {
+                // Ensure that all NaNs have the same hash code
+                return 1;
+            }
+
             long value = *(long*)(&d);
             return unchecked((int)value) ^ ((int)(value >> 32));
         }

--- a/src/mscorlib/shared/System/Double.cs
+++ b/src/mscorlib/shared/System/Double.cs
@@ -242,7 +242,7 @@ namespace System
             if (IsNaN(d))
             {
                 // Ensure that all NaNs have the same hash code
-                return 1;
+                d = double.NaN;
             }
 
             long value = *(long*)(&d);

--- a/src/mscorlib/shared/System/Double.cs
+++ b/src/mscorlib/shared/System/Double.cs
@@ -239,7 +239,9 @@ namespace System
                 return 0;
             }
 
-            if (IsNaN(d))
+#pragma warning disable 1718
+            if (d != d)
+#pragma warning restore
             {
                 // Ensure that all NaNs have the same hash code
                 d = double.NaN;

--- a/src/mscorlib/shared/System/Single.cs
+++ b/src/mscorlib/shared/System/Single.cs
@@ -234,7 +234,7 @@ namespace System
             if (IsNaN(f))
             {
                 // Ensure that all NaNs have the same hash code
-                return 1;
+                f = float.NaN;
             }
 
             int v = *(int*)(&f);

--- a/src/mscorlib/shared/System/Single.cs
+++ b/src/mscorlib/shared/System/Single.cs
@@ -230,6 +230,13 @@ namespace System
                 // Ensure that 0 and -0 have the same hash code
                 return 0;
             }
+
+            if (IsNaN(f))
+            {
+                // Ensure that all NaNs have the same hash code
+                return 1;
+            }
+
             int v = *(int*)(&f);
             return v;
         }

--- a/src/mscorlib/shared/System/Single.cs
+++ b/src/mscorlib/shared/System/Single.cs
@@ -231,7 +231,9 @@ namespace System
                 return 0;
             }
 
-            if (IsNaN(f))
+#pragma warning disable 1718
+            if (f != f)
+#pragma warning restore
             {
                 // Ensure that all NaNs have the same hash code
                 f = float.NaN;


### PR DESCRIPTION
This PR keeps the invariant of GetHashCode and Equals for NaNs. We always return 1 for GetHashCode of NaNs so that all NaNs have the same hash code.

Fix #6237