### PR TITLE
Run clean -all instead of just -b

### DIFF
--- a/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
@@ -67,7 +67,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs) ./clean.sh",
+        "arguments": "run --rm $(DockerCommonRunArgs) ./clean.sh -all",
         "workingFolder": "",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/DotNet-CoreClr-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Linux.json
@@ -67,7 +67,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs) ./clean.sh",
+        "arguments": "run --rm $(DockerCommonRunArgs) ./clean.sh -all",
         "workingFolder": "",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/DotNet-CoreClr-Trusted-Mac.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Mac.json
@@ -12,7 +12,7 @@
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "$(Agent.BuildDirectory)/s/clean.sh",
+        "filename": "$(Agent.BuildDirectory)/s/clean.sh -all",
         "arguments": "",
         "workingFolder": "",
         "failOnStandardError": "false"

--- a/buildpipeline/DotNet-CoreClr-Trusted-Windows-x86.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Windows-x86.json
@@ -51,7 +51,7 @@
       },
       "inputs": {
         "filename": "clean.cmd",
-        "arguments": "",
+        "arguments": "-all",
         "workingFolder": "",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/DotNet-CoreClr-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Windows.json
@@ -51,7 +51,7 @@
       },
       "inputs": {
         "filename": "clean.cmd",
-        "arguments": "",
+        "arguments": "-all",
         "workingFolder": "",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
+++ b/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
@@ -34,7 +34,7 @@
       },
       "inputs": {
         "filename": "clean.cmd",
-        "arguments": "",
+        "arguments": "-all",
         "workingFolder": "",
         "failOnStandardError": "false"
       }


### PR DESCRIPTION
The default option for clean.cmd/.sh changed recently in https://github.com/dotnet/coreclr/pull/14882

@weshaggard 
skip ci please