### PR TITLE
Allow any string length in Environment.SetEnvironmentVariable

### DIFF
--- a/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
+++ b/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
@@ -617,6 +617,7 @@ namespace Microsoft.Win32
         internal const int ERROR_BAD_IMPERSONATION_LEVEL = 0x542;
         internal const int ERROR_CANT_OPEN_ANONYMOUS = 0x543;
         internal const int ERROR_NO_SECURITY_ON_OBJECT = 0x546;
+        internal const int ERROR_NO_SYSTEM_RESOURCES = 0x5AA;
         internal const int ERROR_TRUSTED_RELATIONSHIP_FAILURE = 0x6FD;
 
         // Error codes from ntstatus.h

--- a/src/mscorlib/src/System/Environment.cs
+++ b/src/mscorlib/src/System/Environment.cs
@@ -42,7 +42,7 @@ namespace System
     internal static partial class Environment
     {
         // Assume the following constants include the terminating '\0' - use <, not <=
-        private const int MaxEnvVariableValueLength = 32767;  // maximum length for environment variable name and value
+
         // System environment variables are stored in the registry, and have 
         // a size restriction that is separate from both normal environment 
         // variables and registry value name lengths, according to MSDN.
@@ -476,8 +476,6 @@ namespace System
 
         private static void ValidateVariableAndValue(string variable, ref string value)
         {
-            const int MaxEnvVariableValueLength = 32767;
-
             if (variable == null)
             {
                 throw new ArgumentNullException(nameof(variable));
@@ -490,10 +488,6 @@ namespace System
             {
                 throw new ArgumentException(SR.Argument_StringFirstCharIsZero, nameof(variable));
             }
-            if (variable.Length >= MaxEnvVariableValueLength)
-            {
-                throw new ArgumentException(SR.Argument_LongEnvVarValue, nameof(variable));
-            }
             if (variable.IndexOf('=') != -1)
             {
                 throw new ArgumentException(SR.Argument_IllegalEnvVarName, nameof(variable));
@@ -503,10 +497,6 @@ namespace System
             {
                 // Explicitly null out value if it's empty
                 value = null;
-            }
-            else if (value.Length >= MaxEnvVariableValueLength)
-            {
-                throw new ArgumentException(SR.Argument_LongEnvVarValue, nameof(value));
             }
         }
 
@@ -703,6 +693,9 @@ namespace System
                         // The error message from Win32 is "The filename or extension is too long",
                         // which is not accurate.
                         throw new ArgumentException(SR.Format(SR.Argument_LongEnvVarValue));
+                    case Win32Native.ERROR_NOT_ENOUGH_MEMORY:
+                    case Win32Native.ERROR_NO_SYSTEM_RESOURCES:
+                        throw new OutOfMemoryException(Interop.Kernel32.GetMessage(errorCode));
                     default:
                         throw new ArgumentException(Interop.Kernel32.GetMessage(errorCode));
                 }


### PR DESCRIPTION
Fix for CoreFX [#16766](https://github.com/dotnet/corefx/issues/16766)