### PR TITLE
Externalize exception boxing

### DIFF
--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -100,14 +100,16 @@ namespace System
                                                     ExceptionResource.ArgumentOutOfRange_Count);
         }
 
-        internal static void ThrowWrongKeyTypeArgumentException(object key, Type targetType)
+        internal static void ThrowWrongKeyTypeArgumentException<T>(T key, Type targetType)
         {
-            throw GetWrongKeyTypeArgumentException(key, targetType);
+            // Generic key to move the boxing to the right hand side of throw
+            throw GetWrongKeyTypeArgumentException((object)key, targetType);
         }
 
-        internal static void ThrowWrongValueTypeArgumentException(object value, Type targetType)
+        internal static void ThrowWrongValueTypeArgumentException<T>(T value, Type targetType)
         {
-            throw GetWrongValueTypeArgumentException(value, targetType);
+            // Generic key to move the boxing to the right hand side of throw
+            throw GetWrongValueTypeArgumentException((object)value, targetType);
         }
 
         private static ArgumentException GetAddingDuplicateWithKeyArgumentException(object key)
@@ -115,14 +117,16 @@ namespace System
             return new ArgumentException(SR.Format(SR.Argument_AddingDuplicateWithKey, key));
         }
 
-        internal static void ThrowAddingDuplicateWithKeyArgumentException(object key)
+        internal static void ThrowAddingDuplicateWithKeyArgumentException<T>(T key)
         {
-            throw GetAddingDuplicateWithKeyArgumentException(key);
+            // Generic key to move the boxing to the right hand side of throw
+            throw GetAddingDuplicateWithKeyArgumentException((object)key);
         }
 
-        internal static void ThrowKeyNotFoundException(object key)
+        internal static void ThrowKeyNotFoundException<T>(T key)
         {
-            throw GetKeyNotFoundException(key);
+            // Generic key to move the boxing to the right hand side of throw
+            throw GetKeyNotFoundException((object)key);
         }
 
         internal static void ThrowArgumentException(ExceptionResource resource)


### PR DESCRIPTION
Changes call site in method from

```
G_M61759_IG20:
       488D0D00000000       lea      rcx, [(reloc)]
       E800000000           call     CORINFO_HELP_NEWSFAST
       488BC8               mov      rcx, rax
       8B842498000000       mov      eax, dword ptr [rsp+98H]
       66894108             mov      word  ptr [rcx+8], ax
       E800000000           call     ThrowHelper:ThrowAddingDuplicateWithKeyArgumentException(ref)
       CC   
``` 
to
```
G_M61759_IG20:
       8B8C2498000000       mov      ecx, dword ptr [rsp+98H]
       0FB7C9               movzx    rcx, cx
       E800000000           call     ThrowHelper:ThrowAddingDuplicateWithKeyArgumentException(char)
       CC                   int3    
```

PTAL @jkotas 