### PR TITLE
Unix: Remove MaxPath, MaxName

### DIFF
--- a/src/corefx/System.Globalization.Native/timeZoneInfo.cpp
+++ b/src/corefx/System.Globalization.Native/timeZoneInfo.cpp
@@ -12,21 +12,6 @@
 #include "errors.h"
 
 /*
-Gets the symlink value for the path.
-*/
-extern "C" int32_t GlobalizationNative_ReadLink(const char* path, char* result, size_t resultCapacity)
-{
-    ssize_t r = readlink(path, result, resultCapacity - 1); // subtract one to make room for the NULL character
-
-    if (r >= 0)
-    {
-        result[r] = '\0';
-    }
-
-    return (int32_t)r;
-}
-
-/*
 These values should be kept in sync with the managed Interop.GlobalizationInterop.TimeZoneDisplayNameType enum.
 */
 enum TimeZoneDisplayNameType : int32_t

--- a/src/corefx/System.Globalization.Native/timeZoneInfo.cpp
+++ b/src/corefx/System.Globalization.Native/timeZoneInfo.cpp
@@ -18,11 +18,12 @@ extern "C" int32_t GlobalizationNative_ReadLink(const char* path, char* result, 
 {
     ssize_t r = readlink(path, result, resultCapacity - 1); // subtract one to make room for the NULL character
 
-    if (r < 1 || r >= resultCapacity)
-        return false;
+    if (r >= 0)
+    {
+        result[r] = '\0';
+    }
 
-    result[r] = '\0';
-    return true;
+    return (int32_t)r;
 }
 
 /*

--- a/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.TimeZoneInfo.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.TimeZoneInfo.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
     internal static partial class GlobalizationInterop
     {
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Ansi, EntryPoint = "GlobalizationNative_ReadLink")] // readlink requires char*
-        internal static extern bool ReadLink(string filePath, [Out] StringBuilder result, uint resultCapacity);
+        internal static extern int ReadLink(string filePath, [Out] StringBuilder result, uint resultCapacity);
 
         // needs to be kept in sync with TimeZoneDisplayNameType in System.Globalization.Native
         internal enum TimeZoneDisplayNameType

--- a/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.TimeZoneInfo.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.TimeZoneInfo.cs
@@ -9,9 +9,6 @@ internal static partial class Interop
 {
     internal static partial class GlobalizationInterop
     {
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Ansi, EntryPoint = "GlobalizationNative_ReadLink")] // readlink requires char*
-        internal static extern int ReadLink(string filePath, [Out] StringBuilder result, uint resultCapacity);
-
         // needs to be kept in sync with TimeZoneDisplayNameType in System.Globalization.Native
         internal enum TimeZoneDisplayNameType
         {

--- a/src/mscorlib/shared/Interop/Unix/System.Native/Interop.GetCwd.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Native/Interop.GetCwd.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetCwd", SetLastError = true)]
-        private static unsafe extern byte* GetCwd(byte* buffer, int bufferLength);
+        private static extern unsafe byte* GetCwd(byte* buffer, int bufferLength);
 
         internal static unsafe string GetCwd()
         {      
@@ -25,29 +25,21 @@ internal static partial class Interop
             }
 
             // If that was too small, try increasing large buffer sizes
-            // until we get one that works or until we hit MaxPath.
-            int maxPath = Interop.Sys.MaxPath;
-            if (StackLimit < maxPath)
+            int bufferSize = StackLimit;
+            do
             {
-                int bufferSize = StackLimit;
-                do
+                checked { bufferSize *= 2; }
+                var buf = new byte[bufferSize];
+                fixed (byte* ptr = &buf[0])
                 {
-                    checked { bufferSize *= 2; }
-                    var buf = new byte[Math.Min(bufferSize, maxPath)];
-                    fixed (byte* ptr = &buf[0])
+                    result = GetCwdHelper(ptr, buf.Length);
+                    if (result != null)
                     {
-                        result = GetCwdHelper(ptr, buf.Length);
-                        if (result != null)
-                        {
-                            return result;
-                        }
+                        return result;
                     }
                 }
-                while (bufferSize < maxPath);
             }
-
-            // If we couldn't get the cwd with a MaxPath-sized buffer, something's wrong.
-            throw Interop.GetExceptionForIoErrno(new ErrorInfo(Interop.Error.ENAMETOOLONG));
+            while (true);
         }
 
         private static unsafe string GetCwdHelper(byte* ptr, int bufferSize)

--- a/src/mscorlib/shared/Interop/Unix/System.Native/Interop.PathConf.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Native/Interop.PathConf.cs
@@ -24,50 +24,7 @@ internal static partial class Interop
             PC_VDISABLE         = 9,
         }
 
-        /// <summary>The maximum path length for the system.  -1 if it hasn't yet been initialized.</summary>
-        private static int s_maxPath = -1;
-
-        /// <summary>The maximum name length for the system.  -1 if it hasn't yet been initialized.</summary>
-        private static int s_maxName = -1;
-
-        internal static int MaxPath
-        {
-            get
-            {
-                // Benign race condition on cached value
-                if (s_maxPath < 0) 
-                {
-                    // GetMaximumPath returns a long from PathConf
-                    // but our callers expect an int so we need to convert.
-                    long temp = GetMaximumPath();
-                    if (temp > int.MaxValue)
-                        s_maxPath = int.MaxValue;
-                    else
-                        s_maxPath = Convert.ToInt32(temp);
-                }
-                return s_maxPath; 
-            }
-        }
-
-        internal static int MaxName
-        {
-            get
-            {
-                // Benign race condition on cached value
-                if (s_maxName < 0)
-                {
-                    int result = PathConf("/", PathConfName.PC_NAME_MAX);
-                    s_maxName = result >= 0 ? result : DEFAULT_PC_NAME_MAX;
-                }
-                
-                return s_maxName;
-            }
-        }
-
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_PathConf", SetLastError = true)]
         private static extern int PathConf(string path, PathConfName name);
-
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetMaximumPath")]
-        private static extern long GetMaximumPath();
     }
 }

--- a/src/mscorlib/shared/Interop/Unix/System.Native/Interop.ReadLink.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Native/Interop.ReadLink.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Runtime.InteropServices;
+using System.Text;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        /// <summary>
+        /// Takes a path to a symbolic link and attempts to place the link target path into the buffer. If the buffer is too
+        /// small, the path will be truncated. No matter what, the buffer will not be null terminated. 
+        /// </summary>
+        /// <param name="path">The path to the symlink</param>
+        /// <param name="buffer">The buffer to hold the output path</param>
+        /// <param name="bufferSize">The size of the buffer</param>
+        /// <returns>
+        /// Returns the number of bytes placed into the buffer on success; 0 if the buffer is too small; and -1 on error.
+        /// </returns>
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReadLink", SetLastError = true)]
+        private static extern unsafe int ReadLink(string path, byte[] buffer, int bufferSize);
+
+        /// <summary>
+        /// Takes a path to a symbolic link and returns the link target path.
+        /// </summary>
+        /// <param name="path">The path to the symlink</param>
+        /// <returns>
+        /// Returns the link to the target path on success; and null otherwise.
+        /// </returns>
+        public static string ReadLink(string path)
+        {
+            int bufferSize = 256;
+            do
+            {
+                byte[] buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+                try
+                {
+                    int resultLength = Interop.Sys.ReadLink(path, buffer, buffer.Length);
+                    if (resultLength > 0)
+                    {
+                        // success
+                        return Encoding.UTF8.GetString(buffer, 0, resultLength);
+                    }
+                    else if (resultLength < 0)
+                    {
+                        // error
+                        return null;
+                    }
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(buffer);
+                }
+
+                // buffer was too small, loop around again and try with a larger buffer.
+                bufferSize *= 2;
+            } while (true);
+        }
+    }
+}

--- a/src/mscorlib/shared/Interop/Unix/System.Native/Interop.ReadLink.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Native/Interop.ReadLink.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Buffers;
 using System.Runtime.InteropServices;
+using System.Buffers;
 using System.Text;
 
 internal static partial class Interop
@@ -18,7 +18,7 @@ internal static partial class Interop
         /// <param name="buffer">The buffer to hold the output path</param>
         /// <param name="bufferSize">The size of the buffer</param>
         /// <returns>
-        /// Returns the number of bytes placed into the buffer on success; 0 if the buffer is too small; and -1 on error.
+        /// Returns the number of bytes placed into the buffer on success; bufferSize if the buffer is too small; and -1 on error.
         /// </returns>
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReadLink", SetLastError = true)]
         private static extern unsafe int ReadLink(string path, byte[] buffer, int bufferSize);
@@ -39,15 +39,15 @@ internal static partial class Interop
                 try
                 {
                     int resultLength = Interop.Sys.ReadLink(path, buffer, buffer.Length);
-                    if (resultLength > 0)
-                    {
-                        // success
-                        return Encoding.UTF8.GetString(buffer, 0, resultLength);
-                    }
-                    else if (resultLength < 0)
+                    if (resultLength < 0)
                     {
                         // error
                         return null;
+                    }
+                    else if (resultLength < buffer.Length)
+                    {
+                        // success
+                        return Encoding.UTF8.GetString(buffer, 0, resultLength);
                     }
                 }
                 finally

--- a/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
@@ -714,6 +714,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Unix\System.Native\Interop.Permissions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Unix\System.Native\Interop.PosixFAdvise.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Unix\System.Native\Interop.Read.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Interop\Unix\System.Native\Interop.ReadLink.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Unix\System.Native\Interop.Stat.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Unix\System.Native\Interop.SysLog.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Unix\System.Native\Interop.Unlink.cs" />

--- a/src/mscorlib/shared/System/IO/Path.Unix.cs
+++ b/src/mscorlib/shared/System/IO/Path.Unix.cs
@@ -14,8 +14,6 @@ namespace System.IO
 
         public static char[] GetInvalidPathChars() => new char[] { '\0' };
 
-        internal static int MaxPath => Interop.Sys.MaxPath;
-
         // Expands the given path to a fully qualified path. 
         public static string GetFullPath(string path)
         {

--- a/src/mscorlib/src/System/TimeZoneInfo.Unix.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.Unix.cs
@@ -381,34 +381,19 @@ namespace System
         /// </summary>
         private static string FindTimeZoneIdUsingReadLink(string tzFilePath)
         {
-            int capacity = 4096;
-            do
-            {
-                StringBuilder symlinkPathBuilder = StringBuilderCache.Acquire(capacity);
-                int result = Interop.GlobalizationInterop.ReadLink(tzFilePath, symlinkPathBuilder, (uint)symlinkPathBuilder.Capacity);
-                if (result > 0 && result < symlinkPathBuilder.Capacity)
-                {
-                    string symlinkPath = StringBuilderCache.GetStringAndRelease(symlinkPathBuilder);
-                    // time zone Ids have to point under the time zone directory
-                    string timeZoneDirectory = GetTimeZoneDirectory();
-                    string id = null;
-                    if (symlinkPath.StartsWith(timeZoneDirectory))
-                    {
-                        id = symlinkPath.Substring(timeZoneDirectory.Length);
-                    }
-                    return id;
-                }
-                StringBuilderCache.Release(symlinkPathBuilder);
+            string id = null;
 
-                if (result > 0)
+            string symlinkPath = Interop.Sys.ReadLink(tzFilePath);
+            if (symlinkPath != null)
+            {
+                string timeZoneDirectory = GetTimeZoneDirectory();
+                if (symlinkPath.StartsWith(timeZoneDirectory))
                 {
-                    capacity *= 2;
+                    id = symlinkPath.Substring(timeZoneDirectory.Length);
                 }
-                else
-                {
-                    return null;
-                }
-            } while (true);
+            }
+
+            return id;
         }
 
         /// <summary>

--- a/src/mscorlib/src/System/TimeZoneInfo.Unix.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.Unix.cs
@@ -386,6 +386,9 @@ namespace System
             string symlinkPath = Interop.Sys.ReadLink(tzFilePath);
             if (symlinkPath != null)
             {
+                // Use Path.Combine to resolve links that contain a relative path (e.g. /etc/localtime).
+                symlinkPath = Path.Combine(tzFilePath, symlinkPath);
+
                 string timeZoneDirectory = GetTimeZoneDirectory();
                 if (symlinkPath.StartsWith(timeZoneDirectory))
                 {


### PR DESCRIPTION
PATH_MAX is not an upper bound on path lengths on Unix. system function return
values should be used to determine behavior, instead of limiting the path length.

NAME_MAX depends on the file system used. Its value depends on the path, it is
not constant for the entire system.