### PR TITLE
[Arm64] Add GT_JCMP node

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -3385,6 +3385,28 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
 //------------------------------------------------------------------------
 // genCodeForJumpCompare: Generates code for jmpCompare statement.
 //
+// A GT_JCMP node is created when a comparison and conditional branch
+// can be executed in a single instruction.
+//
+// Arm64 has a few instructions with this behavior.
+//   - cbz/cbnz -- Compare and branch register zero/not zero
+//   - tbz/tbnz -- Test and branch register bit zero/not zero
+//
+// A GT_JCMP cbz/cbnz node is created when there is a GT_EQ or GT_NE
+// integer/unsigned comparison against #0 which is used by a GT_JTRUE
+// condition jump node.
+//
+// A GT_JCMP cbz/cbnz node is created when there is a GT_TEST_EQ or GT_TEST_NE
+// integer/unsigned comparison against against a mask with a single bit set
+// which is used by a GT_JTRUE condition jump node.
+//
+// This node is repsonsible for consuming the register, and emitting the
+// appropriate fused compare/test and branch instruction
+//
+// Two flags guide code generation
+//    GTF_JCMP_TST -- Set if this is a tbz/tbnz rather than cbz/cbnz
+//    GTF_JCMP_EQ  -- Set if this is cbz/tbz rather than cbnz/tbnz
+//
 // Arguments:
 //    tree - The GT_JCMP tree node.
 //

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -3392,11 +3392,14 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
 //   - cbz/cbnz -- Compare and branch register zero/not zero
 //   - tbz/tbnz -- Test and branch register bit zero/not zero
 //
+// The cbz/cbnz supports the normal +/- 1MB branch range for conditional branches
+// The tbz/tbnz supports a  smaller +/- 32KB branch range
+//
 // A GT_JCMP cbz/cbnz node is created when there is a GT_EQ or GT_NE
 // integer/unsigned comparison against #0 which is used by a GT_JTRUE
 // condition jump node.
 //
-// A GT_JCMP cbz/cbnz node is created when there is a GT_TEST_EQ or GT_TEST_NE
+// A GT_JCMP tbz/tbnz node is created when there is a GT_TEST_EQ or GT_TEST_NE
 // integer/unsigned comparison against against a mask with a single bit set
 // which is used by a GT_JTRUE condition jump node.
 //

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -282,6 +282,12 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             genCodeForJumpTrue(treeNode);
             break;
 
+#ifdef _TARGET_ARM64_
+        case GT_JCMP:
+            genCodeForJumpCompare(treeNode->AsOp());
+            break;
+#endif // _TARGET_ARM64_
+
         case GT_JCC:
             genCodeForJcc(treeNode->AsCC());
             break;

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -266,6 +266,9 @@ void genCallInstruction(GenTreeCall* call);
 void genJmpMethod(GenTreePtr jmp);
 BasicBlock* genCallFinally(BasicBlock* block);
 void genCodeForJumpTrue(GenTreePtr tree);
+#ifdef _TARGET_ARM64_
+void genCodeForJumpCompare(GenTreeOp* tree);
+#endif // _TARGET_ARM64_
 
 #if FEATURE_EH_FUNCLETS
 void genEHCatchRet(BasicBlock* block);

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -9952,6 +9952,7 @@ inline bool OperIsControlFlow(genTreeOps oper)
     switch (oper)
     {
         case GT_JTRUE:
+        case GT_JCMP:
         case GT_JCC:
         case GT_SWITCH:
         case GT_LABEL:

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -2542,6 +2542,10 @@ GenTreePtr Compiler::gtReverseCond(GenTree* tree)
         GenTreeCC* cc   = tree->AsCC();
         cc->gtCondition = GenTree::ReverseRelop(cc->gtCondition);
     }
+    else if (tree->OperIs(GT_JCMP))
+    {
+        tree->gtFlags ^= GTF_JCMP_EQ;
+    }
     else
     {
         tree = gtNewOperNode(GT_NOT, TYP_INT, tree);
@@ -9874,6 +9878,11 @@ void Compiler::gtDispNode(GenTreePtr tree, IndentStack* indentStack, __in __in_z
                 }
                 goto DASH;
 
+            case GT_JCMP:
+                printf((tree->gtFlags & GTF_JCMP_TST) ? "T" : "C");
+                printf((tree->gtFlags & GTF_JCMP_EQ) ? "EQ" : "NE");
+                goto DASH;
+
             default:
             DASH:
                 printf("-");
@@ -10786,6 +10795,9 @@ void Compiler::gtDispLeaf(GenTree* tree, IndentStack* indentStack)
         case GT_SETCC:
             printf(" cond=%s", GenTree::OpName(tree->AsCC()->gtCondition));
             break;
+        case GT_JCMP:
+            printf(" cond=%s%s", (tree->gtFlags & GTF_JCMP_TST) ? "TEST_" : "",
+                   (tree->gtFlags & GTF_JCMP_EQ) ? "EQ" : "NE");
 
         default:
             assert(!"don't know how to display tree leaf node");

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -2544,6 +2544,11 @@ GenTreePtr Compiler::gtReverseCond(GenTree* tree)
     }
     else if (tree->OperIs(GT_JCMP))
     {
+        // Flip the GTF_JCMP_EQ
+        //
+        // This causes switching
+        //     cbz <=> cbnz
+        //     tbz <=> tbnz
         tree->gtFlags ^= GTF_JCMP_EQ;
     }
     else

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -991,8 +991,8 @@ public:
 #define GTF_RELOP_ZTT               0x08000000 // GT_<relop> -- Loop test cloned for converting while-loops into do-while
                                                //               with explicit "loop test" in the header block.
 
-#define GTF_JCMP_EQ                 0x80000000 // GTF_JCMP_EQ  -- Branch on equalrather than not equal
-#define GTF_JCMP_TST                0x40000000 // GTF_JCMP_TST -- Use test rather than compare
+#define GTF_JCMP_EQ                 0x80000000 // GTF_JCMP_EQ  -- Branch on equal rather than not equal
+#define GTF_JCMP_TST                0x40000000 // GTF_JCMP_TST -- Use bit test instruction rather than compare against zero instruction
 
 #define GTF_RET_MERGED              0x80000000 // GT_RETURN -- This is a return generated during epilog merging.
 

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -991,6 +991,9 @@ public:
 #define GTF_RELOP_ZTT               0x08000000 // GT_<relop> -- Loop test cloned for converting while-loops into do-while
                                                //               with explicit "loop test" in the header block.
 
+#define GTF_JCMP_EQ                 0x80000000 // GTF_JCMP_EQ  -- Branch on equalrather than not equal
+#define GTF_JCMP_TST                0x40000000 // GTF_JCMP_TST -- Use test rather than compare
+
 #define GTF_RET_MERGED              0x80000000 // GT_RETURN -- This is a return generated during epilog merging.
 
 #define GTF_QMARK_CAST_INSTOF       0x80000000 // GT_QMARK -- Is this a top (not nested) level qmark created for
@@ -1632,7 +1635,7 @@ public:
 
     bool OperIsConditionalJump() const
     {
-        return (gtOper == GT_JTRUE) || (gtOper == GT_JCC);
+        return (gtOper == GT_JTRUE) || (gtOper == GT_JCMP) || (gtOper == GT_JCC);
     }
 
     static bool OperIsBoundsCheck(genTreeOps op)

--- a/src/jit/gtlist.h
+++ b/src/jit/gtlist.h
@@ -225,6 +225,7 @@ GTNODE(SIMD             , GenTreeSIMD        ,0,GTK_BINOP|GTK_EXOP)     // SIMD 
 
 GTNODE(CMP              , GenTreeOp          ,0,GTK_BINOP|GTK_NOVALUE)  // Sets the condition flags according to the compare result. 
                                                                         // N.B. Not a relop, it does not produce a value and it cannot be reversed.
+GTNODE(JCMP             , GenTreeOp          ,0,GTK_BINOP|GTK_NOVALUE)  // Makes a comparison and jump if the condition specified.  Does not set flags
 GTNODE(JCC              , GenTreeCC          ,0,GTK_LEAF|GTK_NOVALUE)   // Checks the condition flags and branch if the condition specified
                                                                         // by GenTreeCC::gtCondition is true.
 GTNODE(SETCC            , GenTreeCC          ,0,GTK_LEAF)               // Checks the condition flags and produces 1 if the condition specified 

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -2184,6 +2184,7 @@ void Compiler::fgComputeLifeLIR(VARSET_TP& life, BasicBlock* block, VARSET_VALAR
 #if defined(FEATURE_SIMD)
             case GT_SIMD_CHK:
 #endif // FEATURE_SIMD
+            case GT_JCMP:
             case GT_CMP:
             case GT_JCC:
             case GT_JTRUE:

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -188,6 +188,7 @@ GenTree* Lowering::LowerNode(GenTree* node)
         case GT_TEST_EQ:
         case GT_TEST_NE:
         case GT_CMP:
+        case GT_JCMP:
             LowerCompare(node);
             break;
 
@@ -5349,6 +5350,7 @@ void Lowering::ContainCheckNode(GenTree* node)
         case GT_TEST_EQ:
         case GT_TEST_NE:
         case GT_CMP:
+        case GT_JCMP:
             ContainCheckCompare(node->AsOp());
             break;
 

--- a/src/jit/lowerarmarch.cpp
+++ b/src/jit/lowerarmarch.cpp
@@ -121,6 +121,7 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode)
             case GT_LE:
             case GT_GE:
             case GT_GT:
+            case GT_JCMP:
                 return emitter::emitIns_valid_imm_for_cmp(immVal, size);
                 break;
             case GT_AND:
@@ -716,6 +717,39 @@ void Lowering::ContainCheckCompare(GenTreeOp* cmp)
             assert(!op1->gtSetFlags());
             op1->gtFlags |= GTF_SET_FLAGS;
             cmp->gtFlags |= GTF_USE_FLAGS;
+        }
+
+        if (!varTypeIsFloating(cmp) && op2->IsCnsIntOrI() && ((cmp->gtFlags & GTF_USE_FLAGS) == 0))
+        {
+            LIR::Use cmpUse;
+            bool     useJCMP = false;
+            uint64_t flags   = 0;
+
+            if (cmp->OperIs(GT_EQ, GT_NE) && op2->IsIntegralConst(0) && BlockRange().TryGetUse(cmp, &cmpUse) &&
+                cmpUse.User()->OperIs(GT_JTRUE))
+            {
+                // Codegen will use cbz or cbnz in codegen which do not affect the flag register
+                flags   = cmp->OperIs(GT_EQ) ? GTF_JCMP_EQ : 0;
+                useJCMP = true;
+            }
+            else if (cmp->OperIs(GT_TEST_EQ, GT_TEST_NE) && isPow2(op2->gtIntCon.IconValue()) &&
+                     BlockRange().TryGetUse(cmp, &cmpUse) && cmpUse.User()->OperIs(GT_JTRUE))
+            {
+                // Codegen will use tbz or tbnz in codegen which do not affect the flag register
+                flags   = GTF_JCMP_TST | (cmp->OperIs(GT_TEST_EQ) ? GTF_JCMP_EQ : 0);
+                useJCMP = true;
+            }
+
+            if (useJCMP)
+            {
+                cmp->gtLsraInfo.isNoRegCompare = true;
+                cmp->SetOper(GT_JCMP);
+
+                cmp->gtFlags &= ~(GTF_JCMP_TST | GTF_JCMP_EQ);
+                cmp->gtFlags |= flags;
+
+                BlockRange().Remove(cmpUse.User());
+            }
         }
 #endif // _TARGET_ARM64_
     }

--- a/src/jit/lowerarmarch.cpp
+++ b/src/jit/lowerarmarch.cpp
@@ -121,7 +121,6 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode)
             case GT_LE:
             case GT_GE:
             case GT_GT:
-            case GT_JCMP:
                 return emitter::emitIns_valid_imm_for_cmp(immVal, size);
                 break;
             case GT_AND:
@@ -130,6 +129,10 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode)
             case GT_TEST_EQ:
             case GT_TEST_NE:
                 return emitter::emitIns_valid_imm_for_alu(immVal, size);
+                break;
+            case GT_JCMP:
+                assert(((parentNode->gtFlags & GTF_JCMP_TST) == 0) ? (immVal == 0) : isPow2(immVal));
+                return true;
                 break;
 #elif defined(_TARGET_ARM_)
             case GT_EQ:

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3554,7 +3554,7 @@ static int ComputeOperandDstCount(GenTree* operand)
         // If an operand has no destination registers but does have source registers, it must be a store
         // or a compare.
         assert(operand->OperIsStore() || operand->OperIsBlkOp() || operand->OperIsPutArgStk() ||
-               operand->OperIsCompare() || operand->OperIs(GT_CMP) || operand->IsSIMDEqualityOrInequality());
+               operand->OperIsCompare() || operand->OperIs(GT_CMP, GT_JCMP) || operand->IsSIMDEqualityOrInequality());
         return 0;
     }
     else if (!operand->OperIsFieldListHead() && (operand->OperIsStore() || operand->TypeGet() == TYP_VOID))

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -10078,6 +10078,21 @@ void LinearScan::handleOutgoingCriticalEdges(BasicBlock* block)
         switchRegs |= genRegMask(op2->gtRegNum);
     }
 
+#ifdef _TARGET_ARM64_
+    // Next, if this blocks ends with a JCMP, we have to make sure not to copy
+    // into the registers that it uses.
+    if (block->bbJumpKind == BBJ_COND)
+    {
+        GenTree* lastNode = LIR::AsRange(block).LastNode();
+
+        if (lastNode->OperIs(GT_JCMP))
+        {
+            GenTree* op1 = lastNode->gtGetOp1();
+            switchRegs |= genRegMask(op1->gtRegNum);
+        }
+    }
+#endif
+
     VarToRegMap sameVarToRegMap = sharedCriticalVarToRegMap;
     regMaskTP   sameWriteRegs   = RBM_NONE;
     regMaskTP   diffReadRegs    = RBM_NONE;

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -10080,7 +10080,8 @@ void LinearScan::handleOutgoingCriticalEdges(BasicBlock* block)
 
 #ifdef _TARGET_ARM64_
     // Next, if this blocks ends with a JCMP, we have to make sure not to copy
-    // into the registers that it uses.
+    // into the register that it uses or modify the local variable it must consume
+    LclVarDsc* jcmpLocalVarDsc = nullptr;
     if (block->bbJumpKind == BBJ_COND)
     {
         GenTree* lastNode = LIR::AsRange(block).LastNode();
@@ -10089,6 +10090,12 @@ void LinearScan::handleOutgoingCriticalEdges(BasicBlock* block)
         {
             GenTree* op1 = lastNode->gtGetOp1();
             switchRegs |= genRegMask(op1->gtRegNum);
+
+            if (op1->IsLocal())
+            {
+                GenTreeLclVarCommon* lcl = op1->AsLclVarCommon();
+                jcmpLocalVarDsc          = &compiler->lvaTable[lcl->gtLclNum];
+            }
         }
     }
 #endif
@@ -10165,6 +10172,13 @@ void LinearScan::handleOutgoingCriticalEdges(BasicBlock* block)
             {
                 sameToReg = REG_NA;
             }
+
+#ifdef _TARGET_ARM64_
+            if (jcmpLocalVarDsc && (jcmpLocalVarDsc->lvVarIndex == outResolutionSetVarIndex))
+            {
+                sameToReg = REG_NA;
+            }
+#endif
 
             // If the var is live only at those blocks connected by a split edge and not live-in at some of the
             // target blocks, we will resolve it the same way as if it were in diffResolutionSet and resolution

--- a/src/jit/lsraarm64.cpp
+++ b/src/jit/lsraarm64.cpp
@@ -354,6 +354,7 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
         case GT_GT:
         case GT_TEST_EQ:
         case GT_TEST_NE:
+        case GT_JCMP:
             TreeNodeInfoInitCmp(tree);
             break;
 

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -922,8 +922,8 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, ArrayStack<G
 #endif // FEATURE_SIMD
 
         default:
-            // CMP, SETCC and JCC nodes should not be present in HIR.
-            assert(!node->OperIs(GT_CMP, GT_SETCC, GT_JCC));
+            // JCMP, CMP, SETCC and JCC nodes should not be present in HIR.
+            assert(!node->OperIs(GT_CMP, GT_SETCC, GT_JCC, GT_JCMP));
             break;
     }
 


### PR DESCRIPTION
Create new node type GT_JCMP to represent a
fused Relop + JTrue which does not set flags

Add lowering code to create GT_JCMP when
Arm64 could use cbz, cbnz, tbz, or tbnz