### PR TITLE
Make sure that Limit::vn is initialized

### DIFF
--- a/src/jit/rangecheck.h
+++ b/src/jit/rangecheck.h
@@ -93,7 +93,7 @@ struct Limit
     {
     }
 
-    Limit(LimitType type, int cns) : cns(cns), type(type)
+    Limit(LimitType type, int cns) : cns(cns), vn(ValueNumStore::NoVN), type(type)
     {
         assert(type == keConstant);
     }


### PR DESCRIPTION
There is code in `RangeCheck::MergeEdgeAssertions` that checks the limit's vn even if the limit type is `keConstant`.