### PR TITLE
Fix FixedReg assert

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -6168,16 +6168,19 @@ bool LinearScan::isSpillCandidate(Interval*     current,
 
     if (refPosition->isFixedRefOfRegMask(candidateBit))
     {
-        // Either there is a fixed reference due to this node, or one associated with a
-        // fixed use fed by a def at this node.
-        // In either case, we must use this register as it's the only candidate
+        // Either:
+        // - there is a fixed reference due to this node, OR
+        // - or there is a fixed use fed by a def at this node, OR
+        // - or we have restricted the set of registers for stress.
+        // In any case, we must use this register as it's the only candidate
         // TODO-CQ: At the time we allocate a register to a fixed-reg def, if it's not going
         // to remain live until the use, we should set the candidates to allRegs(regType)
         // to avoid a spill - codegen can then insert the copy.
         // If this is marked as allocateIfProfitable, the caller will compare the weights
         // of this RefPosition and the RefPosition to which it is currently assigned.
         assert(refPosition->isFixedRegRef ||
-               (refPosition->nextRefPosition != nullptr && refPosition->nextRefPosition->isFixedRegRef));
+               (refPosition->nextRefPosition != nullptr && refPosition->nextRefPosition->isFixedRegRef) ||
+               candidatesAreStressLimited());
         return true;
     }
 

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -630,6 +630,11 @@ private:
         return getLsraRegOptionalControl() == LSRA_REG_OPTIONAL_NO_ALLOC;
     }
 
+    bool candidatesAreStressLimited()
+    {
+        return ((lsraStressMask & (LSRA_LIMIT_MASK | LSRA_SELECT_MASK)) != 0);
+    }
+
     // Dump support
     void lsraDumpIntervals(const char* msg);
     void dumpRefPositions(const char* msg);
@@ -663,6 +668,10 @@ private:
         return true;
     }
     bool getLsraExtendLifeTimes()
+    {
+        return false;
+    }
+    bool candidatesAreStressLimited()
     {
         return false;
     }


### PR DESCRIPTION
With JitStressRegs (various values) it is possible to have RefPositions that have a single candidate, even though they are not really a fixed reference to the given register.

Fix #14624