### PR TITLE
Disabling legacy banckend perf CQ and scenario runs

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -30,7 +30,7 @@ def static getOSGroup(def os) {
     ['Windows_NT'].each { os ->
         ['x64', 'x86'].each { arch ->
             [true, false].each { isSmoketest ->
-                ['ryujit', 'legacy_backend'].each { jit ->
+                ['ryujit'].each { jit ->
 
                     if (arch == 'x64' && jit == 'legacy_backend') {
                         return
@@ -578,7 +578,7 @@ parallel(
 [true, false].each { isPR ->
     ['Windows_NT'].each { os ->
         ['x64', 'x86'].each { arch ->
-            ['ryujit', 'legacy_backend'].each { jit ->
+            ['ryujit'].each { jit ->
 
                 if (arch == 'x64' && jit == 'legacy_backend') {
                     return


### PR DESCRIPTION
- Recent changes to enforce data validation uncovered bug on the legacy backend runs.
  CQ run bug tracked by: https://github.com/dotnet/coreclr/issues/14463
  JitBench run bug tracked by: https://github.com/dotnet/coreclr/issues/14477