### PR TITLE
[Arm64] Enable genSetRegToConst for SIMD nodes

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -1454,7 +1454,17 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
             }
             else
             {
-                genSetRegToIcon(targetReg, cnsVal, targetType);
+                if (varTypeIsSIMD(targetType))
+                {
+                    // A constant value of zero will easily replicate into SIMD type
+                    // Other constants require baseType size which is missing
+                    assert(cnsVal == 0);
+                    getEmitter()->emitIns_R_I(INS_movi, EA_16BYTE, targetReg, 0x00, INS_OPTS_16B);
+                }
+                else
+                {
+                    genSetRegToIcon(targetReg, cnsVal, targetType);
+                }
             }
         }
         break;


### PR DESCRIPTION
@dotnet/jit-contrib @dotnet/arm64-contrib PTAL

It seemed suspicious that this function was called to initialize a SIMD_TYPE to zero, but since it was here is the implementation.