### PR TITLE
Renumber blocks before computing loop nest

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4279,9 +4279,9 @@ private:
     BlockToSwitchDescMap* m_switchDescMap;
 
 public:
-    BlockToSwitchDescMap* GetSwitchDescMap()
+    BlockToSwitchDescMap* GetSwitchDescMap(bool createIfNull = true)
     {
-        if (m_switchDescMap == nullptr)
+        if ((m_switchDescMap == nullptr) && createIfNull)
         {
             m_switchDescMap = new (getAllocator()) BlockToSwitchDescMap(getAllocator());
         }

--- a/tests/src/JIT/Regression/JitBlue/GitHub_13919/GitHub_13919.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_13919/GitHub_13919.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+// Test to make sure we can compute correct loop nest even in the face
+// of loop compaction.
+
+namespace N
+{
+    class C
+    {
+        class Node
+        {
+            public int value;
+            public Node next;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static int Process(Node head, int initial, int final)
+        {
+            int result = 0;
+            for (Node node = head; node != null; node = node.next)
+            {
+                int v = node.value;
+                if (v == initial)
+                {
+                    node.value *= 2;
+                    do
+                    {
+                        result += 5 * node.value;
+                        node.value += 1;
+                    }
+                    while (result < final);
+                    break;
+                }
+                result += v;
+            }
+
+            return result;
+        }
+
+        public static int Main(string[] args)
+        {
+            Node head = new Node { value = 6, next = new Node { value = 13, next = new Node { value = 5, next = null } } };
+
+            int expected = 6 + 5 * 26 + 5 * 27 + 5 * 28;
+            int result = Process(head, 13, expected);
+
+            // Return 100 on success, anything else on error.
+            return result - expected + 100;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_13919/GitHub_13919.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_13919/GitHub_13919.csproj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{9711BC9D-A24D-458D-8357-007D6423C212}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
The loop nest computation expects to be able to test block numbers for
lexical inclusion, so do a renumbering pass first if blocks have been
moved.

Fixes #13919.