### PR TITLE
Copy `GTF_{ASG,EXCEPT}` flags in `gtCloneExpr`.

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -7863,6 +7863,9 @@ DONE:
             copy->gtOp.gtOp1->gtFlags |= GTF_RELOP_QMARK;
         }
 
+        // Clear the copy's GTF_ASG and GTF_EXCEPT bits; these will instead be taken from the source.
+        copy->gtFlags &= ~(GTF_ASG | GTF_EXCEPT);
+
         copy->gtFlags |= addFlags;
     }
 


### PR DESCRIPTION
These flags from the source were being unioned with those of the copy,
which was incorrect in cases where the copy's flags were overly
conservative. This change simply copies the values of these flags from
the source.

Fixes VSO 489992.