### PR TITLE
Update CentOS 6 docker image

### DIFF
--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -26,7 +26,7 @@
         {
           "Name": "DotNet-CoreClr-Trusted-Linux",
           "Parameters": {
-            "DockerTag": "centos-6-d485f41-20173404063424",
+            "DockerTag": "centos-6-376e1a3-20174311014331",
             "Rid": "rhel.6",
 			"PB_AdditionalBuildArgs": "-portablebuild=false"
           },


### PR DESCRIPTION
This update fixes problem with git not supporting https protocol