### PR TITLE
Fixed stack probing for RHEL 6.9 (Linux kernel 2.6.32)

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -6216,7 +6216,7 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
         // loop:
         //      lea esp, [esp - pageSize]   7
         //      test [esp], eax             3
-        //      cmp eax, esp                2
+        //      cmp esp, eax                2
         //      jge loop                    2
         //      lea rsp, [rbp + frameSize]
         //
@@ -6225,7 +6225,7 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
         // loop:
         //      lea rsp, [rsp - pageSize]   8
         //      test [rsp], rax             4
-        //      cmp rax, rsp                3
+        //      cmp rsp, rax                3
         //      jge loop                    2
         //      lea rsp, [rax + frameSize]
         //
@@ -6234,7 +6234,7 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
         // loop:
         //      lea rsp, [rsp - pageSize]   8
         //      test [rsp], rbp             4
-        //      cmp rbp, rsp                3
+        //      cmp rsp, rbp                3
         //      jge loop                    2
         //      lea rsp, [rbp + frameSize]
 
@@ -6244,7 +6244,7 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
 
         getEmitter()->emitIns_R_AR(INS_lea, EA_PTRSIZE, REG_SPBASE, REG_SPBASE, -sPageSize);
         getEmitter()->emitIns_R_AR(INS_TEST, EA_PTRSIZE, initReg, REG_SPBASE, 0);
-        inst_RV_RV(INS_cmp, initReg, REG_SPBASE);
+        inst_RV_RV(INS_cmp, REG_SPBASE, initReg);
 
         int bytesForBackwardJump;
 #ifdef _TARGET_AMD64_

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -6249,10 +6249,10 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
         int bytesForBackwardJump;
 #ifdef _TARGET_AMD64_
         assert((initReg == REG_EAX) || (initReg == REG_EBP)); // We use RBP as initReg for EH funclets.
-        bytesForBackwardJump = -15;
+        bytesForBackwardJump = -17;
 #else  // !_TARGET_AMD64_
         assert(initReg == REG_EAX);
-        bytesForBackwardJump = -12;
+        bytesForBackwardJump = -14;
 #endif // !_TARGET_AMD64_
 
         inst_IV(INS_jge, bytesForBackwardJump); // Branch backwards to start of loop

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -6238,9 +6238,11 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
         //      jge loop                    2
         //      lea rsp, [rbp + frameSize]
 
+        int sPageSize = (int)pageSize;
+
         getEmitter()->emitIns_R_AR(INS_lea, EA_PTRSIZE, initReg, REG_SPBASE, -((ssize_t)frameSize)); // get frame border
 
-        getEmitter()->emitIns_R_AR(INS_lea, EA_PTRSIZE, REG_SPBASE, REG_SPBASE, -((ssize_t)pageSize));
+        getEmitter()->emitIns_R_AR(INS_lea, EA_PTRSIZE, REG_SPBASE, REG_SPBASE, -sPageSize);
         getEmitter()->emitIns_R_AR(INS_TEST, EA_PTRSIZE, initReg, REG_SPBASE, 0);
         inst_RV_RV(INS_cmp, initReg, REG_SPBASE);
 

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -6215,7 +6215,7 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
         //      lea eax, [esp - frameSize]
         // loop:
         //      lea esp, [esp - pageSize]   7
-        //      test [esp], esp             3
+        //      test [esp], eax             3
         //      cmp eax, esp                2
         //      jge loop                    2
         //      lea rsp, [rbp + frameSize]
@@ -6224,7 +6224,7 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
         //      lea rax, [rsp - frameSize]
         // loop:
         //      lea rsp, [rsp - pageSize]   8
-        //      test [rsp], rsp             4
+        //      test [rsp], rax             4
         //      cmp rax, rsp                3
         //      jge loop                    2
         //      lea rsp, [rax + frameSize]
@@ -6233,15 +6233,15 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
         //      lea rbp, [rsp - frameSize]
         // loop:
         //      lea rsp, [rsp - pageSize]   8
-        //      test [rsp], rsp             4
+        //      test [rsp], rbp             4
         //      cmp rbp, rsp                3
         //      jge loop                    2
         //      lea rsp, [rbp + frameSize]
 
-        getEmitter()->emitIns_R_AR(INS_lea, EA_PTRSIZE, initReg, REG_SPBASE, -frameSize); // get frame border
+        getEmitter()->emitIns_R_AR(INS_lea, EA_PTRSIZE, initReg, REG_SPBASE, -((ssize_t)frameSize)); // get frame border
 
-        getEmitter()->emitIns_R_AR(INS_lea, EA_PTRSIZE, REG_SPBASE, REG_SPBASE, -pageSize);
-        getEmitter()->emitIns_R_AR(INS_TEST, EA_PTRSIZE, REG_SPBASE, REG_SPBASE, 0);
+        getEmitter()->emitIns_R_AR(INS_lea, EA_PTRSIZE, REG_SPBASE, REG_SPBASE, -((ssize_t)pageSize));
+        getEmitter()->emitIns_R_AR(INS_TEST, EA_PTRSIZE, initReg, REG_SPBASE, 0);
         inst_RV_RV(INS_cmp, initReg, REG_SPBASE);
 
         int bytesForBackwardJump;


### PR DESCRIPTION
Fixed issue #13740.

The problem was about stack overflow check via probing for enormous frame size. RHEL6.9 uses 2.6.32 Linux kernel which maps new stack pages just in case they are already allocated (using rsp)  otherwise it produces SIGSEGV.

With the fix additional stack space is being allocated page by page on every iteration. It goes over the frame size. After probe stack pointer is restored. 