### PR TITLE
[SOS] Use addresses without sign extension in lldb plugin

### DIFF
--- a/src/ToolBox/SOS/lldbplugin/services.cpp
+++ b/src/ToolBox/SOS/lldbplugin/services.cpp
@@ -8,6 +8,8 @@
 #include <string.h>
 #include <string>
 
+#define CONVERT_FROM_SIGN_EXTENDED(offset) ((ULONG_PTR)(offset))
+
 ULONG g_currentThreadIndex = -1;
 ULONG g_currentThreadSystemId = -1;
 char *g_coreclrDirectory;
@@ -545,6 +547,9 @@ LLDBServices::Disassemble(
     uint8_t byte;
     int cch;
 
+    // lldb doesn't expect sign-extended address
+    offset = CONVERT_FROM_SIGN_EXTENDED(offset);
+
     if (buffer == NULL)
     {
         hr = E_INVALIDARG;
@@ -750,6 +755,9 @@ LLDBServices::ReadVirtual(
     lldb::SBError error;
     size_t read = 0;
 
+    // lldb doesn't expect sign-extended address
+    offset = CONVERT_FROM_SIGN_EXTENDED(offset);
+
     lldb::SBProcess process = GetCurrentProcess();
     if (!process.IsValid())
     {
@@ -775,6 +783,9 @@ LLDBServices::WriteVirtual(
 {
     lldb::SBError error;
     size_t written = 0;
+
+    // lldb doesn't expect sign-extended address
+    offset = CONVERT_FROM_SIGN_EXTENDED(offset);
 
     lldb::SBProcess process = GetCurrentProcess();
     if (!process.IsValid())
@@ -821,6 +832,9 @@ LLDBServices::GetNameByOffset(
     lldb::SBFileSpec file;
     lldb::SBSymbol symbol;
     std::string str;
+
+    // lldb doesn't expect sign-extended address
+    offset = CONVERT_FROM_SIGN_EXTENDED(offset);
 
     target = m_debugger.GetSelectedTarget();
     if (!target.IsValid())
@@ -1012,6 +1026,9 @@ LLDBServices::GetModuleByOffset(
     lldb::SBTarget target;
     int numModules;
 
+    // lldb doesn't expect sign-extended address
+    offset = CONVERT_FROM_SIGN_EXTENDED(offset);
+
     target = m_debugger.GetSelectedTarget();
     if (!target.IsValid())
     {
@@ -1075,6 +1092,9 @@ LLDBServices::GetModuleNames(
     lldb::SBTarget target;
     lldb::SBFileSpec fileSpec;
     HRESULT hr = S_OK;
+
+    // lldb doesn't expect sign-extended address
+    base = CONVERT_FROM_SIGN_EXTENDED(base);
 
     target = m_debugger.GetSelectedTarget();
     if (!target.IsValid())
@@ -1166,6 +1186,9 @@ LLDBServices::GetLineByOffset(
     lldb::SBFileSpec file;
     lldb::SBLineEntry lineEntry;
     std::string str;
+
+    // lldb doesn't expect sign-extended address
+    offset = CONVERT_FROM_SIGN_EXTENDED(offset);
 
     target = m_debugger.GetSelectedTarget();
     if (!target.IsValid())


### PR DESCRIPTION
lldb doesn't expect sign-extended addresses so we need to convert them before using with lldb API.
This patch allows to use SOS plugin for core files in lldb on 32-bit platforms and also fixes output of the 'clrstack -f' command.

For lldb-4.0 result are following on x86:
Without this patch:
- for coredump debugging
```
(lldb) target create --core "core"
Core file '/media/kbaladurin/data/dotnet/coreclr/overlay_coredumpx86_2/core' (i386) was loaded.
(lldb) plugin load libsosplugin.so
(lldb) clrstack -f
Failed to load data access DLL, 0x80131c4f
You can run the debugger command 'setclrpath' to control the load of libmscordaccore.so.
If that succeeds, the SOS command should work on retry.
ClrStack -f  failed
```
- for application debugging:
```
(lldb) clrstack -f
OS Thread Id: 0x553c (1)
Child SP       IP Call Site
FFCDCD8C 00000000 
FFCDCD90 F4F0BA92 
FFCDCDF0 F1E78863 
FFCDCE30 F1E789B2 
FFCDCE70 F1E6DA25 
FFCDCF00 F6799439 
FFCDCF10 F650DD3D 
FFCDD360 F650DAED 
FFCDD3E0 F650F9C3 
FFCDD5B0 F62E7779 
FFCDD5E0 F67F19F2 
FFCDD730 F67EE11E 
FFCDD7A0 F67EDEE0 
FFCDD860 F67EE45E 
FFCDDB30 F62D9F28 
FFCDDCB0 F6262106 
FFCDDD70 0804DBE0 corerun!ExecuteManagedAssembly(char const*, char const*, char const*, int, char const**) + 1856 at /media/kbaladurin/data/dotnet/forked/coreclr/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp:431
FFCDDF10 0804C834 corerun!corerun(int, char const**) + 868 at /media/kbaladurin/data/dotnet/forked/coreclr/src/coreclr/hosts/unixcorerun/corerun.cpp:149
FFCDE040 0804C95A corerun!main + 58 at /media/kbaladurin/data/dotnet/forked/coreclr/src/coreclr/hosts/unixcorerun/corerun.cpp:161
FFCDE060 F7359637 
FFCDE0D0 0804C121 corerun + 33
0804F8B0 0804F910 corerun!__libc_csu_fini
FFCDCDF4          [InlinedCallFrame: ffcdcdf4] 
FFCDCDF4          [InlinedCallFrame: ffcdcdf4] rpinvoke.Program.upcall()
FFCDCDF0 F1E78863 System.Console.dll!DomainBoundILStubClass.() + 75
FFCDCE30 F1E789B2 rpinvoke.dll!rpinvoke.Program.MyView_KeyEvent(System.ConsoleKeyInfo) + 274 [/home/kbaladurin/Desktop/dotnet/coredumps/lldb/dotnet/rpinvoke/Program.cs @ 88]
FFCDCE70 F1E6DA25 rpinvoke.dll!rpinvoke.Program.Main(System.String[]) + 485 [/home/kbaladurin/Desktop/dotnet/coredumps/lldb/dotnet/rpinvoke/Program.cs @ 120]
FFCDD684          [GCFrame: ffcdd684] 
FFCDDC5C          [GCFrame: ffcddc5c] 
```

With this patch:
```
(lldb) target create --core "core"
Core file '/media/kbaladurin/data/dotnet/coreclr/overlay_coredumpx86_1/core' (i386) was loaded.
(lldb) plugin load libsosplugin.so
(lldb) clrstack -f
OS Thread Id: 0x6274 (1)
Child SP       IP Call Site
FFF2FB5C 00000000 
FFF2FB60 F5A01A92 libupcall.so!upcall + 148 at /home/kbaladurin/Desktop/dotnet/coredumps/lldb/dotnet/rpinvoke/upcall-1.cpp:41
FFF2FBC0 EF34D62B 
FFF2FC00 EF34D76E 
FFF2FC40 F2691048 
FFF2FCD0 F68F8F1D libcoreclr.so!CallDescrWorkerInternal + 77 at /media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/i386/asmhelpers.S:306
FFF2FCE0 F65C726D libcoreclr.so!CallDescrWorker(CallDescrData*) + 493 at /media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/callhelpers.cpp:135
FFF30130 F65C7020 libcoreclr.so!CallDescrWorkerWithHandler(CallDescrData*, int) + 688 at /media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/callhelpers.cpp:78
FFF301B0 F65C8F18 libcoreclr.so!MethodDescCallSite::CallTargetWorker(unsigned long long const*, unsigned long long*, int) + 3432 at /media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/callhelpers.cpp:645
FFF30380 F63AE269 libcoreclr.so!MethodDescCallSite::Call(unsigned long long const*) + 73 at /media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/callhelpers.h:433
FFF303B0 F694FA12 libcoreclr.so!RunMain(MethodDesc*, short, int*, REF<PtrArray>*)::$_1::operator()(RunMain(MethodDesc*, short, int*, REF<PtrArray>*) const::Param*) const::'lambda'(RunMain(MethodDesc*, short, int*, REF<PtrArray>*) const::Param*)::operator()(RunMain(MethodDesc*, short, int*, REF<PtrArray>*) const::Param*) const + 946 at /media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/assembly.cpp:1705
FFF30500 F694C09E libcoreclr.so!RunMain(MethodDesc*, short, int*, REF<PtrArray>*)::$_1::operator()(RunMain(MethodDesc*, short, int*, REF<PtrArray>*)::Param*) const + 110 at /media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/assembly.cpp:1720
FFF30570 F694BE5D libcoreclr.so!RunMain(MethodDesc*, short, int*, REF<PtrArray>*) + 541 at /media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/assembly.cpp:1720
FFF30630 F694C3DE libcoreclr.so!Assembly::ExecuteMainMethod(REF<PtrArray>*, int) + 430 at /media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/assembly.cpp:1802
FFF30900 F63A0DA8 libcoreclr.so!CorHost2::ExecuteAssembly(unsigned int, char16_t const*, int, char16_t const**, unsigned int*) + 1576 at /media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/corhost.cpp:501
FFF30A80 F6328A86 libcoreclr.so!coreclr_execute_assembly + 406 at /media/kbaladurin/data/dotnet/forked/coreclr-1/src/dlls/mscoree/unixinterface.cpp:407
FFF30B40 F76E9CB0 corerun!ExecuteManagedAssembly(char const*, char const*, char const*, int, char const**) + 1968 at /media/kbaladurin/data/dotnet/forked/coreclr-1/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp:429
FFF30CF0 F76E8894 corerun!corerun(int, char const**) + 868 at /media/kbaladurin/data/dotnet/forked/coreclr-1/src/coreclr/hosts/unixcorerun/corerun.cpp:149
FFF30E20 F76E89BA corerun!main + 58 at /media/kbaladurin/data/dotnet/forked/coreclr-1/src/coreclr/hosts/unixcorerun/corerun.cpp:161
FFF30E40 F730B637 libc.so.6!__libc_start_main + 247
FFF30EB0 F76E8181 corerun!_start + 33
FFF2FBC4          [InlinedCallFrame: fff2fbc4] 
FFF2FBC4          [InlinedCallFrame: fff2fbc4] Unknown
FFF2FBC0 EF34D62B System.Console.dll!DomainBoundILStubClass.() + 75
FFF2FC00 EF34D76E rpinvoke.dll!/media/kbaladurin/data/dotnet/coreclr/overlay_coredumpx86_1/rpinvoke.dll!Unknown + 262
FFF2FC40 F2691048 rpinvoke.dll!/media/kbaladurin/data/dotnet/coreclr/overlay_coredumpx86_1/rpinvoke.dll!Unknown + 488
FFF30454          [GCFrame: fff30454] 
FFF30A2C          [GCFrame: fff30a2c] 
```