### PR TITLE
Reenable PGO optimization on release builds

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1819,18 +1819,13 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                     if (scenario == 'standalone_gc') {
                         standaloneGc = 'buildstandalonegc'
                     }
-                    
-                    def disablePgo = ''
-                    if (lowerConfiguration == 'release') {
-                        disablePgo = 'nopgooptimize'
-                    }
 
                     if (!enableCorefxTesting) {
                         // We run pal tests on all OS but generate mscorlib (and thus, nuget packages)
                         // only on supported OS platforms.
                         def bootstrapRid = Utilities.getBoostrapPublishRid(os)
                         def bootstrapRidEnv = bootstrapRid != null ? "__PUBLISH_RID=${bootstrapRid} " : ''
-                        buildCommands += "${bootstrapRidEnv}./build.sh verbose ${lowerConfiguration} ${architecture} ${standaloneGc} ${disablePgo}"
+                        buildCommands += "${bootstrapRidEnv}./build.sh verbose ${lowerConfiguration} ${architecture} ${standaloneGc}"
                         buildCommands += "src/pal/tests/palsuite/runpaltests.sh \${WORKSPACE}/bin/obj/${osGroup}.${architecture}.${configuration} \${WORKSPACE}/bin/paltestout"
 
                         // Set time out


### PR DESCRIPTION
The CentOS machines now have the correct version of binutils, so we can reenable pgo optimization for release builds.