### PR TITLE
Fix ValueStringBuilder to return correct array to pool

### DIFF
--- a/src/mscorlib/shared/System/Text/ValueStringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/ValueStringBuilder.cs
@@ -167,7 +167,7 @@ namespace System.Text
             _chars = _arrayToReturnToPool = poolArray;
             if (toReturn != null)
             {
-                ArrayPool<char>.Shared.Return(_arrayToReturnToPool);
+                ArrayPool<char>.Shared.Return(toReturn);
             }
         }
     }


### PR DESCRIPTION
When growing the builder, it's erroneously returning the new array rather than the old one.