### PR TITLE
Fixed GC info for GT_STORE_OBJ node

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -895,6 +895,8 @@ void CodeGen::genCodeForCpObj(GenTreeObj* cpObjNode)
                 attr = EA_GCREF;
             else if (gcPtrs[i] == GCT_BYREF)
                 attr = EA_BYREF;
+            else
+                attr = EA_PTRSIZE;
             emit->emitIns_R_R_I(INS_ldr, attr, tmpReg, REG_WRITE_BARRIER_SRC_BYREF, TARGET_POINTER_SIZE,
                                 INS_FLAGS_DONT_CARE, INS_OPTS_LDST_POST_INC);
             emit->emitIns_R_R_I(INS_str, attr, tmpReg, REG_WRITE_BARRIER_DST_BYREF, TARGET_POINTER_SIZE,


### PR DESCRIPTION
First bug in issue #14383

Fixed GC info for nodes such `GT_STORE_OBJ`

We have a struct S
```
struct S
{
    public String str;  // reference
    public Pad pad;     // very big struct containing lot of doubles
    public String str2; // reference
}
```

The code copies it looked before fix:
```
G_M833_IG03:        ; func=00, offs=000038H, size=0216H, gcrefRegs=0000 {}, byrefRegs=0000 {}, byref
IN0009: 000038  BF00           nop     
byrReg +[r0]
IN000a: 00003A  A842           add     r0, sp, 264	// [V06 loc0]
byrReg +[r1]
IN000b: 00003C  A984           add     r1, sp, 528	// [V01 arg0]
gcrReg +[r2]
IN000c: 00003E  F851 2B04      ldr     r2, [r1!+4]
IN000d: 000042  F840 2B04      str     r2, [r0!+4]
IN000e: 000046  F851 2B04      ldr     r2, [r1!+4]
IN000f: 00004A  F840 2B04      str     r2, [r0!+4]
IN0010: 00004E  F851 2B04      ldr     r2, [r1!+4]
```

after fix is
```
G_M833_IG03:        ; func=00, offs=000038H, size=0216H, gcrefRegs=0000 {}, byrefRegs=0000 {}, byref
IN0009: 000038  BF00           nop     
byrReg +[r0]
IN000a: 00003A  A842           add     r0, sp, 264	// [V06 loc0]
byrReg +[r1]
IN000b: 00003C  A984           add     r1, sp, 528	// [V01 arg0]
gcrReg +[r2]
IN000c: 00003E  F851 2B04      ldr     r2, [r1!+4]
IN000d: 000042  F840 2B04      str     r2, [r0!+4]
IN000e: 000046  F851 2B04      ldr     r2, [r1!+4]
IN000f: 00004A  F840 2B04      str     r2, [r0!+4]
gcrReg -[r2]                                            <== removes r2 from live set
IN0010: 00004E  F851 2B04      ldr     r2, [r1!+4]
```