### PR TITLE
[WIP] Improve Dictionary<K,T> CQ

### DIFF
--- a/src/mscorlib/src/System/Collections/Hashtable.cs
+++ b/src/mscorlib/src/System/Collections/Hashtable.cs
@@ -1472,6 +1472,7 @@ namespace System.Collections
             return GetPrime(newSize);
         }
 
+        public static uint FindBucket(uint hashCode, uint limit) => hashCode % limit;
 
         // This is the maximum prime smaller than Array.MaxArrayLength
         public const int MaxPrimeArrayLength = 0x7FEFFFFD;


### PR DESCRIPTION
Incorporate @AndyAyersMS [Potential CQ improvements in Dictionary<K,T>](https://github.com/dotnet/coreclr/compare/master...AndyAyersMS:DictionaryHacks?expand=1)

> Since calls to the comparer can have arbitrary side effects, the jit will reload data members after the call. This leads to redundant loads and range checks.
>
> Try and eliminate these by caching data members in locals.

For default comparer, use regular inline method calls rather than a virtual function call on interface type

Split default and custom comparer paths

For BCL ValueType primitives  `byte`, `sbyte`, `ushort`, `short`, `uint`, `int`, `ulong`, `long`, `IntPtr`, `UIntPtr`, `Guid` cast via object to the type and use .Equals directly them directly; then rely on the Jit to elide the boxing - meaning the mostly completely inline (e.g. Guid doesn't; though isn't a virtual call)

Find the entry and pass that back using ref returns; rather than index to array that then needs to be looked up again.

More extensive use of ref locals.

Will follow up with metrics
