### PR TITLE
[Arm64] Do not extend within Compare/Test nodes

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -3430,8 +3430,8 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
 
     GenTreePtr op1     = tree->gtOp1;
     GenTreePtr op2     = tree->gtOp2;
-    var_types  op1Type = op1->TypeGet();
-    var_types  op2Type = op2->TypeGet();
+    var_types  op1Type = genActualType(op1->TypeGet());
+    var_types  op2Type = genActualType(op2->TypeGet());
 
     assert(!op1->isUsedFromMemory());
     assert(!op2->isUsedFromMemory());
@@ -3463,29 +3463,9 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
         // We don't support swapping op1 and op2 to generate cmp reg, imm
         assert(!op1->isContainedIntOrIImmed());
 
-        // TODO-ARM64-CQ: the second register argument of a CMP can be sign/zero
-        // extended as part of the instruction (using "CMP (extended register)").
-        // We should use that if possible, swapping operands
-        // (and reversing the condition) if necessary.
         unsigned op1Size = genTypeSize(op1Type);
         unsigned op2Size = genTypeSize(op2Type);
 
-        if ((op1Size < 4) || (op1Size < op2Size))
-        {
-            // We need to sign/zero extend op1 up to 32 or 64 bits.
-            instruction ins = ins_Move_Extend(op1Type, true);
-            inst_RV_RV(ins, op1->gtRegNum, op1->gtRegNum);
-        }
-
-        if (!op2->isContainedIntOrIImmed())
-        {
-            if ((op2Size < 4) || (op2Size < op1Size))
-            {
-                // We need to sign/zero extend op2 up to 32 or 64 bits.
-                instruction ins = ins_Move_Extend(op2Type, true);
-                inst_RV_RV(ins, op2->gtRegNum, op2->gtRegNum);
-            }
-        }
         cmpSize = EA_4BYTE;
         if ((op1Size == EA_8BYTE) || (op2Size == EA_8BYTE))
         {
@@ -3494,6 +3474,20 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
 
         instruction ins = tree->OperIs(GT_TEST_EQ, GT_TEST_NE) ? INS_tst : INS_cmp;
 
+        if (op1Size < cmpSize)
+        {
+            assert(op1Size == 4);
+            bool isTest          = (ins == INS_tst);
+            bool testNeedsExtend = isTest && (!op2->isContainedIntOrIImmed() ||
+                                              (op2->AsIntConCommon()->IconValue() & (~0UL << (8 * op1Size))));
+            if (!isTest || testNeedsExtend)
+            {
+                // We need to sign/zero extend op1 up to 64 bits.
+                instruction ins = ins_Move_Extend(op1Type, true);
+                inst_RV_RV(ins, op1->gtRegNum, op1->gtRegNum);
+            }
+        }
+
         if (op2->isContainedIntOrIImmed())
         {
             GenTreeIntConCommon* intConst = op2->AsIntConCommon();
@@ -3501,7 +3495,23 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
         }
         else
         {
-            emit->emitIns_R_R(ins, cmpSize, op1->gtRegNum, op2->gtRegNum);
+            insOpts extendOpt = INS_OPTS_NONE;
+            if (op2Size < cmpSize)
+            {
+                if (ins == INS_tst)
+                {
+                    // We need to sign/zero extend op1 up to 64 bits.
+                    instruction ins = ins_Move_Extend(op1Type, true);
+                    inst_RV_RV(ins, op1->gtRegNum, op1->gtRegNum);
+                }
+                else
+                {
+                    assert(op2Size == 4);
+                    // Use cmp extended register form to sign/zero extend op2 up to 64 bits
+                    extendOpt = varTypeIsUnsigned(op2Type) ? INS_OPTS_UXTW : INS_OPTS_SXTW;
+                }
+            }
+            emit->emitIns_R_R_I(ins, cmpSize, op1->gtRegNum, op2->gtRegNum, 0, extendOpt);
         }
     }
 

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2368,9 +2368,9 @@ void Lowering::LowerCompare(GenTree* cmp)
             GenTree*  longOp       = op1Is64Bit ? cmp->gtOp.gtOp1 : cmp->gtOp.gtOp2;
             GenTree** smallerOpUse = op2Is64Bit ? &cmp->gtOp.gtOp1 : &cmp->gtOp.gtOp2;
 #ifdef _TARGET_AMD64_
-            var_types smallerType  = (*smallerOpUse)->TypeGet();
+            var_types smallerType = (*smallerOpUse)->TypeGet();
 #elif defined(_TARGET_ARM64_)
-            var_types smallerType  = genActualType((*smallerOpUse)->TypeGet());
+            var_types smallerType = genActualType((*smallerOpUse)->TypeGet());
 #endif // _TARGET_AMD64_
 
             assert(genTypeSize(smallerType) < 8);

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2346,7 +2346,7 @@ void Lowering::LowerCompare(GenTree* cmp)
     }
 #endif
 
-#ifdef _TARGET_AMD64_
+#ifdef _TARGET_64BIT_
     if (cmp->gtGetOp1()->TypeGet() != cmp->gtGetOp2()->TypeGet())
     {
         bool op1Is64Bit = (genTypeSize(cmp->gtGetOp1()->TypeGet()) == 8);
@@ -2367,7 +2367,11 @@ void Lowering::LowerCompare(GenTree* cmp)
 
             GenTree*  longOp       = op1Is64Bit ? cmp->gtOp.gtOp1 : cmp->gtOp.gtOp2;
             GenTree** smallerOpUse = op2Is64Bit ? &cmp->gtOp.gtOp1 : &cmp->gtOp.gtOp2;
+#ifdef _TARGET_AMD64_
             var_types smallerType  = (*smallerOpUse)->TypeGet();
+#elif defined(_TARGET_ARM64_)
+            var_types smallerType  = genActualType((*smallerOpUse)->TypeGet());
+#endif // _TARGET_AMD64_
 
             assert(genTypeSize(smallerType) < 8);
 
@@ -2379,6 +2383,7 @@ void Lowering::LowerCompare(GenTree* cmp)
             {
                 (*smallerOpUse)->gtType = TYP_LONG;
             }
+#ifdef _TARGET_AMD64_
             else
             {
                 GenTree* cast = comp->gtNewCastNode(TYP_LONG, *smallerOpUse, TYP_LONG);
@@ -2386,9 +2391,17 @@ void Lowering::LowerCompare(GenTree* cmp)
                 BlockRange().InsertAfter(cast->gtGetOp1(), cast);
                 ContainCheckCast(cast->AsCast());
             }
+#elif defined(_TARGET_ARM64_)
+            else if (op2Is64Bit && !longOp->IsCnsIntOrI())
+            {
+                // Arm64 can use extended compare if smaller register operand is second
+                cmp->SetOperRaw(GenTree::SwapRelop(cmp->OperGet()));
+                std::swap(cmp->gtOp.gtOp1, cmp->gtOp.gtOp2);
+            }
+#endif // _TARGET_AMD64_
         }
     }
-#endif // _TARGET_AMD64_
+#endif // _TARGET_64BIT_
 
 #if defined(_TARGET_XARCH_) || defined(_TARGET_ARM64_)
     if (cmp->gtGetOp2()->IsIntegralConst())

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2383,7 +2383,6 @@ void Lowering::LowerCompare(GenTree* cmp)
             {
                 (*smallerOpUse)->gtType = TYP_LONG;
             }
-#ifdef _TARGET_AMD64_
             else
             {
                 GenTree* cast = comp->gtNewCastNode(TYP_LONG, *smallerOpUse, TYP_LONG);
@@ -2391,14 +2390,6 @@ void Lowering::LowerCompare(GenTree* cmp)
                 BlockRange().InsertAfter(cast->gtGetOp1(), cast);
                 ContainCheckCast(cast->AsCast());
             }
-#elif defined(_TARGET_ARM64_)
-            else if (op2Is64Bit && !longOp->IsCnsIntOrI())
-            {
-                // Arm64 can use extended compare if smaller register operand is second
-                cmp->SetOperRaw(GenTree::SwapRelop(cmp->OperGet()));
-                std::swap(cmp->gtOp.gtOp1, cmp->gtOp.gtOp2);
-            }
-#endif // _TARGET_AMD64_
         }
     }
 #endif // _TARGET_64BIT_


### PR DESCRIPTION
~~[Arm64] Swap compare operand if longer is second
[Arm64] Enable CMP extended register
    Enable CMP extended register~~
~~Remove unnecessary extends~~
Stop generating mov extends within Compare/Test nodes
    Use genActualType
    Add an assert to detect mismatch sizes



Obsoletes ~~Fixes~~ #13867
