### PR TITLE
Fix debuggable GenTree

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -6063,7 +6063,7 @@ GenTree::VtablePtr GenTree::GetVtableForOper(genTreeOps oper)
 #define GTSTRUCT_3_SPECIAL(nm, tag, tag2, tag3)         /*handle explicitly*/
 #include "gtstructs.h"
 
-// clang-format on
+        // clang-format on
 
         // Handle the special cases.
         // The following opers are in GTSTRUCT_N but no other place (namely, no subtypes).

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -6005,45 +6005,96 @@ GenTree::VtablePtr GenTree::GetVtableForOper(genTreeOps oper)
 {
     noway_assert(oper < GT_COUNT);
 
+    // First, check a cache.
+
     if (s_vtablesForOpers[oper] != nullptr)
     {
         return s_vtablesForOpers[oper];
     }
-    // Otherwise...
+
+    // Otherwise, look up the correct vtable entry. Note that we want the most derived GenTree subtype
+    // for an oper. E.g., GT_LCL_VAR is defined in GTSTRUCT_3 as GenTreeLclVar and in GTSTRUCT_N as
+    // GenTreeLclVarCommon. We want the GenTreeLclVar vtable, since nothing should actually be
+    // instantiated as a GenTreeLclVarCommon.
+
     VtablePtr res = nullptr;
     switch (oper)
     {
-#define GTSTRUCT_0(nm, tag) /*handle explicitly*/
-#define GTSTRUCT_1(nm, tag)                                                                                            \
-    case tag:                                                                                                          \
-    {                                                                                                                  \
-        GenTree##nm gt;                                                                                                \
-        res = *reinterpret_cast<VtablePtr*>(&gt);                                                                      \
-    }                                                                                                                  \
-    break;
-#define GTSTRUCT_2(nm, tag, tag2)             /*handle explicitly*/
-#define GTSTRUCT_3(nm, tag, tag2, tag3)       /*handle explicitly*/
-#define GTSTRUCT_4(nm, tag, tag2, tag3, tag4) /*handle explicitly*/
-#define GTSTRUCT_N(nm, ...)                   /*handle explicitly*/
+
+// clang-format off
+
+#define GTSTRUCT_0(nm, tag)                             /*handle explicitly*/
+#define GTSTRUCT_1(nm, tag)                             \
+        case tag:                                       \
+        {                                               \
+            GenTree##nm gt;                             \
+            res = *reinterpret_cast<VtablePtr*>(&gt);   \
+        }                                               \
+        break;
+#define GTSTRUCT_2(nm, tag, tag2)                       \
+        case tag:                                       \
+        case tag2:                                      \
+        {                                               \
+            GenTree##nm gt;                             \
+            res = *reinterpret_cast<VtablePtr*>(&gt);   \
+        }                                               \
+        break;
+#define GTSTRUCT_3(nm, tag, tag2, tag3)                 \
+        case tag:                                       \
+        case tag2:                                      \
+        case tag3:                                      \
+        {                                               \
+            GenTree##nm gt;                             \
+            res = *reinterpret_cast<VtablePtr*>(&gt);   \
+        }                                               \
+        break;
+#define GTSTRUCT_4(nm, tag, tag2, tag3, tag4)           \
+        case tag:                                       \
+        case tag2:                                      \
+        case tag3:                                      \
+        case tag4:                                      \
+        {                                               \
+            GenTree##nm gt;                             \
+            res = *reinterpret_cast<VtablePtr*>(&gt);   \
+        }                                               \
+        break;
+#define GTSTRUCT_N(nm, ...)                             /*handle explicitly*/
+#define GTSTRUCT_2_SPECIAL(nm, tag, tag2)               /*handle explicitly*/
+#define GTSTRUCT_3_SPECIAL(nm, tag, tag2, tag3)         /*handle explicitly*/
 #include "gtstructs.h"
 
-#if !FEATURE_EH_FUNCLETS
-        // If FEATURE_EH_FUNCLETS is set, then GT_JMP becomes the only member of Val, and will be handled above.
-        case GT_END_LFIN:
-        case GT_JMP:
+// clang-format on
+
+        // Handle the special cases.
+        // The following opers are in GTSTRUCT_N but no other place (namely, no subtypes).
+
+        case GT_STORE_BLK:
+        case GT_BLK:
         {
-            GenTreeVal gt(GT_JMP, TYP_INT, 0);
+            GenTreeBlk gt;
             res = *reinterpret_cast<VtablePtr*>(&gt);
-            break;
-        }
-#endif
-        case GT_OBJ:
-        {
-            GenTreeIntCon dummyOp(TYP_I_IMPL, 0);
-            GenTreeObj    obj(TYP_STRUCT, &dummyOp, NO_CLASS_HANDLE, 0);
-            res = *reinterpret_cast<VtablePtr*>(&obj);
         }
         break;
+
+        case GT_IND:
+        case GT_NULLCHECK:
+        {
+            GenTreeIndir gt;
+            res = *reinterpret_cast<VtablePtr*>(&gt);
+        }
+        break;
+
+        // Handle GT_LIST (but not GT_FIELD_LIST, which is also in a GTSTRUCT_1).
+
+        case GT_LIST:
+        {
+            GenTreeArgList gt;
+            res = *reinterpret_cast<VtablePtr*>(&gt);
+        }
+        break;
+
+        // We don't need to handle GTSTRUCT_N for LclVarCommon, since all those allowed opers are specified
+        // in their proper subtype. Similarly for GenTreeIndir.
 
         default:
         {
@@ -6054,7 +6105,6 @@ GenTree::VtablePtr GenTree::GetVtableForOper(genTreeOps oper)
                 assert(!IsExOp(opKind));
                 assert(OperIsSimple(oper) || OperIsLeaf(oper));
                 // Need to provide non-null operands.
-                Compiler*     comp = (Compiler*)_alloca(sizeof(Compiler));
                 GenTreeIntCon dummyOp(TYP_INT, 0);
                 GenTreeOp     gt(oper, TYP_INT, &dummyOp, ((opKind & GTK_UNOP) ? nullptr : &dummyOp));
                 s_vtableForOp = *reinterpret_cast<VtablePtr*>(&gt);

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -428,8 +428,8 @@ struct GenTree
     __declspec(property(get = As##fn##Ref)) GenTree##fn& gt##fn;
 #endif
 
-#define GTSTRUCT_2_SPECIAL(fn, en, en2)             GTSTRUCT_2(fn, en, en2)
-#define GTSTRUCT_3_SPECIAL(fn, en, en2, en3)        GTSTRUCT_3(fn, en, en2, en3)
+#define GTSTRUCT_2_SPECIAL(fn, en, en2) GTSTRUCT_2(fn, en, en2)
+#define GTSTRUCT_3_SPECIAL(fn, en, en2, en3) GTSTRUCT_3(fn, en, en2, en3)
 
 #include "gtstructs.h"
 

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -313,7 +313,6 @@ class GenTreeOperandIterator;
 /*****************************************************************************/
 
 typedef struct GenTree* GenTreePtr;
-struct GenTreeArgList;
 
 // Forward declarations of the subtypes
 #define GTSTRUCT_0(fn, en) struct GenTree##fn;
@@ -322,6 +321,8 @@ struct GenTreeArgList;
 #define GTSTRUCT_3(fn, en, en2, en3) struct GenTree##fn;
 #define GTSTRUCT_4(fn, en, en2, en3, en4) struct GenTree##fn;
 #define GTSTRUCT_N(fn, ...) struct GenTree##fn;
+#define GTSTRUCT_2_SPECIAL(fn, en, en2) GTSTRUCT_2(fn, en, en2)
+#define GTSTRUCT_3_SPECIAL(fn, en, en2, en3) GTSTRUCT_3(fn, en, en2, en3)
 #include "gtstructs.h"
 
 /*****************************************************************************/
@@ -426,6 +427,9 @@ struct GenTree
     }                                                                                                                  \
     __declspec(property(get = As##fn##Ref)) GenTree##fn& gt##fn;
 #endif
+
+#define GTSTRUCT_2_SPECIAL(fn, en, en2)             GTSTRUCT_2(fn, en, en2)
+#define GTSTRUCT_3_SPECIAL(fn, en, en2, en3)        GTSTRUCT_3(fn, en, en2, en3)
 
 #include "gtstructs.h"
 

--- a/src/jit/gtstructs.h
+++ b/src/jit/gtstructs.h
@@ -30,11 +30,24 @@
 #error  Define GTSTRUCT_N before including this file.
 #endif
 
+#ifndef GTSTRUCT_2_SPECIAL
+#error  Define GTSTRUCT_2_SPECIAL before including this file.
+#endif
+
+#ifndef GTSTRUCT_3_SPECIAL
+#error  Define GTSTRUCT_3_SPECIAL before including this file.
+#endif
+
 /*****************************************************************************/
 
 //
 //       Field name    , Allowed node enum(s)
 //                                  
+// The "SPECIAL" variants indicate that some or all of the allowed opers exist elsewhere. This is
+// used in the DEBUGGABLE_GENTREE implementation when determining which vtable pointer to use for
+// a given oper. For example, IntConCommon (for the GenTreeIntConCommon type) allows opers
+// for all its subtypes. The "SPECIAL" version is attached to the supertypes. "N" is always
+// considered "special".
 
 GTSTRUCT_0(UnOp        , GT_OP)
 GTSTRUCT_0(Op          , GT_OP)
@@ -44,15 +57,15 @@ GTSTRUCT_2(Val         , GT_END_LFIN, GT_JMP)
 GTSTRUCT_1(Val         , GT_JMP)
 #endif
 #ifndef LEGACY_BACKEND
-GTSTRUCT_3(IntConCommon, GT_CNS_INT, GT_CNS_LNG, GT_JMPTABLE)
+GTSTRUCT_3_SPECIAL(IntConCommon, GT_CNS_INT, GT_CNS_LNG, GT_JMPTABLE)
 GTSTRUCT_1(JumpTable   , GT_JMPTABLE)
 #else // LEGACY_BACKEND
-GTSTRUCT_2(IntConCommon, GT_CNS_INT, GT_CNS_LNG)
+GTSTRUCT_2_SPECIAL(IntConCommon, GT_CNS_INT, GT_CNS_LNG)
 #endif// LEGACY_BACKEND
 GTSTRUCT_1(IntCon      , GT_CNS_INT)
 GTSTRUCT_1(LngCon      , GT_CNS_LNG)
-GTSTRUCT_1(DblCon      , GT_CNS_DBL) 
-GTSTRUCT_1(StrCon      , GT_CNS_STR) 
+GTSTRUCT_1(DblCon      , GT_CNS_DBL)
+GTSTRUCT_1(StrCon      , GT_CNS_STR)
 GTSTRUCT_N(LclVarCommon, GT_LCL_VAR, GT_LCL_FLD, GT_REG_VAR, GT_PHI_ARG, GT_STORE_LCL_VAR, GT_STORE_LCL_FLD, GT_LCL_VAR_ADDR, GT_LCL_FLD_ADDR) 
 GTSTRUCT_3(LclVar      , GT_LCL_VAR, GT_LCL_VAR_ADDR, GT_STORE_LCL_VAR) 
 #ifndef LEGACY_BACKEND
@@ -65,7 +78,7 @@ GTSTRUCT_1(Cast        , GT_CAST)
 GTSTRUCT_1(Box         , GT_BOX)
 GTSTRUCT_1(Field       , GT_FIELD) 
 GTSTRUCT_1(Call        , GT_CALL) 
-GTSTRUCT_2(ArgList     , GT_LIST, GT_FIELD_LIST)
+GTSTRUCT_2_SPECIAL(ArgList , GT_LIST, GT_FIELD_LIST)
 GTSTRUCT_1(FieldList   , GT_FIELD_LIST)
 GTSTRUCT_1(Colon       , GT_COLON)
 GTSTRUCT_1(FptrVal     , GT_FTN_ADDR)
@@ -120,6 +133,8 @@ GTSTRUCT_3(MultiRegOp  , GT_MUL_LONG, GT_PUTARG_REG, GT_BITCAST)
 #undef  GTSTRUCT_3
 #undef  GTSTRUCT_4
 #undef  GTSTRUCT_N
+#undef  GTSTRUCT_2_SPECIAL
+#undef  GTSTRUCT_3_SPECIAL
 /*****************************************************************************/
 
 // clang-format on


### PR DESCRIPTION
Since the `DEBUGGABLE_GENTREE` hack was introduced, many new
GenTree types have been introduced, and gtstructs.h has shifted
around. This change fixes it so we should see accurate GenTree
vtable pointers for all cases where SetOper gets called.