### PR TITLE
Ensure CoreCLR Package version overwrite works correctly in test build

### DIFF
--- a/tests/dir.props
+++ b/tests/dir.props
@@ -113,7 +113,7 @@
   <PropertyGroup Condition="'$(OverwriteCoreClrPackageVersion)' == 'true'">
     <VersionToRestore Condition="'$(StableVersion)' != ''">$(StableVersion)</VersionToRestore>
     <VersionToRestore Condition="'$(VersionToRestore)' == ''">$(PackageVersion)-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)</VersionToRestore>
-    <PackageVersionArg>/p:CoreClrPackageVersion=$(VersionToRestore)</PackageVersionArg>
+    <PackageVersionArg>/p:MicrosoftNETCoreRuntimeCoreCLRPackageVersion=$(VersionToRestore)</PackageVersionArg>
   </PropertyGroup>
 
   <!-- Which tests shall we build? Default: Priority 0 tests.


### PR DESCRIPTION
https://github.com/dotnet/coreclr/commit/3c483846130b17c6c3a7d712c139d2195798165e#diff-c5c510ac8d0f1a0f72c08b9ceb7c9a49 updated the property `CoreCLRPackageVersion` to `MicrosoftNETCoreRuntimeCoreCLRPackageVersion` in all places except this one - because this was missed, CoreCLR Package versions weren't being overwritten properly in test builds, meaning we were testing old bits in Helix. This also caused some Helix test failures because we were missing crossgen.exe in Core_Root (the copy mechanism was looking for crossgen in a package with the current version, but only an old package was present, so no crossgen was getting copied into Core_Root).

CC @weshaggard @RussKeldorph @jashook 