### PR TITLE
Updating the xUnit Performance Api with bug fixes to the benchmark scenarios

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -37,7 +37,7 @@
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>2.1.0-preview1-25901-06</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <XunitPackageVersion>2.2.0-beta2-build3300</XunitPackageVersion>
     <XunitConsoleNetcorePackageVersion>1.0.2-prerelease-00177</XunitConsoleNetcorePackageVersion>
-    <XunitPerformanceApiPackageVersion>1.0.0-beta-build0010</XunitPerformanceApiPackageVersion>
+    <XunitPerformanceApiPackageVersion>1.0.0-beta-build0012</XunitPerformanceApiPackageVersion>
     <MicrosoftDiagnosticsTracingTraceEventPackageVersion>1.0.3-alpha-experimental</MicrosoftDiagnosticsTracingTraceEventPackageVersion>
     <VCRuntimeVersion>1.2.0</VCRuntimeVersion>
   </PropertyGroup>

--- a/tests/src/performance/linkbench/linkbench.cs
+++ b/tests/src/performance/linkbench/linkbench.cs
@@ -396,7 +396,10 @@ namespace LinkBench
                 Console.WriteLine($"{string.Join(" ", newArgs)}");
                 using (var h = new XunitPerformanceHarness(newArgs.ToArray()))
                 {
-                    var configuration = new ScenarioConfiguration(new TimeSpan(2000000), emptyCmd);
+                    var configuration = new ScenarioTestConfiguration(new TimeSpan(2000000), emptyCmd)
+                    {
+                        Scenario = new ScenarioBenchmark(CurrentBenchmark.Name) { Namespace = "LinkBench" },
+                    };
                     h.RunScenario(configuration, PostRun);
                 }
             }
@@ -412,15 +415,10 @@ namespace LinkBench
             Console.WriteLine("**********************************************************************");
         }
 
-        private static ScenarioBenchmark PostRun()
+        private static void PostRun(ScenarioBenchmark scenario)
         {
             // The XUnit output doesn't print the benchmark name, so print it now.
             Console.WriteLine("{0}", CurrentBenchmark.Name);
-
-            var scenario = new ScenarioBenchmark(CurrentBenchmark.Name)
-            {
-                Namespace = "LinkBench"
-            };
 
             CurrentBenchmark.Compute();
 
@@ -430,8 +428,6 @@ namespace LinkBench
             addMeasurement(ref scenario, "Total Uninked", SizeMetric, CurrentBenchmark.UnlinkedDirSize);
             addMeasurement(ref scenario, "Total Linked", SizeMetric, CurrentBenchmark.LinkedDirSize);
             addMeasurement(ref scenario, "Total Reduction", PercMetric, CurrentBenchmark.DirSizeReduction);
-
-            return scenario;
         }
 
         private static void addMeasurement(ref ScenarioBenchmark scenario, string name, MetricModel metric, double value)


### PR DESCRIPTION
This newer version fixes collecting data on x86 where:
1. The Jit generate methods at runtime and that are not associated with any loaded module
2. Modules are loaded/unloaded multiple times
3. This newer version of the Api added some breaking changes to the Api interface