### PR TITLE
[x86/Linux] Fix regdisplay initialization in case of WIN64EXCEPTIONS

### DIFF
--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -12565,7 +12565,7 @@ bool Debugger::IsThreadAtSafePlaceWorker(Thread *thread)
         CONTEXT ctx;
         ZeroMemory(&rd, sizeof(rd));
         ZeroMemory(&ctx, sizeof(ctx));
-#if defined(_TARGET_X86_)
+#if defined(_TARGET_X86_) && !defined(WIN64EXCEPTIONS)
         rd.ControlPC = ctx.Eip;
         rd.PCTAddr = (TADDR)&(ctx.Eip);
 #else


### PR DESCRIPTION
Method Debugger::IsThreadAtSafePlaceWorker for x86 sets only ControlPC and PCTAddr fields of REGDISPLAY but there is the assert in StackFrameIterator::Init that checks that field pCurrentContext is not NULL when WIN64EXCEPTIONS is defined.

This patch uses FillRegDisplay function to correctlty initialize regdisplay in case of WIN64EXCEPTIONS and fixes following assert:
```
Assert failure(PID 25339 [0x000062fb], Thread: 25339 [0x62fb]): pRegDisp->pCurrentContext
    File: /media/kbaladurin/data/dotnet/forked/coreclr-1/src/vm/stackwalk.cpp Line: 1181
    Image: /media/kbaladurin/data/dotnet/coreclr/overlay_coredumpx86_1/corerun
```