### PR TITLE
JIT: defer constant-return merging for debug codegen

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -8491,7 +8491,10 @@ private:
         assert(mergingReturns);
 
         BasicBlock* mergedReturnBlock = nullptr;
-        if ((returnBlock != nullptr) && (maxReturns > 1))
+
+        // Do not look for mergable constant returns in debug codegen as
+        // we may lose track of sequence points.
+        if ((returnBlock != nullptr) && (maxReturns > 1) && !comp->opts.compDbgCode)
         {
             // Check to see if this is a constant return so that we can search
             // for and/or create a constant return block for it.


### PR DESCRIPTION
If we merge constant returns into a common point we may lose track of sequence
points. So inhibit this when we are generating debuggable code.

Fixes #14339.