### PR TITLE
Allow coredumps inside docker

### DIFF
--- a/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
@@ -440,7 +440,7 @@
       "value": "coreclr-cross-$(Build.BuildId)"
     },
     "DockerCommonRunArgs": {
-      "value": "--name $(DockerContainerName) -v \"$(DockerVolumeName):$(GitHubDirectory)\" -w=\"$(GitHubDirectory)\" $(DockerImageName)"
+      "value": "--name $(DockerContainerName) --ulimit core=-1 -v \"$(DockerVolumeName):$(GitHubDirectory)\" -w=\"$(GitHubDirectory)\" $(DockerImageName)"
     },
     "PB_CleanAgent": {
       "value": "true"

--- a/buildpipeline/DotNet-CoreClr-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Linux.json
@@ -398,7 +398,7 @@
       "value": "coreclr-$(Build.BuildId)"
     },
     "DockerCommonRunArgs": {
-      "value": "--name $(DockerContainerName) -v \"$(DockerVolumeName):$(GitHubDirectory)\" -w=\"$(GitHubDirectory)\" $(DockerImageName)"
+      "value": "--name $(DockerContainerName) --ulimit core=-1 -v \"$(DockerVolumeName):$(GitHubDirectory)\" -w=\"$(GitHubDirectory)\" $(DockerImageName)"
     },
     "DockerCopyDest": {
       "value": "$(Build.BinariesDirectory)/docker_repo"


### PR DESCRIPTION
This is to allow a dumpfile to be generated inside source directory in the event of a seg fault or crash.

@danmosemsft @weshaggard @MichaelSimons @wtgodbe 