### PR TITLE
[CoreRT] Return CORJIT_OK in case of cross compilation

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -6179,11 +6179,15 @@ _Next:
         compCompileFinish();
 
         // Did we just compile for a target architecture that the VM isn't expecting? If so, the VM
-        // can't used the generated code (and we better be an AltJit!).
-
+        // can't used the generated code (and we better be an AltJit!). Except the case when we
+        // compile for CoreRT (ahead of time cross-compilation).
         if (!info.compMatchedVM)
         {
-            return CORJIT_SKIPPED;
+            if (!IsTargetAbi(CORINFO_CORERT_ABI))
+            {
+                return CORJIT_SKIPPED;
+            }
+            return CORJIT_OK;
         }
 
 #ifdef ALT_JIT


### PR DESCRIPTION
In case of cross compilation on CoreRT we have to return `CORJIT_OK` in `Compiler::compCompileHelper()` to say that compilation was successful.

@jkotas @BruceForstall please take a look. It's also can be fixed in `CorInfoImpl` on CoreRT side but in this case we cannot handle `CORJIT_SKIPPED` propped way.
cc @dotnet/arm32-contrib 