### PR TITLE
Properly update GTF_{ASG,EXCEPT} in call morphing.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -4451,12 +4451,15 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
     }
 #endif // FEATURE_FIXED_OUT_ARGS
 
-    /* Update the 'side effect' flags value for the call */
-    call->gtFlags = (call->gtFlags & ~GTF_ASG) | (flagsSummary & GTF_ALL_EFFECT);
-    if (((flagsSummary & GTF_EXCEPT) == 0) && !call->OperMayThrow(this))
+    // Clear the ASG and EXCEPT (if possible) flags on the call node
+    call->gtFlags &= ~GTF_ASG;
+    if (!call->OperMayThrow(this))
     {
         call->gtFlags &= ~GTF_EXCEPT;
     }
+
+    // Union in the side effect flags from the call's operands
+    call->gtFlags |= flagsSummary & GTF_ALL_EFFECT;
 
     // If the register arguments have already been determined
     // or we have no register arguments then we don't need to

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -4452,10 +4452,8 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
 #endif // FEATURE_FIXED_OUT_ARGS
 
     /* Update the 'side effect' flags value for the call */
-
-    call->gtFlags |= (flagsSummary & GTF_ALL_EFFECT);
-
-    if (!call->OperMayThrow(this) && ((flagsSummary & GTF_EXCEPT) == 0))
+    call->gtFlags = (call->gtFlags & ~GTF_ASG) | (flagsSummary & GTF_ALL_EFFECT);
+    if (((flagsSummary & GTF_EXCEPT) == 0) && !call->OperMayThrow(this))
     {
         call->gtFlags &= ~GTF_EXCEPT;
     }

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_491211/DevDiv_491211.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_491211/DevDiv_491211.il
@@ -1,0 +1,115 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib {}
+.assembly ILGEN_MODULE {}
+
+.class ILGEN_CLASS
+{
+    .method static unsigned int64 ILGEN_METHOD(unsigned int64, int16, int32)
+    {
+        .maxstack  65535
+        .locals init (unsigned int64)
+
+        ldloc.s 0x00
+        brtrue IL_005c
+        ldloc 0x0000
+        conv.r4
+        pop
+        ldloc 0x0000
+        ldc.i4 0x6a468471
+        shr
+        conv.u
+        conv.ovf.i2.un
+        not
+        ldc.i4 0xb2e976cb
+        cgt
+        neg
+        ldc.i8 0x767d5c09ace81d93
+        conv.ovf.i1.un
+        ldc.i4 0x67236301
+        div.un
+        clt
+        ldc.r8 float64(0xe7f6d2d768530c5d)
+        ldc.r8 float64(0x2f88da93e6c4278c)
+        clt.un
+        ldarg 0x0001
+        neg
+        neg
+        cgt.un
+        rem.un
+        not
+        conv.u
+        conv.ovf.u8.un
+        conv.i8
+        nop
+        not
+        conv.r4
+        neg
+        conv.ovf.u
+        starg.s 0x02
+
+IL_005c:
+        ldloc.s 0x00
+        stloc 0x0000
+        ldc.r8 float64(0xcf7b2123eddbb4ef)
+        ckfinite
+        neg
+        ldc.i8 0xc2d58efbc2800db6
+        ldarg.s 0x00
+        not
+        cgt
+        neg
+        ldc.i8 0x205068055965c3cc
+        neg
+        ldarg 0x0001
+        ldarg.s 0x02
+        cgt.un
+        shr
+        ldloc.s 0x00
+        ldarg.s 0x02
+        shr
+        cgt.un
+        add.ovf
+        nop
+        ldarg.s 0x01
+        ldarg 0x0001
+        rem
+        div
+        pop
+        conv.u8
+        neg
+        conv.r8
+        conv.r8
+        ckfinite
+        ldarg.s 0x00
+        pop
+        conv.ovf.u8.un
+        ret
+    }
+
+    .method public static int32 Main()
+    {
+        .entrypoint
+
+        .try
+        {
+            ldc.i8 0
+            ldc.i4 0
+            ldc.i4 0
+            call unsigned int64 ILGEN_CLASS::ILGEN_METHOD(unsigned int64, int16, int32)
+            pop
+            leave done
+        }
+        catch [mscorlib]System.Exception
+        {
+            pop
+            leave done
+        }
+
+    done:
+        ldc.i4 100
+        ret
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_491211/DevDiv_491211.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_491211/DevDiv_491211.ilproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_491211.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
The former is only necessary if it is set on any of the call's
arguments; the latter is necessary if the call may throw or if it is set
on any of the call's arguments.

Fixes DevDiv 491211.