### PR TITLE
[x86/Linux][SOS] Fix DumpStack command output on x86

### DIFF
--- a/src/ToolBox/SOS/Strike/disasm.cpp
+++ b/src/ToolBox/SOS/Strike/disasm.cpp
@@ -923,7 +923,7 @@ BOOL PrintCallInfo(DWORD_PTR vEBP, DWORD_PTR IP, DumpStackFlag& DSFlag, BOOL bSy
 
             // if AMD64 ever becomes a cross platform target this must be resolved through
             // virtual dispatch rather than conditional compilation
-#ifdef _TARGET_AMD64_ 
+#if defined(_TARGET_AMD64_) || defined(_TARGET_X86_)
             // degrade gracefully for debuggees that don't have a runtime loaded, or a DAC available
             eTargetType ett = ettUnk;
             if (!g_bDacBroken)
@@ -940,7 +940,7 @@ BOOL PrintCallInfo(DWORD_PTR vEBP, DWORD_PTR IP, DumpStackFlag& DSFlag, BOOL bSy
                     methodDesc = finalMDorIP;
                 }
             }
-#endif // _TARGET_AMD64_
+#endif // _TARGET_AMD64_ || _TARGET_X86_
             if (methodDesc == 0) 
             {
                 PrintNativeStack(IP, DSFlag.fSuppressSrcInfo);
@@ -962,14 +962,14 @@ BOOL PrintCallInfo(DWORD_PTR vEBP, DWORD_PTR IP, DumpStackFlag& DSFlag, BOOL bSy
             else if ((name = HelperFuncName(IP)) != NULL) {
                 ExtOut(" (JitHelp: %s)", name);
             }
-#ifdef _TARGET_AMD64_
+#if defined(_TARGET_AMD64_) || defined(_TARGET_X86_)
             else if (ett == ettMD || ett == ettStub)
             {
                 NameForMD_s(methodDesc, g_mdName,mdNameLen);                    
                 DMLOut("%s (stub for %S)", DMLIP(IP), g_mdName);
                 // fallthrough to return
             }
-#endif // _TARGET_AMD64_
+#endif // _TARGET_AMD64_ || _TARGET_X86_
             else
             {
                 DMLOut(DMLIP(IP));


### PR DESCRIPTION
On x86 DumpStack command doesn't print symbol information for caller and callee. This patch fixes it and make output the same as on AMD64.

Before this patch:
```
(lldb) sos DumpStack $esp $esp+0x1000
OS Thread Id: 0x644 (1)
Current frame: (MethodDesc f63416d4 + 0x64 rpinvoke.Program.MyStaticCallbackWithException(Int32))
ChildEBP RetAddr  Caller, Callee
FFFFBA68 efc48a6d (MethodDesc f222626c + 0x45 DomainBoundILStubClass.IL_STUB_ReversePInvoke(Int32))
FFFFBA88 f71ee211 f71ee211
FFFFBA98 f71ee1d1 f71ee1d1, calling f71ee1d1
FFFFBAB8 f5900ba2 libupcall.so!register_callback_and_upcall + 0xab [/home/kbaladurin/Desktop/dotnet/coredumps/lldb/dotnet/rpinvoke/upcall-1.cpp:52]
FFFFBAC8 f5900b04 libupcall.so!register_callback_and_upcall + 0xd [/home/kbaladurin/Desktop/dotnet/coredumps/lldb/dotnet/rpinvoke/upcall-1.cpp:45], calling f59007f0
FFFFBADC f73f843b f73f843b, calling f71ee170
FFFFBB08 efc4894e (MethodDesc f222614c + 0x6e DomainBoundILStubClass.IL_STUB_PInvoke(Callback))
FFFFBB18 efc48917 (MethodDesc f222614c + 0x37 DomainBoundILStubClass.IL_STUB_PInvoke(Callback)), calling (MethodDesc f2f33268 + 0 System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(System.Delegate))
FFFFBB38 efc4894e (MethodDesc f222614c + 0x6e DomainBoundILStubClass.IL_STUB_PInvoke(Callback))
FFFFBB68 efc487d5 (MethodDesc f6341714 + 0xdd rpinvoke.Program.MyView_KeyEvent(System.ConsoleKeyInfo)), calling efc43244
FFFFBBA8 f2f80f6b (MethodDesc f6341734 + 0x10b rpinvoke.Program.Main(System.String[])), calling (MethodDesc f6341714 + 0 rpinvoke.Program.MyView_KeyEvent(System.ConsoleKeyInfo))
FFFFBBB8 f2f80f51 (MethodDesc f6341734 + 0xf1 rpinvoke.Program.Main(System.String[])), calling (MethodDesc f6344160 + 0 System.Console.ReadKey(Boolean))
FFFFBC38 f71ecf1d f71ecf1d
FFFFBC48 f6ebb26d f6ebb26d, calling f71eced0
FFFFC098 f6ebb020 f6ebb020, calling f6ebb080
FFFFC0B8 f6cca5ab f6cca5ab, calling f6ca53a0
FFFFC0D8 f6cca84e f6cca84e, calling f6cca84e
FFFFC118 f6ebcf18 f6ebcf18, calling f6ebad70
FFFFC128 f6ebced4 f6ebced4, calling f6ccbe30
FFFFC138 f6ebc992 f6ebc992, calling f6ebd4a0
FFFFC148 f6ebc9a6 f6ebc9a6, calling f6ebd4f0
FFFFC178 f6cbc0d3 f6cbc0d3, calling f6cbc0e0
FFFFC1A8 f6df1f50 f6df1f50, calling f6d575c0
FFFFC278 f6dfcacf f6dfcacf, calling f6df9480
FFFFC298 f6d7e876 f6d7e876, calling f6dfca90
FFFFC2E8 f6ca2269 f6ca2269, calling f6ebc1b0
FFFFC318 f7243a12 f7243a12, calling f6ca2220
FFFFC338 f6d7c28e f6d7c28e
FFFFC358 f6c1933d f6c1933d, calling f6c19730
FFFFC388 f6d7b862 f6d7b862, calling f6c19710
FFFFC3B8 f6cbc12c f6cbc12c, calling f6cbc170
FFFFC3D8 f6c593dd f6c593dd, calling f6c593dd
FFFFC468 f724009e f724009e, calling f7243660
FFFFC478 f6cf6eef f6cf6eef, calling f6cf6f60
FFFFC48C f76dfbc9 f76dfbc9, calling f76dfbc9
FFFFC4D8 f723fe5d f723fe5d, calling f7240030
FFFFC4E8 f6d7f6e4 f6d7f6e4, calling f6d8b990
FFFFC508 f6c1933d f6c1933d, calling f6c19730
FFFFC538 f6cf4ee3 f6cf4ee3, calling f6ca5fb0
FFFFC598 f72403de f72403de, calling f723fc40
FFFFC628 f6db6e46 f6db6e46, calling f6c18140
FFFFC638 f6db6e46 f6db6e46, calling f6c18140
FFFFC768 f6c8bed7 f6c8bed7, calling f6c0fac0
FFFFC778 f6c8bfbd f6c8bfbd, calling f6c58480
FFFFC7A8 f6db4af8 f6db4af8, calling f6db5f40
FFFFC7B4 f7feb4e5 ld-linux.so.2!___tls_get_addr + 0x5, calling ld-linux.so.2 + 0xffffffff
FFFFC7B8 f71da4ee f71da4ee, calling f71da4ee
FFFFC7C4 f7feb4e5 ld-linux.so.2!___tls_get_addr + 0x5, calling ld-linux.so.2 + 0xffffffff
FFFFC7C8 f6c8bed7 f6c8bed7, calling f6c0fac0
FFFFC7D8 f6dbdfc8 f6dbdfc8, calling f6d06740
FFFFC7F8 f6db425e f6db425e, calling f6dbdf90
FFFFC838 f6ca1fa9 f6ca1fa9, calling f6db4100
FFFFC848 f6ca1ff3 f6ca1ff3, calling f6db8f00
FFFFC868 f6c94da8 f6c94da8, calling f7240230
FFFFC888 f6c1fe1e f6c1fe1e, calling f6c1fe1e
FFFFC8E4 f7f97c55 libpthread.so.0!__errno_location + 0x5, calling libpthread.so.0!__x86.get_pc_thunk.ax
FFFFC8E8 f76d1f36 f76d1f36, calling f6c0fbc0
FFFFC948 f6c1df18 f6c1df18, calling f6c1dfa0
FFFFC978 f6c1dea3 f6c1dea3, calling f6c1deb0
FFFFC9B8 f6c1cf09 f6c1cf09, calling f6c1de30
FFFFC9E8 f6c1ca86 f6c1ca86
```
After this patch:
```
(lldb) sos DumpStack $esp $esp+0x1000
OS Thread Id: 0x17f3 (1)
Current frame: (MethodDesc f63416d4 + 0x64 rpinvoke.Program.MyStaticCallbackWithException(Int32))
ChildEBP RetAddr  Caller, Callee
FFFFBA68 efc48a6d (MethodDesc f222626c + 0x45 DomainBoundILStubClass.IL_STUB_ReversePInvoke(Int32))
FFFFBA88 f71ee211 libcoreclr.so!UMThunkStub + 0x6a [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/i386/umthunkstub.S:106]
FFFFBA98 f71ee1d1 libcoreclr.so!UMThunkStub + 0x2a [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/i386/umthunkstub.S:72], calling libcoreclr.so!UMThunkStub + 0x2a [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/i386/umthunkstub.S:72]
FFFFBAB8 f5900ba2 libupcall.so!register_callback_and_upcall + 0xab [/home/kbaladurin/Desktop/dotnet/coredumps/lldb/dotnet/rpinvoke/upcall-1.cpp:52]
FFFFBAC8 f5900b04 libupcall.so!register_callback_and_upcall + 0xd [/home/kbaladurin/Desktop/dotnet/coredumps/lldb/dotnet/rpinvoke/upcall-1.cpp:45], calling libupcall.so!__x86.get_pc_thunk.bx
FFFFBADC f73f843b libcoreclr.so!MarshalNative::GetFunctionPointerForDelegateInternal(int, int, Object*) + 0xdb [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/marshalnative.cpp:395], calling libcoreclr.so!LazyMachStateCaptureState [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/i386/gmsasm.S:12]
FFFFBB08 efc4894e (MethodDesc f222614c + 0x6e DomainBoundILStubClass.IL_STUB_PInvoke(Callback))
FFFFBB18 efc48917 (MethodDesc f222614c + 0x37 DomainBoundILStubClass.IL_STUB_PInvoke(Callback)), calling (MethodDesc f2f33268 + 0 System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(System.Delegate))
FFFFBB38 efc4894e (MethodDesc f222614c + 0x6e DomainBoundILStubClass.IL_STUB_PInvoke(Callback))
FFFFBB68 efc487d5 (MethodDesc f6341714 + 0xdd rpinvoke.Program.MyView_KeyEvent(System.ConsoleKeyInfo)), calling efc43244 (stub for rpinvoke.Program.register_callback_and_upcall(Callback))
FFFFBBA8 f2f80f6b (MethodDesc f6341734 + 0x10b rpinvoke.Program.Main(System.String[])), calling (MethodDesc f6341714 + 0 rpinvoke.Program.MyView_KeyEvent(System.ConsoleKeyInfo))
FFFFBBB8 f2f80f51 (MethodDesc f6341734 + 0xf1 rpinvoke.Program.Main(System.String[])), calling (MethodDesc f6344160 + 0 System.Console.ReadKey(Boolean))
FFFFBC38 f71ecf1d libcoreclr.so!CallDescrWorkerInternal + 0x4d [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/i386/asmhelpers.S:306]
FFFFBC48 f6ebb26d libcoreclr.so!CallDescrWorker(CallDescrData*) + 0x1ed [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/callhelpers.cpp:135], calling libcoreclr.so!CallDescrWorkerInternal [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/i386/asmhelpers.S:262]
FFFFC098 f6ebb020 libcoreclr.so!CallDescrWorkerWithHandler(CallDescrData*, int) + 0x2b0 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/callhelpers.cpp:78], calling libcoreclr.so!CallDescrWorker(CallDescrData*) [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/callhelpers.cpp:89]
FFFFC0B8 f6cca5ab libcoreclr.so!ArgIteratorTemplate<ArgIteratorBase>::GetNextOffset() + 0x16b [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/callingconvention.h:934], calling libcoreclr.so!ArgIteratorBase::NumFixedArgs() [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/callingconvention.h:1673]
FFFFC0D8 f6cca84e libcoreclr.so!ArgDestination::ArgDestination(void*, int, ArgLocDesc*) + 0xe [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/argdestination.h:29], calling libcoreclr.so!ArgDestination::ArgDestination(void*, int, ArgLocDesc*) + 0xe [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/argdestination.h:29]
FFFFC118 f6ebcf18 libcoreclr.so!MethodDescCallSite::CallTargetWorker(unsigned long long const*, unsigned long long*, int) + 0xd68 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/callhelpers.cpp:645], calling libcoreclr.so!CallDescrWorkerWithHandler(CallDescrData*, int) [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/callhelpers.cpp:62]
FFFFC128 f6ebced4 libcoreclr.so!MethodDescCallSite::CallTargetWorker(unsigned long long const*, unsigned long long*, int) + 0xd24 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/callhelpers.cpp:623], calling libcoreclr.so!TransitionBlock::GetOffsetOfArgumentRegisters() [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/callingconvention.h:145]
FFFFC138 f6ebc992 libcoreclr.so!MethodDescCallSite::CallTargetWorker(unsigned long long const*, unsigned long long*, int) + 0x7e2 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/callhelpers.cpp:472], calling libcoreclr.so!ArgIteratorTemplate<ArgIteratorBase>::SizeOfFrameArgumentArray() [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/callingconvention.h:297]
FFFFC148 f6ebc9a6 libcoreclr.so!MethodDescCallSite::CallTargetWorker(unsigned long long const*, unsigned long long*, int) + 0x7f6 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/callhelpers.cpp:477], calling libcoreclr.so!TransitionBlock::GetNegSpaceSize() [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/callingconvention.h:238]
FFFFC178 f6cbc0d3 libcoreclr.so!MethodTable::IsSharedByGenericInstantiations() + 0x73 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/methodtable.inl:1303], calling libcoreclr.so!MethodTable::TestFlagWithMask(MethodTable::WFLAGS_LOW_ENUM, MethodTable::WFLAGS_LOW_ENUM) const [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/methodtable.h:4041]
FFFFC1A8 f6df1f50 libcoreclr.so!SigPointer::PeekElemTypeClosed(Module*, SigTypeContext const*) const + 0x50 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/siginfo.cpp:2447], calling libcoreclr.so!SigParser::PeekElemType(CorElementType*) const [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/inc/sigparser.h:357]
FFFFC278 f6dfcacf libcoreclr.so!MetaSig::IsReturnTypeVoid() const + 0x3f [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/siginfo.cpp:5288], calling libcoreclr.so!MetaSig::GetReturnType() const [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/siginfo.cpp:5280]
FFFFC298 f6d7e876 libcoreclr.so!MethodDesc::IsVoid() + 0x76 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/method.cpp:1117], calling libcoreclr.so!MetaSig::IsReturnTypeVoid() const [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/siginfo.cpp:5286]
FFFFC2E8 f6ca2269 libcoreclr.so!MethodDescCallSite::Call(unsigned long long const*) + 0x49 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/callhelpers.h:433], calling libcoreclr.so!MethodDescCallSite::CallTargetWorker(unsigned long long const*, unsigned long long*, int) [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/callhelpers.cpp:333]
FFFFC318 f7243a12 libcoreclr.so!RunMain(MethodDesc*, short, int*, REF<PtrArray>*)::$_1::operator()(RunMain(MethodDesc*, short, int*, REF<PtrArray>*)::Param*) const::{lambda(RunMain(MethodDesc*, short, int*, REF<PtrArray>*)::Param*)#1}::operator()(RunMain(MethodDesc*, short, int*, REF<PtrArray>*)::Param*) const + 0x3b2 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/assembly.cpp:1705], calling libcoreclr.so!MethodDescCallSite::Call(unsigned long long const*) [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/callhelpers.h:433]
FFFFC338 f6d7c28e libcoreclr.so!MethodDesc::GetSigFromMetadata(IMDInternalImport*, unsigned char const**, unsigned int*) + 0x6e [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/method.cpp:498]
FFFFC358 f6c1933d libcoreclr.so!CHECK::EnterAssert() + 0x6d [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/inc/check.inl:51], calling libcoreclr.so!ClrFlsGetValue(unsigned int) [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/inc/clrhost.h:124]
FFFFC388 f6d7b862 libcoreclr.so!MethodDesc::GetSig(unsigned char const**, unsigned int*) + 0x302 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/method.cpp:471], calling libcoreclr.so!CHECK::LeaveAssert() [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/inc/check.inl:74]
FFFFC3B8 f6cbc12c libcoreclr.so!MethodTable::TestFlagWithMask(MethodTable::WFLAGS_LOW_ENUM, MethodTable::WFLAGS_LOW_ENUM) const + 0x4c [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/classlibnative/../vm/methodtable.h:4043], calling libcoreclr.so!MethodTable::IsStringOrArray() const [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/methodtable.h:1869]
FFFFC3D8 f6c593dd libcoreclr.so!SigParser::SkipBytes(unsigned int) + 0xd [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/inc/sigparser.h:55], calling libcoreclr.so!SigParser::SkipBytes(unsigned int) + 0xd [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/inc/sigparser.h:55]
FFFFC468 f724009e libcoreclr.so!RunMain(MethodDesc*, short, int*, REF<PtrArray>*)::$_1::operator()(RunMain(MethodDesc*, short, int*, REF<PtrArray>*)::Param*) const + 0x6e [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/assembly.cpp:1720], calling libcoreclr.so!RunMain(MethodDesc*, short, int*, REF<PtrArray>*)::$_1::operator()(RunMain(MethodDesc*, short, int*, REF<PtrArray>*)::Param*) const::{lambda(RunMain(MethodDesc*, short, int*, REF<PtrArray>*)::Param*)#1}::operator()(RunMain(MethodDesc*, short, int*, REF<PtrArray>*)::Param*) const [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/assembly.cpp:1676]
FFFFC478 f6cf6eef libcoreclr.so!MethodTable::GetLoaderModule() + 0x4f [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/classlibnative/../vm/methodtable.inl:176], calling libcoreclr.so!RelativePointer<Module*>::type ReadPointer<MethodTable, RelativePointer<Module*> >(MethodTable const*, RelativePointer<Module*> const MethodTable::*) [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/inc/fixuppointer.h:798]
FFFFC48C f76dfbc9 libcoreclr.so!NativeExceptionHolderBase::NativeExceptionHolderBase() + 0x9 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/pal/src/exception/seh.cpp:395], calling libcoreclr.so!NativeExceptionHolderBase::NativeExceptionHolderBase() + 0x9 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/pal/src/exception/seh.cpp:395]
FFFFC4D8 f723fe5d libcoreclr.so!RunMain(MethodDesc*, short, int*, REF<PtrArray>*) + 0x21d [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/assembly.cpp:1720], calling libcoreclr.so!RunMain(MethodDesc*, short, int*, REF<PtrArray>*)::$_1::operator()(RunMain(MethodDesc*, short, int*, REF<PtrArray>*)::Param*) const [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/assembly.cpp:1676]
FFFFC4E8 f6d7f6e4 libcoreclr.so!MethodDesc::GetModule_NoLogging() const + 0x54 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/method.cpp:1526], calling libcoreclr.so!MethodTable::GetModule() [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/methodtable.cpp:382]
FFFFC508 f6c1933d libcoreclr.so!CHECK::EnterAssert() + 0x6d [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/inc/check.inl:51], calling libcoreclr.so!ClrFlsGetValue(unsigned int) [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/inc/clrhost.h:124]
FFFFC538 f6cf4ee3 libcoreclr.so!MethodDesc::GetAssembly() const + 0x113 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/method.hpp:1070], calling libcoreclr.so!Module::GetAssembly() const [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/ceeload.inl:388]
FFFFC598 f72403de libcoreclr.so!Assembly::ExecuteMainMethod(REF<PtrArray>*, int) + 0x1ae [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/assembly.cpp:1802], calling libcoreclr.so!RunMain(MethodDesc*, short, int*, REF<PtrArray>*) [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/assembly.cpp:1619]
FFFFC628 f6db6e46 libcoreclr.so!Object::ValidateInner(int, int, int) + 0xf06 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/object.cpp:1821], calling libcoreclr.so!Exception::HandlerState::DidCatchSO() [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/inc/ex.h:255]
FFFFC638 f6db6e46 libcoreclr.so!Object::ValidateInner(int, int, int) + 0xf06 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/object.cpp:1821], calling libcoreclr.so!Exception::HandlerState::DidCatchSO() [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/inc/ex.h:255]
FFFFC768 f6c8bed7 libcoreclr.so!GetThread + 0x37 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/binder/../vm/threads.inl:35], calling libcoreclr.so + 0xffffffff
FFFFC778 f6c8bfbd libcoreclr.so!Thread::PreemptiveGCDisabled() + 0x8d [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/binder/../vm/threads.h:2195], calling libcoreclr.so!Volatile<unsigned int>::LoadWithoutBarrier() const [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/inc/volatile.h:299]
FFFFC7A8 f6db4af8 libcoreclr.so!Object::Validate(int, int, int) + 0x198 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/object.cpp:1711], calling libcoreclr.so!Object::ValidateInner(int, int, int) [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/object.cpp:1714]
FFFFC7B4 f7feb4e5 ld-linux.so.2!___tls_get_addr + 0x5, calling ld-linux.so.2 + 0xffffffff
FFFFC7B8 f71da4ee libcoreclr.so!WKS::GCHeap::IsHeapPointer(void*, bool) + 0xe [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/gc/gc.cpp:33738], calling libcoreclr.so!WKS::GCHeap::IsHeapPointer(void*, bool) + 0xe [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/gc/gc.cpp:33738]
FFFFC7C4 f7feb4e5 ld-linux.so.2!___tls_get_addr + 0x5, calling ld-linux.so.2 + 0xffffffff
FFFFC7C8 f6c8bed7 libcoreclr.so!GetThread + 0x37 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/binder/../vm/threads.inl:35], calling libcoreclr.so + 0xffffffff
FFFFC7D8 f6dbdfc8 libcoreclr.so!ENABLESTRESSHEAP() + 0x38 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/threads.h:6827], calling libcoreclr.so!Thread::EnableStressHeap() [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/threads.h:4633]
FFFFC7F8 f6db425e libcoreclr.so!OBJECTREF::operator=(OBJECTREF const&) + 0x15e [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/object.cpp:2911], calling libcoreclr.so!ENABLESTRESSHEAP() [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/threads.h:6821]
FFFFC838 f6ca1fa9 libcoreclr.so!REF<PtrArray>::operator=(REF<PtrArray>&&) + 0x39 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/classlibnative/../vm/vars.hpp:235], calling libcoreclr.so!OBJECTREF::operator=(OBJECTREF const&) [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/object.cpp:2885]
FFFFC848 f6ca1ff3 libcoreclr.so!REF<PtrArray>::REF(OBJECTREF const&) + 0x33 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/classlibnative/../vm/vars.hpp:257], calling libcoreclr.so!OBJECTREF::OBJECTREF(OBJECTREF const&) [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/object.cpp:2646]
FFFFC868 f6c94da8 libcoreclr.so!CorHost2::ExecuteAssembly(unsigned int, char16_t const*, int, char16_t const**, unsigned int*) + 0x628 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/corhost.cpp:501], calling libcoreclr.so!Assembly::ExecuteMainMethod(REF<PtrArray>*, int) [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/assembly.cpp:1764]
FFFFC888 f6c1fe1e libcoreclr.so!ClrSafeInt<unsigned int>::Value() const + 0xe [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/inc/safemath.h:284], calling libcoreclr.so!ClrSafeInt<unsigned int>::Value() const + 0xe [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/inc/safemath.h:284]
FFFFC8E4 f7f97c55 libpthread.so.0!__errno_location + 0x5, calling libpthread.so.0!__x86.get_pc_thunk.ax
FFFFC8E8 f76d1f36 libcoreclr.so!CorUnix::CPalThread::SetLastError(unsigned int) + 0x26 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/pal/src/include/pal/thread.hpp:485], calling libcoreclr.so + 0xffffffff
FFFFC948 f6c1df18 libcoreclr.so!BaseHolder<char16_t const*, FunctionBase<char16_t const*, &(void DoNothing<char16_t const*>(char16_t const*)), &(void DeleteArray<char16_t const>(char16_t const*)), (HolderStackValidation)2>, 0u, &(int CompareDefault<char16_t const*>(char16_t const*, char16_t const*)), (HolderStackValidation)2>::BaseHolder(char16_t const*) + 0x68 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/inc/holder.h:264], calling libcoreclr.so!BaseHolder<char16_t const*, FunctionBase<char16_t const*, &(void DoNothing<char16_t const*>(char16_t const*)), &(void DeleteArray<char16_t const>(char16_t const*)), (HolderStackValidation)2>, 0u, &(int CompareDefault<char16_t const*>(char16_t const*, char16_t const*)), (HolderStackValidation)2>::Acquire() [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/inc/holder.h:290]
FFFFC978 f6c1dea3 libcoreclr.so!BaseWrapper<char16_t const*, FunctionBase<char16_t const*, &(void DoNothing<char16_t const*>(char16_t const*)), &(void DeleteArray<char16_t const>(char16_t const*)), (HolderStackValidation)2>, 0u, &(int CompareDefault<char16_t const*>(char16_t const*, char16_t const*)), (HolderStackValidation)2>::BaseWrapper(char16_t const*) + 0x33 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/inc/holder.h:617], calling libcoreclr.so!BaseHolder<char16_t const*, FunctionBase<char16_t const*, &(void DoNothing<char16_t const*>(char16_t const*)), &(void DeleteArray<char16_t const>(char16_t const*)), (HolderStackValidation)2>, 0u, &(int CompareDefault<char16_t const*>(char16_t const*, char16_t const*)), (HolderStackValidation)2>::BaseHolder(char16_t const*) [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/inc/holder.h:261]
FFFFC9B8 f6c1cf09 libcoreclr.so!NewArrayHolder<char16_t const>::NewArrayHolder(char16_t const*) + 0x39 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/inc/holder.h:1078], calling libcoreclr.so!Wrapper<char16_t const*, &(void DoNothing<char16_t const*>(char16_t const*)), &(void DeleteArray<char16_t const>(char16_t const*)), 0u, &(int CompareDefault<char16_t const*>(char16_t const*, char16_t const*)), (HolderStackValidation)2, true>::Wrapper(char16_t const*) [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/inc/holder.h:847]
FFFFC9E8 f6c1ca86 libcoreclr.so!coreclr_execute_assembly + 0x196 [/media/kbaladurin/data/dotnet/forked/coreclr-1/src/dlls/mscoree/unixinterface.cpp:407]
```