### PR TITLE
[x86/Linux] 16-byte aligned StubDispatchFixupStub

### DIFF
--- a/src/vm/i386/asmhelpers.S
+++ b/src/vm/i386/asmhelpers.S
@@ -757,13 +757,16 @@ NESTED_ENTRY StubDispatchFixupStub, _TEXT, NoHandler
 .att_syntax
     pushl       $0
     pushl       $0
+    pushl       $0
 .intel_syntax noprefix
 
     push        eax             // siteAddrForRegisterIndirect (for tailcalls)
     push        esi             // pTransitionBlock
 
+    CHECK_STACK_ALIGNMENT
     call        C_FUNC(StubDispatchFixupWorker)
 
+    mov         esp, esi
     STUB_EPILOG
 
 PATCH_LABEL StubDispatchFixupPatchLabel


### PR DESCRIPTION
StubDispatchFixupStub currently breaks stack alignment, and thus segmentation fault occurs when System.Private.CoreLib.dll is crossgened.

This commit revises StubDispatchFixupStub not to break stack alignment, and ass a stack alignment check before StubDispatchFixupWorker call.