### PR TITLE
Fix formatting break

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2372,7 +2372,7 @@ void Lowering::LowerCompare(GenTree* cmp)
 #ifdef _TARGET_AMD64_
             var_types smallerType = (*smallerOpUse)->TypeGet();
 #elif defined(_TARGET_ARM64_)
-            var_types smallerType = genActualType((*smallerOpUse)->TypeGet());
+            var_types smallerType  = genActualType((*smallerOpUse)->TypeGet());
 #endif // _TARGET_AMD64_
 
             assert(genTypeSize(smallerType) < 8);


### PR DESCRIPTION
#13941 didn't kick off formatting runs, and a break snuck in.

This is blocking #14002.

Not sure why but the formatter insists the space is needed only in the second part.

@sdmaclea @briansull PTAL
cc @dotnet/jit-contrib 