### PR TITLE
Mark packages as non-stable and bump to 1.1.6

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -153,10 +153,10 @@
     <ProjectUrl>https://dot.net</ProjectUrl>
 
     <!-- Central place to set the versions of all nuget packages produced in the repo -->
-    <Version Condition="'$(MSBuildProjectExtension)' == '.pkgproj' and '$(Version)' == ''">1.1.5</Version>
+    <Version Condition="'$(MSBuildProjectExtension)' == '.pkgproj' and '$(Version)' == ''">1.1.6</Version>
 
     <!-- Set the boolean below to true to generate packages with stabilized versions -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <StableVersion Condition="'$(MSBuildProjectExtension)' == '.pkgproj' and '$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == ''">$(Version)</StableVersion>
 
     <!-- On Windows, MSbuild still runs against Desktop FX while it runs on .NET Core on non-Windows. this requires


### PR DESCRIPTION
cc: @weshaggard 