### PR TITLE
Fix rlimit setting of RLIM_NOFILE on OSX

### DIFF
--- a/src/pal/src/file/file.cpp
+++ b/src/pal/src/file/file.cpp
@@ -3521,6 +3521,9 @@ DWORD FILEGetLastErrorFromErrno( void )
     case EIO:
         dwRet = ERROR_WRITE_FAULT;
         break;
+    case EMFILE:
+        dwRet = ERROR_TOO_MANY_OPEN_FILES;
+        break;
     case ERANGE:
         dwRet = ERROR_BAD_PATHNAME;
         break;

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -1065,6 +1065,14 @@ static BOOL INIT_IncreaseDescriptorLimit(void)
     // Set our soft limit for file descriptors to be the same
     // as the max limit.
     rlp.rlim_cur = rlp.rlim_max;
+#ifdef __APPLE__
+    // Based on compatibility note in setrlimit(2) manpage for OSX,
+    // trim the limit to OPEN_MAX.
+    if (rlp.rlim_cur > OPEN_MAX)
+    {
+        rlp.rlim_cur = OPEN_MAX;
+    }
+#endif
     result = setrlimit(RLIMIT_NOFILE, &rlp);
     if (result != 0)
     {


### PR DESCRIPTION
This change fixes an issue with rlimit setting of RLIM_NOFILE. The problem
is that the rlim_max that we get from getrlimit is too large and so setting
the rlimit_cur to that value fails. The OSX man page for rlimit has a compat
note about it, stating that the rlimit_cur needs to be limited to
min(OPEN_MAX, rlim_max) if one wants to set it to rlim_max.

As an add-on change, I've also adds missing conversion from EMFILE errno
to ERROR_TOO_MANY_OPEN_FILES that has obscured the setrlimit issue since
the failure due to small limit was being reported as ERROR_GEN_FAILURE.