### PR TITLE
Fix InitializeArray intrinsic must always be expanded for CoreRT.

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -2587,9 +2587,9 @@ inline IL_OFFSETX Compiler::impCurILOffset(IL_OFFSET offs, bool callInstruction)
 //    true if it is legal, false if it could be a sequence that we do not want to divide.
 bool Compiler::impCanSpillNow(OPCODE prevOpcode)
 {
-    // Don't spill after ldtoken, because it could be a part of the InitializeArray sequence.
+    // Don't spill after ldtoken, newarr and newobj, because it could be a part of the InitializeArray sequence.
     // Avoid breaking up to guarantee that impInitializeArrayIntrinsic can succeed.
-    return prevOpcode != CEE_LDTOKEN;
+    return (prevOpcode != CEE_LDTOKEN) && (prevOpcode != CEE_NEWARR) && (prevOpcode != CEE_NEWOBJ);
 }
 
 /*****************************************************************************


### PR DESCRIPTION
The issue is dotnet/corert#4690.

The problem is the same as the old one(#10215),  we do spill because reach the max tree size.

`impInitializeArrayIntrinsic` relies that the last stmt is the helper call.
We violate it if `MAX_TREE` spill happens before dbg spill on the stmt boundaries. We ends up with the wrong stmt order and can't import the intrinsic.

It works with optimization because we force to spill after 'dup' that are not 'elementary' and the right spills happen before we spill because of `MAX_TREE_SIZE`.

The good example:

```
    [ 1]   7 (0x007) dup
    [ 2]   8 (0x008) ldc.i4.0 0
    [ 3]   9 (0x009) ldc.i4.s 16
    [ 4]  11 (0x00b) newarr 01000047
*****************************************SPILL FOR DBG CODE*********************************************(
 spill tree 9
lvaGrabTemp returning 1 (V01 tmp1) called for impSpillStackEnsure.
assign tree 9 to temp 1


               [000015] ------------             *  STMT      void  (IL 0x007...  ???)
               [000009] ------------             |  /--*  CNS_INT   int    0
               [000014] -A----------             \--*  ASG       int
               [000013] D------N----                \--*  LCL_VAR   int    V01 tmp1

 spill tree 12
lvaGrabTemp returning 2 (V02 tmp2) called for impSpillStackEnsure.
assign tree 12 to temp 2


               [000019] ------------             *  STMT      void  (IL   ???...  ???)
               [000012] --CXG-------             |  /--*  CALL help ref    HELPER.CORINFO_HELP_READYTORUN_NEWARR_1
               [000010] ------------ arg0        |  |  \--*  CNS_INT   int    16
               [000018] -ACXG-------             \--*  ASG       ref
               [000017] D------N----                \--*  LCL_VAR   ref    V02 tmp2

lvaSetClass: setting class for V02 to (0000000000420038) [System.Private.CoreLib]System.Byte[]

)
    [ 4]  16 (0x010) dup
    [ 5]  17 (0x011) ldtoken
    [ 6]  22 (0x016) call 0A000190
In Compiler::impImportCall: opcode is call, kind=0, callRetType is void, structSize is 0
```
The last statement is `[000019]`.

The bad example:
```
    [ 1] 196 (0x0c4) dup
    [ 2] 197 (0x0c5) ldc.i4.s 9
    [ 3] 199 (0x0c7) ldc.i4.s 16
    [ 4] 201 (0x0c9) newarr 01000047
*****************************************SPILL BECAUSE REACHED MAX_TREE_SIZE************************(
 spill tree 273
lvaGrabTemp returning 19 (V19 tmp19) called for impSpillStackEnsure.
assign tree 273 to temp 19


               [000276] ------------             *  STMT      void  (IL   ???...  ???)
               [000273] --CXG-------             |  /--*  CALL help ref    HELPER.CORINFO_HELP_READYTORUN_NEWARR_1
               [000271] ------------ arg0        |  |  \--*  CNS_INT   int    16
               [000275] -ACXG-------             \--*  ASG       ref
               [000274] D------N----                \--*  LCL_VAR   ref    V19 tmp19

lvaSetClass: setting class for V19 to (0000000000420038) [System.Private.CoreLib]System.Byte[]

)
*****************************************SPILL FOR DBG CODE*********************************************(
 spill tree 270
lvaGrabTemp returning 20 (V20 tmp20) called for impSpillStackEnsure.
assign tree 270 to temp 20


               [000280] ------------             *  STMT      void  (IL   ???...  ???)
               [000270] ------------             |  /--*  CNS_INT   int    9
               [000279] -A----------             \--*  ASG       int
               [000278] D------N----                \--*  LCL_VAR   int    V20 tmp20

)
    [ 4] 206 (0x0ce) dup
    [ 5] 207 (0x0cf) ldtoken
    [ 6] 212 (0x0d4) call 0A000190
```
in the bad example we do not spill `[000280]` because it is leaf node, that we ignore 
```
if ((opcodeOffs - lastSpillOffs) > MAX_TREE_SIZE && impCanSpillNow(prevOpcode))
{
  impSpillStackEnsure(spillLeaves = false);
}
```
but then this leave is spilled for dbg code and `000280` becomes the last statement.

I see 3 possible cheap fixes:
1. do not spill after `new_arr`, `new_obj`;
2. search for the correct stmt in the `impInitializeArrayIntrinsic`;
3. swap the order of the spilling because of DBG_CODE and MAX_TREE_SIZE.

I do not like the second variant, because it creates additional checks in the `impInitializeArrayIntrinsic`.
The third variant is good, possible that there are other intrinsics that will benefit from the right order, but it causes asm diffs in CoreCLR.

So this PR implements the first variant as the cheapest to implement and check.
It is safe not to add `dup` into this list, because it doesn't add new stmt or locals. It is important not to add it, because we can create a test, that will cause stack overflow with such exclusion. 
