### PR TITLE
GetEnvironmentVariable: Avoid StringBuilder marshaling overhead

### DIFF
--- a/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
+++ b/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
@@ -687,7 +687,15 @@ namespace Microsoft.Win32
         internal static extern bool SetEnvironmentVariable(string lpName, string lpValue);
 
         [DllImport(Interop.Libraries.Kernel32, CharSet = CharSet.Auto, SetLastError = true, BestFitMapping = false)]
-        internal static extern int GetEnvironmentVariable(string lpName, [Out]StringBuilder lpValue, int size);
+        private static extern unsafe int GetEnvironmentVariable(string lpName, char* lpValue, int size);
+
+        internal static unsafe int GetEnvironmentVariable(string lpName, Span<char> lpValue)
+        {
+            fixed (char* lpValuePtr = &lpValue.DangerousGetPinnableReference())
+            {
+                return GetEnvironmentVariable(lpName, lpValuePtr, lpValue.Length);
+            }
+        }
 
         [DllImport(Interop.Libraries.Kernel32, CharSet = CharSet.Unicode)]
         internal static unsafe extern char* GetEnvironmentStrings();

--- a/src/mscorlib/src/System/Environment.cs
+++ b/src/mscorlib/src/System/Environment.cs
@@ -545,6 +545,11 @@ namespace System
         {
             int requiredSize = Win32Native.GetEnvironmentVariable(variable, buffer);
 
+            if (requiredSize == 0 && Marshal.GetLastWin32Error() == Win32Native.ERROR_ENVVAR_NOT_FOUND)
+            {
+                return null;
+            }
+
             if (requiredSize > buffer.Length)
             {
                 char[] chars = ArrayPool<char>.Shared.Rent(requiredSize);
@@ -556,11 +561,6 @@ namespace System
                 {
                     ArrayPool<char>.Shared.Return(chars, clearArray: true);
                 }
-            }
-
-            if (requiredSize == 0)
-            {
-                return Marshal.GetLastWin32Error() == Win32Native.ERROR_ENVVAR_NOT_FOUND ? null : string.Empty;
             }
 
             return new string(buffer.Slice(0, requiredSize));

--- a/src/mscorlib/src/System/Environment.cs
+++ b/src/mscorlib/src/System/Environment.cs
@@ -14,6 +14,7 @@
 
 namespace System
 {
+    using System.Buffers;
     using System.IO;
     using System.Security;
     using System.Resources;
@@ -536,23 +537,33 @@ namespace System
 
         private static string GetEnvironmentVariableCore(string variable)
         {
-            StringBuilder sb = StringBuilderCache.Acquire(128); // A somewhat reasonable default size
-            int requiredSize = Win32Native.GetEnvironmentVariable(variable, sb, sb.Capacity);
+            Span<char> buffer = stackalloc char[128]; // A somewhat reasonable default size
+            return GetEnvironmentVariableCoreHelper(variable, buffer);
+        }
 
-            if (requiredSize == 0 && Marshal.GetLastWin32Error() == Win32Native.ERROR_ENVVAR_NOT_FOUND)
+        private static string GetEnvironmentVariableCoreHelper(string variable, Span<char> buffer)
+        {
+            int requiredSize = Win32Native.GetEnvironmentVariable(variable, buffer);
+
+            if (requiredSize > buffer.Length)
             {
-                StringBuilderCache.Release(sb);
-                return null;
+                char[] chars = ArrayPool<char>.Shared.Rent(requiredSize);
+                try
+                {
+                    return GetEnvironmentVariableCoreHelper(variable, chars);
+                }
+                finally
+                {
+                    ArrayPool<char>.Shared.Return(chars, clearArray: true);
+                }
             }
 
-            while (requiredSize > sb.Capacity)
+            if (requiredSize == 0)
             {
-                sb.Capacity = requiredSize;
-                sb.Length = 0;
-                requiredSize = Win32Native.GetEnvironmentVariable(variable, sb, sb.Capacity);
+                return Marshal.GetLastWin32Error() == Win32Native.ERROR_ENVVAR_NOT_FOUND ? null : string.Empty;
             }
 
-            return StringBuilderCache.GetStringAndRelease(sb);
+            return new string(buffer.Slice(0, requiredSize));
         }
 
         private static string GetEnvironmentVariableCore(string variable, EnvironmentVariableTarget target)

--- a/src/mscorlib/src/System/Environment.cs
+++ b/src/mscorlib/src/System/Environment.cs
@@ -559,7 +559,7 @@ namespace System
                 }
                 finally
                 {
-                    ArrayPool<char>.Shared.Return(chars, clearArray: true);
+                    ArrayPool<char>.Shared.Return(chars);
                 }
             }
 


### PR DESCRIPTION
Try a stack allocated buffer first, then fallback to using the shared array pool.

Results on my machine:


|             Method |      Mean |     Error |    StdDev |  Gen 0 | Allocated |
|------------------- |----------:|----------:|----------:|-------:|----------:|
|  `"TMP"` Before | 156.51 ns | 2.0132 ns | 1.8831 ns | 0.0875 |     368 B |
|  `"TMP"` After |  92.88 ns | 0.5002 ns | 0.4434 ns | 0.0209 |      88 B |
| `"PATH"` Before | 621.59 ns | 2.2668 ns | 2.1204 ns | 0.9565 |    4016 B |
| `"PATH"` After | 287.02 ns | 1.0377 ns | 0.8666 ns | 0.2704 |    1136 B |


`"TMP"` is under the stack limit and `"PATH"` is over the limit (uses the pool).