### PR TITLE
impImportCall: make the failed imports obvious.

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -13261,6 +13261,9 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                                         newObjThisPtr, prefixFlags, &callInfo, opcodeOffs);
                 if (compDonotInline())
                 {
+                    // We do not check fails after lvaGrabTemp. It is covered with CoreCLR_13272 issue.
+                    assert((callTyp == TYP_UNDEF) ||
+                           (compInlineResult->GetObservation() == InlineObservation::CALLSITE_TOO_MANY_LOCALS));
                     return;
                 }
 

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -6778,6 +6778,10 @@ bool Compiler::impIsImplicitTailCallCandidate(
 //
 // Returns:
 //    Type of the call's return value.
+//    If it is compilation for the inlining and it failed, then result can be TYP_UNDEF.
+//    However, you can not assert that if compInline->IsFailure(), then return value is TYP_UNDEF,
+//    because we do not check NoteFatal results always, it is covered with CoreCLR_13272 issue.
+//
 //
 // Notes:
 //    opcode can be CEE_CALL, CEE_CALLI, CEE_CALLVIRT, or CEE_NEWOBJ.

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -7019,7 +7019,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
             call = impIntrinsic(newobjThis, clsHnd, methHnd, sig, pResolvedToken->token, readonlyCall,
                                 (canTailCall && (tailCall != 0)), isJitIntrinsic, &intrinsicID, &isSpecialIntrinsic);
 
-            if (compIsForInlining() && compInlineResult->IsFailure())
+            if (compDonotInline())
             {
                 return TYP_UNDEF;
             }

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -7212,6 +7212,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
 
                 GenTreePtr thisPtr = impPopStack().val;
                 thisPtr            = impTransformThis(thisPtr, pConstrainedResolvedToken, callInfo->thisTransform);
+                assert(thisPtr != nullptr);
 
                 // Clone the (possibly transformed) "this" pointer
                 GenTreePtr thisPtrCopy;
@@ -7219,6 +7220,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
                                        nullptr DEBUGARG("LDVIRTFTN this pointer"));
 
                 GenTreePtr fptr = impImportLdvirtftn(thisPtr, pResolvedToken, callInfo);
+                assert(fptr != nullptr);
 
                 thisPtr = nullptr; // can't reuse it
 

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -6778,9 +6778,8 @@ bool Compiler::impIsImplicitTailCallCandidate(
 //
 // Returns:
 //    Type of the call's return value.
-//    If it is compilation for the inlining and it failed, then result can be TYP_UNDEF.
-//    However, you can not assert that if compInline->IsFailure(), then return value is TYP_UNDEF,
-//    because we do not check NoteFatal results always, it is covered with CoreCLR_13272 issue.
+//    If we're importing an inlinee and have realized the inline must fail, the call return type should be TYP_UNDEF.
+//    However we can't assert for this here yet because there are cases we miss. See issue #13272.
 //
 //
 // Notes:


### PR DESCRIPTION
Delete unnecessary and confusing dependency on callRetType.

It was part of my refactoring, but I need this change now to make my next changes about GTF_EXCEPT flags readable.

+delete unreached code.