### PR TITLE
Replace ne with eq in publish to azure steps

### DIFF
--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -219,7 +219,7 @@
       "alwaysRun": false,
       "displayName": "Packages -> Azure",
       "timeoutInMinutes": 0,
-      "condition": "and(succeeded(), ne(variables['ConfigurationGroup'], 'Release'))",
+      "condition": "and(succeeded(), eq(variables['ConfigurationGroup'], 'Release'))",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -238,7 +238,7 @@
       "alwaysRun": false,
       "displayName": "Symbol Packages -> Azure",
       "timeoutInMinutes": 0,
-      "condition": "and(succeeded(), ne(variables['ConfigurationGroup'], 'Release'))",
+      "condition": "and(succeeded(), eq(variables['ConfigurationGroup'], 'Release'))",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",


### PR DESCRIPTION
CC @chcosta the reason nothing was publishing is that the "publish to azure" step hardcodes to publish stuff from AzureTransfer/Release/pkg... So the Debug & Checked legs were running that step, but the publish directory was empty, so nothing got published. This should fix the problem.