### PR TITLE
Port flag fix for throughput to release/2.0.0

### DIFF
--- a/tests/scripts/run-throughput-perf.py
+++ b/tests/scripts/run-throughput-perf.py
@@ -383,7 +383,7 @@ def main(args):
                 "--config",
                 "OptLevel",
                 opt_level,
-                "--arch",
+                "--architecture",
                 architecture,
                 "--machinepool",
                 "PerfSnake"
@@ -391,6 +391,9 @@ def main(args):
         log(" ".join(submission_args))
         proc = subprocess.Popen(submission_args)
         proc.communicate()
+        if proc.returncode != 0:
+            os.chdir(current_dir)
+            return -1
 
         # Call upload.py
         upload_args = [python_exe,
@@ -402,6 +405,9 @@ def main(args):
         log(" ".join(upload_args))
         proc = subprocess.Popen(upload_args)
         proc.communicate()
+        if proc.returncode != 0:
+            os.chdir(current_dir)
+            return -1
 
     os.chdir(current_dir)
 


### PR DESCRIPTION
Changes the arch flag to architecture and returns a failure code if submission.py or upload.py fail.