### PR TITLE
[x86/Linux] Fix CopyREGDISPLAY for WIN64EXCEPTIONS

### DIFF
--- a/src/debug/ee/i386/debuggerregdisplayhelper.cpp
+++ b/src/debug/ee/i386/debuggerregdisplayhelper.cpp
@@ -15,4 +15,28 @@
 void CopyREGDISPLAY(REGDISPLAY* pDst, REGDISPLAY* pSrc)
 {
     *pDst = *pSrc;
+
+#ifdef WIN64EXCEPTIONS
+    if (pSrc->pCurrentContextPointers == &(pSrc->ctxPtrsOne))
+    {
+        pDst->pCurrentContextPointers = &(pDst->ctxPtrsOne);
+        pDst->pCallerContextPointers  = &(pDst->ctxPtrsTwo);
+    }
+    else
+    {
+        pDst->pCurrentContextPointers = &(pDst->ctxPtrsTwo);
+        pDst->pCallerContextPointers  = &(pDst->ctxPtrsOne);
+    }
+
+    if (pSrc->pCurrentContext == &(pSrc->ctxOne))
+    {
+        pDst->pCurrentContext = &(pDst->ctxOne);
+        pDst->pCallerContext  = &(pDst->ctxTwo);
+    }
+    else
+    {
+        pDst->pCurrentContext = &(pDst->ctxTwo);
+        pDst->pCallerContext  = &(pDst->ctxOne);
+    }
+#endif
 }


### PR DESCRIPTION
When WIN64EXCEPTIONS is defined, fields pCurrentContextPointers, pCallerContextPointers, pCurrentContext and pCallerContext of the REGDISPLAY are used. So we need to fix their values after coping. Otherwise we can get following assert:
```
Assert failure(PID 25896 [0x00006528], Thread: 25900 [0x652c]): GetRegdisplaySP(display) == GetSP(display->pCurrentContext)
    File: /media/kbaladurin/data/dotnet/forked/coreclr-1/src/inc/regdisp.h Line: 143
    Image: /media/kbaladurin/data/dotnet/coreclr/overlay_coredumpx86_1/corerun
```