### PR TITLE
Fix issue with HFA altjit api

### DIFF
--- a/src/vm/class.cpp
+++ b/src/vm/class.cpp
@@ -1641,7 +1641,14 @@ bool MethodTable::IsHFA()
 #ifdef DACCESS_COMPILE
     return false;
 #else
-    return GetClass()->CheckForHFA();
+    if (GetClass()->GetMethodTable()->IsValueType())
+    {
+        return GetClass()->CheckForHFA();
+    }
+    else
+    {
+        return false;
+    }
 #endif
 }
 #endif // !FEATURE_HFA


### PR DESCRIPTION
One case in the Interop\ArrayMarshalling\ByValArray\MarshalArrayByValTest\MarshalArrayByValTest.cmd
test marshals an array of strings as members of a struct. The !FEATURE_HFA
code for IsHFA() needs to check for value type before calling CheckForHFA(),
which will assert if it is not a value type.

Fixes #14196.