### PR TITLE
StompWriteBarrier initialization path refactoring

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -10602,17 +10602,17 @@ gc_heap::init_gc_heap (int  h_number)
     make_background_mark_stack (b_arr);
 #endif //BACKGROUND_GC
 
+    ephemeral_low = generation_allocation_start(generation_of(max_generation - 1));
+    ephemeral_high = heap_segment_reserved(ephemeral_heap_segment);
     if (heap_number == 0)
     {
+        stomp_write_barrier_initialize(
 #ifdef MULTIPLE_HEAPS
-        ephemeral_low = reinterpret_cast<uint8_t*>(1);
-        ephemeral_high = reinterpret_cast<uint8_t*>(~0);
+            reinterpret_cast<uint8_t*>(1), reinterpret_cast<uint8_t*>(~0)
 #else
-        ephemeral_low = generation_allocation_start(generation_of(max_generation - 1));
-        ephemeral_high = heap_segment_reserved(ephemeral_heap_segment);
+            ephemeral_low, ephemeral_high
 #endif //!MULTIPLE_HEAPS
-
-        stomp_write_barrier_initialize(ephemeral_low, ephemeral_high);
+        );
     }
 
 #ifdef MARK_ARRAY

--- a/src/vm/amd64/jitinterfaceamd64.cpp
+++ b/src/vm/amd64/jitinterfaceamd64.cpp
@@ -278,14 +278,14 @@ PBYTE WriteBarrierManager::CalculatePatchLocation(LPVOID base, LPVOID label, int
     return ((LPBYTE)GetEEFuncEntryPoint(JIT_WriteBarrier) + ((LPBYTE)GetEEFuncEntryPoint(label) - (LPBYTE)GetEEFuncEntryPoint(base) + offset));
 }
 
-void WriteBarrierManager::ChangeWriteBarrierTo(WriteBarrierType newWriteBarrier, bool isRuntimeSuspended)
+int WriteBarrierManager::ChangeWriteBarrierTo(WriteBarrierType newWriteBarrier, bool isRuntimeSuspended)
 {
     GCX_MAYBE_COOP_NO_THREAD_BROKEN((!isRuntimeSuspended && GetThread() != NULL));
-    BOOL bEESuspendedHere = FALSE;
-    if(!isRuntimeSuspended && m_currentWriteBarrier != WRITE_BARRIER_UNINITIALIZED)
+    int flushXrestart = PASS;
+    if (!isRuntimeSuspended && m_currentWriteBarrier != WRITE_BARRIER_UNINITIALIZED)
     {
         ThreadSuspend::SuspendEE(ThreadSuspend::SUSPEND_FOR_GC_PREP);
-        bEESuspendedHere = TRUE;
+        flushXrestart |= EE_RESTART;
     }
 
     _ASSERTE(m_currentWriteBarrier != newWriteBarrier);
@@ -409,13 +409,10 @@ void WriteBarrierManager::ChangeWriteBarrierTo(WriteBarrierType newWriteBarrier,
             UNREACHABLE_MSG("unexpected write barrier type!");
     }
 
-    UpdateEphemeralBounds(true);
-    UpdateWriteWatchAndCardTableLocations(true, false);
+    flushXrestart |= UpdateEphemeralBounds(true);
+    flushXrestart |= UpdateWriteWatchAndCardTableLocations(true, false);
 
-    if(bEESuspendedHere)
-    {
-        ThreadSuspend::RestartEE(FALSE, TRUE);
-    }
+    return flushXrestart;
 }
 
 #undef CALC_PATCH_LOCATION
@@ -521,21 +518,20 @@ bool WriteBarrierManager::NeedDifferentWriteBarrier(bool bReqUpperBoundsCheck, W
     return m_currentWriteBarrier != writeBarrierType;
 }
 
-void WriteBarrierManager::UpdateEphemeralBounds(bool isRuntimeSuspended)
+int WriteBarrierManager::UpdateEphemeralBounds(bool isRuntimeSuspended)
 {
-    bool needToFlushCache = false;
-
     WriteBarrierType newType;
     if (NeedDifferentWriteBarrier(false, &newType))
     {
-        ChangeWriteBarrierTo(newType, isRuntimeSuspended);
-        return; 
+        return ChangeWriteBarrierTo(newType, isRuntimeSuspended);
     }
+
+    int flushXrestart = PASS;
 
 #ifdef _DEBUG
     // Using debug-only write barrier?
     if (m_currentWriteBarrier == WRITE_BARRIER_UNINITIALIZED)
-        return;
+        return flushXrestart;
 #endif
 
     switch (m_currentWriteBarrier)
@@ -549,7 +545,7 @@ void WriteBarrierManager::UpdateEphemeralBounds(bool isRuntimeSuspended)
             if (*(UINT64*)m_pUpperBoundImmediate != (size_t)g_ephemeral_high)
             {
                 *(UINT64*)m_pUpperBoundImmediate = (size_t)g_ephemeral_high;
-                needToFlushCache = true;
+                flushXrestart |= ICACHE_FLUSH;
             }
         }
         //
@@ -564,7 +560,7 @@ void WriteBarrierManager::UpdateEphemeralBounds(bool isRuntimeSuspended)
             if (*(UINT64*)m_pLowerBoundImmediate != (size_t)g_ephemeral_low)
             {
                 *(UINT64*)m_pLowerBoundImmediate = (size_t)g_ephemeral_low;
-                needToFlushCache = true;
+                flushXrestart |= ICACHE_FLUSH;
             }
             break;
         }
@@ -583,13 +579,10 @@ void WriteBarrierManager::UpdateEphemeralBounds(bool isRuntimeSuspended)
             UNREACHABLE_MSG("unexpected m_currentWriteBarrier in UpdateEphemeralBounds");
     }
 
-    if (needToFlushCache)
-    {
-        FlushInstructionCache(GetCurrentProcess(), (PVOID)JIT_WriteBarrier, GetCurrentWriteBarrierSize());
-    }
+    return flushXrestart;
 }
 
-void WriteBarrierManager::UpdateWriteWatchAndCardTableLocations(bool isRuntimeSuspended, bool bReqUpperBoundsCheck)
+int WriteBarrierManager::UpdateWriteWatchAndCardTableLocations(bool isRuntimeSuspended, bool bReqUpperBoundsCheck)
 {
     // If we are told that we require an upper bounds check (GC did some heap reshuffling),
     // we need to switch to the WriteBarrier_PostGrow function for good.
@@ -597,17 +590,16 @@ void WriteBarrierManager::UpdateWriteWatchAndCardTableLocations(bool isRuntimeSu
     WriteBarrierType newType;
     if (NeedDifferentWriteBarrier(bReqUpperBoundsCheck, &newType))
     {
-        ChangeWriteBarrierTo(newType, isRuntimeSuspended);
-        return;
+        return ChangeWriteBarrierTo(newType, isRuntimeSuspended);
     }
+    
+    int flushXrestart = PASS;
 
 #ifdef _DEBUG
     // Using debug-only write barrier?
     if (m_currentWriteBarrier == WRITE_BARRIER_UNINITIALIZED)
-        return;
+        return flushXrestart;
 #endif
-
-    bool fFlushCache = false;
     
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
     switch (m_currentWriteBarrier)
@@ -620,7 +612,7 @@ void WriteBarrierManager::UpdateWriteWatchAndCardTableLocations(bool isRuntimeSu
             if (*(UINT64*)m_pWriteWatchTableImmediate != (size_t)g_sw_ww_table)
             {
                 *(UINT64*)m_pWriteWatchTableImmediate = (size_t)g_sw_ww_table;
-                fFlushCache = true;
+                flushXrestart |= ICACHE_FLUSH;
             }
             break;
 
@@ -632,32 +624,29 @@ void WriteBarrierManager::UpdateWriteWatchAndCardTableLocations(bool isRuntimeSu
     if (*(UINT64*)m_pCardTableImmediate != (size_t)g_card_table)
     {
         *(UINT64*)m_pCardTableImmediate = (size_t)g_card_table;
-        fFlushCache = true;
+        flushXrestart |= ICACHE_FLUSH;
     }
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
     if (*(UINT64*)m_pCardBundleTableImmediate != (size_t)g_card_bundle_table)
     {
         *(UINT64*)m_pCardBundleTableImmediate = (size_t)g_card_bundle_table;
-        fFlushCache = true;
+        flushXrestart |= ICACHE_FLUSH;
     }
 #endif
 
-    if (fFlushCache)
-    {
-        FlushInstructionCache(GetCurrentProcess(), (LPVOID)JIT_WriteBarrier, GetCurrentWriteBarrierSize());
-    }
+    return flushXrestart;
 }
 
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
-void WriteBarrierManager::SwitchToWriteWatchBarrier(bool isRuntimeSuspended)
+int WriteBarrierManager::SwitchToWriteWatchBarrier(bool isRuntimeSuspended)
 {
     WriteBarrierType newWriteBarrierType;
     switch (m_currentWriteBarrier)
     {
         case WRITE_BARRIER_UNINITIALIZED:
             // Using the debug-only write barrier
-            return;
+            return PASS;
 
         case WRITE_BARRIER_PREGROW64:
             newWriteBarrierType = WRITE_BARRIER_WRITE_WATCH_PREGROW64;
@@ -677,17 +666,17 @@ void WriteBarrierManager::SwitchToWriteWatchBarrier(bool isRuntimeSuspended)
             UNREACHABLE();
     }
 
-    ChangeWriteBarrierTo(newWriteBarrierType, isRuntimeSuspended);
+    return ChangeWriteBarrierTo(newWriteBarrierType, isRuntimeSuspended);
 }
 
-void WriteBarrierManager::SwitchToNonWriteWatchBarrier(bool isRuntimeSuspended)
+int WriteBarrierManager::SwitchToNonWriteWatchBarrier(bool isRuntimeSuspended)
 {
     WriteBarrierType newWriteBarrierType;
     switch (m_currentWriteBarrier)
     {
         case WRITE_BARRIER_UNINITIALIZED:
             // Using the debug-only write barrier
-            return;
+            return PASS;
 
         case WRITE_BARRIER_WRITE_WATCH_PREGROW64:
             newWriteBarrierType = WRITE_BARRIER_PREGROW64;
@@ -707,42 +696,47 @@ void WriteBarrierManager::SwitchToNonWriteWatchBarrier(bool isRuntimeSuspended)
             UNREACHABLE();
     }
 
-    ChangeWriteBarrierTo(newWriteBarrierType, isRuntimeSuspended);
+    return ChangeWriteBarrierTo(newWriteBarrierType, isRuntimeSuspended);
 }
 #endif // FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
 
 // This function bashes the super fast amd64 version of the JIT_WriteBarrier
 // helper.  It should be called by the GC whenever the ephermeral region 
 // bounds get changed, but still remain on the top of the GC Heap. 
-void StompWriteBarrierEphemeral(bool isRuntimeSuspended)
+int StompWriteBarrierEphemeral(bool isRuntimeSuspended)
 {
     WRAPPER_NO_CONTRACT;
 
-    g_WriteBarrierManager.UpdateEphemeralBounds(isRuntimeSuspended);
+    return g_WriteBarrierManager.UpdateEphemeralBounds(isRuntimeSuspended);
 }
 
 // This function bashes the super fast amd64 versions of the JIT_WriteBarrier
 // helpers.  It should be called by the GC whenever the ephermeral region gets moved
 // from being at the top of the GC Heap, and/or when the cards table gets moved.
-void StompWriteBarrierResize(bool isRuntimeSuspended, bool bReqUpperBoundsCheck)
+int StompWriteBarrierResize(bool isRuntimeSuspended, bool bReqUpperBoundsCheck)
 {
     WRAPPER_NO_CONTRACT;
 
-    g_WriteBarrierManager.UpdateWriteWatchAndCardTableLocations(isRuntimeSuspended, bReqUpperBoundsCheck);
+    return g_WriteBarrierManager.UpdateWriteWatchAndCardTableLocations(isRuntimeSuspended, bReqUpperBoundsCheck);
+}
+
+void FlushWriteBarrierInstructionCache()
+{
+    FlushInstructionCache(GetCurrentProcess(), (PVOID)JIT_WriteBarrier, g_WriteBarrierManager.GetCurrentWriteBarrierSize());
 }
 
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
-void SwitchToWriteWatchBarrier(bool isRuntimeSuspended)
+int SwitchToWriteWatchBarrier(bool isRuntimeSuspended)
 {
     WRAPPER_NO_CONTRACT;
 
-    g_WriteBarrierManager.SwitchToWriteWatchBarrier(isRuntimeSuspended);
+    return g_WriteBarrierManager.SwitchToWriteWatchBarrier(isRuntimeSuspended);
 }
 
-void SwitchToNonWriteWatchBarrier(bool isRuntimeSuspended)
+int SwitchToNonWriteWatchBarrier(bool isRuntimeSuspended)
 {
     WRAPPER_NO_CONTRACT;
 
-    g_WriteBarrierManager.SwitchToNonWriteWatchBarrier(isRuntimeSuspended);
+    return g_WriteBarrierManager.SwitchToNonWriteWatchBarrier(isRuntimeSuspended);
 }
 #endif // FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP

--- a/src/vm/arm/stubs.cpp
+++ b/src/vm/arm/stubs.cpp
@@ -456,17 +456,17 @@ int StompWriteBarrierResize(bool isRuntimeSuspended, bool bReqUpperBoundsCheck)
     // suspend/resuming the EE under GC stress will trigger a GC and if we're holding the
     // GC lock due to allocating a LOH segment it will cause a deadlock so disable it here.
     GCStressPolicy::InhibitHolder iholder;
-    int flushXrestart = SWB_ICACHE_FLUSH;
+    int stompWBCompleteActions = SWB_ICACHE_FLUSH;
 
     if (!isRuntimeSuspended)
     {
         ThreadSuspend::SuspendEE(ThreadSuspend::SUSPEND_OTHER);
-        flushXrestart |= SWB_EE_RESTART;
+        stompWBCompleteActions |= SWB_EE_RESTART;
     }
 
     UpdateGCWriteBarriers(bReqUpperBoundsCheck);
 
-    return flushXrestart;
+    return stompWBCompleteActions;
 }
 
 int StompWriteBarrierEphemeral(bool isRuntimeSuspended)

--- a/src/vm/arm/stubs.cpp
+++ b/src/vm/arm/stubs.cpp
@@ -442,15 +442,9 @@ void UpdateGCWriteBarriers(bool postGrow = false)
 
         pDesc++;
     }
-
-    // We've changed code so we must flush the instruction cache.
-    BYTE *pbAlteredRange;
-    DWORD cbAlteredRange;
-    ComputeWriteBarrierRange(&pbAlteredRange, &cbAlteredRange);
-    FlushInstructionCache(GetCurrentProcess(), pbAlteredRange, cbAlteredRange);
 }
 
-void StompWriteBarrierResize(bool isRuntimeSuspended, bool bReqUpperBoundsCheck)
+int StompWriteBarrierResize(bool isRuntimeSuspended, bool bReqUpperBoundsCheck)
 {
     // The runtime is not always suspended when this is called (unlike StompWriteBarrierEphemeral) but we have
     // no way to update the barrier code atomically on ARM since each 32-bit value we change is loaded over
@@ -462,26 +456,36 @@ void StompWriteBarrierResize(bool isRuntimeSuspended, bool bReqUpperBoundsCheck)
     // suspend/resuming the EE under GC stress will trigger a GC and if we're holding the
     // GC lock due to allocating a LOH segment it will cause a deadlock so disable it here.
     GCStressPolicy::InhibitHolder iholder;
+    int flushXrestart = ICACHE_FLUSH;
 
-    bool fSuspended = false;
     if (!isRuntimeSuspended)
     {
         ThreadSuspend::SuspendEE(ThreadSuspend::SUSPEND_OTHER);
-        fSuspended = true;
+        flushXrestart |= EE_RESTART;
     }
 
     UpdateGCWriteBarriers(bReqUpperBoundsCheck);
 
-    if (fSuspended)
-        ThreadSuspend::RestartEE(FALSE, TRUE);
+    return flushXrestart;
 }
 
-void StompWriteBarrierEphemeral(bool isRuntimeSuspended)
+int StompWriteBarrierEphemeral(bool isRuntimeSuspended)
 {
     UNREFERENCED_PARAMETER(isRuntimeSuspended);
     _ASSERTE(isRuntimeSuspended);
     UpdateGCWriteBarriers();
+    return ICACHE_FLUSH;
 }
+
+void FlushWriteBarrierInstructionCache()
+{
+    // We've changed code so we must flush the instruction cache.
+    BYTE *pbAlteredRange;
+    DWORD cbAlteredRange;
+    ComputeWriteBarrierRange(&pbAlteredRange, &cbAlteredRange);
+    FlushInstructionCache(GetCurrentProcess(), pbAlteredRange, cbAlteredRange);
+}
+
 #endif // CROSSGEN_COMPILE
 
 #endif // !DACCESS_COMPILE

--- a/src/vm/arm/stubs.cpp
+++ b/src/vm/arm/stubs.cpp
@@ -456,12 +456,12 @@ int StompWriteBarrierResize(bool isRuntimeSuspended, bool bReqUpperBoundsCheck)
     // suspend/resuming the EE under GC stress will trigger a GC and if we're holding the
     // GC lock due to allocating a LOH segment it will cause a deadlock so disable it here.
     GCStressPolicy::InhibitHolder iholder;
-    int flushXrestart = ICACHE_FLUSH;
+    int flushXrestart = SWB_ICACHE_FLUSH;
 
     if (!isRuntimeSuspended)
     {
         ThreadSuspend::SuspendEE(ThreadSuspend::SUSPEND_OTHER);
-        flushXrestart |= EE_RESTART;
+        flushXrestart |= SWB_EE_RESTART;
     }
 
     UpdateGCWriteBarriers(bReqUpperBoundsCheck);
@@ -474,7 +474,7 @@ int StompWriteBarrierEphemeral(bool isRuntimeSuspended)
     UNREFERENCED_PARAMETER(isRuntimeSuspended);
     _ASSERTE(isRuntimeSuspended);
     UpdateGCWriteBarriers();
-    return ICACHE_FLUSH;
+    return SWB_ICACHE_FLUSH;
 }
 
 void FlushWriteBarrierInstructionCache()

--- a/src/vm/arm64/stubs.cpp
+++ b/src/vm/arm64/stubs.cpp
@@ -1357,26 +1357,26 @@ void FlushWriteBarrierInstructionCache()
 int StompWriteBarrierEphemeral(bool isRuntimeSuspended)
 {
     JIT_UpdateWriteBarrierState(GCHeapUtilities::IsServerHeap());
-    return PASS;
+    return SWB_PASS;
 }
 
 int StompWriteBarrierResize(bool isRuntimeSuspended, bool bReqUpperBoundsCheck)
 {
     JIT_UpdateWriteBarrierState(GCHeapUtilities::IsServerHeap());
-    return PASS;
+    return SWB_PASS;
 }
 
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
 int SwitchToWriteWatchBarrier(bool isRuntimeSuspended)
 {
     JIT_UpdateWriteBarrierState(GCHeapUtilities::IsServerHeap());
-    return PASS;
+    return SWB_PASS;
 }
 
 int SwitchToNonWriteWatchBarrier(bool isRuntimeSuspended)
 {
     JIT_UpdateWriteBarrierState(GCHeapUtilities::IsServerHeap());
-    return PASS;
+    return SWB_PASS;
 }
 #endif // FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
 #endif // CROSSGEN_COMPILE

--- a/src/vm/arm64/stubs.cpp
+++ b/src/vm/arm64/stubs.cpp
@@ -1348,26 +1348,35 @@ LONG CLRNoCatchHandler(EXCEPTION_POINTERS* pExceptionInfo, PVOID pv)
     return EXCEPTION_CONTINUE_SEARCH;
 }
 
-#ifndef CROSSGEN_COMPILE
-void StompWriteBarrierEphemeral(bool isRuntimeSuspended)
+void FlushWriteBarrierInstructionCache()
 {
-    JIT_UpdateWriteBarrierState(GCHeapUtilities::IsServerHeap());
+    // this wouldn't be called in arm64, just to comply with gchelpers.h
 }
 
-void StompWriteBarrierResize(bool isRuntimeSuspended, bool bReqUpperBoundsCheck)
+#ifndef CROSSGEN_COMPILE
+int StompWriteBarrierEphemeral(bool isRuntimeSuspended)
 {
     JIT_UpdateWriteBarrierState(GCHeapUtilities::IsServerHeap());
+    return PASS;
+}
+
+int StompWriteBarrierResize(bool isRuntimeSuspended, bool bReqUpperBoundsCheck)
+{
+    JIT_UpdateWriteBarrierState(GCHeapUtilities::IsServerHeap());
+    return PASS;
 }
 
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
-void SwitchToWriteWatchBarrier(bool isRuntimeSuspended)
+int SwitchToWriteWatchBarrier(bool isRuntimeSuspended)
 {
     JIT_UpdateWriteBarrierState(GCHeapUtilities::IsServerHeap());
+    return PASS;
 }
 
-void SwitchToNonWriteWatchBarrier(bool isRuntimeSuspended)
+int SwitchToNonWriteWatchBarrier(bool isRuntimeSuspended)
 {
     JIT_UpdateWriteBarrierState(GCHeapUtilities::IsServerHeap());
+    return PASS;
 }
 #endif // FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
 #endif // CROSSGEN_COMPILE

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -912,6 +912,8 @@ void GCToEEInterface::StompWriteBarrier(WriteBarrierParameters* args)
 #endif
         if (flushXrestart & SWB_EE_RESTART)
         {
+            assert(!args->is_runtime_suspended &&
+                "if runtime was suspended in patching routines then it was in running state at begining");
             ThreadSuspend::RestartEE(FALSE, TRUE);
         }
         return; // unlike other branches we have already done cleanup so bailing out here
@@ -985,6 +987,8 @@ void GCToEEInterface::StompWriteBarrier(WriteBarrierParameters* args)
     }
     if (flushXrestart & SWB_EE_RESTART) 
     {
+        assert(!args->is_runtime_suspended && 
+            "if runtime was suspended in patching routines then it was in running state at begining");
         ThreadSuspend::RestartEE(FALSE, TRUE);
     }
 }

--- a/src/vm/gchelpers.h
+++ b/src/vm/gchelpers.h
@@ -107,10 +107,11 @@ OBJECTREF AllocateObject(MethodTable *pMT
 #endif
     );
 
-extern void StompWriteBarrierEphemeral(bool isRuntimeSuspended);
-extern void StompWriteBarrierResize(bool isRuntimeSuspended, bool bReqUpperBoundsCheck);
-extern void SwitchToWriteWatchBarrier(bool isRuntimeSuspended);
-extern void SwitchToNonWriteWatchBarrier(bool isRuntimeSuspended);
+extern int StompWriteBarrierEphemeral(bool isRuntimeSuspended);
+extern int StompWriteBarrierResize(bool isRuntimeSuspended, bool bReqUpperBoundsCheck);
+extern int SwitchToWriteWatchBarrier(bool isRuntimeSuspended);
+extern int SwitchToNonWriteWatchBarrier(bool isRuntimeSuspended);
+extern void FlushWriteBarrierInstructionCache();
 
 extern void ThrowOutOfMemoryDimensionsExceeded();
 

--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -1682,7 +1682,7 @@ int StompWriteBarrierEphemeral(bool /* isRuntimeSuspended */)
         GC_NOTRIGGER;
     } CONTRACTL_END;
 
-    int flushXrestart = PASS;
+    int flushXrestart = SWB_PASS;
 
 #ifdef WRITE_BARRIER_CHECK 
         // Don't do the fancy optimization if we are checking write barrier
@@ -1703,7 +1703,7 @@ int StompWriteBarrierEphemeral(bool /* isRuntimeSuspended */)
         //avoid trivial self modifying code
         if (*pfunc != (size_t) g_ephemeral_low)
         {
-            flushXrestart |= ICACHE_FLUSH;
+            flushXrestart |= SWB_ICACHE_FLUSH;
             *pfunc = (size_t) g_ephemeral_low;
         }
         if (!WriteBarrierIsPreGrow())
@@ -1716,7 +1716,7 @@ int StompWriteBarrierEphemeral(bool /* isRuntimeSuspended */)
             //avoid trivial self modifying code
             if (*pfunc != (size_t) g_ephemeral_high)
             {
-                flushXrestart |= ICACHE_FLUSH;
+                flushXrestart |= SWB_ICACHE_FLUSH;
                 *pfunc = (size_t) g_ephemeral_high;
             }
         }
@@ -1738,7 +1738,7 @@ int StompWriteBarrierResize(bool isRuntimeSuspended, bool bReqUpperBoundsCheck)
         if (GetThread()) {GC_TRIGGERS;} else {GC_NOTRIGGER;}
     } CONTRACTL_END;
 
-    int flushXrestart = PASS;
+    int flushXrestart = SWB_PASS;
 
 #ifdef WRITE_BARRIER_CHECK 
         // Don't do the fancy optimization if we are checking write barrier
@@ -1763,9 +1763,9 @@ int StompWriteBarrierResize(bool isRuntimeSuspended, bool bReqUpperBoundsCheck)
             if (bReqUpperBoundsCheck)
             {
                 GCX_MAYBE_COOP_NO_THREAD_BROKEN((GetThread()!=NULL));
-                if( !isRuntimeSuspended && !(flushXrestart & EE_RESTART) ) {
+                if( !isRuntimeSuspended && !(flushXrestart & SWB_EE_RESTART) ) {
                     ThreadSuspend::SuspendEE(ThreadSuspend::SUSPEND_FOR_GC_PREP);
-                    flushXrestart |= EE_RESTART;
+                    flushXrestart |= SWB_EE_RESTART;
                 }
 
                 pfunc = (size_t *) JIT_WriteBarrierReg_PostGrow;
@@ -1853,7 +1853,7 @@ int StompWriteBarrierResize(bool isRuntimeSuspended, bool bReqUpperBoundsCheck)
 
     if (bStompWriteBarrierEphemeral)
     {
-        _ASSERTE(isRuntimeSuspended || (flushXrestart & EE_RESTART));
+        _ASSERTE(isRuntimeSuspended || (flushXrestart & SWB_EE_RESTART));
         flushXrestart |= StompWriteBarrierEphemeral(true);
     }
     return flushXrestart;

--- a/src/vm/jitinterface.h
+++ b/src/vm/jitinterface.h
@@ -23,7 +23,7 @@
 #endif // !FEATURE_PAL
 
 
-enum StompWriteBarrierXXXCompletion
+enum StompWriteBarrierCompletionAction
 {
     SWB_PASS = 0x0,
     SWB_ICACHE_FLUSH = 0x1,

--- a/src/vm/jitinterface.h
+++ b/src/vm/jitinterface.h
@@ -22,6 +22,14 @@
 #define MAX_UNCHECKED_OFFSET_FOR_NULL_OBJECT ((GetOsPageSize() / 2) - 1)
 #endif // !FEATURE_PAL
 
+
+enum StompWriteBarrierXXXCompletion
+{
+    PASS = 0x0,
+    ICACHE_FLUSH = 0x1,
+    EE_RESTART = 0x2
+};
+
 class Stub;
 class MethodDesc;
 class FieldDesc;
@@ -294,20 +302,20 @@ public:
     WriteBarrierManager();
     void Initialize();
     
-    void UpdateEphemeralBounds(bool isRuntimeSuspended);
-    void UpdateWriteWatchAndCardTableLocations(bool isRuntimeSuspended, bool bReqUpperBoundsCheck);
+    int UpdateEphemeralBounds(bool isRuntimeSuspended);
+    int UpdateWriteWatchAndCardTableLocations(bool isRuntimeSuspended, bool bReqUpperBoundsCheck);
 
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
-    void SwitchToWriteWatchBarrier(bool isRuntimeSuspended);
-    void SwitchToNonWriteWatchBarrier(bool isRuntimeSuspended);
+    int SwitchToWriteWatchBarrier(bool isRuntimeSuspended);
+    int SwitchToNonWriteWatchBarrier(bool isRuntimeSuspended);
 #endif // FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
+    size_t GetCurrentWriteBarrierSize();
 
 protected:
-    size_t GetCurrentWriteBarrierSize();
     size_t GetSpecificWriteBarrierSize(WriteBarrierType writeBarrier);
     PBYTE  CalculatePatchLocation(LPVOID base, LPVOID label, int offset);
     PCODE  GetCurrentWriteBarrierCode();
-    void   ChangeWriteBarrierTo(WriteBarrierType newWriteBarrier, bool isRuntimeSuspended);
+    int ChangeWriteBarrierTo(WriteBarrierType newWriteBarrier, bool isRuntimeSuspended);
     bool   NeedDifferentWriteBarrier(bool bReqUpperBoundsCheck, WriteBarrierType* pNewWriteBarrierType);
 
 private:    

--- a/src/vm/jitinterface.h
+++ b/src/vm/jitinterface.h
@@ -25,9 +25,9 @@
 
 enum StompWriteBarrierXXXCompletion
 {
-    PASS = 0x0,
-    ICACHE_FLUSH = 0x1,
-    EE_RESTART = 0x2
+    SWB_PASS = 0x0,
+    SWB_ICACHE_FLUSH = 0x1,
+    SWB_EE_RESTART = 0x2
 };
 
 class Stub;


### PR DESCRIPTION
Fix for #12586 

Changes made as proposed in my [comment](https://github.com/dotnet/coreclr/issues/12586#issuecomment-330105442):
> I think we may want to move `FlushInstructionCache` calls from `StompWriteBarrierResize` and `StompWriteBarrierEphemeral` and let them return bool indicating whether instruction cache should be flushed. That way after two consecutive calls to both functions we can flush cache based on returned value.
One drawback of such approach is that those functions may be entered when EE is not suspended and decide to suspend runtime on their own (and restart it before return). In such case we have to flush case before EE restarting. So maybe this part of duties also should be entrusted on caller.

Currently changes only applied for amd64. Just PoC to see what members thinking.
Some notes on comments from original issue:
@swgillespie 
https://github.com/dotnet/coreclr/issues/12586#issuecomment-330926423
> This would involve adding something like GCToOSInterface::FlushInstructionCache, or something like that, if I'm understanding you correctly (pushing the onus of icache flushing onto the caller, i.e. the GC).

All interaction still happen in `GCToEEInterface::StompWriteBarrier`, just little changes were made to interface (`GCToEEInterface` <-> platform dependent code) in `jitinterface.h`

@jkotas 
https://github.com/dotnet/coreclr/issues/12586#issuecomment-330928448
> I think that the right way to solve this is to call GCToEEInterface::StompWriteBarrier just once during the GC initialization, only after the GC has figured out the desired write barrier geometry.

I haven't pushed this so far yet. I considered refactoring only on `GCToEEInterface::StompWriteBarrier` level. To ensure one single call to `GCToEEInterface::StompWriteBarrier` lot of changes has to be done in `GCHeap::Initialize`. I can go for it as part of this PR, but maybe liitle guidance will be required.