### PR TITLE
Fix STRESS_LCL_FLDS for ARM

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -7303,7 +7303,7 @@ Compiler::fgWalkResult Compiler::lvaStressLclFldCB(GenTreePtr* pTree, fgWalkData
 #ifdef _TARGET_ARM_
         // We need to support alignment requirements to access memory on ARM
         unsigned alignment = 1;
-        pComp->codeGen->InferOpSizeAlign(tree, &alignment);
+        pComp->codeGen->InferOpSizeAlign(lcl, &alignment);
         alignment = roundUp(alignment, TARGET_POINTER_SIZE);
         padding   = roundUp(padding, alignment);
 #endif // _TARGET_ARM_


### PR DESCRIPTION
The code in lvaStressLclFldCB to force alignment for ARM was
using the ADDR node, not the LCL_VAR node. For LONG vars, this meant
computing an incorrect offset into the morphed BLK type local
(4 instead of 8).

Partially fixes #14862