### PR TITLE
Disable PGO optimization on linux

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1897,13 +1897,18 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                     if (scenario == 'standalone_gc') {
                         standaloneGc = 'buildstandalonegc'
                     }
+                    
+                    def disablePgo = ''
+                    if (lowerConfiguration == 'release') {
+                        disablePgo = 'nopgooptimize'
+                    }
 
                     if (!enableCorefxTesting) {
                         // We run pal tests on all OS but generate mscorlib (and thus, nuget packages)
                         // only on supported OS platforms.
                         def bootstrapRid = Utilities.getBoostrapPublishRid(os)
                         def bootstrapRidEnv = bootstrapRid != null ? "__PUBLISH_RID=${bootstrapRid} " : ''
-                        buildCommands += "${bootstrapRidEnv}./build.sh verbose ${lowerConfiguration} ${architecture} ${standaloneGc}"
+                        buildCommands += "${bootstrapRidEnv}./build.sh verbose ${lowerConfiguration} ${architecture} ${standaloneGc} ${disablePgo}"
                         buildCommands += "src/pal/tests/palsuite/runpaltests.sh \${WORKSPACE}/bin/obj/${osGroup}.${architecture}.${configuration} \${WORKSPACE}/bin/paltestout"
 
                         // Set time out


### PR DESCRIPTION
With the update to llvm 3.9, the pgo data is incompatible since it was
generated with llvm 3.6. Currently, both the pgo data generation builds
and the automatic updates of counts are currently down, so pgo data is
not being updated. Until these problems are fixed, disable pgo
optimization for release builds on linux.