### PR TITLE
Enable Portable Pdb generation

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -12,9 +12,7 @@
 
   <!-- Set the kind of PDB to Portable and turn on SourceLink (fetching source from GitHub) -->
   <PropertyGroup>
-    <!-- TODO turn on Portable PDB 
     <DebugType Condition="'$(DebugType)' == ''">Portable</DebugType> 
-     -->
     <UseSourceLink>true</UseSourceLink>
   </PropertyGroup>
 


### PR DESCRIPTION
When https://github.com/dotnet/corefx/pull/24025 goes through to change coreFX over to use portable PDBs we want to do the same for System.private.Corelib.pdb in CoreCLR.   This change does this.

This is mostly for uniformity, and the fact that generating portable PDBs for all managed code is our plan going forward.   