### PR TITLE
Use GenericEqualityComparer<string> instead of NonRandomizedStringEqu…

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/Comparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Comparer.cs
@@ -2,15 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// 
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics;
-//using System.Globalization;
 using System.Runtime.CompilerServices;
-using System.Security;
 using System.Runtime.Serialization;
 
 namespace System.Collections.Generic
@@ -50,7 +44,7 @@ namespace System.Collections.Generic
     // means another generic instantiation, which can be costly esp.
     // for value types.
     [Serializable]
-    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     internal sealed class GenericComparer<T> : Comparer<T> where T : IComparable<T>
     {
         public override int Compare(T x, T y)
@@ -65,7 +59,7 @@ namespace System.Collections.Generic
         }
 
         // Equals method for the comparer itself. 
-        public override bool Equals(Object obj) =>
+        public override bool Equals(object obj) =>
             obj != null && GetType() == obj.GetType();
 
         public override int GetHashCode() =>
@@ -73,7 +67,7 @@ namespace System.Collections.Generic
     }
 
     [Serializable]
-    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     internal sealed class NullableComparer<T> : Comparer<T?> where T : struct, IComparable<T>
     {
         public override int Compare(T? x, T? y)
@@ -88,7 +82,7 @@ namespace System.Collections.Generic
         }
 
         // Equals method for the comparer itself. 
-        public override bool Equals(Object obj) =>
+        public override bool Equals(object obj) =>
             obj != null && GetType() == obj.GetType();
 
         public override int GetHashCode() =>
@@ -96,7 +90,7 @@ namespace System.Collections.Generic
     }
 
     [Serializable]
-    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     internal sealed class ObjectComparer<T> : Comparer<T>
     {
         public override int Compare(T x, T y)
@@ -105,7 +99,7 @@ namespace System.Collections.Generic
         }
 
         // Equals method for the comparer itself. 
-        public override bool Equals(Object obj) =>
+        public override bool Equals(object obj) =>
             obj != null && GetType() == obj.GetType();
 
         public override int GetHashCode() =>
@@ -151,7 +145,7 @@ namespace System.Collections.Generic
         }
 
         // Equals method for the comparer itself. 
-        public override bool Equals(Object obj) =>
+        public override bool Equals(object obj) =>
             obj != null && GetType() == obj.GetType();
 
         public override int GetHashCode() =>
@@ -186,7 +180,7 @@ namespace System.Collections.Generic
         }
 
         // Equals method for the comparer itself. 
-        public override bool Equals(Object obj) =>
+        public override bool Equals(object obj) =>
             obj != null && GetType() == obj.GetType();
 
         public override int GetHashCode() =>
@@ -214,7 +208,7 @@ namespace System.Collections.Generic
         }
 
         // Equals method for the comparer itself. 
-        public override bool Equals(Object obj) =>
+        public override bool Equals(object obj) =>
             obj != null && GetType() == obj.GetType();
 
         public override int GetHashCode() =>
@@ -245,7 +239,7 @@ namespace System.Collections.Generic
         }
 
         // Equals method for the comparer itself. 
-        public override bool Equals(Object obj) =>
+        public override bool Equals(object obj) =>
             obj != null && GetType() == obj.GetType();
 
         public override int GetHashCode() =>

--- a/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
@@ -67,7 +67,7 @@ namespace System.Collections.Generic
     // The methods in this class look identical to the inherited methods, but the calls
     // to Equal bind to IEquatable<T>.Equals(T) instead of Object.Equals(Object)
     [Serializable]
-    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     internal sealed class GenericEqualityComparer<T> : EqualityComparer<T> where T : IEquatable<T>
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -127,7 +127,7 @@ namespace System.Collections.Generic
 
         // Equals method for the comparer itself.
         // If in the future this type is made sealed, change the is check to obj != null && GetType() == obj.GetType().
-        public override bool Equals(Object obj) =>
+        public override bool Equals(object obj) =>
             obj is GenericEqualityComparer<T>;
 
         // If in the future this type is made sealed, change typeof(...) to GetType().
@@ -136,7 +136,7 @@ namespace System.Collections.Generic
     }
 
     [Serializable]
-    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     internal sealed class NullableEqualityComparer<T> : EqualityComparer<T?> where T : struct, IEquatable<T>
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -195,7 +195,7 @@ namespace System.Collections.Generic
         }
 
         // Equals method for the comparer itself.
-        public override bool Equals(Object obj) =>
+        public override bool Equals(object obj) =>
             obj != null && GetType() == obj.GetType();
 
         public override int GetHashCode() =>
@@ -203,7 +203,7 @@ namespace System.Collections.Generic
     }
 
     [Serializable]
-    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     internal sealed class ObjectEqualityComparer<T> : EqualityComparer<T>
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -262,7 +262,7 @@ namespace System.Collections.Generic
         }
 
         // Equals method for the comparer itself.
-        public override bool Equals(Object obj) =>
+        public override bool Equals(object obj) =>
             obj != null && GetType() == obj.GetType();
 
         public override int GetHashCode() =>
@@ -272,11 +272,16 @@ namespace System.Collections.Generic
     // We use NonRandomizedStringEqualityComparer as default comparer as it doesnt use the randomized string hashing which 
     // keeps the performance unaffected till we hit collision threshold and then we switch to the comparer which is using 
     // randomized string hashing GenericEqualityComparer<string>
+    // We are keeping serialization support here to support deserialization of .NET Core 2.0 serialization payloads with this type in it.
     [Serializable]
-    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
-    internal sealed class NonRandomizedStringEqualityComparer : EqualityComparer<string>
+    internal sealed class NonRandomizedStringEqualityComparer : EqualityComparer<string>, ISerializable
     {
         private static IEqualityComparer<string> s_nonRandomizedComparer;
+
+        private NonRandomizedStringEqualityComparer() { }
+
+        // This is used by the serialization engine.
+        private NonRandomizedStringEqualityComparer(SerializationInfo information, StreamingContext context) { }
 
         internal static new IEqualityComparer<string> Default
         {
@@ -306,12 +311,18 @@ namespace System.Collections.Generic
             if (obj == null) return 0;
             return obj.GetLegacyNonRandomizedHashCode();
         }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            // We are doing this to stay compatible with .NET Framework.
+            info.SetType(typeof(GenericEqualityComparer<string>));
+        }
     }
 
     // Performance of IndexOf on byte array is very important for some scenarios.
     // We will call the C runtime function memchr, which is optimized.
     [Serializable]
-    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     internal sealed class ByteEqualityComparer : EqualityComparer<byte>
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -354,7 +365,7 @@ namespace System.Collections.Generic
         }
 
         // Equals method for the comparer itself.
-        public override bool Equals(Object obj) =>
+        public override bool Equals(object obj) =>
             obj != null && GetType() == obj.GetType();
 
         public override int GetHashCode() =>
@@ -362,7 +373,7 @@ namespace System.Collections.Generic
     }
 
     [Serializable]
-    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     internal sealed class EnumEqualityComparer<T> : EqualityComparer<T>, ISerializable where T : struct
     {
         internal EnumEqualityComparer() { }
@@ -393,7 +404,7 @@ namespace System.Collections.Generic
         }
 
         // Equals method for the comparer itself.
-        public override bool Equals(Object obj) =>
+        public override bool Equals(object obj) =>
             obj != null && GetType() == obj.GetType();
 
         public override int GetHashCode() =>
@@ -454,7 +465,7 @@ namespace System.Collections.Generic
         }
 
         // Equals method for the comparer itself.
-        public override bool Equals(Object obj) =>
+        public override bool Equals(object obj) =>
             obj != null && GetType() == obj.GetType();
 
         public override int GetHashCode() =>


### PR DESCRIPTION
…alityComparer in serialization

Fixes https://github.com/dotnet/corefx/issues/24938