### PR TITLE
Update jitbench harness to capture steady state data

### DIFF
--- a/tests/src/performance/Scenario/JitBench/IterationData.cs
+++ b/tests/src/performance/Scenario/JitBench/IterationData.cs
@@ -20,5 +20,7 @@ namespace JitBench
         public double FirstRequestTime { get; set; }
 
         public double SteadystateTime { get; set; }
+
+        public double SteadystateMedianTime { get; set; }
     }
 }


### PR DESCRIPTION
Update jitbench SHA to pick up new version that reports steady state
median response time, with fractional digits.