### PR TITLE
Fix a few of createdump bugs.

### DIFF
--- a/src/debug/createdump/crashinfo.h
+++ b/src/debug/createdump/crashinfo.h
@@ -32,7 +32,8 @@ private:
     pid_t m_ppid;                                   // parent pid
     pid_t m_tgid;                                   // process group
     char* m_name;                                   // exe name
-    bool m_sos;                                     // true if running under sos
+    bool m_sos;                                     // if true, running under sos
+    std::string m_coreclrPath;                      // the path of the coreclr module or empty if none
     ICLRDataTarget* m_dataTarget;                   // read process memory, etc.
     std::array<elf_aux_val_t, AT_MAX> m_auxvValues; // auxv values
     std::vector<elf_aux_entry> m_auxvEntries;       // full auxv entries
@@ -46,7 +47,7 @@ public:
     CrashInfo(pid_t pid, ICLRDataTarget* dataTarget, bool sos);
     virtual ~CrashInfo();
     bool EnumerateAndSuspendThreads();
-    bool GatherCrashInfo(const char* programPath, MINIDUMP_TYPE minidumpType);
+    bool GatherCrashInfo(MINIDUMP_TYPE minidumpType);
     void ResumeThreads();
     bool ReadMemory(void* address, void* buffer, size_t size);
     uint64_t GetBaseAddress(uint64_t ip);
@@ -80,7 +81,8 @@ private:
     bool EnumerateModuleMappings();
     bool GetDSOInfo();
     bool GetELFInfo(uint64_t baseAddress);
-    bool EnumerateMemoryRegionsWithDAC(const char* programPath, MINIDUMP_TYPE minidumpType);
+    bool EnumerateProgramHeaders(ElfW(Phdr)* phdrAddr, int phnum, uint64_t baseAddress, ElfW(Dyn)** pdynamicAddr);
+    bool EnumerateMemoryRegionsWithDAC(MINIDUMP_TYPE minidumpType);
     bool EnumerateManagedModules(IXCLRDataProcess* pClrDataProcess);
     bool UnwindAllThreads(IXCLRDataProcess* pClrDataProcess);
     void ReplaceModuleMapping(CLRDATA_ADDRESS baseAddress, const char* pszName);

--- a/src/debug/createdump/createdump.cpp
+++ b/src/debug/createdump/createdump.cpp
@@ -10,7 +10,7 @@ bool g_diagnostics = false;
 // The common create dump code
 //
 bool 
-CreateDumpCommon(const char* programPath, const char* dumpPathTemplate, MINIDUMP_TYPE minidumpType, CrashInfo* crashInfo)
+CreateDumpCommon(const char* dumpPathTemplate, MINIDUMP_TYPE minidumpType, CrashInfo* crashInfo)
 {
     ReleaseHolder<DumpWriter> dumpWriter = new DumpWriter(*crashInfo);
     bool result = false;
@@ -44,7 +44,7 @@ CreateDumpCommon(const char* programPath, const char* dumpPathTemplate, MINIDUMP
         goto exit;
     }
     // Gather all the info about the process, threads (registers, etc.) and memory regions
-    if (!crashInfo->GatherCrashInfo(programPath, minidumpType))
+    if (!crashInfo->GatherCrashInfo(minidumpType))
     {
         goto exit;
     }
@@ -69,5 +69,5 @@ bool
 CreateDumpForSOS(const char* programPath, const char* dumpPathTemplate, pid_t pid, MINIDUMP_TYPE minidumpType, ICLRDataTarget* dataTarget)
 {
     ReleaseHolder<CrashInfo> crashInfo = new CrashInfo(pid, dataTarget, true);
-    return CreateDumpCommon(programPath, dumpPathTemplate, minidumpType, crashInfo);
+    return CreateDumpCommon(dumpPathTemplate, minidumpType, crashInfo);
 }

--- a/src/debug/createdump/datatarget.cpp
+++ b/src/debug/createdump/datatarget.cpp
@@ -52,12 +52,6 @@ DumpDataTarget::QueryInterface(
         AddRef();
         return S_OK;
     }
-    else if (InterfaceId == IID_ICorDebugDataTarget4)
-    {
-        *Interface = (ICorDebugDataTarget4*)this;
-        AddRef();
-        return S_OK;
-    }
     else
     {
         *Interface = NULL;

--- a/src/debug/createdump/main.cpp
+++ b/src/debug/createdump/main.cpp
@@ -12,7 +12,7 @@ const char* g_help = "createdump [options] pid\n"
 "-u, --full - create full core dump.\n" 
 "-d, --diag - enable diagnostic messages.\n";
 
-bool CreateDumpCommon(const char* programPath, const char* dumpPathTemplate, MINIDUMP_TYPE minidumpType, CrashInfo* crashInfo);
+bool CreateDumpCommon(const char* dumpPathTemplate, MINIDUMP_TYPE minidumpType, CrashInfo* crashInfo);
 
 //
 // Main entry point
@@ -34,13 +34,8 @@ int __cdecl main(const int argc, const char* argv[])
         return exitCode;
     }
 
-    // Parse off the program name leaving just the path. Used to locate/load the DAC module.
-    std::string programPath;
-    programPath.append(*argv++);
-    size_t last = programPath.find_last_of('/');
-    programPath = programPath.substr(0, last);
-
     // Parse the command line options and target pid
+    argv++;
     for (int i = 1; i < argc; i++)
     {
         if (*argv != nullptr)
@@ -83,7 +78,7 @@ int __cdecl main(const int argc, const char* argv[])
         // The initialize the data target's ReadVirtual support (opens /proc/$pid/mem)
         if (dataTarget->Initialize(crashInfo))
         {
-            if (!CreateDumpCommon(programPath.c_str(), dumpPathTemplate, minidumpType, crashInfo))
+            if (!CreateDumpCommon(dumpPathTemplate, minidumpType, crashInfo))
             {
                 exitCode = -1;
             }


### PR DESCRIPTION
1) Fix createdump p_vaddr bias/base problem.
2) createdump was loading the DAC from the directory where createdump was executed from and not from the libcoreclr.so path. Fixed this.
3) Don't use the dac if the libcoreclr.so module is not found.
4) Remove the QI of ICoreDebugDataTarget4 in datatarget.cpp. Forgot to do this when the VirtualUnwind function was removed. Caused crash.