### PR TITLE
Unmark unused fields as not lvOnFrame

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -12660,8 +12660,8 @@ GenTree* Compiler::gtFoldTypeCompare(GenTree* tree)
         // If we have class handles, try and resolve the type equality test completely.
         if ((cls1Hnd != nullptr) && (cls2Hnd != nullptr))
         {
-            JITDUMP("Asking runtime to compare %p (%s) and %p (%s) for equality\n", cls1Hnd,
-                    info.compCompHnd->getClassName(cls1Hnd), cls2Hnd, info.compCompHnd->getClassName(cls2Hnd));
+            JITDUMP("Asking runtime to compare %p (%s) and %p (%s) for equality\n", dspPtr(cls1Hnd),
+                    info.compCompHnd->getClassName(cls1Hnd), dspPtr(cls2Hnd), info.compCompHnd->getClassName(cls2Hnd));
             TypeCompareState s = info.compCompHnd->compareTypesForEquality(cls1Hnd, cls2Hnd);
 
             if (s != TypeCompareState::May)

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -9787,7 +9787,7 @@ GenTree* Compiler::impOptimizeCastClassOrIsInst(GenTree* op1, CORINFO_RESOLVED_T
     {
         CORINFO_CLASS_HANDLE toClass = pResolvedToken->hClass;
         JITDUMP("\nConsidering optimization of %s from %s%p (%s) to %p (%s)\n", isCastClass ? "castclass" : "isinst",
-                isExact ? "exact " : "", fromClass, info.compCompHnd->getClassName(fromClass), toClass,
+                isExact ? "exact " : "", dspPtr(fromClass), info.compCompHnd->getClassName(fromClass), dspPtr(toClass),
                 info.compCompHnd->getClassName(toClass));
 
         // Perhaps we know if the cast will succeed or fail.

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -6423,7 +6423,15 @@ void Compiler::lvaAssignFrameOffsetsToPromotedStructs()
             {
                 noway_assert(promotionType == PROMOTION_TYPE_DEPENDENT);
                 noway_assert(varDsc->lvOnFrame);
-                varDsc->lvStkOffs = parentvarDsc->lvStkOffs + varDsc->lvFldOffset;
+                if (parentvarDsc->lvOnFrame)
+                {
+                    varDsc->lvStkOffs = parentvarDsc->lvStkOffs + varDsc->lvFldOffset;
+                }
+                else
+                {
+                    varDsc->lvOnFrame = false;
+                    noway_assert(varDsc->lvRefCnt == 0);
+                }
             }
         }
     }


### PR DESCRIPTION
If a dependently promoted (i.e. non-register candidate) field of a struct is unused, and its parent is not allocated onto the stack, we cannot allocate the dependent fields to the stack either (they were previously being assigned offsets from 0, which may be in the GC ptr area, which causes an assert).

Fix #14548