### PR TITLE
Don't inline GetTaskForResult when await'ing ValueTask

### DIFF
--- a/src/mscorlib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
+++ b/src/mscorlib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
@@ -72,8 +72,9 @@ namespace System.Runtime.CompilerServices
             /// <summary>Gets the task underlying <see cref="_value"/>.</summary>
             internal Task<TResult> AsTask() => _value.AsTask();
 
-            /// <summary>Gets the task underlying <see cref="_value"/>.</summary>
-            (Task, bool) IConfiguredValueTaskAwaiter.GetTask() => (_value.AsTask(), _continueOnCapturedContext);
+            /// <summary>Gets the task underlying the incomplete <see cref="_value"/>.</summary>
+            /// <remarks>This method is used when awaiting and IsCompleted returned false; thus we expect the value task to be wrapping a non-null task.</remarks>
+            (Task, bool) IConfiguredValueTaskAwaiter.GetTask() => (_value.AsTaskExpectNonNull(), _continueOnCapturedContext);
         }
     }
 }

--- a/src/mscorlib/shared/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/mscorlib/shared/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace System.Runtime.CompilerServices
@@ -39,7 +38,8 @@ namespace System.Runtime.CompilerServices
         /// <summary>Gets the task underlying <see cref="_value"/>.</summary>
         internal Task<TResult> AsTask() => _value.AsTask();
 
-        /// <summary>Gets the task underlying <see cref="_value"/>.</summary>
-        Task IValueTaskAwaiter.GetTask() => _value.AsTask();
+        /// <summary>Gets the task underlying the incomplete <see cref="_value"/>.</summary>
+        /// <remarks>This method is used when awaiting and IsCompleted returned false; thus we expect the value task to be wrapping a non-null task.</remarks>
+        Task IValueTaskAwaiter.GetTask() => _value.AsTaskExpectNonNull();
     }
 }

--- a/src/mscorlib/shared/System/Threading/Tasks/ValueTask.cs
+++ b/src/mscorlib/shared/System/Threading/Tasks/ValueTask.cs
@@ -116,6 +116,15 @@ namespace System.Threading.Tasks
             // and the hash code we generate in GetHashCode.
             _task ?? AsyncTaskMethodBuilder<TResult>.GetTaskForResult(_result);
 
+        internal Task<TResult> AsTaskExpectNonNull() =>
+            // Return the task if we were constructed from one, otherwise manufacture one.
+            // Unlike AsTask(), this method is called only when we expect _task to be non-null,
+            // and thus we don't want GetTaskForResult inlined.
+            _task ?? GetTaskForResultNoInlining();
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private Task<TResult> GetTaskForResultNoInlining() => AsyncTaskMethodBuilder<TResult>.GetTaskForResult(_result);
+
         /// <summary>Gets whether the <see cref="ValueTask{TResult}"/> represents a completed operation.</summary>
         public bool IsCompleted => _task == null || _task.IsCompleted;
 


### PR DESCRIPTION
When await'ing a ValueTask, we should only ever end up calling AwaitUnsafeOnCompleted when the ValueTask wraps a non-null _task; if its _task were null, IsCompleted would have returned true due to treating the _result as the successful result.  However, the value task's AsTask() is currently used via an inlined interface invocation in AwaitUnsafeOnCompleted to get the _task from the ValueTask, and AsTask ends up inlining the _task==null branch that inlines AsyncTaskMethodBuilder'1.GetTaskForResult, which ends up bloating the asm unnecessarily.  We can simply change the interface implementation used by AwaitUnsafeOnCompleted to not inline GetTaskForResult.  In a simple example, this cuts the asm for AwaitUnsafeOnCompleted by ~50%.

e.g. for this code:
```C#
using System;
using System.Runtime.CompilerServices;
using System.Threading.Tasks;

class Program
{
    static async Task Main() => await VTMethodAsync();
    static async ValueTask<int> VTMethodAsync() { await Task.Delay(1000); return 42; }
}
```
Before asm for Main's AwaitUnsafeOnCompleted:
```
G_M29712_IG01:
       57                   push     rdi
       56                   push     rsi
       53                   push     rbx
       4883EC40             sub      rsp, 64
       C5F877               vzeroupper
       33C0                 xor      rax, rax
       4889442430           mov      qword ptr [rsp+30H], rax
       488BF2               mov      rsi, rdx

G_M29712_IG02:
       498BD0               mov      rdx, r8
       E83C5BFFFF           call     System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[VoidTaskResult][System.Threading.Tasks.VoidTaskResult]:GetStateMachineBox(byref):ref:this
       488BF8               mov      rdi, rax
       480FBE0E             movsx    rcx, byte  ptr [rsi]

G_M29712_IG03:
       C4E17A6F06           vmovdqu  xmm0, qword ptr [rsi]
       C4E17A7F442430       vmovdqu  qword ptr [rsp+30H], xmm0

G_M29712_IG04:
       488B4C2430           mov      rcx, gword ptr [rsp+30H]
       4885C9               test     rcx, rcx
       7562                 jne      SHORT G_M29712_IG07
       8B742438             mov      esi, dword ptr [rsp+38H]
       8BDE                 mov      ebx, esi
       83FB09               cmp      ebx, 9
       7D38                 jge      SHORT G_M29712_IG05
       83FEFF               cmp      esi, -1
       7C33                 jl       SHORT G_M29712_IG05
       48B928309F03F87F0000 mov      rcx, 0x7FF8039F3028
       BA3B050000           mov      edx, 0x53B
       E81332765F           call     CORINFO_HELP_GETSHARED_NONGCSTATIC_BASE
       48B9782211E8D3010000 mov      rcx, 0x1D3E8112278
       488B09               mov      rcx, gword ptr [rcx]
       8D4301               lea      eax, [rbx+1]
       3B4108               cmp      eax, dword ptr [rcx+8]
       7340                 jae      SHORT G_M29712_IG09
       4863C0               movsxd   rax, eax
       488B5CC110           mov      rbx, gword ptr [rcx+8*rax+16]
       EB1C                 jmp      SHORT G_M29712_IG06

G_M29712_IG05:
       48B950D8E403F87F0000 mov      rcx, 0x7FF803E4D850
       E80530765F           call     CORINFO_HELP_NEWSFAST
       C7403400000001       mov      dword ptr [rax+52], 0x1000000
       897038               mov      dword ptr [rax+56], esi
       488BD8               mov      rbx, rax

G_M29712_IG06:
       488BCB               mov      rcx, rbx

G_M29712_IG07:
       488BD7               mov      rdx, rdi
       41B801000000         mov      r8d, 1
       E867F4FFFF           call     System.Runtime.CompilerServices.TaskAwaiter:UnsafeOnCompletedInternal(ref,ref,bool)
       90                   nop

G_M29712_IG08:
       4883C440             add      rsp, 64
       5B                   pop      rbx
       5E                   pop      rsi
       5F                   pop      rdi
       C3                   ret

G_M29712_IG09:
       E8391F2C5F           call     CORINFO_HELP_RNGCHKFAIL
       CC                   int3
```
After asm for Main's AwaitUnsafeOnCompleted:
```
G_M29707_IG01:
       57                   push     rdi
       56                   push     rsi
       4883EC38             sub      rsp, 56
       C5F877               vzeroupper
       33C0                 xor      rax, rax
       4889442428           mov      qword ptr [rsp+28H], rax
       488BF2               mov      rsi, rdx

G_M29707_IG02:
       498BD0               mov      rdx, r8
       E89D5AFFFF           call     System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[VoidTaskResult][System.Threading.Tasks.VoidTaskResult]:GetStateMachineBox(byref):ref:this
       488BF8               mov      rdi, rax
       480FBE0E             movsx    rcx, byte  ptr [rsi]

G_M29707_IG03:
       C4E17A6F06           vmovdqu  xmm0, qword ptr [rsi]
       C4E17A7F442428       vmovdqu  qword ptr [rsp+28H], xmm0

G_M29707_IG04:
       488B4C2428           mov      rcx, gword ptr [rsp+28H]
       4885C9               test     rcx, rcx
       750D                 jne      SHORT G_M29707_IG05
       488D4C2428           lea      rcx, bword ptr [rsp+28H]
       E83666FFFF           call     System.Threading.Tasks.ValueTask`1[Int32][System.Int32]:GetTaskForResultNoInlining():ref:this
       488BC8               mov      rcx, rax

G_M29707_IG05:
       488BD7               mov      rdx, rdi
       41B801000000         mov      r8d, 1
       E8BDF4FFFF           call     System.Runtime.CompilerServices.TaskAwaiter:UnsafeOnCompletedInternal(ref,ref,bool)
       90                   nop

G_M29707_IG06:
       4883C438             add      rsp, 56
       5E                   pop      rsi
       5F                   pop      rdi
       C3                   ret
```

cc: @AndyAyersMS, @kouvel 