### PR TITLE
fgDebugCheckFlags should use OperMayThrow for all nodes.

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -21080,6 +21080,11 @@ void Compiler::fgDebugCheckFlags(GenTreePtr tree)
     unsigned   treeFlags = tree->gtFlags & GTF_ALL_EFFECT;
     unsigned   chkFlags  = 0;
 
+    if (tree->OperMayThrow(this))
+    {
+        chkFlags |= GTF_EXCEPT;
+    }
+
     /* Is this a leaf node? */
 
     if (kind & GTK_LEAF)
@@ -21241,11 +21246,6 @@ void Compiler::fgDebugCheckFlags(GenTreePtr tree)
             chkFlags |= GTF_ASG;
         }
 
-        if (tree->OperMayThrow(this))
-        {
-            chkFlags |= GTF_EXCEPT;
-        }
-
         if (oper == GT_ADDR && (op1->OperIsLocal() || op1->gtOper == GT_CLS_VAR ||
                                 (op1->gtOper == GT_IND && op1->gtOp.gtOp1->gtOper == GT_CLS_VAR_ADDR)))
         {
@@ -21259,11 +21259,6 @@ void Compiler::fgDebugCheckFlags(GenTreePtr tree)
 
     else
     {
-        if (tree->OperMayThrow(this))
-        {
-            chkFlags |= GTF_EXCEPT;
-        }
-
         switch (tree->OperGet())
         {
             case GT_CALL:

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -5850,7 +5850,6 @@ bool GenTree::OperMayThrow(Compiler* comp)
         case GT_ARR_ELEM:
         case GT_ARR_INDEX:
         case GT_ARR_OFFSET:
-        case GT_CATCH_ARG:
         case GT_LCLHEAP:
         case GT_CKFINITE:
 #ifdef FEATURE_SIMD


### PR DESCRIPTION
This statement should be always true: `(int)tree->operMayThrow()  >= (tree->gtFlags | GTF_EXCEPT)` . It means if tree may throw, than it must be marked with `GTF_EXCEPT`.

It was not checked for leaf nodes in `fgDebugCheckFlags`, so when I enabled it, it showed that for `GT_CATCH_ARG` `operMayThrow` returns wrong result.

Was found as part of my experiments with the fact, that `GTF_EXCEPT` values set in `impImportCall` are not used, because `morph` always rewrites it based on `operMayThrow`.

Maybe we should do the same check with `OperRequiresAsgFlag`.