### PR TITLE
Eliminate duplicate SSA number bookkeeping

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -1619,8 +1619,8 @@ void Compiler::optDebugCheckAssertion(AssertionDsc* assertion)
         case O1K_EXACT_TYPE:
         case O1K_SUBTYPE:
             assert(assertion->op1.lcl.lclNum < lvaCount);
-            assert(optLocalAssertionProp || ((assertion->op1.lcl.ssaNum - SsaConfig::UNINIT_SSA_NUM) <
-                                             lvaTable[assertion->op1.lcl.lclNum].lvNumSsaNames));
+            assert(optLocalAssertionProp ||
+                   lvaTable[assertion->op1.lcl.lclNum].lvPerSsaData.IsValidSsaNum(assertion->op1.lcl.ssaNum));
             break;
         case O1K_ARR_BND:
             // It would be good to check that bnd.vnIdx and bnd.vnLen are valid value numbers.

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -1966,9 +1966,7 @@ void Compiler::compInit(ArenaAllocator* pAlloc, InlineInfo* inlineInfo)
         impSpillCliquePredMembers = JitExpandArray<BYTE>(getAllocator());
         impSpillCliqueSuccMembers = JitExpandArray<BYTE>(getAllocator());
 
-        memset(&lvMemoryPerSsaData, 0, sizeof(PerSsaArray));
-        lvMemoryPerSsaData.Init(getAllocator());
-        lvMemoryNumSsaNames = 0;
+        lvMemoryPerSsaData = SsaDefArray<SsaMemDef>();
 
         //
         // Initialize all the per-method statistics gathering data structures.

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -152,12 +152,7 @@ struct VarScopeDsc
                        // compEnterScopeList and compExitScopeList sorted arrays.
 };
 
-/*****************************************************************************
- *
- *  The following holds the local variable counts and the descriptor table.
- */
-
-// This is the location of a definition.
+// This is the location of a SSA definition.
 struct DefLoc
 {
     BasicBlock* m_blk;
@@ -166,28 +161,156 @@ struct DefLoc
     DefLoc() : m_blk(nullptr), m_tree(nullptr)
     {
     }
-};
 
-// This class encapsulates all info about a local variable that may vary for different SSA names
-// in the family.
-class LclSsaVarDsc
-{
-public:
-    ValueNumPair m_vnPair;
-    DefLoc       m_defLoc;
-
-    LclSsaVarDsc()
+    DefLoc(BasicBlock* block, GenTree* tree) : m_blk(block), m_tree(tree)
     {
     }
 };
 
-typedef JitExpandArray<LclSsaVarDsc> PerSsaArray;
+// This class stores information associated with a LclVar SSA definition.
+class LclSsaVarDsc
+{
+public:
+    LclSsaVarDsc()
+    {
+    }
+
+    LclSsaVarDsc(BasicBlock* block, GenTree* tree) : m_defLoc(block, tree)
+    {
+    }
+
+    ValueNumPair m_vnPair;
+    DefLoc       m_defLoc;
+};
+
+// This class stores information associated with a memory SSA definition.
+class SsaMemDef
+{
+public:
+    ValueNumPair m_vnPair;
+};
+
+//------------------------------------------------------------------------
+// SsaDefArray: A resizable array of SSA definitions.
+//
+// Unlike an ordinary resizable array implementation, this allows only element
+// addition (by calling AllocSsaNum) and has special handling for the special
+// SSA numbers (RESERVED_SSA_NUM, UNINIT_SSA_NUM and FIRST_SSA_NUM).
+// Array elements are default constructed as new SSA numbers are allocated.
+// This includes the element associated with UNINIT_SSA_NUM that is automatically
+// allocated. The array doesn't impose any particular requirements on the elements
+// it stores.
+//
+template <typename T>
+class SsaDefArray
+{
+    T*       m_array;
+    unsigned m_arraySize;
+    unsigned m_count;
+
+    static_assert_no_msg(SsaConfig::RESERVED_SSA_NUM == 0);
+    static_assert_no_msg(SsaConfig::UNINIT_SSA_NUM == 1);
+    static_assert_no_msg(SsaConfig::FIRST_SSA_NUM == 2);
+
+    // Get the minimum valid SSA number.
+    unsigned GetMinSsaNum() const
+    {
+        return SsaConfig::UNINIT_SSA_NUM;
+    }
+
+    // Increase (double) the size of the array.
+    void GrowArray(CompAllocator alloc)
+    {
+        unsigned oldSize = m_arraySize;
+        unsigned newSize = max(2, oldSize * 2);
+
+        T* newArray = alloc.allocate<T>(newSize);
+
+        for (unsigned i = 0; i < oldSize; i++)
+        {
+            newArray[i] = m_array[i];
+        }
+
+        m_array     = newArray;
+        m_arraySize = newSize;
+
+        if (m_count == 0)
+        {
+            // The first time we allocate a SSA number we actually need to allocate 2:
+            // - SsaConfig::UNINIT_SSA_NUM
+            // - SsaConfig::FIRST_SSA_NUM
+            // It would perhaps make more sense to put this code in AllocSsaNum but let's
+            // keep it here because it's rarely run.
+
+            assert(m_arraySize == 2);
+
+            m_array[0] = T();
+            m_count++;
+        }
+    }
+
+public:
+    // Construct an empty SsaDefArray.
+    SsaDefArray() : m_array(nullptr), m_arraySize(0), m_count(0)
+    {
+    }
+
+    // Reset the array (used only if the SSA form is reconstructed).
+    void Reset()
+    {
+        m_count = 0;
+    }
+
+    // Allocate a new SSA number (starting with SsaConfig::FIRST_SSA_NUM).
+    template <class... Args>
+    unsigned AllocSsaNum(CompAllocator alloc, Args&&... args)
+    {
+        if (m_count == m_arraySize)
+        {
+            GrowArray(alloc);
+        }
+
+        unsigned ssaNum    = GetMinSsaNum() + m_count;
+        m_array[m_count++] = T(jitstd::forward<Args>(args)...);
+
+        // Ensure that the first SSA number we allocate is SsaConfig::FIRST_SSA_NUM
+        assert((ssaNum == SsaConfig::FIRST_SSA_NUM) || (m_count > 1));
+
+        return ssaNum;
+    }
+
+    // Get the number of SSA definitions in the array.
+    unsigned GetCount() const
+    {
+        return m_count;
+    }
+
+    // Get a pointer to the SSA definition at the specified index.
+    T* GetSsaDefByIndex(unsigned index)
+    {
+        assert(index < m_count);
+        return &m_array[index];
+    }
+
+    // Check if the specified SSA number is valid.
+    bool IsValidSsaNum(unsigned ssaNum) const
+    {
+        return (GetMinSsaNum() <= ssaNum) && (ssaNum < (GetMinSsaNum() + m_count));
+    }
+
+    // Get a pointer to the SSA definition associated with the specified SSA number.
+    T* GetSsaDef(unsigned ssaNum)
+    {
+        assert(ssaNum != SsaConfig::RESERVED_SSA_NUM);
+        return GetSsaDefByIndex(ssaNum - GetMinSsaNum());
+    }
+};
 
 class LclVarDsc
 {
 public:
     // The constructor. Most things can just be zero'ed.
-    LclVarDsc(Compiler* comp);
+    LclVarDsc();
 
     // note this only packs because var_types is a typedef of unsigned char
     var_types lvType : 5; // TYP_INT/LONG/FLOAT/DOUBLE/REF
@@ -708,23 +831,14 @@ public:
 
     var_types lvaArgType();
 
-    PerSsaArray lvPerSsaData;
-
-#ifdef DEBUG
-    // Keep track of the # of SsaNames, for a bounds check.
-    unsigned lvNumSsaNames;
-#endif
+    SsaDefArray<LclSsaVarDsc> lvPerSsaData;
 
     // Returns the address of the per-Ssa data for the given ssaNum (which is required
     // not to be the SsaConfig::RESERVED_SSA_NUM, which indicates that the variable is
     // not an SSA variable).
     LclSsaVarDsc* GetPerSsaData(unsigned ssaNum)
     {
-        assert(ssaNum != SsaConfig::RESERVED_SSA_NUM);
-        assert(SsaConfig::RESERVED_SSA_NUM == 0);
-        unsigned zeroBased = ssaNum - SsaConfig::UNINIT_SSA_NUM;
-        assert(zeroBased < lvNumSsaNames);
-        return &lvPerSsaData.GetRef(zeroBased);
+        return lvPerSsaData.GetSsaDef(ssaNum);
     }
 
 #ifdef DEBUG
@@ -2949,20 +3063,15 @@ protected:
     void SetVolatileHint(LclVarDsc* varDsc);
 
     // Keeps the mapping from SSA #'s to VN's for the implicit memory variables.
-    PerSsaArray lvMemoryPerSsaData;
-    unsigned    lvMemoryNumSsaNames;
+    SsaDefArray<SsaMemDef> lvMemoryPerSsaData;
 
 public:
     // Returns the address of the per-Ssa data for memory at the given ssaNum (which is required
     // not to be the SsaConfig::RESERVED_SSA_NUM, which indicates that the variable is
     // not an SSA variable).
-    LclSsaVarDsc* GetMemoryPerSsaData(unsigned ssaNum)
+    SsaMemDef* GetMemoryPerSsaData(unsigned ssaNum)
     {
-        assert(ssaNum != SsaConfig::RESERVED_SSA_NUM);
-        assert(SsaConfig::RESERVED_SSA_NUM == 0);
-        ssaNum--;
-        assert(ssaNum < lvMemoryNumSsaNames);
-        return &lvMemoryPerSsaData.GetRef(ssaNum);
+        return lvMemoryPerSsaData.GetSsaDef(ssaNum);
     }
 
     /*
@@ -9259,7 +9368,7 @@ public:
 }; // end of class Compiler
 
 // LclVarDsc constructor. Uses Compiler, so must come after Compiler definition.
-inline LclVarDsc::LclVarDsc(Compiler* comp)
+inline LclVarDsc::LclVarDsc()
     : // Initialize the ArgRegs to REG_STK.
     // The morph will do the right thing to change
     // to the right register if passed in register.
@@ -9273,7 +9382,7 @@ inline LclVarDsc::LclVarDsc(Compiler* comp)
     lvRefBlks(BlockSetOps::UninitVal())
     ,
 #endif // ASSERTION_PROP
-    lvPerSsaData(comp->getAllocator())
+    lvPerSsaData()
 {
 }
 

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -1670,7 +1670,7 @@ inline unsigned Compiler::lvaGrabTemp(bool shortLifetime DEBUGARG(const char* re
 
         for (unsigned i = lvaCount; i < newLvaTableCnt; i++)
         {
-            new (&newLvaTable[i], jitstd::placement_t()) LclVarDsc(this); // call the constructor.
+            new (&newLvaTable[i], jitstd::placement_t()) LclVarDsc(); // call the constructor.
         }
 
 #ifdef DEBUG
@@ -1743,7 +1743,7 @@ inline unsigned Compiler::lvaGrabTemps(unsigned cnt DEBUGARG(const char* reason)
         memset(newLvaTable + lvaCount, 0, (newLvaTableCnt - lvaCount) * sizeof(*lvaTable));
         for (unsigned i = lvaCount; i < newLvaTableCnt; i++)
         {
-            new (&newLvaTable[i], jitstd::placement_t()) LclVarDsc(this); // call the constructor.
+            new (&newLvaTable[i], jitstd::placement_t()) LclVarDsc(); // call the constructor.
         }
 
 #ifdef DEBUG

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -221,7 +221,7 @@ void Compiler::lvaInitTypeRef()
     memset(lvaTable, 0, tableSize);
     for (unsigned i = 0; i < lvaTableCnt; i++)
     {
-        new (&lvaTable[i], jitstd::placement_t()) LclVarDsc(this); // call the constructor.
+        new (&lvaTable[i], jitstd::placement_t()) LclVarDsc(); // call the constructor.
     }
 
     //-------------------------------------------------------------------------

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7002,7 +7002,7 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result)
         memset(lvaTable + startVars, 0, (lvaCount - startVars) * sizeof(*lvaTable));
         for (unsigned i = startVars; i < lvaCount; i++)
         {
-            new (&lvaTable[i], jitstd::placement_t()) LclVarDsc(this); // call the constructor.
+            new (&lvaTable[i], jitstd::placement_t()) LclVarDsc(); // call the constructor.
         }
 
         lvaCount = startVars;

--- a/src/jit/ssabuilder.h
+++ b/src/jit/ssabuilder.h
@@ -132,10 +132,6 @@ private:
     // for variables renaming. Assigns the rhs arguments to the phi, i.e., block's phi node arguments.
     void AssignPhiNodeRhsVariables(BasicBlock* block, SsaRenameState* pRenameState);
 
-    // Requires "tree" to be a local variable node. Maintains a map of <lclNum, ssaNum> -> tree
-    // information in m_defs.
-    void AddDefPoint(GenTree* tree, BasicBlock* blk);
-
 #ifdef DEBUG
     void Print(BasicBlock** postOrder, int count);
 #endif

--- a/src/jit/ssaconfig.h
+++ b/src/jit/ssaconfig.h
@@ -2,23 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// ==++==
-//
-
-//
-
-//
-// ==--==
-
-/*XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-XX                                                                           XX
-XX                                  SSA                                      XX
-XX                                                                           XX
-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-*/
-
 #pragma once
 
 #ifdef DEBUG
@@ -36,12 +19,7 @@ namespace SsaConfig
 // FIRST ssa num is given to the first definition of a variable which can either be:
 // 1. A regular definition in the program.
 // 2. Or initialization by compInitMem.
-static const int FIRST_SSA_NUM = 2;
-
-// UNINIT ssa num is given to variables whose definitions were never encountered:
-// 1. Neither by SsaBuilder
-// 2. Nor were they initialized using compInitMem.
-static const int UNINIT_SSA_NUM = 1;
+static const int FIRST_SSA_NUM = 1;
 
 // Sentinel value to indicate variable not touched by SSA.
 static const int RESERVED_SSA_NUM = 0;

--- a/src/jit/ssarenamestate.cpp
+++ b/src/jit/ssarenamestate.cpp
@@ -2,23 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// ==++==
-//
-
-//
-
-//
-// ==--==
-
-/*XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-XX                                                                           XX
-XX                                  SSA                                      XX
-XX                                                                           XX
-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-*/
-
 #include "jitpch.h"
 #include "ssaconfig.h"
 #include "ssarenamestate.h"
@@ -29,32 +12,13 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
  * @params alloc The allocator class used to allocate jitstd data.
  */
 SsaRenameState::SsaRenameState(CompAllocator alloc, unsigned lvaCount, bool byrefStatesMatchGcHeapStates)
-    : counts(nullptr)
-    , stacks(nullptr)
+    : stacks(nullptr)
     , definedLocs(alloc)
     , memoryStack(alloc)
-    , memoryCount(0)
     , lvaCount(lvaCount)
     , m_alloc(alloc)
     , byrefStatesMatchGcHeapStates(byrefStatesMatchGcHeapStates)
 {
-}
-
-/**
- * Allocates memory to hold SSA variable def counts,
- * if not allocated already.
- *
- */
-void SsaRenameState::EnsureCounts()
-{
-    if (counts == nullptr)
-    {
-        counts = m_alloc.allocate<unsigned>(lvaCount);
-        for (unsigned i = 0; i < lvaCount; ++i)
-        {
-            counts[i] = SsaConfig::FIRST_SSA_NUM;
-        }
-    }
 }
 
 /**
@@ -72,25 +36,6 @@ void SsaRenameState::EnsureStacks()
             stacks[i] = nullptr;
         }
     }
-}
-
-/**
- * Returns a SSA count number for a local variable and does a post increment.
- *
- * If there is no counter for the local yet, initializes it with the default value
- * else, returns the count with a post increment, so the next def gets a new count.
- *
- * @params lclNum The local variable def for which a count has to be returned.
- * @return the variable name for the current definition.
- *
- */
-unsigned SsaRenameState::CountForDef(unsigned lclNum)
-{
-    EnsureCounts();
-    unsigned count = counts[lclNum];
-    counts[lclNum]++;
-    DBG_SSA_JITDUMP("Incrementing counter = %d by 1 for V%02u.\n", count, lclNum);
-    return count;
 }
 
 /**

--- a/src/jit/ssarenamestate.cpp
+++ b/src/jit/ssarenamestate.cpp
@@ -56,10 +56,7 @@ unsigned SsaRenameState::CountForUse(unsigned lclNum)
     DBG_SSA_JITDUMP("[SsaRenameState::CountForUse] V%02u\n", lclNum);
 
     Stack* stack = stacks[lclNum];
-    if (stack == nullptr || stack->empty())
-    {
-        return SsaConfig::UNINIT_SSA_NUM;
-    }
+    noway_assert((stack != nullptr) && !stack->empty());
     return stack->back().m_count;
 }
 

--- a/src/jit/ssarenamestate.h
+++ b/src/jit/ssarenamestate.h
@@ -2,23 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// ==++==
-//
-
-//
-
-//
-// ==--==
-
-/*XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-XX                                                                           XX
-XX                                  SSA                                      XX
-XX                                                                           XX
-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-*/
-
 #pragma once
 
 #include "jitstd.h"
@@ -98,17 +81,11 @@ struct SsaRenameState
 {
     typedef jitstd::list<SsaRenameStateForBlock> Stack;
     typedef Stack**                              Stacks;
-    typedef unsigned*                            Counts;
     typedef jitstd::list<SsaRenameStateLocDef>   DefStack;
 
     SsaRenameState(CompAllocator allocator, unsigned lvaCount, bool byrefStatesMatchGcHeapStates);
 
-    void EnsureCounts();
     void EnsureStacks();
-
-    // Requires "lclNum" to be a variable number for which a new count corresponding to a
-    // definition is desired. The method post increments the counter for the "lclNum."
-    unsigned CountForDef(unsigned lclNum);
 
     // Requires "lclNum" to be a variable number for which an ssa number at the top of the
     // stack is required i.e., for variable "uses."
@@ -122,16 +99,6 @@ struct SsaRenameState
     void PopBlockStacks(BasicBlock* bb);
 
     // Similar functions for the special implicit memory variable.
-    unsigned CountForMemoryDef()
-    {
-        if (memoryCount == 0)
-        {
-            memoryCount = SsaConfig::FIRST_SSA_NUM;
-        }
-        unsigned res = memoryCount;
-        memoryCount++;
-        return res;
-    }
     unsigned CountForMemoryUse(MemoryKind memoryKind)
     {
         if ((memoryKind == GcHeap) && byrefStatesMatchGcHeapStates)
@@ -154,20 +121,12 @@ struct SsaRenameState
 
     void PopBlockMemoryStack(MemoryKind memoryKind, BasicBlock* bb);
 
-    unsigned MemoryCount()
-    {
-        return memoryCount;
-    }
-
 #ifdef DEBUG
     // Debug interface
     void DumpStacks();
 #endif
 
 private:
-    // Map of lclNum -> count.
-    Counts counts;
-
     // Map of lclNum -> SsaRenameStateForBlock.
     Stacks stacks;
 
@@ -176,7 +135,6 @@ private:
 
     // Same state for the special implicit memory variables.
     ConstructedArray<Stack, MemoryKindCount> memoryStack;
-    unsigned memoryCount;
 
     // Number of stacks/counts to allocate.
     unsigned lvaCount;

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -5814,15 +5814,6 @@ void Compiler::fgValueNumberTree(GenTree* tree, bool evalAsgLhsInd)
                     unsigned   ssaNum = lclFld->GetSsaNum();
                     LclVarDsc* varDsc = &lvaTable[lclNum];
 
-                    if (ssaNum == SsaConfig::UNINIT_SSA_NUM)
-                    {
-                        if (varDsc->GetPerSsaData(ssaNum)->m_vnPair.GetLiberal() == ValueNumStore::NoVN)
-                        {
-                            ValueNum vnForLcl                       = vnStore->VNForExpr(compCurBB, lclFld->TypeGet());
-                            varDsc->GetPerSsaData(ssaNum)->m_vnPair = ValueNumPair(vnForLcl, vnForLcl);
-                        }
-                    }
-
                     var_types indType = tree->TypeGet();
                     if (lclFld->gtFieldSeq == FieldSeqStore::NotAField() || fgExcludeFromSsa(lclFld->GetLclNum()))
                     {

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -4545,9 +4545,9 @@ void Compiler::fgValueNumber()
     {
         ValueNumPair noVnp;
         // Make sure the memory SSA names have no value numbers.
-        for (unsigned i = 0; i < lvMemoryNumSsaNames; i++)
+        for (unsigned i = 0; i < lvMemoryPerSsaData.GetCount(); i++)
         {
-            lvMemoryPerSsaData.GetRef(i).m_vnPair = noVnp;
+            lvMemoryPerSsaData.GetSsaDefByIndex(i)->m_vnPair = noVnp;
         }
         for (BasicBlock* blk = fgFirstBB; blk != nullptr; blk = blk->bbNext)
         {


### PR DESCRIPTION
During SSA construction `SsaRenameState` keeps a definition count for each variable in an array. But each variable has a `lvPerSsaData` array that does almost the same thing, count definitions. "Almost" because `lvPerSsaData` is a `JitExpandArray` that tracks only the array size and not the number of elements actually stored in the array.

Replace `JitExpandArray` with purposely designed "array" that is in charge with allocating new SSA numbers  and handles their intricacies - `RESERVED_SSA_NUM`, `UNINIT_SSA_NUM` and `FIRST_SSA_NUM`.

This also allows the removal of the allocator from the array. Allocating new SSA numbers happens only during SSA construction and it's reasonable to pass the allocator to `AllocSsaNum` rather than increase the size of `PerSsaArray` and `LclVarDsc`.

While working on this I realized that `UNINIT_SSA_NUM` isn't actually needed. `SsaBuilder::RenameVariables` starts by assigning SSA numbers to all variables that are live at the start of `fgFirstBB` so it's not possible to encounter an use without a def on the SSA rename stack. And if it happens, well, there's a bug somewhere and falling back to minopts via a `noway_assert` is the appropriate thing to do.

No jit diffs.

0.28% less instructions retired and 0.6% less used memory.

PIN data: https://1drv.ms/x/s!Av4baJYSo5pjgr15HNl1qFfUxIWI8g

MemStats diff: https://gist.github.com/mikedn/68c76ebca65ce1c26e9d145eee420eb3