### PR TITLE
Stop running Windows ARM64 Debug builds (and tests) by default

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1219,7 +1219,7 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                     assert isArmWindowsScenario(scenario)
                     switch (scenario) {
                         case 'default':
-                            if (configuration == 'Debug' || configuration == 'Checked') {
+                            if (configuration == 'Checked') {
                                 Utilities.addDefaultPrivateGithubPRTriggerForBranch(job, branch, contextString, null, arm64Users)
                             }
                             else {


### PR DESCRIPTION
Currently, a PR (from someone on the ARM64 whitelist) will automatically
trigger Windows ARM64 Debug builds. Due to an issue with test definitions,
this also triggers a Debug test run. This is unnecessary; Checked test
runs (and builds) should be sufficient. Save time and machine resources
by not doing Debug builds and tests by default.