### PR TITLE
Fix test native install directory for Loader/NativeLibs and test script

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -126,7 +126,7 @@ function xunit_output_begin {
     if [ -z "$xunitOutputPath" ]; then
         xunitOutputPath=$testRootDir/coreclrtests.xml
     fi
-    if ! [ -e $(basename "$xunitOutputPath") ]; then
+    if ! [ -e $(dirname "$xunitOutputPath") ]; then
         xunitOutputPath=$testRootDir/coreclrtests.xml
     fi
     xunitTestOutputPath=${xunitOutputPath}.test

--- a/tests/src/Loader/NativeLibs/CMakeLists.txt
+++ b/tests/src/Loader/NativeLibs/CMakeLists.txt
@@ -6,4 +6,4 @@ set(CMAKE_SHARED_LIBRARY_PREFIX "")
 set(SOURCES FromNativePaths_lib.cpp FromNativePaths_lib.def)
 add_library(FromNativePaths_lib SHARED ${SOURCES})
 
-install(TARGETS FromNativePaths_lib DESTINATION Loader/NativeLibs)
+install(TARGETS FromNativePaths_lib DESTINATION bin)


### PR DESCRIPTION
Fix install directory for Loader/NativeLibs native build
Loader/NativeLibs/ -> bin/
It's same target directory as other test build (ex. https://github.com/dotnet/coreclr/blob/master/tests/src/Exceptions/ForeignThread/CMakeLists.txt)

And we can remove useless copy from obj directory