### PR TITLE
Update Buildtools and Roslyn

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-02014-02
+2.0.0-prerelease-02027-03

--- a/build-test.cmd
+++ b/build-test.cmd
@@ -22,6 +22,23 @@ set __BuildOS=Windows_NT
 :: is already configured to use that toolset. Otherwise, we will fallback to using the VS2015
 :: toolset if it is installed. Finally, we will fail the script if no supported VS instance
 :: can be found.
+if defined VisualStudioVersion goto :Run
+
+set _VSWHERE="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if exist %_VSWHERE% (
+  for /f "usebackq tokens=*" %%i in (`%_VSWHERE% -latest -property installationPath`) do set _VSCOMNTOOLS=%%i\Common7\Tools
+)
+if not exist "%_VSCOMNTOOLS%" set _VSCOMNTOOLS=%VS140COMNTOOLS%
+if not exist "%_VSCOMNTOOLS%" (
+  echo Error: Visual Studio 2015 or 2017 required.
+  echo        Please see https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/developer-guide.md for build instructions.
+  exit /b 1
+)
+
+call "%_VSCOMNTOOLS%\VsDevCmd.bat"
+
+:Run
+
 if defined VS150COMNTOOLS (
   set "__VSToolsRoot=%VS150COMNTOOLS%"
   set "__VCToolsRoot=%VS150COMNTOOLS%\..\..\VC\Auxiliary\Build"

--- a/build.cmd
+++ b/build.cmd
@@ -19,6 +19,24 @@ set __ThisScriptFull="%~f0"
 :: is already configured to use that toolset. Otherwise, we will fallback to using the VS2015
 :: toolset if it is installed. Finally, we will fail the script if no supported VS instance
 :: can be found.
+
+if defined VisualStudioVersion goto :Run
+
+set _VSWHERE="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if exist %_VSWHERE% (
+  for /f "usebackq tokens=*" %%i in (`%_VSWHERE% -latest -property installationPath`) do set _VSCOMNTOOLS=%%i\Common7\Tools
+)
+if not exist "%_VSCOMNTOOLS%" set _VSCOMNTOOLS=%VS140COMNTOOLS%
+if not exist "%_VSCOMNTOOLS%" (
+  echo Error: Visual Studio 2015 or 2017 required.
+  echo        Please see https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/developer-guide.md for build instructions.
+  exit /b 1
+)
+
+call "%_VSCOMNTOOLS%\VsDevCmd.bat"
+
+:Run
+
 if defined VS150COMNTOOLS (
   set "__VSToolsRoot=%VS150COMNTOOLS%"
   set "__VCToolsRoot=%VS150COMNTOOLS%\..\..\VC\Auxiliary\Build"

--- a/dependencies.props
+++ b/dependencies.props
@@ -15,7 +15,7 @@
   <PropertyGroup>
     <CoreFxCurrentRef>ab762a3c35e208cd698988fb7761bc92be417be9</CoreFxCurrentRef>
     <CoreClrCurrentRef>2a83ae1685d323e6bd206dd2596b953488479922</CoreClrCurrentRef>
-    <BuildToolsCurrentRef>2a83ae1685d323e6bd206dd2596b953488479922</BuildToolsCurrentRef>
+    <BuildToolsCurrentRef>28c7860c2887d685986bc1c85de1e822fee91122</BuildToolsCurrentRef>
     <PgoDataCurrentRef>1a2306063659d9704d06119325ff7c2652b1af0b</PgoDataCurrentRef>
   </PropertyGroup>
 

--- a/dir.props
+++ b/dir.props
@@ -181,6 +181,6 @@
   </ItemGroup>
 
   <!-- Use Roslyn Compilers to build -->
-  <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'!='true' and Exists('$(RoslynPropsFile)') and '$(UseRoslynCompilers)'!='false'" />
-  <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'=='true' and Exists('$(RoslynPropsFile)')" />
+  <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'!='true' and Exists('$(RoslynPropsFile)') and '$(UseRoslynCompilers)'!='false' and '$(RoslynIncompatibleMsbuildVersion)' != 'true'" />
+  <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'=='true' and Exists('$(RoslynPropsFile)') and '$(RoslynIncompatibleMsbuildVersion)' != 'true'" />
 </Project>

--- a/run.cmd
+++ b/run.cmd
@@ -16,26 +16,20 @@ setlocal
 :: is already configured to use that toolset. Otherwise, we will fallback to using the VS2015
 :: toolset if it is installed. Finally, we will fail the script if no supported VS instance
 :: can be found.
-if not defined VisualStudioVersion (
-  if defined VS150COMNTOOLS (
-	 if not exist "%VS150COMNTOOLS%\..\IDE\devenv.exe"      goto NoVS
-	 if not exist "%VS150COMNTOOLS%\..\..\VC\Auxiliary\Build\vcvarsall.bat" goto NoVS
-	 if not exist "%VS150COMNTOOLS%\VsDevCmd.bat" 			  goto NoVS
-    call "%VS150COMNTOOLS%\VsDevCmd.bat"
-    goto :Run
-  ) else if defined VS140COMNTOOLS (
-	 if not exist "%VS140COMNTOOLS%\..\IDE\devenv.exe"      goto NoVS
-	 if not exist "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" goto NoVS
-	 if not exist "%VS140COMNTOOLS%\VsDevCmd.bat" 			  goto NoVS
-    call "%VS140COMNTOOLS%\VsDevCmd.bat"
-    goto :Run
-  )
+if defined VisualStudioVersion goto :Run
 
-  :NoVS
+set _VSWHERE="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if exist %_VSWHERE% (
+  for /f "usebackq tokens=*" %%i in (`%_VSWHERE% -latest -property installationPath`) do set _VSCOMNTOOLS=%%i\Common7\Tools
+)
+if not exist "%_VSCOMNTOOLS%" set _VSCOMNTOOLS=%VS140COMNTOOLS%
+if not exist "%_VSCOMNTOOLS%" (
   echo Error: Visual Studio 2015 or 2017 required.
-  echo        https://github.com/dotnet/coreclr/blob/master/Documentation/building/windows-instructions.md for build instructions.
+  echo        Please see https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/developer-guide.md for build instructions.
   exit /b 1
 )
+
+call "%_VSCOMNTOOLS%\VsDevCmd.bat"
 
 :Run
 :: Clear the 'Platform' env variable for this session, as it's a per-project setting within the build, and

--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -39,6 +39,7 @@
     <_TargetFrameworkDirectories>$(MSBuildThisFileDirectory)/Documentation</_TargetFrameworkDirectories>
     <_FullFrameworkReferenceAssemblyPaths>$(MSBuildThisFileDirectory)/Documentation</_FullFrameworkReferenceAssemblyPaths>
     <SkipCommonResourcesIncludes>true</SkipCommonResourcesIncludes>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <!-- Add Serviceable attribute to the project's metadata -->
   <ItemGroup>

--- a/src/mscorlib/shared/System/Globalization/TimeSpanParse.cs
+++ b/src/mscorlib/shared/System/Globalization/TimeSpanParse.cs
@@ -93,8 +93,7 @@ namespace System.Globalization
             NumOverflow = 4,  // Number that overflowed
         }
 
-        [IsByRefLike]
-        private struct TimeSpanToken
+        private ref struct TimeSpanToken
         {
             internal TTT _ttt;
             internal int _num;                // Store the number that we are parsing (if any)
@@ -131,8 +130,7 @@ namespace System.Globalization
             }
         }
 
-        [IsByRefLike]
-        private struct TimeSpanTokenizer
+        private ref struct TimeSpanTokenizer
         {
             private ReadOnlySpan<char> _value;
             private int _pos;
@@ -241,8 +239,7 @@ namespace System.Globalization
         }
 
         /// <summary>Stores intermediary parsing state for the standard formats.</summary>
-        [IsByRefLike]
-        private struct TimeSpanRawInfo
+        private ref struct TimeSpanRawInfo
         {
             internal TimeSpanFormat.FormatLiterals PositiveInvariant => TimeSpanFormat.PositiveInvariantFormatLiterals;
             internal TimeSpanFormat.FormatLiterals NegativeInvariant => TimeSpanFormat.NegativeInvariantFormatLiterals;
@@ -1430,8 +1427,7 @@ namespace System.Globalization
         private static bool TryParseTimeSpanConstant(ReadOnlySpan<char> input, ref TimeSpanResult result) =>
             new StringParser().TryParse(input, ref result);
 
-        [IsByRefLike]
-        private struct StringParser
+        private ref struct StringParser
         {
             private ReadOnlySpan<char> _str;
             private char _ch;

--- a/src/mscorlib/shared/System/ReadOnlySpan.cs
+++ b/src/mscorlib/shared/System/ReadOnlySpan.cs
@@ -16,10 +16,8 @@ namespace System
     /// or native memory, or to memory allocated on the stack. It is type- and memory-safe.
     /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    [IsReadOnly]
-    [IsByRefLike]
     [NonVersionable]
-    public struct ReadOnlySpan<T>
+    public readonly ref struct ReadOnlySpan<T>
     {
         /// <summary>A byref or a native ptr.</summary>
         private readonly ByReference<T> _pointer;

--- a/src/mscorlib/shared/System/Span.cs
+++ b/src/mscorlib/shared/System/Span.cs
@@ -22,10 +22,8 @@ namespace System
     /// or native memory, or to memory allocated on the stack. It is type- and memory-safe.
     /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    [IsReadOnly]
-    [IsByRefLike]
     [NonVersionable]
-    public struct Span<T>
+    public readonly ref struct Span<T>
     {
         /// <summary>A byref or a native ptr.</summary>
         private readonly ByReference<T> _pointer;

--- a/tests/dir.props
+++ b/tests/dir.props
@@ -84,8 +84,8 @@
   <Import Project="$(ProjectDir)..\dependencies.props" />
 
   <!-- Use Roslyn Compilers to build -->
-  <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'!='true' and Exists('$(RoslynPropsFile)') and '$(UseRoslynCompilers)'!='false'" />
-  <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'=='true' and Exists('$(RoslynPropsFile)')" />
+  <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'!='true' and Exists('$(RoslynPropsFile)') and '$(UseRoslynCompilers)'!='false' and '$(RoslynIncompatibleMsbuildVersion)' != 'true'" />
+  <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'=='true' and Exists('$(RoslynPropsFile)') and '$(RoslynIncompatibleMsbuildVersion)' != 'true'" />
 
    <ItemGroup> 
      <!-- Need to escape double forward slash (%2F) or MSBuild will normalize to one slash on Unix. -->

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -22,6 +22,23 @@ set __MSBuildBuildArch=x64
 :: is already configured to use that toolset. Otherwise, we will fallback to using the VS2015
 :: toolset if it is installed. Finally, we will fail the script if no supported VS instance
 :: can be found.
+if defined VisualStudioVersion goto :Run
+
+set _VSWHERE="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if exist %_VSWHERE% (
+  for /f "usebackq tokens=*" %%i in (`%_VSWHERE% -latest -property installationPath`) do set _VSCOMNTOOLS=%%i\Common7\Tools
+)
+if not exist "%_VSCOMNTOOLS%" set _VSCOMNTOOLS=%VS140COMNTOOLS%
+if not exist "%_VSCOMNTOOLS%" (
+  echo Error: Visual Studio 2015 or 2017 required.
+  echo        Please see https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/developer-guide.md for build instructions.
+  exit /b 1
+)
+
+call "%_VSCOMNTOOLS%\VsDevCmd.bat"
+
+:Run
+
 set __VSVersion=vs2017
 
 if defined VS140COMNTOOLS set __VSVersion=vs2015


### PR DESCRIPTION
cc: @jkotas @VSadov @stephentoub 

Isolating the Update of buildtools from #14159 which includes using the new roslyn compiler. I'm isolating just buildtools update so that we can see if CI errors are triggered at all with the new compiler.