### PR TITLE
Simplify some relop/jtrue related optimizations

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -3298,40 +3298,6 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
     assert(!op1->isUsedFromMemory());
     assert(!op2->isUsedFromMemory());
 
-    // Case of op1 == 0 or op1 != 0:
-    // Optimize generation of 'test' instruction if op1 sets flags.
-    //
-    // This behavior is designed to match the unexpected behavior
-    // of XARCH genCompareInt();
-    //
-    // TODO-Cleanup Review GTF_USE_FLAGS usage
-    // https://github.com/dotnet/coreclr/issues/14093
-    if ((tree->gtFlags & GTF_USE_FLAGS) != 0)
-    {
-        // op1 must set flags
-        assert(op1->gtSetFlags());
-
-        // Must be compare against zero.
-        assert(!tree->OperIs(GT_TEST_EQ, GT_TEST_NE));
-        assert(op2->IsIntegralConst(0));
-        assert(op2->isContained());
-
-        // Just consume the operands
-        genConsumeOperands(tree);
-
-        // No need to generate compare instruction since
-        // op1 sets flags
-
-        // Are we evaluating this into a register?
-        if (targetReg != REG_NA)
-        {
-            genSetRegToCond(targetReg, tree);
-            genProduceReg(tree);
-        }
-
-        return;
-    }
-
     genConsumeOperands(tree);
 
     emitAttr cmpSize = EA_ATTR(genTypeSize(op1Type));

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -887,7 +887,8 @@ void CodeGen::genCodeForBinary(GenTree* treeNode)
     }
 
     // try to use an inc or dec
-    if (oper == GT_ADD && !varTypeIsFloating(treeNode) && src->isContainedIntOrIImmed() && !treeNode->gtOverflowEx())
+    if (oper == GT_ADD && !varTypeIsFloating(treeNode) && src->isContainedIntOrIImmed() && !treeNode->gtOverflowEx() &&
+        !treeNode->gtSetFlags())
     {
         if (src->IsIntegralConst(1))
         {

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -6282,27 +6282,6 @@ void CodeGen::genCompareInt(GenTreePtr treeNode)
         return;
     }
 
-#ifdef FEATURE_SIMD
-    // If we have GT_JTRUE(GT_EQ/NE(GT_SIMD((in)Equality, v1, v2), true/false)),
-    // then we don't need to generate code for GT_EQ/GT_NE, since SIMD (in)Equality intrinsic
-    // would set or clear Zero flag.
-    if ((targetReg == REG_NA) && tree->OperIs(GT_EQ, GT_NE))
-    {
-        // Is it a SIMD (in)Equality that doesn't need to materialize result into a register?
-        if ((op1->gtRegNum == REG_NA) && op1->IsSIMDEqualityOrInequality())
-        {
-            // Must be comparing against true or false.
-            assert(op2->IsIntegralConst(0) || op2->IsIntegralConst(1));
-            assert(op2->isContainedIntOrIImmed());
-
-            // In this case SIMD (in)Equality will set or clear
-            // Zero flag, based on which GT_JTRUE would generate
-            // the right conditional jump.
-            return;
-        }
-    }
-#endif // FEATURE_SIMD
-
     genConsumeOperands(tree);
 
     assert(!op1->isContainedIntOrIImmed());

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -9781,11 +9781,11 @@ int cTreeFlagsIR(Compiler* comp, GenTree* tree)
         {
             chars += printf("[SPILLED_OP2]");
         }
-#endif
         if (tree->gtFlags & GTF_ZSF_SET)
         {
             chars += printf("[ZSF_SET]");
         }
+#endif
 #if FEATURE_SET_FLAGS
         if (tree->gtFlags & GTF_SET_FLAGS)
         {

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -856,11 +856,11 @@ public:
 #ifdef LEGACY_BACKEND
 #define GTF_SPILLED_OPER 0x00000100 // op1 has been spilled
 #define GTF_SPILLED_OP2  0x00000200 // op2 has been spilled
+#define GTF_ZSF_SET      0x00000400 // the zero(ZF) and sign(SF) flags set to the operand
 #else  // !LEGACY_BACKEND
 #define GTF_NOREG_AT_USE 0x00000100 // tree node is in memory at the point of use
 #endif // !LEGACY_BACKEND
 
-#define GTF_ZSF_SET     0x00000400 // the zero(ZF) and sign(SF) flags set to the operand
 #define GTF_SET_FLAGS   0x00000800 // Requires that codegen for this node set the flags. Use gtSetFlags() to check this flag.
 #define GTF_USE_FLAGS   0x00001000 // Indicates that this node uses the flags bits.
 
@@ -2126,12 +2126,14 @@ public:
     bool gtSetFlags() const;
     bool gtRequestSetFlags();
 
+#ifdef LEGACY_BACKEND
     // Returns true if the codegen of this tree node
     // sets ZF and SF flags.
     bool gtSetZSFlags() const
     {
         return (gtFlags & GTF_ZSF_SET) != 0;
     }
+#endif
 
 #ifdef DEBUG
     bool       gtIsValid64RsltMul();

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2612,12 +2612,10 @@ GenTree* Lowering::LowerCompare(GenTree* cmp)
         }
 #endif // _TARGET_XARCH_
     }
-#ifdef _TARGET_XARCH_
-    else if (cmp->OperIs(GT_EQ, GT_NE))
-#else // _TARGET_ARM64_
     else
-#endif
     {
+        assert(cmp->OperIs(GT_EQ, GT_NE, GT_LE, GT_LT, GT_GE, GT_GT));
+
         GenTree* op1 = cmp->gtGetOp1();
         GenTree* op2 = cmp->gtGetOp2();
 

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -137,7 +137,7 @@ private:
     // Call Lowering
     // ------------------------------
     void LowerCall(GenTree* call);
-    void LowerCompare(GenTree* tree);
+    GenTree* LowerCompare(GenTree* tree);
     void LowerJmpMethod(GenTree* jmp);
     void LowerRet(GenTree* ret);
     GenTree* LowerDelegateInvoke(GenTreeCall* call);

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -138,6 +138,7 @@ private:
     // ------------------------------
     void LowerCall(GenTree* call);
     GenTree* LowerCompare(GenTree* tree);
+    GenTree* LowerJTrue(GenTreeOp* jtrue);
     void LowerJmpMethod(GenTree* jmp);
     void LowerRet(GenTree* ret);
     GenTree* LowerDelegateInvoke(GenTreeCall* call);

--- a/src/jit/lowerarmarch.cpp
+++ b/src/jit/lowerarmarch.cpp
@@ -700,29 +700,7 @@ void Lowering::ContainCheckCompare(GenTreeOp* cmp)
         GenTreePtr op1 = cmp->gtOp.gtOp1;
         GenTreePtr op2 = cmp->gtOp.gtOp2;
 
-        // If op1 codegen can set flags op2 is an immediate 0
-        // we don't need to generate cmp instruction,
-        // provided we don't have another GenTree node between op1
-        // and cmp that could potentially modify flags.
-        //
-        // TODO-CQ: right now the below peep is inexpensive and
-        // gets the benefit in most of cases because in majority
-        // of cases op1, op2 and cmp would be in that order in
-        // execution.  In general we should be able to check that all
-        // the nodes that come after op1 in execution order do not
-        // modify the flags so that it is safe to avoid generating a
-        // test instruction.  Such a check requires that on each
-        // GenTree node we need to set the info whether its codegen
-        // will modify flags.
-        if (op2->IsIntegralConst(0) && (op1->gtNext == op2) && (op2->gtNext == cmp) &&
-            !cmp->OperIs(GT_TEST_EQ, GT_TEST_NE) && op1->OperIs(GT_ADD, GT_AND, GT_SUB))
-        {
-            assert(!op1->gtSetFlags());
-            op1->gtFlags |= GTF_SET_FLAGS;
-            cmp->gtFlags |= GTF_USE_FLAGS;
-        }
-
-        if (!varTypeIsFloating(cmp) && op2->IsCnsIntOrI() && ((cmp->gtFlags & GTF_USE_FLAGS) == 0))
+        if (!varTypeIsFloating(cmp) && op2->IsCnsIntOrI())
         {
             LIR::Use cmpUse;
             bool     useJCMP = false;

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -4842,7 +4842,7 @@ void LinearScan::buildIntervals()
             TreeNodeInfoInit(node);
 
             // If the node produces an unused value, mark it as a local def-use
-            if (node->IsValue() && node->IsUnusedValue())
+            if (node->IsValue() && node->IsUnusedValue() && !node->gtLsraInfo.isNoRegCompare)
             {
                 node->gtLsraInfo.isLocalDefUse = true;
                 node->gtLsraInfo.dstCount      = 0;


### PR DESCRIPTION
These optimizations tend to be spread across multiple functions and add more work to common code paths.

SIMD equality is first recognized in `ContainCheckJTrue` and then it needs to be recognized again during codegen
https://github.com/dotnet/coreclr/blob/c90a41bb6b9b5c5cc7f8f29a9d06aa2f9d0e51fd/src/jit/codegenxarch.cpp#L6289-L6293
because ContainCheckJTrue did not actually remove the redundant compare. SIMD equality compares are obviously rare and we're trying to recognize them every time we handle a JTRUE or a compare.

Similarly, the case where the condition flags set by a previous instruction can be used instead of emitting a zero test is handled in `ContainCheckCompare` and `genCompareInt`. The later is supposed to recognize such redundant compares by checking the `GTF_USE_FLAGS` but that flag is really intended to indicate that the node is consuming the condition flags, not that no code should be generated for it. And like in the SIMD case it's again more work pushed down to a common code path, this optimization kicks in for less than 0.5% of all compares.

In both cases lowering can take advantage of CMP, SETCC and JCC to alter the IR in such a way that no special casing is required in subsequent phases.