### PR TITLE
An additional check for DevDiv 521437

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2953,6 +2953,7 @@ GenTree* Lowering::LowerDirectCall(GenTreeCall* call)
 
         if (addr != nullptr)
         {
+            assert(pAddr == nullptr);
             accessType = IAT_VALUE;
         }
         else


### PR DESCRIPTION
When VM returns addr != nullptr from getHelperFtn, it must set pAddr to nullptr.