### PR TITLE
Cleanup SSE3_4 in VM

### DIFF
--- a/src/inc/corjit.h
+++ b/src/inc/corjit.h
@@ -109,7 +109,7 @@ public:
 
     #if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
 
-        CORJIT_FLAG_USE_SSE3_4              = 13,
+        CORJIT_FLAG_UNUSED6                 = 13,
         CORJIT_FLAG_USE_AVX                 = 14,
         CORJIT_FLAG_USE_AVX2                = 15,
         CORJIT_FLAG_USE_AVX_512             = 16,
@@ -175,7 +175,6 @@ public:
         CORJIT_FLAG_USE_PCLMULQDQ           = 52,
         CORJIT_FLAG_USE_POPCNT              = 53
         
-
 #else // !defined(_TARGET_X86_) && !defined(_TARGET_AMD64_)
 
         CORJIT_FLAG_UNUSED12                = 43,

--- a/src/jit/jitee.h
+++ b/src/jit/jitee.h
@@ -41,7 +41,7 @@ public:
 
     #if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
 
-        JIT_FLAG_USE_SSE3_4              = 13,
+        JIT_FLAG_UNUSED6                 = 13,
         JIT_FLAG_USE_AVX                 = 14,
         JIT_FLAG_USE_AVX2                = 15,
         JIT_FLAG_USE_AVX_512             = 16,
@@ -203,7 +203,6 @@ public:
 
 #if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
 
-        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_SSE3_4, JIT_FLAG_USE_SSE3_4);
         FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_AVX, JIT_FLAG_USE_AVX);
         FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_AVX2, JIT_FLAG_USE_AVX2);
         FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_AVX_512, JIT_FLAG_USE_AVX_512);

--- a/src/vm/codeman.cpp
+++ b/src/vm/codeman.cpp
@@ -1331,11 +1331,6 @@ void EEJitManager::SetCpuInfo()
         //    SSSE3 - ECX bit 9    (buffer[9]  & 0x02)
         //    SSE4.2 - ECX bit 20  (buffer[10] & 0x10)
         //    POPCNT - ECX bit 23  (buffer[10] & 0x80)
-        // CORJIT_FLAG_USE_SSE3_4 if the following feature bits are set (input EAX of 1)
-        //    SSE3 - ECX bit 0     (buffer[8]  & 0x01)
-        //    SSSE3 - ECX bit 9    (buffer[9]  & 0x02)
-        //    SSE4.1 - ECX bit 19  (buffer[10] & 0x08)
-        //    SSE4.2 - ECX bit 20  (buffer[10] & 0x10)
         // CORJIT_FLAG_USE_AVX if the following feature bits are set (input EAX of 1), and xmmYmmStateSupport returns 1:
         //    OSXSAVE - ECX bit 27 (buffer[11] & 0x08)
         //    AVX - ECX bit 28     (buffer[11] & 0x10)
@@ -1374,12 +1369,6 @@ void EEJitManager::SetCpuInfo()
                         {
                             CPUCompileFlags.Set(CORJIT_FLAGS::CORJIT_FLAG_USE_POPCNT);
                         }
-                    }
-
-                    if (((buffer[10] & 0x08) != 0) &&       // SSE4.1
-                        ((buffer[10] & 0x10) != 0))         // SSE4.2
-                    {
-                        CPUCompileFlags.Set(CORJIT_FLAGS::CORJIT_FLAG_USE_SSE3_4);
                     }
                 }
             }


### PR DESCRIPTION
RyuJIT no longer needs flag `SSE3_4` due to #14730, remove it from vm.