### PR TITLE
Remove intermediate sync for test build

### DIFF
--- a/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
+++ b/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
@@ -41,24 +41,6 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Sync test native binaries",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "sync.cmd",
-        "arguments": "-ab -AzureAccount=$(CloudDropAccountName) -AzureToken=$(CloudDropAccessToken) -Container=$(PB_ContainerName) -RuntimeId=$(Rid) -BlobNamePrefix=$(PB_BlobNamePrefix)$(PB_BuildType)/TestNativeBins/$(Rid) -- /p:DownloadDirectory=$(Build.SourcesDirectory)/packages/TestNativeBins/$(Rid)",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
       "displayName": "Generate version props file",
       "timeoutInMinutes": 0,
       "task": {

--- a/tests/dir.props
+++ b/tests/dir.props
@@ -89,8 +89,8 @@
       https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json;
       $(RestoreSources)
     </RestoreSources>
-    <RestoreSources Condition="'$(OverwriteCoreClrPackageVersion)' == 'true'">
-      $(PackagesDir)AzureTransfer\;
+    <RestoreSources Condition="'$(IntermediateAzureFeed)' != ''">
+      $(IntermediateAzureFeed);
       $(RestoreSources)
     </RestoreSources>
   </PropertyGroup>


### PR DESCRIPTION
This should fix the build break in official test builds.
@jashook @wtgodbe @weshaggard 