### PR TITLE
Fix zap and ready to run disabling

### DIFF
--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -528,7 +528,7 @@ void Module::Initialize(AllocMemTracker *pamTracker, LPCWSTR szName)
     m_dwTransientFlags &= ~((DWORD)CLASSES_FREED);  // Set flag indicating LookupMaps are now in a consistent and destructable state
 
 #ifdef FEATURE_READYTORUN
-    if (!HasNativeImage() && !IsResource() && ReadyToRunInfo::IsReadyToRunEnabled())
+    if (!HasNativeImage() && !IsResource())
         m_pReadyToRunInfo = ReadyToRunInfo::Initialize(this, pamTracker);
 #endif
 

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -528,7 +528,7 @@ void Module::Initialize(AllocMemTracker *pamTracker, LPCWSTR szName)
     m_dwTransientFlags &= ~((DWORD)CLASSES_FREED);  // Set flag indicating LookupMaps are now in a consistent and destructable state
 
 #ifdef FEATURE_READYTORUN
-    if (!HasNativeImage() && !IsResource())
+    if (!HasNativeImage() && !IsResource() && ReadyToRunInfo::IsReadyToRunEnabled())
         m_pReadyToRunInfo = ReadyToRunInfo::Initialize(this, pamTracker);
 #endif
 

--- a/src/vm/peimagelayout.cpp
+++ b/src/vm/peimagelayout.cpp
@@ -445,7 +445,7 @@ MappedImageLayout::MappedImageLayout(HANDLE hFile, PEImage* pOwner)
         // if (!HasNativeHeader())
         //     ThrowHR(COR_E_BADIMAGEFORMAT);
 
-        if (HasNativeHeader())
+        if (HasNativeHeader() && g_fAllowNativeImages)
         {
             if (!IsNativeMachineFormat())
                 ThrowHR(COR_E_BADIMAGEFORMAT);
@@ -501,7 +501,7 @@ MappedImageLayout::MappedImageLayout(HANDLE hFile, PEImage* pOwner)
     if (!HasCorHeader())
         ThrowHR(COR_E_BADIMAGEFORMAT);
 
-    if (HasNativeHeader() || HasReadyToRunHeader())
+    if ((HasNativeHeader() || HasReadyToRunHeader()) && g_fAllowNativeImages)
     {
         //Do base relocation for PE, if necessary.
         if (!IsNativeMachineFormat())

--- a/src/vm/readytoruninfo.cpp
+++ b/src/vm/readytoruninfo.cpp
@@ -456,6 +456,13 @@ PTR_ReadyToRunInfo ReadyToRunInfo::Initialize(Module * pModule, AllocMemTracker 
 
     PEFile * pFile = pModule->GetFile();
 
+    if (!IsReadyToRunEnabled())
+    {
+        // Log message is ignored in this case.
+        DoLog(NULL);
+        return NULL;
+    }
+
     // Ignore ReadyToRun for introspection-only loads
     if (pFile->IsIntrospectionOnly())
     {
@@ -473,13 +480,6 @@ PTR_ReadyToRunInfo ReadyToRunInfo::Initialize(Module * pModule, AllocMemTracker 
     if (!pLayout->HasReadyToRunHeader())
     {
         DoLog("Ready to Run header not found");
-        return NULL;
-    }
-
-    if (!IsReadyToRunEnabled())
-    {
-        // Log message is ignored in this case.
-        DoLog(NULL);
         return NULL;
     }
 


### PR DESCRIPTION
While the COMPlus_ZapDisable and COMPlus_ReadyToRun config settings
can be used to disable using crossgened / ready to run images, loading
these as IL fails. I have discovered it when helping to boostrap FreeBSD.
This change fixes that.