### PR TITLE
Fix corefx testing invocation

### DIFF
--- a/tests/scripts/run-corefx-tests.py
+++ b/tests/scripts/run-corefx-tests.py
@@ -269,12 +269,8 @@ def main(args):
 
     if Is_windows:
         command = 'build-tests.cmd'
-        if env_script is not None:
-            command = ('cmd /c \"%s&&' % env_script) + command + '\"'
     else:
         command = './build-tests.sh'
-        if env_script is not None:
-            command = ('. %s;' % env_script) + command
 
     command = ' '.join((
         command,
@@ -282,6 +278,9 @@ def main(args):
         '--',
         '/p:WithoutCategories=IgnoreForCI'
     ))
+
+    if env_script is not None:
+        command += (' /p:PreExecutionTestScript=%s' % env_script)
 
     if not Is_windows:
         command += ' /p:TestWithLocalNativeLibraries=true'


### PR DESCRIPTION
Instead of executing the environment-setting script before calling
build-tests, pass the `/p:PreExecutionTestScript=<env_script>`
msbuild property, which will write the environment script directly
into the generated corefx RunTests.cmd scripts. Thus, the
environment changes will be made immediately before the test is run.

Depends on https://github.com/dotnet/buildtools/pull/1723.