### PR TITLE
Fix gtNewStringLiteralNode

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -6229,6 +6229,12 @@ GenTreePtr Compiler::gtNewStringLiteralNode(InfoAccessType iat, void* pValue)
 
     switch (iat)
     {
+        case IAT_VALUE: // constructStringLiteral in CoreRT case can return IAT_VALUE
+            tree         = gtNewIconEmbHndNode(pValue, nullptr, GTF_ICON_STR_HDL, nullptr);
+            tree->gtType = TYP_REF;
+            tree         = gtNewOperNode(GT_NOP, TYP_REF, tree); // prevents constant folding
+            break;
+
         case IAT_PVALUE: // The value needs to be accessed via an indirection
             // Create an indirection
             tree = gtNewIndOfIconHandleNode(TYP_REF, (size_t)pValue, GTF_ICON_STR_HDL, false);


### PR DESCRIPTION
	- there is IAT_VALUE case from constructStringLiteral(CoreRT)

Signed-off-by: Petr Bred <bredpetr@gmail.com>