### PR TITLE
[Local GC] Pre-cleanup for FEATURE_EVENT_TRACE

### DIFF
--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -82,6 +82,7 @@ public:
     static bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name);
     static void WalkAsyncPinnedForPromotion(Object* object, ScanContext* sc, promote_func* callback);
     static void WalkAsyncPinned(Object* object, void* context, void(*callback)(Object*, Object*, void*));
+    static void FireGcStartAndGenerationRanges(uint32_t count, uint32_t depth, uint32_t reason, uint32_t type);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -84,6 +84,7 @@ public:
     static void WalkAsyncPinned(Object* object, void* context, void(*callback)(Object*, Object*, void*));
     static void FireGcStartAndGenerationRanges(uint32_t count, uint32_t depth, uint32_t reason, uint32_t type);
     static void FireGcEndAndGenerationRanges(uint32_t count, uint32_t depth);
+    static void FireAllocationTick(size_t allocationAmount, bool isSohAllocation, uint32_t heapNumber, uint8_t* objectAddress);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -83,6 +83,7 @@ public:
     static void WalkAsyncPinnedForPromotion(Object* object, ScanContext* sc, promote_func* callback);
     static void WalkAsyncPinned(Object* object, void* context, void(*callback)(Object*, Object*, void*));
     static void FireGcStartAndGenerationRanges(uint32_t count, uint32_t depth, uint32_t reason, uint32_t type);
+    static void FireGcEndAndGenerationRanges(uint32_t count, uint32_t depth);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -85,6 +85,7 @@ public:
     static void FireGcStartAndGenerationRanges(uint32_t count, uint32_t depth, uint32_t reason, uint32_t type);
     static void FireGcEndAndGenerationRanges(uint32_t count, uint32_t depth);
     static void FireAllocationTick(size_t allocationAmount, bool isSohAllocation, uint32_t heapNumber, uint8_t* objectAddress);
+    static void FirePinObject(uint8_t* objectAddress, uint8_t** pinningObjectAddress);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/gcee.cpp
+++ b/src/gc/gcee.cpp
@@ -454,33 +454,7 @@ void gc_heap::fire_etw_allocation_event (size_t allocation_amount, int gen_numbe
 
 void gc_heap::fire_etw_pin_object_event (uint8_t* object, uint8_t** ppObject)
 {
-#ifdef FEATURE_REDHAWK
-    UNREFERENCED_PARAMETER(object);
-    UNREFERENCED_PARAMETER(ppObject);
-#else
-    Object* obj = (Object*)object;
-
-    InlineSString<MAX_CLASSNAME_LENGTH> strTypeName; 
-   
-    EX_TRY
-    {
-        FAULT_NOT_FATAL();
-
-        TypeHandle th = obj->GetGCSafeTypeHandleIfPossible();
-        if(th != NULL)
-        {
-            th.GetName(strTypeName);
-        }
-
-        FireEtwPinObjectAtGCTime(ppObject,
-                             object,
-                             obj->GetSize(),
-                             strTypeName.GetUnicode(),
-                             GetClrInstanceId());
-    }
-    EX_CATCH {}
-    EX_END_CATCH(SwallowAllExceptions)
-#endif // FEATURE_REDHAWK
+    GCToEEInterface::FirePinObject(object, ppObject);
 }
 #endif // FEATURE_EVENT_TRACE
 

--- a/src/gc/gcee.cpp
+++ b/src/gc/gcee.cpp
@@ -190,11 +190,7 @@ void GCHeap::UpdatePostGCCounters()
 #endif //ENABLE_PERF_COUNTERS || FEATURE_EVENT_TRACE
 
 #ifdef FEATURE_EVENT_TRACE
-    ETW::GCLog::ETW_GC_INFO Info;
-
-    Info.GCEnd.Depth = condemned_gen;
-    Info.GCEnd.Count = (uint32_t)pSettings->gc_index;
-    ETW::GCLog::FireGcEndAndGenerationRanges(Info.GCEnd.Count, Info.GCEnd.Depth);
+    GCToEEInterface::FireGcEndAndGenerationRanges(condemned_gen, (uint32_t)pSettings->gc_index);
 
     ETW::GCLog::ETW_GC_INFO HeapInfo;
     ZeroMemory(&HeapInfo, sizeof(HeapInfo));

--- a/src/gc/gcee.cpp
+++ b/src/gc/gcee.cpp
@@ -74,10 +74,8 @@ void GCHeap::UpdatePreGCCounters()
 
     GetPerfCounters().m_Security.timeRTchecks = 0;
     GetPerfCounters().m_Security.timeRTchecksBase = 1; // To avoid divide by zero
-
 #endif //ENABLE_PERF_COUNTERS
 
-#ifdef FEATURE_EVENT_TRACE
 #ifdef MULTIPLE_HEAPS
         //take the first heap....
     gc_mechanisms *pSettings = &gc_heap::g_heaps[0]->settings;
@@ -85,27 +83,24 @@ void GCHeap::UpdatePreGCCounters()
     gc_mechanisms *pSettings = &gc_heap::settings;
 #endif //MULTIPLE_HEAPS
 
-    ETW::GCLog::ETW_GC_INFO Info;
+    uint32_t count = (uint32_t)pSettings->gc_index;
+    uint32_t depth = (uint32_t)pSettings->condemned_generation;
+    uint32_t reason = (uint32_t)pSettings->reason;
 
-    Info.GCStart.Count = (uint32_t)pSettings->gc_index;
-    Info.GCStart.Depth = (uint32_t)pSettings->condemned_generation;
-    Info.GCStart.Reason = (ETW::GCLog::ETW_GC_INFO::GC_REASON)((int)(pSettings->reason));
-
-    Info.GCStart.Type = ETW::GCLog::ETW_GC_INFO::GC_NGC;
+    uint32_t type = /*ETW::GCLog::ETW_GC_INFO::GC_NGC*/ 0;
     if (pSettings->concurrent)
     {
-        Info.GCStart.Type = ETW::GCLog::ETW_GC_INFO::GC_BGC;
+        type = /*ETW::GCLog::ETW_GC_INFO::GC_BGC*/ 1;
     }
 #ifdef BACKGROUND_GC
-    else if (Info.GCStart.Depth < max_generation)
+    else if (depth < max_generation)
     {
         if (pSettings->background_p)
-            Info.GCStart.Type = ETW::GCLog::ETW_GC_INFO::GC_FGC;
+            type = /*ETW::GCLog::ETW_GC_INFO::GC_FGC*/ 2;
     }
 #endif //BACKGROUND_GC
 
-    ETW::GCLog::FireGcStartAndGenerationRanges(&Info);
-#endif // FEATURE_EVENT_TRACE
+    GCToEEInterface::FireGcStartAndGenerationRanges(count, depth, reason, type);
 }
 
 void GCHeap::UpdatePostGCCounters()

--- a/src/gc/gcee.cpp
+++ b/src/gc/gcee.cpp
@@ -449,41 +449,9 @@ bool GCHeap::IsConcurrentGCInProgress()
 #ifdef FEATURE_EVENT_TRACE
 void gc_heap::fire_etw_allocation_event (size_t allocation_amount, int gen_number, uint8_t* object_address)
 {
-    void * typeId = nullptr;
-    const WCHAR * name = nullptr;
-#ifdef FEATURE_REDHAWK
-    typeId = RedhawkGCInterface::GetLastAllocEEType();
-#else
-    InlineSString<MAX_CLASSNAME_LENGTH> strTypeName;
-
-    EX_TRY
-    {
-        TypeHandle th = GCToEEInterface::GetThread()->GetTHAllocContextObj();
-
-        if (th != 0)
-        {
-            th.GetName(strTypeName);
-            name = strTypeName.GetUnicode();
-            typeId = th.GetMethodTable();
-        }
-    }
-    EX_CATCH {}
-    EX_END_CATCH(SwallowAllExceptions)
-#endif
-
-    if (typeId != nullptr)
-    {
-        FireEtwGCAllocationTick_V3((uint32_t)allocation_amount,
-                                   ((gen_number == 0) ? ETW::GCLog::ETW_GC_INFO::AllocationSmall : ETW::GCLog::ETW_GC_INFO::AllocationLarge), 
-                                   GetClrInstanceId(),
-                                   allocation_amount,
-                                   typeId, 
-                                   name,
-                                   heap_number,
-                                   object_address
-                                   );
-    }
+    GCToEEInterface::FireAllocationTick(allocation_amount, gen_number == 0, heap_number, object_address);
 }
+
 void gc_heap::fire_etw_pin_object_event (uint8_t* object, uint8_t** ppObject)
 {
 #ifdef FEATURE_REDHAWK

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -288,4 +288,10 @@ inline void GCToEEInterface::FireAllocationTick(size_t allocationAmount, bool is
     g_theGCToCLR->FireAllocationTick(allocationAmount, isSohAllocation, heapNumber, objectAddress);
 }
 
+inline void GCToEEInterface::FirePinObject(uint8_t* objectAddress, uint8_t** pinningObjectAddress) 
+{
+    assert(g_theGCToCLR != nullptr);
+    g_theGCToCLR->FirePinObject(objectAddress, pinningObjectAddress);
+}
+
 #endif // __GCTOENV_EE_STANDALONE_INL__

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -276,4 +276,10 @@ inline void GCToEEInterface::FireGcStartAndGenerationRanges(uint32_t count, uint
     g_theGCToCLR->FireGcStartAndGenerationRanges(count, depth, reason, type);
 }
 
+inline void GCToEEInterface::FireGcEndAndGenerationRanges(uint32_t count, uint32_t depth)
+{
+    assert(g_theGCToCLR != nullptr);
+    g_theGCToCLR->FireGcEndAndGenerationRanges(count, depth);
+}
+
 #endif // __GCTOENV_EE_STANDALONE_INL__

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -261,13 +261,19 @@ inline bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg,
 inline void GCToEEInterface::WalkAsyncPinnedForPromotion(Object* object, ScanContext* sc, promote_func* callback)
 {
     assert(g_theGCToCLR != nullptr);
-    return g_theGCToCLR->WalkAsyncPinnedForPromotion(object, sc, callback);
+    g_theGCToCLR->WalkAsyncPinnedForPromotion(object, sc, callback);
 }
 
 inline void GCToEEInterface::WalkAsyncPinned(Object* object, void* context, void(*callback)(Object*, Object*, void*))
 {
     assert(g_theGCToCLR != nullptr);
-    return g_theGCToCLR->WalkAsyncPinned(object, context, callback);
+    g_theGCToCLR->WalkAsyncPinned(object, context, callback);
+}
+
+inline void GCToEEInterface::FireGcStartAndGenerationRanges(uint32_t count, uint32_t depth, uint32_t reason, uint32_t type)
+{
+    assert(g_theGCToCLR != nullptr);
+    g_theGCToCLR->FireGcStartAndGenerationRanges(count, depth, reason, type);
 }
 
 #endif // __GCTOENV_EE_STANDALONE_INL__

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -282,4 +282,10 @@ inline void GCToEEInterface::FireGcEndAndGenerationRanges(uint32_t count, uint32
     g_theGCToCLR->FireGcEndAndGenerationRanges(count, depth);
 }
 
+inline void GCToEEInterface::FireAllocationTick(size_t allocationAmount, bool isSohAllocation, uint32_t heapNumber, uint8_t* objectAddress) 
+{
+    assert(g_theGCToCLR != nullptr);
+    g_theGCToCLR->FireAllocationTick(allocationAmount, isSohAllocation, heapNumber, objectAddress);
+}
+
 #endif // __GCTOENV_EE_STANDALONE_INL__

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -263,6 +263,9 @@ public:
 
     virtual
     void FireAllocationTick(size_t allocationAmount, bool isSohAllocation, uint32_t heapNumber, uint8_t* objectAddress) = 0;
+
+    virtual
+    void FirePinObject(uint8_t* objectAddress, uint8_t** pinningObjectAddress) = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -255,15 +255,22 @@ public:
     //
     // Routines related to event tracing.
     //
+
+    // Fires the GCStart event, as well as events describing each generation.
     virtual
     void FireGcStartAndGenerationRanges(uint32_t count, uint32_t depth, uint32_t reason, uint32_t type) = 0;
 
+    // Fires the GCStop event, as well as events describing each generation.
     virtual
     void FireGcEndAndGenerationRanges(uint32_t count, uint32_t depth) = 0;
 
+    // Fires the AllocationTick event. The AllocationTick event itself contains the typeId and name
+    // of the last object that was allocated.
     virtual
     void FireAllocationTick(size_t allocationAmount, bool isSohAllocation, uint32_t heapNumber, uint8_t* objectAddress) = 0;
 
+    // Fires the PinObjectAtGCTime event. The PinObjectAtGCTime event contains the name of the type that is
+    // pinned, in addition to the address of the location that is pinning the object.
     virtual
     void FirePinObject(uint8_t* objectAddress, uint8_t** pinningObjectAddress) = 0;
 };

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -257,6 +257,9 @@ public:
     //
     virtual
     void FireGcStartAndGenerationRanges(uint32_t count, uint32_t depth, uint32_t reason, uint32_t type) = 0;
+
+    virtual
+    void FireGcEndAndGenerationRanges(uint32_t count, uint32_t depth) = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -260,6 +260,9 @@ public:
 
     virtual
     void FireGcEndAndGenerationRanges(uint32_t count, uint32_t depth) = 0;
+
+    virtual
+    void FireAllocationTick(size_t allocationAmount, bool isSohAllocation, uint32_t heapNumber, uint8_t* objectAddress) = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -251,6 +251,12 @@ public:
     // This function is a no-op if "object" is not an OverlappedData object.
     virtual
     void WalkAsyncPinned(Object* object, void* context, void(*callback)(Object*, Object*, void*)) = 0;
+
+    //
+    // Routines related to event tracing.
+    //
+    virtual
+    void FireGcStartAndGenerationRanges(uint32_t count, uint32_t depth, uint32_t reason, uint32_t type) = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -337,3 +337,7 @@ void GCToEEInterface::WalkAsyncPinnedForPromotion(Object* object, ScanContext* s
 void GCToEEInterface::WalkAsyncPinned(Object* object, void* context, void (*callback)(Object*, Object*, void*))
 {
 }
+
+void GCToEEInterface::FireGcStartAndGenerationRanges(uint32_t count, uint32_t depth, uint32_t reason, uint32_t type)
+{
+}

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -349,3 +349,7 @@ void GCToEEInterface::FireGcEndAndGenerationRanges(uint32_t count, uint32_t dept
 void GCToEEInterface::FireAllocationTick(size_t allocationAmount, bool isSohAllocation, uint32_t heapNumber, uint8_t* objectAddress)
 {
 }
+
+void GCToEEInterface::FirePinObject(uint8_t* objectAddres, uint8_t** pinningObjectAddress)
+{
+}

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -345,3 +345,7 @@ void GCToEEInterface::FireGcStartAndGenerationRanges(uint32_t count, uint32_t de
 void GCToEEInterface::FireGcEndAndGenerationRanges(uint32_t count, uint32_t depth)
 {
 }
+
+void GCToEEInterface::FireAllocationTick(size_t allocationAmount, bool isSohAllocation, uint32_t heapNumber, uint8_t* objectAddress)
+{
+}

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -341,3 +341,7 @@ void GCToEEInterface::WalkAsyncPinned(Object* object, void* context, void (*call
 void GCToEEInterface::FireGcStartAndGenerationRanges(uint32_t count, uint32_t depth, uint32_t reason, uint32_t type)
 {
 }
+
+void GCToEEInterface::FireGcEndAndGenerationRanges(uint32_t count, uint32_t depth)
+{
+}

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1389,19 +1389,23 @@ void GCToEEInterface::FireGcStartAndGenerationRanges(uint32_t count, uint32_t de
 {
     LIMITED_METHOD_CONTRACT;
 
+#ifdef FEATURE_EVENT_TRACE
     ETW::GCLog::ETW_GC_INFO info;
     info.GCStart.Count = count;
     info.GCStart.Depth = depth;
     info.GCStart.Reason = (ETW::GCLog::ETW_GC_INFO::GC_REASON)reason;
     info.GCStart.Type = (ETW::GCLog::st_GCEventInfo::GC_TYPE)type;
     ETW::GCLog::FireGcStartAndGenerationRanges(&info);
+#endif // FEATURE_EVENT_TRACE
 }
 
 void GCToEEInterface::FireGcEndAndGenerationRanges(uint32_t count, uint32_t depth)
 {
     LIMITED_METHOD_CONTRACT;
 
+#ifdef FEATURE_EVENT_TRACE
     ETW::GCLog::FireGcEndAndGenerationRanges(count, depth);
+#endif // FEATURE_EVENT_TRACE
 }
 
 void GCToEEInterface::FireAllocationTick(size_t allocationAmount, bool isSohAllocation, uint32_t heapNumber, uint8_t* objectAddress)

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1440,3 +1440,31 @@ void GCToEEInterface::FireAllocationTick(size_t allocationAmount, bool isSohAllo
                                    );
     }
 }
+
+void GCToEEInterface::FirePinObject(uint8_t* objectAddress, uint8_t** pinningObjectAddress)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    Object* obj = (Object*)objectAddress;
+
+    InlineSString<MAX_CLASSNAME_LENGTH> strTypeName; 
+   
+    EX_TRY
+    {
+        FAULT_NOT_FATAL();
+
+        TypeHandle th = obj->GetGCSafeTypeHandleIfPossible();
+        if(th != NULL)
+        {
+            th.GetName(strTypeName);
+        }
+
+        FireEtwPinObjectAtGCTime(pinningObjectAddress,
+                             objectAddress,
+                             obj->GetSize(),
+                             strTypeName.GetUnicode(),
+                             GetClrInstanceId());
+    }
+    EX_CATCH {}
+    EX_END_CATCH(SwallowAllExceptions)
+}

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1396,3 +1396,10 @@ void GCToEEInterface::FireGcStartAndGenerationRanges(uint32_t count, uint32_t de
     info.GCStart.Type = (ETW::GCLog::st_GCEventInfo::GC_TYPE)type;
     ETW::GCLog::FireGcStartAndGenerationRanges(&info);
 }
+
+void GCToEEInterface::FireGcEndAndGenerationRanges(uint32_t count, uint32_t depth)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    ETW::GCLog::FireGcEndAndGenerationRanges(count, depth);
+}

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1384,3 +1384,15 @@ void GCToEEInterface::WalkAsyncPinned(Object* object, void* context, void (*call
         }
     }
 }
+
+void GCToEEInterface::FireGcStartAndGenerationRanges(uint32_t count, uint32_t depth, uint32_t reason, uint32_t type)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    ETW::GCLog::ETW_GC_INFO info;
+    info.GCStart.Count = count;
+    info.GCStart.Depth = depth;
+    info.GCStart.Reason = (ETW::GCLog::ETW_GC_INFO::GC_REASON)reason;
+    info.GCStart.Type = (ETW::GCLog::st_GCEventInfo::GC_TYPE)type;
+    ETW::GCLog::FireGcStartAndGenerationRanges(&info);
+}

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -64,6 +64,7 @@ public:
     void WalkAsyncPinned(Object* object, void* context, void(*callback)(Object*, Object*, void*));
     void FireGcStartAndGenerationRanges(uint32_t count, uint32_t depth, uint32_t reason, uint32_t type);
     void FireGcEndAndGenerationRanges(uint32_t count, uint32_t depth);
+    void FireAllocationTick(size_t allocationAmount, bool isSohAllocation, uint32_t heapNumber, uint8_t* objectAddress);
 };
 
 } // namespace standalone

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -65,6 +65,7 @@ public:
     void FireGcStartAndGenerationRanges(uint32_t count, uint32_t depth, uint32_t reason, uint32_t type);
     void FireGcEndAndGenerationRanges(uint32_t count, uint32_t depth);
     void FireAllocationTick(size_t allocationAmount, bool isSohAllocation, uint32_t heapNumber, uint8_t* objectAddress);
+    void FirePinObject(uint8_t* objectAddress, uint8_t** pinningObjectAddress);
 };
 
 } // namespace standalone

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -63,6 +63,7 @@ public:
     void WalkAsyncPinnedForPromotion(Object* object, ScanContext* sc, promote_func* callback);
     void WalkAsyncPinned(Object* object, void* context, void(*callback)(Object*, Object*, void*));
     void FireGcStartAndGenerationRanges(uint32_t count, uint32_t depth, uint32_t reason, uint32_t type);
+    void FireGcEndAndGenerationRanges(uint32_t count, uint32_t depth);
 };
 
 } // namespace standalone

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -62,6 +62,7 @@ public:
     bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name);
     void WalkAsyncPinnedForPromotion(Object* object, ScanContext* sc, promote_func* callback);
     void WalkAsyncPinned(Object* object, void* context, void(*callback)(Object*, Object*, void*));
+    void FireGcStartAndGenerationRanges(uint32_t count, uint32_t depth, uint32_t reason, uint32_t type);
 };
 
 } // namespace standalone


### PR DESCRIPTION
This PR tries to address some of the issues that arise when working towards https://github.com/dotnet/coreclr/issues/11514. It revolves around four problematic events that are fired from within `gcee.cpp`:

* `GcStart` and `GcEnd`, along with corresponding range events that are fired at the start and end of GCs
* `AllocationTick`
* `PinPlugAtGCTime`

Each one of these runs into trouble when building standalone:

1. `GcStart` and `GcEnd` are both fired not by the GC but by `ETW::GCLog::FireGcStartAndGenerationRanges`. Each one of them fires the GcStart/End event and in turn walks each heap to fire events per generation using [this callback](https://github.com/dotnet/coreclr/blob/master/src/gc/gcinterface.h#L783-L784). Out of all of the changes in this PR, I am the least convinced that this code should live on the EE side; it may be desirable to move some of this code back to the GC.
2. `AllocationTick` gets a TypeHandle of the most recently allocated object and uses it to get the name of that type. The GC does not keep track of the most recently allocated object and also is not aware of how to turn TypeHandles into type names - the GC doesn't even know what a TypeHandle is.
3. `PinPlugAtGCTime` gets a TypeHandle for a given pinned object and uses it to get the name of the object.

This PR moves the firing of these events to callbacks on `IGCToCLR` in the hopes of avoiding the above issues.