### PR TITLE
Disable VerifyDependencies target in package restore

### DIFF
--- a/tests/build.proj
+++ b/tests/build.proj
@@ -40,7 +40,7 @@
     <MSBuild Projects="$(MSBuildThisFileDirectory)\src\Common\external\external.depproj" />
   </Target>
 
-  <Target Name="BatchRestorePackages" DependsOnTargets="VerifyDependencies">
+  <Target Name="BatchRestorePackages">
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Restoring all packages..." />
     
     <!-- restore all csproj's with PackageReferences in one pass -->


### PR DESCRIPTION
This task is deprecated now that we no longer use project.json's. CoreFX has already removed it - this PR does the same for CoreCLR.

CC @dagood 