### PR TITLE
[Local GC] Fail fast on exceptions within a standalone GC

### DIFF
--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -7898,7 +7898,8 @@ VEH_ACTION WINAPI CLRVectoredExceptionHandlerPhase3(PEXCEPTION_POINTERS pExcepti
             // on second pass and this subjects us to false positives.
             if ((!fAVisOk) && !(pExceptionRecord->ExceptionFlags & EXCEPTION_UNWINDING))
             {
-                if (IsIPInModule(g_pMSCorEE, (PCODE)GetIP(pContext)))
+                PCODE ip = (PCODE)GetIP(pContext);
+                if (IsIPInModule(g_pMSCorEE, ip) || IsIPInModule(GCHeapUtilities::GetGCModule(), ip))
                 {
                     CONTRACT_VIOLATION(ThrowsViolation|FaultViolation|SOToleranceViolation);
 

--- a/src/vm/gcheaputilities.cpp
+++ b/src/vm/gcheaputilities.cpp
@@ -56,6 +56,9 @@ GC_LOAD_STATUS g_gc_load_status = GC_LOAD_STATUS_BEFORE_START;
 // The version of the GC that we have loaded.
 VersionInfo g_gc_version_info;
 
+// The module that contains the GC.
+HMODULE g_gc_module;
+
 // GC entrypoints for the the linked-in GC. These symbols are invoked
 // directly if we are not using a standalone GC.
 extern "C" void GC_VersionInfo(/* Out */ VersionInfo* info);
@@ -67,6 +70,12 @@ extern "C" HRESULT GC_Initialize(
 );
 
 #ifndef DACCESS_COMPILE
+
+HMODULE GCHeapUtilities::GetGCModule()
+{
+    assert(g_gc_module);
+    return g_gc_module;
+}
 
 namespace
 {
@@ -148,6 +157,7 @@ HRESULT LoadAndInitializeGC(LPWSTR standaloneGcLocation)
         g_pGCHandleManager = manager;
         g_gcDacGlobals = &g_gc_dac_vars;
         g_gc_load_status = GC_LOAD_STATUS_LOAD_COMPLETE;
+        g_gc_module = hMod;
         LOG((LF_GC, LL_INFO100, "GC load successful\n"));
     }
     else
@@ -192,6 +202,7 @@ HRESULT InitializeDefaultGC()
         g_pGCHandleManager = manager;
         g_gcDacGlobals = &g_gc_dac_vars;
         g_gc_load_status = GC_LOAD_STATUS_LOAD_COMPLETE;
+        g_gc_module = GetModuleInst();
         LOG((LF_GC, LL_INFO100, "GC load successful\n"));
     }
     else

--- a/src/vm/gcheaputilities.h
+++ b/src/vm/gcheaputilities.h
@@ -197,6 +197,9 @@ public:
 #endif // FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
 
 #ifndef DACCESS_COMPILE
+    // Gets the module that contains the GC.
+    static HMODULE GetGCModule();
+
     // Loads (if using a standalone GC) and initializes the GC.
     static HRESULT LoadAndInitialize();
 #endif // DACCESS_COMPILE


### PR DESCRIPTION
Fixes #14915. This PR implements option 1 in this comment: https://github.com/dotnet/coreclr/issues/14915#issuecomment-347975999 - if an exception occurs inside the module that contains the GC, we'll fail fast just as we would if the exception occurred in the CoreCLR module.

Note that when not using a standalone GC, the "GC module" will be equal to CoreCLR (`g_pMSCorEE`) since it's the module that contains the GC.

cc @sergiy-k @Maoni0 @jkotas PTAL?