### PR TITLE
Update memory histogram buckets

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -286,9 +286,10 @@ Histogram genTreeNsizHist(genTreeNsizHistBuckets);
 /*****************************************************************************/
 #if MEASURE_MEM_ALLOC
 
-unsigned  memSizeHistBuckets[] = {20, 50, 75, 100, 150, 250, 500, 1000, 5000, 0};
-Histogram memAllocHist(memSizeHistBuckets);
-Histogram memUsedHist(memSizeHistBuckets);
+unsigned  memAllocHistBuckets[] = {64, 128, 192, 256, 512, 1024, 4096, 8192, 0};
+Histogram memAllocHist(memAllocHistBuckets);
+unsigned  memUsedHistBuckets[] = {16, 32, 64, 128, 192, 256, 512, 1024, 4096, 8192, 0};
+Histogram memUsedHist(memUsedHistBuckets);
 
 #endif // MEASURE_MEM_ALLOC
 


### PR DESCRIPTION
Use values that are more likely to match CPU cache sizes (e.g. L1 = 32K and L2 = 256K)

Example output from crossgen corelib:
```
---------------------------------------------------
Distribution of total memory allocated per method (in KB):
     <=         64 ===>   11436 count ( 41% of total)
     65 ..     128 ===>   11816 count ( 85% of total)
    129 ..     192 ===>    2339 count ( 93% of total)
    193 ..     256 ===>     823 count ( 96% of total)
    257 ..     512 ===>     670 count ( 99% of total)
    513 ..    1024 ===>     116 count ( 99% of total)
   1025 ..    4096 ===>      55 count (100% of total)
   4097 ..    8192 ===>       0 count (100% of total)

---------------------------------------------------
Distribution of total memory used      per method (in KB):
     <=         16 ===>       0 count (  0% of total)
     17 ..      32 ===>       7 count (  0% of total)
     33 ..      64 ===>   11442 count ( 42% of total)
     65 ..     128 ===>   11817 count ( 85% of total)
    129 ..     192 ===>    2414 count ( 94% of total)
    193 ..     256 ===>     763 count ( 97% of total)
    257 ..     512 ===>     641 count ( 99% of total)
    513 ..    1024 ===>     130 count ( 99% of total)
   1025 ..    4096 ===>      41 count (100% of total)
   4097 ..    8192 ===>       0 count (100% of total)
```