### PR TITLE
Normalize RIDs

### DIFF
--- a/build-packages.sh
+++ b/build-packages.sh
@@ -16,6 +16,10 @@ initHostDistroRid()
     if [ "$__HostOS" == "Linux" ]; then
         if [ -e /etc/os-release ]; then
             source /etc/os-release
+            if [[ $ID == "alpine" || $ID == "rhel"]]; then
+                # remove the last version digit
+                VERSION_ID=${VERSION_ID%.*}
+            fi
             __HostDistroRid="$ID.$VERSION_ID-$__Arch"
         elif [ -e /etc/redhat-release ]; then
             local redhatRelease=$(</etc/redhat-release)

--- a/build.sh
+++ b/build.sh
@@ -61,6 +61,10 @@ initHostDistroRid()
     if [ "$__HostOS" == "Linux" ]; then
         if [ -e /etc/os-release ]; then
             source /etc/os-release
+            if [[ $ID == "alpine" || $ID == "rhel"]]; then
+                # remove the last version digit
+                VERSION_ID=${VERSION_ID%.*}
+            fi
             __HostDistroRid="$ID.$VERSION_ID-$__HostArch"
         elif [ -e /etc/redhat-release ]; then
             local redhatRelease=$(</etc/redhat-release)


### PR DESCRIPTION
See: https://github.com/dotnet/core-setup/commit/c8a27076f93c3107759b8a86a02ea4f40d100b67

We need to strip the last part of the version number for alpine and rhel because
they are compatible and we don't want the specific versions.

cc @janvorli @eerhardt 

I really hate having to duplicate this RID computing logic all over the place but for now I need to unblock the source-build and we are building packages with the wrong RID on RHEL7.2 currently. 