### PR TITLE
Change how numProc is derived on Linux

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -643,8 +643,10 @@ if [ `uname` = "FreeBSD" ]; then
   __NumProc=`sysctl hw.ncpu | awk '{ print $2+1 }'`
 elif [ `uname` = "NetBSD" ]; then
   __NumProc=$(($(getconf NPROCESSORS_ONLN)+1))
-else
+elif [ `uname` = "Darwin" ]; then
   __NumProc=$(($(getconf _NPROCESSORS_ONLN)+1))
+else
+  __NumProc=$(nproc --all)
 fi
 
 while :; do

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -733,8 +733,10 @@ function run_test {
 # Variables for running tests in the background
 if [ `uname` = "NetBSD" ]; then
     NumProc=$(getconf NPROCESSORS_ONLN)
-else
+elif [ `uname` = "Darwin" ]; then
     NumProc=$(getconf _NPROCESSORS_ONLN)
+else
+    NumProc=$(nproc --all)
 fi
 ((maxProcesses = $NumProc * 3 / 2)) # long tests delay process creation, use a few more processors
 


### PR DESCRIPTION
Before the decision for numProcs to run in parallel for runtests.sh
was based on _NPROCESSORS_ONL. On harware which attempts to save
power (eg arm(64)) this number may be < numProcs.