### PR TITLE
Disable PAX mprotect for native executables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,11 @@ else (WIN32)
     if (AWK STREQUAL "AWK-NOTFOUND")
         message(FATAL_ERROR "AWK not found")
     endif()
+
+    # Try to locate the paxctl tool. Failure to find it is not fatal,
+    # but the generated executables won't work on a system where PAX is set
+    # to prevent applications to create executable memory mappings.
+    find_program(PAXCTL paxctl)
  
     if (CMAKE_SYSTEM_NAME STREQUAL Darwin)
 

--- a/functions.cmake
+++ b/functions.cmake
@@ -192,9 +192,28 @@ function(install_clr targetName)
   endif()  
 endfunction()
 
+# Disable PAX mprotect that would prevent JIT and other codegen in coreclr from working.
+# PAX mprotect prevents:
+# - changing the executable status of memory pages that were
+#   not originally created as executable,
+# - making read-only executable pages writable again,
+# - creating executable pages from anonymous memory,
+# - making read-only-after-relocations (RELRO) data pages writable again.
+function(disable_pax_mprotect targetName)
+  if (NOT PAXCTL STREQUAL "PAXCTL-NOTFOUND")
+    add_custom_command(
+      TARGET ${targetName}
+      POST_BUILD
+      VERBATIM
+      COMMAND ${PAXCTL} -c -m $<TARGET_FILE:${targetName}>
+    )
+  endif()
+endfunction()
+
 function(_add_executable)
     if(NOT WIN32)
       add_executable(${ARGV} ${VERSION_FILE_PATH})
+      disable_pax_mprotect(${ARGV})
     else()
       add_executable(${ARGV})
     endif(NOT WIN32)
@@ -239,28 +258,12 @@ function(verify_dependencies targetName errorMessage)
 endfunction()
 
 function(add_library_clr)
-    if(NOT WIN32)
-      add_library(${ARGV} ${VERSION_FILE_PATH})
-    else()
-      add_library(${ARGV})
-    endif(NOT WIN32)
     add_dependencies(${ARGV0} GeneratedEventingFiles)
-    list(FIND CLR_CROSS_COMPONENTS_LIST ${ARGV0} INDEX)  
-    if (DEFINED CLR_CROSS_COMPONENTS_LIST AND ${INDEX} EQUAL -1)  
-     set_target_properties(${ARGV0} PROPERTIES EXCLUDE_FROM_ALL 1)  
-    endif()  
+    _add_library(${ARGV})
 endfunction()
 
 function(add_executable_clr)
-    if(NOT WIN32)
-      add_executable(${ARGV} ${VERSION_FILE_PATH})
-    else()
-      add_executable(${ARGV})
-    endif(NOT WIN32)
     add_dependencies(${ARGV0} GeneratedEventingFiles)
-    list(FIND CLR_CROSS_COMPONENTS_LIST ${ARGV0} INDEX)  
-    if (DEFINED CLR_CROSS_COMPONENTS_LIST AND ${INDEX} EQUAL -1)  
-     set_target_properties(${ARGV0} PROPERTIES EXCLUDE_FROM_ALL 1)  
-    endif()  
+    _add_executable(${ARGV})
 endfunction()
 


### PR DESCRIPTION
This change adds marking native executables that coreclr build produces
(corerun, coreconsole, crossgen, ilasm, ildasm, crashdump) using the
paxctl tool to allow them running on systems with PAX configured so that
creating executable memory mappings by applications is prohibited.