### PR TITLE
Fix VSO 523532 - Possible mismatch in size on GT_EQ created for switch expansion

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -688,7 +688,7 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
                 //                 |____ (ICon)        (The actual case constant)
                 GenTreePtr gtCaseCond =
                     comp->gtNewOperNode(GT_EQ, TYP_INT, comp->gtNewLclvNode(tempLclNum, tempLclType),
-                                        comp->gtNewIconNode(i, TYP_INT));
+                                        comp->gtNewIconNode(i, tempLclType));
                 /* Increment the lvRefCnt and lvRefCntWtd for temp */
                 tempVarDsc->incRefCnts(blockWeight, comp);
 


### PR DESCRIPTION
Fixes Assertion failed 'genTypeSize(type) >= max(genTypeSize(op1Type), genTypeSize(op2Type))' 
when JIT\Methodical\ELEMENT_TYPE_IU\il_rel\i_seq.exe is run with JitStress=1

In the case that fails we have tempLclType == TYP_LONG