### PR TITLE
Revise class hierarchy for some EqualityComparer<T> subclasses

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -19446,11 +19446,17 @@ CORINFO_CLASS_HANDLE Compiler::impGetSpecialIntrinsicExactReturnType(CORINFO_MET
             assert(sig.sigInst.classInstCount == 1);
             CORINFO_CLASS_HANDLE typeHnd = sig.sigInst.classInst[0];
             assert(typeHnd != nullptr);
+
+            // Lookup can incorrect when we have __Canon as it won't appear
+            // to implement any interface types.
+            //
+            // And if we do not have a final type, devirt & inlining is
+            // unlikely to result in much simplification.
+            //
+            // We can use CORINFO_FLG_FINAL to screen out both of these cases.
             const DWORD typeAttribs = info.compCompHnd->getClassAttribs(typeHnd);
             const bool  isFinalType = ((typeAttribs & CORINFO_FLG_FINAL) != 0);
 
-            // If we do not have a final type, devirt & inlining is
-            // unlikely to result in much simplification.
             if (isFinalType)
             {
                 result = info.compCompHnd->getDefaultEqualityComparerClass(typeHnd);

--- a/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
@@ -68,7 +68,7 @@ namespace System.Collections.Generic
     // to Equal bind to IEquatable<T>.Equals(T) instead of Object.Equals(Object)
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
-    internal class GenericEqualityComparer<T> : EqualityComparer<T> where T : IEquatable<T>
+    internal sealed class GenericEqualityComparer<T> : EqualityComparer<T> where T : IEquatable<T>
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override bool Equals(T x, T y)
@@ -274,7 +274,7 @@ namespace System.Collections.Generic
     // randomized string hashing GenericEqualityComparer<string>
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
-    internal class NonRandomizedStringEqualityComparer : GenericEqualityComparer<string>
+    internal sealed class NonRandomizedStringEqualityComparer : EqualityComparer<string>
     {
         private static IEqualityComparer<string> s_nonRandomizedComparer;
 
@@ -288,6 +288,17 @@ namespace System.Collections.Generic
                 }
                 return s_nonRandomizedComparer;
             }
+        }
+
+        public override bool Equals(string x, string y)
+        {
+            if (x != null)
+            {
+                if (y != null) return x.Equals(y);
+                return false;
+            }
+            if (y != null) return false;
+            return true;
         }
 
         public override int GetHashCode(string obj)


### PR DESCRIPTION
Make GenericEqualityComparer<T> a final class and reparent
NonRandomizedStringEqualityComparer.

Also add a note to the jit sources indicating why we can't be more aggressive
about devirtualizing `get_Default` if we have a shared type (in particular
__Canon).