### PR TITLE
JIT: Use AllocObj for box allocations

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -5449,12 +5449,13 @@ void Compiler::impImportAndPushBox(CORINFO_RESOLVED_TOKEN* pResolvedToken)
                 return;
             }
 
-            op1 = gtNewHelperCallNode(info.compCompHnd->getNewHelper(pResolvedToken, info.compMethodHnd), TYP_REF,
-                                      gtNewArgList(op2));
+            op1 = gtNewAllocObjNode(info.compCompHnd->getNewHelper(pResolvedToken, info.compMethodHnd),
+                                    pResolvedToken->hClass, TYP_REF, op2);
         }
 
-        /* Remember that this basic block contains 'new' of an object */
+        /* Remember that this basic block contains 'new' of an object, and so does this method */
         compCurBB->bbFlags |= BBF_HAS_NEWOBJ;
+        optMethodFlags |= OMF_HAS_NEWOBJ;
 
         GenTreePtr asg = gtNewTempAssign(impBoxTemp, op1);
 


### PR DESCRIPTION
Model box object allocations using the AllocObj tree node. Update
the box deconstruction utility to compensate.

Also set the OMF_HAS_NEWOBJ flag when we generate Box IR; this both
fixes an oversight from before and is a necessary step to trigger the
morphing of AllocObj into a helper call.

No diffs.

Closes #13905.