### PR TITLE
Disable VSD Stub Kind Prediction on H/W Exception

### DIFF
--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -5156,7 +5156,7 @@ static BOOL IsIPinVirtualStub(PCODE f_IP)
     }
 
     VirtualCallStubManager::StubKind sk;
-    VirtualCallStubManager::FindStubManager(f_IP, &sk, false /* usePredictStubKind */);
+    VirtualCallStubManager::FindStubManager(f_IP, &sk, FALSE /* usePredictStubKind */);
 
     if (sk == VirtualCallStubManager::SK_DISPATCH)
     {

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -5156,7 +5156,7 @@ static BOOL IsIPinVirtualStub(PCODE f_IP)
     }
 
     VirtualCallStubManager::StubKind sk;
-    VirtualCallStubManager::FindStubManager(f_IP, &sk);
+    VirtualCallStubManager::FindStubManager(f_IP, &sk, false);
 
     if (sk == VirtualCallStubManager::SK_DISPATCH)
     {

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -5156,7 +5156,7 @@ static BOOL IsIPinVirtualStub(PCODE f_IP)
     }
 
     VirtualCallStubManager::StubKind sk;
-    VirtualCallStubManager::FindStubManager(f_IP, &sk, false);
+    VirtualCallStubManager::FindStubManager(f_IP, &sk, false /* usePredictStubKind */);
 
     if (sk == VirtualCallStubManager::SK_DISPATCH)
     {

--- a/src/vm/virtualcallstub.cpp
+++ b/src/vm/virtualcallstub.cpp
@@ -974,7 +974,7 @@ void VirtualCallStubManager::Reclaim()
 
 //----------------------------------------------------------------------------
 /* static */
-VirtualCallStubManager *VirtualCallStubManager::FindStubManager(PCODE stubAddress,  StubKind* wbStubKind)
+VirtualCallStubManager *VirtualCallStubManager::FindStubManager(PCODE stubAddress,  StubKind* wbStubKind, bool usePredictStubKind)
 {
     CONTRACTL {
         NOTHROW;
@@ -999,7 +999,7 @@ VirtualCallStubManager *VirtualCallStubManager::FindStubManager(PCODE stubAddres
     // VirtualCallStubManager::isDispatchingStub
     //
     CONTRACT_VIOLATION(SOToleranceViolation);
-    kind = pCur->getStubKind(stubAddress);
+    kind = pCur->getStubKind(stubAddress, usePredictStubKind);
     if (kind != SK_UNKNOWN)
     {
         if (wbStubKind)
@@ -1011,7 +1011,7 @@ VirtualCallStubManager *VirtualCallStubManager::FindStubManager(PCODE stubAddres
     // See if we are managed by the shared domain
     //
     pCur = SharedDomain::GetDomain()->GetLoaderAllocator()->GetVirtualCallStubManager();
-    kind = pCur->getStubKind(stubAddress);
+    kind = pCur->getStubKind(stubAddress, usePredictStubKind);
     if (kind != SK_UNKNOWN)
     {
         if (wbStubKind)
@@ -1026,7 +1026,7 @@ VirtualCallStubManager *VirtualCallStubManager::FindStubManager(PCODE stubAddres
     {
         _ASSERTE(pCur != NULL);
 
-        kind = pCur->getStubKind(stubAddress);
+        kind = pCur->getStubKind(stubAddress, usePredictStubKind);
         if (kind != SK_UNKNOWN)
         {
             if (wbStubKind)

--- a/src/vm/virtualcallstub.cpp
+++ b/src/vm/virtualcallstub.cpp
@@ -974,7 +974,7 @@ void VirtualCallStubManager::Reclaim()
 
 //----------------------------------------------------------------------------
 /* static */
-VirtualCallStubManager *VirtualCallStubManager::FindStubManager(PCODE stubAddress,  StubKind* wbStubKind, bool usePredictStubKind)
+VirtualCallStubManager *VirtualCallStubManager::FindStubManager(PCODE stubAddress,  StubKind* wbStubKind, BOOL usePredictStubKind)
 {
     CONTRACTL {
         NOTHROW;

--- a/src/vm/virtualcallstub.h
+++ b/src/vm/virtualcallstub.h
@@ -733,7 +733,7 @@ public:
     // Given a stub address, find the VCSManager that owns it.
     static VirtualCallStubManager *FindStubManager(PCODE addr,
                                                    StubKind* wbStubKind = NULL,
-                                                   bool usePredictStubKind = true);
+                                                   BOOL usePredictStubKind = TRUE);
 
 #ifndef DACCESS_COMPILE
     // insert a linked list of indirection cells at the beginning of m_RecycledIndCellList

--- a/src/vm/virtualcallstub.h
+++ b/src/vm/virtualcallstub.h
@@ -317,7 +317,7 @@ public:
     /* know thine own stubs.  It is possible that when multiple
     virtualcallstub managers are built that these may need to become
     non-static, and the callers modified accordingly */
-    StubKind getStubKind(PCODE stubStartAddress)
+    StubKind getStubKind(PCODE stubStartAddress, bool usePredictStubKind = true)
     {
         WRAPPER_NO_CONTRACT;
         SUPPORTS_DAC;
@@ -329,7 +329,7 @@ public:
 
         // Rather than calling IsInRange(stubStartAddress) for each possible stub kind
         // we can peek at the assembly code and predict which kind of a stub we have
-        StubKind predictedKind = predictStubKind(stubStartAddress);
+        StubKind predictedKind = (usePredictStubKind) ? predictStubKind(stubStartAddress) : SK_UNKNOWN;
 
         if (predictedKind == SK_DISPATCH)
         {
@@ -732,7 +732,8 @@ private:
 public:
     // Given a stub address, find the VCSManager that owns it.
     static VirtualCallStubManager *FindStubManager(PCODE addr,
-                                                   StubKind* wbStubKind = NULL);
+                                                   StubKind* wbStubKind = NULL,
+                                                   bool usePredictStubKind = true);
 
 #ifndef DACCESS_COMPILE
     // insert a linked list of indirection cells at the beginning of m_RecycledIndCellList

--- a/src/vm/virtualcallstub.h
+++ b/src/vm/virtualcallstub.h
@@ -317,7 +317,7 @@ public:
     /* know thine own stubs.  It is possible that when multiple
     virtualcallstub managers are built that these may need to become
     non-static, and the callers modified accordingly */
-    StubKind getStubKind(PCODE stubStartAddress, bool usePredictStubKind = true)
+    StubKind getStubKind(PCODE stubStartAddress, BOOL usePredictStubKind = TRUE)
     {
         WRAPPER_NO_CONTRACT;
         SUPPORTS_DAC;


### PR DESCRIPTION
This commit disables VSD Stub Kind Prediction on H/W Exception (as suggested in #14032) to fix #14031.