### PR TITLE
fix lvaStressLclFldCB

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -7331,11 +7331,10 @@ Compiler::fgWalkResult Compiler::lvaStressLclFldCB(GenTreePtr* pTree, fgWalkData
             /* Change addr(lclVar) to addr(lclVar)+padding */
 
             noway_assert(oper == GT_ADDR);
-            GenTreePtr newAddr = new (pComp, GT_NONE) GenTreeOp(*tree->AsOp());
+            GenTreePtr paddingTree = pComp->gtNewIconNode(padding);
+            GenTreePtr newAddr     = pComp->gtNewOperNode(GT_ADD, tree->gtType, tree, paddingTree);
 
-            tree->ChangeOper(GT_ADD);
-            tree->gtOp.gtOp1 = newAddr;
-            tree->gtOp.gtOp2 = pComp->gtNewIconNode(padding);
+            *pTree = newAddr;
 
             lcl->gtType = TYP_BLK;
         }


### PR DESCRIPTION
Don't create trees with the same ID.

Before the transformation:
```
[000005] L------------ arg2        |  |  \--*  ADDR      byref
[000004] -------------             |  |     \--*  LCL_VAR   long   V04 loc1
```

after the transformation:
 the old version has two trees with [000005] id:
```
[000027] -------------             |  |  /--*  CNS_INT   int    4
[000005] ----G-------- arg2        |  \--*  ADD       byref
[000005] L---G--------             |     \--*  ADDR      byref
[000004] -------------             |        \--*  LCL_VAR   blk   (AX) V04 loc1
```
the new version:
```
[000027] -------------             |  |  /--*  CNS_INT   int    4
[000028] ----G-------- arg2        |  \--*  ADD       byref
[000005] L---G--------             |     \--*  ADDR      byref
[000004] -------------             |        \--*  LCL_VAR   blk   (AX) V04 loc1
```

Fix #14567 .

