### PR TITLE
Move initialization of YieldProcessorNormalized to the finalizer thread

### DIFF
--- a/src/mscorlib/src/Internal/Runtime/Augments/RuntimeThread.cs
+++ b/src/mscorlib/src/Internal/Runtime/Augments/RuntimeThread.cs
@@ -207,8 +207,8 @@ namespace Internal.Runtime.Augments
                 }
 
                 // This is done lazily because the first call to the function below in the process triggers a measurement that
-                // takes a nontrivial amount of time. See Thread::InitializeYieldProcessorNormalized(), which describes and
-                // calculates this value.
+                // takes a nontrivial amount of time if the measurement has not already been done in the backgorund.
+                // See Thread::InitializeYieldProcessorNormalized(), which describes and calculates this value.
                 s_optimalMaxSpinWaitsPerSpinIteration = GetOptimalMaxSpinWaitsPerSpinIterationInternal();
                 Debug.Assert(s_optimalMaxSpinWaitsPerSpinIteration > 0);
                 return s_optimalMaxSpinWaitsPerSpinIteration;

--- a/src/vm/comsynchronizable.cpp
+++ b/src/vm/comsynchronizable.cpp
@@ -1632,8 +1632,9 @@ INT32 QCALLTYPE ThreadNative::GetOptimalMaxSpinWaitsPerSpinIteration()
 
     BEGIN_QCALL;
 
-    Thread::EnsureYieldProcessorNormalizedInitialized();
-    optimalMaxNormalizedYieldsPerSpinIteration = Thread::GetOptimalMaxNormalizedYieldsPerSpinIteration();
+    // RuntimeThread calls this function only once lazily and caches the result, so ensure initialization
+    EnsureYieldProcessorNormalizedInitialized();
+    optimalMaxNormalizedYieldsPerSpinIteration = g_optimalMaxNormalizedYieldsPerSpinIteration;
 
     END_QCALL;
 
@@ -1655,10 +1656,11 @@ FCIMPL1(void, ThreadNative::SpinWait, int iterations)
     // spinning for less than that number of cycles, then switching to preemptive
     // mode won't help a GC start any faster.
     //
-    if (iterations <= 100000 && Thread::IsYieldProcessorNormalizedInitialized())
+    if (iterations <= 100000)
     {
+        YieldProcessorNormalizationInfo normalizationInfo = YieldProcessorNormalizationInfo::GetNormalizationInfo();
         for (int i = 0; i < iterations; i++)
-            Thread::YieldProcessorNormalized();
+            YieldProcessorNormalized(normalizationInfo);
         return;
     }
 
@@ -1668,9 +1670,9 @@ FCIMPL1(void, ThreadNative::SpinWait, int iterations)
     HELPER_METHOD_FRAME_BEGIN_NOPOLL();
     GCX_PREEMP();
 
-    Thread::EnsureYieldProcessorNormalizedInitialized();
+    YieldProcessorNormalizationInfo normalizationInfo = YieldProcessorNormalizationInfo::GetNormalizationInfo();
     for (int i = 0; i < iterations; i++)
-        Thread::YieldProcessorNormalized();
+        YieldProcessorNormalized(normalizationInfo);
 
     HELPER_METHOD_FRAME_END();
 }

--- a/src/vm/comsynchronizable.cpp
+++ b/src/vm/comsynchronizable.cpp
@@ -1658,7 +1658,7 @@ FCIMPL1(void, ThreadNative::SpinWait, int iterations)
     //
     if (iterations <= 100000)
     {
-        YieldProcessorNormalizationInfo normalizationInfo = YieldProcessorNormalizationInfo::GetNormalizationInfo();
+        YieldProcessorNormalizationInfo normalizationInfo;
         for (int i = 0; i < iterations; i++)
             YieldProcessorNormalized(normalizationInfo);
         return;
@@ -1670,7 +1670,7 @@ FCIMPL1(void, ThreadNative::SpinWait, int iterations)
     HELPER_METHOD_FRAME_BEGIN_NOPOLL();
     GCX_PREEMP();
 
-    YieldProcessorNormalizationInfo normalizationInfo = YieldProcessorNormalizationInfo::GetNormalizationInfo();
+    YieldProcessorNormalizationInfo normalizationInfo;
     for (int i = 0; i < iterations; i++)
         YieldProcessorNormalized(normalizationInfo);
 

--- a/src/vm/finalizerthread.cpp
+++ b/src/vm/finalizerthread.cpp
@@ -744,6 +744,8 @@ DWORD WINAPI FinalizerThread::FinalizerThreadStart(void *args)
 #endif
             GetFinalizerThread()->SetBackground(TRUE);
 
+            EnsureYieldProcessorNormalizedInitialized();
+
 #ifdef FEATURE_PROFAPI_ATTACH_DETACH 
             // Add the Profiler Attach Event to the array of event handles that the
             // finalizer thread waits on. If the process is not enabled for profiler

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -11754,7 +11754,7 @@ ULONGLONG Thread::QueryThreadProcessorUsage()
 
 // Defaults are for when InitializeYieldProcessorNormalized has not yet been called or when no measurement is done, and are
 // tuned for Skylake processors
-int g_yieldsPerNormalizedYield = 1; // 9 for pre-Skylake
+int g_yieldsPerNormalizedYield = 1; // current value is for Skylake processors, this would be 9 for pre-Skylake
 int g_optimalMaxNormalizedYieldsPerSpinIteration = 7;
 
 static Volatile<bool> s_isYieldProcessorNormalizedInitialized = false;
@@ -11795,11 +11795,14 @@ void InitializeYieldProcessorNormalized()
     ULONGLONG elapsedTicks;
     do
     {
-        for (int i = 0; i < 10; ++i)
+        // On some systems, querying the high performance counter has relatively significant overhead. Do enough yields to mask
+        // the timing overhead. Assuming one yield has a delay of MinNsPerNormalizedYield, 1000 yields would have a delay in the
+        // low microsecond range.
+        for (int i = 0; i < 1000; ++i)
         {
             YieldProcessor();
         }
-        yieldCount += 10;
+        yieldCount += 1000;
 
         QueryPerformanceCounter(&li);
         ULONGLONG nowTicks = li.QuadPart;


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/13984
- Also moved relevant functions out of the Thread class as requested in the issue
- For some reason, after moving the functions out of the Thread class, YieldProcessorNormalized was not getting inlined anymore. It seems to be important to have it be inlined such that the memory loads are hoisted out of outer loops. To remove the dependency on the compiler to do it (even with forceinline it's not possible to hoist sometimes, for instance InterlockedCompareExchnage loops), changed the signatures to do what is intended.