### PR TITLE
Adding a patch to fix coreclr build for VS 15.5 (using older SDKs).

### DIFF
--- a/src/inc/warningcontrol.h
+++ b/src/inc/warningcontrol.h
@@ -69,6 +69,7 @@
 
 #pragma warning(error   :4700)   // Local used w/o being initialized
 #pragma warning(disable :4706)   // assignment within conditional expression
+#pragma warning(disable :4768)   // __declspec attributes before linkage specification are ignored
 #pragma warning(error   :4806)   // unsafe operation involving type 'bool'
 #pragma warning(disable :4995)   // '_OLD_IOSTREAMS_ARE_DEPRECATED': name was marked as #pragma deprecated
 


### PR DESCRIPTION
cc @jkotas, @AndyAyersMS 

From Andy:
> If you are building with 15.5 you may need this patch. C++ folks elevated 4768  to on by default (apparently a windows ask) but older SDKs have the bad pattern.