### PR TITLE
Fix condition flags reuse optimization

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -887,8 +887,7 @@ void CodeGen::genCodeForBinary(GenTree* treeNode)
     }
 
     // try to use an inc or dec
-    if (oper == GT_ADD && !varTypeIsFloating(treeNode) && src->isContainedIntOrIImmed() && !treeNode->gtOverflowEx() &&
-        !treeNode->gtSetFlags())
+    if (oper == GT_ADD && !varTypeIsFloating(treeNode) && src->isContainedIntOrIImmed() && !treeNode->gtOverflowEx())
     {
         if (src->IsIntegralConst(1))
         {

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2616,10 +2616,8 @@ GenTree* Lowering::LowerCompare(GenTree* cmp)
         }
 #endif // _TARGET_XARCH_
     }
-    else
+    else if (cmp->OperIs(GT_EQ, GT_NE))
     {
-        assert(cmp->OperIs(GT_EQ, GT_NE, GT_LE, GT_LT, GT_GE, GT_GT));
-
         GenTree* op1 = cmp->gtGetOp1();
         GenTree* op2 = cmp->gtGetOp2();
 

--- a/tests/src/JIT/Regression/JitBlue/GitHub_14321/GitHub_14321.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_14321/GitHub_14321.il
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib {auto}
+.assembly extern System.Console {auto}
+.assembly GitHub_14321 {}
+
+.class Program
+{
+    .method static bool TestUnsigned(int32) noinlining
+    {
+		.maxstack 2
+
+		ldarg.0
+		ldc.i4 42
+		sub
+		ldc.i4 0
+		clt.un
+		ret
+    }
+
+    .method static bool TestSignedOverflow(int32) noinlining
+    {
+		.maxstack 2
+
+        ldarg.0
+        ldc.i4 42
+        add
+        ldc.i4 0
+        cgt
+		ret
+    }
+
+    .method static int32 Main() 
+    {
+        .entrypoint
+        .maxstack 1
+
+        ldc.i4 42
+        call bool Program::TestUnsigned(int32)
+		brtrue FAIL
+        ldc.i4 0x7fffffff
+        call bool Program::TestSignedOverflow(int32)
+		brtrue FAIL
+        ldstr "PASS"
+        call void [System.Console]System.Console::WriteLine(string)
+        ldc.i4 100
+        ret
+    FAIL:
+        ldstr "FAIL"
+        call void [System.Console]System.Console::WriteLine(string)
+        ldc.i4 1
+        ret
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_14321/GitHub_14321.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_14321/GitHub_14321.ilproj
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_14321.il" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
This optimization is not valid for unsigned LT/LE/GT/GE relops. Using the Carry flag this way indicates that the operation overflowed, not that the result is less than 0, that's impossible for unsigned integers.

Fixes #14321