### PR TITLE
Disable Automatic PR Perf Jobs

### DIFF
--- a/buildpipeline/perf_pipelinejobs.groovy
+++ b/buildpipeline/perf_pipelinejobs.groovy
@@ -27,6 +27,9 @@ def pipeline = perfPipeline
 params = ['XUNIT_PERFORMANCE_MAX_ITERATION':'6',
           'XUNIT_PERFORMANCE_MAX_ITERATION_INNER_SPECIFIED':'6']
 
+// Allow PR jobs on request.
+pipeline.triggerPipelineOnGithubPRComment(triggerName, params)
+
 // Disable automatic PR runs until throughput issues are addressed.
 // pipeline.triggerPipelineOnEveryGithubPR(triggerName, params)
 pipeline.triggerPipelineOnGithubPush()

--- a/buildpipeline/perf_pipelinejobs.groovy
+++ b/buildpipeline/perf_pipelinejobs.groovy
@@ -27,5 +27,6 @@ def pipeline = perfPipeline
 params = ['XUNIT_PERFORMANCE_MAX_ITERATION':'6',
           'XUNIT_PERFORMANCE_MAX_ITERATION_INNER_SPECIFIED':'6']
 
-pipeline.triggerPipelineOnEveryGithubPR(triggerName, params)
+// Disable automatic PR runs until throughput issues are addressed.
+// pipeline.triggerPipelineOnEveryGithubPR(triggerName, params)
 pipeline.triggerPipelineOnGithubPush()


### PR DESCRIPTION
Due to the current throughput issues, we are disabling automatic performance PR jobs.

They will still run post-merge and can be requested via trigger phrase.

These will be back once throughput issues are addressed.

Filed #15175 to bring these runs back.

cc: @valenis, @adiaaida 