### PR TITLE
Allow cross machine re-crossgen

### DIFF
--- a/src/vm/readytoruninfo.cpp
+++ b/src/vm/readytoruninfo.cpp
@@ -495,12 +495,6 @@ PTR_ReadyToRunInfo ReadyToRunInfo::Initialize(Module * pModule, AllocMemTracker 
         return NULL;
     }
 
-    if (!pLayout->IsNativeMachineFormat())
-    {
-        // For CoreCLR, be strict about disallowing machine mismatches.
-        COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
-    }
-
 #ifdef FEATURE_NATIVE_IMAGE_GENERATION
     // Ignore ReadyToRun during NGen
     if (IsCompilationProcess() && !IsNgenPDBCompilationProcess())
@@ -509,6 +503,12 @@ PTR_ReadyToRunInfo ReadyToRunInfo::Initialize(Module * pModule, AllocMemTracker 
         return NULL;
     }
 #endif
+
+    if (!pLayout->IsNativeMachineFormat())
+    {
+        // For CoreCLR, be strict about disallowing machine mismatches.
+        COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
+    }
 
 #ifndef CROSSGEN_COMPILE
     // The file must have been loaded using LoadLibrary


### PR DESCRIPTION
This allows running crossgen on a library which was crossgened with a different machine format.

This is convenient for bootstrapping a new architecture.

@janvorli PTAL