### PR TITLE
Fix for a special CoreRT helper CORINFO_HELP_JIT_PINVOKE_BEGIN

### DIFF
--- a/Documentation/botr/clr-abi.md
+++ b/Documentation/botr/clr-abi.md
@@ -119,7 +119,7 @@ For IL stubs only, the per-frame initialization includes setting `Thread->m_pFra
 2. For JIT64/AMD64 only: Next for non-IL stubs, the InlinedCallFrame is 'pushed' by setting `Thread->m_pFrame` to point to the InlinedCallFrame (recall that the per-frame initialization already set `InlinedCallFrame->m_pNext` to point to the previous top). For IL stubs this step is accomplished in the per-frame initialization.
 3. The Frame is made active by setting `InlinedCallFrame->m_pCallerReturnAddress`.
 4. The code then toggles the GC mode by setting `Thread->m_fPreemptiveGCDisabled = 0`.
-5. Starting now, no GC pointers may be live in registers.
+5. Starting now, no GC pointers may be live in registers. RyuJit LSRA meets this requirement adding special refPositon `RefTypeKillGCRefs` before unmanaged calls and special helpers.
 6. Then comes the actual call/PInvoke.
 7. The GC mode is set back by setting `Thread->m_fPreemptiveGCDisabled = 1`.
 8. Then we check to see if `g_TrapReturningThreads` is set (non-zero). If it is, we call `CORINFO_HELP_STOP_FOR_GC`.

--- a/Documentation/botr/clr-abi.md
+++ b/Documentation/botr/clr-abi.md
@@ -119,7 +119,7 @@ For IL stubs only, the per-frame initialization includes setting `Thread->m_pFra
 2. For JIT64/AMD64 only: Next for non-IL stubs, the InlinedCallFrame is 'pushed' by setting `Thread->m_pFrame` to point to the InlinedCallFrame (recall that the per-frame initialization already set `InlinedCallFrame->m_pNext` to point to the previous top). For IL stubs this step is accomplished in the per-frame initialization.
 3. The Frame is made active by setting `InlinedCallFrame->m_pCallerReturnAddress`.
 4. The code then toggles the GC mode by setting `Thread->m_fPreemptiveGCDisabled = 0`.
-5. Starting now, no GC pointers may be live in registers. RyuJit LSRA meets this requirement adding special refPositon `RefTypeKillGCRefs` before unmanaged calls and special helpers.
+5. Starting now, no GC pointers may be live in registers. RyuJit LSRA meets this requirement by adding special refPositon `RefTypeKillGCRefs` before unmanaged calls and special helpers.
 6. Then comes the actual call/PInvoke.
 7. The GC mode is set back by setting `Thread->m_fPreemptiveGCDisabled = 1`.
 8. Then we check to see if `g_TrapReturningThreads` is set (non-zero). If it is, we call `CORINFO_HELP_STOP_FOR_GC`.

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -1603,8 +1603,6 @@ void Compiler::fgComputeLifeCall(VARSET_TP& life, GenTreeCall* call)
         }
     }
 
-    /* GC refs cannot be enregistered accross an unmanaged call */
-
     // TODO: we should generate the code for saving to/restoring
     //       from the inlined N/Direct frame instead.
 

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3112,6 +3112,7 @@ bool LinearScan::killGCRefs(GenTree* tree)
 
         if (tree->AsCall()->gtCallMethHnd == compiler->eeFindHelper(CORINFO_HELP_JIT_PINVOKE_BEGIN))
         {
+            assert(compiler->IsTargetAbi(CORINFO_CORERT_ABI));
             return true;
         }
     }

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3112,7 +3112,7 @@ bool LinearScan::killGCRefs(GenTree* tree)
 
         if (tree->AsCall()->gtCallMethHnd == compiler->eeFindHelper(CORINFO_HELP_JIT_PINVOKE_BEGIN))
         {
-            assert(compiler->IsTargetAbi(CORINFO_CORERT_ABI));
+            assert(compiler->opts.ShouldUsePInvokeHelpers());
             return true;
         }
     }

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3093,14 +3093,14 @@ bool LinearScan::buildKillPositionsForNode(GenTree* tree, LsraLocation currentLo
 //------------------------------------------------------------------------
 // killGCRefs:
 // Given some tree node return does it need all GC refs to be spilled from
-// callee safe registers.
+// callee save registers.
 //
 // Arguments:
 //    tree       - the tree for which we ask about gc refs.
 //
 // Return Value:
-//    true       - tree kills GC refs on callee safe registers
-//    false      - tree doesn't affect GC refs on callee safe registers
+//    true       - tree kills GC refs on callee save registers
+//    false      - tree doesn't affect GC refs on callee save registers
 bool LinearScan::killGCRefs(GenTree* tree)
 {
     if (tree->IsCall())

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3079,7 +3079,7 @@ bool LinearScan::buildKillPositionsForNode(GenTree* tree, LsraLocation currentLo
             }
         }
 
-        if (tree->IsCall() && (tree->gtFlags & GTF_CALL_UNMANAGED) != 0)
+        if (killGCRefs(tree))
         {
             RefPosition* pos = newRefPosition((Interval*)nullptr, currentLoc, RefTypeKillGCRefs, tree,
                                               (allRegs(TYP_REF) & ~RBM_ARG_REGS));
@@ -3087,6 +3087,29 @@ bool LinearScan::buildKillPositionsForNode(GenTree* tree, LsraLocation currentLo
         return true;
     }
 
+    return false;
+}
+
+//------------------------------------------------------------------------
+// killGCRefs:
+// Given some tree node return does it need all GC refs to be spilled from
+// callee safe registers.
+//
+// Arguments:
+//    tree       - the tree for which we ask about gc refs.
+//
+// Return Value:
+//    true       - tree kills GC refs on callee safe registers
+//    false      - tree doesn't affect GC refs on callee safe registers
+bool LinearScan::killGCRefs(GenTree* tree)
+{
+    if (tree->IsCall())
+    {
+        if ((tree->gtFlags & GTF_CALL_UNMANAGED) != 0)
+        {
+            return true;
+        }
+    }
     return false;
 }
 

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3109,6 +3109,11 @@ bool LinearScan::killGCRefs(GenTree* tree)
         {
             return true;
         }
+
+        if (tree->AsCall()->gtCallMethHnd == compiler->eeFindHelper(CORINFO_HELP_JIT_PINVOKE_BEGIN))
+        {
+            return true;
+        }
     }
     return false;
 }

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -777,6 +777,8 @@ private:
     // Given some tree node add refpositions for all the registers this node kills
     bool buildKillPositionsForNode(GenTree* tree, LsraLocation currentLoc);
 
+    bool killGCRefs(GenTree* tree);
+
     regMaskTP allRegs(RegisterType rt);
     regMaskTP allRegs(GenTree* tree);
     regMaskTP allMultiRegCallNodeRegs(GenTreeCall* tree);


### PR DESCRIPTION
There is special CoreRT helper that is not unmanaged call itself, but requires all GC refs to be spilled before it.

Fix dotnet/corert#4214.