### PR TITLE
[RyuJIT/armel] Fix regression

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -7117,7 +7117,7 @@ GenTreePtr Compiler::gtNewBitCastNode(var_types type, GenTreePtr arg)
     assert(arg != nullptr);
 
     GenTreePtr node = nullptr;
-#if !defined(LEGACY_BACKEND) && defined(ARM_SOFTFP)
+#if !defined(LEGACY_BACKEND) && defined(_TARGET_ARM_)
     // A BITCAST could be a MultiRegOp on armel since we could move a double register to two int registers.
     node = new (this, GT_PUTARG_REG) GenTreeMultiRegOp(GT_BITCAST, type, arg, nullptr);
 #else

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -6060,7 +6060,8 @@ inline bool GenTree::IsMultiRegNode() const
     }
 
 #if !defined(LEGACY_BACKEND) && defined(_TARGET_ARM_)
-    if (gtOper == GT_MUL_LONG || gtOper == GT_PUTARG_REG || gtOper == GT_BITCAST || OperIsPutArgSplit())
+    if (gtOper == GT_MUL_LONG || gtOper == GT_PUTARG_REG || gtOper == GT_BITCAST || gtOper == GT_COPY ||
+        OperIsPutArgSplit())
     {
         return true;
     }

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -765,7 +765,7 @@ void Lowering::ReplaceArgWithPutArgOrCopy(GenTree** argSlot, GenTree* putArgOrCo
 {
     assert(argSlot != nullptr);
     assert(*argSlot != nullptr);
-    assert(putArgOrCopy->OperIsPutArg() || putArgOrCopy->OperIs(GT_BITCAST));
+    assert(putArgOrCopy->OperIsPutArg() || putArgOrCopy->OperIs(GT_BITCAST) || putArgOrCopy->OperIs(GT_COPY));
 
     GenTree* arg = *argSlot;
 
@@ -1298,18 +1298,27 @@ void Lowering::LowerArg(GenTreeCall* call, GenTreePtr* ppArg)
         {
             var_types intType = (type == TYP_DOUBLE) ? TYP_LONG : TYP_INT;
 
-            GenTreePtr intArg = comp->gtNewBitCastNode(intType, arg);
-            intArg->gtRegNum  = info->regNum;
-#ifdef ARM_SOFTFP
-            if (intType == TYP_LONG)
+            GenTreePtr intArg;
+            if (isReg)
             {
-                assert(info->numRegs == 2);
-                regNumber regNext = REG_NEXT(info->regNum);
-                // double type arg regs can only be either r0:r1 or r2:r3.
-                assert((info->regNum == REG_R0 && regNext == REG_R1) || (info->regNum == REG_R2 && regNext == REG_R3));
-                intArg->AsMultiRegOp()->gtOtherReg = regNext;
-            }
+                intArg           = comp->gtNewBitCastNode(intType, arg);
+                intArg->gtRegNum = info->regNum;
+#ifdef ARM_SOFTFP
+                if (intType == TYP_LONG)
+                {
+                    assert(info->numRegs == 2);
+                    regNumber regNext = REG_NEXT(info->regNum);
+                    // double type arg regs can only be either r0:r1 or r2:r3.
+                    assert((info->regNum == REG_R0 && regNext == REG_R1) ||
+                           (info->regNum == REG_R2 && regNext == REG_R3));
+                    intArg->AsMultiRegOp()->gtOtherReg = regNext;
+                }
 #endif // ARM_SOFTFP
+            }
+            else
+            {
+                intArg = new (comp, GT_COPY) GenTreeCopyOrReload(GT_COPY, intType, arg);
+            }
 
             info->node = intArg;
             ReplaceArgWithPutArgOrCopy(ppArg, intArg);

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -140,6 +140,12 @@ void lsraAssignRegToTree(GenTreePtr tree, regNumber reg, unsigned regIdx)
         GenTreeMultiRegOp* mul = tree->AsMultiRegOp();
         mul->gtOtherReg        = reg;
     }
+    else if (tree->OperGet() == GT_COPY)
+    {
+        assert(regIdx == 1);
+        GenTreeCopyOrReload* copy = tree->AsCopyOrReload();
+        copy->gtOtherRegs[0]      = (regNumberSmall)reg;
+    }
     else if (tree->OperGet() == GT_PUTARG_SPLIT)
     {
         GenTreePutArgSplit* putArg = tree->AsPutArgSplit();

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -690,7 +690,18 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
 
         case GT_COPY:
             info->srcCount = 1;
-            assert(info->dstCount == 1);
+#ifdef ARM_SOFTFP
+            // This case currently only occurs for double types that are passed as TYP_LONG;
+            // actual long types would have been decomposed by now.
+            if (tree->TypeGet() == TYP_LONG)
+            {
+                info->dstCount = 2;
+            }
+            else
+#endif
+            {
+                assert(info->dstCount == 1);
+            }
             break;
 
         case GT_PUTARG_SPLIT:


### PR DESCRIPTION
Fix calling a function passing double-type stack arguments.

Fix #14251

cc: @dotnet/arm32-contrib 