### PR TITLE
Add the capability to force JIT options on the SPMI command line.

### DIFF
--- a/src/ToolBox/superpmi/superpmi/commandline.cpp
+++ b/src/ToolBox/superpmi/superpmi/commandline.cpp
@@ -119,11 +119,17 @@ void CommandLine::DumpHelp(const char* program)
     printf("     Ignored: neither MSVCDIS nor CoreDisTools is available.\n");
 #endif // USE_COREDISTOOLS
     printf("\n");
+    printf(" -forcejitoption key=value\n");
+    printf("     Set the JIT option named \"key\" to \"value\" for JIT 1. Overwrites the existing value if it was already set. NOTE: do not use a \"COMPlus_\" prefix!\n");
+    printf("\n");
+    printf(" -forcejit2option key=value\n");
+    printf("     Set the JIT option named \"key\" to \"value\" for JIT 2. Overwrites the existing value if it was already set. NOTE: do not use a \"COMPlus_\" prefix!\n");
+    printf("\n");
     printf(" -jitoption key=value\n");
-    printf("     Set the JIT option named \"key\" to \"value\" for JIT 1. NOTE: do not use a \"COMPlus_\" prefix!\n");
+    printf("     Set the JIT option named \"key\" to \"value\" for JIT 1 if the option was not set. NOTE: do not use a \"COMPlus_\" prefix!\n");
     printf("\n");
     printf(" -jit2option key=value\n");
-    printf("     Set the JIT option named \"key\" to \"value\" for JIT 2. NOTE: do not use a \"COMPlus_\" prefix!\n");
+    printf("     Set the JIT option named \"key\" to \"value\" for JIT 2 if the option was not set. NOTE: do not use a \"COMPlus_\" prefix!\n");
     printf("\n");
     printf("Inputs are case sensitive.\n");
     printf("\n");
@@ -519,6 +525,22 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
                 {
                     LogError("Cannot use method context hash in parallel mode.");
                     DumpHelp(argv[0]);
+                    return false;
+                }
+            }
+            else if ((_strnicmp(&argv[i][1], "forcejitoption", argLen) == 0))
+            {
+                i++;
+                if (!AddJitOption(i, argc, argv, &o->forceJitOptions))
+                {
+                    return false;
+                }
+            }
+            else if ((_strnicmp(&argv[i][1], "forcejit2option", argLen) == 0))
+            {
+                i++;
+                if (!AddJitOption(i, argc, argv, &o->forceJit2Options))
+                {
                     return false;
                 }
             }

--- a/src/ToolBox/superpmi/superpmi/commandline.cpp
+++ b/src/ToolBox/superpmi/superpmi/commandline.cpp
@@ -169,10 +169,6 @@ static bool ParseJitOption(const char* optionString, wchar_t** key, wchar_t **va
     tempKey[i] = '\0';
 
     const char* tempVal = &optionString[i + 1];
-    if (tempVal[0] == '\0')
-    {
-        return false;
-    }
 
     const unsigned keyLen = i;
     wchar_t* keyBuf = new wchar_t[keyLen + 1];

--- a/src/ToolBox/superpmi/superpmi/commandline.cpp
+++ b/src/ToolBox/superpmi/superpmi/commandline.cpp
@@ -525,48 +525,19 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
             else if ((_strnicmp(&argv[i][1], "jitoption", argLen) == 0))
             {
                 i++;
-
-                wchar_t *key, *value;
-                if ((i >= argc) || !ParseJitOption(argv[i], &key, &value))
+                if (!AddJitOption(i, argc, argv, &o->jitOptions))
                 {
-                    DumpHelp(argv[0]);
                     return false;
                 }
-
-                if (o->jitOptions == nullptr)
-                {
-                    o->jitOptions = new LightWeightMap<DWORD, DWORD>();
-                }
-
-                DWORD keyIndex = (DWORD)o->jitOptions->AddBuffer((unsigned char*)key, sizeof(wchar_t) * ((unsigned int)wcslen(key) + 1));
-                DWORD valueIndex = (DWORD)o->jitOptions->AddBuffer((unsigned char*)value, sizeof(wchar_t) * ((unsigned int)wcslen(value) + 1));
-                o->jitOptions->Add(keyIndex, valueIndex);
-
-                delete[] key;
-                delete[] value;
             }
             else if ((_strnicmp(&argv[i][1], "jit2option", argLen) == 0))
             {
-                i++;
-
-                wchar_t *key, *value;
-                if ((i >= argc) || !ParseJitOption(argv[i], &key, &value))
+                i++;                
+                if (!AddJitOption(i, argc, argv, &o->jit2Options))
                 {
-                    DumpHelp(argv[0]);
                     return false;
                 }
 
-                if (o->jit2Options == nullptr)
-                {
-                    o->jit2Options = new LightWeightMap<DWORD, DWORD>();
-                }
-
-                DWORD keyIndex = (DWORD)o->jit2Options->AddBuffer((unsigned char*)key, sizeof(wchar_t) * ((unsigned int)wcslen(key) + 1));
-                DWORD valueIndex = (DWORD)o->jit2Options->AddBuffer((unsigned char*)value, sizeof(wchar_t) * ((unsigned int)wcslen(value) + 1));
-                o->jit2Options->Add(keyIndex, valueIndex);
-
-                delete[] key;
-                delete[] value;
             }
             else
             {
@@ -635,5 +606,42 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
         DumpHelp(argv[0]);
         return false;
     }
+    return true;
+}
+
+//-------------------------------------------------------------
+// AddJitOption: Parse the value that was passed with -jitOption flag.
+//
+// Arguments:
+//    currArgument - current argument number. Points to the token next to -jitOption. After the function
+//                   points to the last parsed token
+//    argc         - number of all arguments
+//    argv         - arguments as array of char*
+//    pJitOptions  - a jit options map, to store the new option in.
+//
+// Returns:
+//    False if an error occurred, true if the option was parsed and added.
+bool CommandLine::AddJitOption(int& currArgument, int argc, char* argv[], LightWeightMap<DWORD, DWORD>** pJitOptions)
+{
+    wchar_t *key, *value;
+    if ((currArgument >= argc) || !ParseJitOption(argv[currArgument], &key, &value))
+    {
+        DumpHelp(argv[0]);
+        return false;
+    }
+
+    if (*pJitOptions == nullptr)
+    {
+        *pJitOptions = new LightWeightMap<DWORD, DWORD>();
+    }
+
+    LightWeightMap<DWORD, DWORD>* jitOptions = *pJitOptions;
+
+    DWORD keyIndex = (DWORD)jitOptions->AddBuffer((unsigned char*)key, sizeof(wchar_t) * ((unsigned int)wcslen(key) + 1));
+    DWORD valueIndex = (DWORD)jitOptions->AddBuffer((unsigned char*)value, sizeof(wchar_t) * ((unsigned int)wcslen(value) + 1));
+    jitOptions->Add(keyIndex, valueIndex);
+
+    delete[] key;
+    delete[] value;
     return true;
 }

--- a/src/ToolBox/superpmi/superpmi/commandline.cpp
+++ b/src/ToolBox/superpmi/superpmi/commandline.cpp
@@ -121,11 +121,11 @@ void CommandLine::DumpHelp(const char* program)
     printf("\n");
     printf(" -jitoption [force] key=value\n");
     printf("     Set the JIT option named \"key\" to \"value\" for JIT 1 if the option was not set.");
-    printf("     WIth optional force flag overwrites the existing value if it was already set. NOTE: do not use a \"COMPlus_\" prefix!\n");
+    printf("     With optional force flag overwrites the existing value if it was already set. NOTE: do not use a \"COMPlus_\" prefix!\n");
     printf("\n");
     printf(" -jit2option [force] key=value\n");
     printf("     Set the JIT option named \"key\" to \"value\" for JIT 2 if the option was not set.");
-    printf("     WIth optional force flag overwrites the existing value if it was already set. NOTE: do not use a \"COMPlus_\" prefix!\n");
+    printf("     With optional force flag overwrites the existing value if it was already set. NOTE: do not use a \"COMPlus_\" prefix!\n");
     printf("\n");
     printf("Inputs are case sensitive.\n");
     printf("\n");

--- a/src/ToolBox/superpmi/superpmi/commandline.h
+++ b/src/ToolBox/superpmi/superpmi/commandline.h
@@ -75,6 +75,8 @@ public:
 
     static bool Parse(int argc, char* argv[], /* OUT */ Options* o);
 
+    static bool AddJitOption(int& currArgument, int argc, char* argv[], LightWeightMap<DWORD, DWORD>** pJitOptions);
+
 private:
     static void DumpHelp(const char* program);
 };

--- a/src/ToolBox/superpmi/superpmi/commandline.h
+++ b/src/ToolBox/superpmi/superpmi/commandline.h
@@ -79,7 +79,7 @@ public:
 
     static bool Parse(int argc, char* argv[], /* OUT */ Options* o);
 
-    static bool AddJitOption(int& currArgument, int argc, char* argv[], LightWeightMap<DWORD, DWORD>** pJitOptions);
+    static bool AddJitOption(int& currArgument, int argc, char* argv[], LightWeightMap<DWORD, DWORD>** pJitOptions, LightWeightMap<DWORD, DWORD>** pForceJitOptions);
 
 private:
     static void DumpHelp(const char* program);

--- a/src/ToolBox/superpmi/superpmi/commandline.h
+++ b/src/ToolBox/superpmi/superpmi/commandline.h
@@ -42,6 +42,8 @@ public:
             , compileList(nullptr)
             , offset(-1)
             , increment(-1)
+            , forceJitOptions(nullptr)
+            , forceJit2Options(nullptr)
             , jitOptions(nullptr)
             , jit2Options(nullptr)
         {
@@ -69,6 +71,8 @@ public:
         char* compileList;
         int   offset;
         int   increment;
+        LightWeightMap<DWORD, DWORD>* forceJitOptions;
+        LightWeightMap<DWORD, DWORD>* forceJit2Options;
         LightWeightMap<DWORD, DWORD>* jitOptions;
         LightWeightMap<DWORD, DWORD>* jit2Options;
     };

--- a/src/ToolBox/superpmi/superpmi/jithost.cpp
+++ b/src/ToolBox/superpmi/superpmi/jithost.cpp
@@ -64,7 +64,23 @@ void JitHost::freeMemory(void* block, bool usePageAllocator)
 int JitHost::getIntConfigValue(const wchar_t* key, int defaultValue)
 {
     jitInstance.mc->cr->AddCall("getIntConfigValue");
-    int result = jitInstance.mc->repGetIntConfigValue(key, defaultValue);
+
+    int result = defaultValue;
+
+    const wchar_t* forceValue = jitInstance.getForceOption(key);
+
+    if (forceValue != nullptr)
+    {
+        wchar_t* endPtr;
+        result = static_cast<int>(wcstoul(forceValue, &endPtr, 16));
+        bool succeeded = (errno != ERANGE) && (endPtr != forceValue);
+        if (succeeded)
+        {
+            return result;
+        }
+    }
+
+    result = jitInstance.mc->repGetIntConfigValue(key, defaultValue);
 
     if (result != defaultValue)
     {
@@ -80,12 +96,12 @@ int JitHost::getIntConfigValue(const wchar_t* key, int defaultValue)
     // If the result is the default value, probe the JIT options and then the environment. If a value is found, parse
     // it as a hex integer.
 
-    wchar_t* endPtr;
-    bool     succeeded;
-
     const wchar_t* value = jitInstance.getOption(key);
+
+    bool succeeded;
     if (value != nullptr)
     {
+        wchar_t* endPtr;
         result    = static_cast<int>(wcstoul(value, &endPtr, 16));
         succeeded = (errno != ERANGE) && (endPtr != value);
     }
@@ -96,7 +112,7 @@ int JitHost::getIntConfigValue(const wchar_t* key, int defaultValue)
         {
             return defaultValue;
         }
-
+        wchar_t* endPtr;
         result    = static_cast<int>(wcstoul(complus, &endPtr, 16));
         succeeded = (errno != ERANGE) && (endPtr != complus);
         jitInstance.freeLongLivedArray(complus);
@@ -108,9 +124,18 @@ int JitHost::getIntConfigValue(const wchar_t* key, int defaultValue)
 const wchar_t* JitHost::getStringConfigValue(const wchar_t* key)
 {
     jitInstance.mc->cr->AddCall("getStringConfigValue");
-    const wchar_t* result = jitInstance.mc->repGetStringConfigValue(key);
 
-    // If the result is the default value, probe the JIT options and then the environment.
+    const wchar_t* result = nullptr;
+
+    // First check the force options, then mc value. If value is not presented there, probe the JIT options and then the environment.
+
+    result = jitInstance.getForceOption(key);
+
+    if (result == nullptr)
+    {
+        result = jitInstance.mc->repGetStringConfigValue(key);
+    }
+
     if (result == nullptr)
     {
         result = jitInstance.getOption(key);

--- a/src/ToolBox/superpmi/superpmi/jitinstance.cpp
+++ b/src/ToolBox/superpmi/superpmi/jitinstance.cpp
@@ -12,7 +12,7 @@
 #include "errorhandling.h"
 #include "spmiutil.h"
 
-JitInstance* JitInstance::InitJit(char* nameOfJit, bool breakOnAssert, SimpleTimer* st1, MethodContext* firstContext, LightWeightMap<DWORD, DWORD>* options)
+JitInstance* JitInstance::InitJit(char* nameOfJit, bool breakOnAssert, SimpleTimer* st1, MethodContext* firstContext, LightWeightMap<DWORD, DWORD>* forceOptions, LightWeightMap<DWORD, DWORD>* options)
 {
     JitInstance* jit = new JitInstance();
     if (jit == nullptr)
@@ -20,6 +20,8 @@ JitInstance* JitInstance::InitJit(char* nameOfJit, bool breakOnAssert, SimpleTim
         LogError("Failed to allocate a JitInstance");
         return nullptr;
     }
+
+    jit->forceOptions = forceOptions;
 
     jit->options = options;
 
@@ -399,7 +401,17 @@ void JitInstance::timeResult(CORINFO_METHOD_INFO info, unsigned flags)
 
 /*-------------------------- Misc ---------------------------------------*/
 
+const wchar_t* JitInstance::getForceOption(const wchar_t* key)
+{
+    return getOption(key, forceOptions);
+}
+
 const wchar_t* JitInstance::getOption(const wchar_t* key)
+{
+    return getOption(key, options);
+}
+
+const wchar_t* JitInstance::getOption(const wchar_t* key, LightWeightMap<DWORD, DWORD>* options)
 {
     if (options == nullptr)
     {

--- a/src/ToolBox/superpmi/superpmi/jitinstance.h
+++ b/src/ToolBox/superpmi/superpmi/jitinstance.h
@@ -25,6 +25,7 @@ private:
     ICorJitInfo*   icji;
     SimpleTimer    stj;
 
+    LightWeightMap<DWORD, DWORD>* forceOptions;
     LightWeightMap<DWORD, DWORD>* options;
 
     JitInstance(){};
@@ -43,7 +44,7 @@ public:
     ICorJitCompiler* pJitInstance;
 
     // Allocate and initialize the jit provided
-    static JitInstance* InitJit(char* nameOfJit, bool breakOnAssert, SimpleTimer* st1, MethodContext* firstContext, LightWeightMap<DWORD, DWORD>* options);
+    static JitInstance* InitJit(char* nameOfJit, bool breakOnAssert, SimpleTimer* st1, MethodContext* firstContext, LightWeightMap<DWORD, DWORD>* forceOptions, LightWeightMap<DWORD, DWORD>* options);
 
     HRESULT StartUp(char* PathToJit, bool copyJit, bool breakOnDebugBreakorAV, MethodContext* firstContext);
     bool reLoad(MethodContext* firstContext);
@@ -52,7 +53,9 @@ public:
 
     Result CompileMethod(MethodContext* MethodToCompile, int mcIndex, bool collectThroughput);
 
+    const wchar_t* getForceOption(const wchar_t* key);
     const wchar_t* getOption(const wchar_t* key);
+    const wchar_t* getOption(const wchar_t* key, LightWeightMap<DWORD, DWORD>* options);
 
     void* allocateArray(ULONG size);
     void* allocateLongLivedArray(ULONG size);

--- a/src/ToolBox/superpmi/superpmi/parallelsuperpmi.cpp
+++ b/src/ToolBox/superpmi/superpmi/parallelsuperpmi.cpp
@@ -323,8 +323,31 @@ void MergeWorkerMCLs(char* mclFilename, char** arrWorkerMCLPath, int workerCount
         LogError("Unable to write to MCL file %s.", mclFilename);
 }
 
-// From the arguments that we parsed, construct the arguments to pass to the child processes.
 #define MAX_CMDLINE_SIZE 0x1000 // 4 KB
+
+//-------------------------------------------------------------
+// addJitOptionArgument: Writes jitOption arguments to the argument string for a child spmi process.
+//
+// Arguments:
+//    jitOptions   -   map with options
+//    bytesWritten -   size of the argument string in bytes
+//    spmiArgs     -   pointer to the argument string
+//    optionName   -   the jitOption name.
+//
+void addJitOptionArgument(LightWeightMap<DWORD, DWORD>* jitOptions, int &bytesWritten, char * spmiArgs, const char* optionName)
+{
+    if (jitOptions != nullptr)
+    {
+        for (unsigned i = 0; i < jitOptions->GetCount(); i++)
+        {
+            wchar_t* key = (wchar_t*)jitOptions->GetBuffer(jitOptions->GetKey(i));
+            wchar_t* value = (wchar_t*)jitOptions->GetBuffer(jitOptions->GetItem(i));
+            bytesWritten += sprintf_s(spmiArgs + bytesWritten, MAX_CMDLINE_SIZE - bytesWritten, " -%s %S=%S", optionName, key, value);
+        }
+    }
+}
+
+// From the arguments that we parsed, construct the arguments to pass to the child processes.
 char* ConstructChildProcessArgs(const CommandLine::Options& o)
 {
     int   bytesWritten = 0;
@@ -361,25 +384,9 @@ char* ConstructChildProcessArgs(const CommandLine::Options& o)
     ADDARG_STRING(o.targetArchitecture, "-target");
     ADDARG_STRING(o.compileList, "-compile");
 
-    if (o.jitOptions != nullptr)
-    {
-        for (unsigned i = 0; i < o.jitOptions->GetCount(); i++)
-        {
-            wchar_t* key = (wchar_t*)o.jitOptions->GetBuffer(o.jitOptions->GetKey(i));
-            wchar_t* value = (wchar_t*)o.jitOptions->GetBuffer(o.jitOptions->GetItem(i));
-            bytesWritten += sprintf_s(spmiArgs + bytesWritten, MAX_CMDLINE_SIZE - bytesWritten, " -jitoption %S=%S", key, value);
-        }
-    }
+    addJitOptionArgument(o.jitOptions, bytesWritten, spmiArgs, "jitoption");
 
-    if (o.jit2Options != nullptr)
-    {
-        for (unsigned i = 0; i < o.jit2Options->GetCount(); i++)
-        {
-            wchar_t* key = (wchar_t*)o.jit2Options->GetBuffer(o.jit2Options->GetKey(i));
-            wchar_t* value = (wchar_t*)o.jit2Options->GetBuffer(o.jit2Options->GetItem(i));
-            bytesWritten += sprintf_s(spmiArgs + bytesWritten, MAX_CMDLINE_SIZE - bytesWritten, " -jit2option %S=%S", key, value);
-        }
-    }
+    addJitOptionArgument(o.jit2Options, bytesWritten, spmiArgs, "jit2option");
 
     ADDSTRING(o.nameOfJit);
     ADDSTRING(o.nameOfJit2);

--- a/src/ToolBox/superpmi/superpmi/parallelsuperpmi.cpp
+++ b/src/ToolBox/superpmi/superpmi/parallelsuperpmi.cpp
@@ -332,7 +332,7 @@ void MergeWorkerMCLs(char* mclFilename, char** arrWorkerMCLPath, int workerCount
 //    jitOptions   -   map with options
 //    bytesWritten -   size of the argument string in bytes
 //    spmiArgs     -   pointer to the argument string
-//    optionName   -   the jitOption name.
+//    optionName   -   the jitOption name, can include [force] flag.
 //
 void addJitOptionArgument(LightWeightMap<DWORD, DWORD>* jitOptions, int &bytesWritten, char * spmiArgs, const char* optionName)
 {
@@ -384,8 +384,8 @@ char* ConstructChildProcessArgs(const CommandLine::Options& o)
     ADDARG_STRING(o.targetArchitecture, "-target");
     ADDARG_STRING(o.compileList, "-compile");
 
-    addJitOptionArgument(o.forceJitOptions, bytesWritten, spmiArgs, "forcejitoption");
-    addJitOptionArgument(o.forceJit2Options, bytesWritten, spmiArgs, "forcejit2option");
+    addJitOptionArgument(o.forceJitOptions, bytesWritten, spmiArgs, "jitoption force");
+    addJitOptionArgument(o.forceJit2Options, bytesWritten, spmiArgs, "jit2option force");
 
     addJitOptionArgument(o.jitOptions, bytesWritten, spmiArgs, "jitoption");
     addJitOptionArgument(o.jit2Options, bytesWritten, spmiArgs, "jit2option");

--- a/src/ToolBox/superpmi/superpmi/parallelsuperpmi.cpp
+++ b/src/ToolBox/superpmi/superpmi/parallelsuperpmi.cpp
@@ -384,8 +384,10 @@ char* ConstructChildProcessArgs(const CommandLine::Options& o)
     ADDARG_STRING(o.targetArchitecture, "-target");
     ADDARG_STRING(o.compileList, "-compile");
 
-    addJitOptionArgument(o.jitOptions, bytesWritten, spmiArgs, "jitoption");
+    addJitOptionArgument(o.forceJitOptions, bytesWritten, spmiArgs, "forcejitoption");
+    addJitOptionArgument(o.forceJit2Options, bytesWritten, spmiArgs, "forcejit2option");
 
+    addJitOptionArgument(o.jitOptions, bytesWritten, spmiArgs, "jitoption");
     addJitOptionArgument(o.jit2Options, bytesWritten, spmiArgs, "jit2option");
 
     ADDSTRING(o.nameOfJit);

--- a/src/ToolBox/superpmi/superpmi/superpmi.cpp
+++ b/src/ToolBox/superpmi/superpmi/superpmi.cpp
@@ -287,7 +287,7 @@ int __cdecl main(int argc, char* argv[])
         {
             SimpleTimer stInitJit;
 
-            jit = JitInstance::InitJit(o.nameOfJit, o.breakOnAssert, &stInitJit, mc, o.jitOptions);
+            jit = JitInstance::InitJit(o.nameOfJit, o.breakOnAssert, &stInitJit, mc, o.forceJitOptions, o.jitOptions);
             if (jit == nullptr)
             {
                 // InitJit already printed a failure message
@@ -296,7 +296,7 @@ int __cdecl main(int argc, char* argv[])
 
             if (o.nameOfJit2 != nullptr)
             {
-                jit2 = JitInstance::InitJit(o.nameOfJit2, o.breakOnAssert, &stInitJit, mc, o.jit2Options);
+                jit2 = JitInstance::InitJit(o.nameOfJit2, o.breakOnAssert, &stInitJit, mc, o.forceJit2Options, o.jit2Options);
                 if (jit2 == nullptr)
                 {
                     // InitJit already printed a failure message


### PR DESCRIPTION
Allows to rewrite options that were set during the collection.
For example:
`-forcejitoption NgenDump=*` will print all methods even if `NgenDump` was used during the collection.
Also, it allows to fix spmi diff by erasing `AltJit` and `AltJitNgen` for the diff, before we teach primary jit to print asm dump if it is set as altJit.

The first two commits do not introduce changes.