### PR TITLE
Allow CALLEE_IS_FORCE_INLINE precedent over CALLEE_DOES_NOT_RETURN

### DIFF
--- a/src/jit/inlinepolicy.cpp
+++ b/src/jit/inlinepolicy.cpp
@@ -371,7 +371,7 @@ void DefaultPolicy::NoteBool(InlineObservation obs, bool value)
                 break;
 
             case InlineObservation::CALLEE_DOES_NOT_RETURN:
-                m_IsNoReturn      = value;
+                m_IsNoReturn      = (m_IsForceInlineKnown && m_IsForceInline) ? 0 : value;
                 m_IsNoReturnKnown = true;
                 break;
 
@@ -463,7 +463,8 @@ void DefaultPolicy::NoteInt(InlineObservation obs, int value)
 
             unsigned basicBlockCount = static_cast<unsigned>(value);
 
-            if (m_IsNoReturn && (basicBlockCount == 1))
+            // CALLEE_IS_FORCE_INLINE overrides CALLEE_DOES_NOT_RETURN
+            if (m_IsNoReturn && (basicBlockCount == 1) && !m_IsForceInline)
             {
                 SetNever(InlineObservation::CALLEE_DOES_NOT_RETURN);
             }

--- a/src/jit/inlinepolicy.cpp
+++ b/src/jit/inlinepolicy.cpp
@@ -371,7 +371,7 @@ void DefaultPolicy::NoteBool(InlineObservation obs, bool value)
                 break;
 
             case InlineObservation::CALLEE_DOES_NOT_RETURN:
-                m_IsNoReturn      = (m_IsForceInlineKnown && m_IsForceInline) ? 0 : value;
+                m_IsNoReturn      = value;
                 m_IsNoReturnKnown = true;
                 break;
 
@@ -464,7 +464,7 @@ void DefaultPolicy::NoteInt(InlineObservation obs, int value)
             unsigned basicBlockCount = static_cast<unsigned>(value);
 
             // CALLEE_IS_FORCE_INLINE overrides CALLEE_DOES_NOT_RETURN
-            if (m_IsNoReturn && (basicBlockCount == 1) && !m_IsForceInline)
+            if (!m_IsForceInline && m_IsNoReturn && (basicBlockCount == 1))
             {
                 SetNever(InlineObservation::CALLEE_DOES_NOT_RETURN);
             }


### PR DESCRIPTION
Currently `CALLEE_DOES_NOT_RETURN` will take precedent over `CALLEE_IS_FORCE_INLINE` this can be undesirable as there is no way to get a non-returning method to then inline.

Resolves: https://github.com/dotnet/coreclr/issues/14585

@AndyAyersMS @mikedn is this a correct approach?