### PR TITLE
Issue 14860. Disable incompatible test

### DIFF
--- a/tests/testsUnsupportedOnARM32.txt
+++ b/tests/testsUnsupportedOnARM32.txt
@@ -15,3 +15,4 @@ GC/Features/HeapExpansion/pluggaps/pluggaps.sh
 GC/Regressions/v2.0-beta2/460373/460373/460373.sh
 GC/Regressions/v2.0-beta1/149926/149926/149926.sh
 GC/Regressions/v2.0-rtm/494226/494226/494226.sh
+GC/Regressions/dev10bugs/536168/536168/536168.sh


### PR DESCRIPTION
#14860 
Disabled GC test requires much bigger amount of memory than arm32 machine may ever have.