### PR TITLE
Reduce infrastructure steps in Async Stack Traces

### DIFF
--- a/src/mscorlib/src/System/Runtime/ExceptionServices/ExceptionServicesCommon.cs
+++ b/src/mscorlib/src/System/Runtime/ExceptionServices/ExceptionServicesCommon.cs
@@ -130,6 +130,13 @@ namespace System.Runtime.ExceptionServices
             throw m_Exception;
         }
 
+        internal Exception GetThrowableException()
+        {
+            // Restore the exception dispatch details before allowing this exception to be thrown.
+            m_Exception.RestoreExceptionDispatchInfo(this);
+            return m_Exception;
+        }
+
         // Throws the source exception, maintaining the original bucketing details and augmenting
         // rather than replacing the original stack trace.
         public static void Throw(Exception source) => Capture(source).Throw();


### PR DESCRIPTION
Currently the only way to drop something from a stack trace is if it inlines; or if it isn't in the stack. So this change changes the stack when the exception is thrown.

It passes the exceptions back to be thrown at the location, rather than throwing in place (removing from stack)

![throw change](https://aoa.blob.core.windows.net/aspnet/throw-2.png)
The exception resolving functions are not a participant of the exception or trace - nothing wrong has happened in or before them (and they are not in the direct path) - they are orthogonal to it - so having the `throw` where it currently is doesn't add value.

Make sure `ValidateEnd` inlines with the extra exception check (remove by inlining, as now)

So outputs
```

System.Exception: Exception of type 'System.Exception' was thrown.
   at Program.<AsyncMethod>d__1.MoveNext() in C:\StackTraceAsync\Program.cs:line 27
--- End of stack trace from previous location where exception was thrown ---
   at Program.<DelayedAsync>d__2.MoveNext() in C:\StackTraceAsync\Program.cs:line 33
--- End of stack trace from previous location where exception was thrown ---
   at Program.<IntermediateAsync>d__3.MoveNext() in C:\StackTraceAsync\Program.cs:line 39
--- End of stack trace from previous location where exception was thrown ---
   at Program.<AsyncMethod>d__1.MoveNext() in C:\StackTraceAsync\Program.cs:line 22
--- End of stack trace from previous location where exception was thrown ---
...
```
Instead of
```
System.Exception: Exception of type 'System.Exception' was thrown.
   at Program.<AsyncMethod>d__1.MoveNext() in C:\StackTraceAsync\Program.cs:line 27
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Program.<DelayedAsync>d__2.MoveNext() in C:\StackTraceAsync\Program.cs:line 34
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Program.<IntermediateAsync>d__3.MoveNext() in C:\StackTraceAsync\Program.cs:line 39
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Program.<AsyncMethod>d__1.MoveNext() in C:\StackTraceAsync\Program.cs:line 27
--- End of stack trace from previous location where exception was thrown ---
...
```

Main call site change (extra in async method) looks to be

```diff
G_M53132_IG04:
+       mov      rcx, rax
+       call     CORINFO_HELP_THROW
...
        call     TaskAwaiter:HandleNonSuccessAndDebuggerNotification(ref)
-       nop      		
+       test     rax, rax
+       jne      SHORT G_M53132_IG04
```

**Issues/Questions**
* Line numbers go out of sync
* Can Edi exceptions be passed and thrown later?
* Loss of info for "from previous location where exception was thrown"? (Is adding inline info breaking change for stack trace parsers https://github.com/dotnet/coreclr/pull/14564#discussion_r145411185)

Contributes to https://github.com/dotnet/corefx/issues/24627
Contributes to https://github.com/dotnet/corefx/issues/1370

/cc  @joperezr @noahfalk @tmat @davidfowl @davkean @NickCraver