### PR TITLE
StringBuilder: Use Decimal.TryFormat

### DIFF
--- a/src/mscorlib/shared/System/Text/StringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.cs
@@ -1040,7 +1040,18 @@ namespace System.Text
 
         public StringBuilder Append(double value) => Append(value.ToString());
 
-        public StringBuilder Append(decimal value) => Append(value.ToString());
+        public StringBuilder Append(decimal value)
+        {
+            if (value.TryFormat(RemainingCurrentChunk, out int charsWritten))
+            {
+                m_ChunkLength += charsWritten;
+                return this;
+            }
+            else
+            {
+                return Append(value.ToString());
+            }
+        }
 
         [CLSCompliant(false)]
         public StringBuilder Append(ushort value)

--- a/src/mscorlib/src/System/Decimal.cs
+++ b/src/mscorlib/src/System/Decimal.cs
@@ -60,7 +60,7 @@ namespace System
     [Serializable]
     [System.Runtime.Versioning.NonVersionable] // This only applies to field layout
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public partial struct Decimal : IFormattable, IComparable, IConvertible, IComparable<Decimal>, IEquatable<Decimal>, IDeserializationCallback
+    public partial struct Decimal : IFormattable, IComparable, IConvertible, IComparable<Decimal>, IEquatable<Decimal>, IDeserializationCallback, ISpanFormattable
     {
         // Sign mask for the flags field. A value of zero in this bit indicates a
         // positive Decimal value, and a value of one in this bit indicates a


### PR DESCRIPTION
Now that `Decimal` has `TryFormat`, use it from `StringBuilder`.