### PR TITLE
Fix VSO 487701 and 487702.

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -5472,7 +5472,7 @@ regNumber LinearScan::tryAllocateFreeReg(Interval* currentInterval, RefPosition*
     }
 
     RegRecord* availablePhysRegInterval = nullptr;
-    Interval*  intervalToUnassign       = nullptr;
+    bool       unassignInterval         = false;
 
     // Each register will receive a score which is the sum of the scoring criteria below.
     // These were selected on the assumption that they will have an impact on the "goodness"
@@ -5550,7 +5550,7 @@ regNumber LinearScan::tryAllocateFreeReg(Interval* currentInterval, RefPosition*
         if (physRegRecord->assignedInterval == currentInterval)
         {
             availablePhysRegInterval = physRegRecord;
-            intervalToUnassign       = nullptr;
+            unassignInterval         = false;
             break;
         }
 
@@ -5710,7 +5710,7 @@ regNumber LinearScan::tryAllocateFreeReg(Interval* currentInterval, RefPosition*
         {
             bestLocation             = nextPhysRefLocation;
             availablePhysRegInterval = physRegRecord;
-            intervalToUnassign       = physRegRecord->assignedInterval;
+            unassignInterval         = true;
             bestScore                = score;
         }
 
@@ -5723,9 +5723,9 @@ regNumber LinearScan::tryAllocateFreeReg(Interval* currentInterval, RefPosition*
 
     if (availablePhysRegInterval != nullptr)
     {
-        if (isAssigned(availablePhysRegInterval ARM_ARG(currentInterval->registerType)))
+        if (unassignInterval && isAssigned(availablePhysRegInterval ARM_ARG(currentInterval->registerType)))
         {
-            intervalToUnassign = availablePhysRegInterval->assignedInterval;
+            Interval* const intervalToUnassign = availablePhysRegInterval->assignedInterval;
             unassignPhysReg(availablePhysRegInterval ARM_ARG(currentInterval->registerType));
 
             if ((bestScore & VALUE_AVAILABLE) != 0 && intervalToUnassign != nullptr)

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_487701/DevDiv_487701.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_487701/DevDiv_487701.il
@@ -1,0 +1,119 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib {}
+.assembly ILGEN_MODULE {}
+
+.class ILGEN_CLASS
+{
+    .method static native int ILGEN_METHOD(unsigned int8, int64, native int, unsigned int16)
+    {
+        .maxstack  65535
+        .locals init (int16, native unsigned int, int16)
+
+        ldc.i8 0xa67bdf4860e28133
+        ldarg.s 0x01
+        conv.ovf.u8
+        ldarg 0x0002
+        not
+        not
+        ldarg 0x0001
+        conv.i
+        shr.un
+        starg.s 0x03
+        ldc.i8 0xb39ec88a74e0306e
+        ldc.i8 0xc5a0503d9e231fd1
+        not
+        ldarg 0x0002
+        shr
+        neg
+        sub
+        conv.ovf.u.un
+        shl
+        clt
+        ldloc 0x0000
+        ldarg.s 0x01
+        ldarg.s 0x01
+        mul
+        conv.i8
+        conv.ovf.i8
+        conv.u
+        ldloc.s 0x02
+        conv.i
+        mul
+        and
+        shl
+        neg
+        not
+        not
+        brtrue IL_0055
+        ldloc.s 0x02
+        pop
+
+IL_0055:
+        ldarg.s 0x01
+        ldarg.s 0x03
+        shr
+        ldarg 0x0001
+        ldarg.s 0x01
+        div
+        conv.i2
+        ldloc.s 0x00
+        sub
+        conv.ovf.u8.un
+        or
+        neg
+        conv.ovf.u.un
+        not
+        ldarg.s 0x02
+        ldarg 0x0001
+        conv.u2
+        neg
+        shr.un
+        conv.ovf.i8.un
+        conv.ovf.u4.un
+        neg
+        conv.ovf.i8
+        ldarg 0x0001
+        clt
+        neg
+        sub
+        ldloc 0x0000
+        conv.ovf.i1.un
+        ldarg.s 0x03
+        div.un
+        nop
+        sub
+        not
+        not
+        not
+        ret
+    }
+
+    .method public static int32 Main()
+    {
+        .entrypoint
+
+        .try
+        {
+            ldc.i4 0
+            ldc.i8 0
+            ldc.i4 0
+            conv.i
+            ldc.i4 0
+            call native int ILGEN_CLASS::ILGEN_METHOD(unsigned int8, int64, native int, unsigned int16)
+            pop
+            leave done
+        }
+        catch [mscorlib]System.Exception
+        {
+            pop
+            leave done
+        }
+
+    done:
+        ldc.i4 100
+        ret
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_487701/DevDiv_487701.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_487701/DevDiv_487701.ilproj
@@ -10,6 +10,7 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_487701/DevDiv_487701.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_487701/DevDiv_487701.ilproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_487701.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_487702/DevDiv_487702.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_487702/DevDiv_487702.il
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib {}
+.assembly ILGEN_MODULE {}
+
+.class ILGEN_CLASS
+{
+    .method static native int ILGEN_METHOD(unsigned int8, int64, native int, unsigned int16)
+    {
+        .maxstack  65535
+        .locals init (int16, native unsigned int, int16)
+
+        ldarg.s 0x01
+        conv.r4
+        conv.ovf.i8
+        ldarg 0x0001
+        not
+        add.ovf.un
+        ldc.i8 0x3171ecd9351b8edd
+        conv.ovf.i8.un
+        ldarg.s 0x03
+        shr
+        ldloc 0x0002
+        ldloc.s 0x01
+        conv.ovf.i8
+        ldarg 0x0001
+        cgt.un
+        shr.un
+        conv.i2
+        ldarg 0x0003
+        ldarg.s 0x03
+        rem.un
+        ldloc 0x0002
+        conv.u2
+        ldloc.s 0x02
+        rem.un
+        clt
+        cgt
+        conv.ovf.u8.un
+        ldarg 0x0001
+        starg.s 0x01
+        ldc.r8 float64(0xa7450abcb249d654)
+        ckfinite
+        neg
+        pop
+        mul.ovf
+        pop
+        brtrue IL_005d
+        ldc.r8 float64(0xd997fc4323d4242e)
+        pop
+
+IL_005d:
+        ldc.r8 float64(0x4ce121de0d887bd3)
+        ckfinite
+        neg
+        neg
+        ldc.r8 float64(0x7ecd50b46af15c38)
+        ckfinite
+        neg
+        neg
+        ldc.r8 float64(0x731b56a3f8d0df42)
+        neg
+        conv.r.un
+        conv.i8
+        not
+        neg
+        ldloc 0x0000
+        ldloc.s 0x00
+        shl
+        ldarg 0x0003
+        ldloc.s 0x00
+        conv.r.un
+        ldc.r8 float64(0xd7e6bb0db40c537d)
+        ceq
+        div.un
+        or
+        shl
+        ldarg.s 0x01
+        conv.ovf.i8.un
+        neg
+        ldarg 0x0001
+        ldloc 0x0001
+        shr
+        add.ovf
+        starg 0x0001
+        starg 0x0001
+        ceq
+        ret
+    }
+    .method public static int32 Main()
+    {
+        .entrypoint
+
+        .try
+        {
+            ldc.i4 0
+            ldc.i8 0
+            ldc.i4 0
+            conv.i
+            ldc.i4 0
+            call native int ILGEN_CLASS::ILGEN_METHOD(unsigned int8, int64, native int, unsigned int16)
+            pop
+            leave done
+        }
+        catch [mscorlib]System.Exception
+        {
+            pop
+            leave done
+        }
+
+    done:
+        ldc.i4 100
+        ret
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_487702/DevDiv_487702.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_487702/DevDiv_487702.ilproj
@@ -10,6 +10,7 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_487702/DevDiv_487702.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_487702/DevDiv_487702.ilproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_487702.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Both of these issues stem from attempting to unassign a copied interval
from the copied-to register and then reassigning the interval to the
same. This corrupts some of the bookkeeping necessary to track whether
or not the interval in the register needs to be spilled, and the RA ends
up attempting to spill the interval being allocated even though it is
not assigned a register.