### PR TITLE
Remove unused VNF_DIV_UN and VNF_MOD_UN

### DIFF
--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -41,10 +41,6 @@ VNFunc GetVNFuncForOper(genTreeOps oper, bool isUnsigned)
             return VNF_SUB_UN;
         case GT_MUL:
             return VNF_MUL_UN;
-        case GT_DIV:
-            return VNF_DIV_UN;
-        case GT_MOD:
-            return VNF_MOD_UN;
 
         case GT_NOP:
         case GT_COMMA:
@@ -190,16 +186,6 @@ T ValueNumStore::EvalOp(VNFunc vnf, T v0, T v1, ValueNum* pExcSet)
                 return T(UT(v0) - UT(v1));
             case VNF_MUL_UN:
                 return T(UT(v0) * UT(v1));
-            case VNF_DIV_UN:
-                if (IsIntZero(v1))
-                {
-                    *pExcSet = VNExcSetSingleton(VNForFunc(TYP_REF, VNF_DivideByZeroExc));
-                    return (T)0;
-                }
-                else
-                {
-                    return T(UT(v0) / UT(v1));
-                }
             default:
                 // Must be int-specific
                 return EvalOpIntegral(vnf, v0, v1, pExcSet);

--- a/src/jit/valuenumfuncs.h
+++ b/src/jit/valuenumfuncs.h
@@ -136,8 +136,6 @@ ValueNumFuncDef(GT_UN, 2, false, false, false)
 ValueNumFuncDef(ADD_UN, 2, true, false, false)
 ValueNumFuncDef(SUB_UN, 2, false, false, false)
 ValueNumFuncDef(MUL_UN, 2, true, false, false)
-ValueNumFuncDef(DIV_UN, 2, false, false, false)
-ValueNumFuncDef(MOD_UN, 2, false, false, false)
 
 ValueNumFuncDef(StrCns, 2, false, true, false)
 


### PR DESCRIPTION
Integer division operators do not use `GTF_UNSIGNED`. There are distinct unsigned operators (`GT_UDIV` and `GT_UMOD`) and VN already handles those directly.

No diffs.