### PR TITLE
Remove explicit dependency on libnuma

### DIFF
--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -372,12 +372,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL NetBSD)
   )
 endif(CMAKE_SYSTEM_NAME STREQUAL NetBSD)
 
-if(HAVE_NUMA_H)
-  target_link_libraries(coreclrpal
-    numa
-  )
-endif(HAVE_NUMA_H)
-
 add_subdirectory(examples)
 
 if(FEATURE_EVENT_TRACE)


### PR DESCRIPTION
Currently, when coreclr is built on machine that has libnuma installed,
it adds libnuma to its dependencies and so it cannot be used on machines
that don't have libnuma installed. But that is not necessary, the
dependency was changed to soft dependency - PAL loads it only if it is
present and falls back to the non-numa behavior if it is not found.
This change removes the hard libnuma dependency.