### PR TITLE
JIT: fix remorph assert in cast long shift optimization

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -490,6 +490,11 @@ GenTreePtr Compiler::fgMorphCast(GenTreePtr tree)
                 shiftAmount      = gtFoldExpr(shiftAmount);
                 oper->gtOp.gtOp2 = shiftAmount;
 
+#if DEBUG
+                // We may remorph the shift amount tree again later, so clear any morphed flag.
+                shiftAmount->gtDebugFlags &= ~GTF_DEBUG_NODE_MORPHED;
+#endif // DEBUG
+
                 if (shiftAmount->IsIntegralConst())
                 {
                     const ssize_t shiftAmountValue = shiftAmount->AsIntCon()->IconValue();

--- a/tests/src/JIT/Regression/JitBlue/GitHub_15319/GitHub_15319_1.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_15319/GitHub_15319_1.il
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Test for remorphing subexpressions in casts of long shifts.
+
+.assembly extern System.Private.CoreLib {}
+.assembly GitHub_15319_1 {}
+
+.class private auto ansi beforefieldinit Q
+       extends [System.Private.CoreLib]System.Object
+{
+  .method public hidebysig static int32  P(int64 x) cil managed noinlining
+  {
+       ldarg.s      0x0
+       dup         
+       ldarg.s      0x0
+       clt         
+       shl         
+       ret 
+  }
+
+  .method public hidebysig static int32  Main(string[] args) cil managed
+  {
+       .entrypoint
+       ldc.i4.s   100
+       conv.i8
+       call       int32 Q::P(int64)
+       ret
+  }
+} 

--- a/tests/src/JIT/Regression/JitBlue/GitHub_15319/GitHub_15319_1.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_15319/GitHub_15319_1.ilproj
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_15319_1.il" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
In some cases reachable from IL we may simplify the shift amount,
which sets the MORPHED flag, and then later remorph, leading to an assert
in DEBUG/CHECK builds.

Fix is to clear the MORPHED flag.

Added test case.