### PR TITLE
revert_13687

### DIFF
--- a/src/vm/arm64/cgencpu.h
+++ b/src/vm/arm64/cgencpu.h
@@ -79,6 +79,7 @@ typedef INT64 StackElemType;
 // !! This expression assumes STACK_ELEM_SIZE is a power of 2.
 #define StackElemSize(parmSize) (((parmSize) + STACK_ELEM_SIZE - 1) & ~((ULONG)(STACK_ELEM_SIZE - 1)))
 
+#ifdef FEATURE_PAL // TODO-ARM64-WINDOWS Add JIT_Stelem_Ref support
 //
 // JIT HELPERS.
 //
@@ -86,6 +87,7 @@ typedef INT64 StackElemType;
 //
 // optimized static helpers
 #define JIT_Stelem_Ref                      JIT_Stelem_Ref
+#endif
 
 //**********************************************************************
 // Frames


### PR DESCRIPTION
Pr #13687 introduced a stack overflow on windows Arm64 which hits every test. This will add the ifdef back that it removed.

/cc @dotnet/arm64-contrib