### PR TITLE
Fix handling of continuations for captured context

### DIFF
--- a/src/mscorlib/src/System/Threading/Tasks/Task.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/Task.cs
@@ -2644,10 +2644,10 @@ namespace System.Threading.Tasks
                 SynchronizationContext syncCtx = SynchronizationContext.CurrentNoFlow;
                 if (syncCtx != null && syncCtx.GetType() != typeof(SynchronizationContext))
                 {
-                    Action moveNextAction = stateMachineBox.MoveNextAction;
-                    if (!AddTaskContinuation(new SynchronizationContextAwaitTaskContinuation(syncCtx, moveNextAction, flowExecutionContext: false), addBeforeOthers: false))
+                    var tc = new SynchronizationContextAwaitTaskContinuation(syncCtx, stateMachineBox.MoveNextAction, flowExecutionContext: false);
+                    if (!AddTaskContinuation(tc, addBeforeOthers: false))
                     {
-                        AwaitTaskContinuation.UnsafeScheduleAction(moveNextAction, this);
+                        tc.Run(this, canInlineContinuationTask: false);
                     }
                     return;
                 }
@@ -2656,10 +2656,10 @@ namespace System.Threading.Tasks
                     TaskScheduler scheduler = TaskScheduler.InternalCurrent;
                     if (scheduler != null && scheduler != TaskScheduler.Default)
                     {
-                        Action moveNextAction = stateMachineBox.MoveNextAction;
-                        if (!AddTaskContinuation(new TaskSchedulerAwaitTaskContinuation(scheduler, moveNextAction, flowExecutionContext: false), addBeforeOthers: false))
+                        var tc = new TaskSchedulerAwaitTaskContinuation(scheduler, stateMachineBox.MoveNextAction, flowExecutionContext: false);
+                        if (!AddTaskContinuation(tc, addBeforeOthers: false))
                         {
-                            AwaitTaskContinuation.UnsafeScheduleAction(moveNextAction, this);
+                            tc.Run(this, canInlineContinuationTask: false);
                         }
                         return;
                     }


### PR DESCRIPTION
My recent delegate optimization for async methods introduced a race condition that breaks posting back to a captured context.  If the awaited task completes between the time we check IsCompleted and when we try to store the continuation into the Task, we need to queue the continuation for execution, but my change incorrectly queued it to the thread pool rather than to the captured context.

Fixes https://github.com/dotnet/coreclr/issues/14367
cc: @tarekgh, @kouvel, @mconnew 