### PR TITLE
Fix RID extraction in packages and test build for Alpine

### DIFF
--- a/build-packages.sh
+++ b/build-packages.sh
@@ -20,21 +20,21 @@ initHostDistroRid()
                 # remove the last version digit
                 VERSION_ID=${VERSION_ID%.*}
             fi
-            __HostDistroRid="$ID.$VERSION_ID-$__HostArch"
+            __HostDistroRid="$ID.$VERSION_ID-$__Arch"
         elif [ -e /etc/redhat-release ]; then
             local redhatRelease=$(</etc/redhat-release)
             if [[ $redhatRelease == "CentOS release 6."* || $redhatRelease == "Red Hat Enterprise Linux Server release 6."* ]]; then
-               __HostDistroRid="rhel.6-$__HostArch"
+               __HostDistroRid="rhel.6-$__Arch"
             fi
         fi
     fi
     if [ "$__HostOS" == "FreeBSD" ]; then
         __freebsd_version=`sysctl -n kern.osrelease | cut -f1 -d'.'`
-        __HostDistroRid="freebsd.$__freebsd_version-$__HostArch"
+        __HostDistroRid="freebsd.$__freebsd_version-$__Arch"
     fi
 
     if [ "$__HostDistroRid" == "" ]; then
-        echo "WARNING: Can not determine runtime id for current distro."
+        echo "WARNING: Cannot determine runtime id for current distro."
     fi
 }
 
@@ -95,7 +95,7 @@ while :; do
         ;;
         -BuildArch=*)
         unprocessedBuildArgs="$unprocessedBuildArgs $1"
-        __HostArch=$(echo $1| cut -d'=' -f 2)
+        __Arch=$(echo $1| cut -d'=' -f 2)
         ;;
 
         -portablebuild=false)
@@ -111,9 +111,9 @@ done
 # Portable builds target the base RID
 if [ $__IsPortableBuild == 1 ]; then
     if [ "$__BuildOS" == "Linux" ]; then
-        export __DistroRid="linux-$__HostArch"
+        export __DistroRid="linux-$__Arch"
     elif [ "$__BuildOS" == "OSX" ]; then
-        export __DistroRid="osx-$__HostArch"
+        export __DistroRid="osx-$__Arch"
     fi
 else
     # init the host distro name

--- a/build-packages.sh
+++ b/build-packages.sh
@@ -16,13 +16,21 @@ initHostDistroRid()
     if [ "$__HostOS" == "Linux" ]; then
         if [ -e /etc/os-release ]; then
             source /etc/os-release
-            __HostDistroRid="$ID.$VERSION_ID-$__Arch"
+            if [[ $ID == "alpine" ]]; then
+                # remove the last version digit
+                VERSION_ID=${VERSION_ID%.*}
+            fi
+            __HostDistroRid="$ID.$VERSION_ID-$__HostArch"
         elif [ -e /etc/redhat-release ]; then
             local redhatRelease=$(</etc/redhat-release)
             if [[ $redhatRelease == "CentOS release 6."* || $redhatRelease == "Red Hat Enterprise Linux Server release 6."* ]]; then
-               __HostDistroRid="rhel.6-$__Arch"
+               __HostDistroRid="rhel.6-$__HostArch"
             fi
         fi
+    fi
+    if [ "$__HostOS" == "FreeBSD" ]; then
+        __freebsd_version=`sysctl -n kern.osrelease | cut -f1 -d'.'`
+        __HostDistroRid="freebsd.$__freebsd_version-$__HostArch"
     fi
 
     if [ "$__HostDistroRid" == "" ]; then
@@ -87,7 +95,7 @@ while :; do
         ;;
         -BuildArch=*)
         unprocessedBuildArgs="$unprocessedBuildArgs $1"
-        __Arch=$(echo $1| cut -d'=' -f 2)
+        __HostArch=$(echo $1| cut -d'=' -f 2)
         ;;
 
         -portablebuild=false)
@@ -103,9 +111,9 @@ done
 # Portable builds target the base RID
 if [ $__IsPortableBuild == 1 ]; then
     if [ "$__BuildOS" == "Linux" ]; then
-        export __DistroRid="linux-$__Arch"
+        export __DistroRid="linux-$__HostArch"
     elif [ "$__BuildOS" == "OSX" ]; then
-        export __DistroRid="osx-$__Arch"
+        export __DistroRid="osx-$__HostArch"
     fi
 else
     # init the host distro name

--- a/build-test.sh
+++ b/build-test.sh
@@ -24,7 +24,7 @@ initHostDistroRid()
     fi
 
     if [ "$__HostDistroRid" == "" ]; then
-        echo "WARNING: Can not determine runtime id for current distro."
+        echo "WARNING: Cannot determine runtime id for current distro."
     fi
 }
 

--- a/build-test.sh
+++ b/build-test.sh
@@ -2,14 +2,29 @@
 
 initHostDistroRid()
 {
+    __HostDistroRid=""
     if [ "$__HostOS" == "Linux" ]; then
-        if [ ! -e /etc/os-release ]; then
-            echo "WARNING: Can not determine runtime id for current distro."
-            __HostDistroRid=""
-        else
+        if [ -e /etc/os-release ]; then
             source /etc/os-release
+            if [[ $ID == "alpine" ]]; then
+                # remove the last version digit
+                VERSION_ID=${VERSION_ID%.*}
+            fi
             __HostDistroRid="$ID.$VERSION_ID-$__HostArch"
+        elif [ -e /etc/redhat-release ]; then
+            local redhatRelease=$(</etc/redhat-release)
+            if [[ $redhatRelease == "CentOS release 6."* || $redhatRelease == "Red Hat Enterprise Linux Server release 6."* ]]; then
+               __HostDistroRid="rhel.6-$__HostArch"
+            fi
         fi
+    fi
+    if [ "$__HostOS" == "FreeBSD" ]; then
+        __freebsd_version=`sysctl -n kern.osrelease | cut -f1 -d'.'`
+        __HostDistroRid="freebsd.$__freebsd_version-$__HostArch"
+    fi
+
+    if [ "$__HostDistroRid" == "" ]; then
+        echo "WARNING: Can not determine runtime id for current distro."
     fi
 }
 


### PR DESCRIPTION
The host RID extraction in build-packages.sh and build-test.sh
was not matching the one in build.sh.
I've unified this code with the one in build.sh, which fixes Alpine RID
extraction and also adds FreeBSD RID extraction that was added to
build.sh only before.
I've also changed __Arch to __HostArch in build-test.sh to match the other scripts.