### PR TITLE
Disabling non-shipping packages for uwp6.0 and changing prerelease label to avoid clashes

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -8,7 +8,7 @@
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <StableVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == ''">$(PackageVersion)</StableVersion>
 
-    <PreReleaseLabel>preview1</PreReleaseLabel>
+    <PreReleaseLabel>b-uwp6</PreReleaseLabel>
   </PropertyGroup>
   
   <!-- Source of truth for dependency tooling: the commit hash of the dotnet/versions master branch as of the last auto-upgrade. -->

--- a/src/.nuget/packages.builds
+++ b/src/.nuget/packages.builds
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <!-- This property must be set to the same value as $(PackageOutputPath) for the nuspecs and nupkgs to be binplaced to the intended location. -->
     <OutputPath>$(PackageOutputPath)</OutputPath>
-    <BuildAllPackages>false</BuildAllPackages>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(__SkipCoreLibBuild)'==''">
@@ -18,12 +17,12 @@
   <ItemGroup Condition="'$(__SkipNativeBuild)'==''">
     <Project Include="Microsoft.NETCore.Jit\Microsoft.NETCore.Jit.builds" />
     <Project Include="Microsoft.NETCore.TestHost\Microsoft.NETCore.TestHost.builds" />
-    <Project Include="Microsoft.NETCore.Native\Microsoft.NETCore.Native.builds" Condition="'$(BuildAllPackages)' != 'false'" />
+    <Project Include="Microsoft.NETCore.Native\Microsoft.NETCore.Native.builds" />
   </ItemGroup>
 
   <ItemGroup>
     <Project Include="Microsoft.NETCore.ILAsm\Microsoft.NETCore.ILAsm.builds" />
-    <Project Include="Microsoft.NETCore.ILDAsm\Microsoft.NETCore.ILDAsm.builds" Condition="'$(BuildAllPackages)' != 'false'" />
+    <Project Include="Microsoft.NETCore.ILDAsm\Microsoft.NETCore.ILDAsm.builds" />
   </ItemGroup>
 
   <Import Project="$(ToolsDir)versioning.targets" />

--- a/src/.nuget/packages.builds
+++ b/src/.nuget/packages.builds
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <!-- This property must be set to the same value as $(PackageOutputPath) for the nuspecs and nupkgs to be binplaced to the intended location. -->
     <OutputPath>$(PackageOutputPath)</OutputPath>
+    <BuildAllPackages>false</BuildAllPackages>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(__SkipCoreLibBuild)'==''">
@@ -16,11 +17,11 @@
 
   <ItemGroup Condition="'$(__SkipNativeBuild)'==''">
     <Project Include="Microsoft.NETCore.Jit\Microsoft.NETCore.Jit.builds" />
-    <Project Include="Microsoft.NETCore.TestHost\Microsoft.NETCore.TestHost.builds" />
-    <Project Include="Microsoft.NETCore.Native\Microsoft.NETCore.Native.builds" />
+    <Project Include="Microsoft.NETCore.TestHost\Microsoft.NETCore.TestHost.builds" Condition="'$(BuildAllPackages)' != 'false'" />
+    <Project Include="Microsoft.NETCore.Native\Microsoft.NETCore.Native.builds" Condition="'$(BuildAllPackages)' != 'false'" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup  Condition="'$(BuildAllPackages)' != 'false'">
     <Project Include="Microsoft.NETCore.ILAsm\Microsoft.NETCore.ILAsm.builds" />
     <Project Include="Microsoft.NETCore.ILDAsm\Microsoft.NETCore.ILDAsm.builds" />
   </ItemGroup>

--- a/src/.nuget/packages.builds
+++ b/src/.nuget/packages.builds
@@ -17,13 +17,13 @@
 
   <ItemGroup Condition="'$(__SkipNativeBuild)'==''">
     <Project Include="Microsoft.NETCore.Jit\Microsoft.NETCore.Jit.builds" />
-    <Project Include="Microsoft.NETCore.TestHost\Microsoft.NETCore.TestHost.builds" Condition="'$(BuildAllPackages)' != 'false'" />
+    <Project Include="Microsoft.NETCore.TestHost\Microsoft.NETCore.TestHost.builds" />
     <Project Include="Microsoft.NETCore.Native\Microsoft.NETCore.Native.builds" Condition="'$(BuildAllPackages)' != 'false'" />
   </ItemGroup>
 
-  <ItemGroup  Condition="'$(BuildAllPackages)' != 'false'">
+  <ItemGroup>
     <Project Include="Microsoft.NETCore.ILAsm\Microsoft.NETCore.ILAsm.builds" />
-    <Project Include="Microsoft.NETCore.ILDAsm\Microsoft.NETCore.ILDAsm.builds" />
+    <Project Include="Microsoft.NETCore.ILDAsm\Microsoft.NETCore.ILDAsm.builds" Condition="'$(BuildAllPackages)' != 'false'" />
   </ItemGroup>
 
   <Import Project="$(ToolsDir)versioning.targets" />


### PR DESCRIPTION
cc: @weshaggard @joshfree @ericstj @jkotas 

Two reasons why we want to take these changes:

- We want to disable the build of all of the packages that won't be required for shipping uwp6.0. We've done this in corefx and core-setup as well.
- The change in the prerelease label is in order to avoid package clashes on myget once we move packages built from master back to "preview1". Worth noting that packages out of coreclr for uwp6.0 will never go stable, as we only use them as transport packages. Had a chat yesterday with @ericstj @weshaggard and we decided to use the label `b-uwp6`