### PR TITLE
Fix desktop retail build break

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -11224,8 +11224,9 @@ var_types Compiler::GetHfaType(GenTreePtr tree)
 {
 #ifdef FEATURE_HFA
     return GetHfaType(gtGetStructHandleIfPresent(tree));
-#endif
+#else
     return TYP_UNDEF;
+#endif
 }
 
 unsigned Compiler::GetHfaCount(GenTreePtr tree)


### PR DESCRIPTION
error C2220: warning treated as error -
from jit\codegencommon.cpp(11228): warning C4702: unreachable code