### PR TITLE
Fix ARM bad GC info for CpObj

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -892,9 +892,18 @@ void CodeGen::genCodeForCpObj(GenTreeObj* cpObjNode)
         for (unsigned i = 0; i < slots; ++i)
         {
             if (gcPtrs[i] == GCT_GCREF)
+            {
                 attr = EA_GCREF;
+            }
             else if (gcPtrs[i] == GCT_BYREF)
+            {
                 attr = EA_BYREF;
+            }
+            else
+            {
+                attr = EA_PTRSIZE;
+            }
+
             emit->emitIns_R_R_I(INS_ldr, attr, tmpReg, REG_WRITE_BARRIER_SRC_BYREF, TARGET_POINTER_SIZE,
                                 INS_FLAGS_DONT_CARE, INS_OPTS_LDST_POST_INC);
             emit->emitIns_R_R_I(INS_str, attr, tmpReg, REG_WRITE_BARRIER_DST_BYREF, TARGET_POINTER_SIZE,


### PR DESCRIPTION
In the case where the dst lives on the stack, after the first
gcref/byref was copied, we never set the type back to non-GC
for subsequent copies using the same temp register.