### PR TITLE
Ifdef out Compiler::lvaVarPref

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2440,11 +2440,10 @@ public:
 #ifdef LEGACY_BACKEND
     // variable interference graph
     VARSET_TP lvaVarIntf[lclMAX_TRACKED];
-#endif
 
     // variable preference graph
     VARSET_TP lvaVarPref[lclMAX_TRACKED];
-
+#endif
 #if DOUBLE_ALIGN
 #ifdef DEBUG
     // # of procs compiled a with double-aligned stack


### PR DESCRIPTION
This legacy data member makes the Compiler objects 4 kbytes larger than it needs to be...

`nraUsed` drops by 7% and `allocateMemory` by 6%