### PR TITLE
ILLink Perf: Fix Roslyn benchmark

### DIFF
--- a/tests/src/performance/linkbench/scripts/build.cmd
+++ b/tests/src/performance/linkbench/scripts/build.cmd
@@ -119,42 +119,13 @@ exit /b
 
 :Roslyn
 echo Build ** Roslyn **
-pushd %LinkBenchRoot%\roslyn
-
-REM Fetch ILLink
-if not exist illink mkdir illink
-cd illink
-copy %AssetDir%\Roslyn\illinkcsproj illink.csproj 
-call %__dotnet% restore --packages pkg
-if errorlevel 1 set ExitCode=1&&echo Roslyn: IlLink fetch failed
-set __IlLinkDll=%cd%\pkg\microsoft.netcore.illink\0.1.9-preview\lib\netcoreapp1.1\illink.dll
-cd ..
-
-REM Build CscCore
-call Restore.cmd
-REM Fetch the appropriate version of MSBuild to build and publish CscCore 
-for /f "delims=`" %%i in ('powershell -noprofile -executionPolicy RemoteSigned -command "& { . build\scripts\build-utils.ps1;Ensure-MSBuild }"') do set MSBUILD=%%i
-REM publish CscCore for win7-x64
-"%MSBUILD%" src\Compilers\CSharp\CscCore\CscCore.csproj /t:Publish /p:RuntimeIdentifier=win7-x64 /p:Configuration=Release /p:TreatWarningsAsErrors=true /warnaserror /nologo /nodeReuse:false /m 
-if errorlevel 1 set ExitCode=1&& echo Roslyn: publish failed 
-REM Published CscCore to Binaries\Release\Exes\CscCore\win7-x64\publish
-
-REM Create Linker Directory
-cd Binaries\Release\Exes\CscCore\win7-x64\
-mkdir Linked
-
-REM Copy Unmanaged Assets
-cd publish
-FOR /F "delims=" %%I IN ('DIR /b *') DO (
-    %__CORFLAGS% %%I 
-    if errorlevel 1 copy %%I ..\Linked 
-)
-copy *.ni.dll ..\Linked
-
-REM Run Linker
-echo Running %__dotnet1% %__IlLinkDll% -t -c link -a @%AssetDir%\Roslyn\RoslynRoots.txt -x %AssetDir%\Roslyn\RoslynRoots.xml -l none -out ..\Linked
-call %__dotnet1% %__IlLinkDll% -t -c link -a @%AssetDir%\Roslyn\RoslynRoots.txt -x %AssetDir%\Roslyn\RoslynRoots.xml -l none -out ..\Linked
-if errorlevel 1 set ExitCode=1&& echo Roslyn: ILLink failed
-
+pushd %LinkBenchRoot%\roslyn\
+call restore.cmd
+cd src\Compilers\CSharp\csc
+call %__dotnet2% restore -r win10-x64
+call %__dotnet2% publish -c release -r win10-x64 -f netcoreapp2.0 /p:LinkDuringPublish=false --output ..\..\..\..\Binaries\release\Exes\csc\netcoreapp2.0\win10-x64\Unlinked
+if errorlevel 1 set ExitCode=1&&echo Roslyn: publish failed
+call %__dotnet2% publish -c release -r win10-x64 -f netcoreapp2.0 --output ..\..\..\..\Binaries\release\Exes\csc\netcoreapp2.0\win10-x64\Linked
+if errorlevel 1 set ExitCode=1&&echo Roslyn: publish-iLLink failed
 popd
 exit /b

--- a/tests/src/performance/linkbench/scripts/clone.cmd
+++ b/tests/src/performance/linkbench/scripts/clone.cmd
@@ -27,16 +27,19 @@ REM      We use this specific version instead of the latest available from
 REM      the master branch, because the latest CLI generates R2R images for 
 REM      system binaries, while ILLink cannot yet. We need pure MSIL images
 REM      in the unlinked version in order to be able to do a fair dir-size comparison.
-REM .Net1 => This is .Net CLI v 1.1.0
-REM      Since Roslyn targets netcoreapp v1, it cannot use the IlLink.Tasks package.
-REM      We use the ILLink package to get the linker and run it manually.
-REM      Since IlLink.exe from this package only runs on .Net v1
+REM .Net2 => .Net 2.0.0-preview3-006923
+REM      Roslyn needs to build using the dotnet SDK 2.0, because it needs the 
+REM      latest C#7 compiler. However, this means that the directory size comparison 
+REM      is off, because the system-binaries are R2R in the unlinked directory, 
+REM      but MSIL in the linked directory. 
+REM      TODO: Get the correct version of Crossgen, and manually R2R the system
+REM      binaries in the linked directory.
 
 powershell -noprofile -executionPolicy RemoteSigned wget  https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1 -OutFile dotnet-install.ps1
-if not exist %__dotnet%  mkdir .Net  && powershell -noprofile -executionPolicy RemoteSigned -file dotnet-install.ps1 -Channel master -InstallDir .Net -version 2.0.0-preview2-005905
-if not exist %__dotnet1% mkdir .Net1 && powershell -noprofile -executionPolicy RemoteSigned -file dotnet-install.ps1 -InstallDir .Net1
+if not exist %__dotnet%  mkdir .Net && powershell -noprofile -executionPolicy RemoteSigned -file dotnet-install.ps1 -Channel master -InstallDir .Net -version 2.0.0-preview2-005905
+if not exist %__dotnet2% mkdir .Net2 && powershell -noprofile -executionPolicy RemoteSigned -file dotnet-install.ps1 -Channel master -InstallDir .Net2 -version 2.0.0-preview3-006923
 if not exist %__dotnet% set EXITCODE=1&& echo DotNet not installed
-if not exist %__dotnet1% set EXITCODE=1&& echo DotNet.1 not installed
+if not exist %__dotnet2% set EXITCODE=1&& echo DotNet2 not installed
 exit /b 
 
 :HelloWorld


### PR DESCRIPTION
Use ILLink.Tasks package to build the Roslyn linked benchmark,
now that Roslyn can target netcoreapp2.0.