### PR TITLE
[ARM64/Windows] Corrected stack overflow in JIT_Stelem_ref

### DIFF
--- a/src/vm/arm64/asmhelpers.asm
+++ b/src/vm/arm64/asmhelpers.asm
@@ -1467,8 +1467,8 @@ NeedFrame
     bl      ArrayStoreCheck ; ArrayStoreCheck(&val, &array)
 
 DoWrite        
-    ldp     x0, x1, [sp], #16
-    ldr     x2, [sp], #32	
+    ldp     x0, x1, [sp, #16]
+    ldr     x2, [sp, #32]	
     EPILOG_RESTORE_REG_PAIR           fp, lr, #0x48!
     EPILOG_BRANCH JIT_Stelem_DoWrite    
     NESTED_END 

--- a/src/vm/arm64/asmhelpers.asm
+++ b/src/vm/arm64/asmhelpers.asm
@@ -1447,7 +1447,7 @@ ThrowIndexOutOfRangeException
 ;   x12 = array->GetArrayElementTypeHandle()
 ;
     NESTED_ENTRY JIT_Stelem_Ref_NotExactMatch    
-    PROLOG_SAVE_REG_PAIR           fp, lr, #-0x48!    
+    PROLOG_SAVE_REG_PAIR           fp, lr, #-48!    
     stp     x0, x1, [sp, #16]
     str     x2, [sp, #32]
 
@@ -1469,7 +1469,7 @@ NeedFrame
 DoWrite        
     ldp     x0, x1, [sp, #16]
     ldr     x2, [sp, #32]	
-    EPILOG_RESTORE_REG_PAIR           fp, lr, #0x48!
+    EPILOG_RESTORE_REG_PAIR           fp, lr, #48!
     EPILOG_BRANCH JIT_Stelem_DoWrite    
     NESTED_END 
 

--- a/src/vm/arm64/cgencpu.h
+++ b/src/vm/arm64/cgencpu.h
@@ -79,7 +79,6 @@ typedef INT64 StackElemType;
 // !! This expression assumes STACK_ELEM_SIZE is a power of 2.
 #define StackElemSize(parmSize) (((parmSize) + STACK_ELEM_SIZE - 1) & ~((ULONG)(STACK_ELEM_SIZE - 1)))
 
-#ifdef FEATURE_PAL // TODO-ARM64-WINDOWS Add JIT_Stelem_Ref support
 //
 // JIT HELPERS.
 //
@@ -87,7 +86,6 @@ typedef INT64 StackElemType;
 //
 // optimized static helpers
 #define JIT_Stelem_Ref                      JIT_Stelem_Ref
-#endif
 
 //**********************************************************************
 // Frames


### PR DESCRIPTION
Corrected stack overflow caused by incorrect addressing mode usage.