### PR TITLE
Fixed Linux test build

### DIFF
--- a/build-test.sh
+++ b/build-test.sh
@@ -37,6 +37,10 @@ initTargetDistroRid()
             export __DistroRid="osx-$__BuildArch"
         fi
     fi
+
+   if [ "$ID.$VERSION_ID" == "ubuntu.16.04" ]; then
+     export __DistroRid="ubuntu.14.04-$__BuildArch"
+   fi
 }
 
 isMSBuildOnNETCoreSupported()

--- a/tests/build.proj
+++ b/tests/build.proj
@@ -52,8 +52,8 @@
   </Target>
 
   <Target Name="RestorePackage">
-    <Exec Command="$(DotnetRestoreCommand) $(RestoreProj) $(PackageVersionArg)"
-          StandardOutputImportance="Low" />
+    <Exec Condition="'$(RunningOnCore)' == 'false'" Command="$(DotnetRestoreCommand) $(RestoreProj) $(PackageVersionArg)" StandardOutputImportance="Low" />
+    <Exec Condition="'$(RunningOnCore)' == 'true'"  Command="$(DotnetRestoreCommand) -r $(__DistroRid) $(RestoreProj) $(PackageVersionArg)" StandardOutputImportance="Low" />
   </Target>
 
   <!-- Override RestorePackages from dir.traversal.targets and do a batch restore -->


### PR DESCRIPTION
Fixed error occurred on Linux 
`tests/publishdependency.targets(49,5): error : Your project.json doesn't have a runtimes section. You should add '"runtimes": { "ubuntu.14.04-x64": { } }' to your project.json and then re-run NuGet restore. [tests/runtest.proj]`