### PR TITLE
Avoid async method delegate allocation

### DIFF
--- a/src/mscorlib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
+++ b/src/mscorlib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
@@ -39,7 +39,7 @@ namespace System.Runtime.CompilerServices
             /// <summary>The value being awaited.</summary>
             private ValueTask<TResult> _value; // Methods are called on this; avoid making it readonly so as to avoid unnecessary copies
             /// <summary>The value to pass to ConfigureAwait.</summary>
-            private readonly bool _continueOnCapturedContext;
+            internal readonly bool _continueOnCapturedContext;
 
             /// <summary>Initializes the awaiter.</summary>
             /// <param name="value">The value to be awaited.</param>
@@ -66,6 +66,9 @@ namespace System.Runtime.CompilerServices
             /// <summary>Schedules the continuation action for the <see cref="ConfiguredValueTaskAwaitable{TResult}"/>.</summary>
             public void UnsafeOnCompleted(Action continuation) =>
                 _value.AsTask().ConfigureAwait(_continueOnCapturedContext).GetAwaiter().UnsafeOnCompleted(continuation);
+
+            /// <summary>Gets the task underlying <see cref="_value"/>.</summary>
+            internal Task<TResult> AsTask() => _value.AsTask();
         }
     }
 }

--- a/src/mscorlib/shared/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/mscorlib/shared/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -33,5 +33,8 @@ namespace System.Runtime.CompilerServices
         /// <summary>Schedules the continuation action for this ValueTask.</summary>
         public void UnsafeOnCompleted(Action continuation) =>
             _value.AsTask().ConfigureAwait(continueOnCapturedContext: true).GetAwaiter().UnsafeOnCompleted(continuation);
+
+        /// <summary>Gets the task underlying <see cref="_value"/>.</summary>
+        internal Task<TResult> AsTask() => _value.AsTask();
     }
 }

--- a/src/mscorlib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
@@ -56,10 +56,13 @@ namespace System.Runtime.CompilerServices
 {
     /// <summary>Provides an awaiter for awaiting a <see cref="System.Threading.Tasks.Task"/>.</summary>
     /// <remarks>This type is intended for compiler use only.</remarks>
-    public struct TaskAwaiter : ICriticalNotifyCompletion
+    public struct TaskAwaiter : ICriticalNotifyCompletion, ITaskAwaiter
     {
+        // WARNING: Unsafe.As is used to access the generic TaskAwaiter<> as TaskAwaiter.
+        // Its layout must remain the same.
+
         /// <summary>The task being awaited.</summary>
-        private readonly Task m_task;
+        internal readonly Task m_task;
 
         /// <summary>Initializes the <see cref="TaskAwaiter"/>.</summary>
         /// <param name="task">The <see cref="System.Threading.Tasks.Task"/> to be awaited.</param>
@@ -212,6 +215,30 @@ namespace System.Runtime.CompilerServices
             task.SetContinuationForAwait(continuation, continueOnCapturedContext, flowExecutionContext);
         }
 
+        /// <summary>Schedules the continuation onto the <see cref="System.Threading.Tasks.Task"/> associated with this <see cref="TaskAwaiter"/>.</summary>
+        /// <param name="task">The task being awaited.</param>
+        /// <param name="continuation">The action to invoke when the await operation completes.</param>
+        /// <param name="continueOnCapturedContext">Whether to capture and marshal back to the current context.</param>
+        /// <param name="flowExecutionContext">Whether to flow ExecutionContext across the await.</param>
+        /// <exception cref="System.ArgumentNullException">The <paramref name="continuation"/> argument is null (Nothing in Visual Basic).</exception>
+        /// <exception cref="System.NullReferenceException">The awaiter was not properly initialized.</exception>
+        /// <remarks>This method is intended for compiler user rather than use directly in code.</remarks>
+        internal static void UnsafeOnCompletedInternal(Task task, IAsyncStateMachineBox stateMachineBox, bool continueOnCapturedContext)
+        {
+            Debug.Assert(stateMachineBox != null);
+
+            // If TaskWait* ETW events are enabled, trace a beginning event for this await
+            // and set up an ending event to be traced when the asynchronous await completes.
+            if (TplEtwProvider.Log.IsEnabled() || Task.s_asyncDebuggingEnabled)
+            {
+                task.SetContinuationForAwait(OutputWaitEtwEvents(task, stateMachineBox.MoveNextAction), continueOnCapturedContext, flowExecutionContext: false);
+            }
+            else
+            {
+                task.UnsafeSetContinuationForAwait(stateMachineBox, continueOnCapturedContext);
+            }
+        }
+
         /// <summary>
         /// Outputs a WaitBegin ETW event, and augments the continuation action to output a WaitEnd ETW event.
         /// </summary>
@@ -290,8 +317,11 @@ namespace System.Runtime.CompilerServices
 
     /// <summary>Provides an awaiter for awaiting a <see cref="System.Threading.Tasks.Task{TResult}"/>.</summary>
     /// <remarks>This type is intended for compiler use only.</remarks>
-    public struct TaskAwaiter<TResult> : ICriticalNotifyCompletion
+    public struct TaskAwaiter<TResult> : ICriticalNotifyCompletion, ITaskAwaiter
     {
+        // WARNING: Unsafe.As is used to access TaskAwaiter<> as the non-generic TaskAwaiter.
+        // Its layout must remain the same.
+
         /// <summary>The task being awaited.</summary>
         private readonly Task<TResult> m_task;
 
@@ -343,6 +373,20 @@ namespace System.Runtime.CompilerServices
         }
     }
 
+    /// <summary>
+    /// Marker interface used to know whether a particular awaiter is either a
+    /// TaskAwaiter or a TaskAwaiter`1.  It must not be implemented by any other
+    /// awaiters.
+    /// </summary>
+    internal interface ITaskAwaiter { }
+
+    /// <summary>
+    /// Marker interface used to know whether a particular awaiter is either a
+    /// CTA.ConfiguredTaskAwaiter or a CTA`1.ConfiguredTaskAwaiter.  It must not
+    /// be implemented by any other awaiters.
+    /// </summary>
+    internal interface IConfiguredTaskAwaiter { }
+
     /// <summary>Provides an awaitable object that allows for configured awaits on <see cref="System.Threading.Tasks.Task"/>.</summary>
     /// <remarks>This type is intended for compiler use only.</remarks>
     public struct ConfiguredTaskAwaitable
@@ -370,12 +414,15 @@ namespace System.Runtime.CompilerServices
 
         /// <summary>Provides an awaiter for a <see cref="ConfiguredTaskAwaitable"/>.</summary>
         /// <remarks>This type is intended for compiler use only.</remarks>
-        public struct ConfiguredTaskAwaiter : ICriticalNotifyCompletion
+        public struct ConfiguredTaskAwaiter : ICriticalNotifyCompletion, IConfiguredTaskAwaiter
         {
+            // WARNING: Unsafe.As is used to access the generic ConfiguredTaskAwaiter as this.
+            // Its layout must remain the same.
+
             /// <summary>The task being awaited.</summary>
-            private readonly Task m_task;
+            internal readonly Task m_task;
             /// <summary>Whether to attempt marshaling back to the original context.</summary>
-            private readonly bool m_continueOnCapturedContext;
+            internal readonly bool m_continueOnCapturedContext;
 
             /// <summary>Initializes the <see cref="ConfiguredTaskAwaiter"/>.</summary>
             /// <param name="task">The <see cref="System.Threading.Tasks.Task"/> to await.</param>
@@ -456,8 +503,11 @@ namespace System.Runtime.CompilerServices
 
         /// <summary>Provides an awaiter for a <see cref="ConfiguredTaskAwaitable{TResult}"/>.</summary>
         /// <remarks>This type is intended for compiler use only.</remarks>
-        public struct ConfiguredTaskAwaiter : ICriticalNotifyCompletion
+        public struct ConfiguredTaskAwaiter : ICriticalNotifyCompletion, IConfiguredTaskAwaiter
         {
+            // WARNING: Unsafe.As is used to access this as the non-generic ConfiguredTaskAwaiter.
+            // Its layout must remain the same.
+
             /// <summary>The task being awaited.</summary>
             private readonly Task<TResult> m_task;
             /// <summary>Whether to attempt marshaling back to the original context.</summary>

--- a/src/mscorlib/src/System/Threading/Tasks/Task.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/Task.cs
@@ -2627,6 +2627,57 @@ namespace System.Threading.Tasks
             }
         }
 
+        /// <summary>
+        /// Sets a continuation onto the <see cref="System.Threading.Tasks.Task"/>.
+        /// The continuation is scheduled to run in the current synchronization context is one exists, 
+        /// otherwise in the current task scheduler.
+        /// </summary>
+        /// <param name="stateMachineBox">The action to invoke when the <see cref="System.Threading.Tasks.Task"/> has completed.</param>
+        /// <param name="continueOnCapturedContext">
+        /// true to attempt to marshal the continuation back to the original context captured; otherwise, false.
+        /// </param>
+        /// <exception cref="System.InvalidOperationException">The awaiter was not properly initialized.</exception>
+        internal void UnsafeSetContinuationForAwait(IAsyncStateMachineBox stateMachineBox, bool continueOnCapturedContext)
+        {
+            Debug.Assert(stateMachineBox != null);
+
+            // If the caller wants to continue on the current context/scheduler and there is one,
+            // fall back to using the state machine's delegate.
+            if (continueOnCapturedContext)
+            {
+                SynchronizationContext syncCtx = SynchronizationContext.CurrentNoFlow;
+                if (syncCtx != null && syncCtx.GetType() != typeof(SynchronizationContext))
+                {
+                    Action moveNextAction = stateMachineBox.MoveNextAction;
+                    if (!AddTaskContinuation(new SynchronizationContextAwaitTaskContinuation(syncCtx, moveNextAction, flowExecutionContext: false), addBeforeOthers: false))
+                    {
+                        AwaitTaskContinuation.UnsafeScheduleAction(moveNextAction, this);
+                    }
+                    return;
+                }
+                else
+                {
+                    TaskScheduler scheduler = TaskScheduler.InternalCurrent;
+                    if (scheduler != null && scheduler != TaskScheduler.Default)
+                    {
+                        Action moveNextAction = stateMachineBox.MoveNextAction;
+                        if (!AddTaskContinuation(new TaskSchedulerAwaitTaskContinuation(scheduler, moveNextAction, flowExecutionContext: false), addBeforeOthers: false))
+                        {
+                            AwaitTaskContinuation.UnsafeScheduleAction(moveNextAction, this);
+                        }
+                        return;
+                    }
+                }
+            }
+
+            // Otherwise, add the state machine box directly as the ITaskCompletionAction continuation.
+            // If we're unable to because the task has already completed, queue the delegate.
+            if (!AddTaskContinuation(stateMachineBox, addBeforeOthers: false))
+            {
+                AwaitTaskContinuation.UnsafeScheduleAction(stateMachineBox.MoveNextAction, this);
+            }
+        }
+
         /// <summary>Creates an awaitable that asynchronously yields back to the current context when awaited.</summary>
         /// <returns>
         /// A context that, when awaited, will asynchronously transition back into the current context at the 


### PR DESCRIPTION
Previously when a task-returning async method would yield for the first time, there would be four allocations: the task, the state machine object boxed to the heap, a context "runner" object, and a delegate that points to the boxed state machine's MoveNext method.  A recent PR (https://github.com/dotnet/coreclr/pull/13105) changed this to avoid the separate box object and the runner, but that still left the task and the delegate.

This PR avoids the delegate as well in a common case.  For async methods that only ever await Task/Task`1, that aren't using a custom sync context/scheduler, and for which tracing isn't enabled, we know the inner workings of both the builder and the awaiter and can thus bypass the awaiter's pattern APIs; instead of creating the delegate that gets passed to the awaiter and then stored in the wrapped task's continuation slot/list, we can instead just store the boxed state machine directly in the slot/list. 

As a simple example just to highlight the allocation difference:
```C#
using System;
using System.Threading;
using System.Threading.Tasks;

class Program
{
    static async Task Main()
    {
        for (int i = 0; i < 1000; i++)
        {
            await SomeMethod();
        }
    }

    static async Task SomeMethod()
    {
        await Task.Run(() => Thread.Sleep(1));
    }
}
```
Before:
![image](https://user-images.githubusercontent.com/2642209/30833875-d2cfb18e-a21e-11e7-86b3-51157b2df1f4.png)

After:
![image](https://user-images.githubusercontent.com/2642209/30833886-ddd3f266-a21e-11e7-9307-6448c2b91636.png)

cc: @kouvel, @tarekgh, @jkotas

@AndyAyersMS, I had to workaround #12877 and https://github.com/dotnet/coreclr/issues/14177, and the workaround for #12877 isn't stellar so I'll be happy to undo it once that issue is addressed.

@benaadams, it'd be good to know if/how this affects your scenarios.