### PR TITLE
Add support for building under glibc 2.26

### DIFF
--- a/src/pal/src/config.h.in
+++ b/src/pal/src/config.h.in
@@ -77,6 +77,7 @@
 #cmakedefine01 HAVE_PT_REGS
 #cmakedefine01 HAVE_GREGSET_T
 #cmakedefine01 HAVE___GREGSET_T
+#cmakedefine01 HAVE_FPSTATE_GLIBC_RESERVED1
 #cmakedefine01 HAVE_SIGINFO_T
 #cmakedefine01 HAVE_UCONTEXT_T
 #cmakedefine01 HAVE_PTHREAD_RWLOCK_T

--- a/src/pal/src/configure.cmake
+++ b/src/pal/src/configure.cmake
@@ -136,6 +136,7 @@ check_struct_has_member ("struct stat" st_atimensec "sys/types.h;sys/stat.h" HAV
 check_struct_has_member ("struct tm" tm_gmtoff time.h HAVE_TM_GMTOFF)
 check_struct_has_member ("ucontext_t" uc_mcontext.gregs[0] ucontext.h HAVE_GREGSET_T)
 check_struct_has_member ("ucontext_t" uc_mcontext.__gregs[0] ucontext.h HAVE___GREGSET_T)
+check_struct_has_member ("ucontext_t" uc_mcontext.fpregs->__glibc_reserved1[0] ucontext.h HAVE_FPSTATE_GLIBC_RESERVED1)
 check_struct_has_member ("struct sysinfo" mem_unit "sys/sysinfo.h" HAVE_SYSINFO_WITH_MEM_UNIT)
 
 set(CMAKE_EXTRA_INCLUDE_FILES machine/reg.h)

--- a/src/pal/src/include/pal/context.h
+++ b/src/pal/src/include/pal/context.h
@@ -151,15 +151,21 @@ using asm_sigcontext::_xstate;
 
 #ifdef XSTATE_SUPPORTED
 
+#if HAVE_FPSTATE_GLIBC_RESERVED1
+#define FPSTATE_RESERVED __glibc_reserved1
+#else
+#define FPSTATE_RESERVED padding
+#endif
+
 inline _fpx_sw_bytes *FPREG_FpxSwBytes(const ucontext_t *uc)
 {
     // Bytes 464..511 in the FXSAVE format are available for software to use for any purpose. In this case, they are used to
     // indicate information about extended state.
-    _ASSERTE(reinterpret_cast<UINT8 *>(&FPREG_Fpstate(uc)->padding[12]) - reinterpret_cast<UINT8 *>(FPREG_Fpstate(uc)) == 464);
+    _ASSERTE(reinterpret_cast<UINT8 *>(&FPREG_Fpstate(uc)->FPSTATE_RESERVED[12]) - reinterpret_cast<UINT8 *>(FPREG_Fpstate(uc)) == 464);
 
     _ASSERTE(FPREG_Fpstate(uc) != nullptr);
 
-    return reinterpret_cast<_fpx_sw_bytes *>(&FPREG_Fpstate(uc)->padding[12]);
+    return reinterpret_cast<_fpx_sw_bytes *>(&FPREG_Fpstate(uc)->FPSTATE_RESERVED[12]);
 }
 
 inline UINT32 FPREG_ExtendedSize(const ucontext_t *uc)


### PR DESCRIPTION
glibc 2.26 renames a number of identifiers so they are reserved under POSIX. Specifically, `padding` becomes `__glibc_reserved1`. Add a configure test for it and use the appropriate field name.

See https://sourceware.org/bugzilla/show_bug.cgi?id=21457 for more information.

Resolves #13009