### PR TITLE
Fix condition for mustExpand flag

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -3355,7 +3355,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
     if ((methodFlags & CORINFO_FLG_JIT_INTRINSIC) != 0)
     {
         // The recursive calls to Jit intrinsics are must-expand by convention.
-        mustExpand = gtIsRecursiveCall(method);
+        mustExpand = mustExpand || gtIsRecursiveCall(method);
     }
 
     *pIntrinsicID = intrinsicID;


### PR DESCRIPTION
The flag was getting overwritten when both CORINFO_FLG_INTRINSIC and CORINFO_FLG_JIT_INTRINSIC are set