### PR TITLE
Improve Monitor scaling

### DIFF
--- a/src/debug/daccess/request.cpp
+++ b/src/debug/daccess/request.cpp
@@ -3726,7 +3726,7 @@ ClrDataAccess::GetSyncBlockData(unsigned int SBNumber, struct DacpSyncBlockData 
             }
 #endif // FEATURE_COMINTEROP
 
-            pSyncBlockData->MonitorHeld = pBlock->m_Monitor.m_MonitorHeld;
+            pSyncBlockData->MonitorHeld = pBlock->m_Monitor.m_lockState.VolatileLoad().GetMonitorHeldState();
             pSyncBlockData->Recursion = pBlock->m_Monitor.m_Recursion;
             pSyncBlockData->HoldingThread = HOST_CDADDR(pBlock->m_Monitor.m_HoldingThread);
 

--- a/src/debug/daccess/request.cpp
+++ b/src/debug/daccess/request.cpp
@@ -3726,9 +3726,9 @@ ClrDataAccess::GetSyncBlockData(unsigned int SBNumber, struct DacpSyncBlockData 
             }
 #endif // FEATURE_COMINTEROP
 
-            pSyncBlockData->MonitorHeld = pBlock->m_Monitor.m_lockState.VolatileLoad().GetMonitorHeldState();
-            pSyncBlockData->Recursion = pBlock->m_Monitor.m_Recursion;
-            pSyncBlockData->HoldingThread = HOST_CDADDR(pBlock->m_Monitor.m_HoldingThread);
+            pSyncBlockData->MonitorHeld = pBlock->m_Monitor.GetMonitorHeldStateVolatile();
+            pSyncBlockData->Recursion = pBlock->m_Monitor.GetRecursionLevel();
+            pSyncBlockData->HoldingThread = HOST_CDADDR(pBlock->m_Monitor.GetHoldingThread());
 
             if (pBlock->GetAppDomainIndex().m_dwIndex)
             {

--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -657,6 +657,7 @@ RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_SpinLimitProcCap, W("SpinLimitProcCap"), 0x
 RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_SpinLimitProcFactor, W("SpinLimitProcFactor"), 0x4E20, "Hex value specifying the multiplier on NumProcs to use when calculating the maximum spin duration", EEConfig_default)
 RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_SpinLimitConstant, W("SpinLimitConstant"), 0x0, "Hex value specifying the constant to add when calculating the maximum spin duration", EEConfig_default)
 RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_SpinRetryCount, W("SpinRetryCount"), 0xA, "Hex value specifying the number of times the entire spin process is repeated (when applicable)", EEConfig_default)
+RETAIL_CONFIG_DWORD_INFO_EX(INTERNAL_Monitor_SpinCount, W("Monitor_SpinCount"), 0x1e, "Hex value specifying the maximum number of spin iterations Monitor may perform upon contention on acquiring the lock before waiting.", EEConfig_default)
 
 // 
 // Native Binder

--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -656,7 +656,7 @@ RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_SpinBackoffFactor, W("SpinBackoffFactor"), 
 RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_SpinLimitProcCap, W("SpinLimitProcCap"), 0xFFFFFFFF, "Hex value specifying the largest value of NumProcs to use when calculating the maximum spin duration", EEConfig_default)
 RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_SpinLimitProcFactor, W("SpinLimitProcFactor"), 0x4E20, "Hex value specifying the multiplier on NumProcs to use when calculating the maximum spin duration", EEConfig_default)
 RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_SpinLimitConstant, W("SpinLimitConstant"), 0x0, "Hex value specifying the constant to add when calculating the maximum spin duration", EEConfig_default)
-RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_SpinRetryCount, W("SpinRetryCount"), 0x0, "Hex value specifying the number of times the entire spin process is repeated (when applicable)", EEConfig_default)
+RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_SpinRetryCount, W("SpinRetryCount"), 0xA, "Hex value specifying the number of times the entire spin process is repeated (when applicable)", EEConfig_default)
 
 // 
 // Native Binder

--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -656,7 +656,7 @@ RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_SpinBackoffFactor, W("SpinBackoffFactor"), 
 RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_SpinLimitProcCap, W("SpinLimitProcCap"), 0xFFFFFFFF, "Hex value specifying the largest value of NumProcs to use when calculating the maximum spin duration", EEConfig_default)
 RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_SpinLimitProcFactor, W("SpinLimitProcFactor"), 0x4E20, "Hex value specifying the multiplier on NumProcs to use when calculating the maximum spin duration", EEConfig_default)
 RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_SpinLimitConstant, W("SpinLimitConstant"), 0x0, "Hex value specifying the constant to add when calculating the maximum spin duration", EEConfig_default)
-RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_SpinRetryCount, W("SpinRetryCount"), 0xA, "Hex value specifying the number of times the entire spin process is repeated (when applicable)", EEConfig_default)
+RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_SpinRetryCount, W("SpinRetryCount"), 0x0, "Hex value specifying the number of times the entire spin process is repeated (when applicable)", EEConfig_default)
 
 // 
 // Native Binder

--- a/src/inc/utilcode.h
+++ b/src/inc/utilcode.h
@@ -5515,6 +5515,7 @@ struct SpinConstants
     DWORD dwMaximumDuration;
     DWORD dwBackoffFactor;
     DWORD dwRepetitions;
+    DWORD dwMonitorSpinCount;
 };
 
 extern SpinConstants g_SpinConstants;

--- a/src/utilcode/utsem.cpp
+++ b/src/utilcode/utsem.cpp
@@ -79,7 +79,8 @@ SpinConstants g_SpinConstants = {
     50,        // dwInitialDuration 
     40000,     // dwMaximumDuration - ideally (20000 * max(2, numProc)) ... updated in code:InitializeSpinConstants_NoHost
     3,         // dwBackoffFactor
-    10         // dwRepetitions
+    10,        // dwRepetitions
+    0          // dwMonitorSpinCount
 };
 
 inline void InitializeSpinConstants_NoHost()

--- a/src/vm/amd64/asmconstants.h
+++ b/src/vm/amd64/asmconstants.h
@@ -190,22 +190,6 @@ ASMCONSTANT_OFFSETOF_ASSERT(DelegateObject, _methodPtr);
 #define           OFFSETOF__DelegateObject___target         0x08
 ASMCONSTANT_OFFSETOF_ASSERT(DelegateObject, _target);
 
-#define               OFFSETOF__g_SystemInfo__dwNumberOfProcessors  0x20
-ASMCONSTANTS_C_ASSERT(OFFSETOF__g_SystemInfo__dwNumberOfProcessors
-                    == offsetof(SYSTEM_INFO, dwNumberOfProcessors));
-
-#define               OFFSETOF__g_SpinConstants__dwInitialDuration  0x0
-ASMCONSTANTS_C_ASSERT(OFFSETOF__g_SpinConstants__dwInitialDuration
-                    == offsetof(SpinConstants, dwInitialDuration));
-
-#define               OFFSETOF__g_SpinConstants__dwMaximumDuration  0x4
-ASMCONSTANTS_C_ASSERT(OFFSETOF__g_SpinConstants__dwMaximumDuration
-                    == offsetof(SpinConstants, dwMaximumDuration));
-
-#define               OFFSETOF__g_SpinConstants__dwBackoffFactor  0x8
-ASMCONSTANTS_C_ASSERT(OFFSETOF__g_SpinConstants__dwBackoffFactor
-                    == offsetof(SpinConstants, dwBackoffFactor));
-
 #define               OFFSETOF__MethodTable__m_dwFlags              0x00
 ASMCONSTANTS_C_ASSERT(OFFSETOF__MethodTable__m_dwFlags
                     == offsetof(MethodTable, m_dwFlags));

--- a/src/vm/eeconfig.cpp
+++ b/src/vm/eeconfig.cpp
@@ -1013,7 +1013,15 @@ HRESULT EEConfig::sync()
 #endif
 
     dwSpinInitialDuration = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_SpinInitialDuration);
+    if (dwSpinInitialDuration < 1)
+    {
+        dwSpinInitialDuration = 1;
+    }
     dwSpinBackoffFactor = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_SpinBackoffFactor);
+    if (dwSpinBackoffFactor < 2)
+    {
+        dwSpinBackoffFactor = 2;
+    }
     dwSpinLimitProcCap = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_SpinLimitProcCap);
     dwSpinLimitProcFactor = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_SpinLimitProcFactor);
     dwSpinLimitConstant = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_SpinLimitConstant);

--- a/src/vm/eeconfig.cpp
+++ b/src/vm/eeconfig.cpp
@@ -212,6 +212,7 @@ HRESULT EEConfig::Init()
     dwSpinLimitProcFactor = 0x4E20;
     dwSpinLimitConstant = 0x0;
     dwSpinRetryCount = 0xA;
+    dwMonitorSpinCount = 0;
 
     iJitOptimizeType = OPT_DEFAULT;
     fJitFramed = false;
@@ -1026,6 +1027,7 @@ HRESULT EEConfig::sync()
     dwSpinLimitProcFactor = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_SpinLimitProcFactor);
     dwSpinLimitConstant = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_SpinLimitConstant);
     dwSpinRetryCount = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_SpinRetryCount);
+    dwMonitorSpinCount = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_Monitor_SpinCount);
 
     fJitFramed = (GetConfigDWORD_DontUse_(CLRConfig::UNSUPPORTED_JitFramed, fJitFramed) != 0);
     fJitAlignLoops = (GetConfigDWORD_DontUse_(CLRConfig::UNSUPPORTED_JitAlignLoops, fJitAlignLoops) != 0);

--- a/src/vm/eeconfig.h
+++ b/src/vm/eeconfig.h
@@ -272,6 +272,7 @@ public:
     DWORD         SpinLimitProcFactor(void)       const {LIMITED_METHOD_CONTRACT;  return dwSpinLimitProcFactor; }
     DWORD         SpinLimitConstant(void)         const {LIMITED_METHOD_CONTRACT;  return dwSpinLimitConstant; }
     DWORD         SpinRetryCount(void)            const {LIMITED_METHOD_CONTRACT;  return dwSpinRetryCount; }
+    DWORD         MonitorSpinCount(void)          const {LIMITED_METHOD_CONTRACT;  return dwMonitorSpinCount; }
 
     // Jit-config
     
@@ -978,6 +979,7 @@ private: //----------------------------------------------------------------
     DWORD dwSpinLimitProcFactor;
     DWORD dwSpinLimitConstant;
     DWORD dwSpinRetryCount;
+    DWORD dwMonitorSpinCount;
 
 #ifdef VERIFY_HEAP
     int  iGCHeapVerify;

--- a/src/vm/i386/asmconstants.h
+++ b/src/vm/i386/asmconstants.h
@@ -65,20 +65,6 @@ ASMCONSTANTS_C_ASSERT(CONTEXT_Eip == offsetof(CONTEXT,Eip))
 #define CONTEXT_Esp 0xc4
 ASMCONSTANTS_C_ASSERT(CONTEXT_Esp == offsetof(CONTEXT,Esp))
 
-// SYSTEM_INFO from rotor_pal.h
-#define SYSTEM_INFO_dwNumberOfProcessors 20 
-ASMCONSTANTS_C_ASSERT(SYSTEM_INFO_dwNumberOfProcessors == offsetof(SYSTEM_INFO,dwNumberOfProcessors))
-
-// SpinConstants from clr/src/vars.h
-#define SpinConstants_dwInitialDuration 0 
-ASMCONSTANTS_C_ASSERT(SpinConstants_dwInitialDuration == offsetof(SpinConstants,dwInitialDuration))
-
-#define SpinConstants_dwMaximumDuration 4 
-ASMCONSTANTS_C_ASSERT(SpinConstants_dwMaximumDuration == offsetof(SpinConstants,dwMaximumDuration))
-
-#define SpinConstants_dwBackoffFactor 8
-ASMCONSTANTS_C_ASSERT(SpinConstants_dwBackoffFactor == offsetof(SpinConstants,dwBackoffFactor))
-
 #ifndef WIN64EXCEPTIONS
 // EHContext from clr/src/vm/i386/cgencpu.h
 #define EHContext_Eax 0x00

--- a/src/vm/interpreter.cpp
+++ b/src/vm/interpreter.cpp
@@ -1756,7 +1756,7 @@ static void MonitorEnter(Object* obj, BYTE* pbLockTaken)
         GET_THREAD()->PulseGCMode();
     }
     objRef->EnterObjMonitor();
-    _ASSERTE ((objRef->GetSyncBlock()->GetMonitor()->m_Recursion == 1 && pThread->m_dwLockCount == lockCount + 1) ||
+    _ASSERTE ((objRef->GetSyncBlock()->GetMonitor()->GetRecursionLevel() == 1 && pThread->m_dwLockCount == lockCount + 1) ||
               pThread->m_dwLockCount == lockCount);
     if (pbLockTaken != 0) *pbLockTaken = 1;
 

--- a/src/vm/jithelpers.cpp
+++ b/src/vm/jithelpers.cpp
@@ -4416,7 +4416,7 @@ NOINLINE static void JIT_MonEnter_Helper(Object* obj, BYTE* pbLockTaken, LPVOID 
         GET_THREAD()->PulseGCMode();
     }
     objRef->EnterObjMonitor();
-    _ASSERTE ((objRef->GetSyncBlock()->GetMonitor()->m_Recursion == 1 && pThread->m_dwLockCount == lockCount + 1) ||
+    _ASSERTE ((objRef->GetSyncBlock()->GetMonitor()->GetRecursionLevel() == 1 && pThread->m_dwLockCount == lockCount + 1) ||
               pThread->m_dwLockCount == lockCount);
     if (pbLockTaken != 0) *pbLockTaken = 1;
 

--- a/src/vm/jithelpers.cpp
+++ b/src/vm/jithelpers.cpp
@@ -4432,39 +4432,13 @@ NOINLINE static void JIT_MonEnter_Helper(Object* obj, BYTE* pbLockTaken, LPVOID 
 HCIMPL_MONHELPER(JIT_MonEnterWorker_Portable, Object* obj)
 {
     FCALL_CONTRACT;
-    
-    AwareLock::EnterHelperResult result;
-    Thread * pCurThread;
 
-    if (obj == NULL)
-    {
-        goto FramedLockHelper;
-    }
-
-    pCurThread = GetThread();
-
-    if (pCurThread->CatchAtSafePointOpportunistic()) 
-    {
-        goto FramedLockHelper;
-    }
-
-    result = obj->EnterObjMonitorHelper(pCurThread);
-    if (result == AwareLock::EnterHelperResult_Entered)
+    if (obj != nullptr && obj->TryEnterObjMonitorSpinHelper())
     {
         MONHELPER_STATE(*pbLockTaken = 1);
         return;
     }
-    if (result == AwareLock::EnterHelperResult_Contention)
-    {
-        result = obj->EnterObjMonitorHelperSpin(pCurThread);
-        if (result == AwareLock::EnterHelperResult_Entered)
-        {
-            MONHELPER_STATE(*pbLockTaken = 1);
-            return;
-        }
-    }
 
-FramedLockHelper:
     FC_INNER_RETURN_VOID(JIT_MonEnter_Helper(obj, MONHELPER_ARG, GetEEFuncEntryPointMacro(JIT_MonEnter)));
 }
 HCIMPLEND
@@ -4473,36 +4447,11 @@ HCIMPL1(void, JIT_MonEnter_Portable, Object* obj)
 {
     FCALL_CONTRACT;
 
-    Thread * pCurThread;
-    AwareLock::EnterHelperResult result;
-    
-    if (obj == NULL)
-    {
-        goto FramedLockHelper;
-    }
-
-    pCurThread = GetThread();
-
-    if (pCurThread->CatchAtSafePointOpportunistic()) 
-    {
-        goto FramedLockHelper;
-    }
-
-    result = obj->EnterObjMonitorHelper(pCurThread);
-    if (result == AwareLock::EnterHelperResult_Entered)
+    if (obj != nullptr && obj->TryEnterObjMonitorSpinHelper())
     {
         return;
     }
-    if (result == AwareLock::EnterHelperResult_Contention)
-    {
-        result = obj->EnterObjMonitorHelperSpin(pCurThread);
-        if (result == AwareLock::EnterHelperResult_Entered)
-        {
-            return;
-        }
-    }
 
-FramedLockHelper:
     FC_INNER_RETURN_VOID(JIT_MonEnter_Helper(obj, NULL, GetEEFuncEntryPointMacro(JIT_MonEnter)));
 }
 HCIMPLEND
@@ -4511,38 +4460,12 @@ HCIMPL2(void, JIT_MonReliableEnter_Portable, Object* obj, BYTE* pbLockTaken)
 {
     FCALL_CONTRACT;
 
-    Thread * pCurThread;
-    AwareLock::EnterHelperResult result;
-    
-    if (obj == NULL)
-    {
-        goto FramedLockHelper;
-    }
-
-    pCurThread = GetThread();
-
-    if (pCurThread->CatchAtSafePointOpportunistic()) 
-    {
-        goto FramedLockHelper;
-    }
-
-    result = obj->EnterObjMonitorHelper(pCurThread);
-    if (result == AwareLock::EnterHelperResult_Entered)
+    if (obj != nullptr && obj->TryEnterObjMonitorSpinHelper())
     {
         *pbLockTaken = 1;
         return;
     }
-    if (result == AwareLock::EnterHelperResult_Contention)
-    {
-        result = obj->EnterObjMonitorHelperSpin(pCurThread);
-        if (result == AwareLock::EnterHelperResult_Entered)
-        {
-            *pbLockTaken = 1;
-            return;
-        }
-    }
 
-FramedLockHelper:
     FC_INNER_RETURN_VOID(JIT_MonEnter_Helper(obj, pbLockTaken, GetEEFuncEntryPointMacro(JIT_MonReliableEnter)));
 }
 HCIMPLEND

--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -497,6 +497,8 @@ class Object
         return GetHeader()->TryEnterObjMonitor(timeOut);
     }
 
+    bool TryEnterObjMonitorSpinHelper();
+
     FORCEINLINE AwareLock::EnterHelperResult EnterObjMonitorHelper(Thread* pCurThread)
     {
         WRAPPER_NO_CONTRACT;

--- a/src/vm/syncblk.cpp
+++ b/src/vm/syncblk.cpp
@@ -3097,6 +3097,12 @@ BOOL AwareLock::EnterEpilogHelper(Thread* pCurThread, INT32 timeOut)
     STATIC_CONTRACT_MODE_COOPERATIVE;
     STATIC_CONTRACT_GC_TRIGGERS;
 
+    // IMPORTANT!!!
+    // The caller has already registered a waiter. This function needs to unregister the waiter on all paths (exception paths
+    // included). On runtimes where thread-abort is supported, a thread-abort also needs to unregister the waiter. There may be
+    // a possibility for preemptive GC toggles below to handle a thread-abort, that should be taken into consideration when
+    // porting this code back to .NET Framework.
+
     // Require all callers to be in cooperative mode.  If they have switched to preemptive
     // mode temporarily before calling here, then they are responsible for protecting
     // the object associated with this lock.

--- a/src/vm/syncblk.cpp
+++ b/src/vm/syncblk.cpp
@@ -2157,7 +2157,7 @@ BOOL ObjHeader::GetThreadOwningMonitorLock(DWORD *pThreadId, DWORD *pAcquisition
             SyncBlock* psb = g_pSyncTable[(int)index].m_SyncBlock;
 
             _ASSERTE(psb->GetMonitor() != NULL);
-            Thread* pThread = psb->GetMonitor()->m_HoldingThread;
+            Thread* pThread = psb->GetMonitor()->GetHoldingThread();
             if(pThread == NULL)
             {
                 *pThreadId = 0;
@@ -2167,7 +2167,7 @@ BOOL ObjHeader::GetThreadOwningMonitorLock(DWORD *pThreadId, DWORD *pAcquisition
             else
             {
                 *pThreadId = pThread->GetThreadId();
-                *pAcquisitionCount = psb->GetMonitor()->m_Recursion;
+                *pAcquisitionCount = psb->GetMonitor()->GetRecursionLevel();
                 return TRUE;
             }
         }
@@ -2774,8 +2774,7 @@ SyncBlock *ObjHeader::GetSyncBlock()
                                 // The lock is orphaned.
                                 pThread = (Thread*) -1;
                             }
-                            syncBlock->InitState();
-                            syncBlock->SetAwareLock(pThread, recursionLevel + 1);
+                            syncBlock->InitState(recursionLevel + 1, pThread);
                         }
                     }
                     else if ((bits & BIT_SBLK_IS_HASHCODE) != 0)

--- a/src/vm/syncblk.cpp
+++ b/src/vm/syncblk.cpp
@@ -1917,8 +1917,12 @@ AwareLock::EnterHelperResult ObjHeader::EnterObjMonitorHelperSpin(Thread* pCurTh
         return AwareLock::EnterHelperResult_Contention;
     }
 
-    for (DWORD spinCount = g_SpinConstants.dwInitialDuration; AwareLock::SpinWaitAndBackOffBeforeOperation(&spinCount);)
+    DWORD maxSpinCount = g_SpinConstants.dwMaximumDuration;
+    DWORD backoffFactor = g_SpinConstants.dwBackoffFactor;
+    for (DWORD spinCount = g_SpinConstants.dwInitialDuration; spinCount <= maxSpinCount; spinCount *= backoffFactor)
     {
+        AwareLock::SpinWait(spinCount);
+
         LONG oldValue = m_SyncBlockValue.LoadWithoutBarrier();
 
         // Since spinning has begun, chances are good that the monitor has already switched to AwareLock mode, so check for that
@@ -1931,21 +1935,40 @@ AwareLock::EnterHelperResult ObjHeader::EnterObjMonitorHelperSpin(Thread* pCurTh
                 return AwareLock::EnterHelperResult_UseSlowPath;
             }
 
-            // Check the recursive case once before the spin loop. If it's not the recursive case in the beginning, it will not
-            // be in the future, so the spin loop can avoid checking the recursive case.
             SyncBlock *syncBlock = g_pSyncTable[oldValue & MASK_SYNCBLOCKINDEX].m_SyncBlock;
             _ASSERTE(syncBlock != NULL);
             AwareLock *awareLock = &syncBlock->m_Monitor;
-            if (awareLock->EnterHelper(pCurThread, true /* checkRecursiveCase */))
+
+            AwareLock::EnterHelperResult result = awareLock->TryEnterBeforeSpinLoopHelper(pCurThread);
+            if (result != AwareLock::EnterHelperResult_Contention)
+            {
+                return result;
+            }
+
+            spinCount *= backoffFactor;
+            if (spinCount <= maxSpinCount)
+            {
+                while (true)
+                {
+                    AwareLock::SpinWait(spinCount);
+
+                    spinCount *= backoffFactor;
+                    if (spinCount > maxSpinCount)
+                    {
+                        // The last lock attempt for this spin will be done after the loop
+                        break;
+                    }
+
+                    if (awareLock->TryEnterInsideSpinLoopHelper(pCurThread))
+                    {
+                        return AwareLock::EnterHelperResult_Entered;
+                    }
+                }
+            }
+
+            if (awareLock->TryEnterAfterSpinLoopHelper(pCurThread))
             {
                 return AwareLock::EnterHelperResult_Entered;
-            }
-            while (AwareLock::SpinWaitAndBackOffBeforeOperation(&spinCount))
-            {
-                if (awareLock->EnterHelper(pCurThread, false /* checkRecursiveCase */))
-                {
-                    return AwareLock::EnterHelperResult_Entered;
-                }
             }
             break;
         }
@@ -2917,73 +2940,45 @@ void AwareLock::Enter()
     }
     CONTRACTL_END;
 
-    Thread  *pCurThread = GetThread();
-
-    for (;;) 
+    Thread *pCurThread = GetThread();
+    LockState state = m_lockState;
+    if (!state.IsLocked() || m_HoldingThread != pCurThread)
     {
-        // Read existing lock state.
-        LONG state = m_MonitorHeld.LoadWithoutBarrier();
-
-        if (state == 0) 
+        if (m_lockState.InterlockedTryLock_Or_RegisterWaiter(state))
         {
-            // Common case: lock not held, no waiters. Attempt to acquire lock by
-            // switching lock bit.
-            if (FastInterlockCompareExchange((LONG*)&m_MonitorHeld, 1, 0) == 0)
-            {
-                break;
-            }
-        } 
-        else 
-        {
-            // It's possible to get here with waiters but no lock held, but in this
-            // case a signal is about to be fired which will wake up a waiter. So
-            // for fairness sake we should wait too.
-            // Check first for recursive lock attempts on the same thread.
-            if (m_HoldingThread == pCurThread)
-            {    
-                goto Recursion;
-            }
-
-            // Attempt to increment this count of waiters then goto contention
-            // handling code.
-            if (FastInterlockCompareExchange((LONG*)&m_MonitorHeld, (state + 2), state) == state)
-            {
-                 goto MustWait;
-            }
-        }
-    }
-
-    // We get here if we successfully acquired the mutex.
-    m_HoldingThread = pCurThread;
-    m_Recursion = 1;
-    pCurThread->IncLockCount();
+            // We get here if we successfully acquired the mutex.
+            m_HoldingThread = pCurThread;
+            m_Recursion = 1;
+            pCurThread->IncLockCount();
 
 #if defined(_DEBUG) && defined(TRACK_SYNC)
-    {
-        // The best place to grab this is from the ECall frame
-        Frame   *pFrame = pCurThread->GetFrame();
-        int      caller = (pFrame && pFrame != FRAME_TOP
-                            ? (int) pFrame->GetReturnAddress()
-                            : -1);
-        pCurThread->m_pTrackSync->EnterSync(caller, this);
-    }
+            // The best place to grab this is from the ECall frame
+            Frame   *pFrame = pCurThread->GetFrame();
+            int      caller = (pFrame && pFrame != FRAME_TOP
+                                ? (int)pFrame->GetReturnAddress()
+                                : -1);
+            pCurThread->m_pTrackSync->EnterSync(caller, this);
 #endif
+            return;
+        }
 
-    return;
+        // Lock was not acquired and the waiter was registered
 
-MustWait:
-    // Didn't manage to get the mutex, must wait.
-    EnterEpilog(pCurThread);
-    return;
+        // Didn't manage to get the mutex, must wait.
+        // The precondition for EnterEpilog is that the count of waiters be bumped
+        // to account for this thread, which was done above.
+        EnterEpilog(pCurThread);
+        return;
+    }
 
-Recursion:
     // Got the mutex via recursive locking on the same thread.
     _ASSERTE(m_Recursion >= 1);
     m_Recursion++;
+
 #if defined(_DEBUG) && defined(TRACK_SYNC)
     // The best place to grab this is from the ECall frame
     Frame   *pFrame = pCurThread->GetFrame();
-    int      caller = (pFrame && pFrame != FRAME_TOP ? (int) pFrame->GetReturnAddress() : -1);
+    int      caller = (pFrame && pFrame != FRAME_TOP ? (int)pFrame->GetReturnAddress() : -1);
     pCurThread->m_pTrackSync->EnterSync(caller, this);
 #endif
 }
@@ -3000,123 +2995,58 @@ BOOL AwareLock::TryEnter(INT32 timeOut)
     }
     CONTRACTL_END;
 
-    if (timeOut != 0)
-    {
-        LARGE_INTEGER qpFrequency, qpcStart, qpcEnd;
-        BOOL canUseHighRes = QueryPerformanceCounter(&qpcStart);
-
-        // try some more busy waiting
-        if (Contention(timeOut))
-            return TRUE;
-
-        DWORD elapsed = 0;
-        if (canUseHighRes && QueryPerformanceCounter(&qpcEnd) && QueryPerformanceFrequency(&qpFrequency))
-            elapsed = (DWORD)((qpcEnd.QuadPart-qpcStart.QuadPart)/(qpFrequency.QuadPart/1000));
-
-        if (elapsed >= (DWORD)timeOut)
-            return FALSE;
-
-        if (timeOut != (INT32)INFINITE)
-            timeOut -= elapsed;
-    }
-
     Thread  *pCurThread = GetThread();
-    TESTHOOKCALL(AppDomainCanBeUnloaded(pCurThread->GetDomain()->GetId().m_dwId,FALSE));    
+    TESTHOOKCALL(AppDomainCanBeUnloaded(pCurThread->GetDomain()->GetId().m_dwId, FALSE));
 
-    if (pCurThread->IsAbortRequested()) 
+    if (pCurThread->IsAbortRequested())
     {
         pCurThread->HandleThreadAbort();
     }
 
-retry:
-
-    for (;;) {
-
-        // Read existing lock state.
-        LONG state = m_MonitorHeld.LoadWithoutBarrier();
-
-        if (state == 0) 
+    LockState state = m_lockState;
+    if (!state.IsLocked() || m_HoldingThread != pCurThread)
+    {
+        if (timeOut == 0
+                ? m_lockState.InterlockedTryLock(state)
+                : m_lockState.InterlockedTryLock_Or_RegisterWaiter(state))
         {
-            // Common case: lock not held, no waiters. Attempt to acquire lock by
-            // switching lock bit.
-            if (FastInterlockCompareExchange((LONG*)&m_MonitorHeld, 1, 0) == 0)
-            {
-                break;
-            } 
-        }
-        else 
-        {
-            // It's possible to get here with waiters but no lock held, but in this
-            // case a signal is about to be fired which will wake up a waiter. So
-            // for fairness sake we should wait too.
-            // Check first for recursive lock attempts on the same thread.
-            if (m_HoldingThread == pCurThread)
-            {
-                goto Recursion;
-            }
-            else
-            {
-                goto WouldBlock;
-            }
-        }
-    }
-
-    // We get here if we successfully acquired the mutex.
-    m_HoldingThread = pCurThread;
-    m_Recursion = 1;
-    pCurThread->IncLockCount();
+            // We get here if we successfully acquired the mutex.
+            m_HoldingThread = pCurThread;
+            m_Recursion = 1;
+            pCurThread->IncLockCount();
 
 #if defined(_DEBUG) && defined(TRACK_SYNC)
-    {
-        // The best place to grab this is from the ECall frame
-        Frame   *pFrame = pCurThread->GetFrame();
-        int      caller = (pFrame && pFrame != FRAME_TOP ? (int) pFrame->GetReturnAddress() : -1);
-        pCurThread->m_pTrackSync->EnterSync(caller, this);
-    }
+            // The best place to grab this is from the ECall frame
+            Frame   *pFrame = pCurThread->GetFrame();
+            int      caller = (pFrame && pFrame != FRAME_TOP ? (int)pFrame->GetReturnAddress() : -1);
+            pCurThread->m_pTrackSync->EnterSync(caller, this);
 #endif
-
-    return TRUE;
-
-WouldBlock:
-    // Didn't manage to get the mutex, return failure if no timeout, else wait
-    // for at most timeout milliseconds for the mutex.
-    if (!timeOut)
-    {
-        return FALSE;
-    }
-
-    // The precondition for EnterEpilog is that the count of waiters be bumped
-    // to account for this thread
-
-    for (;;)
-    {
-        // Read existing lock state.
-        LONG state = m_MonitorHeld.LoadWithoutBarrier();
-
-        if (state == 0)
-        {
-            goto retry;
+            return true;
         }
 
-        if (FastInterlockCompareExchange((LONG*)&m_MonitorHeld, (state + 2), state) == state)
+        // Lock was not acquired and the waiter was registered if the timeout is nonzero
+
+        // Didn't manage to get the mutex, return failure if no timeout, else wait
+        // for at most timeout milliseconds for the mutex.
+        if (timeOut == 0)
         {
-            break;
+            return false;
         }
+
+        // The precondition for EnterEpilog is that the count of waiters be bumped
+        // to account for this thread, which was done above
+        return EnterEpilog(pCurThread, timeOut);
     }
 
-    return EnterEpilog(pCurThread, timeOut);
-
-Recursion:
     // Got the mutex via recursive locking on the same thread.
     _ASSERTE(m_Recursion >= 1);
     m_Recursion++;
 #if defined(_DEBUG) && defined(TRACK_SYNC)
     // The best place to grab this is from the ECall frame
     Frame   *pFrame = pCurThread->GetFrame();
-    int      caller = (pFrame && pFrame != FRAME_TOP ? (int) pFrame->GetReturnAddress() : -1);
+    int      caller = (pFrame && pFrame != FRAME_TOP ? (int)pFrame->GetReturnAddress() : -1);
     pCurThread->m_pTrackSync->EnterSync(caller, this);
 #endif
-
     return true;
 }
 
@@ -3146,21 +3076,17 @@ BOOL AwareLock::EnterEpilogHelper(Thread* pCurThread, INT32 timeOut)
     STATIC_CONTRACT_MODE_COOPERATIVE;
     STATIC_CONTRACT_GC_TRIGGERS;
 
-    DWORD ret = 0;
-    BOOL finished = false;
-
     // Require all callers to be in cooperative mode.  If they have switched to preemptive
     // mode temporarily before calling here, then they are responsible for protecting
     // the object associated with this lock.
     _ASSERTE(pCurThread->PreemptiveGCDisabled());
 
-
-
-    OBJECTREF    obj = GetOwningObject();
+    OBJECTREF obj = GetOwningObject();
 
     // We cannot allow the AwareLock to be cleaned up underneath us by the GC.
     IncrementTransientPrecious();
 
+    DWORD ret;
     GCPROTECT_BEGIN(obj);
     {
         if (!m_SemEvent.IsMonitorEventAllocated())
@@ -3183,103 +3109,113 @@ BOOL AwareLock::EnterEpilogHelper(Thread* pCurThread, INT32 timeOut)
             } param;
             param.pThis = this;
             param.timeOut = timeOut;
-            param.ret = ret;
+
+            // Measure the time we wait so that, in the case where we wake up
+            // and fail to acquire the mutex, we can adjust remaining timeout
+            // accordingly.
+            ULONGLONG start = CLRGetTickCount64();
 
             EE_TRY_FOR_FINALLY(Param *, pParam, &param)
             {
-                // Measure the time we wait so that, in the case where we wake up
-                // and fail to acquire the mutex, we can adjust remaining timeout
-                // accordingly.
-                ULONGLONG start = CLRGetTickCount64();
-
                 pParam->ret = pParam->pThis->m_SemEvent.Wait(pParam->timeOut, TRUE);
                 _ASSERTE((pParam->ret == WAIT_OBJECT_0) || (pParam->ret == WAIT_TIMEOUT));
-
-                // When calculating duration we consider a couple of special cases.
-                // If the end tick is the same as the start tick we make the
-                // duration a millisecond, to ensure we make forward progress if
-                // there's a lot of contention on the mutex. Secondly, we have to
-                // cope with the case where the tick counter wrapped while we where
-                // waiting (we can cope with at most one wrap, so don't expect three
-                // month timeouts to be very accurate). Luckily for us, the latter
-                // case is taken care of by 32-bit modulo arithmetic automatically.
-
-                if (pParam->timeOut != (INT32) INFINITE)
-                {
-                    ULONGLONG end = CLRGetTickCount64();
-                    ULONGLONG duration;
-                    if (end == start)
-                    {
-                        duration = 1;
-                    }
-                    else
-                    {
-                        duration = end - start;
-                    }
-                    duration = min(duration, (DWORD)pParam->timeOut);
-                    pParam->timeOut -= (INT32)duration;
-                }
             }
             EE_FINALLY
             {
                 if (GOT_EXCEPTION())
                 {
-                    // We must decrement the waiter count.
-                    for (;;)
-                    {
-                        LONG state = m_MonitorHeld.LoadWithoutBarrier();
-                        _ASSERTE((state >> 1) != 0);
-                        if (FastInterlockCompareExchange((LONG*)&m_MonitorHeld, state - 2, state) == state)
-                        {
-                            break;
-                        }
-                    }
+                    // It is likely the case that An APC threw an exception, for instance Thread.Interrupt(). The wait subsystem
+                    // guarantees that if a signal to the event being waited upon is observed by the woken thread, that thread's
+                    // wait will return WAIT_OBJECT_0. So in any race between m_SemEvent being signaled and the wait throwing an
+                    // exception, a thread that is woken by an exception would not observe the signal, and the signal would wake
+                    // another thread as necessary.
 
-                    // And signal the next waiter, else they'll wait forever.
-                    m_SemEvent.Set();
+                    // We must decrement the waiter count.
+                    m_lockState.InterlockedUnregisterWaiter();
                 }
             } EE_END_FINALLY;
 
             ret = param.ret;
-
-            if (ret == WAIT_OBJECT_0)
-            {
-                // Attempt to acquire lock (this also involves decrementing the waiter count).
-                for (;;) 
-                {
-                    LONG state = m_MonitorHeld.LoadWithoutBarrier();
-                    _ASSERTE(((size_t)state >> 1) != 0);
-
-                    if ((size_t)state & 1)
-                    {
-                        break;
-                    }
-
-                    if (FastInterlockCompareExchange((LONG*)&m_MonitorHeld, ((state - 2) | 1), state) == state)
-                    {
-                        finished = true;
-                        break;
-                    }
-                }
-            }
-            else
+            if (ret != WAIT_OBJECT_0)
             {
                 // We timed out, decrement waiter count.
-                for (;;) 
+                m_lockState.InterlockedUnregisterWaiter();
+                break;
+            }
+
+            if (m_lockState.InterlockedTry_LockAndUnregisterWaiterAndObserveWakeSignal())
+            {
+                break;
+            }
+
+            // Spin a bit while trying to acquire the lock. This has a few benefits:
+            // - Spinning helps to reduce waiter starvation. Since other non-waiter threads can take the lock while there are
+            //   waiters (see LockState::InterlockedTryLock()), once a waiter wakes it will be able to better compete
+            //   with other spinners for the lock.
+            // - If there is another thread that is repeatedly acquiring and releasing the lock, spinning before waiting again
+            //   helps to prevent a waiter from repeatedly context-switching in and out
+            // - Further in the same situation above, waking up and waiting shortly thereafter deprioritizes this waiter because
+            //   events release waiters in FIFO order. Spinning a bit helps a waiter to retain its priority at least for one
+            //   spin duration before it gets deprioritized behind all other waiters.
+            if (g_SystemInfo.dwNumberOfProcessors > 1)
+            {
+                DWORD maxSpinCount = g_SpinConstants.dwMaximumDuration;
+                DWORD spinCount = g_SpinConstants.dwInitialDuration;
+                if (spinCount <= maxSpinCount)
                 {
-                    LONG state = m_MonitorHeld.LoadWithoutBarrier();
-                    _ASSERTE((state >> 1) != 0);
-                    if (FastInterlockCompareExchange((LONG*)&m_MonitorHeld, state - 2, state) == state)
+                    bool acquiredLock = false;
+                    DWORD backoffFactor = g_SpinConstants.dwBackoffFactor;
+                    while (true)
                     {
-                        finished = true;
+                        SpinWait(spinCount);
+
+                        spinCount *= backoffFactor;
+                        if (spinCount > maxSpinCount)
+                        {
+                            // The last lock attempt for this spin will be done after the loop
+                            break;
+                        }
+
+                        if (m_lockState.InterlockedTry_LockAndUnregisterWaiterAndObserveWakeSignal())
+                        {
+                            acquiredLock = true;
+                            break;
+                        }
+                    }
+                    if (acquiredLock)
+                    {
                         break;
                     }
                 }
+
+                if (m_lockState.InterlockedObserveWakeSignal_Try_LockAndUnregisterWaiter())
+                {
+                    break;
+                }
             }
 
-            if (finished)
+            // When calculating duration we consider a couple of special cases.
+            // If the end tick is the same as the start tick we make the
+            // duration a millisecond, to ensure we make forward progress if
+            // there's a lot of contention on the mutex. Secondly, we have to
+            // cope with the case where the tick counter wrapped while we where
+            // waiting (we can cope with at most one wrap, so don't expect three
+            // month timeouts to be very accurate). Luckily for us, the latter
+            // case is taken care of by 32-bit modulo arithmetic automatically.
+            if (timeOut != (INT32)INFINITE)
             {
-                break;
+                ULONGLONG end = CLRGetTickCount64();
+                ULONGLONG duration;
+                if (end == start)
+                {
+                    duration = 1;
+                }
+                else
+                {
+                    duration = end - start;
+                }
+                duration = min(duration, (DWORD)timeOut);
+                timeOut -= (INT32)duration;
             }
         }
 
@@ -3290,7 +3226,7 @@ BOOL AwareLock::EnterEpilogHelper(Thread* pCurThread, INT32 timeOut)
 
     if (ret == WAIT_TIMEOUT)
     {
-        return FALSE;
+        return false;
     }
 
     m_HoldingThread = pCurThread;
@@ -3300,11 +3236,10 @@ BOOL AwareLock::EnterEpilogHelper(Thread* pCurThread, INT32 timeOut)
 #if defined(_DEBUG) && defined(TRACK_SYNC)
     // The best place to grab this is from the ECall frame
     Frame   *pFrame = pCurThread->GetFrame();
-    int      caller = (pFrame && pFrame != FRAME_TOP ? (int) pFrame->GetReturnAddress() : -1);
+    int      caller = (pFrame && pFrame != FRAME_TOP ? (int)pFrame->GetReturnAddress() : -1);
     pCurThread->m_pTrackSync->EnterSync(caller, this);
 #endif
-
-    return (ret != WAIT_TIMEOUT);
+    return true;
 }
 
 
@@ -3337,155 +3272,6 @@ BOOL AwareLock::Leave()
         _ASSERTE(action == AwareLock::LeaveHelperAction_Error);
         return FALSE;
     }
-}
-
-#ifdef _DEBUG
-#define _LOGCONTENTION
-#endif // _DEBUG
-
-#ifdef  _LOGCONTENTION
-inline void LogContention()
-{
-    WRAPPER_NO_CONTRACT;
-#ifdef LOGGING
-    if (LoggingOn(LF_SYNC, LL_INFO100))
-    {
-        LogSpewAlways("Contention: Stack Trace Begin\n");
-        void LogStackTrace();
-        LogStackTrace();
-        LogSpewAlways("Contention: Stack Trace End\n");
-    }
-#endif
-}
-#else
-#define LogContention()
-#endif
-
-
-
-bool AwareLock::Contention(INT32 timeOut)
-{
-    CONTRACTL
-    {
-        INSTANCE_CHECK;
-        THROWS;
-        GC_TRIGGERS;
-        MODE_ANY;
-        INJECT_FAULT(COMPlusThrowOM(););
-    }
-    CONTRACTL_END;
-
-    DWORD startTime = 0;
-    if (timeOut != (INT32)INFINITE)
-        startTime = GetTickCount();
-
-    COUNTER_ONLY(GetPerfCounters().m_LocksAndThreads.cContention++);
-
-
-    LogContention();
-    Thread      *pCurThread = GetThread();
-    OBJECTREF    obj = GetOwningObject();
-    bool    bEntered = false;
-    bool   bKeepGoing = true;
-
-    // We cannot allow the AwareLock to be cleaned up underneath us by the GC.
-    IncrementTransientPrecious();
-
-    GCPROTECT_BEGIN(obj);
-    {
-        GCX_PREEMP();
-
-        // Try spinning and yielding before eventually blocking.
-        // The limit of 10 is largely arbitrary - feel free to tune if you have evidence
-        // you're making things better  
-        for (DWORD iter = 0; iter < g_SpinConstants.dwRepetitions && bKeepGoing; iter++)
-        {
-            DWORD i = g_SpinConstants.dwInitialDuration;
-
-            do
-            {
-                if (TryEnter())
-                {
-                    bEntered = true;
-                    goto entered;
-                }
-
-                if (g_SystemInfo.dwNumberOfProcessors <= 1)
-                {
-                    bKeepGoing = false;
-                    break;
-                }
-
-                if (timeOut != (INT32)INFINITE && GetTickCount() - startTime >= (DWORD)timeOut)
-                {
-                    bKeepGoing = false;
-                    break;
-                }
-                
-                // Spin for i iterations, and make sure to never go more than 20000 iterations between
-                // checking if we should SwitchToThread
-                int remainingDelay = i;
-
-                while (remainingDelay > 0)
-                {
-                    int currentDelay = min(remainingDelay, 20000);
-                    remainingDelay -= currentDelay;
-
-                    // Delay by approximately 2*currentDelay clock cycles (Pentium III).
-
-                    // This is brittle code - future processors may of course execute this
-                    // faster or slower, and future code generators may eliminate the loop altogether.
-                    // The precise value of the delay is not critical, however, and I can't think
-                    // of a better way that isn't machine-dependent. 
-                    for (int delayCount = currentDelay; (--delayCount != 0); )
-                    {
-                        YieldProcessor();           // indicate to the processor that we are spining
-                    }
-
-                    // TryEnter will not take the lock if it has waiters.  This means we should not spin
-                    // for long periods without giving the waiters a chance to run, since we won't
-                    // make progress until they run and they may be waiting for our CPU.  So once
-                    // we're spinning >20000 iterations, check every 20000 iterations if there are
-                    // waiters and if so call SwitchToThread.
-                    //
-                    // Since this only affects the spinning heuristic, calling HasWaiters now
-                    // and getting a dirty read is fine.  Note that it is important that TryEnter 
-                    // not take the lock because we could easily starve waiting threads.  
-                    // They make only one attempt before going back to sleep, and spinners on 
-                    // other CPUs would likely get the lock.  We could fix this by allowing a 
-                    // woken thread to become a spinner again, at which point there are no 
-                    // starvation concerns and TryEnter can take the lock.
-                    if (remainingDelay > 0 && HasWaiters())
-                    {
-                        __SwitchToThread(0, CALLER_LIMITS_SPINNING);
-                    }
-                }
-
-                // exponential backoff: wait a factor longer in the next iteration
-                i *= g_SpinConstants.dwBackoffFactor;
-            }
-            while (i < g_SpinConstants.dwMaximumDuration);
-
-            {
-                GCX_COOP();
-                pCurThread->HandleThreadAbort();
-            }
-
-            __SwitchToThread(0, CALLER_LIMITS_SPINNING);
-        }
-entered: ;
-    }
-    GCPROTECT_END();
-    // we are in co-operative mode so no need to keep this set
-    DecrementTransientPrecious();
-    if (!bEntered && timeOut == (INT32)INFINITE)
-    {
-        // We've tried hard to enter - we need to eventually block to avoid wasting too much cpu
-        // time.
-        Enter();
-        bEntered = TRUE;
-    }
-    return bEntered;
 }
 
 

--- a/src/vm/syncblk.h
+++ b/src/vm/syncblk.h
@@ -438,7 +438,7 @@ private:
 
     DWORD m_waiterStarvationStartTimeMs;
 
-    static const DWORD WaiterStarvationDurationMsBeforeStoppingPreemptingWaiters = 1000;
+    static const DWORD WaiterStarvationDurationMsBeforeStoppingPreemptingWaiters = 100;
 
     // Only SyncBlocks can create AwareLocks.  Hence this private constructor.
     AwareLock(DWORD indx)

--- a/src/vm/syncblk.h
+++ b/src/vm/syncblk.h
@@ -231,7 +231,7 @@ public:
             //   bit 0: 1 if locked, 0 otherwise
             //   bits 1-31: waiter count
             UINT32 state = m_state;
-            return (state & IsLockedMask) + (state >> (WaiterCountShift - 1));
+            return (state & IsLockedMask) + (state >> WaiterCountShift << 1);
         }
 
     public:

--- a/src/vm/syncblk.h
+++ b/src/vm/syncblk.h
@@ -277,7 +277,7 @@ private:
         }
 
     private:
-        bool IncrementSpinnerCount()
+        bool TryIncrementSpinnerCount()
         {
             WRAPPER_NO_CONTRACT;
 

--- a/src/vm/syncblk.h
+++ b/src/vm/syncblk.h
@@ -448,7 +448,8 @@ private:
           m_HoldingThread(NULL),
 #endif // DACCESS_COMPILE          
           m_TransientPrecious(0),
-          m_dwSyncIndex(indx)
+          m_dwSyncIndex(indx),
+          m_waiterStarvationStartTimeMs(0)
     {
         LIMITED_METHOD_CONTRACT;
     }

--- a/src/vm/syncblk.inl
+++ b/src/vm/syncblk.inl
@@ -90,7 +90,7 @@ FORCEINLINE AwareLock::EnterHelperResult AwareLock::LockState::InterlockedTry_Lo
         {
             newState.InvertIsLocked();
         }
-        else if (!newState.IncrementSpinnerCount())
+        else if (!newState.TryIncrementSpinnerCount())
         {
             return EnterHelperResult_UseSlowPath;
         }

--- a/src/vm/syncblk.inl
+++ b/src/vm/syncblk.inl
@@ -148,7 +148,8 @@ FORCEINLINE bool AwareLock::LockState::InterlockedUnregisterSpinner_TryLock()
         return false;
     }
 
-    LockState state = stateBeforeUpdate - SpinnerCountIncrement;
+    LockState state = stateBeforeUpdate;
+    state.DecrementSpinnerCount();
     _ASSERTE(!state.IsLocked());
     do
     {
@@ -218,8 +219,8 @@ FORCEINLINE bool AwareLock::LockState::InterlockedTry_LockAndUnregisterWaiterAnd
 
         LockState newState = state;
         newState.InvertIsLocked();
-        newState.DecrementWaiterCount();
         newState.InvertIsWaiterSignaledToWake();
+        newState.DecrementWaiterCount();
 
         LockState stateBeforeUpdate = CompareExchange(newState, state);
         if (stateBeforeUpdate == state)
@@ -247,7 +248,8 @@ FORCEINLINE bool AwareLock::LockState::InterlockedObserveWakeSignal_Try_LockAndU
         return false;
     }
 
-    LockState state = stateBeforeUpdate - IsWaiterSignaledToWakeMask;
+    LockState state = stateBeforeUpdate;
+    state.InvertIsWaiterSignaledToWake();
     _ASSERTE(!state.IsLocked());
     do
     {

--- a/src/vm/syncblk.inl
+++ b/src/vm/syncblk.inl
@@ -8,34 +8,280 @@
 
 #ifndef DACCESS_COMPILE
 
-FORCEINLINE bool AwareLock::SpinWaitAndBackOffBeforeOperation(DWORD *spinCountRef)
+FORCEINLINE bool AwareLock::LockState::InterlockedTryLock()
 {
-    CONTRACTL{
-        SO_TOLERANT;
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_COOPERATIVE;
-    } CONTRACTL_END;
+    WRAPPER_NO_CONTRACT;
+    return InterlockedTryLock(*this);
+}
 
-    _ASSERTE(spinCountRef != nullptr);
-    DWORD &spinCount = *spinCountRef;
-    _ASSERTE(g_SystemInfo.dwNumberOfProcessors != 1);
+FORCEINLINE bool AwareLock::LockState::InterlockedTryLock(LockState state)
+{
+    WRAPPER_NO_CONTRACT;
 
-    if (spinCount > g_SpinConstants.dwMaximumDuration)
+    // The monitor is fair to release waiters in FIFO order, but allows non-waiters to acquire the lock if it's available to
+    // avoid lock convoys.
+    //
+    // Lock convoys can be detrimental to performance in scenarios where work is being done on multiple threads and the work
+    // involves periodically taking a particular lock for a short time to access shared resources. With a lock convoy, once
+    // there is a waiter for the lock (which is not uncommon in such scenarios), a worker thread would be forced to
+    // context-switch on the subsequent attempt to acquire the lock, often long before the worker thread exhausts its time
+    // slice. This process repeats as long as the lock has a waiter, forcing every worker to context-switch on each attempt to
+    // acquire the lock, killing performance and creating a negative feedback loop that makes it more likely for the lock to
+    // have waiters. To avoid the lock convoy, each worker needs to be allowed to acquire the lock multiple times in sequence
+    // despite there being a waiter for the lock in order to have the worker continue working efficiently during its time slice
+    // as long as the lock is not contended.
+    //
+    // This scheme has the possibility to starve waiters, but that would only happen if the lock is taken very frequently or if
+    // it is heavily contended. Neither of these issues is common, and they typically indicate issues with lock usage in the
+    // app, which the app may have to fix. For example, lock is held for too long, lock does not remain released for long
+    // enough, lock is acquired and released too frequently, too many threads, etc.
+    if (!state.IsLocked())
+    {
+        LockState newState = state;
+        newState.InvertIsLocked();
+
+        return CompareExchangeAcquire(newState, state) == state;
+    }
+    return false;
+}
+
+FORCEINLINE bool AwareLock::LockState::InterlockedUnlock()
+{
+    WRAPPER_NO_CONTRACT;
+    static_assert_no_msg(IsLockedMask == 1);
+    _ASSERTE(IsLocked());
+
+    LockState state = InterlockedDecrementRelease((LONG *)&m_state);
+    while (true)
+    {
+        // Keep track of whether a thread has been signaled to wake but has not yet woken from the wait.
+        // IsWaiterSignaledToWakeMask is cleared when a signaled thread wakes up by observing a signal. Since threads can
+        // preempt waiting threads and acquire the lock (see InterlockedTryLock()), it allows for example, one thread to acquire
+        // and release the lock multiple times while there are multiple waiting threads. In such a case, we don't want that
+        // thread to signal a waiter every time it releases the lock, as that will cause unnecessary context switches with more
+        // and more signaled threads waking up, finding that the lock is still locked, and going right back into a wait state.
+        // So, signal only one waiting thread at a time.
+        if (!state.NeedToSignalWaiter())
+        {
+            return false;
+        }
+
+        LockState newState = state;
+        newState.InvertIsWaiterSignaledToWake();
+
+        LockState stateBeforeUpdate = CompareExchange(newState, state);
+        if (stateBeforeUpdate == state)
+        {
+            return true;
+        }
+
+        state = stateBeforeUpdate;
+    }
+}
+
+FORCEINLINE AwareLock::EnterHelperResult AwareLock::LockState::InterlockedTry_LockOrRegisterSpinner(LockState state)
+{
+    WRAPPER_NO_CONTRACT;
+
+    while (true)
+    {
+        LockState newState = state;
+        if (!state.IsLocked())
+        {
+            newState.InvertIsLocked();
+        }
+        else if (!newState.IncrementSpinnerCount())
+        {
+            return EnterHelperResult_UseSlowPath;
+        }
+
+        LockState stateBeforeUpdate = CompareExchange(newState, state);
+        if (stateBeforeUpdate == state)
+        {
+            return !state.IsLocked() ? EnterHelperResult_Entered : EnterHelperResult_Contention;
+        }
+
+        state = stateBeforeUpdate;
+    }
+}
+
+FORCEINLINE bool AwareLock::LockState::InterlockedTry_LockAndUnregisterSpinner()
+{
+    WRAPPER_NO_CONTRACT;
+
+    // This function is called from inside a spin loop, it must unregister the spinner if and only if the lock is acquired
+    LockState state = *this;
+    while (true)
+    {
+        _ASSERTE(state.HasAnySpinners());
+        if (state.IsLocked())
+        {
+            return false;
+        }
+
+        LockState newState = state;
+        newState.InvertIsLocked();
+        newState.DecrementSpinnerCount();
+
+        LockState stateBeforeUpdate = CompareExchange(newState, state);
+        if (stateBeforeUpdate == state)
+        {
+            return true;
+        }
+
+        state = stateBeforeUpdate;
+    }
+}
+
+FORCEINLINE bool AwareLock::LockState::InterlockedUnregisterSpinner_TryLock()
+{
+    WRAPPER_NO_CONTRACT;
+
+    // This function is called at the end of a spin loop, it must unregister the spinner always and acquire the lock if it's
+    // available. If the lock is available, a spinner must acquire the lock along with unregistering itself, because a lock
+    // releaser does not wake a waiter when there is a spinner registered.
+
+    LockState stateBeforeUpdate = InterlockedExchangeAdd((LONG *)&m_state, -(LONG)SpinnerCountIncrement);
+    _ASSERTE(stateBeforeUpdate.HasAnySpinners());
+    if (stateBeforeUpdate.IsLocked())
     {
         return false;
     }
 
-    for (DWORD i = 0; i < spinCount; i++)
+    LockState state = stateBeforeUpdate - SpinnerCountIncrement;
+    _ASSERTE(!state.IsLocked());
+    do
     {
-        YieldProcessor();
-    }
+        LockState newState = state;
+        newState.InvertIsLocked();
 
-    spinCount *= g_SpinConstants.dwBackoffFactor;
-    return true;
+        LockState stateBeforeUpdate = CompareExchangeAcquire(newState, state);
+        if (stateBeforeUpdate == state)
+        {
+            return true;
+        }
+
+        state = stateBeforeUpdate;
+    } while (!state.IsLocked());
+    return false;
 }
 
-FORCEINLINE bool AwareLock::EnterHelper(Thread* pCurThread, bool checkRecursiveCase)
+FORCEINLINE bool AwareLock::LockState::InterlockedTryLock_Or_RegisterWaiter(LockState state)
+{
+    WRAPPER_NO_CONTRACT;
+
+    while (true)
+    {
+        LockState newState = state;
+        if (!state.IsLocked())
+        {
+            newState.InvertIsLocked();
+        }
+        else
+        {
+            newState.IncrementWaiterCount();
+        }
+
+        LockState stateBeforeUpdate = CompareExchange(newState, state);
+        if (stateBeforeUpdate == state)
+        {
+            return !state.IsLocked();
+        }
+
+        state = stateBeforeUpdate;
+    }
+}
+
+FORCEINLINE void AwareLock::LockState::InterlockedUnregisterWaiter()
+{
+    WRAPPER_NO_CONTRACT;
+
+    LockState stateBeforeUpdate = InterlockedExchangeAdd((LONG *)&m_state, -(LONG)WaiterCountIncrement);
+    _ASSERTE(stateBeforeUpdate.HasAnyWaiters());
+}
+
+FORCEINLINE bool AwareLock::LockState::InterlockedTry_LockAndUnregisterWaiterAndObserveWakeSignal()
+{
+    WRAPPER_NO_CONTRACT;
+
+    // This function is called from the waiter's spin loop and should observe the wake signal only if the lock is taken, to
+    // prevent a lock releaser from waking another waiter while one is already spinning to acquire the lock
+    LockState state = *this;
+    while (true)
+    {
+        _ASSERTE(state.HasAnyWaiters());
+        _ASSERTE(state.IsWaiterSignaledToWake());
+        if (state.IsLocked())
+        {
+            return false;
+        }
+
+        LockState newState = state;
+        newState.InvertIsLocked();
+        newState.DecrementWaiterCount();
+        newState.InvertIsWaiterSignaledToWake();
+
+        LockState stateBeforeUpdate = CompareExchange(newState, state);
+        if (stateBeforeUpdate == state)
+        {
+            return true;
+        }
+
+        state = stateBeforeUpdate;
+    }
+}
+
+FORCEINLINE bool AwareLock::LockState::InterlockedObserveWakeSignal_Try_LockAndUnregisterWaiter()
+{
+    WRAPPER_NO_CONTRACT;
+
+    // This function is called at the end of the waiter's spin loop. It must observe the wake signal always, and if the lock is
+    // available, it must acquire the lock and unregister the waiter. If the lock is available, a waiter must acquire the lock
+    // along with observing the wake signal, because a lock releaser does not wake a waiter when a waiter was signaled but the
+    // wake signal has not been observed.
+
+    LockState stateBeforeUpdate = InterlockedExchangeAdd((LONG *)&m_state, -(LONG)IsWaiterSignaledToWakeMask);
+    _ASSERTE(stateBeforeUpdate.IsWaiterSignaledToWake());
+    if (stateBeforeUpdate.IsLocked())
+    {
+        return false;
+    }
+
+    LockState state = stateBeforeUpdate - IsWaiterSignaledToWakeMask;
+    _ASSERTE(!state.IsLocked());
+    do
+    {
+        _ASSERTE(state.HasAnyWaiters());
+        LockState newState = state;
+        newState.InvertIsLocked();
+        newState.DecrementWaiterCount();
+
+        LockState stateBeforeUpdate = CompareExchange(newState, state);
+        if (stateBeforeUpdate == state)
+        {
+            return true;
+        }
+
+        state = stateBeforeUpdate;
+    } while (!state.IsLocked());
+    return false;
+}
+
+FORCEINLINE void AwareLock::SpinWait(DWORD spinCount)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    _ASSERTE(g_SystemInfo.dwNumberOfProcessors != 1);
+    _ASSERTE(spinCount != 0);
+    _ASSERTE(spinCount <= g_SpinConstants.dwMaximumDuration);
+
+    do
+    {
+        YieldProcessor();
+    } while (--spinCount != 0);
+}
+
+FORCEINLINE bool AwareLock::TryEnterHelper(Thread* pCurThread)
 {
     CONTRACTL{
         SO_TOLERANT;
@@ -44,23 +290,104 @@ FORCEINLINE bool AwareLock::EnterHelper(Thread* pCurThread, bool checkRecursiveC
         MODE_ANY;
     } CONTRACTL_END;
 
-    LONG state = m_MonitorHeld.LoadWithoutBarrier();
-    if (state == 0)
+    if (m_lockState.InterlockedTryLock())
     {
-        if (InterlockedCompareExchangeAcquire((LONG*)&m_MonitorHeld, 1, 0) == 0)
-        {
-            m_HoldingThread = pCurThread;
-            m_Recursion = 1;
-            pCurThread->IncLockCount();
-            return true;
-        }
+        m_HoldingThread = pCurThread;
+        m_Recursion = 1;
+        pCurThread->IncLockCount();
+        return true;
     }
-    else if (checkRecursiveCase && GetOwningThread() == pCurThread) /* monitor is held, but it could be a recursive case */
+
+    if (GetOwningThread() == pCurThread) /* monitor is held, but it could be a recursive case */
     {
         m_Recursion++;
         return true;
     }
     return false;
+}
+
+FORCEINLINE AwareLock::EnterHelperResult AwareLock::TryEnterBeforeSpinLoopHelper(Thread *pCurThread)
+{
+    CONTRACTL{
+        SO_TOLERANT;
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
+    } CONTRACTL_END;
+
+    LockState state = m_lockState;
+
+    // Check the recursive case once before the spin loop. If it's not the recursive case in the beginning, it will not
+    // be in the future, so the spin loop can avoid checking the recursive case.
+    if (!state.IsLocked() || GetOwningThread() != pCurThread)
+    {
+        // Not a recursive enter, try to acquire the lock or register the spinner
+        EnterHelperResult result = m_lockState.InterlockedTry_LockOrRegisterSpinner(state);
+        if (result != EnterHelperResult_Entered)
+        {
+            // EnterHelperResult_Contention: Lock was not acquired and the spinner was registered
+            // EnterHelperResult_UseSlowPath: Reached the maximum number of spinners, just wait
+            return result;
+        }
+
+        // Lock was acquired and the spinner was not registered
+        m_HoldingThread = pCurThread;
+        m_Recursion = 1;
+        pCurThread->IncLockCount();
+        return EnterHelperResult_Entered;
+    }
+
+    // Recursive enter
+    m_Recursion++;
+    return EnterHelperResult_Entered;
+}
+
+FORCEINLINE bool AwareLock::TryEnterInsideSpinLoopHelper(Thread *pCurThread)
+{
+    CONTRACTL{
+        SO_TOLERANT;
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
+    } CONTRACTL_END;
+
+    // Try to acquire the lock and unregister the spinner. The recursive case is not checked here because
+    // TryEnterBeforeSpinLoopHelper() would have taken care of that case before the spin loop.
+    if (!m_lockState.InterlockedTry_LockAndUnregisterSpinner())
+    {
+        // Lock was not acquired and the spinner was not unregistered
+        return false;
+    }
+
+    // Lock was acquired and spinner was unregistered
+    m_HoldingThread = pCurThread;
+    m_Recursion = 1;
+    pCurThread->IncLockCount();
+    return true;
+}
+
+FORCEINLINE bool AwareLock::TryEnterAfterSpinLoopHelper(Thread *pCurThread)
+{
+    CONTRACTL{
+        SO_TOLERANT;
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
+    } CONTRACTL_END;
+
+    // Unregister the spinner and try to acquire the lock. A spinner must not unregister itself without trying to acquire the
+    // lock because a lock releaser does not wake a waiter when a spinner can acquire the lock.
+    if (!m_lockState.InterlockedUnregisterSpinner_TryLock())
+    {
+        // Spinner was unregistered and the lock was not acquired
+        return false;
+    }
+
+    // Spinner was unregistered and the lock was acquired
+    m_HoldingThread = pCurThread;
+    m_Recursion = 1;
+    pCurThread->IncLockCount();
+    return true;
 }
 
 FORCEINLINE AwareLock::EnterHelperResult ObjHeader::EnterObjMonitorHelper(Thread* pCurThread)
@@ -105,7 +432,7 @@ FORCEINLINE AwareLock::EnterHelperResult ObjHeader::EnterObjMonitorHelper(Thread
 
         SyncBlock *syncBlock = g_pSyncTable[oldValue & MASK_SYNCBLOCKINDEX].m_SyncBlock;
         _ASSERTE(syncBlock != NULL);
-        if (syncBlock->m_Monitor.EnterHelper(pCurThread, true /* checkRecursiveCase */))
+        if (syncBlock->m_Monitor.TryEnterHelper(pCurThread))
         {
             return AwareLock::EnterHelperResult_Entered;
         }
@@ -159,7 +486,7 @@ FORCEINLINE AwareLock::LeaveHelperAction AwareLock::LeaveHelper(Thread* pCurThre
     if (m_HoldingThread != pCurThread)
         return AwareLock::LeaveHelperAction_Error;
 
-    _ASSERTE((size_t)m_MonitorHeld & 1);
+    _ASSERTE(m_lockState.IsLocked());
     _ASSERTE(m_Recursion >= 1);
 
 #if defined(_DEBUG) && defined(TRACK_SYNC) && !defined(CROSSGEN_COMPILE)
@@ -174,14 +501,14 @@ FORCEINLINE AwareLock::LeaveHelperAction AwareLock::LeaveHelper(Thread* pCurThre
         m_HoldingThread->DecLockCount();
         m_HoldingThread = NULL;
 
-        // Clear lock bit.
-        LONG state = InterlockedDecrementRelease((LONG*)&m_MonitorHeld);
-
-        // If wait count is non-zero on successful clear, we must signal the event.
-        if (state & ~1)
+        // Clear lock bit and determine whether we must signal a waiter to wake
+        if (!m_lockState.InterlockedUnlock())
         {
-            return AwareLock::LeaveHelperAction_Signal;
+            return AwareLock::LeaveHelperAction_None;
         }
+
+        // There is a waiter and we must signal a waiter to wake
+        return AwareLock::LeaveHelperAction_Signal;
     }
     return AwareLock::LeaveHelperAction_None;
 }

--- a/src/vm/syncblk.inl
+++ b/src/vm/syncblk.inl
@@ -269,18 +269,14 @@ FORCEINLINE bool AwareLock::LockState::InterlockedObserveWakeSignal_Try_LockAndU
     return false;
 }
 
-FORCEINLINE void AwareLock::SpinWait(DWORD spinCount)
+FORCEINLINE void AwareLock::SpinWait(const YieldProcessorNormalizationInfo &normalizationInfo, DWORD spinIteration)
 {
-    LIMITED_METHOD_CONTRACT;
+    WRAPPER_NO_CONTRACT;
 
     _ASSERTE(g_SystemInfo.dwNumberOfProcessors != 1);
-    _ASSERTE(spinCount != 0);
-    _ASSERTE(spinCount <= g_SpinConstants.dwMaximumDuration);
+    _ASSERTE(spinIteration < g_SpinConstants.dwMonitorSpinCount);
 
-    do
-    {
-        YieldProcessor();
-    } while (--spinCount != 0);
+    YieldProcessorWithBackOffNormalized(normalizationInfo, spinIteration);
 }
 
 FORCEINLINE bool AwareLock::TryEnterHelper(Thread* pCurThread)

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -1244,7 +1244,7 @@ void Dbg_TrackSyncStack::EnterSync(UINT_PTR caller, void *pAwareLock)
     STRESS_LOG4(LF_SYNC, LL_INFO100, "Dbg_TrackSyncStack::EnterSync, IP=%p, Recursion=%d, MonitorHeld=%d, HoldingThread=%p.\n",
                     caller,
                     ((AwareLock*)pAwareLock)->m_Recursion,
-                    ((AwareLock*)pAwareLock)->m_MonitorHeld.LoadWithoutBarrier(),
+                    (int)((AwareLock*)pAwareLock)->m_lockState,
                     ((AwareLock*)pAwareLock)->m_HoldingThread );
 
     if (m_Active)
@@ -1270,7 +1270,7 @@ void Dbg_TrackSyncStack::LeaveSync(UINT_PTR caller, void *pAwareLock)
     STRESS_LOG4(LF_SYNC, LL_INFO100, "Dbg_TrackSyncStack::LeaveSync, IP=%p, Recursion=%d, MonitorHeld=%d, HoldingThread=%p.\n",
                     caller,
                     ((AwareLock*)pAwareLock)->m_Recursion,
-                    ((AwareLock*)pAwareLock)->m_MonitorHeld.LoadWithoutBarrier(),
+                    (int)((AwareLock*)pAwareLock)->m_lockState,
                     ((AwareLock*)pAwareLock)->m_HoldingThread );
 
     if (m_Active)

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -1241,11 +1241,11 @@ void Dbg_TrackSyncStack::EnterSync(UINT_PTR caller, void *pAwareLock)
 {
     LIMITED_METHOD_CONTRACT;
 
-    STRESS_LOG4(LF_SYNC, LL_INFO100, "Dbg_TrackSyncStack::EnterSync, IP=%p, Recursion=%d, MonitorHeld=%d, HoldingThread=%p.\n",
+    STRESS_LOG4(LF_SYNC, LL_INFO100, "Dbg_TrackSyncStack::EnterSync, IP=%p, Recursion=%u, LockState=%x, HoldingThread=%p.\n",
                     caller,
-                    ((AwareLock*)pAwareLock)->m_Recursion,
-                    (int)((AwareLock*)pAwareLock)->m_lockState,
-                    ((AwareLock*)pAwareLock)->m_HoldingThread );
+                    ((AwareLock*)pAwareLock)->GetRecursionLevel(),
+                    ((AwareLock*)pAwareLock)->GetLockState(),
+                    ((AwareLock*)pAwareLock)->GetHoldingThread());
 
     if (m_Active)
     {
@@ -1267,11 +1267,11 @@ void Dbg_TrackSyncStack::LeaveSync(UINT_PTR caller, void *pAwareLock)
 {
     WRAPPER_NO_CONTRACT;
 
-    STRESS_LOG4(LF_SYNC, LL_INFO100, "Dbg_TrackSyncStack::LeaveSync, IP=%p, Recursion=%d, MonitorHeld=%d, HoldingThread=%p.\n",
+    STRESS_LOG4(LF_SYNC, LL_INFO100, "Dbg_TrackSyncStack::LeaveSync, IP=%p, Recursion=%u, LockState=%x, HoldingThread=%p.\n",
                     caller,
-                    ((AwareLock*)pAwareLock)->m_Recursion,
-                    (int)((AwareLock*)pAwareLock)->m_lockState,
-                    ((AwareLock*)pAwareLock)->m_HoldingThread );
+                    ((AwareLock*)pAwareLock)->GetRecursionLevel(),
+                    ((AwareLock*)pAwareLock)->GetLockState(),
+                    ((AwareLock*)pAwareLock)->GetHoldingThread());
 
     if (m_Active)
     {

--- a/src/vm/vars.cpp
+++ b/src/vm/vars.cpp
@@ -146,7 +146,8 @@ SpinConstants g_SpinConstants = {
     50,        // dwInitialDuration 
     40000,     // dwMaximumDuration - ideally (20000 * max(2, numProc))
     3,         // dwBackoffFactor
-    10         // dwRepetitions
+    10,        // dwRepetitions
+    0          // dwMonitorSpinCount
 };
 
 // support for Event Tracing for Windows (ETW)


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/13978
- Refactored AwareLock::m_MonitorHeld into a class LockState with operations to mutate the state
- Allowed the lock to be taken by a non-waiter when there is a waiter to prevent creating lock convoys
- Added a bit to LockState to indicate that a waiter is signaled to wake, to avoid waking more than one waiter at a time. A waiter that wakes by observing the signal unsets this bit. See AwareLock::EnterEpilogHelper().
- Added a spinner count to LockState. Spinners now register and unregister themselves and lock releasers don't wake a waiter when there is a registered spinner (the spinner guarantees to take the lock if it's available when unregistering itself)
  - This was necessary mostly on Windows to reduce CPU usage to the expected level in contended cases with several threads. I believe it's the priority boost Windows gives to signaled threads, which seems to cause waiters to much more frequently succeed in acquiring the lock. This causes a CPU usage problem because once the woken waiter releases the lock, on the next lock attempt it will become a spinner. This keeps repeating, converting several waiters into spinners unnecessarily. Before registering spinners, I saw typically 4-6 spinners under contention (with delays inside and outside the lock) when I expected to have only 1-2 spinners at most.
  - It costs an interlocked operation before and after the spin loop, doesn't seem to be too significant since spinning is a relatively slow path anyway, and the reduction in CPU usage in turn reduces contention on the lock and lets more useful work get done
- Updated waiters to spin a bit before going back to waiting, reasons are explained in AwareLock::EnterEpilogHelper()
- Removed AwareLock::Contention() and any references (this removes the 10 repeats of the entire spin loop in that function). With the lock convoy issue gone, this appears to no longer be necessary.

Perf
- On Windows, throughput has increased significantly starting at slightly lower than proc count threads. On Linux, latency and throughput have increased more significantly at similar proc counts.
- Most of the larger regressions are in the unlocked fast paths. The code there hasn't changed and is almost identical (minor layout differences), I'm just considering this noise until we figure out how to get consistently faster code generated.
- The smaller regressions are within noise range

Processor for numbers below: Core i7 6700 4-core 8-thread

Monitor spin tests
---

- With default spin counts
- Code is in https://github.com/dotnet/coreclr/pull/13670

```
Spin (Windows x64)                                      Left score        Right score       ∆ Score %
------------------------------------------------------  ----------------  ----------------  ---------
MonitorEnterExitLatency 02T                                665.73 ±0.46%     660.39 ±0.54%     -0.80%
MonitorEnterExitLatency 04T                               1499.47 ±0.52%    1502.81 ±0.29%      0.22%
MonitorEnterExitLatency 08T                               1731.28 ±0.10%    1743.89 ±0.14%      0.73%
MonitorEnterExitLatency 16T                               1707.25 ±0.31%    1747.36 ±0.24%      2.35%
MonitorEnterExitThroughput Delay 01T                      5138.81 ±0.09%    5120.83 ±0.10%     -0.35%
MonitorEnterExitThroughput Delay 02T                      4959.48 ±0.15%    4981.27 ±0.10%      0.44%
MonitorEnterExitThroughput Delay 04T                      4462.47 ±0.69%    4760.78 ±0.05%      6.68%
MonitorEnterExitThroughput Delay 08T                      3745.69 ±0.03%    4698.01 ±0.26%     25.42%
MonitorEnterExitThroughput Delay 16T                      3711.20 ±0.34%    4725.44 ±0.38%     27.33%
MonitorEnterExitThroughput_AwareLock 1T                  61200.72 ±0.03%   58933.89 ±0.06%     -3.70%
MonitorEnterExitThroughput_ThinLock 1T                   59430.78 ±0.05%   59396.10 ±0.03%     -0.06%
MonitorReliableEnterExitLatency 02T                        706.79 ±0.24%     705.74 ±0.41%     -0.15%
MonitorReliableEnterExitLatency 04T                       1491.37 ±0.26%    1525.77 ±0.17%      2.31%
MonitorReliableEnterExitLatency 08T                       1722.46 ±0.06%    1703.50 ±0.08%     -1.10%
MonitorReliableEnterExitLatency 16T                       1679.43 ±0.29%    1710.93 ±0.19%      1.88%
MonitorReliableEnterExitThroughput Delay 01T              5064.57 ±0.14%    5083.21 ±0.16%      0.37%
MonitorReliableEnterExitThroughput Delay 02T              4917.33 ±0.11%    4962.94 ±0.09%      0.93%
MonitorReliableEnterExitThroughput Delay 04T              4710.53 ±0.22%    4728.52 ±0.12%      0.38%
MonitorReliableEnterExitThroughput Delay 08T              3733.62 ±0.04%    4745.75 ±0.12%     27.11%
MonitorReliableEnterExitThroughput Delay 16T              3648.78 ±0.37%    4718.97 ±0.31%     29.33%
MonitorReliableEnterExitThroughput_AwareLock 1T          58397.83 ±0.06%   58527.30 ±0.11%      0.22%
MonitorReliableEnterExitThroughput_ThinLock 1T           58441.90 ±0.03%   56825.30 ±0.03%     -2.77%
MonitorTryEnterExitWhenUnlockedThroughput_AwareLock 1T   57540.11 ±0.05%   58440.14 ±0.05%      1.56%
MonitorTryEnterExitWhenUnlockedThroughput_ThinLock 1T    57684.81 ±0.04%   57747.39 ±0.06%      0.11%
MonitorTryEnterWhenLockedThroughput_AwareLock 1T        261834.12 ±0.12%  244767.50 ±0.07%     -6.52%
MonitorTryEnterWhenLockedThroughput_ThinLock 1T         241360.92 ±0.15%  261689.44 ±0.04%      8.42%
------------------------------------------------------  ----------------  ----------------  ---------
Total                                                     7513.73 ±0.19%    7828.46 ±0.16%      4.19%
```

```
Spin (Linux x64)                                        Left score        Right score       ∆ Score %
------------------------------------------------------  ----------------  ----------------  ---------
MonitorEnterExitLatency 02T                               3561.29 ±0.64%    3606.19 ±0.31%      1.26%
MonitorEnterExitLatency 04T                               3440.76 ±0.12%    3464.48 ±0.12%      0.69%
MonitorEnterExitLatency 08T                               2292.54 ±0.50%    3429.38 ±0.46%     49.59%
MonitorEnterExitLatency 16T                               2095.67 ±0.67%    3433.30 ±0.30%     63.83%
MonitorEnterExitThroughput Delay 01T                      5043.59 ±0.31%    5008.86 ±0.26%     -0.69%
MonitorEnterExitThroughput Delay 02T                      4972.94 ±0.04%    4955.36 ±0.03%     -0.35%
MonitorEnterExitThroughput Delay 04T                      4707.27 ±0.08%    4650.77 ±0.06%     -1.20%
MonitorEnterExitThroughput Delay 08T                      2637.27 ±0.20%    4601.87 ±0.22%     74.49%
MonitorEnterExitThroughput Delay 16T                      2312.48 ±0.81%    4650.57 ±0.11%    101.11%
MonitorEnterExitThroughput_AwareLock 1T                  58822.27 ±0.03%   57910.71 ±0.10%     -1.55%
MonitorEnterExitThroughput_ThinLock 1T                   57274.55 ±0.15%   56441.84 ±0.22%     -1.45%
MonitorReliableEnterExitLatency 02T                       3558.43 ±0.27%    3553.18 ±0.61%     -0.15%
MonitorReliableEnterExitLatency 04T                       2920.09 ±0.20%    3440.91 ±0.14%     17.84%
MonitorReliableEnterExitLatency 08T                       2269.82 ±0.05%    3052.08 ±6.08%     34.46%
MonitorReliableEnterExitLatency 16T                       2086.47 ±0.75%    3275.11 ±2.67%     56.97%
MonitorReliableEnterExitThroughput Delay 01T              5169.16 ±0.64%    5189.40 ±0.14%      0.39%
MonitorReliableEnterExitThroughput Delay 02T              5075.91 ±0.26%    5074.15 ±0.05%     -0.03%
MonitorReliableEnterExitThroughput Delay 04T              4602.26 ±1.49%    4767.14 ±0.05%      3.58%
MonitorReliableEnterExitThroughput Delay 08T              2773.58 ±0.07%    4744.31 ±0.28%     71.05%
MonitorReliableEnterExitThroughput Delay 16T              2438.12 ±0.66%    4776.94 ±0.13%     95.93%
MonitorReliableEnterExitThroughput_AwareLock 1T          56198.53 ±0.11%   55248.53 ±0.07%     -1.69%
MonitorReliableEnterExitThroughput_ThinLock 1T           56322.95 ±0.11%   55207.00 ±0.24%     -1.98%
MonitorTryEnterExitWhenUnlockedThroughput_AwareLock 1T   54299.42 ±0.10%   54580.95 ±0.07%      0.52%
MonitorTryEnterExitWhenUnlockedThroughput_ThinLock 1T    55292.39 ±0.20%   53787.62 ±0.26%     -2.72%
MonitorTryEnterWhenLockedThroughput_AwareLock 1T        216569.65 ±0.26%  213135.11 ±0.32%     -1.59%
MonitorTryEnterWhenLockedThroughput_ThinLock 1T         225565.05 ±0.68%  230333.25 ±0.22%      2.11%
------------------------------------------------------  ----------------  ----------------  ---------
Total                                                     8698.50 ±0.36%   10232.00 ±0.53%     17.63%
```

Raw numbers
---

Code is in https://github.com/dotnet/coreclr/issues/13978

Default spin heuristics
---

```
Tc = Thread count
WB = Windows baseline
WC = Windows changed
LB = Linux baseline
LC = Linux changed
L/ms = Locks taken per millisecond
Cpu = Number of threads worth of full CPU usage
```

Tc | WB L/ms | Cpu | WC L/ms | Cpu | LB L/ms | Cpu | LC L/ms | Cpu
--: | --: | --: | --: | --: | --: | --: | --: | --:
1 | 5344.76 | 1 | 5262.77 | 1 | 5148.87 | 1 | 5044.62 | 1
1 | 5391.14 | 1 | 5433.34 | 1 | 5368.91 | 1 | 5262.98 | 1
1 | 5348.51 | 1 | 5296.45 | 1 | 5111.95 | 1 | 4988.24 | 1
2 | 5168.75 | 2 | 5110.51 | 2 | 4938.35 | 2 | 4882.07 | 2
2 | 5130.30 | 2 | 5130.79 | 2 | 4989.40 | 2 | 4857.45 | 2
2 | 5156.88 | 2 | 5117.37 | 2 | 4958.15 | 2 | 4932.81 | 2
4 | 4671.16 | 4 | 4885.46 | 4 | 4732.73 | 4 | 4655.51 | 3
4 | 4846.14 | 4 | 4847.92 | 4 | 4390.75 | 4 | 4597.65 | 3
4 | 9572.59 | 4 | 4839.56 | 4 | 4731.39 | 4 | 4652.74 | 3
8 | 3967.98 | 8 | 4832.56 | 4 | 2827.30 | 8 | 4621.80 | 3
8 | 4379.97 | 8 | 4901.81 | 4 | 2824.45 | 8 | 4574.13 | 3
8 | 4413.90 | 8 | 4826.43 | 4 | 2819.81 | 8 | 4642.79 | 3
16 | 3867.15 | 8 | 4826.82 | 4 | 2413.83 | 8 | 4634.02 | 3
16 | 4846.04 | 8 | 4815.79 | 4 | 2524.47 | 8 | 4604.29 | 3
16 | 5695.38 | 8 | 4853.34 | 4 | 2363.39 | 8 | 4633.61 | 3
32 | 3454.42 | 8 | 4615.44 | 4 | 1150.34 | 8 | 4665.71 | 3
32 | 6477.07 | 8 | 4508.67 | 4 | 1607.75 | 8 | 4665.56 | 3
32 | 7059.96 | 8 | 4479.78 | 4 | 1777.20 | 8 | 4659.60 | 3
64 | 3282.26 | 8 | 4611.93 | 4 | 0.70 | 8 | 4573.43 | 3
64 | 4991.26 | 8 | 4883.61 | 4 | 0.72 | 8 | 4672.35 | 3
64 | 7521.77 | 8 | 4907.73 | 4 | 0.56 | 8 | 4654.06 | 3
128 | 3149.11 | 8 | 4836.03 | 4 | 0.62 | 8 | 4621.83 | 3
128 | 8962.21 | 8 | 4872.29 | 4 | 0.61 | 8 | 4565.08 | 3
128 | 7503.35 | 8 | 4858.68 | 4 | 0.72 | 8 | 4667.60 | 3
256 | 3310.44 | 8 | 4755.44 | 4 | 82.47 | 8 | 4648.06 | 3
256 | 6567.14 | 8 | 4852.55 | 4 | 0.82 | 8 | 4626.99 | 3
256 | 5420.92 | 8 | 4884.91 | 4 | 0.79 | 8 | 4657.88 | 3
512 | 2081.56 | 8 | 4900.86 | 4 | 0.61 | 8 | 4648.02 | 3
512 | 4125.43 | 8 | 4863.88 | 4 | 0.71 | 8 | 4578.18 | 3
512 | 3685.25 | 8 | 4898.62 | 4 | 0.77 | 8 | 4601.07 | 3
1024 | 1436.46 | 8 | 4842.57 | 4 | 0.61 | 8 | 4593.89 | 3
1024 | 2900.22 | 8 | 4880.87 | 4 | 0.91 | 8 | 4627.16 | 3
1024 | 3808.18 | 8 | 4917.50 | 4 | 0.81 | 8 | 4615.44 | 3

Lower spin counts
---

```
set COMPlus_SpinInitialDuration=0x1
set COMPlus_SpinLimitProcFactor=0x80
set COMPlus_SpinBackoffFactor=0x2
set COMPlus_SpinRetryCount=0x0
```

Tc | WB L/ms | Cpu | WC L/ms | Cpu | LB L/ms | Cpu | LC L/ms | Cpu
--: | --: | --: | --: | --: | --: | --: | --: | --:
1 | 5335.34 | 1 | 5264.16 | 1 | 4493.90 | 1 | 5019.77 | 1
1 | 5448.57 | 1 | 5439.20 | 1 | 4866.98 | 1 | 4872.09 | 1
1 | 5325.00 | 1 | 5297.86 | 1 | 5078.65 | 1 | 4541.78 | 1
2 | 4923.72 | 2 | 4859.70 | 2 | 4494.79 | 2 | 4565.30 | 2
2 | 4929.58 | 2 | 4834.64 | 2 | 4052.52 | 2 | 4582.16 | 2
2 | 4888.14 | 2 | 4865.00 | 2 | 3864.39 | 2 | 4572.25 | 2
4 | 4546.01 | 4 | 4357.90 | 3 | 90.96 | 2 | 3448.15 | 3
4 | 4531.11 | 4 | 4367.87 | 3 | 100.28 | 2 | 3449.68 | 3
4 | 4541.45 | 4 | 4357.42 | 3 | 125.34 | 2 | 3542.46 | 3
8 | 3752.67 | 8 | 4317.60 | 3 | 86.85 | 2 | 4700.69 | 3
8 | 3765.35 | 8 | 4367.94 | 3 | 83.59 | 2 | 4592.01 | 3
8 | 3716.64 | 8 | 4289.56 | 3 | 81.16 | 2 | 4554.52 | 3
16 | 97.13 | 8 | 4241.93 | 3 | 74.24 | 2 | 4550.29 | 2
16 | 96.85 | 8 | 4242.78 | 3 | 84.72 | 2 | 4416.01 | 2
16 | 97.21 | 8 | 4239.82 | 3 | 78.49 | 2 | 4560.80 | 2
32 | 97.11 | 8 | 4382.21 | 3 | 89.36 | 2 | 4405.91 | 2
32 | 96.83 | 8 | 4371.04 | 3 | 85.16 | 2 | 4255.65 | 2
32 | 97.18 | 8 | 4330.79 | 3 | 86.11 | 2 | 4158.98 | 2
64 | 96.86 | 8 | 4385.51 | 3 | 71.96 | 2 | 3839.43 | 2
64 | 97.08 | 8 | 4375.39 | 3 | 83.92 | 2 | 4145.21 | 2
64 | 96.84 | 8 | 4369.57 | 3 | 77.99 | 2 | 4261.37 | 2

Spinning disabled
---

```
set COMPlus_SpinInitialDuration=0x1
set COMPlus_SpinLimitProcFactor=0x0
set COMPlus_SpinBackoffFactor=0x2
set COMPlus_SpinRetryCount=0x0
```

Tc | WB L/ms | Cpu | WC L/ms | Cpu | LB L/ms | Cpu | LC L/ms | Cpu
--: | --: | --: | --: | --: | --: | --: | --: | --:
1 | 5268.41 | 1.0 | 5343.09 | 1 | 5030.34 | 1.0 | 5034.13 | 1
1 | 5464.13 | 1.0 | 5348.70 | 1 | 5361.13 | 1.0 | 5028.44 | 1
1 | 5255.47 | 1.0 | 5317.01 | 1 | 5055.16 | 1.0 | 4867.83 | 1
2 | 157.00 | 1.5 | 2930.07 | 2 | 92.38 | 1.5 | 2475.49 | 2
2 | 272.23 | 1.5 | 2964.10 | 2 | 93.58 | 1.5 | 2418.42 | 2
2 | 269.83 | 1.5 | 2939.90 | 2 | 89.18 | 1.5 | 2374.65 | 2
4 | 215.94 | 1.5 | 2835.81 | 2 | 101.05 | 1.5 | 2125.89 | 2
4 | 213.10 | 1.5 | 2713.06 | 2 | 99.78 | 1.5 | 2002.67 | 2
4 | 214.34 | 1.5 | 2725.35 | 2 | 119.61 | 1.5 | 2089.86 | 2
8 | 215.03 | 1.5 | 2908.95 | 2 | 102.79 | 1.5 | 4650.46 | 2
8 | 219.86 | 1.5 | 2853.62 | 2 | 86.06 | 1.5 | 4718.31 | 2
8 | 209.58 | 1.5 | 2882.41 | 2 | 110.83 | 1.5 | 4561.14 | 2
16 | 217.18 | 1.5 | 2886.65 | 2 | 96.64 | 1.5 | 4770.49 | 2
16 | 213.08 | 1.5 | 2884.71 | 2 | 94.27 | 1.5 | 4687.61 | 2
16 | 220.32 | 1.5 | 2870.19 | 2 | 96.02 | 1.5 | 4735.26 | 2