### PR TITLE
JIT: fix overly aggressive box-unbox.any assert

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -14811,7 +14811,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
                     impResolveToken(codeAddr + (sz + 1), &unboxResolvedToken, CORINFO_TOKENKIND_Class);
 
-                    // See if token types a equal.
+                    // See if the resolved tokens describe types that are equal.
                     const TypeCompareState compare =
                         info.compCompHnd->compareTypesForEquality(unboxResolvedToken.hClass, resolvedToken.hClass);
 
@@ -14822,10 +14822,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         // Skip the next unbox.any instruction
                         sz += sizeof(mdToken) + 1;
                         break;
-                    }
-                    else
-                    {
-                        assert(unboxResolvedToken.hClass != resolvedToken.hClass);
                     }
                 }
 


### PR DESCRIPTION
A recently added assert was trying to ensure that `compareTypesForEqualty`
caught all the box-unbox.any cases we got before by direct handle comparison.
But there are cases where identical handles cannot resolve equality
comparisons, eg when the handles represent shared types like __Canon, and
the assert was not screening for those.

Seems simplest just to remove the assert, it was really only of value when
coding up the new jit interface method.

Closes #14780.