### PR TITLE
fix for il to native mapping etw events

### DIFF
--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -3029,7 +3029,7 @@ DebuggerMethodInfo *Debugger::GetOrCreateMethodInfo(Module *pModule, mdMethodDef
  * structs will be returned, and some of the ilOffsets in this array
  * may be the values specified in CorDebugIlToNativeMappingTypes.
  ******************************************************************************/
-HRESULT Debugger::GetILToNativeMapping(UINT_PTR pNativeCodeStartAddress, ULONG32 cMap,
+HRESULT Debugger::GetILToNativeMapping(PCODE pNativeCodeStartAddress, ULONG32 cMap,
                                        ULONG32 *pcMap, COR_DEBUG_IL_TO_NATIVE_MAP map[])
 {
     CONTRACTL
@@ -3133,7 +3133,8 @@ HRESULT Debugger::GetILToNativeMapping(UINT_PTR pNativeCodeStartAddress, ULONG32
 //
 
 HRESULT Debugger::GetILToNativeMappingIntoArrays(
-    UINT_PTR pCode, 
+    MethodDesc * pMethodDesc,
+    PCODE pCode, 
     USHORT cMapMax, 
     USHORT * pcMap,
     UINT ** prguiILOffset, 
@@ -3157,7 +3158,7 @@ HRESULT Debugger::GetILToNativeMappingIntoArrays(
 
     // Get the JIT info by functionId.
 
-    DebuggerJitInfo * pDJI = GetJitInfoFromAddr(pCode);
+    DebuggerJitInfo * pDJI = GetJitInfo(pMethodDesc, (const BYTE *)pCode);
 
     // Dunno what went wrong
     if (pDJI == NULL)

--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -3133,7 +3133,7 @@ HRESULT Debugger::GetILToNativeMapping(UINT_PTR pNativeCodeStartAddress, ULONG32
 //
 
 HRESULT Debugger::GetILToNativeMappingIntoArrays(
-    MethodDesc * pMD, 
+    UINT_PTR pCode, 
     USHORT cMapMax, 
     USHORT * pcMap,
     UINT ** prguiILOffset, 
@@ -3157,7 +3157,7 @@ HRESULT Debugger::GetILToNativeMappingIntoArrays(
 
     // Get the JIT info by functionId.
 
-    DebuggerJitInfo * pDJI = GetLatestJitInfoFromMethodDesc(pMD);
+    DebuggerJitInfo * pDJI = GetJitInfoFromAddr(pCode);
 
     // Dunno what went wrong
     if (pDJI == NULL)

--- a/src/debug/ee/debugger.h
+++ b/src/debug/ee/debugger.h
@@ -2025,11 +2025,12 @@ public:
     DebuggerJitInfo *GetLatestJitInfoFromMethodDesc(MethodDesc * pMethodDesc);
 
 
-    HRESULT GetILToNativeMapping(UINT_PTR pNativeCodeStartAddress, ULONG32 cMap, ULONG32 *pcMap,
+    HRESULT GetILToNativeMapping(PCODE pNativeCodeStartAddress, ULONG32 cMap, ULONG32 *pcMap,
                                  COR_DEBUG_IL_TO_NATIVE_MAP map[]);
 
     HRESULT GetILToNativeMappingIntoArrays(
-        UINT_PTR pCode, 
+        MethodDesc * pMethodDesc,
+        PCODE pCode, 
         USHORT cMapMax, 
         USHORT * pcMap,
         UINT ** prguiILOffset, 

--- a/src/debug/ee/debugger.h
+++ b/src/debug/ee/debugger.h
@@ -2029,7 +2029,7 @@ public:
                                  COR_DEBUG_IL_TO_NATIVE_MAP map[]);
 
     HRESULT GetILToNativeMappingIntoArrays(
-        MethodDesc * pMD, 
+        UINT_PTR pCode, 
         USHORT cMapMax, 
         USHORT * pcMap,
         UINT ** prguiILOffset, 

--- a/src/inc/eventtracebase.h
+++ b/src/inc/eventtracebase.h
@@ -547,7 +547,7 @@ namespace ETW
             BOOL fGetReJitIDs);
         static VOID SendEventsForNgenMethods(Module *pModule, DWORD dwEventOptions);
         static VOID SendMethodJitStartEvent(MethodDesc *pMethodDesc, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL);
-        static VOID SendMethodILToNativeMapEvent(MethodDesc * pMethodDesc, DWORD dwEventOptions, ReJITID rejitID);
+        static VOID SendMethodILToNativeMapEvent(MethodDesc * pMethodDesc, DWORD dwEventOptions, SIZE_T pCode, ReJITID rejitID);
         static VOID SendMethodEvent(MethodDesc *pMethodDesc, DWORD dwEventOptions, BOOL bIsJit, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL, SIZE_T pCode = 0, ReJITID rejitID = 0);
         static VOID SendHelperEvent(ULONGLONG ullHelperStartAddress, ULONG ulHelperSize, LPCWSTR pHelperName);
     public:

--- a/src/vm/dbginterface.h
+++ b/src/vm/dbginterface.h
@@ -279,13 +279,14 @@ public:
                                                                             DWORD nativeOffset,
                                                                             DWORD *ilOffset) = 0;
 
-    virtual HRESULT GetILToNativeMapping(UINT_PTR pNativeCodeStartAddress,
+    virtual HRESULT GetILToNativeMapping(PCODE pNativeCodeStartAddress,
                                          ULONG32 cMap,
                                          ULONG32 *pcMap,
                                          COR_DEBUG_IL_TO_NATIVE_MAP map[]) = 0;
 
     virtual HRESULT GetILToNativeMappingIntoArrays(
-        UINT_PTR pCode, 
+        MethodDesc * pMethodDesc,
+        PCODE pCode, 
         USHORT cMapMax, 
         USHORT * pcMap,
         UINT ** prguiILOffset, 

--- a/src/vm/dbginterface.h
+++ b/src/vm/dbginterface.h
@@ -285,7 +285,7 @@ public:
                                          COR_DEBUG_IL_TO_NATIVE_MAP map[]) = 0;
 
     virtual HRESULT GetILToNativeMappingIntoArrays(
-        MethodDesc * pMD, 
+        UINT_PTR pCode, 
         USHORT cMapMax, 
         USHORT * pcMap,
         UINT ** prguiILOffset, 

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -5253,7 +5253,7 @@ VOID ETW::MethodLog::MethodJitted(MethodDesc *pMethodDesc, SString *namespaceOrC
             _ASSERTE(g_pDebugInterface != NULL);
             g_pDebugInterface->InitializeLazyDataIfNecessary();
             
-            ETW::MethodLog::SendMethodILToNativeMapEvent(pMethodDesc, ETW::EnumerationLog::EnumerationStructs::JitMethodILToNativeMap, rejitID);
+            ETW::MethodLog::SendMethodILToNativeMapEvent(pMethodDesc, ETW::EnumerationLog::EnumerationStructs::JitMethodILToNativeMap, pCode, rejitID);
         }
 
     } EX_CATCH { } EX_END_CATCH(SwallowAllExceptions);
@@ -6664,7 +6664,7 @@ VOID ETW::MethodLog::SendMethodEvent(MethodDesc *pMethodDesc, DWORD dwEventOptio
 //
 
 // static
-VOID ETW::MethodLog::SendMethodILToNativeMapEvent(MethodDesc * pMethodDesc, DWORD dwEventOptions, ReJITID rejitID)
+VOID ETW::MethodLog::SendMethodILToNativeMapEvent(MethodDesc * pMethodDesc, DWORD dwEventOptions, SIZE_T pCode, ReJITID rejitID)
 {
     CONTRACTL
     {
@@ -6697,7 +6697,7 @@ VOID ETW::MethodLog::SendMethodILToNativeMapEvent(MethodDesc * pMethodDesc, DWOR
     NewArrayHolder<UINT> rguiNativeOffset;
 
     HRESULT hr = g_pDebugInterface->GetILToNativeMappingIntoArrays(
-        pMethodDesc,
+        pCode,
         kMapEntriesMax,
         &cMap,
         &rguiILOffset,
@@ -6871,7 +6871,7 @@ VOID ETW::MethodLog::SendEventsForJitMethodsHelper(BaseDomain *pDomainFilter,
 
         // Send any supplemental events requested for this MethodID
         if (fSendILToNativeMapEvent)
-            ETW::MethodLog::SendMethodILToNativeMapEvent(pMD, dwEventOptions, rejitID);
+            ETW::MethodLog::SendMethodILToNativeMapEvent(pMD, dwEventOptions, codeStart, rejitID);
 
         // When we're called to announce unloads, then the methodunload event itself must
         // come after any supplemental events, so that the method unload event is the

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -6697,6 +6697,7 @@ VOID ETW::MethodLog::SendMethodILToNativeMapEvent(MethodDesc * pMethodDesc, DWOR
     NewArrayHolder<UINT> rguiNativeOffset;
 
     HRESULT hr = g_pDebugInterface->GetILToNativeMappingIntoArrays(
+        pMethodDesc,
         pCode,
         kMapEntriesMax,
         &cMap,


### PR DESCRIPTION
Fix for #14947, previously the il to native mapping ETW events would always emit events for the same native code version, this change fixes that. 