### PR TITLE
Add multiarch arm64(32) Documentation

### DIFF
--- a/Documentation/building/unix-test-instructions.md
+++ b/Documentation/building/unix-test-instructions.md
@@ -40,6 +40,46 @@ Or
 >`coreclr/Tools/dotnetcli/dotnet coreclr/Tools/MSBuild.dll /maxcpucount coreclr/tests/src/JIT/CodeGenBringUpTests/Array1.csproj /p:__BuildType=Release /p:__BuildOS=OSX`
 
 
+**Aarch64/armhf multiarch**
+
+For machines that have aarch64/armhf support, all the armhf packages will need to also be downloaded. Please note you will need to enable multiplatform support as well. Check with your distro provider or kernel options to see if this is supported. For simplicity, these instructions relate to aarch64 ubuntu enabling arm32 (hf) coreclr runs.
+
+Please make sure your device is running a 64 bit aarch64 kernel.
+
+```
+# Example output
+
+[ubuntu:~]: uname -a
+Linux tegra-ubuntu 4.4.38-tegra #1 SMP PREEMPT Thu Jul 20 00:41:06 PDT 2017 aarch64 aarch64 aarch64 GNU/Linux
+
+```
+
+```
+# Enable armhf multiplatform support
+[ubuntu:~]: sudo dpkg --add-architecture armhf
+[ubuntu:~]: sudo apt-get update
+
+[ubuntu:~]: sudo apt-get install libstdc++6:armhf
+````
+
+At this point you should be able to run a 32bit corerun. You can verify this by downloading and running a recently built arm32 coreclr.
+
+```
+[ubuntu:~]: wget https://ci.dot.net/job/dotnet_coreclr/job/master/job/armlb_cross_checked_ubuntu/lastSuccessfulBuild/artifact/*zip*/archive.zip --no-check-certificate
+[ubuntu:~]: unzip archive.zip
+[ubuntu:~]: chmod +x && ./archive/bin/Product/Linux.arm.Checked/corerun
+Execute the specified managed assembly with the passed in arguments
+
+Options:
+-c, --clr-path  path to the libcoreclr.so and the managed CLR assemblies
+```
+
+Now download the coreclr armhf dependencies.
+
+```
+sudo apt-get install libunwind8:armhf libunwind8-dev:armhf libicu-dev:armhf liblttng-ust-dev:armhf libcurl4-openssl-dev:armhf libicu-dev:armhf libssl-dev uuid-dev:armhf libkrb5-dev:armhf
+```
+
 **Running tests**
 
 The following instructions assume that on the Unix machine:


### PR DESCRIPTION
Helps setup running armhf code on an arm64 kernel.

/cc @BruceForstall 