### PR TITLE
The !DumpArray sos command emits invalid DML for array elements

### DIFF
--- a/src/ToolBox/SOS/Strike/strike.cpp
+++ b/src/ToolBox/SOS/Strike/strike.cpp
@@ -1967,7 +1967,7 @@ HRESULT PrintArray(DacpObjectData& objData, DumpArrayFlags& flags, BOOL isPermSe
 
             if (isElementValueType)
             {
-                DMLOut( " %s\n", DMLValueClass(objData.MethodTable, p_Element));
+                DMLOut( " %s\n", DMLValueClass(objData.ElementTypeHandle, p_Element));
             }
             else
             {


### PR DESCRIPTION
Element MethodTable is reported correctly but for individual elements, the generated DML uses the MT of the array, not the element, thus giving incorrect results. Only value types are affected.

```
0:007> !DumpArray /d 02b16574
Name:        WindowsFormsApplication2_SOS_bug.Test[]
MethodTable: 011c82ec
EEClass:     011c8290
Size:        412(0x19c) bytes
Array:       Rank 1, Number of elements 100, Type VALUETYPE
Element Methodtable: 011c824c
[0] 02b1657c => **here is the problem**