### PR TITLE
Add configuration knobs to control "IsSupported" and fix a bug

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -2443,6 +2443,52 @@ const char* Compiler::compLocalVarName(unsigned varNum, unsigned offs)
 #endif // DEBUG
 /*****************************************************************************/
 
+#ifdef _TARGET_XARCH_
+static bool configEnableISA(InstructionSet isa)
+{
+#ifdef DEBUG
+    switch (isa)
+    {
+        case InstructionSet_SSE:
+            return JitConfig.EnableSSE() != 0;
+        case InstructionSet_SSE2:
+            return JitConfig.EnableSSE2() != 0;
+        case InstructionSet_SSE3:
+            return JitConfig.EnableSSE3() != 0;
+        case InstructionSet_SSSE3:
+            return JitConfig.EnableSSSE3() != 0;
+        case InstructionSet_SSE41:
+            return JitConfig.EnableSSE41() != 0;
+        case InstructionSet_SSE42:
+            return JitConfig.EnableSSE42() != 0;
+        case InstructionSet_AVX:
+            return JitConfig.EnableAVX() != 0;
+        case InstructionSet_AVX2:
+            return JitConfig.EnableAVX2() != 0;
+
+        case InstructionSet_AES:
+            return JitConfig.EnableAES() != 0;
+        case InstructionSet_BMI1:
+            return JitConfig.EnableBMI1() != 0;
+        case InstructionSet_BMI2:
+            return JitConfig.EnableBMI2() != 0;
+        case InstructionSet_FMA:
+            return JitConfig.EnableFMA() != 0;
+        case InstructionSet_LZCNT:
+            return JitConfig.EnableLZCNT() != 0;
+        case InstructionSet_PCLMULQDQ:
+            return JitConfig.EnablePCLMULQDQ() != 0;
+        case InstructionSet_POPCNT:
+            return JitConfig.EnablePOPCNT() != 0;
+        default:
+            return false;
+    }
+#else
+    return true;
+#endif
+}
+#endif // _TARGET_XARCH_
+
 void Compiler::compSetProcessor()
 {
     const JitFlags& jitFlags = *opts.jitFlags;
@@ -2558,59 +2604,104 @@ void Compiler::compSetProcessor()
     {
         if (opts.compCanUseSSE2)
         {
-            opts.setSupportedISA(InstructionSet_SSE);
-            opts.setSupportedISA(InstructionSet_SSE2);
+            if (configEnableISA(InstructionSet_SSE))
+            {
+                opts.setSupportedISA(InstructionSet_SSE);
+            }
+            if (configEnableISA(InstructionSet_SSE2))
+            {
+                opts.setSupportedISA(InstructionSet_SSE2);
+            }
             if (jitFlags.IsSet(JitFlags::JIT_FLAG_USE_AES))
             {
-                opts.setSupportedISA(InstructionSet_AES);
+                if (configEnableISA(InstructionSet_AES))
+                {
+                    opts.setSupportedISA(InstructionSet_AES);
+                }
             }
             if (jitFlags.IsSet(JitFlags::JIT_FLAG_USE_AVX))
             {
-                opts.setSupportedISA(InstructionSet_AVX);
+                if (configEnableISA(InstructionSet_AVX))
+                {
+                    opts.setSupportedISA(InstructionSet_AVX);
+                }
             }
             if (jitFlags.IsSet(JitFlags::JIT_FLAG_USE_AVX2))
             {
-                opts.setSupportedISA(InstructionSet_AVX2);
+                if (configEnableISA(InstructionSet_AVX2))
+                {
+                    opts.setSupportedISA(InstructionSet_AVX2);
+                }
             }
             if (jitFlags.IsSet(JitFlags::JIT_FLAG_USE_BMI1))
             {
-                opts.setSupportedISA(InstructionSet_BMI1);
+                if (configEnableISA(InstructionSet_BMI1))
+                {
+                    opts.setSupportedISA(InstructionSet_BMI1);
+                }
             }
             if (jitFlags.IsSet(JitFlags::JIT_FLAG_USE_BMI2))
             {
-                opts.setSupportedISA(InstructionSet_BMI2);
+                if (configEnableISA(InstructionSet_BMI2))
+                {
+                    opts.setSupportedISA(InstructionSet_BMI2);
+                }
             }
             if (jitFlags.IsSet(JitFlags::JIT_FLAG_USE_FMA))
             {
-                opts.setSupportedISA(InstructionSet_FMA);
+                if (configEnableISA(InstructionSet_FMA))
+                {
+                    opts.setSupportedISA(InstructionSet_FMA);
+                }
             }
             if (jitFlags.IsSet(JitFlags::JIT_FLAG_USE_LZCNT))
             {
-                opts.setSupportedISA(InstructionSet_LZCNT);
+                if (configEnableISA(InstructionSet_LZCNT))
+                {
+                    opts.setSupportedISA(InstructionSet_LZCNT);
+                }
             }
             if (jitFlags.IsSet(JitFlags::JIT_FLAG_USE_PCLMULQDQ))
             {
-                opts.setSupportedISA(InstructionSet_PCLMULQDQ);
+                if (configEnableISA(InstructionSet_PCLMULQDQ))
+                {
+                    opts.setSupportedISA(InstructionSet_PCLMULQDQ);
+                }
             }
             if (jitFlags.IsSet(JitFlags::JIT_FLAG_USE_POPCNT))
             {
-                opts.setSupportedISA(InstructionSet_POPCNT);
+                if (configEnableISA(InstructionSet_POPCNT))
+                {
+                    opts.setSupportedISA(InstructionSet_POPCNT);
+                }
             }
             if (jitFlags.IsSet(JitFlags::JIT_FLAG_USE_SSE3))
             {
-                opts.setSupportedISA(InstructionSet_SSE3);
+                if (configEnableISA(InstructionSet_SSE3))
+                {
+                    opts.setSupportedISA(InstructionSet_SSE3);
+                }
             }
             if (jitFlags.IsSet(JitFlags::JIT_FLAG_USE_SSE41))
             {
-                opts.setSupportedISA(InstructionSet_SSE41);
+                if (configEnableISA(InstructionSet_SSE41))
+                {
+                    opts.setSupportedISA(InstructionSet_SSE41);
+                }
             }
             if (jitFlags.IsSet(JitFlags::JIT_FLAG_USE_SSE42))
             {
-                opts.setSupportedISA(InstructionSet_SSE42);
+                if (configEnableISA(InstructionSet_SSE42))
+                {
+                    opts.setSupportedISA(InstructionSet_SSE42);
+                }
             }
             if (jitFlags.IsSet(JitFlags::JIT_FLAG_USE_SSSE3))
             {
-                opts.setSupportedISA(InstructionSet_SSSE3);
+                if (configEnableISA(InstructionSet_SSSE3))
+                {
+                    opts.setSupportedISA(InstructionSet_SSSE3);
+                }
             }
         }
     }

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7832,7 +7832,7 @@ private:
     bool compSupports(InstructionSet isa)
     {
 #ifdef _TARGET_XARCH_
-        return (opts.compSupportsISA & (1 << isa)) != 0;
+        return (opts.compSupportsISA & (1ULL << isa)) != 0;
 #else
         return false;
 #endif
@@ -7952,7 +7952,7 @@ public:
         uint64_t compSupportsISA;
         void setSupportedISA(InstructionSet isa)
         {
-            compSupportsISA |= 1 << isa;
+            compSupportsISA |= 1ULL << isa;
         }
 #endif
 

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -186,7 +186,26 @@ CONFIG_STRING(NgenDumpFgDir, W("NgenDumpFgDir"))                 // Ngen Xml Flo
 CONFIG_STRING(NgenDumpFgFile, W("NgenDumpFgFile"))               // Ngen Xml Flowgraph support
 CONFIG_STRING(NgenDumpIRFormat, W("NgenDumpIRFormat"))           // Same as JitDumpIRFormat, but for ngen
 CONFIG_STRING(NgenDumpIRPhase, W("NgenDumpIRPhase"))             // Same as JitDumpIRPhase, but for ngen
-#endif                                                           // defined(DEBUG)
+
+#if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
+CONFIG_INTEGER(EnableSSE, W("EnableSSE"), 1)     // Enable SSE
+CONFIG_INTEGER(EnableSSE2, W("EnableSSE2"), 1)   // Enable SSE2
+CONFIG_INTEGER(EnableSSE3, W("EnableSSE3"), 1)   // Enable SSE3
+CONFIG_INTEGER(EnableSSSE3, W("EnableSSSE3"), 1) // Enable SSSE3
+CONFIG_INTEGER(EnableSSE41, W("EnableSSE41"), 1) // Enable SSE41
+CONFIG_INTEGER(EnableSSE42, W("EnableSSE42"), 1) // Enable SSE42
+// EnableAVX is already defined for DEBUG and non-DEBUG mode both
+CONFIG_INTEGER(EnableAVX2, W("EnableAVX2"), 1) // Enable AVX2
+
+CONFIG_INTEGER(EnableAES, W("EnableAES"), 1)             // Enable AES
+CONFIG_INTEGER(EnableBMI1, W("EnableBMI1"), 1)           // Enable BMI1
+CONFIG_INTEGER(EnableBMI2, W("EnableBMI2"), 1)           // Enable BMI2
+CONFIG_INTEGER(EnableFMA, W("EnableFMA"), 1)             // Enable FMA
+CONFIG_INTEGER(EnableLZCNT, W("EnableLZCNT"), 1)         // Enable AES
+CONFIG_INTEGER(EnablePCLMULQDQ, W("EnablePCLMULQDQ"), 1) // Enable PCLMULQDQ
+CONFIG_INTEGER(EnablePOPCNT, W("EnablePOPCNT"), 1)       // Enable POPCNT
+#endif                                                   // defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
+#endif                                                   // defined(DEBUG)
 
 #ifdef FEATURE_ENABLE_NO_RANGE_CHECKS
 CONFIG_INTEGER(JitNoRangeChks, W("JitNoRngChks"), 0) // If 1, don't generate range checks


### PR DESCRIPTION
This PR adds 14 knobs for debug mode (we already have `EnableAVX`):
```
EnableSSE
EnableSSE2
EnableSSE3
EnableSSSE3
EnableSSE41
EnableSSE42
EnableAVX2
EnableAES
EnableBMI1
EnableBMI2
EnableFMA
EnableLZCNT
EnablePCLMULQDQ
EnablePOPCNT
```

Meanwhile, fixed a bug in `compSupports` and `opt.setSupportedISA`.