### PR TITLE
Improve runtest.sh concurrency

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -740,20 +740,56 @@ else
 fi
 ((maxProcesses = $NumProc * 3 / 2)) # long tests delay process creation, use a few more processors
 
-((nextProcessIndex = 0))
 ((processCount = 0))
 declare -a scriptFilePaths
 declare -a outputFilePaths
 declare -a processIds
 declare -a testStartTimes
+processIndexNone=$maxProcesses
+waitProcessIndex=$processIndexNone
+pidNone=0
+
+function waitany {
+    local pid
+    local exitcode
+    while true; do
+        for (( i=0; i<$maxProcesses; i++ )); do
+            pid=${processIds[$i]}
+            if [ -z "$pid" ] || [ "$pid" == "$pidNone" ]; then
+                continue
+            fi
+            if ! kill -0 $pid 2>/dev/null; then
+                wait $pid
+                exitcode=$?
+                waitProcessIndex=$i
+                processIds[$i]=$pidNone
+                return $exitcode
+            fi
+        done
+        sleep 0.1
+    done
+}
+
+function get_available_process_index {
+    local pid
+    local i=0
+    for (( i=0; i<$maxProcesses; i++ )); do
+        pid=${processIds[$i]}
+        if [ -z "$pid" ] || [ "$pid" == "$pidNone" ]; then
+            break
+        fi
+    done
+    echo $i
+}
 
 function finish_test {
-    wait ${processIds[$nextProcessIndex]}
+    waitany
     local testScriptExitCode=$?
+    local finishedProcessIndex=$waitProcessIndex
     ((--processCount))
 
-    local scriptFilePath=${scriptFilePaths[$nextProcessIndex]}
-    local outputFilePath=${outputFilePaths[$nextProcessIndex]}
+    local scriptFilePath=${scriptFilePaths[$finishedProcessIndex]}
+    local outputFilePath=${outputFilePaths[$finishedProcessIndex]}
     local scriptFileName=$(basename "$scriptFilePath")
 
     local testEndTime=
@@ -766,7 +802,7 @@ function finish_test {
 
     if [ "$showTime" == "ON" ]; then
         testEndTime=$(date +%s)
-        testRunningTime=$(( $testEndTime - ${testStartTimes[$nextProcessIndex]} ))
+        testRunningTime=$(( $testEndTime - ${testStartTimes[$finishedProcessIndex]} ))
         header=$header$(printf "[%4ds]" $testRunningTime)
     fi
 
@@ -805,14 +841,9 @@ function finish_test {
 
 function finish_remaining_tests {
     # Finish the remaining tests in the order in which they were started
-    if ((nextProcessIndex >= processCount)); then
-        ((nextProcessIndex = 0))
-    fi
     while ((processCount > 0)); do
         finish_test
-        ((nextProcessIndex = (nextProcessIndex + 1) % maxProcesses))
     done
-    ((nextProcessIndex = 0))
 }
 
 function prep_test {
@@ -835,6 +866,7 @@ function prep_test {
 }
 
 function start_test {
+    local nextProcessIndex=$(get_available_process_index)
     local scriptFilePath=$1
     if ((runFailingTestsOnly == 1)) && ! is_failing_test "$scriptFilePath"; then
         return
@@ -846,8 +878,9 @@ function start_test {
         return
     fi
 
-    if ((nextProcessIndex < processCount)); then
+    if ((nextProcessIndex == processIndexNone)); then
         finish_test
+        nextProcessIndex=$(get_available_process_index)
     fi
 
     scriptFilePaths[$nextProcessIndex]=$scriptFilePath
@@ -869,7 +902,6 @@ function start_test {
     fi
     processIds[$nextProcessIndex]=$!
 
-    ((nextProcessIndex = (nextProcessIndex + 1) % maxProcesses))
     ((++processCount))
 }
 

--- a/tests/testsUnsupportedOnARM32.txt
+++ b/tests/testsUnsupportedOnARM32.txt
@@ -10,3 +10,8 @@ JIT/Methodical/xxobj/sizeof/_il_relsizeof32/_il_relsizeof32.sh
 JIT/Methodical/xxobj/sizeof/_il_relsizeof64/_il_relsizeof64.sh
 JIT/Regression/JitBlue/devdiv_902271/DevDiv_902271/DevDiv_902271.sh
 JIT/jit64/opt/cse/HugeArray1/HugeArray1.sh
+JIT/jit64/opt/cse/hugeSimpleExpr1/hugeSimpleExpr1.sh
+GC/Features/HeapExpansion/pluggaps/pluggaps.sh
+GC/Regressions/v2.0-beta2/460373/460373/460373.sh
+GC/Regressions/v2.0-beta1/149926/149926/149926.sh
+GC/Regressions/v2.0-rtm/494226/494226/494226.sh


### PR DESCRIPTION
`runtest.sh` runs next tests immediately after any of child processes is done