### PR TITLE
[RyuJIT/ARM32] Remove NYI: struct return from multi-reg GT_CALL

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -3668,9 +3668,6 @@ void CodeGen::genStructReturn(GenTreePtr treeNode)
     }
     else // op1 must be multi-reg GT_CALL
     {
-#ifdef _TARGET_ARM_
-        NYI_ARM("struct return from multi-reg GT_CALL");
-#endif
         assert(op1->IsMultiRegCall() || op1->IsCopyOrReloadOfMultiRegCall());
 
         genConsumeRegs(op1);


### PR DESCRIPTION
Remove useless NYI_ARM: struct return from multi-reg GT_CALL in codegenarmarch.cpp
