### PR TITLE
Allow non-abstract non-public interface methods in ILAsm

### DIFF
--- a/src/ilasm/assem.cpp
+++ b/src/ilasm/assem.cpp
@@ -339,7 +339,6 @@ BOOL Assembler::AddMethod(Method *pMethod)
     {
         char sz[1024];
         sz[0] = 0;
-        if(fIsInterface  && (!IsMdStatic(pMethod->m_Attr))) strcat_s(sz,1024," non-static declared in interface");
         if(fIsImport) strcat_s(sz,1024," imported");
         if(IsMdAbstract(pMethod->m_Attr)) strcat_s(sz,1024," abstract");
         if(IsMdPinvokeImpl(pMethod->m_Attr)) strcat_s(sz,1024," pinvoke");

--- a/src/ilasm/assembler.cpp
+++ b/src/ilasm/assembler.cpp
@@ -705,24 +705,6 @@ void Assembler::StartMethod(__in __nullterminated char* name, BinStr* sig, CorMe
             {
                 flags = (CorMethodAttr)(flags | mdSpecialName);
                 if(IsTdInterface(m_pCurClass->m_Attr)) report->error("Instance constructor in interface\n");
-
-            }
-            if(!IsMdStatic(flags))
-            {
-                if(IsTdInterface(m_pCurClass->m_Attr))
-                {
-                    if(!IsMdPublic(flags)) report->error("Non-public instance method in interface\n");
-                    if((!(IsMdVirtual(flags) && IsMdAbstract(flags))))
-                    {
-                        if(OnErrGo) report->error("Non-virtual, non-abstract instance method in interface\n");
-                        else
-                        {
-                            report->warn("Non-virtual, non-abstract instance method in interface, set to such\n");
-                            flags = (CorMethodAttr)(flags |mdVirtual | mdAbstract);
-                        }
-                    }
-    
-                }
             }
             m_pCurMethod = new Method(this, m_pCurClass, name, sig, flags);
         }


### PR DESCRIPTION
This is to support the default interface method feature in C#.
See https://github.com/dotnet/csharplang/blob/5971e753a20a32e5f471a5439c88e667e32413f0/proposals/default-interface-methods.md

I'm pulling this out of the dev/defaultintf branch in preparation to move the feature to master. We'll need a packaged version of ILAsm to be able to compile the tests.