### PR TITLE
small changes to get coreclr building on FreeBSD again

### DIFF
--- a/src/gc/handletable.cpp
+++ b/src/gc/handletable.cpp
@@ -561,7 +561,7 @@ uintptr_t HndCompareExchangeHandleExtraInfo(OBJECTHANDLE handle, uint32_t uType,
     }
 
     _ASSERTE(!"Shouldn't be trying to call HndCompareExchangeHandleExtraInfo on handle types without extra info");
-    return NULL;
+    return (uintptr_t)NULL;
 }
 #endif // !DACCESS_COMPILE
 

--- a/src/gc/handletablescan.cpp
+++ b/src/gc/handletablescan.cpp
@@ -1360,7 +1360,7 @@ void xxxTableScanQueuedBlocksAsync(PTR_HandleTable pTable, PTR_TableSegment pSeg
 
 #ifndef DACCESS_COMPILE
     // loop through, unlock all the blocks we had locked, and reset the queue nodes
-    ProcessScanQueue(pAsyncInfo, UnlockAndForgetQueuedBlocks, NULL, FALSE);
+    ProcessScanQueue(pAsyncInfo, UnlockAndForgetQueuedBlocks, (uintptr_t)NULL, FALSE);
 #endif
 
     // we are done processing this segment
@@ -1836,7 +1836,7 @@ void CALLBACK xxxTableScanHandlesAsync(PTR_HandleTable pTable,
         asyncInfo.pScanQueue = initialNode.pNext;
 
         // loop through and free all the queue nodes
-        ProcessScanQueue(&asyncInfo, FreeScanQNode, NULL, TRUE);
+        ProcessScanQueue(&asyncInfo, FreeScanQNode, (uintptr_t)NULL, TRUE);
     }
 
     // unlink our async scanning info from the table

--- a/src/gc/unix/cgroup.cpp
+++ b/src/gc/unix/cgroup.cpp
@@ -11,6 +11,10 @@ Module Name:
 Abstract:
     Read memory and cpu limits for the current process
 --*/
+#ifdef __FreeBSD__
+#define _WITH_GETLINE
+#endif
+
 #include <cstdint>
 #include <cstddef>
 #include <cassert>


### PR DESCRIPTION
Small changes to get around new compiler warnings. There really should be no functional impact. 

coreclr bulid again on FreeBSD 11.0 with clang 3.9

This is part of https://github.com/dotnet/corefx/issues/1626