### PR TITLE
Eliminate double delete in EventPipeProvider cleanup

### DIFF
--- a/src/vm/eventpipeconfiguration.cpp
+++ b/src/vm/eventpipeconfiguration.cpp
@@ -413,17 +413,12 @@ void EventPipeConfiguration::DeleteDeferredProviders()
     while(pElem != NULL)
     {
         EventPipeProvider *pProvider = pElem->GetValue();
+        pElem = m_pProviderList->GetNext(pElem);
         if(pProvider->GetDeleteDeferred())
         {
-            SListElem<EventPipeProvider*> *pNextElem = m_pProviderList->GetNext(pElem);
             // The act of deleting the provider unregisters it,
             // removes it from the list, and deletes the list element
             delete(pProvider);
-            pElem = pNextElem;
-        }
-        else
-        {
-            pElem = m_pProviderList->GetNext(pElem);
         }
     }
 }

--- a/src/vm/eventpipeconfiguration.cpp
+++ b/src/vm/eventpipeconfiguration.cpp
@@ -415,12 +415,16 @@ void EventPipeConfiguration::DeleteDeferredProviders()
         EventPipeProvider *pProvider = pElem->GetValue();
         if(pProvider->GetDeleteDeferred())
         {
+            SListElem<EventPipeProvider*> *pNextElem = m_pProviderList->GetNext(pElem);
             // The act of deleting the provider unregisters it,
             // removes it from the list, and deletes the list element
             delete(pProvider);
+            pElem = pNextElem;
         }
-
-        pElem = m_pProviderList->GetNext(pElem);
+        else
+        {
+            pElem = m_pProviderList->GetNext(pElem);
+        }
     }
 }
 

--- a/src/vm/eventpipeconfiguration.cpp
+++ b/src/vm/eventpipeconfiguration.cpp
@@ -415,16 +415,12 @@ void EventPipeConfiguration::DeleteDeferredProviders()
         EventPipeProvider *pProvider = pElem->GetValue();
         if(pProvider->GetDeleteDeferred())
         {
-            // The act of deleting the provider unregisters it and removes it from the list.
+            // The act of deleting the provider unregisters it,
+            // removes it from the list, and deletes the list element
             delete(pProvider);
-            SListElem<EventPipeProvider*> *pCurElem = pElem;
-            pElem = m_pProviderList->GetNext(pElem);
-            delete(pCurElem);
         }
-        else
-        {
-            pElem = m_pProviderList->GetNext(pElem);
-        }
+
+        pElem = m_pProviderList->GetNext(pElem);
     }
 }
 


### PR DESCRIPTION
Deletion of the list element occurs as a result of deleting the provider through the UnregisterProvider function which is unconditionally called from the EventPipeProvider deconstructor

Closes: https://github.com/dotnet/coreclr/issues/13818