### PR TITLE
move fgFixupStructReturn call to the beggining of fgMorphCall

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -3065,11 +3065,6 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
         call->fgArgInfo = new (this, CMK_Unknown) fgArgInfo(this, call, numArgs);
     }
 
-    if (varTypeIsStruct(call))
-    {
-        fgFixupStructReturn(call);
-    }
-
     /* First we morph the argument subtrees ('this' pointer, arguments, etc.).
      * During the first call to fgMorphArgs we also record the
      * information about late arguments we have in 'fgArgInfo'.
@@ -8253,6 +8248,10 @@ GenTreePtr Compiler::fgAssignRecursiveCallArgToCallerParam(GenTreePtr       arg,
 
 GenTreePtr Compiler::fgMorphCall(GenTreeCall* call)
 {
+    if (varTypeIsStruct(call))
+    {
+        fgFixupStructReturn(call);
+    }
     if (call->CanTailCall())
     {
         // It should either be an explicit (i.e. tail prefixed) or an implicit tail call
@@ -8396,11 +8395,6 @@ GenTreePtr Compiler::fgMorphCall(GenTreeCall* call)
             }
         }
 #endif // FEATURE_TAILCALL_OPT
-
-        if (varTypeIsStruct(call))
-        {
-            fgFixupStructReturn(call);
-        }
 
         var_types callType = call->TypeGet();
 


### PR DESCRIPTION
This transformation looked strange in the list of the tail call checks.

It was done twice during the tail call optimization and in the args morphing. The problem is that if the tail call optimization was aborted it was not clear was `fgFixupStructReturn` called or not.

No spmi diffs.