### PR TITLE
Make Array.Reverse faster

### DIFF
--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -1707,13 +1707,14 @@ namespace System
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
             Contract.EndContractBlock();
 
+            ref T p = ref Unsafe.As<byte, T>(ref array.GetRawSzArrayData());
             int i = index;
             int j = index + length - 1;
             while (i < j)
             {
-                T temp = array[i];
-                array[i] = array[j];
-                array[j] = temp;
+                T temp = Unsafe.Add(ref p, i);
+                Unsafe.Add(ref p, i) = Unsafe.Add(ref p, j);
+                Unsafe.Add(ref p, j) = temp;
                 i++;
                 j--;
             }

--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -1657,22 +1657,15 @@ namespace System
             if (r)
                 return;
 
-            int i = index;
-            int j = index + length - 1;
             Object[] objArray = array as Object[];
             if (objArray != null)
             {
-                while (i < j)
-                {
-                    Object temp = objArray[i];
-                    objArray[i] = objArray[j];
-                    objArray[j] = temp;
-                    i++;
-                    j--;
-                }
+                Array.Reverse<object>(objArray, index, length);
             }
             else
             {
+                int i = index;
+                int j = index + length - 1;
                 while (i < j)
                 {
                     Object temp = array.GetValue(i);


### PR DESCRIPTION
Array.Reverse showed up as hot method in profiles of real workloads (e.g. it is called from Json.NET frequently via List.Reverse)