### PR TITLE
Add GetReference and TryGetArray to MemoryMarshal

### DIFF
--- a/src/mscorlib/shared/System/ReadOnlyMemory.cs
+++ b/src/mscorlib/shared/System/ReadOnlyMemory.cs
@@ -29,7 +29,7 @@ namespace System
         private readonly int _index;
         private readonly int _length;
 
-        private const int RemoveOwnedFlagBitMask = 0x7FFFFFFF;
+        internal const int RemoveOwnedFlagBitMask = 0x7FFFFFFF;
 
         /// <summary>
         /// Creates a new memory over the entirety of the target array.

--- a/src/mscorlib/shared/System/ReadOnlySpan.cs
+++ b/src/mscorlib/shared/System/ReadOnlySpan.cs
@@ -323,7 +323,7 @@ namespace System
         public static ReadOnlySpan<T> Empty => default(ReadOnlySpan<T>);
 
         // This exposes the internal representation for Span-related apis use only.
-        internal ByReference<T> Pointer => _pointer;
+        internal ref readonly T Reference => ref _pointer.Value;
 
         /// <summary>Gets an enumerator for this span.</summary>
         public Enumerator GetEnumerator() => new Enumerator(this);

--- a/src/mscorlib/shared/System/ReadOnlySpan.cs
+++ b/src/mscorlib/shared/System/ReadOnlySpan.cs
@@ -322,6 +322,9 @@ namespace System
         /// </summary>
         public static ReadOnlySpan<T> Empty => default(ReadOnlySpan<T>);
 
+        // This exposes the internal representation for Span-related apis use only.
+        internal ByReference<T> Pointer => _pointer;
+
         /// <summary>Gets an enumerator for this span.</summary>
         public Enumerator GetEnumerator() => new Enumerator(this);
 

--- a/src/mscorlib/shared/System/ReadOnlySpan.cs
+++ b/src/mscorlib/shared/System/ReadOnlySpan.cs
@@ -21,7 +21,7 @@ namespace System
     public readonly ref struct ReadOnlySpan<T>
     {
         /// <summary>A byref or a native ptr.</summary>
-        private readonly ByReference<T> _pointer;
+        internal readonly ByReference<T> _pointer;
         /// <summary>The number of elements this ReadOnlySpan contains.</summary>
 #if PROJECTN
         [Bound]
@@ -321,9 +321,6 @@ namespace System
         /// Returns a 0-length read-only span whose base is the null pointer.
         /// </summary>
         public static ReadOnlySpan<T> Empty => default(ReadOnlySpan<T>);
-
-        // This exposes the internal representation for Span-related apis use only.
-        internal ref readonly T Reference => ref _pointer.Value;
 
         /// <summary>Gets an enumerator for this span.</summary>
         public Enumerator GetEnumerator() => new Enumerator(this);

--- a/src/mscorlib/shared/System/Runtime/InteropServices/MemoryMarshal.cs
+++ b/src/mscorlib/shared/System/Runtime/InteropServices/MemoryMarshal.cs
@@ -26,16 +26,10 @@ namespace System.Runtime.InteropServices
             Unsafe.As<ReadOnlyMemory<T>, Memory<T>>(ref readOnlyMemory);
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ref T GetReference<T>(in Span<T> span)
-        {
-            return ref span.Pointer.Value;
-        }
+        public static ref T GetReference<T>(in Span<T> span) => ref span.Reference;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ref readonly T GetReference<T>(in ReadOnlySpan<T> span)
-        {
-            return ref span.Pointer.Value;
-        }
+        public static ref readonly T GetReference<T>(in ReadOnlySpan<T> span) => ref span.Reference;
 
         public static bool TryGetArray<T>(ReadOnlyMemory<T> readOnlyMemory, out ArraySegment<T> arraySegment)
         {

--- a/src/mscorlib/shared/System/Runtime/InteropServices/MemoryMarshal.cs
+++ b/src/mscorlib/shared/System/Runtime/InteropServices/MemoryMarshal.cs
@@ -25,11 +25,13 @@ namespace System.Runtime.InteropServices
         public static Memory<T> AsMemory<T>(ReadOnlyMemory<T> readOnlyMemory) =>
             Unsafe.As<ReadOnlyMemory<T>, Memory<T>>(ref readOnlyMemory);
         
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref T GetReference<T>(in Span<T> span)
         {
             return ref span.Pointer.Value;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref readonly T GetReference<T>(in ReadOnlySpan<T> span)
         {
             return ref span.Pointer.Value;

--- a/src/mscorlib/shared/System/Runtime/InteropServices/MemoryMarshal.cs
+++ b/src/mscorlib/shared/System/Runtime/InteropServices/MemoryMarshal.cs
@@ -24,12 +24,10 @@ namespace System.Runtime.InteropServices
         /// </remarks>
         public static Memory<T> AsMemory<T>(ReadOnlyMemory<T> readOnlyMemory) =>
             Unsafe.As<ReadOnlyMemory<T>, Memory<T>>(ref readOnlyMemory);
-        
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ref T GetReference<T>(in Span<T> span) => ref span.Reference;
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ref readonly T GetReference<T>(in ReadOnlySpan<T> span) => ref span.Reference;
+        public static ref T GetReference<T>(Span<T> span) => ref span._pointer.Value;
+
+        public static ref readonly T GetReference<T>(ReadOnlySpan<T> span) => ref span._pointer.Value;
 
         public static bool TryGetArray<T>(ReadOnlyMemory<T> readOnlyMemory, out ArraySegment<T> arraySegment)
         {

--- a/src/mscorlib/shared/System/Runtime/InteropServices/MemoryMarshal.cs
+++ b/src/mscorlib/shared/System/Runtime/InteropServices/MemoryMarshal.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.Runtime.CompilerServices;
 
 namespace System.Runtime.InteropServices
@@ -23,5 +24,36 @@ namespace System.Runtime.InteropServices
         /// </remarks>
         public static Memory<T> AsMemory<T>(ReadOnlyMemory<T> readOnlyMemory) =>
             Unsafe.As<ReadOnlyMemory<T>, Memory<T>>(ref readOnlyMemory);
+        
+        public static ref T GetReference<T>(in Span<T> span)
+        {
+            return ref span.Pointer.Value;
+        }
+
+        public static ref readonly T GetReference<T>(in ReadOnlySpan<T> span)
+        {
+            return ref span.Pointer.Value;
+        }
+
+        public static bool TryGetArray<T>(ReadOnlyMemory<T> readOnlyMemory, out ArraySegment<T> arraySegment)
+        {
+            object obj = readOnlyMemory.GetObjectStartLength(out int index, out int length);
+            if (index < 0)
+            {
+                if (((OwnedMemory<T>)obj).TryGetArray(out var segment))
+                {
+                    arraySegment = new ArraySegment<T>(segment.Array, segment.Offset + (index & ReadOnlyMemory<T>.RemoveOwnedFlagBitMask), length);
+                    return true;
+                }
+            }
+            else if (obj is T[] arr)
+            {
+                arraySegment = new ArraySegment<T>(arr, index, length);
+                return true;
+            }
+
+            arraySegment = default;
+            return false;
+        }
     }
 }

--- a/src/mscorlib/shared/System/Span.cs
+++ b/src/mscorlib/shared/System/Span.cs
@@ -27,7 +27,7 @@ namespace System
     public readonly ref struct Span<T>
     {
         /// <summary>A byref or a native ptr.</summary>
-        private readonly ByReference<T> _pointer;
+        internal readonly ByReference<T> _pointer;
         /// <summary>The number of elements this Span contains.</summary>
 #if PROJECTN
         [Bound]
@@ -408,9 +408,6 @@ namespace System
         /// Returns an empty <see cref="Span{T}"/>
         /// </summary>
         public static Span<T> Empty => default(Span<T>);
-
-        // This exposes the internal representation for Span-related apis use only.
-        internal ref T Reference => ref _pointer.Value;
 
         /// <summary>Gets an enumerator for this span.</summary>
         public Enumerator GetEnumerator() => new Enumerator(this);

--- a/src/mscorlib/shared/System/Span.cs
+++ b/src/mscorlib/shared/System/Span.cs
@@ -409,6 +409,9 @@ namespace System
         /// </summary>
         public static Span<T> Empty => default(Span<T>);
 
+        // This exposes the internal representation for Span-related apis use only.
+        internal ByReference<T> Pointer => _pointer;
+
         /// <summary>Gets an enumerator for this span.</summary>
         public Enumerator GetEnumerator() => new Enumerator(this);
 

--- a/src/mscorlib/shared/System/Span.cs
+++ b/src/mscorlib/shared/System/Span.cs
@@ -410,7 +410,7 @@ namespace System
         public static Span<T> Empty => default(Span<T>);
 
         // This exposes the internal representation for Span-related apis use only.
-        internal ByReference<T> Pointer => _pointer;
+        internal ref T Reference => ref _pointer.Value;
 
         /// <summary>Gets an enumerator for this span.</summary>
         public Enumerator GetEnumerator() => new Enumerator(this);


### PR DESCRIPTION
Sets up the ground work for:
https://github.com/dotnet/corefx/issues/25412
https://github.com/dotnet/corefx/issues/25615

Test updates and changes in corefx ~to follow after.~ https://github.com/dotnet/corefx/pull/25789

Following the staging plan from here: https://github.com/dotnet/corefx/issues/23881#issuecomment-343767740

1. Add MemoryExtensions.GetReference/TryGetArray
2. Convert all uses of DangerousGetPinnableReference/DangerousTryGetArray in coreclr, corefx, corert, corefxlab, aspnet, ... to MemoryExtensions.GetReference
3. Change DangerousGetPinnableReference to whatever we like to make it fit the pinning pattern and remove DangerousTryGetArray.

Doing it this way will avoid the need for complex staging or things being on the floor for extensive periods of time.


cc @jkotas, @stephentoub, @KrzysztofCwalina 