### PR TITLE
Fix perf-prep for throughput

### DIFF
--- a/tests/scripts/perf-prep.sh
+++ b/tests/scripts/perf-prep.sh
@@ -68,7 +68,7 @@ python3.5 ./tests/scripts/Microsoft.BenchView.JSONFormat/tools/machinedata.py
 
 if [ $throughput -eq 1 ]; then
     # Download throughput benchmarks
-    if [ -d "Microsoft.Benchview.ThroughputBenchmarks.x64.Windows_NT" ]; then
+    if [ ! -d "Microsoft.Benchview.ThroughputBenchmarks.x64.Windows_NT" ]; then
         mkdir Microsoft.Benchview.ThroughputBenchmarks.x64.Windows_NT
         cd Microsoft.Benchview.ThroughputBenchmarks.x64.Windows_NT
 


### PR DESCRIPTION
There is a missing ! before checking to see if the throughput benchmarks
have already been downloaded. Currently, we download them if they
already exist, where we want to download them if they don't already
exist. This change fixes that.