### PR TITLE
Disable tiered compilation for dynamic methods

### DIFF
--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -1244,7 +1244,8 @@ public:
             !IsEnCMethod() &&
             HasNativeCodeSlot() &&
             !IsUnboxingStub() &&
-            !IsInstantiatingStub();
+            !IsInstantiatingStub() &&
+            !IsDynamicMethod();
 
         // We should add an exclusion for modules with debuggable code gen flags
 


### PR DESCRIPTION
Fixing an oversight from earlier, tiered compilation isn't designed to handle dynamic methods yet because of their limited lifetime. There may be other issues but a basic one would be having the method get collected while its MethodDesc is in the tiered compilation queue which results in use after free memory issues.