### PR TITLE
[ARM64/Windows] optimal value of CopyThreshold for Windows after performance analysis

### DIFF
--- a/src/mscorlib/src/System/Buffer.cs
+++ b/src/mscorlib/src/System/Buffer.cs
@@ -263,9 +263,9 @@ namespace System
             const nuint CopyThreshold = 2048;
 #elif ARM64
 #if PLATFORM_WINDOWS
-            // TODO-ARM64-WINDOWS-OPT determine optimal value for Windows
+            // Determined optimal value for Windows.
             // https://github.com/dotnet/coreclr/issues/13843
-            const nuint CopyThreshold = 2048;
+            const nuint CopyThreshold = UInt64.MaxValue;
 #else // PLATFORM_WINDOWS
             // Managed code is currently faster than glibc unoptimized memmove
             // TODO-ARM64-UNIX-OPT revisit when glibc optimized memmove is in Linux distros


### PR DESCRIPTION
Tested with new value of copyThreshold= Uint64.maxValue. This value looks best.