### PR TITLE
ARM64: Fix two register selection issues

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -6149,8 +6149,15 @@ bool LinearScan::isSpillCandidate(Interval*     current,
 #endif
     {
         RefPosition* nextPhysRegPosition = physRegRecord->getNextRefPosition();
-        assert((nextPhysRegPosition->nodeLocation == refLocation && candidateBit != refPosition->registerAssignment)
-                   ARM64_ONLY(|| (physRegRecord->regNum == REG_IP0) || (physRegRecord->regNum == REG_IP1)));
+#ifdef _TARGET_ARM64_
+        // On ARM64, we may need to actually allocate IP0 and IP1 in some cases, but we don't include it in
+        // the allocation order for tryAllocateFreeReg.
+        if ((physRegRecord->regNum != REG_IP0) && (physRegRecord->regNum != REG_IP1))
+#endif // _TARGET_ARM64_
+        {
+            assert((nextPhysRegPosition != nullptr) && (nextPhysRegPosition->nodeLocation == refLocation) &&
+                   (candidateBit != refPosition->registerAssignment));
+        }
         return false;
     }
 

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -1611,7 +1611,7 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
                                    REG_V28, REG_V29, REG_V30, REG_V31, \
                                    REG_V7,  REG_V6,  REG_V5,  REG_V4,  \
                                    REG_V8,  REG_V9,  REG_V10, REG_V11, \
-                                   REG_V12, REG_V13, REG_V14, REG_V16, \
+                                   REG_V12, REG_V13, REG_V14, REG_V15, \
                                    REG_V3,  REG_V2, REG_V1,  REG_V0 
 
   #define REG_CALLEE_SAVED_ORDER   REG_R19,REG_R20,REG_R21,REG_R22,REG_R23,REG_R24,REG_R25,REG_R26,REG_R27,REG_R28


### PR DESCRIPTION
On ARM64 IP0 and IP1 are not in the register selection order, though there are some cases where they must be allocated. See #14607. So we may see them as free when looking for a register to spill.
Also, V15 was missing from the selection order (V16 was in the order twice).

Fix #14626