### PR TITLE
[Jit] fix DevDiv_499435

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -14284,11 +14284,10 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
                 {
                     /* Both tree and op1 are GT_COMMA nodes */
                     /* Change the tree's op1 to the throw node: op1->gtOp.gtOp1 */
-                    op1 = tree->gtOp.gtOp1 = throwNode;
+                    tree->gtOp.gtOp1 = throwNode;
 
-                    /* Reset the assignment flag */
-                    if (((op1 == nullptr) || ((op1->gtFlags & GTF_ASG) == 0)) &&
-                        ((op2 == nullptr) || ((op2->gtFlags & GTF_ASG) == 0)))
+                    // Possibly reset the assignment flag
+                    if (((throwNode->gtFlags & GTF_ASG) == 0) && ((op2 == nullptr) || ((op2->gtFlags & GTF_ASG) == 0)))
                     {
                         tree->gtFlags &= ~GTF_ASG;
                     }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -14284,7 +14284,15 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
                 {
                     /* Both tree and op1 are GT_COMMA nodes */
                     /* Change the tree's op1 to the throw node: op1->gtOp.gtOp1 */
-                    tree->gtOp.gtOp1 = throwNode;
+                    op1 = tree->gtOp.gtOp1 = throwNode;
+
+                    /* Reset the assignment flag */
+                    if (((op1 == nullptr) || ((op1->gtFlags & GTF_ASG) == 0)) &&
+                        ((op2 == nullptr) || ((op2->gtFlags & GTF_ASG) == 0)))
+                    {
+                        tree->gtFlags &= ~GTF_ASG;
+                    }
+
                     return tree;
                 }
                 else if (oper != GT_NOP)


### PR DESCRIPTION
Another issue with an extra flag on the tree after the assertion propagation phase. The previous issue was #14102.

In this case the problem tree is 144:
```
     ( 49, 42) [000067] ------------             *  STMT      void
N019 ( 49, 42) [000044] -ACXG-------             |  /--*  CAST_ovfl long <- ulong <- int $1c6
N017 (  1,  1) [000143] ------------             |  |  |  /--*  LCL_VAR   int    V07 cse0          $28b
N018 ( 42, 34) [000144] -ACXG-------             |  |  \--*  COMMA     int    $28b
N011 ( 21, 21) [000041] ---X-----U--             |  |     |        /--*  CAST_ovfl int <- uint <- ulong $289
N010 ( 14, 13) [000040] ---X-----U--             |  |     |        |  \--*  CAST      long <- uint $1c3
N008 (  8,  9) [000038] ---X-----U--             |  |     |        |     |  /--*  CAST_ovfl long <- ulong $1c1
N007 (  1,  1) [000037] ------------             |  |     |        |     |  |  \--*  CNS_INT   long   0 $80
N009 ( 13, 11) [000039] N--X-----U--             |  |     |        |     \--*  GT        int    $286
N006 (  1,  1) [000036] ------------             |  |     |        |        \--*  CNS_INT   long   0 $80
N013 ( 26, 26) [000042] ---X----RU--             |  |     |     /--*  SUB_ovfl  int    $28b
N012 (  1,  1) [000035] ------------             |  |     |     |  \--*  CNS_INT   int    0 $40
N015 ( 26, 26) [000139] -A-X----R---             |  |     |  /--*  ASG       int    $VN.Void
N014 (  1,  1) [000138] D------N----             |  |     |  |  \--*  LCL_VAR   int    V07 cse0          $28b
N016 ( 41, 33) [000142] -ACXG-------             |  |     \--*  COMMA     void   $183
N005 ( 15,  7) [000130] --CXG-------             |  |        \--*  CALL help void   HELPER.CORINFO_HELP_OVERFLOW $183
N003 (  1,  1) [000128] ------------ arg0 in rcx |  |           \--*  CNS_INT   int    0 $40
N021 ( 49, 42) [000066] -ACXG---R---             \--*  ASG       long   $1c6
N020 (  1,  1) [000065] D------N----                \--*  LCL_VAR   long   V03 tmp1         d:3 $1c4
```

We morph 142 as:
```
N013 ( 26, 26) [000042] ------------                /--*  CNS_INT   int    0 $40
N015 ( 26, 26) [000139] -A------R---             /--*  ASG       int    $VN.Void
N014 (  1,  1) [000138] D------N----             |  \--*  LCL_VAR   int    V07 cse0          $28b
N016 ( 41, 33) [000142] -ACXG-------             *  COMMA     void   $183
N005 ( 15,  7) [000130] --CXG-------             \--*  CALL help void   HELPER.CORINFO_HELP_OVERFLOW $183
N003 (  1,  1) [000128] ------------ arg0 in rcx    \--*  CNS_INT   int    0 $40
```
and then in the parent node do this optimization and end up with:
```
N006 (  1,  1) [000143] ------------                /--*  CNS_INT   long   0 $80
N007 ( 16,  8) [000144] -ACXG-------             /--*  COMMA     long   $28b
N005 ( 15,  7) [000130] --CXG-------             |  \--*  CALL help void   HELPER.CORINFO_HELP_OVERFLOW $183
N003 (  1,  1) [000128] ------------ arg0 in rcx |     \--*  CNS_INT   int    0 $40
N009 ( 16,  8) [000066] -ACXG---R---             *  ASG       long   $1c6
N008 (  1,  1) [000065] D------N----             \--*  LCL_VAR   long   V03 tmp1         d:3 $1c4
```

Update: 000144 has an extra assignment flag from the deleted 000142.