### PR TITLE
fix gtDispTree

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -10936,8 +10936,11 @@ void Compiler::gtDispTree(GenTreePtr   tree,
                 indentStack->Push(IIEmbedded);
                 lowerArc = IIEmbedded;
                 break;
+            case IINone:
+                indentStack->Push(IINone);
+                lowerArc = IINone;
             default:
-                // Should never get here; just use IINone.
+                unreached();
                 break;
         }
     }

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -10939,6 +10939,7 @@ void Compiler::gtDispTree(GenTreePtr   tree,
             case IINone:
                 indentStack->Push(IINone);
                 lowerArc = IINone;
+                break;
             default:
                 unreached();
                 break;


### PR DESCRIPTION
It is a legal situation when we pass ILNone (for example for local stores:
`gtDispChild(tree->gtOp.gtOp1, indentStack, IINone);`). In this code we
poped a value and didn't push anything back, it ended with the stack
underflow.

