### PR TITLE
Remove invalid assert in CLRLifoSemaphore

### DIFF
--- a/src/vm/synch.cpp
+++ b/src/vm/synch.cpp
@@ -973,7 +973,6 @@ void CLRLifoSemaphore::Release(INT32 releaseCount)
         if (countsBeforeUpdate == counts)
         {
             _ASSERTE((UINT32)releaseCount <= m_maximumSignalCount - counts.signalCount);
-            _ASSERTE(newCounts.countOfWaitersSignaledToWake <= newCounts.waiterCount);
             if (countOfWaitersToWake <= 0)
             {
                 return;


### PR DESCRIPTION
After https://github.com/dotnet/coreclr/pull/14535, the assert is no longer valid. A thread that times out does not decrement the count of waiters signaled to wake because a timed-out thread does not observe a signal to the object that was waited upon. If there were no other waiters to observe the signal, the count of waiters signaled to wake can become greater than the waiter count. This is valid, and tracks how many signals are pending. I don't think there is a good way to update the assert to reflect this, removed the assert.

Fixes https://github.com/dotnet/coreclr/issues/14800

Repro:
```c#
// Change ThreadpoolMgr::WorkerTimeout to 1

        int processorCount = Environment.ProcessorCount;
        {
            int minw, minc, maxw, maxc;
            ThreadPool.GetMinThreads(out minw, out minc);
            ThreadPool.GetMaxThreads(out maxw, out maxc);
            ThreadPool.SetMaxThreads(minw, maxc);
        }

        var t = new Thread(() =>
        {
            while (true)
            {
                var timeoutCallbacksReady = new CountdownEvent(processorCount - 1);
                var quitTimeoutCallback = new ManualResetEvent(false);
                var timeoutCallback = new WaitCallback(state =>
                {
                    timeoutCallbacksReady.Signal();
                    quitTimeoutCallback.WaitOne();
                });
                for (int i = 1; i < processorCount; ++i)
                    ThreadPool.QueueUserWorkItem(timeoutCallback);
                timeoutCallbacksReady.Wait();
                quitTimeoutCallback.Set();
                Thread.Sleep(2);
            }
        });
        t.IsBackground = true;
        t.Start();

        var releaseCallbackComplete = new AutoResetEvent(false);
        var releaseCallback = new WaitCallback(state => releaseCallbackComplete.Set());
        while (true)
        {
            ThreadPool.QueueUserWorkItem(releaseCallback);
            releaseCallbackComplete.WaitOne();
        }
```