### PR TITLE
Avoid provider-related costs for default integer formatting

### DIFF
--- a/src/mscorlib/shared/System/Byte.cs
+++ b/src/mscorlib/shared/System/Byte.cs
@@ -174,22 +174,22 @@ namespace System
 
         public override String ToString()
         {
-            return Number.FormatInt32(m_value, null, NumberFormatInfo.CurrentInfo);
+            return Number.FormatInt32(m_value, null, null);
         }
 
         public String ToString(String format)
         {
-            return Number.FormatInt32(m_value, format, NumberFormatInfo.CurrentInfo);
+            return Number.FormatInt32(m_value, format, null);
         }
 
         public String ToString(IFormatProvider provider)
         {
-            return Number.FormatInt32(m_value, null, NumberFormatInfo.GetInstance(provider));
+            return Number.FormatInt32(m_value, null, provider);
         }
 
         public String ToString(String format, IFormatProvider provider)
         {
-            return Number.FormatInt32(m_value, format, NumberFormatInfo.GetInstance(provider));
+            return Number.FormatInt32(m_value, format, provider);
         }
 
         // TODO https://github.com/dotnet/corefx/issues/25337: Remove this overload once corefx is updated to target the new signatures
@@ -198,7 +198,7 @@ namespace System
 
         public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider provider = null)
         {
-            return Number.TryFormatInt32(m_value, format, NumberFormatInfo.GetInstance(provider), destination, out charsWritten);
+            return Number.TryFormatInt32(m_value, format, provider, destination, out charsWritten);
         }
 
         //

--- a/src/mscorlib/shared/System/Globalization/NumberFormatInfo.cs
+++ b/src/mscorlib/shared/System/Globalization/NumberFormatInfo.cs
@@ -218,34 +218,24 @@ namespace System.Globalization
 
         public static NumberFormatInfo GetInstance(IFormatProvider formatProvider)
         {
-            if (formatProvider != null)
+            return formatProvider == null ?
+                CurrentInfo : // Fast path for a null provider
+                GetProviderNonNull(formatProvider);
+
+            NumberFormatInfo GetProviderNonNull(IFormatProvider provider)
             {
-                // Fast case for a regular CultureInfo
-                NumberFormatInfo info;
-                CultureInfo cultureProvider = formatProvider as CultureInfo;
-                if (cultureProvider != null && !cultureProvider._isInherited)
+                // Fast path for a regular CultureInfo
+                if (provider is CultureInfo cultureProvider && !cultureProvider._isInherited)
                 {
                     return cultureProvider.numInfo ?? cultureProvider.NumberFormat;
                 }
 
-                // Fast case for an NFI;
-                info = formatProvider as NumberFormatInfo;
-                if (info != null)
-                {
-                    return info;
-                }
-
-                info = formatProvider.GetFormat(typeof(NumberFormatInfo)) as NumberFormatInfo;
-                if (info != null)
-                {
-                    return info;
-                }
+                return
+                    provider as NumberFormatInfo ?? // Fast path for an NFI
+                    provider.GetFormat(typeof(NumberFormatInfo)) as NumberFormatInfo ??
+                    CurrentInfo;
             }
-
-            return CurrentInfo;
         }
-
-
 
         public Object Clone()
         {

--- a/src/mscorlib/shared/System/Int16.cs
+++ b/src/mscorlib/shared/System/Int16.cs
@@ -69,22 +69,28 @@ namespace System
 
         public override String ToString()
         {
-            return Number.FormatInt32(m_value, null, NumberFormatInfo.CurrentInfo);
+            return Number.FormatInt32(m_value, null, null);
         }
 
         public String ToString(IFormatProvider provider)
         {
-            return Number.FormatInt32(m_value, null, NumberFormatInfo.GetInstance(provider));
+            return Number.FormatInt32(m_value, null, provider);
         }
 
         public String ToString(String format)
         {
-            return ToString(format, NumberFormatInfo.CurrentInfo);
+            return ToString(format, null);
         }
 
         public String ToString(String format, IFormatProvider provider)
         {
-            return ToString(format, NumberFormatInfo.GetInstance(provider));
+            if (m_value < 0 && format != null && format.Length > 0 && (format[0] == 'X' || format[0] == 'x'))
+            {
+                uint temp = (uint)(m_value & 0x0000FFFF);
+                return Number.FormatUInt32(temp, format, provider);
+            }
+
+            return Number.FormatInt32(m_value, format, provider);
         }
 
         // TODO https://github.com/dotnet/corefx/issues/23642: Remove once corefx has been updated with new overloads.
@@ -93,24 +99,12 @@ namespace System
 
         public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider provider = null)
         {
-            NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
-
             if (m_value < 0 && format.Length > 0 && (format[0] == 'X' || format[0] == 'x'))
             {
                 uint temp = (uint)(m_value & 0x0000FFFF);
-                return Number.TryFormatUInt32(temp, format, info, destination, out charsWritten);
+                return Number.TryFormatUInt32(temp, format, provider, destination, out charsWritten);
             }
-            return Number.TryFormatInt32(m_value, format, info, destination, out charsWritten);
-        }
-
-        private String ToString(String format, NumberFormatInfo info)
-        {
-            if (m_value < 0 && format != null && format.Length > 0 && (format[0] == 'X' || format[0] == 'x'))
-            {
-                uint temp = (uint)(m_value & 0x0000FFFF);
-                return Number.FormatUInt32(temp, format, info);
-            }
-            return Number.FormatInt32(m_value, format, info);
+            return Number.TryFormatInt32(m_value, format, provider, destination, out charsWritten);
         }
 
         public static short Parse(String s)

--- a/src/mscorlib/shared/System/Int32.cs
+++ b/src/mscorlib/shared/System/Int32.cs
@@ -78,22 +78,22 @@ namespace System
 
         public override String ToString()
         {
-            return Number.FormatInt32(m_value, null, NumberFormatInfo.CurrentInfo);
+            return Number.FormatInt32(m_value, null, null);
         }
 
         public String ToString(String format)
         {
-            return Number.FormatInt32(m_value, format, NumberFormatInfo.CurrentInfo);
+            return Number.FormatInt32(m_value, format, null);
         }
 
         public String ToString(IFormatProvider provider)
         {
-            return Number.FormatInt32(m_value, null, NumberFormatInfo.GetInstance(provider));
+            return Number.FormatInt32(m_value, null, provider);
         }
 
         public String ToString(String format, IFormatProvider provider)
         {
-            return Number.FormatInt32(m_value, format, NumberFormatInfo.GetInstance(provider));
+            return Number.FormatInt32(m_value, format, provider);
         }
 
         // TODO https://github.com/dotnet/corefx/issues/23642: Remove once corefx has been updated with new overloads.
@@ -102,7 +102,7 @@ namespace System
 
         public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider provider = null)
         {
-            return Number.TryFormatInt32(m_value, format, NumberFormatInfo.GetInstance(provider), destination, out charsWritten);
+            return Number.TryFormatInt32(m_value, format, provider, destination, out charsWritten);
         }
 
         public static int Parse(String s)

--- a/src/mscorlib/shared/System/Int64.cs
+++ b/src/mscorlib/shared/System/Int64.cs
@@ -75,22 +75,22 @@ namespace System
 
         public override String ToString()
         {
-            return Number.FormatInt64(m_value, null, NumberFormatInfo.CurrentInfo);
+            return Number.FormatInt64(m_value, null, null);
         }
 
         public String ToString(IFormatProvider provider)
         {
-            return Number.FormatInt64(m_value, null, NumberFormatInfo.GetInstance(provider));
+            return Number.FormatInt64(m_value, null, provider);
         }
 
         public String ToString(String format)
         {
-            return Number.FormatInt64(m_value, format, NumberFormatInfo.CurrentInfo);
+            return Number.FormatInt64(m_value, format, null);
         }
 
         public String ToString(String format, IFormatProvider provider)
         {
-            return Number.FormatInt64(m_value, format, NumberFormatInfo.GetInstance(provider));
+            return Number.FormatInt64(m_value, format, provider);
         }
 
         // TODO https://github.com/dotnet/corefx/issues/23642: Remove once corefx has been updated with new overloads.
@@ -99,7 +99,7 @@ namespace System
 
         public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider provider = null)
         {
-            return Number.TryFormatInt64(m_value, format, NumberFormatInfo.GetInstance(provider), destination, out charsWritten);
+            return Number.TryFormatInt64(m_value, format, provider, destination, out charsWritten);
         }
 
         public static long Parse(String s)

--- a/src/mscorlib/shared/System/Number.Formatting.cs
+++ b/src/mscorlib/shared/System/Number.Formatting.cs
@@ -576,10 +576,16 @@ namespace System
             return false;
         }
 
-        public static string FormatInt32(int value, ReadOnlySpan<char> format, NumberFormatInfo info)
+        public static string FormatInt32(int value, ReadOnlySpan<char> format, IFormatProvider provider)
         {
-            int digits;
-            char fmt = ParseFormatSpecifier(format, out digits);
+            // Fast path for default format with a non-negative value
+            if (value >= 0 && format.Length == 0)
+            {
+                return UInt32ToDecStr((uint)value, digits: -1);
+            }
+
+            char fmt = ParseFormatSpecifier(format, out int digits);
+            NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
 
             char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
             if ((fmtUpper == 'G' && digits < 1) || fmtUpper == 'D')
@@ -616,10 +622,16 @@ namespace System
             }
         }
 
-        public static bool TryFormatInt32(int value, ReadOnlySpan<char> format, NumberFormatInfo info, Span<char> destination, out int charsWritten)
+        public static bool TryFormatInt32(int value, ReadOnlySpan<char> format, IFormatProvider provider, Span<char> destination, out int charsWritten)
         {
-            int digits;
-            char fmt = ParseFormatSpecifier(format, out digits);
+            // Fast path for default format with a non-negative value
+            if (value >= 0 && format.Length == 0)
+            {
+                return TryUInt32ToDecStr((uint)value, digits: -1, destination, out charsWritten);
+            }
+
+            char fmt = ParseFormatSpecifier(format, out int digits);
+            NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
 
             char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
             if ((fmtUpper == 'G' && digits < 1) || fmtUpper == 'D')
@@ -656,10 +668,16 @@ namespace System
             }
         }
 
-        public static string FormatUInt32(uint value, ReadOnlySpan<char> format, NumberFormatInfo info)
+        public static string FormatUInt32(uint value, ReadOnlySpan<char> format, IFormatProvider provider)
         {
-            int digits;
-            char fmt = ParseFormatSpecifier(format, out digits);
+            // Fast path for default format
+            if (format.Length == 0)
+            {
+                return UInt32ToDecStr(value, digits: -1);
+            }
+
+            char fmt = ParseFormatSpecifier(format, out int digits);
+            NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
 
             char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
             if ((fmtUpper == 'G' && digits < 1) || fmtUpper == 'D')
@@ -694,10 +712,16 @@ namespace System
             }
         }
 
-        public static bool TryFormatUInt32(uint value, ReadOnlySpan<char> format, NumberFormatInfo info, Span<char> destination, out int charsWritten)
+        public static bool TryFormatUInt32(uint value, ReadOnlySpan<char> format, IFormatProvider provider, Span<char> destination, out int charsWritten)
         {
-            int digits;
-            char fmt = ParseFormatSpecifier(format, out digits);
+            // Fast path for default format
+            if (format.Length == 0)
+            {
+                return TryUInt32ToDecStr(value, digits: -1, destination, out charsWritten);
+            }
+
+            char fmt = ParseFormatSpecifier(format, out int digits);
+            NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
 
             char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
             if ((fmtUpper == 'G' && digits < 1) || fmtUpper == 'D')
@@ -732,10 +756,16 @@ namespace System
             }
         }
 
-        public static string FormatInt64(long value, ReadOnlySpan<char> format, NumberFormatInfo info)
+        public static string FormatInt64(long value, ReadOnlySpan<char> format, IFormatProvider provider)
         {
-            int digits;
-            char fmt = ParseFormatSpecifier(format, out digits);
+            // Fast path for default format with a non-negative value
+            if (value >= 0 && format.Length == 0)
+            {
+                return UInt64ToDecStr((ulong)value, digits: -1);
+            }
+
+            char fmt = ParseFormatSpecifier(format, out int digits);
+            NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
 
             char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
             if ((fmtUpper == 'G' && digits < 1) || fmtUpper == 'D')
@@ -773,10 +803,16 @@ namespace System
             }
         }
 
-        public static bool TryFormatInt64(long value, ReadOnlySpan<char> format, NumberFormatInfo info, Span<char> destination, out int charsWritten)
+        public static bool TryFormatInt64(long value, ReadOnlySpan<char> format, IFormatProvider provider, Span<char> destination, out int charsWritten)
         {
-            int digits;
-            char fmt = ParseFormatSpecifier(format, out digits);
+            // Fast path for default format with a non-negative value
+            if (value >= 0 && format.Length == 0)
+            {
+                return TryUInt64ToDecStr((ulong)value, digits: -1, destination, out charsWritten);
+            }
+
+            char fmt = ParseFormatSpecifier(format, out int digits);
+            NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
 
             char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
             if ((fmtUpper == 'G' && digits < 1) || fmtUpper == 'D')
@@ -814,10 +850,16 @@ namespace System
             }
         }
 
-        public static string FormatUInt64(ulong value, ReadOnlySpan<char> format, NumberFormatInfo info)
+        public static string FormatUInt64(ulong value, ReadOnlySpan<char> format, IFormatProvider provider)
         {
-            int digits;
-            char fmt = ParseFormatSpecifier(format, out digits);
+            // Fast path for default format
+            if (format.Length == 0)
+            {
+                return UInt64ToDecStr(value, digits: -1);
+            }
+
+            char fmt = ParseFormatSpecifier(format, out int digits);
+            NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
 
             char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
             if ((fmtUpper == 'G' && digits < 1) || fmtUpper == 'D')
@@ -853,10 +895,16 @@ namespace System
             }
         }
 
-        public static bool TryFormatUInt64(ulong value, ReadOnlySpan<char> format, NumberFormatInfo info, Span<char> destination, out int charsWritten)
+        public static bool TryFormatUInt64(ulong value, ReadOnlySpan<char> format, IFormatProvider provider, Span<char> destination, out int charsWritten)
         {
-            int digits;
-            char fmt = ParseFormatSpecifier(format, out digits);
+            // Fast path for default format
+            if (format.Length == 0)
+            {
+                return TryUInt64ToDecStr(value, digits: -1, destination, out charsWritten);
+            }
+
+            char fmt = ParseFormatSpecifier(format, out int digits);
+            NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
 
             char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
             if ((fmtUpper == 'G' && digits < 1) || fmtUpper == 'D')

--- a/src/mscorlib/shared/System/SByte.cs
+++ b/src/mscorlib/shared/System/SByte.cs
@@ -73,22 +73,27 @@ namespace System
         // Provides a string representation of a byte.
         public override String ToString()
         {
-            return Number.FormatInt32(m_value, null, NumberFormatInfo.CurrentInfo);
+            return Number.FormatInt32(m_value, null, null);
         }
 
         public String ToString(IFormatProvider provider)
         {
-            return Number.FormatInt32(m_value, null, NumberFormatInfo.GetInstance(provider));
+            return Number.FormatInt32(m_value, null, provider);
         }
 
         public String ToString(String format)
         {
-            return ToString(format, NumberFormatInfo.CurrentInfo);
+            return ToString(format, null);
         }
 
         public String ToString(String format, IFormatProvider provider)
         {
-            return ToString(format, NumberFormatInfo.GetInstance(provider));
+            if (m_value < 0 && format != null && format.Length > 0 && (format[0] == 'X' || format[0] == 'x'))
+            {
+                uint temp = (uint)(m_value & 0x000000FF);
+                return Number.FormatUInt32(temp, format, provider);
+            }
+            return Number.FormatInt32(m_value, format, provider);
         }
 
         // TODO https://github.com/dotnet/corefx/issues/23642: Remove once corefx has been updated with new overloads.
@@ -97,24 +102,12 @@ namespace System
 
         public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider provider = null)
         {
-            NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
-
             if (m_value < 0 && format.Length > 0 && (format[0] == 'X' || format[0] == 'x'))
             {
                 uint temp = (uint)(m_value & 0x000000FF);
-                return Number.TryFormatUInt32(temp, format, info, destination, out charsWritten);
+                return Number.TryFormatUInt32(temp, format, provider, destination, out charsWritten);
             }
-            return Number.TryFormatInt32(m_value, format, info, destination, out charsWritten);
-        }
-
-        private String ToString(String format, NumberFormatInfo info)
-        {
-            if (m_value < 0 && format != null && format.Length > 0 && (format[0] == 'X' || format[0] == 'x'))
-            {
-                uint temp = (uint)(m_value & 0x000000FF);
-                return Number.FormatUInt32(temp, format, info);
-            }
-            return Number.FormatInt32(m_value, format, info);
+            return Number.TryFormatInt32(m_value, format, provider, destination, out charsWritten);
         }
 
         [CLSCompliant(false)]

--- a/src/mscorlib/shared/System/UInt16.cs
+++ b/src/mscorlib/shared/System/UInt16.cs
@@ -69,23 +69,23 @@ namespace System
         // Converts the current value to a String in base-10 with no extra padding.
         public override String ToString()
         {
-            return Number.FormatUInt32(m_value, null, NumberFormatInfo.CurrentInfo);
+            return Number.FormatUInt32(m_value, null, null);
         }
 
         public String ToString(IFormatProvider provider)
         {
-            return Number.FormatUInt32(m_value, null, NumberFormatInfo.GetInstance(provider));
+            return Number.FormatUInt32(m_value, null, provider);
         }
 
 
         public String ToString(String format)
         {
-            return Number.FormatUInt32(m_value, format, NumberFormatInfo.CurrentInfo);
+            return Number.FormatUInt32(m_value, format, null);
         }
 
         public String ToString(String format, IFormatProvider provider)
         {
-            return Number.FormatUInt32(m_value, format, NumberFormatInfo.GetInstance(provider));
+            return Number.FormatUInt32(m_value, format, provider);
         }
 
         // TODO https://github.com/dotnet/corefx/issues/23642: Remove once corefx has been updated with new overloads.
@@ -94,7 +94,7 @@ namespace System
 
         public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider provider = null)
         {
-            return Number.TryFormatUInt32(m_value, format, NumberFormatInfo.GetInstance(provider), destination, out charsWritten);
+            return Number.TryFormatUInt32(m_value, format, provider, destination, out charsWritten);
         }
 
         [CLSCompliant(false)]

--- a/src/mscorlib/shared/System/UInt32.cs
+++ b/src/mscorlib/shared/System/UInt32.cs
@@ -78,22 +78,22 @@ namespace System
         // The base 10 representation of the number with no extra padding.
         public override String ToString()
         {
-            return Number.FormatUInt32(m_value, null, NumberFormatInfo.CurrentInfo);
+            return Number.FormatUInt32(m_value, null, null);
         }
 
         public String ToString(IFormatProvider provider)
         {
-            return Number.FormatUInt32(m_value, null, NumberFormatInfo.GetInstance(provider));
+            return Number.FormatUInt32(m_value, null, provider);
         }
 
         public String ToString(String format)
         {
-            return Number.FormatUInt32(m_value, format, NumberFormatInfo.CurrentInfo);
+            return Number.FormatUInt32(m_value, format, null);
         }
 
         public String ToString(String format, IFormatProvider provider)
         {
-            return Number.FormatUInt32(m_value, format, NumberFormatInfo.GetInstance(provider));
+            return Number.FormatUInt32(m_value, format, provider);
         }
 
         // TODO https://github.com/dotnet/corefx/issues/23642: Remove once corefx has been updated with new overloads.
@@ -102,7 +102,7 @@ namespace System
 
         public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider provider = null)
         {
-            return Number.TryFormatUInt32(m_value, format, NumberFormatInfo.GetInstance(provider), destination, out charsWritten);
+            return Number.TryFormatUInt32(m_value, format, provider, destination, out charsWritten);
         }
 
         [CLSCompliant(false)]

--- a/src/mscorlib/shared/System/UInt64.cs
+++ b/src/mscorlib/shared/System/UInt64.cs
@@ -76,22 +76,22 @@ namespace System
 
         public override String ToString()
         {
-            return Number.FormatUInt64(m_value, null, NumberFormatInfo.CurrentInfo);
+            return Number.FormatUInt64(m_value, null, null);
         }
 
         public String ToString(IFormatProvider provider)
         {
-            return Number.FormatUInt64(m_value, null, NumberFormatInfo.GetInstance(provider));
+            return Number.FormatUInt64(m_value, null, provider);
         }
 
         public String ToString(String format)
         {
-            return Number.FormatUInt64(m_value, format, NumberFormatInfo.CurrentInfo);
+            return Number.FormatUInt64(m_value, format, null);
         }
 
         public String ToString(String format, IFormatProvider provider)
         {
-            return Number.FormatUInt64(m_value, format, NumberFormatInfo.GetInstance(provider));
+            return Number.FormatUInt64(m_value, format, provider);
         }
 
         // TODO https://github.com/dotnet/corefx/issues/23642: Remove once corefx has been updated with new overloads.
@@ -100,7 +100,7 @@ namespace System
 
         public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider provider = null)
         {
-            return Number.TryFormatUInt64(m_value, format, NumberFormatInfo.GetInstance(provider), destination, out charsWritten);
+            return Number.TryFormatUInt64(m_value, format, provider, destination, out charsWritten);
         }
 
         [CLSCompliant(false)]


### PR DESCRIPTION
One of the biggest costs when invoking Int32.ToString() and similar methods is in fetching the current culture, accessing its number information, etc.  And if a culture is provided explicitly, there are still costs related to casts.  But when the default format is used for non-negative integer values, the number format information isn't used at all, and we can skip the associated costs.  This improves formatting perf in such cases by upwards of ~25%.

cc: @jkotas, @ahsonkhan, @KrzysztofCwalina 

Before:
![image](https://user-images.githubusercontent.com/2642209/33384932-5440d028-d4f5-11e7-8bfe-e155cebefc80.png)

After:
![image](https://user-images.githubusercontent.com/2642209/33385048-aa284548-d4f5-11e7-9a45-b8cbc6595214.png)
