### PR TITLE
Fix test StackCommitCommon

### DIFF
--- a/tests/src/baseservices/threading/commitstackonlyasneeded/StackCommitCommon.cs
+++ b/tests/src/baseservices/threading/commitstackonlyasneeded/StackCommitCommon.cs
@@ -236,9 +236,19 @@ namespace StackCommitTest
 
         public static void Run(Action action)
         {
-            new Finalizer(action);
+            //We need to allocate the object inside of a seperate method to ensure that
+            //the reference will be eliminated before GC.Collect is called. Technically
+            //even across methods we probably don't make any formal guarantees but this
+            //is sufficient for current runtime implementations.
+            CreateUnreferencedObject(action);
             GC.Collect();
             GC.WaitForPendingFinalizers();
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static void CreateUnreferencedObject(Action action)
+        {
+            new Finalizer(action);
         }
     }
 }


### PR DESCRIPTION
This test will hang if run with non-optimized jitted code because it takes a dependency on exactly when locally allocated objects go out of scope. Although I doubt CLI spec guarantees the new code will always work either, it does work with the runtime/JIT as currently implemented.