### PR TITLE
Fix expected values in fannkuch-redux-5

### DIFF
--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/fannkuch-redux/fannkuch-redux-5.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/fannkuch-redux/fannkuch-redux-5.cs
@@ -108,14 +108,14 @@ namespace BenchmarksGame
             int n = args.Length > 0 ? int.Parse(args[0]) : 7;
             int sum = Bench(n, true);
 
-            int expected = 228;
+            int expected = 16;
 
             // Return 100 on success, anything else on failure.
             return sum - expected + 100;
         }
 
         [Benchmark(InnerIterationCount = 20)]
-        [InlineData(10, 73196)]
+        [InlineData(10, 38)]
         public static void RunBench(int n, int expectedSum)
         {
             Benchmark.Iterate(() =>
@@ -152,7 +152,7 @@ namespace BenchmarksGame
             }
             if (verbose) Console.Out.WriteLineAsync(chksum + "\nPfannkuchen(" + n + ") = " + maxflips);
 
-            return chksum;
+            return maxflips;
         }
     }
 }


### PR DESCRIPTION
The validation logic was testing against `chksum`, which actually can
vary depending on the number of processors (as that is used to determine
the number of threads across which the work is partitioned, and the
checksum is sensitive to the bucketing).  Change it to test against
`maxflips` instead, which is stable.

Fixes #14040.