### PR TITLE
Revert "Add RuntimeFeature detection for default interface method (#11940)

### DIFF
--- a/src/mscorlib/shared/System/Runtime/CompilerServices/RuntimeFeature.cs
+++ b/src/mscorlib/shared/System/Runtime/CompilerServices/RuntimeFeature.cs
@@ -11,19 +11,17 @@ namespace System.Runtime.CompilerServices
         /// </summary>
         public const string PortablePdb = nameof(PortablePdb);
 
-        /// Indicates that this version of runtime supports default interface method implementations.
-        /// </summary>
-        public const string DefaultImplementationsOfInterfaces = nameof(DefaultImplementationsOfInterfaces);
-
         /// <summary>
         /// Checks whether a certain feature is supported by the Runtime.
         /// </summary>
         public static bool IsSupported(string feature)
         {
+            // Features should be added as public const string fields in the same class.
+            // Example: public const string FeatureName = nameof(FeatureName);
+
             switch (feature)
             {
-                case PortablePdb:
-                case DefaultImplementationsOfInterfaces:
+                case nameof(PortablePdb):
                     return true;
             }
 


### PR DESCRIPTION
We might also want to kick `RuntimeFeature.cs` out of the shared partition. It seems like a pretty bad idea to have this in `shared` since this is implementation specific *by definition*.