### PR TITLE
[RyuJIT/ARM32] Fix resolving TYP_DOUBLE and TYP_FLOAT intervals

### DIFF
--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -445,6 +445,15 @@ public:
         InsertAtBottom
     };
 
+#ifdef _TARGET_ARM_
+    void addResolutionForDouble(BasicBlock*     block,
+                                GenTreePtr      insertionPoint,
+                                Interval**      sourceIntervals,
+                                regNumberSmall* location,
+                                regNumber       toReg,
+                                regNumber       fromReg,
+                                ResolveType     resolveType);
+#endif
     void addResolution(
         BasicBlock* block, GenTreePtr insertionPoint, Interval* interval, regNumber outReg, regNumber inReg);
 


### PR DESCRIPTION
When generating fromReg to toReg move to resolve edges,
we have to consider either of fromReg and toReg can contain double type.

If TYP_DOUBLE interval occupies fromReg/toReg, we have to look up two float registers when making decisions.

Three are various cases as below and case 4 causes an assertion from  `JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59782\b59782\b59782.cmd`  at issue #14374.

1. From dX (double interval) to dY (double interval) // No problem
2. From dX (double interval) to **dY (two float intervals)** // Fixed by this PR
3. From dX (double interval) to dY (1st float reg is assigned to a float interval) // No problem
4. From dX (double interval) to **dY (2nd float reg is assigned to a float interval)** // Fixed by this PR
5. From dX (double interval) to dY (free) // No problem

6. From sX (float interval) to sY (float interval) // No problem 
7. From sX (float interval) to sY (part of a double interval) // I'm still looking at this case.
8. From sX (float interval) to sY (free) // No problem



This PR partially resolve an assertion in #14374.
`JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59782\b59782\b59782.cmd` is passed with this PR.

And remaining assertion is being previously addressed by PR #14588.