### PR TITLE
[RyuJIT/ARM32] Fast tail call: Init LSRA to use R12 to save jump target

### DIFF
--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -400,13 +400,15 @@ void LinearScan::TreeNodeInfoInitCall(GenTreeCall* call)
         // computed into a register.
         if (call->IsFastTailCall())
         {
-            NYI_ARM("tail call");
-
 #ifdef _TARGET_ARM64_
             // Fast tail call - make sure that call target is always computed in IP0
             // so that epilog sequence can generate "br xip0" to achieve fast tail call.
             ctrlExpr->gtLsraInfo.setSrcCandidates(this, genRegMask(REG_IP0));
-#endif // _TARGET_ARM64_
+#else  // !_TARGET_ARM64_
+            // Fast tail call - make sure that call target is always computed in r12
+            // so that epilog sequence can generate "mov  pc, r12" to achieve fast tail call.
+            ctrlExpr->gtLsraInfo.setSrcCandidates(this, genRegMask(REG_R12));
+#endif // !_TARGET_ARM64_
         }
     }
 #ifdef _TARGET_ARM_

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -406,8 +406,8 @@ void LinearScan::TreeNodeInfoInitCall(GenTreeCall* call)
             ctrlExpr->gtLsraInfo.setSrcCandidates(this, genRegMask(REG_IP0));
 #else  // !_TARGET_ARM64_
             // Fast tail call - make sure that call target is always computed in r12
-            // so that epilog sequence can generate "mov  pc, r12" to achieve fast tail call.
-            ctrlExpr->gtLsraInfo.setSrcCandidates(this, genRegMask(REG_R12));
+            // so that epilog sequence can generate "br r12" to achieve fast tail call.
+            ctrlExpr->gtLsraInfo.setSrcCandidates(this, RBM_R12);
 #endif // !_TARGET_ARM64_
         }
     }


### PR DESCRIPTION
To save jump target of fast tail call on ARM32, we use r12.
It is not affect to generated code on arm32 yet, because call->IsFastTailCall() is always false now.