### PR TITLE
Expose Environment.ProcessorCount via EnvironmentAugments

### DIFF
--- a/src/mscorlib/src/Internal/Runtime/Augments/EnvironmentAugments.cs
+++ b/src/mscorlib/src/Internal/Runtime/Augments/EnvironmentAugments.cs
@@ -23,6 +23,7 @@ namespace Internal.Runtime.Augments
         public static string GetEnvironmentVariable(string variable, EnvironmentVariableTarget target) => Environment.GetEnvironmentVariable(variable, target);
         public static IEnumerable<KeyValuePair<string, string>> EnumerateEnvironmentVariables() => Environment.EnumerateEnvironmentVariables();
         public static IEnumerable<KeyValuePair<string, string>> EnumerateEnvironmentVariables(EnvironmentVariableTarget target) => Environment.EnumerateEnvironmentVariables(target);
+        public static int ProcessorCount => Environment.ProcessorCount;
 
         public static void SetEnvironmentVariable(string variable, string value) => Environment.SetEnvironmentVariable(variable, value);
         public static void SetEnvironmentVariable(string variable, string value, EnvironmentVariableTarget target) => Environment.SetEnvironmentVariable(variable, value, target);


### PR DESCRIPTION
This allows corefx and and corert to use the coreclr implementation and will fix https://github.com/dotnet/corefx/issues/25193.

Once this is merged, I'll make PRs in corefx and corert repos.

CC @jkotas @stephentoub 