### PR TITLE
fix DevDiv_278523 test source code 

### DIFF
--- a/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523_32.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523_32.il
@@ -64,13 +64,12 @@
         .entrypoint
         .locals init (int32 V_0)
 
-        ldc.i4 100
-        dup
-
         sizeof [mscorlib]System.IntPtr
         ldc.i4 8
         beq.s _64bit
 
+        ldc.i4 100
+        dup
         call int32 C::Test32Bit(int32)
         bne.un.s fail
         br.s success

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523_64.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523_64.il
@@ -66,9 +66,6 @@
         .entrypoint
         .locals init (int32 V_0)
 
-        ldc.i4 100
-        dup
-
         sizeof [mscorlib]System.IntPtr
         ldc.i4 8
         beq.s _64bit
@@ -77,6 +74,8 @@
         br.s fail
 
 _64bit:
+        ldc.i4 100
+        dup
         call int32 C::Test64Bit(int32)
         bne.un.s fail
 


### PR DESCRIPTION
There were different stack depths when the execution enters the last block in miOpts.
Full opts removes one condition and delete the second way.
Fix #13908 