### PR TITLE
Fix issue causing tracing tests to never run in CI

### DIFF
--- a/tests/runtest.proj
+++ b/tests/runtest.proj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <DisabledTestDir Include="Common" />
+    <DisabledTestDir Include="tracing" />
     <_SkipTestDir Include="@(DisabledTestDir)" />
   </ItemGroup>
 

--- a/tests/src/dirs.proj
+++ b/tests/src/dirs.proj
@@ -30,7 +30,6 @@
       <DisabledProjects Include="Performance\performance.csproj" />
       <DisabledProjects Include="Loader\classloader\generics\regressions\DD117522\Test.csproj" />
       <DisabledProjects Include="Loader\classloader\generics\GenericMethods\VSW491668.csproj" /> <!-- issue 5501 -->
-      <DisabledProjects Include="tracing\**" Condition="'$(BuildOS)' != 'Linux'" />
     </ItemGroup>
     
     <ItemGroup>

--- a/tests/src/tracing/common/common.csproj
+++ b/tests/src/tracing/common/common.csproj
@@ -12,6 +12,7 @@
     <CLRTestKind>BuildOnly</CLRTestKind>
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">

--- a/tests/src/tracing/eventsourcesmoke/eventsourcesmoke.csproj
+++ b/tests/src/tracing/eventsourcesmoke/eventsourcesmoke.csproj
@@ -12,6 +12,7 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">


### PR DESCRIPTION
Previous to this PR tracing tests do not build on Windows. I did not understand when I first wrote the tests that they would be build on Windows then transferred to Linux in the CI, and therefore never run. This PR fixes this to chose whether to run the tests at runtime, not at build time. This will allow the Windows machine to build the tests and the Linux machine to run them. 