### PR TITLE
Cleanup some mixed type relops the JIT produces

### DIFF
--- a/src/jit/loopcloning.h
+++ b/src/jit/loopcloning.h
@@ -327,7 +327,7 @@ struct LC_Ident
         Null,
     };
 
-    INT64     constant; // The constant value if this node is of type "Const", or the lcl num if "Var"
+    unsigned  constant; // The constant value if this node is of type "Const", or the lcl num if "Var"
     LC_Array  arrLen;   // The LC_Array if the type is "ArrLen"
     IdentType type;     // The type of this object
 
@@ -355,7 +355,7 @@ struct LC_Ident
         switch (type)
         {
             case Const:
-                printf("%I64d", constant);
+                printf("%u", constant);
                 break;
             case Var:
                 printf("V%02d", constant);
@@ -376,7 +376,7 @@ struct LC_Ident
     LC_Ident() : type(Invalid)
     {
     }
-    LC_Ident(INT64 constant, IdentType type) : constant(constant), type(type)
+    LC_Ident(unsigned constant, IdentType type) : constant(constant), type(type)
     {
     }
     explicit LC_Ident(IdentType type) : type(type)
@@ -392,7 +392,7 @@ struct LC_Ident
 
 /**
  *
- *  Symbolic representation of an expr that involves an "LC_Ident" or an "LC_Ident - constant"
+ *  Symbolic representation of an expr that involves an "LC_Ident"
  */
 struct LC_Expr
 {
@@ -400,11 +400,9 @@ struct LC_Expr
     {
         Invalid,
         Ident,
-        IdentPlusConst
     };
 
     LC_Ident ident;
-    INT64    constant;
     ExprType type;
 
     // Equality operator
@@ -418,12 +416,6 @@ struct LC_Expr
             return false;
         }
 
-        // If the type involves arithmetic, the constant should match.
-        if (type == IdentPlusConst && constant != that.constant)
-        {
-            return false;
-        }
-
         // Check if the ident match.
         return (ident == that.ident);
     }
@@ -431,13 +423,7 @@ struct LC_Expr
 #ifdef DEBUG
     void Print()
     {
-        if (type == IdentPlusConst)
-        {
-            printf("(%I64d - ", constant);
-            ident.Print();
-            printf(")");
-        }
-        else
+        if (type == Ident)
         {
             ident.Print();
         }
@@ -448,9 +434,6 @@ struct LC_Expr
     {
     }
     explicit LC_Expr(const LC_Ident& ident) : ident(ident), type(Ident)
-    {
-    }
-    LC_Expr(const LC_Ident& ident, INT64 constant) : ident(ident), constant(constant), type(IdentPlusConst)
     {
     }
 

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2367,54 +2367,6 @@ void Lowering::LowerCompare(GenTree* cmp)
     }
 #endif
 
-#ifdef _TARGET_64BIT_
-    if (cmp->gtGetOp1()->TypeGet() != cmp->gtGetOp2()->TypeGet())
-    {
-        bool op1Is64Bit = (genTypeSize(cmp->gtGetOp1()->TypeGet()) == 8);
-        bool op2Is64Bit = (genTypeSize(cmp->gtGetOp2()->TypeGet()) == 8);
-
-        if (op1Is64Bit != op2Is64Bit)
-        {
-            //
-            // Normally this should not happen. IL allows comparing int32 to native int but the importer
-            // automatically inserts a cast from int32 to long on 64 bit architectures. However, the JIT
-            // accidentally generates int/long comparisons internally:
-            //   - loop cloning compares int (and even small int) index limits against long constants
-            //
-            // TODO-Cleanup: The above mentioned issues should be fixed and then the code below may be
-            // replaced with an assert or at least simplified. The special casing of constants in code
-            // below is only necessary to prevent worse code generation for switches and loop cloning.
-            //
-
-            GenTree*  longOp       = op1Is64Bit ? cmp->gtOp.gtOp1 : cmp->gtOp.gtOp2;
-            GenTree** smallerOpUse = op2Is64Bit ? &cmp->gtOp.gtOp1 : &cmp->gtOp.gtOp2;
-#ifdef _TARGET_AMD64_
-            var_types smallerType = (*smallerOpUse)->TypeGet();
-#elif defined(_TARGET_ARM64_)
-            var_types smallerType  = genActualType((*smallerOpUse)->TypeGet());
-#endif // _TARGET_AMD64_
-
-            assert(genTypeSize(smallerType) < 8);
-
-            if (longOp->IsCnsIntOrI() && genTypeCanRepresentValue(smallerType, longOp->AsIntCon()->IconValue()))
-            {
-                longOp->gtType = smallerType;
-            }
-            else if ((*smallerOpUse)->IsCnsIntOrI())
-            {
-                (*smallerOpUse)->gtType = TYP_LONG;
-            }
-            else
-            {
-                GenTree* cast = comp->gtNewCastNode(TYP_LONG, *smallerOpUse, TYP_LONG);
-                *smallerOpUse = cast;
-                BlockRange().InsertAfter(cast->gtGetOp1(), cast);
-                ContainCheckCast(cast->AsCast());
-            }
-        }
-    }
-#endif // _TARGET_64BIT_
-
 #if defined(_TARGET_XARCH_) || defined(_TARGET_ARM64_)
     if (cmp->gtGetOp2()->IsIntegralConst())
     {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -11276,6 +11276,8 @@ GenTree* Compiler::fgMorphRecognizeBoxNullable(GenTree* compare)
         compare->gtOp.gtOp2 = newOp;
     }
 
+    opCns->gtType = TYP_INT;
+
     return compare;
 }
 

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -4615,7 +4615,7 @@ bool Compiler::optDeriveLoopCloningConditions(unsigned loopNum, LoopCloneContext
                 JITDUMP("> limit %d is invalid\n", limit);
                 return false;
             }
-            ident = LC_Ident(limit, LC_Ident::Const);
+            ident = LC_Ident(static_cast<unsigned>(limit), LC_Ident::Const);
         }
         else if (loop->lpFlags & LPFLG_VAR_LIMIT)
         {


### PR DESCRIPTION
`fgMorphRecognizeBoxNullable` produces a `TYP_REF`/`TYP_BOOL` relop because it doesn't change the constant type from `TYP_REF` to `TYP_INT`.

Loop cloning always produces `TYP_LONG` constants even though it doesn't support `TYP_LONG` iteration variables, limits etc.

These mixed type relops require lowering/codegen to do more work.

No diffs.