### PR TITLE
Make GitHub_14116 test work on 32 bit

### DIFF
--- a/tests/src/JIT/Regression/JitBlue/GitHub_14116/GitHub_14116.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_14116/GitHub_14116.il
@@ -14,7 +14,8 @@
     {
 		.maxstack 4
 
-		ldc.i8 0xFFFFFFF100000000
+		ldc.i8 0xFFFFFFF1FFFFFFFF
+		conv.i
 		newarr [mscorlib]System.Int32
 		dup
 


### PR DESCRIPTION
newarr expects int32 or native int on the stack. x64 JIT hapilly allows an int64 as well but the x86 JIT asserts.

Also change the constant to 0xFFFFFFF1FFFFFFFF so OverflowException is thrown on 32 bit as well.

Fixes #14152