### PR TITLE
[RyuJIT/ARM32] Add ADDR and fixup return type correctly

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -8136,41 +8136,6 @@ GenTreePtr Compiler::impFixupCallStructReturn(GenTreeCall* call, CORINFO_CLASS_H
 
 #else // not FEATURE_UNIX_AMD64_STRUCT_PASSING
 
-#if FEATURE_MULTIREG_RET && defined(_TARGET_ARM_)
-    // There is no fixup necessary if the return type is a HFA struct.
-    // HFA structs are returned in registers for ARM32 and ARM64
-    //
-    if (!call->IsVarargs() && IsHfa(retClsHnd))
-    {
-        if (call->CanTailCall())
-        {
-            if (info.compIsVarArgs)
-            {
-                // We cannot tail call because control needs to return to fixup the calling
-                // convention for result return.
-                call->gtCallMoreFlags &= ~GTF_CALL_M_EXPLICIT_TAILCALL;
-            }
-            else
-            {
-                // If we can tail call returning HFA, then don't assign it to
-                // a variable back and forth.
-                return call;
-            }
-        }
-
-        if (call->gtFlags & GTF_CALL_INLINE_CANDIDATE)
-        {
-            return call;
-        }
-
-        unsigned retRegCount = retTypeDesc->GetReturnRegCount();
-        if (retRegCount >= 2)
-        {
-            return impAssignMultiRegTypeToVar(call, retClsHnd);
-        }
-    }
-#endif // _TARGET_ARM_
-
     // Check for TYP_STRUCT type that wraps a primitive type
     // Such structs are returned using a single register
     // and we change the return type on those calls here.

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -630,6 +630,17 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
             TreeNodeInfoInitCall(tree->AsCall());
             break;
 
+        case GT_ADDR:
+        {
+            // For a GT_ADDR, the child node should not be evaluated into a register
+            GenTreePtr child = tree->gtOp.gtOp1;
+            assert(!isCandidateLocalRef(child));
+            assert(child->isContained());
+            assert(info->dstCount == 1);
+            info->srcCount = 0;
+        }
+        break;
+
         case GT_STORE_BLK:
         case GT_STORE_OBJ:
         case GT_STORE_DYN_BLK:


### PR DESCRIPTION
Fix #13739 

- Add ADDR case for `TreeNodeInfoInit()`
- We don't need special handling of HFA for ARM32 anymore.


