### PR TITLE
Restore #13148

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -24,7 +24,7 @@
   <!-- Source of truth for dependency tooling: the commit hash of the dotnet/versions master branch as of the last auto-upgrade. -->
   <PropertyGroup>
     <CoreFxCurrentRef>ac4c079ac61d3a69fff717ce7ef9c7b880c4ad6d</CoreFxCurrentRef>
-    <CoreClrCurrentRef>4dd4bc933ecb18df77beb65afe79b118cae240d4</CoreClrCurrentRef>
+    <CoreClrCurrentRef>a97bcb7231471554cf5cf9b685e60ccbaf505d1f</CoreClrCurrentRef>
     <BuildToolsCurrentRef>ac4c079ac61d3a69fff717ce7ef9c7b880c4ad6d</BuildToolsCurrentRef>
     <PgoDataCurrentRef>ac4c079ac61d3a69fff717ce7ef9c7b880c4ad6d</PgoDataCurrentRef>
   </PropertyGroup>
@@ -34,7 +34,7 @@
     <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.5.0-preview1-25907-04</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
     <MicrosoftNETCorePlatformsPackageVersion>2.1.0-preview1-25907-04</MicrosoftNETCorePlatformsPackageVersion>
     <PgoDataPackageVersion>99.99.99-master-20171107-0019</PgoDataPackageVersion>
-    <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>2.1.0-preview1-25901-06</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
+    <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>2.1.0-dev-di-25528-01</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <XunitPackageVersion>2.2.0-beta2-build3300</XunitPackageVersion>
     <XunitConsoleNetcorePackageVersion>1.0.2-prerelease-00177</XunitConsoleNetcorePackageVersion>
     <XunitPerformanceApiPackageVersion>1.0.0-beta-build0010</XunitPerformanceApiPackageVersion>


### PR DESCRIPTION
Use ILAsm from this branch. This was lost in merges because the property got renamed.

We should really just port the ILAsm part of the feature to master...