### PR TITLE
Fix bug causing unnecessary amounts of data to be written to trace files

### DIFF
--- a/src/scripts/genEventPipe.py
+++ b/src/scripts/genEventPipe.py
@@ -198,7 +198,7 @@ def generateWriteEventBody(template, providerName, eventName):
     }\n\n"""
 
     body = "    EventPipe::WriteEvent(*EventPipeEvent" + \
-        eventName + ", (BYTE *)buffer, size);\n"
+        eventName + ", (BYTE *)buffer, offset);\n"
 
     footer = """
     if (!fixedBuffer)


### PR DESCRIPTION
This PR fixes an issue where the buffers being sent to EventPipe were larger than the data they contained. This did not cause functional errors, but resulted in unnecessarily large files and wasted time writing blank data. This PR results in ~30% reduction in file size

This fix changes the generated events to tell the EventPipe the runtime calculated size rather than the build-time estimated size. The build-time estimate is done here, and tends to be an overestimate as a low estimate would cause a seg fault https://github.com/dotnet/coreclr/blob/master/src/scripts/genXplatEventing.py#L137-L146

Closes: #13706