### PR TITLE
JIT: have gtClone handle long constants

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -7142,6 +7142,10 @@ GenTreePtr Compiler::gtClone(GenTree* tree, bool complexOK)
             }
             break;
 
+        case GT_CNS_LNG:
+            copy = gtNewLconNode(tree->gtLngCon.gtLconVal);
+            break;
+
         case GT_LCL_VAR:
             // Remember that the LclVar node has been cloned. The flag will be set
             // on 'copy' as well.
@@ -12807,6 +12811,7 @@ GenTree* Compiler::gtOptimizeEnumHasFlag(GenTree* thisOp, GenTree* flagOp)
     if (thisVal->IsIntegralConst())
     {
         thisValOpt = gtClone(thisVal);
+        assert(thisValOpt != nullptr);
     }
     else
     {
@@ -12819,8 +12824,10 @@ GenTree* Compiler::gtOptimizeEnumHasFlag(GenTree* thisOp, GenTree* flagOp)
 
     if (flagVal->IsIntegralConst())
     {
-        flagValOpt     = gtClone(flagVal);
+        flagValOpt = gtClone(flagVal);
+        assert(flagValOpt != nullptr);
         flagValOptCopy = gtClone(flagVal);
+        assert(flagValOptCopy != nullptr);
     }
     else
     {


### PR DESCRIPTION
The `Enum.HasFlag` opt needs to clone the enum values, and they
can be long constants. Make sure `gtClone` handles this case.

Closes #14149.