### PR TITLE
[Arm64] genStoreLclTypeSIMD12 update life

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -4898,6 +4898,10 @@ void CodeGen::genStoreLclTypeSIMD12(GenTree* treeNode)
 
     // 4-byte write
     getEmitter()->emitIns_S_R(INS_str, EA_4BYTE, tmpReg, varNum, offs + 8);
+
+    genUpdateLife(treeNode);
+
+    compiler->lvaTable[varNum].lvRegNum = REG_STK;
 }
 
 #endif // FEATURE_SIMD


### PR DESCRIPTION
This code is added in the SIMD12 path because the !SIMD12 path updates life.  I think this is correct, but code coverage and/or JitStress did not detect this issue.

XARCH code is also missing this life update.

@dotnet/jit-contrib @dotnet/arm64-contrib PTAL