### PR TITLE
HashCode based on xxHash32

### DIFF
--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -221,3 +221,31 @@ License notice for the Printing Floating-Point Numbers
   3. This notice may not be removed or altered from any source
      distribution.
 ******************************************************************************/
+
+License notice for xxHash
+-------------------------
+
+xxHash Library
+Copyright (c) 2012-2014, Yann Collet
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -3691,4 +3691,7 @@
   <data name="Memory_OutstandingReferences" xml:space="preserve">
     <value>Release all references before disposing this instance.</value>
   </data>
+  <data name="HashCode_EqualityNotSupported" xml:space="preserve">
+    <value>HashCode is a mutable struct and should not be compared with other HashCodes.</value>
+  </data>
 </root>

--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -3691,7 +3691,10 @@
   <data name="Memory_OutstandingReferences" xml:space="preserve">
     <value>Release all references before disposing this instance.</value>
   </data>
-  <data name="HashCode_EqualityNotSupported" xml:space="preserve">
+  <data name="HashCode_HashCodeNotSupported" xml:space="preserve">
     <value>HashCode is a mutable struct and should not be compared with other HashCodes. Use ToHashCode to retrieve the computed hash code.</value>
+  </data>
+  <data name="HashCode_EqualityNotSupported" xml:space="preserve">
+    <value>HashCode is a mutable struct and should not be compared with other HashCodes.</value>
   </data>
 </root>

--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -3692,6 +3692,6 @@
     <value>Release all references before disposing this instance.</value>
   </data>
   <data name="HashCode_EqualityNotSupported" xml:space="preserve">
-    <value>HashCode is a mutable struct and should not be compared with other HashCodes.</value>
+    <value>HashCode is a mutable struct and should not be compared with other HashCodes. Use ToHashCode to retrieve the computed hash code.</value>
   </data>
 </root>

--- a/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
@@ -159,6 +159,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\UmAlQuraCalendar.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\UnicodeCategory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Guid.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\HashCode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\HResults.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IAsyncResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\ICloneable.cs" />

--- a/src/mscorlib/shared/System/HashCode.cs
+++ b/src/mscorlib/shared/System/HashCode.cs
@@ -312,7 +312,7 @@ namespace System
         {
             if (comparer is null)
             {
-                Add(value);
+                Add(value?.GetHashCode() ?? 0);
             }
             else
             {
@@ -320,7 +320,6 @@ namespace System
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void Add(int value)
         {
             // The original xxHash works as follows:

--- a/src/mscorlib/shared/System/HashCode.cs
+++ b/src/mscorlib/shared/System/HashCode.cs
@@ -1,0 +1,435 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+/*
+
+The xxHash32 implementation is based on the code published by Yann Collet:
+https://raw.githubusercontent.com/Cyan4973/xxHash/5c174cfa4e45a42f94082dc0d4539b39696afea1/xxhash.c
+
+  xxHash - Fast Hash algorithm
+  Copyright (C) 2012-2016, Yann Collet
+  
+  BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+  
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+  
+  * Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the following disclaimer
+  in the documentation and/or other materials provided with the
+  distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  
+  You can contact the author at :
+  - xxHash homepage: http://www.xxhash.com
+  - xxHash source repository : https://github.com/Cyan4973/xxHash
+
+*/
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace System
+{
+    // xxHash32 is used for the hash code.
+    // https://github.com/Cyan4973/xxHash
+
+    public struct HashCode
+    {
+        private static readonly uint s_seed = GenerateGlobalSeed();
+
+        private const uint Prime1 = 2654435761U;
+        private const uint Prime2 = 2246822519U;
+        private const uint Prime3 = 3266489917U;
+        private const uint Prime4 = 668265263U;
+        private const uint Prime5 = 374761393U;
+
+        private uint _v1, _v2, _v3, _v4;
+        private uint _queue1, _queue2, _queue3;
+        private uint _length;
+
+        private static unsafe uint GenerateGlobalSeed()
+        {
+            uint result;
+            Interop.GetRandomBytes((byte*)&result, sizeof(int));
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Combine<T1>(T1 value1)
+        {
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+
+            uint hash = MixEmptyState();
+            hash += 4;
+
+            hash = QueueRound(hash, hc1);
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Combine<T1, T2>(T1 value1, T2 value2)
+        {
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+            var hc2 = (uint)(value2?.GetHashCode() ?? 0);
+
+            uint hash = MixEmptyState();
+            hash += 8;
+
+            hash = QueueRound(hash, hc1);
+            hash = QueueRound(hash, hc2);
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Combine<T1, T2, T3>(T1 value1, T2 value2, T3 value3)
+        {
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+            var hc2 = (uint)(value2?.GetHashCode() ?? 0);
+            var hc3 = (uint)(value3?.GetHashCode() ?? 0);
+
+            uint hash = MixEmptyState();
+            hash += 12;
+
+            hash = QueueRound(hash, hc1);
+            hash = QueueRound(hash, hc2);
+            hash = QueueRound(hash, hc3);
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Combine<T1, T2, T3, T4>(T1 value1, T2 value2, T3 value3, T4 value4)
+        {
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+            var hc2 = (uint)(value2?.GetHashCode() ?? 0);
+            var hc3 = (uint)(value3?.GetHashCode() ?? 0);
+            var hc4 = (uint)(value4?.GetHashCode() ?? 0);
+
+            Initialize(out uint v1, out uint v2, out uint v3, out uint v4);
+
+            v1 = Round(v1, hc1);
+            v2 = Round(v2, hc2);
+            v3 = Round(v3, hc3);
+            v4 = Round(v4, hc4);
+
+            uint hash = MixState(v1, v2, v3, v4);
+            hash += 16;
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Combine<T1, T2, T3, T4, T5>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5)
+        {
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+            var hc2 = (uint)(value2?.GetHashCode() ?? 0);
+            var hc3 = (uint)(value3?.GetHashCode() ?? 0);
+            var hc4 = (uint)(value4?.GetHashCode() ?? 0);
+            var hc5 = (uint)(value5?.GetHashCode() ?? 0);
+
+            Initialize(out uint v1, out uint v2, out uint v3, out uint v4);
+
+            v1 = Round(v1, hc1);
+            v2 = Round(v2, hc2);
+            v3 = Round(v3, hc3);
+            v4 = Round(v4, hc4);
+
+            uint hash = MixState(v1, v2, v3, v4);
+            hash += 20;
+
+            hash = QueueRound(hash, hc5);
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Combine<T1, T2, T3, T4, T5, T6>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6)
+        {
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+            var hc2 = (uint)(value2?.GetHashCode() ?? 0);
+            var hc3 = (uint)(value3?.GetHashCode() ?? 0);
+            var hc4 = (uint)(value4?.GetHashCode() ?? 0);
+            var hc5 = (uint)(value5?.GetHashCode() ?? 0);
+            var hc6 = (uint)(value6?.GetHashCode() ?? 0);
+
+            Initialize(out uint v1, out uint v2, out uint v3, out uint v4);
+
+            v1 = Round(v1, hc1);
+            v2 = Round(v2, hc2);
+            v3 = Round(v3, hc3);
+            v4 = Round(v4, hc4);
+
+            uint hash = MixState(v1, v2, v3, v4);
+            hash += 24;
+
+            hash = QueueRound(hash, hc5);
+            hash = QueueRound(hash, hc6);
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Combine<T1, T2, T3, T4, T5, T6, T7>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7)
+        {
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+            var hc2 = (uint)(value2?.GetHashCode() ?? 0);
+            var hc3 = (uint)(value3?.GetHashCode() ?? 0);
+            var hc4 = (uint)(value4?.GetHashCode() ?? 0);
+            var hc5 = (uint)(value5?.GetHashCode() ?? 0);
+            var hc6 = (uint)(value6?.GetHashCode() ?? 0);
+            var hc7 = (uint)(value7?.GetHashCode() ?? 0);
+
+            Initialize(out uint v1, out uint v2, out uint v3, out uint v4);
+
+            v1 = Round(v1, hc1);
+            v2 = Round(v2, hc2);
+            v3 = Round(v3, hc3);
+            v4 = Round(v4, hc4);
+
+            uint hash = MixState(v1, v2, v3, v4);
+            hash += 28;
+
+            hash = QueueRound(hash, hc5);
+            hash = QueueRound(hash, hc6);
+            hash = QueueRound(hash, hc7);
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Combine<T1, T2, T3, T4, T5, T6, T7, T8>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8)
+        {
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+            var hc2 = (uint)(value2?.GetHashCode() ?? 0);
+            var hc3 = (uint)(value3?.GetHashCode() ?? 0);
+            var hc4 = (uint)(value4?.GetHashCode() ?? 0);
+            var hc5 = (uint)(value5?.GetHashCode() ?? 0);
+            var hc6 = (uint)(value6?.GetHashCode() ?? 0);
+            var hc7 = (uint)(value7?.GetHashCode() ?? 0);
+            var hc8 = (uint)(value8?.GetHashCode() ?? 0);
+
+            Initialize(out uint v1, out uint v2, out uint v3, out uint v4);
+
+            v1 = Round(v1, hc1);
+            v2 = Round(v2, hc2);
+            v3 = Round(v3, hc3);
+            v4 = Round(v4, hc4);
+
+            v1 = Round(v1, hc5);
+            v2 = Round(v2, hc6);
+            v3 = Round(v3, hc7);
+            v4 = Round(v4, hc8);
+
+            uint hash = MixState(v1, v2, v3, v4);
+            hash += 32;
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint Rol(uint value, int count)
+            => (value << count) | (value >> (32 - count));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Initialize(out uint v1, out uint v2, out uint v3, out uint v4)
+        {
+            v1 = s_seed + Prime1 + Prime2;
+            v2 = s_seed + Prime2;
+            v3 = s_seed + 0;
+            v4 = s_seed - Prime1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint Round(uint hash, uint input)
+        {
+            hash += input * Prime2;
+            hash = Rol(hash, 13);
+            hash *= Prime1;
+            return hash;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint QueueRound(uint hash, uint queuedValue)
+        {
+            hash += queuedValue * Prime3;
+            return Rol(hash, 17) * Prime4;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint MixState(uint v1, uint v2, uint v3, uint v4)
+        {
+            return Rol(v1, 1) + Rol(v2, 7) + Rol(v3, 12) + Rol(v4, 18);
+        }
+
+        private static uint MixEmptyState()
+        {
+            return s_seed + Prime5;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint MixFinal(uint hash)
+        {
+            hash ^= hash >> 15;
+            hash *= Prime2;
+            hash ^= hash >> 13;
+            hash *= Prime3;
+            hash ^= hash >> 16;
+            return hash;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Add<T>(T value)
+        {
+            Add(value?.GetHashCode() ?? 0);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Add<T>(T value, IEqualityComparer<T> comparer)
+        {
+            if (comparer is null)
+                comparer = EqualityComparer<T>.Default;
+            Add(comparer.GetHashCode(value));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void Add(int value)
+        {
+            // Note that x & 0x3 is like mod 3, but faster.
+
+            var val = (uint)value;
+            uint position = _length & 0x3;
+
+            // xxHash works as follows:
+            // 0. Initialize immediately. We can't do this in a struct (no default
+            //    ctor).
+            // 1. Accumulate blocks of length 16 (4 uints) into 4 accumulators.
+            // 2. Accumulate remaining blocks of length 4 (1 uint) into the hash.
+            // 3. Accumulate remaining blocks of length 1 into the hash.
+
+            // There is no need for *3 as this type only accepts ints. _queue1,
+            // _queue2 and _queue3 are basically a buffer so that when ToHashCode is
+            // called we can execute *2 correctly. That's what first three case
+            // statements do.
+
+            // We need to initialize the xxHash32 state (_v1 -> _v4) lazily (see *0)
+            // and the last place that can be done if you look at the original code
+            // is just before the first block of 16 bytes is mixed in. The xxHash32
+            // state is never used for streams containing fewer than 16 bytes.
+
+            // A bloom filter is used to determine whether the default case statement
+            // has even been executed. To do that we check if the length is smaller
+            // than 4 (_length ^ position will be non-zero if this is the case). The
+            // case statement is for values larger than 2, so the check only succeeds
+            // on exactly 3.
+
+            // To see what's really going on here, have a look at the Combine methods.
+
+            // Switch can't be inlined.
+
+            if (position == 0)
+                _queue1 = val;
+            else if (position == 1)
+                _queue2 = val;
+            else if (position == 2)
+                _queue3 = val;
+            else // == 3
+            {
+                // length smaller than 4?
+                if ((_length ^ position) == 0)
+                    Initialize(out _v1, out _v2, out _v3, out _v4);
+
+                _v1 = Round(_v1, _queue1);
+                _v2 = Round(_v2, _queue2);
+                _v3 = Round(_v3, _queue3);
+                _v4 = Round(_v4, val);
+            }
+
+            // Throw for more than uint.MaxValue fields.
+            _length = checked(_length + 1);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int ToHashCode()
+        {
+            uint position = _length & 0x3;
+
+            // If the length is less than 3, _v1 -> _v4 don't contain
+            // anything yet. xxHash32 treats this differently.
+
+            uint hash = (_length ^ position) == 0
+                ? MixEmptyState()
+                : MixState(_v1, _v2, _v3, _v4);
+
+            // Multiply by 4 because we've been counting in ints, not
+            // bytes.
+
+            hash += _length * 4;
+
+            // Mix what remains in the queue
+            // Switch can't be inlined right now, so use as few
+            // branches as possible instead.
+
+            if (position > 0)
+            {
+                hash = QueueRound(hash, _queue1);
+                if (position > 1)
+                {
+                    hash = QueueRound(hash, _queue2);
+                    if (position > 2)
+                        hash = QueueRound(hash, _queue3);
+                }
+            }
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+#       pragma warning disable 0809
+        // Obsolete member 'memberA' overrides non-obsolete member 'memberB'. 
+        // Disallowing GetHashCode is by design
+
+        // * We decided to not override GetHashCode() to produce the hash code 
+        //   as this would be weird, both naming-wise as well as from a behavioral 
+        //   standpoint (GetHashCode() should return the object's hash code, not 
+        //   the one being computed).
+
+        // * Even though ToHashCode() can be called safely multiple times on this
+        //   implementation, it is not part of the contract. If the implementation
+        //   has to change in the future we don't want to worry about people who
+        //   might have incorrectly used this type.
+
+        [Obsolete("Use ToHashCode to retrieve the computed hash code.", error: true)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public override int GetHashCode() => throw new NotSupportedException();
+#       pragma warning restore 0809
+
+    }
+}

--- a/src/mscorlib/shared/System/HashCode.cs
+++ b/src/mscorlib/shared/System/HashCode.cs
@@ -312,6 +312,8 @@ namespace System
         {
             if (comparer is null)
             {
+                // Prevent unessecary generic method instantiation by manually
+                // inlining.
                 Add(value?.GetHashCode() ?? 0);
             }
             else

--- a/src/mscorlib/shared/System/HashCode.cs
+++ b/src/mscorlib/shared/System/HashCode.cs
@@ -312,7 +312,7 @@ namespace System
         {
             if (comparer is null)
             {
-                // Prevent unessecary generic method instantiation by manually
+                // Prevent unnecessary generic method instantiation by manually
                 // inlining.
                 Add(value?.GetHashCode() ?? 0);
             }

--- a/src/mscorlib/shared/System/HashCode.cs
+++ b/src/mscorlib/shared/System/HashCode.cs
@@ -376,6 +376,10 @@ namespace System
             // Storing the value of _length locally shaves of quite a few bytes
             // in the resulting machine code.
             uint length = _length;
+            
+            // position refers to the *next* queue position in this method, so
+            // position == 1 means that _queue1 is populated; _queue2 would have
+            // been populated on the next call to Add.
             uint position = length % 4;
 
             // If the length is less than 4, _v1 to _v4 don't contain anything
@@ -383,19 +387,16 @@ namespace System
 
             uint hash = length < 4 ? MixEmptyState() : MixState(_v1, _v2, _v3, _v4);
 
-            // Multiply by 4 because we've been counting in bytes, not ints.
+            // _length is incremented once per Add(Int32) and is therefore 4
+            // times too small (xxHash length is in bytes, not ints).
 
             hash += length * 4;
 
             // Mix what remains in the queue
 
-            // Switch can't be inlined right now, so emulate case statement
-            // fallthrough using goto.
-
-            // position refers to the *next* queue position in this method, so
-            // position == 1 means that _queue1 is populated; _queue2 would have
-            // been populated on the next call to Add.
-
+            // Switch can't be inlined right now, so use as few branches as
+            // possible by manually excluding impossible scenarios (position > 1
+            // is always false if position is not > 0).
             if (position > 0)
             {
                 hash = QueueRound(hash, _queue1);
@@ -427,9 +428,9 @@ namespace System
 
         [Obsolete("HashCode is a mutable struct and should not be compared with other HashCodes. Use ToHashCode to retrieve the computed hash code.", error: true)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override int GetHashCode() => throw new NotSupportedException(SR.HashCode_EqualityNotSupported);
+        public override int GetHashCode() => throw new NotSupportedException(SR.HashCode_HashCodeNotSupported);
 
-        [Obsolete("HashCode is a mutable struct and should not be compared with other HashCodes. Use ToHashCode to retrieve the computed hash code.", error: true)]
+        [Obsolete("HashCode is a mutable struct and should not be compared with other HashCodes.", error: true)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj) => throw new NotSupportedException(SR.HashCode_EqualityNotSupported);
 #pragma warning restore 0809

--- a/src/mscorlib/shared/System/HashCode.cs
+++ b/src/mscorlib/shared/System/HashCode.cs
@@ -310,16 +310,7 @@ namespace System
 
         public void Add<T>(T value, IEqualityComparer<T> comparer)
         {
-            if (comparer is null)
-            {
-                // Prevent unnecessary generic method instantiation by manually
-                // inlining.
-                Add(value?.GetHashCode() ?? 0);
-            }
-            else
-            {
-                Add(comparer.GetHashCode(value));
-            }
+            Add(comparer != null ? comparer.GetHashCode(value) : (value?.GetHashCode() ?? 0));
         }
 
         private void Add(int value)

--- a/src/mscorlib/shared/System/HashCode.cs
+++ b/src/mscorlib/shared/System/HashCode.cs
@@ -71,7 +71,6 @@ namespace System
             return result;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Combine<T1>(T1 value1)
         {
             var hc1 = (uint)(value1?.GetHashCode() ?? 0);
@@ -85,7 +84,6 @@ namespace System
             return (int)hash;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Combine<T1, T2>(T1 value1, T2 value2)
         {
             var hc1 = (uint)(value1?.GetHashCode() ?? 0);
@@ -101,7 +99,6 @@ namespace System
             return (int)hash;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Combine<T1, T2, T3>(T1 value1, T2 value2, T3 value3)
         {
             var hc1 = (uint)(value1?.GetHashCode() ?? 0);
@@ -119,7 +116,6 @@ namespace System
             return (int)hash;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Combine<T1, T2, T3, T4>(T1 value1, T2 value2, T3 value3, T4 value4)
         {
             var hc1 = (uint)(value1?.GetHashCode() ?? 0);
@@ -141,7 +137,6 @@ namespace System
             return (int)hash;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Combine<T1, T2, T3, T4, T5>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5)
         {
             var hc1 = (uint)(value1?.GetHashCode() ?? 0);
@@ -166,7 +161,6 @@ namespace System
             return (int)hash;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Combine<T1, T2, T3, T4, T5, T6>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6)
         {
             var hc1 = (uint)(value1?.GetHashCode() ?? 0);
@@ -193,7 +187,6 @@ namespace System
             return (int)hash;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Combine<T1, T2, T3, T4, T5, T6, T7>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7)
         {
             var hc1 = (uint)(value1?.GetHashCode() ?? 0);
@@ -222,7 +215,6 @@ namespace System
             return (int)hash;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Combine<T1, T2, T3, T4, T5, T6, T7, T8>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8)
         {
             var hc1 = (uint)(value1?.GetHashCode() ?? 0);
@@ -304,13 +296,11 @@ namespace System
             return hash;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Add<T>(T value)
         {
             Add(value?.GetHashCode() ?? 0);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Add<T>(T value, IEqualityComparer<T> comparer)
         {
             if (comparer is null)
@@ -321,7 +311,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void Add(int value)
         {
-            // Note that x & 0x3 is like mod 3, but faster.
+            // Note that x & 0x3 is like mod 4, but faster.
 
             var val = (uint)value;
             uint position = _length & 0x3;
@@ -375,7 +365,6 @@ namespace System
             _length = checked(_length + 1);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int ToHashCode()
         {
             uint position = _length & 0x3;


### PR DESCRIPTION
## [Migrated Pull Request](https://github.com/dotnet/corefx/pull/25013)

See the original PR for full discussion on the code.

Fixes ["Proposal: Add System.HashCode to make it easier to generate good hash codes."](https://github.com/dotnet/corefx/issues/14354) in corefx.

Works by maintaining the xxHash32 state variables (v1 -> v4, length) as well as a queue of values that fall outside of the block size (16 bytes/4 ints). The seed is initialized to random bytes.

Tests against known xxHash32 vectors are provided in the original pull request.

## [Performance](https://github.com/jcdickinson/Benchmarks/tree/corefx-hashcode)

``` ini

BenchmarkDotNet=v0.10.9, OS=Windows 10 Redstone 2 (10.0.15063)
Processor=Intel Core i7-4800MQ CPU 2.70GHz (Haswell), ProcessorCount=8
Frequency=2630627 Hz, Resolution=380.1375 ns, Timer=TSC
.NET Core SDK=2.0.2
  [Host]     : .NET Core 2.0.0 (Framework 4.6.00001.0), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.0 (Framework 4.6.00001.0), 64bit RyuJIT


```
 |                  Method |     Mean |     Error |    StdDev | Scaled |
 |------------------------ |---------:|----------:|----------:|-------:|
 |                  Unsafe | 79.98 ns | 1.4723 ns | 1.3772 ns |   1.00 |
 |    'Calls, No Inlining' | 40.34 ns | 0.1778 ns | 0.1576 ns |   0.50 |
 | 'Unrolled, No Inlining' | 12.19 ns | 0.0433 ns | 0.0384 ns |   0.15 |
 |       'Calls, Inlining' | 34.55 ns | 0.1372 ns | 0.1216 ns |   0.43 |
 |    'Unrolled, Inlining' | 12.22 ns | 0.0885 ns | 0.0785 ns |   0.15 |

## Deviations from xxHash32

* Length is stored as the number of hashed fields (not bytes). It is multiplied at the end by 4 so that it behaves exactly like xxHash32.
* The structure won't accept more than `uint.MaxValue` values, failing with an `OverflowException`. This is to prevent the possibility of it re-initializing.
* The code that mixes in individual bytes is omitted - this struct only accepts `int`.


## 3rd Party Code

Submission containing materials of a third party: 

 | Author | Project | License | Comments |
 |------- |--------:|--------:|---------:|
 | Cyan4973 | [xxHash](https://github.com/Cyan4973/xxHash) | BSD | Reference, not copied code |

cc: @morganbr