### PR TITLE
ARMARCH: no cascaded adds in addr mode

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2018,7 +2018,7 @@ AGAIN:
         }
 #endif // LEGACY_BACKEND
 
-#if defined(_TARGET_ARM64_) || (defined(_TARGET_ARM_) && !defined(LEGACY_BACKEND))
+#if defined(_TARGET_ARMARCH_) && !defined(LEGACY_BACKEND)
         if (cns == 0)
 #endif
         {
@@ -2038,7 +2038,7 @@ AGAIN:
 
                     goto AGAIN;
 
-#if SCALED_ADDR_MODES && !defined(_TARGET_ARM64_) && !(defined(_TARGET_ARM_) && !defined(LEGACY_BACKEND))
+#if SCALED_ADDR_MODES && (!defined(_TARGET_ARMARCH_) || defined(LEGACY_BACKEND))
                 // TODO-ARM64-CQ, TODO-ARM-CQ: For now we don't try to create a scaled index.
                 case GT_MUL:
                     if (op1->gtOverflow())
@@ -2103,7 +2103,7 @@ AGAIN:
 
         switch (op1->gtOper)
         {
-#if !defined(_TARGET_ARM64_) && !(defined(_TARGET_ARM_) && !defined(LEGACY_BACKEND))
+#if !defined(_TARGET_ARMARCH_) || defined(LEGACY_BACKEND)
             // TODO-ARM64-CQ, TODO-ARM-CQ: For now we don't try to create a scaled index.
             case GT_ADD:
 
@@ -2165,7 +2165,7 @@ AGAIN:
                 break;
 
 #endif // SCALED_ADDR_MODES
-#endif // !_TARGET_ARM64_ && !(_TARGET_ARM_ && !LEGACY_BACKEND)
+#endif // !_TARGET_ARMARCH || LEGACY_BACKEND
 
             case GT_NOP:
 
@@ -2194,7 +2194,7 @@ AGAIN:
         noway_assert(op2);
         switch (op2->gtOper)
         {
-#if !defined(_TARGET_ARM64_) && !(defined(_TARGET_ARM_) && !defined(LEGACY_BACKEND))
+#if !defined(_TARGET_ARMARCH_) || defined(LEGACY_BACKEND)
             // TODO-ARM64-CQ, TODO-ARM-CQ: For now we don't try to create a scaled index.
             case GT_ADD:
 
@@ -2252,7 +2252,7 @@ AGAIN:
                 break;
 
 #endif // SCALED_ADDR_MODES
-#endif // !_TARGET_ARM64_ && !(_TARGET_ARM_ && !LEGACY_BACKEND)
+#endif // !_TARGET_ARMARCH || LEGACY_BACKEND
 
             case GT_NOP:
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2162,7 +2162,7 @@ public:
 
     unsigned gtSetListOrder(GenTree* list, bool regs, bool isListCallArgs);
 
-    void gtWalkOp(GenTree** op1, GenTree** op2, GenTree* adr, bool constOnly);
+    void gtWalkOp(GenTree** op1, GenTree** op2, GenTree* base, bool constOnly);
 
 #ifdef DEBUG
     unsigned gtHashValue(GenTree* tree);


### PR DESCRIPTION
On ARM and ARM64, cascaded `ADD`s in the op2 position are not folded into a single addressing mode. However, in `gtSetEvalOrder` it assumes that they will, so it walks both operands of the addr looking for more `ADD`s. This leads to an assert because the leaf nodes it winds up with are not the same as those returned by `genCreateAddrMode()`.

Fix #14665