### PR TITLE
Put default interface support behind a COMPlus switch

### DIFF
--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -873,7 +873,7 @@ RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_TieredCompilation, W("EXPERIMENTAL_TieredCo
 // TypeLoader
 // 
 CONFIG_DWORD_INFO(INTERNAL_TypeLoader_InjectInterfaceDuplicates, W("INTERNAL_TypeLoader_InjectInterfaceDuplicates"), 0, "Injects duplicates in interface map for all types.")
-CONFIG_DWORD_INFO(UNSUPPORTED_TypeLoader_DefaultInterfaces, W("UNSUPPORTED_TypeLoader_DefaultInterfaces"), 0, "Enables support for default interfaces.")
+RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_TypeLoader_DefaultInterfaces, W("UNSUPPORTED_TypeLoader_DefaultInterfaces"), 0, "Enables support for default interfaces.")
 
 // 
 // Virtual call stubs

--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -873,6 +873,7 @@ RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_TieredCompilation, W("EXPERIMENTAL_TieredCo
 // TypeLoader
 // 
 CONFIG_DWORD_INFO(INTERNAL_TypeLoader_InjectInterfaceDuplicates, W("INTERNAL_TypeLoader_InjectInterfaceDuplicates"), 0, "Injects duplicates in interface map for all types.")
+CONFIG_DWORD_INFO(UNSUPPORTED_TypeLoader_DefaultInterfaces, W("UNSUPPORTED_TypeLoader_DefaultInterfaces"), 0, "Enables support for default interfaces.")
 
 // 
 // Virtual call stubs

--- a/src/vm/classcompat.cpp
+++ b/src/vm/classcompat.cpp
@@ -2612,6 +2612,26 @@ VOID    MethodTableBuilder::EnumerateClassMethods()
             }
         }
 
+        // Some interface checks.
+        if (fIsClassInterface && (CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_TypeLoader_DefaultInterfaces) == 0))
+        {
+            if (IsMdVirtual(dwMemberAttrs))
+            {
+                if (!IsMdAbstract(dwMemberAttrs))
+                {
+                    BuildMethodTableThrowException(BFA_VIRTUAL_NONAB_INT_METHOD);
+                }
+            } 
+            else
+            {
+                // Instance field/method
+                if (!IsMdStatic(dwMemberAttrs))
+                {
+                    BuildMethodTableThrowException(BFA_NONVIRT_INST_INT_METHOD);
+                }
+            }
+        }
+
         // No synchronized methods in ValueTypes
         if(fIsClassValueType && IsMiSynchronized(dwImplFlags))
         {

--- a/src/vm/classcompat.cpp
+++ b/src/vm/classcompat.cpp
@@ -2613,11 +2613,11 @@ VOID    MethodTableBuilder::EnumerateClassMethods()
         }
 
         // Some interface checks.
-        if (fIsClassInterface && (CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_TypeLoader_DefaultInterfaces) == 0))
+        if (fIsClassInterface)
         {
             if (IsMdVirtual(dwMemberAttrs))
             {
-                if (!IsMdAbstract(dwMemberAttrs))
+                if (!IsMdAbstract(dwMemberAttrs) && (CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_TypeLoader_DefaultInterfaces) == 0))
                 {
                     BuildMethodTableThrowException(BFA_VIRTUAL_NONAB_INT_METHOD);
                 }
@@ -2625,7 +2625,7 @@ VOID    MethodTableBuilder::EnumerateClassMethods()
             else
             {
                 // Instance field/method
-                if (!IsMdStatic(dwMemberAttrs))
+                if (!IsMdStatic(dwMemberAttrs) && (CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_TypeLoader_DefaultInterfaces) == 0))
                 {
                     BuildMethodTableThrowException(BFA_NONVIRT_INST_INT_METHOD);
                 }

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -2900,6 +2900,26 @@ MethodTableBuilder::EnumerateClassMethods()
             }
         }
 
+        // Some interface checks.
+        if (fIsClassInterface && (CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_TypeLoader_DefaultInterfaces) == 0))
+        {
+            if (IsMdVirtual(dwMemberAttrs))
+            {
+                if (!IsMdAbstract(dwMemberAttrs))
+                {
+                    BuildMethodTableThrowException(BFA_VIRTUAL_NONAB_INT_METHOD);
+                }
+            }
+            else
+            {
+                // Instance field/method
+                if (!IsMdStatic(dwMemberAttrs))
+                {
+                    BuildMethodTableThrowException(BFA_NONVIRT_INST_INT_METHOD);
+                }
+            }
+        }
+
         // No synchronized methods in ValueTypes
         if(fIsClassValueType && IsMiSynchronized(dwImplFlags))
         {

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -2901,11 +2901,11 @@ MethodTableBuilder::EnumerateClassMethods()
         }
 
         // Some interface checks.
-        if (fIsClassInterface && (CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_TypeLoader_DefaultInterfaces) == 0))
+        if (fIsClassInterface)
         {
             if (IsMdVirtual(dwMemberAttrs))
             {
-                if (!IsMdAbstract(dwMemberAttrs))
+                if (!IsMdAbstract(dwMemberAttrs) && (CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_TypeLoader_DefaultInterfaces) == 0))
                 {
                     BuildMethodTableThrowException(BFA_VIRTUAL_NONAB_INT_METHOD);
                 }
@@ -2913,7 +2913,7 @@ MethodTableBuilder::EnumerateClassMethods()
             else
             {
                 // Instance field/method
-                if (!IsMdStatic(dwMemberAttrs))
+                if (!IsMdStatic(dwMemberAttrs) && (CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_TypeLoader_DefaultInterfaces) == 0))
                 {
                     BuildMethodTableThrowException(BFA_NONVIRT_INST_INT_METHOD);
                 }

--- a/tests/src/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrainedcall.ilproj
+++ b/tests/src/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrainedcall.ilproj
@@ -16,7 +16,21 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <!-- Use ILAsm that we just built for the new fixes required in default interface methods -->
-    <UseCustomILAsm>True</UseCustomILAsm>    
+    <UseCustomILAsm>True</UseCustomILAsm>
+
+    <CLRTestBatchPreCommands>
+<![CDATA[
+      $(CLRTestBatchPreCommands)
+set COMPlus_UNSUPPORTED_TypeLoader_DefaultInterfaces=1
+    ]]>
+    </CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands>
+<![CDATA[
+      $(BashCLRTestPreCommands)
+export COMPlus_UNSUPPORTED_TypeLoader_DefaultInterfaces=1
+    ]]>
+    </BashCLRTestPreCommands>
+    
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/src/Loader/classloader/DefaultInterfaceMethods/diamondshape/diamondshape.ilproj
+++ b/tests/src/Loader/classloader/DefaultInterfaceMethods/diamondshape/diamondshape.ilproj
@@ -17,6 +17,20 @@
     <CLRTestPriority>0</CLRTestPriority>
     <!-- Use ILAsm that we just built for the new fixes required in default interface methods -->
     <UseCustomILAsm>True</UseCustomILAsm>    
+
+    <CLRTestBatchPreCommands>
+<![CDATA[
+      $(CLRTestBatchPreCommands)
+set COMPlus_UNSUPPORTED_TypeLoader_DefaultInterfaces=1
+    ]]>
+    </CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands>
+<![CDATA[
+      $(BashCLRTestPreCommands)
+export COMPlus_UNSUPPORTED_TypeLoader_DefaultInterfaces=1
+    ]]>
+    </BashCLRTestPreCommands>
+
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/src/Loader/classloader/DefaultInterfaceMethods/genericmethods/genericmethods.ilproj
+++ b/tests/src/Loader/classloader/DefaultInterfaceMethods/genericmethods/genericmethods.ilproj
@@ -17,6 +17,20 @@
     <CLRTestPriority>0</CLRTestPriority>
     <!-- Use ILAsm that we just built for the new fixes required in default interface methods -->
     <UseCustomILAsm>True</UseCustomILAsm>
+
+    <CLRTestBatchPreCommands>
+<![CDATA[
+      $(CLRTestBatchPreCommands)
+set COMPlus_UNSUPPORTED_TypeLoader_DefaultInterfaces=1
+    ]]>
+    </CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands>
+<![CDATA[
+      $(BashCLRTestPreCommands)
+export COMPlus_UNSUPPORTED_TypeLoader_DefaultInterfaces=1
+    ]]>
+    </BashCLRTestPreCommands>
+
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/src/Loader/classloader/DefaultInterfaceMethods/methodimpl/methodimpl.ilproj
+++ b/tests/src/Loader/classloader/DefaultInterfaceMethods/methodimpl/methodimpl.ilproj
@@ -17,6 +17,20 @@
     <CLRTestPriority>0</CLRTestPriority>
     <!-- Use ILAsm that we just built for the new fixes required in default interface methods -->
     <UseCustomILAsm>True</UseCustomILAsm>
+
+    <CLRTestBatchPreCommands>
+<![CDATA[
+      $(CLRTestBatchPreCommands)
+set COMPlus_UNSUPPORTED_TypeLoader_DefaultInterfaces=1
+    ]]>
+    </CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands>
+<![CDATA[
+      $(BashCLRTestPreCommands)
+export COMPlus_UNSUPPORTED_TypeLoader_DefaultInterfaces=1
+    ]]>
+    </BashCLRTestPreCommands>
+
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/src/Loader/classloader/DefaultInterfaceMethods/sharedgenerics/sharedgenerics.ilproj
+++ b/tests/src/Loader/classloader/DefaultInterfaceMethods/sharedgenerics/sharedgenerics.ilproj
@@ -17,6 +17,20 @@
     <CLRTestPriority>0</CLRTestPriority>
     <!-- Use ILAsm that we just built for the new fixes required in default interface methods -->
     <UseCustomILAsm>True</UseCustomILAsm>
+
+    <CLRTestBatchPreCommands>
+<![CDATA[
+      $(CLRTestBatchPreCommands)
+set COMPlus_UNSUPPORTED_TypeLoader_DefaultInterfaces=1
+    ]]>
+    </CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands>
+<![CDATA[
+      $(BashCLRTestPreCommands)
+export COMPlus_UNSUPPORTED_TypeLoader_DefaultInterfaces=1
+    ]]>
+    </BashCLRTestPreCommands>
+
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/src/Loader/classloader/DefaultInterfaceMethods/simple/simple.ilproj
+++ b/tests/src/Loader/classloader/DefaultInterfaceMethods/simple/simple.ilproj
@@ -16,7 +16,21 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <!-- Use ILAsm that we just built for the new fixes required in default interface methods -->
-    <UseCustomILAsm>True</UseCustomILAsm>    
+    <UseCustomILAsm>True</UseCustomILAsm>  
+
+    <CLRTestBatchPreCommands>
+<![CDATA[
+      $(CLRTestBatchPreCommands)
+set COMPlus_UNSUPPORTED_TypeLoader_DefaultInterfaces=1
+    ]]>
+    </CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands>
+<![CDATA[
+      $(BashCLRTestPreCommands)
+export COMPlus_UNSUPPORTED_TypeLoader_DefaultInterfaces=1
+    ]]>
+    </BashCLRTestPreCommands>
+  
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/src/Loader/classloader/DefaultInterfaceMethods/valuetypes/valuetypes.ilproj
+++ b/tests/src/Loader/classloader/DefaultInterfaceMethods/valuetypes/valuetypes.ilproj
@@ -17,6 +17,20 @@
     <CLRTestPriority>0</CLRTestPriority>
     <!-- Use ILAsm that we just built for the new fixes required in default interface methods -->
     <UseCustomILAsm>True</UseCustomILAsm>    
+
+    <CLRTestBatchPreCommands>
+<![CDATA[
+      $(CLRTestBatchPreCommands)
+set COMPlus_UNSUPPORTED_TypeLoader_DefaultInterfaces=1
+    ]]>
+    </CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands>
+<![CDATA[
+      $(BashCLRTestPreCommands)
+export COMPlus_UNSUPPORTED_TypeLoader_DefaultInterfaces=1
+    ]]>
+    </BashCLRTestPreCommands>
+
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Restoring some deleted checks (with a small twist that they use `fIsClassInterface` instead of `IsInterface()`).