### PR TITLE
Fix incorrect treatment of pointer as fixed

### DIFF
--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -709,7 +709,7 @@ INT_PTR QCALLTYPE EventPipeInternal::CreateProvider(
 
     BEGIN_QCALL;
 
-    pProvider = EventPipe::CreateProvider(SL(providerName), pCallbackFunc, NULL);
+    pProvider = EventPipe::CreateProvider(providerName, pCallbackFunc, NULL);
 
     END_QCALL;
 


### PR DESCRIPTION
Previous to this commit I erroneously constructed a string literal upon receiving the provider name across a QCALL boundary. After more extensive use the error started to appear that names would be randomly replaced by garbage, with led me to find my error