### PR TITLE
Fix BinaryWriter/Reader span parameter names

### DIFF
--- a/src/mscorlib/shared/System/IO/BinaryWriter.cs
+++ b/src/mscorlib/shared/System/IO/BinaryWriter.cs
@@ -390,33 +390,33 @@ namespace System.IO
             }
         }
 
-        public virtual void Write(ReadOnlySpan<byte> value)
+        public virtual void Write(ReadOnlySpan<byte> buffer)
         {
             if (GetType() == typeof(BinaryWriter))
             {
-                OutStream.Write(value);
+                OutStream.Write(buffer);
             }
             else
             {
-                byte[] buffer = ArrayPool<byte>.Shared.Rent(value.Length);
+                byte[] array = ArrayPool<byte>.Shared.Rent(buffer.Length);
                 try
                 {
-                    value.CopyTo(buffer);
-                    Write(buffer, 0, value.Length);
+                    buffer.CopyTo(array);
+                    Write(array, 0, buffer.Length);
                 }
                 finally
                 {
-                    ArrayPool<byte>.Shared.Return(buffer);
+                    ArrayPool<byte>.Shared.Return(array);
                 }
             }
         }
 
-        public virtual void Write(ReadOnlySpan<char> value)
+        public virtual void Write(ReadOnlySpan<char> chars)
         {
-            byte[] bytes = ArrayPool<byte>.Shared.Rent(_encoding.GetMaxByteCount(value.Length));
+            byte[] bytes = ArrayPool<byte>.Shared.Rent(_encoding.GetMaxByteCount(chars.Length));
             try
             {
-                int bytesWritten = _encoding.GetBytes(value, bytes);
+                int bytesWritten = _encoding.GetBytes(chars, bytes);
                 Write(bytes, 0, bytesWritten);
             }
             finally

--- a/src/mscorlib/src/System/IO/BinaryReader.cs
+++ b/src/mscorlib/src/System/IO/BinaryReader.cs
@@ -346,12 +346,12 @@ namespace System.IO
             return InternalReadChars(new Span<char>(buffer, index, count));
         }
 
-        public virtual int Read(Span<char> destination)
+        public virtual int Read(Span<char> buffer)
         {
             if (_stream == null)
                 __Error.FileNotOpen();
 
-            return InternalReadChars(destination);
+            return InternalReadChars(buffer);
         }
 
         private int InternalReadChars(Span<char> buffer)
@@ -560,12 +560,12 @@ namespace System.IO
             return _stream.Read(buffer, index, count);
         }
 
-        public virtual int Read(Span<byte> destination)
+        public virtual int Read(Span<byte> buffer)
         {
             if (_stream == null)
                 __Error.FileNotOpen();
 
-            return _stream.Read(destination);
+            return _stream.Read(buffer);
         }
 
         public virtual byte[] ReadBytes(int count)


### PR DESCRIPTION
Per API review, they should match the corresponding overloads' existing parameter names.