### PR TITLE
Fix deadlock in ReadyToRun scenarios between EH and code heap deletion

### DIFF
--- a/src/vm/codeman.cpp
+++ b/src/vm/codeman.cpp
@@ -6917,6 +6917,14 @@ BOOL ReadyToRunJitManager::JitCodeToMethodInfo(RangeSection * pRangeSection,
     if (MethodIndex < 0)
         return FALSE;
 
+    if (ppMethodDesc == NULL && pCodeInfo == NULL)
+    {
+        // Bail early if caller doesn't care about the MethodDesc or EECodeInfo.
+        // Avoiding the method desc lookups below also prevents deadlocks when this
+        // is called from IsManagedCode.
+        return TRUE;
+    }
+
 #ifdef WIN64EXCEPTIONS
     // Save the raw entry
     PTR_RUNTIME_FUNCTION RawFunctionEntry = pRuntimeFunctions + MethodIndex;


### PR DESCRIPTION
If the caller to `ReadyToRunJitManager::JitCodeToMethodInfo` doesn't care about the `MethodDesc` or `EECodeInfo` for the code (and passes in NULL for both), we shouldn't be doing any lookups to determine the method desc.

Turns out this pattern is used every time we call `IsManagedCode` in the ReadyToRun case (since we just want to know whether the code is managed or not) so this will avoid some extra work.

Also, this fixes the bug reported in #9745 where the pointless lookup causes the following deadlock (copied from my [comment in that thread](https://github.com/dotnet/coreclr/issues/9745#issuecomment-336309648)):

> When the LoaderAllocator gets destroyed, it calls LoaderAllocator::GCLoaderAllocators which tries to delete unreferenced domain assemblies. The destructor for Assembly calls Assembly::Terminate which suspends the EE and then calls ExecutionManager::Unload. At this point, the ExecutionManager tries to delete code heaps, but in order to do so, it must acquire a writer lock (which in turn requires that there are no more readers active). This thread is stuck waiting here because...
> 
> ...on another thread, System.Management.Automation.LocationGlobber.ExpandMshGlobPath threw an ItemNotFoundException, and we're in the process of dispatching that exception. One of the first things we need to do is unwind to the first managed call frame. This means checking if the code is managed and to do so, we first acquire the ExecutionManager's reader lock (because the scan flags for that thread tell us we need to). Now comes the part where ReadyToRun comes in: while we're holding the lock, we call JitCodeToMethodInfo, and the ReadyToRun version of that (ReadyToRunJitManager::JitCodeToMethodInfo) calls ReadyToRunInfo::GetMethodDescForEntryPoint which tries to do a hashmap lookup to find the MethodDesc corresponding to the entry point. However, HashMap::LookupValue tries to RareDisablePreemptiveGC before doing anything, and so the thread gets stuck while still holding the reader lock we got before.

Also, I couldn't help but fix some weird casing for locals in this function while I was touching it 😄 

@jkotas PTAL