### PR TITLE
[RyuJIT/ARM32] Fast tail call: code generation

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -69,12 +69,11 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
 
     switch (treeNode->gtOper)
     {
-#ifdef _TARGET_ARM64_
-
         case GT_START_NONGC:
             getEmitter()->emitDisableGC();
             break;
 
+#ifdef _TARGET_ARM64_
         case GT_PROF_HOOK:
             // We should be seeing this only if profiler hook is needed
             noway_assert(compiler->compIsProfilerHookNeeded());
@@ -567,9 +566,6 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
     // All other calls - stk arg is setup in out-going arg area.
     if (treeNode->putInIncomingArgArea())
     {
-        NYI_ARM("genPutArgStk: fast tail call");
-
-#ifdef _TARGET_ARM64_
         varNumOut    = getFirstArgWithStackSlot();
         argOffsetMax = compiler->compArgSize;
 #if FEATURE_FASTTAILCALL
@@ -582,7 +578,6 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
         LclVarDsc* varDsc = &(compiler->lvaTable[varNumOut]);
         assert(varDsc != nullptr);
 #endif // FEATURE_FASTTAILCALL
-#endif // _TARGET_ARM64_
     }
     else
     {

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2266,14 +2266,19 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
 
         genConsumeReg(target);
 
-        NYI_ARM("fast tail call");
-
 #ifdef _TARGET_ARM64_
         // Use IP0 as the call target register.
         if (target->gtRegNum != REG_IP0)
         {
             inst_RV_RV(INS_mov, REG_IP0, target->gtRegNum);
         }
+#elif defined(_TARGET_ARM_)
+        // Use R12 as the call target register.
+        if (target->gtRegNum != REG_R12)
+        {
+            inst_RV_RV(INS_mov, REG_R12, target->gtRegNum);
+        }
+
 #endif // _TARGET_ARM64_
 
         return;

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2261,20 +2261,11 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
 
         genConsumeReg(target);
 
-#ifdef _TARGET_ARM64_
-        // Use IP0 as the call target register.
-        if (target->gtRegNum != REG_IP0)
+        // Use IP0 on ARM64 and R12 on ARM32 as the call target register.
+        if (target->gtRegNum != REG_FASTTAILCALL_TARGET)
         {
-            inst_RV_RV(INS_mov, REG_IP0, target->gtRegNum);
+            inst_RV_RV(INS_mov, REG_FASTTAILCALL_TARGET, target->gtRegNum);
         }
-#elif defined(_TARGET_ARM_)
-        // Use R12 as the call target register.
-        if (target->gtRegNum != REG_R12)
-        {
-            inst_RV_RV(INS_mov, REG_R12, target->gtRegNum);
-        }
-
-#endif // _TARGET_ARM64_
 
         return;
     }

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -11312,7 +11312,7 @@ instruction CodeGen::genMapShiftInsToShiftByConstantIns(instruction ins, int shi
 
 #endif // _TARGET_XARCH_
 
-#if !defined(LEGACY_BACKEND) && (defined(_TARGET_XARCH_) || defined(_TARGET_ARMARCH_))
+#if !defined(LEGACY_BACKEND)
 
 //------------------------------------------------------------------------------------------------ //
 // getFirstArgWithStackSlot - returns the first argument with stack slot on the caller's frame.
@@ -11366,16 +11366,16 @@ unsigned CodeGen::getFirstArgWithStackSlot()
     }
 
     return baseVarNum;
-#elif defined(_TARGET_AMDARCH_)
+#elif defined(_TARGET_AMD64_)
     return 0;
-#else
+#else  // _TARGET_X86
     // Not implemented for x86.
     NYI_X86("getFirstArgWithStackSlot not yet implemented for x86.");
     return BAD_VAR_NUM;
-#endif // FEATURE_UNIX_AMD64_STRUCT_PASSING || _TARGET_ARMARCH_
+#endif // _TARGET_X86_
 }
 
-#endif // !LEGACY_BACKEND && (_TARGET_XARCH_ || _TARGET_ARMARCH_)
+#endif // !LEGACY_BACKEND
 
 //------------------------------------------------------------------------
 // genSinglePush: Report a change in stack level caused by a single word-sized push instruction

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -11378,7 +11378,7 @@ instruction CodeGen::genMapShiftInsToShiftByConstantIns(instruction ins, int shi
 
 #endif // _TARGET_XARCH_
 
-#if !defined(LEGACY_BACKEND) && (defined(_TARGET_XARCH_) || defined(_TARGET_ARM64_))
+#if !defined(LEGACY_BACKEND) && (defined(_TARGET_XARCH_) || defined(_TARGET_ARMARCH_))
 
 //------------------------------------------------------------------------------------------------ //
 // getFirstArgWithStackSlot - returns the first argument with stack slot on the caller's frame.
@@ -11390,13 +11390,13 @@ instruction CodeGen::genMapShiftInsToShiftByConstantIns(instruction ins, int shi
 //    On x64 Windows the caller always creates slots (homing space) in its frame for the
 //    first 4 arguments of a callee (register passed args). So, the the variable number
 //    (lclNum) for the first argument with a stack slot is always 0.
-//    For System V systems or arm64, there is no such calling convention requirement, and the code needs to find
+//    For System V systems or armarch, there is no such calling convention requirement, and the code needs to find
 //    the first stack passed argument from the caller. This is done by iterating over
 //    all the lvParam variables and finding the first with lvArgReg equals to REG_STK.
 //
 unsigned CodeGen::getFirstArgWithStackSlot()
 {
-#if defined(FEATURE_UNIX_AMD64_STRUCT_PASSING) || defined(_TARGET_ARM64_)
+#if defined(FEATURE_UNIX_AMD64_STRUCT_PASSING) || defined(_TARGET_ARMARCH_)
     unsigned baseVarNum = 0;
 #if defined(FEATURE_UNIX_AMR64_STRUCT_PASSING)
     baseVarNum = compiler->lvaFirstStackIncomingArgNum;
@@ -11432,16 +11432,16 @@ unsigned CodeGen::getFirstArgWithStackSlot()
     }
 
     return baseVarNum;
-#elif defined(_TARGET_AMD64_)
+#elif defined(_TARGET_AMDARCH_)
     return 0;
 #else
     // Not implemented for x86.
     NYI_X86("getFirstArgWithStackSlot not yet implemented for x86.");
     return BAD_VAR_NUM;
-#endif // FEATURE_UNIX_AMD64_STRUCT_PASSING || _TARGET_ARM64_
+#endif // FEATURE_UNIX_AMD64_STRUCT_PASSING || _TARGET_ARMARCH_
 }
 
-#endif // !LEGACY_BACKEND && (_TARGET_XARCH_ || _TARGET_ARM64_)
+#endif // !LEGACY_BACKEND && (_TARGET_XARCH_ || _TARGET_ARMARCH_)
 
 //------------------------------------------------------------------------
 // genSinglePush: Report a change in stack level caused by a single word-sized push instruction

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -53,9 +53,7 @@ void genPutArgSplit(GenTreePutArgSplit* treeNode);
 unsigned getBaseVarForPutArgStk(GenTreePtr treeNode);
 #endif // _TARGET_XARCH_
 
-#if defined(_TARGET_XARCH_) || defined(_TARGET_ARM64_)
 unsigned getFirstArgWithStackSlot();
-#endif // _TARGET_XARCH_ || _TARGET_ARM64_
 
 void genCompareFloat(GenTreePtr treeNode);
 void genCompareInt(GenTreePtr treeNode);

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -407,10 +407,10 @@ void LinearScan::TreeNodeInfoInitCall(GenTreeCall* call)
             // so that epilog sequence can generate "br xip0" to achieve fast tail call.
             ctrlExpr->gtLsraInfo.setSrcCandidates(this, genRegMask(REG_IP0));
 #else  // !_TARGET_ARM64_
-            // Fast tail call - make sure that call target is always computed in r12
+            // Fast tail call - make sure that call target is always computed in R12
             // so that epilog sequence can generate "br r12" to achieve fast tail call.
             ctrlExpr->gtLsraInfo.setSrcCandidates(this, RBM_R12);
-#endif // !_TARGET_ARM64_
+#endif // _TARGET_ARM_
         }
     }
 #ifdef _TARGET_ARM_

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -402,15 +402,9 @@ void LinearScan::TreeNodeInfoInitCall(GenTreeCall* call)
         // computed into a register.
         if (call->IsFastTailCall())
         {
-#ifdef _TARGET_ARM64_
-            // Fast tail call - make sure that call target is always computed in IP0
-            // so that epilog sequence can generate "br xip0" to achieve fast tail call.
-            ctrlExpr->gtLsraInfo.setSrcCandidates(this, genRegMask(REG_IP0));
-#else  // !_TARGET_ARM64_
-            // Fast tail call - make sure that call target is always computed in R12
-            // so that epilog sequence can generate "br r12" to achieve fast tail call.
-            ctrlExpr->gtLsraInfo.setSrcCandidates(this, RBM_R12);
-#endif // _TARGET_ARM_
+            // Fast tail call - make sure that call target is always computed in R12(ARM32)/IP0(ARM64)
+            // so that epilog sequence can generate "br xip0/r12" to achieve fast tail call.
+            ctrlExpr->gtLsraInfo.setSrcCandidates(this, RBM_FASTTAILCALL_TARGET);
         }
     }
 #ifdef _TARGET_ARM_

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -1248,6 +1248,8 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define RBM_CALLEE_TRASH_NOGC   RBM_CALLEE_TRASH
 #endif
   #define REG_DEFAULT_HELPER_CALL_TARGET REG_R12
+  #define REG_FASTTAILCALL_TARGET REG_R12   // Target register for fast tail call
+  #define RBM_FASTTAILCALL_TARGET RBM_R12
 
   #define RBM_ALLINT              (RBM_INT_CALLEE_SAVED | RBM_INT_CALLEE_TRASH)
   #define RBM_ALLFLOAT            (RBM_FLT_CALLEE_SAVED | RBM_FLT_CALLEE_TRASH)
@@ -1587,6 +1589,8 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define RBM_CALLEE_TRASH        (RBM_INT_CALLEE_TRASH | RBM_FLT_CALLEE_TRASH)
   #define RBM_CALLEE_TRASH_NOGC   (RBM_R12|RBM_R13|RBM_R14|RBM_R15|RBM_IP1)
   #define REG_DEFAULT_HELPER_CALL_TARGET REG_R12
+  #define REG_FASTTAILCALL_TARGET REG_IP0   // Target register for fast tail call
+  #define RBM_FASTTAILCALL_TARGET RBM_IP0
 
   #define RBM_ALLINT              (RBM_INT_CALLEE_SAVED | RBM_INT_CALLEE_TRASH)
   #define RBM_ALLFLOAT            (RBM_FLT_CALLEE_SAVED | RBM_FLT_CALLEE_TRASH)


### PR DESCRIPTION
Code generation for call node and epilog when callee is fast tail call.
Code generation for GT_START_NONGC which is used to prevent GC in fast tail call.

It is not affect to generated code on arm32 yet, because call->IsFastTailCall() is always false now.