### PR TITLE
Add empty perf pipeline job

### DIFF
--- a/buildpipeline/perf-pipeline.groovy
+++ b/buildpipeline/perf-pipeline.groovy
@@ -1,0 +1,14 @@
+@Library('dotnet-ci') _
+
+// Incoming parameters.  Access with "params.<param name>".
+// Note that the parameters will be set as env variables so we cannot use names that conflict
+// with the engineering system parameter names.
+
+//--------------------- Windows Functions ----------------------------//
+
+stage ('Basic') {
+    simpleNode('Windows_NT', '20170427-elevated') {
+        checkout scm
+    }
+}
+

--- a/buildpipeline/perf-pipelinejobs.groovy
+++ b/buildpipeline/perf-pipelinejobs.groovy
@@ -1,0 +1,28 @@
+import jobs.generation.JobReport;
+import jobs.generation.Utilities;
+import org.dotnet.ci.pipelines.Pipeline
+
+// The input project name (e.g. dotnet/corefx)
+def project = GithubProject
+// The input branch name (e.g. master)
+def branch = GithubBranchName
+
+// **************************
+// Define innerloop testing. Any configuration in ForPR will run for every PR but all other configurations
+// will have a trigger that can be
+// **************************
+
+def perfPipeline = Pipeline.createPipelineForGithub(this, project, branch, 'buildpipeline/perf-pipeline.groovy')
+
+def triggerName = "Perf Build and Test"
+def pipeline = perfPipeline
+
+// If we were using parameters for the pipeline job, we would define an array of parameter pairs
+// and pass that array as a parameter to the trigger functions. Ie:
+// def params = ['CGroup':'Release',
+//               'AGroup':'x64',
+//               'OGroup':'Windows_NT']
+// pipeline.triggerPipelinOnGithubPRComment(triggerName, params)
+
+pipeline.triggerPipelineOnEveryGithubPR(triggerName)
+pipeline.triggerPipelineOnGithubPush()


### PR DESCRIPTION
This is step one of adding the pipeline job for performance runs. In
this change, we add perf-pipelinejobs.groovy, which defines what Jenkins
will see in the UI. perf-pipeline.groovy is basically an empty job, so
we can test the actual perf-pipeline work after this is checked in,
which is step two.