### PR TITLE
Adding {RO}Memory<T> debugger view

### DIFF
--- a/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
@@ -201,6 +201,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\MarshalByRefObject.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\MemberAccessException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Memory.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\MemoryDebugView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\MethodAccessException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\MidpointRounding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\MissingMethodException.cs" />

--- a/src/mscorlib/shared/System/MemoryDebugView.cs
+++ b/src/mscorlib/shared/System/MemoryDebugView.cs
@@ -24,7 +24,7 @@ namespace System
         public T[] Items
         {
             // This is a work around since we cannot use _memory.ToArray() due to
-            // VSTS bug 286592: https://devdiv.visualstudio.com/DevDiv/_workitems?id=286592
+            // https://devdiv.visualstudio.com/DevDiv/_workitems?id=286592
             get
             {
                 if (_memory.DangerousTryGetArray(out ArraySegment<T> segment))

--- a/src/mscorlib/shared/System/MemoryDebugView.cs
+++ b/src/mscorlib/shared/System/MemoryDebugView.cs
@@ -23,7 +23,8 @@ namespace System
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
         public T[] Items
         {
-            // This is a work around since we cannot use _memory.ToArray() due to VSTS bug 286592
+            // This is a work around since we cannot use _memory.ToArray() due to
+            // VSTS bug 286592: https://devdiv.visualstudio.com/DevDiv/_workitems?id=286592
             get
             {
                 if (_memory.DangerousTryGetArray(out ArraySegment<T> segment))

--- a/src/mscorlib/shared/System/MemoryDebugView.cs
+++ b/src/mscorlib/shared/System/MemoryDebugView.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace System
+{
+    internal sealed class MemoryDebugView<T>
+    {
+        private readonly ReadOnlyMemory<T> _memory;
+
+        public MemoryDebugView(Memory<T> memory)
+        {
+            _memory = memory;
+        }
+
+        public MemoryDebugView(ReadOnlyMemory<T> memory)
+        {
+            _memory = memory;
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public T[] Items
+        {
+            // This is a work around since we cannot use _memory.ToArray() due to VSTS bug 286592
+            get
+            {
+                if (_memory.DangerousTryGetArray(out ArraySegment<T> segment))
+                {
+                    T[] array = new T[_memory.Length];
+                    Array.Copy(segment.Array, segment.Offset, array, 0, array.Length);
+                    return array;
+                }
+                return Array.Empty<T>();
+            }
+        }
+    }
+}

--- a/src/mscorlib/shared/System/ReadOnlyMemory.cs
+++ b/src/mscorlib/shared/System/ReadOnlyMemory.cs
@@ -12,6 +12,7 @@ using System.Runtime.InteropServices;
 
 namespace System
 {
+    [DebuggerTypeProxy(typeof(ReadOnlyMemoryDebugView<>))]
     public struct ReadOnlyMemory<T>
     {
         // The highest order bit of _index is used to discern whether _arrayOrOwnedMemory is an array or an owned memory
@@ -219,7 +220,20 @@ namespace System
         /// allocates, so should generally be avoided, however it is sometimes
         /// necessary to bridge the gap with APIs written in terms of arrays.
         /// </summary>
-        public T[] ToArray() => Span.ToArray();
+        public T[] ToArray()
+        {
+            if (_index < 0)
+            {
+                Span<T> span = ((OwnedMemory<T>)_arrayOrOwnedMemory).AsSpan().Slice(_index & RemoveOwnedFlagBitMask, _length);
+                return span.ToArray();
+            }
+            else
+            {
+                T[] result = new T[_length];
+                Array.Copy((T[])_arrayOrOwnedMemory, result, _length);
+                return result;
+            }
+        }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj)
@@ -266,5 +280,24 @@ namespace System
             return CombineHashCodes(CombineHashCodes(h1, h2), h3);
         }
 
+    }
+
+    internal sealed class ReadOnlyMemoryDebugView<T>
+    {
+        private readonly ReadOnlyMemory<T> _memory;
+
+        public ReadOnlyMemoryDebugView(ReadOnlyMemory<T> memory)
+        {
+            _memory = memory;
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public T[] Items
+        {
+            get
+            {
+                return _memory.ToArray();
+            }
+        }
     }
 }

--- a/src/mscorlib/shared/System/ReadOnlySpan.cs
+++ b/src/mscorlib/shared/System/ReadOnlySpan.cs
@@ -15,6 +15,7 @@ namespace System
     /// ReadOnlySpan represents a contiguous region of arbitrary memory. Unlike arrays, it can point to either managed
     /// or native memory, or to memory allocated on the stack. It is type- and memory-safe.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     [IsReadOnly]
     [IsByRefLike]
     [NonVersionable]
@@ -117,6 +118,9 @@ namespace System
             _pointer = new ByReference<T>(ref ptr);
             _length = length;
         }
+
+        //Debugger Display = {T[length]}
+        private string DebuggerDisplay => string.Format("{{{0}[{1}]}}", typeof(T).Name, _length);
 
         /// <summary>
         /// Returns a reference to the 0th element of the Span. If the Span is empty, returns a reference to the location where the 0th element

--- a/src/mscorlib/shared/System/Span.cs
+++ b/src/mscorlib/shared/System/Span.cs
@@ -21,6 +21,7 @@ namespace System
     /// Span represents a contiguous region of arbitrary memory. Unlike arrays, it can point to either managed
     /// or native memory, or to memory allocated on the stack. It is type- and memory-safe.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     [IsReadOnly]
     [IsByRefLike]
     [NonVersionable]
@@ -129,6 +130,9 @@ namespace System
             _pointer = new ByReference<T>(ref ptr);
             _length = length;
         }
+
+        //Debugger Display = {T[length]}
+        private string DebuggerDisplay => string.Format("{{{0}[{1}]}}", typeof(T).Name, _length);
 
         /// <summary>
         /// Returns a reference to the 0th element of the Span. If the Span is empty, returns a reference to the location where the 0th element


### PR DESCRIPTION
Related PR: https://github.com/dotnet/corefx/pull/24203

Adding:
- MemoryDebugView
- ReadOnlyMemoryDebugView

Updating implementation of ToArray() so it doesn't have to go through the Span when not necessary.

cc @KrzysztofCwalina, @stephentoub, @shiftylogic 