### PR TITLE
Mark packages as non-stable and bump to 1.0.11 servicing

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -155,12 +155,12 @@
     <ExternalExpectedPrerelease>servicing-25316-00</ExternalExpectedPrerelease>
 
     <!-- Central place to set the versions of all nuget packages produced in the repo -->
-    <Version Condition="'$(MSBuildProjectExtension)' == '.pkgproj' and '$(Version)' == ''">1.0.10</Version>
+    <Version Condition="'$(MSBuildProjectExtension)' == '.pkgproj' and '$(Version)' == ''">1.0.11</Version>
     <WindowsAPISetPackageVersion>1.0.1</WindowsAPISetPackageVersion>
     <Win8ArmPackageVersion>$(Version)-$(ExternalExpectedPrerelease)</Win8ArmPackageVersion>
 
     <!-- Set the boolean below to true to generate packages with stabilized versions -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <StableVersion Condition="'$(MSBuildProjectExtension)' == '.pkgproj' and '$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == ''">$(Version)</StableVersion>
     <Win8ArmPackageVersion Condition="'$(StabilizePackageVersion)' == 'true'">$(StableVersion)</Win8ArmPackageVersion>
 


### PR DESCRIPTION
cc: @weshaggard 