### PR TITLE
[x86/Linux] Use VI tag instead of VV

### DIFF
--- a/src/classlibnative/float/floatdouble.cpp
+++ b/src/classlibnative/float/floatdouble.cpp
@@ -162,7 +162,7 @@ FCIMPLEND
 /*=====================================ModF=====================================
 **
 ==============================================================================*/
-FCIMPL2_VV(double, COMDouble::ModF, double x, double* intptr)
+FCIMPL2_VI(double, COMDouble::ModF, double x, double* intptr)
     FCALL_CONTRACT;
 
     return (double)modf(x, intptr);

--- a/src/classlibnative/float/floatsingle.cpp
+++ b/src/classlibnative/float/floatsingle.cpp
@@ -160,7 +160,7 @@ FCIMPLEND
 /*=====================================ModF=====================================
 **
 ==============================================================================*/
-FCIMPL2_VV(float, COMSingle::ModF, float x, float* intptr)
+FCIMPL2_VI(float, COMSingle::ModF, float x, float* intptr)
     FCALL_CONTRACT;
 
     return (float)modff(x, intptr);

--- a/src/classlibnative/inc/floatdouble.h
+++ b/src/classlibnative/inc/floatdouble.h
@@ -23,7 +23,7 @@ public:
     FCDECL2_VV(static double, FMod, double x, double y);
     FCDECL1_V(static double, Log, double x);
     FCDECL1_V(static double, Log10, double x);
-    FCDECL2_VV(static double, ModF, double x, double* intptr);
+    FCDECL2_VI(static double, ModF, double x, double* intptr);
     FCDECL2_VV(static double, Pow, double x, double y);
     FCDECL1_V(static double, Sin, double x);
     FCDECL1_V(static double, Sinh, double x);

--- a/src/classlibnative/inc/floatsingle.h
+++ b/src/classlibnative/inc/floatsingle.h
@@ -23,7 +23,7 @@ public:
     FCDECL2_VV(static float, FMod, float x, float y);
     FCDECL1_V(static float, Log, float x);
     FCDECL1_V(static float, Log10, float x);
-    FCDECL2_VV(static float, ModF, float x, float* intptr);
+    FCDECL2_VI(static float, ModF, float x, float* intptr);
     FCDECL2_VV(static float, Pow, float x, float y);
     FCDECL1_V(static float, Sin, float x);
     FCDECL1_V(static float, Sinh, float x);


### PR DESCRIPTION
COMSingle::ModF/COMDouble::ModF passes a pointer (which should be treated as a integer value) as 2nd argument, but are declared with _VV tag.