### PR TITLE
Fix GenTree definition for GT_BITCAST

### DIFF
--- a/src/jit/gtlist.h
+++ b/src/jit/gtlist.h
@@ -69,7 +69,7 @@ GTNODE(CAST             , GenTreeCast        ,0,GTK_UNOP|GTK_EXOP)      // conve
 #if !defined(LEGACY_BACKEND) && defined(_TARGET_ARM_)
 GTNODE(BITCAST          , GenTreeMultiRegOp  ,0,GTK_UNOP)               // reinterpretation of bits as another type
 #else
-GTNODE(BITCAST          , GenTreeUnOp        ,0,GTK_UNOP)               // reinterpretation of bits as another type
+GTNODE(BITCAST          , GenTreeOp          ,0,GTK_UNOP)               // reinterpretation of bits as another type
 #endif
 GTNODE(CKFINITE         , GenTreeOp          ,0,GTK_UNOP|GTK_NOCONTAIN) // Check for NaN
 GTNODE(LCLHEAP          , GenTreeOp          ,0,GTK_UNOP|GTK_NOCONTAIN) // alloca()


### PR DESCRIPTION
Nothing should be defined as GenTreeUnOp; use GenTreeOp instead.