### PR TITLE
Delete OldStyleClearD.

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -4563,7 +4563,7 @@ ASSERT_TP* Compiler::optInitAssertionDataflowFlags()
     }
     // Compute the data flow values for all tracked expressions
     // IN and OUT never change for the initial basic block B1
-    BitVecOps::OldStyleClearD(apTraits, fgFirstBB->bbAssertionIn);
+    BitVecOps::ClearD(apTraits, fgFirstBB->bbAssertionIn);
     return jumpDestOut;
 }
 

--- a/src/jit/bitset.h
+++ b/src/jit/bitset.h
@@ -202,15 +202,6 @@ class BitSetOps
     // be copied into the lhs.
     static void AssignNoCopy(Env env, BitSetType& lhs, BitSetValueArgType rhs);
 
-    // Destructively set "bs" to be the empty set.  This method is unique, in that it does *not*
-    // require "bs" to be a bitset of the current epoch.  It ensures that it is after, however.
-    // (If the representation is indirect, this requires allocating a new, empty representation.
-    // If this is a performance issue, we could provide a new version of OldStyleClearD that assumes/asserts
-    // that the rep is for the current epoch -- this would be useful if a given bitset were repeatedly
-    // cleared within an epoch.)
-    // TODO #11263: delete it.
-    static void OldStyleClearD(Env env, BitSetType& bs);
-
     // Destructively set "bs" to be the empty set.
     static void ClearD(Env env, BitSetType& bs);
 
@@ -337,11 +328,6 @@ public:
     {
         BitSetTraits::GetOpCounter(env)->RecordOp(BitSetSupport::BSOP_AssignNocopy);
         BSO::AssignNoCopy(env, lhs, rhs);
-    }
-    static void OldStyleClearD(Env env, BitSetType& bs)
-    {
-        BitSetTraits::GetOpCounter(env)->RecordOp(BitSetSupport::BSOP_OldStyleClearD);
-        BSO::OldStyleClearD(env, bs);
     }
     static void ClearD(Env env, BitSetType& bs)
     {

--- a/src/jit/bitsetasshortlong.h
+++ b/src/jit/bitsetasshortlong.h
@@ -43,7 +43,6 @@ private:
     static void DiffDLong(Env env, BitSetShortLongRep& bs1, BitSetShortLongRep bs2);
     static void AddElemDLong(Env env, BitSetShortLongRep& bs, unsigned i);
     static void RemoveElemDLong(Env env, BitSetShortLongRep& bs, unsigned i);
-    static void OldStyleClearDLong(Env env, BitSetShortLongRep& bs);
     static void ClearDLong(Env env, BitSetShortLongRep& bs);
     static BitSetShortLongRep MakeUninitArrayBits(Env env);
     static BitSetShortLongRep MakeEmptyArrayBits(Env env);
@@ -121,19 +120,6 @@ public:
     static void AssignNoCopy(Env env, BitSetShortLongRep& lhs, BitSetShortLongRep rhs)
     {
         lhs = rhs;
-    }
-
-    static void OldStyleClearD(Env env, BitSetShortLongRep& bs)
-    {
-        if (IsShort(env))
-        {
-            bs = (BitSetShortLongRep) nullptr;
-        }
-        else
-        {
-            assert(bs != UninitVal());
-            OldStyleClearDLong(env, bs);
-        }
     }
 
     static void ClearD(Env env, BitSetShortLongRep& bs)
@@ -669,18 +655,6 @@ void BitSetOps</*BitSetType*/ BitSetShortLongRep,
     size_t   mask  = ((size_t)1) << (i % BitsInSizeT);
     mask           = ~mask;
     bs[index] &= mask;
-}
-
-template <typename Env, typename BitSetTraits>
-void BitSetOps</*BitSetType*/ BitSetShortLongRep,
-               /*Brand*/ BSShortLong,
-               /*Env*/ Env,
-               /*BitSetTraits*/ BitSetTraits>::OldStyleClearDLong(Env env, BitSetShortLongRep& bs)
-{
-    assert(!IsShort(env));
-    // Recall that OldStyleClearD does *not* require "bs" to be of the current epoch.
-    // Therefore, we must allocate a new representation.
-    bs = MakeEmptyArrayBits(env);
 }
 
 template <typename Env, typename BitSetTraits>

--- a/src/jit/bitsetasuint64.h
+++ b/src/jit/bitsetasuint64.h
@@ -44,11 +44,6 @@ public:
         lhs = rhs;
     }
 
-    static void OldStyleClearD(Env env, UINT64& bs)
-    {
-        bs = 0;
-    }
-
     static void ClearD(Env env, UINT64& bs)
     {
         bs = 0;

--- a/src/jit/bitsetasuint64inclass.h
+++ b/src/jit/bitsetasuint64inclass.h
@@ -168,16 +168,6 @@ private:
         return res;
     }
 
-    inline void OldStyleClearD(Env env)
-    {
-        // Recall that OldStyleClearD does *not* require "*this" to be of the current epoch.
-        Uint64BitSetOps::OldStyleClearD(env, m_bits);
-#ifdef DEBUG
-        // But it updates it to of the current epoch.
-        m_epoch = BitSetTraits::GetEpoch(env);
-#endif
-    }
-
     inline void ClearD(Env env)
     {
         assert(m_epoch == BitSetTraits::GetEpoch(env));
@@ -320,11 +310,6 @@ public:
     static void AssignNoCopy(Env env, BST& lhs, BSTValArg rhs)
     {
         lhs = rhs;
-    }
-
-    static void OldStyleClearD(Env env, BST& bs)
-    {
-        bs.OldStyleClearD(env);
     }
 
     static void ClearD(Env env, BST& bs)

--- a/src/jit/copyprop.cpp
+++ b/src/jit/copyprop.cpp
@@ -303,7 +303,7 @@ void Compiler::optBlockCopyProp(BasicBlock* block, LclNumToGenTreePtrStack* curS
     VarSetOps::Assign(this, compCurLife, block->bbLiveIn);
     for (GenTreePtr stmt = block->bbTreeList; stmt; stmt = stmt->gtNext)
     {
-        VarSetOps::OldStyleClearD(this, optCopyPropKillSet);
+        VarSetOps::ClearD(this, optCopyPropKillSet);
 
         // Walk the tree to find if any local variable can be replaced with current live definitions.
         for (GenTreePtr tree = stmt->gtStmt.gtStmtList; tree; tree = tree->gtNext)

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -1471,8 +1471,8 @@ void emitter::emitBegProlog()
     /* Nothing is live on entry to the prolog */
 
     // These were initialized to Empty at the start of compilation.
-    VarSetOps::OldStyleClearD(emitComp, emitInitGCrefVars);
-    VarSetOps::OldStyleClearD(emitComp, emitPrevGCrefVars);
+    VarSetOps::ClearD(emitComp, emitInitGCrefVars);
+    VarSetOps::ClearD(emitComp, emitPrevGCrefVars);
     emitInitGCrefRegs = RBM_NONE;
     emitPrevGCrefRegs = RBM_NONE;
     emitInitByrefRegs = RBM_NONE;
@@ -4560,7 +4560,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
 
     /* Assume no live GC ref variables on entry */
 
-    VarSetOps::OldStyleClearD(emitComp, emitThisGCrefVars); // This is initialized to Empty at the start of codegen.
+    VarSetOps::ClearD(emitComp, emitThisGCrefVars); // This is initialized to Empty at the start of codegen.
     emitThisGCrefRegs = emitThisByrefRegs = RBM_NONE;
     emitThisGCrefVset                     = true;
 

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -10422,7 +10422,7 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
     if (fgDomsComputed && block->bbNum > fgDomBBcount)
     {
         BlockSetOps::Assign(this, block->bbReach, bNext->bbReach);
-        BlockSetOps::OldStyleClearD(this, bNext->bbReach);
+        BlockSetOps::ClearD(this, bNext->bbReach);
 
         block->bbIDom = bNext->bbIDom;
         bNext->bbIDom = nullptr;

--- a/src/jit/regalloc.cpp
+++ b/src/jit/regalloc.cpp
@@ -1342,7 +1342,7 @@ RET:
         while (iter.NextElem(&varNum))
         {
             // We'll need this for one of the calls...
-            VarSetOps::OldStyleClearD(this, varAsSet);
+            VarSetOps::ClearD(this, varAsSet);
             VarSetOps::AddElemD(this, varAsSet, varNum);
 
             // If this varBit and lastUse?
@@ -6352,7 +6352,7 @@ void Compiler::rpPredictRegUse()
         /*  Zero the variable/register interference graph */
         for (unsigned i = 0; i < REG_COUNT; i++)
         {
-            VarSetOps::OldStyleClearD(this, raLclRegIntf[i]);
+            VarSetOps::ClearD(this, raLclRegIntf[i]);
         }
 
         // if there are PInvoke calls and compLvFrameListRoot is enregistered,


### PR DESCRIPTION
I think it is good time to do this change, because we are far enough from the next release.

I checked each file to confirm that it is safe to delete the old version.
There are two reasons why each replacement is risk-free:
1. There is code around this OldStyleClearD that uses the same set type without recreating it;
2. There are no epoch changes in this phase;
Fix #11263.