### PR TITLE
Fixed morphing of artificially created structs

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -9566,7 +9566,8 @@ inline LclVarDsc::LclVarDsc(Compiler* comp)
     _lvOtherArgReg(REG_STK)
     ,
 #endif // FEATURE_MULTIREG_ARGS
-    lvGcLayout(nullptr),
+    lvGcLayout(nullptr)
+    ,
 #if ASSERTION_PROP
     lvRefBlks(BlockSetOps::UninitVal())
     ,

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -9566,6 +9566,7 @@ inline LclVarDsc::LclVarDsc(Compiler* comp)
     _lvOtherArgReg(REG_STK)
     ,
 #endif // FEATURE_MULTIREG_ARGS
+    lvGcLayout(nullptr),
 #if ASSERTION_PROP
     lvRefBlks(BlockSetOps::UninitVal())
     ,

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -5037,7 +5037,8 @@ GenTreePtr Compiler::fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr f
             noway_assert(elemCount <= 4);
 #endif
 
-            if (varDsc->lvGcLayout != nullptr) {
+            if (varDsc->lvGcLayout != nullptr)
+            {
 
                 for (unsigned inx = 0; inx < elemCount; inx++)
                 {
@@ -5066,7 +5067,8 @@ GenTreePtr Compiler::fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr f
                 // ByRef like span structs.  The added check for "CONTAINS_STACK_PTR" is the particular bit.
                 // When this is set the struct will contain a ByRef that could be a GC pointer or a native
                 // pointer.
-                assert(((structFlags & CORINFO_FLG_CONTAINS_STACK_PTR) == 0) && (((structFlags & CORINFO_FLG_CONTAINS_GC_PTR) == 0)));
+                assert(((structFlags & CORINFO_FLG_CONTAINS_STACK_PTR) == 0) &&
+                       (((structFlags & CORINFO_FLG_CONTAINS_GC_PTR) == 0)));
 #endif // DEBUG
             }
         }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -5043,7 +5043,7 @@ GenTreePtr Compiler::fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr f
                 varDsc->lvGcLayout = (BYTE*)compGetMem((varDsc->lvSize() / sizeof(void*)) * sizeof(BYTE), CMK_LvaTable);
                 unsigned  numGCVars;
                 var_types simdBaseType = TYP_UNKNOWN;
-                varDsc->lvType = impNormStructType(objClass, varDsc->lvGcLayout, &numGCVars, &simdBaseType);
+                varDsc->lvType         = impNormStructType(objClass, varDsc->lvGcLayout, &numGCVars, &simdBaseType);
             }
 
             for (unsigned inx = 0; inx < elemCount; inx++)


### PR DESCRIPTION
Fixed #14955.

In case we have a value type created from raw block of memory corresponding local remains uninitialized.
```
      sizeof value class JitTest.ValueClass
      localloc <= result type is TYP_BLK, `argValue` in morph
      dup
      initobj value class JitTest.ValueClass <= result type is TYP_STRUCT which proxies TYP_BLK, `arg` in morph
      ldobj value class JitTest.ValueClass
      tail.call int32 JitTest.TestClass::TestFunc2(value class JitTest.ValueClass)
```

My change fixes problematic assert and GC info verification loop where SIGSEGV happens. 