### PR TITLE
Argument register & stack size calculation for fast tail call

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -8343,10 +8343,8 @@ public:
         unsigned  compArgsCount;     // Number of arguments (incl. implicit and     hidden)
 
 #if FEATURE_FASTTAILCALL
-        unsigned compArgRegCount;      // Number of incoming integer argument registers used for incoming arguments
-        unsigned compFloatArgRegCount; // Number of incoming floating argument registers used for incoming arguments
-        size_t   compArgStackSize;     // Incoming argument stack size in bytes
-#endif                                 // FEATURE_FASTTAILCALL
+        size_t compArgStackSize; // Incoming argument stack size in bytes
+#endif                           // FEATURE_FASTTAILCALL
 
         unsigned compRetBuffArg; // position of hidden return param var (0, 1) (BAD_VAR_NUM means not present);
         int compTypeCtxtArg; // position of hidden param for type context for generic code (CORINFO_CALLCONV_PARAMTYPE)

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -235,17 +235,6 @@ void Compiler::lvaInitTypeRef()
 
     lvaInitArgs(&varDscInfo);
 
-#if FEATURE_FASTTAILCALL
-    //-------------------------------------------------------------------------
-    // Save the register usage information and stack size.
-    //-------------------------------------------------------------------------
-
-    info.compArgRegCount      = varDscInfo.intRegArgNum;
-    info.compFloatArgRegCount = varDscInfo.floatRegArgNum;
-    info.compArgStackSize     = varDscInfo.stackArgSize;
-
-#endif // FEATURE_FASTTAILCALL
-
     //-------------------------------------------------------------------------
     // Finally the local variables
     //-------------------------------------------------------------------------
@@ -366,6 +355,13 @@ void Compiler::lvaInitArgs(InitVarDscInfo* varDscInfo)
 #if !FEATURE_STACK_FP_X87
     codeGen->floatRegState.rsCalleeRegArgCount = varDscInfo->floatRegArgNum;
 #endif // FEATURE_STACK_FP_X87
+
+#if FEATURE_FASTTAILCALL
+    // Save the stack usage information
+    // We can get register usage information using codeGen->intRegState and
+    // codeGen->floatRegState
+    info.compArgStackSize = varDscInfo->stackArgSize;
+#endif // FEATURE_FASTTAILCALL
 
     // The total argument size must be aligned.
     noway_assert((compArgSize % sizeof(void*)) == 0);
@@ -951,7 +947,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo)
 
 #endif // _TARGET_XXX_
 
-#ifdef FEATURE_FASTTAILCALL
+#if FEATURE_FASTTAILCALL
             varDscInfo->stackArgSize += (unsigned)roundUp(argSize, TARGET_POINTER_SIZE);
 #endif // FEATURE_FASTTAILCALL
         }
@@ -1050,9 +1046,9 @@ void Compiler::lvaInitGenericsCtxt(InitVarDscInfo* varDscInfo)
             // For the RyuJIT backend, we need to mark these as being on the stack,
             // as this is not done elsewhere in the case that canEnreg returns false.
             varDsc->lvOnFrame = true;
-#ifdef FEATURE_FASTTAILCALL
+#if FEATURE_FASTTAILCALL
             varDscInfo->stackArgSize += TARGET_POINTER_SIZE;
-#endif
+#endif // FEATURE_FASTTAILCALL
         }
 #endif // !LEGACY_BACKEND
 
@@ -1126,9 +1122,9 @@ void Compiler::lvaInitVarArgsHandle(InitVarDscInfo* varDscInfo)
             // For the RyuJIT backend, we need to mark these as being on the stack,
             // as this is not done elsewhere in the case that canEnreg returns false.
             varDsc->lvOnFrame = true;
-#ifdef FEATURE_FASTTAILCALL
+#if FEATURE_FASTTAILCALL
             varDscInfo->stackArgSize += TARGET_POINTER_SIZE;
-#endif
+#endif // FEATURE_FASTTAILCALL
         }
 #endif // !LEGACY_BACKEND
 

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -243,6 +243,7 @@ void Compiler::lvaInitTypeRef()
     info.compArgRegCount      = varDscInfo.intRegArgNum;
     info.compFloatArgRegCount = varDscInfo.floatRegArgNum;
     info.compArgStackSize     = varDscInfo.stackArgSize;
+
 #endif // FEATURE_FASTTAILCALL
 
     //-------------------------------------------------------------------------

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7253,8 +7253,8 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
     // Note that callee being a vararg method is not a problem since we can account the params being passed.
     unsigned nCallerArgs = info.compArgsCount;
 
-    size_t callerArgRegCount      = info.compArgRegCount;
-    size_t callerFloatArgRegCount = info.compFloatArgRegCount;
+    size_t callerArgRegCount      = codeGen->intRegState.rsCalleeRegArgCount;
+    size_t callerFloatArgRegCount = codeGen->floatRegState.rsCalleeRegArgCount;
 
     // Count the callee args including implicit and hidden.
     // Note that GenericContext and VarargCookie are added by importer while

--- a/src/jit/register_arg_convention.h
+++ b/src/jit/register_arg_convention.h
@@ -26,7 +26,8 @@ struct InitVarDscInfo
     bool      anyFloatStackArgs;
 #endif // _TARGET_ARM_
 
-#ifdef FEATURE_FASTTAILCALL
+#if FEATURE_FASTTAILCALL
+    // It is used to calculate argument stack size information in byte
     unsigned stackArgSize;
 #endif // FEATURE_FASTTAILCALL
 
@@ -47,7 +48,7 @@ public:
         anyFloatStackArgs    = false;
 #endif // _TARGET_ARM_
 
-#ifdef FEATURE_FASTTAILCALL
+#if FEATURE_FASTTAILCALL
         stackArgSize = 0;
 #endif // FEATURE_FASTTAILCALL
     }

--- a/src/jit/register_arg_convention.h
+++ b/src/jit/register_arg_convention.h
@@ -26,6 +26,11 @@ struct InitVarDscInfo
     bool      anyFloatStackArgs;
 #endif // _TARGET_ARM_
 
+#ifdef FEATURE_FASTTAILCALL
+    unsigned stackArgSize;
+#endif // FEATURE_FASTTAILCALL
+
+
 public:
     // set to initial values
     void Init(LclVarDsc* lvaTable, bool _hasRetBufArg)
@@ -42,6 +47,10 @@ public:
         fltArgSkippedRegMask = RBM_NONE;
         anyFloatStackArgs    = false;
 #endif // _TARGET_ARM_
+
+#ifdef FEATURE_FASTTAILCALL
+        stackArgSize = 0;
+#endif // FEATURE_FASTTAILCALL
     }
 
     // return ref to current register arg for this type

--- a/src/jit/register_arg_convention.h
+++ b/src/jit/register_arg_convention.h
@@ -30,7 +30,6 @@ struct InitVarDscInfo
     unsigned stackArgSize;
 #endif // FEATURE_FASTTAILCALL
 
-
 public:
     // set to initial values
     void Init(LclVarDsc* lvaTable, bool _hasRetBufArg)


### PR DESCRIPTION
Save caller register count & stack size using argument varDsc initialization.
It remove duplicate calculation for register count (varDscInfo->allocRegArg()) 
and add stack size count in varDsc initialization.

And it is preperation for fast tail call on ARM32.

cc/ @dotnet/jit-contrib 