### PR TITLE
Fixed block copy for structs containing gcrefs

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -878,8 +878,8 @@ void CodeGen::genCodeForCpObj(GenTreeObj* cpObjNode)
     regNumber tmpReg = cpObjNode->ExtractTempReg();
     assert(genIsValidIntReg(tmpReg));
 
-    emitter* emit  = getEmitter();
-    BYTE* gcPtrs = cpObjNode->gtGcPtrs;
+    emitter* emit   = getEmitter();
+    BYTE*    gcPtrs = cpObjNode->gtGcPtrs;
 
     unsigned gcPtrCount = cpObjNode->gtGcPtrCount;
 


### PR DESCRIPTION
Issue #14383.
Fixed code generation for `GT_STORE_OBJ` node containing gcref. In case we have struct with both gcref non-gcref we may receive GC signal during copy code when temporary register holds non-ref value, but marked as gcref. So such situation obviously leds to gc hole.

-----

We have a struct S
```
struct S
{
    public String str;  // reference
    public Pad pad;     // very big struct containing lot of doubles
    public String str2; // reference
}
```
And the which copies it
Before:
```
G_M833_IG03:

IN0009: 000038      nop     
IN000a: 00003A      add     r0, sp, 264	// [V06 loc0]
IN000b: 00003C      add     r1, sp, 528	// [V01 arg0]
IN000c: 00003E      ldr     r2, [r1!+4]
IN000d: 000042      str     r2, [r0!+4]
IN000e: 000046      ldr     r2, [r1!+4]
IN000f: 00004A      str     r2, [r0!+4]
IN0010: 00004E      ldr     r2, [r1!+4]
IN0011: 000052      str     r2, [r0!+4]
```

After:
```
G_M833_IG03:
000038  BF00           nop     
00003A  A842           add     r0, sp, 264	// [V06 loc0]
00003C  A984           add     r1, sp, 528	// [V01 arg0]
00003E  F242 6C11      movw    r12, 0x2611
000042  F6C6 1C65      movt    r12, 0x6965
000046  47E0           blx     r12		// CORINFO_HELP_ASSIGN_BYREF
000048  F242 6C11      movw    r12, 0x2611
00004C  F6C6 1C65      movt    r12, 0x6965
000050  47E0           blx     r12		// CORINFO_HELP_ASSIGN_BYREF
000052  F851 2B04      ldr     r2, [r1!+4]
000056  F840 2B04      str     r2, [r0!+4]
00005A  F851 2B04      ldr     r2, [r1!+4]
```

So you can see that 2 `CORINFO_HELP_ASSIGN_BYREF` was added which correspond to 2 references in the original struct. 
