### PR TITLE
[Arm64] Add emitters for cbz, cbnz, tbz, and tbnz

### DIFF
--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -3646,19 +3646,17 @@ AGAIN:
 
         if (emitIsCondJump(jmp))
         {
-            ssz = JCC_SIZE_SMALL;
-            nsd = JCC_DIST_SMALL_MAX_NEG;
-            psd = JCC_DIST_SMALL_MAX_POS;
+            ssz         = JCC_SIZE_SMALL;
+            bool isTest = (jmp->idIns() == INS_tbz) || (jmp->idIns() == INS_tbnz);
+
+            nsd = (isTest) ? TB_DIST_SMALL_MAX_NEG : JCC_DIST_SMALL_MAX_POS;
+            psd = (isTest) ? TB_DIST_SMALL_MAX_POS : JCC_DIST_SMALL_MAX_POS;
         }
         else if (emitIsUncondJump(jmp))
         {
             // Nothing to do; we don't shrink these.
             assert(jmp->idjShort);
             ssz = JMP_SIZE_SMALL;
-        }
-        else if (emitIsCmpJump(jmp))
-        {
-            NYI("branch shortening compare-and-branch instructions");
         }
         else if (emitIsLoadLabel(jmp))
         {

--- a/src/jit/emitarm64.h
+++ b/src/jit/emitarm64.h
@@ -781,6 +781,8 @@ void emitIns_R_D(instruction ins, emitAttr attr, unsigned offs, regNumber reg);
 
 void emitIns_J_R(instruction ins, emitAttr attr, BasicBlock* dst, regNumber reg);
 
+void emitIns_J_R_I(instruction ins, emitAttr attr, BasicBlock* dst, regNumber reg, int imm);
+
 void emitIns_I_AR(
     instruction ins, emitAttr attr, int val, regNumber reg, int offs, int memCookie = 0, void* clsCookie = NULL);
 
@@ -856,17 +858,8 @@ BYTE* emitOutputShortConstant(
 
 inline bool emitIsCondJump(instrDesc* jmp)
 {
-    return ((jmp->idInsFmt() == IF_BI_0B) || (jmp->idInsFmt() == IF_LARGEJMP));
-}
-
-/*****************************************************************************
- *
- *  Given an instrDesc, return true if it's a compare and jump.
- */
-
-inline bool emitIsCmpJump(instrDesc* jmp)
-{
-    return ((jmp->idInsFmt() == IF_BI_1A) || (jmp->idInsFmt() == IF_BI_1B));
+    return ((jmp->idInsFmt() == IF_BI_0B) || (jmp->idInsFmt() == IF_BI_1A) || (jmp->idInsFmt() == IF_BI_1B) ||
+            (jmp->idInsFmt() == IF_LARGEJMP));
 }
 
 /*****************************************************************************

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -1804,6 +1804,9 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define JCC_DIST_SMALL_MAX_NEG  (-1048576)
   #define JCC_DIST_SMALL_MAX_POS  (+1048575)
 
+  #define TB_DIST_SMALL_MAX_NEG   (-32768)
+  #define TB_DIST_SMALL_MAX_POS   (+32767)
+
   #define JCC_SIZE_SMALL          (4)
   #define JCC_SIZE_LARGE          (8)
 


### PR DESCRIPTION
This adds the emitters and runtime code necessary to generate `tbz`, `tbnz`, `cbz`, and `cbnz`.  It does not yet adjust code generation.

I had a previous change which also implemented code generation, but it needed rework.  This code was tested with that change and is passing 99.9% of tests.  It seems best to start reviewing this separately as it is orthogonal.

Depending on time frame, I may amend this change with the lowering/codegen piece, but I would prefer merging this first to keep them independent.

@briansull This is the type of code you reviewed for me in the past.  PTAL.
cc/ @dotnet/arm64-contrib @dotnet/jit-contrib 