### PR TITLE
Download test native binaries to correct location

### DIFF
--- a/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
+++ b/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
@@ -58,7 +58,7 @@
       },
       "inputs": {
         "filename": "sync.cmd",
-        "arguments": "-ab -AzureAccount=$(CloudDropAccountName) -AzureToken=$(CloudDropAccessToken) -Container=$(PB_ContainerName) -RuntimeId=$(Rid) -BlobNamePrefix=$(PB_BlobNamePrefix)$(PB_BuildType)/TestNativeBins/$(Rid) -- /p:DownloadDirectory=$(Build.SourcesDirectory)/packages/TestNativeBins/$(Rid)",
+        "arguments": "-ab -AzureAccount=$(CloudDropAccountName) -AzureToken=$(CloudDropAccessToken) -Container=$(PB_ContainerName) -RuntimeId=$(Rid) -BlobNamePrefix=$(PB_BlobNamePrefix)$(PB_BuildType)/TestNativeBins/$(Rid) -- /p:DownloadDirectory=$(Build.SourcesDirectory)/packages/TestNativeBins/$(Rid)/$(PB_BuildType)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }


### PR DESCRIPTION
Many CoreCLR tests have been failing in Helix. It looks like at least some of these are because we're downloading test native binaries to the wrong place - build-test.cmd looks for them in `packages/TestNativeBins/{RID}/{BuildType}` - we were previously leaving off the `{BuildType}`. Therefore test native binaries have been missing from the Helix payload, causing those tests that require them to fail.

CC @MattGal @RussKeldorph 