### PR TITLE
[RyuJIT] Fix assertion condition for interval of constant value in LSRA

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -5913,9 +5913,24 @@ bool LinearScan::checkActiveInterval(Interval* interval, LsraLocation refLocatio
             else
             {
                 RefPosition* nextAssignedRef = recentAssignedRef->nextRefPosition;
+#ifdef _TARGET_ARM_
+                // This function is invoked only from allocateBusyReg() through checkActiveIntervals().
+                //
+                // For ARM32, when we try to allocate a double register which consists of two float registers,
+                // tryAllocateFreeReg() may fail to allocate a double register even if one of two float
+                // reigsters is assigned to a inactive constant interval.
+                // https://github.com/dotnet/coreclr/pull/14080
+                //
+                // Therefore an inactive constant interval may be encountered here.
+                assert(nextAssignedRef != nullptr || interval->isConstant);
+                if (nextAssignedRef != nullptr)
+                    assert(nextAssignedRef->nodeLocation == refLocation ||
+                           (nextAssignedRef->nodeLocation + 1 == refLocation && nextAssignedRef->delayRegFree));
+#else  // !_TARGET_ARM_
                 assert(nextAssignedRef != nullptr);
                 assert(nextAssignedRef->nodeLocation == refLocation ||
                        (nextAssignedRef->nodeLocation + 1 == refLocation && nextAssignedRef->delayRegFree));
+#endif // !_TARGET_ARM_
             }
         }
         return false;


### PR DESCRIPTION
Fix #13750

Update condition for assertion to handle a constant interval,
because we do not free registers assigned to a constant interval as below.

https://github.com/dotnet/coreclr/blob/8342127913aa9c2dd1c17b05ea9c97c76e9be5ac/src/jit/lsra.cpp#L7634-L7650


