### PR TITLE
[Arm64] SIMD applyCalleeSaveHeuristics

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -721,9 +721,9 @@ void LinearScan::applyCalleeSaveHeuristics(RefPosition* rp)
     Interval* theInterval = rp->getInterval();
 
 #ifdef DEBUG
-    regMaskTP calleeSaveMask = calleeSaveRegs(getRegisterType(theInterval, rp));
     if (doReverseCallerCallee())
     {
+        regMaskTP calleeSaveMask = calleeSaveRegs(theInterval->registerType);
         rp->registerAssignment =
             getConstrainedRegMask(rp->registerAssignment, calleeSaveMask, rp->minRegCandidateCount);
     }


### PR DESCRIPTION
`getRegisterType()` was incorrectly being called here.  Per the `getRegisterType()` function comment this should only be called when the register is about to be consumed.  In this case the register is not necessarily being consumed.  In the case of incoming arguments it is being produced.

For ARM64 with SIMD, this caused an assert because the assign register was a Integer register due to ABI constraints (SIMD args are passed in integer registers, while the SIMD reg uses float during computation.

This seems to me like the correct fix.

@dotnet/jit-contrib @dotnet/arm64-contrib 