### PR TITLE
Port EventSource Nuget Package Changes

### DIFF
--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -2086,6 +2086,9 @@
   <data name="EventSource_AddScalarOutOfRange" xml:space="preserve">
     <value>Getting out of bounds during scalar addition.</value>
   </data>
+  <data name="EventSource_BadHexDigit" xml:space="preserve">
+    <value>Bad Hexidecimal digit "{0}".</value>
+  </data>
   <data name="EventSource_ChannelTypeDoesNotMatchEventChannelValue" xml:space="preserve">
     <value>Channel {0} does not match event channel value {1}.</value>
   </data>
@@ -2097,6 +2100,9 @@
   </data>
   <data name="EventSource_EnumKindMismatch" xml:space="preserve">
     <value>The type of {0} is not expected in {1}.</value>
+  </data>
+  <data name="EventSource_EvenHexDigits" xml:space="preserve">
+    <value>Must have an even number of Hexidecimal digits.</value>
   </data>
   <data name="EventSource_EventChannelOutOfRange" xml:space="preserve">
     <value>Channel {0} has a value of {1} which is outside the legal range (16-254).</value>
@@ -2122,6 +2128,9 @@
   <data name="EventSource_EventSourceGuidInUse" xml:space="preserve">
     <value>An instance of EventSource with Guid {0} already exists.</value>
   </data>
+  <data name="EventSource_EventTooBig" xml:space="preserve">
+    <value>The payload for a single event is too large.</value>
+  </data>
   <data name="EventSource_EventWithAdminChannelMustHaveMessage" xml:space="preserve">
     <value>Event {0} specifies an Admin channel {1}. It must specify a Message property.</value>
   </data>
@@ -2133,6 +2142,9 @@
   </data>
   <data name="EventSource_IllegalTaskValue" xml:space="preserve">
     <value>Task {0} has a value of {1} which is outside the legal range (1-65535).</value>
+  </data>
+  <data name="EventSource_IllegalValue" xml:space="preserve">
+    <value>Illegal value "{0}" (prefix strings with @ to indicate a literal string).</value>
   </data>
   <data name="EventSource_IncorrentlyAuthoredTypeInfo" xml:space="preserve">
     <value>Incorrectly-authored TypeInfo - a type should be serialized as one field or as one group</value>
@@ -2230,6 +2242,9 @@
   <data name="EventSource_ToString" xml:space="preserve">
     <value>EventSource({0}, {1})</value>
   </data>
+  <data name="EventSource_TraitEven" xml:space="preserve">
+    <value>There must be an even number of trait strings (they are key-value pairs).</value>
+  </data>
   <data name="EventSource_TypeMustBeSealedOrAbstract" xml:space="preserve">
     <value>Event source types must be sealed or abstract.</value>
   </data>
@@ -2244,6 +2259,9 @@
   </data>
   <data name="EventSource_UndefinedOpcode" xml:space="preserve">
     <value>Use of undefined opcode value {0} for event {1}.</value>
+  </data>
+  <data name="EventSource_UnknownEtwTrait" xml:space="preserve">
+    <value>Unknown ETW trait "{0}".</value>
   </data>
   <data name="EventSource_UnsupportedEventTypeInManifest" xml:space="preserve">
     <value>Unsupported type {0} in event source.</value>

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/ActivityTracker.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/ActivityTracker.cs
@@ -5,6 +5,12 @@
 using System;
 using System.Diagnostics;
 using System.Threading;
+#if !ES_BUILD_AGAINST_DOTNET_V35
+using Contract = System.Diagnostics.Contracts.Contract;
+#else
+using Contract = Microsoft.Diagnostics.Contracts.Internal.Contract;
+#endif
+
 #if ES_BUILD_STANDALONE
 namespace Microsoft.Diagnostics.Tracing
 #else
@@ -37,6 +43,7 @@ namespace System.Diagnostics.Tracing
     /// </summary>
     internal class ActivityTracker
     {
+
         /// <summary>
         /// Called on work item begins.  The activity name = providerName + activityName without 'Start' suffix.
         /// It updates CurrentActivityId to track.   

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/EventDescriptor.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/EventDescriptor.cs
@@ -9,6 +9,12 @@ using System.Runtime.InteropServices;
 using Environment = Microsoft.Diagnostics.Tracing.Internal.Environment;
 #endif
 
+#if !ES_BUILD_AGAINST_DOTNET_V35
+using Contract = System.Diagnostics.Contracts.Contract;
+#else
+using Contract = Microsoft.Diagnostics.Contracts.Internal.Contract;
+#endif
+
 #if ES_BUILD_STANDALONE
 namespace Microsoft.Diagnostics.Tracing
 #else
@@ -83,12 +89,12 @@ namespace System.Diagnostics.Tracing
         {
             if (id < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(id), Resources.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                throw new ArgumentOutOfRangeException(nameof(id), SR.ArgumentOutOfRange_NeedNonNegNum);
             }
 
             if (id > ushort.MaxValue)
             {
-                throw new ArgumentOutOfRangeException(nameof(id), Resources.GetResourceString("ArgumentOutOfRange_NeedValidId", 1, ushort.MaxValue));
+                throw new ArgumentOutOfRangeException(nameof(id), SR.Format(SR.ArgumentOutOfRange_NeedValidId, 1, ushort.MaxValue));
             }
 
             m_traceloggingId = 0;
@@ -101,12 +107,12 @@ namespace System.Diagnostics.Tracing
 
             if (task < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(task), Resources.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                throw new ArgumentOutOfRangeException(nameof(task), SR.ArgumentOutOfRange_NeedNonNegNum);
             }
 
             if (task > ushort.MaxValue)
             {
-                throw new ArgumentOutOfRangeException(nameof(task), Resources.GetResourceString("ArgumentOutOfRange_NeedValidId", 1, ushort.MaxValue));
+                throw new ArgumentOutOfRangeException(nameof(task), SR.Format(SR.ArgumentOutOfRange_NeedValidId, 1, ushort.MaxValue));
             }
 
             m_task = (ushort)task;

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/EventProvider.cs
@@ -14,6 +14,12 @@ using System.Security.Permissions;
 using System.Threading;
 using System;
 
+#if !ES_BUILD_AGAINST_DOTNET_V35
+using Contract = System.Diagnostics.Contracts.Contract;
+#else
+using Contract = Microsoft.Diagnostics.Contracts.Internal.Contract;
+#endif
+
 #if ES_BUILD_AGAINST_DOTNET_V35
 using Microsoft.Internal;       // for Tuple (can't define alias for open generic types so we "use" the whole namespace)
 #endif
@@ -628,6 +634,7 @@ namespace System.Diagnostics.Tracing
             if ((level <= m_level) ||
                 (m_level == 0))
             {
+
                 //
                 // Check if Keyword is enabled
                 //

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -197,6 +197,12 @@ using System.Threading.Tasks;
 
 using Microsoft.Reflection;
 
+#if !ES_BUILD_AGAINST_DOTNET_V35
+using Contract = System.Diagnostics.Contracts.Contract;
+#else
+using Contract = Microsoft.Diagnostics.Contracts.Internal.Contract;
+#endif
+
 #if CORECLR || ES_BUILD_PN
 using Internal.Runtime.Augments;
 #endif
@@ -244,6 +250,7 @@ namespace System.Diagnostics.Tracing
     /// </remarks>
     public partial class EventSource : IDisposable
     {
+
 #if FEATURE_EVENTSOURCE_XPLAT
         private static readonly EventListener persistent_Xplat_Listener = XplatEventLogger.InitializePersistentListener();
 #endif //FEATURE_EVENTSOURCE_XPLAT
@@ -421,7 +428,7 @@ namespace System.Diagnostics.Tracing
 
             if (name == null)
             {
-                throw new ArgumentException(Resources.GetResourceString("Argument_InvalidTypeName"), nameof(eventSourceType));
+                throw new ArgumentException(SR.Argument_InvalidTypeName, nameof(eventSourceType));
             }
             return GenerateGuidFromName(name.ToUpperInvariant());       // Make it case insensitive.  
         }
@@ -507,7 +514,7 @@ namespace System.Diagnostics.Tracing
             // User-defined EventCommands should not conflict with the reserved commands.
             if ((int)command <= (int)EventCommand.Update && (int)command != (int)EventCommand.SendManifest)
             {
-                throw new ArgumentException(Resources.GetResourceString("EventSource_InvalidCommand"), nameof(command));
+                throw new ArgumentException(SR.EventSource_InvalidCommand, nameof(command));
             }
 
             eventSource.SendCommand(null, 0, 0, command, true, EventLevel.LogAlways, EventKeywords.None, commandArguments);
@@ -586,7 +593,7 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         public override string ToString()
         {
-            return Resources.GetResourceString("EventSource_ToString", Name, Guid);
+            return SR.Format(SR.EventSource_ToString, Name, Guid);
         }
 
         /// <summary>
@@ -1250,6 +1257,7 @@ namespace System.Diagnostics.Tracing
 #if FEATURE_MANAGED_ETW
                     if (m_eventData[eventId].EnabledForETW)
                     {
+
 #if FEATURE_ACTIVITYSAMPLING
                         // this code should be kept in sync with WriteEventVarargs().
                         SessionMask etwSessions = SessionMask.All;
@@ -1520,17 +1528,17 @@ namespace System.Diagnostics.Tracing
                 m_traits = traits;
                 if (m_traits != null && m_traits.Length % 2 != 0)
                 {
-                    throw new ArgumentException(Resources.GetResourceString("TraitEven"), nameof(traits));
+                    throw new ArgumentException(SR.EventSource_TraitEven, nameof(traits));
                 }
 
                 if (eventSourceGuid == Guid.Empty)
                 {
-                    throw new ArgumentException(Resources.GetResourceString("EventSource_NeedGuid"));
+                    throw new ArgumentException(SR.EventSource_NeedGuid);
                 }
 
                 if (eventSourceName == null)
                 {
-                    throw new ArgumentException(Resources.GetResourceString("EventSource_NeedName"));
+                    throw new ArgumentException(SR.EventSource_NeedName);
                 }
 
                 m_name = eventSourceName;
@@ -1983,7 +1991,7 @@ namespace System.Diagnostics.Tracing
                         // which would cause a cryptic IndexOutOfRangeException later if we don't catch it here.
                         if (!m_eventData[eventId].HasRelatedActivityID)
                         {
-                            throw new ArgumentException(Resources.GetResourceString("EventSource_NoRelatedActivityId"));
+                            throw new ArgumentException(SR.EventSource_NoRelatedActivityId);
                         }
                     }
 
@@ -2184,7 +2192,7 @@ namespace System.Diagnostics.Tracing
 
             if (!typesMatch)
             {
-                System.Diagnostics.Debugger.Log(0, null, Resources.GetResourceString("EventSource_VarArgsParameterMismatch") + "\r\n");
+                System.Diagnostics.Debugger.Log(0, null, SR.EventSource_VarArgsParameterMismatch + "\r\n");
             }
 #endif //!ES_BUILD_PCL
         }
@@ -2211,7 +2219,7 @@ namespace System.Diagnostics.Tracing
             }
             if (eventDataCount != modifiedParamCount)
             {
-                ReportOutOfBandMessage(Resources.GetResourceString("EventSource_EventParametersMismatch", eventId, eventDataCount, paramCount), true);
+                ReportOutOfBandMessage(SR.Format(SR.EventSource_EventParametersMismatch, eventId, eventDataCount, paramCount), true);
                 paramCount = Math.Min(paramCount, eventDataCount);
             }
 
@@ -2501,20 +2509,20 @@ namespace System.Diagnostics.Tracing
                 switch (EventProvider.GetLastWriteEventError())
                 {
                     case EventProvider.WriteEventErrorCode.EventTooBig:
-                        ReportOutOfBandMessage(errorPrefix + ": " + Resources.GetResourceString("EventSource_EventTooBig"), true);
-                        if (ThrowOnEventWriteErrors) throw new EventSourceException(Resources.GetResourceString("EventSource_EventTooBig"), innerEx);
+                        ReportOutOfBandMessage(errorPrefix + ": " + SR.EventSource_EventTooBig, true);
+                        if (ThrowOnEventWriteErrors) throw new EventSourceException(SR.EventSource_EventTooBig, innerEx);
                         break;
                     case EventProvider.WriteEventErrorCode.NoFreeBuffers:
-                        ReportOutOfBandMessage(errorPrefix + ": " + Resources.GetResourceString("EventSource_NoFreeBuffers"), true);
-                        if (ThrowOnEventWriteErrors) throw new EventSourceException(Resources.GetResourceString("EventSource_NoFreeBuffers"), innerEx);
+                        ReportOutOfBandMessage(errorPrefix + ": " + SR.EventSource_NoFreeBuffers, true);
+                        if (ThrowOnEventWriteErrors) throw new EventSourceException(SR.EventSource_NoFreeBuffers, innerEx);
                         break;
                     case EventProvider.WriteEventErrorCode.NullInput:
-                        ReportOutOfBandMessage(errorPrefix + ": " + Resources.GetResourceString("EventSource_NullInput"), true);
-                        if (ThrowOnEventWriteErrors) throw new EventSourceException(Resources.GetResourceString("EventSource_NullInput"), innerEx);
+                        ReportOutOfBandMessage(errorPrefix + ": " + SR.EventSource_NullInput, true);
+                        if (ThrowOnEventWriteErrors) throw new EventSourceException(SR.EventSource_NullInput, innerEx);
                         break;
                     case EventProvider.WriteEventErrorCode.TooManyArgs:
-                        ReportOutOfBandMessage(errorPrefix + ": " + Resources.GetResourceString("EventSource_TooManyArgs"), true);
-                        if (ThrowOnEventWriteErrors) throw new EventSourceException(Resources.GetResourceString("EventSource_TooManyArgs"), innerEx);
+                        ReportOutOfBandMessage(errorPrefix + ": " + SR.EventSource_TooManyArgs, true);
+                        if (ThrowOnEventWriteErrors) throw new EventSourceException(SR.EventSource_TooManyArgs, innerEx);
                         break;
                     default:
                         if (innerEx != null)
@@ -2705,7 +2713,7 @@ namespace System.Diagnostics.Tracing
                 commandArgs.dispatcher = GetDispatcher(commandArgs.listener);
                 if (commandArgs.dispatcher == null && commandArgs.listener != null)     // dispatcher == null means ETW dispatcher
                 {
-                    throw new ArgumentException(Resources.GetResourceString("EventSource_ListenerNotFound"));
+                    throw new ArgumentException(SR.EventSource_ListenerNotFound);
                 }
 
                 if (commandArgs.Arguments == null)
@@ -2786,7 +2794,7 @@ namespace System.Diagnostics.Tracing
 
                         if (commandArgs.listener == null && commandArgs.Arguments.Count > 0 && commandArgs.perEventSourceSessionId != sessionIdBit)
                         {
-                            throw new ArgumentException(Resources.GetResourceString("EventSource_SessionIdError",
+                            throw new ArgumentException(SR.Format(SR.EventSource_SessionIdError,
                                                     commandArgs.perEventSourceSessionId + SessionMask.SHIFT_SESSION_TO_KEYWORD,
                                                         sessionIdBit + SessionMask.SHIFT_SESSION_TO_KEYWORD));
                         }
@@ -3143,7 +3151,7 @@ namespace System.Diagnostics.Tracing
                     {
                         if (eventSource != this)
                         {
-                            throw new ArgumentException(Resources.GetResourceString("EventSource_EventSourceGuidInUse", m_guid));
+                            throw new ArgumentException(SR.Format(SR.EventSource_EventSourceGuidInUse, m_guid));
                         }
                     }
                 }
@@ -3241,7 +3249,11 @@ namespace System.Diagnostics.Tracing
                     // 5 chunks, so only the largest manifests will hit the pause.
                     if ((envelope.ChunkNumber % 5) == 0)
                     {
+#if ES_BUILD_STANDALONE
+                        Thread.Sleep(15);
+#else
                         RuntimeThread.Sleep(15);
+#endif
                     }
                 }
             }
@@ -3326,7 +3338,7 @@ namespace System.Diagnostics.Tracing
             return null;
 #else // ES_BUILD_PCL && ES_BUILD_PN
             // Don't use nameof here because the resource doesn't exist on some platforms, which results in a compilation error.
-            throw new ArgumentException(Resources.GetResourceString("EventSource", "EventSource_PCLPlatformNotSupportedReflection"));
+            throw new ArgumentException("EventSource_PCLPlatformNotSupportedReflection", "EventSource");
 #endif
         }
 
@@ -3402,7 +3414,7 @@ namespace System.Diagnostics.Tracing
             if (eventSourceType.IsAbstract() && (flags & EventManifestOptions.Strict) == 0)
                 return null;
 
-#if DEBUG && ES_BUILD_STANDALONE
+#if DEBUG && ES_BUILD_STANDALONE && TEST_SUPPORT
             TestSupport.TestHooks.MaybeThrow(eventSourceType,
                                         TestSupport.Category.ManifestError,
                                         "EventSource_CreateManifestAndDescriptors",
@@ -3443,11 +3455,11 @@ namespace System.Diagnostics.Tracing
 
                     if (!typeMatch)
                     {
-                        manifest.ManifestError(Resources.GetResourceString("EventSource_TypeMustDeriveFromEventSource"));
+                        manifest.ManifestError(SR.EventSource_TypeMustDeriveFromEventSource);
                     }
                     if (!eventSourceType.IsAbstract() && !eventSourceType.IsSealed())
                     {
-                        manifest.ManifestError(Resources.GetResourceString("EventSource_TypeMustBeSealedOrAbstract"));
+                        manifest.ManifestError(SR.EventSource_TypeMustBeSealedOrAbstract);
                     }
                 }
 
@@ -3463,7 +3475,7 @@ namespace System.Diagnostics.Tracing
                     {
                         if (eventSourceType.IsAbstract())
                         {
-                            manifest.ManifestError(Resources.GetResourceString("EventSource_AbstractMustNotDeclareKTOC", nestedType.Name));
+                            manifest.ManifestError(SR.Format(SR.EventSource_AbstractMustNotDeclareKTOC, nestedType.Name));
                         }
                         else
                         {
@@ -3506,7 +3518,7 @@ namespace System.Diagnostics.Tracing
                         {
                             if (eventAttribute != null)
                             {
-                                manifest.ManifestError(Resources.GetResourceString("EventSource_AbstractMustNotDeclareEventMethods", method.Name, eventAttribute.EventId));
+                                manifest.ManifestError(SR.Format(SR.EventSource_AbstractMustNotDeclareEventMethods, method.Name, eventAttribute.EventId));
                             }
                             continue;
                         }
@@ -3535,12 +3547,12 @@ namespace System.Diagnostics.Tracing
                         }
                         else if (eventAttribute.EventId <= 0)
                         {
-                            manifest.ManifestError(Resources.GetResourceString("EventSource_NeedPositiveId", method.Name), true);
+                            manifest.ManifestError(SR.Format(SR.EventSource_NeedPositiveId, method.Name), true);
                             continue;   // don't validate anything else for this event
                         }
                         if (method.Name.LastIndexOf('.') >= 0)
                         {
-                            manifest.ManifestError(Resources.GetResourceString("EventSource_EventMustNotBeExplicitImplementation", method.Name, eventAttribute.EventId));
+                            manifest.ManifestError(SR.Format(SR.EventSource_EventMustNotBeExplicitImplementation, method.Name, eventAttribute.EventId));
                         }
 
                         eventId++;
@@ -3588,6 +3600,7 @@ namespace System.Diagnostics.Tracing
                                             string.Compare(startEventMetadata.Name, 0, taskName, 0, taskName.Length) == 0 &&
                                             string.Compare(startEventMetadata.Name, taskName.Length, s_ActivityStartSuffix, 0, Math.Max(startEventMetadata.Name.Length - taskName.Length, s_ActivityStartSuffix.Length)) == 0)
                                         {
+
                                             // Make the stop event match the start event
                                             eventAttribute.Task = (EventTask)startEventMetadata.Descriptor.Task;
                                             noTask = false;
@@ -3595,7 +3608,7 @@ namespace System.Diagnostics.Tracing
                                     }
                                     if (noTask && (flags & EventManifestOptions.Strict) != 0)        // Throw an error if we can compatibly.   
                                     {
-                                        throw new ArgumentException(Resources.GetResourceString("EventSource_StopsFollowStarts"));
+                                        throw new ArgumentException(SR.EventSource_StopsFollowStarts);
                                     }
                                 }
                             }
@@ -3748,7 +3761,7 @@ namespace System.Diagnostics.Tracing
 #endif
             return;
             Error:
-            manifest.ManifestError(Resources.GetResourceString("EventSource_EnumKindMismatch", staticField.Name, staticField.FieldType.Name, providerEnumKind));
+            manifest.ManifestError(SR.Format(SR.EventSource_EnumKindMismatch, staticField.Name, staticField.FieldType.Name, providerEnumKind));
         }
 
         // Helper used by code:CreateManifestAndDescriptors to add a code:EventData descriptor for a method
@@ -3831,12 +3844,12 @@ namespace System.Diagnostics.Tracing
             int eventArg = GetHelperCallFirstArg(method);
             if (eventArg >= 0 && evtId != eventArg)
             {
-                manifest.ManifestError(Resources.GetResourceString("EventSource_MismatchIdToWriteEvent", evtName, evtId, eventArg), true);
+                manifest.ManifestError(SR.Format(SR.EventSource_MismatchIdToWriteEvent, evtName, evtId, eventArg), true);
             }
 
             if (evtId < eventData.Length && eventData[evtId].Descriptor.EventId != 0)
             {
-                manifest.ManifestError(Resources.GetResourceString("EventSource_EventIdReused", evtName, evtId, eventData[evtId].Name), true);
+                manifest.ManifestError(SR.Format(SR.EventSource_EventIdReused, evtName, evtId, eventData[evtId].Name), true);
             }
 
             // We give a task to things if they don't have one.  
@@ -3850,7 +3863,7 @@ namespace System.Diagnostics.Tracing
 
                 if (eventData[idx].Descriptor.Task == (int)eventAttribute.Task && eventData[idx].Descriptor.Opcode == (int)eventAttribute.Opcode)
                 {
-                    manifest.ManifestError(Resources.GetResourceString("EventSource_TaskOpcodePairReused",
+                    manifest.ManifestError(SR.Format(SR.EventSource_TaskOpcodePairReused,
                                             evtName, evtId, eventData[idx].Name, idx));
                     // If we are not strict stop on first error.   We have had problems with really large providers taking forever.  because of many errors.  
                     if ((options & EventManifestOptions.Strict) == 0)
@@ -3875,7 +3888,7 @@ namespace System.Diagnostics.Tracing
                 }
                 if (failure)
                 {
-                    manifest.ManifestError(Resources.GetResourceString("EventSource_EventMustHaveTaskIfNonDefaultOpcode", evtName, evtId));
+                    manifest.ManifestError(SR.Format(SR.EventSource_EventMustHaveTaskIfNonDefaultOpcode, evtName, evtId));
                 }
             }
 
@@ -3885,7 +3898,7 @@ namespace System.Diagnostics.Tracing
             // taskName & opcodeName could be passed in by the caller which has opTab & taskTab handy
             // if (!(((int)eventAttribute.Opcode == 0 && evtName == taskName) || (evtName == taskName+opcodeName)))
             // {
-            //     throw new WarningException(Resources.GetResourceString("EventSource_EventNameDoesNotEqualTaskPlusOpcode"));
+            //     throw new WarningException(SR.EventSource_EventNameDoesNotEqualTaskPlusOpcode);
             // }
 
             if (eventsByName == null)
@@ -3893,7 +3906,7 @@ namespace System.Diagnostics.Tracing
 
             if (eventsByName.ContainsKey(evtName))
             {
-                manifest.ManifestError(Resources.GetResourceString("EventSource_EventNameReused", evtName), true);
+                manifest.ManifestError(SR.Format(SR.EventSource_EventNameReused, evtName), true);
             }
 
             eventsByName[evtName] = evtName;
@@ -4085,7 +4098,7 @@ namespace System.Diagnostics.Tracing
                                 EventSourceSettings.EtwSelfDescribingEventFormat;
             if ((settings & evtFormatMask) == evtFormatMask)
             {
-                throw new ArgumentException(Resources.GetResourceString("EventSource_InvalidEventFormat"), nameof(settings));
+                throw new ArgumentException(SR.EventSource_InvalidEventFormat, nameof(settings));
             }
 
             // If you did not explicitly ask for manifest, you get self-describing.  
@@ -4232,7 +4245,7 @@ namespace System.Diagnostics.Tracing
             0x87, 0xF8, 0x1A, 0x15, 0xBF, 0xC1, 0x30, 0xFB,
         };
 
-        #endregion
+#endregion
     }
 
     /// <summary>
@@ -4509,7 +4522,7 @@ namespace System.Diagnostics.Tracing
         }
 
 
-        #region private
+#region private
         /// <summary>
         /// This routine adds newEventSource to the global list of eventSources, it also assigns the
         /// ID to the eventSource (which is simply the ordinal in the global list).
@@ -4705,7 +4718,7 @@ namespace System.Diagnostics.Tracing
                 // Disallow creating EventListener reentrancy. 
                 if (s_CreatingListener)
                 {
-                    throw new InvalidOperationException(Resources.GetResourceString("EventSource_ListenerCreatedInsideCallback"));
+                    throw new InvalidOperationException(SR.EventSource_ListenerCreatedInsideCallback);
                 }
 
                 try
@@ -4779,7 +4792,7 @@ namespace System.Diagnostics.Tracing
         /// Used to register AD/Process shutdown callbacks.
         /// </summary>
         private static bool s_EventSourceShutdownRegistered = false;
-        #endregion
+#endregion
     }
 
     /// <summary>
@@ -4821,7 +4834,7 @@ namespace System.Diagnostics.Tracing
             return eventSource.EnableEventForDispatcher(dispatcher, eventId, false);
         }
 
-        #region private
+#region private
 
         internal EventCommandEventArgs(EventCommand command, IDictionary<string, string> arguments, EventSource eventSource,
             EventListener listener, int perEventSourceSessionId, int etwSessionId, bool enable, EventLevel level, EventKeywords matchAnyKeyword)
@@ -4849,7 +4862,7 @@ namespace System.Diagnostics.Tracing
         internal EventKeywords matchAnyKeyword;
         internal EventCommandEventArgs nextCommand;     // We form a linked list of these deferred commands.      
 
-        #endregion
+#endregion
     }
 
     /// <summary>
@@ -4932,6 +4945,7 @@ namespace System.Diagnostics.Tracing
                 // do the lazy init if you know it is contract based (EventID >= 0)
                 if (EventId >= 0 && m_payloadNames == null)
                 {
+
                     var names = new List<string>();
                     foreach (var parameter in m_eventSource.m_eventData[EventId].Parameters)
                     {
@@ -5068,7 +5082,7 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        #region private
+#region private
         internal EventWrittenEventArgs(EventSource eventSource)
         {
             m_eventSource = eventSource;
@@ -5081,7 +5095,7 @@ namespace System.Diagnostics.Tracing
         internal EventOpcode m_opcode;
         internal EventLevel m_level;
         internal EventKeywords m_keywords;
-        #endregion
+#endregion
     }
 
     /// <summary>
@@ -5193,10 +5207,10 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         public EventActivityOptions ActivityOptions { get; set; }
 
-        #region private
+#region private
         EventOpcode m_opcode;
         private bool m_opcodeSet;
-        #endregion
+#endregion
     }
 
     /// <summary>
@@ -5336,7 +5350,7 @@ namespace System.Diagnostics.Tracing
     };
 
 
-    #region private classes
+#region private classes
 
 #if FEATURE_ACTIVITYSAMPLING
 
@@ -5684,7 +5698,7 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        #region private
+#region private
 
         /// <summary>
         /// Creates a new ActivityFilter that is triggered by 'eventId' from 'source' ever
@@ -5853,7 +5867,7 @@ namespace System.Diagnostics.Tracing
 
         ActivityFilter m_next;      // We create a linked list of these
         Action<Guid> m_myActivityDelegate;
-        #endregion
+#endregion
     };
 
 
@@ -6161,12 +6175,12 @@ namespace System.Diagnostics.Tracing
             {
                 if (value <= 10 || value >= 239)
                 {
-                    ManifestError(Resources.GetResourceString("EventSource_IllegalOpcodeValue", name, value));
+                    ManifestError(SR.Format(SR.EventSource_IllegalOpcodeValue, name, value));
                 }
                 string prevName;
                 if (opcodeTab.TryGetValue(value, out prevName) && !name.Equals(prevName, StringComparison.Ordinal))
                 {
-                    ManifestError(Resources.GetResourceString("EventSource_OpcodeCollision", name, prevName, value));
+                    ManifestError(SR.Format(SR.EventSource_OpcodeCollision, name, prevName, value));
                 }
             }
             opcodeTab[value] = name;
@@ -6177,12 +6191,12 @@ namespace System.Diagnostics.Tracing
             {
                 if (value <= 0 || value >= 65535)
                 {
-                    ManifestError(Resources.GetResourceString("EventSource_IllegalTaskValue", name, value));
+                    ManifestError(SR.Format(SR.EventSource_IllegalTaskValue, name, value));
                 }
                 string prevName;
                 if (taskTab != null && taskTab.TryGetValue(value, out prevName) && !name.Equals(prevName, StringComparison.Ordinal))
                 {
-                    ManifestError(Resources.GetResourceString("EventSource_TaskCollision", name, prevName, value));
+                    ManifestError(SR.Format(SR.EventSource_TaskCollision, name, prevName, value));
                 }
             }
             if (taskTab == null)
@@ -6193,18 +6207,18 @@ namespace System.Diagnostics.Tracing
         {
             if ((value & (value - 1)) != 0)   // Is it a power of 2?
             {
-                ManifestError(Resources.GetResourceString("EventSource_KeywordNeedPowerOfTwo", "0x" + value.ToString("x", CultureInfo.CurrentCulture), name), true);
+                ManifestError(SR.Format(SR.EventSource_KeywordNeedPowerOfTwo, "0x" + value.ToString("x", CultureInfo.CurrentCulture), name), true);
             }
             if ((flags & EventManifestOptions.Strict) != 0)
             {
                 if (value >= 0x0000100000000000UL && !name.StartsWith("Session", StringComparison.Ordinal))
                 {
-                    ManifestError(Resources.GetResourceString("EventSource_IllegalKeywordsValue", name, "0x" + value.ToString("x", CultureInfo.CurrentCulture)));
+                    ManifestError(SR.Format(SR.EventSource_IllegalKeywordsValue, name, "0x" + value.ToString("x", CultureInfo.CurrentCulture)));
                 }
                 string prevName;
                 if (keywordTab != null && keywordTab.TryGetValue(value, out prevName) && !name.Equals(prevName, StringComparison.Ordinal))
                 {
-                    ManifestError(Resources.GetResourceString("EventSource_KeywordCollision", name, prevName, "0x" + value.ToString("x", CultureInfo.CurrentCulture)));
+                    ManifestError(SR.Format(SR.EventSource_KeywordCollision, name, prevName, "0x" + value.ToString("x", CultureInfo.CurrentCulture)));
                 }
             }
             if (keywordTab == null)
@@ -6220,13 +6234,13 @@ namespace System.Diagnostics.Tracing
         {
             EventChannel chValue = (EventChannel)value;
             if (value < (int)EventChannel.Admin || value > 255)
-                ManifestError(Resources.GetResourceString("EventSource_EventChannelOutOfRange", name, value));
+                ManifestError(SR.Format(SR.EventSource_EventChannelOutOfRange, name, value));
             else if (chValue >= EventChannel.Admin && chValue <= EventChannel.Debug &&
                      channelAttribute != null && EventChannelToChannelType(chValue) != channelAttribute.EventChannelType)
             {
                 // we want to ensure developers do not define EventChannels that conflict with the builtin ones,
                 // but we want to allow them to override the default ones...
-                ManifestError(Resources.GetResourceString("EventSource_ChannelTypeDoesNotMatchEventChannelValue",
+                ManifestError(SR.Format(SR.EventSource_ChannelTypeDoesNotMatchEventChannelValue,
                                                                             name, ((EventChannel)value).ToString()));
             }
 
@@ -6400,7 +6414,7 @@ namespace System.Diagnostics.Tracing
             }
 
             if (channelTab.Count == MaxCountChannels)
-                ManifestError(Resources.GetResourceString("EventSource_MaxChannelExceeded"));
+                ManifestError(SR.EventSource_MaxChannelExceeded);
 
             ChannelInfo info;
             if (!channelTab.TryGetValue((int)channel, out info))
@@ -6446,6 +6460,7 @@ namespace System.Diagnostics.Tracing
 
         private string CreateManifestString()
         {
+
 #if FEATURE_MANAGED_ETW_CHANNELS
             // Write out the channels
             if (channelTab != null)
@@ -6513,6 +6528,7 @@ namespace System.Diagnostics.Tracing
             // Write out the tasks
             if (taskTab != null)
             {
+
                 sb.Append(" <tasks>").AppendLine();
                 var sortedTasks = new List<int>(taskTab.Keys);
                 sortedTasks.Sort();
@@ -6657,7 +6673,7 @@ namespace System.Diagnostics.Tracing
             return sb.ToString();
         }
 
-        #region private
+#region private
         private void WriteNameAndMessageAttribs(StringBuilder stringBuilder, string elementName, string name)
         {
             stringBuilder.Append(" name=\"").Append(name).Append("\"");
@@ -6681,7 +6697,7 @@ namespace System.Diagnostics.Tracing
             string prevValue;
             if (stringTab.TryGetValue(key, out prevValue) && !prevValue.Equals(value))
             {
-                ManifestError(Resources.GetResourceString("EventSource_DuplicateStringKey", key), true);
+                ManifestError(SR.Format(SR.EventSource_DuplicateStringKey, key), true);
                 return;
             }
 
@@ -6737,7 +6753,7 @@ namespace System.Diagnostics.Tracing
             if (channelTab == null || !channelTab.TryGetValue((int)channel, out info))
             {
                 if (channel < EventChannel.Admin) // || channel > EventChannel.Debug)
-                    ManifestError(Resources.GetResourceString("EventSource_UndefinedChannel", channel, eventName));
+                    ManifestError(SR.Format(SR.EventSource_UndefinedChannel, channel, eventName));
 
                 // allow channels to be auto-defined.  The well known ones get their well known names, and the
                 // rest get names Channel<N>.  This allows users to modify the Manifest if they want more advanced features. 
@@ -6750,13 +6766,13 @@ namespace System.Diagnostics.Tracing
 
                 AddChannel(channelName, (int)channel, GetDefaultChannelAttribute(channel));
                 if (!channelTab.TryGetValue((int)channel, out info))
-                    ManifestError(Resources.GetResourceString("EventSource_UndefinedChannel", channel, eventName));
+                    ManifestError(SR.Format(SR.EventSource_UndefinedChannel, channel, eventName));
             }
             // events that specify admin channels *must* have non-null "Message" attributes
             if (resources != null && eventMessage == null)
                 eventMessage = resources.GetString("event_" + eventName, CultureInfo.InvariantCulture);
             if (info.Attribs.EventChannelType == EventChannelType.Admin && eventMessage == null)
-                ManifestError(Resources.GetResourceString("EventSource_EventWithAdminChannelMustHaveMessage", eventName, info.Name));
+                ManifestError(SR.Format(SR.EventSource_EventWithAdminChannelMustHaveMessage, eventName, info.Name));
             return info.Name;
         }
 #endif
@@ -6804,7 +6820,7 @@ namespace System.Diagnostics.Tracing
             string ret;
             if (opcodeTab == null || !opcodeTab.TryGetValue((int)opcode, out ret))
             {
-                ManifestError(Resources.GetResourceString("EventSource_UndefinedOpcode", opcode, eventName), true);
+                ManifestError(SR.Format(SR.EventSource_UndefinedOpcode, opcode, eventName), true);
                 ret = null;
             }
             return ret;
@@ -6833,7 +6849,7 @@ namespace System.Diagnostics.Tracing
                     }
                     if (keyword == null)
                     {
-                        ManifestError(Resources.GetResourceString("EventSource_UndefinedKeyword", "0x" + bit.ToString("x", CultureInfo.CurrentCulture), eventName), true);
+                        ManifestError(SR.Format(SR.EventSource_UndefinedKeyword, "0x" + bit.ToString("x", CultureInfo.CurrentCulture), eventName), true);
                         keyword = string.Empty;
                     }
                     if (ret.Length != 0 && keyword.Length != 0)
@@ -6926,7 +6942,7 @@ namespace System.Diagnostics.Tracing
                     }
                     else
                     {
-                        ManifestError(Resources.GetResourceString("EventSource_UnsupportedMessageProperty", evtName, eventMessage));
+                        ManifestError(SR.Format(SR.EventSource_UnsupportedMessageProperty, evtName, eventMessage));
                     }
                 }
                 else if ((chIdx = "&<>'\"\r\n\t".IndexOf(eventMessage[i])) >= 0)
@@ -7003,7 +7019,7 @@ namespace System.Diagnostics.Tracing
         string eventName;               // Name of the event currently being processed. 
         int numParams;                  // keeps track of the number of args the event has. 
         List<int> byteArrArgIndices;    // keeps track of the index of each byte[] argument
-        #endregion
+#endregion
     }
 
     /// <summary>
@@ -7027,6 +7043,6 @@ namespace System.Diagnostics.Tracing
 #endif
     };
 
-    #endregion
+#endregion
 }
 

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/EventSourceException.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/EventSourceException.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Resources;
 using System.Runtime.Serialization;
 
 #if ES_BUILD_STANDALONE
@@ -27,7 +28,7 @@ namespace System.Diagnostics.Tracing
         /// Initializes a new instance of the EventSourceException class.
         /// </summary>
         public EventSourceException() :
-            base(Resources.GetResourceString("EventSource_ListenerWriteFailure")) { }
+            base(SR.EventSource_ListenerWriteFailure) { }
 
         /// <summary>
         /// Initializes a new instance of the EventSourceException class with a specified error message.
@@ -48,6 +49,6 @@ namespace System.Diagnostics.Tracing
 #endif
 
         internal EventSourceException(Exception innerException) :
-            base(Resources.GetResourceString("EventSource_ListenerWriteFailure"), innerException) { }
+            base(SR.EventSource_ListenerWriteFailure, innerException) { }
     }
 }

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/IEventProvider.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/IEventProvider.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Microsoft.Win32;
 
 #if ES_BUILD_STANDALONE

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/StubEnvironment.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/StubEnvironment.cs
@@ -356,3 +356,18 @@ namespace System
     }    
 }
 #endif
+
+#if ES_BUILD_STANDALONE
+namespace Microsoft.Win32
+{
+    using System.Runtime.InteropServices;
+    using System.Security;
+
+    [SuppressUnmanagedCodeSecurityAttribute()]
+    internal static class Win32Native
+    {
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        internal static extern uint GetCurrentProcessId();
+    }
+}
+#endif

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/DataCollector.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/DataCollector.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Resources;
 using System.Runtime.InteropServices;
 using System.Security;
 
@@ -85,7 +86,7 @@ namespace System.Diagnostics.Tracing
                 var scratchNew = scratchOld + size;
                 if (this.scratchEnd < scratchNew)
                 {
-                    throw new IndexOutOfRangeException(Resources.GetResourceString("EventSource_AddScalarOutOfRange"));
+                    throw new IndexOutOfRangeException(SR.EventSource_AddScalarOutOfRange);
                 }
 
                 this.ScalarsBegin();
@@ -272,13 +273,13 @@ namespace System.Diagnostics.Tracing
             var pinsTemp = this.pins;
             if (this.pinsEnd <= pinsTemp)
             {
-                throw new IndexOutOfRangeException(Resources.GetResourceString("EventSource_PinArrayOutOfRange"));
+                throw new IndexOutOfRangeException(SR.EventSource_PinArrayOutOfRange);
             }
 
             var datasTemp = this.datas;
             if (this.datasEnd <= datasTemp)
             {
-                throw new IndexOutOfRangeException(Resources.GetResourceString("EventSource_DataDescriptorsOutOfRange"));
+                throw new IndexOutOfRangeException(SR.EventSource_DataDescriptorsOutOfRange);
             }
 
             this.pins = pinsTemp + 1;
@@ -296,7 +297,7 @@ namespace System.Diagnostics.Tracing
                 var datasTemp = this.datas;
                 if (this.datasEnd <= datasTemp)
                 {
-                    throw new IndexOutOfRangeException(Resources.GetResourceString("EventSource_DataDescriptorsOutOfRange"));
+                    throw new IndexOutOfRangeException(SR.EventSource_DataDescriptorsOutOfRange);
                 }
 
                 datasTemp->DataPointer = (IntPtr) this.scratch;

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/EventPayload.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/EventPayload.cs
@@ -6,6 +6,12 @@ using System.Collections.Generic;
 using System.Collections;
 using System.Diagnostics;
 
+#if !ES_BUILD_AGAINST_DOTNET_V35
+using Contract = System.Diagnostics.Contracts.Contract;
+#else
+using Contract = Microsoft.Diagnostics.Contracts.Internal.Contract;
+#endif
+
 #if ES_BUILD_STANDALONE
 namespace Microsoft.Diagnostics.Tracing
 #else

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/EventSourceActivity.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/EventSourceActivity.cs
@@ -4,6 +4,12 @@
 
 using System;
 
+#if !ES_BUILD_AGAINST_DOTNET_V35
+using Contract = System.Diagnostics.Contracts.Contract;
+#else
+using Contract = Microsoft.Diagnostics.Contracts.Internal.Contract;
+#endif
+
 #if ES_BUILD_STANDALONE
 namespace Microsoft.Diagnostics.Tracing
 #else

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/FieldMetadata.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/FieldMetadata.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Resources;
 using Encoding = System.Text.Encoding;
 
 #if ES_BUILD_STANDALONE
@@ -128,17 +129,17 @@ namespace System.Diagnostics.Tracing
             {
                 if (coreType == (int)TraceLoggingDataType.Nil)
                 {
-                    throw new NotSupportedException(Resources.GetResourceString("EventSource_NotSupportedArrayOfNil"));
+                    throw new NotSupportedException(SR.EventSource_NotSupportedArrayOfNil);
                 }
                 if (coreType == (int)TraceLoggingDataType.Binary)
                 {
-                    throw new NotSupportedException(Resources.GetResourceString("EventSource_NotSupportedArrayOfBinary"));
+                    throw new NotSupportedException(SR.EventSource_NotSupportedArrayOfBinary);
                 }
 #if !BROKEN_UNTIL_M3
                 if (coreType == (int)TraceLoggingDataType.Utf16String ||
                     coreType == (int)TraceLoggingDataType.MbcsString)
                 {
-                    throw new NotSupportedException(Resources.GetResourceString("EventSource_NotSupportedArrayOfNullTerminatedString"));
+                    throw new NotSupportedException(SR.EventSource_NotSupportedArrayOfNullTerminatedString);
                 }
 #endif
             }
@@ -160,7 +161,7 @@ namespace System.Diagnostics.Tracing
             this.outType++;
             if ((this.outType & Statics.OutTypeMask) == 0)
             {
-                throw new NotSupportedException(Resources.GetResourceString("EventSource_TooManyFields"));
+                throw new NotSupportedException(SR.EventSource_TooManyFields);
             }
         }
 

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/PropertyValue.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/PropertyValue.cs
@@ -1,8 +1,19 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
 
+#if !ES_BUILD_AGAINST_DOTNET_V35
+using Contract = System.Diagnostics.Contracts.Contract;
+#else
+using Contract = Microsoft.Diagnostics.Contracts.Internal.Contract;
+#endif
+
+#if ES_BUILD_STANDALONE
+namespace Microsoft.Diagnostics.Tracing
+#else
 namespace System.Diagnostics.Tracing
+#endif
 {
     /// <summary>
     /// Holds property values of any type.  For common value types, we have inline storage so that we don't need

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/SimpleTypeInfos.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/SimpleTypeInfos.cs
@@ -7,6 +7,12 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Diagnostics;
 
+#if !ES_BUILD_AGAINST_DOTNET_V35
+using Contract = System.Diagnostics.Contracts.Contract;
+#else
+using Contract = Microsoft.Diagnostics.Contracts.Internal.Contract;
+#endif
+
 #if ES_BUILD_STANDALONE
 namespace Microsoft.Diagnostics.Tracing
 #else

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/Statics.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/Statics.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Resources;
 using System.Runtime.CompilerServices;
 using Encoding = System.Text.Encoding;
 
@@ -531,7 +532,7 @@ namespace System.Diagnostics.Tracing
 
             if (recursionCheck.Contains(dataType))
             {
-                throw new NotSupportedException(Resources.GetResourceString("EventSource_RecursiveTypeDefinition"));
+                throw new NotSupportedException(SR.EventSource_RecursiveTypeDefinition);
             }
 
             recursionCheck.Add(dataType);
@@ -714,7 +715,7 @@ namespace System.Diagnostics.Tracing
                     }
                     else
                     {
-                        throw new ArgumentException(Resources.GetResourceString("EventSource_NonCompliantTypeError", dataType.Name));
+                        throw new ArgumentException(SR.Format(SR.EventSource_NonCompliantTypeError, dataType.Name));
                     }
                 }
             }

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
@@ -24,14 +24,17 @@ using EventDescriptor = Microsoft.Diagnostics.Tracing.EventDescriptor;
 #endif
 
 using System;
+using System.Resources;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Collections.ObjectModel;
 
 #if !ES_BUILD_AGAINST_DOTNET_V35
+using Contract = System.Diagnostics.Contracts.Contract;
 using System.Collections.Generic;
 using System.Text;
 #else
+using Contract = Microsoft.Diagnostics.Contracts.Internal.Contract;
 using System.Collections.Generic;
 using System.Text;
 #endif
@@ -114,7 +117,6 @@ namespace System.Diagnostics.Tracing
                 throw new ArgumentNullException(nameof(eventName));
             }
 
-
             if (!this.IsEnabled())
             {
                 return;
@@ -139,7 +141,6 @@ namespace System.Diagnostics.Tracing
             {
                 throw new ArgumentNullException(nameof(eventName));
             }
-
 
             if (!this.IsEnabled())
             {
@@ -774,7 +775,7 @@ namespace System.Diagnostics.Tracing
                             }
                             else
                             {
-                                throw new ArgumentException(Resources.GetResourceString("UnknownEtwTrait", etwTrait), "traits");
+                                throw new ArgumentException(SR.Format(SR.EventSource_UnknownEtwTrait, etwTrait), "traits");
                             }
                         }
                         string value = m_traits[i + 1];
@@ -817,7 +818,7 @@ namespace System.Diagnostics.Tracing
                     {
                         if (!(i + 1 < value.Length))
                         {
-                            throw new ArgumentException(Resources.GetResourceString("EvenHexDigits"), "traits");
+                            throw new ArgumentException(SR.EventSource_EvenHexDigits, "traits");
                         }
                         metaData.Add((byte)(HexDigit(value[i]) * 16 + HexDigit(value[i + 1])));
                         i++;
@@ -830,7 +831,7 @@ namespace System.Diagnostics.Tracing
             }
             else
             {
-                throw new ArgumentException(Resources.GetResourceString("IllegalValue", value), "traits");
+                throw new ArgumentException(SR.Format(SR.EventSource_IllegalValue, value), "traits");
             }
 
             return metaData.Count - startPos;
@@ -854,7 +855,7 @@ namespace System.Diagnostics.Tracing
                 return (c - 'A' + 10);
             }
             
-            throw new ArgumentException(Resources.GetResourceString("BadHexDigit", c), "traits");
+            throw new ArgumentException(SR.Format(SR.EventSource_BadHexDigit, c), "traits");
         }
 
         private NameInfo UpdateDescriptor(

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventTypes.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventTypes.cs
@@ -6,6 +6,12 @@ using System;
 using System.Collections.Generic;
 using Interlocked = System.Threading.Interlocked;
 
+#if !ES_BUILD_AGAINST_DOTNET_V35
+using Contract = System.Diagnostics.Contracts.Contract;
+#else
+using Contract = Microsoft.Diagnostics.Contracts.Internal.Contract;
+#endif
+
 #if ES_BUILD_STANDALONE
 namespace Microsoft.Diagnostics.Tracing
 #else
@@ -91,7 +97,6 @@ namespace System.Diagnostics.Tracing
                 throw new ArgumentNullException(nameof(name));
             }
 
-
             this.typeInfos = MakeArray(paramInfos);
             this.name = name;
             this.tags = tags;
@@ -127,7 +132,6 @@ namespace System.Diagnostics.Tracing
             {
                 throw new ArgumentNullException(nameof(defaultName));
             }
-
 
             this.typeInfos = typeInfos;
             this.name = defaultName;
@@ -207,7 +211,6 @@ namespace System.Diagnostics.Tracing
                 throw new ArgumentNullException(nameof(paramInfos));
             }
 
-
             var recursionCheck = new List<Type>(paramInfos.Length);
             var result = new TraceLoggingTypeInfo[paramInfos.Length];
             for (int i = 0; i < paramInfos.Length; ++i)
@@ -224,7 +227,6 @@ namespace System.Diagnostics.Tracing
             {
                 throw new ArgumentNullException(nameof(types));
             }
-
 
             var recursionCheck = new List<Type>(types.Length);
             var result = new TraceLoggingTypeInfo[types.Length];
@@ -243,7 +245,6 @@ namespace System.Diagnostics.Tracing
             {
                 throw new ArgumentNullException(nameof(typeInfos));
             }
-
 
             return (TraceLoggingTypeInfo[])typeInfos.Clone(); ;
         }

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingMetadataCollector.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingMetadataCollector.cs
@@ -232,7 +232,7 @@ namespace System.Diagnostics.Tracing
 
             if (this.BeginningBufferedArray)
             {
-                throw new NotSupportedException(Resources.GetResourceString("EventSource_NotSupportedNestedArraysEnums"));
+                throw new NotSupportedException(SR.EventSource_NotSupportedNestedArraysEnums);
             }
 
             this.impl.AddScalar(2);
@@ -244,7 +244,7 @@ namespace System.Diagnostics.Tracing
         {
             if (this.bufferedArrayFieldCount >= 0)
             {
-                throw new NotSupportedException(Resources.GetResourceString("EventSource_NotSupportedNestedArraysEnums"));
+                throw new NotSupportedException(SR.EventSource_NotSupportedNestedArraysEnums);
             }
 
             this.bufferedArrayFieldCount = 0;
@@ -255,7 +255,7 @@ namespace System.Diagnostics.Tracing
         {
             if (this.bufferedArrayFieldCount != 1)
             {
-                throw new InvalidOperationException(Resources.GetResourceString("EventSource_IncorrentlyAuthoredTypeInfo"));
+                throw new InvalidOperationException(SR.EventSource_IncorrentlyAuthoredTypeInfo);
             }
 
             this.bufferedArrayFieldCount = int.MinValue;
@@ -274,7 +274,7 @@ namespace System.Diagnostics.Tracing
         {
             if (this.BeginningBufferedArray)
             {
-                throw new NotSupportedException(Resources.GetResourceString("EventSource_NotSupportedCustomSerializedData"));
+                throw new NotSupportedException(SR.EventSource_NotSupportedCustomSerializedData);
             }
 
             this.impl.AddScalar(2);

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingTypeInfo.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingTypeInfo.cs
@@ -5,6 +5,12 @@
 using System;
 using System.Collections.Generic;
 
+#if !ES_BUILD_AGAINST_DOTNET_V35
+using Contract = System.Diagnostics.Contracts.Contract;
+#else
+using Contract = Microsoft.Diagnostics.Contracts.Internal.Contract;
+#endif
+
 #if ES_BUILD_STANDALONE
 namespace Microsoft.Diagnostics.Tracing
 #else
@@ -33,7 +39,6 @@ namespace System.Diagnostics.Tracing
                 throw new ArgumentNullException(nameof(dataType));
             }
 
-
             this.name = dataType.Name;
             this.dataType = dataType;
             this.propertyValueFactory = PropertyValue.GetFactory(dataType);
@@ -56,7 +61,6 @@ namespace System.Diagnostics.Tracing
             {
                 throw new ArgumentNullException(nameof(name));
             }
-
 
             Statics.CheckName(name);
 


### PR DESCRIPTION
Several code changes have been made to the EventSource codebase in order to support producing the Microsoft.Diagnostics.Tracing.EventSource.Redist package.  This PR brings these changes back from CoreFx.

These changes are a combination of the shared source changes from https://github.com/dotnet/corefx/pull/24405 and https://github.com/dotnet/corefx/pull/24808.

Following this PR, we will start mirroring the shared source to CoreFx to avoid needing these manual port PRs.