### PR TITLE
Remove out-of-use method and properties from appdomain

### DIFF
--- a/src/debug/daccess/request.cpp
+++ b/src/debug/daccess/request.cpp
@@ -2584,134 +2584,27 @@ HRESULT
 ClrDataAccess::GetApplicationBase(CLRDATA_ADDRESS appDomain, int count,
                                   __out_z __inout_ecount(count) wchar_t *base, unsigned int *pNeeded)
 {
-    if (appDomain == NULL || (base == NULL && pNeeded == NULL) || (base != NULL && count == 0))
-    {
-        return E_INVALIDARG;
-    }
+    // Method is not supported on CoreCLR
 
-    SOSDacEnter();
-    AppDomain* pAppDomain = PTR_AppDomain(TO_TADDR(appDomain));
-
-    // Turn from bytes to wide characters
-    if ((PTR_BaseDomain(pAppDomain) == PTR_BaseDomain(SharedDomain::GetDomain())) ||
-        (PTR_BaseDomain(pAppDomain) == PTR_BaseDomain(SystemDomain::System())))
-    {
-        // Shared domain and SystemDomain don't have this field.
-        if (base)
-            base[0] = 0;
-
-        if (pNeeded)
-            *pNeeded = 1;
-    }
-
-    if (!pAppDomain->m_applicationBase.IsEmpty())
-    {
-        if (!pAppDomain->m_applicationBase.
-            DacGetUnicode(count, base, pNeeded))
-        {
-            hr = E_FAIL;
-        }
-    }
-    else
-    {
-        if (base)
-            base[0] = 0;
-        
-        if (pNeeded)
-            *pNeeded = 1;
-    }
-
-    SOSDacLeave();
-    return hr;
+    return E_FAIL;
 }
 
 HRESULT
 ClrDataAccess::GetPrivateBinPaths(CLRDATA_ADDRESS appDomain, int count,
                                   __out_z __inout_ecount(count) wchar_t *paths, unsigned int *pNeeded)
 {
-    if (appDomain == NULL || (paths == NULL && pNeeded == NULL) || (paths != NULL && count == 0))
-        return E_INVALIDARG;
+    // Method is not supported on CoreCLR
 
-    SOSDacEnter();
-    AppDomain* pAppDomain = PTR_AppDomain(TO_TADDR(appDomain));
-
-    // Turn from bytes to wide characters
-    if ((PTR_BaseDomain(pAppDomain) == PTR_BaseDomain(SharedDomain::GetDomain())) ||
-        (PTR_BaseDomain(pAppDomain) == PTR_BaseDomain(SystemDomain::System())))
-    {
-        // Shared domain and SystemDomain don't have this field.
-        if (pNeeded)
-            *pNeeded = 1;
-
-        if (paths)
-            paths[0] = 0;
-
-        hr = S_OK;
-    }
-
-    if (!pAppDomain->m_privateBinPaths.IsEmpty())
-    {
-        if (!pAppDomain->m_privateBinPaths.DacGetUnicode(count, paths, pNeeded))
-        {
-            hr = E_FAIL;
-        }
-    }
-    else
-    {
-        if (paths)
-            paths[0] = 0;
-
-        if (pNeeded)
-            *pNeeded = 1;
-    }
-
-    SOSDacLeave();
-    return hr;
+    return E_FAIL;
 }
 
 HRESULT
 ClrDataAccess::GetAppDomainConfigFile(CLRDATA_ADDRESS appDomain, int count,
                                       __out_z __inout_ecount(count) wchar_t *configFile, unsigned int *pNeeded)
 {
-    if (appDomain == NULL || (configFile == NULL && pNeeded == NULL) || (configFile != NULL && count == 0))
-    {
-        return E_INVALIDARG;
-    }
+    // Method is not supported on CoreCLR
 
-    SOSDacEnter();
-    AppDomain* pAppDomain = PTR_AppDomain(TO_TADDR(appDomain));
-
-    // Turn from bytes to wide characters
-
-    if ((PTR_BaseDomain(pAppDomain) == PTR_BaseDomain(SharedDomain::GetDomain())) ||
-        (PTR_BaseDomain(pAppDomain) == PTR_BaseDomain(SystemDomain::System())))
-    {
-        // Shared domain and SystemDomain don't have this field.
-        if (configFile)
-            configFile[0] = 0;
-
-        if (pNeeded)
-            *pNeeded = 1;
-    }
-
-    if (!pAppDomain->m_configFile.IsEmpty())
-    {
-        if (!pAppDomain->m_configFile.DacGetUnicode(count, configFile, pNeeded))
-        {
-            hr = E_FAIL;
-        }
-    }
-    else
-    {
-        if (configFile)
-            configFile[0] = 0;
-
-        if (pNeeded)
-            *pNeeded = 1;
-    }
-    
-    SOSDacLeave();
-    return hr;
+    return E_FAIL;
 }
 
 HRESULT

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -6422,22 +6422,6 @@ PVOID AppDomain::GetFriendlyNameNoSet(bool* isUtf8)
 
 #endif // DACCESS_COMPILE
 
-void AppDomain::CacheStringsForDAC()
-{
-    CONTRACTL
-    {
-        THROWS;
-        GC_TRIGGERS;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
-
-    //
-    // If the application base, private bin paths, and configuration file are
-    // available, cache them so DAC can read them out of memory
-    //
-}
-
 #ifndef DACCESS_COMPILE
 
 BOOL AppDomain::AddFileToCache(AssemblySpec* pSpec, PEAssembly *pFile, BOOL fAllowFailure)
@@ -7694,8 +7678,6 @@ void AppDomain::InitializeDomainContext(BOOL allowRedirects,
         setupDomain.Call(args);
     }
     GCPROTECT_END();
-
-    CacheStringsForDAC();
 #endif // CROSSGEN_COMPILE
 }
 

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -3655,10 +3655,6 @@ private:
     // The default context for this domain
     Context *m_pDefaultContext;
 
-    SString         m_applicationBase;
-    SString         m_privateBinPaths;
-    SString         m_configFile;
-
     ArrayList        m_failedAssemblies;
 
     DomainAssembly * m_anonymouslyHostedDynamicMethodsAssembly;

--- a/src/vm/corhost.cpp
+++ b/src/vm/corhost.cpp
@@ -716,8 +716,6 @@ HRESULT CorHost2::_CreateAppDomain(
 
 
         pDomain->DoSetup(&_gc.setupInfo);
-
-        pDomain->CacheStringsForDAC();
         
         GCPROTECT_END();
 


### PR DESCRIPTION
Not supported on CoreCLR appdomain's method and properties were removed

#15001