### PR TITLE
Fixed excessed indirection in protojit for tailcalls

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -4014,7 +4014,10 @@ GenTree* Lowering::LowerVirtualStubCall(GenTreeCall* call)
 
         // fgMorphArgs will have created trees to pass the address in VirtualStubParam.reg.
         // All we have to do here is add an indirection to generate the actual call target.
-        if (call->gtCallAddr->gtOper != GT_IND) { // check if it hasn't been inderected during the morph phase
+
+        // check if it hasn't been inderected during the morph phase
+        if (call->gtCallAddr->gtOper != GT_IND)
+        {
             GenTree* ind = Ind(call->gtCallAddr);
             ind->gtFlags |= GTF_IND_REQ_ADDR_IN_REG;
 

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -4014,13 +4014,14 @@ GenTree* Lowering::LowerVirtualStubCall(GenTreeCall* call)
 
         // fgMorphArgs will have created trees to pass the address in VirtualStubParam.reg.
         // All we have to do here is add an indirection to generate the actual call target.
+        if (call->gtCallAddr->gtOper != GT_IND) { // check if it hasn't been inderected during the morph phase
+            GenTree* ind = Ind(call->gtCallAddr);
+            ind->gtFlags |= GTF_IND_REQ_ADDR_IN_REG;
 
-        GenTree* ind = Ind(call->gtCallAddr);
-        ind->gtFlags |= GTF_IND_REQ_ADDR_IN_REG;
-
-        BlockRange().InsertAfter(call->gtCallAddr, ind);
-        ContainCheckIndir(ind->AsIndir());
-        call->gtCallAddr = ind;
+            BlockRange().InsertAfter(call->gtCallAddr, ind);
+            ContainCheckIndir(ind->AsIndir());
+            call->gtCallAddr = ind;
+        }
     }
     else
     {


### PR DESCRIPTION
Issue #13213 in case of protojit
If we have indirected `callvirt` tailcall, we might get into the situation when additional `load` is made.
```
...
000094  4798           blx     r3               // CORINFO_HELP_RUNTIMEHANDLE_METHOD
000096  4604           mov     r4, r0
...
0000B6  6821           ldr     r1, [r4]
0000B8  6809           ldr     r1, [r1] <=== excessed inderection
0000BA  F647 3EE1      movw    lr, 0x7be1
0000BE  F2C6 3E98      movt    lr, 0x6398
0000C2  47F0           blx     lr               // CORINFO_HELP_TAILCALL
```
`CORINFO_HELP_TAILCALL` helper takes invocation address as its 2nd argument. 
`CORINFO_HELP_RUNTIMEHANDLE_METHOD` returns `CORINFO_GENERIC_HANDLE`  which points to actual address, but indirecting 2 times we getting instruction code instead of address of the code.

The correct assembly has to be
```
...
000094  4798           blx     r3               // CORINFO_HELP_RUNTIMEHANDLE_METHOD
000096  4604           mov     r4, r0
...
0000B6  6825           ldr     r5, [r4]
0000B8  4629           mov     r1, r5
0000BA  F647 34E1      movw    r4, 0x7be1
0000BE  F2C6 645A      movt    r4, 0x665a
0000C2  47A0           blx     r4               // CORINFO_HELP_TAILCALL
```