### PR TITLE
Move '-all' from filename to args in Mac build

### DIFF
--- a/buildpipeline/DotNet-CoreClr-Trusted-Mac.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Mac.json
@@ -12,8 +12,8 @@
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "$(Agent.BuildDirectory)/s/clean.sh -all",
-        "arguments": "",
+        "filename": "$(Agent.BuildDirectory)/s/clean.sh",
+        "arguments": "-all",
         "workingFolder": "",
         "failOnStandardError": "false"
       }


### PR DESCRIPTION
skip ci please

Fixes https://github.com/dotnet/coreclr/pull/14978#pullrequestreview-75916716

Adding ` -all` to the filename caused this error in the [official build](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build?_a=summary&buildId=1131260):

```
Failed which: Not found /Users/buildagent/agent/_work/249/s/clean.sh -all: null
undefined failed with error: Failed which: Not found /Users/buildagent/agent/_work/249/s/clean.sh -all: null
```