### PR TITLE
Fixed return constant value cache on 32 bit VMs

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -8609,6 +8609,14 @@ private:
             return nullptr;
         }
 
+#if defined(_TARGET_X86_) || defined(_TARGET_ARM_)
+        if (retExpr->gtOper != GT_CNS_INT)
+        {
+            // There is no long cache in 32 bit VM so skip it
+            return nullptr;
+        }
+#endif // _TARGET_X86_ || _TARGET_ARM_
+
         return retExpr->AsIntConCommon();
     }
 

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -8360,13 +8360,8 @@ private:
 
         if (returnConst != nullptr)
         {
-            returnExpr = comp->gtNewOperNode(GT_RETURN, returnConst->gtType, returnConst);
-#ifdef _TARGET_64BIT_
-            returnConstants[index] = returnConst->LngValue();
-#else
-            returnConstants[index] =
-                returnConst->gtOper == GT_CNS_LNG ? returnConst->LngValue() : (INT64)returnConst->IconValue();
-#endif // _TARGET_64BIT_
+            returnExpr             = comp->gtNewOperNode(GT_RETURN, returnConst->gtType, returnConst);
+            returnConstants[index] = returnConst->IntegralValue();
         }
         else if (comp->compMethodHasRetVal())
         {
@@ -8634,11 +8629,7 @@ private:
     //
     BasicBlock* FindConstReturnBlock(GenTreeIntConCommon* constExpr, unsigned searchLimit, unsigned* index)
     {
-#ifdef _TARGET_64BIT_
-        INT64 constVal = constExpr->LngValue();
-#else
-        INT64 constVal = constExpr->gtOper == GT_CNS_LNG ? constExpr->LngValue() : (INT64)constExpr->IconValue();
-#endif // _TARGET_64BIT_
+        INT64 constVal = constExpr->IntegralValue();
 
         for (unsigned i = 0; i < searchLimit; ++i)
         {

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -8360,11 +8360,12 @@ private:
 
         if (returnConst != nullptr)
         {
-            returnExpr             = comp->gtNewOperNode(GT_RETURN, returnConst->gtType, returnConst);
+            returnExpr = comp->gtNewOperNode(GT_RETURN, returnConst->gtType, returnConst);
 #ifdef _TARGET_64BIT_
             returnConstants[index] = returnConst->LngValue();
 #else
-            returnConstants[index] = returnConst->gtOper == GT_CNS_LNG ? returnConst->LngValue() : (INT64)returnConst->IconValue();
+            returnConstants[index] =
+                returnConst->gtOper == GT_CNS_LNG ? returnConst->LngValue() : (INT64)returnConst->IconValue();
 #endif // _TARGET_64BIT_
         }
         else if (comp->compMethodHasRetVal())

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -2543,6 +2543,7 @@ struct GenTreeIntConCommon : public GenTree
     inline void SetLngValue(INT64 val);
     inline ssize_t IconValue();
     inline void SetIconValue(ssize_t val);
+    inline INT64 IntegralValue();
 
     GenTreeIntConCommon(genTreeOps oper, var_types type DEBUGARG(bool largeNode = false))
         : GenTree(oper, type DEBUGARG(largeNode))
@@ -2777,6 +2778,15 @@ inline void GenTreeIntConCommon::SetIconValue(ssize_t val)
 {
     assert(gtOper == GT_CNS_INT); //  We should never see a GT_CNS_LNG for a 64-bit target!
     AsIntCon()->gtIconVal = val;
+}
+
+inline INT64 GenTreeIntConCommon::IntegralValue()
+{
+#ifdef _TARGET_64BIT_
+    return LngValue();
+#else
+    return gtOper == GT_CNS_LNG ? LngValue() : (INT64)IconValue();
+#endif // _TARGET_64BIT_
 }
 
 /* gtDblCon -- double  constant (GT_CNS_DBL) */

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_491206/DevDiv_491206.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_491206/DevDiv_491206.il
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib {}
+.assembly a {}
+.module a.exe
+
+// This test originally triggered an assert Extra_flags_on_tree, because fgMorphCast did not reset an asignment flag, when
+// its children was optimized in the assertion propogation. 
+
+.class ILGEN_CLASS
+{
+    .method public hidebysig static int64  DoubleToInt64(float64 val) cil managed
+    {
+      // Code size       108 (0x6c)
+      .maxstack  2
+      .locals init (float64 V_0)
+      IL_0000:  ldarg.0
+      IL_0001:  call       bool [mscorlib]System.Double::IsNaN(float64)
+      IL_0006:  brfalse.s  IL_000b
+      IL_0008:  ldc.i4.0
+      IL_0009:  conv.i8
+      IL_000a:  ret
+      IL_000b:  ldc.r8     -9.2233720368547758e+018
+      IL_0014:  ldarg.0
+      IL_0015:  bgt.un.s   IL_0026
+      IL_0017:  ldarg.0
+      IL_0018:  ldc.r8     9.2233720368547758e+018
+      IL_0021:  bgt.un.s   IL_0026
+      IL_0023:  ldarg.0
+      IL_0024:  conv.i8
+      IL_0025:  ret
+      IL_0026:  ldarg.0
+      IL_0027:  call       bool [mscorlib]System.Double::IsInfinity(float64)
+      IL_002c:  brfalse.s  IL_0031
+      IL_002e:  ldc.i4.0
+      IL_002f:  conv.i8
+      IL_0030:  ret
+      IL_0031:  ldarg.0
+      IL_0032:  call       int32 [mscorlib]System.Math::Sign(float64)
+      IL_0037:  conv.r8
+      IL_0038:  ldarg.0
+      IL_0039:  call       float64 [mscorlib]System.Math::Abs(float64)
+      IL_003e:  call       float64 [mscorlib]System.Math::Floor(float64)
+      IL_0043:  mul
+      IL_0044:  ldc.r8     1.8446744073709552e+019
+      IL_004d:  call       float64 [mscorlib]System.Math::IEEERemainder(float64,
+                                                                        float64)
+      IL_0052:  stloc.0
+      IL_0053:  ldloc.0
+      IL_0054:  ldc.r8     9.2233720368547758e+018
+      IL_005d:  bne.un.s   IL_0069
+      IL_005f:  ldc.i8     0x8000000000000000
+      IL_0068:  ret
+      IL_0069:  ldloc.0
+      IL_006a:  conv.i8
+      IL_006b:  ret
+    } // end of method DoubleToInt64
+    
+    .method public static int32 Main()
+    {
+        .entrypoint
+          ldc.r8     9.2233720368547758e+018
+          call       int64 ILGEN_CLASS::DoubleToInt64(float64)
+          pop
+          ldc.i4.0
+          ret
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_491206/DevDiv_491206.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_491206/DevDiv_491206.il
@@ -64,7 +64,7 @@
           ldc.r8     9.2233720368547758e+018
           call       int64 ILGEN_CLASS::DoubleToInt64(float64)
           pop
-          ldc.i4.0
+          ldc.i4 100
           ret
     }
 }

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_491206/DevDiv_491206.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_491206/DevDiv_491206.ilproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_491206.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Fixed DevDiv_491206.
The problem was about `MergedReturns` optimization. Since we have only `ptrdiff_t` int cache for return constants so we cannot optimize long ones on 32 bit VMs. The PR fixes this adding support of long values too.