### PR TITLE
Separate Profile=On and Off for perf pipeline

### DIFF
--- a/buildpipeline/perf-pipeline.groovy
+++ b/buildpipeline/perf-pipeline.groovy
@@ -57,20 +57,14 @@ def windowsPerf(String arch, String config, String uploadString, String runType,
 
         // We run run-xunit-perf differently for each of the different job types
 
-        String profileArg = "stopwatch"
-
-        if (isProfileOn) {
-            profileArg = "BranchMispredictions+CacheMisses+InstructionRetired"
-        }
+        String profileArg = isProfileOn ? "BranchMispredictions+CacheMisses+InstructionRetired" : "stopwatch"
 
         String runXUnitCommonArgs = "-arch ${arch} -configuration ${config} -generateBenchviewData \"%WORKSPACE%\\Microsoft.Benchview.JSONFormat\\tools\" ${uploadString} ${pgoTestFlag} -runtype ${runType} ${testEnv} -optLevel ${opt_level} -jitName ${jit} -outputdir \"%WORKSPACE%\\bin\\sandbox_logs\""
         if (scenario == 'perf') {
             String runXUnitPerfCommonArgs = "${runXUnitCommonArgs} -stabilityPrefix \"START \"CORECLR_PERF_RUN\" /B /WAIT /HIGH /AFFINITY 0x2\""
             String runXUnitPerflabArgs = "${runXUnitPerfCommonArgs} -testBinLoc bin\\tests\\${os}.${arch}.${config}\\performance\\perflab\\Perflab -library"
 
-            if (isProfileOn) {
-                profileArg = "default+${profileArg}+gcapi"
-            }
+            profileArg = isProfileOn ? "default+${profileArg}+gcapi" : profileArg
             bat "tests\\scripts\\run-xunit-perf.cmd ${runXUnitPerflabArgs} -collectionFlags ${profileArg}"
 
             String runXUnitCodeQualityArgs = "${runXUnitPerfCommonArgs} -testBinLoc bin\\tests\\${os}.${arch}.${config}\\Jit\\Performance\\CodeQuality"
@@ -357,7 +351,7 @@ if (!isPR()) {
 
                         outerLoopTests["windows ${arch} ${jit} ${opt_level} ${pgo_enabled} throughput"] = {
                             simpleNode('windows_server_2016_clr_perf', 180) {
-                                windowsThroughput(arch, 'Windows_NT', config, runType, opt_level, jit, pgo_enabled, false, is ProfileOn)
+                                windowsThroughput(arch, 'Windows_NT', config, runType, opt_level, jit, pgo_enabled, false, isProfileOn)
                             }
                         }
                     }

--- a/buildpipeline/perf-pipeline.groovy
+++ b/buildpipeline/perf-pipeline.groovy
@@ -60,7 +60,7 @@ def windowsPerf(String arch, String config, String uploadString, String runType,
         String profileArg = "stopwatch"
 
         if (isProfileOn) {
-            profileArg = "BranchMispredictions+CacheMisses+InstructionRetired)
+            profileArg = "BranchMispredictions+CacheMisses+InstructionRetired"
         }
 
         String runXUnitCommonArgs = "-arch ${arch} -configuration ${config} -generateBenchviewData \"%WORKSPACE%\\Microsoft.Benchview.JSONFormat\\tools\" ${uploadString} ${pgoTestFlag} -runtype ${runType} ${testEnv} -optLevel ${opt_level} -jitName ${jit} -outputdir \"%WORKSPACE%\\bin\\sandbox_logs\""

--- a/buildpipeline/perf-pipeline.groovy
+++ b/buildpipeline/perf-pipeline.groovy
@@ -25,7 +25,7 @@ def windowsBuild(String arch, String config, String pgo, boolean isBaseline) {
     stash name: "nt-${arch}-${pgo}${baselineString}-test-artifacts", includes: 'bin/tests/**'
 }
 
-def windowsPerf(String arch, String config, String uploadString, String runType, String opt_level, String jit, String pgo, String scenario, boolean isBaseline) {
+def windowsPerf(String arch, String config, String uploadString, String runType, String opt_level, String jit, String pgo, String scenario, boolean isBaseline, boolean isProfileOn) {
     withCredentials([string(credentialsId: 'CoreCLR Perf BenchView Sas', variable: 'BV_UPLOAD_SAS_TOKEN')]) {
         checkout scm
         String baselineString = ""
@@ -56,24 +56,32 @@ def windowsPerf(String arch, String config, String uploadString, String runType,
         bat "tests\\runtest.cmd ${config} ${arch} GenerateLayoutOnly"
 
         // We run run-xunit-perf differently for each of the different job types
+
+        String profileArg = "stopwatch"
+
+        if (isProfileOn) {
+            profileArg = "BranchMispredictions+CacheMisses+InstructionRetired)
+        }
+
         String runXUnitCommonArgs = "-arch ${arch} -configuration ${config} -generateBenchviewData \"%WORKSPACE%\\Microsoft.Benchview.JSONFormat\\tools\" ${uploadString} ${pgoTestFlag} -runtype ${runType} ${testEnv} -optLevel ${opt_level} -jitName ${jit} -outputdir \"%WORKSPACE%\\bin\\sandbox_logs\""
         if (scenario == 'perf') {
             String runXUnitPerfCommonArgs = "${runXUnitCommonArgs} -stabilityPrefix \"START \"CORECLR_PERF_RUN\" /B /WAIT /HIGH /AFFINITY 0x2\""
             String runXUnitPerflabArgs = "${runXUnitPerfCommonArgs} -testBinLoc bin\\tests\\${os}.${arch}.${config}\\performance\\perflab\\Perflab -library"
-            bat "tests\\scripts\\run-xunit-perf.cmd ${runXUnitPerflabArgs} -collectionFlags stopwatch"
-            bat "tests\\scripts\\run-xunit-perf.cmd ${runXUnitPerflabArgs} -collectionFlags default+BranchMispredictions+CacheMisses+InstructionRetired+gcapi"
+
+            if (isProfileOn) {
+                profileArg = "default+${profileArg}+gcapi"
+            }
+            bat "tests\\scripts\\run-xunit-perf.cmd ${runXUnitPerflabArgs} -collectionFlags ${profileArg}"
 
             String runXUnitCodeQualityArgs = "${runXUnitPerfCommonArgs} -testBinLoc bin\\tests\\${os}.${arch}.${config}\\Jit\\Performance\\CodeQuality"
-            bat "tests\\scripts\\run-xunit-perf.cmd ${runXUnitCodeQualityArgs} -collectionFlags stopwatch"
-            bat "tests\\scripts\\run-xunit-perf.cmd ${runXUnitCodeQualityArgs} -collectionFlags default+BranchMispredictions+CacheMisses+InstructionRetired+gcapi"
+            bat "tests\\scripts\\run-xunit-perf.cmd ${runXUnitCodeQualityArgs} -collectionFlags ${profileArg}"
         }
         else if (scenario == 'jitbench') {
             String runXUnitPerfCommonArgs = "${runXUnitCommonArgs} -stabilityPrefix \"START \"CORECLR_PERF_RUN\" /B /WAIT /HIGH\" -scenarioTest"
             runXUnitPerfCommonArgs = "${runXUnitPerfCommonArgs} -testBinLoc bin\\tests\\${os}.${arch}.${config}\\performance\\Scenario\\JitBench -group CoreCLR-Scenarios"
-            bat "tests\\scripts\\run-xunit-perf.cmd ${runXUnitPerfCommonArgs} -collectionFlags stopwatch"
 
-            if (opt_level != 'min_opt') {
-                bat "tests\\scripts\\run-xunit-perf.cmd ${runXUnitPerfCommonArgs} -collectionFlags BranchMispredictions+CacheMisses+InstructionRetired"
+            if (!(opt_level == 'min_opt' && isProfileOn)) {
+                bat "tests\\scripts\\run-xunit-perf.cmd ${runXUnitPerfCommonArgs} -collectionFlags ${profileArgs}"
             }
         }
         else if (scenario == 'illink') {
@@ -312,7 +320,7 @@ def innerLoopTests = [:]
             if (isPR() || !isBaseline) {
                 innerLoopTests["windows ${arch} ryujit ${opt_level} pgo${baseline} perf"] = {
                     simpleNode('windows_server_2016_clr_perf', 180) {
-                        windowsPerf(arch, config, uploadString, runType, opt_level, 'ryujit', 'pgo', 'perf', isBaseline)
+                        windowsPerf(arch, config, uploadString, runType, opt_level, 'ryujit', 'pgo', 'perf', isBaseline, true)
                     }
                 }
             }
@@ -340,15 +348,17 @@ if (!isPR()) {
         ['min_opt', 'full_opt'].each { opt_level ->
             ['ryujit'].each { jit ->
                 ['pgo', 'nopgo'].each { pgo_enabled ->
-                    outerLoopTests["windows ${arch} ${jit} ${opt_level} ${pgo_enabled} perf"] = {
-                        simpleNode('windows_server_2016_clr_perf', 180) {
-                            windowsPerf(arch, config, uploadString, runType, opt_level, jit, pgo_enabled, 'perf', false)
+                    [true, false].each { isProfileOn ->
+                        outerLoopTests["windows ${arch} ${jit} ${opt_level} ${pgo_enabled} perf"] = {
+                            simpleNode('windows_server_2016_clr_perf', 180) {
+                                windowsPerf(arch, config, uploadString, runType, opt_level, jit, pgo_enabled, 'perf', false, isProfileOn)
+                            }
                         }
-                    }
 
-                    outerLoopTests["windows ${arch} ${jit} ${opt_level} ${pgo_enabled} throughput"] = {
-                        simpleNode('windows_server_2016_clr_perf', 180) {
-                            windowsThroughput(arch, 'Windows_NT', config, runType, opt_level, jit, pgo_enabled, false)
+                        outerLoopTests["windows ${arch} ${jit} ${opt_level} ${pgo_enabled} throughput"] = {
+                            simpleNode('windows_server_2016_clr_perf', 180) {
+                                windowsThroughput(arch, 'Windows_NT', config, runType, opt_level, jit, pgo_enabled, false, is ProfileOn)
+                            }
                         }
                     }
                 }

--- a/buildpipeline/perf_pipelinejobs.groovy
+++ b/buildpipeline/perf_pipelinejobs.groovy
@@ -24,5 +24,8 @@ def pipeline = perfPipeline
 //               'OGroup':'Windows_NT']
 // pipeline.triggerPipelinOnGithubPRComment(triggerName, params)
 
-pipeline.triggerPipelineOnEveryGithubPR(triggerName)
+params = ['XUNIT_PERFORMANCE_MAX_ITERATION':'6',
+          'XUNIT_PERFORMANCE_MAX_ITERATION_INNER_SPECIFIED', '6']
+
+pipeline.triggerPipelineOnEveryGithubPR(triggerName, params)
 pipeline.triggerPipelineOnGithubPush()

--- a/buildpipeline/perf_pipelinejobs.groovy
+++ b/buildpipeline/perf_pipelinejobs.groovy
@@ -25,7 +25,7 @@ def pipeline = perfPipeline
 // pipeline.triggerPipelinOnGithubPRComment(triggerName, params)
 
 params = ['XUNIT_PERFORMANCE_MAX_ITERATION':'6',
-          'XUNIT_PERFORMANCE_MAX_ITERATION_INNER_SPECIFIED', '6']
+          'XUNIT_PERFORMANCE_MAX_ITERATION_INNER_SPECIFIED':'6']
 
 pipeline.triggerPipelineOnEveryGithubPR(triggerName, params)
 pipeline.triggerPipelineOnGithubPush()


### PR DESCRIPTION
In pipeline jobs, we can separate these two runs into separate runs.
Doing so decreases the time spent running windows jobs since we are not
running them in sequence. Only run Profile=On scenarios for PRs. This
should reduce the time spent running the PR job.