### PR TITLE
[GDBJIT] Fix calculation of debuginfo's size.

### DIFF
--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -121,12 +121,21 @@ struct SymbolsInfo
 class DwarfDumpable
 {
 public:
+    DwarfDumpable() :
+        m_base_ptr(nullptr),
+        m_is_visited(false)
+    {
+    }
+
     // writes all string literals this type needs to ptr
     virtual void DumpStrings(char* ptr, int& offset) = 0;
 
     virtual void DumpDebugInfo(char* ptr, int& offset) = 0;
 
     virtual ~DwarfDumpable() {}
+
+    char *m_base_ptr;
+    bool m_is_visited;
 };
 
 class LocalsInfo


### PR DESCRIPTION
Information about each type is dumped once but during debuginfo's size calculation it was taken into account several time. Due to it size of debuginfo section could be in several times bigger than needed that in some cases leaded to OOM.