### PR TITLE
[Local GC] Move IsGCThread and IsGCSpecialThread to GCToEEInterface

### DIFF
--- a/src/gc/env/gcenv.base.h
+++ b/src/gc/env/gcenv.base.h
@@ -420,12 +420,6 @@ typedef PTR_PTR_Object PTR_UNCHECKED_OBJECTREF;
 
 class Thread;
 
-inline bool IsGCSpecialThread()
-{
-    // [LOCALGC TODO] this is not correct
-    return false;
-}
-
 inline bool dbgOnly_IsSpecialEEThread()
 {
     return false;
@@ -453,12 +447,6 @@ namespace ETW
         GC_ROOT_OVERFLOW = 5
     } GC_ROOT_KIND;
 };
-
-inline bool IsGCThread()
-{
-    // [LOCALGC TODO] this is not correct
-    return false;
-}
 
 inline bool FitsInU1(uint64_t val)
 {

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -80,6 +80,8 @@ public:
     static bool GetIntConfigValue(const char* key, int64_t* value);
     static bool GetStringConfigValue(const char* key, const char** value);
     static void FreeStringConfigValue(const char* key);
+    static bool IsGCThread();
+    static bool IsGCSpecialThread();
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -1740,7 +1740,7 @@ static BOOL try_enter_spin_lock(GCSpinLock *pSpinLock)
 inline
 static void leave_spin_lock(GCSpinLock *pSpinLock)
 {
-    BOOL gc_thread_p = IsGCSpecialThread();
+    bool gc_thread_p = GCToEEInterface::IsGCSpecialThread();
 //    _ASSERTE((pSpinLock->holding_thread == GCToEEInterface::GetThread()) || gc_thread_p || pSpinLock->released_by_gc_p);
     pSpinLock->released_by_gc_p = gc_thread_p;
     pSpinLock->holding_thread = (Thread*) -1;
@@ -7450,7 +7450,7 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
 
             // Either this thread was the thread that did the suspension which means we are suspended; or this is called
             // from a GC thread which means we are in a blocking GC and also suspended.
-            BOOL is_runtime_suspended = IsGCThread();
+            bool is_runtime_suspended = GCToEEInterface::IsGCThread();
             if (!is_runtime_suspended)
             {
                 // Note on points where the runtime is suspended anywhere in this function. Upon an attempt to suspend the
@@ -7513,7 +7513,7 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
             // to be changed, so we are doing this after all global state has
             // been updated. See the comment above suspend_EE() above for more
             // info.
-            stomp_write_barrier_resize(!!IsGCThread(), la != saved_g_lowest_address);
+            stomp_write_barrier_resize(GCToEEInterface::IsGCThread(), la != saved_g_lowest_address);
         }
 
 
@@ -15519,8 +15519,8 @@ void gc_heap::gc1()
 #endif //BACKGROUND_GC
     {
 #ifndef FEATURE_REDHAWK
-        // IsGCThread() always returns false on CoreRT, but this assert is useful in CoreCLR.
-        assert(!!IsGCThread());
+        // GCToEEInterface::IsGCThread() always returns false on CoreRT, but this assert is useful in CoreCLR.
+        assert(GCToEEInterface::IsGCThread());
 #endif // FEATURE_REDHAWK
         adjust_ephemeral_limits();
     }
@@ -34013,7 +34013,7 @@ bool GCHeap::StressHeap(gc_alloc_context * context)
 
 #ifdef BACKGROUND_GC
         // don't trigger a GC from the GC threads but still trigger GCs from user threads.
-        if (IsGCSpecialThread())
+        if (GCToEEInterface::IsGCSpecialThread())
         {
             return FALSE;
         }

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -246,4 +246,16 @@ inline void GCToEEInterface::FreeStringConfigValue(const char* value)
     g_theGCToCLR->FreeStringConfigValue(value);
 }
 
+inline bool GCToEEInterface::IsGCThread()
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->IsGCThread();
+}
+
+inline bool GCToEEInterface::IsGCSpecialThread()
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->IsGCSpecialThread();
+}
+
 #endif // __GCTOENV_EE_STANDALONE_INL__

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -191,6 +191,17 @@ public:
 
     virtual
     void FreeStringConfigValue(const char* value) = 0;
+
+    // Asks the EE about whether or not the current thread is a GC thread:
+    // a server GC thread, background GC thread, or the thread that suspended
+    // the EE at the start of a GC.
+    virtual
+    bool IsGCThread() = 0;
+
+    // Asks the EE about whether or not the current thread is a GC "special"
+    // thread: a server GC thread or a background GC thread.
+    virtual
+    bool IsGCSpecialThread() = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -316,6 +316,16 @@ void GCToEEInterface::FreeStringConfigValue(const char *value)
 
 }
 
+bool GCToEEInterface::IsGCThread()
+{
+    return false;
+}
+
+bool GCToEEInterface::IsGCSpecialThread()
+{
+    return false;
+}
+
 MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
 {
     return g_pFreeObjectMethodTable;

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1169,3 +1169,13 @@ void GCToEEInterface::FreeStringConfigValue(const char* value)
 {
     delete [] value;
 }
+
+bool GCToEEInterface::IsGCThread()
+{
+    return ::IsGCThread();
+}
+
+bool GCToEEInterface::IsGCSpecialThread()
+{
+    return ::IsGCSpecialThread();
+}

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1172,10 +1172,10 @@ void GCToEEInterface::FreeStringConfigValue(const char* value)
 
 bool GCToEEInterface::IsGCThread()
 {
-    return ::IsGCThread();
+    return !!::IsGCThread();
 }
 
 bool GCToEEInterface::IsGCSpecialThread()
 {
-    return ::IsGCSpecialThread();
+    return !!::IsGCSpecialThread();
 }

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -58,6 +58,8 @@ public:
     bool GetIntConfigValue(const char* key, int64_t* value);
     bool GetStringConfigValue(const char* key, const char** value);
     void FreeStringConfigValue(const char* value);
+    bool IsGCThread();
+    bool IsGCSpecialThread();
 };
 
 } // namespace standalone


### PR DESCRIPTION
Partially (1) addresses a correctness issue with standalone GC that were caused by stubbed-out implementations of these functions. These functions are not used in performance-critical paths and as such we can tolerate an additional indirection when running standalone. (based on a discussion with @Maoni0 earlier today).

(1): There is an additional bug related to server GC thread startup that results in heap corruption when running with a standalone GC - the `ThreadType_GC` flag does not get set on Server GC threads and they are not recognized as GC threads by `IsGCThread` and `IsGCSpecialThread`. I will have a PR out for this issue in the next day or so since the fixes are kinda orthogonal.

@jkotas @Maoni0 @sergiy-k PTAL?