### PR TITLE
[WIP] Add coreclr_preload_assembly to CoreCLR host API

### DIFF
--- a/src/coreclr/hosts/inc/coreclrhost.h
+++ b/src/coreclr/hosts/inc/coreclrhost.h
@@ -15,7 +15,10 @@
 #define CORECLR_HOSTING_API(function, ...) \
     extern "C" int function(__VA_ARGS__); \
     typedef int (*function##_ptr)(__VA_ARGS__)
-    
+
+CORECLR_HOSTING_API(coreclr_preload_assembly,
+            const char* assemblyPath);
+
 CORECLR_HOSTING_API(coreclr_initialize,
             const char* exePath,
             const char* appDomainFriendlyName,

--- a/src/dlls/mscoree/mscorwks_ntdef.src
+++ b/src/dlls/mscoree/mscorwks_ntdef.src
@@ -17,6 +17,7 @@ EXPORTS
         g_CLREngineMetrics                                  @2 data
         
         ; Unix hosting API
+        coreclr_preload_assembly
         coreclr_create_delegate
         coreclr_execute_assembly
         coreclr_initialize

--- a/src/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/dlls/mscoree/mscorwks_unixexports.src
@@ -1,4 +1,5 @@
 ; Unix hosting API
+coreclr_preload_assembly
 coreclr_create_delegate
 coreclr_execute_assembly
 coreclr_initialize

--- a/src/inc/corhost.h
+++ b/src/inc/corhost.h
@@ -389,6 +389,11 @@ public:
         LPCWSTR* argv,
         DWORD* pReturnValue);
 
+    static HRESULT PreloadAssembly(
+        LPCSTR szPath);
+
+    static HRESULT UnloadPreloadedAssemblies();
+
     static STARTUP_FLAGS GetStartupFlags();
 
     static EInitializeNewDomainFlags GetAppDomainManagerInitializeNewDomainFlags();

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -2620,6 +2620,8 @@ Abstract
 
 Parameters:
     IN hFile    - The file to load
+    IN wszPath  - File path
+    OUT isPreloaded - Flag whether pefile was preloaded
 
 Return value:
     A valid base address if successful.
@@ -2627,7 +2629,7 @@ Return value:
 --*/
 void *
 PALAPI
-PAL_LOADLoadPEFile(HANDLE hFile);
+PAL_LOADLoadPEFile(HANDLE hFile, LPCWSTR wszPath, BOOL *isPreloaded);
 
 /*++
     PAL_LOADUnloadPEFile
@@ -2644,6 +2646,36 @@ Return value:
 BOOL 
 PALAPI
 PAL_LOADUnloadPEFile(void * ptr);
+
+/*++
+Function:
+  PAL_LOADPreloadPEFile
+
+Abstract
+  Preloads a PE file into memory.  Properly maps all of the sections in the PE file.  Returns a pointer to the
+  loaded base.
+
+Parameters:
+    IN szPath    - path of file to load
+
+Return value:
+    A valid base address if successful.
+    0 if failure
+--*/
+void *
+PAL_LOADPreloadPEFile(LPCSTR szPath);
+
+/*++
+    PAL_LOADUnloadPreloadedPEFiles
+
+    Unload all PE files that were loaded by PAL_LOADPreloadPEFile().
+
+Return value:
+    TRUE - success
+    FALSE - failure
+--*/
+BOOL
+PAL_LOADUnloadPreloadedPEFiles();
 
 #ifdef UNICODE
 #define LoadLibrary LoadLibraryW

--- a/src/pal/src/include/pal/dbgmsg.h
+++ b/src/pal/src/include/pal/dbgmsg.h
@@ -245,6 +245,7 @@ extern Volatile<BOOL> dbg_master_switch ;
 #define DBGOUT_(x) NOTRACE
 #define ERROR     NOTRACE
 #define ERROR_(x) NOTRACE
+#define ERROR__(condition,x) NOTRACE
 #define DBG_PRINTF(level, channel, bHeader) NOTRACE
 
 #define CHECK_STACK_ALIGN
@@ -312,6 +313,10 @@ bool DBG_ShouldCheckStackAlignment();
     DBG_PRINTF(DLI_ERROR,defdbgchan,TRUE)
 
 #define ERROR_(x) \
+    DBG_PRINTF(DLI_ERROR,DCI_##x,TRUE)
+
+#define ERROR__(condition,x) \
+    if (condition)\
     DBG_PRINTF(DLI_ERROR,DCI_##x,TRUE)
 
 #define DBG_PRINTF(level, channel, bHeader) \

--- a/src/pal/src/include/pal/map.hpp
+++ b/src/pal/src/include/pal/map.hpp
@@ -77,15 +77,59 @@ extern "C"
         Map a PE format file into memory like Windows LoadLibrary() would do.
         Doesn't apply base relocations if the function is relocated.
 
+        There are two scenarios:
+
+        - image could be preloaded and then MAPMapPEFile is called for it
+        - image is loaded with MAPMapPEFile
+
+        In the first scenario, hFile and lpPreloadedBase are supposed to be NULL, and szPath and size - non-NULL.
+        In the second scenario, hFile and lpPreloadedBase are supposed to be non-NULL, and szPath and size - NULL.
+
+        See coreclr_preload_assembly for further details.
+
     Parameters:
         IN hFile - file to map
+        IN szPath - path to mapped file
+        OUT size - mapped virtual size
+        IN lpPreloadedBase - previously loaded base
 
     Return value:
         non-NULL - the base address of the mapped image
         NULL - error, with last error set.
     --*/
 
-    void * MAPMapPEFile(HANDLE hFile);
+    void * MAPMapPEFile(HANDLE hFile, LPCSTR szPath, SIZE_T *size, LPVOID lpPreloadedBase);
+
+    /*++
+        MAPApplyBaseRelocationsPreloadedPEFile -
+
+        Apply base relocations to preloaded image
+
+    Parameters:
+        IN lpMappedImage - base address of preloaded image
+        IN virtualSize - virtual size of preloaded image
+
+    Return value:
+        true - if relocations were applied successfully
+        false - otherwise
+    --*/
+
+    bool MAPApplyBaseRelocationsPreloadedPEFile(LPVOID lpMappedImage, SIZE_T virtualSize);
+
+    /*++
+        MAPUnmapPreloadedPEFile -
+
+        Unmap a PE file
+
+    Parameters:
+        IN lpMappedImage - address of mapped file
+        IN size - virtual size
+
+    Return value:
+        returns TRUE if successful, FALSE otherwise
+    --*/
+
+    BOOL MAPUnmapPreloadedPEFile(LPVOID lpMappedImage, SIZE_T size);
 
     /*++
     Function :

--- a/src/pal/src/include/pal/module.h
+++ b/src/pal/src/include/pal/module.h
@@ -51,6 +51,20 @@ typedef struct _MODSTRUCT
     struct _MODSTRUCT *prev;
 } MODSTRUCT;
 
+/*++
+    LOADFindPreloadedPEFile -
+
+    Find image in list of preloaded
+
+Parameters:
+    IN wszPath - path to mapped file
+
+Return value:
+    non-NULL - the base address of the mapped image
+    NULL - image is not in the list of preloaded.
+--*/
+
+void * LOADFindPreloadedPEFile(LPCWSTR wszPath);
 
 /*++
 Function :
@@ -145,12 +159,14 @@ Abstract
 
 Parameters:
     IN hFile    - The file to load
+    IN wszPath  - File path
+    OUT isPreloaded - Flag whether pefile was preloaded
 
 Return value:
     A valid base address if successful.
     0 if failure
 --*/
-void * PAL_LOADLoadPEFile(HANDLE hFile);
+void * PAL_LOADLoadPEFile(HANDLE hFile, LPCWSTR wszPath, BOOL *isPreloaded);
 
 /*++
     PAL_LOADUnloadPEFile
@@ -165,6 +181,36 @@ Return value:
     FALSE - failure (incorrect ptr, etc.)
 --*/
 BOOL PAL_LOADUnloadPEFile(void * ptr);
+
+/*++
+Function:
+  PAL_LOADPreloadPEFile
+
+Abstract
+  Preloads a PE file into memory.  Properly maps all of the sections in the PE file.  Returns a pointer to the
+  loaded base.
+
+Parameters:
+    IN szPath    - path of file to load
+
+Return value:
+    A valid base address if successful.
+    0 if failure
+--*/
+void *
+PAL_LOADPreloadPEFile(LPCSTR szPath);
+
+/*++
+    PAL_LOADUnloadPreloadedPEFiles
+
+    Unload all PE files that were loaded by PAL_LOADPreloadPEFile().
+
+Return value:
+    TRUE - success
+    FALSE - failure
+--*/
+BOOL
+PAL_LOADUnloadPreloadedPEFiles();
 
 /*++
     LOADInitializeCoreCLRModule

--- a/src/vm/peimagelayout.h
+++ b/src/vm/peimagelayout.h
@@ -69,7 +69,7 @@ public:
     const SString& GetPath();
 
 #ifdef FEATURE_PREJIT
-    void ApplyBaseRelocations();
+    void ApplyBaseRelocations(BOOL isRelocated);
 #endif
 
 public:
@@ -130,7 +130,7 @@ protected:
     CLRMapViewHolder m_FileView;
 public:
 #ifndef DACCESS_COMPILE    
-    MappedImageLayout(HANDLE hFile, PEImage* pOwner);    
+    MappedImageLayout(HANDLE hFile, PEImage* pOwner);
 #endif
 };
 


### PR DESCRIPTION
This pull request adds `coreclr_preload_assembly` to host API, which loads assembly image to memory and applies relocations. `coreclr_preload_assembly` is supposed to be called only before initialization of CoreCLR.

Is it correct to call `PAL_malloc` before CoreCLR is initialized?

`PAL_ForceRelocs` is ignored for preloaded assembly images.

cc @ruben-ayrapetyan @Dmitri-Botcharnikov @kvochko 