### PR TITLE
Fix build break when VS2015 is not installed.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -46,6 +46,23 @@ call "%_VSCOMNTOOLS%\VsDevCmd.bat"
 
 :Run
 
+REM Make the work-around to a bug in the microsoft.dotnet.buildtools.coreclr package until it is fixed.  
+reg query HKEY_CLASSES_ROOT\WOW6432Node\CLSID\{3BFCEA48-620F-4B6B-81F7-B9AF75454C7D}\InprocServer32 > NUL: 2>&1
+if NOT '%ERRORLEVEL%' == '0' (
+    echo.
+    echo.**********************************************************************************
+    echo.Error: We have detected that the msdia120.dll is not registered.   
+    echo.This is necessary for the build to complete without a Class_Not_Registered error.
+    echo.
+    echo.You can fix this by 
+    echo.  1. Launching the "Developer Command Prompt for VS2017" with Administrative privileges
+    echo.  2. Running  regsvr32.exe "%%VSINSTALLDIR%%\Common7\IDE\msdia120.dll"  
+    echo.
+    echo.This will only need to be done once for the lifetime of hte machine.
+    echo.For more details see: https://github.com/dotnet/coreclr/issues/11305
+    exit /b 1
+)
+
 if defined VS150COMNTOOLS (
   set "__VSToolsRoot=%VS150COMNTOOLS%"
   set "__VCToolsRoot=%VS150COMNTOOLS%\..\..\VC\Auxiliary\Build"

--- a/build.cmd
+++ b/build.cmd
@@ -58,7 +58,7 @@ if NOT '%ERRORLEVEL%' == '0' (
     echo.  1. Launching the "Developer Command Prompt for VS2017" with Administrative privileges
     echo.  2. Running  regsvr32.exe "%%VSINSTALLDIR%%\Common7\IDE\msdia120.dll"  
     echo.
-    echo.This will only need to be done once for the lifetime of hte machine.
+    echo.This will only need to be done once for the lifetime of the machine.
     echo.For more details see: https://github.com/dotnet/coreclr/issues/11305
     exit /b 1
 )


### PR DESCRIPTION
If you ONLY install VS2017 (now the common scneario)
and build coreclr, it will fail  with COM with a Class_Not_Registered error

This is because a build-tools package is depending on an old COM object
that has gone way in VS2017.

While we sort getting a proper fix, this makes the work-around (which
is registering the DLL by hand) discoverable.

See https://github.com/dotnet/coreclr/issues/11305 for details.

@lt72 @russellhadley @briansull 