### PR TITLE
[RyuJit][x86] delegate setting of the unused flag to rewriteWith

### DIFF
--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -315,11 +315,6 @@ GenTree* DecomposeLongs::FinalizeDecomposition(LIR::Use& use,
     assert(Range().Contains(hiResult));
 
     GenTree* gtLong = new (m_compiler, GT_LONG) GenTreeOp(GT_LONG, TYP_LONG, loResult, hiResult);
-    if (use.IsDummyUse())
-    {
-        gtLong->SetUnusedValue();
-    }
-
     loResult->ClearUnusedValue();
     hiResult->ClearUnusedValue();
 
@@ -1080,10 +1075,6 @@ GenTree* DecomposeLongs::DecomposeShift(LIR::Use& use)
         {
             GenTree* next = shift->gtNext;
             // Remove shift and don't do anything else.
-            if (shift->IsUnusedValue())
-            {
-                gtLong->SetUnusedValue();
-            }
             Range().Remove(shift);
             use.ReplaceWith(m_compiler, gtLong);
             return next;
@@ -1454,11 +1445,6 @@ GenTree* DecomposeLongs::DecomposeShift(LIR::Use& use)
 
         GenTree* call = m_compiler->gtNewHelperCallNode(helper, TYP_LONG, argList);
         call->gtFlags |= shift->gtFlags & GTF_ALL_EFFECT;
-
-        if (shift->IsUnusedValue())
-        {
-            call->SetUnusedValue();
-        }
 
         GenTreeCall*    callNode    = call->AsCall();
         ReturnTypeDesc* retTypeDesc = callNode->GetReturnTypeDesc();

--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -315,12 +315,12 @@ GenTree* DecomposeLongs::FinalizeDecomposition(LIR::Use& use,
     assert(Range().Contains(hiResult));
 
     GenTree* gtLong = new (m_compiler, GT_LONG) GenTreeOp(GT_LONG, TYP_LONG, loResult, hiResult);
-    loResult->ClearUnusedValue();
-    hiResult->ClearUnusedValue();
-
     Range().InsertAfter(insertResultAfter, gtLong);
 
     use.ReplaceWith(m_compiler, gtLong);
+
+    loResult->ClearUnusedValue();
+    hiResult->ClearUnusedValue();
 
     return gtLong->gtNext;
 }

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -191,6 +191,11 @@ void LIR::Use::ReplaceWith(Compiler* compiler, GenTree* replacement)
     assert(IsDummyUse() || m_range->Contains(m_user));
     assert(m_range->Contains(replacement));
 
+    if (Def()->IsUnusedValue())
+    {
+        replacement->SetUnusedValue();
+    }
+
     if (!IsDummyUse())
     {
         m_user->ReplaceOperand(m_edge, replacement);


### PR DESCRIPTION
Do not bother users of `LIR:Use::ReplaceWith` with controlling `IsUnused` on the new node and set this flag inside `ReplaceWith`.
