### PR TITLE
Do not remove NOPs used by calls.

### DIFF
--- a/tests/src/JIT/Regression/JitBlue/DevDiv_487703/DevDiv_487703.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_487703/DevDiv_487703.il
@@ -1,0 +1,101 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib {}
+.assembly ILGEN_MODULE {}
+
+.class ILGEN_CLASS
+{
+    .method static native int ILGEN_METHOD(unsigned int8, int64, native int, unsigned int16)
+    {
+        .maxstack 65535
+        .locals init (int16, native unsigned int, int16)
+
+        ldarg 0x0001
+        not
+        not
+        ldloc 0x0001
+        ldc.i4 0x2355d706
+        shr.un
+        conv.ovf.u
+        shl
+        conv.r4
+        conv.ovf.i8.un
+        ldarg.s 0x01
+        bgt IL_0046
+        ldc.r8 float64(0x79823c520c130b7d)
+        ldc.r8 float64(0x51258d8dce722010)
+        clt.un
+        conv.ovf.u8
+        conv.ovf.u8
+        conv.ovf.u8
+        starg 0x0001
+        ldc.i8 0xb5b97539501b5ea7
+        ldarg.s 0x01
+        rem.un
+        starg 0x0001
+
+IL_0046:
+        ldarg.s 0x01
+        conv.r8
+        ldc.r8 float64(0x99a91c7c78b49624)
+        rem
+        ldc.r8 float64(0xb5e326c6a003a09f)
+        rem
+        ldc.r8 float64(0x2a45f60bdc59b68d)
+        conv.r4
+        ckfinite
+        cgt
+        brtrue IL_0070
+        nop
+
+IL_0070:
+        ldc.r8 float64(0x7c6a79c2ec1fbbd6)
+        ldc.r8 float64(0xd9d5979e677611ac)
+        neg
+        rem
+        ldc.r8 float64(0xec1c1addb2cd8fa9)
+        ckfinite
+        rem
+        conv.r8
+        ldloc.s 0x01
+        conv.r.un
+        div
+        conv.r.un
+        conv.ovf.i8
+        brtrue IL_00a1
+        ldloc.s 0x01
+        stloc 0x0000
+
+IL_00a1:
+        ldarg.s 0x00
+        ret   
+    }
+
+    .method public static int32 Main()
+    {
+        .entrypoint
+
+        .try
+        {
+            ldc.i4 0
+            ldc.i8 0
+            ldc.i4 0
+            conv.i
+            ldc.i4 0
+            call native int ILGEN_CLASS::ILGEN_METHOD(unsigned int8, int64, native int, unsigned int16)
+            pop
+            leave done
+        }
+        catch [mscorlib]System.Exception
+        {
+            pop
+            leave done
+        }
+
+    done:
+        ldc.i4 100
+        ret
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_487703/DevDiv_487703.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_487703/DevDiv_487703.ilproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_487703.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Instead of removing dead stores that are marked as late args, we replace
them with NOPs. This obviates the need to update the call's argument
table, but requires that the NOP itself not be DCE'd. This change marks
these NOPs with the `ORDER_SIDEEFF` flag s.t. DCE will not remove them.

Fixes VSO 487703.