### PR TITLE
Eliminate gtLsraInfo from GenTree

### DIFF
--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -10070,11 +10070,13 @@ void emitter::emitDispImm(ssize_t imm, bool addComma, bool alwaysHex /* =false *
         printf("#");
     }
 
-    // Munge any pointers if we want diff-able disassembly
+    // Munge any pointers if we want diff-able disassembly.
+    // Since some may be emitted as partial words, print as diffable anything that has
+    // significant bits beyond the lowest 8-bits.
     if (emitComp->opts.disDiffable)
     {
-        ssize_t top44bits = (imm >> 20);
-        if ((top44bits != 0) && (top44bits != -1))
+        ssize_t top56bits = (imm >> 8);
+        if ((top56bits != 0) && (top56bits != -1))
             imm = 0xD1FFAB1E;
     }
 

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -1763,3 +1763,10 @@ void LIR::InsertBeforeTerminator(BasicBlock* block, LIR::Range&& range)
 
     blockRange.InsertBefore(insertionPoint, std::move(range));
 }
+
+#ifdef DEBUG
+void GenTree::dumpLIRFlags()
+{
+    JITDUMP("[%c%c%c]", IsUnusedValue() ? 'U' : '-', IsRegOptional() ? 'O' : '-');
+}
+#endif

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -1767,6 +1767,6 @@ void LIR::InsertBeforeTerminator(BasicBlock* block, LIR::Range&& range)
 #ifdef DEBUG
 void GenTree::dumpLIRFlags()
 {
-    JITDUMP("[%c%c%c]", IsUnusedValue() ? 'U' : '-', IsRegOptional() ? 'O' : '-');
+    JITDUMP("[%c%c]", IsUnusedValue() ? 'U' : '-', IsRegOptional() ? 'O' : '-');
 }
 #endif

--- a/src/jit/lir.h
+++ b/src/jit/lir.h
@@ -38,6 +38,9 @@ public:
                                 // that this bit should not be assumed to be valid
                                 // at all points during compilation: it is currently
                                 // only computed during target-dependent lowering.
+
+            RegOptional = 0x04, // Set on a node if it produces a value, but does not
+                                // require a register (i.e. it can be used from memory).
         };
     };
 
@@ -325,6 +328,21 @@ inline void GenTree::ClearUnusedValue()
 inline bool GenTree::IsUnusedValue() const
 {
     return (gtLIRFlags & LIR::Flags::UnusedValue) != 0;
+}
+
+inline void GenTree::SetRegOptional()
+{
+    gtLIRFlags |= LIR::Flags::RegOptional;
+}
+
+inline void GenTree::ClearRegOptional()
+{
+    gtLIRFlags &= ~LIR::Flags::RegOptional;
+}
+
+inline bool GenTree::IsRegOptional() const
+{
+    return (gtLIRFlags & LIR::Flags::RegOptional) != 0;
 }
 
 #endif // _LIR_H_

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -224,22 +224,6 @@ private:
     bool IsCallTargetInRange(void* addr);
 
 #if defined(_TARGET_XARCH_)
-    //----------------------------------------------------------------------
-    // SetRegOptional - sets a bit to indicate to LSRA that register
-    // for a given tree node is optional for codegen purpose.  If no
-    // register is allocated to such a tree node, its parent node treats
-    // it as a contained memory operand during codegen.
-    //
-    // Arguments:
-    //    tree    -   GenTree node
-    //
-    // Returns
-    //    None
-    void SetRegOptional(GenTree* tree)
-    {
-        tree->gtLsraInfo.regOptional = true;
-    }
-
     GenTree* PreferredRegOptionalOperand(GenTree* tree);
 
     // ------------------------------------------------------------------
@@ -273,13 +257,18 @@ private:
         const bool op1Legal = tree->OperIsCommutative() && (operatorSize == genTypeSize(op1->TypeGet()));
         const bool op2Legal = operatorSize == genTypeSize(op2->TypeGet());
 
+        GenTree* regOptionalOperand = nullptr;
         if (op1Legal)
         {
-            SetRegOptional(op2Legal ? PreferredRegOptionalOperand(tree) : op1);
+            regOptionalOperand = op2Legal ? PreferredRegOptionalOperand(tree) : op1;
         }
         else if (op2Legal)
         {
-            SetRegOptional(op2);
+            regOptionalOperand = op2;
+        }
+        if (regOptionalOperand != nullptr)
+        {
+            regOptionalOperand->SetRegOptional();
         }
     }
 #endif // defined(_TARGET_XARCH_)

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -472,8 +472,6 @@ void Lowering::LowerPutArgStk(GenTreePutArgStk* putArgStk)
             head->gtSeqNum = fieldList->gtSeqNum;
 #endif // DEBUG
 
-            head->gtLsraInfo = fieldList->gtLsraInfo;
-
             BlockRange().InsertAfter(fieldList, head);
             BlockRange().Remove(fieldList);
 
@@ -515,7 +513,7 @@ void Lowering::LowerPutArgStk(GenTreePutArgStk* putArgStk)
                     LclVarDsc* varDsc = &(comp->lvaTable[fieldNode->AsLclVarCommon()->gtLclNum]);
                     if (!varDsc->lvDoNotEnregister)
                     {
-                        SetRegOptional(fieldNode);
+                        fieldNode->SetRegOptional();
                     }
                     else
                     {
@@ -533,7 +531,7 @@ void Lowering::LowerPutArgStk(GenTreePutArgStk* putArgStk)
                     // than spilling, but this situation is not all that common, as most cases of promoted
                     // structs do not have a large number of fields, and of those most are lclVars or
                     // copy-propagated constants.
-                    SetRegOptional(fieldNode);
+                    fieldNode->SetRegOptional();
                 }
             }
 
@@ -1655,12 +1653,12 @@ void Lowering::ContainCheckMul(GenTreeOp* node)
             // Has a contained immediate operand.
             // Only 'other' operand can be marked as reg optional.
             assert(other != nullptr);
-            SetRegOptional(other);
+            other->SetRegOptional();
         }
         else if (hasImpliedFirstOperand)
         {
             // Only op2 can be marke as reg optional.
-            SetRegOptional(op2);
+            op2->SetRegOptional();
         }
         else
         {
@@ -1779,7 +1777,7 @@ void Lowering::ContainCheckCast(GenTreeCast* node)
             {
                 // Mark castOp as reg optional to indicate codegen
                 // can still generate code if it is on stack.
-                SetRegOptional(castOp);
+                castOp->SetRegOptional();
             }
         }
     }
@@ -1854,7 +1852,7 @@ void Lowering::ContainCheckCompare(GenTreeOp* cmp)
         {
             // SSE2 allows only otherOp to be a memory-op. Since otherOp is not
             // contained, we can mark it reg-optional.
-            SetRegOptional(otherOp);
+            otherOp->SetRegOptional();
         }
 
         return;
@@ -1875,7 +1873,7 @@ void Lowering::ContainCheckCompare(GenTreeOp* cmp)
             }
             else
             {
-                SetRegOptional(op1);
+                op1->SetRegOptional();
             }
         }
     }
@@ -1894,14 +1892,14 @@ void Lowering::ContainCheckCompare(GenTreeOp* cmp)
         }
         else if (op1->IsCnsIntOrI())
         {
-            SetRegOptional(op2);
+            op2->SetRegOptional();
         }
         else
         {
             // One of op1 or op2 could be marked as reg optional
             // to indicate that codegen can still generate code
             // if one of them is on stack.
-            SetRegOptional(PreferredRegOptionalOperand(cmp));
+            PreferredRegOptionalOperand(cmp)->SetRegOptional();
         }
     }
 }
@@ -2142,7 +2140,7 @@ void Lowering::ContainCheckBoundsChk(GenTreeBoundsChk* node)
         else
         {
             // We can mark 'other' as reg optional, since it is not contained.
-            SetRegOptional(other);
+            other->SetRegOptional();
         }
     }
 }
@@ -2167,7 +2165,7 @@ void Lowering::ContainCheckIntrinsic(GenTreeOp* node)
         {
             // Mark the operand as reg optional since codegen can still
             // generate code if op1 is on stack.
-            SetRegOptional(op1);
+            op1->SetRegOptional();
         }
     }
 }

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3998,7 +3998,7 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
             {
                 // This is the 2nd or subsequent register defined by a multi-reg node.
                 // Connect them using 'relatedInterval'.
-                noway_assert((prevInterval != nullptr) && (prevInterval->relatedInterval == nullptr));
+                noway_assert(prevInterval != nullptr);
                 prevInterval->relatedInterval = interval;
                 prevInterval                  = interval;
                 prevInterval->isMultiReg      = true;

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -41,27 +41,225 @@ inline regMaskTP calleeSaveRegs(RegisterType rt)
 
 struct LocationInfo
 {
+    Interval*    interval;
+    GenTree*     treeNode;
     LsraLocation loc;
+    TreeNodeInfo info;
 
-    // Reg Index in case of multi-reg result producing call node.
-    // Indicates the position of the register that this location refers to.
-    // The max bits needed is based on max value of MAX_RET_REG_COUNT value
-    // across all targets and that happens 4 on on Arm.  Hence index value
-    // would be 0..MAX_RET_REG_COUNT-1.
-    unsigned multiRegIdx : 2;
-
-    Interval* interval;
-    GenTree*  treeNode;
-
-    LocationInfo(LsraLocation l, Interval* i, GenTree* t, unsigned regIdx = 0)
-        : loc(l), multiRegIdx(regIdx), interval(i), treeNode(t)
+    LocationInfo(LsraLocation l, Interval* i, GenTree* t, unsigned regIdx = 0) : interval(i), treeNode(t), loc(l)
     {
-        assert(multiRegIdx == regIdx);
     }
 
     // default constructor for data structures
     LocationInfo()
     {
+    }
+};
+
+//------------------------------------------------------------------------
+// LocationInfoListNode: used to store a single `LocationInfo` value for a
+//                       node during `buildIntervals`.
+//
+// This is the node type for `LocationInfoList` below.
+//
+class LocationInfoListNode final : public LocationInfo
+{
+    friend class LocationInfoList;
+    friend class LocationInfoListNodePool;
+
+    LocationInfoListNode* m_next; // The next node in the list
+
+public:
+    LocationInfoListNode(LsraLocation l, Interval* i, GenTree* t, unsigned regIdx = 0) : LocationInfo(l, i, t, regIdx)
+    {
+    }
+
+    //------------------------------------------------------------------------
+    // LocationInfoListNode::Next: Returns the next node in the list.
+    LocationInfoListNode* Next() const
+    {
+        return m_next;
+    }
+};
+
+//------------------------------------------------------------------------
+// LocationInfoList: used to store a list of `LocationInfo` values for a
+//                   node during `buildIntervals`.
+//
+// This list of 'LocationInfoListNode's contains the source nodes consumed by
+// a node, and is created by 'TreeNodeInfoInit'.
+//
+class LocationInfoList final
+{
+    friend class LocationInfoListNodePool;
+
+    LocationInfoListNode* m_head; // The head of the list
+    LocationInfoListNode* m_tail; // The tail of the list
+
+public:
+    LocationInfoList() : m_head(nullptr), m_tail(nullptr)
+    {
+    }
+
+    LocationInfoList(LocationInfoListNode* node) : m_head(node), m_tail(node)
+    {
+        assert(m_head->m_next == nullptr);
+    }
+
+    //------------------------------------------------------------------------
+    // LocationInfoList::IsEmpty: Returns true if the list is empty.
+    //
+    bool IsEmpty() const
+    {
+        return m_head == nullptr;
+    }
+
+    //------------------------------------------------------------------------
+    // LocationInfoList::Begin: Returns the first node in the list.
+    //
+    LocationInfoListNode* Begin() const
+    {
+        return m_head;
+    }
+
+    //------------------------------------------------------------------------
+    // LocationInfoList::End: Returns the position after the last node in the
+    //                        list. The returned value is suitable for use as
+    //                        a sentinel for iteration.
+    //
+    LocationInfoListNode* End() const
+    {
+        return nullptr;
+    }
+
+    //------------------------------------------------------------------------
+    // LocationInfoList::End: Returns the position after the last node in the
+    //                        list. The returned value is suitable for use as
+    //                        a sentinel for iteration.
+    //
+    LocationInfoListNode* Last() const
+    {
+        return m_tail;
+    }
+
+    //------------------------------------------------------------------------
+    // LocationInfoList::Append: Appends a node to the list.
+    //
+    // Arguments:
+    //    node - The node to append. Must not be part of an existing list.
+    //
+    void Append(LocationInfoListNode* node)
+    {
+        assert(node->m_next == nullptr);
+
+        if (m_tail == nullptr)
+        {
+            assert(m_head == nullptr);
+            m_head = node;
+        }
+        else
+        {
+            m_tail->m_next = node;
+        }
+
+        m_tail = node;
+    }
+    //------------------------------------------------------------------------
+    // LocationInfoList::Append: Appends another list to this list.
+    //
+    // Arguments:
+    //    other - The list to append.
+    //
+    void Append(LocationInfoList other)
+    {
+        if (m_tail == nullptr)
+        {
+            assert(m_head == nullptr);
+            m_head = other.m_head;
+        }
+        else
+        {
+            m_tail->m_next = other.m_head;
+        }
+
+        m_tail = other.m_tail;
+    }
+
+    //------------------------------------------------------------------------
+    // LocationInfoList::Prepend: Prepends a node to the list.
+    //
+    // Arguments:
+    //    node - The node to prepend. Must not be part of an existing list.
+    //
+    void Prepend(LocationInfoListNode* node)
+    {
+        assert(node->m_next == nullptr);
+
+        if (m_head == nullptr)
+        {
+            assert(m_tail == nullptr);
+            m_tail = node;
+        }
+        else
+        {
+            node->m_next = m_head;
+        }
+
+        m_head = node;
+    }
+
+    //------------------------------------------------------------------------
+    // LocationInfoList::Add: Adds a node to the list.
+    //
+    // Arguments:
+    //    node    - The node to add. Must not be part of an existing list.
+    //    prepend - True if it should be prepended (otherwise is appended)
+    //
+    void Add(LocationInfoListNode* node, bool prepend)
+    {
+        if (prepend)
+        {
+            Prepend(node);
+        }
+        else
+        {
+            Append(node);
+        }
+    }
+
+    //------------------------------------------------------------------------
+    // GetTreeNodeInfo - retrieve the TreeNodeInfo for the given node
+    //
+    // Notes:
+    //     The TreeNodeInfoInit methods use this helper to retrieve the TreeNodeInfo for child nodes
+    //     from the useList being constructed. Note that, if the user knows the order of the operands,
+    //     it is expected that they should just retrieve them directly.
+
+    TreeNodeInfo& GetTreeNodeInfo(GenTree* node)
+    {
+        for (LocationInfoListNode *listNode = Begin(), *end = End(); listNode != end; listNode = listNode->Next())
+        {
+            if (listNode->treeNode == node)
+            {
+                return listNode->info;
+            }
+        }
+        assert(!"GetTreeNodeInfo didn't find the node");
+        unreached();
+    }
+
+    //------------------------------------------------------------------------
+    // LocationInfoList::GetSecond: Gets the second node in the list.
+    //
+    // Arguments:
+    //    (DEBUG ONLY) treeNode - The GenTree* we expect to be in the second node.
+    //
+    LocationInfoListNode* GetSecond(INDEBUG(GenTree* treeNode))
+    {
+        noway_assert((Begin() != nullptr) && (Begin()->Next() != nullptr));
+        LocationInfoListNode* second = Begin()->Next();
+        assert(second->treeNode == treeNode);
+        return second;
     }
 };
 
@@ -417,13 +615,13 @@ public:
     // Insert a copy in the case where a tree node value must be moved to a different
     // register at the point of use, or it is reloaded to a different register
     // than the one it was spilled from
-    void insertCopyOrReload(BasicBlock* block, GenTreePtr tree, unsigned multiRegIdx, RefPosition* refPosition);
+    void insertCopyOrReload(BasicBlock* block, GenTree* tree, unsigned multiRegIdx, RefPosition* refPosition);
 
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
     // Insert code to save and restore the upper half of a vector that lives
     // in a callee-save register at the point of a call (the upper half is
     // not preserved).
-    void insertUpperVectorSaveAndReload(GenTreePtr tree, RefPosition* refPosition, BasicBlock* block);
+    void insertUpperVectorSaveAndReload(GenTree* tree, RefPosition* refPosition, BasicBlock* block);
 #endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
 
     // resolve along one block-block edge
@@ -455,7 +653,7 @@ public:
                                 ResolveType     resolveType);
 #endif
     void addResolution(
-        BasicBlock* block, GenTreePtr insertionPoint, Interval* interval, regNumber outReg, regNumber inReg);
+        BasicBlock* block, GenTree* insertionPoint, Interval* interval, regNumber outReg, regNumber inReg);
 
     void handleOutgoingCriticalEdges(BasicBlock* block);
 
@@ -645,10 +843,20 @@ private:
     }
 
     // Dump support
+    void dumpOperandToLocationInfoMap();
     void lsraDumpIntervals(const char* msg);
     void dumpRefPositions(const char* msg);
     void dumpVarRefPositions(const char* msg);
 
+    // Checking code
+    static bool IsLsraAdded(GenTree* node)
+    {
+        return ((node->gtDebugFlags & GTF_DEBUG_NODE_LSRA_ADDED) != 0);
+    }
+    static void SetLsraAdded(GenTree* node)
+    {
+        node->gtDebugFlags |= GTF_DEBUG_NODE_LSRA_ADDED;
+    }
     static bool IsResolutionMove(GenTree* node);
     static bool IsResolutionNode(LIR::Range& containingRange, GenTree* node);
 
@@ -679,6 +887,10 @@ private:
     bool getLsraExtendLifeTimes()
     {
         return false;
+    }
+    static void SetLsraAdded(GenTree* node)
+    {
+        // do nothing; checked only under #DEBUG
     }
     bool candidatesAreStressLimited()
     {
@@ -745,8 +957,7 @@ private:
     void buildRefPositionsForNode(GenTree*                  tree,
                                   BasicBlock*               block,
                                   LocationInfoListNodePool& listNodePool,
-                                  HashTableBase<GenTree*, LocationInfoList>& operandToLocationInfoMap,
-                                  LsraLocation loc);
+                                  LsraLocation              loc);
 
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
     VARSET_VALRET_TP buildUpperVectorSaveRefPositions(GenTree* tree, LsraLocation currentLoc);
@@ -764,11 +975,6 @@ private:
     // Update reg state for an incoming register argument
     void updateRegStateForArg(LclVarDsc* argDsc);
 
-    inline bool isLocalDefUse(GenTree* tree)
-    {
-        return tree->gtLsraInfo.isLocalDefUse;
-    }
-
     inline bool isCandidateLocalRef(GenTree* tree)
     {
         if (tree->IsLocal())
@@ -782,7 +988,7 @@ private:
         return false;
     }
 
-    static Compiler::fgWalkResult markAddrModeOperandsHelperMD(GenTreePtr tree, void* p);
+    static Compiler::fgWalkResult markAddrModeOperandsHelperMD(GenTree* tree, void* p);
 
     // Return the registers killed by the given tree node.
     regMaskTP getKillSetForNode(GenTree* tree);
@@ -796,6 +1002,7 @@ private:
     regMaskTP allSIMDRegs();
     regMaskTP internalFloatRegCandidates();
 
+    bool isMultiRegRelated(RefPosition* refPosition, LsraLocation location);
     bool registerIsFree(regNumber regNum, RegisterType regType);
     bool registerIsAvailable(RegRecord*    physRegRecord,
                              LsraLocation  currentLoc,
@@ -804,34 +1011,27 @@ private:
     void freeRegister(RegRecord* physRegRecord);
     void freeRegisters(regMaskTP regsToFree);
 
-    regMaskTP getUseCandidates(GenTree* useNode);
-    regMaskTP getDefCandidates(GenTree* tree);
     var_types getDefType(GenTree* tree);
 
     RefPosition* defineNewInternalTemp(GenTree*     tree,
                                        RegisterType regType,
-                                       LsraLocation currentLoc,
                                        regMaskTP regMask DEBUGARG(unsigned minRegCandidateCount));
 
-    int buildInternalRegisterDefsForNode(GenTree*     tree,
-                                         LsraLocation currentLoc,
+    int buildInternalRegisterDefsForNode(GenTree*      tree,
+                                         TreeNodeInfo* info,
                                          RefPosition* defs[] DEBUGARG(unsigned minRegCandidateCount));
 
-    void buildInternalRegisterUsesForNode(GenTree*     tree,
-                                          LsraLocation currentLoc,
-                                          RefPosition* defs[],
+    void buildInternalRegisterUsesForNode(GenTree*      tree,
+                                          TreeNodeInfo* info,
+                                          RefPosition*  defs[],
                                           int total DEBUGARG(unsigned minRegCandidateCount));
 
-    void resolveLocalRef(BasicBlock* block, GenTreePtr treeNode, RefPosition* currentRefPosition);
+    void resolveLocalRef(BasicBlock* block, GenTree* treeNode, RefPosition* currentRefPosition);
 
-    void insertMove(BasicBlock* block, GenTreePtr insertionPoint, unsigned lclNum, regNumber inReg, regNumber outReg);
+    void insertMove(BasicBlock* block, GenTree* insertionPoint, unsigned lclNum, regNumber inReg, regNumber outReg);
 
-    void insertSwap(BasicBlock* block,
-                    GenTreePtr  insertionPoint,
-                    unsigned    lclNum1,
-                    regNumber   reg1,
-                    unsigned    lclNum2,
-                    regNumber   reg2);
+    void insertSwap(
+        BasicBlock* block, GenTree* insertionPoint, unsigned lclNum1, regNumber reg1, unsigned lclNum2, regNumber reg2);
 
 public:
     // TODO-Cleanup: unused?
@@ -994,11 +1194,8 @@ private:
     //     shown.
 
     enum LsraTupleDumpMode{LSRA_DUMP_PRE, LSRA_DUMP_REFPOS, LSRA_DUMP_POST};
-    void lsraGetOperandString(GenTreePtr        tree,
-                              LsraTupleDumpMode mode,
-                              char*             operandString,
-                              unsigned          operandStringLength);
-    void lsraDispNode(GenTreePtr tree, LsraTupleDumpMode mode, bool hasDest);
+    void lsraGetOperandString(GenTree* tree, LsraTupleDumpMode mode, char* operandString, unsigned operandStringLength);
+    void lsraDispNode(GenTree* tree, LsraTupleDumpMode mode, bool hasDest);
     void DumpOperandDefs(
         GenTree* operand, bool& first, LsraTupleDumpMode mode, char* operandString, const unsigned operandStringLength);
     void TupleStyleDump(LsraTupleDumpMode mode);
@@ -1172,6 +1369,8 @@ private:
 
     // The bbNum of the block being currently allocated or resolved.
     unsigned int curBBNum;
+    // The current location
+    LsraLocation currentLoc;
     // The ordinal of the block we're on (i.e. this is the curBBSeqNum-th block we've allocated).
     unsigned int curBBSeqNum;
     // The number of blocks that we've sequenced.
@@ -1246,31 +1445,99 @@ private:
     // TreeNodeInfo methods
     //-----------------------------------------------------------------------
 
-    void TreeNodeInfoInit(GenTree* stmt);
+    // The operandToLocationInfoMap is used for the transient TreeNodeInfo that is computed by
+    // the TreeNodeInfoInit methods, and used in building RefPositions.
+    typedef SmallHashTable<GenTree*, LocationInfoListNode*, 32> OperandToLocationInfoMap;
+    OperandToLocationInfoMap* operandToLocationInfoMap;
+    // The useList is constructed for each node by the TreeNodeInfoInit methods.
+    // It contains the TreeNodeInfo for its operands, in their order of use.
+    LocationInfoList useList;
 
-    void TreeNodeInfoInitCheckByteable(GenTree* tree);
+    // Get the LocationInfoListNode for the given node, and put it into the useList.
+    // The node must not be contained, and must have been processed by buildRefPositionsForNode().
+    void appendLocationInfoToList(GenTree* node)
+    {
+        LocationInfoListNode* locationInfo;
+        bool                  found = operandToLocationInfoMap->TryRemove(node, &locationInfo);
+        assert(found);
+        useList.Append(locationInfo);
+    }
+    // Get the LocationInfoListNodes for the given node, and return it, but don't put it into the useList.
+    // The node must not be contained, and must have been processed by buildRefPositionsForNode().
+    LocationInfoListNode* getLocationInfo(GenTree* node)
+    {
+        LocationInfoListNode* locationInfo;
+        bool                  found = operandToLocationInfoMap->TryRemove(node, &locationInfo);
+        assert(found);
+        return locationInfo;
+    }
+    //------------------------------------------------------------------------
+    // appendBinaryLocationInfoToList: Get the LocationInfoListNodes for the operands of the
+    //    given node, and put them into the useList.
+    //
+    // Arguments:
+    //    node - a GenTreeOp
+    //
+    // Return Value:
+    //    The number of actual register operands.
+    //
+    // Notes:
+    //    The operands must already have been processed by buildRefPositionsForNode, and their
+    //    LocationInfoListNodes placed in the operandToLocationInfoMap.
+    //
+    int appendBinaryLocationInfoToList(GenTreeOp* node)
+    {
+        bool                  found;
+        LocationInfoListNode* op1LocationInfo = nullptr;
+        LocationInfoListNode* op2LocationInfo = nullptr;
+        int                   srcCount        = 0;
+        GenTree*              op1             = node->gtOp1;
+        GenTree*              op2             = node->gtGetOp2IfPresent();
+        if (node->IsReverseOp() && op2 != nullptr)
+        {
+            srcCount += GetOperandInfo(op2);
+            op2 = nullptr;
+        }
+        if (op1 != nullptr)
+        {
+            srcCount += GetOperandInfo(op1);
+        }
+        if (op2 != nullptr)
+        {
+            srcCount += GetOperandInfo(op2);
+        }
+        return srcCount;
+    }
+
+    // This is the main entry point for computing the TreeNodeInfo for a node.
+    void TreeNodeInfoInit(GenTree* stmt, TreeNodeInfo* info);
+
+    void TreeNodeInfoInitCheckByteable(GenTree* tree, TreeNodeInfo* info);
 
     bool CheckAndSetDelayFree(GenTree* delayUseSrc);
 
-    void TreeNodeInfoInitSimple(GenTree* tree);
-    int GetOperandSourceCount(GenTree* node);
-    int GetIndirSourceCount(GenTreeIndir* indirTree);
-    void HandleFloatVarArgs(GenTreeCall* call, GenTree* argNode, bool* callHasFloatRegArgs);
+    void TreeNodeInfoInitSimple(GenTree* tree, TreeNodeInfo* info);
+    int GetOperandInfo(GenTree* node);
+    int GetOperandInfo(GenTree* node, LocationInfoListNode** pFirstInfo);
+    int GetIndirInfo(GenTreeIndir* indirTree);
+    void HandleFloatVarArgs(GenTreeCall* call, TreeNodeInfo* info, GenTree* argNode, bool* callHasFloatRegArgs);
 
-    void TreeNodeInfoInitStoreLoc(GenTree* tree);
-    void TreeNodeInfoInitReturn(GenTree* tree);
-    void TreeNodeInfoInitShiftRotate(GenTree* tree);
-    void TreeNodeInfoInitPutArgReg(GenTreeUnOp* node);
-    void TreeNodeInfoInitCall(GenTreeCall* call);
-    void TreeNodeInfoInitCmp(GenTreePtr tree);
-    void TreeNodeInfoInitStructArg(GenTreePtr structArg);
-    void TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode);
-    void TreeNodeInfoInitModDiv(GenTree* tree);
-    void TreeNodeInfoInitIntrinsic(GenTree* tree);
-    void TreeNodeInfoInitStoreLoc(GenTreeLclVarCommon* tree);
-    void TreeNodeInfoInitIndir(GenTreeIndir* indirTree);
-    void TreeNodeInfoInitGCWriteBarrier(GenTree* tree);
-    void TreeNodeInfoInitCast(GenTree* tree);
+    void TreeNodeInfoInitStoreLoc(GenTree* tree, TreeNodeInfo* info);
+    void TreeNodeInfoInitReturn(GenTree* tree, TreeNodeInfo* info);
+    // This method, unlike the others, returns the number of sources, since it may be called when
+    // 'tree' is contained.
+    int TreeNodeInfoInitShiftRotate(GenTree* tree, TreeNodeInfo* info);
+    void TreeNodeInfoInitPutArgReg(GenTreeUnOp* node, TreeNodeInfo* info);
+    void TreeNodeInfoInitCall(GenTreeCall* call, TreeNodeInfo* info);
+    void TreeNodeInfoInitCmp(GenTree* tree, TreeNodeInfo* info);
+    void TreeNodeInfoInitStructArg(GenTree* structArg, TreeNodeInfo* info);
+    void TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode, TreeNodeInfo* info);
+    void TreeNodeInfoInitModDiv(GenTree* tree, TreeNodeInfo* info);
+    void TreeNodeInfoInitIntrinsic(GenTree* tree, TreeNodeInfo* info);
+    void TreeNodeInfoInitStoreLoc(GenTreeLclVarCommon* tree, TreeNodeInfo* info);
+    void TreeNodeInfoInitIndir(GenTreeIndir* indirTree, TreeNodeInfo* info);
+    void TreeNodeInfoInitGCWriteBarrier(GenTree* tree, TreeNodeInfo* info);
+    void TreeNodeInfoInitCast(GenTree* tree, TreeNodeInfo* info);
 
 #ifdef _TARGET_X86_
     bool ExcludeNonByteableRegisters(GenTree* tree);
@@ -1278,24 +1545,24 @@ private:
 
 #if defined(_TARGET_XARCH_)
     // returns true if the tree can use the read-modify-write memory instruction form
-    bool isRMWRegOper(GenTreePtr tree);
-    void TreeNodeInfoInitMul(GenTreePtr tree);
+    bool isRMWRegOper(GenTree* tree);
+    void TreeNodeInfoInitMul(GenTree* tree, TreeNodeInfo* info);
     void SetContainsAVXFlags(bool isFloatingPointType = true, unsigned sizeOfSIMDVector = 0);
 #endif // defined(_TARGET_XARCH_)
 
 #ifdef FEATURE_SIMD
-    void TreeNodeInfoInitSIMD(GenTreeSIMD* tree);
+    void TreeNodeInfoInitSIMD(GenTreeSIMD* tree, TreeNodeInfo* info);
 #endif // FEATURE_SIMD
 
 #if FEATURE_HW_INTRINSICS
-    void TreeNodeInfoInitHWIntrinsic(GenTreeHWIntrinsic* intrinsicTree);
+    void TreeNodeInfoInitHWIntrinsic(GenTreeHWIntrinsic* intrinsicTree, TreeNodeInfo* info);
 #endif // FEATURE_HW_INTRINSICS
 
-    void TreeNodeInfoInitPutArgStk(GenTreePutArgStk* argNode);
+    void TreeNodeInfoInitPutArgStk(GenTreePutArgStk* argNode, TreeNodeInfo* info);
 #ifdef _TARGET_ARM_
-    void TreeNodeInfoInitPutArgSplit(GenTreePutArgSplit* tree);
+    void TreeNodeInfoInitPutArgSplit(GenTreePutArgSplit* tree, TreeNodeInfo* info);
 #endif
-    void TreeNodeInfoInitLclHeap(GenTree* tree);
+    void TreeNodeInfoInitLclHeap(GenTree* tree, TreeNodeInfo* info);
 };
 
 /*XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -1325,10 +1592,11 @@ public:
         , isStructField(false)
         , isPromotedStruct(false)
         , hasConflictingDefUse(false)
-        , hasNonCommutativeRMWDef(false)
+        , hasInterferingUses(false)
         , isSpecialPutArg(false)
         , preferCalleeSave(false)
         , isConstant(false)
+        , isMultiReg(false)
         , physReg(REG_COUNT)
 #ifdef DEBUG
         , intervalIndex(0)
@@ -1382,8 +1650,9 @@ public:
     // true if this is an SDSU interval for which the def and use have conflicting register
     // requirements
     bool hasConflictingDefUse : 1;
-    // true if this interval is defined by a non-commutative 2-operand instruction
-    bool hasNonCommutativeRMWDef : 1;
+    // true if this interval's defining node has "delayRegFree" uses, either due to it being an RMW instruction,
+    // OR because it requires an internal register that differs from the target.
+    bool hasInterferingUses : 1;
 
     // True if this interval is defined by a putArg, whose source is a non-last-use lclVar.
     // During allocation, this flag will be cleared if the source is not already in the required register.
@@ -1397,6 +1666,9 @@ public:
     // True if this interval is defined by a constant node that may be reused and/or may be
     // able to reuse a constant that's already in a register.
     bool isConstant : 1;
+
+    // True if this Interval is defined by a node that produces multiple registers.
+    bool isMultiReg : 1;
 
     // The register to which it is currently assigned.
     regNumber physReg;

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -767,7 +767,6 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree, TreeNodeInfo* info)
             info->srcCount = 1;
             assert(info->dstCount == 1);
             LocationInfoListNode* locationInfo = getLocationInfo(tree->gtOp.gtOp1);
-            locationInfo->info.isTgtPref       = true;
             useList.Append(locationInfo);
             regNumber argReg  = tree->gtRegNum;
             regMaskTP argMask = genRegMask(argReg);

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -38,22 +38,25 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // Return Value:
 //    None.
 //
-void LinearScan::TreeNodeInfoInitReturn(GenTree* tree)
+void LinearScan::TreeNodeInfoInitReturn(GenTree* tree, TreeNodeInfo* info)
 {
-    TreeNodeInfo* info = &(tree->gtLsraInfo);
-    GenTree*      op1  = tree->gtGetOp1();
+    GenTree* op1 = tree->gtGetOp1();
 
     assert(info->dstCount == 0);
     if (tree->TypeGet() == TYP_LONG)
     {
         assert((op1->OperGet() == GT_LONG) && op1->isContained());
-        GenTree* loVal = op1->gtGetOp1();
-        GenTree* hiVal = op1->gtGetOp2();
-        info->srcCount = 2;
-        loVal->gtLsraInfo.setSrcCandidates(this, RBM_LNGRET_LO);
-        hiVal->gtLsraInfo.setSrcCandidates(this, RBM_LNGRET_HI);
+        GenTree* loVal                  = op1->gtGetOp1();
+        GenTree* hiVal                  = op1->gtGetOp2();
+        info->srcCount                  = 2;
+        LocationInfoListNode* loValInfo = getLocationInfo(loVal);
+        LocationInfoListNode* hiValInfo = getLocationInfo(hiVal);
+        loValInfo->info.setSrcCandidates(this, RBM_LNGRET_LO);
+        hiValInfo->info.setSrcCandidates(this, RBM_LNGRET_HI);
+        useList.Append(loValInfo);
+        useList.Append(hiValInfo);
     }
-    else
+    else if ((tree->TypeGet() != TYP_VOID) && !op1->isContained())
     {
         regMaskTP useCandidates = RBM_NONE;
 
@@ -95,17 +98,17 @@ void LinearScan::TreeNodeInfoInitReturn(GenTree* tree)
             }
         }
 
+        LocationInfoListNode* locationInfo = getLocationInfo(op1);
         if (useCandidates != RBM_NONE)
         {
-            tree->gtOp.gtOp1->gtLsraInfo.setSrcCandidates(this, useCandidates);
+            locationInfo->info.setSrcCandidates(this, useCandidates);
         }
+        useList.Append(locationInfo);
     }
 }
 
-void LinearScan::TreeNodeInfoInitLclHeap(GenTree* tree)
+void LinearScan::TreeNodeInfoInitLclHeap(GenTree* tree, TreeNodeInfo* info)
 {
-    TreeNodeInfo* info = &(tree->gtLsraInfo);
-
     assert(info->dstCount == 1);
 
     // Need a variable number of temp regs (see genLclHeap() in codegenarm.cpp):
@@ -175,6 +178,7 @@ void LinearScan::TreeNodeInfoInitLclHeap(GenTree* tree)
         // target (regCnt) + tmp + [psp]
         info->srcCount         = 1;
         info->internalIntCount = hasPspSym ? 2 : 1;
+        appendLocationInfoToList(size);
     }
 
     // If we are needed in temporary registers we should be sure that
@@ -201,11 +205,10 @@ void LinearScan::TreeNodeInfoInitLclHeap(GenTree* tree)
 //    requirements needed by LSRA to build the Interval Table (source,
 //    destination and internal [temp] register counts).
 //
-void LinearScan::TreeNodeInfoInit(GenTree* tree)
+void LinearScan::TreeNodeInfoInit(GenTree* tree, TreeNodeInfo* info)
 {
-    unsigned      kind         = tree->OperKind();
-    TreeNodeInfo* info         = &(tree->gtLsraInfo);
-    RegisterType  registerType = TypeGet(tree);
+    unsigned     kind         = tree->OperKind();
+    RegisterType registerType = TypeGet(tree);
 
     if (tree->isContained())
     {
@@ -235,7 +238,7 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
 
         case GT_STORE_LCL_FLD:
         case GT_STORE_LCL_VAR:
-            TreeNodeInfoInitStoreLoc(tree->AsLclVarCommon());
+            TreeNodeInfoInitStoreLoc(tree->AsLclVarCommon(), info);
             break;
 
         case GT_NOP:
@@ -260,6 +263,7 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
             op1 = tree->gtOp.gtOp1;
             assert(varTypeIsFloating(op1));
             assert(op1->TypeGet() == tree->TypeGet());
+            appendLocationInfoToList(op1);
 
             switch (tree->gtIntrinsic.gtIntrinsicId)
             {
@@ -277,7 +281,6 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
 
         case GT_CAST:
         {
-            info->srcCount = 1;
             assert(info->dstCount == 1);
 
             // Non-overflow casts to/from float/double are done using SSE2 instructions
@@ -287,6 +290,7 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
             var_types  castToType = tree->CastToType();
             GenTreePtr castOp     = tree->gtCast.CastOp();
             var_types  castOpType = castOp->TypeGet();
+            info->srcCount        = GetOperandInfo(castOp);
             if (tree->gtFlags & GTF_UNSIGNED)
             {
                 castOpType = genUnsignedType(castOpType);
@@ -371,8 +375,9 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
             break;
 
         case GT_SWITCH_TABLE:
-            info->srcCount = 2;
             assert(info->dstCount == 0);
+            info->srcCount = appendBinaryLocationInfoToList(tree->AsOp());
+            assert(info->srcCount == 2);
             break;
 
         case GT_ASG:
@@ -395,9 +400,9 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
                 // everything is made explicit by adding casts.
                 assert(tree->gtOp.gtOp1->TypeGet() == tree->gtOp.gtOp2->TypeGet());
 
-                info->srcCount = 2;
                 assert(info->dstCount == 1);
-
+                info->srcCount = appendBinaryLocationInfoToList(tree->AsOp());
+                assert(info->srcCount == 2);
                 break;
             }
 
@@ -406,8 +411,9 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
         case GT_AND:
         case GT_OR:
         case GT_XOR:
-            info->srcCount = tree->gtOp.gtOp2->isContained() ? 1 : 2;
             assert(info->dstCount == 1);
+            info->srcCount = appendBinaryLocationInfoToList(tree->AsOp());
+            assert(info->srcCount == (tree->gtOp.gtOp2->isContained() ? 1 : 2));
             break;
 
         case GT_RETURNTRAP:
@@ -415,6 +421,7 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
             // + a conditional call
             info->srcCount = 1;
             assert(info->dstCount == 0);
+            appendLocationInfoToList(tree->gtOp.gtOp1);
             break;
 
         case GT_MUL:
@@ -430,14 +437,16 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
         case GT_MULHI:
         case GT_UDIV:
         {
-            info->srcCount = 2;
             assert(info->dstCount == 1);
+            info->srcCount = appendBinaryLocationInfoToList(tree->AsOp());
+            assert(info->srcCount == 2);
         }
         break;
 
         case GT_MUL_LONG:
-            info->srcCount = 2;
             info->dstCount = 2;
+            info->srcCount = appendBinaryLocationInfoToList(tree->AsOp());
+            assert(info->srcCount == 2);
             break;
 
         case GT_LIST:
@@ -457,9 +466,11 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
             tree->ClearUnusedValue();
             info->isLocalDefUse = false;
 
-            // An unused GT_LONG node needs to consume its sources.
+            // An unused GT_LONG node needs to consume its sources, but need not produce a register.
             info->srcCount = 2;
             info->dstCount = 0;
+            appendLocationInfoToList(tree->gtGetOp1());
+            appendLocationInfoToList(tree->gtGetOp2());
             break;
 
         case GT_CNS_DBL:
@@ -481,7 +492,7 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
             break;
 
         case GT_RETURN:
-            TreeNodeInfoInitReturn(tree);
+            TreeNodeInfoInitReturn(tree, info);
             break;
 
         case GT_RETFILT:
@@ -496,7 +507,9 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
 
                 info->srcCount = 1;
                 info->setSrcCandidates(this, RBM_INTRET);
-                tree->gtOp.gtOp1->gtLsraInfo.setSrcCandidates(this, RBM_INTRET);
+                LocationInfoListNode* locationInfo = getLocationInfo(tree->gtOp.gtOp1);
+                locationInfo->info.setSrcCandidates(this, RBM_INTRET);
+                useList.Append(locationInfo);
             }
             break;
 
@@ -508,6 +521,8 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
             // Consumes arrLen & index - has no result
             info->srcCount = 2;
             assert(info->dstCount == 0);
+            appendLocationInfoToList(tree->AsBoundsChk()->gtIndex);
+            appendLocationInfoToList(tree->AsBoundsChk()->gtArrLen);
         }
         break;
 
@@ -519,6 +534,7 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
             break;
 
         case GT_ARR_INDEX:
+        {
             info->srcCount = 2;
             assert(info->dstCount == 1);
             info->internalIntCount       = 1;
@@ -526,11 +542,16 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
 
             // For GT_ARR_INDEX, the lifetime of the arrObj must be extended because it is actually used multiple
             // times while the result is being computed.
-            tree->AsArrIndex()->ArrObj()->gtLsraInfo.isDelayFree = true;
-            info->hasDelayFreeSrc                                = true;
-            break;
+            LocationInfoListNode* arrObjInfo = getLocationInfo(tree->AsArrIndex()->ArrObj());
+            arrObjInfo->info.isDelayFree     = true;
+            useList.Append(arrObjInfo);
+            useList.Append(getLocationInfo(tree->AsArrIndex()->IndexExpr()));
+            info->hasDelayFreeSrc = true;
+        }
+        break;
 
         case GT_ARR_OFFSET:
+
             // This consumes the offset, if any, the arrObj and the effective index,
             // and produces the flattened offset for this dimension.
             assert(info->dstCount == 1);
@@ -545,7 +566,10 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
                 // from any of the operand's registers, but may be the same as targetReg.
                 info->internalIntCount = 1;
                 info->srcCount         = 3;
+                appendLocationInfoToList(tree->AsArrOffs()->gtOffset);
             }
+            appendLocationInfoToList(tree->AsArrOffs()->gtIndex);
+            appendLocationInfoToList(tree->AsArrOffs()->gtArrObj);
             break;
 
         case GT_LEA:
@@ -555,15 +579,17 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
 
             // This LEA is instantiating an address, so we set up the srcCount and dstCount here.
             info->srcCount = 0;
+            assert(info->dstCount == 1);
             if (lea->HasBase())
             {
                 info->srcCount++;
+                appendLocationInfoToList(tree->AsAddrMode()->Base());
             }
             if (lea->HasIndex())
             {
                 info->srcCount++;
+                appendLocationInfoToList(tree->AsAddrMode()->Index());
             }
-            assert(info->dstCount == 1);
 
             // An internal register may be needed too; the logic here should be in sync with the
             // genLeaInstruction()'s requirements for a such register.
@@ -589,11 +615,13 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
         case GT_NEG:
             info->srcCount = 1;
             assert(info->dstCount == 1);
+            appendLocationInfoToList(tree->gtOp.gtOp1);
             break;
 
         case GT_NOT:
             info->srcCount = 1;
             assert(info->dstCount == 1);
+            appendLocationInfoToList(tree->gtOp.gtOp1);
             break;
 
         case GT_LSH:
@@ -602,7 +630,7 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
         case GT_ROR:
         case GT_LSH_HI:
         case GT_RSH_LO:
-            TreeNodeInfoInitShiftRotate(tree);
+            TreeNodeInfoInitShiftRotate(tree, info);
             break;
 
         case GT_EQ:
@@ -612,17 +640,18 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
         case GT_GE:
         case GT_GT:
         case GT_CMP:
-            TreeNodeInfoInitCmp(tree);
+            TreeNodeInfoInitCmp(tree, info);
             break;
 
         case GT_CKFINITE:
             info->srcCount = 1;
             assert(info->dstCount == 1);
             info->internalIntCount = 1;
+            appendLocationInfoToList(tree->gtOp.gtOp1);
             break;
 
         case GT_CALL:
-            TreeNodeInfoInitCall(tree->AsCall());
+            TreeNodeInfoInitCall(tree->AsCall(), info);
             break;
 
         case GT_ADDR:
@@ -639,7 +668,7 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
         case GT_STORE_BLK:
         case GT_STORE_OBJ:
         case GT_STORE_DYN_BLK:
-            TreeNodeInfoInitBlockStore(tree->AsBlk());
+            TreeNodeInfoInitBlockStore(tree->AsBlk(), info);
             break;
 
         case GT_INIT_VAL:
@@ -648,7 +677,7 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
             break;
 
         case GT_LCLHEAP:
-            TreeNodeInfoInitLclHeap(tree);
+            TreeNodeInfoInitLclHeap(tree, info);
             break;
 
         case GT_STOREIND:
@@ -659,14 +688,15 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
             if (compiler->codeGen->gcInfo.gcIsWriteBarrierAsgNode(tree))
             {
                 info->srcCount = 2;
-                TreeNodeInfoInitGCWriteBarrier(tree);
+                TreeNodeInfoInitGCWriteBarrier(tree, info);
                 break;
             }
 
-            TreeNodeInfoInitIndir(tree->AsIndir());
+            TreeNodeInfoInitIndir(tree->AsIndir(), info);
             // No contained source on ARM.
             assert(!src->isContained());
             info->srcCount++;
+            appendLocationInfoToList(src);
         }
         break;
 
@@ -676,12 +706,13 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
             assert(!tree->gtGetOp1()->isContained());
             info->srcCount         = 1;
             info->internalIntCount = 1;
+            appendLocationInfoToList(tree->gtOp.gtOp1);
             break;
 
         case GT_IND:
             assert(info->dstCount == 1);
             info->srcCount = 1;
-            TreeNodeInfoInitIndir(tree->AsIndir());
+            TreeNodeInfoInitIndir(tree->AsIndir(), info);
             break;
 
         case GT_CATCH_ARG:
@@ -716,24 +747,28 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
             {
                 assert(info->dstCount == 1);
             }
+            appendLocationInfoToList(tree->gtOp.gtOp1);
             break;
 
         case GT_PUTARG_SPLIT:
-            TreeNodeInfoInitPutArgSplit(tree->AsPutArgSplit());
+            TreeNodeInfoInitPutArgSplit(tree->AsPutArgSplit(), info);
             break;
 
         case GT_PUTARG_STK:
-            TreeNodeInfoInitPutArgStk(tree->AsPutArgStk());
+            TreeNodeInfoInitPutArgStk(tree->AsPutArgStk(), info);
             break;
 
         case GT_PUTARG_REG:
-            TreeNodeInfoInitPutArgReg(tree->AsUnOp());
+            TreeNodeInfoInitPutArgReg(tree->AsUnOp(), info);
             break;
 
         case GT_BITCAST:
         {
             info->srcCount = 1;
             assert(info->dstCount == 1);
+            LocationInfoListNode* locationInfo = getLocationInfo(tree->gtOp.gtOp1);
+            locationInfo->info.isTgtPref       = true;
+            useList.Append(locationInfo);
             regNumber argReg  = tree->gtRegNum;
             regMaskTP argMask = genRegMask(argReg);
 
@@ -748,7 +783,6 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
 
             info->setDstCandidates(this, argMask);
             info->setSrcCandidates(this, argMask);
-            tree->AsUnOp()->gtOp1->gtLsraInfo.isTgtPref = true;
         }
         break;
 
@@ -782,14 +816,7 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
             }
             else if (kind & (GTK_SMPOP))
             {
-                if (tree->gtGetOp2IfPresent() != nullptr)
-                {
-                    info->srcCount = 2;
-                }
-                else
-                {
-                    info->srcCount = 1;
-                }
+                info->srcCount = appendBinaryLocationInfoToList(tree->AsOp());
             }
             else
             {
@@ -798,9 +825,10 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
             break;
 
         case GT_INDEX_ADDR:
-            info->srcCount         = 2;
             info->dstCount         = 1;
             info->internalIntCount = 1;
+            info->srcCount         = appendBinaryLocationInfoToList(tree->AsOp());
+            assert(info->srcCount == 2);
             break;
     } // end switch (tree->OperGet())
 
@@ -812,6 +840,7 @@ void LinearScan::TreeNodeInfoInit(GenTree* tree)
     assert((info->dstCount < 2) || tree->IsMultiRegNode());
     assert(info->isLocalDefUse == (tree->IsValue() && tree->IsUnusedValue()));
     assert(!tree->IsUnusedValue() || (info->dstCount != 0));
+    assert(info->dstCount == tree->GetRegisterDstCount());
 }
 
 #endif // _TARGET_ARM_

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -555,9 +555,12 @@ void LinearScan::TreeNodeInfoInitCall(GenTreeCall* call, TreeNodeInfo* info)
 #ifdef _TARGET_ARM_
             // The `double` types have been transformed to `long` on armel,
             // while the actual long types have been decomposed.
+            // On ARM we may have bitcasts from DOUBLE to LONG.
             if (argNode->TypeGet() == TYP_LONG)
             {
-                info->srcCount += appendBinaryLocationInfoToList(argNode->AsOp());
+                assert(argNode->IsMultiRegNode());
+                info->srcCount += 2;
+                appendLocationInfoToList(argNode);
             }
             else
 #endif // _TARGET_ARM_

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -39,25 +39,12 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 //    - Setting the appropriate candidates for a store of a multi-reg call return value.
 //    - Handling of contained immediates.
 //
-void LinearScan::TreeNodeInfoInitStoreLoc(GenTreeLclVarCommon* storeLoc)
+void LinearScan::TreeNodeInfoInitStoreLoc(GenTreeLclVarCommon* storeLoc, TreeNodeInfo* info)
 {
-    TreeNodeInfo* info = &(storeLoc->gtLsraInfo);
-    GenTree*      op1  = storeLoc->gtGetOp1();
+    GenTree* op1 = storeLoc->gtGetOp1();
 
     assert(info->dstCount == 0);
-#ifdef _TARGET_ARM_
-    if (varTypeIsLong(op1))
-    {
-        info->srcCount = 2;
-        assert(!op1->OperIs(GT_LONG) || op1->isContained());
-    }
-    else
-#endif // _TARGET_ARM_
-        if (op1->isContained())
-    {
-        info->srcCount = 0;
-    }
-    else if (op1->IsMultiRegCall())
+    if (op1->IsMultiRegCall())
     {
         // This is the case of var = call where call is returning
         // a value in multiple return registers.
@@ -67,15 +54,35 @@ void LinearScan::TreeNodeInfoInitStoreLoc(GenTreeLclVarCommon* storeLoc)
         // srcCount = number of registers in which the value is returned by call
         GenTreeCall*    call        = op1->AsCall();
         ReturnTypeDesc* retTypeDesc = call->GetReturnTypeDesc();
-        info->srcCount              = retTypeDesc->GetReturnRegCount();
+        unsigned        regCount    = retTypeDesc->GetReturnRegCount();
+        info->srcCount              = regCount;
 
         // Call node srcCandidates = Bitwise-OR(allregs(GetReturnRegType(i))) for all i=0..RetRegCount-1
-        regMaskTP srcCandidates = allMultiRegCallNodeRegs(call);
-        op1->gtLsraInfo.setSrcCandidates(this, srcCandidates);
+        regMaskTP             srcCandidates = allMultiRegCallNodeRegs(call);
+        LocationInfoListNode* locInfo       = getLocationInfo(op1);
+        locInfo->info.setSrcCandidates(this, srcCandidates);
+        useList.Append(locInfo);
+    }
+#ifdef _TARGET_ARM_
+    else if (varTypeIsLong(op1))
+    {
+        // The only possible operands for a GT_STORE_LCL_VAR are a multireg call node, which we have
+        // handled above, or a GT_LONG node.
+        assert(!op1->OperIs(GT_LONG) || op1->isContained());
+        info->srcCount = 2;
+        // TODO: Currently, GetOperandInfo always returns 1 for any non-contained node.
+        // Consider enhancing it to handle multi-reg nodes.
+        (void)GetOperandInfo(op1);
+    }
+#endif // _TARGET_ARM_
+    else if (op1->isContained())
+    {
+        info->srcCount = 0;
     }
     else
     {
         info->srcCount = 1;
+        appendLocationInfoToList(op1);
     }
 
 #ifdef FEATURE_SIMD
@@ -99,39 +106,30 @@ void LinearScan::TreeNodeInfoInitStoreLoc(GenTreeLclVarCommon* storeLoc)
 // Return Value:
 //    None.
 //
-void LinearScan::TreeNodeInfoInitCmp(GenTreePtr tree)
+void LinearScan::TreeNodeInfoInitCmp(GenTreePtr tree, TreeNodeInfo* info)
 {
-    TreeNodeInfo* info = &(tree->gtLsraInfo);
+    info->srcCount = appendBinaryLocationInfoToList(tree->AsOp());
 
     assert((info->dstCount == 1) || (tree->TypeGet() == TYP_VOID));
     info->srcCount = tree->gtOp.gtOp2->isContained() ? 1 : 2;
 }
 
-void LinearScan::TreeNodeInfoInitGCWriteBarrier(GenTree* tree)
+void LinearScan::TreeNodeInfoInitGCWriteBarrier(GenTree* tree, TreeNodeInfo* info)
 {
-    GenTreePtr dst  = tree;
-    GenTreePtr addr = tree->gtOp.gtOp1;
-    GenTreePtr src  = tree->gtOp.gtOp2;
+    GenTreePtr            dst      = tree;
+    GenTreePtr            addr     = tree->gtOp.gtOp1;
+    GenTreePtr            src      = tree->gtOp.gtOp2;
+    LocationInfoListNode* addrInfo = getLocationInfo(addr);
+    LocationInfoListNode* srcInfo  = getLocationInfo(src);
 
-    if (addr->OperGet() == GT_LEA)
-    {
-        // In the case where we are doing a helper assignment, if the dst
-        // is an indir through an lea, we need to actually instantiate the
-        // lea in a register
-        GenTreeAddrMode* lea = addr->AsAddrMode();
-
-        short leaSrcCount = 0;
-        if (lea->Base() != nullptr)
-        {
-            leaSrcCount++;
-        }
-        if (lea->Index() != nullptr)
-        {
-            leaSrcCount++;
-        }
-        lea->gtLsraInfo.srcCount = leaSrcCount;
-        lea->gtLsraInfo.dstCount = 1;
-    }
+    // In the case where we are doing a helper assignment, even if the dst
+    // is an indir through an lea, we need to actually instantiate the
+    // lea in a register
+    assert(!addr->isContained() && !src->isContained());
+    useList.Append(addrInfo);
+    useList.Append(srcInfo);
+    info->srcCount = 2;
+    assert(info->dstCount == 0);
 
 #if NOGC_WRITE_BARRIERS
     NYI_ARM("NOGC_WRITE_BARRIERS");
@@ -141,21 +139,21 @@ void LinearScan::TreeNodeInfoInitGCWriteBarrier(GenTree* tree)
     // the 'addr' goes into x14 (REG_WRITE_BARRIER_DST_BYREF)
     // the 'src'  goes into x15 (REG_WRITE_BARRIER)
     //
-    addr->gtLsraInfo.setSrcCandidates(this, RBM_WRITE_BARRIER_DST_BYREF);
-    src->gtLsraInfo.setSrcCandidates(this, RBM_WRITE_BARRIER);
+    addrInfo->info.setSrcCandidates(this, RBM_WRITE_BARRIER_DST_BYREF);
+    srcInfo->info.setSrcCandidates(this, RBM_WRITE_BARRIER);
 #else
     // For the standard JIT Helper calls
     // op1 goes into REG_ARG_0 and
     // op2 goes into REG_ARG_1
     //
-    addr->gtLsraInfo.setSrcCandidates(this, RBM_ARG_0);
-    src->gtLsraInfo.setSrcCandidates(this, RBM_ARG_1);
+    addrInfo->info.setSrcCandidates(this, RBM_ARG_0);
+    srcInfo->info.setSrcCandidates(this, RBM_ARG_1);
 #endif // NOGC_WRITE_BARRIERS
 
     // Both src and dst must reside in a register, which they should since we haven't set
     // either of them as contained.
-    assert(addr->gtLsraInfo.dstCount == 1);
-    assert(src->gtLsraInfo.dstCount == 1);
+    assert(addrInfo->info.dstCount == 1);
+    assert(srcInfo->info.dstCount == 1);
 }
 
 //------------------------------------------------------------------------
@@ -165,7 +163,7 @@ void LinearScan::TreeNodeInfoInitGCWriteBarrier(GenTree* tree)
 // Arguments:
 //    indirTree - GT_IND, GT_STOREIND or block gentree node
 //
-void LinearScan::TreeNodeInfoInitIndir(GenTreeIndir* indirTree)
+void LinearScan::TreeNodeInfoInitIndir(GenTreeIndir* indirTree, TreeNodeInfo* info)
 {
     // If this is the rhs of a block copy (i.e. non-enregisterable struct),
     // it has no register requirements.
@@ -174,9 +172,8 @@ void LinearScan::TreeNodeInfoInitIndir(GenTreeIndir* indirTree)
         return;
     }
 
-    TreeNodeInfo* info    = &(indirTree->gtLsraInfo);
-    bool          isStore = (indirTree->gtOper == GT_STOREIND);
-    info->srcCount        = GetIndirSourceCount(indirTree);
+    bool isStore   = (indirTree->gtOper == GT_STOREIND);
+    info->srcCount = GetIndirInfo(indirTree);
 
     GenTree* addr  = indirTree->Addr();
     GenTree* index = nullptr;
@@ -250,40 +247,47 @@ void LinearScan::TreeNodeInfoInitIndir(GenTreeIndir* indirTree)
 // Return Value:
 //    None.
 //
-void LinearScan::TreeNodeInfoInitShiftRotate(GenTree* tree)
+int LinearScan::TreeNodeInfoInitShiftRotate(GenTree* tree, TreeNodeInfo* info)
 {
-    TreeNodeInfo* info = &(tree->gtLsraInfo);
-
+    GenTreePtr source  = tree->gtOp.gtOp1;
     GenTreePtr shiftBy = tree->gtOp.gtOp2;
-    info->srcCount     = shiftBy->isContained() ? 1 : 2;
-    info->dstCount     = 1;
+    assert(info->dstCount == 1);
+    if (!shiftBy->isContained())
+    {
+        appendLocationInfoToList(shiftBy);
+        info->srcCount = 1;
+    }
 
 #ifdef _TARGET_ARM_
 
     // The first operand of a GT_LSH_HI and GT_RSH_LO oper is a GT_LONG so that
     // we can have a three operand form. Increment the srcCount.
-    GenTreePtr source = tree->gtOp.gtOp1;
     if (tree->OperGet() == GT_LSH_HI || tree->OperGet() == GT_RSH_LO)
     {
         assert((source->OperGet() == GT_LONG) && source->isContained());
-        info->srcCount++;
+        info->srcCount += 2;
 
+        LocationInfoListNode* sourceLoInfo = getLocationInfo(source->gtOp.gtOp1);
+        useList.Append(sourceLoInfo);
+        LocationInfoListNode* sourceHiInfo = getLocationInfo(source->gtOp.gtOp2);
+        useList.Append(sourceHiInfo);
         if (tree->OperGet() == GT_LSH_HI)
         {
-            GenTreePtr sourceLo              = source->gtOp.gtOp1;
-            sourceLo->gtLsraInfo.isDelayFree = true;
+            sourceLoInfo->info.isDelayFree = true;
         }
         else
         {
-            GenTreePtr sourceHi              = source->gtOp.gtOp2;
-            sourceHi->gtLsraInfo.isDelayFree = true;
+            sourceHiInfo->info.isDelayFree = true;
         }
-
-        source->gtLsraInfo.hasDelayFreeSrc = true;
-        info->hasDelayFreeSrc              = true;
+        info->hasDelayFreeSrc = true;
     }
-
+    else
 #endif // _TARGET_ARM_
+    {
+        appendLocationInfoToList(source);
+        info->srcCount++;
+    }
+    return info->srcCount;
 }
 
 //------------------------------------------------------------------------
@@ -299,12 +303,12 @@ void LinearScan::TreeNodeInfoInitShiftRotate(GenTree* tree)
 // Return Value:
 //    None.
 //
-void LinearScan::TreeNodeInfoInitPutArgReg(GenTreeUnOp* node)
+void LinearScan::TreeNodeInfoInitPutArgReg(GenTreeUnOp* node, TreeNodeInfo* info)
 {
     assert(node != nullptr);
     assert(node->OperIsPutArgReg());
-    node->gtLsraInfo.srcCount = 1;
-    regNumber argReg          = node->gtRegNum;
+    info->srcCount   = 1;
+    regNumber argReg = node->gtRegNum;
     assert(argReg != REG_NA);
 
     // Set the register requirements for the node.
@@ -315,19 +319,21 @@ void LinearScan::TreeNodeInfoInitPutArgReg(GenTreeUnOp* node)
     // The actual `long` types must have been transformed as a field list with two fields.
     if (node->TypeGet() == TYP_LONG)
     {
-        node->gtLsraInfo.srcCount++;
-        node->gtLsraInfo.dstCount = node->gtLsraInfo.srcCount;
+        info->srcCount++;
+        info->dstCount = info->srcCount;
         assert(genRegArgNext(argReg) == REG_NEXT(argReg));
         argMask |= genRegMask(REG_NEXT(argReg));
     }
 #endif // _TARGET_ARM_
-
-    node->gtLsraInfo.setDstCandidates(this, argMask);
-    node->gtLsraInfo.setSrcCandidates(this, argMask);
+    info->setDstCandidates(this, argMask);
+    info->setSrcCandidates(this, argMask);
 
     // To avoid redundant moves, have the argument operand computed in the
     // register in which the argument is passed to the call.
-    node->gtOp.gtOp1->gtLsraInfo.setSrcCandidates(this, getUseCandidates(node));
+    LocationInfoListNode* op1Info = getLocationInfo(node->gtOp.gtOp1);
+    op1Info->info.setSrcCandidates(this, info->getSrcCandidates(this));
+    op1Info->info.isDelayFree = true;
+    useList.Append(op1Info);
 }
 
 //------------------------------------------------------------------------
@@ -346,7 +352,7 @@ void LinearScan::TreeNodeInfoInitPutArgReg(GenTreeUnOp* node)
 //    Since the integer register is not associated with the arg node, we will reserve it as
 //    an internal register on the call so that it is not used during the evaluation of the call node
 //    (e.g. for the target).
-void LinearScan::HandleFloatVarArgs(GenTreeCall* call, GenTree* argNode, bool* callHasFloatRegArgs)
+void LinearScan::HandleFloatVarArgs(GenTreeCall* call, TreeNodeInfo* info, GenTree* argNode, bool* callHasFloatRegArgs)
 {
 #if FEATURE_VARARG
     if (call->IsVarargs() && varTypeIsFloating(argNode))
@@ -355,8 +361,8 @@ void LinearScan::HandleFloatVarArgs(GenTreeCall* call, GenTree* argNode, bool* c
 
         regNumber argReg    = argNode->gtRegNum;
         regNumber targetReg = compiler->getCallArgIntRegister(argReg);
-        call->gtLsraInfo.setInternalIntCount(call->gtLsraInfo.internalIntCount + 1);
-        call->gtLsraInfo.addInternalCandidates(this, genRegMask(targetReg));
+        info->setInternalIntCount(info->internalIntCount + 1);
+        info->addInternalCandidates(this, genRegMask(targetReg));
     }
 #endif // FEATURE_VARARG
 }
@@ -370,9 +376,8 @@ void LinearScan::HandleFloatVarArgs(GenTreeCall* call, GenTree* argNode, bool* c
 // Return Value:
 //    None.
 //
-void LinearScan::TreeNodeInfoInitCall(GenTreeCall* call)
+void LinearScan::TreeNodeInfoInitCall(GenTreeCall* call, TreeNodeInfo* info)
 {
-    TreeNodeInfo*   info              = &(call->gtLsraInfo);
     bool            hasMultiRegRetVal = false;
     ReturnTypeDesc* retTypeDesc       = nullptr;
 
@@ -396,7 +401,8 @@ void LinearScan::TreeNodeInfoInitCall(GenTreeCall* call)
         info->dstCount = 0;
     }
 
-    GenTree* ctrlExpr = call->gtControlExpr;
+    GenTree*              ctrlExpr     = call->gtControlExpr;
+    LocationInfoListNode* ctrlExprInfo = nullptr;
     if (call->gtCallType == CT_INDIRECT)
     {
         // either gtControlExpr != null or gtCallAddr != null.
@@ -409,10 +415,10 @@ void LinearScan::TreeNodeInfoInitCall(GenTreeCall* call)
     // set reg requirements on call target represented as control sequence.
     if (ctrlExpr != nullptr)
     {
+        ctrlExprInfo = getLocationInfo(ctrlExpr);
+
         // we should never see a gtControlExpr whose type is void.
         assert(ctrlExpr->TypeGet() != TYP_VOID);
-
-        info->srcCount++;
 
         // In case of fast tail implemented as jmp, make sure that gtControlExpr is
         // computed into a register.
@@ -420,7 +426,7 @@ void LinearScan::TreeNodeInfoInitCall(GenTreeCall* call)
         {
             // Fast tail call - make sure that call target is always computed in R12(ARM32)/IP0(ARM64)
             // so that epilog sequence can generate "br xip0/r12" to achieve fast tail call.
-            ctrlExpr->gtLsraInfo.setSrcCandidates(this, RBM_FASTTAILCALL_TARGET);
+            ctrlExprInfo->info.setSrcCandidates(this, RBM_FASTTAILCALL_TARGET);
         }
     }
 #ifdef _TARGET_ARM_
@@ -492,8 +498,8 @@ void LinearScan::TreeNodeInfoInitCall(GenTreeCall* call)
                 // have been decomposed.
                 if (putArgChild->TypeGet() == TYP_LONG)
                 {
-                    argNode->gtLsraInfo.srcCount = 2;
-                    expectedSlots                = 2;
+                    useList.GetTreeNodeInfo(argNode).srcCount = 2;
+                    expectedSlots                             = 2;
                 }
                 else if (putArgChild->TypeGet() == TYP_DOUBLE)
                 {
@@ -515,6 +521,7 @@ void LinearScan::TreeNodeInfoInitCall(GenTreeCall* call)
             for (GenTreeFieldList* entry = argNode->AsFieldList(); entry != nullptr; entry = entry->Rest())
             {
                 info->srcCount++;
+                appendLocationInfoToList(entry->Current());
 #ifdef DEBUG
                 assert(entry->Current()->OperIs(GT_PUTARG_REG));
                 assert(entry->Current()->gtRegNum == argReg);
@@ -534,25 +541,30 @@ void LinearScan::TreeNodeInfoInitCall(GenTreeCall* call)
 #ifdef _TARGET_ARM_
         else if (argNode->OperGet() == GT_PUTARG_SPLIT)
         {
-            fgArgTabEntryPtr curArgTabEntry = compiler->gtArgEntryByNode(call, argNode);
-            info->srcCount += argNode->AsPutArgSplit()->gtNumRegs;
+            unsigned regCount = argNode->AsPutArgSplit()->gtNumRegs;
+            assert(regCount == curArgTabEntry->numRegs);
+            info->srcCount += regCount;
+            appendLocationInfoToList(argNode);
         }
 #endif
         else
         {
             assert(argNode->OperIs(GT_PUTARG_REG));
             assert(argNode->gtRegNum == argReg);
-            HandleFloatVarArgs(call, argNode, &callHasFloatRegArgs);
-            info->srcCount++;
-
+            HandleFloatVarArgs(call, info, argNode, &callHasFloatRegArgs);
 #ifdef _TARGET_ARM_
-            // The `double` types have been transformed to `long` on arm,
+            // The `double` types have been transformed to `long` on armel,
             // while the actual long types have been decomposed.
             if (argNode->TypeGet() == TYP_LONG)
             {
+                info->srcCount += appendBinaryLocationInfoToList(argNode->AsOp());
+            }
+            else
+#endif // _TARGET_ARM_
+            {
+                appendLocationInfoToList(argNode);
                 info->srcCount++;
             }
-#endif // _TARGET_ARM_
         }
     }
 
@@ -575,21 +587,18 @@ void LinearScan::TreeNodeInfoInitCall(GenTreeCall* call)
             fgArgTabEntryPtr curArgTabEntry = compiler->gtArgEntryByNode(call, arg);
             assert(curArgTabEntry);
 #endif
+#ifdef _TARGET_ARM_
+            // PUTARG_SPLIT nodes must be in the gtCallLateArgs list, since they
+            // define registers used by the call.
+            assert(arg->OperGet() != GT_PUTARG_SPLIT);
+#endif
             if (arg->gtOper == GT_PUTARG_STK)
             {
                 assert(curArgTabEntry->regNum == REG_STK);
             }
-#ifdef _TARGET_ARM_
-            else if (arg->OperGet() == GT_PUTARG_SPLIT)
-            {
-                assert(arg->AsPutArgSplit()->gtNumRegs == curArgTabEntry->numRegs);
-                info->srcCount += arg->gtLsraInfo.dstCount;
-            }
-#endif
             else
             {
-                TreeNodeInfo* argInfo = &(arg->gtLsraInfo);
-                assert((argInfo->dstCount == 0) || (argInfo->isLocalDefUse));
+                assert(!arg->IsValue() || arg->IsUnusedValue());
             }
         }
         args = args->gtOp.gtOp2;
@@ -597,14 +606,20 @@ void LinearScan::TreeNodeInfoInitCall(GenTreeCall* call)
 
     // If it is a fast tail call, it is already preferenced to use IP0.
     // Therefore, no need set src candidates on call tgt again.
-    if (call->IsVarargs() && callHasFloatRegArgs && !call->IsFastTailCall() && (ctrlExpr != nullptr))
+    if (call->IsVarargs() && callHasFloatRegArgs && !call->IsFastTailCall() && (ctrlExprInfo != nullptr))
     {
         NYI_ARM("float reg varargs");
 
         // Don't assign the call target to any of the argument registers because
         // we will use them to also pass floating point arguments as required
         // by Arm64 ABI.
-        ctrlExpr->gtLsraInfo.setSrcCandidates(this, allRegs(TYP_INT) & ~(RBM_ARG_REGS));
+        ctrlExprInfo->info.setSrcCandidates(this, allRegs(TYP_INT) & ~(RBM_ARG_REGS));
+    }
+
+    if (ctrlExprInfo != nullptr)
+    {
+        useList.Append(ctrlExprInfo);
+        info->srcCount++;
     }
 
 #ifdef _TARGET_ARM_
@@ -629,14 +644,14 @@ void LinearScan::TreeNodeInfoInitCall(GenTreeCall* call)
 // Notes:
 //    Set the child node(s) to be contained when we have a multireg arg
 //
-void LinearScan::TreeNodeInfoInitPutArgStk(GenTreePutArgStk* argNode)
+void LinearScan::TreeNodeInfoInitPutArgStk(GenTreePutArgStk* argNode, TreeNodeInfo* info)
 {
     assert(argNode->gtOper == GT_PUTARG_STK);
 
     GenTreePtr putArgChild = argNode->gtOp.gtOp1;
 
-    argNode->gtLsraInfo.srcCount = 0;
-    argNode->gtLsraInfo.dstCount = 0;
+    info->srcCount = 0;
+    info->dstCount = 0;
 
     // Do we have a TYP_STRUCT argument (or a GT_FIELD_LIST), if so it must be a multireg pass-by-value struct
     if ((putArgChild->TypeGet() == TYP_STRUCT) || (putArgChild->OperGet() == GT_FIELD_LIST))
@@ -649,54 +664,51 @@ void LinearScan::TreeNodeInfoInitPutArgStk(GenTreePutArgStk* argNode)
             // We consume all of the items in the GT_FIELD_LIST
             for (GenTreeFieldList* current = putArgChild->AsFieldList(); current != nullptr; current = current->Rest())
             {
-                argNode->gtLsraInfo.srcCount++;
+                appendLocationInfoToList(current->Current());
+                info->srcCount++;
             }
         }
         else
         {
 #ifdef _TARGET_ARM64_
             // We could use a ldp/stp sequence so we need two internal registers
-            argNode->gtLsraInfo.internalIntCount = 2;
+            info->internalIntCount = 2;
 #else  // _TARGET_ARM_
             // We could use a ldr/str sequence so we need a internal register
-            argNode->gtLsraInfo.internalIntCount = 1;
+            info->internalIntCount = 1;
 #endif // _TARGET_ARM_
 
             if (putArgChild->OperGet() == GT_OBJ)
             {
+                assert(putArgChild->isContained());
                 GenTreePtr objChild = putArgChild->gtOp.gtOp1;
                 if (objChild->OperGet() == GT_LCL_VAR_ADDR)
                 {
                     // We will generate all of the code for the GT_PUTARG_STK, the GT_OBJ and the GT_LCL_VAR_ADDR
-                    // as one contained operation
+                    // as one contained operation, and there are no source registers.
                     //
                     assert(objChild->isContained());
                 }
+                else
+                {
+                    // We will generate all of the code for the GT_PUTARG_STK and its child node
+                    // as one contained operation
+                    //
+                    appendLocationInfoToList(objChild);
+                    info->srcCount = 1;
+                }
             }
-
-            // We will generate all of the code for the GT_PUTARG_STK and its child node
-            // as one contained operation
-            //
-            argNode->gtLsraInfo.srcCount = putArgChild->gtLsraInfo.srcCount;
-            assert(putArgChild->isContained());
+            else
+            {
+                // No source registers.
+                putArgChild->OperIs(GT_LCL_VAR);
+            }
         }
     }
     else
     {
         assert(!putArgChild->isContained());
-#if defined(_TARGET_ARM_)
-        // The `double` types have been transformed to `long` on armel,
-        // while the actual long types have been decomposed.
-        const bool isDouble = (putArgChild->TypeGet() == TYP_LONG);
-        if (isDouble)
-        {
-            argNode->gtLsraInfo.srcCount = 2;
-        }
-        else
-#endif // defined(_TARGET_ARM_)
-        {
-            argNode->gtLsraInfo.srcCount = 1;
-        }
+        info->srcCount = GetOperandInfo(putArgChild);
     }
 }
 
@@ -713,14 +725,14 @@ void LinearScan::TreeNodeInfoInitPutArgStk(GenTreePutArgStk* argNode)
 // Notes:
 //    Set the child node(s) to be contained
 //
-void LinearScan::TreeNodeInfoInitPutArgSplit(GenTreePutArgSplit* argNode)
+void LinearScan::TreeNodeInfoInitPutArgSplit(GenTreePutArgSplit* argNode, TreeNodeInfo* info)
 {
     assert(argNode->gtOper == GT_PUTARG_SPLIT);
 
     GenTreePtr putArgChild = argNode->gtOp.gtOp1;
 
     // Registers for split argument corresponds to source
-    argNode->gtLsraInfo.dstCount = argNode->gtNumRegs;
+    info->dstCount = argNode->gtNumRegs;
 
     regNumber argReg  = argNode->gtRegNum;
     regMaskTP argMask = RBM_NONE;
@@ -728,8 +740,8 @@ void LinearScan::TreeNodeInfoInitPutArgSplit(GenTreePutArgSplit* argNode)
     {
         argMask |= genRegMask((regNumber)((unsigned)argReg + i));
     }
-    argNode->gtLsraInfo.setDstCandidates(this, argMask);
-    argNode->gtLsraInfo.setSrcCandidates(this, argMask);
+    info->setDstCandidates(this, argMask);
+    info->setSrcCandidates(this, argMask);
 
     if (putArgChild->OperGet() == GT_FIELD_LIST)
     {
@@ -747,19 +759,21 @@ void LinearScan::TreeNodeInfoInitPutArgSplit(GenTreePutArgSplit* argNode)
         {
             GenTreePtr node = fieldListPtr->gtGetOp1();
             assert(!node->isContained());
-            unsigned  currentRegCount = node->gtLsraInfo.dstCount;
-            regMaskTP sourceMask      = RBM_NONE;
+            LocationInfoListNode* nodeInfo        = getLocationInfo(node);
+            unsigned              currentRegCount = nodeInfo->info.dstCount;
+            regMaskTP             sourceMask      = RBM_NONE;
             if (sourceRegCount < argNode->gtNumRegs)
             {
                 for (unsigned regIndex = 0; regIndex < currentRegCount; regIndex++)
                 {
                     sourceMask |= genRegMask((regNumber)((unsigned)argReg + sourceRegCount + regIndex));
                 }
-                node->gtLsraInfo.setSrcCandidates(this, sourceMask);
+                nodeInfo->info.setSrcCandidates(this, sourceMask);
             }
             sourceRegCount += currentRegCount;
+            useList.Append(nodeInfo);
         }
-        argNode->gtLsraInfo.srcCount = sourceRegCount;
+        info->srcCount += sourceRegCount;
         assert(putArgChild->isContained());
     }
     else
@@ -768,9 +782,9 @@ void LinearScan::TreeNodeInfoInitPutArgSplit(GenTreePutArgSplit* argNode)
         assert(putArgChild->OperGet() == GT_OBJ);
 
         // We can use a ldr/str sequence so we need an internal register
-        argNode->gtLsraInfo.internalIntCount = 1;
-        regMaskTP internalMask               = RBM_ALLINT & ~argMask;
-        argNode->gtLsraInfo.setInternalCandidates(this, internalMask);
+        info->internalIntCount = 1;
+        regMaskTP internalMask = RBM_ALLINT & ~argMask;
+        info->setInternalCandidates(this, internalMask);
 
         GenTreePtr objChild = putArgChild->gtOp.gtOp1;
         if (objChild->OperGet() == GT_LCL_VAR_ADDR)
@@ -782,7 +796,7 @@ void LinearScan::TreeNodeInfoInitPutArgSplit(GenTreePutArgSplit* argNode)
         }
         else
         {
-            argNode->gtLsraInfo.srcCount = GetIndirSourceCount(putArgChild->AsIndir());
+            info->srcCount = GetIndirInfo(putArgChild->AsIndir());
         }
         assert(putArgChild->isContained());
     }
@@ -798,18 +812,33 @@ void LinearScan::TreeNodeInfoInitPutArgSplit(GenTreePutArgSplit* argNode)
 // Return Value:
 //    None.
 //
-void LinearScan::TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode)
+void LinearScan::TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode, TreeNodeInfo* info)
 {
     GenTree* dstAddr = blkNode->Addr();
     unsigned size    = blkNode->gtBlkSize;
     GenTree* source  = blkNode->Data();
 
+    LocationInfoListNode* dstAddrInfo = nullptr;
+    LocationInfoListNode* sourceInfo  = nullptr;
+    LocationInfoListNode* sizeInfo    = nullptr;
+
     // Sources are dest address and initVal or source.
     // We may require an additional source or temp register for the size.
-    blkNode->gtLsraInfo.srcCount = GetOperandSourceCount(dstAddr);
-    assert(blkNode->gtLsraInfo.dstCount == 0);
+    if (!dstAddr->isContained())
+    {
+        info->srcCount++;
+        dstAddrInfo = getLocationInfo(dstAddr);
+    }
+    assert(info->dstCount == 0);
     GenTreePtr srcAddrOrFill = nullptr;
     bool       isInitBlk     = blkNode->OperIsInitBlkOp();
+
+    regMaskTP dstAddrRegMask = RBM_NONE;
+    regMaskTP sourceRegMask  = RBM_NONE;
+    regMaskTP blkSizeRegMask = RBM_NONE;
+
+    short     internalIntCount      = 0;
+    regMaskTP internalIntCandidates = RBM_NONE;
 
     if (isInitBlk)
     {
@@ -820,6 +849,11 @@ void LinearScan::TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode)
             initVal = initVal->gtGetOp1();
         }
         srcAddrOrFill = initVal;
+        if (!initVal->isContained())
+        {
+            info->srcCount++;
+            sourceInfo = getLocationInfo(initVal);
+        }
 
         if (blkNode->gtBlkOpKind == GenTreeBlk::BlkOpKindUnroll)
         {
@@ -828,33 +862,15 @@ void LinearScan::TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode)
             // code sequences to improve CQ.
             // For reference see the code in lsraxarch.cpp.
             NYI_ARM("initblk loop unrolling is currently not implemented.");
-            if (!initVal->isContained())
-            {
-                blkNode->gtLsraInfo.srcCount++;
-            }
         }
         else
         {
             assert(blkNode->gtBlkOpKind == GenTreeBlk::BlkOpKindHelper);
-            // The helper follows the regular ABI.
-            dstAddr->gtLsraInfo.setSrcCandidates(this, RBM_ARG_0);
             assert(!initVal->isContained());
-            blkNode->gtLsraInfo.srcCount++;
-            initVal->gtLsraInfo.setSrcCandidates(this, RBM_ARG_1);
-            if (size != 0)
-            {
-                // Reserve a temp register for the block size argument.
-                blkNode->gtLsraInfo.setInternalCandidates(this, RBM_ARG_2);
-                blkNode->gtLsraInfo.internalIntCount = 1;
-            }
-            else
-            {
-                // The block size argument is a third argument to GT_STORE_DYN_BLK
-                noway_assert(blkNode->gtOper == GT_STORE_DYN_BLK);
-                blkNode->gtLsraInfo.setSrcCount(3);
-                GenTree* sizeNode = blkNode->AsDynBlk()->gtDynamicSize;
-                sizeNode->gtLsraInfo.setSrcCandidates(this, RBM_ARG_2);
-            }
+            // The helper follows the regular ABI.
+            dstAddrRegMask = RBM_ARG_0;
+            sourceRegMask  = RBM_ARG_1;
+            blkSizeRegMask = RBM_ARG_2;
         }
     }
     else
@@ -863,43 +879,42 @@ void LinearScan::TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode)
         // Sources are src and dest and size if not constant.
         if (source->gtOper == GT_IND)
         {
-            srcAddrOrFill = blkNode->Data()->gtGetOp1();
+            assert(source->isContained());
+            srcAddrOrFill = source->gtGetOp1();
+            sourceInfo    = getLocationInfo(srcAddrOrFill);
+            info->srcCount++;
         }
         if (blkNode->OperGet() == GT_STORE_OBJ)
         {
             // CopyObj
             // We don't need to materialize the struct size but we still need
             // a temporary register to perform the sequence of loads and stores.
-            blkNode->gtLsraInfo.internalIntCount = 1;
+            internalIntCount = 1;
 
             if (size >= 2 * REGSIZE_BYTES)
             {
                 // We will use ldp/stp to reduce code size and improve performance
                 // so we need to reserve an extra internal register
-                blkNode->gtLsraInfo.internalIntCount++;
+                internalIntCount++;
             }
 
             // We can't use the special Write Barrier registers, so exclude them from the mask
-            regMaskTP internalIntCandidates = RBM_ALLINT & ~(RBM_WRITE_BARRIER_DST_BYREF | RBM_WRITE_BARRIER_SRC_BYREF);
-            blkNode->gtLsraInfo.setInternalCandidates(this, internalIntCandidates);
+            internalIntCandidates = RBM_ALLINT & ~(RBM_WRITE_BARRIER_DST_BYREF | RBM_WRITE_BARRIER_SRC_BYREF);
 
             // If we have a dest address we want it in RBM_WRITE_BARRIER_DST_BYREF.
-            dstAddr->gtLsraInfo.setSrcCandidates(this, RBM_WRITE_BARRIER_DST_BYREF);
+            dstAddrRegMask = RBM_WRITE_BARRIER_DST_BYREF;
 
             // If we have a source address we want it in REG_WRITE_BARRIER_SRC_BYREF.
             // Otherwise, if it is a local, codegen will put its address in REG_WRITE_BARRIER_SRC_BYREF,
             // which is killed by a StoreObj (and thus needn't be reserved).
             if (srcAddrOrFill != nullptr)
             {
-                srcAddrOrFill->gtLsraInfo.setSrcCandidates(this, RBM_WRITE_BARRIER_SRC_BYREF);
+                sourceRegMask = RBM_WRITE_BARRIER_SRC_BYREF;
             }
         }
         else
         {
             // CopyBlk
-            short     internalIntCount      = 0;
-            regMaskTP internalIntCandidates = RBM_NONE;
-
             if (blkNode->gtBlkOpKind == GenTreeBlk::BlkOpKindUnroll)
             {
                 // In case of a CpBlk with a constant size and less than CPBLK_UNROLL_LIMIT size
@@ -921,67 +936,73 @@ void LinearScan::TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode)
             else
             {
                 assert(blkNode->gtBlkOpKind == GenTreeBlk::BlkOpKindHelper);
-                dstAddr->gtLsraInfo.setSrcCandidates(this, RBM_ARG_0);
+                dstAddrRegMask = RBM_ARG_0;
                 // The srcAddr goes in arg1.
                 if (srcAddrOrFill != nullptr)
                 {
-                    srcAddrOrFill->gtLsraInfo.setSrcCandidates(this, RBM_ARG_1);
+                    sourceRegMask = RBM_ARG_1;
                 }
-                if (size != 0)
-                {
-                    // Reserve a temp register for the block size argument.
-                    internalIntCandidates |= RBM_ARG_2;
-                    internalIntCount++;
-                }
-                else
-                {
-                    // The block size argument is a third argument to GT_STORE_DYN_BLK
-                    assert(blkNode->gtOper == GT_STORE_DYN_BLK);
-                    blkNode->gtLsraInfo.srcCount++;
-                    GenTree* blockSize = blkNode->AsDynBlk()->gtDynamicSize;
-                    blockSize->gtLsraInfo.setSrcCandidates(this, RBM_ARG_2);
-                }
-            }
-            if (internalIntCount != 0)
-            {
-                blkNode->gtLsraInfo.internalIntCount = internalIntCount;
-                blkNode->gtLsraInfo.setInternalCandidates(this, internalIntCandidates);
+                blkSizeRegMask = RBM_ARG_2;
             }
         }
-        blkNode->gtLsraInfo.srcCount += GetOperandSourceCount(source);
     }
-}
-
-//------------------------------------------------------------------------
-// GetOperandSourceCount: Get the source registers for an operand that might be contained.
-//
-// Arguments:
-//    node      - The node of interest
-//
-// Return Value:
-//    The number of source registers used by the *parent* of this node.
-//
-int LinearScan::GetOperandSourceCount(GenTree* node)
-{
-    if (!node->isContained())
+    if (dstAddrInfo != nullptr)
     {
-        return 1;
+        if (dstAddrRegMask != RBM_NONE)
+        {
+            dstAddrInfo->info.setSrcCandidates(this, dstAddrRegMask);
+        }
+        useList.Append(dstAddrInfo);
     }
-
-#if !defined(_TARGET_64BIT_)
-    if (node->OperIs(GT_LONG))
+    if (sourceRegMask != RBM_NONE)
     {
-        return 2;
+        if (sourceInfo != nullptr)
+        {
+            sourceInfo->info.setSrcCandidates(this, sourceRegMask);
+        }
+        else
+        {
+            // This is a local source; we'll use a temp register for its address.
+            internalIntCandidates |= sourceRegMask;
+            internalIntCount++;
+        }
     }
-#endif // !defined(_TARGET_64BIT_)
-
-    if (node->OperIsIndir())
+    if (sourceInfo != nullptr)
     {
-        const unsigned srcCount = GetIndirSourceCount(node->AsIndir());
-        return srcCount;
+        useList.Add(sourceInfo, blkNode->IsReverseOp());
     }
 
-    return 0;
+    if (blkNode->OperIs(GT_STORE_DYN_BLK))
+    {
+        // The block size argument is a third argument to GT_STORE_DYN_BLK
+        info->srcCount++;
+
+        GenTree* blockSize = blkNode->AsDynBlk()->gtDynamicSize;
+        sizeInfo           = getLocationInfo(blockSize);
+        useList.Add(sizeInfo, blkNode->AsDynBlk()->gtEvalSizeFirst);
+    }
+
+    if (blkSizeRegMask != RBM_NONE)
+    {
+        if (size != 0)
+        {
+            // Reserve a temp register for the block size argument.
+            internalIntCandidates |= blkSizeRegMask;
+            internalIntCount++;
+        }
+        else
+        {
+            // The block size argument is a third argument to GT_STORE_DYN_BLK
+            assert((blkNode->gtOper == GT_STORE_DYN_BLK) && (sizeInfo != nullptr));
+            info->setSrcCount(3);
+            sizeInfo->info.setSrcCandidates(this, blkSizeRegMask);
+        }
+    }
+    if (internalIntCount != 0)
+    {
+        info->internalIntCount = internalIntCount;
+        info->setInternalCandidates(this, internalIntCandidates);
+    }
 }
 
 #endif // _TARGET_ARMARCH_

--- a/src/jit/nodeinfo.h
+++ b/src/jit/nodeinfo.h
@@ -15,7 +15,6 @@ class TreeNodeInfo
 public:
     TreeNodeInfo()
     {
-        loc                 = 0;
         _dstCount           = 0;
         _srcCount           = 0;
         _internalIntCount   = 0;
@@ -25,12 +24,9 @@ public:
         dstCandsIndex          = 0;
         internalCandsIndex     = 0;
         isLocalDefUse          = false;
-        isLsraAdded            = false;
         isDelayFree            = false;
         hasDelayFreeSrc        = false;
         isTgtPref              = false;
-        regOptional            = false;
-        definesAnyRegisters    = false;
         isInternalRegDelayFree = false;
 #ifdef DEBUG
         isInitialized = false;
@@ -97,8 +93,6 @@ public:
     void setInternalCandidates(LinearScan* lsra, regMaskTP mask);
     void addInternalCandidates(LinearScan* lsra, regMaskTP mask);
 
-    LsraLocation loc;
-
 public:
     unsigned char srcCandsIndex;
     unsigned char dstCandsIndex;
@@ -116,9 +110,6 @@ public:
     // nodes, or top-level nodes that are non-void.
     unsigned char isLocalDefUse : 1;
 
-    // Is this node added by LSRA, e.g. as a resolution or copy/reload move.
-    unsigned char isLsraAdded : 1;
-
     // isDelayFree is set when the register defined by this node will interfere with the destination
     // of the consuming node, and therefore it must not be freed immediately after use.
     unsigned char isDelayFree : 1;
@@ -132,14 +123,6 @@ public:
     // in the same register as op1.
     unsigned char isTgtPref : 1;
 
-    // Whether a spilled second src can be treated as a contained operand
-    unsigned char regOptional : 1;
-
-    // Whether or not a node defines any registers, whether directly (for nodes where dstCout is non-zero)
-    // or indirectly (for contained nodes, which propagate the transitive closure of the registers
-    // defined by their inputs). Used during buildRefPositionsForNode in order to avoid unnecessary work.
-    unsigned char definesAnyRegisters : 1;
-
     // Whether internal register needs to be different from targetReg
     // in which result is produced.
     unsigned char isInternalRegDelayFree : 1;
@@ -151,7 +134,7 @@ public:
 
 public:
     // Initializes the TreeNodeInfo value with the given values.
-    void Initialize(LinearScan* lsra, GenTree* node, LsraLocation location);
+    void Initialize(LinearScan* lsra, GenTree* node);
 
 #ifdef DEBUG
     void dump(LinearScan* lsra);


### PR DESCRIPTION
Generate TreeNodeInfo into the map when building RefPositions.
Add some new methods and flags for former gtLsraInfo functionality that's used outside of LSRA:
- GenTree::GetRegisterDstCount() (number of registers defined by a node)
- LIR::Flags::RegOptional
- gtDebugFlags::GTF_DEBUG_NODE_LSRA_ADDED

Fix #7255