### PR TITLE
Shorten delay in some monitor tests to avoid timeout

### DIFF
--- a/tests/src/baseservices/threading/generics/Monitor/MonitorHelper.cs
+++ b/tests/src/baseservices/threading/generics/Monitor/MonitorHelper.cs
@@ -12,6 +12,7 @@ class TestHelper
 	private int m_iRequestedEntries;
 	public ManualResetEvent m_Event;
 	public bool m_bError;
+    private Random m_rng = new Random(0);
 
 	public bool Error
 	{		
@@ -42,12 +43,12 @@ class TestHelper
 	public void DoWork()
 	{
 		int snapshot = m_iSharedData;
-		Thread.Sleep(5);
+        Delayer.Delay(Delayer.RandomShortDelay(m_rng));
 #if (DEBUG)
 		Console.WriteLine("Entering Monitor: " + m_iSharedData);
 #endif
 		m_iSharedData++;
-		Thread.Sleep(1);
+        Delayer.Delay(Delayer.RandomShortDelay(m_rng));
 		if(m_iSharedData != snapshot + 1)
 		{
 			Error = true;
@@ -86,4 +87,26 @@ class TestHelper
 			Monitor.Exit(monitor);
 		}
 	}
+
+    private static class Delayer
+    {
+        private static uint[] s_delayValues = new uint[32];
+
+        public static uint RandomShortDelay(Random rng) => (uint)rng.Next(4, 10);
+        public static uint RandomMediumDelay(Random rng) => (uint)rng.Next(10, 15);
+        public static uint RandomLongDelay(Random rng) => (uint)rng.Next(15, 20);
+
+        public static void Delay(uint n)
+        {
+            Thread.Sleep(0);
+            s_delayValues[16] += Fib(n);
+        }
+
+        private static uint Fib(uint n)
+        {
+            if (n <= 1)
+                return n;
+            return Fib(n - 2) + Fib(n - 1);
+        }
+    }
 }

--- a/tests/src/baseservices/threading/generics/Monitor/MonitorHelper.cs
+++ b/tests/src/baseservices/threading/generics/Monitor/MonitorHelper.cs
@@ -3,90 +3,91 @@
 // See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
+
 delegate void MonitorDelegate(object monitor);
 delegate void MonitorDelegateTS(object monitor,int timeout);
-	
+
 class TestHelper
 {
-	private int m_iSharedData;
-	private int m_iRequestedEntries;
-	public ManualResetEvent m_Event;
-	public bool m_bError;
+    private int m_iSharedData;
+    private int m_iRequestedEntries;
+    public ManualResetEvent m_Event;
+    public bool m_bError;
     private Random m_rng = new Random(0);
 
-	public bool Error
-	{		
-		set
-		{
-			lock(typeof(TestHelper))
-			{
-				m_bError = value;
-			}
-		}
-		get
-		{
-			lock(typeof(TestHelper))
-			{
-				return m_bError;
-			}
-		}
-	}
+    public bool Error
+    {        
+        set
+        {
+            lock(typeof(TestHelper))
+            {
+                m_bError = value;
+            }
+        }
+        get
+        {
+            lock(typeof(TestHelper))
+            {
+                return m_bError;
+            }
+        }
+    }
 
-	public TestHelper(int num)
-	{
-		m_Event = new ManualResetEvent(false);
-		m_iSharedData = 0;
-		m_iRequestedEntries = num;
-		m_bError = false;
-	}
-	
-	public void DoWork()
-	{
-		int snapshot = m_iSharedData;
+    public TestHelper(int num)
+    {
+        m_Event = new ManualResetEvent(false);
+        m_iSharedData = 0;
+        m_iRequestedEntries = num;
+        m_bError = false;
+    }
+    
+    public void DoWork()
+    {
+        int snapshot = m_iSharedData;
         Delayer.Delay(Delayer.RandomShortDelay(m_rng));
 #if (DEBUG)
-		Console.WriteLine("Entering Monitor: " + m_iSharedData);
+        Console.WriteLine("Entering Monitor: " + m_iSharedData);
 #endif
-		m_iSharedData++;
+        m_iSharedData++;
         Delayer.Delay(Delayer.RandomShortDelay(m_rng));
-		if(m_iSharedData != snapshot + 1)
-		{
-			Error = true;
-			Console.WriteLine("Failure!!!");
-		}
+        if(m_iSharedData != snapshot + 1)
+        {
+            Error = true;
+            Console.WriteLine("Failure!!!");
+        }
 #if (DEBUG)
-		Console.WriteLine("Leaving Monitor: " + m_iSharedData);        
+        Console.WriteLine("Leaving Monitor: " + m_iSharedData);        
 #endif
-		if(m_iSharedData == m_iRequestedEntries)
-			m_Event.Set();
-	}	
-	public void Consumer(object monitor)
-	{
-		lock(monitor)
-		{
-			DoWork();
-		}	
-	}
-	public void ConsumerTryEnter(object monitor,int timeout)
-	{
-		try
-		{
-			bool tookLock = false;
-			
-			Monitor.TryEnter(monitor,timeout, ref tookLock);
+        if(m_iSharedData == m_iRequestedEntries)
+            m_Event.Set();
+    }    
+    public void Consumer(object monitor)
+    {
+        lock(monitor)
+        {
+            DoWork();
+        }    
+    }
+    public void ConsumerTryEnter(object monitor,int timeout)
+    {
+        try
+        {
+            bool tookLock = false;
+            
+            Monitor.TryEnter(monitor,timeout, ref tookLock);
 
-			while(!tookLock) {				
-				Thread.Sleep(0);
-				Monitor.TryEnter(monitor,timeout, ref tookLock);
-			}
+            while(!tookLock) {                
+                Thread.Sleep(0);
+                Monitor.TryEnter(monitor,timeout, ref tookLock);
+            }
 
-			DoWork();
-		}
-		finally
-		{
-			Monitor.Exit(monitor);
-		}
-	}
+            DoWork();
+        }
+        finally
+        {
+            Monitor.Exit(monitor);
+        }
+    }
 
     private static class Delayer
     {


### PR DESCRIPTION
Each test takes a minimum of 3 seconds and in EnterExit14, there are 72 tests adding to 3.6 minutes. The default timeout is 10 minutes but in debug build it's a bit slower and there is a bunch of logging output that slows it down even more and may time out. This is way to long for the test anyway. Replaced Sleep(1+) in the test with a Sleep(0) and a short CPU-bound delay. The test finishes within a few seconds now in debug build.