### PR TITLE
Revert "Use ILAsm from buildtools (#15172)"

### DIFF
--- a/tests/dir.props
+++ b/tests/dir.props
@@ -43,6 +43,7 @@
     <_TargetFrameworkDirectories Condition="'$(BuildToolsTargetsDesktop)' != 'true'">$(MSBuildThisFileDirectory)/Documentation</_TargetFrameworkDirectories>
     <_FullFrameworkReferenceAssemblyPaths Condition="'$(BuildToolsTargetsDesktop)' != 'true'">$(MSBuildThisFileDirectory)/Documentation</_FullFrameworkReferenceAssemblyPaths>
     <ExcludeSigningImport>true</ExcludeSigningImport>
+    <SkipImportILTargets>true</SkipImportILTargets>
   </PropertyGroup>
 
   <!-- Common properties -->

--- a/tests/src/IL.targets
+++ b/tests/src/IL.targets
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Required by Microsoft.Common.targets -->
+  <Target Name="CreateManifestResourceNames" Condition="'@(EmbeddedResource)' != ''" />
+
+  <Target Name="CoreCompile"
+          Inputs="$(MSBuildAllProjects);
+                  @(Compile)"
+          Outputs="@(IntermediateAssembly);"
+          Returns=""
+          DependsOnTargets="$(CoreCompileDependsOn)">
+    <PropertyGroup>
+      <_ShellKeyMarker Condition="'$(RunningOnUnix)' == 'true'">-</_ShellKeyMarker>  <!-- Work around ilasm comandline parser bugs... -->
+      <_ShellKeyMarker Condition="'$(RunningOnUnix)' != 'true'">/</_ShellKeyMarker>
+      <_ilasm>ilasm</_ilasm>
+      <_ilasm Condition="'$(RunningOnUnix)' == 'true'">$(CoreCLRBinDir)ilasm</_ilasm>
+      <_OutputTypeArgument Condition="'$(OutputType)' == 'Library'">$(_ShellKeyMarker)DLL</_OutputTypeArgument>
+      <_OutputTypeArgument Condition="'$(OutputType)' == 'Exe'">$(_ShellKeyMarker)EXE</_OutputTypeArgument>
+      <_IlasmSwitches>-QUIET -NOLOGO</_IlasmSwitches>
+      <_IlasmSwitches Condition="'$(FoldIdenticalMethods)' == 'True'">$(_IlasmSwitches) -FOLD</_IlasmSwitches>
+      <_IlasmSwitches Condition="'$(SizeOfStackReserve)' != ''">$(_IlasmSwitches) -STACK=$(SizeOfStackReserve)</_IlasmSwitches>
+      <_IlasmSwitches Condition="'$(DebugType)' == 'Full'">$(_IlasmSwitches) -DEBUG</_IlasmSwitches>
+      <_IlasmSwitches Condition="'$(DebugType)' == 'Impl'">$(_IlasmSwitches) -DEBUG=IMPL</_IlasmSwitches>
+      <_IlasmSwitches Condition="'$(DebugType)' == 'PdbOnly'">$(_IlasmSwitches) -DEBUG=OPT</_IlasmSwitches>
+      <_IlasmSwitches Condition="'$(Optimize)' == 'True'">$(_IlasmSwitches) -OPTIMIZE</_IlasmSwitches>
+    </PropertyGroup>
+
+    <Exec Command="$(_ilasm) $(_OutputTypeArgument) $(_ShellKeyMarker)OUTPUT=@(IntermediateAssembly) $(_IlasmSwitches) @(Compile)">
+      <Output TaskParameter="ExitCode" PropertyName="_ILAsmExitCode" />
+    </Exec>
+    <Error Text="ILAsm failed" Condition="'$(_ILAsmExitCode)' != '0'" />
+  </Target>
+
+  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
+
+</Project>

--- a/tests/src/dir.targets
+++ b/tests/src/dir.targets
@@ -106,9 +106,10 @@
   <PropertyGroup Condition="'$(ProjectLanguage)' == ''">
     <ProjectLanguage Condition="'$(MSBuildProjectExtension)' == '.ilproj' OR '$(Language)' == 'IL'">IL</ProjectLanguage>
     <ProjectLanguage Condition="'$(MSBuildProjectExtension)' == '.csproj' OR '$(Language)' == 'C#' OR '$(ProjectLanguage)'==''">CSharp</ProjectLanguage>
-
-    <SkipImportILTargets Condition="'$(CLRTestPriority)' &gt; '$(CLRTestPriorityToBuild)'">true</SkipImportILTargets>
   </PropertyGroup>
+  
+  <Import Project="$(ProjectDir)src\IL.targets" Condition="'$(ProjectLanguage)' == 'IL' And '$(CLRTestPriority)' &lt;= '$(CLRTestPriorityToBuild)'" />
+
 
   <Import Project="CLRTest.Execute.targets" />
   <Target Name="CreateExecuteScript" 


### PR DESCRIPTION
This reverts commit e864120d14c829df6f6d4c6cff6f3d23db19606c.

Revert #15172 to fix Windows ARM/ARMLB/ARM64 builds