### PR TITLE
Fix IsSafeToContained.

### DIFF
--- a/src/jit/sideeffects.cpp
+++ b/src/jit/sideeffects.cpp
@@ -263,6 +263,10 @@ void AliasSet::AddNode(Compiler* compiler, GenTree* node)
 
             m_lclVarReads.Add(compiler, lclNum);
         }
+        if (!operand->IsArgPlaceHolderNode() && operand->isContained())
+        {
+            AddNode(compiler, operand);
+        }
         return GenTree::VisitResult::Continue;
     });
 

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -184,9 +184,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeGeneratorTests\TypeGeneratorTest683\Generated683\*">
             <Issue>6707</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\GitHub_13910\GitHub_13910\GitHub_13910.cmd">
-            <Issue>13910</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- The following are x86 failures -->


### PR DESCRIPTION
When AliasSet adds a node, it must also add all nodes that are executed inside it (they are marked as contained).
Fixes #13910 and DevDiv_489990.

Please note that `IsSafeToContainMem` already takes linear time complexity and we can call it linear number of times, that leads to quadratic algorithm. This fix doesn't change the asymptotic, but can make it a bit slower.
There is a simple way how to do `IsSafeToContainMem` O(1) if we are able to determinate the order between two random instruction and have a normal map. like std::map.

