### PR TITLE
[release/2.0.0] Skip PPDB conversion: add SkipCreateWindowsPdbsFromPortablePdbs=true

### DIFF
--- a/buildpipeline/DotNet-Trusted-Publish-Symbols.json
+++ b/buildpipeline/DotNet-Trusted-Publish-Symbols.json
@@ -56,7 +56,7 @@
         "scriptName": "",
         "arguments": "-BuildType $(PB_BuildType) -SymPkgGlob $(PB_AzureContainerSymbolPackageGlob) -Branch $(SourceBranch)",
         "workingFolder": "$(Pipeline.SourcesDirectory)",
-        "inlineScript": "param($BuildType, $SymPkgGlob, $Branch)\nif ($BuildType -ne \"Release\") { exit }\n$archive = $Branch.StartsWith(\"release/\")\n\n$target = \"UnzipSymbolPackagesForPublish\"\nif ($archive) { $target = \"SubmitSymbolsRequest\" }\n\n.\\run.cmd build -- `\n/t:$target `\n/p:SymbolPackagesToPublishGlob=$SymPkgGlob `\n/p:ArchiveSymbols=$archive `\n/v:D",
+        "inlineScript": "param($BuildType, $SymPkgGlob, $Branch)\nif ($BuildType -ne \"Release\") { exit }\n$archive = $Branch.StartsWith(\"release/\")\n\n$target = \"UnzipSymbolPackagesForPublish\"\nif ($archive) { $target = \"SubmitSymbolsRequest\" }\n\n.\\run.cmd build -- `\n/t:$target `\n/p:SymbolPackagesToPublishGlob=$SymPkgGlob `\n/p:ArchiveSymbols=$archive `\n/p:SkipCreateWindowsPdbsFromPortablePdbs=true `\n/v:D",
         "failOnStandardError": "true"
       }
     },


### PR DESCRIPTION
Temporarily skip PPDB conversion to PDB to unblock official builds. (https://github.com/dotnet/core-eng/issues/1769)

There's more investigation to do to figure out why it's failing (the conversion seems to work for the same files in master) but this should unblock the build until someone has time to do that.