### PR TITLE
Fix semaphore spinning fix to not spin when count available

### DIFF
--- a/src/mscorlib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/mscorlib/src/System/Threading/SemaphoreSlim.cs
@@ -350,22 +350,23 @@ namespace System.Threading
                 // Perf: first spin wait for the count to be positive.
                 //       This additional amount of spinwaiting in addition
                 //       to Monitor.Enter()’s spinwaiting has shown measurable perf gains in test scenarios.
-                //
-
-                // Monitor.Enter followed by Monitor.Wait is much more expensive than waiting on an event as it involves another
-                // spin, contention, etc. The usual number of spin iterations that would otherwise be used here is increased to
-                // lessen that extra expense of doing a proper wait.
-                int spinCount = SpinWait.SpinCountforSpinBeforeWait * 4;
-                int sleep1Threshold = SpinWait.Sleep1ThresholdForSpinBeforeWait * 4;
-
-                SpinWait spinner = new SpinWait();
-                while (spinner.Count < spinCount)
+                if (m_currentCount == 0)
                 {
-                    spinner.SpinOnce(sleep1Threshold);
+                    // Monitor.Enter followed by Monitor.Wait is much more expensive than waiting on an event as it involves another
+                    // spin, contention, etc. The usual number of spin iterations that would otherwise be used here is increased to
+                    // lessen that extra expense of doing a proper wait.
+                    int spinCount = SpinWait.SpinCountforSpinBeforeWait * 4;
+                    const int Sleep1Threshold = SpinWait.Sleep1ThresholdForSpinBeforeWait * 4;
 
-                    if (m_currentCount != 0)
+                    var spinner = new SpinWait();
+                    while (spinner.Count < spinCount)
                     {
-                        break;
+                        spinner.SpinOnce(Sleep1Threshold);
+
+                        if (m_currentCount != 0)
+                        {
+                            break;
+                        }
                     }
                 }
 


### PR DESCRIPTION
A recent fix around SemaphoreSlim's spinning has led to it spinning even when spinning isn't necessary, resulting in measurable overheads when trying to acquire a semaphore that has count available.  This fixes that by putting back the check to avoid spinning if count is known to be available.

Fixes https://github.com/dotnet/coreclr/issues/14980
cc: @kouvel, @benaadams 

Timings for doing wait/release repeatedly on a semaphore with count available...

Before:

|    Method |       Mean |     Error |    StdDev |
---------- |-----------:|----------:|----------:|
| WaitAsync() |   413.5 ns |  6.752 ns |  6.316 ns |
|  Wait(0) | 1,050.8 ns | 21.816 ns | 25.124 ns |
|      Wait() | 1,090.8 ns | 21.090 ns | 24.288 ns |

After:

|    Method |     Mean |    Error |    StdDev |
---------- |---------:|---------:|----------:|
| WaitAsync() | 421.6 ns | 8.478 ns | 17.883 ns |
|  Wait(0) | 465.4 ns | 8.847 ns | 10.189 ns |
|      Wait() | 457.3 ns | 6.808 ns |  6.368 ns |

