### PR TITLE
Do not call fgCheckStmtAfterTailCall if already has aborted tail call.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8478,9 +8478,12 @@ GenTreePtr Compiler::fgMorphCall(GenTreeCall* call)
         }
 #endif // FEATURE_PAL
 
-        if (!fgCheckStmtAfterTailCall())
+        if (szFailReason == nullptr)
         {
-            szFailReason = "Unexpected statements after the tail call";
+            if (!fgCheckStmtAfterTailCall())
+            {
+                szFailReason = "Unexpected statements after the tail call";
+            }
         }
 
         if (szFailReason != nullptr)


### PR DESCRIPTION
Do not check stmts after the tail call candidate if the optimization has been aborted already.

Fix #15056