### PR TITLE
Reenable PGO on Linux Release builds

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1912,17 +1912,12 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                         standaloneGc = 'buildstandalonegc'
                     }
                     
-                    def disablePgo = ''
-                    if (lowerConfiguration == 'release') {
-                        disablePgo = 'nopgooptimize'
-                    }
-
                     if (!enableCorefxTesting) {
                         // We run pal tests on all OS but generate mscorlib (and thus, nuget packages)
                         // only on supported OS platforms.
                         def bootstrapRid = Utilities.getBoostrapPublishRid(os)
                         def bootstrapRidEnv = bootstrapRid != null ? "__PUBLISH_RID=${bootstrapRid} " : ''
-                        buildCommands += "${bootstrapRidEnv}./build.sh verbose ${lowerConfiguration} ${architecture} ${standaloneGc} ${disablePgo}"
+                        buildCommands += "${bootstrapRidEnv}./build.sh verbose ${lowerConfiguration} ${architecture} ${standaloneGc}"
                         buildCommands += "src/pal/tests/palsuite/runpaltests.sh \${WORKSPACE}/bin/obj/${osGroup}.${architecture}.${configuration} \${WORKSPACE}/bin/paltestout"
 
                         // Set time out


### PR DESCRIPTION
Now that all the machines have been updated to have llvm 3.9 with PGO
support, reenable PGO builds.