### PR TITLE
CLRLifoSemaphore cleanup

### DIFF
--- a/src/vm/synch.h
+++ b/src/vm/synch.h
@@ -205,6 +205,12 @@ private:
             return data;
         }
 
+        Counts operator -() const
+        {
+            LIMITED_METHOD_CONTRACT;
+            return -(INT64)data;
+        }
+
         Counts &operator =(UINT64 data)
         {
             LIMITED_METHOD_CONTRACT;
@@ -213,16 +219,16 @@ private:
             return *this;
         }
 
-        Counts VolatileLoad() const
-        {
-            LIMITED_METHOD_CONTRACT;
-            return ::VolatileLoad(&data);
-        }
-
         Counts CompareExchange(Counts toCounts, Counts fromCounts)
         {
             LIMITED_METHOD_CONTRACT;
             return (UINT64)InterlockedCompareExchange64((LONG64 *)&data, (LONG64)toCounts, (LONG64)fromCounts);
+        }
+
+        Counts ExchangeAdd(Counts toAdd)
+        {
+            LIMITED_METHOD_CONTRACT;
+            return (UINT64)InterlockedExchangeAdd64((LONG64 *)&data, (LONG64)toAdd);
         }
     };
 


### PR DESCRIPTION
- Removed volatile loads. They don't actually help with anything. Should help a bit on arm, haven't tested.
  - I had added them initially out of pattern and could have left them out. There was some concern before that without a volatile load a compiler could replace local uses with a memory load and that would change the meaning of what is intended, but that doesn't apply to these kind of loops because it would be incorrect to do so, the concern may apply to loops like the following:
    ```c#
    while(true)
    {
        Counts counts = m_counts;
        if(InterlockedCompareExchange(&m_counts, counts + 1, counts) == counts)
            break;
    }
    ```
    Where if the 3rd argument is replaced by the compiler with m_counts, it may yield an incorrect result. It's an invalid optimization but anyway that can't be done in the type of loops used in this code because the initial value used for subsequent loop iterations is the result of the compare-exchange operation and not the memory location.
- No need to decrement the count of waiters woken upon timeout. I had initially copied that part of the code from SemaphoreSlim, which needs it because it uses a Monitor that doesn't provide the same guarantees as the wait objects used here. It's not needed here.
- No change to perf on x64, I plan on testing arm as part of issue #14067 once I have some time and get a machine.