### PR TITLE
Fix warning about signed/unsigned mismatch in new assert

### DIFF
--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -3985,8 +3985,16 @@ void emitter::emitIns_R_R(
             assert(isValidVectorDatasize(size));
             assert(isValidArrangement(size, opt));
             elemsize = optGetElemsize(opt);
-            assert(size == (ins == INS_xtn) ? EA_8BYTE : EA_16BYTE); // Size is determined by instruction
-            assert(elemsize != EA_8BYTE);                            // Narrowing must not end with 8 byte data
+            // size is determined by instruction
+            if (ins == INS_xtn)
+            {
+                assert(size == EA_8BYTE);
+            }
+            else // ins == INS_xtn2
+            {
+                assert(size == EA_16BYTE);
+            }
+            assert(elemsize != EA_8BYTE); // Narrowing must not end with 8 byte data
             fmt = IF_DV_2M;
             break;
 


### PR DESCRIPTION
The desktop CLR build issued a warning (which was treated as an error)
The warning was that unsigned and signed types were mixed in an '==' comparison
The problem may have been due to a missing set of parenthesis in the complex assert.

But to fix this I just expanded this assert into an if then else, which is what we typically use elsewhere in this file.


