### PR TITLE
Fix devdiv 491210

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2459,6 +2459,8 @@ void fgArgInfo::EvalArgsToTemps()
                 noway_assert(parent->OperIsList());
                 noway_assert(parent->gtOp.gtOp1 == argx);
 
+                parent->gtFlags |= (setupArg->gtFlags & GTF_ALL_EFFECT);
+
                 parent->gtOp.gtOp1 = setupArg;
             }
             else
@@ -2482,8 +2484,12 @@ void fgArgInfo::EvalArgsToTemps()
             noway_assert(tmpRegArgNext->OperIsList());
             noway_assert(tmpRegArgNext->Current());
             tmpRegArgNext->gtOp.gtOp2 = compiler->gtNewArgList(defArg);
+
+            tmpRegArgNext->gtFlags |= (defArg->gtFlags & GTF_ALL_EFFECT);
             tmpRegArgNext             = tmpRegArgNext->Rest();
         }
+
+        tmpRegArgNext->gtFlags |= (defArg->gtFlags & GTF_ALL_EFFECT);
 
         curArgTabEntry->node       = defArg;
         curArgTabEntry->lateArgInx = regArgInx++;

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2486,7 +2486,7 @@ void fgArgInfo::EvalArgsToTemps()
             tmpRegArgNext->gtOp.gtOp2 = compiler->gtNewArgList(defArg);
 
             tmpRegArgNext->gtFlags |= (defArg->gtFlags & GTF_ALL_EFFECT);
-            tmpRegArgNext             = tmpRegArgNext->Rest();
+            tmpRegArgNext = tmpRegArgNext->Rest();
         }
 
         tmpRegArgNext->gtFlags |= (defArg->gtFlags & GTF_ALL_EFFECT);


### PR DESCRIPTION
Specifically, this insures the GT_LIST nodes of gtCallArgs
and gtCallLateArgs flags are set correctly, based on their
child nodes.

This fixes VSO Issue 491210.

/cc @dotnet/jit-contrib 