### PR TITLE
[Local GC] Unify background GC thread and server GC thread creation

### DIFF
--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -79,7 +79,7 @@ public:
     static void FreeStringConfigValue(const char* key);
     static bool IsGCThread();
     static bool IsGCSpecialThread();
-    static bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const wchar_t* name);
+    static bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -79,7 +79,7 @@ public:
     static void FreeStringConfigValue(const char* key);
     static bool IsGCThread();
     static bool IsGCSpecialThread();
-    static Thread* CreateThread(void (*threadStart)(void*), void* arg);
+    static Thread* CreateThread(void (*threadStart)(void*), void* arg, bool is_special, const wchar_t* name);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -78,8 +78,8 @@ public:
     static bool GetStringConfigValue(const char* key, const char** value);
     static void FreeStringConfigValue(const char* key);
     static bool IsGCThread();
-    static bool IsGCSpecialThread();
-    static bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name);
+    static bool CurrentThreadWasCreatedByGC();
+    static bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const wchar_t* name);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -79,7 +79,7 @@ public:
     static void FreeStringConfigValue(const char* key);
     static bool IsGCThread();
     static bool CurrentThreadWasCreatedByGC();
-    static bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const wchar_t* name);
+    static bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -79,7 +79,7 @@ public:
     static void FreeStringConfigValue(const char* key);
     static bool IsGCThread();
     static bool IsGCSpecialThread();
-    static bool CreateThread(void (*threadStart)(void*), void* arg, bool is_special, bool is_suspendable, const wchar_t* name);
+    static bool CreateThread(void (*threadStart)(void*), void* arg, bool is_special, const wchar_t* name);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -56,9 +56,6 @@ public:
     static bool CatchAtSafePoint(Thread * pThread);
 
     static void GcEnumAllocContexts(enum_alloc_context_func* fn, void* param);
-
-    static Thread* CreateBackgroundThread(GCBackgroundThreadFunction threadStart, void* arg);
-
     // Diagnostics methods.
     static void DiagGCStart(int gen, bool isInduced);
     static void DiagUpdateGenerationBounds();
@@ -82,6 +79,7 @@ public:
     static void FreeStringConfigValue(const char* key);
     static bool IsGCThread();
     static bool IsGCSpecialThread();
+    static Thread* CreateThread(void (*threadStart)(void*), void* arg);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -79,7 +79,7 @@ public:
     static void FreeStringConfigValue(const char* key);
     static bool IsGCThread();
     static bool IsGCSpecialThread();
-    static bool CreateThread(void (*threadStart)(void*), void* arg, bool is_special, const wchar_t* name);
+    static bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const wchar_t* name);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -79,7 +79,7 @@ public:
     static void FreeStringConfigValue(const char* key);
     static bool IsGCThread();
     static bool IsGCSpecialThread();
-    static Thread* CreateThread(void (*threadStart)(void*), void* arg, bool is_special, const wchar_t* name);
+    static bool CreateThread(void (*threadStart)(void*), void* arg, bool is_special, bool is_suspendable, const wchar_t* name);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -78,7 +78,7 @@ public:
     static bool GetStringConfigValue(const char* key, const char** value);
     static void FreeStringConfigValue(const char* key);
     static bool IsGCThread();
-    static bool CurrentThreadWasCreatedByGC();
+    static bool WasCurrentThreadCreatedByGC();
     static bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name);
 };
 

--- a/src/gc/env/gcenv.os.h
+++ b/src/gc/env/gcenv.os.h
@@ -298,6 +298,15 @@ public:
     //  The number of processors
     static uint32_t GetCurrentProcessCpuCount();
 
+    // Sets the calling thread's affinity to only run on the processor specified
+    // in the GCThreadAffinity structure.
+    // Parameters:
+    //  affinity - The requested affinity for the calling thread. At most one processor
+    //             can be provided.
+    // Return:
+    //  true if setting the affinity was successful, false otherwise.
+    static bool SetThreadAffinity(GCThreadAffinity* affinity);
+
     // Get affinity mask of the current process
     // Parameters:
     //  processMask - affinity mask for the specified process

--- a/src/gc/env/gcenv.os.h
+++ b/src/gc/env/gcenv.os.h
@@ -243,15 +243,6 @@ public:
     // Thread and process
     //
 
-    // Create a new thread
-    // Parameters:
-    //  function - the function to be executed by the thread
-    //  param    - parameters of the thread
-    //  affinity - processor affinity of the thread
-    // Return:
-    //  true if it has succeeded, false if it has failed
-    static bool CreateThread(GCThreadFunction function, void* param, GCThreadAffinity* affinity);
-
     // Causes the calling thread to sleep for the specified number of milliseconds
     // Parameters:
     //  sleepMSec   - time to sleep before switching to another thread

--- a/src/gc/env/gcenv.os.h
+++ b/src/gc/env/gcenv.os.h
@@ -307,6 +307,14 @@ public:
     //  true if setting the affinity was successful, false otherwise.
     static bool SetThreadAffinity(GCThreadAffinity* affinity);
 
+    // Boosts the calling thread's thread priority to a level higher than the default
+    // for new threads.
+    // Parameters:
+    //  None.
+    // Return:
+    //  true if the priority boost was successful, false otherwise.
+    static bool BoostThreadPriority();
+
     // Get affinity mask of the current process
     // Parameters:
     //  processMask - affinity mask for the specified process

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -5351,7 +5351,7 @@ void set_thread_affinity_mask_for_heap(int heap_number, GCThreadAffinity* affini
 bool gc_heap::create_gc_thread ()
 {
     dprintf (3, ("Creating gc thread\n"));
-    return GCToEEInterface::CreateThread(gc_thread_stub, this, false, false, L"Server GC");
+    return GCToEEInterface::CreateThread(gc_thread_stub, this, false, L"Server GC");
 }
 
 #ifdef _MSC_VER
@@ -26718,7 +26718,7 @@ BOOL gc_heap::create_bgc_thread(gc_heap* gh)
 
     //dprintf (2, ("Creating BGC thread"));
 
-    gh->bgc_thread_running = GCToEEInterface::CreateThread(gh->bgc_thread_stub, gh, true, true, L"Background GC");
+    gh->bgc_thread_running = GCToEEInterface::CreateThread(gh->bgc_thread_stub, gh, true, L"Background GC");
     return gh->bgc_thread_running;
 }
 

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -24922,6 +24922,8 @@ void gc_heap::gc_thread_stub (void* arg)
         }
     }
 
+    // server GC threads run at a higher priority than normal.
+    GCToOSInterface::BoostThreadPriority();
     _alloca (256*heap->heap_number);
     heap->gc_thread_function();
 }

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -5351,7 +5351,7 @@ void set_thread_affinity_mask_for_heap(int heap_number, GCThreadAffinity* affini
 bool gc_heap::create_gc_thread ()
 {
     dprintf (3, ("Creating gc thread\n"));
-    return GCToEEInterface::CreateThread(gc_thread_stub, this, false, L"Server GC") != nullptr;
+    return GCToEEInterface::CreateThread(gc_thread_stub, this, false, false, L"Server GC");
 }
 
 #ifdef _MSC_VER
@@ -24940,6 +24940,8 @@ void gc_heap::gc_thread_stub (void* arg)
 void gc_heap::bgc_thread_stub (void* arg)
 {
     gc_heap* heap = (gc_heap*)arg;
+    heap->bgc_thread = GCToEEInterface::GetThread();
+    assert(heap->bgc_thread != nullptr);
     heap->bgc_thread_function();
 }
 #ifdef _MSC_VER
@@ -26714,9 +26716,7 @@ BOOL gc_heap::create_bgc_thread(gc_heap* gh)
 
     //dprintf (2, ("Creating BGC thread"));
 
-    gh->bgc_thread = GCToEEInterface::CreateThread(gh->bgc_thread_stub, gh, true, L"Background GC");
-    gh->bgc_thread_running = (gh->bgc_thread != NULL);    
-
+    gh->bgc_thread_running = GCToEEInterface::CreateThread(gh->bgc_thread_stub, gh, true, true, L"Background GC");
     return gh->bgc_thread_running;
 }
 

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -5351,7 +5351,7 @@ void set_thread_affinity_mask_for_heap(int heap_number, GCThreadAffinity* affini
 bool gc_heap::create_gc_thread ()
 {
     dprintf (3, ("Creating gc thread\n"));
-    return GCToEEInterface::CreateThread(gc_thread_stub, this, false, L"Server GC");
+    return GCToEEInterface::CreateThread(gc_thread_stub, this, false, "Server GC");
 }
 
 #ifdef _MSC_VER
@@ -26688,7 +26688,6 @@ BOOL gc_heap::prepare_bgc_thread(gc_heap* gh)
     BOOL success = FALSE;
     BOOL thread_created = FALSE;
     dprintf (2, ("Preparing gc thread"));
-
     gh->bgc_threads_timeout_cs.Enter();
     if (!(gh->bgc_thread_running))
     {
@@ -26718,7 +26717,7 @@ BOOL gc_heap::create_bgc_thread(gc_heap* gh)
 
     //dprintf (2, ("Creating BGC thread"));
 
-    gh->bgc_thread_running = GCToEEInterface::CreateThread(gh->bgc_thread_stub, gh, true, L"Background GC");
+    gh->bgc_thread_running = GCToEEInterface::CreateThread(gh->bgc_thread_stub, gh, true, "Background GC");
     return gh->bgc_thread_running;
 }
 

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -1740,7 +1740,7 @@ static BOOL try_enter_spin_lock(GCSpinLock *pSpinLock)
 inline
 static void leave_spin_lock(GCSpinLock *pSpinLock)
 {
-    bool gc_thread_p = GCToEEInterface::CurrentThreadWasCreatedByGC();
+    bool gc_thread_p = GCToEEInterface::WasCurrentThreadCreatedByGC();
 //    _ASSERTE((pSpinLock->holding_thread == GCToEEInterface::GetThread()) || gc_thread_p || pSpinLock->released_by_gc_p);
     pSpinLock->released_by_gc_p = gc_thread_p;
     pSpinLock->holding_thread = (Thread*) -1;
@@ -34013,7 +34013,7 @@ bool GCHeap::StressHeap(gc_alloc_context * context)
 
 #ifdef BACKGROUND_GC
         // don't trigger a GC from the GC threads but still trigger GCs from user threads.
-        if (GCToEEInterface::CurrentThreadWasCreatedByGC())
+        if (GCToEEInterface::WasCurrentThreadCreatedByGC())
         {
             return FALSE;
         }

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -24932,6 +24932,11 @@ void gc_heap::gc_thread_stub (void* arg)
             set_thread_group_affinity_for_heap(heap->heap_number, &affinity);
         else
             set_thread_affinity_mask_for_heap(heap->heap_number, &affinity);
+
+        if (!GCToOSInterface::SetThreadAffinity(&affinity))
+        {
+            dprintf(1, ("Failed to set thread affinity for server GC thread"));
+        }
     }
 
     _alloca (256*heap->heap_number);

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -1740,7 +1740,7 @@ static BOOL try_enter_spin_lock(GCSpinLock *pSpinLock)
 inline
 static void leave_spin_lock(GCSpinLock *pSpinLock)
 {
-    bool gc_thread_p = GCToEEInterface::IsGCSpecialThread();
+    bool gc_thread_p = GCToEEInterface::CurrentThreadWasCreatedByGC();
 //    _ASSERTE((pSpinLock->holding_thread == GCToEEInterface::GetThread()) || gc_thread_p || pSpinLock->released_by_gc_p);
     pSpinLock->released_by_gc_p = gc_thread_p;
     pSpinLock->holding_thread = (Thread*) -1;
@@ -34013,7 +34013,7 @@ bool GCHeap::StressHeap(gc_alloc_context * context)
 
 #ifdef BACKGROUND_GC
         // don't trigger a GC from the GC threads but still trigger GCs from user threads.
-        if (GCToEEInterface::IsGCSpecialThread())
+        if (GCToEEInterface::CurrentThreadWasCreatedByGC())
         {
             return FALSE;
         }

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -5351,24 +5351,7 @@ void set_thread_affinity_mask_for_heap(int heap_number, GCThreadAffinity* affini
 bool gc_heap::create_gc_thread ()
 {
     dprintf (3, ("Creating gc thread\n"));
-
-    GCThreadAffinity affinity;
-    affinity.Group = GCThreadAffinity::None;
-    affinity.Processor = GCThreadAffinity::None;
-
-    if (!gc_thread_no_affinitize_p)
-    {
-        // We are about to set affinity for GC threads. It is a good place to set up NUMA and
-        // CPU groups because the process mask, processor number, and group number are all
-        // readily available.
-        if (CPUGroupInfo::CanEnableGCCPUGroups()) 
-            set_thread_group_affinity_for_heap(heap_number, &affinity);
-        else
-            set_thread_affinity_mask_for_heap(heap_number, &affinity);
-    }
-
-    //return GCToEEInterface::CreateThread(gc_thread_stub, this, &affinity);
-    return GCToEEInterface::CreateThread(gc_thread_stub, this) != nullptr;
+    return GCToEEInterface::CreateThread(gc_thread_stub, this, false, L"Server GC") != nullptr;
 }
 
 #ifdef _MSC_VER
@@ -26731,7 +26714,7 @@ BOOL gc_heap::create_bgc_thread(gc_heap* gh)
 
     //dprintf (2, ("Creating BGC thread"));
 
-    gh->bgc_thread = GCToEEInterface::CreateThread(gh->bgc_thread_stub, gh);
+    gh->bgc_thread = GCToEEInterface::CreateThread(gh->bgc_thread_stub, gh, true, L"Background GC");
     gh->bgc_thread_running = (gh->bgc_thread != NULL);    
 
     return gh->bgc_thread_running;

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -252,7 +252,7 @@ inline bool GCToEEInterface::IsGCSpecialThread()
     return g_theGCToCLR->IsGCSpecialThread();
 }
 
-inline bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const wchar_t* name)
+inline bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name)
 {
     assert(g_theGCToCLR != nullptr);
     return g_theGCToCLR->CreateThread(threadStart, arg, is_suspendable, name);

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -252,10 +252,10 @@ inline bool GCToEEInterface::IsGCSpecialThread()
     return g_theGCToCLR->IsGCSpecialThread();
 }
 
-inline bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_special, const wchar_t* name)
+inline bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const wchar_t* name)
 {
     assert(g_theGCToCLR != nullptr);
-    return g_theGCToCLR->CreateThread(threadStart, arg, is_special, name);
+    return g_theGCToCLR->CreateThread(threadStart, arg, is_suspendable, name);
 }
 
 

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -252,10 +252,10 @@ inline bool GCToEEInterface::IsGCSpecialThread()
     return g_theGCToCLR->IsGCSpecialThread();
 }
 
-inline bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_special, bool is_suspendable, const wchar_t* name)
+inline bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_special, const wchar_t* name)
 {
     assert(g_theGCToCLR != nullptr);
-    return g_theGCToCLR->CreateThread(threadStart, arg, is_special, is_suspendable, name);
+    return g_theGCToCLR->CreateThread(threadStart, arg, is_special, name);
 }
 
 

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -252,10 +252,10 @@ inline bool GCToEEInterface::IsGCSpecialThread()
     return g_theGCToCLR->IsGCSpecialThread();
 }
 
-inline Thread* GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg)
+inline Thread* GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_special, const wchar_t* name)
 {
     assert(g_theGCToCLR != nullptr);
-    return g_theGCToCLR->CreateThread(threadStart, arg);
+    return g_theGCToCLR->CreateThread(threadStart, arg, is_special, name);
 }
 
 

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -252,10 +252,10 @@ inline bool GCToEEInterface::IsGCSpecialThread()
     return g_theGCToCLR->IsGCSpecialThread();
 }
 
-inline Thread* GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_special, const wchar_t* name)
+inline bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_special, bool is_suspendable, const wchar_t* name)
 {
     assert(g_theGCToCLR != nullptr);
-    return g_theGCToCLR->CreateThread(threadStart, arg, is_special, name);
+    return g_theGCToCLR->CreateThread(threadStart, arg, is_special, is_suspendable, name);
 }
 
 

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -246,10 +246,10 @@ inline bool GCToEEInterface::IsGCThread()
     return g_theGCToCLR->IsGCThread();
 }
 
-inline bool GCToEEInterface::CurrentThreadWasCreatedByGC()
+inline bool GCToEEInterface::WasCurrentThreadCreatedByGC()
 {
     assert(g_theGCToCLR != nullptr);
-    return g_theGCToCLR->CurrentThreadWasCreatedByGC();
+    return g_theGCToCLR->WasCurrentThreadCreatedByGC();
 }
 
 inline bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name)

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -246,10 +246,10 @@ inline bool GCToEEInterface::IsGCThread()
     return g_theGCToCLR->IsGCThread();
 }
 
-inline bool GCToEEInterface::IsGCSpecialThread()
+inline bool GCToEEInterface::CurrentThreadWasCreatedByGC()
 {
     assert(g_theGCToCLR != nullptr);
-    return g_theGCToCLR->IsGCSpecialThread();
+    return g_theGCToCLR->CurrentThreadWasCreatedByGC();
 }
 
 inline bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name)

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -132,12 +132,6 @@ inline void GCToEEInterface::GcEnumAllocContexts(enum_alloc_context_func* fn, vo
     g_theGCToCLR->GcEnumAllocContexts(fn, param);
 }
 
-inline Thread* GCToEEInterface::CreateBackgroundThread(GCBackgroundThreadFunction threadStart, void* arg)
-{
-    assert(g_theGCToCLR != nullptr);
-    return g_theGCToCLR->CreateBackgroundThread(threadStart, arg);
-}
-
 inline void GCToEEInterface::DiagGCStart(int gen, bool isInduced)
 {
     assert(g_theGCToCLR != nullptr);
@@ -257,5 +251,12 @@ inline bool GCToEEInterface::IsGCSpecialThread()
     assert(g_theGCToCLR != nullptr);
     return g_theGCToCLR->IsGCSpecialThread();
 }
+
+inline Thread* GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg)
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->CreateThread(threadStart, arg);
+}
+
 
 #endif // __GCTOENV_EE_STANDALONE_INL__

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -98,9 +98,9 @@ public:
     virtual
     void GcEnumAllocContexts(enum_alloc_context_func* fn, void* param) = 0;
 
-    // Creates and returns a new background thread.
+    // Creates and returns a new thread.
     virtual
-    Thread* CreateBackgroundThread(GCBackgroundThreadFunction threadStart, void* arg) = 0;
+    Thread* CreateThread(void (*threadStart)(void*), void* arg) = 0;
 
     // When a GC starts, gives the diagnostics code a chance to run.
     virtual

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -218,7 +218,7 @@ public:
     // Returns true if the current thread is either a background GC thread
     // or a server GC thread.
     virtual
-    bool CurrentThreadWasCreatedByGC() = 0;
+    bool WasCurrentThreadCreatedByGC() = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -207,16 +207,18 @@ public:
     virtual
     void FreeStringConfigValue(const char* value) = 0;
 
-    // Asks the EE about whether or not the current thread is a GC thread:
-    // a server GC thread, background GC thread, or the thread that suspended
-    // the EE at the start of a GC.
+    // Returns true if this thread is a "GC thread", or a thread capable of
+    // doing GC work. Threads are either /always/ GC threads
+    // (if they were created for this purpose - background GC threads
+    // and server GC threads) or they became GC threads by suspending the EE
+    // and initiating a collection.
     virtual
     bool IsGCThread() = 0;
 
-    // Asks the EE about whether or not the current thread is a GC "special"
-    // thread: a server GC thread or a background GC thread.
+    // Returns true if the current thread is either a background GC thread
+    // or a server GC thread.
     virtual
-    bool IsGCSpecialThread() = 0;
+    bool CurrentThreadWasCreatedByGC() = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -100,7 +100,7 @@ public:
 
     // Creates and returns a new thread.
     virtual
-    bool CreateThread(void (*threadStart)(void*), void* arg, bool is_special, bool is_suspendable, const wchar_t* name) = 0;
+    bool CreateThread(void (*threadStart)(void*), void* arg, bool is_special, const wchar_t* name) = 0;
 
     // When a GC starts, gives the diagnostics code a chance to run.
     virtual

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -100,7 +100,7 @@ public:
 
     // Creates and returns a new thread.
     virtual
-    Thread* CreateThread(void (*threadStart)(void*), void* arg) = 0;
+    Thread* CreateThread(void (*threadStart)(void*), void* arg, bool is_special, const wchar_t* name) = 0;
 
     // When a GC starts, gives the diagnostics code a chance to run.
     virtual

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -100,7 +100,7 @@ public:
 
     // Creates and returns a new thread.
     virtual
-    Thread* CreateThread(void (*threadStart)(void*), void* arg, bool is_special, const wchar_t* name) = 0;
+    bool CreateThread(void (*threadStart)(void*), void* arg, bool is_special, bool is_suspendable, const wchar_t* name) = 0;
 
     // When a GC starts, gives the diagnostics code a chance to run.
     virtual

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -79,6 +79,9 @@ public:
 
     // Gets the Thread instance for the current thread, or null if no thread
     // instance is associated with this thread.
+    //
+    // If the GC created the current thread, GetThread returns null for threads
+    // that were not created as suspendable (see `IGCHeap::CreateThread`).
     virtual
     Thread* GetThread() = 0;
 
@@ -99,8 +102,20 @@ public:
     void GcEnumAllocContexts(enum_alloc_context_func* fn, void* param) = 0;
 
     // Creates and returns a new thread.
+    // Parameters:
+    //  threadStart - The function that will serve as the thread stub for the
+    //                new thread. It will be invoked immediately upon the
+    //                new thread upon creation.
+    //  arg - The argument that will be passed verbatim to threadStart.
+    //  is_suspendable - Whether or not the thread that is created should be suspendable
+    //                   from a runtime perspective. Threads that are suspendable have
+    //                   a VM Thread object associated with them that can be accessed
+    //                   using `IGCHeap::GetThread`.
+    //  name - The name of this thread, optionally used for diagnostic purposes.
+    // Returns:
+    //  true if the thread was started successfully, false if not.
     virtual
-    bool CreateThread(void (*threadStart)(void*), void* arg, bool is_special, const wchar_t* name) = 0;
+    bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const wchar_t* name) = 0;
 
     // When a GC starts, gives the diagnostics code a chance to run.
     virtual

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -115,7 +115,7 @@ public:
     // Returns:
     //  true if the thread was started successfully, false if not.
     virtual
-    bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const wchar_t* name) = 0;
+    bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name) = 0;
 
     // When a GC starts, gives the diagnostics code a chance to run.
     virtual

--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -2671,11 +2671,11 @@ protected:
     PER_HEAP
     void kill_gc_thread();
     PER_HEAP
-    uint32_t bgc_thread_function();
+    void bgc_thread_function();
     PER_HEAP_ISOLATED
     void do_background_gc();
     static
-    uint32_t __stdcall bgc_thread_stub (void* arg);
+    void bgc_thread_stub (void* arg);
 
 #endif //BACKGROUND_GC
  

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -325,7 +325,7 @@ MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
     return g_pFreeObjectMethodTable;
 }
 
-bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_special, const wchar_t* name)
+bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const wchar_t* name)
 {
-    return nullptr;
+    return false;
 }

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -325,7 +325,7 @@ MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
     return g_pFreeObjectMethodTable;
 }
 
-bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const wchar_t* name)
+bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name)
 {
     return false;
 }

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -325,7 +325,7 @@ MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
     return g_pFreeObjectMethodTable;
 }
 
-Thread* GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg)
+Thread* GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_special, const wchar_t* name)
 {
     return nullptr;
 }

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -231,12 +231,6 @@ void GCToEEInterface::SyncBlockCachePromotionsGranted(int /*max_gen*/)
 {
 }
 
-Thread* GCToEEInterface::CreateBackgroundThread(GCBackgroundThreadFunction threadStart, void* arg)
-{
-    // TODO: Implement for background GC
-    return NULL;
-}
-
 void GCToEEInterface::DiagGCStart(int gen, bool isInduced)
 {
 }
@@ -329,4 +323,9 @@ bool GCToEEInterface::IsGCSpecialThread()
 MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
 {
     return g_pFreeObjectMethodTable;
+}
+
+Thread* GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg)
+{
+    return nullptr;
 }

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -315,7 +315,7 @@ bool GCToEEInterface::IsGCThread()
     return false;
 }
 
-bool GCToEEInterface::IsGCSpecialThread()
+bool GCToEEInterface::CurrentThreadWasCreatedByGC()
 {
     return false;
 }

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -325,7 +325,7 @@ MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
     return g_pFreeObjectMethodTable;
 }
 
-bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_special, bool is_suspendable, const wchar_t* name)
+bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_special, const wchar_t* name)
 {
     return nullptr;
 }

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -315,7 +315,7 @@ bool GCToEEInterface::IsGCThread()
     return false;
 }
 
-bool GCToEEInterface::CurrentThreadWasCreatedByGC()
+bool GCToEEInterface::WasCurrentThreadCreatedByGC()
 {
     return false;
 }

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -325,7 +325,7 @@ MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
     return g_pFreeObjectMethodTable;
 }
 
-Thread* GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_special, const wchar_t* name)
+bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_special, bool is_suspendable, const wchar_t* name)
 {
     return nullptr;
 }

--- a/src/gc/unix/gcenv.unix.cpp
+++ b/src/gc/unix/gcenv.unix.cpp
@@ -679,27 +679,6 @@ uint32_t GCToOSInterface::GetLowPrecisionTimeStamp()
     return retval;
 }
 
-// Parameters of the GC thread stub
-struct GCThreadStubParam
-{
-    GCThreadFunction GCThreadFunction;
-    void* GCThreadParam;
-};
-
-// GC thread stub to convert GC thread function to an OS specific thread function
-static void* GCThreadStub(void* param)
-{
-    GCThreadStubParam *stubParam = (GCThreadStubParam*)param;
-    GCThreadFunction function = stubParam->GCThreadFunction;
-    void* threadParam = stubParam->GCThreadParam;
-
-    delete stubParam;
-
-    function(threadParam);
-
-    return NULL;
-}
-
 // Gets the total number of processors on the machine, not taking
 // into account current process affinity.
 // Return:

--- a/src/gc/unix/gcenv.unix.cpp
+++ b/src/gc/unix/gcenv.unix.cpp
@@ -402,8 +402,28 @@ size_t GCToOSInterface::GetLargestOnDieCacheSize(bool trueSize)
     return 0;
 }
 
+// Sets the calling thread's affinity to only run on the processor specified
+// in the GCThreadAffinity structure.
+// Parameters:
+//  affinity - The requested affinity for the calling thread. At most one processor
+//             can be provided.
+// Return:
+//  true if setting the affinity was successful, false otherwise.
 bool GCToOSInterface::SetThreadAffinity(GCThreadAffinity* affinity)
 {
+    // [LOCALGC TODO] Thread affinity for unix
+    return false;
+}
+
+// Boosts the calling thread's thread priority to a level higher than the default
+// for new threads.
+// Parameters:
+//  None.
+// Return:
+//  true if the priority boost was successful, false otherwise.
+bool GCToOSInterface::BoostThreadPriority()
+{
+    // [LOCALGC TODO] Thread priority for unix
     return false;
 }
 

--- a/src/gc/unix/gcenv.unix.cpp
+++ b/src/gc/unix/gcenv.unix.cpp
@@ -402,6 +402,11 @@ size_t GCToOSInterface::GetLargestOnDieCacheSize(bool trueSize)
     return 0;
 }
 
+bool GCToOSInterface::SetThreadAffinity(GCThreadAffinity* affinity)
+{
+    return false;
+}
+
 /*++
 Function:
   GetFullAffinityMask

--- a/src/gc/unix/gcenv.unix.cpp
+++ b/src/gc/unix/gcenv.unix.cpp
@@ -675,47 +675,6 @@ static void* GCThreadStub(void* param)
     return NULL;
 }
 
-// Create a new thread for GC use
-// Parameters:
-//  function - the function to be executed by the thread
-//  param    - parameters of the thread
-//  affinity - processor affinity of the thread
-// Return:
-//  true if it has succeeded, false if it has failed
-bool GCToOSInterface::CreateThread(GCThreadFunction function, void* param, GCThreadAffinity* affinity)
-{
-    std::unique_ptr<GCThreadStubParam> stubParam(new (std::nothrow) GCThreadStubParam());
-    if (!stubParam)
-    {
-        return false;
-    }
-
-    stubParam->GCThreadFunction = function;
-    stubParam->GCThreadParam = param;
-
-    pthread_attr_t attrs;
-
-    int st = pthread_attr_init(&attrs);
-    assert(st == 0);
-
-    // Create the thread as detached, that means not joinable
-    st = pthread_attr_setdetachstate(&attrs, PTHREAD_CREATE_DETACHED);
-    assert(st == 0);
-
-    pthread_t threadId;
-    st = pthread_create(&threadId, &attrs, GCThreadStub, stubParam.get());
-
-    if (st == 0)
-    {
-        stubParam.release();
-    }
-
-    int st2 = pthread_attr_destroy(&attrs);
-    assert(st2 == 0);
-
-    return (st == 0);
-}
-
 // Gets the total number of processors on the machine, not taking
 // into account current process affinity.
 // Return:

--- a/src/gc/windows/gcenv.windows.cpp
+++ b/src/gc/windows/gcenv.windows.cpp
@@ -387,6 +387,11 @@ size_t GCToOSInterface::GetLargestOnDieCacheSize(bool trueSize)
     return 0;
 }
 
+bool GCToOSInterface::SetThreadAffinity(GCThreadAffinity* affinity)
+{
+    return false;
+}
+
 // Get affinity mask of the current process
 // Parameters:
 //  processMask - affinity mask for the specified process

--- a/src/gc/windows/gcenv.windows.cpp
+++ b/src/gc/windows/gcenv.windows.cpp
@@ -387,6 +387,13 @@ size_t GCToOSInterface::GetLargestOnDieCacheSize(bool trueSize)
     return 0;
 }
 
+// Sets the calling thread's affinity to only run on the processor specified
+// in the GCThreadAffinity structure.
+// Parameters:
+//  affinity - The requested affinity for the calling thread. At most one processor
+//             can be provided.
+// Return:
+//  true if setting the affinity was successful, false otherwise.
 bool GCToOSInterface::SetThreadAffinity(GCThreadAffinity* affinity)
 {
     assert(affinity != nullptr);
@@ -409,6 +416,17 @@ bool GCToOSInterface::SetThreadAffinity(GCThreadAffinity* affinity)
 
     // Given affinity must specify at least one processor to use.
     return false;
+}
+
+// Boosts the calling thread's thread priority to a level higher than the default
+// for new threads.
+// Parameters:
+//  None.
+// Return:
+//  true if the priority boost was successful, false otherwise.
+bool GCToOSInterface::BoostThreadPriority()
+{
+    return !!SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST);
 }
 
 // Get affinity mask of the current process

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1285,9 +1285,6 @@ namespace
             return false;
         }
 
-        // the thread starts suspended - kick it off.
-        ResumeThread(args.Thread);
-
         // Wait for the thread to be in its main loop
         uint32_t res = args.ThreadStartedEvent.Wait(INFINITE, FALSE);
         args.ThreadStartedEvent.CloseEvent();

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1291,7 +1291,7 @@ namespace
     }
 } // anonymous namespace
 
-bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_special, bool is_suspendable, const wchar_t* name)
+bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_special, const wchar_t* name)
 {
     LIMITED_METHOD_CONTRACT;
     if (is_special)

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1291,10 +1291,10 @@ namespace
     }
 } // anonymous namespace
 
-bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_special, const wchar_t* name)
+bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const wchar_t* name)
 {
     LIMITED_METHOD_CONTRACT;
-    if (is_special)
+    if (is_suspendable)
     {
         return CreateSuspendableThread(threadStart, arg, name);
     }

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1201,8 +1201,24 @@ namespace
         };
 
         InlineSString<MaxThreadNameSize> wideName;
-        wideName.SetUTF8(name);
-        if (!args.Thread->CreateNewThread(0, threadStub, &args, wideName.GetUnicode()))
+        const WCHAR* namePtr;
+        EX_TRY
+        {
+            if (name != nullptr)
+            {
+                wideName.SetUTF8(name);
+                namePtr = wideName.GetUnicode();
+            }
+        }
+        EX_CATCH
+        {
+            // we're not obligated to provide a name - if it's not valid,
+            // just report nullptr as the name.
+            namePtr = nullptr;
+        }
+        EX_END_CATCH(SwallowAllExceptions)
+
+        if (!args.Thread->CreateNewThread(0, threadStub, &args, namePtr))
         {
             args.Thread->DecExternalCount(FALSE);
             args.ThreadStartedEvent.CloseEvent();

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1114,7 +1114,7 @@ bool GCToEEInterface::IsGCThread()
     return !!::IsGCThread();
 }
 
-bool GCToEEInterface::IsGCSpecialThread()
+bool GCToEEInterface::CurrentThreadWasCreatedByGC()
 {
     return !!::IsGCSpecialThread();
 }

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1243,7 +1243,7 @@ namespace
         return true;
     }
 
-    bool CreateUnsuspendableThread(
+    bool CreateNonSuspendableThread(
         void (*threadStart)(void*),
         void* argument,
         const char* name)
@@ -1304,6 +1304,6 @@ bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool i
     }
     else
     {
-        return CreateUnsuspendableThread(threadStart, arg, name);
+        return CreateNonSuspendableThread(threadStart, arg, name);
     }
 }

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1114,7 +1114,7 @@ bool GCToEEInterface::IsGCThread()
     return !!::IsGCThread();
 }
 
-bool GCToEEInterface::CurrentThreadWasCreatedByGC()
+bool GCToEEInterface::WasCurrentThreadCreatedByGC()
 {
     return !!::IsGCSpecialThread();
 }

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -59,7 +59,7 @@ public:
     void FreeStringConfigValue(const char* value);
     bool IsGCThread();
     bool IsGCSpecialThread();
-	bool CreateThread(void (*threadStart)(void*), void* arg, bool is_special, bool is_suspendable, const wchar_t* name);
+	bool CreateThread(void (*threadStart)(void*), void* arg, bool is_special, const wchar_t* name);
 };
 
 } // namespace standalone

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -36,7 +36,6 @@ public:
     gc_alloc_context * GetAllocContext(Thread * pThread);
     bool CatchAtSafePoint(Thread * pThread);
     void GcEnumAllocContexts(enum_alloc_context_func* fn, void* param);
-    Thread* CreateBackgroundThread(GCBackgroundThreadFunction threadStart, void* arg);
 
     // Diagnostics methods.
     void DiagGCStart(int gen, bool isInduced);
@@ -60,6 +59,7 @@ public:
     void FreeStringConfigValue(const char* value);
     bool IsGCThread();
     bool IsGCSpecialThread();
+	Thread* CreateThread(void (*threadStart)(void*), void* arg);
 };
 
 } // namespace standalone

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -59,7 +59,7 @@ public:
     void FreeStringConfigValue(const char* value);
     bool IsGCThread();
     bool IsGCSpecialThread();
-	Thread* CreateThread(void (*threadStart)(void*), void* arg);
+	Thread* CreateThread(void (*threadStart)(void*), void* arg, bool is_special, const wchar_t* name);
 };
 
 } // namespace standalone

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -59,7 +59,7 @@ public:
     void FreeStringConfigValue(const char* value);
     bool IsGCThread();
     bool IsGCSpecialThread();
-    bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const wchar_t* name);
+    bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name);
 };
 
 } // namespace standalone

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -59,7 +59,7 @@ public:
     void FreeStringConfigValue(const char* value);
     bool IsGCThread();
     bool IsGCSpecialThread();
-	Thread* CreateThread(void (*threadStart)(void*), void* arg, bool is_special, const wchar_t* name);
+	bool CreateThread(void (*threadStart)(void*), void* arg, bool is_special, bool is_suspendable, const wchar_t* name);
 };
 
 } // namespace standalone

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -58,7 +58,7 @@ public:
     bool GetStringConfigValue(const char* key, const char** value);
     void FreeStringConfigValue(const char* value);
     bool IsGCThread();
-    bool CurrentThreadWasCreatedByGC();
+    bool WasCurrentThreadCreatedByGC();
     bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name);
 };
 

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -59,7 +59,7 @@ public:
     void FreeStringConfigValue(const char* value);
     bool IsGCThread();
     bool CurrentThreadWasCreatedByGC();
-    bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const wchar_t* name);
+    bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name);
 };
 
 } // namespace standalone

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -59,7 +59,7 @@ public:
     void FreeStringConfigValue(const char* value);
     bool IsGCThread();
     bool IsGCSpecialThread();
-	bool CreateThread(void (*threadStart)(void*), void* arg, bool is_special, const wchar_t* name);
+    bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const wchar_t* name);
 };
 
 } // namespace standalone

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -58,8 +58,8 @@ public:
     bool GetStringConfigValue(const char* key, const char** value);
     void FreeStringConfigValue(const char* value);
     bool IsGCThread();
-    bool IsGCSpecialThread();
-    bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name);
+    bool CurrentThreadWasCreatedByGC();
+    bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const wchar_t* name);
 };
 
 } // namespace standalone

--- a/src/vm/gcenv.os.cpp
+++ b/src/vm/gcenv.os.cpp
@@ -628,62 +628,6 @@ static DWORD WINAPI GCThreadStub(void* param)
     return 0;
 }
 
-// Create a new thread
-// Parameters:
-//  function - the function to be executed by the thread
-//  param    - parameters of the thread
-//  affinity - processor affinity of the thread
-// Return:
-//  true if it has succeeded, false if it has failed
-bool GCToOSInterface::CreateThread(GCThreadFunction function, void* param, GCThreadAffinity* affinity)
-{
-    LIMITED_METHOD_CONTRACT;
-
-    uint32_t thread_id;
-
-    NewHolder<GCThreadStubParam> stubParam = new (nothrow) GCThreadStubParam();
-    if (stubParam == NULL)
-    {
-        return false;
-    }
-
-    stubParam->GCThreadFunction = function;
-    stubParam->GCThreadParam = param;
-
-    HANDLE gc_thread = Thread::CreateUtilityThread(Thread::StackSize_Medium, GCThreadStub, stubParam, CREATE_SUSPENDED, (DWORD*)&thread_id);
-
-    if (!gc_thread)
-    {
-        return false;
-    }
-
-    stubParam.SuppressRelease();
-
-    SetThreadPriority(gc_thread, /* THREAD_PRIORITY_ABOVE_NORMAL );*/ THREAD_PRIORITY_HIGHEST );
-
-    if (affinity->Group != GCThreadAffinity::None)
-    {
-        _ASSERTE(affinity->Processor != GCThreadAffinity::None);
-        GROUP_AFFINITY ga;
-        ga.Group = (WORD)affinity->Group;
-        ga.Reserved[0] = 0; // reserve must be filled with zero
-        ga.Reserved[1] = 0; // otherwise call may fail
-        ga.Reserved[2] = 0;
-        ga.Mask = (size_t)1 << affinity->Processor;
-
-        CPUGroupInfo::SetThreadGroupAffinity(gc_thread, &ga, NULL);
-    }
-    else if (affinity->Processor != GCThreadAffinity::None)
-    {
-        SetThreadAffinityMask(gc_thread, (DWORD_PTR)1 << affinity->Processor);
-    }
-
-    ResumeThread(gc_thread);
-    CloseHandle(gc_thread);
-
-    return true;
-}
-
 uint32_t GCToOSInterface::GetTotalProcessorCount()
 {
     LIMITED_METHOD_CONTRACT;

--- a/src/vm/gcenv.os.cpp
+++ b/src/vm/gcenv.os.cpp
@@ -329,6 +329,13 @@ size_t GCToOSInterface::GetLargestOnDieCacheSize(bool trueSize)
     return ::GetLargestOnDieCacheSize(trueSize);
 }
 
+// Sets the calling thread's affinity to only run on the processor specified
+// in the GCThreadAffinity structure.
+// Parameters:
+//  affinity - The requested affinity for the calling thread. At most one processor
+//             can be provided.
+// Return:
+//  true if setting the affinity was successful, false otherwise.
 bool GCToOSInterface::SetThreadAffinity(GCThreadAffinity* affinity)
 {
     LIMITED_METHOD_CONTRACT;
@@ -353,6 +360,17 @@ bool GCToOSInterface::SetThreadAffinity(GCThreadAffinity* affinity)
 
     // Given affinity must specify at least one processor to use.
     return false;
+}
+
+// Boosts the calling thread's thread priority to a level higher than the default
+// for new threads.
+// Parameters:
+//  None.
+// Return:
+//  true if the priority boost was successful, false otherwise.
+bool GCToOSInterface::BoostThreadPriority()
+{
+    return !!SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST);
 }
 
 // Get affinity mask of the current process

--- a/src/vm/gcenv.os.cpp
+++ b/src/vm/gcenv.os.cpp
@@ -649,29 +649,6 @@ uint32_t GCToOSInterface::GetLowPrecisionTimeStamp()
     return ::GetTickCount();
 }
 
-// Parameters of the GC thread stub
-struct GCThreadStubParam
-{
-    GCThreadFunction GCThreadFunction;
-    void* GCThreadParam;
-};
-
-// GC thread stub to convert GC thread function to an OS specific thread function
-static DWORD WINAPI GCThreadStub(void* param)
-{
-    WRAPPER_NO_CONTRACT;
-
-    GCThreadStubParam *stubParam = (GCThreadStubParam*)param;
-    GCThreadFunction function = stubParam->GCThreadFunction;
-    void* threadParam = stubParam->GCThreadParam;
-
-    delete stubParam;
-
-    function(threadParam);
-
-    return 0;
-}
-
 uint32_t GCToOSInterface::GetTotalProcessorCount()
 {
     LIMITED_METHOD_CONTRACT;

--- a/src/vm/gcenv.os.cpp
+++ b/src/vm/gcenv.os.cpp
@@ -329,6 +329,32 @@ size_t GCToOSInterface::GetLargestOnDieCacheSize(bool trueSize)
     return ::GetLargestOnDieCacheSize(trueSize);
 }
 
+bool GCToOSInterface::SetThreadAffinity(GCThreadAffinity* affinity)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    assert(affinity != nullptr);
+    if (affinity->Group != GCThreadAffinity::None)
+    {
+        assert(affinity->Processor != GCThreadAffinity::None);
+        
+        GROUP_AFFINITY ga;
+        ga.Group = (WORD)affinity->Group;
+        ga.Reserved[0] = 0; // reserve must be filled with zero
+        ga.Reserved[1] = 0; // otherwise call may fail
+        ga.Reserved[2] = 0;
+        ga.Mask = (size_t)1 << affinity->Processor;
+        return !!SetThreadGroupAffinity(GetCurrentThread(), &ga, nullptr);
+    }
+    else if (affinity->Processor != GCThreadAffinity::None)
+    {
+        return !!SetThreadAffinityMask(GetCurrentThread(), (DWORD_PTR)1 << affinity->Processor);
+    }
+
+    // Given affinity must specify at least one processor to use.
+    return false;
+}
+
 // Get affinity mask of the current process
 // Parameters:
 //  processMask - affinity mask for the specified process


### PR DESCRIPTION
Apologies for the big PR - this ended up being a nontrivial refactoring that resulted in a fair amount of code shuffle.

The big idea behind this PR is to unify the creation of threads in the GC so that they all go through the same code path. The GC creates threads for two reasons:

1. Background GC threads. One thread is created for every heap but they are left unaffinitized and run at the default scheduling priority. They are unique in that they can be suspended and, as such, have a cooperative/preemptive mode; if a foreground GC happens during a background GC, the GC will transition the running BGC thread to preemptive mode and back (blocking the BGC thread until the FGC completes).
2. Server GC threads. One thread is created for every heap and they (by default) are affinitized to a single core. They run at a higher priority than the default and can't be suspended.

Previously, these two threads were created with two different APIs: background GC threads were created with `GCToEEInterface::CreateBackgroundThread` while server GC threads were created with `GCToOSInterface::CreateThread`. This PR unifies them to instead both use `GCToEEInterface::CreateThread`, a new API.

In order to accomodate these two thread types, `GCToEEInterface::CreateThread` has two code paths; one for threads that can be suspended and ones that can't. They are adapted from the existing code in both `GCToEEInterface::CreateBackgroundThread` and `GCToOSInterface::CreateThread`, respectively. Some additional thread setup code that previously lived in `gc.cpp` (e.g. committing the thread stack and setting `ThreadType_GC` on server GC thrads) was also moved to `GCToEEInterface::CreateThread`, where it should be.

Since `GCToEEInterface::CreateThread` doesn't set thread affinity or thread priority, two new `GCToOSInterface` APIs were added to do so: `GCToOSInterface::SetThreadAffinity` and `GCToOSInterface::BoostThreadPriority`. These have been implemented for the non-standalone GC case and in the standalone GC case for Windows platforms:

```
0:014> ~11   <-- server GC thread
  11  Id: 5394.779c Suspend: 1 Teb: 00000057`68673000 Unfrozen
      Start: CoreCLR!<lambda_5c590d503e0569183472d6ea9c775c63>::<lambda_invoker_cdecl> (00007ff9`c5813900)
      Priority: 2  Priority class: 32  Affinity: 40 <-- boosted priority and single proc affinity
0:014> ~0    <-- user thread
   0  Id: 5394.3ae4 Suspend: 1 Teb: 00000057`6865d000 Unfrozen
      Start: CoreRun!wmainCRTStartup (00007ff6`8a6e3aa0)
      Priority: 0  Priority class: 32  Affinity: ff
0:014> ~10  <-- server GC thread
  10  Id: 5394.5d40 Suspend: 1 Teb: 00000057`68671000 Unfrozen
      Start: CoreCLR!<lambda_5c590d503e0569183472d6ea9c775c63>::<lambda_invoker_cdecl> (00007ff9`c5813900)
      Priority: 2  Priority class: 32  Affinity: 20 <-- boosted priority and single proc affinity
```

@jkotas @janvorli @sergiy-k PTAL? also cc @Maoni0 who is OOF