### PR TITLE
Report registers as dead in GCInfo before the RhpPInvoke helper.

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2265,7 +2265,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
     // the GC pointer state before the callsite.
     // We can't utilize the typical lazy killing of GC pointers
     // at (or inside) the callsite.
-    if (call->IsUnmanaged())
+    if (compiler->killGCRefs(call))
     {
         genDefineTempLabel(genCreateTempLabel());
     }

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -5283,7 +5283,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
     // the GC pointer state before the callsite.
     // We can't utilize the typical lazy killing of GC pointers
     // at (or inside) the callsite.
-    if (call->IsUnmanaged())
+    if (compiler->killGCRefs(call))
     {
         genDefineTempLabel(genCreateTempLabel());
     }

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11403,16 +11403,17 @@ HelperCallProperties Compiler::s_helperCallProperties;
 // Return Value:
 //    true       - tree kills GC refs on callee save registers
 //    false      - tree doesn't affect GC refs on callee save registers
-bool Compiler::killGCRefs(GenTree* tree)
+bool Compiler::killGCRefs(GenTreePtr tree)
 {
     if (tree->IsCall())
     {
-        if ((tree->gtFlags & GTF_CALL_UNMANAGED) != 0)
+        GenTreeCall* call = tree->AsCall();
+        if (call->IsUnmanaged())
         {
             return true;
         }
 
-        if (tree->AsCall()->gtCallMethHnd == eeFindHelper(CORINFO_HELP_JIT_PINVOKE_BEGIN))
+        if (call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_JIT_PINVOKE_BEGIN))
         {
             assert(opts.ShouldUsePInvokeHelpers());
             return true;

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11391,3 +11391,32 @@ HelperCallProperties Compiler::s_helperCallProperties;
 
 /*****************************************************************************/
 /*****************************************************************************/
+
+//------------------------------------------------------------------------
+// killGCRefs:
+// Given some tree node return does it need all GC refs to be spilled from
+// callee save registers.
+//
+// Arguments:
+//    tree       - the tree for which we ask about gc refs.
+//
+// Return Value:
+//    true       - tree kills GC refs on callee save registers
+//    false      - tree doesn't affect GC refs on callee save registers
+bool Compiler::killGCRefs(GenTree* tree)
+{
+    if (tree->IsCall())
+    {
+        if ((tree->gtFlags & GTF_CALL_UNMANAGED) != 0)
+        {
+            return true;
+        }
+
+        if (tree->AsCall()->gtCallMethHnd == eeFindHelper(CORINFO_HELP_JIT_PINVOKE_BEGIN))
+        {
+            assert(opts.ShouldUsePInvokeHelpers());
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -9564,6 +9564,8 @@ public:
     void fgMorphMultiregStructArgs(GenTreeCall* call);
     GenTreePtr fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr fgEntryPtr);
 
+    bool killGCRefs(GenTree* tree);
+
 }; // end of class Compiler
 
 // Inline methods of CompAllocator.

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -9564,7 +9564,7 @@ public:
     void fgMorphMultiregStructArgs(GenTreeCall* call);
     GenTreePtr fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr fgEntryPtr);
 
-    bool killGCRefs(GenTree* tree);
+    bool killGCRefs(GenTreePtr tree);
 
 }; // end of class Compiler
 

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3083,7 +3083,7 @@ bool LinearScan::buildKillPositionsForNode(GenTree* tree, LsraLocation currentLo
             }
         }
 
-        if (killGCRefs(tree))
+        if (compiler->killGCRefs(tree))
         {
             RefPosition* pos = newRefPosition((Interval*)nullptr, currentLoc, RefTypeKillGCRefs, tree,
                                               (allRegs(TYP_REF) & ~RBM_ARG_REGS));
@@ -3091,35 +3091,6 @@ bool LinearScan::buildKillPositionsForNode(GenTree* tree, LsraLocation currentLo
         return true;
     }
 
-    return false;
-}
-
-//------------------------------------------------------------------------
-// killGCRefs:
-// Given some tree node return does it need all GC refs to be spilled from
-// callee save registers.
-//
-// Arguments:
-//    tree       - the tree for which we ask about gc refs.
-//
-// Return Value:
-//    true       - tree kills GC refs on callee save registers
-//    false      - tree doesn't affect GC refs on callee save registers
-bool LinearScan::killGCRefs(GenTree* tree)
-{
-    if (tree->IsCall())
-    {
-        if ((tree->gtFlags & GTF_CALL_UNMANAGED) != 0)
-        {
-            return true;
-        }
-
-        if (tree->AsCall()->gtCallMethHnd == compiler->eeFindHelper(CORINFO_HELP_JIT_PINVOKE_BEGIN))
-        {
-            assert(compiler->opts.ShouldUsePInvokeHelpers());
-            return true;
-        }
-    }
     return false;
 }
 

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -772,8 +772,6 @@ private:
     // Given some tree node add refpositions for all the registers this node kills
     bool buildKillPositionsForNode(GenTree* tree, LsraLocation currentLoc);
 
-    bool killGCRefs(GenTree* tree);
-
     regMaskTP allRegs(RegisterType rt);
     regMaskTP allRegs(GenTree* tree);
     regMaskTP allMultiRegCallNodeRegs(GenTreeCall* tree);


### PR DESCRIPTION
`CORINFO_HELP_JIT_PINVOKE_BEGIN` makes transition to preemptive mode before a P/Invoke, so it requires GC pointer state to be cleared before the helper.

I checked other occurrences of `IsUnmanaged()` and looks like they already consider or do not need to consider this helper case.

If `opts.ShouldUsePInvokeHelpers()` is enabled, than the state before the P/Invoke must be clean, so we can rewrite it as:


```
if (opts.ShouldUsePInvokeHelpers())
{
    if (call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_JIT_PINVOKE_BEGIN))
    {
        return true;
    }
    else if (call->IsUnmanaged())
    {
       assert that the state has been cleared already.
       return false;
    }
}
else if (call->IsUnmanaged())
{
    return true;
}
```
but it doesn't harm to return true for unmanaged calls always.

Fix dotnet/corert#4676 .

Checked that it fixes the original test.