### PR TITLE
Fix call to submission.py in run-throughput-perf.py

### DIFF
--- a/tests/scripts/run-throughput-perf.py
+++ b/tests/scripts/run-throughput-perf.py
@@ -444,7 +444,7 @@ def main(args):
                 "--config",
                 "PGO",
                 pgo_string,
-                "--arch",
+                "--architecture",
                 architecture,
                 "--machinepool",
                 "PerfSnake"
@@ -452,6 +452,9 @@ def main(args):
         log(" ".join(submission_args))
         proc = subprocess.Popen(submission_args)
         proc.communicate()
+        if proc.returncode != 0:
+            os.chdir(current_dir)
+            return -1
 
         # Call upload.py
         upload_args = [python_exe,
@@ -463,6 +466,9 @@ def main(args):
         log(" ".join(upload_args))
         proc = subprocess.Popen(upload_args)
         proc.communicate()
+        if proc.returncode != 0:
+            os.chdir(current_dir)
+            return -1
 
     os.chdir(current_dir)
 


### PR DESCRIPTION
In run-throughput-perf.py, we were calling submission.py with --arch,
but submission.py requires -arch or --architecture. This recently made
submission.py start failing in throughput jobs.

This change also fixes run-throughput-perf so that if submission.py or
upload.py fail, the script fails so we see these jobs as failing in the
lab.