### PR TITLE
[Arm64] SIMD impAssignMultiRegTypeToVar

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -15648,6 +15648,7 @@ GenTreePtr Compiler::impAssignMultiRegTypeToVar(GenTreePtr op, CORINFO_CLASS_HAN
 {
     unsigned tmpNum = lvaGrabTemp(true DEBUGARG("Return value temp for multireg return."));
     impAssignTempGen(tmpNum, op, hClass, (unsigned)CHECK_SPILL_ALL);
+    op->gtType     = impNormStructType(hClass);
     GenTreePtr ret = gtNewLclvNode(tmpNum, op->gtType);
 
     // TODO-1stClassStructs: Handle constant propagation and CSE-ing of multireg returns.


### PR DESCRIPTION
@dotnet/jit-contrib @dotnet/arm64-contrib PTAL

Multireg SIMD struct return type was not being normalized.  This was causing type mismatch asserts.  

Let me know if this is the wrong way to normalize the struct return type.