### PR TITLE
Fix numa build break

### DIFF
--- a/src/pal/src/numa/numashim.h
+++ b/src/pal/src/numa/numashim.h
@@ -13,6 +13,8 @@
 #include <numa.h>
 #include <numaif.h>
 
+#define numa_free_cpumask numa_bitmask_free
+
 // List of all functions from the numa library that are used
 #define FOR_ALL_NUMA_FUNCTIONS \
     PER_FUNCTION_BLOCK(numa_available) \


### PR DESCRIPTION
This change fixes a break in build of coreclr on machines with libnuma
installed. The problem was that the numa header contains a couple of
inlined functions and we were using one of them. That made it to
have a hard reference to a function from the numa library that we
need to be soft so that coreclr can work even on machines without
the libnuma installed.
Fortunately, this inlined function was just a pass through wrapper around
another function from the library, so defining a symbol with the name of the 
inline function to the name of the function it calls fixes the problem. While
we could replace all uses of the inline function in our source code by
the other function, the way I did it preserves the readability of the code 
(numa_allocate_cpumask is matched by numa_free_cpumask)