### PR TITLE
Use AsyncTaskCache in ValueTask.AsTask()

### DIFF
--- a/src/mscorlib/shared/System/Threading/Tasks/ValueTask.cs
+++ b/src/mscorlib/shared/System/Threading/Tasks/ValueTask.cs
@@ -114,7 +114,7 @@ namespace System.Threading.Tasks
             // Return the task if we were constructed from one, otherwise manufacture one.  We don't
             // cache the generated task into _task as it would end up changing both equality comparison
             // and the hash code we generate in GetHashCode.
-            _task ?? Task.FromResult(_result);
+            _task ?? AsyncTaskMethodBuilder<TResult>.GetTaskForResult(_result);
 
         /// <summary>Gets whether the <see cref="ValueTask{TResult}"/> represents a completed operation.</summary>
         public bool IsCompleted => _task == null || _task.IsCompleted;

--- a/src/mscorlib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -719,7 +719,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="result">The result for which we need a task.</param>
         /// <returns>The completed task containing the result.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // method looks long, but for a given TResult it results in a relatively small amount of asm
-        private Task<TResult> GetTaskForResult(TResult result)
+        internal static Task<TResult> GetTaskForResult(TResult result)
         {
             Contract.Ensures(
                 EqualityComparer<TResult>.Default.Equals(result, Contract.Result<Task<TResult>>().Result),


### PR DESCRIPTION
We can avoid task allocations for common values by using the same task cache that async methods do.  This is important to avoid allocations in certain cases when switching from Task-returning to ValueTask-returning methods.  If at some point we change Task.FromResult to use the same cache, this can be reverted.

cc: @kouvel, @tarekgh 