### PR TITLE
Marking {ReadOnly}Memory structs as readonly

### DIFF
--- a/src/mscorlib/shared/System/Memory.cs
+++ b/src/mscorlib/shared/System/Memory.cs
@@ -14,7 +14,7 @@ namespace System
 {
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     [DebuggerTypeProxy(typeof(MemoryDebugView<>))]
-    public struct Memory<T>
+    public readonly struct Memory<T>
     {
         // NOTE: With the current implementation, Memory<T> and ReadOnlyMemory<T> must have the same layout,
         // as code uses Unsafe.As to cast between them.

--- a/src/mscorlib/shared/System/ReadOnlyMemory.cs
+++ b/src/mscorlib/shared/System/ReadOnlyMemory.cs
@@ -14,7 +14,7 @@ namespace System
 {
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     [DebuggerTypeProxy(typeof(MemoryDebugView<>))]
-    public struct ReadOnlyMemory<T>
+    public readonly struct ReadOnlyMemory<T>
     {
         // NOTE: With the current implementation, Memory<T> and ReadOnlyMemory<T> must have the same layout,
         // as code uses Unsafe.As to cast between them.


### PR DESCRIPTION
Fixes issue https://github.com/dotnet/corefx/issues/23809
https://github.com/dotnet/coreclr/pull/13886#issuecomment-328285541

Related PR for corefx: https://github.com/dotnet/corefx/pull/24245

Previous PR was closed: https://github.com/dotnet/coreclr/pull/14180

cc @KrzysztofCwalina, @VSadov, @jkotas 
