### PR TITLE
Fix genPrepForEHCodegen for arm64

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -433,15 +433,15 @@ void CodeGen::genPrepForEHCodegen()
             // has BBF_HAS_LABEL set.
         }
 
-#ifdef _TARGET_AMD64_
+#if FEATURE_EH_CALLFINALLY_THUNKS
         if (HBtab->HasFinallyHandler())
         {
             anyFinallys = true;
         }
-#endif // _TARGET_AMD64_
+#endif // FEATURE_EH_CALLFINALLY_THUNKS
     }
 
-#ifdef _TARGET_AMD64_
+#if FEATURE_EH_CALLFINALLY_THUNKS
     if (anyFinallys)
     {
         for (BasicBlock* block = compiler->fgFirstBB; block != nullptr; block = block->bbNext)
@@ -460,7 +460,7 @@ void CodeGen::genPrepForEHCodegen()
             } // block is BBJ_CALLFINALLY
         }     // for each block
     }         // if (anyFinallys)
-#endif        // _TARGET_AMD64_
+#endif        // FEATURE_EH_CALLFINALLY_THUNKS
 }
 
 void CodeGenInterface::genUpdateLife(GenTreePtr tree)


### PR DESCRIPTION
Enable amd64 code for arm64 as well, to match the expectation of
where labels exist in genReportEH. Fixes #14831, a unique case
during MinOpts (and probably only minopts) where dead code follows
a call/finally block sequence.