### PR TITLE
Fix RyuJIT/arm32 GT_MUL_LONG node bashing

### DIFF
--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -1458,6 +1458,15 @@ inline void GenTree::SetOper(genTreeOps oper, ValueNumberUpdate vnUpdate)
         gtIntCon.gtFieldSeq = nullptr;
     }
 
+#if !defined(LEGACY_BACKEND) && defined(_TARGET_ARM_)
+    if (oper == GT_MUL_LONG)
+    {
+        // We sometimes bash GT_MUL to GT_MUL_LONG, which converts it from GenTreeOp to GenTreeMultiRegOp.
+        gtMultiRegOp.gtOtherReg = REG_NA;
+        gtMultiRegOp.ClearOtherRegFlags();
+    }
+#endif
+
     if (vnUpdate == CLEAR_VN)
     {
         // Clear the ValueNum field as well.


### PR DESCRIPTION
For RyuJIT/arm32, during decomposition we can bash GT_MUL to
GT_MUL_LONG, which changes its type from GenTreeOp to
GenTreeMultiRegOp. When we do this, we need to initialize
the additional fields in GenTreeMultiRegOp. If we don't,
we get asserts in JitDumps, and presumably other bad things
happen.