### PR TITLE
Make order of elements consistent in MemberInfoCache.Insert 

### DIFF
--- a/src/mscorlib/src/System/RtType.cs
+++ b/src/mscorlib/src/System/RtType.cs
@@ -458,8 +458,8 @@ namespace System
 
                                     Volatile.Write(ref m_cacheComplete, true);
                                 }
-                                else
-                                    list = m_allMembers;
+
+                                list = m_allMembers;
                                 break;
 
                             default:


### PR DESCRIPTION
When enumerating members of a type by reflection (through `Type.GetFields` for instance), the list of 
the members is read from the cache by `MemberInfoCache<T>.GetMemberList`. If the cache isn't fully populated yet, `MemberInfoCache<T>.Populate` will fetch the required members, then they will be merged to the cache in `MemberInfoCache<T>.Insert`. Then, the list constructed by `Populate` will be returned. In subsequent calls, the cached list will be directly returned.

This behavior leads to `GetMembers` returning members in different order if some conditions are met. For example, the following scenario:

1. Type `SomeAttribute` has two fields, `Field1` and `Field2`
2. For some reasons, `Field2` is already in the cache
3. Type.GetFields is called. The cache is incomplete, so `Populate` will fetch all the members, in order: `Field1, Field2`. 
4. `Insert` adds the missing value at the end of the cache. The cache now contains `Field2, Field1`.
5. The values fetched by `Populate` are returned. `Type.GetMembers` therefore returns `Field1, Field2`
6. Later on, `Type.GetMembers` is called again. This time, the cache is already fully populated, so the cached list is returned as-is. Therefore, `Type.GetMembers` returns `Field2, Field1`.

Repro code:

```C#
    class Program
    {
        static void Main(string[] args)
        {
            void DisplayAttributes()
            {
                var fields = new SomeAttribute()
                    .GetType()
                    .GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);

                foreach (var field in fields)
                {
                    Console.WriteLine(field.Name);
                }
            }

            // This will put field2 in the cache, 
            // because it's referenced by the attribute applied on SomeClass
            typeof(SomeClass).GetCustomAttributes(false);

            DisplayAttributes(); // Will print field1 field2
            DisplayAttributes(); // Will print field2 field1
        }

        [SomeAttribute(field2 = 1)]
        class SomeClass
        {
        }

        class SomeAttribute : System.Attribute
        {
            uint field1 = 1234567;
            public uint field2;
        }
    }
```

This is an issue because some callers expect the order of the fields to be consistent. For instance, `Attribute.GetHashCode`:

```C#
static void Main(string[] args)
{
    typeof(SomeClass).GetCustomAttributes(false);

    var tt = new SomeAttribute();
    Console.WriteLine(tt.GetHashCode()); // Prints 1234567
    Console.WriteLine(tt.GetHashCode()); // Prints 0
    Console.WriteLine(tt.GetHashCode()); // Prints 0
}

[SomeAttribute(field2 = 1)]
class SomeClass
{
}

class SomeAttribute : System.Attribute
{
    uint field1=1234567;
    public uint field2;            
}
```

This was originally spotted on StackOverflow (https://stackoverflow.com/questions/43028703/reflection-renders-hashcode-unstable/) so it can happen in the wild.