### PR TITLE
[Jit] fgMorphCast does not reset GTF_ASG

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -502,6 +502,9 @@ OPTIMIZECAST:
     /* Reset the call flag */
     tree->gtFlags &= ~GTF_CALL;
 
+    /* Reset the assignment flag */
+    tree->gtFlags &= ~GTF_ASG;
+
     /* unless we have an overflow cast, reset the except flag */
     if (!tree->gtOverflow())
     {

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_495792/DevDiv_495792.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_495792/DevDiv_495792.il
@@ -106,18 +106,35 @@
     .method private static int32 Main()
     {
         .entrypoint
-        .maxstack  10
-                
-        ldc.i4 3
-        conv.i1
-        ldc.i8 2
-        conv.u8
-        ldc.i4 3
-
-        call unsigned int64 ILGEN_CLASS::ILGEN_METHOD(unsigned int8, unsigned int64, int32)
-        pop
-
-        ldc.i4 100
-        ret
+        .maxstack  3
+        .locals init ([0] class [mscorlib]System.OverflowException e,
+               [1] int32 V_1)
+        IL_0000:  nop
+        .try
+        {
+        IL_0001:  nop
+        IL_0002:  ldc.i4.3
+        IL_0003:  ldc.i4.2
+        IL_0004:  conv.i8
+        IL_0005:  ldc.i4.3
+        IL_0006:  call       uint64 ILGEN_CLASS::ILGEN_METHOD(uint8,
+                                                              uint64,
+                                                              int32)
+        IL_000b:  pop
+        IL_000c:  nop
+        IL_000d:  leave.s    IL_0014
+        }  // end .try
+        catch [mscorlib]System.OverflowException 
+        {
+        IL_000f:  stloc.0
+        IL_0010:  nop
+        IL_0011:  nop
+        IL_0012:  leave.s    IL_0014
+        }  // end handler
+        IL_0014:  ldc.i4.s   100
+        IL_0016:  stloc.1
+        IL_0017:  br.s       IL_0019
+        IL_0019:  ldloc.1
+        IL_001a:  ret
     }
 }

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_495792/DevDiv_495792.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_495792/DevDiv_495792.il
@@ -1,0 +1,123 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib {}
+.assembly a {}
+.module a.exe
+
+// This test originally triggered an assert Extra_flags_on_tree, because fgMorphCast did not reset an asignment flag, when
+// its children was optimized in the assertion propogation. 
+
+.class ILGEN_CLASS
+{
+   .method static unsigned int64 ILGEN_METHOD(unsigned int8, unsigned int64, int32)
+   {
+        .maxstack  65535
+        .locals init (int8, float64)
+        IL_0000: ldarg.s 0x01
+        IL_0002: ldarg 0x0001
+        IL_0006: ldarg.s 0x01
+        IL_0008: clt.un
+        IL_000a: conv.ovf.i8.un
+        IL_000b: cgt.un
+        IL_000d: ldloc.s 0x01
+        IL_000f: conv.ovf.u1
+        IL_0010: and
+        IL_0011: conv.r8
+        IL_0012: conv.ovf.i8
+        IL_0013: neg
+        IL_0014: conv.i1
+        IL_0015: nop
+        IL_0016: ldloc 0x0001
+        IL_001a: nop
+        IL_001b: dup
+        IL_001c: div
+        IL_001d: conv.ovf.u4
+        IL_001e: ldc.i8 0xf65065040a910acc
+        IL_0027: conv.ovf.i8.un
+        IL_0028: starg.s 0x01
+        IL_002a: rem.un
+        IL_002b: ldloc.s 0x00
+        IL_002d: ldloc 0x0000
+        IL_0031: mul.ovf
+        IL_0032: starg 0x0002
+        IL_0036: ldloc.s 0x01
+        IL_0038: ldarg 0x0001
+        IL_003c: conv.r.un
+        IL_003d: ldloc 0x0001
+        IL_0041: div
+        IL_0042: conv.r4
+        IL_0043: neg
+        IL_0044: add
+        IL_0045: ldc.i4 0x79464b58
+        IL_004a: conv.ovf.i1.un
+        IL_004b: ldarg.s 0x01
+        IL_004d: conv.ovf.i4
+        IL_004e: mul
+        IL_004f: ldloc.s 0x01
+        IL_0051: conv.r4
+        IL_0052: conv.ovf.i
+        IL_0053: ldarg.s 0x00
+        IL_0055: shr.un
+        IL_0056: mul.ovf
+        IL_0057: conv.r8
+        IL_0058: add
+        IL_0059: conv.ovf.i1
+        IL_005a: conv.ovf.i2
+        IL_005b: ldc.i8 0x2b5e7f8df42cece0
+        IL_0064: starg 0x0001
+        IL_0068: neg
+        IL_0069: nop
+        IL_006a: bgt 
+        IL_0074
+        IL_006f: ldarg 0x0000
+        IL_0073: pop
+        IL_0074: ldarg.s 0x01
+        IL_0076: ldarg 0x0001
+        IL_007a: ldarg.s 0x00
+        IL_007c: ldloc 0x0001
+        IL_0080: ldloc.s 0x01
+        IL_0082: neg
+        IL_0083: clt.un
+        IL_0085: clt
+        IL_0087: not
+        IL_0088: ldarg.s 0x00
+        IL_008a: ldarg.s 0x00
+        IL_008c: sub.ovf
+        IL_008d: xor
+        IL_008e: ldarg.s 0x02
+        IL_0090: dup
+        IL_0091: rem
+        IL_0092: shl
+        IL_0093: conv.ovf.u2.un
+        IL_0094: shr
+        IL_0095: ldarg 0x0001
+        IL_0099: pop
+        IL_009a: ldarg 0x0001
+        IL_009e: clt
+        IL_00a0: ldc.r8 float64(0x739233eae9c3b79a)
+        IL_00a9: conv.u4
+        IL_00aa: div.un
+        IL_00ab: pop
+        IL_00ac: ret   
+    }
+    
+    .method private static int32 Main()
+    {
+        .entrypoint
+        .maxstack  10
+                
+        ldc.i4 3
+        conv.i1
+        ldc.i8 2
+        conv.u8
+        ldc.i4 3
+
+        call unsigned int64 ILGEN_CLASS::ILGEN_METHOD(unsigned int8, unsigned int64, int32)
+        pop
+
+        ldc.i4 100
+        ret
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_495792/DevDiv_495792.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_495792/DevDiv_495792.ilproj
@@ -10,6 +10,7 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_495792/DevDiv_495792.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_495792/DevDiv_495792.ilproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_495792.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
In the issue during the assertion propagation phase fgMorph transforms such IL:
```
     (154, 98) [000071] ------------             *  STMT      void
+N038 (154, 98) [000066] -ACXG-------             \--*  CAST_ovfl int <- short <- int $313
+N037 (147, 90) [000065] -ACXG-------                \--*  CAST_ovfl int <- byte <- int $310
+N036 (140, 82) [000134] -ACXG-------                   \--*  CALL help int    HELPER.CORINFO_HELP_DBL2INT_OVF $30d
N032 (  1,  2) [000042] ------------                      |     /--*  CNS_DBL   double 0.00000000000000000 $140
N033 ( 57, 26) [000050] ------------                      |  /--*  ADD       double $385
N031 ( 51, 20) [000049] ------------                      |  |  \--*  CAST      double <- float $384
N030 ( 45, 14) [000048] ------------                      |  |     \--*  NEG       float  $480
N029 ( 44, 13) [000047] ------------                      |  |        \--*  CAST      float <- double $441
N028 ( 38,  7) [000046] ------------                      |  |           \--*  CNS_DBL   double -1.#IND000000000000 $141
N034 (126, 76) [000064] -ACXG------- arg0 in mm0          \--*  ADD       double $387
N025 ( 64, 46) [000063] -ACXG-------                         \--*  CAST      double <- long $383
N021 (  1,  1) [000163] ------------                            |        /--*  LCL_VAR   int    V11 cse1          $30c
N022 (  4,  5) [000164] -A----------                            |     /--*  COMMA     int    $30c
N018 (  3,  4) [000147] ------------                            |     |  |  /--*  CAST      int <- ubyte <- int $30c
N017 (  2,  2) [000059] ------------                            |     |  |  |  \--*  LCL_VAR   int    V00 arg0         u:2 $80
N020 (  3,  4) [000162] -A------R---                            |     |  \--*  ASG       int    $VN.Void
N019 (  1,  1) [000161] D------N----                            |     |     \--*  LCL_VAR   int    V11 cse1          $30c
N023 ( 35, 26) [000060] -ACX--------                            |  /--*  RSZ       long   $3c5
N016 ( 27, 20) [000058] --CX--------                            |  |  \--*  CALL help long   HELPER.CORINFO_HELP_DBL2LNG_OVF $3c3
N014 ( 13, 14) [000143] ------------ arg0 in mm0                |  |     \--*  CNS_DBL   double 0.00000000000000000 $140
N024 ( 58, 40) [000062] -ACXG-------                            \--*  MUL_ovfl  long   $3c6
+N008 (  1,  1) [000159] ------------                               |  /--*  CNS_INT   long   0 $340
+N009 ( 16,  8) [000160] --CXG-------                               \--*  COMMA     long   $30b
+N007 ( 15,  7) [000139] --CXG-------                                  \--*  CALL help void   HELPER.CORINFO_HELP_OVERFLOW $2c5
+N005 (  1,  1) [000137] ------------ arg0 in rcx                         \--*  CNS_INT   int    0 $40
```

into 
```
N013 ( 44, 30) [000066] -ACXG-------             *  CAST_ovfl int <- short <- int $313
N012 ( 37, 22) [000065] -ACXG-------             \--*  CAST_ovfl int <- byte <- int $310
N011 ( 30, 14) [000134] --CXG-------                \--*  CALL help int    HELPER.CORINFO_HELP_DBL2INT_OVF $30d
N008 (  1,  1) [000159] ------------                   |  /--*  CNS_DBL   double 0.00000000000000000 $140
N009 ( 16,  8) [000160] --CXG------- arg0 in mm0       \--*  COMMA     double $30b
N007 ( 15,  7) [000139] --CXG-------                      \--*  CALL help void   HELPER.CORINFO_HELP_OVERFLOW $2c5
N005 (  1,  1) [000137] ------------ arg0 in rcx             \--*  CNS_INT   int    0 $40
```

The problem is that 000065 should not have the ASG flag after that morphing.
The tree undo 000060 is deleted because the left child 000160 always throws an exception.
