### PR TITLE
JIT: enable aggressive inline policy for Tier1

### DIFF
--- a/src/jit/inlinepolicy.cpp
+++ b/src/jit/inlinepolicy.cpp
@@ -85,7 +85,13 @@ InlinePolicy* InlinePolicy::GetPolicy(Compiler* compiler, bool isPrejitRoot)
         return new (compiler, CMK_Inlining) ModelPolicy(compiler, isPrejitRoot);
     }
 
-    // Use the default policy by default
+    // If optimizing for speed, use the FullPolicy.
+    if (compiler->opts.compCodeOpt == Compiler::FAST_CODE)
+    {
+        return new (compiler, CMK_Inlining) FullPolicy(compiler, isPrejitRoot);
+    }
+
+    // Otherwise use the DefaultPolicy.
     return new (compiler, CMK_Inlining) DefaultPolicy(compiler, isPrejitRoot);
 }
 
@@ -2132,8 +2138,6 @@ void ModelPolicy::DetermineProfitability(CORINFO_METHOD_INFO* methodInfo)
     }
 }
 
-#if defined(DEBUG) || defined(INLINE_DATA)
-
 //------------------------------------------------------------------------/
 // FullPolicy: construct a new FullPolicy
 //
@@ -2187,6 +2191,8 @@ void FullPolicy::DetermineProfitability(CORINFO_METHOD_INFO* methodInfo)
 
     return;
 }
+
+#if defined(DEBUG) || defined(INLINE_DATA)
 
 //------------------------------------------------------------------------/
 // SizePolicy: construct a new SizePolicy

--- a/src/jit/inlinepolicy.h
+++ b/src/jit/inlinepolicy.h
@@ -349,7 +349,6 @@ public:
         return "FullPolicy";
     }
 #endif // defined(DEBUG) || defined(INLINE_DATA)
-
 };
 
 #if defined(DEBUG) || defined(INLINE_DATA)

--- a/src/jit/inlinepolicy.h
+++ b/src/jit/inlinepolicy.h
@@ -12,13 +12,13 @@
 // LegalPolicy          - partial class providing common legality checks
 // DefaultPolicy        - default inliner policy
 // DiscretionaryPolicy  - default variant with uniform size policy
+// FullPolicy           - inline aggressively up to size and depth limits
 // ModelPolicy          - policy based on statistical modelling
 //
 // These experimental policies are available only in
 // DEBUG or release+INLINE_DATA builds of the jit.
 //
 // RandomPolicy         - randomized inlining
-// FullPolicy           - inlines everything up to size and depth limits
 // SizePolicy           - tries not to increase method sizes
 //
 // The default policy in use is the DefaultPolicy.
@@ -327,8 +327,6 @@ private:
 
 #endif // defined(DEBUG) || defined(INLINE_DATA)
 
-#if defined(DEBUG) || defined(INLINE_DATA)
-
 // FullPolicy is an experimental policy that will always inline if
 // possible, subject to externally settable depth and size limits.
 //
@@ -344,12 +342,17 @@ public:
     // Policy determinations
     void DetermineProfitability(CORINFO_METHOD_INFO* methodInfo) override;
 
+#if defined(DEBUG) || defined(INLINE_DATA)
     // Miscellaneous
     const char* GetName() const override
     {
         return "FullPolicy";
     }
+#endif // defined(DEBUG) || defined(INLINE_DATA)
+
 };
+
+#if defined(DEBUG) || defined(INLINE_DATA)
 
 // SizePolicy is an experimental policy that will inline as much
 // as possible without increasing the (estimated) method size.

--- a/tests/src/performance/Scenario/JitBench/JitBenchHarness.cs
+++ b/tests/src/performance/Scenario/JitBench/JitBenchHarness.cs
@@ -39,7 +39,6 @@ namespace JitBench
                     startInfo.Environment.Add("COMPlus_EXPERIMENTAL_TieredCompilation", "1");
                     scenarioName += " Tiering";
                 }
-
                 if (options.Minopts)
                 {
                     startInfo.Environment.Add("COMPlus_JITMinOpts", "1");
@@ -57,6 +56,8 @@ namespace JitBench
                     startInfo.Environment.Add("COMPlus_ZapDisable", "1");
                     scenarioName += " NoNgen";
                 }
+
+                PrintHeader($"Running scenario '{scenarioName}'");
 
                 var program = new JitBenchHarness();
                 try


### PR DESCRIPTION
Some preliminary work to address the impact of tiering on steady-state
performance. When the jit is asked to rejit a method, use a much more
aggressive inlinling policy than we use for normal jitting.

This version of jit codgen can also be tested explicitly by setting

  `COMPlus_JitOptimizeType=2`

or in debug/chk by setting

  `COMPlus_JitInlinePolicyFull=1`

It is not otherwise reachable.

This policy is quite likely *too* aggressive and we will likely adjust things
as we get more experience looking at steady-state perf under tiering.

The remainder of the jit's behavior is not impacted, though it might be
reasonable to increase some of the thresholds and alter some of the cost
models used in other phases.

Also modify jitbench to be a bit more explicit about which mode it thinks it
is running, as a way to double-check that we're measuring what we think we are.