### PR TITLE
Fix two issues in managed number formatting

### DIFF
--- a/src/mscorlib/shared/System/Number.Formatting.cs
+++ b/src/mscorlib/shared/System/Number.Formatting.cs
@@ -72,8 +72,12 @@ namespace System
             {
                 NumberBuffer number = default;
                 Int32ToNumber(value, ref number);
-                Span<char> stackBuffer = stackalloc char[CharStackBufferSize];
-                var sb = new ValueStringBuilder(stackBuffer);
+                ValueStringBuilder sb;
+                unsafe
+                {
+                    char* stackPtr = stackalloc char[CharStackBufferSize];
+                    sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
+                }
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info, false);
@@ -108,8 +112,12 @@ namespace System
             {
                 NumberBuffer number = default;
                 Int32ToNumber(value, ref number);
-                Span<char> stackBuffer = stackalloc char[CharStackBufferSize];
-                var sb = new ValueStringBuilder(stackBuffer);
+                ValueStringBuilder sb;
+                unsafe
+                {
+                    char* stackPtr = stackalloc char[CharStackBufferSize];
+                    sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
+                }
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info, false);
@@ -142,8 +150,12 @@ namespace System
             {
                 NumberBuffer number = default;
                 UInt32ToNumber(value, ref number);
-                Span<char> stackBuffer = stackalloc char[CharStackBufferSize];
-                var sb = new ValueStringBuilder(stackBuffer);
+                ValueStringBuilder sb;
+                unsafe
+                {
+                    char* stackPtr = stackalloc char[CharStackBufferSize];
+                    sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
+                }
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info, false);
@@ -176,8 +188,12 @@ namespace System
             {
                 NumberBuffer number = default;
                 UInt32ToNumber(value, ref number);
-                Span<char> stackBuffer = stackalloc char[CharStackBufferSize];
-                var sb = new ValueStringBuilder(stackBuffer);
+                ValueStringBuilder sb;
+                unsafe
+                {
+                    char* stackPtr = stackalloc char[CharStackBufferSize];
+                    sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
+                }
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info, false);
@@ -213,8 +229,12 @@ namespace System
             {
                 NumberBuffer number = default;
                 Int64ToNumber(value, ref number);
-                Span<char> stackBuffer = stackalloc char[CharStackBufferSize];
-                var sb = new ValueStringBuilder(stackBuffer);
+                ValueStringBuilder sb;
+                unsafe
+                {
+                    char* stackPtr = stackalloc char[CharStackBufferSize];
+                    sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
+                }
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info, false);
@@ -250,8 +270,12 @@ namespace System
             {
                 NumberBuffer number = default;
                 Int64ToNumber(value, ref number);
-                Span<char> stackBuffer = stackalloc char[CharStackBufferSize];
-                var sb = new ValueStringBuilder(stackBuffer);
+                ValueStringBuilder sb;
+                unsafe
+                {
+                    char* stackPtr = stackalloc char[CharStackBufferSize];
+                    sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
+                }
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info, false);
@@ -285,8 +309,12 @@ namespace System
             {
                 NumberBuffer number = default;
                 UInt64ToNumber(value, ref number);
-                Span<char> stackBuffer = stackalloc char[CharStackBufferSize];
-                var sb = new ValueStringBuilder(stackBuffer);
+                ValueStringBuilder sb;
+                unsafe
+                {
+                    char* stackPtr = stackalloc char[CharStackBufferSize];
+                    sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
+                }
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info, false);
@@ -320,8 +348,12 @@ namespace System
             {
                 NumberBuffer number = default;
                 UInt64ToNumber(value, ref number);
-                Span<char> stackBuffer = stackalloc char[CharStackBufferSize];
-                var sb = new ValueStringBuilder(stackBuffer);
+                ValueStringBuilder sb;
+                unsafe
+                {
+                    char* stackPtr = stackalloc char[CharStackBufferSize];
+                    sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
+                }
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info, false);

--- a/src/mscorlib/shared/System/Number.Formatting.cs
+++ b/src/mscorlib/shared/System/Number.Formatting.cs
@@ -15,10 +15,8 @@ namespace System
         private const int MaxUInt32HexDigits = 8;
         private const int MaxUInt32DecDigits = 10;
         private const int MaxUInt64DecDigits = 20;
-        private const int MinStringBufferSize = 105;
+        private const int CharStackBufferSize = 32;
         private const string PosNumberFormat = "#";
-
-        private static readonly char[] s_numberToStringScratch = new char[MinStringBufferSize];
 
         private static readonly string[] s_posCurrencyFormats =
         {
@@ -74,7 +72,8 @@ namespace System
             {
                 NumberBuffer number = default;
                 Int32ToNumber(value, ref number);
-                var sb = new ValueStringBuilder(s_numberToStringScratch);
+                Span<char> stackBuffer = stackalloc char[CharStackBufferSize];
+                var sb = new ValueStringBuilder(stackBuffer);
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info, false);
@@ -109,7 +108,8 @@ namespace System
             {
                 NumberBuffer number = default;
                 Int32ToNumber(value, ref number);
-                var sb = new ValueStringBuilder(s_numberToStringScratch);
+                Span<char> stackBuffer = stackalloc char[CharStackBufferSize];
+                var sb = new ValueStringBuilder(stackBuffer);
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info, false);
@@ -142,7 +142,8 @@ namespace System
             {
                 NumberBuffer number = default;
                 UInt32ToNumber(value, ref number);
-                var sb = new ValueStringBuilder(s_numberToStringScratch);
+                Span<char> stackBuffer = stackalloc char[CharStackBufferSize];
+                var sb = new ValueStringBuilder(stackBuffer);
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info, false);
@@ -175,7 +176,8 @@ namespace System
             {
                 NumberBuffer number = default;
                 UInt32ToNumber(value, ref number);
-                var sb = new ValueStringBuilder(s_numberToStringScratch);
+                Span<char> stackBuffer = stackalloc char[CharStackBufferSize];
+                var sb = new ValueStringBuilder(stackBuffer);
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info, false);
@@ -211,7 +213,8 @@ namespace System
             {
                 NumberBuffer number = default;
                 Int64ToNumber(value, ref number);
-                var sb = new ValueStringBuilder(s_numberToStringScratch);
+                Span<char> stackBuffer = stackalloc char[CharStackBufferSize];
+                var sb = new ValueStringBuilder(stackBuffer);
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info, false);
@@ -247,7 +250,8 @@ namespace System
             {
                 NumberBuffer number = default;
                 Int64ToNumber(value, ref number);
-                var sb = new ValueStringBuilder(s_numberToStringScratch);
+                Span<char> stackBuffer = stackalloc char[CharStackBufferSize];
+                var sb = new ValueStringBuilder(stackBuffer);
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info, false);
@@ -281,7 +285,8 @@ namespace System
             {
                 NumberBuffer number = default;
                 UInt64ToNumber(value, ref number);
-                var sb = new ValueStringBuilder(s_numberToStringScratch);
+                Span<char> stackBuffer = stackalloc char[CharStackBufferSize];
+                var sb = new ValueStringBuilder(stackBuffer);
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info, false);
@@ -315,7 +320,8 @@ namespace System
             {
                 NumberBuffer number = default;
                 UInt64ToNumber(value, ref number);
-                var sb = new ValueStringBuilder(s_numberToStringScratch);
+                Span<char> stackBuffer = stackalloc char[CharStackBufferSize];
+                var sb = new ValueStringBuilder(stackBuffer);
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info, false);

--- a/src/mscorlib/shared/System/Text/ValueStringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/ValueStringBuilder.cs
@@ -167,7 +167,7 @@ namespace System.Text
             _chars = _arrayToReturnToPool = poolArray;
             if (toReturn != null)
             {
-                ArrayPool<char>.Shared.Return(_arrayToReturnToPool);
+                ArrayPool<char>.Shared.Return(toReturn);
             }
         }
     }


### PR DESCRIPTION
I introduced two bugs in the managed formatting work, at least one of which is the cause of the non-deterministic failures in https://github.com/dotnet/corefx/pull/25348#issuecomment-345524624.
1. When ValueStringBuilder grew, it returned the wrong buffer to the pool.  I fixed it to return the correct buffer.
2. The initial buffer used was meant to be a thread-static, but was erroneously just a static, such that parallel formatting could end up stomping on the same buffer.  I changed it to just use stack space rather than pay for the thread-static lookup.