### PR TITLE
JIT: look through GT_RET_EXPR when forming inline candidates

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -23229,11 +23229,7 @@ GenTreePtr Compiler::fgInlinePrependStatements(InlineInfo* inlineInfo)
                         //
                         // Chase through any GT_RET_EXPRs to find the actual argument
                         // expression.
-                        GenTree* actualArgNode = argNode;
-                        while (actualArgNode->gtOper == GT_RET_EXPR)
-                        {
-                            actualArgNode = actualArgNode->gtRetExpr.gtInlineCandidate;
-                        }
+                        GenTree* actualArgNode = argNode->gtRetExprVal();
 
                         // For case (1)
                         //

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -1813,6 +1813,9 @@ public:
 
     inline GenTreePtr gtEffectiveVal(bool commaOnly = false);
 
+    // Tunnel through any GT_RET_EXPRs
+    inline GenTree* gtRetExprVal();
+
     // Return the child of this node if it is a GT_RELOAD or GT_COPY; otherwise simply return the node itself
     inline GenTree* gtSkipReloadOrCopy();
 
@@ -6126,6 +6129,33 @@ inline GenTreePtr GenTree::gtEffectiveVal(bool commaOnly)
         else
         {
             return effectiveVal;
+        }
+    }
+}
+
+//-------------------------------------------------------------------------
+// gtRetExprVal - walk back through GT_RET_EXPRs
+//
+// Returns:
+//    tree representing return value from a successful inline,
+//    or original call for failed or yet to be determined inline.
+//
+// Notes:
+//    Multi-level inlines can form chains of GT_RET_EXPRs.
+//    This method walks back to the root of the chain.
+
+inline GenTree* GenTree::gtRetExprVal()
+{
+    GenTree* retExprVal = this;
+    for (;;)
+    {
+        if (retExprVal->gtOper == GT_RET_EXPR)
+        {
+            retExprVal = retExprVal->gtRetExpr.gtInlineCandidate;
+        }
+        else
+        {
+            return retExprVal;
         }
     }
 }

--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -515,6 +515,7 @@ struct InlArgInfo
     unsigned   argIsThis : 1;               // the argument is the 'this' pointer
     unsigned   argHasSideEff : 1;           // the argument has side effects
     unsigned   argHasGlobRef : 1;           // the argument has a global ref
+    unsigned   argHasCallerLocalRef : 1;    // the argument value depends on an aliased caller local
     unsigned   argHasTmp : 1;               // the argument will be evaluated to a temp
     unsigned   argHasLdargaOp : 1;          // Is there LDARGA(s) operation on this argument?
     unsigned   argHasStargOp : 1;           // Is there STARG(s) operation on this argument?


### PR DESCRIPTION
If an inline candidate has args that come from calls that are inline
candidates, the arg trees for the candidate may be GT_RET_EXPRs. Since
the jit inlines in preorder, any arg inlines will have been resolved
by the time we get to the candidate. So, the jit can look back through
the GT_RET_EXPR to get a better handle on the actual arg tree.

Doing this has several small benefits:
* It short-circuits parts of the subsequent GT_RET_EXPR update and so
saves a little bit of throughput.
* It potentially allows for more streamlined arg passing since the actual
node side effects may be less constraining than the placeholder effects on
the GT_RET_EXPR (which must be "worst case").
* It may unblock inlines as actual arg values can be seen when evaluating
the candidate for profitability.

During testing I found cases where looking at the actual arg seemed to
degrade information. This turned out to be a misuse of `argHasLdargaOp`
to indicate that a caller-supplied argument was potentially locally
aliased.

This misuse was blocking type propagation when the actual arg tree was seen to
be an aliasable local reference instead of the formerly opaque GT_RET_EXPR.
To fix this, I split out the aliased arg case with a different flag. All
that the jit needs to ensure in the aliased case is that it does not directly
substitute the arg; the arg must be evaluated at the point of the call. The
type of the actual can safely propagate to the arg as long as the arg itself
is not modifiable.

Added a utility for walking back through GT_RET_EXPRs and updated the
other case where the jit was doing this to use the utility as well.

Closes #14174.