### PR TITLE
linux-performance-tracing: COMPLUS_Event*Filter -> COMPlus_Event*Filter

### DIFF
--- a/Documentation/project-docs/linux-performance-tracing.md
+++ b/Documentation/project-docs/linux-performance-tracing.md
@@ -119,8 +119,8 @@ Filtering is implemented on Windows through the latest mechanisms provided with 
 
 On Linux those mechanisms are not available yet. Instead, there are two environment variables that exist just on linux to do some basic filtering. 
 
-* COMPLUS_EventSourceFilter – filter event sources by name
-* COMPLUS_EventNameFilter – filter events by name
+* COMPlus_EventSourceFilter – filter event sources by name
+* COMPlus_EventNameFilter – filter events by name
 
 Setting one or both of these variables will only enable collecting events that contain the name you specify as a substring. Strings are treated as case insensitive. 
 


### PR DESCRIPTION
The environment variable names are case-sensitive.

CC @vancem @brianrob 