### PR TITLE
Jumpstub fixes

### DIFF
--- a/src/debug/daccess/fntableaccess.h
+++ b/src/debug/daccess/fntableaccess.h
@@ -41,9 +41,7 @@ struct FakeHeapList
     DWORD_PTR           mapBase;        // changed from PBYTE
     DWORD_PTR           pHdrMap;        // changed from DWORD*
     size_t              maxCodeHeapSize;
-    DWORD               cBlocks;
-    bool                bFull;          // Heap is considered full do not use for new allocations
-    bool                bFullForJumpStubs; // Heap is considered full do not use for new allocations of jump stubs
+    size_t              reserveForJumpStubs;
 };
 
 typedef struct _FakeHpRealCodeHdr

--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -599,7 +599,7 @@ RETAIL_CONFIG_STRING_INFO(INTERNAL_WinMDPath, W("WinMDPath"), "Path for Windows 
 // Loader heap
 // 
 CONFIG_DWORD_INFO_EX(INTERNAL_LoaderHeapCallTracing, W("LoaderHeapCallTracing"), 0, "Loader heap troubleshooting", CLRConfig::REGUTIL_default)
-RETAIL_CONFIG_DWORD_INFO(INTERNAL_CodeHeapReserveForJumpStubs, W("CodeHeapReserveForJumpStubs"), 2, "Percentage of code heap to reserve for jump stubs")
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_CodeHeapReserveForJumpStubs, W("CodeHeapReserveForJumpStubs"), 1, "Percentage of code heap to reserve for jump stubs")
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_NGenReserveForJumpStubs, W("NGenReserveForJumpStubs"), 0, "Percentage of ngen image size to reserve for jump stubs")
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_BreakOnOutOfMemoryWithinRange, W("BreakOnOutOfMemoryWithinRange"), 0, "Break before out of memory within range exception is thrown")
 

--- a/src/inc/loaderheap.h
+++ b/src/inc/loaderheap.h
@@ -417,7 +417,7 @@ public:
 #endif
 
 protected:
-    void *UnlockedAllocMemForCode_NoThrow(size_t dwHeaderSize, size_t dwCodeSize, DWORD dwCodeAlignment);
+    void *UnlockedAllocMemForCode_NoThrow(size_t dwHeaderSize, size_t dwCodeSize, DWORD dwCodeAlignment, size_t dwReserveForJumpStubs);
 
     void UnlockedSetReservedRegion(BYTE* dwReservedRegionAddress, SIZE_T dwReservedRegionSize, BOOL fReleaseMemory);
 };
@@ -838,10 +838,10 @@ public:
 
 
 public:
-    void *AllocMemForCode_NoThrow(size_t dwHeaderSize, size_t dwCodeSize, DWORD dwCodeAlignment)
+    void *AllocMemForCode_NoThrow(size_t dwHeaderSize, size_t dwCodeSize, DWORD dwCodeAlignment, size_t dwReserveForJumpStubs)
     {
         WRAPPER_NO_CONTRACT;
-        return UnlockedAllocMemForCode_NoThrow(dwHeaderSize, dwCodeSize, dwCodeAlignment);
+        return UnlockedAllocMemForCode_NoThrow(dwHeaderSize, dwCodeSize, dwCodeAlignment, dwReserveForJumpStubs);
     }
 
     void SetReservedRegion(BYTE* dwReservedRegionAddress, SIZE_T dwReservedRegionSize, BOOL fReleaseMemory)

--- a/src/utilcode/loaderheap.cpp
+++ b/src/utilcode/loaderheap.cpp
@@ -1731,7 +1731,7 @@ void *UnlockedLoaderHeap::UnlockedAllocAlignedMem(size_t  dwRequestedSize,
 
 
 
-void *UnlockedLoaderHeap::UnlockedAllocMemForCode_NoThrow(size_t dwHeaderSize, size_t dwCodeSize, DWORD dwCodeAlignment)
+void *UnlockedLoaderHeap::UnlockedAllocMemForCode_NoThrow(size_t dwHeaderSize, size_t dwCodeSize, DWORD dwCodeAlignment, size_t dwReserveForJumpStubs)
 {
     CONTRACT(void*)
     {
@@ -1753,7 +1753,7 @@ void *UnlockedLoaderHeap::UnlockedAllocMemForCode_NoThrow(size_t dwHeaderSize, s
     //
     // Thus, we'll request as much heap growth as is needed for the worst case (we request an extra dwCodeAlignment - 1 bytes)
 
-    S_SIZE_T cbAllocSize = S_SIZE_T(dwHeaderSize) + S_SIZE_T(dwCodeSize) + S_SIZE_T(dwCodeAlignment - 1);
+    S_SIZE_T cbAllocSize = S_SIZE_T(dwHeaderSize) + S_SIZE_T(dwCodeSize) + S_SIZE_T(dwCodeAlignment - 1) + S_SIZE_T(dwReserveForJumpStubs);
     if( cbAllocSize.IsOverflow() )
     {
         RETURN NULL;

--- a/src/vm/amd64/cgencpu.h
+++ b/src/vm/amd64/cgencpu.h
@@ -379,7 +379,8 @@ void EncodeLoadAndJumpThunk (LPBYTE pBuffer, LPVOID pv, LPVOID pTarget);
 
 
 // Get Rel32 destination, emit jumpStub if necessary
-INT32 rel32UsingJumpStub(INT32 UNALIGNED * pRel32, PCODE target, MethodDesc *pMethod, LoaderAllocator *pLoaderAllocator = NULL);
+INT32 rel32UsingJumpStub(INT32 UNALIGNED * pRel32, PCODE target, MethodDesc *pMethod, 
+    LoaderAllocator *pLoaderAllocator = NULL, bool throwOnOutOfMemoryWithinRange = true);
 
 // Get Rel32 destination, emit jumpStub if necessary into a preallocated location
 INT32 rel32UsingPreallocatedJumpStub(INT32 UNALIGNED * pRel32, PCODE target, PCODE jumpStubAddr);

--- a/src/vm/codeman.h
+++ b/src/vm/codeman.h
@@ -365,9 +365,11 @@ struct CodeHeapRequestInfo
     const BYTE * m_hiAddr;          // hihest address to use to satisfy our request (0 -- don't care)
     size_t       m_requestSize;     // minimum size that must be made available
     size_t       m_reserveSize;     // Amount that VirtualAlloc will reserved
+    size_t       m_reserveForJumpStubs; // Amount to reserve for jump stubs (won't be allocated)
     bool         m_isDynamicDomain;
     bool         m_isCollectible;
-    
+    bool         m_throwOnOutOfMemoryWithinRange;
+
     bool   IsDynamicDomain()                    { return m_isDynamicDomain;    }
     void   SetDynamicDomain()                   { m_isDynamicDomain = true;    }
 
@@ -378,20 +380,26 @@ struct CodeHeapRequestInfo
     
     size_t getReserveSize()                     { return m_reserveSize;        }
     void   setReserveSize(size_t reserveSize)   { m_reserveSize = reserveSize; }
+
+    size_t getReserveForJumpStubs()             { return m_reserveForJumpStubs; }
+    void   setReserveForJumpStubs(size_t size)  { m_reserveForJumpStubs = size; }
+
+    bool   getThrowOnOutOfMemoryWithinRange()   { return m_throwOnOutOfMemoryWithinRange; }
+    void   setThrowOnOutOfMemoryWithinRange(bool value) { m_throwOnOutOfMemoryWithinRange = value; }
         
     void   Init();
     
     CodeHeapRequestInfo(MethodDesc *pMD)
         : m_pMD(pMD), m_pAllocator(0), 
           m_loAddr(0), m_hiAddr(0),
-          m_requestSize(0), m_reserveSize(0)
+          m_requestSize(0), m_reserveSize(0), m_reserveForJumpStubs(0)
     { WRAPPER_NO_CONTRACT;   Init(); }
     
     CodeHeapRequestInfo(MethodDesc *pMD, LoaderAllocator* pAllocator,
                         BYTE * loAddr, BYTE * hiAddr)
         : m_pMD(pMD), m_pAllocator(pAllocator), 
           m_loAddr(loAddr), m_hiAddr(hiAddr),
-          m_requestSize(0), m_reserveSize(0)
+          m_requestSize(0), m_reserveSize(0), m_reserveForJumpStubs(0)
     { WRAPPER_NO_CONTRACT;   Init(); }
 };
 
@@ -433,7 +441,7 @@ public:
 
     // Alloc the specified numbers of bytes for code. Returns NULL if the request does not fit
     // Space for header is reserved immediately before. It is not included in size.
-    virtual void* AllocMemForCode_NoThrow(size_t header, size_t size, DWORD alignment) = 0;
+    virtual void* AllocMemForCode_NoThrow(size_t header, size_t size, DWORD alignment, size_t reserveForJumpStubs) = 0;
 
 #ifdef DACCESS_COMPILE
     virtual void EnumMemoryRegions(CLRDataEnumMemoryFlags flags) = 0;
@@ -467,9 +475,7 @@ typedef struct _HeapList
     PTR_DWORD           pHdrMap;        // bit array used to find the start of methods
 
     size_t              maxCodeHeapSize;// Size of the entire contiguous block of memory
-    DWORD               cBlocks;        // Number of allocations
-    bool                bFull;          // Heap is considered full do not use for new allocations
-    bool                bFullForJumpStubs; // Heap is considered full do not use for new allocations of jump stubs
+    size_t              reserveForJumpStubs; // Amount of memory reserved for jump stubs in this block
 
 #if defined(_TARGET_AMD64_)
     BYTE        CLRPersonalityRoutine[JUMP_ALLOCATE_SIZE];                 // jump thunk to personality routine
@@ -482,18 +488,6 @@ typedef struct _HeapList
 
     void SetNext(PTR_HeapList next)
     { hpNext = next; }
-
-    void SetHeapFull() 
-    { VolatileStore(&bFull, true); }
-
-    bool IsHeapFull() 
-    { return VolatileLoad(&bFull); }
-
-    void SetHeapFullForJumpStubs() 
-    { VolatileStore(&bFullForJumpStubs, true); }
-
-    bool IsHeapFullForJumpStubs() 
-    { return VolatileLoad(&bFullForJumpStubs); }
 
 } HeapList;
 
@@ -527,7 +521,7 @@ public:
         WRAPPER_NO_CONTRACT;
     }
 
-    virtual void* AllocMemForCode_NoThrow(size_t header, size_t size, DWORD alignment) DAC_EMPTY_RET(NULL);
+    virtual void* AllocMemForCode_NoThrow(size_t header, size_t size, DWORD alignment, size_t reserveForJumpStubs) DAC_EMPTY_RET(NULL);
 
 #ifdef DACCESS_COMPILE
     virtual void EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
@@ -1015,7 +1009,7 @@ public:
 
     BOOL                LoadJIT();
 
-    CodeHeader*         allocCode(MethodDesc* pFD, size_t blockSize, CorJitAllocMemFlag flag
+    CodeHeader*         allocCode(MethodDesc* pFD, size_t blockSize, size_t reserveForJumpStubs, CorJitAllocMemFlag flag
 #ifdef WIN64EXCEPTIONS
                                   , UINT nUnwindInfos
                                   , TADDR * pModuleBase
@@ -1025,7 +1019,8 @@ public:
     EE_ILEXCEPTION*     allocEHInfo(CodeHeader* pCodeHeader, unsigned numClauses, size_t * pAllocationSize);
     JumpStubBlockHeader* allocJumpStubBlock(MethodDesc* pMD, DWORD numJumps, 
                                             BYTE * loAddr, BYTE * hiAddr,
-                                            LoaderAllocator *pLoaderAllocator);
+                                            LoaderAllocator *pLoaderAllocator,
+                                            bool throwOnOutOfMemoryWithinRange);
 
     void *              allocCodeFragmentBlock(size_t blockSize, unsigned alignment, LoaderAllocator *pLoaderAllocator, StubCodeBlockKind kind);
 #endif // !DACCESS_COMPILE && !CROSSGEN_COMPILE
@@ -1091,11 +1086,10 @@ private :
 #ifndef DACCESS_COMPILE
 #ifndef CROSSGEN_COMPILE
     HeapList*   NewCodeHeap(CodeHeapRequestInfo *pInfo, DomainCodeHeapList *pADHeapList);
-    HeapList*   GetCodeHeap(CodeHeapRequestInfo *pInfo);
     bool        CanUseCodeHeap(CodeHeapRequestInfo *pInfo, HeapList *pCodeHeap);
     void*       allocCodeRaw(CodeHeapRequestInfo *pInfo, 
                              size_t header, size_t blockSize, unsigned align,
-                             HeapList ** ppCodeHeap /* Writeback, Can be null */ );
+                             HeapList ** ppCodeHeap);
 
     DomainCodeHeapList *GetCodeHeapList(CodeHeapRequestInfo *pInfo, LoaderAllocator *pAllocator, BOOL fDynamicOnly = FALSE);
     DomainCodeHeapList *CreateCodeHeapList(CodeHeapRequestInfo *pInfo);
@@ -1357,7 +1351,8 @@ public:
                           PCODE target,
                           BYTE * loAddr,
                           BYTE * hiAddr,
-                          LoaderAllocator *pLoaderAllocator = NULL);
+                          LoaderAllocator *pLoaderAllocator = NULL,
+                          bool throwOnOutOfMemoryWithinRange = true);
 #endif
 
 private:
@@ -1430,7 +1425,8 @@ private:
     static PCODE getNextJumpStub(MethodDesc* pMD,
                                  PCODE target,
                                  BYTE * loAddr,  BYTE * hiAddr,
-                                 LoaderAllocator *pLoaderAllocator);
+                                 LoaderAllocator *pLoaderAllocator,
+                                 bool throwOnOutOfMemoryWithinRange);
 #endif    
 
 private:

--- a/src/vm/crossgencompile.cpp
+++ b/src/vm/crossgencompile.cpp
@@ -263,7 +263,8 @@ BOOL Runtime_Test_For_SSE2()
 #endif
 
 #ifdef _TARGET_AMD64_
-INT32 rel32UsingJumpStub(INT32 UNALIGNED * pRel32, PCODE target, MethodDesc *pMethod, LoaderAllocator *pLoaderAllocator /* = NULL */)
+INT32 rel32UsingJumpStub(INT32 UNALIGNED * pRel32, PCODE target, MethodDesc *pMethod,
+    LoaderAllocator *pLoaderAllocator /* = NULL */, bool throwOnOutOfMemoryWithinRange /*= true*/)
 {
     // crossgen does not have jump stubs
     return 0;

--- a/src/vm/dynamicmethod.cpp
+++ b/src/vm/dynamicmethod.cpp
@@ -322,64 +322,21 @@ HeapList* HostCodeHeap::CreateCodeHeap(CodeHeapRequestInfo *pInfo, EEJitManager 
         GC_NOTRIGGER;
         MODE_ANY;
         INJECT_FAULT(COMPlusThrowOM());
-        POSTCONDITION(CheckPointer(RETVAL));
+        POSTCONDITION(CheckPointer(RETVAL) || !pInfo->getThrowOnOutOfMemoryWithinRange());
     }
     CONTRACT_END;
 
-    size_t MaxCodeHeapSize  = pInfo->getRequestSize();
-    size_t ReserveBlockSize = MaxCodeHeapSize + sizeof(HeapList);
+    NewHolder<HostCodeHeap> pCodeHeap(new HostCodeHeap(pJitManager));
 
-    ReserveBlockSize += sizeof(TrackAllocation) + GetOsPageSize(); // make sure we have enough for the allocation
-    // take a conservative size for the nibble map, we may change that later if appropriate
-    size_t nibbleMapSize = ROUND_UP_TO_PAGE(HEAP2MAPSIZE(ROUND_UP_TO_PAGE(ALIGN_UP(ReserveBlockSize, VIRTUAL_ALLOC_RESERVE_GRANULARITY))));
-    size_t heapListSize = (sizeof(HeapList) + CODE_SIZE_ALIGN - 1) & (~(CODE_SIZE_ALIGN - 1));
-    size_t otherData = heapListSize;
-    // make conservative estimate of the memory needed for otherData
-    size_t reservedData = (otherData + HOST_CODEHEAP_SIZE_ALIGN - 1) & (~(HOST_CODEHEAP_SIZE_ALIGN - 1));
-    
-    NewHolder<HostCodeHeap> pCodeHeap(new HostCodeHeap(ReserveBlockSize + nibbleMapSize + reservedData, pJitManager, pInfo));
-    LOG((LF_BCL, LL_INFO10, "Level2 - CodeHeap creation {0x%p} - requested 0x%p, size available 0x%p, private data 0x%p, nibble map 0x%p\n", 
-                            (HostCodeHeap*)pCodeHeap, ReserveBlockSize, pCodeHeap->m_TotalBytesAvailable, reservedData, nibbleMapSize));
+    HeapList *pHp = pCodeHeap->InitializeHeapList(pInfo);
+    if (pHp == NULL)
+    {
+        _ASSERTE(!pInfo->getThrowOnOutOfMemoryWithinRange());
+        RETURN NULL;
+    }
 
-    BYTE *pBuffer = pCodeHeap->InitCodeHeapPrivateData(ReserveBlockSize, reservedData, nibbleMapSize);
-    _ASSERTE(IS_ALIGNED(pBuffer, GetOsPageSize()));
     LOG((LF_BCL, LL_INFO100, "Level2 - CodeHeap creation {0x%p} - base addr 0x%p, size available 0x%p, nibble map ptr 0x%p\n",
-                            (HostCodeHeap*)pCodeHeap, pCodeHeap->m_pBaseAddr, pCodeHeap->m_TotalBytesAvailable, pBuffer));
-
-    void* pHdrMap = pBuffer;
-
-    HeapList *pHp = (HeapList*)pCodeHeap->AllocMemory(otherData, 0);
-    pHp->pHeap = (PTR_CodeHeap)pCodeHeap;
-    // wire it back
-    pCodeHeap->m_pHeapList = (PTR_HeapList)pHp;
-    // assign beginning of nibble map
-    pHp->pHdrMap = (PTR_DWORD)(DWORD*)pHdrMap;
-
-    TrackAllocation *pTracker = *((TrackAllocation**)pHp - 1);
-    LOG((LF_BCL, LL_INFO100, "Level2 - CodeHeap creation {0x%p} - size available 0x%p, private data ptr [0x%p, 0x%p]\n",
-                            (HostCodeHeap*)pCodeHeap, pCodeHeap->m_TotalBytesAvailable, pTracker, pTracker->size));
-
-    // need to update the reserved data
-    pCodeHeap->m_ReservedData += pTracker->size;
-
-    pHp->startAddress    = dac_cast<TADDR>(pCodeHeap->m_pBaseAddr) + pTracker->size;
-    pHp->mapBase         = ROUND_DOWN_TO_PAGE(pHp->startAddress);  // round down to next lower page align
-    pHp->endAddress      = pHp->startAddress;
-
-    pHp->maxCodeHeapSize = pCodeHeap->m_TotalBytesAvailable - pTracker->size;
-    _ASSERTE(pHp->maxCodeHeapSize >= MaxCodeHeapSize);
-
-    // We do not need to memset this memory, since ClrVirtualAlloc() guarantees that the memory is zero.
-    // Furthermore, if we avoid writing to it, these pages don't come into our working set
-
-    pHp->bFull           = FALSE;
-    pHp->cBlocks         = 0;
-#ifdef _WIN64
-    emitJump((LPBYTE)pHp->CLRPersonalityRoutine, (void *)ProcessCLRException);
-#endif
-
-    // zero the ref count as now starts the real counter
-    pCodeHeap->m_AllocationCount = 0;
+                            (HostCodeHeap*)pCodeHeap, pCodeHeap->m_pBaseAddr, pCodeHeap->m_TotalBytesAvailable, pCodeHeap->m_pHeapList->pHdrMap));
 
     pCodeHeap.SuppressRelease();
 
@@ -387,7 +344,7 @@ HeapList* HostCodeHeap::CreateCodeHeap(CodeHeapRequestInfo *pInfo, EEJitManager 
     RETURN pHp;
 }
 
-HostCodeHeap::HostCodeHeap(size_t ReserveBlockSize, EEJitManager *pJitManager, CodeHeapRequestInfo *pInfo)
+HostCodeHeap::HostCodeHeap(EEJitManager *pJitManager)
 {
     CONTRACTL
     {
@@ -398,45 +355,31 @@ HostCodeHeap::HostCodeHeap(size_t ReserveBlockSize, EEJitManager *pJitManager, C
     }
     CONTRACTL_END;
 
-    // reserve ReserveBlockSize rounded-up to VIRTUAL_ALLOC_RESERVE_GRANULARITY of memory
-    ReserveBlockSize = ALIGN_UP(ReserveBlockSize, VIRTUAL_ALLOC_RESERVE_GRANULARITY);
-
-    if (pInfo->m_loAddr != NULL || pInfo->m_hiAddr != NULL)
-    {
-        m_pBaseAddr = ClrVirtualAllocWithinRange(pInfo->m_loAddr, pInfo->m_hiAddr,
-                                                ReserveBlockSize, MEM_RESERVE, PAGE_NOACCESS);
-        if (!m_pBaseAddr)
-            ThrowOutOfMemoryWithinRange();
-    }
-    else
-    {
-        m_pBaseAddr = ClrVirtualAllocExecutable(ReserveBlockSize, MEM_RESERVE, PAGE_NOACCESS);
-        if (!m_pBaseAddr)
-            ThrowOutOfMemory();
-    }
-
-    m_pLastAvailableCommittedAddr = m_pBaseAddr;
-    m_TotalBytesAvailable = ReserveBlockSize;
+    m_pBaseAddr = NULL;
+    m_pLastAvailableCommittedAddr = NULL;
+    m_TotalBytesAvailable = 0;
+    m_ApproximateLargestBlock = 0;
     m_AllocationCount = 0;
-    m_ReservedData = 0;
+    m_pHeapList = NULL;
     m_pJitManager = (PTR_EEJitManager)pJitManager;
     m_pFreeList = NULL;
-    m_pAllocator = pInfo->m_pAllocator;
+    m_pAllocator = NULL;
     m_pNextHeapToRelease = NULL;
-    LOG((LF_BCL, LL_INFO100, "Level2 - CodeHeap creation {0x%p, vt(0x%x)} - base addr 0x%p, total size 0x%p\n", 
-                            this, *(size_t*)this, m_pBaseAddr, m_TotalBytesAvailable));
 }
 
 HostCodeHeap::~HostCodeHeap()
 {
     LIMITED_METHOD_CONTRACT;
 
+    if (m_pHeapList != NULL && m_pHeapList->pHdrMap != NULL)
+        delete[] m_pHeapList->pHdrMap;
+
     if (m_pBaseAddr)
         ClrVirtualFree(m_pBaseAddr, 0, MEM_RELEASE);
     LOG((LF_BCL, LL_INFO10, "Level1 - CodeHeap destroyed {0x%p}\n", this));
 }
 
-BYTE* HostCodeHeap::InitCodeHeapPrivateData(size_t ReserveBlockSize, size_t otherData, size_t nibbleMapSize)
+HeapList* HostCodeHeap::InitializeHeapList(CodeHeapRequestInfo *pInfo)
 {
     CONTRACTL
     {
@@ -446,43 +389,79 @@ BYTE* HostCodeHeap::InitCodeHeapPrivateData(size_t ReserveBlockSize, size_t othe
     }
     CONTRACTL_END;
 
-    size_t nibbleNewSize = ROUND_UP_TO_PAGE(HEAP2MAPSIZE(ROUND_UP_TO_PAGE(m_TotalBytesAvailable)));
-    if (m_TotalBytesAvailable - nibbleNewSize < ReserveBlockSize + otherData)
+    size_t ReserveBlockSize = pInfo->getRequestSize();
+
+    // Add TrackAllocation, HeapList and very conservative padding to make sure we have enough for the allocation
+    ReserveBlockSize += sizeof(TrackAllocation) + sizeof(HeapList) + HOST_CODEHEAP_SIZE_ALIGN + 0x100;
+
+    // reserve ReserveBlockSize rounded-up to VIRTUAL_ALLOC_RESERVE_GRANULARITY of memory
+    ReserveBlockSize = ALIGN_UP(ReserveBlockSize, VIRTUAL_ALLOC_RESERVE_GRANULARITY);
+
+    if (pInfo->m_loAddr != NULL || pInfo->m_hiAddr != NULL)
     {
-        // the new allocation for the nibble map would notleave enough room for the requested memory, bail out
-        nibbleNewSize = nibbleMapSize;
+        m_pBaseAddr = ClrVirtualAllocWithinRange(pInfo->m_loAddr, pInfo->m_hiAddr,
+            ReserveBlockSize, MEM_RESERVE, PAGE_NOACCESS);
+        if (!m_pBaseAddr)
+        {
+            if (pInfo->getThrowOnOutOfMemoryWithinRange())
+                ThrowOutOfMemoryWithinRange();
+            return NULL;
+        }
+    }
+    else
+    {
+        // top up the ReserveBlockSize to suggested minimum
+        ReserveBlockSize = max(ReserveBlockSize, pInfo->getReserveSize());
+
+        m_pBaseAddr = ClrVirtualAllocExecutable(ReserveBlockSize, MEM_RESERVE, PAGE_NOACCESS);
+        if (!m_pBaseAddr)
+            ThrowOutOfMemory();
     }
 
-    BYTE *pAddress = (BYTE*)ROUND_DOWN_TO_PAGE(dac_cast<TADDR>(m_pLastAvailableCommittedAddr) + 
-                                               m_TotalBytesAvailable - nibbleNewSize);
-    _ASSERTE(m_pLastAvailableCommittedAddr + m_TotalBytesAvailable >= pAddress + nibbleNewSize);
-    if (NULL == ClrVirtualAlloc(pAddress, nibbleNewSize, MEM_COMMIT, PAGE_EXECUTE_READWRITE))
+    m_pLastAvailableCommittedAddr = m_pBaseAddr;
+    m_TotalBytesAvailable = ReserveBlockSize;
+    m_ApproximateLargestBlock = ReserveBlockSize;
+    m_pAllocator = pInfo->m_pAllocator;
+
+    TrackAllocation *pTracker = AllocMemory_NoThrow(0, sizeof(HeapList), sizeof(void*), 0);
+    if (pTracker == NULL)
+    {
+        // This should only ever happen with fault injection
+        _ASSERTE(g_pConfig->ShouldInjectFault(INJECTFAULT_DYNAMICCODEHEAP));
         ThrowOutOfMemory();
-    m_TotalBytesAvailable = pAddress - m_pLastAvailableCommittedAddr;
-    _ASSERTE(m_TotalBytesAvailable >= ReserveBlockSize + otherData);
-    return pAddress;
-}
-
- // used to flag a block that is too small
-#define UNUSABLE_BLOCK      ((size_t)-1)
- 
-size_t HostCodeHeap::GetPadding(TrackAllocation *pCurrent, size_t size, DWORD alignment)
-{
-    LIMITED_METHOD_CONTRACT;
-    if (pCurrent->size < size)
-        return UNUSABLE_BLOCK;
-    size_t padding = 0;
-    if (alignment)
-    {
-        size_t pointer = (size_t)((BYTE*)pCurrent + sizeof(TrackAllocation));
-        padding = ((pointer + (size_t)alignment - 1) & (~((size_t)alignment - 1))) - pointer;
     }
-    if (pCurrent->size < size + padding)
-        return UNUSABLE_BLOCK;
-    return padding;
+
+    HeapList* pHp = (HeapList *)(pTracker + 1);
+
+    pHp->hpNext = NULL;
+    pHp->pHeap = (PTR_CodeHeap)this;
+    // wire it back
+    m_pHeapList = (PTR_HeapList)pHp;
+
+    LOG((LF_BCL, LL_INFO100, "Level2 - CodeHeap creation {0x%p} - size available 0x%p, private data ptr [0x%p, 0x%p]\n",
+        (HostCodeHeap*)this, m_TotalBytesAvailable, pTracker, pTracker->size));
+
+    // It is imporant to exclude the CLRPersonalityRoutine from the tracked range
+    pHp->startAddress = dac_cast<TADDR>(m_pBaseAddr) + pTracker->size;
+    pHp->mapBase = ROUND_DOWN_TO_PAGE(pHp->startAddress);  // round down to next lower page align
+    pHp->pHdrMap = NULL;
+    pHp->endAddress = pHp->startAddress;
+
+    pHp->maxCodeHeapSize = m_TotalBytesAvailable - pTracker->size;
+    pHp->reserveForJumpStubs = 0;
+
+#ifdef _WIN64
+    emitJump((LPBYTE)pHp->CLRPersonalityRoutine, (void *)ProcessCLRException);
+#endif
+
+    size_t nibbleMapSize = HEAP2MAPSIZE(ROUND_UP_TO_PAGE(pHp->maxCodeHeapSize));
+    pHp->pHdrMap = new DWORD[nibbleMapSize / sizeof(DWORD)];
+    ZeroMemory(pHp->pHdrMap, nibbleMapSize);
+
+    return pHp;
 }
 
-void* HostCodeHeap::AllocFromFreeList(size_t size, DWORD alignment)
+HostCodeHeap::TrackAllocation* HostCodeHeap::AllocFromFreeList(size_t header, size_t size, DWORD alignment, size_t reserveForJumpStubs)
 {
     CONTRACTL
     {
@@ -500,19 +479,16 @@ void* HostCodeHeap::AllocFromFreeList(size_t size, DWORD alignment)
         TrackAllocation *pPrevious = NULL;
         while (pCurrent)
         {
-            // GetPadding will return UNUSABLE_BLOCK if the current block is not big enough
-            size_t padding = GetPadding(pCurrent, size, alignment);
-            if (UNUSABLE_BLOCK != padding)
+            BYTE* pPointer = ALIGN_UP((BYTE*)(pCurrent + 1) + header, alignment);
+            size_t realSize = ALIGN_UP(pPointer + size, sizeof(void*)) - (BYTE*)pCurrent;
+            if (pCurrent->size >= realSize + reserveForJumpStubs)
             {
                 // found a block
                 LOG((LF_BCL, LL_INFO100, "Level2 - CodeHeap [0x%p] - Block found, size 0x%X\n", this, pCurrent->size));
-                size_t realSize = size + padding;
-                BYTE *pPointer = (BYTE*)pCurrent + sizeof(TrackAllocation) + padding;
-                _ASSERTE((size_t)(pPointer - (BYTE*)pCurrent) >= sizeof(TrackAllocation));
 
                 // The space left is not big enough for a new block, let's just
                 // update the TrackAllocation record for the current block
-                if (pCurrent->size - realSize <= sizeof(TrackAllocation))
+                if (pCurrent->size - realSize < max(HOST_CODEHEAP_SIZE_ALIGN, sizeof(TrackAllocation)))
                 {
                     LOG((LF_BCL, LL_INFO100, "Level2 - CodeHeap [0x%p] - Item removed %p, size 0x%X\n", this, pCurrent, pCurrent->size));
                     // remove current
@@ -545,13 +521,10 @@ void* HostCodeHeap::AllocFromFreeList(size_t size, DWORD alignment)
                     pCurrent->size = realSize;
                 }
 
-                // now fill all the padding data correctly
                 pCurrent->pHeap = this;
-                // store the location of the TrackAllocation record right before pPointer
-                *((void**)pPointer - 1) = pCurrent;
 
                 LOG((LF_BCL, LL_INFO100, "Level2 - CodeHeap [0x%p] - Allocation returned %p, size 0x%X - data -> %p\n", this, pCurrent, pCurrent->size, pPointer));
-                return pPointer;
+                return pCurrent;
             }
             pPrevious = pCurrent;
             pCurrent = pCurrent->pNext;
@@ -656,7 +629,7 @@ void HostCodeHeap::AddToFreeList(TrackAllocation *pBlockToInsert)
                                                         m_pFreeList, m_pFreeList->size));
 }
 
-void* HostCodeHeap::AllocMemForCode_NoThrow(size_t header, size_t size, DWORD alignment)
+void* HostCodeHeap::AllocMemForCode_NoThrow(size_t header, size_t size, DWORD alignment, size_t reserveForJumpStubs)
 {
     CONTRACTL
     {
@@ -667,45 +640,36 @@ void* HostCodeHeap::AllocMemForCode_NoThrow(size_t header, size_t size, DWORD al
     CONTRACTL_END;
 
     _ASSERTE(header == sizeof(CodeHeader));
+    _ASSERTE(alignment <= HOST_CODEHEAP_SIZE_ALIGN);
 
-    // The code allocator has to guarantee that there is only one entrypoint per nibble map entry. 
+    // The code allocator has to guarantee that there is only one entrypoint per nibble map entry.
     // It is guaranteed because of HostCodeHeap allocator always aligns the size up to HOST_CODEHEAP_SIZE_ALIGN,
     // and because the size of nibble map entries (BYTES_PER_BUCKET) is smaller than HOST_CODEHEAP_SIZE_ALIGN.
     // Assert the later fact here.
     _ASSERTE(HOST_CODEHEAP_SIZE_ALIGN >= BYTES_PER_BUCKET);
 
-    BYTE * pMem = (BYTE *)AllocMemory_NoThrow(size + sizeof(CodeHeader) + (alignment - 1), sizeof(void *));
-    if (pMem == NULL)
+    header += sizeof(TrackAllocation*);
+
+    TrackAllocation* pTracker = AllocMemory_NoThrow(header, size, alignment, reserveForJumpStubs);
+    if (pTracker == NULL)
         return NULL;
 
-    BYTE * pCode = (BYTE *)ALIGN_UP(pMem + sizeof(CodeHeader), alignment);
+    BYTE * pCode = ALIGN_UP((BYTE*)(pTracker + 1) + header, alignment);
 
-    // Update tracker to account for the alignment we have just added
-    TrackAllocation *pTracker = *((TrackAllocation **)pMem - 1);
-
-    CodeHeader * pHdr = dac_cast<PTR_CodeHeader>(pCode) - 1;
+    // Pointer to the TrackAllocation record is stored just before the code header
+    CodeHeader * pHdr = (CodeHeader *)pCode - 1;
     *((TrackAllocation **)(pHdr) - 1) = pTracker;
+
+    _ASSERTE(pCode + size <= (BYTE*)pTracker + pTracker->size);
+
+    // ref count the whole heap
+    m_AllocationCount++;
+    LOG((LF_BCL, LL_INFO100, "Level2 - CodeHeap [0x%p] - ref count %d\n", this, m_AllocationCount));
 
     return pCode;
 }
 
-void* HostCodeHeap::AllocMemory(size_t size, DWORD alignment)
-{
-    CONTRACTL
-    {
-        THROWS;
-        GC_NOTRIGGER;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
-
-    void *pAllocation = AllocMemory_NoThrow(size, alignment);
-    if (!pAllocation)
-        ThrowOutOfMemory();
-    return pAllocation;
-}
-
-void* HostCodeHeap::AllocMemory_NoThrow(size_t size, DWORD alignment)
+HostCodeHeap::TrackAllocation* HostCodeHeap::AllocMemory_NoThrow(size_t header, size_t size, DWORD alignment, size_t reserveForJumpStubs)
 {
     CONTRACTL
     {
@@ -725,18 +689,15 @@ void* HostCodeHeap::AllocMemory_NoThrow(size_t size, DWORD alignment)
     }
 #endif // _DEBUG
 
-    // honor alignment (should assert the value is proper)
-    if (alignment)
-        size = (size + (size_t)alignment - 1) & (~((size_t)alignment - 1));
-    // align size to HOST_CODEHEAP_SIZE_ALIGN always
-    size = (size + HOST_CODEHEAP_SIZE_ALIGN - 1) & (~(HOST_CODEHEAP_SIZE_ALIGN - 1));
-
-    size += sizeof(TrackAllocation);
+    // Skip walking the free list if the cached size of the largest block is not enough
+    size_t totalRequiredSize = ALIGN_UP(sizeof(TrackAllocation) + header + size + (alignment - 1) + reserveForJumpStubs, sizeof(void*));
+    if (totalRequiredSize > m_ApproximateLargestBlock)
+        return NULL;
 
     LOG((LF_BCL, LL_INFO100, "Level2 - CodeHeap [0x%p] - Allocation requested 0x%X\n", this, size));
 
-    void *pAddr = AllocFromFreeList(size, alignment);
-    if (!pAddr)
+    TrackAllocation* pTracker = AllocFromFreeList(header, size, alignment, reserveForJumpStubs);
+    if (!pTracker)
     {
         // walk free list to end to find available space
         size_t availableInFreeList = 0;
@@ -751,8 +712,9 @@ void* HostCodeHeap::AllocMemory_NoThrow(size_t size, DWORD alignment)
         {
             availableInFreeList = pLastBlock->size;
         }
-        _ASSERTE(size > availableInFreeList);
-        size_t sizeToCommit = size - availableInFreeList; 
+
+        _ASSERTE(totalRequiredSize > availableInFreeList);
+        size_t sizeToCommit = totalRequiredSize - availableInFreeList;
         sizeToCommit = ROUND_UP_TO_PAGE(size); // round up to page
 
         if (m_pLastAvailableCommittedAddr + sizeToCommit <= m_pBaseAddr + m_TotalBytesAvailable)
@@ -768,20 +730,18 @@ void* HostCodeHeap::AllocMemory_NoThrow(size_t size, DWORD alignment)
             pBlockToInsert->size = sizeToCommit;
             m_pLastAvailableCommittedAddr += sizeToCommit;
             AddToFreeList(pBlockToInsert);
-            pAddr = AllocFromFreeList(size, alignment);
+            pTracker = AllocFromFreeList(header, size, alignment, reserveForJumpStubs);
+            _ASSERTE(pTracker != NULL);
         }
         else
         {
             LOG((LF_BCL, LL_INFO100, "Level2 - CodeHeap [0x%p] - allocation failed:\n\tm_pLastAvailableCommittedAddr: 0x%X\n\tsizeToCommit: 0x%X\n\tm_pBaseAddr: 0x%X\n\tm_TotalBytesAvailable: 0x%X\n", this, m_pLastAvailableCommittedAddr, sizeToCommit, m_pBaseAddr, m_TotalBytesAvailable));
-            return NULL;
+            // Update largest available block size
+            m_ApproximateLargestBlock = totalRequiredSize - 1;
         }
     }
 
-    _ASSERTE(pAddr);
-    // ref count the whole heap
-    m_AllocationCount++;
-    LOG((LF_BCL, LL_INFO100, "Level2 - CodeHeap [0x%p] - ref count %d\n", this, m_AllocationCount));
-    return pAddr;
+    return pTracker;
 }
 
 #endif //!DACCESS_COMPILE
@@ -856,6 +816,8 @@ void HostCodeHeap::FreeMemForCode(void * codeStart)
 
     TrackAllocation *pTracker = HostCodeHeap::GetTrackAllocation((TADDR)codeStart);
     AddToFreeList(pTracker);
+
+    m_ApproximateLargestBlock += pTracker->size;
 
     m_AllocationCount--;
     LOG((LF_BCL, LL_INFO100, "Level2 - CodeHeap released [0x%p, vt(0x%x)] - ref count %d\n", this, *(size_t*)this, m_AllocationCount));

--- a/src/vm/jitinterface.h
+++ b/src/vm/jitinterface.h
@@ -1360,11 +1360,29 @@ public:
         LIMITED_METHOD_CONTRACT;
         return m_fRel32Overflow;
     }
+
+    size_t GetReserveForJumpStubs()
+    {
+        LIMITED_METHOD_CONTRACT;
+        return m_reserveForJumpStubs;
+    }
+
+    void SetReserveForJumpStubs(size_t value)
+    {
+        LIMITED_METHOD_CONTRACT;
+        m_reserveForJumpStubs = value;
+    }
 #else
     BOOL JitAgain()
     {
         LIMITED_METHOD_CONTRACT;
         return FALSE;
+    }
+
+    size_t GetReserveForJumpStubs()
+    {
+        LIMITED_METHOD_CONTRACT;
+        return 0;
     }
 #endif
 
@@ -1385,6 +1403,7 @@ public:
 #ifdef _TARGET_AMD64_
           m_fAllowRel32(FALSE),
           m_fRel32Overflow(FALSE),
+          m_reserveForJumpStubs(0),
 #endif
           m_GCinfo_len(0),
           m_EHinfo_len(0),
@@ -1469,6 +1488,7 @@ protected :
     BOOL                    m_fAllowRel32;      // Use 32-bit PC relative address modes
     BOOL                    m_fRel32Overflow;   // Overflow while trying to use encode 32-bit PC relative address. 
                                                 // The code will need to be regenerated with m_fRel32Allowed == FALSE.
+    size_t                  m_reserveForJumpStubs; // Space to reserve for jump stubs when allocating code
 #endif
 
 #if defined(_DEBUG)


### PR DESCRIPTION
This set of changes is fixing #14995  and #14996, and improves reliability of jump stub allocation. The key changes are:

- Retry JITing on failure to allocate jump stub. Failure to allocate jump during JITing is not fatal anymore. There is extra memory reserved for jump stubs on retry to ensure that the retry succeeds allocating the jump stubs that it needs with high probability.

- Reserve space for jump stubs for precodes and other code fragments at the end of each code heap segment. This is trying to ensure that eventual allocation of jump stubs for precodes and other code fragments succeeds. Accounting is done conservatively - reserves more than strictly required. It wastes a bit of address space, but no actual memory. Also, this reserve is not used to allocate jump stubs for JITed code since the JITing can recover from failure to allocate the jump stub now.

My plan is to port these changes to .NET Framework as well since these issues affect important workloads there.