### PR TITLE
Update build definition execute conditions for api v3.2

### DIFF
--- a/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
@@ -121,6 +121,7 @@
       }
     },
     {
+      "environment": {},
       "enabled": false,
       "continueOnError": false,
       "alwaysRun": false,
@@ -180,6 +181,7 @@
       }
     },
     {
+      "environment": {},
       "enabled": false,
       "continueOnError": false,
       "alwaysRun": false,
@@ -262,7 +264,7 @@
       "environment": {},
       "enabled": true,
       "continueOnError": true,
-      "alwaysRun": true,
+      "alwaysRun": false,
       "displayName": "Create Copy Container",
       "timeoutInMinutes": 0,
       "refName": "Task14",
@@ -285,6 +287,7 @@
       "alwaysRun": true,
       "displayName": "Expose Docker repo for publishing",
       "timeoutInMinutes": 0,
+      "condition": "succeededOrFailed()",
       "refName": "Task15",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -305,6 +308,7 @@
       "alwaysRun": true,
       "displayName": "Copy Files to: $(Build.StagingDirectory)\\BuildLogs",
       "timeoutInMinutes": 0,
+      "condition": "succeededOrFailed()",
       "refName": "CopyFiles1",
       "task": {
         "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
@@ -327,6 +331,7 @@
       "alwaysRun": true,
       "displayName": "Publish Artifact: BuildLogs",
       "timeoutInMinutes": 0,
+      "condition": "succeededOrFailed()",
       "refName": "PublishBuildArtifacts2",
       "task": {
         "id": "2ff763a7-ce83-4e1f-bc89-0ae63477cebe",
@@ -346,9 +351,10 @@
       "environment": {},
       "enabled": true,
       "continueOnError": true,
-      "alwaysRun": true,
+      "alwaysRun": false,
       "displayName": "Cleanup Docker",
       "timeoutInMinutes": 0,
+      "condition": "always()",
       "refName": "Task16",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -366,9 +372,10 @@
       "environment": {},
       "enabled": true,
       "continueOnError": true,
-      "alwaysRun": true,
+      "alwaysRun": false,
       "displayName": "Cleanup VSTS Agent",
       "timeoutInMinutes": 0,
+      "condition": "always()",
       "refName": "Task17",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -387,27 +394,6 @@
     {
       "enabled": false,
       "definition": {
-        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
-      },
-      "inputs": {
-        "additionalFields": "{}"
-      }
-    },
-    {
-      "enabled": false,
-      "definition": {
-        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
-      },
-      "inputs": {
-        "multipliers": "[]",
-        "parallel": "false",
-        "continueOnError": "true",
-        "additionalFields": "{}"
-      }
-    },
-    {
-      "enabled": false,
-      "definition": {
         "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
       },
       "inputs": {
@@ -422,6 +408,16 @@
         "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
       },
       "inputs": {
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5d58cc01-7c75-450c-be18-a388ddb129ec"
+      },
+      "inputs": {
+        "branchFilters": "[\"+refs/heads/*\"]",
         "additionalFields": "{}"
       }
     }
@@ -538,6 +534,7 @@
   "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)-$(DockerTag)",
   "jobAuthorizationScope": "projectCollection",
   "jobTimeoutInMinutes": 90,
+  "jobCancelTimeoutInMinutes": 5,
   "repository": {
     "properties": {
       "labelSources": "0",
@@ -545,7 +542,9 @@
       "fetchDepth": "0",
       "gitLfsSupport": "false",
       "skipSyncSource": "false",
-      "cleanOptions": "0"
+      "cleanOptions": "0",
+      "checkoutNestedSubmodules": "false",
+      "labelSourcesFormat": "$(build.buildNumber)"
     },
     "id": "670e3783-ab4f-44fc-9786-d332007da311",
     "type": "TfsGit",
@@ -557,6 +556,7 @@
   },
   "processParameters": {},
   "quality": "definition",
+  "drafts": [],
   "queue": {
     "id": 36,
     "name": "DotNet-Build",
@@ -576,7 +576,7 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418098211,
+    "revision": 418098432,
     "visibility": "organization"
   }
 }

--- a/buildpipeline/DotNet-CoreClr-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Linux.json
@@ -224,7 +224,7 @@
       "environment": {},
       "enabled": true,
       "continueOnError": true,
-      "alwaysRun": true,
+      "alwaysRun": false,
       "displayName": "Create Copy Container",
       "timeoutInMinutes": 0,
       "refName": "Task12",
@@ -247,6 +247,7 @@
       "alwaysRun": true,
       "displayName": "Expose Docker repo for publishing",
       "timeoutInMinutes": 0,
+      "condition": "succeededOrFailed()",
       "refName": "Task13",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -267,6 +268,7 @@
       "alwaysRun": true,
       "displayName": "Copy Files to: $(Build.StagingDirectory)\\BuildLogs",
       "timeoutInMinutes": 0,
+      "condition": "succeededOrFailed()",
       "refName": "CopyFiles1",
       "task": {
         "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
@@ -289,6 +291,7 @@
       "alwaysRun": true,
       "displayName": "Publish Artifact: BuildLogs",
       "timeoutInMinutes": 0,
+      "condition": "succeededOrFailed()",
       "refName": "PublishBuildArtifacts2",
       "task": {
         "id": "2ff763a7-ce83-4e1f-bc89-0ae63477cebe",
@@ -308,9 +311,10 @@
       "environment": {},
       "enabled": true,
       "continueOnError": true,
-      "alwaysRun": true,
+      "alwaysRun": false,
       "displayName": "Cleanup Docker",
       "timeoutInMinutes": 0,
+      "condition": "always()",
       "refName": "Task14",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -328,9 +332,10 @@
       "environment": {},
       "enabled": true,
       "continueOnError": true,
-      "alwaysRun": true,
+      "alwaysRun": false,
       "displayName": "Cleanup VSTS Agent",
       "timeoutInMinutes": 0,
+      "condition": "always()",
       "refName": "Task15",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -349,27 +354,6 @@
     {
       "enabled": false,
       "definition": {
-        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
-      },
-      "inputs": {
-        "additionalFields": "{}"
-      }
-    },
-    {
-      "enabled": false,
-      "definition": {
-        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
-      },
-      "inputs": {
-        "multipliers": "[]",
-        "parallel": "false",
-        "continueOnError": "true",
-        "additionalFields": "{}"
-      }
-    },
-    {
-      "enabled": false,
-      "definition": {
         "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
       },
       "inputs": {
@@ -384,6 +368,16 @@
         "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
       },
       "inputs": {
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5d58cc01-7c75-450c-be18-a388ddb129ec"
+      },
+      "inputs": {
+        "branchFilters": "[\"+refs/heads/*\"]",
         "additionalFields": "{}"
       }
     }
@@ -462,7 +456,7 @@
       "value": "true"
     },
     "PB_AdditionalBuildArgs": {
-      "value":""
+      "value": ""
     },
     "VsoAccountName": {
       "value": "dn-bot"
@@ -500,6 +494,7 @@
   "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)-$(DockerTag)",
   "jobAuthorizationScope": "projectCollection",
   "jobTimeoutInMinutes": 90,
+  "jobCancelTimeoutInMinutes": 5,
   "repository": {
     "properties": {
       "labelSources": "0",
@@ -507,7 +502,9 @@
       "fetchDepth": "0",
       "gitLfsSupport": "false",
       "skipSyncSource": "false",
-      "cleanOptions": "1"
+      "cleanOptions": "1",
+      "checkoutNestedSubmodules": "false",
+      "labelSourcesFormat": "$(build.buildNumber)"
     },
     "id": "670e3783-ab4f-44fc-9786-d332007da311",
     "type": "TfsGit",
@@ -519,6 +516,7 @@
   },
   "processParameters": {},
   "quality": "definition",
+  "drafts": [],
   "queue": {
     "id": 36,
     "name": "DotNet-Build",
@@ -538,7 +536,7 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418098211,
+    "revision": 418098432,
     "visibility": "organization"
   }
 }

--- a/buildpipeline/DotNet-CoreClr-Trusted-Mac.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Mac.json
@@ -140,13 +140,14 @@
         "failOnStandardError": "false"
       }
     },
-    {   
+    {
       "environment": {},
       "enabled": true,
       "continueOnError": true,
       "alwaysRun": true,
       "displayName": "Copy Files to: $(Build.StagingDirectory)\\BuildLogs",
       "timeoutInMinutes": 0,
+      "condition": "succeededOrFailed()",
       "refName": "CopyFiles1",
       "task": {
         "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
@@ -169,6 +170,7 @@
       "alwaysRun": true,
       "displayName": "Publish Artifact: BuildLogs",
       "timeoutInMinutes": 0,
+      "condition": "succeededOrFailed()",
       "refName": "PublishBuildArtifacts1",
       "task": {
         "id": "2ff763a7-ce83-4e1f-bc89-0ae63477cebe",
@@ -189,27 +191,6 @@
     {
       "enabled": false,
       "definition": {
-        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
-      },
-      "inputs": {
-        "additionalFields": "{}"
-      }
-    },
-    {
-      "enabled": false,
-      "definition": {
-        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
-      },
-      "inputs": {
-        "multipliers": "[]",
-        "parallel": "false",
-        "continueOnError": "true",
-        "additionalFields": "{}"
-      }
-    },
-    {
-      "enabled": false,
-      "definition": {
         "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
       },
       "inputs": {
@@ -224,6 +205,16 @@
         "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
       },
       "inputs": {
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5d58cc01-7c75-450c-be18-a388ddb129ec"
+      },
+      "inputs": {
+        "branchFilters": "[\"+refs/heads/*\"]",
         "additionalFields": "{}"
       }
     }
@@ -275,6 +266,7 @@
   "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)",
   "jobAuthorizationScope": "projectCollection",
   "jobTimeoutInMinutes": 60,
+  "jobCancelTimeoutInMinutes": 5,
   "repository": {
     "properties": {
       "labelSources": "0",
@@ -282,7 +274,9 @@
       "fetchDepth": "0",
       "gitLfsSupport": "false",
       "skipSyncSource": "false",
-      "cleanOptions": "0"
+      "cleanOptions": "0",
+      "checkoutNestedSubmodules": "false",
+      "labelSourcesFormat": "$(build.buildNumber)"
     },
     "id": "670e3783-ab4f-44fc-9786-d332007da311",
     "type": "TfsGit",
@@ -292,7 +286,9 @@
     "clean": "true",
     "checkoutSubmodules": false
   },
+  "processParameters": {},
   "quality": "definition",
+  "drafts": [],
   "queue": {
     "id": 330,
     "name": "DotNetCore-Build",
@@ -312,7 +308,7 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418098211,
+    "revision": 418098432,
     "visibility": "organization"
   }
 }

--- a/buildpipeline/DotNet-CoreClr-Trusted-Windows-x86.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Windows-x86.json
@@ -7,8 +7,8 @@
       "alwaysRun": false,
       "displayName": "Install Signing Plugin",
       "timeoutInMinutes": 0,
-      "refName": "Task1",
       "condition": "and(succeeded(), in(variables.PB_SignType, 'real', 'test'))",
+      "refName": "Task1",
       "task": {
         "id": "30666190-6959-11e5-9f96-f56098202fef",
         "versionSpec": "1.*",
@@ -117,6 +117,10 @@
       },
       "inputs": {
         "solution": "src\\sign.builds",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "14.0",
+        "msbuildArchitecture": "x86",
+        "msbuildLocation": "",
         "platform": "",
         "configuration": "",
         "msbuildArguments": "/p:SignType=$(PB_SignType) /p:BuildType=$(PB_BuildType) /p:BuildArch=$(Architecture)",
@@ -124,11 +128,7 @@
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
         "logProjectEvents": "false",
-        "createLogFile": "false",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "14.0",
-        "msbuildArchitecture": "x86",
-        "msbuildLocation": ""
+        "createLogFile": "false"
       }
     },
     {
@@ -195,9 +195,10 @@
       "environment": {},
       "enabled": true,
       "continueOnError": false,
-      "alwaysRun": true,
+      "alwaysRun": false,
       "displayName": "Perform Cleanup Tasks",
       "timeoutInMinutes": 0,
+      "condition": "always()",
       "refName": "Task10",
       "task": {
         "id": "521a94ea-9e68-468a-8167-6dcf361ea776",
@@ -213,6 +214,7 @@
       "alwaysRun": true,
       "displayName": "Copy Files to: $(Build.StagingDirectory)\\BuildLogs",
       "timeoutInMinutes": 0,
+      "condition": "succeededOrFailed()",
       "refName": "CopyFiles1",
       "task": {
         "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
@@ -235,6 +237,7 @@
       "alwaysRun": true,
       "displayName": "Publish Artifact: BuildLogs",
       "timeoutInMinutes": 0,
+      "condition": "succeededOrFailed()",
       "refName": "PublishBuildArtifacts1",
       "task": {
         "id": "2ff763a7-ce83-4e1f-bc89-0ae63477cebe",
@@ -265,7 +268,6 @@
       },
       "inputs": {
         "PathtoPublish": "$(Build.StagingDirectory)\\symbols",
-        "Contents": "bin\\Product\\*$(Architecture).$(PB_BuildType)\\*.dll\nbin\\Product\\*$(Architecture).$(PB_BuildType)\\PDB\\*.pdb",
         "ArtifactName": "symbols",
         "ArtifactType": "FilePath",
         "TargetPath": "\\\\cpvsbuild\\drops\\DotNetCore\\$(Build.DefinitionName)\\$(Build.BuildNumber)\\FullSymbols",
@@ -275,27 +277,6 @@
     }
   ],
   "options": [
-    {
-      "enabled": false,
-      "definition": {
-        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
-      },
-      "inputs": {
-        "additionalFields": "{}"
-      }
-    },
-    {
-      "enabled": false,
-      "definition": {
-        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
-      },
-      "inputs": {
-        "multipliers": "[]",
-        "parallel": "false",
-        "continueOnError": "true",
-        "additionalFields": "{}"
-      }
-    },
     {
       "enabled": false,
       "definition": {
@@ -313,6 +294,16 @@
         "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
       },
       "inputs": {
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5d58cc01-7c75-450c-be18-a388ddb129ec"
+      },
+      "inputs": {
+        "branchFilters": "[\"+refs/heads/*\"]",
         "additionalFields": "{}"
       }
     }
@@ -388,6 +379,7 @@
   "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)",
   "jobAuthorizationScope": "projectCollection",
   "jobTimeoutInMinutes": 180,
+  "jobCancelTimeoutInMinutes": 5,
   "repository": {
     "properties": {
       "labelSources": "0",
@@ -395,7 +387,9 @@
       "fetchDepth": "0",
       "gitLfsSupport": "false",
       "skipSyncSource": "false",
-      "cleanOptions": "0"
+      "cleanOptions": "0",
+      "checkoutNestedSubmodules": "false",
+      "labelSourcesFormat": "$(build.buildNumber)"
     },
     "id": "670e3783-ab4f-44fc-9786-d332007da311",
     "type": "TfsGit",
@@ -405,7 +399,9 @@
     "clean": "true",
     "checkoutSubmodules": false
   },
+  "processParameters": {},
   "quality": "definition",
+  "drafts": [],
   "queue": {
     "id": 36,
     "name": "DotNet-Build",
@@ -425,7 +421,7 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418098211,
+    "revision": 418098432,
     "visibility": "organization"
   }
 }

--- a/buildpipeline/DotNet-CoreClr-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Windows.json
@@ -7,8 +7,8 @@
       "alwaysRun": false,
       "displayName": "Install Signing Plugin",
       "timeoutInMinutes": 0,
-      "refName": "Task1",
       "condition": "and(succeeded(), in(variables.PB_SignType, 'real', 'test'))",
+      "refName": "Task1",
       "task": {
         "id": "30666190-6959-11e5-9f96-f56098202fef",
         "versionSpec": "1.*",
@@ -117,6 +117,10 @@
       },
       "inputs": {
         "solution": "src\\sign.builds",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "14.0",
+        "msbuildArchitecture": "x86",
+        "msbuildLocation": "",
         "platform": "",
         "configuration": "",
         "msbuildArguments": "/p:SignType=$(PB_SignType) /p:BuildType=$(PB_BuildType) /p:BuildArch=$(Architecture)",
@@ -124,11 +128,7 @@
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
         "logProjectEvents": "false",
-        "createLogFile": "false",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "14.0",
-        "msbuildArchitecture": "x86",
-        "msbuildLocation": ""
+        "createLogFile": "false"
       }
     },
     {
@@ -195,9 +195,10 @@
       "environment": {},
       "enabled": true,
       "continueOnError": false,
-      "alwaysRun": true,
+      "alwaysRun": false,
       "displayName": "Perform Cleanup Tasks",
       "timeoutInMinutes": 0,
+      "condition": "always()",
       "refName": "Task10",
       "task": {
         "id": "521a94ea-9e68-468a-8167-6dcf361ea776",
@@ -213,6 +214,7 @@
       "alwaysRun": true,
       "displayName": "Copy Files to: $(Build.StagingDirectory)\\BuildLogs",
       "timeoutInMinutes": 0,
+      "condition": "succeededOrFailed()",
       "refName": "CopyFiles1",
       "task": {
         "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
@@ -235,6 +237,7 @@
       "alwaysRun": true,
       "displayName": "Publish Artifact: BuildLogs",
       "timeoutInMinutes": 0,
+      "condition": "succeededOrFailed()",
       "refName": "PublishBuildArtifacts1",
       "task": {
         "id": "2ff763a7-ce83-4e1f-bc89-0ae63477cebe",
@@ -265,7 +268,6 @@
       },
       "inputs": {
         "PathtoPublish": "$(Build.StagingDirectory)\\symbols",
-        "Contents": "bin\\Product\\*$(Architecture).$(PB_BuildType)\\*.dll\nbin\\Product\\*$(Architecture).$(PB_BuildType)\\PDB\\*.pdb",
         "ArtifactName": "symbols",
         "ArtifactType": "FilePath",
         "TargetPath": "\\\\cpvsbuild\\drops\\DotNetCore\\$(Build.DefinitionName)\\$(Build.BuildNumber)\\FullSymbols",
@@ -275,27 +277,6 @@
     }
   ],
   "options": [
-    {
-      "enabled": false,
-      "definition": {
-        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
-      },
-      "inputs": {
-        "additionalFields": "{}"
-      }
-    },
-    {
-      "enabled": false,
-      "definition": {
-        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
-      },
-      "inputs": {
-        "multipliers": "[]",
-        "parallel": "false",
-        "continueOnError": "true",
-        "additionalFields": "{}"
-      }
-    },
     {
       "enabled": false,
       "definition": {
@@ -313,6 +294,16 @@
         "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
       },
       "inputs": {
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5d58cc01-7c75-450c-be18-a388ddb129ec"
+      },
+      "inputs": {
+        "branchFilters": "[\"+refs/heads/*\"]",
         "additionalFields": "{}"
       }
     }
@@ -381,6 +372,7 @@
   "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)-$(Architecture)",
   "jobAuthorizationScope": "projectCollection",
   "jobTimeoutInMinutes": 180,
+  "jobCancelTimeoutInMinutes": 5,
   "repository": {
     "properties": {
       "labelSources": "0",
@@ -388,7 +380,9 @@
       "fetchDepth": "0",
       "gitLfsSupport": "false",
       "skipSyncSource": "false",
-      "cleanOptions": "0"
+      "cleanOptions": "0",
+      "checkoutNestedSubmodules": "false",
+      "labelSourcesFormat": "$(build.buildNumber)"
     },
     "id": "670e3783-ab4f-44fc-9786-d332007da311",
     "type": "TfsGit",
@@ -398,7 +392,9 @@
     "clean": "false",
     "checkoutSubmodules": false
   },
+  "processParameters": {},
   "quality": "definition",
+  "drafts": [],
   "queue": {
     "id": 36,
     "name": "DotNet-Build",
@@ -418,7 +414,7 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418098211,
+    "revision": 418098432,
     "visibility": "organization"
   }
 }

--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -22,25 +22,25 @@
       }
     },
     {
-        "environment": {},
-        "enabled": true,
-        "continueOnError": false,
-        "alwaysRun": false,
-        "displayName": "Install Signing Plugin",
-        "timeoutInMinutes": 0,
+      "environment": {},
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Install Signing Plugin",
+      "timeoutInMinutes": 0,
+      "condition": "and(succeeded(), in(variables.PB_SignType, 'real', 'test'))",
       "refName": "Task2",
-        "condition": "and(succeeded(), in(variables.PB_SignType, 'real', 'test'))",
-        "task": {
-            "id": "30666190-6959-11e5-9f96-f56098202fef",
-            "versionSpec": "1.*",
-            "definitionType": "task"
-        },
-        "inputs": {
-            "signType": "real",
-            "zipSources": "true",
-            "version": "",
-            "feedSource": "https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json"
-        }
+      "task": {
+        "id": "30666190-6959-11e5-9f96-f56098202fef",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "signType": "real",
+        "zipSources": "true",
+        "version": "",
+        "feedSource": "https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json"
+      }
     },
     {
       "environment": {},
@@ -59,8 +59,8 @@
         "scriptType": "filePath",
         "scriptName": "scripts/DotNet-Trusted-Publish/Fetch-Tools.ps1",
         "arguments": "$(Build.StagingDirectory)\\ToolingDownload",
-        "inlineScript": "# You can write your powershell scripts inline here. \n# You can also pass predefined and custom variables to this scripts using arguments\n\n Write-Host \"Hello World\"",
         "workingFolder": "",
+        "inlineScript": "# You can write your powershell scripts inline here. \n# You can also pass predefined and custom variables to this scripts using arguments\n\n Write-Host \"Hello World\"",
         "failOnStandardError": "true"
       }
     },
@@ -81,8 +81,8 @@
         "scriptType": "inlineScript",
         "scriptName": "",
         "arguments": "-gitUrl $(VstsRepoGitUrl) -root $(Pipeline.SourcesDirectory)",
-        "inlineScript": "param($gitUrl, $root)\n\nif (Test-Path $root)\n{\n  Remove-Item -Recurse -Force $root\n}\ngit clone $gitUrl $root 2>&1 | Write-Host\ncd $root\ngit checkout $env:SourceVersion 2>&1 | Write-Host\n\nWrite-Host (\"##vso[task.setvariable variable=Pipeline.SourcesDirectory;]$root\")",
         "workingFolder": "",
+        "inlineScript": "param($gitUrl, $root)\n\nif (Test-Path $root)\n{\n  Remove-Item -Recurse -Force $root\n}\ngit clone $gitUrl $root 2>&1 | Write-Host\ncd $root\ngit checkout $env:SourceVersion 2>&1 | Write-Host\n\nWrite-Host (\"##vso[task.setvariable variable=Pipeline.SourcesDirectory;]$root\")",
         "failOnStandardError": "true"
       }
     },
@@ -133,8 +133,8 @@
       "alwaysRun": false,
       "displayName": "Inject signed symbol catalogs",
       "timeoutInMinutes": 0,
-      "refName": "Task7",
       "condition": "and(succeeded(), ne(variables['PB_SignType'], 'oss'))",
+      "refName": "Task7",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -164,8 +164,8 @@
         "scriptType": "inlineScript",
         "scriptName": "",
         "arguments": "",
-        "inlineScript": "if ($env:ConfigurationGroup -ne \"Release\") { exit }\n\n& $env:Build_SourcesDirectory\\scripts\\DotNet-Trusted-Publish\\Embed-Index.ps1 `\n  $env:Pipeline_SourcesDirectory\\packages\\AzureTransfer\\$env:ConfigurationGroup\\$env:SymbolPackageLocation `\n  $env:Build_StagingDirectory\\IndexedSymbolPackages",
         "workingFolder": "",
+        "inlineScript": "if ($env:ConfigurationGroup -ne \"Release\") { exit }\n\n& $env:Build_SourcesDirectory\\scripts\\DotNet-Trusted-Publish\\Embed-Index.ps1 `\n  $env:Pipeline_SourcesDirectory\\packages\\AzureTransfer\\$env:ConfigurationGroup\\$env:SymbolPackageLocation `\n  $env:Build_StagingDirectory\\IndexedSymbolPackages",
         "failOnStandardError": "true"
       }
     },
@@ -186,8 +186,8 @@
         "scriptType": "inlineScript",
         "scriptName": "",
         "arguments": "",
-        "inlineScript": "#if ($env:UseLegacyBuildScripts -eq \"true\")\n#{\n  msbuild build.proj /t:CreateOrUpdateCurrentVersionFile /p:OfficialBuildId=$env:OfficialBuildId /p:BuildVersionFile=bin\\obj\\BuildVersion-$env:OfficialBuildId.props\n#}\n#else\n#{\n#  .\\build-managed.cmd -GenerateVersion \"-OfficialBuildId=$env:OfficialBuildId\"\n#}",
         "workingFolder": "$(Pipeline.SourcesDirectory)",
+        "inlineScript": "#if ($env:UseLegacyBuildScripts -eq \"true\")\n#{\n  msbuild build.proj /t:CreateOrUpdateCurrentVersionFile /p:OfficialBuildId=$env:OfficialBuildId /p:BuildVersionFile=bin\\obj\\BuildVersion-$env:OfficialBuildId.props\n#}\n#else\n#{\n#  .\\build-managed.cmd -GenerateVersion \"-OfficialBuildId=$env:OfficialBuildId\"\n#}",
         "failOnStandardError": "true"
       }
     },
@@ -218,8 +218,8 @@
       "alwaysRun": false,
       "displayName": "packages -> dotnet.myget.org",
       "timeoutInMinutes": 0,
-      "refName": "Task11",
       "condition": "and(succeeded(), contains(variables.PB_PublishType, 'myget'), eq(variables.ConfigurationGroup, 'Release'))",
+      "refName": "Task11",
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
         "versionSpec": "1.*",
@@ -241,8 +241,8 @@
       "alwaysRun": false,
       "displayName": "symbol packages -> dotnet.myget.org",
       "timeoutInMinutes": 0,
-      "refName": "Task12",
       "condition": "and(succeeded(), contains(variables.PB_PublishType, 'myget'), eq(variables.ConfigurationGroup, 'Release'))",
+      "refName": "Task12",
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
         "versionSpec": "1.*",
@@ -264,8 +264,8 @@
       "alwaysRun": false,
       "displayName": "Packages -> Blob Feed",
       "timeoutInMinutes": 0,
-      "refName": "Task13",
       "condition": "and(succeeded(),  contains(variables.PB_PublishType, 'blob'), eq(variables.ConfigurationGroup, 'Release'))",
+      "refName": "Task13",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -285,8 +285,8 @@
       "alwaysRun": false,
       "displayName": "Symbol Packages -> Blob Feed",
       "timeoutInMinutes": 0,
-      "refName": "Task14",
       "condition": "and(succeeded(),  contains(variables.PB_PublishType, 'blob'), eq(variables.ConfigurationGroup, 'Release'))",
+      "refName": "Task14",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -300,6 +300,7 @@
       }
     },
     {
+      "environment": {},
       "enabled": false,
       "continueOnError": false,
       "alwaysRun": false,
@@ -315,12 +316,13 @@
         "scriptType": "inlineScript",
         "scriptName": "",
         "arguments": "$(VstsAuthedNuGetConfigPath) $(VstsFeedUrl) $(VstsPat)",
-        "inlineScript": "param($path, $url, $pat)\n\nSet-Content $path @\"\n<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<configuration>\n  <packageSources>\n    <add key=\"vsts-dotnet-core\" value=\"$url\" />\n  </packageSources>\n  <packageSourceCredentials>\n    <vsts-dotnet-core>\n      <add key=\"Username\" value=\"VssSessionToken\" />\n      <add key=\"ClearTextPassword\" value=\"$pat\" />\n    </vsts-dotnet-core>\n  </packageSourceCredentials>\n</configuration>\n\"@",
         "workingFolder": "",
+        "inlineScript": "param($path, $url, $pat)\n\nSet-Content $path @\"\n<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<configuration>\n  <packageSources>\n    <add key=\"vsts-dotnet-core\" value=\"$url\" />\n  </packageSources>\n  <packageSourceCredentials>\n    <vsts-dotnet-core>\n      <add key=\"Username\" value=\"VssSessionToken\" />\n      <add key=\"ClearTextPassword\" value=\"$pat\" />\n    </vsts-dotnet-core>\n  </packageSourceCredentials>\n</configuration>\n\"@",
         "failOnStandardError": "true"
       }
     },
     {
+      "environment": {},
       "enabled": false,
       "continueOnError": false,
       "alwaysRun": false,
@@ -336,8 +338,8 @@
         "scriptType": "inlineScript",
         "scriptName": "",
         "arguments": "",
-        "inlineScript": "if ($env:ConfigurationGroup -ne \"Release\") { exit }\n& $env:CustomNuGetPath push $env:Pipeline.SourcesDirectory\\packages\\AzureTransfer\\$env:ConfigurationGroup\\$env:AzureContainerPackageGlob placeholderapikey -Source vsts-dotnet-core -ConfigFile $env:VstsAuthedNuGetConfigPath -Timeout 3600",
         "workingFolder": "",
+        "inlineScript": "if ($env:ConfigurationGroup -ne \"Release\") { exit }\n& $env:CustomNuGetPath push $env:Pipeline.SourcesDirectory\\packages\\AzureTransfer\\$env:ConfigurationGroup\\$env:AzureContainerPackageGlob placeholderapikey -Source vsts-dotnet-core -ConfigFile $env:VstsAuthedNuGetConfigPath -Timeout 3600",
         "failOnStandardError": "true"
       }
     },
@@ -348,8 +350,8 @@
       "alwaysRun": false,
       "displayName": "Update versions repository",
       "timeoutInMinutes": 0,
-      "refName": "Task17",
       "condition": "and(succeeded(), contains(variables.PB_PublishType, 'versions'), eq(variables.ConfigurationGroup, 'Release'))",
+      "refName": "Task17",
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
         "versionSpec": "1.*",
@@ -359,8 +361,8 @@
         "scriptType": "inlineScript",
         "scriptName": "",
         "arguments": "-gitHubAuthToken $(UpdatePublishedVersions.AuthToken) -root $(Pipeline.SourcesDirectory) -configGroup $(ConfigurationGroup)",
-        "inlineScript": "param($gitHubAuthToken, $root, $configGroup)\nif ($configGroup -ne \"Release\" ) { exit }\ncd $root\n. $root\\UpdatePublishedVersions.ps1 `\n  -gitHubUser dotnet-build-bot -gitHubEmail dotnet-build-bot@microsoft.com `\n  -gitHubAuthToken $gitHubAuthToken `\n  -versionsRepoOwner $env:VersionsRepoOwner -versionsRepo versions `\n  -versionsRepoPath build-info/dotnet/$env:GitHubRepositoryName/$env:SourceBranch `\n  -nupkgPath $root\\packages\\AzureTransfer\\$env:ConfigurationGroup\\$env:AzureContainerPackageGlob",
         "workingFolder": "",
+        "inlineScript": "param($gitHubAuthToken, $root, $configGroup)\nif ($configGroup -ne \"Release\" ) { exit }\ncd $root\n. $root\\UpdatePublishedVersions.ps1 `\n  -gitHubUser dotnet-build-bot -gitHubEmail dotnet-build-bot@microsoft.com `\n  -gitHubAuthToken $gitHubAuthToken `\n  -versionsRepoOwner $env:VersionsRepoOwner -versionsRepo versions `\n  -versionsRepoPath build-info/dotnet/$env:GitHubRepositoryName/$env:SourceBranch `\n  -nupkgPath $root\\packages\\AzureTransfer\\$env:ConfigurationGroup\\$env:AzureContainerPackageGlob",
         "failOnStandardError": "true"
       }
     },
@@ -381,8 +383,8 @@
         "scriptType": "inlineScript",
         "scriptName": "",
         "arguments": "$(OfficialBuildId) $(Pipeline.SourcesDirectory)",
-        "inlineScript": "param(\n  [string]$OfficialBuildId,\n  [string]$SourcesDir\n)\n$VersionPropsFile=$SourcesDir + \"\\bin\\obj\\BuildVersion-\" + $OfficialBuildId + \".props\"\n[xml]$versionXml=Get-Content $VersionPropsFile\n$env:BuildNumber=$versionXml.Project.PropertyGroup.BuildNumberMajor.InnerText + \".\" + $versionXml.Project.PropertyGroup.BuildNumberMinor.InnerText\nWrite-Host (\"##vso[task.setvariable variable=BuildNumber;]$env:BuildNumber\")",
         "workingFolder": "",
+        "inlineScript": "param(\n  [string]$OfficialBuildId,\n  [string]$SourcesDir\n)\n$VersionPropsFile=$SourcesDir + \"\\bin\\obj\\BuildVersion-\" + $OfficialBuildId + \".props\"\n[xml]$versionXml=Get-Content $VersionPropsFile\n$env:BuildNumber=$versionXml.Project.PropertyGroup.BuildNumberMajor.InnerText + \".\" + $versionXml.Project.PropertyGroup.BuildNumberMinor.InnerText\nWrite-Host (\"##vso[task.setvariable variable=BuildNumber;]$env:BuildNumber\")",
         "failOnStandardError": "true"
       }
     },
@@ -443,6 +445,7 @@
       "alwaysRun": true,
       "displayName": "Copy Files to: $(Build.StagingDirectory)\\DebugLogs",
       "timeoutInMinutes": 0,
+      "condition": "succeededOrFailed()",
       "refName": "CopyFiles1",
       "task": {
         "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
@@ -465,6 +468,7 @@
       "alwaysRun": true,
       "displayName": "Publish Artifact: DebugLogs",
       "timeoutInMinutes": 0,
+      "condition": "succeededOrFailed()",
       "refName": "PublishBuildArtifacts1",
       "task": {
         "id": "2ff763a7-ce83-4e1f-bc89-0ae63477cebe",
@@ -481,43 +485,23 @@
       }
     },
     {
-        "environment": {},
-        "enabled": true,
-        "continueOnError": false,
-        "alwaysRun": false,
-        "displayName": "Send Telemetry",
-        "timeoutInMinutes": 0,
-        "refName": "Task19",
-        "task": {
-            "id": "521a94ea-9e68-468a-8167-6dcf361ea776",
-            "versionSpec": "1.*",
-            "definitionType": "task"
-        },
-        "inputs": {}
+      "environment": {},
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Send Telemetry",
+      "timeoutInMinutes": 0,
+      "condition": "always()",
+      "refName": "Task19",
+      "task": {
+        "id": "521a94ea-9e68-468a-8167-6dcf361ea776",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {}
     }
   ],
   "options": [
-    {
-      "enabled": false,
-      "definition": {
-        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
-      },
-      "inputs": {
-        "additionalFields": "{}"
-      }
-    },
-    {
-      "enabled": false,
-      "definition": {
-        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
-      },
-      "inputs": {
-        "multipliers": "[]",
-        "parallel": "false",
-        "continueOnError": "true",
-        "additionalFields": "{}"
-      }
-    },
     {
       "enabled": false,
       "definition": {
@@ -535,6 +519,16 @@
         "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
       },
       "inputs": {
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5d58cc01-7c75-450c-be18-a388ddb129ec"
+      },
+      "inputs": {
+        "branchFilters": "[\"+refs/heads/*\"]",
         "additionalFields": "{}"
       }
     }
@@ -734,6 +728,7 @@
   "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)",
   "jobAuthorizationScope": "projectCollection",
   "jobTimeoutInMinutes": 180,
+  "jobCancelTimeoutInMinutes": 5,
   "repository": {
     "properties": {
       "labelSources": "0",
@@ -741,7 +736,9 @@
       "fetchDepth": "0",
       "gitLfsSupport": "false",
       "skipSyncSource": "false",
-      "cleanOptions": "0"
+      "cleanOptions": "0",
+      "checkoutNestedSubmodules": "false",
+      "labelSourcesFormat": "$(build.buildNumber)"
     },
     "id": "0a2b2664-c1be-429c-9b40-8a24dee27a4a",
     "type": "TfsGit",
@@ -751,7 +748,9 @@
     "clean": "true",
     "checkoutSubmodules": false
   },
+  "processParameters": {},
   "quality": "definition",
+  "drafts": [],
   "queue": {
     "id": 36,
     "name": "DotNet-Build",
@@ -771,7 +770,7 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418098211,
+    "revision": 418098432,
     "visibility": "organization"
   }
 }

--- a/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
+++ b/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
@@ -7,8 +7,8 @@
       "alwaysRun": false,
       "displayName": "Run script $(VS140COMNTOOLS)\\VsDevCmd.bat",
       "timeoutInMinutes": 0,
-      "refName": "Task1",
       "condition": "ne(variables['PB_SkipTests'], 'true')",
+      "refName": "Task1",
       "task": {
         "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
         "versionSpec": "1.*",
@@ -29,8 +29,8 @@
       "alwaysRun": false,
       "displayName": "Run clean.cmd",
       "timeoutInMinutes": 0,
-      "refName": "Task2",
       "condition": "ne(variables['PB_SkipTests'], 'true')",
+      "refName": "Task2",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -48,9 +48,10 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "Run sync.cmd",
       "timeoutInMinutes": 0,
-      "refName": "Task3",
       "condition": "ne(variables['PB_SkipTests'], 'true')",
+      "refName": "Task3",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -70,8 +71,8 @@
       "alwaysRun": false,
       "displayName": "Generate version props file",
       "timeoutInMinutes": 0,
-      "refName": "Task4",
       "condition": "ne(variables['PB_SkipTests'], 'true')",
+      "refName": "Task4",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -91,8 +92,8 @@
       "alwaysRun": false,
       "displayName": "Run build-test.cmd",
       "timeoutInMinutes": 0,
-      "refName": "Task5",
       "condition": "ne(variables['PB_SkipTests'], 'true')",
+      "refName": "Task5",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -111,8 +112,8 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Send job to Helix",
-      "condition": "ne(variables['PB_SkipTests'], 'true')",
       "timeoutInMinutes": 0,
+      "condition": "ne(variables['PB_SkipTests'], 'true')",
       "refName": "Task6",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -133,6 +134,7 @@
       "alwaysRun": true,
       "displayName": "Copy Files to: $(Build.StagingDirectory)\\BuildLogs",
       "timeoutInMinutes": 0,
+      "condition": "succeededOrFailed()",
       "refName": "CopyFiles1",
       "task": {
         "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
@@ -155,6 +157,7 @@
       "alwaysRun": true,
       "displayName": "Publish Artifact: BuildLogs",
       "timeoutInMinutes": 0,
+      "condition": "succeededOrFailed()",
       "refName": "PublishBuildArtifacts1",
       "task": {
         "id": "2ff763a7-ce83-4e1f-bc89-0ae63477cebe",
@@ -175,27 +178,6 @@
     {
       "enabled": false,
       "definition": {
-        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
-      },
-      "inputs": {
-        "additionalFields": "{}"
-      }
-    },
-    {
-      "enabled": false,
-      "definition": {
-        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
-      },
-      "inputs": {
-        "multipliers": "[]",
-        "parallel": "false",
-        "continueOnError": "true",
-        "additionalFields": "{}"
-      }
-    },
-    {
-      "enabled": false,
-      "definition": {
         "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
       },
       "inputs": {
@@ -210,6 +192,16 @@
         "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
       },
       "inputs": {
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5d58cc01-7c75-450c-be18-a388ddb129ec"
+      },
+      "inputs": {
+        "branchFilters": "[\"+refs/heads/*\"]",
         "additionalFields": "{}"
       }
     }
@@ -291,7 +283,7 @@
       "value": "linux"
     },
     "IntermediateAzureFeed": {
-      "value": "https://dotnetbuildoutput.blob.core.windows.net/$(PB_ContainerName)/$(PB_BlobNamePrefix)$(PB_BuildType)/pkg/index.json",
+      "value": "https://dotnetbuildoutput.blob.core.windows.net/$(PB_ContainerName)/$(PB_BlobNamePrefix)$(PB_BuildType)/pkg/index.json"
     },
     "RuntimeIDArg": {
       "value": "runtimeid linux-x64"
@@ -322,6 +314,7 @@
   "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)-$(Rid)",
   "jobAuthorizationScope": "projectCollection",
   "jobTimeoutInMinutes": 180,
+  "jobCancelTimeoutInMinutes": 5,
   "repository": {
     "properties": {
       "labelSources": "0",
@@ -329,7 +322,9 @@
       "fetchDepth": "0",
       "gitLfsSupport": "false",
       "skipSyncSource": "false",
-      "cleanOptions": "0"
+      "cleanOptions": "0",
+      "checkoutNestedSubmodules": "false",
+      "labelSourcesFormat": "$(build.buildNumber)"
     },
     "id": "670e3783-ab4f-44fc-9786-d332007da311",
     "type": "TfsGit",
@@ -339,7 +334,9 @@
     "clean": "true",
     "checkoutSubmodules": false
   },
+  "processParameters": {},
   "quality": "definition",
+  "drafts": [],
   "queue": {
     "id": 36,
     "name": "DotNet-Build",
@@ -359,7 +356,7 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418098211,
+    "revision": 418098432,
     "visibility": "organization"
   }
 }


### PR DESCRIPTION
CoreClr PipeBuild master now runs using VSTS api v3.2. Build definitions need to be updated to use the new api. Some older concepts (like "alwaysRun") are no longer obeyed in the newer api format.
dotnet/core-eng

https://github.com/dotnet/core-eng/issues/2142