### PR TITLE
Additional parameter validation for StartNoGCRegion

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -15895,15 +15895,9 @@ start_no_gc_region_status gc_heap::prepare_for_no_gc_region (uint64_t total_size
     size_t total_allowed_soh_allocation = max_soh_allocated * num_heaps;
     const size_t max_alloc_scale = static_cast<size_t>(SIZE_T_MAX / 1.05f);
 
-    // requested sizes of 0 make no sense.
-    if (total_size == 0)
-    {
-        status = start_no_gc_too_large;
-        goto done;
-    }
-
+    assert(total_size != 0);
     // requested sizes that would cause 1.05 * total_size to not fit in a size_t
-    // also make no sense.
+    // make no sense.
     if (total_size > max_alloc_scale)
     {
         status = start_no_gc_too_large;
@@ -15912,21 +15906,10 @@ start_no_gc_region_status gc_heap::prepare_for_no_gc_region (uint64_t total_size
 
     if (loh_size_known)
     {
-        if (loh_size == 0)
-        {
-            status = start_no_gc_too_large;
-            goto done;
-        }
+        assert(loh_size != 0);
+        assert(loh_size <= total_size);
 
-        // According to the documentation, TryStartNoGCRegion must fail if
-        // it can't allocate total_size - loh_size for the SOH. This only makes
-        // any kind of sense if total_size > loh_size.
-        if (total_size < loh_size)
-        {
-            status = start_no_gc_too_large;
-            goto done;
-        }
-
+        // same for loh_size.
         if (loh_size > max_alloc_scale)
         {
             status = start_no_gc_too_large;
@@ -15939,8 +15922,8 @@ start_no_gc_region_status gc_heap::prepare_for_no_gc_region (uint64_t total_size
     if (loh_size_known)
     {
         assert(loh_size != 0);
-        assert(total_size >= loh_size);
         loh_size = (size_t)((float)loh_size * 1.05);
+        assert(loh_size <= total_size);
         allocation_no_gc_loh = (size_t)loh_size;
         allocation_no_gc_soh = (size_t)(total_size - loh_size);
     }

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -15901,6 +15901,7 @@ start_no_gc_region_status gc_heap::prepare_for_no_gc_region (uint64_t total_size
 
     int soh_align_const = get_alignment_constant (TRUE);
     size_t max_soh_allocated = soh_segment_size - segment_info_size - eph_gen_starts_size;
+    size_t size_per_heap = 0;
     const double scale_factor = 1.05;
 
     int num_heaps = 1;
@@ -15949,7 +15950,6 @@ start_no_gc_region_status gc_heap::prepare_for_no_gc_region (uint64_t total_size
     if (disallow_full_blocking)
         current_no_gc_region_info.minimal_gc_p = TRUE;
 
-    size_t size_per_heap = 0;
     if (allocation_no_gc_soh != 0)
     {
         assert(allocation_no_gc_soh <= SIZE_T_MAX);

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -15886,6 +15886,13 @@ start_no_gc_region_status gc_heap::prepare_for_no_gc_region (uint64_t total_size
     size_t allocation_no_gc_loh = 0;
     size_t allocation_no_gc_soh = 0;
     size_t size_per_heap = 0;
+    int soh_align_const = get_alignment_constant (TRUE);
+    size_t max_soh_allocated = (soh_segment_size - segment_info_size - eph_gen_starts_size);
+    int num_heaps = 1;
+#ifdef MULTIPLE_HEAPS
+    num_heaps = n_heaps;
+#endif //MULTIPLE_HEAPS
+    size_t total_allowed_soh_allocation = max_soh_allocated * num_heaps;
 
     // requested sizes of 0 make no sense.
     if (total_size == 0)
@@ -15928,14 +15935,6 @@ start_no_gc_region_status gc_heap::prepare_for_no_gc_region (uint64_t total_size
         allocation_no_gc_loh = (size_t)total_size;
     }
 
-    int soh_align_const = get_alignment_constant (TRUE);
-    size_t max_soh_allocated = (soh_segment_size - segment_info_size - eph_gen_starts_size);
-
-    int num_heaps = 1;
-#ifdef MULTIPLE_HEAPS
-    num_heaps = n_heaps;
-#endif //MULTIPLE_HEAPS
-    size_t total_allowed_soh_allocation = max_soh_allocated * num_heaps;
 
     if (allocation_no_gc_soh > total_allowed_soh_allocation)
     {

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -15910,6 +15910,7 @@ start_no_gc_region_status gc_heap::prepare_for_no_gc_region (uint64_t total_size
 #endif // MULTIPLE_HEAPS
 
     uint64_t total_allowed_soh_allocation = max_soh_allocated * num_heaps;
+    // [LOCALGC TODO]
     // In theory, the upper limit here is the physical memory of the machine, not
     // SIZE_T_MAX. This is not true today because total_physical_mem can be
     // larger than SIZE_T_MAX if running in wow64 on a machine with more than
@@ -15940,19 +15941,11 @@ start_no_gc_region_status gc_heap::prepare_for_no_gc_region (uint64_t total_size
         allocation_no_gc_loh = min (allocation_no_gc_loh, total_allowed_loh_alloc_scaled);
     }
 
-
-    if (allocation_no_gc_soh > total_allowed_soh_allocation)
-    {
-        status = start_no_gc_too_large;
-        goto done;
-    }
-
     if (disallow_full_blocking)
         current_no_gc_region_info.minimal_gc_p = TRUE;
 
     if (allocation_no_gc_soh != 0)
     {
-        assert(allocation_no_gc_soh <= SIZE_T_MAX);
         current_no_gc_region_info.soh_allocation_size = static_cast<size_t>(allocation_no_gc_soh);
         size_per_heap = current_no_gc_region_info.soh_allocation_size;
 #ifdef MULTIPLE_HEAPS
@@ -15969,7 +15962,6 @@ start_no_gc_region_status gc_heap::prepare_for_no_gc_region (uint64_t total_size
 
     if (allocation_no_gc_loh != 0)
     {
-        assert(allocation_no_gc_soh <= SIZE_T_MAX);
         current_no_gc_region_info.loh_allocation_size = static_cast<size_t>(allocation_no_gc_loh);
         size_per_heap = current_no_gc_region_info.loh_allocation_size;
 #ifdef MULTIPLE_HEAPS

--- a/src/mscorlib/src/System/GC.cs
+++ b/src/mscorlib/src/System/GC.cs
@@ -422,7 +422,7 @@ namespace System
             Succeeded = 0,
             NotEnoughMemory = 1,
             AmountTooLarge = 2,
-            AlreadyInProgress = 3,
+            AlreadyInProgress = 3
         }
 
         private enum EndNoGCRegionStatus

--- a/src/mscorlib/src/System/GC.cs
+++ b/src/mscorlib/src/System/GC.cs
@@ -24,6 +24,7 @@ using System.Runtime.ConstrainedExecution;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using System.Diagnostics;
 
 namespace System
 {
@@ -421,7 +422,7 @@ namespace System
             Succeeded = 0,
             NotEnoughMemory = 1,
             AmountTooLarge = 2,
-            AlreadyInProgress = 3
+            AlreadyInProgress = 3,
         }
 
         private enum EndNoGCRegionStatus
@@ -434,14 +435,37 @@ namespace System
 
         private static bool StartNoGCRegionWorker(long totalSize, bool hasLohSize, long lohSize, bool disallowFullBlockingGC)
         {
+            if (totalSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(totalSize), "totalSize can't be zero or negative");
+            }
+
+            if (hasLohSize)
+            {
+                if (lohSize <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(lohSize), "lohSize can't be zero or negative");
+                }
+
+                if (lohSize > totalSize)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(lohSize), "lohSize can't be greater than totalSize");
+                }
+            }
+
             StartNoGCRegionStatus status = (StartNoGCRegionStatus)_StartNoGCRegion(totalSize, hasLohSize, lohSize, disallowFullBlockingGC);
-            if (status == StartNoGCRegionStatus.AmountTooLarge)
-                throw new ArgumentOutOfRangeException(nameof(totalSize),
-                    "totalSize is too large. For more information about setting the maximum size, see \"Latency Modes\" in http://go.microsoft.com/fwlink/?LinkId=522706");
-            else if (status == StartNoGCRegionStatus.AlreadyInProgress)
-                throw new InvalidOperationException("The NoGCRegion mode was already in progress");
-            else if (status == StartNoGCRegionStatus.NotEnoughMemory)
-                return false;
+            switch (status)
+            {
+                case StartNoGCRegionStatus.NotEnoughMemory:
+                    return false;
+                case StartNoGCRegionStatus.AlreadyInProgress:
+                    throw new InvalidOperationException("The NoGCRegion mode was already in progress");
+                case StartNoGCRegionStatus.AmountTooLarge:
+                    throw new ArgumentOutOfRangeException(nameof(totalSize),
+                        "totalSize is too large. For more information about setting the maximum size, see \"Latency Modes\" in http://go.microsoft.com/fwlink/?LinkId=522706");
+            }
+
+            Debug.Assert(status == StartNoGCRegionStatus.Succeeded);
             return true;
         }
 


### PR DESCRIPTION
`GC.TryStartNoGCRegion` today behaves unexpectedly in corner cases:

1. If asked to start a no GC region with a total budget of 0, `GC.TryStartNoGCRegion` does not return an error but also doesn't do anything other than set the No GC region status (i.e. it doesn't set `soh_allocation_no_gc`), so it won't attempt to avoid GCs and it'll exit the no GC region next time a GC occurs through the normal means.

2. If asked to start a no GC region with an LOH budget greater than the the total budget, a subtraction operation underflows resulting in a SOH allocation budget that is extremely large, way larger than an ephemeral segment, which will cause the GC to report that the budget requested is too large to accommodate. If your LOH budget is large enough, you'll underflow back into the range of an ephemeral segment, so a no GC region will start successfully - but the SOH allocation budget will be completely bogus.

To address these two problems, this PR adds some additional argument validation to avoid getting into these two states. This PR will be accompanied with an additional PR to CoreFX to add additional unit tests for these corner cases.

Addresses https://github.com/dotnet/coreclr/issues/13736

cc @sergiy-k @Maoni0 @adityamandaleeka 