### PR TITLE
rewrite binary search in LWM.

### DIFF
--- a/src/ToolBox/superpmi/superpmi-shared/lightweightmap.h
+++ b/src/ToolBox/superpmi/superpmi-shared/lightweightmap.h
@@ -374,7 +374,7 @@ public:
         // O(log n) version
         int first = 0;
         int mid   = 0;
-        int last  = numItems;
+        int last  = numItems - 1;
         while (first <= last)
         {
             mid     = (first + last) / 2; // compute mid point.


### PR DESCRIPTION
The old version was wrong. I rewrote it with a standard binary search template, when only one border is valid.

Example when the old code was wrong:
```
LVM<int, int> map;
map.Add(0, 0);
assert(map.GetIndex(randomMemoryPadding) == -1); 
```
The `GetIndex` call on the first iteration in the loop will go to 
`first = mid + 1; // repeat search in top half. `
`first == 1` after that, that points to uninitialized memory (`numItems == 1`, last valid index is 0)
then, because loop condition is written wrong: `while (first <= last) ` it will repeat iteration with `first ==1, last == 1, mid == 1', and `int res = memcmp(&pKeys[mid], &key, sizeof(_Key)); ` could return 0 when running release, assert will fail.


