### PR TITLE
Forbid to clone GT_RET_EXPR

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -7393,6 +7393,9 @@ GenTreePtr Compiler::gtCloneExpr(
                 goto DONE;
 
             case GT_RET_EXPR:
+                // GT_RET_EXPR is unique node, that contains a link to a gtInlineCandidate node,
+                // that is part of another statement. We cannot clone both here and cannot
+                // create another GT_RET_EXPR that points to the same gtInlineCandidate.
                 NO_WAY("Cloning of GT_RET_EXPR node not supported");
                 goto DONE;
 

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -7393,7 +7393,7 @@ GenTreePtr Compiler::gtCloneExpr(
                 goto DONE;
 
             case GT_RET_EXPR:
-                copy = gtNewInlineCandidateReturnExpr(tree->gtRetExpr.gtInlineCandidate, tree->gtType);
+                NO_WAY("Cloning of GT_RET_EXPR node not supported");
                 goto DONE;
 
             case GT_MEMORYBARRIER:


### PR DESCRIPTION
It potentially create non-unique trees.
Fix #13435.