### PR TITLE
Disable ARM tests

### DIFF
--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -21833,7 +21833,7 @@ RelativePath=JIT\SIMD\VectorConvert_r\VectorConvert_r.cmd
 WorkingDir=JIT\SIMD\VectorConvert_r
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS
+Categories=EXPECTED_FAIL;14665
 HostStyle=0
 
 [b13466.cmd_2743]
@@ -43017,7 +43017,7 @@ RelativePath=JIT\SIMD\VectorConvert_ro\VectorConvert_ro.cmd
 WorkingDir=JIT\SIMD\VectorConvert_ro
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS
+Categories=EXPECTED_FAIL;14665
 HostStyle=0
 
 [b53650.cmd_5397]

--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -4681,7 +4681,7 @@ RelativePath=GC\Regressions\dev10bugs\536168\536168\536168.cmd
 WorkingDir=GC\Regressions\dev10bugs\536168\536168
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;Pri1
+Categories=EXPECTED_FAIL;Pri1
 HostStyle=0
 
 [ldvirtftn.cmd_589]
@@ -16617,7 +16617,7 @@ RelativePath=GC\Features\LOHFragmentation\lohfragmentation\lohfragmentation.cmd
 WorkingDir=GC\Features\LOHFragmentation\lohfragmentation
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;Pri1
+Categories=EXPECTED_FAIL;Pri1
 HostStyle=0
 
 [CharIsLetter1.cmd_2089]
@@ -34785,7 +34785,7 @@ RelativePath=GC\Features\BackgroundGC\foregroundgc\foregroundgc.cmd
 WorkingDir=GC\Features\BackgroundGC\foregroundgc
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;Pri1
+Categories=EXPECTED_FAIL;Pri1
 HostStyle=0
 
 [_il_relldsfld_mul.cmd_4367]


### PR DESCRIPTION
Disable 3 GC tests for ARM that are disabled elsewhere, due to excessive resource usage.

Disable 2 VectorConvert tests due to #14665, now appearing in non-stress runs.
