### PR TITLE
JIT: mark part of runtime lookup tree as nonfaulting and invariant

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -2028,9 +2028,11 @@ GenTreePtr Compiler::impRuntimeLookupToTree(CORINFO_RESOLVED_TOKEN* pResolvedTok
         slot           = gtNewLclvNode(slotLclNum, TYP_I_IMPL);
         GenTree* add   = gtNewOperNode(GT_ADD, TYP_I_IMPL, slot, gtNewIconNode(-1, TYP_I_IMPL));
         GenTree* indir = gtNewOperNode(GT_IND, TYP_I_IMPL, add);
+        indir->gtFlags |= GTF_IND_NONFAULTING;
+        indir->gtFlags |= GTF_IND_INVARIANT;
+
         slot           = gtNewLclvNode(slotLclNum, TYP_I_IMPL);
         GenTree* asg   = gtNewAssignNode(slot, indir);
-
         GenTree* colon = new (this, GT_COLON) GenTreeColon(TYP_VOID, gtNewNothingNode(), asg);
         GenTree* qmark = gtNewQmarkNode(TYP_VOID, relop, colon);
         impAppendTree(qmark, (unsigned)CHECK_SPILL_NONE, impCurStmtOffs);


### PR DESCRIPTION
An indir in the runtime lookup sequence wasn't marked as nonfaulting
so dead context trees could not be entirely cleaned up.

Also added invariant since this particular lookup sequence will always
return the same result.