### PR TITLE
Don't early-propagate negative array lengths

### DIFF
--- a/src/jit/earlyprop.cpp
+++ b/src/jit/earlyprop.cpp
@@ -289,9 +289,9 @@ bool Compiler::optEarlyPropRewriteTree(GenTreePtr tree)
         {
             assert(actualVal->IsCnsIntOrI());
 
-            if (actualVal->gtIntCon.gtIconVal > INT32_MAX)
+            if ((actualVal->AsIntCon()->IconValue() < 0) || (actualVal->AsIntCon()->IconValue() > INT32_MAX))
             {
-                // Don't propagate array lengths that are beyond the maximum value of a GT_ARR_LENGTH.
+                // Don't propagate array lengths that are beyond the maximum value of a GT_ARR_LENGTH or negative.
                 // node. CORINFO_HELP_NEWARR_1_OBJ helper call allows to take a long integer as the
                 // array length argument, but the type of GT_ARR_LENGTH is always INT32.
                 return false;

--- a/tests/src/JIT/Regression/JitBlue/GitHub_14116/GitHub_14116.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_14116/GitHub_14116.il
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib {auto}
+.assembly extern System.Console {auto}
+.assembly GitHub_14116 {}
+
+.class Program
+{
+    .field static int8 s8;
+
+    .method static int32[] Test() noinlining
+    {
+		.maxstack 4
+
+		ldc.i8 0xFFFFFFF100000000
+		newarr [mscorlib]System.Int32
+		dup
+
+		ldc.i4.0
+		ldc.i4.0
+		stelem.i4
+
+		ret
+    }
+
+    .method static int32 Main() 
+    {
+        .entrypoint
+        .maxstack 1
+
+        ldc.i4 -1
+        stsfld int8 Program::s8
+
+        .try
+        {
+            call int32[] Program::Test()
+            leave FAIL
+        }
+        catch [mscorlib]System.OverflowException
+        {
+            pop
+            leave PASS
+        }
+    FAIL:
+        ldstr "FAIL"
+        call void [System.Console]System.Console::WriteLine(string)
+        ldc.i4 1
+        ret
+    PASS: 
+        ldstr "PASS"
+        call void [System.Console]System.Console::WriteLine(string)
+        ldc.i4 100
+        ret
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_14116/GitHub_14116.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_14116/GitHub_14116.ilproj
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_14116.il" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
There's no need for that and if the negative array length is not representable in 32 bit we'll end up producing a GT_CNS_INT node that has TYP_INT and a 64 bit value.

That's because the original type (always TYP_INT) of the GT_ARR_LENGTH is preserved when changing the node to GT_CNS_INT.

Fixes #14116