### PR TITLE
Fix broken ARM64 build

### DIFF
--- a/src/pal/src/misc/sysinfo.cpp
+++ b/src/pal/src/misc/sysinfo.cpp
@@ -489,7 +489,7 @@ PAL_GetLogicalProcessorCacheSizeFromOS()
         // Assume L3$/CPU grows linearly from 256K to 1.5M/CPU as logicalCPUs grows from 2 to 12 CPUs
         DWORD logicalCPUs = PAL_GetLogicalCpuCountFromOS();
 
-        cacheSize = logicalCPUs*std::min(1536, std::max(256, logicalCPUs*128))*1024;
+        cacheSize = logicalCPUs*std::min(1536, std::max(256, (int)logicalCPUs*128))*1024;
     }
 #endif
 


### PR DESCRIPTION
The std::max was being passed arguments of different types (int and DWORD).