### PR TITLE
Reset static state per iteration for k-nucleotide-9

### DIFF
--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/k-nucleotide/k-nucleotide-9.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/k-nucleotide/k-nucleotide-9.cs
@@ -266,7 +266,7 @@ namespace BenchmarksGame
             return (ok ? 100 : -1);
         }
 
-        [Benchmark(InnerIterationCount = 1)]
+        [Benchmark(InnerIterationCount = 10)]
         public static void RunBench()
         {
             var helpers = new TestHarnessHelpers(bigInput: true);
@@ -281,6 +281,11 @@ namespace BenchmarksGame
 
         static bool Bench(TestHarnessHelpers helpers, bool verbose)
         {
+            // Reset static state
+            threeBlocks.Clear();
+            threeStart = 0;
+            threeEnd = 0;
+
             tonum['c'] = 1; tonum['C'] = 1;
             tonum['g'] = 2; tonum['G'] = 2;
             tonum['t'] = 3; tonum['T'] = 3;


### PR DESCRIPTION
Otherwise iterations keep getting slower and slower.

Also bump inner iteration count to 10 to restore the nominal one second
duration per iteration.