### PR TITLE
Allow GT_CALL as BYREF operand for SIMD intrinsics

### DIFF
--- a/src/jit/simd.cpp
+++ b/src/jit/simd.cpp
@@ -691,8 +691,8 @@ GenTreePtr Compiler::impSIMDPopStack(var_types type, bool expectAddr)
     }
     else if (tree->gtType == TYP_BYREF)
     {
-        assert(tree->IsLocal() || (tree->OperGet() == GT_RET_EXPR) ||
-               (tree->gtOper == GT_ADDR) && varTypeIsSIMD(tree->gtGetOp1()));
+        assert(tree->IsLocal() || (tree->OperGet() == GT_RET_EXPR) || (tree->OperGet() == GT_CALL) ||
+               ((tree->gtOper == GT_ADDR) && varTypeIsSIMD(tree->gtGetOp1())));
     }
 
     return tree;


### PR DESCRIPTION
This is an extension of #13965: in the MinOpts case, we don't
have GT_RET_EXPR -- we have GT_CALL instead.

We now see IR like:
```
[000429] --C-G--N----              |  |  \--*  BLK(32)   simd32
[000413] --C-G-------              |  |     \--*  CALL      byref  System.Runtime.CompilerServices.Unsafe.AsRef
[000410] ------------              |  |        |     /--*  CNS_INT   int    2
[000411] ------------              |  |        |  /--*  MUL       int
[000409] ------------              |  |        |  |  \--*  CAST      int <- int
[000408] ------------              |  |        |  |     \--*  CNS_INT   int    16 Vector<T>.Count
[000412] ------------ arg0         |  |        \--*  ADD       int
[000407] ------------              |  |           \--*  LCL_VAR   int    V01 arg1
```

Whereas in the optimizing case, we see:
```
[000060] ------------              *  STMT      void  (IL   ???...  ???)
[000058] I-C-G-------              \--*  CALL      byref  System.Runtime.CompilerServices.Unsafe.AsRef (exactContextHnd=0x028FAFF8)
[000055] ------------                 |     /--*  CNS_INT   int    2
[000056] ------------                 |  /--*  MUL       int
[000054] ------------                 |  |  \--*  CAST      int <- int
[000053] ------------                 |  |     \--*  CNS_INT   int    16 Vector<T>.Count
[000057] ------------ arg0            \--*  ADD       int
[000052] ------------                    \--*  LCL_VAR   int    V01 arg1

...

[000076] --C----N----              |  |  \--*  BLK(32)   simd32
[000065] --C---------              |  |     \--*  RET_EXPR  byref (inl return from call [000058])
```

Fixes #14301