### PR TITLE
Reduce allocations in StringBuilder.AppendFormat for primitive types

### DIFF
--- a/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
@@ -210,6 +210,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\IObservable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IObserver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IProgress.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\ISpanFormattable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Int16.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Int32.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Int64.cs" />

--- a/src/mscorlib/shared/System/Byte.cs
+++ b/src/mscorlib/shared/System/Byte.cs
@@ -12,7 +12,7 @@ namespace System
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public struct Byte : IComparable, IConvertible, IFormattable, IComparable<Byte>, IEquatable<Byte>
+    public struct Byte : IComparable, IConvertible, IFormattable, IComparable<Byte>, IEquatable<Byte>, ISpanFormattable
     {
         private byte m_value; // Do not rename (binary serialization)
 

--- a/src/mscorlib/shared/System/DateTime.cs
+++ b/src/mscorlib/shared/System/DateTime.cs
@@ -53,7 +53,7 @@ namespace System
     [StructLayout(LayoutKind.Auto)]
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
-    public readonly partial struct DateTime : IComparable, IFormattable, IConvertible, IComparable<DateTime>, IEquatable<DateTime>, ISerializable
+    public readonly partial struct DateTime : IComparable, IFormattable, IConvertible, IComparable<DateTime>, IEquatable<DateTime>, ISerializable, ISpanFormattable
     {
         // Number of 100ns ticks per time unit
         private const long TicksPerMillisecond = 10000;

--- a/src/mscorlib/shared/System/DateTimeOffset.cs
+++ b/src/mscorlib/shared/System/DateTimeOffset.cs
@@ -31,7 +31,7 @@ namespace System
     [StructLayout(LayoutKind.Auto)]
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
-    public struct DateTimeOffset : IComparable, IFormattable, IComparable<DateTimeOffset>, IEquatable<DateTimeOffset>, ISerializable, IDeserializationCallback
+    public struct DateTimeOffset : IComparable, IFormattable, IComparable<DateTimeOffset>, IEquatable<DateTimeOffset>, ISerializable, IDeserializationCallback, ISpanFormattable
     {
         // Constants
         internal const Int64 MaxOffset = TimeSpan.TicksPerHour * 14;

--- a/src/mscorlib/shared/System/Guid.cs
+++ b/src/mscorlib/shared/System/Guid.cs
@@ -13,7 +13,7 @@ namespace System
     [Serializable]
     [Runtime.Versioning.NonVersionable] // This only applies to field layout
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public partial struct Guid : IFormattable, IComparable, IComparable<Guid>, IEquatable<Guid>
+    public partial struct Guid : IFormattable, IComparable, IComparable<Guid>, IEquatable<Guid>, ISpanFormattable
     {
         public static readonly Guid Empty = new Guid();
 
@@ -1425,6 +1425,12 @@ namespace System
 
             charsWritten = guidSize;
             return true;
+        }
+
+        bool ISpanFormattable.TryFormat(Span<char> destination, out int charsWritten, string format, IFormatProvider provider)
+        {
+            // Like with the IFormattable implementation, provider is ignored.
+            return TryFormat(destination, out charsWritten, format);
         }
     }
 }

--- a/src/mscorlib/shared/System/ISpanFormattable.cs
+++ b/src/mscorlib/shared/System/ISpanFormattable.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System
+{
+    internal interface ISpanFormattable
+    {
+        bool TryFormat(Span<char> destination, out int charsWritten, string format = null, IFormatProvider provider = null);
+    }
+}

--- a/src/mscorlib/shared/System/Int16.cs
+++ b/src/mscorlib/shared/System/Int16.cs
@@ -12,7 +12,7 @@ namespace System
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public struct Int16 : IComparable, IConvertible, IFormattable, IComparable<Int16>, IEquatable<Int16>
+    public struct Int16 : IComparable, IConvertible, IFormattable, IComparable<Int16>, IEquatable<Int16>, ISpanFormattable
     {
         private short m_value; // Do not rename (binary serialization)
 

--- a/src/mscorlib/shared/System/Int32.cs
+++ b/src/mscorlib/shared/System/Int32.cs
@@ -12,7 +12,7 @@ namespace System
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public struct Int32 : IComparable, IConvertible, IFormattable, IComparable<Int32>, IEquatable<Int32>
+    public struct Int32 : IComparable, IConvertible, IFormattable, IComparable<Int32>, IEquatable<Int32>, ISpanFormattable
     {
         private int m_value; // Do not rename (binary serialization)
 

--- a/src/mscorlib/shared/System/Int64.cs
+++ b/src/mscorlib/shared/System/Int64.cs
@@ -12,7 +12,7 @@ namespace System
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public struct Int64 : IComparable, IConvertible, IFormattable, IComparable<Int64>, IEquatable<Int64>
+    public struct Int64 : IComparable, IConvertible, IFormattable, IComparable<Int64>, IEquatable<Int64>, ISpanFormattable
     {
         private long m_value; // Do not rename (binary serialization)
 

--- a/src/mscorlib/shared/System/SByte.cs
+++ b/src/mscorlib/shared/System/SByte.cs
@@ -12,7 +12,7 @@ namespace System
     [Serializable]
     [CLSCompliant(false)]    [StructLayout(LayoutKind.Sequential)]
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public struct SByte : IComparable, IConvertible, IFormattable, IComparable<SByte>, IEquatable<SByte>
+    public struct SByte : IComparable, IConvertible, IFormattable, IComparable<SByte>, IEquatable<SByte>, ISpanFormattable
     {
         private sbyte m_value; // Do not rename (binary serialization)
 

--- a/src/mscorlib/shared/System/Text/StringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.cs
@@ -1617,9 +1617,24 @@ namespace System.Text
 
                 if (s == null)
                 {
-                    IFormattable formattableArg = arg as IFormattable;
+                    // If arg is ISpanFormattable and the beginning doesn't need padding,
+                    // try formatting it into the remaining current chunk.
+                    if (arg is ISpanFormattable spanFormattableArg &&
+                        (leftJustify || width == 0) &&
+                        spanFormattableArg.TryFormat(RemainingCurrentChunk, out int charsWritten, itemFormat, provider))
+                    {
+                        m_ChunkLength += charsWritten;
 
-                    if (formattableArg != null)
+                        // Pad the end, if needed.
+                        int padding = width - charsWritten;
+                        if (leftJustify && padding > 0) Append(' ', padding);
+
+                        // Continue to parse other characters.
+                        continue;
+                    }
+
+                    // Otherwise, fallback to trying IFormattable or calling ToString.
+                    if (arg is IFormattable formattableArg)
                     {
                         s = formattableArg.ToString(itemFormat, provider);
                     }

--- a/src/mscorlib/shared/System/TimeSpan.cs
+++ b/src/mscorlib/shared/System/TimeSpan.cs
@@ -28,7 +28,7 @@ namespace System
     // an appropriate custom ILMarshaler to keep WInRT interop scenarios enabled.
     //
     [Serializable]
-    public struct TimeSpan : IComparable, IComparable<TimeSpan>, IEquatable<TimeSpan>, IFormattable
+    public struct TimeSpan : IComparable, IComparable<TimeSpan>, IEquatable<TimeSpan>, IFormattable, ISpanFormattable
     {
         public const long TicksPerMillisecond = 10000;
         private const double MillisecondsPerTick = 1.0 / TicksPerMillisecond;

--- a/src/mscorlib/shared/System/UInt16.cs
+++ b/src/mscorlib/shared/System/UInt16.cs
@@ -13,7 +13,7 @@ namespace System
     [CLSCompliant(false)]
     [StructLayout(LayoutKind.Sequential)]
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public struct UInt16 : IComparable, IConvertible, IFormattable, IComparable<UInt16>, IEquatable<UInt16>
+    public struct UInt16 : IComparable, IConvertible, IFormattable, IComparable<UInt16>, IEquatable<UInt16>, ISpanFormattable
     {
         private ushort m_value; // Do not rename (binary serialization)
 

--- a/src/mscorlib/shared/System/UInt32.cs
+++ b/src/mscorlib/shared/System/UInt32.cs
@@ -13,7 +13,7 @@ namespace System
     [CLSCompliant(false)]
     [StructLayout(LayoutKind.Sequential)]
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public struct UInt32 : IComparable, IConvertible, IFormattable, IComparable<UInt32>, IEquatable<UInt32>
+    public struct UInt32 : IComparable, IConvertible, IFormattable, IComparable<UInt32>, IEquatable<UInt32>, ISpanFormattable
     {
         private uint m_value; // Do not rename (binary serialization)
 

--- a/src/mscorlib/shared/System/UInt64.cs
+++ b/src/mscorlib/shared/System/UInt64.cs
@@ -13,7 +13,7 @@ namespace System
     [CLSCompliant(false)]
     [StructLayout(LayoutKind.Sequential)]
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public struct UInt64 : IComparable, IConvertible, IFormattable, IComparable<UInt64>, IEquatable<UInt64>
+    public struct UInt64 : IComparable, IConvertible, IFormattable, IComparable<UInt64>, IEquatable<UInt64>, ISpanFormattable
     {
         private ulong m_value; // Do not rename (binary serialization)
 

--- a/src/mscorlib/shared/System/Version.cs
+++ b/src/mscorlib/shared/System/Version.cs
@@ -16,8 +16,7 @@ namespace System
 
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public sealed class Version : ICloneable, IComparable
-        , IComparable<Version>, IEquatable<Version>
+    public sealed class Version : ICloneable, IComparable, IComparable<Version>, IEquatable<Version>, ISpanFormattable
     {
         // AssemblyName depends on the order staying the same
         private readonly int _Major; // Do not rename (binary serialization)
@@ -226,6 +225,12 @@ namespace System
             StringBuilderCache.Release(sb);
             charsWritten = 0;
             return false;
+        }
+
+        bool ISpanFormattable.TryFormat(Span<char> destination, out int charsWritten, string format, IFormatProvider provider)
+        {
+            // format and provider are ignored.
+            return TryFormat(destination, out charsWritten);
         }
 
         private int DefaultFormatFieldCount =>


### PR DESCRIPTION
Use the new `TryFormat` APIs to avoid string allocations for primitive types inside `StringBuilder.AppendFormat`, used by `string.Format`/interpolated strings.

Benchmark:

```c#
using System;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Attributes.Jobs;
using BenchmarkDotNet.Running;

[MemoryDiagnoser]
[InProcess]
public class Program
{
    public static void Main() => BenchmarkRunner.Run<Program>();

    public static readonly Guid s_guid = new Guid("8759798E-3430-47AA-9A53-C6813F1A7456");

    [Benchmark]
    public void StringFormat()
    {
        Guid guid = s_guid;
        int value = 42;
        for (int i = 0; i < 100_000; i++) string.Format("{0} blah {1}", guid, value);
    }
}
```

Before:

```
       Method |     Mean |     Error |    StdDev |     Gen 0 | Allocated |
------------- |---------:|----------:|----------:|----------:|----------:|
 StringFormat | 20.78 ms | 0.1334 ms | 0.1183 ms | 7437.5000 |  29.75 MB |
```

After:

```
       Method |     Mean |     Error |    StdDev |     Gen 0 | Allocated |
------------- |---------:|----------:|----------:|----------:|----------:|
 StringFormat | 19.80 ms | 0.0735 ms | 0.0688 ms | 4187.5000 |  16.78 MB |
```

Additional improvements can be looked into subsequently, such as avoiding any `itemFormat` string allocations.