### PR TITLE
Improve SSA topological sort

### DIFF
--- a/src/jit/arraystack.h
+++ b/src/jit/arraystack.h
@@ -40,6 +40,18 @@ public:
         tosIndex++;
     }
 
+    template <typename... Args>
+    void Emplace(Args&&... args)
+    {
+        if (tosIndex == maxIndex)
+        {
+            Realloc();
+        }
+
+        new (&data[tosIndex], jitstd::placement_t()) T(jitstd::forward<Args>(args)...);
+        tosIndex++;
+    }
+
     void Realloc()
     {
         // get a new chunk 2x the size of the old one

--- a/src/jit/block.cpp
+++ b/src/jit/block.cpp
@@ -64,12 +64,8 @@ unsigned SsaStressHashHelper()
 }
 #endif
 
-EHSuccessorIter::EHSuccessorIter(Compiler* comp, BasicBlock* block)
-    : m_comp(comp)
-    , m_block(block)
-    , m_curRegSucc(nullptr)
-    , m_curTry(comp->ehGetBlockExnFlowDsc(block))
-    , m_remainingRegSuccs(block->NumSucc(comp))
+EHSuccessorIterPosition::EHSuccessorIterPosition(Compiler* comp, BasicBlock* block)
+    : m_remainingRegSuccs(block->NumSucc(comp)), m_curRegSucc(nullptr), m_curTry(comp->ehGetBlockExnFlowDsc(block))
 {
     // If "block" is a "leave helper" block (the empty BBJ_ALWAYS block that pairs with a
     // preceding BBJ_CALLFINALLY block to implement a "leave" IL instruction), then no exceptions
@@ -86,11 +82,11 @@ EHSuccessorIter::EHSuccessorIter(Compiler* comp, BasicBlock* block)
     if (m_curTry == nullptr && m_remainingRegSuccs > 0)
     {
         // Examine the successors to see if any are the start of try blocks.
-        FindNextRegSuccTry();
+        FindNextRegSuccTry(comp, block);
     }
 }
 
-void EHSuccessorIter::FindNextRegSuccTry()
+void EHSuccessorIterPosition::FindNextRegSuccTry(Compiler* comp, BasicBlock* block)
 {
     assert(m_curTry == nullptr);
 
@@ -98,32 +94,32 @@ void EHSuccessorIter::FindNextRegSuccTry()
     while (m_remainingRegSuccs > 0)
     {
         m_remainingRegSuccs--;
-        m_curRegSucc = m_block->GetSucc(m_remainingRegSuccs, m_comp);
-        if (m_comp->bbIsTryBeg(m_curRegSucc))
+        m_curRegSucc = block->GetSucc(m_remainingRegSuccs, comp);
+        if (comp->bbIsTryBeg(m_curRegSucc))
         {
             assert(m_curRegSucc->hasTryIndex()); // Since it is a try begin.
             unsigned newTryIndex = m_curRegSucc->getTryIndex();
 
             // If the try region started by "m_curRegSucc" (represented by newTryIndex) contains m_block,
             // we've already yielded its handler, as one of the EH handler successors of m_block itself.
-            if (m_comp->bbInExnFlowRegions(newTryIndex, m_block))
+            if (comp->bbInExnFlowRegions(newTryIndex, block))
             {
                 continue;
             }
 
             // Otherwise, consider this try.
-            m_curTry = m_comp->ehGetDsc(newTryIndex);
+            m_curTry = comp->ehGetDsc(newTryIndex);
             break;
         }
     }
 }
 
-void EHSuccessorIter::operator++(void)
+void EHSuccessorIterPosition::Advance(Compiler* comp, BasicBlock* block)
 {
     assert(m_curTry != nullptr);
     if (m_curTry->ebdEnclosingTryIndex != EHblkDsc::NO_ENCLOSING_INDEX)
     {
-        m_curTry = m_comp->ehGetDsc(m_curTry->ebdEnclosingTryIndex);
+        m_curTry = comp->ehGetDsc(m_curTry->ebdEnclosingTryIndex);
 
         // If we've gone over into considering try's containing successors,
         // then the enclosing try must have the successor as its first block.
@@ -142,10 +138,10 @@ void EHSuccessorIter::operator++(void)
 
     // We've exhausted all try blocks.
     // See if there are any remaining regular successors that start try blocks.
-    FindNextRegSuccTry();
+    FindNextRegSuccTry(comp, block);
 }
 
-BasicBlock* EHSuccessorIter::operator*()
+BasicBlock* EHSuccessorIterPosition::Current(Compiler* comp, BasicBlock* block)
 {
     assert(m_curTry != nullptr);
     return m_curTry->ExFlowBlock();

--- a/src/jit/ssabuilder.cpp
+++ b/src/jit/ssabuilder.cpp
@@ -174,73 +174,63 @@ int SsaBuilder::TopologicalSort(BasicBlock** postOrder, int count)
     DBEXEC(VERBOSE, comp->fgDispBasicBlocks());
     DBEXEC(VERBOSE, comp->fgDispHandlerTab());
 
+    auto DumpBlockAndSuccessors = [](Compiler* comp, BasicBlock* block) {
+#ifdef DEBUG
+        if (comp->verboseSsa)
+        {
+            printf("[SsaBuilder::TopologicalSort] Pushing BB%02u: [", block->bbNum);
+            AllSuccessorEnumerator successors(comp, block);
+            unsigned               index = 0;
+            while (true)
+            {
+                bool        isEHsucc = successors.IsNextEHSuccessor();
+                BasicBlock* succ     = successors.NextSuccessor(comp);
+
+                if (succ == nullptr)
+                {
+                    break;
+                }
+
+                printf("%s%sBB%02u", (index++ ? ", " : ""), (isEHsucc ? "[EH]" : ""), succ->bbNum);
+            }
+            printf("]\n");
+        }
+#endif
+    };
+
     // Compute order.
     int         postIndex = 0;
     BasicBlock* block     = comp->fgFirstBB;
     BitVecOps::AddElemD(&m_visitedTraits, m_visited, block->bbNum);
 
-    ArrayStack<BasicBlock*>      blocks(comp);
-    ArrayStack<AllSuccessorIter> iterators(comp);
-    ArrayStack<AllSuccessorIter> ends(comp);
+    ArrayStack<AllSuccessorEnumerator> blocks(comp);
 
-    // there are three stacks used here and all should be same height
-    // the first is for blocks
-    // the second is the iterator to keep track of what succ of the block we are looking at
-    // and the third is the end marker iterator
-    blocks.Push(block);
-    iterators.Push(block->GetAllSuccs(comp).begin());
-    ends.Push(block->GetAllSuccs(comp).end());
+    blocks.Emplace(comp, block);
+    DumpBlockAndSuccessors(comp, block);
 
     while (blocks.Height() > 0)
     {
-        block = blocks.Top();
+        BasicBlock* block = blocks.TopRef().Block();
+        BasicBlock* succ  = blocks.TopRef().NextSuccessor(comp);
 
-#ifdef DEBUG
-        if (comp->verboseSsa)
-        {
-            printf("[SsaBuilder::TopologicalSort] Visiting BB%02u: ", block->bbNum);
-            printf("[");
-            unsigned numSucc = block->NumSucc(comp);
-            for (unsigned i = 0; i < numSucc; ++i)
-            {
-                printf("BB%02u, ", block->GetSucc(i, comp)->bbNum);
-            }
-            EHSuccessorIter end = block->GetEHSuccs(comp).end();
-            for (EHSuccessorIter ehsi = block->GetEHSuccs(comp).begin(); ehsi != end; ++ehsi)
-            {
-                printf("[EH]BB%02u, ", (*ehsi)->bbNum);
-            }
-            printf("]\n");
-        }
-#endif
-
-        if (iterators.TopRef() != ends.TopRef())
+        if (succ != nullptr)
         {
             // if the block on TOS still has unreached successors, visit them
-            AllSuccessorIter& iter = iterators.TopRef();
-            BasicBlock*       succ = *iter;
-            ++iter;
-
-            // push the children
             if (BitVecOps::TryAddElemD(&m_visitedTraits, m_visited, succ->bbNum))
             {
-                blocks.Push(succ);
-                iterators.Push(succ->GetAllSuccs(comp).begin());
-                ends.Push(succ->GetAllSuccs(comp).end());
+                blocks.Emplace(comp, succ);
+                DumpBlockAndSuccessors(comp, succ);
             }
         }
         else
         {
             // all successors have been visited
             blocks.Pop();
-            iterators.Pop();
-            ends.Pop();
 
+            DBG_SSA_JITDUMP("[SsaBuilder::TopologicalSort] postOrder[%d] = BB%02u\n", postIndex, block->bbNum);
             postOrder[postIndex]  = block;
             block->bbPostOrderNum = postIndex;
             postIndex += 1;
-
-            DBG_SSA_JITDUMP("postOrder[%d] = %s\n", postIndex, block->dspToString());
         }
     }
 


### PR DESCRIPTION
The iterator model isn't a very good fit for block successor iteration. These iterators are quite large (`AllSuccessorIter` has 64 bytes on 64 bit hosts) and the need to maintain 2 iterators (current and end) only make things worse when iterators need to be stored in containers. `SsaBuilder::TopologicalSort` uses 3 stacks, 2 containing iterators and one containing `BasicBlock` pointers. Visiting a block practically requires pushing 136 bytes containing a lot of redundant stuff:
* the second iterator should not be needed
* the block pointer is already present in the first iterator (and it appears twice in `AllSuccessorIter`)
* the compiler pointer isn't really needed and also appears twice in `AllSuccessorIter`

This change extracts the iteration logic into "position" classes that contain only the state need to maintain the current successor. These classes can then be used to build iterators or other mechanism that are more useful in some scenarios - an "enumerator" for example.

This reduces memory usage by 0.3% (`CMK_ArrayStack` drops by more than half) and also provides a small reduction in instructions retired.

Mem stats diff: https://gist.github.com/mikedn/45d7a3873965c627a080191a4c4f51bf

PIN data: https://1drv.ms/x/s!Av4baJYSo5pjgr5i7PW4L3NcAyr9sQ