### PR TITLE
Set toolset dir only for ARM64

### DIFF
--- a/buildpipeline/DotNet-CoreClr-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Windows.json
@@ -87,7 +87,7 @@
       },
       "inputs": {
         "filename": "build.cmd",
-        "arguments": "$(Architecture) $(PB_BuildType) skiptests skipbuildpackages $(PB_EnforcePGO) toolset_dir C:\\tools\\clr -OfficialBuildId=$(OfficialBuildId) -Priority=$(Priority) -skiprestore -- /p:SignType=$(PB_SignType) /flp:\"v=diag\"",
+        "arguments": "$(Architecture) $(PB_BuildType) skiptests skipbuildpackages $(PB_EnforcePGO) $(ToolsetArgs) -OfficialBuildId=$(OfficialBuildId) -Priority=$(Priority) -skiprestore -- /p:SignType=$(PB_SignType) /flp:\"v=diag\"",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -279,6 +279,10 @@
     },
     "Architecture": {
       "value": "x64",
+      "allowOverride": true
+    },
+    "ToolsetArgs": {
+      "value": "",
       "allowOverride": true
     },
     "Priority": {

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -80,7 +80,8 @@
         {
           "Name": "DotNet-CoreClr-Trusted-Windows",
           "Parameters": {
-            "Architecture": "arm64"
+            "Architecture": "arm64",
+            "ToolsetArgs": "toolset_dir C:\\tools\\clr"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",


### PR DESCRIPTION
This removes toolset dir from being passed to x64 and arm official builds .

@wtgodbe @jashook @BruceForstall @weshaggard 