### PR TITLE
Re-enable Standalone GC job, running daily

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -608,7 +608,7 @@ def static addNonPRTriggers(def job, def branch, def isPR, def architecture, def
             assert (configuration == 'Release' || configuration == 'Checked')
             // TODO: Add once external email sending is available again
             // addEmailPublisher(job, 'dotnetgctests@microsoft.com')
-            Utilities.addPeriodicTrigger(job, '@weekly')
+            Utilities.addPeriodicTrigger(job, '@daily')
             break
         case 'gc_reliability_framework':
             assert (os == 'Ubuntu' || os == 'Windows_NT' || os == 'OSX10.12')
@@ -1587,9 +1587,6 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                     else if (isLongGc(scenario)) {
                         buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${arch} ${buildOpts}"
                     }
-                    else if (scenario == 'standalone_gc') {
-                        buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${arch} ${buildOpts} buildstandalonegc"
-                    }
                     else if (scenario == 'formatting') {
                         buildCommands += "python -u tests\\scripts\\format.py -c %WORKSPACE% -o Windows_NT -a ${arch}"
                         Utilities.addArchival(newJob, "format.patch", "", true, false)
@@ -1614,6 +1611,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                         def illinkArguments = ''
                         def testEnvStr = ''
                         def runtestArguments = ''
+                        def standaloneGcStr = ''
 
                         if (scenario == 'r2r' ||
                             scenario == 'r2r_gcstress15' ||
@@ -1672,6 +1670,9 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                         else if (isLongGc(scenario)) {
                             gcTestArguments = "${scenario} sequential"
                         }
+                        else if (scenario == 'standalone_gc') {
+                            standaloneGcStr = "gcname clrgc.dll"
+                        }
                         else if (scenario == 'illink')
                         {
                             illinkArguments = "link %WORKSPACE%\\linker\\linker\\bin\\netcore_Release\\netcoreapp2.0\\win10-${arch}\\publish\\illink.exe"
@@ -1710,7 +1711,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                             testEnvStr = "TestEnv ${envScriptPath}"
                         }
 
-                        runtestArguments = "${lowerConfiguration} ${arch} ${gcstressStr} ${crossgenStr} ${runcrossgentestsStr} ${runjitstressStr} ${runjitstressregsStr} ${runjitmioptsStr} ${runjitforcerelocsStr} ${runjitdisasmStr} ${runilasmroundtripStr} ${gcTestArguments} ${illinkArguments} collectdumps ${testEnvStr}"
+                        runtestArguments = "${lowerConfiguration} ${arch} ${gcstressStr} ${crossgenStr} ${runcrossgentestsStr} ${runjitstressStr} ${runjitstressregsStr} ${runjitmioptsStr} ${runjitforcerelocsStr} ${runjitdisasmStr} ${runilasmroundtripStr} ${gcTestArguments} ${illinkArguments} collectdumps ${testEnvStr} ${standaloneGcStr}"
 
                         // If we are running a stress mode, we should write out the set of key
                         // value env pairs to a file at this point and then we'll pass that to runtest.cmd
@@ -1865,17 +1866,12 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                         buildCommands += "./tests/scripts/build_illink.sh --clone --arch=${architecture}"
                     }
 
-                    def standaloneGc = ''
-                    if (scenario == 'standalone_gc') {
-                        standaloneGc = 'buildstandalonegc'
-                    }
-
                     if (!enableCorefxTesting) {
                         // We run pal tests on all OS but generate mscorlib (and thus, nuget packages)
                         // only on supported OS platforms.
                         def bootstrapRid = Utilities.getBoostrapPublishRid(os)
                         def bootstrapRidEnv = bootstrapRid != null ? "__PUBLISH_RID=${bootstrapRid} " : ''
-                        buildCommands += "${bootstrapRidEnv}./build.sh verbose ${lowerConfiguration} ${architecture} ${standaloneGc}"
+                        buildCommands += "${bootstrapRidEnv}./build.sh verbose ${lowerConfiguration} ${architecture}" 
                         buildCommands += "src/pal/tests/palsuite/runpaltests.sh \${WORKSPACE}/bin/obj/${osGroup}.${architecture}.${configuration} \${WORKSPACE}/bin/paltestout"
 
                         // Set time out
@@ -1912,13 +1908,8 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                     }
                     break
                 case 'arm64':
-                    def standaloneGc = ''
-                    if (scenario == 'standalone_gc') {
-                        standaloneGc = 'buildstandalonegc'
-                    }
-
                     if (!enableCorefxTesting) {
-                        buildCommands += "ROOTFS_DIR=/opt/arm64-xenial-rootfs ./build.sh verbose ${lowerConfiguration} ${architecture} cross clang3.8 ${standaloneGc}"
+                        buildCommands += "ROOTFS_DIR=/opt/arm64-xenial-rootfs ./build.sh verbose ${lowerConfiguration} ${architecture} cross clang3.8"
                         
                         // HACK -- Arm64 does not have corefx jobs yet.
                         buildCommands += "git clone https://github.com/dotnet/corefx fx"
@@ -2547,6 +2538,7 @@ combinedScenarios.each { scenario ->
                     def gcstressStr = ''
                     def illinkStr = ''
                     def layoutOnlyStr =''
+                    def standaloneGcStr = ''
 
                     if (scenario == 'r2r' || Constants.r2rJitStressScenarios.containsKey(scenario) ) {
                             crossgenStr = '--crossgen'
@@ -2622,6 +2614,20 @@ combinedScenarios.each { scenario ->
 
                     if (isGcReliabilityFramework(scenario)) {
                         layoutOnlyStr = '--build-overlay-only'
+                    }
+
+                    if (scenario == 'standalone_gc') {
+                        def osGroup = getOSGroup(os)
+                        if (osGroup == 'OSX') {
+                            standaloneGcStr = '--gcname=libclrgc.dylib'
+                        }
+                        else if (osGroup == 'Linux') {
+                            standaloneGcStr = '--gcname=libclrgc.so'
+                        }
+                        else {
+                            println("Unexpected OS group: ${osGroup} for os ${os}")
+                            assert false
+                        }
                     }
 
                     def windowsArmJob = (os == "Windows_NT" && architecture in validWindowsNTCrossArches)
@@ -2725,7 +2731,7 @@ combinedScenarios.each { scenario ->
                 --limitedDumpGeneration \\
             ${testEnvOpt} ${serverGCString} ${gcstressStr} ${crossgenStr} ${runcrossgentestsStr} ${runjitstressStr} \\
             ${runjitstressregsStr} ${runjitmioptsStr} ${runjitforcerelocsStr} ${runjitdisasmStr} ${runilasmroundtripStr} \\
-            ${illinkStr} ${sequentialString} ${playlistString} ${layoutOnlyStr}""")
+            ${illinkStr} ${sequentialString} ${playlistString} ${layoutOnlyStr} ${standaloneGcStr}""")
 
                                 if (isGcReliabilityFramework(scenario)) {
                                     // runtest.sh doesn't actually execute the reliability framework - do it here.

--- a/netci.groovy
+++ b/netci.groovy
@@ -2617,7 +2617,6 @@ combinedScenarios.each { scenario ->
                     }
 
                     if (scenario == 'standalone_gc') {
-                        def osGroup = getOSGroup(os)
                         if (osGroup == 'OSX') {
                             standaloneGcStr = '--gcname=libclrgc.dylib'
                         }

--- a/netci.groovy
+++ b/netci.groovy
@@ -1584,7 +1584,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                             Constants.r2rJitStressScenarios.containsKey(scenario)) {
                         buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${arch} ${buildOpts}"
                     }
-                    else if (isLongGc(scenario)) {
+                    else if (isLongGc(scenario) || scenario == 'standalone_gc') {
                         buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${arch} ${buildOpts}"
                     }
                     else if (scenario == 'formatting') {

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -106,6 +106,7 @@ if /i "%1" == "PerfTests"             (set __PerfTests=true&shift&goto Arg_Loop)
 if /i "%1" == "runcrossgentests"      (set RunCrossGen=true&shift&goto Arg_Loop)
 if /i "%1" == "link"                  (set DoLink=true&set ILLINK=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "tieredcompilation"     (set COMPLUS_EXPERIMENTAL_TieredCompilation=1&shift&goto Arg_Loop)
+if /i "%1" == "gcname"                (set COMPlus_GCName=%2&shift&shift&goto Arg_Loop)
 
 REM change it to COMPlus_GCStress when we stop using xunit harness
 if /i "%1" == "gcstresslevel"         (set __GCSTRESSLEVEL=%2&set __TestTimeout=1800000&shift&shift&goto Arg_Loop)
@@ -482,6 +483,7 @@ echo                               4: GC on every allowable JITed instruction
 echo                               8: GC on every allowable NGEN instruction
 echo                              16: GC only on a unique stack trace
 echo tieredcompilation         - Run the tests with COMPlus_EXPERIMENTAL_TieredCompilation=1
+echo gcname ^<n^>              - Runs the tests with COMPlus_GCName=n
 echo msbuildargs ^<args...^>     - Pass all subsequent args directly to msbuild invocations.
 echo ^<CORE_ROOT^>               - Path to the runtime to test (if specified).
 echo.

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -52,6 +52,7 @@ function print_usage {
     echo '  --jitforcerelocs                 : Runs the tests with COMPlus_ForceRelocs=1'
     echo '  --jitdisasm                      : Runs jit-dasm on the tests'
     echo '  --gcstresslevel=<n>              : Runs the tests with COMPlus_GCStress=n'
+    echo '  --gcname=<n>                     : Runs the tests with COMPlus_GCName=n'
     echo '  --ilasmroundtrip                 : Runs ilasm round trip on the tests'
     echo '    0: None                                1: GC on all allocs and '"'easy'"' places'
     echo '    2: GC on transitions to preemptive GC  4: GC on every allowable JITed instr'
@@ -1143,6 +1144,9 @@ do
         --gcstresslevel=*)
             export COMPlus_GCStress=${i#*=}
             ;;            
+        --gcname=*)
+            export COMPlus_GCName=${i#*=}
+            ;;
         --show-time)
             showTime=ON
             ;;


### PR DESCRIPTION
The way standalone GCs work have changed a little and so the CI has been broken (it expected to run against a linked-in GC, but one that went through the interface indirections). Since we can now build and load a fully standalone GC, this PR fixes up the CI to actually do that on the standalone GC run. It also ups the run frequency to once a day.

This PR also adds the `gcname` parameter to both `runtest` scripts, which controls the value of the `COMPlus_GCName` variable when running tests.

cc @sergiy-k @Maoni0 