### PR TITLE
[Local GC] Fix an issue where the size of ScanContext differs between EE and GC

### DIFF
--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -837,15 +837,21 @@ struct ScanContext
     bool concurrent; //TRUE: concurrent scanning 
 #if CHECK_APP_DOMAIN_LEAKS || defined (FEATURE_APPDOMAIN_RESOURCE_MONITORING) || defined (DACCESS_COMPILE)
     AppDomain *pCurrentDomain;
+#else
+    void* _unused1;
 #endif //CHECK_APP_DOMAIN_LEAKS || FEATURE_APPDOMAIN_RESOURCE_MONITORING || DACCESS_COMPILE
 
 #ifndef FEATURE_REDHAWK
 #if defined(GC_PROFILING) || defined (DACCESS_COMPILE)
     MethodDesc *pMD;
+#else
+    void* _unused2;
 #endif //GC_PROFILING || DACCESS_COMPILE
 #endif // FEATURE_REDHAWK
 #if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
     EtwGCRootKind dwEtwRootKind;
+#else
+    int _unused3;
 #endif // GC_PROFILING || FEATURE_EVENT_TRACE
     
     ScanContext()


### PR DESCRIPTION
If the EE is built with `FEATURE_APPDOMAIN_RESOURCE_MONITORING`, `GC_PROFILING`, or `FEATURE_EVENT_TRACE` and a standalone GC does not, the EE expects the `ScanContext` class to be much larger than it actually is. Since the GC allocates a `ScanContext` on its stack before calling into the EE and handing it a pointer to the `ScanContext`, a size overrun results in corruption of the GC's stack and everything falls apart after that.

This PR provides a stopgap fix before the issue is fully addressed as a part of https://github.com/dotnet/coreclr/issues/11515. With this change, all CoreCLR tests pass with workstation and non-concurrent GC.

cc @sergiy-k @jkotas @Maoni0 (oof) PTAL?