### PR TITLE
Fix Powershell error

### DIFF
--- a/build-test.cmd
+++ b/build-test.cmd
@@ -316,9 +316,9 @@ if errorlevel 1 (
 
 REM Prepare the Test Drop
 REM Cleans any NI from the last run
-powershell "-NoProfile Get-ChildItem -path %__TestWorkingDir% -Include '*.ni.*' -Recurse -Force | Remove-Item -force"
+powershell -NoProfile "Get-ChildItem -path %__TestWorkingDir% -Include '*.ni.*' -Recurse -Force | Remove-Item -force"
 REM Cleans up any lock folder used for synchronization from last run
-powershell "-NoProfile Get-ChildItem -path %__TestWorkingDir% -Include 'lock' -Recurse -Force |  where {$_.Attributes -eq 'Directory'}| Remove-Item -force -Recurse"
+powershell -NoProfile "Get-ChildItem -path %__TestWorkingDir% -Include 'lock' -Recurse -Force |  where {$_.Attributes -eq 'Directory'}| Remove-Item -force -Recurse"
 
 set CORE_ROOT=%__TestBinDir%\Tests\Core_Root
 set CORE_ROOT_STAGE=%__TestBinDir%\Tests\Core_Root_Stage

--- a/tests/debugger_tests/ConfigFilesGenerators/GenerateConfig.cmd
+++ b/tests/debugger_tests/ConfigFilesGenerators/GenerateConfig.cmd
@@ -33,7 +33,7 @@ if exist %__ConfigFileName% (
 )
 
 :: powershell "Get-Content %__TemplateFileName% -replace (""##Insert_Runtime_Root##"", ""%__RuntimeRoot%"") | Output-File %__ConfigFileName% "
-powershell "-NoProfile (Get-Content \"%__TemplateFileName%\")`"^
+powershell -NoProfile "(Get-Content \"%__TemplateFileName%\")`"^
     "-replace \"##Insert_Runtime_Root##\", \"%__RuntimeRoot%\" `"^
     "|ForEach-Object{$_ -replace \"##Insert_Nuget_Cache_Root##\", \"%__NugetCacheDir%\"} `"^
     "|ForEach-Object{$_ -replace \"##Cli_Path##\", \"%__CliPath%\"} `"^

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -190,9 +190,9 @@ if defined DoLink (
 
 REM Prepare the Test Drop
 REM Cleans any NI from the last run
-powershell "-NoProfile Get-ChildItem -path %__TestWorkingDir% -Include '*.ni.*' -Recurse -Force | Remove-Item -force"
+powershell -NoProfile "Get-ChildItem -path %__TestWorkingDir% -Include '*.ni.*' -Recurse -Force | Remove-Item -force"
 REM Cleans up any lock folder used for synchronization from last run
-powershell "-NoProfile Get-ChildItem -path %__TestWorkingDir% -Include 'lock' -Recurse -Force |  where {$_.Attributes -eq 'Directory'}| Remove-Item -force -Recurse"
+powershell -NoProfile "Get-ChildItem -path %__TestWorkingDir% -Include 'lock' -Recurse -Force |  where {$_.Attributes -eq 'Directory'}| Remove-Item -force -Recurse"
 
 if defined CORE_ROOT goto SkipCoreRootSetup
 

--- a/tests/scripts/run-gc-reliability-framework.cmd
+++ b/tests/scripts/run-gc-reliability-framework.cmd
@@ -6,7 +6,7 @@
 
 set CORE_ROOT=%CD%\bin\tests\Windows_NT.%1.%2\Tests\Core_Root
 set FRAMEWORK_DIR=%CD%\bin\tests\Windows_NT.%1.%2\GC\Stress\Framework\ReliabilityFramework
-powershell "-NoProfile %CORE_ROOT%\CoreRun.exe %FRAMEWORK_DIR%\ReliabilityFramework.exe %FRAMEWORK_DIR%\testmix_gc.config"
+powershell -NoProfile "%CORE_ROOT%\CoreRun.exe %FRAMEWORK_DIR%\ReliabilityFramework.exe %FRAMEWORK_DIR%\testmix_gc.config"
 if %ERRORLEVEL% == 100 (
     @rem The ReliabilityFramework returns 100 on success and 99 on failure
     echo ReliabilityFramework successful


### PR DESCRIPTION
Don't put `-NoProfile` in quotes.

When in quotes, I see this error (from `tests\runtest.cmd`):
```
-NoProfile : The term '-NoProfile' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify
that the path is correct and try again.
At line:1 char:1
+ -NoProfile Get-ChildItem -path c:\gh\coreclr\tests\..\bin\tests\Windo ...
+ ~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (-NoProfile:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```
