### PR TITLE
Cleanup of Lowering & LsraInfo

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -538,8 +538,8 @@ void CodeGen::genIntrinsic(GenTreePtr treeNode)
 void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
 {
     assert(treeNode->OperIs(GT_PUTARG_STK));
-    var_types  targetType = treeNode->TypeGet();
     GenTreePtr source     = treeNode->gtOp1;
+    var_types  targetType = source->TypeGet();
     emitter*   emit       = getEmitter();
 
     // This is the varNum for our store operations,

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -398,11 +398,8 @@ void CodeGen::genCodeForBBlist()
         // performed at the end of each block.
         // TODO: could these checks be performed more frequently? E.g., at each location where
         // the register allocator says there are no live non-variable registers. Perhaps this could
-        // be done by (a) keeping a running count of live non-variable registers by using
-        // gtLsraInfo.srcCount and gtLsraInfo.dstCount to decrement and increment the count, respectively,
-        // and running the checks when the count is zero. Or, (b) use the map maintained by LSRA
-        // (operandToLocationInfoMap) to mark a node somehow when, after the execution of that node,
-        // there will be no live non-variable registers.
+        // be done by using the map maintained by LSRA (operandToLocationInfoMap) to mark a node
+        // somehow when, after the execution of that node, there will be no live non-variable registers.
 
         regSet.rsSpillChk();
 
@@ -1375,15 +1372,12 @@ void CodeGen::genConsumePutStructArgStk(GenTreePutArgStk* putArgNode,
                                         regNumber         srcReg,
                                         regNumber         sizeReg)
 {
-    assert(varTypeIsStruct(putArgNode));
-
     // The putArgNode children are always contained. We should not consume any registers.
     assert(putArgNode->gtGetOp1()->isContained());
 
-    GenTree* dstAddr = putArgNode;
-
     // Get the source address.
     GenTree* src = putArgNode->gtGetOp1();
+    assert(varTypeIsStruct(src));
     assert((src->gtOper == GT_OBJ) || ((src->gtOper == GT_IND && varTypeIsSIMD(src))));
     GenTree* srcAddr = src->gtGetOp1();
 
@@ -1406,6 +1400,7 @@ void CodeGen::genConsumePutStructArgStk(GenTreePutArgStk* putArgNode,
     assert(dstReg != REG_SPBASE);
     inst_RV_RV(INS_mov, dstReg, REG_SPBASE);
 #else  // !_TARGET_X86_
+    GenTree* dstAddr = putArgNode;
     if (dstAddr->gtRegNum != dstReg)
     {
         // Generate LEA instruction to load the stack of the outgoing var + SlotNum offset (or the incoming arg area

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -8113,7 +8113,7 @@ void CodeGen::genPutStructArgStk(GenTreePutArgStk* putArgStk)
     var_types targetType = source->TypeGet();
 
 #if defined(_TARGET_X86_) && defined(FEATURE_SIMD)
-    if (targetType == TYP_SIMD12)
+    if (varTypeIsSIMD(targetType) && (putArgStk->gtNumSlots == 3))
     {
         genPutArgStkSIMD12(putArgStk);
         return;

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -8113,7 +8113,7 @@ void CodeGen::genPutStructArgStk(GenTreePutArgStk* putArgStk)
     var_types targetType = source->TypeGet();
 
 #if defined(_TARGET_X86_) && defined(FEATURE_SIMD)
-    if (varTypeIsSIMD(targetType) && (putArgStk->gtNumSlots == 3))
+    if (putArgStk->isSIMD12())
     {
         genPutArgStkSIMD12(putArgStk);
         return;

--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -274,31 +274,7 @@ GenTree* DecomposeLongs::DecomposeNode(GenTree* tree)
     // element into two elements: one for each half of the GT_LONG.
     if ((use.Def()->OperGet() == GT_LONG) && !use.IsDummyUse() && (use.User()->OperGet() == GT_FIELD_LIST))
     {
-        GenTreeOp* value = use.Def()->AsOp();
-        Range().Remove(value);
-
-        // The node returned by `use.User()` is the head of the field list. We need to find the actual node that uses
-        // the `GT_LONG` so that we can split it.
-        GenTreeFieldList* listNode = use.User()->AsFieldList();
-        for (; listNode != nullptr; listNode = listNode->Rest())
-        {
-            if (listNode->Current() == value)
-            {
-                break;
-            }
-        }
-
-        assert(listNode != nullptr);
-        GenTree* rest = listNode->gtOp2;
-
-        GenTreeFieldList* loNode = listNode;
-        loNode->gtOp1            = value->gtOp1;
-        loNode->gtFieldType      = TYP_INT;
-
-        GenTreeFieldList* hiNode =
-            new (m_compiler, GT_FIELD_LIST) GenTreeFieldList(value->gtOp2, loNode->gtFieldOffset + 4, TYP_INT, loNode);
-
-        hiNode->gtOp2 = rest;
+        DecomposeFieldList(use.User()->AsFieldList(), use.Def()->AsOp());
     }
 
 #ifdef DEBUG
@@ -722,6 +698,49 @@ GenTree* DecomposeLongs::DecomposeCnsLng(LIR::Use& use)
     Range().InsertAfter(loResult, hiResult);
 
     return FinalizeDecomposition(use, loResult, hiResult, hiResult);
+}
+
+//------------------------------------------------------------------------
+// DecomposeFieldList: Decompose GT_FIELD_LIST.
+//
+// Arguments:
+//    listNode - the head of the FIELD_LIST that contains the given GT_LONG.
+//    longNode - the node to decompose
+//
+// Return Value:
+//    The next node to process.
+//
+// Notes:
+//    Split a LONG field list element into two elements: one for each half of the GT_LONG.
+//
+GenTree* DecomposeLongs::DecomposeFieldList(GenTreeFieldList* listNode, GenTreeOp* longNode)
+{
+    assert(longNode->OperGet() == GT_LONG);
+    // We are given the head of the field list. We need to find the actual node that uses
+    // the `GT_LONG` so that we can split it.
+    for (; listNode != nullptr; listNode = listNode->Rest())
+    {
+        if (listNode->Current() == longNode)
+        {
+            break;
+        }
+    }
+    assert(listNode != nullptr);
+
+    Range().Remove(longNode);
+
+    GenTree* rest = listNode->gtOp2;
+
+    GenTreeFieldList* loNode = listNode;
+    loNode->gtType           = TYP_INT;
+    loNode->gtOp1            = longNode->gtOp1;
+    loNode->gtFieldType      = TYP_INT;
+
+    GenTreeFieldList* hiNode =
+        new (m_compiler, GT_FIELD_LIST) GenTreeFieldList(longNode->gtOp2, loNode->gtFieldOffset + 4, TYP_INT, loNode);
+    hiNode->gtOp2 = rest;
+
+    return listNode->gtNext;
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/decomposelongs.h
+++ b/src/jit/decomposelongs.h
@@ -45,6 +45,7 @@ private:
     GenTree* DecomposeStoreLclFld(LIR::Use& use);
     GenTree* DecomposeCast(LIR::Use& use);
     GenTree* DecomposeCnsLng(LIR::Use& use);
+    GenTree* DecomposeFieldList(GenTreeFieldList* listNode, GenTreeOp* longNode);
     GenTree* DecomposeCall(LIR::Use& use);
     GenTree* DecomposeInd(LIR::Use& use);
     GenTree* DecomposeStoreInd(LIR::Use& use);

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -14465,6 +14465,10 @@ bool Compiler::fgOptimizeBranchToNext(BasicBlock* block, BasicBlock* bNext, Basi
             LIR::Range& blockRange = LIR::AsRange(block);
             GenTree*    jmp        = blockRange.LastNode();
             assert(jmp->OperIsConditionalJump());
+            if (jmp->OperGet() == GT_JTRUE)
+            {
+                jmp->gtOp.gtOp1->gtFlags &= ~GTF_SET_FLAGS;
+            }
 
             bool               isClosed;
             unsigned           sideEffects;

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -11077,25 +11077,28 @@ void Compiler::gtDispTree(GenTreePtr   tree,
                    tree->AsFieldList()->gtFieldOffset);
         }
 #if FEATURE_PUT_STRUCT_ARG_STK
-        else if ((tree->OperGet() == GT_PUTARG_STK) &&
-                 (tree->AsPutArgStk()->gtPutArgStkKind != GenTreePutArgStk::Kind::Invalid))
+        else if (tree->OperGet() == GT_PUTARG_STK)
         {
-            switch (tree->AsPutArgStk()->gtPutArgStkKind)
+            printf(" (%d slots)", tree->AsPutArgStk()->gtNumSlots);
+            if (tree->AsPutArgStk()->gtPutArgStkKind != GenTreePutArgStk::Kind::Invalid)
             {
-                case GenTreePutArgStk::Kind::RepInstr:
-                    printf(" (RepInstr)");
-                    break;
-                case GenTreePutArgStk::Kind::Unroll:
-                    printf(" (Unroll)");
-                    break;
-                case GenTreePutArgStk::Kind::Push:
-                    printf(" (Push)");
-                    break;
-                case GenTreePutArgStk::Kind::PushAllSlots:
-                    printf(" (PushAllSlots)");
-                    break;
-                default:
-                    unreached();
+                switch (tree->AsPutArgStk()->gtPutArgStkKind)
+                {
+                    case GenTreePutArgStk::Kind::RepInstr:
+                        printf(" (RepInstr)");
+                        break;
+                    case GenTreePutArgStk::Kind::Unroll:
+                        printf(" (Unroll)");
+                        break;
+                    case GenTreePutArgStk::Kind::Push:
+                        printf(" (Push)");
+                        break;
+                    case GenTreePutArgStk::Kind::PushAllSlots:
+                        printf(" (PushAllSlots)");
+                        break;
+                    default:
+                        unreached();
+                }
             }
         }
 #endif // FEATURE_PUT_STRUCT_ARG_STK

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -1089,6 +1089,13 @@ bool GenTreeCall::AreArgsComplete() const
     return false;
 }
 
+#if !defined(FEATURE_PUT_STRUCT_ARG_STK) && !defined(LEGACY_BACKEND)
+unsigned GenTreePutArgStk::getArgSize()
+{
+    return genTypeSize(genActualType(gtOp1->gtType));
+}
+#endif // !defined(FEATURE_PUT_STRUCT_ARG_STK) && !defined(LEGACY_BACKEND)
+
 /*****************************************************************************
  *
  *  Returns non-zero if the two trees are identical.

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -5265,6 +5265,13 @@ struct GenTreePutArgStk : public GenTreeUnOp
         return gtNumSlots * TARGET_POINTER_SIZE;
     }
 
+    // Return true if this is a PutArgStk of a SIMD12 struct.
+    // This is needed because such values are re-typed to SIMD16, and the type of PutArgStk is VOID.
+    unsigned isSIMD12()
+    {
+        return (varTypeIsSIMD(gtOp1) && (gtNumSlots == 3));
+    }
+
     //------------------------------------------------------------------------
     // setGcPointers: Sets the number of references and the layout of the struct object returned by the VM.
     //

--- a/src/jit/gtlist.h
+++ b/src/jit/gtlist.h
@@ -57,7 +57,7 @@ GTNODE(ARR_LENGTH       , GenTreeArrLen      ,0,GTK_UNOP|GTK_EXOP)      // array
 
 GTNODE(INTRINSIC        , GenTreeIntrinsic   ,0,GTK_BINOP|GTK_EXOP)     // intrinsics
 
-GTNODE(LOCKADD          , GenTreeOp          ,0,GTK_BINOP|GTK_NOVALUE)
+GTNODE(LOCKADD          , GenTreeOp          ,0,GTK_BINOP)
 GTNODE(XADD             , GenTreeOp          ,0,GTK_BINOP)
 GTNODE(XCHG             , GenTreeOp          ,0,GTK_BINOP)
 GTNODE(CMPXCHG          , GenTreeCmpXchg     ,0,GTK_SPECIAL)

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1075,18 +1075,20 @@ GenTreePtr Lowering::NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntryP
             // Make sure state is correct. The PUTARG_STK has TYP_VOID, as it doesn't produce
             // a result. So the type of its operand must be the correct type to push on the stack.
             // For a FIELD_LIST, this will be the type of the field (not the type of the arg),
-            // but otherwise it is generally the type of the operand. However, in the case of
-            // TYP_SIMD12 the type of the operand may need to be modified.
+            // but otherwise it is generally the type of the operand.
             PUT_STRUCT_ARG_STK_ONLY(assert(info->isStruct == varTypeIsStruct(type)));
+            if ((arg->OperGet() != GT_FIELD_LIST))
+            {
 #if defined(FEATURE_SIMD) && defined(FEATURE_PUT_STRUCT_ARG_STK)
-            if (type == TYP_SIMD12)
-            {
-                arg->gtType = type;
-            }
-            else
+                if (type == TYP_SIMD12)
+                {
+                    assert(info->numSlots == 3);
+                }
+                else
 #endif // defined(FEATURE_SIMD) && defined(FEATURE_PUT_STRUCT_ARG_STK)
-            {
-                assert((genActualType(arg->TypeGet()) == type) || (arg->OperGet() == GT_FIELD_LIST));
+                {
+                    assert(genActualType(arg->TypeGet()) == type);
+                }
             }
 
             putArg =

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1072,11 +1072,27 @@ GenTreePtr Lowering::NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntryP
             // This provides the info to put this argument in in-coming arg area slot
             // instead of in out-going arg area slot.
 
-            PUT_STRUCT_ARG_STK_ONLY(assert(info->isStruct == varTypeIsStruct(type))); // Make sure state is correct
+            // Make sure state is correct. The PUTARG_STK has TYP_VOID, as it doesn't produce
+            // a result. So the type of its operand must be the correct type to push on the stack.
+            // For a FIELD_LIST, this will be the type of the field (not the type of the arg),
+            // but otherwise it is generally the type of the operand. However, in the case of
+            // TYP_SIMD12 the type of the operand may need to be modified.
+            PUT_STRUCT_ARG_STK_ONLY(assert(info->isStruct == varTypeIsStruct(type)));
+#if defined(FEATURE_SIMD) && defined(FEATURE_PUT_STRUCT_ARG_STK)
+            if (type == TYP_SIMD12)
+            {
+                arg->gtType = type;
+            }
+            else
+#endif // defined(FEATURE_SIMD) && defined(FEATURE_PUT_STRUCT_ARG_STK)
+            {
+                assert((genActualType(arg->TypeGet()) == type) || (arg->OperGet() == GT_FIELD_LIST));
+            }
 
-            putArg = new (comp, GT_PUTARG_STK)
-                GenTreePutArgStk(GT_PUTARG_STK, type, arg, info->slotNum PUT_STRUCT_ARG_STK_ONLY_ARG(info->numSlots),
-                                 call->IsFastTailCall(), call);
+            putArg =
+                new (comp, GT_PUTARG_STK) GenTreePutArgStk(GT_PUTARG_STK, TYP_VOID, arg,
+                                                           info->slotNum PUT_STRUCT_ARG_STK_ONLY_ARG(info->numSlots),
+                                                           call->IsFastTailCall(), call);
 
 #ifdef FEATURE_PUT_STRUCT_ARG_STK
             // If the ArgTabEntry indicates that this arg is a struct
@@ -1259,7 +1275,7 @@ void Lowering::LowerArg(GenTreeCall* call, GenTreePtr* ppArg)
             GenTreeFieldList* fieldList = new (comp, GT_FIELD_LIST) GenTreeFieldList(argLo, 0, TYP_INT, nullptr);
             // Only the first fieldList node (GTF_FIELD_LIST_HEAD) is in the instruction sequence.
             (void)new (comp, GT_FIELD_LIST) GenTreeFieldList(argHi, 4, TYP_INT, fieldList);
-            putArg = NewPutArg(call, fieldList, info, TYP_VOID);
+            putArg = NewPutArg(call, fieldList, info, type);
 
             BlockRange().InsertBefore(arg, putArg);
             BlockRange().Remove(arg);
@@ -1268,17 +1284,17 @@ void Lowering::LowerArg(GenTreeCall* call, GenTreePtr* ppArg)
         }
         else
         {
+            assert(arg->OperGet() == GT_LONG);
             // For longs, we will replace the GT_LONG with a GT_FIELD_LIST, and put that under a PUTARG_STK.
             // Although the hi argument needs to be pushed first, that will be handled by the general case,
             // in which the fields will be reversed.
-            noway_assert(arg->OperGet() == GT_LONG);
             assert(info->numSlots == 2);
             GenTreePtr        argLo     = arg->gtGetOp1();
             GenTreePtr        argHi     = arg->gtGetOp2();
             GenTreeFieldList* fieldList = new (comp, GT_FIELD_LIST) GenTreeFieldList(argLo, 0, TYP_INT, nullptr);
             // Only the first fieldList node (GTF_FIELD_LIST_HEAD) is in the instruction sequence.
             (void)new (comp, GT_FIELD_LIST) GenTreeFieldList(argHi, 4, TYP_INT, fieldList);
-            putArg           = NewPutArg(call, fieldList, info, TYP_VOID);
+            putArg           = NewPutArg(call, fieldList, info, type);
             putArg->gtRegNum = info->regNum;
 
             // We can't call ReplaceArgWithPutArgOrCopy here because it presumes that we are keeping the original arg.
@@ -2742,7 +2758,7 @@ GenTree* Lowering::LowerJTrue(GenTreeOp* jtrue)
             relop->SetOper(GT_JCMP);
             relop->gtFlags &= ~(GTF_JCMP_TST | GTF_JCMP_EQ);
             relop->gtFlags |= flags;
-            relop->gtLsraInfo.isNoRegCompare = true;
+            relop->gtType = TYP_VOID;
 
             relopOp2->SetContained();
 
@@ -5721,8 +5737,9 @@ void Lowering::ContainCheckRet(GenTreeOp* ret)
 void Lowering::ContainCheckJTrue(GenTreeOp* node)
 {
     // The compare does not need to be generated into a register.
-    GenTree* cmp                   = node->gtGetOp1();
-    cmp->gtLsraInfo.isNoRegCompare = true;
+    GenTree* cmp = node->gtGetOp1();
+    cmp->gtType  = TYP_VOID;
+    cmp->gtFlags |= GTF_SET_FLAGS;
 }
 
 #endif // !LEGACY_BACKEND

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -474,8 +474,9 @@ void Lowering::LowerPutArgStk(GenTreePutArgStk* putArgStk)
             BlockRange().InsertAfter(fieldList, head);
             BlockRange().Remove(fieldList);
 
-            fieldList        = head;
-            putArgStk->gtOp1 = fieldList;
+            fieldList         = head;
+            putArgStk->gtOp1  = fieldList;
+            putArgStk->gtType = fieldList->gtType;
         }
 
         // Now that the fields have been sorted, the kind of code we will generate.
@@ -557,7 +558,7 @@ void Lowering::LowerPutArgStk(GenTreePutArgStk* putArgStk)
     GenTreePtr src = putArgStk->gtOp1;
 
 #ifdef FEATURE_PUT_STRUCT_ARG_STK
-    if (putArgStk->TypeGet() != TYP_STRUCT)
+    if (src->TypeGet() != TYP_STRUCT)
 #endif // FEATURE_PUT_STRUCT_ARG_STK
     {
         // If the child of GT_PUTARG_STK is a constant, we don't need a register to
@@ -858,8 +859,7 @@ void Lowering::LowerSIMD(GenTreeSIMD* simdNode)
         }
 
         simdNode->gtFlags |= GTF_SET_FLAGS;
-        simdNode->SetUnusedValue();
-        simdNode->gtLsraInfo.isNoRegCompare = true;
+        simdNode->gtType = TYP_VOID;
     }
 #endif
     ContainCheckSIMD(simdNode);

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -4839,7 +4839,7 @@ void LinearScan::buildIntervals()
             TreeNodeInfoInit(node);
 
             // If the node produces an unused value, mark it as a local def-use
-            if (node->IsValue() && node->IsUnusedValue() && !node->gtLsraInfo.isNoRegCompare)
+            if (node->IsValue() && node->IsUnusedValue())
             {
                 node->gtLsraInfo.isLocalDefUse = true;
                 node->gtLsraInfo.dstCount      = 0;

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3592,7 +3592,6 @@ static int ComputeOperandDstCount(GenTree* operand)
         // pointers to argument setup stores.
         return 0;
     }
-#ifdef _TARGET_ARMARCH_
     else if (operand->OperIsPutArgStk())
     {
         // A PUTARG_STK argument is an operand of a call, but is neither contained, nor does it produce
@@ -3600,7 +3599,6 @@ static int ComputeOperandDstCount(GenTree* operand)
         assert(!operand->isContained());
         return 0;
     }
-#endif // _TARGET_ARMARCH_
     else
     {
         // If a field list or non-void-typed operand is not an unused value and does not have source registers,

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -1225,7 +1225,7 @@ private:
 
     void TreeNodeInfoInitCheckByteable(GenTree* tree);
 
-    void SetDelayFree(GenTree* delayUseSrc);
+    bool SetDelayFree(GenTree* delayUseSrc);
 
     void TreeNodeInfoInitSimple(GenTree* tree);
     int GetOperandSourceCount(GenTree* node);

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -1225,7 +1225,7 @@ private:
 
     void TreeNodeInfoInitCheckByteable(GenTree* tree);
 
-    bool SetDelayFree(GenTree* delayUseSrc);
+    bool CheckAndSetDelayFree(GenTree* delayUseSrc);
 
     void TreeNodeInfoInitSimple(GenTree* tree);
     int GetOperandSourceCount(GenTree* node);

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -214,7 +214,18 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
     }
 
     // Set the default dstCount. This may be modified below.
-    info->dstCount = tree->IsValue() ? 1 : 0;
+    if (tree->IsValue())
+    {
+        info->dstCount = 1;
+        if (tree->IsUnusedValue())
+        {
+            info->isLocalDefUse = true;
+        }
+    }
+    else
+    {
+        info->dstCount = 0;
+    }
 
     switch (tree->OperGet())
     {
@@ -442,6 +453,10 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
 
         case GT_LONG:
             assert(tree->IsUnusedValue()); // Contained nodes are already processed, only unused GT_LONG can reach here.
+                                           // An unused GT_LONG doesn't produce any registers.
+            tree->gtType = TYP_VOID;
+            tree->ClearUnusedValue();
+            info->isLocalDefUse = false;
 
             // An unused GT_LONG node needs to consume its sources.
             info->srcCount = 2;
@@ -785,6 +800,8 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
     }
     // We need to be sure that we've set info->srcCount and info->dstCount appropriately
     assert((info->dstCount < 2) || tree->IsMultiRegNode());
+    assert(info->isLocalDefUse == (tree->IsValue() && tree->IsUnusedValue()));
+    assert(!tree->IsUnusedValue() || (info->dstCount != 0));
 }
 
 #endif // _TARGET_ARM_

--- a/src/jit/lsraarm64.cpp
+++ b/src/jit/lsraarm64.cpp
@@ -58,7 +58,18 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
     }
 
     // Set the default dstCount. This may be modified below.
-    info->dstCount = tree->IsValue() ? 1 : 0;
+    if (tree->IsValue())
+    {
+        info->dstCount = 1;
+        if (tree->IsUnusedValue())
+        {
+            info->isLocalDefUse = true;
+        }
+    }
+    else
+    {
+        info->dstCount = 0;
+    }
 
     switch (tree->OperGet())
     {
@@ -667,6 +678,8 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
     }
     // We need to be sure that we've set info->srcCount and info->dstCount appropriately
     assert((info->dstCount < 2) || tree->IsMultiRegCall());
+    assert(info->isLocalDefUse == (tree->IsValue() && tree->IsUnusedValue()));
+    assert(!tree->IsUnusedValue() || (info->dstCount != 0));
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -92,15 +92,8 @@ void LinearScan::TreeNodeInfoInitCmp(GenTreePtr tree)
 {
     TreeNodeInfo* info = &(tree->gtLsraInfo);
 
+    assert((info->dstCount == 1) || (tree->TypeGet() == TYP_VOID));
     info->srcCount = tree->gtOp.gtOp2->isContained() ? 1 : 2;
-    if (info->isNoRegCompare)
-    {
-        info->dstCount = 0;
-    }
-    else
-    {
-        assert((info->dstCount == 1) || tree->OperIs(GT_CMP, GT_TEST_EQ, GT_TEST_NE));
-    }
 }
 
 void LinearScan::TreeNodeInfoInitGCWriteBarrier(GenTree* tree)

--- a/src/jit/lsraxarch.cpp
+++ b/src/jit/lsraxarch.cpp
@@ -709,7 +709,7 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
             {
                 delayUseSrc = op2;
             }
-            if ((delayUseSrc != nullptr) && SetDelayFree(delayUseSrc))
+            if ((delayUseSrc != nullptr) && CheckAndSetDelayFree(delayUseSrc))
             {
                 info->hasDelayFreeSrc = true;
             }
@@ -724,7 +724,19 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
     assert(!tree->IsUnusedValue() || (info->dstCount != 0));
 }
 
-bool LinearScan::SetDelayFree(GenTree* delayUseSrc)
+//---------------------------------------------------------------------
+// CheckAndSetDelayFree - Set isDelayFree on the given operand or its child(ren), if appropriate
+//
+// Arguments
+//    delayUseSrc - a node that may have a delayed use
+//
+// Return Value:
+//    True iff the node or one of its children has been marked isDelayFree
+//
+// Notes:
+//    Only register operands should be marked isDelayFree, not contained immediates or memory.
+//
+bool LinearScan::CheckAndSetDelayFree(GenTree* delayUseSrc)
 {
     // If delayUseSrc is an indirection and it doesn't produce a result, then we need to set "delayFree'
     // on the base & index, if any.
@@ -1680,7 +1692,7 @@ void LinearScan::TreeNodeInfoInitPutArgStk(GenTreePutArgStk* putArgStk)
 
 #if defined(FEATURE_SIMD) && defined(_TARGET_X86_)
     // For PutArgStk of a TYP_SIMD12, we need an extra register.
-    if (varTypeIsSIMD(type) && (putArgStk->gtNumSlots == 3))
+    if (putArgStk->isSIMD12())
     {
         info->srcCount           = putArgStk->gtOp1->gtLsraInfo.dstCount;
         info->internalFloatCount = 1;
@@ -2739,7 +2751,7 @@ void LinearScan::TreeNodeInfoInitMul(GenTreePtr tree)
     {
         containedMemOp = op2;
     }
-    if ((containedMemOp != nullptr) && SetDelayFree(containedMemOp))
+    if ((containedMemOp != nullptr) && CheckAndSetDelayFree(containedMemOp))
     {
         info->hasDelayFreeSrc = true;
     }

--- a/src/jit/lsraxarch.cpp
+++ b/src/jit/lsraxarch.cpp
@@ -1680,7 +1680,7 @@ void LinearScan::TreeNodeInfoInitPutArgStk(GenTreePutArgStk* putArgStk)
 
 #if defined(FEATURE_SIMD) && defined(_TARGET_X86_)
     // For PutArgStk of a TYP_SIMD12, we need an extra register.
-    if (type == TYP_SIMD12)
+    if (varTypeIsSIMD(type) && (putArgStk->gtNumSlots == 3))
     {
         info->srcCount           = putArgStk->gtOp1->gtLsraInfo.dstCount;
         info->internalFloatCount = 1;

--- a/src/jit/nodeinfo.h
+++ b/src/jit/nodeinfo.h
@@ -32,7 +32,6 @@ public:
         regOptional            = false;
         definesAnyRegisters    = false;
         isInternalRegDelayFree = false;
-        isNoRegCompare         = false;
 #ifdef DEBUG
         isInitialized = false;
 #endif
@@ -144,9 +143,6 @@ public:
     // Whether internal register needs to be different from targetReg
     // in which result is produced.
     unsigned char isInternalRegDelayFree : 1;
-
-    // True if this is a compare feeding a JTRUE that doesn't need to be generated into a register.
-    unsigned char isNoRegCompare : 1;
 
 #ifdef DEBUG
     // isInitialized is set when the tree node is handled.

--- a/tests/src/JIT/SIMD/Matrix4x4.cs
+++ b/tests/src/JIT/SIMD/Matrix4x4.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+using System.Numerics;
+
+class Matrix4x4Test
+{
+    private const int Pass = 100;
+    private const int Fail = -1;
+
+    public static int Matrix4x4CreateScaleCenterTest3()
+    {
+        int returnVal = Pass;
+        Vector3 scale = new Vector3(3, 4, 5);
+        Vector3 center = new Vector3(23, 42, 666);
+
+        Matrix4x4 scaleAroundZero = Matrix4x4.CreateScale(scale.X, scale.Y, scale.Z, Vector3.Zero);
+        Matrix4x4 scaleAroundZeroExpected = Matrix4x4.CreateScale(scale.X, scale.Y, scale.Z);
+        if (!scaleAroundZero.Equals(scaleAroundZeroExpected))
+        {
+            returnVal = Fail;
+        }
+
+        Matrix4x4 scaleAroundCenter = Matrix4x4.CreateScale(scale.X, scale.Y, scale.Z, center);
+        Matrix4x4 scaleAroundCenterExpected = Matrix4x4.CreateTranslation(-center) * Matrix4x4.CreateScale(scale.X, scale.Y, scale.Z) * Matrix4x4.CreateTranslation(center);
+        if (!scaleAroundCenter.Equals(scaleAroundCenterExpected))
+        {
+            returnVal = Fail;
+        }
+        return returnVal;
+    }
+
+    static int Main()
+    {
+        return Matrix4x4CreateScaleCenterTest3();
+    }
+}

--- a/tests/src/JIT/SIMD/Matrix4x4_r.csproj
+++ b/tests/src/JIT/SIMD/Matrix4x4_r.csproj
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize></Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Matrix4x4.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/SIMD/Matrix4x4_ro.csproj
+++ b/tests/src/JIT/SIMD/Matrix4x4_ro.csproj
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Matrix4x4.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/SIMD/Plane.cs
+++ b/tests/src/JIT/SIMD/Plane.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+using System.Numerics;
+
+class PlaneTest
+{
+    private const int Pass = 100;
+    private const int Fail = -1;
+
+    public static int PlaneCreateFromVerticesTest()
+    {
+        int returnVal = Pass;
+
+        Vector3 point1 = new Vector3(0.0f, 1.0f, 1.0f);
+        Vector3 point2 = new Vector3(0.0f, 0.0f, 1.0f);
+        Vector3 point3 = new Vector3(1.0f, 0.0f, 1.0f);
+
+        Plane target = Plane.CreateFromVertices(point1, point2, point3);
+        Plane expected = new Plane(new Vector3(0, 0, 1), -1.0f);
+        if (!target.Equals(expected))
+        {
+            returnVal = Fail;
+        }
+        return returnVal;
+    }
+
+    static int Main()
+    {
+        return PlaneCreateFromVerticesTest();
+    }
+}

--- a/tests/src/JIT/SIMD/Plane_r.csproj
+++ b/tests/src/JIT/SIMD/Plane_r.csproj
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize></Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Plane.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/SIMD/Plane_ro.csproj
+++ b/tests/src/JIT/SIMD/Plane_ro.csproj
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Plane.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
These are preparatory changes for eliminating gtLsraInfo.

Register requirements should never be set on contained nodes. This includes setting isDelayFree and restricting to byte registers for x86.
- This results in net positive diffs for the framework (eliminating incorrect setting of hasDelayFreeSrc), though a net regression for the tests on x86 (including many instances of effectively the same code).
- The regressions are largely related to issue #11274.

Improve consistency of IsValue():
- Any node that can be contained should produce a value, and have a type (e.g. GT_FIELD_LIST).
- Some value nodes (GTK_NOVALUE isn't set) are allowed to have TYP_VOID, in which case IsValue() should return false.
  - This simplifies IsValue().
- Any node that can be assigned a register should return true for IsValue() (e.g. GT_LOCKADD).
- PUTARG_STK doesn't produce a value; get type from its operand.
  - This requires some fixing up of SIMD12 operands.
- Unused GT_LONG nodes shouldn't define any registers

Eliminate isNoRegCompare, by setting type of JTRUE operand to TYP_VOID
  - Set GTF_SET_FLAGS on the operand to ensure it is not eliminated as dead code.