### PR TITLE
Implemented TailCall ELT hook for arm32 Linux

### DIFF
--- a/src/vm/arm/asmhelpers.S
+++ b/src/vm/arm/asmhelpers.S
@@ -662,11 +662,11 @@ NESTED_ENTRY ProfileEnterNaked, _TEXT, NoHandler
     PROLOG_PUSH "{r4, r5, r7, r11, lr}"
     PROLOG_STACK_SAVE_OFFSET r7, #8
 
-    // fields of PLATFORM_SPECIFIC_DATA, in reverse order
+    // fields of PROFILE_PLATFORM_SPECIFIC_DATA, in reverse order
 
     // UINT32      r0;         // Keep r0 & r1 contiguous to make returning 64-bit results easier
     // UINT32      r1;
-    // void       *R11;
+    // void       *r11;
     // void       *Pc;
     // union                   // Float arg registers as 32-bit (s0-s15) and 64-bit (d0-d7)
     // {
@@ -705,11 +705,11 @@ NESTED_ENTRY ProfileLeaveNaked, _TEXT, NoHandler
     PROLOG_PUSH "{r1, r2, r4, r5, r7, r11, lr}"
     PROLOG_STACK_SAVE_OFFSET r7, #16
 
-    // fields of PLATFORM_SPECIFIC_DATA, in reverse order
+    // fields of PROFILE_PLATFORM_SPECIFIC_DATA, in reverse order
 
     // UINT32      r0;         // Keep r0 & r1 contiguous to make returning 64-bit results easier
     // UINT32      r1;
-    // void       *R11;
+    // void       *r11;
     // void       *Pc;
     // union                   // Float arg registers as 32-bit (s0-s15) and 64-bit (d0-d7)
     // {
@@ -734,7 +734,7 @@ NESTED_ENTRY ProfileLeaveNaked, _TEXT, NoHandler
     push        { lr }
     push        { r11 }
     push        { r1 }
-    push        { r2 }
+    push        { r0 }
     mov         r1, sp
     bl          C_FUNC(ProfileLeave)
     EPILOG_STACK_RESTORE_OFFSET r7, #16
@@ -748,11 +748,11 @@ NESTED_ENTRY ProfileTailcallNaked, _TEXT, NoHandler
     PROLOG_PUSH "{r1, r2, r4, r5, r7, r11, lr}"
     PROLOG_STACK_SAVE_OFFSET r7, #16
 
-    // fields of PLATFORM_SPECIFIC_DATA, in reverse order
+    // fields of PROFILE_PLATFORM_SPECIFIC_DATA, in reverse order
 
     // UINT32      r0;         // Keep r0 & r1 contiguous to make returning 64-bit results easier
     // UINT32      r1;
-    // void       *R11;
+    // void       *r11;
     // void       *Pc;
     // union                   // Float arg registers as 32-bit (s0-s15) and 64-bit (d0-d7)
     // {
@@ -777,7 +777,7 @@ NESTED_ENTRY ProfileTailcallNaked, _TEXT, NoHandler
     push        { lr }
     push        { r11 }
     push        { r1 }
-    push        { r2 }
+    push        { r0 }
     mov         r1, sp
     bl          C_FUNC(ProfileTailcall)
     EPILOG_STACK_RESTORE_OFFSET r7, #16

--- a/src/vm/arm/asmhelpers.S
+++ b/src/vm/arm/asmhelpers.S
@@ -741,6 +741,49 @@ NESTED_ENTRY ProfileLeaveNaked, _TEXT, NoHandler
     EPILOG_POP "{r1, r2, r4, r5, r7, r11, pc}"
 NESTED_END ProfileLeaveNaked, _TEXT
 
+//
+// EXTERN_C void ProfileTailcallNaked(FunctionIDOrClientID functionIDOrClientID);
+//
+NESTED_ENTRY ProfileTailcallNaked, _TEXT, NoHandler
+    PROLOG_PUSH "{r1, r2, r4, r5, r7, r11, lr}"
+    PROLOG_STACK_SAVE_OFFSET r7, #16
+
+    // fields of PLATFORM_SPECIFIC_DATA, in reverse order
+
+    // UINT32      r0;         // Keep r0 & r1 contiguous to make returning 64-bit results easier
+    // UINT32      r1;
+    // void       *R11;
+    // void       *Pc;
+    // union                   // Float arg registers as 32-bit (s0-s15) and 64-bit (d0-d7)
+    // {
+    //     UINT32  s[16];
+    //     UINT64  d[8];
+    // };
+    // FunctionID  functionId;
+    // void       *probeSp;    // stack pointer of managed function 
+    // void       *profiledSp; // location of arguments on stack
+    // LPVOID      hiddenArg;
+    // UINT32      flags;
+    movw        r4, #2
+    push        { /* flags      */ r4 }
+    movw        r4, #0
+    push        { /* hiddenArg  */ r4 }
+    add         r5, r11, #8
+    push        { /* profiledSp */ r5 }
+    add         r5, sp, #40
+    push        { /* probeSp    */ r5 }
+    push        { /* functionId */ r0 }
+    vpush.64    { d0 - d7 }
+    push        { lr }
+    push        { r11 }
+    push        { r1 }
+    push        { r2 }
+    mov         r1, sp
+    bl          C_FUNC(ProfileTailcall)
+    EPILOG_STACK_RESTORE_OFFSET r7, #16
+    EPILOG_POP "{r1, r2, r4, r5, r7, r11, pc}"
+NESTED_END ProfileTailcallNaked, _TEXT
+
 // EXTERN_C int __fastcall HelperMethodFrameRestoreState(
 //         INDEBUG_COMMA(HelperMethodFrame *pFrame)
 //         MachState *pState

--- a/src/vm/arm/unixstubs.cpp
+++ b/src/vm/arm/unixstubs.cpp
@@ -15,9 +15,4 @@ extern "C"
     {
         PORTABILITY_ASSERT("Implement for PAL");
     }
-
-    void ProfileTailcallNaked(FunctionIDOrClientID functionIDOrClientID)
-    {
-        PORTABILITY_ASSERT("Implement for PAL");
-    }
 };


### PR DESCRIPTION
Issue #13993
Implementation is the same as LEAVE hook except stub using in it. The windows implementation is also similar to LEAVE and already exists.

Unfortunately tailcall optimization is not implemented in JIT for arm32 (see src/jit/target.h: 1194/1195) the real goal of this PR to add this hook by request from diagnostic team. 