### PR TITLE
spill GT_RET_EXPR inside fat calli candidates.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3059,6 +3059,7 @@ protected:
     GenTreePtr impTreeList; // Trees for the BB being imported
     GenTreePtr impTreeLast; // The last tree for the current BB
 
+public:
     enum
     {
         CHECK_SPILL_ALL  = -1,
@@ -5797,11 +5798,7 @@ public:
         optMethodFlags &= ~OMF_HAS_FATPOINTER;
     }
 
-    void addFatPointerCandidate(GenTreeCall* call)
-    {
-        setMethodHasFatPointer();
-        call->SetFatPointerCandidate();
-    }
+    void addFatPointerCandidate(GenTreeCall* call);
 
     unsigned optMethodFlags;
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3066,7 +3066,6 @@ public:
         CHECK_SPILL_NONE = -2
     };
 
-public:
     void impBeginTreeList();
     void impEndTreeList(BasicBlock* block, GenTreePtr firstStmt, GenTreePtr lastStmt);
     void impEndTreeList(BasicBlock* block);

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -19377,3 +19377,69 @@ CORINFO_RESOLVED_TOKEN* Compiler::impAllocateToken(CORINFO_RESOLVED_TOKEN token)
     *memory                        = token;
     return memory;
 }
+
+//------------------------------------------------------------------------
+// SpillRetExprHelper: iterate through arguments tree and spill ret_expr to local varibales.
+//
+class SpillRetExprHelper
+{
+public:
+    SpillRetExprHelper(Compiler* comp) : comp(comp)
+    {
+    }
+
+    void StoreRetExprResultsInArgs(GenTreeCall* call)
+    {
+        GenTreePtr args = call->gtCallArgs;
+        if (args != nullptr)
+        {
+            comp->fgWalkTreePre(&args, SpillRetExprVisitor, this);
+        }
+    }
+
+private:
+    static Compiler::fgWalkResult SpillRetExprVisitor(GenTree** pTree, Compiler::fgWalkData* fgWalkPre)
+    {
+        assert((pTree != nullptr) && (*pTree != nullptr));
+        GenTreePtr tree = *pTree;
+        if ((tree->gtFlags & GTF_CALL) == 0)
+        {
+            // Trees with ret_expr are marked as GTF_CALL.
+            return Compiler::WALK_SKIP_SUBTREES;
+        }
+        if (tree->OperGet() == GT_RET_EXPR)
+        {
+            SpillRetExprHelper* walker = static_cast<SpillRetExprHelper*>(fgWalkPre->pCallbackData);
+            walker->StoreRetExprAsLocalVar(pTree);
+        }
+        return Compiler::WALK_CONTINUE;
+    }
+
+    void StoreRetExprAsLocalVar(GenTreePtr* pRetExpr)
+    {
+        GenTreePtr retExpr = *pRetExpr;
+        assert(retExpr->OperGet() == GT_RET_EXPR);
+        JITDUMP("Store return expression %u  as a local var.\n", retExpr->gtTreeID);
+        unsigned tmp = comp->lvaGrabTemp(true DEBUGARG("spilling ret_expr"));
+        comp->impAssignTempGen(tmp, retExpr, (unsigned)Compiler::CHECK_SPILL_NONE);
+        *pRetExpr = comp->gtNewLclvNode(tmp, retExpr->TypeGet());
+    }
+
+private:
+    Compiler* comp;
+};
+
+//------------------------------------------------------------------------
+// addFatPointerCandidate: mark the call and the method, that they have a fat pointer candidate.
+//                         Spill ret_expr in the call node, because they can't be cloned.
+//
+// Arguments:
+//    call - fat calli candidate
+//
+void Compiler::addFatPointerCandidate(GenTreeCall* call)
+{
+    setMethodHasFatPointer();
+    call->SetFatPointerCandidate();
+    SpillRetExprHelper helper(this);
+    helper.StoreRetExprResultsInArgs(call);
+}

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -19395,6 +19395,11 @@ public:
         {
             comp->fgWalkTreePre(&args, SpillRetExprVisitor, this);
         }
+        GenTreePtr thisArg = call->gtCallObjp;
+        if (thisArg != nullptr)
+        {
+            comp->fgWalkTreePre(&thisArg, SpillRetExprVisitor, this);
+        }
     }
 
 private:


### PR DESCRIPTION
If we have such call, that is marked as fat pointer candidate:
```
[000070] --CXG-------              *  CALL ind nullcheck int
[000061] ------------ this in rcx  |  +--*  LCL_VAR   ref    V03 tmp1
[000059] --C--------- arg1         |--*  RET_EXPR  ref   (inl return from call [000054])
[000069] ------------ calli tgt    \--*  LCL_VAR   long   V06 tmp4
```
then spill all ret expr from its arguments as locals:

```
[000073] ------------              *  STMT      void  (IL   ???...  ???)
[000059] --C---------              |  /--*  RET_EXPR  ref   (inl return from call [000054])
[000072] -AC---------              \--*  ASG       ref
[000071] D------N----                 \--*  LCL_VAR   ref    V07 tmp5

[000077] ------------              *  STMT      void  (IL   ???...  ???)
[000070] --CXG-------              |  /--*  CALL ind nullcheck int
[000061] ------------ this in rcx  |  |  +--*  LCL_VAR   ref    V03 tmp1
[000074] ------------ arg1         |  |  +--*  LCL_VAR   ref    V07 tmp5
[000069] ------------ calli tgt    |  |  \--*  LCL_VAR   long   V06 tmp4
[000076] -ACXG-------              \--*  ASG       int
[000075] D------N----                 \--*  LCL_VAR   int    V08 tmp6

```

Fix dotnet/corert#4251.
