### PR TITLE
Fix a bad cast in AsyncPinObject

### DIFF
--- a/src/gc/objecthandle.cpp
+++ b/src/gc/objecthandle.cpp
@@ -285,7 +285,7 @@ void CALLBACK AsyncPinObject(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *pExtraInf
     Object **pRef = (Object **)pObjRef;
     _ASSERTE(lp2);
     promote_func* callback = (promote_func*)lp2;
-    callback(pRef, (ScanContext *)lp2, GC_CALL_PINNED);
+    callback(pRef, (ScanContext *)lp1, GC_CALL_PINNED);
     Object* pPinnedObj = *pRef;
     if (!HndIsNullOrDestroyedHandle(pPinnedObj))
     {


### PR DESCRIPTION
This unfortunate typo casts a function pointer (`promote_func`) to a `ScanContext`. This is obviously doomed and results in crashes in most cases. It is really suspect that this wasn't caught by our test gauntlet; perhaps we don't do I/O often in the CoreCLR test suite.

At any rate, this fixes https://github.com/dotnet/coreclr/issues/15432. I was also able to test the fix for this bug with the official latest 2.1.0-preview1 SDK build by loading a standalone GC containing my fix, though, so that's exciting!