### PR TITLE
[Local GC] Fix (another) ScanContext layout issue when building without FEATURE_REDHAWK

### DIFF
--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -841,13 +841,11 @@ struct ScanContext
     void* _unused1;
 #endif //CHECK_APP_DOMAIN_LEAKS || FEATURE_APPDOMAIN_RESOURCE_MONITORING || DACCESS_COMPILE
 
-#ifndef FEATURE_REDHAWK
 #if defined(GC_PROFILING) || defined (DACCESS_COMPILE)
     MethodDesc *pMD;
 #else
     void* _unused2;
 #endif //GC_PROFILING || DACCESS_COMPILE
-#endif // FEATURE_REDHAWK
 #if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
     EtwGCRootKind dwEtwRootKind;
 #else


### PR DESCRIPTION
Fundamentally this is the same issue as https://github.com/dotnet/coreclr/pull/14747 - `FEATURE_REDHAWK` is currently defined for a standalone GC and thus `_unused2` is not included in the `ScanContext`. This presents much differently than the previous issue, though - an out-of-bounds write to a `ScanContext` on the GC's stack this time clobbers the stack slot that MSVC has previously used to save `rdi`, which results in `gc_heap::relocate_phase` trashing `rdi` when it shouldn't. The function that calls `relocate_phase` has allocated the constant 0 for `rdi`, so all uses of the constant 0 (namely, boolean `false`) become not-false in the function that calls `relocate_phase` and false literals magically become true.

The end result is that the GC crashes because it attempted to write a (literal) 0 to a global variable, but 0 (rdi) was *actually* the random value that `gc_heap::relocate_phase` trashed it with. This non-zero global variable (the mark stack TOS) eventually causes us to read garbage memory.

This PR fixes the issue by *actually* fixing the underlying layout problem:

```
0:000> ?? sizeof(clrgc!ScanContext)
unsigned int64 0x38
0:000> ?? sizeof(coreclr!ScanContext)
unsigned int64 0x38
0:000> dt clrgc!ScanContext
   +0x000 thread_under_crawl : Ptr64 Thread
   +0x008 thread_number    : Int4B
   +0x010 stack_limit      : Uint8B
   +0x018 promotion        : Bool
   +0x019 concurrent       : Bool
   +0x020 _unused1         : Ptr64 Void
   +0x028 _unused2         : Ptr64 Void
   +0x030 _unused3         : Int4B
0:000> dt coreclr!ScanContext
   +0x000 thread_under_crawl : Ptr64 Thread
   +0x008 thread_number    : Int4B
   +0x010 stack_limit      : Uint8B
   +0x018 promotion        : Bool
   +0x019 concurrent       : Bool
   +0x020 pCurrentDomain   : Ptr64 AppDomain
   +0x028 pMD              : Ptr64 MethodDesc
   +0x030 dwEtwRootKind    : EtwGCRootKind
```

After this fix, checked and release standalone GCs pass all functional tests. (This doesn't repro on Debug builds).

I think this one took some time off of my life... @sergiy-k PTAL?
