### PR TITLE
undef NULL to fix compilation problems on FreeBSD after 08d39dd.

### DIFF
--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -279,12 +279,10 @@ PAL_IsDebuggerPresent(VOID);
 
 #undef NULL
 
-#ifndef NULL
 #if defined(__cplusplus)
 #define NULL    0
 #else
 #define NULL    ((void *)0)
-#endif
 #endif
 
 #if defined(PAL_STDCPP_COMPAT) && !defined(__cplusplus)

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -277,9 +277,7 @@ PAL_IsDebuggerPresent(VOID);
 #define _UI32_MAX UINT_MAX
 #define _UI32_MIN UINT_MIN
 
-#ifdef PAL_STDCPP_COMPAT
 #undef NULL
-#endif
 
 #ifndef NULL
 #if defined(__cplusplus)


### PR DESCRIPTION
On FreeBSD NULL expands to nullptr and breaks macros after refacto