### PR TITLE
Enable RyuJIT/arm32 crossgen compilation of S.P.C.dll

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -139,6 +139,7 @@ set __BuildTests=1
 set __BuildPackages=1
 set __BuildNativeCoreLib=1
 set __RestoreOptData=1
+set __AltJitCrossgen=0
 
 @REM CMD has a nasty habit of eating "=" on the argument list, so passing:
 @REM    -priority=1
@@ -206,6 +207,7 @@ if /i "%1" == "-enforcepgo"          (set __EnforcePgo=1&set processedArgs=!proc
 if /i "%1" == "-nopgooptimize"       (set __PgoOptimize=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "-ibcinstrument"       (set __IbcTuning=/Tuning&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "-toolset_dir"         (set __ToolsetDir=%2&set __PassThroughArgs=%__PassThroughArgs% %2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)
+if /i "%1" == "-altjitcrossgen"      (set __AltJitCrossgen=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 
 REM TODO these are deprecated remove them eventually
 REM don't add more, use the - syntax instead
@@ -228,9 +230,6 @@ if /i "%1" == "nopgooptimize"       (set __PgoOptimize=0&set processedArgs=!proc
 if /i "%1" == "enforcepgo"          (set __EnforcePgo=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "ibcinstrument"       (set __IbcTuning=/Tuning&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "toolset_dir"         (set __ToolsetDir=%2&set __PassThroughArgs=%__PassThroughArgs% %2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)
-
-@REM The following can be deleted once the CI system that passes it is updated to not pass it.
-if /i "%1" == "altjitcrossgen"      (set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 
 if [!processedArgs!]==[] (
   set __UnprocessedBuildArgs=%__args%
@@ -528,7 +527,7 @@ if /i "%__DoCrossArchBuild%"=="1" (
 
     @call %__ProjectDir%\run.cmd build -Project=%__CrossCompIntermediatesDir%\install.vcxproj -configuration=%__BuildType% -platform=%__CrossArch% -MsBuildLog=!__MsbuildLog! -MsBuildWrn=!__MsbuildWrn! -MsBuildErr=!__MsbuildErr! %__RunArgs% -MSBuildNodeCount="/m:2" %__UnprocessedBuildArgs%
 
-        if not !errorlevel! == 0 (
+    if not !errorlevel! == 0 (
         echo %__MsgPrefix%Error: cross-arch components build failed. Refer to the build log files for details:
         echo     !__BuildLog!
         echo     !__BuildWrn!
@@ -602,7 +601,8 @@ REM Need diasymreader.dll on your path for /CreatePdb
 set PATH=%PATH%;%WinDir%\Microsoft.Net\Framework64\V4.0.30319;%WinDir%\Microsoft.Net\Framework\V4.0.30319
 
 if %__BuildNativeCoreLib% EQU 1 (
-    echo %__MsgPrefix%Generating native image of System.Private.CoreLib for %__BuildOS%.%__BuildArch%.%__BuildType%
+    echo %__MsgPrefix%Generating native image of System.Private.CoreLib for %__BuildOS%.%__BuildArch%.%__BuildType%. Logging to "%__CrossGenCoreLibLog%".
+    if exist "%__CrossGenCoreLibLog%" del "%__CrossGenCoreLibLog%"
 
     REM Need VS native tools environment for the **target** arch when running instrumented binaries
     if %__PgoInstrument% EQU 1 (
@@ -629,9 +629,23 @@ if %__BuildNativeCoreLib% EQU 1 (
         REM End HACK
     )
 
+    if %__AltJitCrossgen% EQU 1 (
+        REM Set altjit flags for the crossgen run. Note that this entire crossgen section is within a setlocal/endlocal scope,
+        REM so we don't need to save or unset these afterwards.
+        echo %__MsgPrefix%Setting altjit environment variables.
+        echo %__MsgPrefix%Setting altjit environment variables. >> "%__CrossGenCoreLibLog%"
+        set COMPlus_AltJit=*
+        set COMPlus_AltJitNgen=*
+        set COMPlus_AltJitName=protojit.dll
+        set COMPlus_AltJitAssertOnNYI=1
+        set COMPlus_NoGuiOnAssert=1
+        set COMPlus_ContinueOnAssert=0
+    )
+
     set NEXTCMD="%__CrossgenExe%" %__IbcTuning% /Platform_Assemblies_Paths "%__BinDir%"\IL /out "%__BinDir%\System.Private.CoreLib.dll" "%__BinDir%\IL\System.Private.CoreLib.dll"
     echo %__MsgPrefix%!NEXTCMD!
-    !NEXTCMD! > "%__CrossGenCoreLibLog%" 2>&1
+    echo %__MsgPrefix%!NEXTCMD! >> "%__CrossGenCoreLibLog%"
+    !NEXTCMD! >> "%__CrossGenCoreLibLog%" 2>&1
     if NOT !errorlevel! == 0 (
         echo %__MsgPrefix%Error: CrossGen System.Private.CoreLib build failed. Refer to %__CrossGenCoreLibLog%
         :: Put it in the same log, helpful for Jenkins
@@ -641,6 +655,7 @@ if %__BuildNativeCoreLib% EQU 1 (
 
     set NEXTCMD="%__CrossgenExe%" /Platform_Assemblies_Paths "%__BinDir%" /CreatePdb "%__BinDir%\PDB" "%__BinDir%\System.Private.CoreLib.dll"
     echo %__MsgPrefix%!NEXTCMD!
+    echo %__MsgPrefix%!NEXTCMD! >> "%__CrossGenCoreLibLog%"
     !NEXTCMD! >> "%__CrossGenCoreLibLog%" 2>&1
     if NOT !errorlevel! == 0 (
         echo %__MsgPrefix%Error: CrossGen /CreatePdb System.Private.CoreLib build failed. Refer to %__CrossGenCoreLibLog%
@@ -841,6 +856,7 @@ echo -disableoss: Disable Open Source Signing for System.Private.CoreLib.
 echo -priority=^<N^> : specify a set of test that will be built and run, with priority N.
 echo -officialbuildid=^<ID^>: specify the official build ID to be used by this build.
 echo -Rebuild: passes /t:rebuild to the build projects.
+echo -altjitcrossgen: run crossgen using altjit ^(used for JIT testing^).
 echo portable : build for portable RID.
 echo.
 echo If "all" is specified, then all build architectures and types are built. If, in addition,

--- a/netci.groovy
+++ b/netci.groovy
@@ -1793,8 +1793,15 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
 
                     def buildArchitecture = 'arm'
 
+                    // For 'arm' (the RyuJIT/arm32 architecture), tell build.cmd to use RyuJIT/arm32 for crossgen compilation.
+                    // RyuJIT/arm32 is currently not the default JIT; it is an aljit. So, this is a special case.
+                    def armCrossgenOpt = ''
+                    if (architecture == 'arm') {
+                        armCrossgenOpt = '-altjitcrossgen'
+                    }
+
                     // This is now a build only job. Do not run tests. Use the flow job.
-                    buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${buildArchitecture} -priority=${priority}"
+                    buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${buildArchitecture} -priority=${priority} ${armCrossgenOpt}"
                     
                     // Zip up the tests directory so that we don't use so much space/time copying
                     // 10s of thousands of files around.

--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -253,9 +253,10 @@ endif (FEATURE_MERGE_JIT_AND_ENGINE)
 
 add_subdirectory(standalone)
 
-if (CLR_CMAKE_PLATFORM_ARCH_ARM)
+if (CLR_CMAKE_TARGET_ARCH_ARM)
+    # Build RyuJIT/arm32 protojit to run on both x86 host (crossgen build) and arm host (native).
     add_subdirectory(protojit)
-endif (CLR_CMAKE_PLATFORM_ARCH_ARM)
+endif (CLR_CMAKE_TARGET_ARCH_ARM)
 
 if (CLR_CMAKE_PLATFORM_ARCH_I386 OR CLR_CMAKE_PLATFORM_ARCH_AMD64)
     # On x86, build RyuJIT/ARM32 cross-compiling altjit.


### PR DESCRIPTION
Currently, an ARM build and CI test run uses the legacy backend
arm32 JIT. This change enables a build of RyuJIT/arm32 as a
cross-targeting protojit.dll (altjit) in the cross tools (placed
next to the x86 hosted crossgen.exe in the build), and uses that
RyuJIT/arm32 cross-compiler to build System.Private.CoreLib.dll.
The CI system when testing RyuJIT/arm32 will use this to test
the crossgen'ed System.Private.CoreLib.dll built by RyuJIT/arm32
for all "arm" architecture jobs.