### PR TITLE
[Local GC] Move knowledge of overlapped I/O objects to the EE through four callbacks

### DIFF
--- a/src/gc/env/common.h
+++ b/src/gc/env/common.h
@@ -16,6 +16,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <wchar.h>
 #include <assert.h>

--- a/src/gc/env/gcenv.base.h
+++ b/src/gc/env/gcenv.base.h
@@ -320,6 +320,11 @@ inline void* ALIGN_DOWN(void* ptr, size_t alignment)
     return reinterpret_cast<void*>(ALIGN_DOWN(as_size_t, alignment));
 }
 
+inline int GetRandomInt(int max)
+{
+    return rand() % max;
+}
+
 typedef struct _PROCESSOR_NUMBER {
     uint16_t Group;
     uint8_t Number;

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -80,8 +80,8 @@ public:
     static bool IsGCThread();
     static bool WasCurrentThreadCreatedByGC();
     static bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name);
-    static void WalkOverlappedObjectForPromotion(Object* object, ScanContext* sc, promote_func* callback);
-    static void WalkOverlappedObject(Object* object, void* context, void(*callback)(Object*, Object*, void*));
+    static void WalkAsyncPinnedForPromotion(Object* object, ScanContext* sc, promote_func* callback);
+    static void WalkAsyncPinned(Object* object, void* context, void(*callback)(Object*, Object*, void*));
     static void OverlappedClearIfComplete(Object* object);
     static void OverlappedSetPinnedHandle(Object* object, OBJECTHANDLE handle);
 };

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -80,6 +80,10 @@ public:
     static bool IsGCThread();
     static bool WasCurrentThreadCreatedByGC();
     static bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name);
+    static void WalkOverlappedObjectForPromotion(Object* object, ScanContext* sc, promote_func* callback);
+    static void WalkOverlappedObject(Object* object, void* context, void(*callback)(Object*, Object*, void*));
+    static void OverlappedClearIfComplete(Object* object);
+    static void OverlappedSetPinnedHandle(Object* object, OBJECTHANDLE handle);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -82,8 +82,6 @@ public:
     static bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name);
     static void WalkAsyncPinnedForPromotion(Object* object, ScanContext* sc, promote_func* callback);
     static void WalkAsyncPinned(Object* object, void* context, void(*callback)(Object*, Object*, void*));
-    static void OverlappedClearIfComplete(Object* object);
-    static void OverlappedSetPinnedHandle(Object* object, OBJECTHANDLE handle);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -258,16 +258,16 @@ inline bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg,
     return g_theGCToCLR->CreateThread(threadStart, arg, is_suspendable, name);
 }
 
-inline void GCToEEInterface::WalkOverlappedObjectForPromotion(Object* object, ScanContext* sc, promote_func* callback)
+inline void GCToEEInterface::WalkAsyncPinnedForPromotion(Object* object, ScanContext* sc, promote_func* callback)
 {
     assert(g_theGCToCLR != nullptr);
-    return g_theGCToCLR->WalkOverlappedObjectForPromotion(object, sc, callback);
+    return g_theGCToCLR->WalkAsyncPinnedForPromotion(object, sc, callback);
 }
 
-inline void GCToEEInterface::WalkOverlappedObject(Object* object, void* context, void(*callback)(Object*, Object*, void*))
+inline void GCToEEInterface::WalkAsyncPinned(Object* object, void* context, void(*callback)(Object*, Object*, void*))
 {
     assert(g_theGCToCLR != nullptr);
-    return g_theGCToCLR->WalkOverlappedObject(object, context, callback);
+    return g_theGCToCLR->WalkAsyncPinned(object, context, callback);
 }
 
 inline void GCToEEInterface::OverlappedClearIfComplete(Object* object)

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -258,5 +258,28 @@ inline bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg,
     return g_theGCToCLR->CreateThread(threadStart, arg, is_suspendable, name);
 }
 
+inline void GCToEEInterface::WalkOverlappedObjectForPromotion(Object* object, ScanContext* sc, promote_func* callback)
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->WalkOverlappedObjectForPromotion(object, sc, callback);
+}
+
+inline void GCToEEInterface::WalkOverlappedObject(Object* object, void* context, void(*callback)(Object*, Object*, void*))
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->WalkOverlappedObject(object, context, callback);
+}
+
+inline void GCToEEInterface::OverlappedClearIfComplete(Object* object)
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->OverlappedClearIfComplete(object);
+}
+
+inline void GCToEEInterface::OverlappedSetPinnedHandle(Object* object, OBJECTHANDLE handle) 
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->OverlappedSetPinnedHandle(object, handle);
+}
 
 #endif // __GCTOENV_EE_STANDALONE_INL__

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -270,16 +270,4 @@ inline void GCToEEInterface::WalkAsyncPinned(Object* object, void* context, void
     return g_theGCToCLR->WalkAsyncPinned(object, context, callback);
 }
 
-inline void GCToEEInterface::OverlappedClearIfComplete(Object* object)
-{
-    assert(g_theGCToCLR != nullptr);
-    return g_theGCToCLR->OverlappedClearIfComplete(object);
-}
-
-inline void GCToEEInterface::OverlappedSetPinnedHandle(Object* object, OBJECTHANDLE handle) 
-{
-    assert(g_theGCToCLR != nullptr);
-    return g_theGCToCLR->OverlappedSetPinnedHandle(object, handle);
-}
-
 #endif // __GCTOENV_EE_STANDALONE_INL__

--- a/src/gc/gchandletable.cpp
+++ b/src/gc/gchandletable.cpp
@@ -57,11 +57,11 @@ OBJECTHANDLE GCHandleStore::CreateDependentHandle(Object* primary, Object* secon
     return handle;
 }
 
-void GCHandleStore::RelocateAsyncPinnedHandles(IGCHandleStore* pTarget)
+void GCHandleStore::RelocateAsyncPinnedHandles(IGCHandleStore* pTarget, void (*clearIfComplete)(Object*), void (*setHandle)(Object*, OBJECTHANDLE))
 {
     // assumption - the IGCHandleStore is an instance of GCHandleStore
     GCHandleStore* other = static_cast<GCHandleStore*>(pTarget);
-    ::Ref_RelocateAsyncPinHandles(&_underlyingBucket, &other->_underlyingBucket);
+    ::Ref_RelocateAsyncPinHandles(&_underlyingBucket, &other->_underlyingBucket, clearIfComplete, setHandle);
 }
 
 bool GCHandleStore::EnumerateAsyncPinnedHandles(async_pin_enum_fn callback, void* context)

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -23,7 +23,7 @@ public:
 
     virtual OBJECTHANDLE CreateDependentHandle(Object* primary, Object* secondary);
 
-    virtual void RelocateAsyncPinnedHandles(IGCHandleStore* pTarget);
+    virtual void RelocateAsyncPinnedHandles(IGCHandleStore* pTarget, void (*clearIfCompleteCallback)(Object* object), void (*setHandle)(Object* object, OBJECTHANDLE handle));
 
     virtual bool EnumerateAsyncPinnedHandles(async_pin_enum_fn callback, void* context);
 

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -231,7 +231,7 @@ public:
     //
     // This function is a no-op if "object" is not an OverlappedData object.
     virtual
-    void WalkOverlappedObjectForPromotion(Object* object, ScanContext* sc, promote_func* callback) = 0;
+    void WalkAsyncPinnedForPromotion(Object* object, ScanContext* sc, promote_func* callback) = 0;
 
     // Given an object, if this object is an instance of `System.Threading.OverlappedData` and the
     // runtime treats instances of this class specially, traverses the objects that are directly
@@ -250,7 +250,7 @@ public:
     //
     // This function is a no-op if "object" is not an OverlappedData object.
     virtual
-    void WalkOverlappedObject(Object* object, void* context, void(*callback)(Object*, Object*, void*)) = 0;
+    void WalkAsyncPinned(Object* object, void* context, void(*callback)(Object*, Object*, void*)) = 0;
 
     // Given an object, if this object is an instance of `System.Threading.OverlappedData` and the
     // runtime treats instances of this class specially, the runtime is given a chance to eagerly remove the

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -251,19 +251,6 @@ public:
     // This function is a no-op if "object" is not an OverlappedData object.
     virtual
     void WalkAsyncPinned(Object* object, void* context, void(*callback)(Object*, Object*, void*)) = 0;
-
-    // Given an object, if this object is an instance of `System.Threading.OverlappedData` and the
-    // runtime treats instances of this class specially, the runtime is given a chance to eagerly remove the
-    // pin to the target object if the overlapped I/O operation has already completed.
-    //
-    // This function is a no-op if "object" is not an OverlappedData object.
-    virtual
-    void OverlappedClearIfComplete(Object* object) = 0;
-
-    // If the given object is an instance of `System.Threading.OverlappedData`, sets the self-pinning
-    // handle of the overlapped data object to the given handle.
-    virtual
-    void OverlappedSetPinnedHandle(Object* object, OBJECTHANDLE handle) = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -219,6 +219,51 @@ public:
     // or a server GC thread.
     virtual
     bool WasCurrentThreadCreatedByGC() = 0;
+
+    // Given an object, if this object is an instance of `System.Threading.OverlappedData`,
+    // and the runtime treats instances of this class specially, traverses the objects that
+    // are directly or (once) indirectly pinned by this object and reports them to the GC for
+    // the purposes of relocation and promotion.
+    //
+    // Overlapped objects are very special and as such the objects they wrap can't be promoted in
+    // the same manner as normal objects. This callback gives the EE the opportunity to hide these
+    // details, if they are implemented at all.
+    //
+    // This function is a no-op if "object" is not an OverlappedData object.
+    virtual
+    void WalkOverlappedObjectForPromotion(Object* object, ScanContext* sc, promote_func* callback) = 0;
+
+    // Given an object, if this object is an instance of `System.Threading.OverlappedData` and the
+    // runtime treats instances of this class specially, traverses the objects that are directly
+    // or once indirectly pinned by this object and invokes the given callback on them. The callback
+    // is passed the following arguments:
+    //     Object* "from" - The object that "caused" the "to" object to be pinned. If a single object
+    //                      is pinned directly by this OverlappedData, this object will be the
+    //                      OverlappedData object itself. If an array is pinned by this OverlappedData,
+    //                      this object will be the pinned array.
+    //     Object* "to"   - The object that is pinned by the "from" object. If a single object is pinned
+    //                      by an OverlappedData, "to" will be that single object. If an array is pinned
+    //                      by an OverlappedData, the callback will be invoked on all elements of that
+    //                      array and each element will be a "to" object.
+    //     void* "context" - Passed verbatim from "WalkOverlappedObject" to the callback function.
+    // The "context" argument will be passed directly to the callback without modification or inspection.
+    //
+    // This function is a no-op if "object" is not an OverlappedData object.
+    virtual
+    void WalkOverlappedObject(Object* object, void* context, void(*callback)(Object*, Object*, void*)) = 0;
+
+    // Given an object, if this object is an instance of `System.Threading.OverlappedData` and the
+    // runtime treats instances of this class specially, the runtime is given a chance to eagerly remove the
+    // pin to the target object if the overlapped I/O operation has already completed.
+    //
+    // This function is a no-op if "object" is not an OverlappedData object.
+    virtual
+    void OverlappedClearIfComplete(Object* object) = 0;
+
+    // If the given object is an instance of `System.Threading.OverlappedData`, sets the self-pinning
+    // handle of the overlapped data object to the given handle.
+    virtual
+    void OverlappedSetPinnedHandle(Object* object, OBJECTHANDLE handle) = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -111,6 +111,17 @@ struct WriteBarrierParameters
     uint8_t* write_watch_table;
 };
 
+// Opaque type for tracking object pointers
+#ifndef DACCESS_COMPILE
+struct OBJECTHANDLE__
+{
+    void* unused;
+};
+typedef struct OBJECTHANDLE__* OBJECTHANDLE;
+#else
+typedef uintptr_t OBJECTHANDLE;
+#endif
+
  /*
   * Scanning callback.
   */
@@ -393,16 +404,7 @@ typedef void (* fq_scan_fn)(Object** ppObject, ScanContext *pSC, uint32_t dwFlag
 typedef void (* handle_scan_fn)(Object** pRef, Object* pSec, uint32_t flags, ScanContext* context, bool isDependent);
 typedef bool (* async_pin_enum_fn)(Object* object, void* context);
 
-// Opaque type for tracking object pointers
-#ifndef DACCESS_COMPILE
-struct OBJECTHANDLE__
-{
-    void* unused;
-};
-typedef struct OBJECTHANDLE__* OBJECTHANDLE;
-#else
-typedef uintptr_t OBJECTHANDLE;
-#endif
+
 
 class IGCHandleStore {
 public:

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -421,7 +421,14 @@ public:
 
     virtual OBJECTHANDLE CreateDependentHandle(Object* primary, Object* secondary) = 0;
 
-    virtual void RelocateAsyncPinnedHandles(IGCHandleStore* pTarget) = 0;
+    // Relocates async pinned handles from a condemned handle store to the default domain's handle store.
+    //
+    // The two callbacks are called when:
+    //   1. clearIfComplete is called whenever the handle table observes an async pin that is still live.
+    //      The callback gives a chance for the EE to unpin the referents if the overlapped operation is complete.
+    //   2. setHandle is called whenever the GC has relocated the async pin to a new handle table. The passed-in
+    //      handle is the newly-allocated handle in the default domain that should be assigned to the overlapped object.
+    virtual void RelocateAsyncPinnedHandles(IGCHandleStore* pTarget, void (*clearIfComplete)(Object*), void (*setHandle)(Object*, OBJECTHANDLE)) = 0;
 
     virtual bool EnumerateAsyncPinnedHandles(async_pin_enum_fn callback, void* context) = 0;
 

--- a/src/gc/handletable.cpp
+++ b/src/gc/handletable.cpp
@@ -1178,7 +1178,10 @@ BOOL  Ref_HandleAsyncPinHandles(async_pin_enum_fn asyncPinCallback, void* contex
     return result;
 }
 
-void  Ref_RelocateAsyncPinHandles(HandleTableBucket *pSource, HandleTableBucket *pTarget)
+void  Ref_RelocateAsyncPinHandles(HandleTableBucket *pSource,
+    HandleTableBucket *pTarget,
+    void (*clearIfComplete)(Object* object),
+    void (*setHandle)(Object* object, OBJECTHANDLE handle))
 {
     CONTRACTL
     {
@@ -1190,7 +1193,7 @@ void  Ref_RelocateAsyncPinHandles(HandleTableBucket *pSource, HandleTableBucket 
     int limit = getNumberOfSlots();
     for (int n = 0; n < limit; n ++ )
     {
-        TableRelocateAsyncPinHandles(Table(pSource->pTable[n]), Table(pTarget->pTable[n]));
+        TableRelocateAsyncPinHandles(Table(pSource->pTable[n]), Table(pTarget->pTable[n]), clearIfComplete, setHandle);
     }
 }
 

--- a/src/gc/handletablecore.cpp
+++ b/src/gc/handletablecore.cpp
@@ -663,7 +663,7 @@ __inline void SegmentUnMarkFreeMask(TableSegment *pSegment, _UNCHECKED_OBJECTREF
 
 // Prepare a segment to be moved to default domain.
 // Remove all non-async pin handles.
-void SegmentPreCompactAsyncPinHandles(TableSegment *pSegment)
+void SegmentPreCompactAsyncPinHandles(TableSegment *pSegment, void (*clearIfComplete)(Object*))
 {
     CONTRACTL
     {
@@ -755,7 +755,7 @@ void SegmentPreCompactAsyncPinHandles(TableSegment *pSegment)
             _UNCHECKED_OBJECTREF value = *pValue;
             if (!HndIsNullOrDestroyedHandle(value))
             {
-                GCToEEInterface::OverlappedClearIfComplete((Object*)value);
+                ((Object*)value);
             }
             else
             {
@@ -829,7 +829,7 @@ BOOL SegmentCopyAsyncPinHandle(TableSegment *pSegment, _UNCHECKED_OBJECTREF *h)
     return TRUE;
 }
 
-void SegmentCompactAsyncPinHandles(TableSegment *pSegment, TableSegment **ppWorkerSegment)
+void SegmentCompactAsyncPinHandles(TableSegment *pSegment, TableSegment **ppWorkerSegment, void (*clearIfComplete)(Object*))
 {
     CONTRACTL
     {
@@ -863,7 +863,7 @@ void SegmentCompactAsyncPinHandles(TableSegment *pSegment, TableSegment **ppWork
             _UNCHECKED_OBJECTREF value = *pValue;
             if (!HndIsNullOrDestroyedHandle(value))
             {
-                GCToEEInterface::OverlappedClearIfComplete((Object*)value);
+                clearIfComplete((Object*)value);
                 fNeedNewSegment = !SegmentCopyAsyncPinHandle(*ppWorkerSegment,pValue);
             }
             if (fNeedNewSegment)
@@ -871,7 +871,7 @@ void SegmentCompactAsyncPinHandles(TableSegment *pSegment, TableSegment **ppWork
                 _ASSERTE ((*ppWorkerSegment)->rgFreeCount[HNDTYPE_ASYNCPINNED] == 0 &&
                           (*ppWorkerSegment)->bFreeList == BLOCK_INVALID);
                 TableSegment *pNextSegment = (*ppWorkerSegment)->pNextSegment;
-                SegmentPreCompactAsyncPinHandles(pNextSegment);
+                SegmentPreCompactAsyncPinHandles(pNextSegment, clearIfComplete);
                 *ppWorkerSegment = pNextSegment;
                 if (pNextSegment == pSegment)
                 {
@@ -941,7 +941,10 @@ BOOL SegmentHandleAsyncPinHandles (TableSegment *pSegment, const AsyncPinCallbac
 }
 
 // Replace an async pin handle with one from default domain
-bool SegmentRelocateAsyncPinHandles (TableSegment *pSegment, HandleTable *pTargetTable)
+bool SegmentRelocateAsyncPinHandles (TableSegment *pSegment,
+    HandleTable *pTargetTable,
+    void (*clearIfComplete)(Object*),
+    void (*setHandle)(Object*, OBJECTHANDLE))
 {
     CONTRACTL
     {
@@ -975,7 +978,7 @@ bool SegmentRelocateAsyncPinHandles (TableSegment *pSegment, HandleTable *pTarge
             _UNCHECKED_OBJECTREF value = *pValue;
             if (!HndIsNullOrDestroyedHandle(value))
             {
-                GCToEEInterface::OverlappedClearIfComplete((Object*)value);
+                clearIfComplete((Object*)value);
                 OBJECTHANDLE selfHandle = HndCreateHandle((HHANDLETABLE)pTargetTable, HNDTYPE_ASYNCPINNED, ObjectToOBJECTREF(value));
                 if (!selfHandle)
                 {
@@ -983,7 +986,7 @@ bool SegmentRelocateAsyncPinHandles (TableSegment *pSegment, HandleTable *pTarge
                     return false;
                 }
 
-                GCToEEInterface::OverlappedSetPinnedHandle((Object*)value, selfHandle);
+                setHandle((Object*)value, selfHandle);
                 *pValue = NULL;
             }
             pValue ++;
@@ -1033,7 +1036,10 @@ BOOL TableHandleAsyncPinHandles(HandleTable *pTable, const AsyncPinCallbackConte
 //       from a again.
 //    c. After copying all handles to worker segments, move the segments to default domain.
 // It is very important that in step 2, we should not fail for OOM, which means no memory allocation.
-void TableRelocateAsyncPinHandles(HandleTable *pTable, HandleTable *pTargetTable)
+void TableRelocateAsyncPinHandles(HandleTable *pTable,
+    HandleTable *pTargetTable,
+    void (*clearIfComplete)(Object*),
+    void (*setHandle)(Object*, OBJECTHANDLE))
 {
     CONTRACTL
     {
@@ -1058,7 +1064,7 @@ void TableRelocateAsyncPinHandles(HandleTable *pTable, HandleTable *pTargetTable
     // Step 1: replace pinning handles with ones from default domain
     while (pSegment)
     {
-        wasSuccessful = wasSuccessful && SegmentRelocateAsyncPinHandles (pSegment, pTargetTable);
+        wasSuccessful = wasSuccessful && SegmentRelocateAsyncPinHandles (pSegment, pTargetTable, clearIfComplete, setHandle);
         if (!wasSuccessful)
         {
             break;
@@ -1110,12 +1116,12 @@ SLOW_PATH:
         // Compact async pinning handles into the smallest number of leading segments we can (the worker
         // segments).
         TableSegment *pWorkerSegment = pTable->pSegmentList;
-        SegmentPreCompactAsyncPinHandles (pWorkerSegment);
+        SegmentPreCompactAsyncPinHandles (pWorkerSegment, clearIfComplete);
 
         pSegment = pWorkerSegment->pNextSegment;
         while (pSegment)
         {
-            SegmentCompactAsyncPinHandles (pSegment, &pWorkerSegment);
+            SegmentCompactAsyncPinHandles (pSegment, &pWorkerSegment, clearIfComplete);
             pSegment= pSegment->pNextSegment;
         }
 

--- a/src/gc/handletablecore.cpp
+++ b/src/gc/handletablecore.cpp
@@ -755,7 +755,7 @@ void SegmentPreCompactAsyncPinHandles(TableSegment *pSegment, void (*clearIfComp
             _UNCHECKED_OBJECTREF value = *pValue;
             if (!HndIsNullOrDestroyedHandle(value))
             {
-                ((Object*)value);
+                clearIfComplete((Object*)value);
             }
             else
             {

--- a/src/gc/handletablecore.cpp
+++ b/src/gc/handletablecore.cpp
@@ -661,7 +661,6 @@ __inline void SegmentUnMarkFreeMask(TableSegment *pSegment, _UNCHECKED_OBJECTREF
     pSegment->rgFreeMask[uMask] &= ~(1<<uBit);
 }
 
-#ifndef FEATURE_REDHAWK
 // Prepare a segment to be moved to default domain.
 // Remove all non-async pin handles.
 void SegmentPreCompactAsyncPinHandles(TableSegment *pSegment)
@@ -1008,8 +1007,6 @@ BOOL TableHandleAsyncPinHandles(HandleTable *pTable, const AsyncPinCallbackConte
     }
     CONTRACTL_END;
 
-    _ASSERTE (pTable->uADIndex.m_dwIndex == DefaultADID);
-
     BOOL result = FALSE;
     TableSegment *pSegment = pTable->pSegmentList;
 
@@ -1167,7 +1164,6 @@ SLOW_PATH:
         break;
     }
 }
-#endif // !FEATURE_REDHAWK
 
 /*
  * Check if a handle is part of a HandleTable

--- a/src/gc/handletablepriv.h
+++ b/src/gc/handletablepriv.h
@@ -795,7 +795,7 @@ BOOL TableHandleAsyncPinHandles(HandleTable *pTable, const AsyncPinCallbackConte
  * Replaces async pin handles with ones in default domain.
  *
  */
-void TableRelocateAsyncPinHandles(HandleTable *pTable, HandleTable *pTargetTable);
+void TableRelocateAsyncPinHandles(HandleTable *pTable, HandleTable *pTargetTable, void (*clearIfComplete)(Object*), void (*setHandle)(Object*, OBJECTHANDLE));
 
 /*
  * Check if a handle is part of a HandleTable

--- a/src/gc/handletablescan.cpp
+++ b/src/gc/handletablescan.cpp
@@ -818,7 +818,7 @@ void BlockResetAgeMapForBlocksWorker(uint32_t *pdwGen, uint32_t dwClumpMask, Sca
                     if (minAge > thisAge)
                         minAge = thisAge;
 
-                    GCToEEInterface::WalkOverlappedObject(*pValue, &minAge,
+                    GCToEEInterface::WalkAsyncPinned(*pValue, &minAge,
                         [](Object*, Object* to, void* ctx)
                         {
                             int* minAge = reinterpret_cast<int*>(ctx);
@@ -969,7 +969,7 @@ void BlockVerifyAgeMapForBlocksWorker(uint32_t *pdwGen, uint32_t dwClumpMask, Sc
                 if (!HndIsNullOrDestroyedHandle(*pValue))
                 {
                     VerifyObjectAndAge((*pValue), (*pValue), minAge);
-                    GCToEEInterface::WalkOverlappedObject(*pValue, &minAge,
+                    GCToEEInterface::WalkAsyncPinned(*pValue, &minAge,
                         [](Object* from, Object* object, void* age)
                         {
                             uint8_t* minAge = reinterpret_cast<uint8_t*>(age);

--- a/src/gc/handletablescan.cpp
+++ b/src/gc/handletablescan.cpp
@@ -20,10 +20,6 @@
 #include "objecthandle.h"
 #include "handletablepriv.h"
 
-#ifndef FEATURE_REDHAWK
-#include "nativeoverlapped.h"
-#endif // FEATURE_REDHAWK
-
 
 /****************************************************************************
  *
@@ -822,33 +818,17 @@ void BlockResetAgeMapForBlocksWorker(uint32_t *pdwGen, uint32_t dwClumpMask, Sca
                     if (minAge > thisAge)
                         minAge = thisAge;
 
-#ifndef FEATURE_REDHAWK
-                    if ((*pValue)->GetGCSafeMethodTable() == g_pOverlappedDataClass)
-                    {
-                        // reporting the pinned user objects
-                        OverlappedDataObject *pOverlapped = (OverlappedDataObject *)(*pValue);
-                        if (pOverlapped->m_userObject != NULL)
+                    GCToEEInterface::WalkOverlappedObject(*pValue, &minAge,
+                        [](Object*, Object* to, void* ctx)
                         {
-                            Object * pUserObject = OBJECTREFToObject(pOverlapped->m_userObject);
-                            thisAge = g_theGCHeap->WhichGeneration(pUserObject);
-                            if (minAge > thisAge)
-                                minAge = thisAge;
-                            if (pOverlapped->m_isArray)
+                            int* minAge = reinterpret_cast<int*>(ctx);
+                            int generation = g_theGCHeap->WhichGeneration(to);
+                            if (*minAge > generation)
                             {
-                                ArrayBase* pUserArrayObject = (ArrayBase*)pUserObject;
-                                Object **pObj = (Object**)pUserArrayObject->GetDataPtr(TRUE);
-                                size_t num = pUserArrayObject->GetNumComponents();
-                                for (size_t i = 0; i < num; i ++)
-                                {
-                                     thisAge = g_theGCHeap->WhichGeneration(pObj[i]);
-                                     if (minAge > thisAge)
-                                         minAge = thisAge;
-                                 }                                    
-                            }                            
-                        }
-                    }
-#endif // !FEATURE_REDHAWK                    
-                }
+                                *minAge = generation;
+                            }
+                        });
+               }
             }
             _ASSERTE(FitsInU1(minAge));
             ((uint8_t *)pSegment->rgGeneration)[uClump] = static_cast<uint8_t>(minAge);
@@ -920,9 +900,8 @@ static void VerifyObject(_UNCHECKED_OBJECTREF from, _UNCHECKED_OBJECTREF obj)
 #endif // FEATURE_REDHAWK
 }
 
-static void VerifyObjectAndAge(_UNCHECKED_OBJECTREF *pValue, _UNCHECKED_OBJECTREF from, _UNCHECKED_OBJECTREF obj, uint8_t minAge)
+static void VerifyObjectAndAge(_UNCHECKED_OBJECTREF from, _UNCHECKED_OBJECTREF obj, uint8_t minAge)
 {
-    UNREFERENCED_PARAMETER(pValue);
     VerifyObject(from, obj);
 
     int thisAge = g_theGCHeap->WhichGeneration(obj);
@@ -989,29 +968,13 @@ void BlockVerifyAgeMapForBlocksWorker(uint32_t *pdwGen, uint32_t dwClumpMask, Sc
             {
                 if (!HndIsNullOrDestroyedHandle(*pValue))
                 {
-                    VerifyObjectAndAge(pValue, (*pValue), (*pValue), minAge);
-#ifndef FEATURE_REDHAWK
-                    if ((*pValue)->GetGCSafeMethodTable() == g_pOverlappedDataClass)
-                    {
-                        // reporting the pinned user objects
-                        OverlappedDataObject *pOverlapped = (OverlappedDataObject *)(*pValue);
-                        if (pOverlapped->m_userObject != NULL)
+                    VerifyObjectAndAge((*pValue), (*pValue), minAge);
+                    GCToEEInterface::WalkOverlappedObject(*pValue, &minAge,
+                        [](Object* from, Object* object, void* age)
                         {
-                            Object * pUserObject = OBJECTREFToObject(pOverlapped->m_userObject);
-                            VerifyObjectAndAge(pValue, (*pValue), pUserObject, minAge);
-                            if (pOverlapped->m_isArray)
-                            {
-                                ArrayBase* pUserArrayObject = (ArrayBase*)pUserObject;
-                                Object **pObj = (Object**)pUserArrayObject->GetDataPtr(TRUE);
-                                size_t num = pUserArrayObject->GetNumComponents();
-                                for (size_t i = 0; i < num; i ++)
-                                {
-                                     VerifyObjectAndAge(pValue, pUserObject, pObj[i], minAge);
-                                }                                    
-                            }                            
-                        }
-                    }
-#endif // !FEATURE_REDHAWK
+                            uint8_t* minAge = reinterpret_cast<uint8_t*>(age);
+                            VerifyObjectAndAge(from, object, *minAge);
+                        });
 
                     if (uType == HNDTYPE_DEPENDENT)
                     {

--- a/src/gc/objecthandle.cpp
+++ b/src/gc/objecthandle.cpp
@@ -278,7 +278,7 @@ void CALLBACK PinObject(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *pExtraInfo, ui
     Object * pPinnedObj = *pRef;
     if (!HndIsNullOrDestroyedHandle(pPinnedObj))
     {
-        GCToEEInterface::WalkOverlappedObjectForPromotion(pPinnedObj, (ScanContext *)lp1, callback);
+        GCToEEInterface::WalkAsyncPinnedForPromotion(pPinnedObj, (ScanContext *)lp1, callback);
     }
 }
 
@@ -393,14 +393,12 @@ void CALLBACK UpdatePointer(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *pExtraInfo
  */
 void CALLBACK ScanPointerForProfilerAndETW(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *pExtraInfo, uintptr_t lp1, uintptr_t lp2)
 {
-#ifndef FEATURE_REDHAWK
     CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
     }
     CONTRACTL_END;
-#endif // FEATURE_REDHAWK
     UNREFERENCED_PARAMETER(pExtraInfo);
     handle_scan_fn fn = (handle_scan_fn)lp2;
 

--- a/src/gc/objecthandle.h
+++ b/src/gc/objecthandle.h
@@ -81,7 +81,7 @@ void Ref_Shutdown();
 HandleTableBucket* Ref_CreateHandleTableBucket(void* context);
 bool Ref_InitializeHandleTableBucket(HandleTableBucket* bucket, void* context);
 BOOL Ref_HandleAsyncPinHandles(async_pin_enum_fn callback, void* context);
-void Ref_RelocateAsyncPinHandles(HandleTableBucket *pSource, HandleTableBucket *pTarget);
+void Ref_RelocateAsyncPinHandles(HandleTableBucket *pSource, HandleTableBucket *pTarget, void (*clearIfComplete)(Object*), void (*setHandle)(Object*, OBJECTHANDLE));
 void Ref_RemoveHandleTableBucket(HandleTableBucket *pBucket);
 void Ref_DestroyHandleTableBucket(HandleTableBucket *pBucket);
 

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -337,11 +337,3 @@ void GCToEEInterface::WalkAsyncPinnedForPromotion(Object* object, ScanContext* s
 void GCToEEInterface::WalkAsyncPinned(Object* object, void* context, void (*callback)(Object*, Object*, void*))
 {
 }
-
-void GCToEEInterface::OverlappedClearIfComplete(Object* object)
-{
-}
-
-void GCToEEInterface::OverlappedSetPinnedHandle(Object* object, OBJECTHANDLE handle)
-{
-}

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -330,11 +330,11 @@ bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool i
     return false;
 }
 
-void GCToEEInterface::WalkOverlappedObjectForPromotion(Object* object, ScanContext* sc, promote_func* callback)
+void GCToEEInterface::WalkAsyncPinnedForPromotion(Object* object, ScanContext* sc, promote_func* callback)
 {
 }
 
-void GCToEEInterface::WalkOverlappedObject(Object* object, void* context, void (*callback)(Object*, Object*, void*))
+void GCToEEInterface::WalkAsyncPinned(Object* object, void* context, void (*callback)(Object*, Object*, void*))
 {
 }
 

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -329,3 +329,19 @@ bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool i
 {
     return false;
 }
+
+void GCToEEInterface::WalkOverlappedObjectForPromotion(Object* object, ScanContext* sc, promote_func* callback)
+{
+}
+
+void GCToEEInterface::WalkOverlappedObject(Object* object, void* context, void (*callback)(Object*, Object*, void*))
+{
+}
+
+void GCToEEInterface::OverlappedClearIfComplete(Object* object)
+{
+}
+
+void GCToEEInterface::OverlappedSetPinnedHandle(Object* object, OBJECTHANDLE handle)
+{
+}

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -9071,7 +9071,43 @@ void AppDomain::HandleAsyncPinHandles()
     // 4. Then we can delete all AsyncPinHandle marked with READYTOCLEAN.
     IGCHandleStore *pBucketInDefault = SystemDomain::System()->DefaultDomain()->m_handleStore;
 
-    pBucket->RelocateAsyncPinnedHandles(pBucketInDefault);
+    auto clearIfComplete = [](Object* object)
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        assert(object != nullptr);
+        if (object->GetGCSafeMethodTable() != g_pOverlappedDataClass)
+        {
+            return;
+        }
+
+        OVERLAPPEDDATAREF overlapped = (OVERLAPPEDDATAREF)(ObjectToOBJECTREF((Object*)object));
+        if (overlapped->HasCompleted())
+        {
+            // IO has finished.  We don't need to pin the user buffer any longer.
+            overlapped->m_userObject = NULL;
+        }
+
+        BashMTForPinnedObject(ObjectToOBJECTREF(object));
+    };
+
+    auto setHandle = [](Object* object, OBJECTHANDLE handle)
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        assert(object != nullptr);
+        assert(handle);
+
+        if (object->GetGCSafeMethodTable() != g_pOverlappedDataClass)
+        {
+            return;
+        }
+
+        OverlappedDataObject* overlapped = (OverlappedDataObject*)object;
+        overlapped->m_pinSelf = handle;
+    };
+
+    pBucket->RelocateAsyncPinnedHandles(pBucketInDefault, clearIfComplete, setHandle);
 
     OverlappedDataObject::RequestCleanup();
 }

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1307,3 +1307,117 @@ bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool i
         return CreateNonSuspendableThread(threadStart, arg, name);
     }
 }
+
+void GCToEEInterface::WalkOverlappedObjectForPromotion(Object* object, ScanContext* sc, promote_func* callback)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    assert(object != nullptr);
+    assert(sc != nullptr);
+    assert(callback != nullptr);
+    if (object->GetGCSafeMethodTable() != g_pOverlappedDataClass)
+    {
+        // not an overlapped data object - nothing to do.
+        return;
+    }
+
+    // reporting the pinned user objects
+    OverlappedDataObject *pOverlapped = (OverlappedDataObject *)object;
+    if (pOverlapped->m_userObject != NULL)
+    {
+        //callback(OBJECTREF_TO_UNCHECKED_OBJECTREF(pOverlapped->m_userObject), (ScanContext *)lp1, GC_CALL_PINNED);
+        if (pOverlapped->m_isArray)
+        {
+            // OverlappedDataObject is very special.  An async pin handle keeps it alive.
+            // During GC, we also make sure
+            // 1. m_userObject itself does not move if m_userObject is not array
+            // 2. Every object pointed by m_userObject does not move if m_userObject is array
+            // We do not want to pin m_userObject if it is array.  But m_userObject may be updated
+            // during relocation phase before OverlappedDataObject is doing relocation.
+            // m_userObjectInternal is used to track the location of the m_userObject before it is updated.
+            pOverlapped->m_userObjectInternal = static_cast<void*>(OBJECTREFToObject(pOverlapped->m_userObject));
+            ArrayBase* pUserObject = (ArrayBase*)OBJECTREFToObject(pOverlapped->m_userObject);
+            Object **ppObj = (Object**)pUserObject->GetDataPtr(TRUE);
+            size_t num = pUserObject->GetNumComponents();
+            for (size_t i = 0; i < num; i++)
+            {
+                callback(ppObj + i, sc, GC_CALL_PINNED);
+            }
+        }
+        else
+        {
+            callback(&OBJECTREF_TO_UNCHECKED_OBJECTREF(pOverlapped->m_userObject), (ScanContext *)sc, GC_CALL_PINNED);
+        }
+    }
+
+    if (pOverlapped->GetAppDomainId() != DefaultADID && pOverlapped->GetAppDomainIndex().m_dwIndex == DefaultADID)
+    {
+        OverlappedDataObject::MarkCleanupNeededFromGC();
+    }
+}
+
+void GCToEEInterface::WalkOverlappedObject(Object* object, void* context, void (*callback)(Object*, Object*, void*))
+{
+    LIMITED_METHOD_CONTRACT;
+
+    assert(object != nullptr);
+    assert(callback != nullptr);
+
+    if (object->GetGCSafeMethodTable() != g_pOverlappedDataClass)
+    {
+        return;
+    }
+
+    OverlappedDataObject *pOverlapped = (OverlappedDataObject *)(object);
+    if (pOverlapped->m_userObject != NULL)
+    {
+        Object * pUserObject = OBJECTREFToObject(pOverlapped->m_userObject);
+        callback(object, pUserObject, context);
+        if (pOverlapped->m_isArray)
+        {
+            ArrayBase* pUserArrayObject = (ArrayBase*)pUserObject;
+            Object **pObj = (Object**)pUserArrayObject->GetDataPtr(TRUE);
+            size_t num = pUserArrayObject->GetNumComponents();
+            for (size_t i = 0; i < num; i ++)
+            {
+                callback(pUserObject, pObj[i], context);
+            }
+        }
+    }
+}
+
+void GCToEEInterface::OverlappedClearIfComplete(Object* object)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    assert(object != nullptr);
+    if (object->GetGCSafeMethodTable() != g_pOverlappedDataClass)
+    {
+        return;
+    }
+
+    OVERLAPPEDDATAREF overlapped = (OVERLAPPEDDATAREF)(ObjectToOBJECTREF((Object*)object));
+    if (overlapped->HasCompleted())
+    {
+        // IO has finished.  We don't need to pin the user buffer any longer.
+        overlapped->m_userObject = NULL;
+    }
+
+    BashMTForPinnedObject(ObjectToOBJECTREF(object));
+}
+
+void GCToEEInterface::OverlappedSetPinnedHandle(Object* object, OBJECTHANDLE handle) 
+{
+    LIMITED_METHOD_CONTRACT;
+
+    assert(object != nullptr);
+    assert(handle);
+
+    if (object->GetGCSafeMethodTable() != g_pOverlappedDataClass)
+    {
+        return;
+    }
+
+    OverlappedDataObject* overlapped = (OverlappedDataObject*)object;
+    overlapped->m_pinSelf = handle;
+}

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1308,7 +1308,7 @@ bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool i
     }
 }
 
-void GCToEEInterface::WalkOverlappedObjectForPromotion(Object* object, ScanContext* sc, promote_func* callback)
+void GCToEEInterface::WalkAsyncPinnedForPromotion(Object* object, ScanContext* sc, promote_func* callback)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -1356,7 +1356,7 @@ void GCToEEInterface::WalkOverlappedObjectForPromotion(Object* object, ScanConte
     }
 }
 
-void GCToEEInterface::WalkOverlappedObject(Object* object, void* context, void (*callback)(Object*, Object*, void*))
+void GCToEEInterface::WalkAsyncPinned(Object* object, void* context, void (*callback)(Object*, Object*, void*))
 {
     LIMITED_METHOD_CONTRACT;
 

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1385,39 +1385,3 @@ void GCToEEInterface::WalkAsyncPinned(Object* object, void* context, void (*call
         }
     }
 }
-
-void GCToEEInterface::OverlappedClearIfComplete(Object* object)
-{
-    LIMITED_METHOD_CONTRACT;
-
-    assert(object != nullptr);
-    if (object->GetGCSafeMethodTable() != g_pOverlappedDataClass)
-    {
-        return;
-    }
-
-    OVERLAPPEDDATAREF overlapped = (OVERLAPPEDDATAREF)(ObjectToOBJECTREF((Object*)object));
-    if (overlapped->HasCompleted())
-    {
-        // IO has finished.  We don't need to pin the user buffer any longer.
-        overlapped->m_userObject = NULL;
-    }
-
-    BashMTForPinnedObject(ObjectToOBJECTREF(object));
-}
-
-void GCToEEInterface::OverlappedSetPinnedHandle(Object* object, OBJECTHANDLE handle) 
-{
-    LIMITED_METHOD_CONTRACT;
-
-    assert(object != nullptr);
-    assert(handle);
-
-    if (object->GetGCSafeMethodTable() != g_pOverlappedDataClass)
-    {
-        return;
-    }
-
-    OverlappedDataObject* overlapped = (OverlappedDataObject*)object;
-    overlapped->m_pinSelf = handle;
-}

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1201,7 +1201,7 @@ namespace
         };
 
         InlineSString<MaxThreadNameSize> wideName;
-        const WCHAR* namePtr;
+        const WCHAR* namePtr = nullptr;
         EX_TRY
         {
             if (name != nullptr)
@@ -1214,7 +1214,6 @@ namespace
         {
             // we're not obligated to provide a name - if it's not valid,
             // just report nullptr as the name.
-            namePtr = nullptr;
         }
         EX_END_CATCH(SwallowAllExceptions)
 

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -60,8 +60,8 @@ public:
     bool IsGCThread();
     bool WasCurrentThreadCreatedByGC();
     bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name);
-    void WalkOverlappedObjectForPromotion(Object* object, ScanContext* sc, promote_func* callback);
-    void WalkOverlappedObject(Object* object, void* context, void(*callback)(Object*, Object*, void*));
+    void WalkAsyncPinnedForPromotion(Object* object, ScanContext* sc, promote_func* callback);
+    void WalkAsyncPinned(Object* object, void* context, void(*callback)(Object*, Object*, void*));
     void OverlappedClearIfComplete(Object* object);
     void OverlappedSetPinnedHandle(Object* object, OBJECTHANDLE handle);
 };

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -60,6 +60,10 @@ public:
     bool IsGCThread();
     bool WasCurrentThreadCreatedByGC();
     bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name);
+    void WalkOverlappedObjectForPromotion(Object* object, ScanContext* sc, promote_func* callback);
+    void WalkOverlappedObject(Object* object, void* context, void(*callback)(Object*, Object*, void*));
+    void OverlappedClearIfComplete(Object* object);
+    void OverlappedSetPinnedHandle(Object* object, OBJECTHANDLE handle);
 };
 
 } // namespace standalone

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -62,8 +62,6 @@ public:
     bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name);
     void WalkAsyncPinnedForPromotion(Object* object, ScanContext* sc, promote_func* callback);
     void WalkAsyncPinned(Object* object, void* context, void(*callback)(Object*, Object*, void*));
-    void OverlappedClearIfComplete(Object* object);
-    void OverlappedSetPinnedHandle(Object* object, OBJECTHANDLE handle);
 };
 
 } // namespace standalone

--- a/src/vm/gcenv.ee.standalone.cpp
+++ b/src/vm/gcenv.ee.standalone.cpp
@@ -6,6 +6,7 @@
 #include "gcenv.h"
 #include "gcenv.ee.h"
 #include "threadsuspend.h"
+#include "nativeoverlapped.h"
 
 #ifdef FEATURE_COMINTEROP
 #include "runtimecallablewrapper.h"

--- a/src/vm/gcenv.ee.static.cpp
+++ b/src/vm/gcenv.ee.static.cpp
@@ -6,6 +6,7 @@
 #include "gcenv.h"
 #include "../gc/env/gcenv.ee.h"
 #include "threadsuspend.h"
+#include "nativeoverlapped.h"
 
 #ifdef FEATURE_COMINTEROP
 #include "runtimecallablewrapper.h"


### PR DESCRIPTION
For better or for worse, both the runtime and the GC have deep knowledge about the runtime data structures behind overlapped I/O. This knowledge is centered around the existence and layout of the [`System.Threading.OverlappedData` class](https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/Threading/Overlapped.cs#L123). The handle table is aware of this class because the runtime creates "async pinned handles" that refer to them and they are treated specially when marking through the handle table.

OverlappedData objects are special in that the objects that they refer to are logically pinned, even though there are no pinning handles in the handle table. This is achieved by treating the `m_userObject` field specially when marking through the heap:
* If `m_userObject` is an ordinary object, it is reported to the GC as pinned
* If `m_userObject` is an array, all pointers within the array are reported to the GC as pinned, but *not the array itself*.

OverlappedData objects are special also in that their lifetime is based on an overlapped I/O request and as such the kernel may reappear at any time to signal the completion of the request. If an app domain is unloaded while such an I/O request is still in flight, the handle table must relocate these handles to a new app domain to avoid crashing when the I/O request *does* return. (Does not apply to CoreCLR, which only has one app domain).

This PR attempts to abstract these details behind four new additions to `IGCToCLR`:

* `WalkOverlappedObject` - Given an object, *if that object is `System.Threading.OverlappedData`*, invoke a callback on all objects that would be considered pinned by this object.
* `WalkOverlappedObjectForPromotion` - Similar to `WalkOverlappedObject`. Given an object, if that object is `System.Threading.OverlappedData`, invoke the promotion callback on all objects that would be considered pinned. This is different than the above callback because OverlappedData objects are extremely special and it is not correct to update the `m_userObject` field when doing a GC; this is taken care of after a GC is completed. The runtime accomplishes this with a second field `m_userObjectInternal` that records any relocations that may occur on the object being reported. (This can happen because, if `m_userObject` is an array, it is not pinned.)
* `OverlappedClearIfComplete` - Once an Overlapped I/O request completes, the objects to which the OverlappedData object refer to no longer need to be pinned. This callback gives the EE a chance to unpin the data associated with an OverlappedData object if the I/O request has completed.
* `OverlappedSetPinnedHandle` - When relocating an OverlappedData handle from a condemned app domain, the handle table allocates a new async pinned handle belonging to another app domain. This callback informs the EE of the existence of this new handle.

This set of callbacks is not pretty but it does cover all of the uses of `OverlappedData` within the GC that I could find. Not all of this code can be fully tested (e.g. app domain loading in CoreCLR) but I am in the process of validating the aspects of this change that I *can* test. A nice side-effect of this change is that it eliminates a number of places where overlapped data object traversal code was copy-pasted between different areas of the handle table.

This PR addresses the main blocker for https://github.com/dotnet/coreclr/issues/14701.

cc @jkotas @sergiy-k @Maoni0 PTAL?
