### PR TITLE
Streamline fgExcludeFromSsa

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -1296,8 +1296,8 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
             noway_assert(lclNum < lvaCount);
             LclVarDsc* lclVar = &lvaTable[lclNum];
 
-            //  If the local variable has its address exposed then bail
-            if (fgExcludeFromSsa(lclNum))
+            //  If the local variable is not in SSA then bail
+            if (!lvaInSsa(lclNum))
             {
                 goto DONE_ASSERTION;
             }

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -330,6 +330,8 @@ public:
     unsigned char lvFieldAccessed : 1;   // The var is a struct local, and a field of the variable is accessed.  Affects
                                          // struct promotion.
 
+    unsigned char lvInSsa : 1; // The variable is in SSA form (set by SsaBuilder)
+
 #ifdef DEBUG
     // These further document the reasons for setting "lvDoNotEnregister".  (Note that "lvAddrExposed" is one of the
     // reasons;
@@ -3025,6 +3027,13 @@ public:
     unsigned lvaGSSecurityCookie; // LclVar number
     bool     lvaTempsHaveLargerOffsetThanVars();
 
+    // Returns "true" iff local variable "lclNum" is in SSA form.
+    bool lvaInSsa(unsigned lclNum)
+    {
+        assert(lclNum < lvaCount);
+        return lvaTable[lclNum].lvInSsa;
+    }
+
     unsigned lvaSecurityObject;  // variable representing the security object on the stack
     unsigned lvaStubArgumentVar; // variable representing the secret stub argument coming in EAX
 
@@ -4132,9 +4141,6 @@ public:
     void fgResetForSsa();
 
     unsigned fgSsaPassesCompleted; // Number of times fgSsaBuild has been run.
-
-    // Returns "true" iff lcl "lclNum" should be excluded from SSA.
-    inline bool fgExcludeFromSsa(unsigned lclNum);
 
     // Returns "true" if a struct temp of the given type requires needs zero init in this block
     inline bool fgStructTempNeedsExplicitZeroInit(LclVarDsc* varDsc, BasicBlock* block);

--- a/src/jit/copyprop.cpp
+++ b/src/jit/copyprop.cpp
@@ -38,7 +38,7 @@ void Compiler::optBlockCopyPropPopStacks(BasicBlock* block, LclNumToGenTreePtrSt
                 continue;
             }
             unsigned lclNum = tree->gtLclVarCommon.gtLclNum;
-            if (fgExcludeFromSsa(lclNum))
+            if (!lvaInSsa(lclNum))
             {
                 continue;
             }
@@ -153,8 +153,8 @@ void Compiler::optCopyProp(BasicBlock* block, GenTree* stmt, GenTree* tree, LclN
     }
     unsigned lclNum = tree->AsLclVarCommon()->GetLclNum();
 
-    // Skip address exposed variables.
-    if (fgExcludeFromSsa(lclNum))
+    // Skip non-SSA variables.
+    if (!lvaInSsa(lclNum))
     {
         return;
     }
@@ -287,7 +287,7 @@ void Compiler::optCopyProp(BasicBlock* block, GenTree* stmt, GenTree* tree, LclN
  */
 bool Compiler::optIsSsaLocal(GenTree* tree)
 {
-    return tree->IsLocal() && !fgExcludeFromSsa(tree->AsLclVarCommon()->GetLclNum());
+    return tree->IsLocal() && lvaInSsa(tree->AsLclVarCommon()->GetLclNum());
 }
 
 //------------------------------------------------------------------------------

--- a/src/jit/earlyprop.cpp
+++ b/src/jit/earlyprop.cpp
@@ -273,7 +273,7 @@ GenTree* Compiler::optEarlyPropRewriteTree(GenTree* tree)
         return nullptr;
     }
 
-    if (!objectRefPtr->OperIsScalarLocal() || fgExcludeFromSsa(objectRefPtr->AsLclVarCommon()->GetLclNum()))
+    if (!objectRefPtr->OperIsScalarLocal() || !lvaInSsa(objectRefPtr->AsLclVarCommon()->GetLclNum()))
 
     {
         return nullptr;
@@ -442,7 +442,7 @@ GenTree* Compiler::optPropGetValueRec(unsigned lclNum, unsigned ssaNum, optPropK
             assert(treelhs == treeDefParent->gtGetOp1());
             GenTree* treeRhs = treeDefParent->gtGetOp2();
 
-            if (treeRhs->OperIsScalarLocal() && !fgExcludeFromSsa(treeRhs->AsLclVarCommon()->GetLclNum()))
+            if (treeRhs->OperIsScalarLocal() && lvaInSsa(treeRhs->AsLclVarCommon()->GetLclNum()))
             {
                 // Recursively track the Rhs
                 unsigned rhsLclNum = treeRhs->AsLclVarCommon()->GetLclNum();

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17712,7 +17712,7 @@ void Compiler::fgRetypeImplicitByRefArgs()
 
             // Since this previously was a TYP_STRUCT and we have changed it to a TYP_BYREF
             // make sure that the following flag is not set as these will force SSA to
-            // exclude tracking/enregistering these LclVars. (see fgExcludeFromSsa)
+            // exclude tracking/enregistering these LclVars. (see SsaBuilder::IncludeInSsa)
             //
             varDsc->lvOverlappingFields = 0; // This flag could have been set, clear it.
 

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -7178,7 +7178,7 @@ bool Compiler::optTreeIsValidAtLoopHead(GenTree* tree, unsigned lnum)
         unsigned             lclNum = lclVar->gtLclNum;
 
         // The lvlVar must be have an Ssa tracked lifetime
-        if (fgExcludeFromSsa(lclNum))
+        if (!lvaInSsa(lclNum))
         {
             return false;
         }
@@ -7627,7 +7627,7 @@ void Compiler::optComputeLoopSideEffectsOfBlock(BasicBlock* blk)
                     {
                         // If it's a local byref for which we recorded a value number, use that...
                         GenTreeLclVar* argLcl = arg->AsLclVar();
-                        if (!fgExcludeFromSsa(argLcl->GetLclNum()))
+                        if (lvaInSsa(argLcl->GetLclNum()))
                         {
                             ValueNum argVN =
                                 lvaTable[argLcl->GetLclNum()].GetPerSsaData(argLcl->GetSsaNum())->m_vnPair.GetLiberal();
@@ -7717,7 +7717,7 @@ void Compiler::optComputeLoopSideEffectsOfBlock(BasicBlock* blk)
                     if (rhsVN != ValueNumStore::NoVN)
                     {
                         rhsVN = vnStore->VNNormVal(rhsVN);
-                        if (!fgExcludeFromSsa(lhsLcl->GetLclNum()))
+                        if (lvaInSsa(lhsLcl->GetLclNum()))
                         {
                             lvaTable[lhsLcl->GetLclNum()]
                                 .GetPerSsaData(lhsLcl->GetSsaNum())

--- a/src/jit/ssabuilder.h
+++ b/src/jit/ssabuilder.h
@@ -24,6 +24,8 @@ private:
         m_pCompiler->EndPhase(phase);
     }
 
+    bool IncludeInSsa(unsigned lclNum);
+
 public:
     // Constructor
     SsaBuilder(Compiler* pCompiler);


### PR DESCRIPTION
This function is relatively expensive due to the many checks it does. Adding an `LclVarDsc` "in SSA" bit that is set during SSA construction by calling `fgExcludeFromSsa` only once per variable results in 0.35% drop in instructions retired.

Most of the checks done in `fgExcludeFromSsa` are implied by `lvTracked` and they could probably be converted to asserts. But `lvOverlappingFields` is not implied by `lvTracked` so even if all redundant checks are converted to asserts `fgExcludeFromSsa` still needs 2 checks rather than just one.

Incidentally, this difference between tracked variables and SSA variables results in SSA and value numbers being assigned to some variables that are actually excluded from SSA - `SsaBuilder::RenameVariables` and `fgValueNumber` assign numbers to all live in `fgFirstBB` variables that require initialization without checking `fgExcludeFromSsa` first. Structs with overlapping fields are not common but properly excluding them is still enough to save 0.15% memory when compiling corelib.

- Replace calls to `fgExcludeFromSsa` with calls to `lvaInSsa` (the old name is kind of weird, it has nothing to do with the flow graph and "exclude" results in double negation)
- Move `fgExcludeFromSsa` logic to `SsaBuild::IncludeInSsa` and use it to initialize `LclVarDsc::lvInSsa` for all variables
- Change `RenameVariables` and `fgValueNumber` to call `lvaInSsa` before assigning numbers to live in `fgFirstBB` variables

PIN data: https://1drv.ms/x/s!Av4baJYSo5pjgrsOjE-3c5Tow10lFw

MemStats diff: https://gist.github.com/mikedn/9c9d6d7b40306d9fff18109c3a4b5e9c