### PR TITLE
Segregate merged returns by constant value

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -8152,10 +8152,455 @@ bool Compiler::fgMoreThanOneReturnBlock()
     return false;
 }
 
+namespace
+{
+// Define a helper class for merging return blocks (which we do when the input has
+// more than the limit for this configuration).
+//
+// Notes: sets fgReturnCount, genReturnBB, and genReturnLocal.
+class MergedReturns
+{
+public:
+#ifdef JIT32_GCENCODER
+
+    // X86 GC encoding has a hard limit of SET_EPILOGCNT_MAX epilogs.
+    const static unsigned ReturnCountHardLimit = SET_EPILOGCNT_MAX;
+#else  // JIT32_GCENCODER
+
+    // We currently apply a hard limit of '4' to all other targets (see
+    // the other uses of SET_EPILOGCNT_MAX), though it would be good
+    // to revisit that decision based on CQ analysis.
+    const static unsigned ReturnCountHardLimit = 4;
+#endif // JIT32_GCENCODER
+
+private:
+    Compiler* comp;
+
+    // As we discover returns, we'll record them in `returnBlocks`, until
+    // the limit is reached, at which point we'll keep track of the merged
+    // return blocks in `returnBlocks`.
+    BasicBlock* returnBlocks[ReturnCountHardLimit];
+
+    // Each constant value returned gets its own merged return block that
+    // returns that constant (up to the limit on number of returns); in
+    // `returnConstants` we track the constant values returned by these
+    // merged constant return blocks.
+    ssize_t returnConstants[ReturnCountHardLimit];
+
+    // Number of return blocks allowed
+    PhasedVar<unsigned> maxReturns;
+
+    // Flag to keep track of when we've hit the limit of returns and are
+    // actively merging returns together.
+    bool mergingReturns = false;
+
+public:
+    MergedReturns(Compiler* comp) : comp(comp)
+    {
+        comp->fgReturnCount = 0;
+    }
+
+    void SetMaxReturns(unsigned value)
+    {
+        maxReturns = value;
+        maxReturns.MarkAsReadOnly();
+    }
+
+    //------------------------------------------------------------------------
+    // Record: Make note of a return block in the input program.
+    //
+    // Arguments:
+    //    returnBlock - Block in the input that has jump kind BBJ_RETURN
+    //
+    // Notes:
+    //    Updates fgReturnCount appropriately, and generates a merged return
+    //    block if necessary.  If a constant merged return block is used,
+    //    `returnBlock` is rewritten to jump to it.  If a non-constant return
+    //    block is used, `genReturnBB` is set to that block, and `genReturnLocal`
+    //    is set to the lclvar that it returns; morph will need to rewrite
+    //    `returnBlock` to set the local and jump to the return block in such
+    //    cases, which it will do after some key transformations like rewriting
+    //    tail calls and calls that return to hidden buffers.  In either of these
+    //    cases, `fgReturnCount` and the merged return block's profile information
+    //    will be updated to reflect or anticipate the rewrite of `returnBlock`.
+    //
+    void Record(BasicBlock* returnBlock)
+    {
+        // Add this return to our tally
+        unsigned oldReturnCount = comp->fgReturnCount++;
+
+        if (!mergingReturns)
+        {
+            if (oldReturnCount < maxReturns)
+            {
+                // No need to merge just yet; simply record this return.
+                returnBlocks[oldReturnCount] = returnBlock;
+                return;
+            }
+
+            // We'e reached our threshold
+            mergingReturns = true;
+
+            // Merge any returns we've already identified
+            for (unsigned i = 0, searchLimit = 0; i < oldReturnCount; ++i)
+            {
+                BasicBlock* mergedReturnBlock = Merge(returnBlocks[i], searchLimit);
+                if (returnBlocks[searchLimit] == mergedReturnBlock)
+                {
+                    // We've added a new block to the searchable set
+                    ++searchLimit;
+                }
+            }
+        }
+
+        // We have too many returns, so merge this one in.
+        // Search limit is new return count minus one (to exclude this block).
+        unsigned searchLimit = comp->fgReturnCount - 1;
+        Merge(returnBlock, searchLimit);
+    }
+
+    //------------------------------------------------------------------------
+    // EagerCreate: Force creation of a non-constant merged return block `genReturnBB`.
+    //
+    // Return Value:
+    //    The newly-created block which returns `genReturnLocal`.
+    //
+    BasicBlock* EagerCreate()
+    {
+        mergingReturns = true;
+        return Merge(nullptr, 0);
+    }
+
+private:
+    //------------------------------------------------------------------------
+    // CreateReturnBB: Create a basic block to serve as a merged return point, stored to
+    //    `returnBlocks` at the given index, and optionally returning the given constant.
+    //
+    // Arguments:
+    //    index - Index into `returnBlocks` to store the new block into.
+    //    returnConst - Constant that the new block should return; may be nullptr to
+    //      indicate that the new merged return is for the non-constant case, in which
+    //      case, if the method's return type is non-void, `comp->genReturnLocal` will
+    //      be initialized to a new local of the appropriate type, and the new block will
+    //      return it.
+    //
+    // Return Value:
+    //    The new merged return block.
+    //
+    BasicBlock* CreateReturnBB(unsigned index, GenTreeIntConCommon* returnConst = nullptr)
+    {
+        BasicBlock* newReturnBB = comp->fgNewBBinRegion(BBJ_RETURN);
+        newReturnBB->bbRefs     = 1; // bbRefs gets update later, for now it should be 1
+        comp->fgReturnCount++;
+
+        newReturnBB->bbFlags |= (BBF_INTERNAL | BBF_DONT_REMOVE);
+
+        noway_assert(newReturnBB->bbNext == nullptr);
+
+#ifdef DEBUG
+        if (comp->verbose)
+        {
+            printf("\n newReturnBB [BB%02u] created\n", newReturnBB->bbNum);
+        }
+#endif
+
+        // We have profile weight, the weight is zero, and the block is run rarely,
+        // until we prove otherwise by merging other returns into this one.
+        newReturnBB->bbFlags |= (BBF_PROF_WEIGHT | BBF_RUN_RARELY);
+        newReturnBB->bbWeight = 0;
+
+        GenTreePtr returnExpr;
+
+        if (returnConst != nullptr)
+        {
+            returnExpr             = comp->gtNewOperNode(GT_RETURN, returnConst->gtType, returnConst);
+            returnConstants[index] = returnConst->IconValue();
+        }
+        else if (comp->compMethodHasRetVal())
+        {
+            // There is a return value, so create a temp for it.  Real returns will store the value in there and
+            // it'll be reloaded by the single return.
+            unsigned returnLocalNum   = comp->lvaGrabTemp(true DEBUGARG("Single return block return value"));
+            comp->genReturnLocal      = returnLocalNum;
+            LclVarDsc& returnLocalDsc = comp->lvaTable[returnLocalNum];
+
+            if (comp->compMethodReturnsNativeScalarType())
+            {
+                returnLocalDsc.lvType = genActualType(comp->info.compRetNativeType);
+            }
+            else if (comp->compMethodReturnsRetBufAddr())
+            {
+                returnLocalDsc.lvType = TYP_BYREF;
+            }
+            else if (comp->compMethodReturnsMultiRegRetType())
+            {
+                returnLocalDsc.lvType = TYP_STRUCT;
+                comp->lvaSetStruct(returnLocalNum, comp->info.compMethodInfo->args.retTypeClass, true);
+                returnLocalDsc.lvIsMultiRegRet = true;
+            }
+            else
+            {
+                assert(!"unreached");
+            }
+
+            if (varTypeIsFloating(returnLocalDsc.lvType))
+            {
+                comp->compFloatingPointUsed = true;
+            }
+
+            if (!varTypeIsFloating(comp->info.compRetType))
+            {
+                returnLocalDsc.setPrefReg(REG_INTRET, comp);
+            }
+#ifdef REG_FLOATRET
+            else
+            {
+                returnLocalDsc.setPrefReg(REG_FLOATRET, comp);
+            }
+#endif
+
+#ifdef DEBUG
+            // This temporary should not be converted to a double in stress mode,
+            // because we introduce assigns to it after the stress conversion
+            returnLocalDsc.lvKeepType = 1;
+#endif
+
+            GenTreePtr retTemp = comp->gtNewLclvNode(returnLocalNum, returnLocalDsc.TypeGet());
+
+            // make sure copy prop ignores this node (make sure it always does a reload from the temp).
+            retTemp->gtFlags |= GTF_DONT_CSE;
+            returnExpr = comp->gtNewOperNode(GT_RETURN, retTemp->gtType, retTemp);
+        }
+        else
+        {
+            // return void
+            noway_assert(comp->info.compRetType == TYP_VOID || varTypeIsStruct(comp->info.compRetType));
+            comp->genReturnLocal = BAD_VAR_NUM;
+
+            returnExpr = new (comp, GT_RETURN) GenTreeOp(GT_RETURN, TYP_VOID);
+        }
+
+        // Add 'return' expression to the return block
+        comp->fgInsertStmtAtEnd(newReturnBB, returnExpr);
+        // Flag that this 'return' was generated by return merging so that subsequent
+        // return block morhping will know to leave it alone.
+        returnExpr->gtFlags |= GTF_RET_MERGED;
+
+#ifdef DEBUG
+        if (comp->verbose)
+        {
+            printf("\nmergeReturns statement tree ");
+            Compiler::printTreeID(returnExpr);
+            printf(" added to genReturnBB %s\n", newReturnBB->dspToString());
+            comp->gtDispTree(returnExpr);
+            printf("\n");
+        }
+#endif
+        assert(index < maxReturns);
+        returnBlocks[index] = newReturnBB;
+        return newReturnBB;
+    }
+
+    //------------------------------------------------------------------------
+    // Merge: Find or create an appropriate merged return block for the given input block.
+    //
+    // Arguments:
+    //    returnBlock - Return block from the input program to find a merged return for.
+    //                  May be nullptr to indicate that new block suitable for non-constant
+    //                  returns should be generated but no existing block modified.
+    //    searchLimit - Blocks in `returnBlocks` up to but not including index `searchLimit`
+    //                  will be checked to see if we already have an appropriate merged return
+    //                  block for this case.  If a new block must be created, it will be stored
+    //                  to `returnBlocks` at index `searchLimit`.
+    //
+    // Return Value:
+    //    Merged return block suitable for handling this return value.  May be newly-created
+    //    or pre-existing.
+    //
+    // Notes:
+    //    If a constant-valued merged return block is used, `returnBlock` will be rewritten to
+    //    jump to the merged return block and its `GT_RETURN` statement will be removed.  If
+    //    a non-constant-valued merged return block is used, `genReturnBB` and `genReturnLocal`
+    //    will be set so that Morph can perform that rewrite, which it will do after some key
+    //    transformations like rewriting tail calls and calls that return to hidden buffers.
+    //    In either of these cases, `fgReturnCount` and the merged return block's profile
+    //    information will be updated to reflect or anticipate the rewrite of `returnBlock`.
+    //
+    BasicBlock* Merge(BasicBlock* returnBlock, unsigned searchLimit)
+    {
+        assert(mergingReturns);
+
+        BasicBlock* mergedReturnBlock = nullptr;
+        if ((returnBlock != nullptr) && (maxReturns > 1))
+        {
+            // Check to see if this is a constant return so that we can search
+            // for and/or create a constant return block for it.
+
+            GenTreeIntConCommon* retConst = GetReturnConst(returnBlock);
+            if (retConst != nullptr)
+            {
+                // We have a constant.  Now find or create a corresponding return block.
+
+                BasicBlock* constReturnBlock = FindConstReturnBlock(retConst, searchLimit);
+
+                if (constReturnBlock == nullptr)
+                {
+                    // We didn't find a const return block.  See if we have space left
+                    // to make one.
+
+                    // We have already allocated `searchLimit` slots.
+                    unsigned slotsReserved = searchLimit;
+                    if (comp->genReturnBB == nullptr)
+                    {
+                        // We haven't made a non-const return yet, so we have to reserve
+                        // a slot for one.
+                        ++slotsReserved;
+                    }
+
+                    if (slotsReserved < maxReturns)
+                    {
+                        // We have enough space to allocate a slot for this constant.
+                        constReturnBlock = CreateReturnBB(searchLimit, retConst);
+                    }
+                }
+
+                if (constReturnBlock != nullptr)
+                {
+                    // Found a constant merged return block.
+                    mergedReturnBlock = constReturnBlock;
+
+                    // Change BBJ_RETURN to BBJ_ALWAYS targeting const return block.
+                    assert((comp->info.compFlags & CORINFO_FLG_SYNCH) == 0);
+                    returnBlock->bbJumpKind = BBJ_ALWAYS;
+                    returnBlock->bbJumpDest = constReturnBlock;
+
+                    // Remove GT_RETURN since constReturnBlock returns the constant.
+                    assert(returnBlock->lastStmt()->gtStmtExpr->OperIs(GT_RETURN));
+                    assert(returnBlock->lastStmt()->gtStmtExpr->gtGetOp1()->IsIntegralConst());
+                    comp->fgRemoveStmt(returnBlock, returnBlock->lastStmt());
+                }
+            }
+        }
+
+        if (mergedReturnBlock == nullptr)
+        {
+            // No constant return block for this return; use the general one.
+            mergedReturnBlock = comp->genReturnBB;
+            if (mergedReturnBlock == nullptr)
+            {
+                // No general merged return for this function yet; create one.
+                // There had better still be room left in the array.
+                assert(searchLimit < maxReturns);
+                mergedReturnBlock = CreateReturnBB(searchLimit);
+                comp->genReturnBB = mergedReturnBlock;
+            }
+        }
+
+        if (returnBlock != nullptr)
+        {
+            // Propagate profile weight and related annotations to the merged block.
+            // Return weight should never exceed entry weight, so cap it to avoid nonsensical
+            // hot returns in synthetic profile settings.
+            mergedReturnBlock->bbWeight =
+                min(mergedReturnBlock->bbWeight + returnBlock->bbWeight, comp->fgFirstBB->bbWeight);
+            if (!returnBlock->hasProfileWeight())
+            {
+                mergedReturnBlock->bbFlags &= ~BBF_PROF_WEIGHT;
+            }
+            if (mergedReturnBlock->bbWeight > 0)
+            {
+                mergedReturnBlock->bbFlags &= ~BBF_RUN_RARELY;
+            }
+
+            // Update fgReturnCount to reflect or anticipate that `returnBlock` will no longer
+            // be a return point.
+            comp->fgReturnCount--;
+        }
+
+        return mergedReturnBlock;
+    }
+
+    //------------------------------------------------------------------------
+    // GetReturnConst: If the given block returns an integral constant, return the
+    //     GenTreeIntConCommon that represents the constant.
+    //
+    // Arguments:
+    //    returnBlock - Block whose return value is to be inspected.
+    //
+    // Return Value:
+    //    GenTreeIntCommon that is the argument of `returnBlock`'s `GT_RETURN` if
+    //    such exists; nullptr otherwise.
+    //
+    static GenTreeIntConCommon* GetReturnConst(BasicBlock* returnBlock)
+    {
+        GenTreeStmt* lastStmt = returnBlock->lastStmt();
+        if (lastStmt == nullptr)
+        {
+            return nullptr;
+        }
+
+        GenTreePtr lastExpr = lastStmt->gtStmtExpr;
+        if (!lastExpr->OperIs(GT_RETURN))
+        {
+            return nullptr;
+        }
+
+        GenTreePtr retExpr = lastExpr->gtGetOp1();
+        if ((retExpr == nullptr) || !retExpr->IsIntegralConst())
+        {
+            return nullptr;
+        }
+
+        return retExpr->AsIntConCommon();
+    }
+
+    //------------------------------------------------------------------------
+    // FindConstReturnBlock: Scan the already-created merged return blocks, up to `searchLimit`,
+    //     and return the one corresponding to the given const expression if it exists.
+    //
+    // Arguments:
+    //    constExpr - GenTreeIntCommon representing the constant return value we're
+    //        searching for.
+    //    searchLimit - Check `returnBlocks`/`returnConstants` up to but not including
+    //        this index.
+    //
+    // Return Value:
+    //    A block that returns the same constant, if one is found; otherwise nullptr.
+    //
+    BasicBlock* FindConstReturnBlock(GenTreeIntConCommon* constExpr, unsigned searchLimit)
+    {
+        ssize_t constVal = constExpr->IconValue();
+
+        for (unsigned i = 0; i < searchLimit; ++i)
+        {
+            // Need to check both for matching const val and for genReturnBB
+            // because genReturnBB is used for non-constant returns and its
+            // corresponding entry in the returnConstants array is garbage.
+            if (returnConstants[i] == constVal)
+            {
+                BasicBlock* returnBlock = returnBlocks[i];
+
+                if (returnBlock == comp->genReturnBB)
+                {
+                    // This is the block used for non-constant returns, so
+                    // its returnConstants entry is just garbage; don't be
+                    // fooled.
+                    continue;
+                }
+
+                return returnBlock;
+            }
+        }
+
+        return nullptr;
+    }
+};
+}
+
 /*****************************************************************************
- *
- *  Add any internal blocks/trees we may need
- */
+*
+*  Add any internal blocks/trees we may need
+*/
 
 void Compiler::fgAddInternal()
 {
@@ -8172,17 +8617,17 @@ void Compiler::fgAddInternal()
 #endif // !LEGACY_BACKEND
 
     /*
-        <BUGNUM> VSW441487 </BUGNUM>
+    <BUGNUM> VSW441487 </BUGNUM>
 
-        The "this" pointer is implicitly used in the following cases:
-            1. Locking of synchronized methods
-            2. Dictionary access of shared generics code
-            3. If a method has "catch(FooException<T>)", the EH code accesses "this" to determine T.
-            4. Initializing the type from generic methods which require precise cctor semantics
-            5. Verifier does special handling of "this" in the .ctor
+    The "this" pointer is implicitly used in the following cases:
+    1. Locking of synchronized methods
+    2. Dictionary access of shared generics code
+    3. If a method has "catch(FooException<T>)", the EH code accesses "this" to determine T.
+    4. Initializing the type from generic methods which require precise cctor semantics
+    5. Verifier does special handling of "this" in the .ctor
 
-        However, we might overwrite it with a "starg 0".
-        In this case, we will redirect all "ldarg(a)/starg(a) 0" to a temp lvaTable[lvaArg0Var]
+    However, we might overwrite it with a "starg 0".
+    In this case, we will redirect all "ldarg(a)/starg(a) 0" to a temp lvaTable[lvaArg0Var]
     */
 
     if (!info.compIsStatic)
@@ -8196,7 +8641,7 @@ void Compiler::fgAddInternal()
 #ifndef JIT32_GCENCODER
             lva0CopiedForGenericsCtxt = ((info.compMethodInfo->options & CORINFO_GENERICS_CTXT_FROM_THIS) != 0);
 #else  // JIT32_GCENCODER
-            lva0CopiedForGenericsCtxt = false;
+            lva0CopiedForGenericsCtxt          = false;
 #endif // JIT32_GCENCODER
             noway_assert(lva0CopiedForGenericsCtxt || !lvaTable[info.compThisArg].lvAddrExposed);
             noway_assert(!lvaTable[info.compThisArg].lvHasILStoreOp);
@@ -8242,448 +8687,7 @@ void Compiler::fgAddInternal()
     }
 
     // Merge return points if required or beneficial
-    CLANG_FORMAT_COMMENT_ANCHOR;
-
-#ifdef JIT32_GCENCODER
-
-    // X86 GC encoding has a hard limit of SET_EPILOGCNT_MAX epilogs.
-    const unsigned returnCountHardLimit = SET_EPILOGCNT_MAX;
-#else  // JIT32_GCENCODER
-
-    // We currently apply a hard limit of '4' to all other targets (see
-    // the other uses of SET_EPILOGCNT_MAX), though it would be good
-    // to revisit that decision based on CQ analysis.
-    const unsigned returnCountHardLimit = 4;
-#endif // JIT32_GCENCODER
-
-    // Define a helper class for merging return blocks (which we do when the input has
-    // more than the limit for this configuration).
-    //
-    // Notes: sets fgReturnCount, genReturnBB, and genReturnLocal.
-    class MergedReturns
-    {
-        Compiler* comp;
-
-        // As we discover returns, we'll record them in `returnBlocks`, until
-        // the limit is reached, at which point we'll keep track of the merged
-        // return blocks in `returnBlocks`.
-        BasicBlock* returnBlocks[returnCountHardLimit];
-
-        // Each constant value returned gets its own merged return block that
-        // returns that constant (up to the limit on number of returns); in
-        // `returnConstants` we track the constant values returned by these
-        // merged constant return blocks.
-        ssize_t returnConstants[returnCountHardLimit];
-
-        // Number of return blocks allowed
-        PhasedVar<unsigned> maxReturns;
-
-        // Flag to keep track of when we've hit the limit of returns and are
-        // actively merging returns together.
-        bool mergingReturns = false;
-
-    public:
-        MergedReturns(Compiler* comp) : comp(comp)
-        {
-            comp->fgReturnCount = 0;
-        }
-
-        void SetMaxReturns(unsigned value)
-        {
-            maxReturns = value;
-            maxReturns.MarkAsReadOnly();
-        }
-
-        //------------------------------------------------------------------------
-        // Record: Make note of a return block in the input program.
-        //
-        // Arguments:
-        //    returnBlock - Block in the input that has jump kind BBJ_RETURN
-        //
-        // Notes:
-        //    Updates fgReturnCount appropriately, and generates a merged return
-        //    block if necessary.  If a constant merged return block is used,
-        //    `returnBlock` is rewritten to jump to it.  If a non-constant return
-        //    block is used, `genReturnBB` is set to that block, and `genReturnLocal`
-        //    is set to the lclvar that it returns; morph will need to rewrite
-        //    `returnBlock` to set the local and jump to the return block in such
-        //    cases, which it will do after some key transformations like rewriting
-        //    tail calls and calls that return to hidden buffers.  In either of these
-        //    cases, `fgReturnCount` and the merged return block's profile information
-        //    will be updated to reflect or anticipate the rewrite of `returnBlock`.
-        //
-        void Record(BasicBlock* returnBlock)
-        {
-            // Add this return to our tally
-            unsigned oldReturnCount = comp->fgReturnCount++;
-
-            if (!mergingReturns)
-            {
-                if (oldReturnCount < maxReturns)
-                {
-                    // No need to merge just yet; simply record this return.
-                    returnBlocks[oldReturnCount] = returnBlock;
-                    return;
-                }
-
-                // We'e reached our threshold
-                mergingReturns = true;
-
-                // Merge any returns we've already identified
-                for (unsigned i = 0, searchLimit = 0; i < oldReturnCount; ++i)
-                {
-                    BasicBlock* mergedReturnBlock = Merge(returnBlocks[i], searchLimit);
-                    if (returnBlocks[searchLimit] == mergedReturnBlock)
-                    {
-                        // We've added a new block to the searchable set
-                        ++searchLimit;
-                    }
-                }
-            }
-
-            // We have too many returns, so merge this one in.
-            // Search limit is new return count minus one (to exclude this block).
-            unsigned searchLimit = comp->fgReturnCount - 1;
-            Merge(returnBlock, searchLimit);
-        }
-
-        //------------------------------------------------------------------------
-        // EagerCreate: Force creation of a non-constant merged return block `genReturnBB`.
-        //
-        // Return Value:
-        //    The newly-created block which returns `genReturnLocal`.
-        //
-        BasicBlock* EagerCreate()
-        {
-            mergingReturns = true;
-            return Merge(nullptr, 0);
-        }
-
-    private:
-        //------------------------------------------------------------------------
-        // CreateReturnBB: Create a basic block to serve as a merged return point, stored to
-        //    `returnBlocks` at the given index, and optionally returning the given constant.
-        //
-        // Arguments:
-        //    index - Index into `returnBlocks` to store the new block into.
-        //    returnConst - Constant that the new block should return; may be nullptr to
-        //      indicate that the new merged return is for the non-constant case, in which
-        //      case, if the method's return type is non-void, `comp->genReturnLocal` will
-        //      be initialized to a new local of the appropriate type, and the new block will
-        //      return it.
-        //
-        // Return Value:
-        //    The new merged return block.
-        //
-        BasicBlock* CreateReturnBB(unsigned index, GenTreeIntConCommon* returnConst = nullptr)
-        {
-            BasicBlock* newReturnBB = comp->fgNewBBinRegion(BBJ_RETURN);
-            newReturnBB->bbRefs     = 1; // bbRefs gets update later, for now it should be 1
-            comp->fgReturnCount++;
-
-            newReturnBB->bbFlags |= (BBF_INTERNAL | BBF_DONT_REMOVE);
-
-            noway_assert(newReturnBB->bbNext == nullptr);
-
-#ifdef DEBUG
-            if (comp->verbose)
-            {
-                printf("\n newReturnBB [BB%02u] created\n", newReturnBB->bbNum);
-            }
-#endif
-
-            // We have profile weight, the weight is zero, and the block is run rarely,
-            // until we prove otherwise by merging other returns into this one.
-            newReturnBB->bbFlags |= (BBF_PROF_WEIGHT | BBF_RUN_RARELY);
-            newReturnBB->bbWeight = 0;
-
-            GenTreePtr returnExpr;
-
-            if (returnConst != nullptr)
-            {
-                returnExpr             = comp->gtNewOperNode(GT_RETURN, returnConst->gtType, returnConst);
-                returnConstants[index] = returnConst->IconValue();
-            }
-            else if (comp->compMethodHasRetVal())
-            {
-                // There is a return value, so create a temp for it.  Real returns will store the value in there and
-                // it'll be reloaded by the single return.
-                unsigned returnLocalNum   = comp->lvaGrabTemp(true DEBUGARG("Single return block return value"));
-                comp->genReturnLocal      = returnLocalNum;
-                LclVarDsc& returnLocalDsc = comp->lvaTable[returnLocalNum];
-
-                if (comp->compMethodReturnsNativeScalarType())
-                {
-                    returnLocalDsc.lvType = genActualType(comp->info.compRetNativeType);
-                }
-                else if (comp->compMethodReturnsRetBufAddr())
-                {
-                    returnLocalDsc.lvType = TYP_BYREF;
-                }
-                else if (comp->compMethodReturnsMultiRegRetType())
-                {
-                    returnLocalDsc.lvType = TYP_STRUCT;
-                    comp->lvaSetStruct(returnLocalNum, comp->info.compMethodInfo->args.retTypeClass, true);
-                    returnLocalDsc.lvIsMultiRegRet = true;
-                }
-                else
-                {
-                    assert(!"unreached");
-                }
-
-                if (varTypeIsFloating(returnLocalDsc.lvType))
-                {
-                    comp->compFloatingPointUsed = true;
-                }
-
-                if (!varTypeIsFloating(comp->info.compRetType))
-                {
-                    returnLocalDsc.setPrefReg(REG_INTRET, comp);
-                }
-#ifdef REG_FLOATRET
-                else
-                {
-                    returnLocalDsc.setPrefReg(REG_FLOATRET, comp);
-                }
-#endif
-
-#ifdef DEBUG
-                // This temporary should not be converted to a double in stress mode,
-                // because we introduce assigns to it after the stress conversion
-                returnLocalDsc.lvKeepType = 1;
-#endif
-
-                GenTreePtr retTemp = comp->gtNewLclvNode(returnLocalNum, returnLocalDsc.TypeGet());
-
-                // make sure copy prop ignores this node (make sure it always does a reload from the temp).
-                retTemp->gtFlags |= GTF_DONT_CSE;
-                returnExpr = comp->gtNewOperNode(GT_RETURN, retTemp->gtType, retTemp);
-            }
-            else
-            {
-                // return void
-                noway_assert(comp->info.compRetType == TYP_VOID || varTypeIsStruct(comp->info.compRetType));
-                comp->genReturnLocal = BAD_VAR_NUM;
-
-                returnExpr = new (comp, GT_RETURN) GenTreeOp(GT_RETURN, TYP_VOID);
-            }
-
-            // Add 'return' expression to the return block
-            comp->fgInsertStmtAtEnd(newReturnBB, returnExpr);
-            // Flag that this 'return' was generated by return merging so that subsequent
-            // return block morhping will know to leave it alone.
-            returnExpr->gtFlags |= GTF_RET_MERGED;
-
-#ifdef DEBUG
-            if (comp->verbose)
-            {
-                printf("\nmergeReturns statement tree ");
-                printTreeID(returnExpr);
-                printf(" added to genReturnBB %s\n", newReturnBB->dspToString());
-                comp->gtDispTree(returnExpr);
-                printf("\n");
-            }
-#endif
-            assert(index < maxReturns);
-            returnBlocks[index] = newReturnBB;
-            return newReturnBB;
-        }
-
-        //------------------------------------------------------------------------
-        // Merge: Find or create an appropriate merged return block for the given input block.
-        //
-        // Arguments:
-        //    returnBlock - Return block from the input program to find a merged return for.
-        //                  May be nullptr to indicate that new block suitable for non-constant
-        //                  returns should be generated but no existing block modified.
-        //    searchLimit - Blocks in `returnBlocks` up to but not including index `searchLimit`
-        //                  will be checked to see if we already have an appropriate merged return
-        //                  block for this case.  If a new block must be created, it will be stored
-        //                  to `returnBlocks` at index `searchLimit`.
-        //
-        // Return Value:
-        //    Merged return block suitable for handling this return value.  May be newly-created
-        //    or pre-existing.
-        //
-        // Notes:
-        //    If a constant-valued merged return block is used, `returnBlock` will be rewritten to
-        //    jump to the merged return block and its `GT_RETURN` statement will be removed.  If
-        //    a non-constant-valued merged return block is used, `genReturnBB` and `genReturnLocal`
-        //    will be set so that Morph can perform that rewrite, which it will do after some key
-        //    transformations like rewriting tail calls and calls that return to hidden buffers.
-        //    In either of these cases, `fgReturnCount` and the merged return block's profile
-        //    information will be updated to reflect or anticipate the rewrite of `returnBlock`.
-        //
-        BasicBlock* Merge(BasicBlock* returnBlock, unsigned searchLimit)
-        {
-            assert(mergingReturns);
-
-            BasicBlock* mergedReturnBlock = nullptr;
-            if ((returnBlock != nullptr) && (maxReturns > 1))
-            {
-                // Check to see if this is a constant return so that we can search
-                // for and/or create a constant return block for it.
-
-                GenTreeIntConCommon* retConst = GetReturnConst(returnBlock);
-                if (retConst != nullptr)
-                {
-                    // We have a constant.  Now find or create a corresponding return block.
-
-                    BasicBlock* constReturnBlock = FindConstReturnBlock(retConst, searchLimit);
-
-                    if (constReturnBlock == nullptr)
-                    {
-                        // We didn't find a const return block.  See if we have space left
-                        // to make one.
-
-                        // We have already allocated `searchLimit` slots.
-                        unsigned slotsReserved = searchLimit;
-                        if (comp->genReturnBB == nullptr)
-                        {
-                            // We haven't made a non-const return yet, so we have to reserve
-                            // a slot for one.
-                            ++slotsReserved;
-                        }
-
-                        if (slotsReserved < maxReturns)
-                        {
-                            // We have enough space to allocate a slot for this constant.
-                            constReturnBlock = CreateReturnBB(searchLimit, retConst);
-                        }
-                    }
-
-                    if (constReturnBlock != nullptr)
-                    {
-                        // Found a constant merged return block.
-                        mergedReturnBlock = constReturnBlock;
-
-                        // Change BBJ_RETURN to BBJ_ALWAYS targeting const return block.
-                        assert((comp->info.compFlags & CORINFO_FLG_SYNCH) == 0);
-                        returnBlock->bbJumpKind = BBJ_ALWAYS;
-                        returnBlock->bbJumpDest = constReturnBlock;
-
-                        // Remove GT_RETURN since constReturnBlock returns the constant.
-                        assert(returnBlock->lastStmt()->gtStmtExpr->OperIs(GT_RETURN));
-                        assert(returnBlock->lastStmt()->gtStmtExpr->gtGetOp1()->IsIntegralConst());
-                        comp->fgRemoveStmt(returnBlock, returnBlock->lastStmt());
-                    }
-                }
-            }
-
-            if (mergedReturnBlock == nullptr)
-            {
-                // No constant return block for this return; use the general one.
-                mergedReturnBlock = comp->genReturnBB;
-                if (mergedReturnBlock == nullptr)
-                {
-                    // No general merged return for this function yet; create one.
-                    // There had better still be room left in the array.
-                    assert(searchLimit < maxReturns);
-                    mergedReturnBlock = CreateReturnBB(searchLimit);
-                    comp->genReturnBB = mergedReturnBlock;
-                }
-            }
-
-            if (returnBlock != nullptr)
-            {
-                // Propagate profile weight and related annotations to the merged block.
-                // Return weight should never exceed entry weight, so cap it to avoid nonsensical
-                // hot returns in synthetic profile settings.
-                mergedReturnBlock->bbWeight =
-                    min(mergedReturnBlock->bbWeight + returnBlock->bbWeight, comp->fgFirstBB->bbWeight);
-                if (!returnBlock->hasProfileWeight())
-                {
-                    mergedReturnBlock->bbFlags &= ~BBF_PROF_WEIGHT;
-                }
-                if (mergedReturnBlock->bbWeight > 0)
-                {
-                    mergedReturnBlock->bbFlags &= ~BBF_RUN_RARELY;
-                }
-
-                // Update fgReturnCount to reflect or anticipate that `returnBlock` will no longer
-                // be a return point.
-                comp->fgReturnCount--;
-            }
-
-            return mergedReturnBlock;
-        }
-
-        //------------------------------------------------------------------------
-        // GetReturnConst: If the given block returns an integral constant, return the
-        //     GenTreeIntConCommon that represents the constant.
-        //
-        // Arguments:
-        //    returnBlock - Block whose return value is to be inspected.
-        //
-        // Return Value:
-        //    GenTreeIntCommon that is the argument of `returnBlock`'s `GT_RETURN` if
-        //    such exists; nullptr otherwise.
-        //
-        static GenTreeIntConCommon* GetReturnConst(BasicBlock* returnBlock)
-        {
-            GenTreeStmt* lastStmt = returnBlock->lastStmt();
-            if (lastStmt == nullptr)
-            {
-                return nullptr;
-            }
-
-            GenTreePtr lastExpr = lastStmt->gtStmtExpr;
-            if (!lastExpr->OperIs(GT_RETURN))
-            {
-                return nullptr;
-            }
-
-            GenTreePtr retExpr = lastExpr->gtGetOp1();
-            if ((retExpr == nullptr) || !retExpr->IsIntegralConst())
-            {
-                return nullptr;
-            }
-
-            return retExpr->AsIntConCommon();
-        }
-
-        //------------------------------------------------------------------------
-        // FindConstReturnBlock: Scan the already-created merged return blocks, up to `searchLimit`,
-        //     and return the one corresponding to the given const expression if it exists.
-        //
-        // Arguments:
-        //    constExpr - GenTreeIntCommon representing the constant return value we're
-        //        searching for.
-        //    searchLimit - Check `returnBlocks`/`returnConstants` up to but not including
-        //        this index.
-        //
-        // Return Value:
-        //    A block that returns the same constant, if one is found; otherwise nullptr.
-        //
-        BasicBlock* FindConstReturnBlock(GenTreeIntConCommon* constExpr, unsigned searchLimit)
-        {
-            ssize_t constVal = constExpr->IconValue();
-
-            for (unsigned i = 0; i < searchLimit; ++i)
-            {
-                // Need to check both for matching const val and for genReturnBB
-                // because genReturnBB is used for non-constant returns and its
-                // corresponding entry in the returnConstants array is garbage.
-                if (returnConstants[i] == constVal)
-                {
-                    BasicBlock* returnBlock = returnBlocks[i];
-
-                    if (returnBlock == comp->genReturnBB)
-                    {
-                        // This is the block used for non-constant returns, so
-                        // its returnConstants entry is just garbage; don't be
-                        // fooled.
-                        continue;
-                    }
-
-                    return returnBlock;
-                }
-            }
-
-            return nullptr;
-        }
-
-    } merger(this);
+    MergedReturns merger(this);
 
 #if FEATURE_EH_FUNCLETS
     // Add the synchronized method enter/exit calls and try/finally protection. Note
@@ -8742,7 +8746,7 @@ void Compiler::fgAddInternal()
         }
         else
         {
-            merger.SetMaxReturns(returnCountHardLimit);
+            merger.SetMaxReturns(MergedReturns::ReturnCountHardLimit);
         }
     }
 

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -8115,7 +8115,7 @@ void Compiler::fgAddReversePInvokeEnterExit()
 
     assert(genReturnBB != nullptr);
 
-    fgInsertStmtAtEnd(genReturnBB, tree);
+    fgInsertStmtNearEnd(genReturnBB, tree);
 
 #ifdef DEBUG
     if (verbose)
@@ -8850,7 +8850,7 @@ void Compiler::fgAddInternal()
             tree = gtNewHelperCallNode(CORINFO_HELP_MON_EXIT, TYP_VOID, gtNewArgList(tree));
         }
 
-        fgInsertStmtAtEnd(genReturnBB, tree);
+        fgInsertStmtNearEnd(genReturnBB, tree);
 
 #ifdef DEBUG
         if (verbose)

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -991,6 +991,8 @@ public:
 #define GTF_RELOP_ZTT               0x08000000 // GT_<relop> -- Loop test cloned for converting while-loops into do-while
                                                //               with explicit "loop test" in the header block.
 
+#define GTF_RET_MERGED              0x80000000 // GT_RETURN -- This is a return generated during epilog merging.
+
 #define GTF_QMARK_CAST_INSTOF       0x80000000 // GT_QMARK -- Is this a top (not nested) level qmark created for
                                                //             castclass or instanceof?
 

--- a/tests/src/JIT/opt/Loops/SearchLoopTail.cs
+++ b/tests/src/JIT/opt/Loops/SearchLoopTail.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Test for tail merging/duplication of search loops returning constants.
+
+using System.Runtime.CompilerServices;
+
+namespace N
+{
+    public static class C
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static bool HasPrimeUnderTwenty(int first, int last)
+        {
+            for (int n = first; n <= last; ++n)
+            {
+                if (n == 2) return true;
+                if (n == 3) return true;
+                if (n == 5) return true;
+                if (n == 7) return true;
+                if (n == 11) return true;
+                if (n == 13) return true;
+                if (n == 17) return true;
+                if (n == 19) return true;
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static int Distance_abCD(string s)
+        {
+            int c_index = 0;
+            bool sawA = false;
+            bool sawB = false;
+            int index = 0;
+
+            foreach (char c in s)
+            {
+                if (c == 'A') sawA = true;
+                if (c == 'B')
+                {
+                    if (!sawA) return -1;
+                    sawB = true;
+                }
+                if (c == 'C')
+                {
+                    if (!sawB) return -1;
+                    c_index = index;
+                }
+                if (c == 'D')
+                {
+                    if (c_index == 0) return -1;
+                    return (index - c_index);
+                }
+                ++index;
+            }
+
+            return -1;
+        }
+
+        public static int Main(string[] args)
+        {
+            if (HasPrimeUnderTwenty(22, 36) || !HasPrimeUnderTwenty(-1, 4))
+            {
+                return -1;
+            }
+
+            if ((Distance_abCD("xxxxAyyyyBzyzyzC1234D") != 5) || (Distance_abCD("nnABmmDC") != -1))
+            {
+                return -1;
+            }
+
+            return 100;
+        }
+    }
+}

--- a/tests/src/JIT/opt/Loops/SearchLoopTail.csproj
+++ b/tests/src/JIT/opt/Loops/SearchLoopTail.csproj
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{9CB0C981-4704-41FD-9061-915DE23663F2}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT	.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
The JIT enforces a limit on the number of epilogs emitted in any given
method.  Change the logic so that when this merging kicks in, returns of
constant values are given merged return blocks distinct from each other
and from the general return block, as long as we can do so without going
over the limit.  This particularly helps avoid redundancy (while still
keeping method size down) in methods with a large number of constant
returns but only a few distinct constants, which is true of many
predicate methods with bool return type.

This is the compiler portion of #13466 and dotnet/corefx#23395.