### PR TITLE
[Arm64/Arm] Favor emitActualTypeSize for non-memory

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -1463,7 +1463,7 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
         case GT_CNS_DBL:
         {
             emitter*       emit       = getEmitter();
-            emitAttr       size       = emitTypeSize(tree);
+            emitAttr       size       = emitActualTypeSize(tree);
             GenTreeDblCon* dblConst   = tree->AsDblCon();
             double         constValue = dblConst->gtDblCon.gtDconVal;
 
@@ -1509,7 +1509,7 @@ void CodeGen::genCodeForMulHi(GenTreeOp* treeNode)
     regNumber targetReg  = treeNode->gtRegNum;
     var_types targetType = treeNode->TypeGet();
     emitter*  emit       = getEmitter();
-    emitAttr  attr       = emitTypeSize(treeNode);
+    emitAttr  attr       = emitActualTypeSize(treeNode);
     unsigned  isUnsigned = (treeNode->gtFlags & GTF_UNSIGNED);
 
     GenTreePtr op1 = treeNode->gtGetOp1();
@@ -1561,7 +1561,7 @@ void CodeGen::genCodeForBinary(GenTree* treeNode)
     // The arithmetic node must be sitting in a register (since it's not contained)
     assert(targetReg != REG_NA);
 
-    regNumber r = emit->emitInsTernary(ins, emitTypeSize(treeNode), treeNode, op1, op2);
+    regNumber r = emit->emitInsTernary(ins, emitActualTypeSize(treeNode), treeNode, op1, op2);
     assert(r == targetReg);
 
     genProduceReg(treeNode);
@@ -1798,7 +1798,7 @@ void CodeGen::genReturn(GenTreePtr treeNode)
 
         if (movRequired)
         {
-            emitAttr attr = emitTypeSize(targetType);
+            emitAttr attr = emitActualTypeSize(targetType);
             getEmitter()->emitIns_R_R(INS_mov, attr, retReg, op1->gtRegNum);
         }
     }
@@ -2184,7 +2184,7 @@ void CodeGen::genCodeForNegNot(GenTree* tree)
     // The src must be a register.
     regNumber operandReg = genConsumeReg(operand);
 
-    getEmitter()->emitIns_R_R(ins, emitTypeSize(tree), targetReg, operandReg);
+    getEmitter()->emitIns_R_R(ins, emitActualTypeSize(tree), targetReg, operandReg);
 
     genProduceReg(tree);
 }
@@ -2749,7 +2749,7 @@ void CodeGen::genTableBasedSwitch(GenTree* treeNode)
     getEmitter()->emitIns_R_R_R(INS_add, EA_PTRSIZE, baseReg, baseReg, tmpReg);
 
     // br baseReg
-    getEmitter()->emitIns_R(INS_br, emitTypeSize(TYP_I_IMPL), baseReg);
+    getEmitter()->emitIns_R(INS_br, emitActualTypeSize(TYP_I_IMPL), baseReg);
 }
 
 // emits the table and an instruction to get the address of the first element
@@ -2784,7 +2784,7 @@ void CodeGen::genJumpTable(GenTree* treeNode)
     // Access to inline data is 'abstracted' by a special type of static member
     // (produced by eeFindJitDataOffs) which the emitter recognizes as being a reference
     // to constant data, not a real static field.
-    getEmitter()->emitIns_R_C(INS_adr, emitTypeSize(TYP_I_IMPL), treeNode->gtRegNum, REG_NA,
+    getEmitter()->emitIns_R_C(INS_adr, emitActualTypeSize(TYP_I_IMPL), treeNode->gtRegNum, REG_NA,
                               compiler->eeFindJitDataOffs(jmpTabBase), 0);
     genProduceReg(treeNode);
 }
@@ -2840,7 +2840,7 @@ void CodeGen::genLockedInstructions(GenTreeOp* treeNode)
     default:
         unreached();
     }
-    getEmitter()->emitInsBinary(ins, emitTypeSize(data), &i, data);
+    getEmitter()->emitInsBinary(ins, emitActualTypeSize(data), &i, data);
 
     if (treeNode->gtRegNum != REG_NA)
     {
@@ -3279,7 +3279,7 @@ void CodeGen::genIntToFloatCast(GenTreePtr treeNode)
 
     genConsumeOperands(treeNode->AsOp());
 
-    getEmitter()->emitIns_R_R(ins, emitTypeSize(dstType), treeNode->gtRegNum, op1->gtRegNum, cvtOption);
+    getEmitter()->emitIns_R_R(ins, emitActualTypeSize(dstType), treeNode->gtRegNum, op1->gtRegNum, cvtOption);
 
     genProduceReg(treeNode);
 }
@@ -3394,8 +3394,8 @@ void CodeGen::genCkfinite(GenTreePtr treeNode)
     regNumber intReg = treeNode->GetSingleTempReg();
     regNumber fpReg  = genConsumeReg(op1);
 
-    emit->emitIns_R_R(ins_Copy(targetType), emitTypeSize(treeNode), intReg, fpReg);
-    emit->emitIns_R_R_I(INS_lsr, emitTypeSize(targetType), intReg, intReg, shiftAmount);
+    emit->emitIns_R_R(ins_Copy(targetType), emitActualTypeSize(treeNode), intReg, fpReg);
+    emit->emitIns_R_R_I(INS_lsr, emitActualTypeSize(targetType), intReg, intReg, shiftAmount);
 
     // Mask of exponent with all 1's and check if the exponent is all 1's
     emit->emitIns_R_R_I(INS_and, EA_4BYTE, intReg, intReg, expMask);
@@ -3408,7 +3408,7 @@ void CodeGen::genCkfinite(GenTreePtr treeNode)
     // if it is a finite value copy it to targetReg
     if (treeNode->gtRegNum != fpReg)
     {
-        emit->emitIns_R_R(ins_Copy(targetType), emitTypeSize(treeNode), treeNode->gtRegNum, fpReg);
+        emit->emitIns_R_R(ins_Copy(targetType), emitActualTypeSize(treeNode), treeNode->gtRegNum, fpReg);
     }
     genProduceReg(treeNode);
 }

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -3376,9 +3376,6 @@ void CodeGen::genFloatToIntCast(GenTreePtr treeNode)
 // Assumptions:
 //    GT_CKFINITE node has reserved an internal register.
 //
-// TODO-ARM64-CQ - mark the operand as contained if known to be in
-// memory (e.g. field or an array element).
-//
 void CodeGen::genCkfinite(GenTreePtr treeNode)
 {
     assert(treeNode->OperGet() == GT_CKFINITE);

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -1615,7 +1615,8 @@ void CodeGen::genCodeForIndexAddr(GenTreeIndexAddr* node)
     {
         case 1:
             // dest = base + index
-            getEmitter()->emitIns_R_R_R(INS_add, emitActualTypeSize(node), node->gtRegNum, base->gtRegNum, index->gtRegNum);
+            getEmitter()->emitIns_R_R_R(INS_add, emitActualTypeSize(node), node->gtRegNum, base->gtRegNum,
+                                        index->gtRegNum);
             break;
 
         case 2:

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -456,18 +456,18 @@ void CodeGen::genIntrinsic(GenTreePtr treeNode)
     {
         case CORINFO_INTRINSIC_Abs:
             genConsumeOperands(treeNode->AsOp());
-            getEmitter()->emitInsBinary(INS_ABS, emitTypeSize(treeNode), treeNode, srcNode);
+            getEmitter()->emitInsBinary(INS_ABS, emitActualTypeSize(treeNode), treeNode, srcNode);
             break;
 
         case CORINFO_INTRINSIC_Round:
             NYI_ARM("genIntrinsic for round - not implemented yet");
             genConsumeOperands(treeNode->AsOp());
-            getEmitter()->emitInsBinary(INS_ROUND, emitTypeSize(treeNode), treeNode, srcNode);
+            getEmitter()->emitInsBinary(INS_ROUND, emitActualTypeSize(treeNode), treeNode, srcNode);
             break;
 
         case CORINFO_INTRINSIC_Sqrt:
             genConsumeOperands(treeNode->AsOp());
-            getEmitter()->emitInsBinary(INS_SQRT, emitTypeSize(treeNode), treeNode, srcNode);
+            getEmitter()->emitInsBinary(INS_SQRT, emitActualTypeSize(treeNode), treeNode, srcNode);
             break;
 
         default:
@@ -1098,7 +1098,7 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
                 if (targetReg == addrReg && idx != treeNode->gtNumRegs - 1)
                 {
                     assert(targetReg != baseReg);
-                    emit->emitIns_R_R(INS_mov, emitTypeSize(type), baseReg, addrReg);
+                    emit->emitIns_R_R(INS_mov, emitActualTypeSize(type), baseReg, addrReg);
                     addrReg = baseReg;
                 }
 
@@ -1235,10 +1235,10 @@ void CodeGen::genRangeCheck(GenTreePtr oper)
     assert(bndsChkType == TYP_INT || bndsChkType == TYP_LONG);
 
     // The type of the bounds check should always wide enough to compare against the index.
-    assert(emitTypeSize(bndsChkType) >= emitTypeSize(genActualType(src1->TypeGet())));
+    assert(emitTypeSize(bndsChkType) >= emitActualTypeSize(src1->TypeGet()));
 #endif // DEBUG
 
-    getEmitter()->emitInsBinary(INS_cmp, emitTypeSize(bndsChkType), src1, src2);
+    getEmitter()->emitInsBinary(INS_cmp, emitActualTypeSize(bndsChkType), src1, src2);
     genJumpToThrowHlpBlk(jmpKind, SCK_RNGCHK_FAIL, bndsChk->gtIndRngFailBB);
 }
 
@@ -1476,7 +1476,7 @@ void CodeGen::genCodeForShift(GenTreePtr tree)
     var_types   targetType = tree->TypeGet();
     genTreeOps  oper       = tree->OperGet();
     instruction ins        = genGetInsForOper(oper, targetType);
-    emitAttr    size       = emitTypeSize(tree);
+    emitAttr    size       = emitActualTypeSize(tree);
 
     assert(tree->gtRegNum != REG_NA);
 
@@ -1606,7 +1606,7 @@ void CodeGen::genCodeForIndexAddr(GenTreeIndexAddr* node)
 #endif
 
         // Generate the range check.
-        getEmitter()->emitInsBinary(INS_cmp, emitTypeSize(TYP_I_IMPL), index, &arrLen);
+        getEmitter()->emitInsBinary(INS_cmp, emitActualTypeSize(TYP_I_IMPL), index, &arrLen);
         genJumpToThrowHlpBlk(genJumpKindForOper(GT_GE, CK_UNSIGNED), SCK_RNGCHK_FAIL, node->gtIndRngFailBB);
     }
 
@@ -1615,7 +1615,7 @@ void CodeGen::genCodeForIndexAddr(GenTreeIndexAddr* node)
     {
         case 1:
             // dest = base + index
-            getEmitter()->emitIns_R_R_R(INS_add, emitTypeSize(node), node->gtRegNum, base->gtRegNum, index->gtRegNum);
+            getEmitter()->emitIns_R_R_R(INS_add, emitActualTypeSize(node), node->gtRegNum, base->gtRegNum, index->gtRegNum);
             break;
 
         case 2:
@@ -1627,7 +1627,7 @@ void CodeGen::genCodeForIndexAddr(GenTreeIndexAddr* node)
             BitScanForward(&lsl, node->gtElemSize);
 
             // dest = base + index * scale
-            genScaledAdd(emitTypeSize(node), node->gtRegNum, base->gtRegNum, index->gtRegNum, lsl);
+            genScaledAdd(emitActualTypeSize(node), node->gtRegNum, base->gtRegNum, index->gtRegNum, lsl);
             break;
         }
 
@@ -1637,14 +1637,14 @@ void CodeGen::genCodeForIndexAddr(GenTreeIndexAddr* node)
             CodeGen::genSetRegToIcon(tmpReg, (ssize_t)node->gtElemSize, TYP_INT);
 
             // dest = index * tmp + base
-            getEmitter()->emitIns_R_R_R_R(INS_MULADD, emitTypeSize(node), node->gtRegNum, index->gtRegNum, tmpReg,
+            getEmitter()->emitIns_R_R_R_R(INS_MULADD, emitActualTypeSize(node), node->gtRegNum, index->gtRegNum, tmpReg,
                                           base->gtRegNum);
             break;
         }
     }
 
     // dest = dest + elemOffs
-    getEmitter()->emitIns_R_R_I(INS_add, emitTypeSize(node), node->gtRegNum, node->gtRegNum, node->gtElemOffset);
+    getEmitter()->emitIns_R_R_I(INS_add, emitActualTypeSize(node), node->gtRegNum, node->gtRegNum, node->gtElemOffset);
 
     gcInfo.gcMarkRegSetNpt(base->gtGetRegMask());
 
@@ -2867,12 +2867,12 @@ void CodeGen::genFloatToFloatCast(GenTreePtr treeNode)
         insOpts cvtOption = (srcType == TYP_FLOAT) ? INS_OPTS_S_TO_D  // convert Single to Double
                                                    : INS_OPTS_D_TO_S; // convert Double to Single
 
-        getEmitter()->emitIns_R_R(INS_fcvt, emitTypeSize(treeNode), treeNode->gtRegNum, op1->gtRegNum, cvtOption);
+        getEmitter()->emitIns_R_R(INS_fcvt, emitActualTypeSize(treeNode), treeNode->gtRegNum, op1->gtRegNum, cvtOption);
     }
     else if (treeNode->gtRegNum != op1->gtRegNum)
     {
         // If double to double cast or float to float cast. Emit a move instruction.
-        getEmitter()->emitIns_R_R(INS_mov, emitTypeSize(treeNode), treeNode->gtRegNum, op1->gtRegNum);
+        getEmitter()->emitIns_R_R(INS_mov, emitActualTypeSize(treeNode), treeNode->gtRegNum, op1->gtRegNum);
     }
 
 #endif // _TARGET_*

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -2382,11 +2382,12 @@ inline emitAttr emitTypeSize(T type)
 
 extern const unsigned short emitTypeActSz[TYP_COUNT];
 
-inline emitAttr emitActualTypeSize(var_types type)
+template <class T>
+inline emitAttr emitActualTypeSize(T type)
 {
-    assert(type < TYP_COUNT);
-    assert(emitTypeActSz[type] > 0);
-    return (emitAttr)emitTypeActSz[type];
+    assert(TypeGet(type) < TYP_COUNT);
+    assert(emitTypeActSz[TypeGet(type)] > 0);
+    return (emitAttr)emitTypeActSz[TypeGet(type)];
 }
 
 /*****************************************************************************


### PR DESCRIPTION
In general, for ARM/ARM64 emitActualTypeSize should be used for register operations, while emitTypeSize() should be used for memory operations.

This PR, fixes all Arm64 cases and shared Arm64 & Arm cases.  Arm only cases are not touched.

Also remove bogus CQ ToDo

Fixes #13917