### PR TITLE
Fix RyuJIT/arm32 GS cookie check before JMP call

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2647,7 +2647,7 @@ emitJumpKind CodeGen::genJumpKindForOper(genTreeOps cmp, CompareKind compareKind
 #ifdef _TARGET_ARMARCH_
 //------------------------------------------------------------------------
 // genEmitGSCookieCheck: Generate code to check that the GS cookie
-// wasn't thrashed by a buffer overrun. Coomon code for ARM32 and ARM64
+// wasn't thrashed by a buffer overrun. Common code for ARM32 and ARM64.
 //
 void CodeGen::genEmitGSCookieCheck(bool pushReg)
 {
@@ -2658,8 +2658,14 @@ void CodeGen::genEmitGSCookieCheck(bool pushReg)
     if (!pushReg && (compiler->info.compRetType == TYP_REF))
         gcInfo.gcRegGCrefSetCur |= RBM_INTRET;
 
-    regNumber regGSConst = REG_TMP_0;
-    regNumber regGSValue = REG_TMP_1;
+    // We need two temporary registers, to load the GS cookie values and compare them. We can't use
+    // any argument registers if 'pushReg' is true (meaning we have a JMP call). They should be
+    // callee-trash registers, which should not contain anything interesting at this point.
+    // We don't have any IR node representing this check, so LSRA can't communicate registers
+    // for us to use.
+
+    regNumber regGSConst = REG_GSCOOKIE_TMP_0;
+    regNumber regGSValue = REG_GSCOOKIE_TMP_1;
 
     if (compiler->gsGlobalSecurityCookieAddr == nullptr)
     {

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -1318,6 +1318,12 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define REG_TMP_1                REG_R2
   #define RBM_TMP_1                RBM_R2
 
+#ifndef LEGACY_BACKEND
+  // Temporary registers used for the GS cookie check.
+  #define REG_GSCOOKIE_TMP_0       REG_R12
+  #define REG_GSCOOKIE_TMP_1       REG_LR
+#endif // !LEGACY_BACKEND
+
   //  This is the first register pair in REG_TMP_ORDER
   #define REG_PAIR_TMP             REG_PAIR_R2R3
   #define REG_PAIR_TMP_REVERSE     REG_PAIR_R3R2
@@ -1637,6 +1643,10 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   //  This is the second register in REG_TMP_ORDER
   #define REG_TMP_1                REG_R10
   #define RBM_TMP_1                RBM_R10
+
+  // Temporary registers used for the GS cookie check.
+  #define REG_GSCOOKIE_TMP_0       REG_R9
+  #define REG_GSCOOKIE_TMP_1       REG_R10
 
   // register to hold shift amount; no special register is required on ARM64.
   #define REG_SHIFT                REG_NA


### PR DESCRIPTION
The GS cookie check was using r2/r3 registers, after they had been
reloaded as outgoing argument registers for the JMP call, thus
trashing them. Change the temp regs used to r12/lr, the only
non-argument, non-callee-saved registers available on arm32.

Partially fixes #14862