### PR TITLE
[RyuJIT] Fix bad VEX encoding to avoid false register dependency

### DIFF
--- a/src/jit/emitxarch.h
+++ b/src/jit/emitxarch.h
@@ -179,11 +179,11 @@ void SetContains256bitAVX(bool value)
     contains256bitAVXInstruction = value;
 }
 
-bool IsThreeOperandBinaryAVXInstruction(instruction ins);
-bool IsThreeOperandMoveAVXInstruction(instruction ins);
+bool IsDstDstSrcAVXInstruction(instruction ins);
+bool IsDstSrcSrcAVXInstruction(instruction ins);
 bool IsThreeOperandAVXInstruction(instruction ins)
 {
-    return (IsThreeOperandBinaryAVXInstruction(ins) || IsThreeOperandMoveAVXInstruction(ins));
+    return (IsDstDstSrcAVXInstruction(ins) || IsDstSrcSrcAVXInstruction(ins));
 }
 bool Is4ByteAVXInstruction(instruction ins);
 #else  // !FEATURE_AVX_SUPPORT
@@ -203,11 +203,11 @@ bool hasVexPrefix(code_t code)
 {
     return false;
 }
-bool IsThreeOperandBinaryAVXInstruction(instruction ins)
+bool IsDstDstSrcAVXInstruction(instruction ins)
 {
     return false;
 }
-bool IsThreeOperandMoveAVXInstruction(instruction ins)
+bool IsDstSrcSrcAVXInstruction(instruction ins)
 {
     return false;
 }

--- a/src/jit/simdcodegenxarch.cpp
+++ b/src/jit/simdcodegenxarch.cpp
@@ -680,7 +680,7 @@ void CodeGen::genSIMDScalarMove(
                 if (srcReg != targetReg)
                 {
                     instruction ins = ins_Store(baseType);
-                    if (getEmitter()->IsThreeOperandMoveAVXInstruction(ins))
+                    if (getEmitter()->IsDstSrcSrcAVXInstruction(ins))
                     {
                         // In general, when we use a three-operands move instruction, we want to merge the src with
                         // itself. This is an exception in that we actually want the "merge" behavior, so we must
@@ -709,7 +709,7 @@ void CodeGen::genSIMDScalarMove(
                 if (srcReg != targetReg)
                 {
                     instruction ins = ins_Copy(baseType);
-                    assert(!getEmitter()->IsThreeOperandMoveAVXInstruction(ins));
+                    assert(!getEmitter()->IsDstSrcSrcAVXInstruction(ins));
                     inst_RV_RV(ins, targetReg, srcReg, baseType, emitTypeSize(baseType));
                 }
                 break;


### PR DESCRIPTION
This codegen issue was detected from [SqrtDouble and SqrtSinge benchmarks](https://github.com/dotnet/coreclr/tree/master/tests/src/JIT/Performance/CodeQuality/Math/Functions).

Disassembly of a hot loop in SqrtDouble shows the second operand of `vsqrtsd` always set to `xmm0` (the default value of VEX.vvvv in RyuJIT).
```asm
Block 2:
--
vaddsd xmm1, xmm1, qword ptr   [rip+0xd9]
vsqrtsd xmm2, xmm0, xmm1  ;;; xmm0 is not allocated to vsqrtsd
vaddsd xmm0, xmm0, xmm2
inc edi
cmp edi, 0x1388
jl 0x7fc0b96f3efe <Block 2>
```
This codegen introduces false register dependency on `xmm0` that causes obviously higher CPI. Meanwhile, **we recommend that keep the second operand same as the third one rather than same as the destination for this kind of instructions**. 

| code                     | execution time |
|--------------------------|----------------|
| `vsqrtsd dst, xmm0, src` | 3.07s          |
| `vsqrtsd dst, dst, src`  | 2.25s          |
| `vsqrtsd dst, src, src`  | 0.84s          |


The codegen after this change
```asm
Block 2:
--
vaddsd xmm1, xmm1, qword ptr   [rip+0xd4]
vsqrtsd xmm2, xmm1, xmm1
vaddsd xmm0, xmm0, xmm2
inc edi
cmp edi, 0x1388
jl 0x7fe8c0da44ab <Block 2>
```