### PR TITLE
SIMD Handle negative indicies in get_Item

### DIFF
--- a/src/jit/simd.cpp
+++ b/src/jit/simd.cpp
@@ -2533,7 +2533,7 @@ GenTreePtr Compiler::impSIMDIntrinsic(OPCODE                opcode,
             op2              = impSIMDPopStack(TYP_INT);
             op1              = impSIMDPopStack(simdType, instMethod);
             int vectorLength = getSIMDVectorLength(size, baseType);
-            if (!op2->IsCnsIntOrI() || op2->AsIntCon()->gtIconVal >= vectorLength)
+            if (!op2->IsCnsIntOrI() || op2->AsIntCon()->gtIconVal >= vectorLength || op2->AsIntCon()->gtIconVal < 0)
             {
                 // We need to bounds-check the length of the vector.
                 // For that purpose, we need to clone the index expression.


### PR DESCRIPTION
@dotnet/jit-contrib Negative const index range check was missing.

Note: `VectorGetIndexerOutOfRange` fails to range check for negative indicies. #14793 

