### PR TITLE
Fixing Retain to return MemoryHandle with correct PinnedPointer

### DIFF
--- a/src/mscorlib/shared/System/Buffers/MemoryHandle.cs
+++ b/src/mscorlib/shared/System/Buffers/MemoryHandle.cs
@@ -21,7 +21,7 @@ namespace System.Buffers
             _handle = handle;
         }
 
-        public void AddOffset(int offset)
+        internal void AddOffset(int offset)
         {
             if (_pointer == null)
             {

--- a/src/mscorlib/shared/System/Buffers/MemoryHandle.cs
+++ b/src/mscorlib/shared/System/Buffers/MemoryHandle.cs
@@ -21,6 +21,18 @@ namespace System.Buffers
             _handle = handle;
         }
 
+        public void AddOffset(int offset)
+        {
+            if (_pointer == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.pointer);
+            }
+            else
+            {
+                _pointer = (void*)((byte*)_pointer + offset);
+            }
+        }
+
         [CLSCompliant(false)]
         public void* PinnedPointer => _pointer;
 

--- a/src/mscorlib/shared/System/Memory.cs
+++ b/src/mscorlib/shared/System/Memory.cs
@@ -185,6 +185,7 @@ namespace System
                 if (_index < 0)
                 {
                     memoryHandle = ((OwnedMemory<T>)_arrayOrOwnedMemory).Pin();
+                    memoryHandle.AddOffset((_index & RemoveOwnedFlagBitMask) * Unsafe.SizeOf<T>());
                 }
                 else
                 {

--- a/src/mscorlib/shared/System/ReadOnlyMemory.cs
+++ b/src/mscorlib/shared/System/ReadOnlyMemory.cs
@@ -170,6 +170,7 @@ namespace System
                 if (_index < 0)
                 {
                     memoryHandle = ((OwnedMemory<T>)_arrayOrOwnedMemory).Pin();
+                    memoryHandle.AddOffset((_index & RemoveOwnedFlagBitMask) * Unsafe.SizeOf<T>());
                 }
                 else
                 {

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -430,7 +430,8 @@ namespace System
         s,
         keyValuePair,
         input,
-        ownedMemory
+        ownedMemory,
+        pointer
     }
 
     //


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/24317

- AddOffset throws if PinnedPointer is null. Should it fail silently and do nothing?
- Would it be better to create a setter for PinnedPointer instead of the AddOffset API?

Related PR: https://github.com/dotnet/corefx/pull/24323

cc @pakrym, @KrzysztofCwalina, @stephentoub, @davidfowl, @jkotas 