### PR TITLE
Don't set BuildVersionFile when doing a test build

### DIFF
--- a/tests/dir.props
+++ b/tests/dir.props
@@ -103,10 +103,6 @@
     <RestorePackages>false</RestorePackages>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <BuildVersionFile>$(BaseIntermediateOutputPath)BuildVersion-$(OfficialBuildId).props</BuildVersionFile>
-  </PropertyGroup>
-
   <!-- If we want to overwrite the desired CoreCLR package version, we need to get the new version from the generated props file in bin/obj -->
   <Import Condition="'$(OverwriteCoreClrPackageVersion)' == 'true'" Project="$(BuildVersionFile)" />
 

--- a/tests/dir.props
+++ b/tests/dir.props
@@ -103,6 +103,10 @@
     <RestorePackages>false</RestorePackages>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(OverwriteCoreClrPackageVersion)' == 'true'">
+    <BuildVersionFile>$(BaseIntermediateOutputPath)BuildVersion-$(OfficialBuildId).props</BuildVersionFile>
+  </PropertyGroup>
+
   <!-- If we want to overwrite the desired CoreCLR package version, we need to get the new version from the generated props file in bin/obj -->
   <Import Condition="'$(OverwriteCoreClrPackageVersion)' == 'true'" Project="$(BuildVersionFile)" />
 


### PR DESCRIPTION
Fixes the underlying perf bug that caused https://github.com/dotnet/coreclr/issues/15405 and is probably slowing down the CI a lot.

The problem here is that `tests/dir.props` attempts to re-calculate `BuildVersionFile` and does so incorrectly, despite the value already being set. At the time that `BuildVersionFile` is evaluated in `tests/dir.props`, `OfficialBuildId` is not set, which results in `BuildVersionFile` being "BuildVersion-.props". From there, all of the projects in the test build get into a nasty loop:

1. The build is expecting a "BuildVersion-(current date, e.g. 20171207).props" file to be present as the "version props" file. On the start of a test project build, this file is checked for existence and, if it doesn't exist, the `CreateOrUpdateCurrentVersionFile` target is fired.
2. `CreateOrUpdateCurrentVersionFile` gathers version information by invoking `git` twice and a handful of other programs in order to figure out who is doing the build and what time it is occuring.
3. `CreateOrUpdateCurrentVersionFile` saves this version info to what it believes to be `BuildVersionFile`, which has been changed to be something incorrect ("BuildVersion-.props"). Usually, this file exists already and so nothing happens.

Because the version file that is being generated has an unexpected name, MSBuild *always* triggers `CreateOrUpdateCurrentVersionFile`, which hits the disk at least twice (for git) for *every* project in the transitive closure of the project being built. I first noticed this bug when I saw that a bunch of tests that compile with `ilasm` were building very slowly and it turns out that this is because each ilasm test references another project, so the above loop was occurring twice (for a total of 4 git invocations) for every IL test build.

This PR removes the assignment to `BuildVersionFile` in `tests/dir.props` because, as far as I can tell, `BuildVersionFile` already has the right value assigned to it when `tests/dir.props` is imported and there's no need to re-assign it.