### PR TITLE
[Arm64] Fix bogus assert

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -6150,8 +6150,13 @@ int Compiler::lvaAllocLocalAndSetVirtualOffset(unsigned lclNum, unsigned size, i
 #endif
                             ))
     {
+#ifdef _TARGET_ARM64_
+        // Note that stack offsets are negative or equal to zero
+        assert(stkOffs <= 0);
+#else
         // Note that stack offsets are negative
         assert(stkOffs < 0);
+#endif
 
         // alignment padding
         unsigned pad = 0;

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -6150,13 +6150,8 @@ int Compiler::lvaAllocLocalAndSetVirtualOffset(unsigned lclNum, unsigned size, i
 #endif
                             ))
     {
-#ifdef _TARGET_ARM64_
         // Note that stack offsets are negative or equal to zero
         assert(stkOffs <= 0);
-#else
-        // Note that stack offsets are negative
-        assert(stkOffs < 0);
-#endif
 
         // alignment padding
         unsigned pad = 0;


### PR DESCRIPTION
@dotnet/jit-contrib @dotnet/arm64-contrib PTAL

When debugging SIMD code, I was hitting this assert.  While looking at the caller, I saw nothing to guarantee the offset was not zero.  So I assumed the assert was bogus.

My assumption is that the difference is due to differences in frame layout for arm64.  The frame pointer seemed to be handled in a different place in the callers code.

See https://github.com/dotnet/coreclr/blob/master/src/jit/lclvars.cpp#L5468-L5479