### PR TITLE
[Local GC] Refactor calls involving thread modes, suspension, and all…

### DIFF
--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -46,14 +46,14 @@ public:
     static void SyncBlockCachePromotionsGranted(int max_gen);
 
     // Thread functions
-    static bool IsPreemptiveGCDisabled(Thread * pThread);
-    static void EnablePreemptiveGC(Thread * pThread);
-    static void DisablePreemptiveGC(Thread * pThread);
+    static bool IsPreemptiveGCDisabled();
+    static void EnablePreemptiveGC();
+    static void DisablePreemptiveGC();
     static bool TrapReturningThreads();
     static Thread* GetThread();
 
-    static gc_alloc_context * GetAllocContext(Thread * pThread);
-    static bool CatchAtSafePoint(Thread * pThread);
+    static gc_alloc_context * GetAllocContext();
+    static bool CatchAtSafePoint();
 
     static void GcEnumAllocContexts(enum_alloc_context_func* fn, void* param);
 

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -1370,7 +1370,7 @@ void recursive_gc_sync::begin_foreground()
 {
     dprintf (2, ("begin_foreground"));
 
-    BOOL cooperative_mode = FALSE;
+    bool cooperative_mode = false;
     if (gc_background_running)
     {
         gc_heap::fire_alloc_wait_event_begin (awr_fgc_wait_for_bgc);
@@ -1644,7 +1644,7 @@ void WaitLongerNoInstru (int i)
 inline
 static void safe_switch_to_thread()
 {
-    BOOL cooperative_mode = gc_heap::enable_preemptive();
+    bool cooperative_mode = gc_heap::enable_preemptive();
 
     GCToOSInterface::YieldThread(0);
 
@@ -1883,7 +1883,7 @@ static void leave_spin_lock (GCSpinLock * spin_lock)
 
 #endif //_DEBUG
 
-BOOL gc_heap::enable_preemptive ()
+bool gc_heap::enable_preemptive ()
 {
     bool cooperative_mode = GCToEEInterface::IsPreemptiveGCDisabled();
     if (cooperative_mode)
@@ -1894,7 +1894,7 @@ BOOL gc_heap::enable_preemptive ()
     return cooperative_mode;
 }
 
-void gc_heap::disable_preemptive (BOOL restore_cooperative)
+void gc_heap::disable_preemptive (bool restore_cooperative)
 {
     if (restore_cooperative)
     {
@@ -10223,7 +10223,7 @@ gc_heap* gc_heap::make_gc_heap (
 uint32_t
 gc_heap::wait_for_gc_done(int32_t timeOut)
 {
-    BOOL cooperative_mode = enable_preemptive ();
+    bool cooperative_mode = enable_preemptive ();
 
     uint32_t dwWaitResult = NOERROR;
 
@@ -12329,7 +12329,7 @@ BOOL gc_heap::allocate_small (int gen_number,
             add_saved_spinlock_info (me_release, mt_alloc_small);
             dprintf (SPINLOCK_LOG, ("[%d]spin Lmsl", heap_number));
             leave_spin_lock (&more_space_lock);
-            BOOL cooperative_mode = enable_preemptive ();
+            bool cooperative_mode = enable_preemptive ();
             GCToOSInterface::Sleep (bgc_alloc_spin);
             disable_preemptive (cooperative_mode);
             enter_spin_lock (&more_space_lock);
@@ -12857,7 +12857,7 @@ BOOL gc_heap::allocate_large (int gen_number,
                     add_saved_spinlock_info (me_release, mt_alloc_large);
                     dprintf (SPINLOCK_LOG, ("[%d]spin Lmsl loh", heap_number));
                     leave_spin_lock (&more_space_lock);
-                    BOOL cooperative_mode = enable_preemptive ();
+                    bool cooperative_mode = enable_preemptive ();
                     GCToOSInterface::YieldThread (bgc_alloc_spin_loh);
                     disable_preemptive (cooperative_mode);
                     enter_spin_lock (&more_space_lock);
@@ -15608,8 +15608,7 @@ void gc_heap::gc1()
         )
     {
 #ifdef BACKGROUND_GC
-        Thread* current_thread = GCToEEInterface::GetThread();
-        BOOL cooperative_mode = TRUE;
+        bool cooperative_mode = TRUE;
 
         if (settings.concurrent)
         {
@@ -34977,7 +34976,7 @@ GCHeap::GarbageCollectGeneration (unsigned int gen, gc_reason reason)
 #else
     gc_heap* hpt = 0;
 #endif //MULTIPLE_HEAPS
-    BOOL cooperative_mode = TRUE;
+    bool cooperative_mode = true;
     dynamic_data* dd = hpt->dynamic_data_of (gen);
     size_t localCount = dd_collection_count (dd);
 

--- a/src/gc/gcee.cpp
+++ b/src/gc/gcee.cpp
@@ -534,10 +534,10 @@ uint32_t gc_heap::user_thread_wait (GCEvent *event, BOOL no_mode_change, int tim
     if (!no_mode_change)
     {
         pCurThread = GCToEEInterface::GetThread();
-        mode = pCurThread ? GCToEEInterface::IsPreemptiveGCDisabled(pCurThread) : false;
+        mode = pCurThread ? GCToEEInterface::IsPreemptiveGCDisabled() : false;
         if (mode)
         {
-            GCToEEInterface::EnablePreemptiveGC(pCurThread);
+            GCToEEInterface::EnablePreemptiveGC();
         }
     }
 
@@ -545,7 +545,7 @@ uint32_t gc_heap::user_thread_wait (GCEvent *event, BOOL no_mode_change, int tim
 
     if (!no_mode_change && mode)
     {
-        GCToEEInterface::DisablePreemptiveGC(pCurThread);
+        GCToEEInterface::DisablePreemptiveGC();
     }
 
     return dwWaitResult;

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -83,23 +83,23 @@ inline void GCToEEInterface::SyncBlockCachePromotionsGranted(int max_gen)
     g_theGCToCLR->SyncBlockCachePromotionsGranted(max_gen);
 }
 
-inline bool GCToEEInterface::IsPreemptiveGCDisabled(Thread * pThread)
+inline bool GCToEEInterface::IsPreemptiveGCDisabled()
 {
     assert(g_theGCToCLR != nullptr);
-    return g_theGCToCLR->IsPreemptiveGCDisabled(pThread);
+    return g_theGCToCLR->IsPreemptiveGCDisabled();
 }
 
 
-inline void GCToEEInterface::EnablePreemptiveGC(Thread * pThread)
+inline void GCToEEInterface::EnablePreemptiveGC()
 {
     assert(g_theGCToCLR != nullptr);
-    g_theGCToCLR->EnablePreemptiveGC(pThread);
+    g_theGCToCLR->EnablePreemptiveGC();
 }
 
-inline void GCToEEInterface::DisablePreemptiveGC(Thread * pThread)
+inline void GCToEEInterface::DisablePreemptiveGC()
 {
     assert(g_theGCToCLR != nullptr);
-    g_theGCToCLR->DisablePreemptiveGC(pThread);
+    g_theGCToCLR->DisablePreemptiveGC();
 }
 
 inline Thread* GCToEEInterface::GetThread()
@@ -114,16 +114,16 @@ inline bool GCToEEInterface::TrapReturningThreads()
     return g_theGCToCLR->TrapReturningThreads();
 }
 
-inline gc_alloc_context * GCToEEInterface::GetAllocContext(Thread * pThread)
+inline gc_alloc_context * GCToEEInterface::GetAllocContext()
 {
     assert(g_theGCToCLR != nullptr);
-    return g_theGCToCLR->GetAllocContext(pThread);
+    return g_theGCToCLR->GetAllocContext();
 }
 
-inline bool GCToEEInterface::CatchAtSafePoint(Thread * pThread)
+inline bool GCToEEInterface::CatchAtSafePoint()
 {
     assert(g_theGCToCLR != nullptr);
-    return g_theGCToCLR->CatchAtSafePoint(pThread);
+    return g_theGCToCLR->CatchAtSafePoint();
 }
 
 inline void GCToEEInterface::GcEnumAllocContexts(enum_alloc_context_func* fn, void* param)

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -65,17 +65,17 @@ public:
     virtual
     void SyncBlockCachePromotionsGranted(int max_gen) = 0;
 
-    // Queries whether or not the given thread has preemptive GC disabled.
+    // Queries whether or not the current thread has preemptive GC disabled.
     virtual
-    bool IsPreemptiveGCDisabled(Thread * pThread) = 0;
+    bool IsPreemptiveGCDisabled() = 0;
 
-    // Enables preemptive GC on the given thread.
+    // Enables preemptive GC on the current thread.
     virtual
-    void EnablePreemptiveGC(Thread * pThread) = 0;
+    void EnablePreemptiveGC() = 0;
 
-    // Disables preemptive GC on the given thread.
+    // Disables preemptive GC on the current thread.
     virtual
-    void DisablePreemptiveGC(Thread * pThread) = 0;
+    void DisablePreemptiveGC() = 0;
 
     // Gets the Thread instance for the current thread, or null if no thread
     // instance is associated with this thread.
@@ -86,13 +86,13 @@ public:
     virtual
     bool TrapReturningThreads() = 0;
 
-    // Retrieves the alloc context associated with a given thread.
+    // Retrieves the alloc context associated with the current thread.
     virtual
-    gc_alloc_context * GetAllocContext(Thread * pThread) = 0;
+    gc_alloc_context * GetAllocContext() = 0;
 
     // Returns true if this thread is waiting to reach a safe point.
     virtual
-    bool CatchAtSafePoint(Thread * pThread) = 0;
+    bool CatchAtSafePoint() = 0;
 
     // Calls the given enum_alloc_context_func with every active alloc context.
     virtual

--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -2750,12 +2750,12 @@ public:
     PER_HEAP_ISOLATED
     uint32_t wait_for_gc_done(int32_t timeOut = INFINITE);
 
-    // Returns TRUE if the thread used to be in cooperative mode 
+    // Returns TRUE if the current thread used to be in cooperative mode 
     // before calling this function.
     PER_HEAP_ISOLATED
-    BOOL enable_preemptive (Thread* current_thread);
+    BOOL enable_preemptive ();
     PER_HEAP_ISOLATED
-    void disable_preemptive (Thread* current_thread, BOOL restore_cooperative);
+    void disable_preemptive (BOOL restore_cooperative);
 
     /* ------------------- per heap members --------------------------*/
 

--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -2753,9 +2753,9 @@ public:
     // Returns TRUE if the current thread used to be in cooperative mode 
     // before calling this function.
     PER_HEAP_ISOLATED
-    BOOL enable_preemptive ();
+    bool enable_preemptive ();
     PER_HEAP_ISOLATED
-    void disable_preemptive (BOOL restore_cooperative);
+    void disable_preemptive (bool restore_cooperative);
 
     /* ------------------- per heap members --------------------------*/
 

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -88,9 +88,9 @@ uint32_t CLREventStatic::Wait(uint32_t dwMilliseconds, bool bAlertable)
 
         if (NULL != pCurThread)
         {
-            if (GCToEEInterface::IsPreemptiveGCDisabled(pCurThread))
+            if (GCToEEInterface::IsPreemptiveGCDisabled())
             {
-                GCToEEInterface::EnablePreemptiveGC(pCurThread);
+                GCToEEInterface::EnablePreemptiveGC();
                 disablePreemptive = true;
             }
         }
@@ -99,7 +99,7 @@ uint32_t CLREventStatic::Wait(uint32_t dwMilliseconds, bool bAlertable)
 
         if (disablePreemptive)
         {
-            GCToEEInterface::DisablePreemptiveGC(pCurThread);
+            GCToEEInterface::DisablePreemptiveGC();
         }
     }
 
@@ -175,18 +175,21 @@ bool GCToEEInterface::RefCountedHandleCallbacks(Object * pObject)
     return false;
 }
 
-bool GCToEEInterface::IsPreemptiveGCDisabled(Thread * pThread)
+bool GCToEEInterface::IsPreemptiveGCDisabled()
 {
+    Thread* pThread = ::GetThread();
     return pThread->PreemptiveGCDisabled();
 }
 
-void GCToEEInterface::EnablePreemptiveGC(Thread * pThread)
+void GCToEEInterface::EnablePreemptiveGC()
 {
+    Thread* pThread = ::GetThread();
     return pThread->EnablePreemptiveGC();
 }
 
-void GCToEEInterface::DisablePreemptiveGC(Thread * pThread)
+void GCToEEInterface::DisablePreemptiveGC()
 {
+    Thread* pThread = ::GetThread();
     pThread->DisablePreemptiveGC();
 }
 
@@ -200,13 +203,15 @@ bool GCToEEInterface::TrapReturningThreads()
     return !!g_TrapReturningThreads;
 }
 
-gc_alloc_context * GCToEEInterface::GetAllocContext(Thread * pThread)
+gc_alloc_context * GCToEEInterface::GetAllocContext()
 {
+    Thread* pThread = ::GetThread();
     return pThread->GetAllocContext();
 }
 
-bool GCToEEInterface::CatchAtSafePoint(Thread * pThread)
+bool GCToEEInterface::CatchAtSafePoint()
 {
+    Thread* pThread = ::GetThread();
     return pThread->CatchAtSafePoint();
 }
 

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -169,7 +169,7 @@ void GCToEEInterface::GcScanRoots(promote_func* fn, int condemned, int max_gen, 
         STRESS_LOG2(LF_GC | LF_GCROOTS, LL_INFO100, "{ Starting scan of Thread %p ID = %x\n", pThread, pThread->GetThreadId());
 
         if (GCHeapUtilities::GetGCHeap()->IsThreadUsingAllocationContextHeap(
-            GCToEEInterface::GetAllocContext(pThread), sc->thread_number))
+            pThread->GetAllocContext(), sc->thread_number))
         {
             sc->thread_under_crawl = pThread;
 #ifdef FEATURE_EVENT_TRACE
@@ -303,15 +303,21 @@ void GCToEEInterface::SyncBlockCachePromotionsGranted(int max_gen)
     SyncBlockCache::GetSyncBlockCache()->GCDone(FALSE, max_gen);
 }
 
-gc_alloc_context * GCToEEInterface::GetAllocContext(Thread * pThread)
+gc_alloc_context * GCToEEInterface::GetAllocContext()
 {
     WRAPPER_NO_CONTRACT;
+    
+    Thread* pThread = ::GetThread();
+    assert(pThread != nullptr);
     return pThread->GetAllocContext();
 }
 
-bool GCToEEInterface::CatchAtSafePoint(Thread * pThread)
+bool GCToEEInterface::CatchAtSafePoint()
 {
     WRAPPER_NO_CONTRACT;
+
+    Thread* pThread = ::GetThread();
+    assert(pThread != nullptr);
     return !!pThread->CatchAtSafePoint();
 }
 
@@ -338,22 +344,39 @@ void GCToEEInterface::GcEnumAllocContexts(enum_alloc_context_func* fn, void* par
     }
 }
 
-bool GCToEEInterface::IsPreemptiveGCDisabled(Thread * pThread)
+bool GCToEEInterface::IsPreemptiveGCDisabled()
 {
     WRAPPER_NO_CONTRACT;
-    return !!pThread->PreemptiveGCDisabled();
+
+    Thread* pThread = ::GetThread();
+    if (pThread)
+    {
+        return !!pThread->PreemptiveGCDisabled();
+    }
+
+    return false;
 }
 
-void GCToEEInterface::EnablePreemptiveGC(Thread * pThread)
+void GCToEEInterface::EnablePreemptiveGC()
 {
     WRAPPER_NO_CONTRACT;
-    pThread->EnablePreemptiveGC();
+
+    Thread* pThread = ::GetThread();
+    if (pThread)
+    {
+        pThread->EnablePreemptiveGC();
+    }
 }
 
-void GCToEEInterface::DisablePreemptiveGC(Thread * pThread)
+void GCToEEInterface::DisablePreemptiveGC()
 {
     WRAPPER_NO_CONTRACT;
-    pThread->DisablePreemptiveGC();
+
+    Thread* pThread = ::GetThread();
+    if (pThread)
+    {
+        pThread->DisablePreemptiveGC();
+    }
 }
 
 Thread* GCToEEInterface::GetThread()

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -28,13 +28,13 @@ public:
     void SyncBlockCacheWeakPtrScan(HANDLESCANPROC scanProc, uintptr_t lp1, uintptr_t lp2);
     void SyncBlockCacheDemote(int max_gen);
     void SyncBlockCachePromotionsGranted(int max_gen);
-    bool IsPreemptiveGCDisabled(Thread * pThread);
-    void EnablePreemptiveGC(Thread * pThread);
-    void DisablePreemptiveGC(Thread * pThread);
+    bool IsPreemptiveGCDisabled();
+    void EnablePreemptiveGC();
+    void DisablePreemptiveGC();
     Thread* GetThread();
     bool TrapReturningThreads();
-    gc_alloc_context * GetAllocContext(Thread * pThread);
-    bool CatchAtSafePoint(Thread * pThread);
+    gc_alloc_context * GetAllocContext();
+    bool CatchAtSafePoint();
     void GcEnumAllocContexts(enum_alloc_context_func* fn, void* param);
     Thread* CreateBackgroundThread(GCBackgroundThreadFunction threadStart, void* arg);
 


### PR DESCRIPTION
…oc contexts to always operate on current thread. Fixes https://github.com/dotnet/coreclr/issues/12043.

These methods on the GC/EE interface always act on the current thread, so it is not necessary to perform another interface call to get the current thread - the implementations of these functions can instead get the current thread and potentially act on it if it is not-null. With this change, many calls to `GCToEEInterface::GetThread` are now unnecessary within `gc.cpp`, since the only reason GetThread was called was to obtain the current thread to pass to functions that operate on the thread passed as an argument.

This PR is quite large so I'm putting it out early to begin the validation process. There are many diffs within `gc.cpp` so I'd like leave this PR open until @Maoni0 gets a chance to review it (and to get CI cycles).

cc @jkotas @sergiy-k PTAL? thoughts on the general approach?