### PR TITLE
Move I{Configured}ValueTaskAwaiter interfaces to correct location

### DIFF
--- a/src/mscorlib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
+++ b/src/mscorlib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
@@ -77,4 +77,12 @@ namespace System.Runtime.CompilerServices
             (Task, bool) IConfiguredValueTaskAwaiter.GetTask() => (_value.AsTaskExpectNonNull(), _continueOnCapturedContext);
         }
     }
+
+    /// <summary>
+    /// Internal interface used to enable extract the Task from arbitrary configured ValueTask awaiters.
+    /// </summary>
+    internal interface IConfiguredValueTaskAwaiter
+    {
+        (Task task, bool continueOnCapturedContext) GetTask();
+    }
 }

--- a/src/mscorlib/shared/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/mscorlib/shared/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -42,4 +42,12 @@ namespace System.Runtime.CompilerServices
         /// <remarks>This method is used when awaiting and IsCompleted returned false; thus we expect the value task to be wrapping a non-null task.</remarks>
         Task IValueTaskAwaiter.GetTask() => _value.AsTaskExpectNonNull();
     }
+
+    /// <summary>
+    /// Internal interface used to enable extract the Task from arbitrary ValueTask awaiters.
+    /// </summary>>
+    internal interface IValueTaskAwaiter
+    {
+        Task GetTask();
+    }
 }

--- a/src/mscorlib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
@@ -391,22 +391,6 @@ namespace System.Runtime.CompilerServices
     /// </summary>
     internal interface IConfiguredTaskAwaiter { }
 
-    /// <summary>
-    /// Internal interface used to enable extract the Task from arbitrary ValueTask awaiters.
-    /// </summary>>
-    internal interface IValueTaskAwaiter
-    {
-        Task GetTask();
-    }
-
-    /// <summary>
-    /// Internal interface used to enable extract the Task from arbitrary configured ValueTask awaiters.
-    /// </summary>
-    internal interface IConfiguredValueTaskAwaiter
-    {
-        (Task task, bool continueOnCapturedContext) GetTask();
-    }
-
     /// <summary>Provides an awaitable object that allows for configured awaits on <see cref="System.Threading.Tasks.Task"/>.</summary>
     /// <remarks>This type is intended for compiler use only.</remarks>
     public struct ConfiguredTaskAwaitable


### PR DESCRIPTION
They need to be in the shared partition.

cc: @jkotas 