### PR TITLE
Undo unnecessary change from DateTime.Parse commit

### DIFF
--- a/src/mscorlib/src/System/String.Comparison.cs
+++ b/src/mscorlib/src/System/String.Comparison.cs
@@ -219,12 +219,20 @@ namespace System
             }
         }
 
-        private unsafe static int CompareOrdinalHelper(string strA, string strB)
+        private static unsafe int CompareOrdinalHelper(String strA, String strB)
         {
+            Debug.Assert(strA != null);
+            Debug.Assert(strB != null);
+
+            // NOTE: This may be subject to change if eliminating the check
+            // in the callers makes them small enough to be inlined
+            Debug.Assert(strA._firstChar == strB._firstChar,
+                "For performance reasons, callers of this method should " +
+                "check/short-circuit beforehand if the first char is the same.");
+
             int length = Math.Min(strA.Length, strB.Length);
 
-            fixed (char* ap = strA)
-            fixed (char* bp = strB)
+            fixed (char* ap = &strA._firstChar) fixed (char* bp = &strB._firstChar)
             {
                 char* a = ap;
                 char* b = bp;


### PR DESCRIPTION
This change shouldn't have been included in my DateTime.Parse span change (https://github.com/dotnet/coreclr/pull/14352).  It was left- over from some local experimentation.  The change doesn't hurt anything functionally, but it does undo a small optimization; I've not measured whether it's impactful or not, so I'm putting it back the way it was.