### PR TITLE
Fix type for lvaCachedGenericContextArgOffs

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2536,9 +2536,9 @@ public:
     unsigned lvaShadowSPslotsVar; // TYP_BLK variable for all the shadow SP slots
 #endif                            // FEATURE_EH_FUNCLETS
 
-    unsigned lvaCachedGenericContextArgOffs;
-    unsigned lvaCachedGenericContextArgOffset(); // For CORINFO_CALLCONV_PARAMTYPE and if generic context is passed as
-                                                 // THIS pointer
+    int lvaCachedGenericContextArgOffs;
+    int lvaCachedGenericContextArgOffset(); // For CORINFO_CALLCONV_PARAMTYPE and if generic context is passed as
+                                            // THIS pointer
 
     unsigned lvaLocAllocSPvar; // variable which has the result of the last alloca/localloc
 

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -2336,7 +2336,7 @@ inline bool Compiler::lvaReportParamTypeArg()
 
 //*****************************************************************************
 
-inline unsigned Compiler::lvaCachedGenericContextArgOffset()
+inline int Compiler::lvaCachedGenericContextArgOffset()
 {
     assert(lvaDoneFrameLayout == FINAL_FRAME_LAYOUT);
 


### PR DESCRIPTION
lvaCachedGenericContextArgOffs should be signed since it's initially
assigned with a negative virtual offset. Finally depending on
frame pointer use with different arch, it could become positive or negative.
Luckily enough, so far such issue was by-passed since amd64 encoder didn't
care such signness when encoding move offset even though the value is
negative. For arm64, it is typically positive since FP is saved on the
bottom of stack.