### PR TITLE
[ARM] Fix SetDebuggerREGDISPLAYFromREGDISPLAY() function

### DIFF
--- a/src/debug/shared/arm/primitives.cpp
+++ b/src/debug/shared/arm/primitives.cpp
@@ -80,8 +80,15 @@ void CORDbgSetDebuggerREGDISPLAYFromContext(DebuggerREGDISPLAY *pDRD,
 void SetDebuggerREGDISPLAYFromREGDISPLAY(DebuggerREGDISPLAY* pDRD, REGDISPLAY* pRD)
 {
     SUPPORTS_DAC_HOST_ONLY;
-    
+    // CORDbgSetDebuggerREGDISPLAYFromContext() checks the context flags.  In cases where we don't have a filter
+    // context from the thread, we initialize a CONTEXT on the stack and use that to do our stack walking.  We never
+    // initialize the context flags in such cases.  Since this function is called from the stackwalker, we can
+    // guarantee that the integer, control, and floating point sections are valid.  So we set the flags here and
+    // restore them afterwards.
+    DWORD contextFlags = pRD->pCurrentContext->ContextFlags;
+    pRD->pCurrentContext->ContextFlags = CONTEXT_FULL;
     CORDbgSetDebuggerREGDISPLAYFromContext(pDRD, reinterpret_cast<DT_CONTEXT*>(pRD->pCurrentContext));
+    pRD->pCurrentContext->ContextFlags = contextFlags;
 
     pDRD->SP   = pRD->SP;
     pDRD->PC   = (SIZE_T)*(pRD->pPC);


### PR DESCRIPTION
This PR fixes SetDebuggerREGDISPLAYFromREGDISPLAY() function for ARM architecture.

Use the same logic as in AMD64 code: when setting DebuggerREGDISPLAY from the context,
the context flags might not be initialized. Since it is only called from stackwalker,
we can copy valid integer, control, and floating point sections from the context.

Without this fix, the debugger (using ICorDebug) is unable to get local variables and arguments when a managed exception happens with unmanaged frames on the stack:
```
Func2  <- Managed exception happens here
Func1
[Unamanged frame]
...
[Unmanaged frame]
Func0
```

@mikem8361 @janvorli @jkotas PTAL

CC @Dmitri-Botcharnikov @kbaladurin @chunseoklee