### PR TITLE
[RyuJIT] Rename and Simplify SSE3_4 flag

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -2510,12 +2510,13 @@ void Compiler::compSetProcessor()
     CLANG_FORMAT_COMMENT_ANCHOR;
 
 #ifdef _TARGET_XARCH_
-    opts.compCanUseSSE3_4 = false;
-    if (!jitFlags.IsSet(JitFlags::JIT_FLAG_PREJIT) && jitFlags.IsSet(JitFlags::JIT_FLAG_USE_SSE3_4))
+    opts.compCanUseSSE4 = false;
+    if (!jitFlags.IsSet(JitFlags::JIT_FLAG_PREJIT) && jitFlags.IsSet(JitFlags::JIT_FLAG_USE_SSE41) &&
+        jitFlags.IsSet(JitFlags::JIT_FLAG_USE_SSE42))
     {
         if (JitConfig.EnableSSE3_4() != 0)
         {
-            opts.compCanUseSSE3_4 = true;
+            opts.compCanUseSSE4 = true;
         }
     }
 
@@ -2538,9 +2539,9 @@ void Compiler::compSetProcessor()
             codeGen->getEmitter()->SetContainsAVX(false);
             codeGen->getEmitter()->SetContains256bitAVX(false);
         }
-        else if (opts.compCanUseSSE3_4)
+        else if (opts.compCanUseSSE4)
         {
-            codeGen->getEmitter()->SetUseSSE3_4(true);
+            codeGen->getEmitter()->SetUseSSE4(true);
         }
     }
 #endif // _TARGET_XARCH_

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7364,7 +7364,7 @@ private:
             return SIMD_AVX2_Supported;
         }
 
-        if (CanUseSSE3_4())
+        if (CanUseSSE4())
         {
             return SIMD_SSE4_Supported;
         }
@@ -7851,10 +7851,10 @@ private:
     }
 
     // Whether SSE3, SSE3, SSE4.1 and SSE4.2 is available
-    bool CanUseSSE3_4() const
+    bool CanUseSSE4() const
     {
 #ifdef _TARGET_XARCH_
-        return opts.compCanUseSSE3_4;
+        return opts.compCanUseSSE4;
 #else
         return false;
 #endif
@@ -7983,10 +7983,10 @@ public:
         bool compUseFCOMI;
         bool compUseCMOV;
 #ifdef _TARGET_XARCH_
-        bool compCanUseSSE2;   // Allow CodeGen to use "movq XMM" instructions
-        bool compCanUseSSE3_4; // Allow CodeGen to use SSE3, SSSE3, SSE4.1 and SSE4.2 instructions
-        bool compCanUseAVX;    // Allow CodeGen to use AVX 256-bit vectors for SIMD operations
-#endif                         // _TARGET_XARCH_
+        bool compCanUseSSE2; // Allow CodeGen to use "movq XMM" instructions
+        bool compCanUseSSE4; // Allow CodeGen to use SSE3, SSSE3, SSE4.1 and SSE4.2 instructions
+        bool compCanUseAVX;  // Allow CodeGen to use AVX 256-bit vectors for SIMD operations
+#endif                       // _TARGET_XARCH_
 
 #ifdef _TARGET_XARCH_
         uint64_t compSupportsISA;

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -427,7 +427,7 @@ public:
 #endif // DEBUG
 
 #ifdef _TARGET_XARCH_
-        SetUseSSE3_4(false);
+        SetUseSSE4(false);
         SetUseAVX(false);
 #endif // _TARGET_XARCH_
     }

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -136,10 +136,10 @@ bool emitter::Is4ByteAVXInstruction(instruction ins)
 bool emitter::Is4ByteSSE4Instruction(instruction ins)
 {
 #ifdef LEGACY_BACKEND
-    // On legacy backend SSE3_4 is not enabled.
+    // On legacy backend SSE4 is not enabled.
     return false;
 #else
-    return UseSSE3_4() && IsSSE4Instruction(ins) && EncodedBySSE38orSSE3A(ins);
+    return UseSSE4() && IsSSE4Instruction(ins) && EncodedBySSE38orSSE3A(ins);
 #endif
 }
 
@@ -3813,7 +3813,7 @@ void emitter::emitIns_R_R_I(instruction ins, emitAttr attr, regNumber reg1, regN
         // AVX: 3 byte VEX prefix + 1 byte opcode + 1 byte ModR/M + 1 byte immediate
         // SSE4: 4 byte opcode + 1 byte ModR/M + 1 byte immediate
         // SSE2: 3 byte opcode + 1 byte ModR/M + 1 byte immediate
-        sz = (UseAVX() || UseSSE3_4()) ? 6 : 5;
+        sz = (UseAVX() || UseSSE4()) ? 6 : 5;
     }
 
 #ifdef _TARGET_AMD64_

--- a/src/jit/emitxarch.h
+++ b/src/jit/emitxarch.h
@@ -94,14 +94,14 @@ code_t AddRexXPrefix(instruction ins, code_t code);
 code_t AddRexBPrefix(instruction ins, code_t code);
 code_t AddRexPrefix(instruction ins, code_t code);
 
-bool useSSE3_4Encodings;
-bool UseSSE3_4()
+bool useSSE4Encodings;
+bool UseSSE4()
 {
-    return useSSE3_4Encodings;
+    return useSSE4Encodings;
 }
-void SetUseSSE3_4(bool value)
+void SetUseSSE4(bool value)
 {
-    useSSE3_4Encodings = value;
+    useSSE4Encodings = value;
 }
 bool EncodedBySSE38orSSE3A(instruction ins);
 bool Is4ByteSSE4Instruction(instruction ins);

--- a/src/jit/simd.cpp
+++ b/src/jit/simd.cpp
@@ -1200,7 +1200,7 @@ GenTreePtr Compiler::impSIMDAbs(CORINFO_CLASS_HANDLE typeHnd, var_types baseType
         assert(getSIMDSupportLevel() >= SIMD_SSE4_Supported);
         if (baseType == TYP_LONG)
         {
-            // SSE3_4/AVX2 don't support abs on long type vector.
+            // SSE4/AVX2 don't support abs on long type vector.
             useConditionalSelect = true;
         }
     }
@@ -1410,7 +1410,7 @@ GenTreePtr Compiler::impSIMDMinMax(SIMDIntrinsicID      intrinsicId,
     // For other integer types we compute min/max as follows
     //
     // int32/uint32 (SSE2)
-    // int64/uint64 (SSE2&SSE3_4):
+    // int64/uint64 (SSE2&SSE4):
     //       compResult        = (op1 < op2) in case of Min
     //                           (op1 > op2) in case of Max
     //       Min/Max(op1, op2) = Select(compResult, op1, op2)


### PR DESCRIPTION
- See the background in #14678.
- Remove `SSE3_4` <del>from the VM side</del> and only define it in RyuJIT by `SSE41 && SSE42`. 

Related to #14065