### PR TITLE
[Arm64] Allow IsContainableMemoryOp() use

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2695,7 +2695,11 @@ GenTree* Lowering::LowerCompare(GenTree* cmp)
 #ifdef _TARGET_ARM64_
                     (op2Value == 0) && cmp->OperIs(GT_EQ, GT_NE, GT_GT) &&
 #endif
-                    (castOp->OperIs(GT_CALL, GT_LCL_VAR) || castOp->OperIsLogical() || IsContainableMemoryOp(castOp));
+                    (castOp->OperIs(GT_CALL, GT_LCL_VAR) || castOp->OperIsLogical()
+#ifdef _TARGET_XARCH_
+                     || IsContainableMemoryOp(castOp)
+#endif
+                         );
 
                 if (removeCast)
                 {

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -1973,7 +1973,6 @@ void LinearScan::identifyCandidatesExceptionDataflow()
 //
 bool LinearScan::isContainableMemoryOp(GenTree* node)
 {
-#ifdef _TARGET_XARCH_
     if (node->isMemoryOp())
     {
         return true;
@@ -1987,7 +1986,6 @@ bool LinearScan::isContainableMemoryOp(GenTree* node)
         LclVarDsc* varDsc = &compiler->lvaTable[node->AsLclVar()->gtLclNum];
         return varDsc->lvDoNotEnregister;
     }
-#endif // _TARGET_XARCH_
     return false;
 }
 


### PR DESCRIPTION
I want to use `IsContainableMemoryOp()` in ARM64 when I implement containing SIMD `getItem()` `this`

@dotnet/jit-contrib @dotnet/arm64-contrib PTAL