### PR TITLE
Do not ask call about GTF_RET flag.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -16882,7 +16882,7 @@ void Compiler::fgMorphBlocks()
                 GenTreePtr last = (block->bbTreeList != nullptr) ? block->bbTreeList->gtPrev : nullptr;
                 GenTreePtr ret  = (last != nullptr) ? last->gtStmt.gtStmtExpr : nullptr;
 
-                if ((ret != nullptr) && ((ret->gtFlags & GTF_RET_MERGED) != 0))
+                if ((ret != nullptr) && (ret->OperGet() == GT_RETURN) && ((ret->gtFlags & GTF_RET_MERGED) != 0))
                 {
                     // This return was generated during epilog merging, so leave it alone
                 }


### PR DESCRIPTION
GTF_RET means that this flag is valid only for GTF_RET node, but this check was missed.
The issue was in collision between GTF_RET_MERGED and GTF_CALL_UNMANAGED.
It would be nice one fine day to rewrite all `gtFlags &` with `isSmthSet` and `assert` that it is called with the right `OperGet`.

The issue example:
```
[000002] ------------              *  STMT      void  (IL 0x000...  ???)
[000001] I-C-G-------              \--*  CALL      void   System.GC.Collect (exactContextHnd=0x080EDF25)
```
The block jump was set to (return) because of `JitTailCallStress` mode, call was inlined:
`[000007] --C-G-------              \--*  CALL unman void   System.GC._Collect` 
and `0x80000000` was set, then we read this value as `GTF_RET_MERGED`.
Fix #14376 .