### PR TITLE
Replace JitHelpers.UnsafeCast with Unsafe.As

### DIFF
--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -2612,7 +2612,7 @@ namespace System
         {
             //! Warning: "this" is an array, not an SZArrayHelper. See comments above
             //! or you may introduce a security hole!
-            T[] _this = JitHelpers.UnsafeCast<T[]>(this);
+            T[] _this = Unsafe.As<T[]>(this);
             return _this.Length == 0 ? SZGenericArrayEnumerator<T>.Empty : new SZGenericArrayEnumerator<T>(_this);
         }
 
@@ -2624,7 +2624,7 @@ namespace System
             //! Warning: "this" is an array, not an SZArrayHelper. See comments above
             //! or you may introduce a security hole!
 
-            T[] _this = JitHelpers.UnsafeCast<T[]>(this);
+            T[] _this = Unsafe.As<T[]>(this);
             Array.Copy(_this, 0, array, index, _this.Length);
         }
 
@@ -2632,7 +2632,7 @@ namespace System
         {
             //! Warning: "this" is an array, not an SZArrayHelper. See comments above
             //! or you may introduce a security hole!
-            T[] _this = JitHelpers.UnsafeCast<T[]>(this);
+            T[] _this = Unsafe.As<T[]>(this);
             return _this.Length;
         }
 
@@ -2643,7 +2643,7 @@ namespace System
         {
             //! Warning: "this" is an array, not an SZArrayHelper. See comments above
             //! or you may introduce a security hole!
-            T[] _this = JitHelpers.UnsafeCast<T[]>(this);
+            T[] _this = Unsafe.As<T[]>(this);
             if ((uint)index >= (uint)_this.Length)
             {
                 ThrowHelper.ThrowArgumentOutOfRange_IndexException();
@@ -2656,7 +2656,7 @@ namespace System
         {
             //! Warning: "this" is an array, not an SZArrayHelper. See comments above
             //! or you may introduce a security hole!
-            T[] _this = JitHelpers.UnsafeCast<T[]>(this);
+            T[] _this = Unsafe.As<T[]>(this);
             if ((uint)index >= (uint)_this.Length)
             {
                 ThrowHelper.ThrowArgumentOutOfRange_IndexException();
@@ -2675,7 +2675,7 @@ namespace System
         {
             //! Warning: "this" is an array, not an SZArrayHelper. See comments above
             //! or you may introduce a security hole!
-            T[] _this = JitHelpers.UnsafeCast<T[]>(this);
+            T[] _this = Unsafe.As<T[]>(this);
             return Array.IndexOf(_this, value, 0, _this.Length) >= 0;
         }
 
@@ -2696,7 +2696,7 @@ namespace System
         {
             //! Warning: "this" is an array, not an SZArrayHelper. See comments above
             //! or you may introduce a security hole!
-            T[] _this = JitHelpers.UnsafeCast<T[]>(this);
+            T[] _this = Unsafe.As<T[]>(this);
             return Array.IndexOf(_this, value, 0, _this.Length);
         }
 

--- a/src/mscorlib/src/System/MulticastDelegate.cs
+++ b/src/mscorlib/src/System/MulticastDelegate.cs
@@ -67,7 +67,7 @@ namespace System
             // the types are the same, obj should also be a
             // MulticastDelegate
             Debug.Assert(obj is MulticastDelegate, "Shouldn't have failed here since we already checked the types are the same!");
-            var d = JitHelpers.UnsafeCast<MulticastDelegate>(obj);
+            var d = Unsafe.As<MulticastDelegate>(obj);
 
             if (_invocationCount != (IntPtr)0)
             {

--- a/src/mscorlib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -762,7 +762,7 @@ namespace System.Runtime.CompilerServices
                 {
                     Boolean value = (Boolean)(object)result;
                     Task<Boolean> task = value ? AsyncTaskCache.TrueTask : AsyncTaskCache.FalseTask;
-                    return JitHelpers.UnsafeCast<Task<TResult>>(task); // UnsafeCast avoids type check we know will succeed
+                    return Unsafe.As<Task<TResult>>(task); // UnsafeCast avoids type check we know will succeed
                 }
                 // For Int32, we cache a range of common values, e.g. [-1,4).
                 else if (typeof(TResult) == typeof(Int32))
@@ -775,7 +775,7 @@ namespace System.Runtime.CompilerServices
                         value >= AsyncTaskCache.INCLUSIVE_INT32_MIN)
                     {
                         Task<Int32> task = AsyncTaskCache.Int32Tasks[value - AsyncTaskCache.INCLUSIVE_INT32_MIN];
-                        return JitHelpers.UnsafeCast<Task<TResult>>(task); // UnsafeCast avoids a type check we know will succeed
+                        return Unsafe.As<Task<TResult>>(task); // UnsafeCast avoids a type check we know will succeed
                     }
                 }
                 // For other known value types, we only special-case 0 / default(TResult).

--- a/src/mscorlib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
@@ -585,7 +585,7 @@ namespace System.Runtime.CompilerServices
             {
                 object secondary;
                 int entryIndex = FindEntry(key, out secondary);
-                value = JitHelpers.UnsafeCast<TValue>(secondary);
+                value = Unsafe.As<TValue>(secondary);
                 return entryIndex != -1;
             }
 
@@ -627,8 +627,8 @@ namespace System.Runtime.CompilerServices
 
                     if (oKey != null)
                     {
-                        key = JitHelpers.UnsafeCast<TKey>(oKey);
-                        value = JitHelpers.UnsafeCast<TValue>(oValue);
+                        key = Unsafe.As<TKey>(oKey);
+                        value = Unsafe.As<TValue>(oValue);
                         return true;
                     }
                 }

--- a/src/mscorlib/src/System/Runtime/CompilerServices/jithelpers.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/jithelpers.cs
@@ -95,23 +95,6 @@ namespace System.Runtime.CompilerServices
         }
 
 #if _DEBUG
-        [FriendAccessAllowed]
-        static internal T UnsafeCast<T>(Object o) where T : class
-        {
-            T ret = UnsafeCastInternal<T>(o);
-            Debug.Assert(ret == (o as T), "Invalid use of JitHelpers.UnsafeCast!");
-            return ret;
-        }
-
-        // The IL body of this method is not critical, but its body will be replaced with unsafe code, so
-        // this method is effectively critical
-        static private T UnsafeCastInternal<T>(Object o) where T : class
-        {
-            // The body of this function will be replaced by the EE with unsafe code that just returns o!!!
-            // See getILIntrinsicImplementation for how this happens.  
-            throw new InvalidOperationException();
-        }
-
         static internal int UnsafeEnumCast<T>(T val) where T : struct		// Actually T must be 4 byte (or less) enum
         {
             Debug.Assert(typeof(T).IsEnum
@@ -203,12 +186,7 @@ namespace System.Runtime.CompilerServices
         // Used for unsafe pinning of arbitrary objects.
         static internal PinningHelper GetPinningHelper(Object o)
         {
-            // This cast is really unsafe - call the private version that does not assert in debug
-#if _DEBUG
-            return UnsafeCastInternal<PinningHelper>(o);
-#else
-            return UnsafeCast<PinningHelper>(o);
-#endif
+            return Unsafe.As<PinningHelper>(o);
         }
 
 #if _DEBUG

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/BindableVectorToCollectionAdapter.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/BindableVectorToCollectionAdapter.cs
@@ -35,7 +35,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         [Pure]
         internal int Count()
         {
-            IBindableVector _this = JitHelpers.UnsafeCast<IBindableVector>(this);
+            IBindableVector _this = Unsafe.As<IBindableVector>(this);
             uint size = _this.Size;
             if (((uint)Int32.MaxValue) < size)
             {
@@ -94,7 +94,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
                 throw new ArgumentException(SR.Argument_IndexOutOfArrayBounds);
 
             // We need to verify the index as we;
-            IBindableVector _this = JitHelpers.UnsafeCast<IBindableVector>(this);
+            IBindableVector _this = Unsafe.As<IBindableVector>(this);
 
             for (uint i = 0; i < srcLen; i++)
             {

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/BindableVectorToListAdapter.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/BindableVectorToListAdapter.cs
@@ -37,7 +37,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (index < 0)
                 throw new ArgumentOutOfRangeException(nameof(index));
 
-            IBindableVector _this = JitHelpers.UnsafeCast<IBindableVector>(this);
+            IBindableVector _this = Unsafe.As<IBindableVector>(this);
             return GetAt(_this, (uint)index);
         }
 
@@ -47,14 +47,14 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (index < 0)
                 throw new ArgumentOutOfRangeException(nameof(index));
 
-            IBindableVector _this = JitHelpers.UnsafeCast<IBindableVector>(this);
+            IBindableVector _this = Unsafe.As<IBindableVector>(this);
             SetAt(_this, (uint)index, value);
         }
 
         // int Add(object value)
         internal int Add(object value)
         {
-            IBindableVector _this = JitHelpers.UnsafeCast<IBindableVector>(this);
+            IBindableVector _this = Unsafe.As<IBindableVector>(this);
             _this.Append(value);
 
             uint size = _this.Size;
@@ -69,7 +69,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // bool Contains(object item)
         internal bool Contains(object item)
         {
-            IBindableVector _this = JitHelpers.UnsafeCast<IBindableVector>(this);
+            IBindableVector _this = Unsafe.As<IBindableVector>(this);
 
             uint index;
             return _this.IndexOf(item, out index);
@@ -78,7 +78,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // void Clear()
         internal void Clear()
         {
-            IBindableVector _this = JitHelpers.UnsafeCast<IBindableVector>(this);
+            IBindableVector _this = Unsafe.As<IBindableVector>(this);
             _this.Clear();
         }
 
@@ -99,7 +99,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // int IndexOf(object item)
         internal int IndexOf(object item)
         {
-            IBindableVector _this = JitHelpers.UnsafeCast<IBindableVector>(this);
+            IBindableVector _this = Unsafe.As<IBindableVector>(this);
 
             uint index;
             bool exists = _this.IndexOf(item, out index);
@@ -121,14 +121,14 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (index < 0)
                 throw new ArgumentOutOfRangeException(nameof(index));
 
-            IBindableVector _this = JitHelpers.UnsafeCast<IBindableVector>(this);
+            IBindableVector _this = Unsafe.As<IBindableVector>(this);
             InsertAtHelper(_this, (uint)index, item);
         }
 
         // bool Remove(object item)
         internal void Remove(object item)
         {
-            IBindableVector _this = JitHelpers.UnsafeCast<IBindableVector>(this);
+            IBindableVector _this = Unsafe.As<IBindableVector>(this);
 
             uint index;
             bool exists = _this.IndexOf(item, out index);
@@ -150,7 +150,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (index < 0)
                 throw new ArgumentOutOfRangeException(nameof(index));
 
-            IBindableVector _this = JitHelpers.UnsafeCast<IBindableVector>(this);
+            IBindableVector _this = Unsafe.As<IBindableVector>(this);
             RemoveAtHelper(_this, (uint)index);
         }
 

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/DictionaryToMapAdapter.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/DictionaryToMapAdapter.cs
@@ -35,7 +35,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // V Lookup(K key)
         internal V Lookup<K, V>(K key)
         {
-            IDictionary<K, V> _this = JitHelpers.UnsafeCast<IDictionary<K, V>>(this);
+            IDictionary<K, V> _this = Unsafe.As<IDictionary<K, V>>(this);
             V value;
             bool keyFound = _this.TryGetValue(key, out value);
 
@@ -52,21 +52,21 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // uint Size { get }
         internal uint Size<K, V>()
         {
-            IDictionary<K, V> _this = JitHelpers.UnsafeCast<IDictionary<K, V>>(this);
+            IDictionary<K, V> _this = Unsafe.As<IDictionary<K, V>>(this);
             return (uint)_this.Count;
         }
 
         // bool HasKey(K key)
         internal bool HasKey<K, V>(K key)
         {
-            IDictionary<K, V> _this = JitHelpers.UnsafeCast<IDictionary<K, V>>(this);
+            IDictionary<K, V> _this = Unsafe.As<IDictionary<K, V>>(this);
             return _this.ContainsKey(key);
         }
 
         // IMapView<K, V> GetView()
         internal IReadOnlyDictionary<K, V> GetView<K, V>()
         {
-            IDictionary<K, V> _this = JitHelpers.UnsafeCast<IDictionary<K, V>>(this);
+            IDictionary<K, V> _this = Unsafe.As<IDictionary<K, V>>(this);
             Debug.Assert(_this != null);
 
             // Note: This dictionary is not really read-only - you could QI for a modifiable
@@ -82,7 +82,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // bool Insert(K key, V value)
         internal bool Insert<K, V>(K key, V value)
         {
-            IDictionary<K, V> _this = JitHelpers.UnsafeCast<IDictionary<K, V>>(this);
+            IDictionary<K, V> _this = Unsafe.As<IDictionary<K, V>>(this);
             bool replacing = _this.ContainsKey(key);
             _this[key] = value;
             return replacing;
@@ -91,7 +91,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // void Remove(K key)
         internal void Remove<K, V>(K key)
         {
-            IDictionary<K, V> _this = JitHelpers.UnsafeCast<IDictionary<K, V>>(this);
+            IDictionary<K, V> _this = Unsafe.As<IDictionary<K, V>>(this);
             bool removed = _this.Remove(key);
 
             if (!removed)
@@ -105,7 +105,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // void Clear()
         internal void Clear<K, V>()
         {
-            IDictionary<K, V> _this = JitHelpers.UnsafeCast<IDictionary<K, V>>(this);
+            IDictionary<K, V> _this = Unsafe.As<IDictionary<K, V>>(this);
             _this.Clear();
         }
     }

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/EnumeratorToIteratorAdapter.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/EnumeratorToIteratorAdapter.cs
@@ -32,7 +32,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // This method is invoked when First is called on a managed implementation of IIterable<T>.
         internal IIterator<T> First_Stub<T>()
         {
-            IEnumerable<T> _this = JitHelpers.UnsafeCast<IEnumerable<T>>(this);
+            IEnumerable<T> _this = Unsafe.As<IEnumerable<T>>(this);
             return new EnumeratorToIteratorAdapter<T>(_this.GetEnumerator());
         }
     }
@@ -60,7 +60,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // This method is invoked when First is called on a managed implementation of IBindableIterable.
         internal IBindableIterator First_Stub()
         {
-            IEnumerable _this = JitHelpers.UnsafeCast<IEnumerable>(this);
+            IEnumerable _this = Unsafe.As<IEnumerable>(this);
             return new EnumeratorToIteratorAdapter<object>(new NonGenericToGenericEnumerator(_this.GetEnumerator()));
         }
     }

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/IClosable.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/IClosable.cs
@@ -32,7 +32,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
         public void Close()
         {
-            IDisposable _this = JitHelpers.UnsafeCast<IDisposable>(this);
+            IDisposable _this = Unsafe.As<IDisposable>(this);
             _this.Dispose();
         }
     }
@@ -47,7 +47,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
         private void Dispose()
         {
-            IClosable _this = JitHelpers.UnsafeCast<IClosable>(this);
+            IClosable _this = Unsafe.As<IClosable>(this);
             _this.Close();
         }
     }

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/ICustomPropertyProvider.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/ICustomPropertyProvider.cs
@@ -439,7 +439,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         private IBindableVector GetIBindableVectorNoThrow()
         {
             if ((_flags & InterfaceForwardingSupport.IBindableVector) != 0)
-                return JitHelpers.UnsafeCast<IBindableVector>(_target);
+                return Unsafe.As<IBindableVector>(_target);
             else
                 return null;
         }
@@ -447,7 +447,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         private IVector_Raw<T1> GetVectorOfT()
         {
             if ((_flags & InterfaceForwardingSupport.IVector) != 0)
-                return JitHelpers.UnsafeCast<IVector_Raw<T1>>(_target);
+                return Unsafe.As<IVector_Raw<T1>>(_target);
             else
                 throw new InvalidOperationException();  // We should not go down this path, unless Jupiter pass this out to managed code
                                                         // and managed code use reflection to do the cast
@@ -513,7 +513,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         private IBindableVectorView GetIBindableVectorViewNoThrow()
         {
             if ((_flags & InterfaceForwardingSupport.IBindableVectorView) != 0)
-                return JitHelpers.UnsafeCast<IBindableVectorView>(_target);
+                return Unsafe.As<IBindableVectorView>(_target);
             else
                 return null;
         }
@@ -521,7 +521,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         private IVectorView<T2> GetVectorViewOfT()
         {
             if ((_flags & InterfaceForwardingSupport.IVectorView) != 0)
-                return JitHelpers.UnsafeCast<IVectorView<T2>>(_target);
+                return Unsafe.As<IVectorView<T2>>(_target);
             else
                 throw new InvalidOperationException();  // We should not go down this path, unless Jupiter pass this out to managed code
                                                         // and managed code use reflection to do the cast

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/IMapViewToIReadOnlyDictionaryAdapter.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/IMapViewToIReadOnlyDictionaryAdapter.cs
@@ -38,14 +38,14 @@ namespace System.Runtime.InteropServices.WindowsRuntime
                 throw new ArgumentNullException(nameof(key));
             Contract.EndContractBlock();
 
-            IMapView<K, V> _this = JitHelpers.UnsafeCast<IMapView<K, V>>(this);
+            IMapView<K, V> _this = Unsafe.As<IMapView<K, V>>(this);
             return Lookup(_this, key);
         }
 
         // IEnumerable<K> Keys { get }
         internal IEnumerable<K> Keys<K, V>()
         {
-            IMapView<K, V> _this = JitHelpers.UnsafeCast<IMapView<K, V>>(this);
+            IMapView<K, V> _this = Unsafe.As<IMapView<K, V>>(this);
             IReadOnlyDictionary<K, V> roDictionary = (IReadOnlyDictionary<K, V>)_this;
             return new ReadOnlyDictionaryKeyCollection<K, V>(roDictionary);
         }
@@ -53,7 +53,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // IEnumerable<V> Values { get }
         internal IEnumerable<V> Values<K, V>()
         {
-            IMapView<K, V> _this = JitHelpers.UnsafeCast<IMapView<K, V>>(this);
+            IMapView<K, V> _this = Unsafe.As<IMapView<K, V>>(this);
             IReadOnlyDictionary<K, V> roDictionary = (IReadOnlyDictionary<K, V>)_this;
             return new ReadOnlyDictionaryValueCollection<K, V>(roDictionary);
         }
@@ -65,7 +65,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (key == null)
                 throw new ArgumentNullException(nameof(key));
 
-            IMapView<K, V> _this = JitHelpers.UnsafeCast<IMapView<K, V>>(this);
+            IMapView<K, V> _this = Unsafe.As<IMapView<K, V>>(this);
             return _this.HasKey(key);
         }
 
@@ -75,7 +75,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (key == null)
                 throw new ArgumentNullException(nameof(key));
 
-            IMapView<K, V> _this = JitHelpers.UnsafeCast<IMapView<K, V>>(this);
+            IMapView<K, V> _this = Unsafe.As<IMapView<K, V>>(this);
 
             // It may be faster to call HasKey then Lookup.  On failure, we would otherwise
             // throw an exception from Lookup.

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/IReadOnlyDictionaryToIMapViewAdapter.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/IReadOnlyDictionaryToIMapViewAdapter.cs
@@ -34,7 +34,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // V Lookup(K key)
         internal V Lookup<K, V>(K key)
         {
-            IReadOnlyDictionary<K, V> _this = JitHelpers.UnsafeCast<IReadOnlyDictionary<K, V>>(this);
+            IReadOnlyDictionary<K, V> _this = Unsafe.As<IReadOnlyDictionary<K, V>>(this);
             V value;
             bool keyFound = _this.TryGetValue(key, out value);
 
@@ -51,21 +51,21 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // uint Size { get }
         internal uint Size<K, V>()
         {
-            IReadOnlyDictionary<K, V> _this = JitHelpers.UnsafeCast<IReadOnlyDictionary<K, V>>(this);
+            IReadOnlyDictionary<K, V> _this = Unsafe.As<IReadOnlyDictionary<K, V>>(this);
             return (uint)_this.Count;
         }
 
         // bool HasKey(K key)
         internal bool HasKey<K, V>(K key)
         {
-            IReadOnlyDictionary<K, V> _this = JitHelpers.UnsafeCast<IReadOnlyDictionary<K, V>>(this);
+            IReadOnlyDictionary<K, V> _this = Unsafe.As<IReadOnlyDictionary<K, V>>(this);
             return _this.ContainsKey(key);
         }
 
         // void Split(out IMapView<K, V> first, out IMapView<K, V> second)
         internal void Split<K, V>(out IMapView<K, V> first, out IMapView<K, V> second)
         {
-            IReadOnlyDictionary<K, V> _this = JitHelpers.UnsafeCast<IReadOnlyDictionary<K, V>>(this);
+            IReadOnlyDictionary<K, V> _this = Unsafe.As<IReadOnlyDictionary<K, V>>(this);
 
             if (_this.Count < 2)
             {

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/IReadOnlyListToIVectorViewAdapter.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/IReadOnlyListToIVectorViewAdapter.cs
@@ -34,7 +34,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // T GetAt(uint index)
         internal T GetAt<T>(uint index)
         {
-            IReadOnlyList<T> _this = JitHelpers.UnsafeCast<IReadOnlyList<T>>(this);
+            IReadOnlyList<T> _this = Unsafe.As<IReadOnlyList<T>>(this);
             EnsureIndexInt32(index, _this.Count);
 
             try
@@ -51,14 +51,14 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // uint Size { get }
         internal uint Size<T>()
         {
-            IReadOnlyList<T> _this = JitHelpers.UnsafeCast<IReadOnlyList<T>>(this);
+            IReadOnlyList<T> _this = Unsafe.As<IReadOnlyList<T>>(this);
             return (uint)_this.Count;
         }
 
         // bool IndexOf(T value, out uint index)
         internal bool IndexOf<T>(T value, out uint index)
         {
-            IReadOnlyList<T> _this = JitHelpers.UnsafeCast<IReadOnlyList<T>>(this);
+            IReadOnlyList<T> _this = Unsafe.As<IReadOnlyList<T>>(this);
 
             int ind = -1;
             int max = _this.Count;
@@ -84,7 +84,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // uint GetMany(uint startIndex, T[] items)
         internal uint GetMany<T>(uint startIndex, T[] items)
         {
-            IReadOnlyList<T> _this = JitHelpers.UnsafeCast<IReadOnlyList<T>>(this);
+            IReadOnlyList<T> _this = Unsafe.As<IReadOnlyList<T>>(this);
 
             // REX spec says "calling GetMany with startIndex equal to the length of the vector 
             // (last valid index + 1) and any specified capacity will succeed and return zero actual

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/IVectorViewToIReadOnlyListAdapter.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/IVectorViewToIReadOnlyListAdapter.cs
@@ -39,7 +39,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (index < 0)
                 throw new ArgumentOutOfRangeException(nameof(index));
 
-            IVectorView<T> _this = JitHelpers.UnsafeCast<IVectorView<T>>(this);
+            IVectorView<T> _this = Unsafe.As<IVectorView<T>>(this);
 
             try
             {
@@ -68,12 +68,12 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
             if (target != null)
             {
-                return (JitHelpers.UnsafeCast<Indexer_Get_Delegate<T>>(target))(index);
+                return (Unsafe.As<Indexer_Get_Delegate<T>>(target))(index);
             }
 
             if (fUseString)
             {
-                return JitHelpers.UnsafeCast<T>(Indexer_Get<string>(index));
+                return Unsafe.As<T>(Indexer_Get<string>(index));
             }
 
             return Indexer_Get<T>(index);

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/IteratorToEnumeratorAdapter.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/IteratorToEnumeratorAdapter.cs
@@ -35,7 +35,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // This method is invoked when GetEnumerator is called on a WinRT-backed implementation of IEnumerable<T>.
         internal IEnumerator<T> GetEnumerator_Stub<T>()
         {
-            IIterable<T> _this = JitHelpers.UnsafeCast<IIterable<T>>(this);
+            IIterable<T> _this = Unsafe.As<IIterable<T>>(this);
             return new IteratorToEnumeratorAdapter<T>(_this.First());
         }
 
@@ -53,12 +53,12 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
             if (target != null)
             {
-                return (JitHelpers.UnsafeCast<GetEnumerator_Delegate<T>>(target))();
+                return (Unsafe.As<GetEnumerator_Delegate<T>>(target))();
             }
 
             if (fUseString)
             {
-                return JitHelpers.UnsafeCast<IEnumerator<T>>(GetEnumerator_Stub<string>());
+                return Unsafe.As<IEnumerator<T>>(GetEnumerator_Stub<string>());
             }
 
             return GetEnumerator_Stub<T>();
@@ -88,7 +88,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // This method is invoked when GetEnumerator is called on a WinRT-backed implementation of IEnumerable.
         internal IEnumerator GetEnumerator_Stub()
         {
-            IBindableIterable _this = JitHelpers.UnsafeCast<IBindableIterable>(this);
+            IBindableIterable _this = Unsafe.As<IBindableIterable>(this);
             return new IteratorToEnumeratorAdapter<object>(new NonGenericToGenericIterator(_this.First()));
         }
     }

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/ListToBindableVectorAdapter.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/ListToBindableVectorAdapter.cs
@@ -35,7 +35,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // object GetAt(uint index)
         internal object GetAt(uint index)
         {
-            IList _this = JitHelpers.UnsafeCast<IList>(this);
+            IList _this = Unsafe.As<IList>(this);
             EnsureIndexInt32(index, _this.Count);
 
             try
@@ -51,21 +51,21 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // uint Size { get }
         internal uint Size()
         {
-            IList _this = JitHelpers.UnsafeCast<IList>(this);
+            IList _this = Unsafe.As<IList>(this);
             return (uint)_this.Count;
         }
 
         // IBindableVectorView GetView()
         internal IBindableVectorView GetView()
         {
-            IList _this = JitHelpers.UnsafeCast<IList>(this);
+            IList _this = Unsafe.As<IList>(this);
             return new ListToBindableVectorViewAdapter(_this);
         }
 
         // bool IndexOf(object value, out uint index)
         internal bool IndexOf(object value, out uint index)
         {
-            IList _this = JitHelpers.UnsafeCast<IList>(this);
+            IList _this = Unsafe.As<IList>(this);
             int ind = _this.IndexOf(value);
 
             if (-1 == ind)
@@ -81,7 +81,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // void SetAt(uint index, object value)
         internal void SetAt(uint index, object value)
         {
-            IList _this = JitHelpers.UnsafeCast<IList>(this);
+            IList _this = Unsafe.As<IList>(this);
             EnsureIndexInt32(index, _this.Count);
 
             try
@@ -97,7 +97,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // void InsertAt(uint index, object value)
         internal void InsertAt(uint index, object value)
         {
-            IList _this = JitHelpers.UnsafeCast<IList>(this);
+            IList _this = Unsafe.As<IList>(this);
 
             // Inserting at an index one past the end of the list is equivalent to appending
             // so we need to ensure that we're within (0, count + 1).
@@ -118,7 +118,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // void RemoveAt(uint index)
         internal void RemoveAt(uint index)
         {
-            IList _this = JitHelpers.UnsafeCast<IList>(this);
+            IList _this = Unsafe.As<IList>(this);
             EnsureIndexInt32(index, _this.Count);
 
             try
@@ -136,14 +136,14 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // void Append(object value)
         internal void Append(object value)
         {
-            IList _this = JitHelpers.UnsafeCast<IList>(this);
+            IList _this = Unsafe.As<IList>(this);
             _this.Add(value);
         }
 
         // void RemoveAtEnd()
         internal void RemoveAtEnd()
         {
-            IList _this = JitHelpers.UnsafeCast<IList>(this);
+            IList _this = Unsafe.As<IList>(this);
             if (_this.Count == 0)
             {
                 Exception e = new InvalidOperationException(SR.InvalidOperation_CannotRemoveLastFromEmptyCollection);
@@ -158,7 +158,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // void Clear()
         internal void Clear()
         {
-            IList _this = JitHelpers.UnsafeCast<IList>(this);
+            IList _this = Unsafe.As<IList>(this);
             _this.Clear();
         }
 

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/ListToVectorAdapter.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/ListToVectorAdapter.cs
@@ -35,7 +35,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // T GetAt(uint index)
         internal T GetAt<T>(uint index)
         {
-            IList<T> _this = JitHelpers.UnsafeCast<IList<T>>(this);
+            IList<T> _this = Unsafe.As<IList<T>>(this);
             EnsureIndexInt32(index, _this.Count);
 
             try
@@ -51,14 +51,14 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // uint Size { get }
         internal uint Size<T>()
         {
-            IList<T> _this = JitHelpers.UnsafeCast<IList<T>>(this);
+            IList<T> _this = Unsafe.As<IList<T>>(this);
             return (uint)_this.Count;
         }
 
         // IVectorView<T> GetView()
         internal IReadOnlyList<T> GetView<T>()
         {
-            IList<T> _this = JitHelpers.UnsafeCast<IList<T>>(this);
+            IList<T> _this = Unsafe.As<IList<T>>(this);
             Debug.Assert(_this != null);
 
             // Note: This list is not really read-only - you could QI for a modifiable
@@ -74,7 +74,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // bool IndexOf(T value, out uint index)
         internal bool IndexOf<T>(T value, out uint index)
         {
-            IList<T> _this = JitHelpers.UnsafeCast<IList<T>>(this);
+            IList<T> _this = Unsafe.As<IList<T>>(this);
             int ind = _this.IndexOf(value);
 
             if (-1 == ind)
@@ -90,7 +90,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // void SetAt(uint index, T value)
         internal void SetAt<T>(uint index, T value)
         {
-            IList<T> _this = JitHelpers.UnsafeCast<IList<T>>(this);
+            IList<T> _this = Unsafe.As<IList<T>>(this);
             EnsureIndexInt32(index, _this.Count);
 
             try
@@ -106,7 +106,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // void InsertAt(uint index, T value)
         internal void InsertAt<T>(uint index, T value)
         {
-            IList<T> _this = JitHelpers.UnsafeCast<IList<T>>(this);
+            IList<T> _this = Unsafe.As<IList<T>>(this);
 
             // Inserting at an index one past the end of the list is equivalent to appending
             // so we need to ensure that we're within (0, count + 1).
@@ -127,7 +127,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // void RemoveAt(uint index)
         internal void RemoveAt<T>(uint index)
         {
-            IList<T> _this = JitHelpers.UnsafeCast<IList<T>>(this);
+            IList<T> _this = Unsafe.As<IList<T>>(this);
             EnsureIndexInt32(index, _this.Count);
 
             try
@@ -145,14 +145,14 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // void Append(T value)
         internal void Append<T>(T value)
         {
-            IList<T> _this = JitHelpers.UnsafeCast<IList<T>>(this);
+            IList<T> _this = Unsafe.As<IList<T>>(this);
             _this.Add(value);
         }
 
         // void RemoveAtEnd()
         internal void RemoveAtEnd<T>()
         {
-            IList<T> _this = JitHelpers.UnsafeCast<IList<T>>(this);
+            IList<T> _this = Unsafe.As<IList<T>>(this);
             if (_this.Count == 0)
             {
                 Exception e = new InvalidOperationException(SR.InvalidOperation_CannotRemoveLastFromEmptyCollection);
@@ -167,21 +167,21 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // void Clear()
         internal void Clear<T>()
         {
-            IList<T> _this = JitHelpers.UnsafeCast<IList<T>>(this);
+            IList<T> _this = Unsafe.As<IList<T>>(this);
             _this.Clear();
         }
 
         // uint GetMany(uint startIndex, T[] items)
         internal uint GetMany<T>(uint startIndex, T[] items)
         {
-            IList<T> _this = JitHelpers.UnsafeCast<IList<T>>(this);
+            IList<T> _this = Unsafe.As<IList<T>>(this);
             return GetManyHelper<T>(_this, startIndex, items);
         }
 
         // void ReplaceAll(T[] items)
         internal void ReplaceAll<T>(T[] items)
         {
-            IList<T> _this = JitHelpers.UnsafeCast<IList<T>>(this);
+            IList<T> _this = Unsafe.As<IList<T>>(this);
             _this.Clear();
 
             if (items != null)

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/MapToCollectionAdapter.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/MapToCollectionAdapter.cs
@@ -37,7 +37,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         [Pure]
         internal int Count<K, V>()
         {
-            object _this = JitHelpers.UnsafeCast<object>(this);
+            object _this = Unsafe.As<object>(this);
 
             IMap<K, V> _this_map = _this as IMap<K, V>;
             if (_this_map != null)
@@ -53,7 +53,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             }
             else
             {
-                IVector<KeyValuePair<K, V>> _this_vector = JitHelpers.UnsafeCast<IVector<KeyValuePair<K, V>>>(this);
+                IVector<KeyValuePair<K, V>> _this_vector = Unsafe.As<IVector<KeyValuePair<K, V>>>(this);
                 uint size = _this_vector.Size;
 
                 if (((uint)Int32.MaxValue) < size)
@@ -74,7 +74,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // void Add(T item)
         internal void Add<K, V>(KeyValuePair<K, V> item)
         {
-            object _this = JitHelpers.UnsafeCast<object>(this);
+            object _this = Unsafe.As<object>(this);
 
             IDictionary<K, V> _this_dictionary = _this as IDictionary<K, V>;
             if (_this_dictionary != null)
@@ -83,7 +83,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             }
             else
             {
-                IVector<KeyValuePair<K, V>> _this_vector = JitHelpers.UnsafeCast<IVector<KeyValuePair<K, V>>>(this);
+                IVector<KeyValuePair<K, V>> _this_vector = Unsafe.As<IVector<KeyValuePair<K, V>>>(this);
                 _this_vector.Append(item);
             }
         }
@@ -91,7 +91,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // void Clear()
         internal void Clear<K, V>()
         {
-            object _this = JitHelpers.UnsafeCast<object>(this);
+            object _this = Unsafe.As<object>(this);
 
             IMap<K, V> _this_map = _this as IMap<K, V>;
             if (_this_map != null)
@@ -100,7 +100,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             }
             else
             {
-                IVector<KeyValuePair<K, V>> _this_vector = JitHelpers.UnsafeCast<IVector<KeyValuePair<K, V>>>(this);
+                IVector<KeyValuePair<K, V>> _this_vector = Unsafe.As<IVector<KeyValuePair<K, V>>>(this);
                 _this_vector.Clear();
             }
         }
@@ -108,7 +108,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // bool Contains(T item)
         internal bool Contains<K, V>(KeyValuePair<K, V> item)
         {
-            object _this = JitHelpers.UnsafeCast<object>(this);
+            object _this = Unsafe.As<object>(this);
 
             IDictionary<K, V> _this_dictionary = _this as IDictionary<K, V>;
             if (_this_dictionary != null)
@@ -123,7 +123,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             }
             else
             {
-                IVector<KeyValuePair<K, V>> _this_vector = JitHelpers.UnsafeCast<IVector<KeyValuePair<K, V>>>(this);
+                IVector<KeyValuePair<K, V>> _this_vector = Unsafe.As<IVector<KeyValuePair<K, V>>>(this);
 
                 uint index;
                 return _this_vector.IndexOf(item, out index);
@@ -147,7 +147,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
             Contract.EndContractBlock();
 
-            IIterable<KeyValuePair<K, V>> _this = JitHelpers.UnsafeCast<IIterable<KeyValuePair<K, V>>>(this);
+            IIterable<KeyValuePair<K, V>> _this = Unsafe.As<IIterable<KeyValuePair<K, V>>>(this);
             foreach (KeyValuePair<K, V> mapping in _this)
             {
                 array[arrayIndex++] = mapping;
@@ -157,7 +157,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // bool Remove(T item)
         internal bool Remove<K, V>(KeyValuePair<K, V> item)
         {
-            object _this = JitHelpers.UnsafeCast<object>(this);
+            object _this = Unsafe.As<object>(this);
 
             IDictionary<K, V> _this_dictionary = _this as IDictionary<K, V>;
             if (_this_dictionary != null)
@@ -166,7 +166,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             }
             else
             {
-                IVector<KeyValuePair<K, V>> _this_vector = JitHelpers.UnsafeCast<IVector<KeyValuePair<K, V>>>(this);
+                IVector<KeyValuePair<K, V>> _this_vector = Unsafe.As<IVector<KeyValuePair<K, V>>>(this);
                 uint index;
                 bool exists = _this_vector.IndexOf(item, out index);
 

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/MapToDictionaryAdapter.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/MapToDictionaryAdapter.cs
@@ -38,7 +38,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
             Contract.EndContractBlock();
 
-            IMap<K, V> _this = JitHelpers.UnsafeCast<IMap<K, V>>(this);
+            IMap<K, V> _this = Unsafe.As<IMap<K, V>>(this);
             return Lookup(_this, key);
         }
 
@@ -50,14 +50,14 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
             Contract.EndContractBlock();
 
-            IMap<K, V> _this = JitHelpers.UnsafeCast<IMap<K, V>>(this);
+            IMap<K, V> _this = Unsafe.As<IMap<K, V>>(this);
             Insert(_this, key, value);
         }
 
         // ICollection<K> Keys { get }
         internal ICollection<K> Keys<K, V>()
         {
-            IMap<K, V> _this = JitHelpers.UnsafeCast<IMap<K, V>>(this);
+            IMap<K, V> _this = Unsafe.As<IMap<K, V>>(this);
             IDictionary<K, V> dictionary = (IDictionary<K, V>)_this;
             return new DictionaryKeyCollection<K, V>(dictionary);
         }
@@ -65,7 +65,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // ICollection<V> Values { get }
         internal ICollection<V> Values<K, V>()
         {
-            IMap<K, V> _this = JitHelpers.UnsafeCast<IMap<K, V>>(this);
+            IMap<K, V> _this = Unsafe.As<IMap<K, V>>(this);
             IDictionary<K, V> dictionary = (IDictionary<K, V>)_this;
             return new DictionaryValueCollection<K, V>(dictionary);
         }
@@ -77,7 +77,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (key == null)
                 throw new ArgumentNullException(nameof(key));
 
-            IMap<K, V> _this = JitHelpers.UnsafeCast<IMap<K, V>>(this);
+            IMap<K, V> _this = Unsafe.As<IMap<K, V>>(this);
             return _this.HasKey(key);
         }
 
@@ -92,7 +92,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
             Contract.EndContractBlock();
 
-            IMap<K, V> _this = JitHelpers.UnsafeCast<IMap<K, V>>(this);
+            IMap<K, V> _this = Unsafe.As<IMap<K, V>>(this);
             Insert(_this, key, value);
         }
 
@@ -102,7 +102,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (key == null)
                 throw new ArgumentNullException(nameof(key));
 
-            IMap<K, V> _this = JitHelpers.UnsafeCast<IMap<K, V>>(this);
+            IMap<K, V> _this = Unsafe.As<IMap<K, V>>(this);
             if (!_this.HasKey(key))
                 return false;
 
@@ -126,7 +126,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (key == null)
                 throw new ArgumentNullException(nameof(key));
 
-            IMap<K, V> _this = JitHelpers.UnsafeCast<IMap<K, V>>(this);
+            IMap<K, V> _this = Unsafe.As<IMap<K, V>>(this);
             if (!_this.HasKey(key))
             {
                 value = default(V);

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/MapViewToReadOnlyCollectionAdapter.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/MapViewToReadOnlyCollectionAdapter.cs
@@ -37,7 +37,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         [Pure]
         internal int Count<K, V>()
         {
-            object _this = JitHelpers.UnsafeCast<object>(this);
+            object _this = Unsafe.As<object>(this);
 
             IMapView<K, V> _this_map = _this as IMapView<K, V>;
             if (_this_map != null)
@@ -53,7 +53,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             }
             else
             {
-                IVectorView<KeyValuePair<K, V>> _this_vector = JitHelpers.UnsafeCast<IVectorView<KeyValuePair<K, V>>>(this);
+                IVectorView<KeyValuePair<K, V>> _this_vector = Unsafe.As<IVectorView<KeyValuePair<K, V>>>(this);
                 uint size = _this_vector.Size;
 
                 if (((uint)Int32.MaxValue) < size)

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/VectorToCollectionAdapter.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/VectorToCollectionAdapter.cs
@@ -34,7 +34,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         [Pure]
         internal int Count<T>()
         {
-            IVector<T> _this = JitHelpers.UnsafeCast<IVector<T>>(this);
+            IVector<T> _this = Unsafe.As<IVector<T>>(this);
             uint size = _this.Size;
             if (((uint)Int32.MaxValue) < size)
             {
@@ -53,21 +53,21 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // void Add(T item)
         internal void Add<T>(T item)
         {
-            IVector<T> _this = JitHelpers.UnsafeCast<IVector<T>>(this);
+            IVector<T> _this = Unsafe.As<IVector<T>>(this);
             _this.Append(item);
         }
 
         // void Clear()
         internal void Clear<T>()
         {
-            IVector<T> _this = JitHelpers.UnsafeCast<IVector<T>>(this);
+            IVector<T> _this = Unsafe.As<IVector<T>>(this);
             _this.Clear();
         }
 
         // bool Contains(T item)
         internal bool Contains<T>(T item)
         {
-            IVector<T> _this = JitHelpers.UnsafeCast<IVector<T>>(this);
+            IVector<T> _this = Unsafe.As<IVector<T>>(this);
 
             uint index;
             return _this.IndexOf(item, out index);
@@ -90,7 +90,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
             Contract.EndContractBlock();
 
-            IVector<T> _this = JitHelpers.UnsafeCast<IVector<T>>(this);
+            IVector<T> _this = Unsafe.As<IVector<T>>(this);
             int count = Count<T>();
             for (int i = 0; i < count; i++)
             {
@@ -101,7 +101,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         // bool Remove(T item)
         internal bool Remove<T>(T item)
         {
-            IVector<T> _this = JitHelpers.UnsafeCast<IVector<T>>(this);
+            IVector<T> _this = Unsafe.As<IVector<T>>(this);
 
             uint index;
             bool exists = _this.IndexOf(item, out index);

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/VectorToListAdapter.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/VectorToListAdapter.cs
@@ -36,7 +36,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (index < 0)
                 throw new ArgumentOutOfRangeException(nameof(index));
 
-            IVector<T> _this = JitHelpers.UnsafeCast<IVector<T>>(this);
+            IVector<T> _this = Unsafe.As<IVector<T>>(this);
             return GetAt(_this, (uint)index);
         }
 
@@ -46,14 +46,14 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (index < 0)
                 throw new ArgumentOutOfRangeException(nameof(index));
 
-            IVector<T> _this = JitHelpers.UnsafeCast<IVector<T>>(this);
+            IVector<T> _this = Unsafe.As<IVector<T>>(this);
             SetAt(_this, (uint)index, value);
         }
 
         // int IndexOf(T item)
         internal int IndexOf<T>(T item)
         {
-            IVector<T> _this = JitHelpers.UnsafeCast<IVector<T>>(this);
+            IVector<T> _this = Unsafe.As<IVector<T>>(this);
 
             uint index;
             bool exists = _this.IndexOf(item, out index);
@@ -75,7 +75,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (index < 0)
                 throw new ArgumentOutOfRangeException(nameof(index));
 
-            IVector<T> _this = JitHelpers.UnsafeCast<IVector<T>>(this);
+            IVector<T> _this = Unsafe.As<IVector<T>>(this);
             InsertAtHelper<T>(_this, (uint)index, item);
         }
 
@@ -85,7 +85,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (index < 0)
                 throw new ArgumentOutOfRangeException(nameof(index));
 
-            IVector<T> _this = JitHelpers.UnsafeCast<IVector<T>>(this);
+            IVector<T> _this = Unsafe.As<IVector<T>>(this);
             RemoveAtHelper<T>(_this, (uint)index);
         }
 

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/VectorViewToReadOnlyCollectionAdapter.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/VectorViewToReadOnlyCollectionAdapter.cs
@@ -34,7 +34,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         [Pure]
         internal int Count<T>()
         {
-            IVectorView<T> _this = JitHelpers.UnsafeCast<IVectorView<T>>(this);
+            IVectorView<T> _this = Unsafe.As<IVectorView<T>>(this);
             uint size = _this.Size;
             if (((uint)Int32.MaxValue) < size)
             {

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -6746,18 +6746,7 @@ bool getILIntrinsicImplementation(MethodDesc * ftn,
     // Compare tokens to cover all generic instantiations
     // The body of the first method is simply ret Arg0. The second one first casts the arg to I4.
 
-    if (tk == MscorlibBinder::GetMethod(METHOD__JIT_HELPERS__UNSAFE_CAST)->GetMemberDef())
-    {
-        // Return the argument that was passed in.
-        static const BYTE ilcode[] = { CEE_LDARG_0, CEE_RET };
-        methInfo->ILCode = const_cast<BYTE*>(ilcode);
-        methInfo->ILCodeSize = sizeof(ilcode);
-        methInfo->maxStack = 1;
-        methInfo->EHcount = 0;
-        methInfo->options = (CorInfoOptions)0;
-        return true;
-    }
-    else if (tk == MscorlibBinder::GetMethod(METHOD__JIT_HELPERS__UNSAFE_CAST_TO_STACKPTR)->GetMemberDef())
+    if (tk == MscorlibBinder::GetMethod(METHOD__JIT_HELPERS__UNSAFE_CAST_TO_STACKPTR)->GetMemberDef())
     {
         // Return the argument that was passed in converted to IntPtr
         static const BYTE ilcode[] = { CEE_LDARG_0, CEE_CONV_I, CEE_RET };

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -762,12 +762,10 @@ DEFINE_METHOD(RUNTIME_HELPERS,      IS_REFERENCE_OR_CONTAINS_REFERENCES, IsRefer
 
 DEFINE_CLASS(JIT_HELPERS,           CompilerServices,       JitHelpers)
 #ifdef _DEBUG
-DEFINE_METHOD(JIT_HELPERS,          UNSAFE_CAST,            UnsafeCastInternal, NoSig)
 DEFINE_METHOD(JIT_HELPERS,          UNSAFE_ENUM_CAST,       UnsafeEnumCastInternal, NoSig)
 DEFINE_METHOD(JIT_HELPERS,          UNSAFE_ENUM_CAST_LONG,  UnsafeEnumCastLongInternal, NoSig)
 DEFINE_METHOD(JIT_HELPERS,          UNSAFE_CAST_TO_STACKPTR,UnsafeCastToStackPointerInternal, NoSig)
 #else // _DEBUG
-DEFINE_METHOD(JIT_HELPERS,          UNSAFE_CAST,            UnsafeCast, NoSig)
 DEFINE_METHOD(JIT_HELPERS,          UNSAFE_ENUM_CAST,       UnsafeEnumCast, NoSig)
 DEFINE_METHOD(JIT_HELPERS,          UNSAFE_ENUM_CAST_LONG,  UnsafeEnumCastLong, NoSig)
 DEFINE_METHOD(JIT_HELPERS,          UNSAFE_CAST_TO_STACKPTR,UnsafeCastToStackPointer, NoSig)


### PR DESCRIPTION
Both methods do the same, but the latter one is the official public name for the functionality