### PR TITLE
Fixed cookies for finally blocks

### DIFF
--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -273,7 +273,7 @@ void CodeGen::genCodeForBBlist()
 
         block->bbEmitCookie = nullptr;
 
-        if (block->bbFlags & (BBF_JMP_TARGET | BBF_HAS_LABEL))
+        if ((block->bbFlags & (BBF_JMP_TARGET | BBF_HAS_LABEL)) || block->bbJumpKind == BBJ_CALLFINALLY)
         {
             /* Mark a label and update the current set of live GC refs */
 


### PR DESCRIPTION
Fixed #14831 

Finally block which either starts or finishes exception handler didn't have emit cookie. Added it for such blocks. 