### PR TITLE
Workaround GetSystemTimePreciseAsFileTime inaccuracies

### DIFF
--- a/src/classlibnative/bcltype/system.cpp
+++ b/src/classlibnative/bcltype/system.cpp
@@ -60,7 +60,9 @@ void WINAPI InitializeGetSystemTimeAsFileTime(LPFILETIME lpSystemTimeAsFileTime)
             //     https://github.com/dotnet/coreclr/issues/14187
             // If it's inaccurate, though, we expect it to be wildly inaccurate, so as a
             // workaround/heuristic, we get both the "normal" and "precise" times, and as
-            // long as they're close, we use the precise one.
+            // long as they're close, we use the precise one. This workaround can be removed
+            // when we better understand what's causing the drift and the issue is no longer
+            // a problem or can be better worked around on all targeted OSes.
 
             FILETIME systemTimeResult;
             ::GetSystemTimeAsFileTime(&systemTimeResult);


### PR DESCRIPTION
On misconfigured systems, GetSystemTimePreciseAsFileTime may drift quickly from GetSystemTimeAsFileTime.  We want to use the former, though.  As a workaround/heuristic, when checking whether we have GetSystemTimePreciseAsFileTime, invoke both and ensure they're "close", falling back to GetSystemTimeAsFileTime if it seems like the precise variant has run away.

Closes https://github.com/dotnet/coreclr/issues/14187
cc: @vancem, @jkotas