### PR TITLE
Fix 14455: _opt_relrotarg_valref test failure on amd64.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8120,9 +8120,9 @@ void Compiler::fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCa
             if (!varDsc->lvIsParam)
             {
                 var_types lclType            = varDsc->TypeGet();
-                bool      isILTemp           = (varNum < info.compLocalsCount);
+                bool      isUserLocal        = (varNum < info.compLocalsCount);
                 bool      structWithGCFields = ((lclType == TYP_STRUCT) && (varDsc->lvStructGcCount > 0));
-                if (isILTemp || structWithGCFields)
+                if (isUserLocal || structWithGCFields)
                 {
                     GenTreePtr lcl  = gtNewLclvNode(varNum, lclType);
                     GenTreePtr init = nullptr;

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8109,7 +8109,7 @@ void Compiler::fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCa
 
     // If compInitMem is set, we may need to zero-initialize some locals. Normally it's done in the prolog
     // but this loop can't include the prolog. Since we don't have liveness information, we insert zero-initialization
-    // for all non-parameter non-temp locals as well as temp structs with GC fields.
+    // for all non-parameter IL locals as well as temp structs with GC fields.
     // Liveness phase will remove unnecessary initializations.
     if (info.compInitMem)
     {
@@ -8117,14 +8117,15 @@ void Compiler::fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCa
         LclVarDsc* varDsc;
         for (varNum = 0, varDsc = lvaTable; varNum < lvaCount; varNum++, varDsc++)
         {
-            var_types lclType = varDsc->TypeGet();
             if (!varDsc->lvIsParam)
             {
-                if (!varDsc->lvIsTemp || ((lclType == TYP_STRUCT) && (varDsc->lvStructGcCount > 0)))
+                var_types lclType            = varDsc->TypeGet();
+                bool      isILTemp           = (varNum < info.compLocalsCount);
+                bool      structWithGCFields = ((lclType == TYP_STRUCT) && (varDsc->lvStructGcCount > 0));
+                if (isILTemp || structWithGCFields)
                 {
-                    var_types  lclType = varDsc->TypeGet();
-                    GenTreePtr lcl     = gtNewLclvNode(varNum, lclType);
-                    GenTreePtr init    = nullptr;
+                    GenTreePtr lcl  = gtNewLclvNode(varNum, lclType);
+                    GenTreePtr init = nullptr;
                     if (lclType == TYP_STRUCT)
                     {
                         const bool isVolatile  = false;

--- a/tests/src/JIT/Regression/JitBlue/GitHub_14455/GitHub_14455.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_14455/GitHub_14455.il
@@ -1,0 +1,105 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// It is a non-stress repro for the issue #14455.
+// growTree is optimized as fast tail call and converted to a loop.
+// `starg.s 0` forces the jit to create a temp for the modifiable this.
+// Before the fix the jit zero-initialized all long-live locals in the end of the loop,
+// on the last iteration it set `this` to `null` and the return block was trying to use
+// `null` to write `m_rightChild` in, that caused a runtime exception.
+
+
+.assembly extern System.Runtime {auto}
+.assembly GitHub_14455 {}
+
+.class public auto ansi beforefieldinit Rotate.Node
+       extends [System.Runtime]System.Object
+{
+  .field public class Rotate.Node m_leftChild
+  .field public class Rotate.Node m_rightChild
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+    IL_0006:  ret
+  } // end of method Node::.ctor
+
+  .method family hidebysig virtual instance void 
+          Finalize() cil managed
+  {
+    .override [System.Runtime]System.Object::Finalize
+    // Code size       10 (0xa)
+    .maxstack  1
+    .try
+    {
+      IL_0000:  leave.s    IL_0009
+
+    }  // end .try
+    finally
+    {
+      IL_0002:  ldarg.0
+      IL_0003:  call       instance void [System.Runtime]System.Object::Finalize()
+      IL_0008:  endfinally
+    }  // end handler
+    IL_0009:  ret
+  } // end of method Node::Finalize
+
+  .method public hidebysig instance void 
+          growTree(int32 maxHeight) cil managed
+  {
+    // Code size       72 (0x48)
+    .maxstack  4
+    .locals init (class Rotate.Node V_0)
+    IL_0000:  ldarg.1
+    IL_0001:  ldc.i4.0
+    IL_0002:  ble.s      IL_0037
+
+    IL_0004:  ldarg.0
+    IL_0005:  newobj     instance void Rotate.Node::.ctor()
+    IL_000a:  stfld      class Rotate.Node Rotate.Node::m_leftChild
+    IL_000f:  ldarg.0
+    IL_0010:  ldfld      class Rotate.Node Rotate.Node::m_leftChild
+    IL_0015:  ldarg.1
+    IL_0016:  ldc.i4.1
+    IL_0017:  sub
+    IL_0018:  callvirt   instance void Rotate.Node::growTree(int32)
+    IL_001d:  ldarg.0
+    IL_001e:  newobj     instance void Rotate.Node::.ctor()
+    IL_0023:  stfld      class Rotate.Node Rotate.Node::m_rightChild
+    IL_0028:  ldarg.0
+    IL_0029:  ldfld      class Rotate.Node Rotate.Node::m_rightChild
+    IL_002e:  ldarg.1
+    IL_002f:  ldc.i4.1
+    IL_0030:  sub
+    IL_0031:  callvirt   instance void Rotate.Node::growTree(int32)
+    IL_0036:  ret
+			  ldarg.0 
+		      starg.s 0 // Force to create a temp for the modifiable this.
+    IL_0037:  ldarg.0
+    IL_0038:  ldarg.0
+    IL_0039:  ldnull
+    IL_003a:  dup
+    IL_003b:  stloc.0
+    IL_003c:  stfld      class Rotate.Node Rotate.Node::m_rightChild
+    IL_0041:  ldloc.0
+    IL_0042:  stfld      class Rotate.Node Rotate.Node::m_leftChild
+    IL_0047:  ret
+  } // end of method Node::growTree
+
+  .method public hidebysig static int32  Main() cil managed
+  {
+    .entrypoint
+    // Code size       14 (0xe)
+    .maxstack  8
+    IL_0000:  newobj     instance void Rotate.Node::.ctor()
+    IL_0005:  ldc.i4.4
+    IL_0006:  callvirt   instance void Rotate.Node::growTree(int32)
+    IL_000b:  ldc.i4.s   100
+    IL_000d:  ret
+  } // end of method Node::Main
+
+} // end of class Rotate.Node

--- a/tests/src/JIT/Regression/JitBlue/GitHub_14455/GitHub_14455.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_14455/GitHub_14455.ilproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_14455.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Do not zero-initialize temps, that were created by jit and do not have GC refs.
The confusion was that `varDsc->lvIsTemp` means `short live` variable, when we wanted to ask is it IL temp or not.

Fix #14455.