### PR TITLE
Fix calling convention gap in ILGenerator.EmitCalli

### DIFF
--- a/src/mscorlib/src/System/Reflection/Emit/ILGenerator.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/ILGenerator.cs
@@ -531,6 +531,51 @@ namespace System.Reflection.Emit
             PutInteger4(modBuilder.GetSignatureToken(sig).Token);
         }
 
+        public virtual void EmitCalli(OpCode opcode, CallingConvention unmanagedCallConv, Type returnType, Type[] parameterTypes)
+        {
+            int stackchange = 0;
+            int cParams = 0;
+            int i;
+            SignatureHelper sig;
+
+            ModuleBuilder modBuilder = (ModuleBuilder)m_methodBuilder.Module;
+
+            if (parameterTypes != null)
+            {
+                cParams = parameterTypes.Length;
+            }
+
+            sig = SignatureHelper.GetMethodSigHelper(
+                modBuilder,
+                unmanagedCallConv,
+                returnType);
+
+            if (parameterTypes != null)
+            {
+                for (i = 0; i < cParams; i++)
+                {
+                    sig.AddArgument(parameterTypes[i]);
+                }
+            }
+
+            // If there is a non-void return type, push one.
+            if (returnType != typeof(void))
+                stackchange++;
+
+            // Pop off arguments if any.
+            if (parameterTypes != null)
+                stackchange -= cParams;
+
+            // Pop the native function pointer.
+            stackchange--;
+            UpdateStackSize(OpCodes.Calli, stackchange);
+
+            EnsureCapacity(7);
+            Emit(OpCodes.Calli);
+            RecordTokenFixup();
+            PutInteger4(modBuilder.GetSignatureToken(sig).Token);
+        }
+
         public virtual void EmitCall(OpCode opcode, MethodInfo methodInfo, Type[] optionalParameterTypes)
         {
             if (methodInfo == null)


### PR DESCRIPTION
ILGenerator is missing the overload of EmitCalli that takes a System.Runtime.InteropServices.CallingConvention enum. This is the unmanaged calling convention enum that includes CDecl.

Fixes: https://github.com/dotnet/corefx/issues/9800