### PR TITLE
Add double/float.TryFormat

### DIFF
--- a/src/classlibnative/bcltype/number.cpp
+++ b/src/classlibnative/bcltype/number.cpp
@@ -2009,26 +2009,28 @@ ParseSection:
 #pragma warning(pop)
 #endif
 
-FCIMPL3(void, COMNumber::DoubleToNumberFC, double value, int precision, BYTE* number)
+FCIMPL3(void, COMNumber::DoubleToNumberFC, double value, int precision, NUMBER* number)
 {
     FCALL_CONTRACT;
 
-    DoubleToNumber(value, precision, (NUMBER*)number);
+    DoubleToNumber(value, precision, number);
 }
 FCIMPLEND
 
-FCIMPL2(void, COMNumber::NumberToDoubleFC, BYTE* number, double* result)
+FCIMPL1(double, COMNumber::NumberToDoubleFC, NUMBER* number)
 {
     FCALL_CONTRACT;
 
-    NumberToDouble((NUMBER*)number, result);
+    double d = 0;
+    NumberToDouble(number, &d);
+    return d;
 }
 FCIMPLEND
 
-FCIMPL2(FC_BOOL_RET, COMNumber::NumberBufferToDecimal, BYTE* number, DECIMAL* value)
+FCIMPL2(FC_BOOL_RET, COMNumber::NumberBufferToDecimal, NUMBER* number, DECIMAL* value)
 {
     FCALL_CONTRACT;
 
-    FC_RETURN_BOOL(COMDecimal::NumberToDecimal((NUMBER *) number, value) != 0);
+    FC_RETURN_BOOL(COMDecimal::NumberToDecimal(number, value) != 0);
 }
 FCIMPLEND

--- a/src/classlibnative/bcltype/number.h
+++ b/src/classlibnative/bcltype/number.h
@@ -31,10 +31,9 @@ struct NUMBER {
 class COMNumber
 {
 public:
-    static FCDECL3_VII(Object*, FormatDouble,  double  value, StringObject* formatUNSAFE, NumberFormatInfo* numfmtUNSAFE);
-    static FCDECL3_VII(Object*, FormatSingle,  float   value, StringObject* formatUNSAFE, NumberFormatInfo* numfmtUNSAFE);
+    static FCDECL3(void, DoubleToNumberFC, double value, int precision, BYTE* number);
+    static FCDECL2(void, NumberToDoubleFC, BYTE* number, double* value);
     static FCDECL2(FC_BOOL_RET, NumberBufferToDecimal, BYTE* number, DECIMAL* value);
-    static FCDECL2(FC_BOOL_RET, NumberBufferToDouble, BYTE* number, double* value);
     
     static wchar_t* Int32ToDecChars(__in wchar_t* p, unsigned int value, int digits);
 };

--- a/src/classlibnative/bcltype/number.h
+++ b/src/classlibnative/bcltype/number.h
@@ -31,9 +31,9 @@ struct NUMBER {
 class COMNumber
 {
 public:
-    static FCDECL3(void, DoubleToNumberFC, double value, int precision, BYTE* number);
-    static FCDECL2(void, NumberToDoubleFC, BYTE* number, double* value);
-    static FCDECL2(FC_BOOL_RET, NumberBufferToDecimal, BYTE* number, DECIMAL* value);
+    static FCDECL3(void, DoubleToNumberFC, double value, int precision, NUMBER* number);
+    static FCDECL1(double, NumberToDoubleFC, NUMBER* number);
+    static FCDECL2(FC_BOOL_RET, NumberBufferToDecimal, NUMBER* number, DECIMAL* value);
     
     static wchar_t* Int32ToDecChars(__in wchar_t* p, unsigned int value, int digits);
 };

--- a/src/mscorlib/shared/System/Double.cs
+++ b/src/mscorlib/shared/System/Double.cs
@@ -22,7 +22,7 @@ namespace System
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public struct Double : IComparable, IConvertible, IFormattable, IComparable<Double>, IEquatable<Double>
+    public struct Double : IComparable, IConvertible, IFormattable, IComparable<Double>, IEquatable<Double>, ISpanFormattable
     {
         private double m_value; // Do not rename (binary serialization)
 
@@ -251,6 +251,11 @@ namespace System
         public String ToString(String format, IFormatProvider provider)
         {
             return Number.FormatDouble(m_value, format, NumberFormatInfo.GetInstance(provider));
+        }
+
+        public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider provider = null)
+        {
+            return Number.TryFormatDouble(m_value, format, NumberFormatInfo.GetInstance(provider), destination, out charsWritten);
         }
 
         public static double Parse(String s)

--- a/src/mscorlib/shared/System/Number.Formatting.cs
+++ b/src/mscorlib/shared/System/Number.Formatting.cs
@@ -9,9 +9,242 @@ using System.Text;
 
 namespace System
 {
+    // The Format methods provided by the numeric classes convert
+    // the numeric value to a string using the format string given by the
+    // format parameter. If the format parameter is null or
+    // an empty string, the number is formatted as if the string "G" (general
+    // format) was specified. The info parameter specifies the
+    // NumberFormatInfo instance to use when formatting the number. If the
+    // info parameter is null or omitted, the numeric formatting information
+    // is obtained from the current culture. The NumberFormatInfo supplies
+    // such information as the characters to use for decimal and thousand
+    // separators, and the spelling and placement of currency symbols in monetary
+    // values.
+    //
+    // Format strings fall into two categories: Standard format strings and
+    // user-defined format strings. A format string consisting of a single
+    // alphabetic character (A-Z or a-z), optionally followed by a sequence of
+    // digits (0-9), is a standard format string. All other format strings are
+    // used-defined format strings.
+    //
+    // A standard format string takes the form Axx, where A is an
+    // alphabetic character called the format specifier and xx is a
+    // sequence of digits called the precision specifier. The format
+    // specifier controls the type of formatting applied to the number and the
+    // precision specifier controls the number of significant digits or decimal
+    // places of the formatting operation. The following table describes the
+    // supported standard formats.
+    //
+    // C c - Currency format. The number is
+    // converted to a string that represents a currency amount. The conversion is
+    // controlled by the currency format information of the NumberFormatInfo
+    // used to format the number. The precision specifier indicates the desired
+    // number of decimal places. If the precision specifier is omitted, the default
+    // currency precision given by the NumberFormatInfo is used.
+    //
+    // D d - Decimal format. This format is
+    // supported for integral types only. The number is converted to a string of
+    // decimal digits, prefixed by a minus sign if the number is negative. The
+    // precision specifier indicates the minimum number of digits desired in the
+    // resulting string. If required, the number will be left-padded with zeros to
+    // produce the number of digits given by the precision specifier.
+    //
+    // E e Engineering (scientific) format.
+    // The number is converted to a string of the form
+    // "-d.ddd...E+ddd" or "-d.ddd...e+ddd", where each
+    // 'd' indicates a digit (0-9). The string starts with a minus sign if the
+    // number is negative, and one digit always precedes the decimal point. The
+    // precision specifier indicates the desired number of digits after the decimal
+    // point. If the precision specifier is omitted, a default of 6 digits after
+    // the decimal point is used. The format specifier indicates whether to prefix
+    // the exponent with an 'E' or an 'e'. The exponent is always consists of a
+    // plus or minus sign and three digits.
+    //
+    // F f Fixed point format. The number is
+    // converted to a string of the form "-ddd.ddd....", where each
+    // 'd' indicates a digit (0-9). The string starts with a minus sign if the
+    // number is negative. The precision specifier indicates the desired number of
+    // decimal places. If the precision specifier is omitted, the default numeric
+    // precision given by the NumberFormatInfo is used.
+    //
+    // G g - General format. The number is
+    // converted to the shortest possible decimal representation using fixed point
+    // or scientific format. The precision specifier determines the number of
+    // significant digits in the resulting string. If the precision specifier is
+    // omitted, the number of significant digits is determined by the type of the
+    // number being converted (10 for int, 19 for long, 7 for
+    // float, 15 for double, 19 for Currency, and 29 for
+    // Decimal). Trailing zeros after the decimal point are removed, and the
+    // resulting string contains a decimal point only if required. The resulting
+    // string uses fixed point format if the exponent of the number is less than
+    // the number of significant digits and greater than or equal to -4. Otherwise,
+    // the resulting string uses scientific format, and the case of the format
+    // specifier controls whether the exponent is prefixed with an 'E' or an 'e'.
+    //
+    // N n Number format. The number is
+    // converted to a string of the form "-d,ddd,ddd.ddd....", where
+    // each 'd' indicates a digit (0-9). The string starts with a minus sign if the
+    // number is negative. Thousand separators are inserted between each group of
+    // three digits to the left of the decimal point. The precision specifier
+    // indicates the desired number of decimal places. If the precision specifier
+    // is omitted, the default numeric precision given by the
+    // NumberFormatInfo is used.
+    //
+    // X x - Hexadecimal format. This format is
+    // supported for integral types only. The number is converted to a string of
+    // hexadecimal digits. The format specifier indicates whether to use upper or
+    // lower case characters for the hexadecimal digits above 9 ('X' for 'ABCDEF',
+    // and 'x' for 'abcdef'). The precision specifier indicates the minimum number
+    // of digits desired in the resulting string. If required, the number will be
+    // left-padded with zeros to produce the number of digits given by the
+    // precision specifier.
+    //
+    // Some examples of standard format strings and their results are shown in the
+    // table below. (The examples all assume a default NumberFormatInfo.)
+    //
+    // Value        Format  Result
+    // 12345.6789   C       $12,345.68
+    // -12345.6789  C       ($12,345.68)
+    // 12345        D       12345
+    // 12345        D8      00012345
+    // 12345.6789   E       1.234568E+004
+    // 12345.6789   E10     1.2345678900E+004
+    // 12345.6789   e4      1.2346e+004
+    // 12345.6789   F       12345.68
+    // 12345.6789   F0      12346
+    // 12345.6789   F6      12345.678900
+    // 12345.6789   G       12345.6789
+    // 12345.6789   G7      12345.68
+    // 123456789    G7      1.234568E8
+    // 12345.6789   N       12,345.68
+    // 123456789    N4      123,456,789.0000
+    // 0x2c45e      x       2c45e
+    // 0x2c45e      X       2C45E
+    // 0x2c45e      X8      0002C45E
+    //
+    // Format strings that do not start with an alphabetic character, or that start
+    // with an alphabetic character followed by a non-digit, are called
+    // user-defined format strings. The following table describes the formatting
+    // characters that are supported in user defined format strings.
+    //
+    // 
+    // 0 - Digit placeholder. If the value being
+    // formatted has a digit in the position where the '0' appears in the format
+    // string, then that digit is copied to the output string. Otherwise, a '0' is
+    // stored in that position in the output string. The position of the leftmost
+    // '0' before the decimal point and the rightmost '0' after the decimal point
+    // determines the range of digits that are always present in the output
+    // string.
+    //
+    // # - Digit placeholder. If the value being
+    // formatted has a digit in the position where the '#' appears in the format
+    // string, then that digit is copied to the output string. Otherwise, nothing
+    // is stored in that position in the output string.
+    //
+    // . - Decimal point. The first '.' character
+    // in the format string determines the location of the decimal separator in the
+    // formatted value; any additional '.' characters are ignored. The actual
+    // character used as a the decimal separator in the output string is given by
+    // the NumberFormatInfo used to format the number.
+    //
+    // , - Thousand separator and number scaling.
+    // The ',' character serves two purposes. First, if the format string contains
+    // a ',' character between two digit placeholders (0 or #) and to the left of
+    // the decimal point if one is present, then the output will have thousand
+    // separators inserted between each group of three digits to the left of the
+    // decimal separator. The actual character used as a the decimal separator in
+    // the output string is given by the NumberFormatInfo used to format the
+    // number. Second, if the format string contains one or more ',' characters
+    // immediately to the left of the decimal point, or after the last digit
+    // placeholder if there is no decimal point, then the number will be divided by
+    // 1000 times the number of ',' characters before it is formatted. For example,
+    // the format string '0,,' will represent 100 million as just 100. Use of the
+    // ',' character to indicate scaling does not also cause the formatted number
+    // to have thousand separators. Thus, to scale a number by 1 million and insert
+    // thousand separators you would use the format string '#,##0,,'.
+    //
+    // % - Percentage placeholder. The presence of
+    // a '%' character in the format string causes the number to be multiplied by
+    // 100 before it is formatted. The '%' character itself is inserted in the
+    // output string where it appears in the format string.
+    //
+    // E+ E- e+ e-   - Scientific notation.
+    // If any of the strings 'E+', 'E-', 'e+', or 'e-' are present in the format
+    // string and are immediately followed by at least one '0' character, then the
+    // number is formatted using scientific notation with an 'E' or 'e' inserted
+    // between the number and the exponent. The number of '0' characters following
+    // the scientific notation indicator determines the minimum number of digits to
+    // output for the exponent. The 'E+' and 'e+' formats indicate that a sign
+    // character (plus or minus) should always precede the exponent. The 'E-' and
+    // 'e-' formats indicate that a sign character should only precede negative
+    // exponents.
+    //
+    // \ - Literal character. A backslash character
+    // causes the next character in the format string to be copied to the output
+    // string as-is. The backslash itself isn't copied, so to place a backslash
+    // character in the output string, use two backslashes (\\) in the format
+    // string.
+    //
+    // 'ABC' "ABC" - Literal string. Characters
+    // enclosed in single or double quotation marks are copied to the output string
+    // as-is and do not affect formatting.
+    //
+    // ; - Section separator. The ';' character is
+    // used to separate sections for positive, negative, and zero numbers in the
+    // format string.
+    //
+    // Other - All other characters are copied to
+    // the output string in the position they appear.
+    //
+    // For fixed point formats (formats not containing an 'E+', 'E-', 'e+', or
+    // 'e-'), the number is rounded to as many decimal places as there are digit
+    // placeholders to the right of the decimal point. If the format string does
+    // not contain a decimal point, the number is rounded to the nearest
+    // integer. If the number has more digits than there are digit placeholders to
+    // the left of the decimal point, the extra digits are copied to the output
+    // string immediately before the first digit placeholder.
+    //
+    // For scientific formats, the number is rounded to as many significant digits
+    // as there are digit placeholders in the format string.
+    //
+    // To allow for different formatting of positive, negative, and zero values, a
+    // user-defined format string may contain up to three sections separated by
+    // semicolons. The results of having one, two, or three sections in the format
+    // string are described in the table below.
+    //
+    // Sections:
+    //
+    // One - The format string applies to all values.
+    //
+    // Two - The first section applies to positive values
+    // and zeros, and the second section applies to negative values. If the number
+    // to be formatted is negative, but becomes zero after rounding according to
+    // the format in the second section, then the resulting zero is formatted
+    // according to the first section.
+    //
+    // Three - The first section applies to positive
+    // values, the second section applies to negative values, and the third section
+    // applies to zeros. The second section may be left empty (by having no
+    // characters between the semicolons), in which case the first section applies
+    // to all non-zero values. If the number to be formatted is non-zero, but
+    // becomes zero after rounding according to the format in the first or second
+    // section, then the resulting zero is formatted according to the third
+    // section.
+    //
+    // For both standard and user-defined formatting operations on values of type
+    // float and double, if the value being formatted is a NaN (Not
+    // a Number) or a positive or negative infinity, then regardless of the format
+    // string, the resulting string is given by the NaNSymbol,
+    // PositiveInfinitySymbol, or NegativeInfinitySymbol property of
+    // the NumberFormatInfo used to format the number.
+
     internal static partial class Number
     {
         internal const int DecimalPrecision = 29; // Decimal.DecCalc also uses this value
+        private const int FloatPrecision = 7;
+        private const int DoublePrecision = 15;
+        private const int ScaleNAN = unchecked((int)0x80000000);
+        private const int ScaleINF = 0x7FFFFFFF;
         private const int MaxUInt32HexDigits = 8;
         private const int MaxUInt32DecDigits = 10;
         private const int MaxUInt64DecDigits = 20;
@@ -129,6 +362,176 @@ namespace System
                 *dst++ = *p++;
             }
             *dst = '\0';
+        }
+
+        public static string FormatDouble(double value, string format, NumberFormatInfo info)
+        {
+            ValueStringBuilder sb;
+            unsafe
+            {
+                char* stackPtr = stackalloc char[CharStackBufferSize];
+                sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
+            }
+
+            char fmt = ParseFormatSpecifier(format, out int digits);
+            int precision = DoublePrecision;
+            NumberBuffer number = default;
+
+            switch (fmt)
+            {
+                case 'R':
+                case 'r':
+                    {
+                        // In order to give numbers that are both friendly to display and round-trippable, we parse the
+                        // number using 15 digits and then determine if it round trips to the same value. If it does, we
+                        // convert that NUMBER to a string, otherwise we reparse using 17 digits and display that.
+                        DoubleToNumber(value, DoublePrecision, ref number);
+                        if (number.scale == ScaleNAN)
+                        {
+                            return info.NaNSymbol;
+                        }
+                        else if (number.scale == ScaleINF)
+                        {
+                            return number.sign ? info.NegativeInfinitySymbol : info.PositiveInfinitySymbol;
+                        }
+
+                        if (NumberToDouble(ref number) == value)
+                        {
+                            NumberToString(ref sb, ref number, 'G', DoublePrecision, info, isDecimal: false);
+                        }
+                        else
+                        {
+                            DoubleToNumber(value, 17, ref number);
+                            NumberToString(ref sb, ref number, 'G', 17, info, isDecimal: false);
+                        }
+
+                        return sb.GetString();
+                    }
+
+                case 'E':
+                case 'e':
+                    // Round values less than E14 to 15 digits
+                    if (digits > 14)
+                    {
+                        precision = 17;
+                    }
+                    break;
+
+                case 'G':
+                case 'g':
+                    // Round values less than G15 to 15 digits. G16 and G17 will not be touched.
+                    if (digits > 15)
+                    {
+                        precision = 17;
+                    }
+                    break;
+            }
+
+            DoubleToNumber(value, precision, ref number);
+            if (number.scale == ScaleNAN)
+            {
+                return info.NaNSymbol;
+            }
+            else if (number.scale == ScaleINF)
+            {
+                return number.sign ? info.NegativeInfinitySymbol : info.PositiveInfinitySymbol;
+            }
+
+            if (fmt != 0)
+            {
+                NumberToString(ref sb, ref number, fmt, digits, info, isDecimal: false);
+            }
+            else
+            {
+                NumberToStringFormat(ref sb, ref number, format, info);
+            }
+
+            return sb.GetString();
+        }
+
+        public static string FormatSingle(float value, string format, NumberFormatInfo info)
+        {
+            ValueStringBuilder sb;
+            unsafe
+            {
+                char* stackPtr = stackalloc char[CharStackBufferSize];
+                sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
+            }
+
+            char fmt = ParseFormatSpecifier(format, out int digits);
+            int precision = FloatPrecision;
+            NumberBuffer number = default;
+
+            switch (fmt)
+            {
+                case 'R':
+                case 'r':
+                    {
+                        // In order to give numbers that are both friendly to display and round-trippable, we parse the
+                        // number using 7 digits and then determine if it round trips to the same value. If it does, we
+                        // convert that NUMBER to a string, otherwise we reparse using 9 digits and display that.
+                        DoubleToNumber(value, FloatPrecision, ref number);
+                        if (number.scale == ScaleNAN)
+                        {
+                            return info.NaNSymbol;
+                        }
+                        else if (number.scale == ScaleINF)
+                        {
+                            return number.sign ? info.NegativeInfinitySymbol : info.PositiveInfinitySymbol;
+                        }
+
+                        if ((float)NumberToDouble(ref number) == value)
+                        {
+                            NumberToString(ref sb, ref number, 'G', FloatPrecision, info, isDecimal: false);
+                        }
+                        else
+                        {
+                            DoubleToNumber(value, 9, ref number);
+                            NumberToString(ref sb, ref number, 'G', 9, info, isDecimal: false);
+                        }
+
+                        return sb.GetString();
+                    }
+
+                case 'E':
+                case 'e':
+                    // Round values less than E14 to 15 digits.
+                    if (digits > 6)
+                    {
+                        precision = 9;
+                    }
+                    break;
+
+                case 'G':
+                case 'g':
+                    // Round values less than G15 to 15 digits. G16 and G17 will not be touched.
+                    if (digits > 7)
+                    {
+                        precision = 9;
+                    }
+                    break;
+            }
+
+            DoubleToNumber(value, precision, ref number);
+            if (number.scale == ScaleNAN)
+            {
+                return info.NaNSymbol;
+            }
+            else if (number.scale == ScaleINF)
+            {
+                return number.sign ? info.NegativeInfinitySymbol : info.PositiveInfinitySymbol;
+            }
+
+            if (fmt != 0)
+            {
+                NumberToString(ref sb, ref number, fmt, digits, info, false);
+            }
+            else
+            {
+                NumberToStringFormat(ref sb, ref number, format, info);
+            }
+
+            return sb.GetString();
         }
 
         public static string FormatInt32(int value, ReadOnlySpan<char> format, NumberFormatInfo info)

--- a/src/mscorlib/shared/System/Number.Formatting.cs
+++ b/src/mscorlib/shared/System/Number.Formatting.cs
@@ -306,7 +306,7 @@ namespace System
                 NumberToStringFormat(ref sb, ref number, format, info);
             }
 
-            return sb.GetString();
+            return sb.ToString();
         }
 
         public static bool TryFormatDecimal(decimal value, ReadOnlySpan<char> format, NumberFormatInfo info, Span<char> destination, out int charsWritten)
@@ -405,7 +405,7 @@ namespace System
                             NumberToString(ref sb, ref number, 'G', 17, info, isDecimal: false);
                         }
 
-                        return sb.GetString();
+                        return sb.ToString();
                     }
 
                 case 'E':
@@ -446,7 +446,7 @@ namespace System
                 NumberToStringFormat(ref sb, ref number, format, info);
             }
 
-            return sb.GetString();
+            return sb.ToString();
         }
 
         public static string FormatSingle(float value, string format, NumberFormatInfo info)
@@ -490,7 +490,7 @@ namespace System
                             NumberToString(ref sb, ref number, 'G', 9, info, isDecimal: false);
                         }
 
-                        return sb.GetString();
+                        return sb.ToString();
                     }
 
                 case 'E':
@@ -531,7 +531,7 @@ namespace System
                 NumberToStringFormat(ref sb, ref number, format, info);
             }
 
-            return sb.GetString();
+            return sb.ToString();
         }
 
         public static string FormatInt32(int value, ReadOnlySpan<char> format, NumberFormatInfo info)
@@ -570,7 +570,7 @@ namespace System
                 {
                     NumberToStringFormat(ref sb, ref number, format, info);
                 }
-                return sb.GetString();
+                return sb.ToString();
             }
         }
 
@@ -648,7 +648,7 @@ namespace System
                 {
                     NumberToStringFormat(ref sb, ref number, format, info);
                 }
-                return sb.GetString();
+                return sb.ToString();
             }
         }
 
@@ -727,7 +727,7 @@ namespace System
                 {
                     NumberToStringFormat(ref sb, ref number, format, info);
                 }
-                return sb.GetString();
+                return sb.ToString();
             }
         }
 
@@ -807,7 +807,7 @@ namespace System
                 {
                     NumberToStringFormat(ref sb, ref number, format, info);
                 }
-                return sb.GetString();
+                return sb.ToString();
             }
         }
 

--- a/src/mscorlib/shared/System/Number.Parsing.cs
+++ b/src/mscorlib/shared/System/Number.Parsing.cs
@@ -4,10 +4,24 @@
 
 using System.Diagnostics;
 using System.Globalization;
-using System.Text;
 
 namespace System
 {
+    // The Parse methods provided by the numeric classes convert a
+    // string to a numeric value. The optional style parameter specifies the
+    // permitted style of the numeric string. It must be a combination of bit flags
+    // from the NumberStyles enumeration. The optional info parameter
+    // specifies the NumberFormatInfo instance to use when parsing the
+    // string. If the info parameter is null or omitted, the numeric
+    // formatting information is obtained from the current culture.
+    //
+    // Numeric strings produced by the Format methods using the Currency,
+    // Decimal, Engineering, Fixed point, General, or Number standard formats
+    // (the C, D, E, F, G, and N format specifiers) are guaranteed to be parseable
+    // by the Parse methods if the NumberStyles.Any style is
+    // specified. Note, however, that the Parse methods do not accept
+    // NaNs or Infinities.
+
     internal partial class Number
     {
         private const int Int32Precision = 10;
@@ -913,5 +927,37 @@ namespace System
         }
 
         private static bool IsWhite(char ch) => ch == 0x20 || (ch >= 0x09 && ch <= 0x0D);
+
+        private static bool NumberBufferToDouble(ref NumberBuffer number, ref double value)
+        {
+            double d = NumberToDouble(ref number);
+            uint e = DoubleHelper.Exponent(d);
+            ulong m = DoubleHelper.Mantissa(d);
+
+            if (e == 0x7FF)
+            {
+                return false;
+            }
+
+            if (e == 0 && m == 0)
+            {
+                d = 0;
+            }
+
+            value = d;
+            return true;
+        }
+
+        private static class DoubleHelper
+        {
+            public static unsafe uint Exponent(double d) =>
+                (*((uint*)&d + 1) >> 20) & 0x000007ff;
+
+            public static unsafe ulong Mantissa(double d) =>
+                *((uint*)&d) | ((ulong)(*((uint*)&d + 1) & 0x000fffff) << 32);
+
+            public static unsafe bool Sign(double d) =>
+                (*((uint*)&d + 1) >> 31) != 0;
+        }
     }
 }

--- a/src/mscorlib/shared/System/Number.Parsing.cs
+++ b/src/mscorlib/shared/System/Number.Parsing.cs
@@ -954,7 +954,7 @@ namespace System
                 (*((uint*)&d + 1) >> 20) & 0x000007ff;
 
             public static unsafe ulong Mantissa(double d) =>
-                *((uint*)&d) | ((ulong)(*((uint*)&d + 1) & 0x000fffff) << 32);
+                *((ulong*)&d) & 0x000fffffffffffff;
 
             public static unsafe bool Sign(double d) =>
                 (*((uint*)&d + 1) >> 31) != 0;

--- a/src/mscorlib/shared/System/Single.cs
+++ b/src/mscorlib/shared/System/Single.cs
@@ -21,7 +21,7 @@ namespace System
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public struct Single : IComparable, IConvertible, IFormattable, IComparable<Single>, IEquatable<Single>
+    public struct Single : IComparable, IConvertible, IFormattable, IComparable<Single>, IEquatable<Single>, ISpanFormattable
     {
         private float m_value; // Do not rename (binary serialization)
 
@@ -243,6 +243,11 @@ namespace System
         public String ToString(String format, IFormatProvider provider)
         {
             return Number.FormatSingle(m_value, format, NumberFormatInfo.GetInstance(provider));
+        }
+
+        public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider provider = null)
+        {
+            return Number.TryFormatSingle(m_value, format, NumberFormatInfo.GetInstance(provider), destination, out charsWritten);
         }
 
         // Parses a float from a String in the given style.  If

--- a/src/mscorlib/shared/System/Text/StringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.cs
@@ -956,33 +956,6 @@ namespace System.Text
 
         public StringBuilder Append(bool value) => Append(value.ToString());
 
-        [CLSCompliant(false)]
-        public StringBuilder Append(sbyte value)
-        {
-            if (value.TryFormat(RemainingCurrentChunk, out int charsWritten))
-            {
-                m_ChunkLength += charsWritten;
-                return this;
-            }
-            else
-            {
-                return Append(value.ToString());
-            }
-        }
-
-        public StringBuilder Append(byte value)
-        {
-            if (value.TryFormat(RemainingCurrentChunk, out int charsWritten))
-            {
-                m_ChunkLength += charsWritten;
-                return this;
-            }
-            else
-            {
-                return Append(value.ToString());
-            }
-        }
-
         public StringBuilder Append(char value)
         {
             if (m_ChunkLength < m_ChunkChars.Length)
@@ -997,124 +970,41 @@ namespace System.Text
             return this;
         }
 
-        public StringBuilder Append(short value)
-        {
-            if (value.TryFormat(RemainingCurrentChunk, out int charsWritten))
-            {
-                m_ChunkLength += charsWritten;
-                return this;
-            }
-            else
-            {
-                return Append(value.ToString());
-            }
-        }
+        [CLSCompliant(false)]
+        public StringBuilder Append(sbyte value) => AppendSpanFormattable(value);
 
-        public StringBuilder Append(int value)
-        {
-            if (value.TryFormat(RemainingCurrentChunk, out int charsWritten))
-            {
-                m_ChunkLength += charsWritten;
-                return this;
-            }
-            else
-            {
-                return Append(value.ToString());
-            }
-        }
+        public StringBuilder Append(byte value) => AppendSpanFormattable(value);
 
-        public StringBuilder Append(long value)
-        {
-            if (value.TryFormat(RemainingCurrentChunk, out int charsWritten))
-            {
-                m_ChunkLength += charsWritten;
-                return this;
-            }
-            else
-            {
-                return Append(value.ToString());
-            }
-        }
+        public StringBuilder Append(short value) => AppendSpanFormattable(value);
 
-        public StringBuilder Append(float value)
-        {
-            if (value.TryFormat(RemainingCurrentChunk, out int charsWritten))
-            {
-                m_ChunkLength += charsWritten;
-                return this;
-            }
-            else
-            {
-                return Append(value.ToString());
-            }
-        }
+        public StringBuilder Append(int value) => AppendSpanFormattable(value);
 
-        public StringBuilder Append(double value)
-        {
-            if (value.TryFormat(RemainingCurrentChunk, out int charsWritten))
-            {
-                m_ChunkLength += charsWritten;
-                return this;
-            }
-            else
-            {
-                return Append(value.ToString());
-            }
-        }
+        public StringBuilder Append(long value) => AppendSpanFormattable(value);
 
-        public StringBuilder Append(decimal value)
-        {
-            if (value.TryFormat(RemainingCurrentChunk, out int charsWritten))
-            {
-                m_ChunkLength += charsWritten;
-                return this;
-            }
-            else
-            {
-                return Append(value.ToString());
-            }
-        }
+        public StringBuilder Append(float value) => AppendSpanFormattable(value);
+
+        public StringBuilder Append(double value) => AppendSpanFormattable(value);
+
+        public StringBuilder Append(decimal value) => AppendSpanFormattable(value);
 
         [CLSCompliant(false)]
-        public StringBuilder Append(ushort value)
-        {
-            if (value.TryFormat(RemainingCurrentChunk, out int charsWritten))
-            {
-                m_ChunkLength += charsWritten;
-                return this;
-            }
-            else
-            {
-                return Append(value.ToString());
-            }
-        }
+        public StringBuilder Append(ushort value) => AppendSpanFormattable(value);
 
         [CLSCompliant(false)]
-        public StringBuilder Append(uint value)
-        {
-            if (value.TryFormat(RemainingCurrentChunk, out int charsWritten))
-            {
-                m_ChunkLength += charsWritten;
-                return this;
-            }
-            else
-            {
-                return Append(value.ToString());
-            }
-        }
+        public StringBuilder Append(uint value) => AppendSpanFormattable(value);
 
         [CLSCompliant(false)]
-        public StringBuilder Append(ulong value)
+        public StringBuilder Append(ulong value) => AppendSpanFormattable(value);
+
+        private StringBuilder AppendSpanFormattable<T>(T value) where T : ISpanFormattable
         {
-            if (value.TryFormat(RemainingCurrentChunk, out int charsWritten))
+            if (value.TryFormat(RemainingCurrentChunk, out int charsWritten, format: default, provider: null))
             {
                 m_ChunkLength += charsWritten;
                 return this;
             }
-            else
-            {
-                return Append(value.ToString());
-            }
+
+            return Append(value.ToString());
         }
 
         public StringBuilder Append(object value) => (value == null) ? this : Append(value.ToString());

--- a/src/mscorlib/shared/System/Text/StringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.cs
@@ -1036,9 +1036,31 @@ namespace System.Text
             }
         }
 
-        public StringBuilder Append(float value) => Append(value.ToString());
+        public StringBuilder Append(float value)
+        {
+            if (value.TryFormat(RemainingCurrentChunk, out int charsWritten))
+            {
+                m_ChunkLength += charsWritten;
+                return this;
+            }
+            else
+            {
+                return Append(value.ToString());
+            }
+        }
 
-        public StringBuilder Append(double value) => Append(value.ToString());
+        public StringBuilder Append(double value)
+        {
+            if (value.TryFormat(RemainingCurrentChunk, out int charsWritten))
+            {
+                m_ChunkLength += charsWritten;
+                return this;
+            }
+            else
+            {
+                return Append(value.ToString());
+            }
+        }
 
         public StringBuilder Append(decimal value)
         {

--- a/src/mscorlib/src/System/Number.CoreCLR.cs
+++ b/src/mscorlib/src/System/Number.CoreCLR.cs
@@ -2,307 +2,44 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Globalization;
 using System.Runtime.CompilerServices;
 
 namespace System
 {
-    // The Number class implements methods for formatting and parsing
-    // numeric values. To format and parse numeric values, applications should
-    // use the Format and Parse methods provided by the numeric
-    // classes (Byte, Int16, Int32, Int64,
-    // Single, Double, Currency, and Decimal). Those
-    // Format and Parse methods share a common implementation
-    // provided by this class, and are thus documented in detail here.
-    //
-    // Formatting
-    //
-    // The Format methods provided by the numeric classes are all of the
-    // form
-    //
-    //  public static String Format(XXX value, String format);
-    //  public static String Format(XXX value, String format, NumberFormatInfo info);
-    //
-    // where XXX is the name of the particular numeric class. The methods convert
-    // the numeric value to a string using the format string given by the
-    // format parameter. If the format parameter is null or
-    // an empty string, the number is formatted as if the string "G" (general
-    // format) was specified. The info parameter specifies the
-    // NumberFormatInfo instance to use when formatting the number. If the
-    // info parameter is null or omitted, the numeric formatting information
-    // is obtained from the current culture. The NumberFormatInfo supplies
-    // such information as the characters to use for decimal and thousand
-    // separators, and the spelling and placement of currency symbols in monetary
-    // values.
-    //
-    // Format strings fall into two categories: Standard format strings and
-    // user-defined format strings. A format string consisting of a single
-    // alphabetic character (A-Z or a-z), optionally followed by a sequence of
-    // digits (0-9), is a standard format string. All other format strings are
-    // used-defined format strings.
-    //
-    // A standard format string takes the form Axx, where A is an
-    // alphabetic character called the format specifier and xx is a
-    // sequence of digits called the precision specifier. The format
-    // specifier controls the type of formatting applied to the number and the
-    // precision specifier controls the number of significant digits or decimal
-    // places of the formatting operation. The following table describes the
-    // supported standard formats.
-    //
-    // C c - Currency format. The number is
-    // converted to a string that represents a currency amount. The conversion is
-    // controlled by the currency format information of the NumberFormatInfo
-    // used to format the number. The precision specifier indicates the desired
-    // number of decimal places. If the precision specifier is omitted, the default
-    // currency precision given by the NumberFormatInfo is used.
-    //
-    // D d - Decimal format. This format is
-    // supported for integral types only. The number is converted to a string of
-    // decimal digits, prefixed by a minus sign if the number is negative. The
-    // precision specifier indicates the minimum number of digits desired in the
-    // resulting string. If required, the number will be left-padded with zeros to
-    // produce the number of digits given by the precision specifier.
-    //
-    // E e Engineering (scientific) format.
-    // The number is converted to a string of the form
-    // "-d.ddd...E+ddd" or "-d.ddd...e+ddd", where each
-    // 'd' indicates a digit (0-9). The string starts with a minus sign if the
-    // number is negative, and one digit always precedes the decimal point. The
-    // precision specifier indicates the desired number of digits after the decimal
-    // point. If the precision specifier is omitted, a default of 6 digits after
-    // the decimal point is used. The format specifier indicates whether to prefix
-    // the exponent with an 'E' or an 'e'. The exponent is always consists of a
-    // plus or minus sign and three digits.
-    //
-    // F f Fixed point format. The number is
-    // converted to a string of the form "-ddd.ddd....", where each
-    // 'd' indicates a digit (0-9). The string starts with a minus sign if the
-    // number is negative. The precision specifier indicates the desired number of
-    // decimal places. If the precision specifier is omitted, the default numeric
-    // precision given by the NumberFormatInfo is used.
-    //
-    // G g - General format. The number is
-    // converted to the shortest possible decimal representation using fixed point
-    // or scientific format. The precision specifier determines the number of
-    // significant digits in the resulting string. If the precision specifier is
-    // omitted, the number of significant digits is determined by the type of the
-    // number being converted (10 for int, 19 for long, 7 for
-    // float, 15 for double, 19 for Currency, and 29 for
-    // Decimal). Trailing zeros after the decimal point are removed, and the
-    // resulting string contains a decimal point only if required. The resulting
-    // string uses fixed point format if the exponent of the number is less than
-    // the number of significant digits and greater than or equal to -4. Otherwise,
-    // the resulting string uses scientific format, and the case of the format
-    // specifier controls whether the exponent is prefixed with an 'E' or an
-    // 'e'.
-    //
-    // N n Number format. The number is
-    // converted to a string of the form "-d,ddd,ddd.ddd....", where
-    // each 'd' indicates a digit (0-9). The string starts with a minus sign if the
-    // number is negative. Thousand separators are inserted between each group of
-    // three digits to the left of the decimal point. The precision specifier
-    // indicates the desired number of decimal places. If the precision specifier
-    // is omitted, the default numeric precision given by the
-    // NumberFormatInfo is used.
-    //
-    // X x - Hexadecimal format. This format is
-    // supported for integral types only. The number is converted to a string of
-    // hexadecimal digits. The format specifier indicates whether to use upper or
-    // lower case characters for the hexadecimal digits above 9 ('X' for 'ABCDEF',
-    // and 'x' for 'abcdef'). The precision specifier indicates the minimum number
-    // of digits desired in the resulting string. If required, the number will be
-    // left-padded with zeros to produce the number of digits given by the
-    // precision specifier.
-    //
-    // Some examples of standard format strings and their results are shown in the
-    // table below. (The examples all assume a default NumberFormatInfo.)
-    //
-    // Value        Format  Result
-    // 12345.6789   C       $12,345.68
-    // -12345.6789  C       ($12,345.68)
-    // 12345        D       12345
-    // 12345        D8      00012345
-    // 12345.6789   E       1.234568E+004
-    // 12345.6789   E10     1.2345678900E+004
-    // 12345.6789   e4      1.2346e+004
-    // 12345.6789   F       12345.68
-    // 12345.6789   F0      12346
-    // 12345.6789   F6      12345.678900
-    // 12345.6789   G       12345.6789
-    // 12345.6789   G7      12345.68
-    // 123456789    G7      1.234568E8
-    // 12345.6789   N       12,345.68
-    // 123456789    N4      123,456,789.0000
-    // 0x2c45e      x       2c45e
-    // 0x2c45e      X       2C45E
-    // 0x2c45e      X8      0002C45E
-    //
-    // Format strings that do not start with an alphabetic character, or that start
-    // with an alphabetic character followed by a non-digit, are called
-    // user-defined format strings. The following table describes the formatting
-    // characters that are supported in user defined format strings.
-    //
-    // 
-    // 0 - Digit placeholder. If the value being
-    // formatted has a digit in the position where the '0' appears in the format
-    // string, then that digit is copied to the output string. Otherwise, a '0' is
-    // stored in that position in the output string. The position of the leftmost
-    // '0' before the decimal point and the rightmost '0' after the decimal point
-    // determines the range of digits that are always present in the output
-    // string.
-    //
-    // # - Digit placeholder. If the value being
-    // formatted has a digit in the position where the '#' appears in the format
-    // string, then that digit is copied to the output string. Otherwise, nothing
-    // is stored in that position in the output string.
-    //
-    // . - Decimal point. The first '.' character
-    // in the format string determines the location of the decimal separator in the
-    // formatted value; any additional '.' characters are ignored. The actual
-    // character used as a the decimal separator in the output string is given by
-    // the NumberFormatInfo used to format the number.
-    //
-    // , - Thousand separator and number scaling.
-    // The ',' character serves two purposes. First, if the format string contains
-    // a ',' character between two digit placeholders (0 or #) and to the left of
-    // the decimal point if one is present, then the output will have thousand
-    // separators inserted between each group of three digits to the left of the
-    // decimal separator. The actual character used as a the decimal separator in
-    // the output string is given by the NumberFormatInfo used to format the
-    // number. Second, if the format string contains one or more ',' characters
-    // immediately to the left of the decimal point, or after the last digit
-    // placeholder if there is no decimal point, then the number will be divided by
-    // 1000 times the number of ',' characters before it is formatted. For example,
-    // the format string '0,,' will represent 100 million as just 100. Use of the
-    // ',' character to indicate scaling does not also cause the formatted number
-    // to have thousand separators. Thus, to scale a number by 1 million and insert
-    // thousand separators you would use the format string '#,##0,,'.
-    //
-    // % - Percentage placeholder. The presence of
-    // a '%' character in the format string causes the number to be multiplied by
-    // 100 before it is formatted. The '%' character itself is inserted in the
-    // output string where it appears in the format string.
-    //
-    // E+ E- e+ e-   - Scientific notation.
-    // If any of the strings 'E+', 'E-', 'e+', or 'e-' are present in the format
-    // string and are immediately followed by at least one '0' character, then the
-    // number is formatted using scientific notation with an 'E' or 'e' inserted
-    // between the number and the exponent. The number of '0' characters following
-    // the scientific notation indicator determines the minimum number of digits to
-    // output for the exponent. The 'E+' and 'e+' formats indicate that a sign
-    // character (plus or minus) should always precede the exponent. The 'E-' and
-    // 'e-' formats indicate that a sign character should only precede negative
-    // exponents.
-    //
-    // \ - Literal character. A backslash character
-    // causes the next character in the format string to be copied to the output
-    // string as-is. The backslash itself isn't copied, so to place a backslash
-    // character in the output string, use two backslashes (\\) in the format
-    // string.
-    //
-    // 'ABC' "ABC" - Literal string. Characters
-    // enclosed in single or double quotation marks are copied to the output string
-    // as-is and do not affect formatting.
-    //
-    // ; - Section separator. The ';' character is
-    // used to separate sections for positive, negative, and zero numbers in the
-    // format string.
-    //
-    // Other - All other characters are copied to
-    // the output string in the position they appear.
-    //
-    // For fixed point formats (formats not containing an 'E+', 'E-', 'e+', or
-    // 'e-'), the number is rounded to as many decimal places as there are digit
-    // placeholders to the right of the decimal point. If the format string does
-    // not contain a decimal point, the number is rounded to the nearest
-    // integer. If the number has more digits than there are digit placeholders to
-    // the left of the decimal point, the extra digits are copied to the output
-    // string immediately before the first digit placeholder.
-    //
-    // For scientific formats, the number is rounded to as many significant digits
-    // as there are digit placeholders in the format string.
-    //
-    // To allow for different formatting of positive, negative, and zero values, a
-    // user-defined format string may contain up to three sections separated by
-    // semicolons. The results of having one, two, or three sections in the format
-    // string are described in the table below.
-    //
-    // Sections:
-    //
-    // One - The format string applies to all values.
-    //
-    // Two - The first section applies to positive values
-    // and zeros, and the second section applies to negative values. If the number
-    // to be formatted is negative, but becomes zero after rounding according to
-    // the format in the second section, then the resulting zero is formatted
-    // according to the first section.
-    //
-    // Three - The first section applies to positive
-    // values, the second section applies to negative values, and the third section
-    // applies to zeros. The second section may be left empty (by having no
-    // characters between the semicolons), in which case the first section applies
-    // to all non-zero values. If the number to be formatted is non-zero, but
-    // becomes zero after rounding according to the format in the first or second
-    // section, then the resulting zero is formatted according to the third
-    // section.
-    //
-    // For both standard and user-defined formatting operations on values of type
-    // float and double, if the value being formatted is a NaN (Not
-    // a Number) or a positive or negative infinity, then regardless of the format
-    // string, the resulting string is given by the NaNSymbol,
-    // PositiveInfinitySymbol, or NegativeInfinitySymbol property of
-    // the NumberFormatInfo used to format the number.
-    //
-    // Parsing
-    //
-    // The Parse methods provided by the numeric classes are all of the form
-    //
-    //  public static XXX Parse(String s);
-    //  public static XXX Parse(String s, int style);
-    //  public static XXX Parse(String s, int style, NumberFormatInfo info);
-    //
-    // where XXX is the name of the particular numeric class. The methods convert a
-    // string to a numeric value. The optional style parameter specifies the
-    // permitted style of the numeric string. It must be a combination of bit flags
-    // from the NumberStyles enumeration. The optional info parameter
-    // specifies the NumberFormatInfo instance to use when parsing the
-    // string. If the info parameter is null or omitted, the numeric
-    // formatting information is obtained from the current culture.
-    //
-    // Numeric strings produced by the Format methods using the Currency,
-    // Decimal, Engineering, Fixed point, General, or Number standard formats
-    // (the C, D, E, F, G, and N format specifiers) are guaranteed to be parseable
-    // by the Parse methods if the NumberStyles.Any style is
-    // specified. Note, however, that the Parse methods do not accept
-    // NaNs or Infinities.
     internal static partial class Number
     {
+        public static unsafe void DoubleToNumber(double value, int precision, ref NumberBuffer number)
+        {
+            fixed (NumberBuffer* numberPtr = &number)
+            {
+                DoubleToNumber(value, precision, (byte*)numberPtr);
+            }
+        }
         [MethodImpl(MethodImplOptions.InternalCall)]
-        public static extern string FormatDouble(double value, string format, NumberFormatInfo info);
+        private static extern unsafe void DoubleToNumber(double value, int precision, byte* number);
 
+
+        public static unsafe double NumberToDouble(ref NumberBuffer number)
+        {
+            fixed (NumberBuffer* numberPtr = &number)
+            {
+                double d = 0;
+                NumberToDouble((byte*)numberPtr, &d);
+                return d;
+            }
+        }
         [MethodImpl(MethodImplOptions.InternalCall)]
-        public static extern string FormatSingle(float value, string format, NumberFormatInfo info);
+        private static extern unsafe void NumberToDouble(byte* number, double* result);
+
 
         public static unsafe bool NumberBufferToDecimal(ref Number.NumberBuffer number, ref decimal value)
         {
-            fixed (Number.NumberBuffer* numberPtr = &number)
+            fixed (NumberBuffer* numberPtr = &number)
             {
                 return NumberBufferToDecimal((byte*)numberPtr, ref value);
             }
         }
-
-        public static unsafe bool NumberBufferToDouble(ref Number.NumberBuffer number, ref double value)
-        {
-            fixed (Number.NumberBuffer* numberPtr = &number)
-            {
-                return NumberBufferToDouble((byte*)numberPtr, ref value);
-            }
-        }
-
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private unsafe static extern bool NumberBufferToDecimal(byte* number, ref decimal value);
-
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        private unsafe static extern bool NumberBufferToDouble(byte* number, ref double value);
+        private static extern unsafe bool NumberBufferToDecimal(byte* number, ref decimal value);
     }
 }

--- a/src/mscorlib/src/System/Number.CoreCLR.cs
+++ b/src/mscorlib/src/System/Number.CoreCLR.cs
@@ -8,38 +8,13 @@ namespace System
 {
     internal static partial class Number
     {
-        public static unsafe void DoubleToNumber(double value, int precision, ref NumberBuffer number)
-        {
-            fixed (NumberBuffer* numberPtr = &number)
-            {
-                DoubleToNumber(value, precision, (byte*)numberPtr);
-            }
-        }
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern unsafe void DoubleToNumber(double value, int precision, byte* number);
+        public static extern void DoubleToNumber(double value, int precision, ref NumberBuffer number);
 
-
-        public static unsafe double NumberToDouble(ref NumberBuffer number)
-        {
-            fixed (NumberBuffer* numberPtr = &number)
-            {
-                double d = 0;
-                NumberToDouble((byte*)numberPtr, &d);
-                return d;
-            }
-        }
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern unsafe void NumberToDouble(byte* number, double* result);
+        public static extern double NumberToDouble(ref NumberBuffer number);
 
-
-        public static unsafe bool NumberBufferToDecimal(ref Number.NumberBuffer number, ref decimal value)
-        {
-            fixed (NumberBuffer* numberPtr = &number)
-            {
-                return NumberBufferToDecimal((byte*)numberPtr, ref value);
-            }
-        }
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern unsafe bool NumberBufferToDecimal(byte* number, ref decimal value);
+        public static extern bool NumberBufferToDecimal(ref NumberBuffer number, ref decimal value);
     }
 }

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -744,10 +744,9 @@ FCFuncStart(gWaitHandleFuncs)
 FCFuncEnd()
 
 FCFuncStart(gNumberFuncs)
-    FCFuncElement("FormatDouble", COMNumber::FormatDouble)
-    FCFuncElement("FormatSingle", COMNumber::FormatSingle)
+    FCFuncElement("DoubleToNumber", COMNumber::DoubleToNumberFC)
+    FCFuncElement("NumberToDouble", COMNumber::NumberToDoubleFC)
     FCFuncElement("NumberBufferToDecimal", COMNumber::NumberBufferToDecimal)
-    FCFuncElement("NumberBufferToDouble", COMNumber::NumberBufferToDouble)
 FCFuncEnd()
 
 #ifdef FEATURE_COMINTEROP


### PR DESCRIPTION
- Move FormatDouble and FormatSingle to managed. Instead of making fcalls to FormatDouble and FormatSingle, move them to managed, and use fcalls for the DoubleToNumber and NumberToDouble they call, shifting down the layer that's implemented in native.  This allows us to then much more easily add TryFormat methods for double and float while also sharing more code between coreclr and corert, from which the managed implementations were taken (they're a direct port of these native implementations from coreclr).  In the process, I also eliminated one fcall that can be implemented in managed easily.  The remaining fcalls are more substantial and will eventually require more effort to bring to managed.  I also moved comments around to avoid having those duplicated as well.

- Port ValueStringBuilder updates/fixes from corefx.  This brings it back into sync with the version there.

- Add double/float.TryFormat. Also implement ISpanFormattable so that string.Format and StringBuilder.AppendFormat take optimized paths with double and float, and update StringBuilder.Append(double/float) to use the new TryFormat methods.

- Reduce duplicate code for span formatting in StringBuilder.  Use a generic method to avoid 11 copies of the same code.

Contributes to https://github.com/dotnet/corefx/issues/25373
cc: @jkotas, @ahsonkhan, @KrzysztofCwalina 