### PR TITLE
Remove low value purpose comments

### DIFF
--- a/src/mscorlib/shared/System/Byte.cs
+++ b/src/mscorlib/shared/System/Byte.cs
@@ -2,16 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-/*============================================================
-**
-**
-**
-** Purpose: This class will encapsulate a byte and provide an
-**          Object representation of it.
-**
-** 
-===========================================================*/
-
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/mscorlib/shared/System/Int16.cs
+++ b/src/mscorlib/shared/System/Int16.cs
@@ -2,16 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-/*============================================================
-**
-**
-**
-** Purpose: This class will encapsulate a short and provide an
-**          Object representation of it.
-**
-** 
-===========================================================*/
-
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/mscorlib/shared/System/Int32.cs
+++ b/src/mscorlib/shared/System/Int32.cs
@@ -2,16 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-/*============================================================
-**
-**
-**
-** Purpose: A representation of a 32 bit 2's complement 
-**          integer.
-**
-** 
-===========================================================*/
-
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/mscorlib/shared/System/Int64.cs
+++ b/src/mscorlib/shared/System/Int64.cs
@@ -2,16 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-/*============================================================
-**
-**
-**
-** Purpose: This class will encapsulate a long and provide an
-**          Object representation of it.
-**
-** 
-===========================================================*/
-
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/mscorlib/shared/System/UInt16.cs
+++ b/src/mscorlib/shared/System/UInt16.cs
@@ -2,15 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-/*============================================================
-**
-**
-** Purpose: This class will encapsulate a short and provide an
-**          Object representation of it.
-**
-** 
-===========================================================*/
-
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/mscorlib/shared/System/UInt32.cs
+++ b/src/mscorlib/shared/System/UInt32.cs
@@ -2,16 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-/*============================================================
-**
-**
-**
-** Purpose: This class will encapsulate an uint and 
-**          provide an Object representation of it.
-**
-** 
-===========================================================*/
-
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/mscorlib/shared/System/UInt64.cs
+++ b/src/mscorlib/shared/System/UInt64.cs
@@ -2,15 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-/*============================================================
-**
-**
-** Purpose: This class will encapsulate an unsigned long and 
-**          provide an Object representation of it.
-**
-** 
-===========================================================*/
-
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;


### PR DESCRIPTION
Most of the purpose comments removed referred to the struct as a "class" which is confusing. In addition, these value types are simple enough they don't warrant a full purpose description. Resolves #13479.