### PR TITLE
Fix archiving of smarty results

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -2167,14 +2167,17 @@ Constants.allScenarios.each { scenario ->
                         }
                     }
                     else {
+                        // Non-Windows
                         if (architecture == 'arm64') {
                             if (scenario != 'default' && scenario != 'r2r' && scenario != 'gcstress0x3' && scenario != 'gcstress0xc') {
                                 return
                             }
-                    else if (architecture == 'x86') {
-                        // Linux/x86 only want default test
-                        if (scenario != 'default') {
-                            return
+                        }
+                        else if (architecture == 'x86') {
+                            // Linux/x86 only want default test
+                            if (scenario != 'default') {
+                                return
+                            }
                         }
                     }
 


### PR DESCRIPTION
Run the command to ZIP the output directory in the same
"Execute Batch File" step as the smarty. Otherwise, a failure
of smarty will cause Jenkins to not run the subsequent batch file
steps, including the ZIP step.

Also, preserve the smarty error code to use that as the batch
file step exit code.