### PR TITLE
Update lab build CentOS 6 docker image

### DIFF
--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -26,7 +26,7 @@
         {
           "Name": "DotNet-CoreClr-Trusted-Linux",
           "Parameters": {
-            "DockerTag": "centos-6-c8c9b08-20174310104313",
+            "DockerTag": "centos-6-376e1a3-20174311014331",
             "Rid": "rhel.6",
             "PB_AdditionalBuildArgs": "-portablebuild=false"
           },


### PR DESCRIPTION
Update the release/2.0.0 CentOS 6 image used for lab builds
to contain Clang 3.9 supporting PGO. The lab tests for RHEL.6 in
release/2.0.0 are consistently failing and this might be the reason.
The master branch has been using this docker image for quite some time.