### PR TITLE
Improve SSA renaming memory usage

### DIFF
--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -5050,10 +5050,10 @@ struct GenTreePhiArg : public GenTreeLclVarCommon
 {
     BasicBlock* gtPredBB;
 
-    GenTreePhiArg(var_types type, unsigned lclNum, unsigned snum, BasicBlock* block)
+    GenTreePhiArg(var_types type, unsigned lclNum, unsigned ssaNum, BasicBlock* block)
         : GenTreeLclVarCommon(GT_PHI_ARG, type, lclNum), gtPredBB(block)
     {
-        SetSsaNum(snum);
+        SetSsaNum(ssaNum);
     }
 
 #if DEBUGGABLE_GENTREE

--- a/src/jit/ssabuilder.cpp
+++ b/src/jit/ssabuilder.cpp
@@ -1479,31 +1479,6 @@ void SsaBuilder::AssignPhiNodeRhsVariables(BasicBlock* block, SsaRenameState* pR
 }
 
 /**
- * Walk the block's tree in the evaluation order and reclaim rename stack for var definitions.
- *
- * @param block Block for which SSA variables have to be renamed.
- * @param pRenameState The incremental rename information stored during renaming process.
- *
- */
-void SsaBuilder::BlockPopStacks(BasicBlock* block, SsaRenameState* pRenameState)
-{
-    // Pop the names given to the non-phi nodes.
-    pRenameState->PopBlockStacks(block);
-
-    // And for memory.
-    for (MemoryKind memoryKind : allMemoryKinds())
-    {
-        if ((memoryKind == GcHeap) && m_pCompiler->byrefStatesMatchGcHeapStates)
-        {
-            // GcHeap and ByrefExposed share a rename stack, so don't try
-            // to pop it a second time.
-            continue;
-        }
-        pRenameState->PopBlockMemoryStack(memoryKind, block);
-    }
-}
-
-/**
  * Perform variable renaming.
  *
  * Walks the blocks and renames all var defs with ssa numbers and all uses with the
@@ -1626,7 +1601,7 @@ void SsaBuilder::RenameVariables(BlkToBlkVectorMap* domTree, SsaRenameState* pRe
         else
         {
             // Done, pop all SSA numbers pushed in this block.
-            BlockPopStacks(block, pRenameState);
+            pRenameState->PopBlockStacks(block);
             DBG_SSA_JITDUMP("[SsaBuilder::RenameVariables] done with " FMT_BB "\n", block->bbNum);
         }
     }

--- a/src/jit/ssabuilder.cpp
+++ b/src/jit/ssabuilder.cpp
@@ -1540,7 +1540,7 @@ void SsaBuilder::RenameVariables(BlkToBlkVectorMap* domTree, SsaRenameState* pRe
             // In ValueNum we'd assume un-inited variables get FIRST_SSA_NUM.
             assert(ssaNum == SsaConfig::FIRST_SSA_NUM);
 
-            pRenameState->Push(nullptr, lclNum, ssaNum);
+            pRenameState->Push(m_pCompiler->fgFirstBB, lclNum, ssaNum);
         }
     }
 

--- a/src/jit/ssabuilder.h
+++ b/src/jit/ssabuilder.h
@@ -120,15 +120,15 @@ private:
     // implies that any definition occurring within "tree" is a phi definition.
     void TreeRenameVariables(GenTree* tree, BasicBlock* block, SsaRenameState* pRenameState, bool isPhiDefn);
 
-    // Assumes that "block" contains a definition for local var "lclNum", with SSA number "count".
+    // Assumes that "block" contains a definition for local var "lclNum", with SSA number "ssaNum".
     // IF "block" is within one or more try blocks,
     // and the local variable is live at the start of the corresponding handlers,
-    // add this SSA number "count" to the argument list of the phi for the variable in the start
+    // add this SSA number "ssaNum" to the argument list of the phi for the variable in the start
     // block of those handlers.
-    void AddDefToHandlerPhis(BasicBlock* block, unsigned lclNum, unsigned count);
+    void AddDefToHandlerPhis(BasicBlock* block, unsigned lclNum, unsigned ssaNum);
 
     // Same as above, for memory.
-    void AddMemoryDefToHandlerPhis(MemoryKind memoryKind, BasicBlock* block, unsigned count);
+    void AddMemoryDefToHandlerPhis(MemoryKind memoryKind, BasicBlock* block, unsigned ssaNum);
 
     // Requires "block" to be non-NULL.  Requires "pRenameState" to be non-NULL and be currently used
     // for variables renaming. Assigns the rhs arguments to the phi, i.e., block's phi node arguments.

--- a/src/jit/ssabuilder.h
+++ b/src/jit/ssabuilder.h
@@ -105,12 +105,6 @@ private:
     // Assigns gtSsaNames to all variables.
     void RenameVariables(BlkToBlkVectorMap* domTree, SsaRenameState* pRenameState);
 
-    // Requires "block" to be any basic block participating in variable renaming, and has at least a
-    // definition that pushed a ssa number into the rename stack for a variable. Requires "pRenameState"
-    // to have variable stacks that have counts pushed into them for the block while assigning def
-    // numbers. Pops the stack for any local variable that has an entry for block on top.
-    void BlockPopStacks(BasicBlock* block, SsaRenameState* pRenameState);
-
     // Requires "block" to be non-NULL; and is searched for defs and uses to assign ssa numbers.
     // Requires "pRenameState" to be non-NULL and be currently used for variables renaming.
     void BlockRenameVariables(BasicBlock* block, SsaRenameState* pRenameState);

--- a/src/jit/ssabuilder.h
+++ b/src/jit/ssabuilder.h
@@ -9,7 +9,7 @@
 
 #include "compiler.h"
 
-struct SsaRenameState;
+class SsaRenameState;
 
 typedef int LclVarNum;
 

--- a/src/jit/ssarenamestate.cpp
+++ b/src/jit/ssarenamestate.cpp
@@ -73,9 +73,7 @@ void SsaRenameState::Push(BasicBlock* bb, unsigned lclNum, unsigned count)
 {
     EnsureStacks();
 
-    // We'll use BB00 here to indicate the "block before any real blocks..."
-    DBG_SSA_JITDUMP("[SsaRenameState::Push] " FMT_BB ", V%02u, count = %d\n", bb != nullptr ? bb->bbNum : 0, lclNum,
-                    count);
+    DBG_SSA_JITDUMP("[SsaRenameState::Push] " FMT_BB ", V%02u, count = %d\n", bb->bbNum, lclNum, count);
 
     Stack* stack = stacks[lclNum];
 
@@ -160,8 +158,7 @@ void SsaRenameState::DumpStack(Stack* stack, const char* name, ...)
 
         for (Stack::reverse_iterator i = stack->rbegin(); i != stack->rend(); ++i)
         {
-            printf("%s<" FMT_BB ", %u>", (i == stack->rbegin()) ? "" : ", ", (i->m_bb != nullptr) ? i->m_bb->bbNum : 0,
-                   i->m_count);
+            printf("%s<" FMT_BB ", %u>", (i == stack->rbegin()) ? "" : ", ", i->m_bb->bbNum, i->m_count);
         }
 
         printf("\n");

--- a/src/jit/ssarenamestate.cpp
+++ b/src/jit/ssarenamestate.cpp
@@ -66,15 +66,27 @@ void SsaRenameState::Push(BasicBlock* block, unsigned lclNum, unsigned ssaNum)
     DBG_SSA_JITDUMP("[SsaRenameState::Push] " FMT_BB ", V%02u, count = %d\n", block->bbNum, lclNum, ssaNum);
 
     EnsureStacks();
+    Push(&m_stacks[lclNum], block, ssaNum);
+}
 
-    StackNode* top = m_stacks[lclNum].Top();
+//------------------------------------------------------------------------
+// Push: Push a SSA number onto a stack
+//
+// Arguments:
+//    stack  - The stack to push to
+//    block  - The block where the SSA definition occurs
+//    ssaNum - The SSA number
+//
+void SsaRenameState::Push(Stack* stack, BasicBlock* block, unsigned ssaNum)
+{
+    StackNode* top = stack->Top();
 
     if ((top == nullptr) || (top->m_block != block))
     {
-        m_stacks[lclNum].Push(AllocStackNode(m_stackListTail, block, ssaNum));
+        stack->Push(AllocStackNode(m_stackListTail, block, ssaNum));
         // Append the stack to the stack list. The stack list allows PopBlockStacks
         // to easily find stacks that need popping.
-        m_stackListTail = &m_stacks[lclNum];
+        m_stackListTail = stack;
     }
     else
     {
@@ -83,7 +95,7 @@ void SsaRenameState::Push(BasicBlock* block, unsigned lclNum, unsigned ssaNum)
         top->m_ssaNum = ssaNum;
     }
 
-    INDEBUG(DumpStack(&m_stacks[lclNum]));
+    INDEBUG(DumpStack(stack));
 }
 
 void SsaRenameState::PopBlockStacks(BasicBlock* block)

--- a/src/jit/ssarenamestate.cpp
+++ b/src/jit/ssarenamestate.cpp
@@ -11,13 +11,8 @@
  *
  * @params alloc The allocator class used to allocate jitstd data.
  */
-SsaRenameState::SsaRenameState(CompAllocator alloc, unsigned lvaCount, bool byrefStatesMatchGcHeapStates)
-    : stacks(nullptr)
-    , definedLocs(alloc)
-    , memoryStack(alloc)
-    , lvaCount(lvaCount)
-    , m_alloc(alloc)
-    , byrefStatesMatchGcHeapStates(byrefStatesMatchGcHeapStates)
+SsaRenameState::SsaRenameState(CompAllocator alloc, unsigned lvaCount)
+    : stacks(nullptr), definedLocs(alloc), memoryStack(alloc), lvaCount(lvaCount), m_alloc(alloc)
 {
 }
 

--- a/src/jit/ssarenamestate.cpp
+++ b/src/jit/ssarenamestate.cpp
@@ -12,7 +12,7 @@
  * @params alloc The allocator class used to allocate jitstd data.
  */
 SsaRenameState::SsaRenameState(CompAllocator alloc, unsigned lvaCount)
-    : stacks(nullptr), definedLocs(alloc), memoryStack(alloc), lvaCount(lvaCount), m_alloc(alloc)
+    : stacks(nullptr), definedLocs(alloc), memoryStack{Stack(alloc), Stack(alloc)}, lvaCount(lvaCount), m_alloc(alloc)
 {
 }
 

--- a/src/jit/ssarenamestate.h
+++ b/src/jit/ssarenamestate.h
@@ -86,8 +86,7 @@ public:
 
     void PushMemory(MemoryKind memoryKind, BasicBlock* block, unsigned ssaNum)
     {
-        m_memoryStack[memoryKind].Push(AllocStackNode(m_stackListTail, block, ssaNum));
-        m_stackListTail = &m_memoryStack[memoryKind];
+        Push(&m_memoryStack[memoryKind], block, ssaNum);
     }
 
 private:
@@ -110,6 +109,9 @@ private:
 
         return new (stack, jitstd::placement_t()) StackNode(jitstd::forward<Args>(args)...);
     }
+
+    // Push a SSA number onto a stack
+    void Push(Stack* stack, BasicBlock* block, unsigned ssaNum);
 
     INDEBUG(void DumpStack(Stack* stack);)
 };

--- a/src/jit/ssarenamestate.h
+++ b/src/jit/ssarenamestate.h
@@ -83,7 +83,7 @@ struct SsaRenameState
     typedef Stack**                              Stacks;
     typedef jitstd::list<SsaRenameStateLocDef>   DefStack;
 
-    SsaRenameState(CompAllocator allocator, unsigned lvaCount, bool byrefStatesMatchGcHeapStates);
+    SsaRenameState(CompAllocator allocator, unsigned lvaCount);
 
     void EnsureStacks();
 
@@ -101,21 +101,11 @@ struct SsaRenameState
     // Similar functions for the special implicit memory variable.
     unsigned CountForMemoryUse(MemoryKind memoryKind)
     {
-        if ((memoryKind == GcHeap) && byrefStatesMatchGcHeapStates)
-        {
-            // Share rename stacks in this configuration.
-            memoryKind = ByrefExposed;
-        }
         return memoryStack[memoryKind].back().m_count;
     }
 
     void PushMemory(MemoryKind memoryKind, BasicBlock* bb, unsigned count)
     {
-        if ((memoryKind == GcHeap) && byrefStatesMatchGcHeapStates)
-        {
-            // Share rename stacks in this configuration.
-            memoryKind = ByrefExposed;
-        }
         memoryStack[memoryKind].push_back(SsaRenameStateForBlock(bb, count));
     }
 
@@ -138,7 +128,4 @@ private:
 
     // Allocator to allocate stacks.
     CompAllocator m_alloc;
-
-    // Indicates whether GcHeap and ByrefExposed use the same state.
-    bool byrefStatesMatchGcHeapStates;
 };

--- a/src/jit/ssarenamestate.h
+++ b/src/jit/ssarenamestate.h
@@ -121,12 +121,9 @@ struct SsaRenameState
 
     void PopBlockMemoryStack(MemoryKind memoryKind, BasicBlock* bb);
 
-#ifdef DEBUG
-    // Debug interface
-    void DumpStacks();
-#endif
-
 private:
+    INDEBUG(void DumpStack(Stack* stack, const char* name, ...);)
+
     // Map of lclNum -> SsaRenameStateForBlock.
     Stacks stacks;
 

--- a/src/jit/ssarenamestate.h
+++ b/src/jit/ssarenamestate.h
@@ -55,24 +55,24 @@ public:
 
 struct SsaRenameStateForBlock
 {
-    BasicBlock* m_bb;
-    unsigned    m_count;
+    BasicBlock* m_block;
+    unsigned    m_ssaNum;
 
-    SsaRenameStateForBlock(BasicBlock* bb, unsigned count) : m_bb(bb), m_count(count)
+    SsaRenameStateForBlock(BasicBlock* block, unsigned ssaNum) : m_block(block), m_ssaNum(ssaNum)
     {
     }
-    SsaRenameStateForBlock() : m_bb(nullptr), m_count(0)
+    SsaRenameStateForBlock() : m_block(nullptr), m_ssaNum(0)
     {
     }
 };
 
-// A record indicating that local "m_loc" was defined in block "m_bb".
+// A record indicating that local "m_lclNum" was defined in block "m_block".
 struct SsaRenameStateLocDef
 {
-    BasicBlock* m_bb;
+    BasicBlock* m_block;
     unsigned    m_lclNum;
 
-    SsaRenameStateLocDef(BasicBlock* bb, unsigned lclNum) : m_bb(bb), m_lclNum(lclNum)
+    SsaRenameStateLocDef(BasicBlock* block, unsigned lclNum) : m_block(block), m_lclNum(lclNum)
     {
     }
 };
@@ -87,29 +87,27 @@ struct SsaRenameState
 
     void EnsureStacks();
 
-    // Requires "lclNum" to be a variable number for which an ssa number at the top of the
-    // stack is required i.e., for variable "uses."
-    unsigned CountForUse(unsigned lclNum);
+    // Get the SSA number at the top of the stack for the specified variable.
+    unsigned Top(unsigned lclNum);
 
-    // Requires "lclNum" to be a variable number, and requires "count" to represent
-    // an ssa number, that needs to be pushed on to the stack corresponding to the lclNum.
-    void Push(BasicBlock* bb, unsigned lclNum, unsigned count);
+    // Push a SSA number onto the stack for the specified variable.
+    void Push(BasicBlock* block, unsigned lclNum, unsigned ssaNum);
 
-    // Pop all stacks that have an entry for "bb" on top.
-    void PopBlockStacks(BasicBlock* bb);
+    // Pop all stacks that have an entry for "block" on top.
+    void PopBlockStacks(BasicBlock* block);
 
     // Similar functions for the special implicit memory variable.
-    unsigned CountForMemoryUse(MemoryKind memoryKind)
+    unsigned TopMemory(MemoryKind memoryKind)
     {
-        return memoryStack[memoryKind].back().m_count;
+        return memoryStack[memoryKind].back().m_ssaNum;
     }
 
-    void PushMemory(MemoryKind memoryKind, BasicBlock* bb, unsigned count)
+    void PushMemory(MemoryKind memoryKind, BasicBlock* block, unsigned ssaNum)
     {
-        memoryStack[memoryKind].push_back(SsaRenameStateForBlock(bb, count));
+        memoryStack[memoryKind].push_back(SsaRenameStateForBlock(block, ssaNum));
     }
 
-    void PopBlockMemoryStack(MemoryKind memoryKind, BasicBlock* bb);
+    void PopBlockMemoryStack(MemoryKind memoryKind, BasicBlock* block);
 
 private:
     INDEBUG(void DumpStack(Stack* stack, const char* name, ...);)


### PR DESCRIPTION
This change mainly replaces the use of `jitstd::list` with a simple singly list based stack that uses less memory. `jitstd::list` wastes memory both because it's a doubly linked list and because the list object is quite large (head/tail pointers, size, allocators) and there are many of them (basically one for each tracked variable). It also makes memory reuse difficult - removed nodes could be reused but to do that you'd need to make a custom `jitstd` allocator that maintains a pool of nodes. Doable, but quite a bit of work due to `jitstd` using old style C++ (pre C++ 11) allocators.

Since this is likely the last large change I'm going to make to `SsaRenameState` I went an extra mile and cleaned up the whole code - comments, names etc.

This saves ~1% overall used memory, 34% `CMK_SSA` memory and ~0.1% instructions retired.

Mem diff: https://gist.github.com/mikedn/f0be27a9432e6814245d818e1a0e0b1f
PIN data: https://1drv.ms/x/s!Av4baJYSo5pjgsAnoh04vA3ZEWWD4w

Somewhat strangely, the amount of allocated memory increases a bit - 65 allocator pages. Took me a while to figure out why. Due to the fact that the slab allocator caches pages > 64k you can end up in a situation where the old code was lucky and got a larger page (e.g. 74k in one example I looked at) and after these changes it gets a normal, 64k page and then it needs another page for the rest of 10k it needs.

No x86/x64 FX diffs.

Contributes to #15108