### PR TITLE
[dev/release/2.0.0] Use restore with no --source for optdata proj feed

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -25,7 +25,12 @@
   </Target>
 
   <Target Name="RestoreOptData">
-    <Exec Command="$(DotnetRestoreCommand) $(SourceDir).nuget/optdata/optdata.csproj" />
+    <PropertyGroup>
+      <OptDataRestoreCommand>"$(DotnetToolCommand)"</OptDataRestoreCommand>
+      <OptDataRestoreCommand>$(OptDataRestoreCommand) restore</OptDataRestoreCommand>
+      <OptDataRestoreCommand>$(OptDataRestoreCommand) --packages "$(PackagesDir.TrimEnd('/').TrimEnd('\'))"</OptDataRestoreCommand>
+    </PropertyGroup>
+    <Exec Command="$(OptDataRestoreCommand) $(SourceDir).nuget/optdata/optdata.csproj" />
   </Target>
 
   <!--

--- a/src/.nuget/optdata/optdata.csproj
+++ b/src/.nuget/optdata/optdata.csproj
@@ -8,6 +8,14 @@
     <RuntimeIdentifiers>win7-x64;win7-x86;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
+  <!-- Add optimization data package restore source. -->
+  <PropertyGroup>
+    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
+      https://dotnet.myget.org/F/dotnet-core-optimization-data/api/v3/index.json;
+      $(RestoreSources)
+    </RestoreSources>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="optimization.PGO.CoreCLR" Version="$(PgoDataPackageVersion)" Condition="'$(PgoDataPackageVersion)'!=''" />
     <PackageReference Include="optimization.IBC.CoreCLR" Version="$(IbcDataPackageVersion)" Condition="'$(IbcDataPackageVersion)'!=''" />


### PR DESCRIPTION
This lets dotnet pick up RestoreSources hierarchically rather than only use what's predefined in DotnetRestoreCommand (in dir.props).

We might want to make a sourceless `DotnetRestoreCommand` available in BuildTools for this scenario, or change how we run restores overall to use the new tooling more effectively.

This fixes the package restore CI error in https://github.com/dotnet/source-build/pull/242. I didn't catch that in my local testing because I didn't clear out `packages`. This is the same problem as before: a nuget.config contains this info but those aren't being detected/used anymore.