### PR TITLE
ignore GT_ARGPLACE before gtUseNum check.

### DIFF
--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -1112,13 +1112,14 @@ void CodeGen::genConsumeRegAndCopy(GenTree* node, regNumber needReg)
 void CodeGen::genNumberOperandUse(GenTree* const operand, int& useNum) const
 {
     assert(operand != nullptr);
-    assert(operand->gtUseNum == -1);
 
     // Ignore argument placeholders.
     if (operand->OperGet() == GT_ARGPLACE)
     {
         return;
     }
+
+    assert(operand->gtUseNum == -1);
 
     if (!operand->isContained() && !operand->IsCopyOrReload())
     {


### PR DESCRIPTION
Fix #13508.

cc @dotnet/jit-contrib 