### PR TITLE
﻿Improve thread pool worker thread's spinning for work

### DIFF
--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -943,7 +943,7 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_ThreadPool_ForceMaxWorkerThreads, W("ThreadPoo
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_ThreadPool_DisableStarvationDetection, W("ThreadPool_DisableStarvationDetection"), 0, "Disables the ThreadPool feature that forces new threads to be added when workitems run for too long")
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_ThreadPool_DebugBreakOnWorkerStarvation, W("ThreadPool_DebugBreakOnWorkerStarvation"), 0, "Breaks into the debugger if the ThreadPool detects work queue starvation")
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_ThreadPool_EnableWorkerTracking, W("ThreadPool_EnableWorkerTracking"), 0, "Enables extra expensive tracking of how many workers threads are working simultaneously")
-RETAIL_CONFIG_DWORD_INFO(INTERNAL_ThreadPool_UnfairSemaphoreSpinLimit, W("ThreadPool_UnfairSemaphoreSpinLimit"), 50, "Per processor limit used when calculating spin duration in UnfairSemaphore::Wait")
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_ThreadPool_UnfairSemaphoreSpinLimit, W("ThreadPool_UnfairSemaphoreSpinLimit"), 0x46, "Maximum number of spins a thread pool worker thread performs before waiting for work")
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_Thread_UseAllCpuGroups, W("Thread_UseAllCpuGroups"), 0, "Specifies if to automatically distribute thread across CPU Groups")
 
 CONFIG_DWORD_INFO(INTERNAL_ThreadpoolTickCountAdjustment, W("ThreadpoolTickCountAdjustment"), 0, "")

--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -943,7 +943,12 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_ThreadPool_ForceMaxWorkerThreads, W("ThreadPoo
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_ThreadPool_DisableStarvationDetection, W("ThreadPool_DisableStarvationDetection"), 0, "Disables the ThreadPool feature that forces new threads to be added when workitems run for too long")
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_ThreadPool_DebugBreakOnWorkerStarvation, W("ThreadPool_DebugBreakOnWorkerStarvation"), 0, "Breaks into the debugger if the ThreadPool detects work queue starvation")
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_ThreadPool_EnableWorkerTracking, W("ThreadPool_EnableWorkerTracking"), 0, "Enables extra expensive tracking of how many workers threads are working simultaneously")
+#ifdef _TARGET_ARM64_
+// Spinning scheme is currently different on ARM64, see CLRLifoSemaphore::Wait(DWORD, UINT32, UINT32)
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_ThreadPool_UnfairSemaphoreSpinLimit, W("ThreadPool_UnfairSemaphoreSpinLimit"), 0x32, "Maximum number of spins per processor a thread pool worker thread performs before waiting for work")
+#else // !_TARGET_ARM64_
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_ThreadPool_UnfairSemaphoreSpinLimit, W("ThreadPool_UnfairSemaphoreSpinLimit"), 0x46, "Maximum number of spins a thread pool worker thread performs before waiting for work")
+#endif // _TARGET_ARM64_
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_Thread_UseAllCpuGroups, W("Thread_UseAllCpuGroups"), 0, "Specifies if to automatically distribute thread across CPU Groups")
 
 CONFIG_DWORD_INFO(INTERNAL_ThreadpoolTickCountAdjustment, W("ThreadpoolTickCountAdjustment"), 0, "")

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -1467,6 +1467,13 @@ WaitForSingleObject(
 PALIMPORT
 DWORD
 PALAPI
+PAL_WaitForSingleObjectPrioritized(
+            IN HANDLE hHandle,
+            IN DWORD dwMilliseconds);
+
+PALIMPORT
+DWORD
+PALAPI
 WaitForSingleObjectEx(
             IN HANDLE hHandle,
             IN DWORD dwMilliseconds,

--- a/src/pal/src/include/pal/corunix.hpp
+++ b/src/pal/src/include/pal/corunix.hpp
@@ -773,7 +773,8 @@ namespace CorUnix
         RegisterWaitingThread(
             WaitType eWaitType,
             DWORD dwIndex,
-            bool fAltertable
+            bool fAltertable,
+            bool fPrioritize
             ) = 0;
 
         //

--- a/src/pal/src/include/pal/synchobjects.hpp
+++ b/src/pal/src/include/pal/synchobjects.hpp
@@ -40,7 +40,8 @@ namespace CorUnix
         CONST HANDLE *lpHandles,
         BOOL bWaitAll,
         DWORD dwMilliseconds,
-        BOOL bAlertable);
+        BOOL bAlertable,
+        BOOL bPrioritize = FALSE);
     
     PAL_ERROR InternalSleepEx(
         CPalThread * pthrCurrent,

--- a/src/pal/src/synchmgr/synchmanager.cpp
+++ b/src/pal/src/synchmgr/synchmanager.cpp
@@ -3867,7 +3867,7 @@ namespace CorUnix
                 pwtlnNew->shridWaitingState = pwtlnOld->shridWaitingState;
                 pwtlnNew->ptwiWaitInfo = pwtlnOld->ptwiWaitInfo;
 
-                psdShared->SharedWaiterEnqueue(rgshridWTLNodes[i]);
+                psdShared->SharedWaiterEnqueue(rgshridWTLNodes[i], false);
                 psdShared->AddRef();
 
                 _ASSERTE(pwtlnOld = pwtlnOld->ptwiWaitInfo->rgpWTLNodes[pwtlnOld->dwObjIndex]);

--- a/src/pal/src/synchmgr/synchmanager.hpp
+++ b/src/pal/src/synchmgr/synchmanager.hpp
@@ -206,8 +206,8 @@ namespace CorUnix
             CPalThread * pthrCurrent,
             CPalThread * pthrTarget);
 
-        void WaiterEnqueue(WaitingThreadsListNode * pwtlnNewNode);
-        void SharedWaiterEnqueue(SharedID shridNewNode);
+        void WaiterEnqueue(WaitingThreadsListNode * pwtlnNewNode, bool fPrioritize);
+        void SharedWaiterEnqueue(SharedID shridNewNode, bool fPrioritize);
 
         // Object Domain accessor methods
         ObjectDomain GetObjectDomain(void)
@@ -464,7 +464,8 @@ namespace CorUnix
         virtual PAL_ERROR RegisterWaitingThread(
             WaitType wtWaitType,
             DWORD dwIndex,
-            bool fAlertable);
+            bool fAlertable,
+            bool fPrioritize);
 
         virtual void ReleaseController(void);
 

--- a/src/vm/synch.cpp
+++ b/src/vm/synch.cpp
@@ -590,6 +590,376 @@ DWORD CLRSemaphore::Wait(DWORD dwMilliseconds, BOOL alertable)
     }
 }
 
+void CLRLifoSemaphore::Create(INT32 initialSignalCount, INT32 maximumSignalCount)
+{
+    CONTRACTL
+    {
+        THROWS;
+        GC_NOTRIGGER;
+        SO_TOLERANT;
+    }
+    CONTRACTL_END;
+
+    _ASSERTE(maximumSignalCount > 0);
+    _ASSERTE(initialSignalCount <= maximumSignalCount);
+    _ASSERTE(m_handle == nullptr);
+
+#ifdef FEATURE_PAL
+    HANDLE h = UnsafeCreateSemaphore(nullptr, initialSignalCount, maximumSignalCount, nullptr);
+#else // !FEATURE_PAL
+    HANDLE h = CreateIoCompletionPort(INVALID_HANDLE_VALUE, nullptr, 0, maximumSignalCount);
+#endif // FEATURE_PAL
+    if (h == nullptr)
+    {
+        ThrowOutOfMemory();
+    }
+
+    m_handle = h;
+    m_counts.signalCount = initialSignalCount;
+    INDEBUG(m_maximumSignalCount = maximumSignalCount);
+}
+
+void CLRLifoSemaphore::Close()
+{
+    LIMITED_METHOD_CONTRACT;
+
+    if (m_handle == nullptr)
+    {
+        return;
+    }
+
+    CloseHandle(m_handle);
+    m_handle = nullptr;
+}
+
+bool CLRLifoSemaphore::WaitForSignal(DWORD timeoutMs)
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        SO_TOLERANT;
+    }
+    CONTRACTL_END;
+
+    _ASSERTE(timeoutMs != 0);
+    _ASSERTE(m_handle != nullptr);
+    _ASSERTE(m_counts.waiterCount != (UINT16)0);
+
+    while (true)
+    {
+        // Wait for a signal
+        BOOL waitSuccessful;
+        {
+#ifdef FEATURE_PAL
+            // Do a prioritized wait to get LIFO waiter release order
+            DWORD waitResult = PAL_WaitForSingleObjectPrioritized(m_handle, timeoutMs);
+            _ASSERTE(waitResult == WAIT_OBJECT_0 || waitResult == WAIT_TIMEOUT);
+            waitSuccessful = waitResult == WAIT_OBJECT_0;
+#else // !FEATURE_PAL
+            // I/O completion ports release waiters in LIFO order, see
+            // https://msdn.microsoft.com/en-us/library/windows/desktop/aa365198(v=vs.85).aspx
+            DWORD numberOfBytes;
+            ULONG_PTR completionKey;
+            LPOVERLAPPED overlapped;
+            waitSuccessful = GetQueuedCompletionStatus(m_handle, &numberOfBytes, &completionKey, &overlapped, timeoutMs);
+            _ASSERTE(waitSuccessful || GetLastError() == WAIT_TIMEOUT);
+            _ASSERTE(overlapped == nullptr);
+#endif // FEATURE_PAL
+        }
+
+        // Unregister the waiter if this thread will not be waiting anymore, and try to acquire the semaphore
+        Counts counts = m_counts.VolatileLoad();
+        while (true)
+        {
+            _ASSERTE(counts.waiterCount != (UINT16)0);
+            Counts newCounts = counts;
+            if (counts.signalCount != 0)
+            {
+                --newCounts.signalCount;
+                --newCounts.waiterCount;
+            }
+            else if (!waitSuccessful)
+            {
+                --newCounts.waiterCount;
+            }
+
+            // This waiter has woken up and this needs to be reflected in the count of waiters signaled to wake. Since we don't
+            // have thread-specific signal state, there is not enough information to tell whether this thread woke up because it
+            // was signaled. For instance, this thread may have timed out and then we don't know whether this thread also got
+            // signaled. So in any woken case, decrement the count if possible. As such, timeouts could cause more waiters to
+            // wake than necessary.
+            if (counts.countOfWaitersSignaledToWake != (UINT8)0)
+            {
+                --newCounts.countOfWaitersSignaledToWake;
+            }
+
+            Counts countsBeforeUpdate = m_counts.CompareExchange(newCounts, counts);
+            if (countsBeforeUpdate == counts)
+            {
+                if (counts.signalCount != 0)
+                {
+                    return true;
+                }
+                break;
+            }
+
+            counts = countsBeforeUpdate;
+        }
+
+        if (!waitSuccessful)
+        {
+            return false;
+        }
+    }
+}
+
+bool CLRLifoSemaphore::Wait(DWORD timeoutMs)
+{
+    WRAPPER_NO_CONTRACT;
+
+    _ASSERTE(m_handle != nullptr);
+
+    // Acquire the semaphore or register as a waiter
+    Counts counts = m_counts.VolatileLoad();
+    while (true)
+    {
+        _ASSERTE(counts.signalCount <= m_maximumSignalCount);
+        Counts newCounts = counts;
+        if (counts.signalCount != 0)
+        {
+            --newCounts.signalCount;
+        }
+        else if (timeoutMs != 0)
+        {
+            ++newCounts.waiterCount;
+            _ASSERTE(newCounts.waiterCount != 0);
+        }
+
+        Counts countsBeforeUpdate = m_counts.CompareExchange(newCounts, counts);
+        if (countsBeforeUpdate == counts)
+        {
+            return counts.signalCount != 0 || (timeoutMs != 0 && WaitForSignal(timeoutMs));
+        }
+
+        counts = countsBeforeUpdate;
+    }
+}
+
+bool CLRLifoSemaphore::Wait(DWORD timeoutMs, UINT32 spinCount)
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        SO_TOLERANT;
+    }
+    CONTRACTL_END;
+
+    _ASSERTE(m_handle != nullptr);
+
+    if (timeoutMs == 0 || spinCount == 0)
+    {
+        return Wait(timeoutMs);
+    }
+
+    // Try to acquire the semaphore or register as a spinner
+    Counts counts = m_counts.VolatileLoad();
+    while (true)
+    {
+        Counts newCounts = counts;
+        if (counts.signalCount != 0)
+        {
+            --newCounts.signalCount;
+        }
+        else
+        {
+            ++newCounts.spinnerCount;
+            if (newCounts.spinnerCount == (UINT8)0)
+            {
+                // Maximum number of spinners reached, register as a waiter instead
+                --newCounts.spinnerCount;
+                ++newCounts.waiterCount;
+                _ASSERTE(newCounts.waiterCount != 0);
+            }
+        }
+
+        Counts countsBeforeUpdate = m_counts.CompareExchange(newCounts, counts);
+        if (countsBeforeUpdate == counts)
+        {
+            if (counts.signalCount != 0)
+            {
+                return true;
+            }
+            if (newCounts.waiterCount != counts.waiterCount)
+            {
+                return WaitForSignal(timeoutMs);
+            }
+            break;
+        }
+
+        counts = countsBeforeUpdate;
+    }
+
+    Thread::EnsureYieldProcessorNormalizedInitialized();
+    const UINT32 Sleep0Threshold = 10;
+#ifdef FEATURE_PAL
+    // The PAL's wait subsystem is quite slow, spin more to compensate for the more expensive wait
+    spinCount *= 2;
+#endif // FEATURE_PAL
+    for (UINT32 i = 0; i < spinCount; ++i)
+    {
+        // Wait
+        //
+        // (i - Sleep0Threshold) % 2 != 0: The purpose of this check is to interleave Thread.Yield/Sleep(0) with
+        // Thread.SpinWait. Otherwise, the following issues occur:
+        //   - When there are no threads to switch to, Yield and Sleep(0) become no-op and it turns the spin loop into a
+        //     busy-spin that may quickly reach the max spin count and cause the thread to enter a wait state. Completing the
+        //     spin loop too early can cause excessive context switcing from the wait.
+        //   - If there are multiple threads doing Yield and Sleep(0) (typically from the same spin loop due to contention),
+        //     they may switch between one another, delaying work that can make progress.
+        if (i < Sleep0Threshold || (i - Sleep0Threshold) % 2 != 0)
+        {
+            Thread::YieldProcessorNormalizedWithBackOff(i);
+        }
+        else
+        {
+            // Not doing SwitchToThread(), it does not seem to have any benefit over Sleep(0)
+            ClrSleepEx(0, false);
+        }
+
+        // Try to acquire the semaphore and unregister as a spinner
+        counts = m_counts.VolatileLoad();
+        while (true)
+        {
+            _ASSERTE(counts.spinnerCount != (UINT8)0);
+            if (counts.signalCount == 0)
+            {
+                break;
+            }
+
+            Counts newCounts = counts;
+            --newCounts.signalCount;
+            --newCounts.spinnerCount;
+
+            Counts countsBeforeUpdate = m_counts.CompareExchange(newCounts, counts);
+            if (countsBeforeUpdate == counts)
+            {
+                return true;
+            }
+
+            counts = countsBeforeUpdate;
+        }
+    }
+
+    // Unregister as a spinner, and acquire the semaphore or register as a waiter
+    counts = m_counts.VolatileLoad();
+    while (true)
+    {
+        _ASSERTE(counts.spinnerCount != (UINT8)0);
+        Counts newCounts = counts;
+        --newCounts.spinnerCount;
+        if (counts.signalCount != 0)
+        {
+            --newCounts.signalCount;
+        }
+        else
+        {
+            ++newCounts.waiterCount;
+            _ASSERTE(newCounts.waiterCount != 0);
+        }
+
+        Counts countsBeforeUpdate = m_counts.CompareExchange(newCounts, counts);
+        if (countsBeforeUpdate == counts)
+        {
+            return counts.signalCount != 0 || WaitForSignal(timeoutMs);
+        }
+
+        counts = countsBeforeUpdate;
+    }
+}
+
+void CLRLifoSemaphore::Release(INT32 releaseCount)
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        SO_TOLERANT;
+    }
+    CONTRACTL_END;
+
+    _ASSERTE(releaseCount > 0);
+    _ASSERTE(releaseCount <= m_maximumSignalCount);
+    _ASSERTE(m_handle != INVALID_HANDLE_VALUE);
+
+    INT32 countOfWaitersToWake;
+    Counts counts = m_counts.VolatileLoad();
+    while (true)
+    {
+        Counts newCounts = counts;
+
+        // Increase the signal count. The addition doesn't overflow because of the limit on the max signal count in Create.
+        newCounts.signalCount += releaseCount;
+        _ASSERTE(newCounts.signalCount > counts.signalCount);
+
+        // Determine how many waiters to wake, taking into account how many spinners and waiters there are and how many waiters
+        // have previously been signaled to wake but have not yet woken
+        countOfWaitersToWake =
+            (INT32)min(newCounts.signalCount, (UINT32)newCounts.waiterCount + newCounts.spinnerCount) -
+            newCounts.spinnerCount -
+            newCounts.countOfWaitersSignaledToWake;
+        if (countOfWaitersToWake > 0)
+        {
+            // Ideally, limiting to a maximum of releaseCount would not be necessary and could be an assert instead, but since
+            // WaitForSignal() does not have enough information to tell whether a woken thread was signaled, and due to the cap
+            // below, it's possible for countOfWaitersSignaledToWake to be less than the number of threads that have actually
+            // been signaled to wake.
+            if (countOfWaitersToWake > releaseCount)
+            {
+                countOfWaitersToWake = releaseCount;
+            }
+
+            // Cap countOfWaitersSignaledToWake to its max value. It's ok to ignore some woken threads in this count, it just
+            // means some more threads will be woken next time. Typically, it won't reach the max anyway.
+            newCounts.countOfWaitersSignaledToWake += (UINT8)min(countOfWaitersToWake, (INT32)UINT8_MAX);
+            if (newCounts.countOfWaitersSignaledToWake <= counts.countOfWaitersSignaledToWake)
+            {
+                newCounts.countOfWaitersSignaledToWake = UINT8_MAX;
+            }
+        }
+
+        Counts countsBeforeUpdate = m_counts.CompareExchange(newCounts, counts);
+        if (countsBeforeUpdate == counts)
+        {
+            _ASSERTE((UINT32)releaseCount <= m_maximumSignalCount - counts.signalCount);
+            _ASSERTE(newCounts.countOfWaitersSignaledToWake <= newCounts.waiterCount);
+            if (countOfWaitersToWake <= 0)
+            {
+                return;
+            }
+            break;
+        }
+
+        counts = countsBeforeUpdate;
+    }
+
+    // Wake waiters
+#ifdef FEATURE_PAL
+    BOOL released = UnsafeReleaseSemaphore(m_handle, countOfWaitersToWake, nullptr);
+    _ASSERTE(released);
+#else // !FEATURE_PAL
+    while (--countOfWaitersToWake >= 0)
+    {
+        while (!PostQueuedCompletionStatus(m_handle, 0, 0, nullptr))
+        {
+            // Probably out of memory. It's not valid to stop and throw here, so try again after a delay.
+            ClrSleepEx(1, false);
+        }
+    }
+#endif // FEATURE_PAL
+}
+
 void CLRMutex::Create(LPSECURITY_ATTRIBUTES lpMutexAttributes, BOOL bInitialOwner, LPCTSTR lpName)
 {
     CONTRACTL

--- a/src/vm/synch.cpp
+++ b/src/vm/synch.cpp
@@ -835,7 +835,7 @@ bool CLRLifoSemaphore::Wait(DWORD timeoutMs, UINT32 spinCount, UINT32 processorC
 
         // Determine whether to spin further
         double spinnersPerProcessor = (double)counts.spinnerCount / processorCount;
-        int spinLimit = (int)(spinCountPerProcessor / spinnersPerProcessor + 0.5);
+        UINT32 spinLimit = (UINT32)(spinCountPerProcessor / spinnersPerProcessor + 0.5);
         if (i >= spinLimit)
         {
             break;

--- a/src/vm/synch.cpp
+++ b/src/vm/synch.cpp
@@ -842,8 +842,8 @@ bool CLRLifoSemaphore::Wait(DWORD timeoutMs, UINT32 spinCount, UINT32 processorC
         }
     }
 #else // !_TARGET_ARM64_
-    Thread::EnsureYieldProcessorNormalizedInitialized();
     const UINT32 Sleep0Threshold = 10;
+    YieldProcessorWithBackOffNormalizationInfo normalizationInfo;
 #ifdef FEATURE_PAL
     // The PAL's wait subsystem is quite slow, spin more to compensate for the more expensive wait
     spinCount *= 2;
@@ -861,7 +861,7 @@ bool CLRLifoSemaphore::Wait(DWORD timeoutMs, UINT32 spinCount, UINT32 processorC
         //     they may switch between one another, delaying work that can make progress.
         if (i < Sleep0Threshold || (i - Sleep0Threshold) % 2 != 0)
         {
-            Thread::YieldProcessorNormalizedWithBackOff(i);
+            YieldProcessorWithBackOffNormalized(normalizationInfo, i);
         }
         else
         {

--- a/src/vm/synch.cpp
+++ b/src/vm/synch.cpp
@@ -751,8 +751,8 @@ bool CLRLifoSemaphore::Wait(DWORD timeoutMs, UINT32 spinCount, UINT32 processorC
     CONTRACTL
     {
         NOTHROW;
-    GC_NOTRIGGER;
-    SO_TOLERANT;
+        GC_NOTRIGGER;
+        SO_TOLERANT;
     }
     CONTRACTL_END;
 

--- a/src/vm/synch.cpp
+++ b/src/vm/synch.cpp
@@ -733,7 +733,7 @@ bool CLRLifoSemaphore::Wait(DWORD timeoutMs)
         else if (timeoutMs != 0)
         {
             ++newCounts.waiterCount;
-            _ASSERTE(newCounts.waiterCount != 0);
+            _ASSERTE(newCounts.waiterCount != (UINT16)0); // overflow check, this many waiters is currently not supported
         }
 
         Counts countsBeforeUpdate = m_counts.CompareExchange(newCounts, counts);
@@ -780,7 +780,7 @@ bool CLRLifoSemaphore::Wait(DWORD timeoutMs, UINT32 spinCount)
                 // Maximum number of spinners reached, register as a waiter instead
                 --newCounts.spinnerCount;
                 ++newCounts.waiterCount;
-                _ASSERTE(newCounts.waiterCount != 0);
+                _ASSERTE(newCounts.waiterCount != (UINT16)0); // overflow check, this many waiters is currently not supported
             }
         }
 
@@ -866,7 +866,7 @@ bool CLRLifoSemaphore::Wait(DWORD timeoutMs, UINT32 spinCount)
         else
         {
             ++newCounts.waiterCount;
-            _ASSERTE(newCounts.waiterCount != 0);
+            _ASSERTE(newCounts.waiterCount != (UINT16)0); // overflow check, this many waiters is currently not supported
         }
 
         Counts countsBeforeUpdate = m_counts.CompareExchange(newCounts, counts);

--- a/src/vm/synch.cpp
+++ b/src/vm/synch.cpp
@@ -890,7 +890,7 @@ void CLRLifoSemaphore::Release(INT32 releaseCount)
     CONTRACTL_END;
 
     _ASSERTE(releaseCount > 0);
-    _ASSERTE(releaseCount <= m_maximumSignalCount);
+    _ASSERTE((UINT32)releaseCount <= m_maximumSignalCount);
     _ASSERTE(m_handle != INVALID_HANDLE_VALUE);
 
     INT32 countOfWaitersToWake;

--- a/src/vm/synch.h
+++ b/src/vm/synch.h
@@ -257,7 +257,9 @@ public:
     void Release(INT32 releaseCount);
 
 private:
+    BYTE __padding1[MAX_CACHE_LINE_SIZE]; // padding to ensure that m_counts gets its own cache line
     Counts m_counts;
+    BYTE __padding2[MAX_CACHE_LINE_SIZE]; // padding to ensure that m_counts gets its own cache line
 
 #if defined(DEBUG)
     UINT32 m_maximumSignalCount;

--- a/src/vm/synch.h
+++ b/src/vm/synch.h
@@ -253,7 +253,7 @@ private:
     bool WaitForSignal(DWORD timeoutMs);
 public:
     bool Wait(DWORD timeoutMs);
-    bool Wait(DWORD timeoutMs, UINT32 spinCount);
+    bool Wait(DWORD timeoutMs, UINT32 spinCount, UINT32 processorCount);
     void Release(INT32 releaseCount);
 
 private:

--- a/src/vm/synch.h
+++ b/src/vm/synch.h
@@ -177,6 +177,97 @@ private:
     HANDLE m_handle;
 };
 
+class CLRLifoSemaphore
+{
+private:
+    struct Counts
+    {
+        union
+        {
+            struct
+            {
+                UINT32 signalCount;
+                UINT16 waiterCount;
+                UINT8 spinnerCount;
+                UINT8 countOfWaitersSignaledToWake;
+            };
+            UINT64 data;
+        };
+
+        Counts(UINT64 data = 0) : data(data)
+        {
+            LIMITED_METHOD_CONTRACT;
+        }
+
+        operator UINT64() const
+        {
+            LIMITED_METHOD_CONTRACT;
+            return data;
+        }
+
+        Counts &operator =(UINT64 data)
+        {
+            LIMITED_METHOD_CONTRACT;
+
+            this->data = data;
+            return *this;
+        }
+
+        Counts VolatileLoad() const
+        {
+            LIMITED_METHOD_CONTRACT;
+            return ::VolatileLoad(&data);
+        }
+
+        Counts CompareExchange(Counts toCounts, Counts fromCounts)
+        {
+            LIMITED_METHOD_CONTRACT;
+            return (UINT64)InterlockedCompareExchange64((LONG64 *)&data, (LONG64)toCounts, (LONG64)fromCounts);
+        }
+    };
+
+public:
+    CLRLifoSemaphore() : m_handle(nullptr)
+    {
+        LIMITED_METHOD_CONTRACT;
+    }
+
+    ~CLRLifoSemaphore()
+    {
+        WRAPPER_NO_CONTRACT;
+        Close();
+    }
+
+public:
+    void Create(INT32 initialSignalCount, INT32 maximumSignalCount);
+    void Close();
+
+public:
+    BOOL IsValid() const
+    {
+        LIMITED_METHOD_CONTRACT;
+        return m_handle != nullptr;
+    }
+
+private:
+    bool WaitForSignal(DWORD timeoutMs);
+public:
+    bool Wait(DWORD timeoutMs);
+    bool Wait(DWORD timeoutMs, UINT32 spinCount);
+    void Release(INT32 releaseCount);
+
+private:
+    Counts m_counts;
+
+#if defined(DEBUG)
+    UINT32 m_maximumSignalCount;
+#endif // _DEBUG && !FEATURE_PAL
+
+    // When FEATURE_PAL is defined, this is a handle to an instance of the PAL's LIFO semaphore. When FEATURE_PAL is not
+    // defined, this is a handle to an I/O completion port.
+    HANDLE m_handle;
+};
+
 class CLRMutex {
 public:
     CLRMutex()

--- a/src/vm/win32threadpool.cpp
+++ b/src/vm/win32threadpool.cpp
@@ -2131,7 +2131,7 @@ WaitForWork:
     FireEtwThreadPoolWorkerThreadWait(counts.NumActive, counts.NumRetired, GetClrInstanceId());
 
 RetryWaitForWork:
-    if (WorkerSemaphore->Wait(AppX::IsAppXProcess() ? WorkerTimeoutAppX : WorkerTimeout, WorkerThreadSpinLimit))
+    if (WorkerSemaphore->Wait(AppX::IsAppXProcess() ? WorkerTimeoutAppX : WorkerTimeout, WorkerThreadSpinLimit, NumberOfProcessors))
     {
         foundWork = true;
         goto Work;

--- a/src/vm/win32threadpool.cpp
+++ b/src/vm/win32threadpool.cpp
@@ -103,6 +103,7 @@ DWORD ThreadpoolMgr::NextCompletedWorkRequestsTime;
 
 LARGE_INTEGER ThreadpoolMgr::CurrentSampleStartTime;
 
+unsigned int ThreadpoolMgr::WorkerThreadSpinLimit;
 int ThreadpoolMgr::ThreadAdjustmentInterval;
 
 #define INVALID_HANDLE ((HANDLE) -1)
@@ -136,8 +137,8 @@ CLREvent * ThreadpoolMgr::RetiredCPWakeupEvent;       // wakeup event for comple
 CrstStatic ThreadpoolMgr::WaitThreadsCriticalSection;
 ThreadpoolMgr::LIST_ENTRY ThreadpoolMgr::WaitThreadsHead;
 
-ThreadpoolMgr::UnfairSemaphore* ThreadpoolMgr::WorkerSemaphore;
-CLRSemaphore* ThreadpoolMgr::RetiredWorkerSemaphore;
+CLRLifoSemaphore* ThreadpoolMgr::WorkerSemaphore;
+CLRLifoSemaphore* ThreadpoolMgr::RetiredWorkerSemaphore;
 
 CrstStatic ThreadpoolMgr::TimerQueueCriticalSection;
 HANDLE ThreadpoolMgr::TimerThread=NULL;
@@ -353,6 +354,7 @@ BOOL ThreadpoolMgr::Initialize()
 
     EX_TRY
     {
+        WorkerThreadSpinLimit = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_ThreadPool_UnfairSemaphoreSpinLimit);
         ThreadAdjustmentInterval = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_HillClimbing_SampleIntervalLow);
         
         pADTPCount->InitResources();
@@ -370,26 +372,26 @@ BOOL ThreadpoolMgr::Initialize()
         RetiredCPWakeupEvent->CreateAutoEvent(FALSE);
         _ASSERTE(RetiredCPWakeupEvent->IsValid());
 
-        int spinLimitPerProcessor = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_ThreadPool_UnfairSemaphoreSpinLimit);
-        WorkerSemaphore = new UnfairSemaphore(ThreadCounter::MaxPossibleCount, spinLimitPerProcessor);
+        WorkerSemaphore = new CLRLifoSemaphore();
+        WorkerSemaphore->Create(0, ThreadCounter::MaxPossibleCount);
 
-        RetiredWorkerSemaphore = new CLRSemaphore();
+        RetiredWorkerSemaphore = new CLRLifoSemaphore();
         RetiredWorkerSemaphore->Create(0, ThreadCounter::MaxPossibleCount);
 
-    //ThreadPool_CPUGroup
-    if (CPUGroupInfo::CanEnableGCCPUGroups() && CPUGroupInfo::CanEnableThreadUseAllCpuGroups())
+        //ThreadPool_CPUGroup
+        if (CPUGroupInfo::CanEnableGCCPUGroups() && CPUGroupInfo::CanEnableThreadUseAllCpuGroups())
             RecycledLists.Initialize( CPUGroupInfo::GetNumActiveProcessors() );
         else
-        RecycledLists.Initialize( g_SystemInfo.dwNumberOfProcessors );
-    /*
-        {
-            SYSTEM_INFO sysInfo;
+            RecycledLists.Initialize( g_SystemInfo.dwNumberOfProcessors );
+        /*
+            {
+                SYSTEM_INFO sysInfo;
 
-            ::GetSystemInfo( &sysInfo );
+                ::GetSystemInfo( &sysInfo );
 
-            RecycledLists.Initialize( sysInfo.dwNumberOfProcessors );
-        }
-    */
+                RecycledLists.Initialize( sysInfo.dwNumberOfProcessors );
+            }
+        */
     }
     EX_CATCH
     {
@@ -1034,9 +1036,7 @@ void ThreadpoolMgr::MaybeAddWorkingWorker()
 
     if (toUnretire > 0)
     {
-        LONG previousCount;
-        INDEBUG(BOOL success =) RetiredWorkerSemaphore->Release((LONG)toUnretire, &previousCount);            
-        _ASSERTE(success);
+        RetiredWorkerSemaphore->Release(toUnretire);
     }
 
     if (toRelease > 0)
@@ -2055,10 +2055,7 @@ Retire:
     while (true)
     {
 RetryRetire:
-        DWORD result = RetiredWorkerSemaphore->Wait(AppX::IsAppXProcess() ? WorkerTimeoutAppX : WorkerTimeout, FALSE);
-        _ASSERTE(WAIT_OBJECT_0 == result || WAIT_TIMEOUT == result);
-
-        if (WAIT_OBJECT_0 == result)
+        if (RetiredWorkerSemaphore->Wait(AppX::IsAppXProcess() ? WorkerTimeoutAppX : WorkerTimeout))
         {
             foundWork = true;
 
@@ -2134,59 +2131,57 @@ WaitForWork:
     FireEtwThreadPoolWorkerThreadWait(counts.NumActive, counts.NumRetired, GetClrInstanceId());
 
 RetryWaitForWork:
-    if (!WorkerSemaphore->Wait(AppX::IsAppXProcess() ? WorkerTimeoutAppX : WorkerTimeout))
+    if (WorkerSemaphore->Wait(AppX::IsAppXProcess() ? WorkerTimeoutAppX : WorkerTimeout, WorkerThreadSpinLimit))
     {
-        if (!IsIoPending())
+        foundWork = true;
+        goto Work;
+    }
+
+    if (!IsIoPending())
+    {
+        //
+        // We timed out, and are about to exit.  This puts us in a very similar situation to the
+        // retirement case above - someone may think we're still waiting, and go ahead and:
+        //
+        // 1) Increment NumWorking
+        // 2) Signal WorkerSemaphore
+        //
+        // The solution is much like retirement; when we're decrementing NumActive, we need to make
+        // sure it doesn't drop below NumWorking.  If it would, then we need to go back and wait 
+        // again.
+        //
+
+        DangerousNonHostedSpinLockHolder tal(&ThreadAdjustmentLock);
+
+        // counts volatile read paired with CompareExchangeCounts loop set
+        counts = WorkerCounter.DangerousGetDirtyCounts();
+        while (true)
         {
-            //
-            // We timed out, and are about to exit.  This puts us in a very similar situation to the
-            // retirement case above - someone may think we're still waiting, and go ahead and:
-            //
-            // 1) Increment NumWorking
-            // 2) Signal WorkerSemaphore
-            //
-            // The solution is much like retirement; when we're decrementing NumActive, we need to make
-            // sure it doesn't drop below NumWorking.  If it would, then we need to go back and wait 
-            // again.
-            //
-
-            DangerousNonHostedSpinLockHolder tal(&ThreadAdjustmentLock);
-
-            // counts volatile read paired with CompareExchangeCounts loop set
-            counts = WorkerCounter.DangerousGetDirtyCounts();
-            while (true)
+            if (counts.NumActive == counts.NumWorking)
             {
-                if (counts.NumActive == counts.NumWorking)
-                {
-                    goto RetryWaitForWork;
-                }
-
-                newCounts = counts;
-                newCounts.NumActive--;
-
-                // if we timed out while active, then Hill Climbing needs to be told that we need fewer threads
-                newCounts.MaxWorking = max(MinLimitTotalWorkerThreads, min(newCounts.NumActive, newCounts.MaxWorking));
-
-                oldCounts = WorkerCounter.CompareExchangeCounts(newCounts, counts);
-
-                if (oldCounts == counts)
-                {
-                    HillClimbingInstance.ForceChange(newCounts.MaxWorking, ThreadTimedOut);
-                    goto Exit;
-                }
-
-                counts = oldCounts;
+                goto RetryWaitForWork;
             }
-        }
-        else
-        {
-            goto RetryWaitForWork;
+
+            newCounts = counts;
+            newCounts.NumActive--;
+
+            // if we timed out while active, then Hill Climbing needs to be told that we need fewer threads
+            newCounts.MaxWorking = max(MinLimitTotalWorkerThreads, min(newCounts.NumActive, newCounts.MaxWorking));
+
+            oldCounts = WorkerCounter.CompareExchangeCounts(newCounts, counts);
+
+            if (oldCounts == counts)
+            {
+                HillClimbingInstance.ForceChange(newCounts.MaxWorking, ThreadTimedOut);
+                goto Exit;
+            }
+
+            counts = oldCounts;
         }
     }
     else
     {
-        foundWork = true;
-        goto Work;
+        goto RetryWaitForWork;
     }
 
 Exit:


### PR DESCRIPTION
Closes https://github.com/dotnet/coreclr/issues/5928

Replaced UnfairSemaphore with a new implementation in CLRLifoSemaphore
- UnfairSemaphore had a some benefits:
  - It tracked the number of spinners and avoids waking up waiters as long as the signal count can be satisfied by spinners
  - Since spinners get priority over waiters, that's the main "unfair" part of it that allows hot threads to remain hot and cold threads to remain cold. However, waiters are still released in FIFO order.
  - Spinning helps with throughput when incoming work is bursty
- All of the above benefits were retained in CLRLifoSemaphore and some were improved:
  - Similarly to UnfairSemaphore, the number of spinners are tracked and preferenced to avoid waking up waiters
  - For waiting, on Windows, a I/O completion port is used since it releases waiters in LIFO order. For Unix, added a prioritized wait function to the PAL to register waiters in reverse order for LIFO release behavior. This allows cold waiters to time out more easily since they will be used less frequently.
  - Similarly to SemaphoreSlim, the number of waiters that were signaled to wake but have not yet woken is tracked to help avoid waking up an excessive number of waiters
  - Added some YieldProcessorNormalized() calls to the spin loop. This avoids thrashing on Sleep(0) by adding a delay to the spin loop to allow it to be more effective when there are no threads to switch to, or the only other threads to switch to are other similar spinners.
  - Removed the processor count multiplier on the max spin count and retuned the default max spin count. The processor count multiplier was causing excessive CPU usage on machines with many processors.

Perf results

For the test case in https://github.com/dotnet/coreclr/issues/5928, CPU time spent in UnfairSemaphore::Wait was halved. CPU time % spent in UnfairSemaphore::Wait relative to time spent in WorkerThreadStart reduced from about 88% to 78%.

Updated spin perf code here: https://github.com/dotnet/coreclr/pull/13670
- NPc = (N * proc count) threads
- MPcWi = (M * proc count) work items
- BurstWorkThroughput queues that many work items in a burst, then releases the thread pool threads to process all of them, and once all are processed, repeats
- SustainedWorkThroughput has work items queue another of itself with some initial number of work items such that the work item count never reaches zero

```
Spin                                          Left score      Right score     ∆ Score %
--------------------------------------------  --------------  --------------  ---------
ThreadPoolBurstWorkThroughput 1Pc 000.25PcWi   276.10 ±1.09%   268.90 ±1.36%     -2.61%
ThreadPoolBurstWorkThroughput 1Pc 000.50PcWi   362.63 ±0.47%   388.82 ±0.33%      7.22%
ThreadPoolBurstWorkThroughput 1Pc 001.00PcWi   498.33 ±0.32%   797.01 ±0.29%     59.94%
ThreadPoolBurstWorkThroughput 1Pc 004.00PcWi  1222.52 ±0.42%  1348.78 ±0.47%     10.33%
ThreadPoolBurstWorkThroughput 1Pc 016.00PcWi  1672.72 ±0.48%  1724.06 ±0.47%      3.07%
ThreadPoolBurstWorkThroughput 1Pc 064.00PcWi  1853.94 ±0.25%  1868.36 ±0.45%      0.78%
ThreadPoolBurstWorkThroughput 1Pc 256.00PcWi  1849.30 ±0.24%  1902.58 ±0.48%      2.88%
ThreadPoolSustainedWorkThroughput 1Pc         1495.62 ±0.78%  1505.89 ±0.20%      0.69%
--------------------------------------------  --------------  --------------  ---------
Total                                          922.22 ±0.51%  1004.59 ±0.51%      8.93%
```

Numbers on Linux were similar with a slightly different spread and no regressions.

I also tried the plaintext benchmark from https://github.com/aspnet/benchmarks on Windows (couldn't get it to build on Linux at the time). No noticeable change to throughput or latency, and the CPU time spent in UnfairSemaphore::Wait decreased a little from ~2% to ~0.5% in CLRLifoSemaphore::Wait.