### PR TITLE
Add retry logic for setup of dotnet cli

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -43,6 +43,27 @@ display_error_message()
     cat "$__init_tools_log" 1>&2
 }
 
+# Executes a command and retries if it fails.
+execute_with_retry() {
+    local count=0
+    local retries=${retries:-5}
+    local waitFactor=${waitFactor:-6} 
+    until "$@"; do
+        local exit=$?
+        count=$(( $count + 1 ))
+        if [ $count -lt $retries ]; then
+            local wait=$(( waitFactor ** (( count - 1 )) ))
+            echo "Retry $count/$retries exited $exit, retrying in $wait seconds..."
+            sleep $wait
+        else    
+            say_err "Retry $count/$retries exited $exit, no more retries left."
+            return $exit
+        fi
+    done
+
+    return 0
+}
+
 if [ ! -e $__DOTNET_PATH ]; then
     if [ -z "$__DOTNET_PKG" ]; then
         if [ "$(uname -m | grep "i[3456]86")" = "i686" ]; then
@@ -97,15 +118,20 @@ if [ ! -e $__DOTNET_PATH ]; then
 
     echo "Installing dotnet cli..."
     __DOTNET_LOCATION="https://dotnetcli.azureedge.net/dotnet/Sdk/${__DOTNET_TOOLS_VERSION}/${__DOTNET_PKG}.tar.gz"
-    # curl has HTTPS CA trust-issues less often than wget, so lets try that first.
-    echo "Installing '${__DOTNET_LOCATION}' to '$__DOTNET_PATH/dotnet.tar'" >> $__init_tools_log
-    if command -v curl > /dev/null; then
-        curl --retry 10 -sSL --create-dirs -o $__DOTNET_PATH/dotnet.tar ${__DOTNET_LOCATION}
-    else
-        wget -q -O $__DOTNET_PATH/dotnet.tar ${__DOTNET_LOCATION}
-    fi
-    cd $__DOTNET_PATH
-    tar -xf $__DOTNET_PATH/dotnet.tar
+
+    install_dotnet_cli() {
+        echo "Installing '${__DOTNET_LOCATION}' to '$__DOTNET_PATH/dotnet.tar'" >> "$__init_tools_log"
+        rm -rf -- "$__DOTNET_PATH/*"
+        # curl has HTTPS CA trust-issues less often than wget, so lets try that first.
+        if command -v curl > /dev/null; then
+            curl --retry 10 -sSL --create-dirs -o $__DOTNET_PATH/dotnet.tar ${__DOTNET_LOCATION}
+        else
+            wget -q -O $__DOTNET_PATH/dotnet.tar ${__DOTNET_LOCATION}
+        fi
+        cd $__DOTNET_PATH
+        tar -xf $__DOTNET_PATH/dotnet.tar
+    }
+    execute_with_retry install_dotnet_cli >> "$__init_tools_log" 2>&1
 
     cd $__scriptpath
 fi


### PR DESCRIPTION
Copy init-tools.sh retry logic from corefx.

Fixes dotnet/core-eng#1966