### PR TITLE
[RyuJIT/ARM32] JitStress=1 test: padding local variable

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -7332,6 +7332,14 @@ Compiler::fgWalkResult Compiler::lvaStressLclFldCB(GenTreePtr* pTree, fgWalkData
         // Calculate padding
         unsigned padding = LCL_FLD_PADDING(lclNum);
 
+#ifdef _TARGET_ARM_
+        // We need to support alignment requirements to access memory on ARM
+        unsigned alignment = 1;
+        pComp->codeGen->InferOpSizeAlign(tree, &alignment);
+        alignment = roundUp(alignment, TARGET_POINTER_SIZE);
+        padding   = roundUp(padding, alignment);
+#endif // _TARGET_ARM_
+
         // Change the variable to a TYP_BLK
         if (varType != TYP_BLK)
         {


### PR DESCRIPTION
JitStress=1 make padding for local variable.
On ARM32, we need to support stack alignment when we generate padding.

Fix #13738 