### PR TITLE
Fix RyuJIT/arm32 asserts

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -614,7 +614,8 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
         {
             genConsumeReg(source);
             emit->emitIns_S_R(storeIns, storeAttr, source->gtRegNum, varNumOut, argOffsetOut);
-            if (compiler->opts.compUseSoftFP && targetType == TYP_LONG)
+#ifdef _TARGET_ARM_
+            if (targetType == TYP_LONG)
             {
                 // This case currently only occurs for double types that are passed as TYP_LONG;
                 // actual long types would have been decomposed by now.
@@ -624,6 +625,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
                 argOffsetOut += EA_4BYTE;
                 emit->emitIns_S_R(storeIns, storeAttr, otherReg, varNumOut, argOffsetOut);
             }
+#endif // _TARGET_ARM_
         }
         argOffsetOut += EA_SIZE_IN_BYTES(storeAttr);
         assert(argOffsetOut <= argOffsetMax); // We can't write beyound the outgoing area area
@@ -2211,16 +2213,6 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
             {
                 inst_RV_RV(ins_Move_Extend(argNode->TypeGet(), true), argReg, argNode->gtRegNum);
             }
-        }
-
-        // In the case of a varargs call,
-        // the ABI dictates that if we have floating point args,
-        // we must pass the enregistered arguments in both the
-        // integer and floating point registers so, let's do that.
-        if (call->IsVarargs() && varTypeIsFloating(argNode))
-        {
-            NYI_ARM("CodeGen - IsVarargs");
-            NYI_ARM64("CodeGen - IsVarargs");
         }
     }
 

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -940,7 +940,7 @@ public:
 #define GTF_FLD_INITCLASS           0x20000000 // GT_FIELD/GT_CLS_VAR -- field access requires preceding class/static init helper
 
 #define GTF_INX_RNGCHK              0x80000000 // GT_INDEX -- the array reference should be range-checked.
-#define GTF_INX_REFARR_LAYOUT       0x20000000 // GT_INDEX -- same as GTF_IND_REFARR_LAYOUT
+#define GTF_INX_REFARR_LAYOUT       0x20000000 // GT_INDEX
 #define GTF_INX_STRING_LAYOUT       0x40000000 // GT_INDEX -- this uses the special string array layout
 
 #define GTF_IND_ARR_LEN             0x80000000 // GT_IND   -- the indirection represents an array length (of the REF
@@ -1339,11 +1339,7 @@ public:
     bool OperIsMultiRegOp() const
     {
 #if !defined(LEGACY_BACKEND) && defined(_TARGET_ARM_)
-#ifdef ARM_SOFTFP
-        if (gtOper == GT_MUL_LONG || gtOper == GT_PUTARG_REG)
-#else
-        if (gtOper == GT_MUL_LONG)
-#endif
+        if ((gtOper == GT_MUL_LONG) || (gtOper == GT_PUTARG_REG) || (gtOper == GT_BITCAST))
         {
             return true;
         }
@@ -1696,9 +1692,9 @@ public:
 #ifdef FEATURE_SIMD
             case GT_SIMD:
 #endif // !FEATURE_SIMD
-#if !defined(LEGACY_BACKEND) && _TARGET_ARM_
+#if !defined(LEGACY_BACKEND) && defined(_TARGET_ARM_)
             case GT_PUTARG_REG:
-#endif // !defined(LEGACY_BACKEND) && _TARGET_ARM_
+#endif // !defined(LEGACY_BACKEND) && defined(_TARGET_ARM_)
                 return true;
             default:
                 return false;
@@ -6116,8 +6112,7 @@ inline bool GenTree::IsMultiRegNode() const
     }
 
 #if !defined(LEGACY_BACKEND) && defined(_TARGET_ARM_)
-    if (gtOper == GT_MUL_LONG || gtOper == GT_PUTARG_REG || gtOper == GT_BITCAST || gtOper == GT_COPY ||
-        OperIsPutArgSplit())
+    if (OperIsMultiRegOp() || OperIsPutArgSplit() || (gtOper == GT_COPY))
     {
         return true;
     }

--- a/src/jit/gtstructs.h
+++ b/src/jit/gtstructs.h
@@ -108,11 +108,7 @@ GTSTRUCT_1(AllocObj    , GT_ALLOCOBJ)
 GTSTRUCT_1(RuntimeLookup, GT_RUNTIMELOOKUP)
 GTSTRUCT_2(CC          , GT_JCC, GT_SETCC)
 #if !defined(LEGACY_BACKEND) && defined(_TARGET_ARM_)
-#ifdef ARM_SOFTFP
 GTSTRUCT_3(MultiRegOp  , GT_MUL_LONG, GT_PUTARG_REG, GT_BITCAST)
-#else
-GTSTRUCT_1(MultiRegOp  , GT_MUL_LONG)
-#endif
 #endif
 /*****************************************************************************/
 #undef  GTSTRUCT_0

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1310,7 +1310,8 @@ void Lowering::LowerArg(GenTreeCall* call, GenTreePtr* ppArg)
             {
                 intArg           = comp->gtNewBitCastNode(intType, arg);
                 intArg->gtRegNum = info->regNum;
-#ifdef ARM_SOFTFP
+
+#ifdef _TARGET_ARM_
                 if (intType == TYP_LONG)
                 {
                     assert(info->numRegs == 2);
@@ -1320,7 +1321,7 @@ void Lowering::LowerArg(GenTreeCall* call, GenTreePtr* ppArg)
                            (info->regNum == REG_R2 && regNext == REG_R3));
                     intArg->AsMultiRegOp()->gtOtherReg = regNext;
                 }
-#endif // ARM_SOFTFP
+#endif // _TARGET_ARM_
             }
             else
             {
@@ -1334,7 +1335,7 @@ void Lowering::LowerArg(GenTreeCall* call, GenTreePtr* ppArg)
             arg  = intArg;
             type = intType;
         }
-#endif
+#endif // _TARGET_ARMARCH_
 
         putArg = NewPutArg(call, arg, info, type);
 

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -690,7 +690,7 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
 
         case GT_COPY:
             info->srcCount = 1;
-#ifdef ARM_SOFTFP
+#ifdef _TARGET_ARM_
             // This case currently only occurs for double types that are passed as TYP_LONG;
             // actual long types would have been decomposed by now.
             if (tree->TypeGet() == TYP_LONG)
@@ -722,7 +722,7 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
             assert(info->dstCount == 1);
             regNumber argReg  = tree->gtRegNum;
             regMaskTP argMask = genRegMask(argReg);
-#ifdef ARM_SOFTFP
+
             // If type of node is `long` then it is actually `double`.
             // The actual `long` types must have been transformed as a field list with two fields.
             if (tree->TypeGet() == TYP_LONG)
@@ -731,7 +731,7 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
                 assert(genRegArgNext(argReg) == REG_NEXT(argReg));
                 argMask |= genRegMask(REG_NEXT(argReg));
             }
-#endif // ARM_SOFTFP
+
             info->setDstCandidates(this, argMask);
             info->setSrcCandidates(this, argMask);
             tree->AsUnOp()->gtOp1->gtLsraInfo.isTgtPref = true;


### PR DESCRIPTION
Fix #14199: propagate `GTF_EXCEPT` bits from the end of `GT_FIELD_LIST`
lists to the beginning, to avoid "Missing flags on tree" asserts.

Fix #14198: for RyuJIT/arm32, `GT_BITCAST` needs to be a MultiRegOp.
This is required when a varargs function, which includes the tailcall
helper, needs to pass a double in integer registers. We can end up
with `GT_PUTARG_REG/long(GT_BITCAST/long(double tree))`.

Fixed various GenTree node flags dumping issues.