### PR TITLE
Have a Type.IsCollectible property.

### DIFF
--- a/src/mscorlib/shared/System/Reflection/TypeDelegator.cs
+++ b/src/mscorlib/shared/System/Reflection/TypeDelegator.cs
@@ -112,6 +112,9 @@ namespace System.Reflection
         protected override bool IsCOMObjectImpl() => typeImpl.IsCOMObject;
         public override bool IsByRefLike => typeImpl.IsByRefLike;
         public override bool IsConstructedGenericType => typeImpl.IsConstructedGenericType;
+
+        public override bool IsCollectible => typeImpl.IsCollectible;
+
         public override Type GetElementType() => typeImpl.GetElementType();
         protected override bool HasElementTypeImpl() => typeImpl.HasElementType;
 

--- a/src/mscorlib/shared/System/Type.cs
+++ b/src/mscorlib/shared/System/Type.cs
@@ -102,6 +102,8 @@ namespace System
         public bool IsContextful => IsContextfulImpl();
         protected virtual bool IsContextfulImpl() => false;
 
+        public virtual bool IsCollectible => true;
+
         public virtual bool IsEnum => IsSubclassOf(typeof(Enum));
         public bool IsMarshalByRef => IsMarshalByRefImpl();
         protected virtual bool IsMarshalByRefImpl() => false;

--- a/src/mscorlib/src/System/RtType.cs
+++ b/src/mscorlib/src/System/RtType.cs
@@ -2459,7 +2459,7 @@ namespace System
                     IntPtr gcHandle = Interlocked.CompareExchange(ref m_cache, newgcHandle, IntPtr.Zero);
                     // Leak the handle if the type is collectible. It will be reclaimed when
                     // the type goes away.
-                    if (gcHandle != IntPtr.Zero && !IsCollectible())
+                    if (gcHandle != IntPtr.Zero && !IsCollectible)
                         GCHandle.InternalFree(newgcHandle);
                 }
 
@@ -3151,10 +3151,7 @@ namespace System
             return new RuntimeTypeHandle(this);
         }
 
-        internal bool IsCollectible()
-        {
-            return RuntimeTypeHandle.IsCollectible(GetTypeHandleInternal());
-        }
+        public sealed override bool IsCollectible => RuntimeTypeHandle.IsCollectible(GetTypeHandleInternal());
 
         protected override TypeCode GetTypeCodeImpl()
         {


### PR DESCRIPTION
dotnet/corefx#25671 asks for this as a public API, but this just seeks to make it available to corefx.

Motivation discussed at dotnet/corefx#25663 and dotnet/corefx#25670

Mirror PR to corert will need an overload making runtime types return false there.

cc @jkotas 