### PR TITLE
Use stackalloc in string.Split

### DIFF
--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -614,6 +614,7 @@
     <Compile Include="$(BclSourcesRoot)\mscorlib.Friends.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="shared\System\Buffers\ValueListBuilder.cs" />
     <Compile Include="src\System\Runtime\RuntimeImports.cs" />
   </ItemGroup>
   <Import Project="shared\System.Private.CoreLib.Shared.projitems" />

--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -614,7 +614,6 @@
     <Compile Include="$(BclSourcesRoot)\mscorlib.Friends.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="shared\System\Buffers\ValueListBuilder.cs" />
     <Compile Include="src\System\Runtime\RuntimeImports.cs" />
   </ItemGroup>
   <Import Project="shared\System.Private.CoreLib.Shared.projitems" />

--- a/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
@@ -71,6 +71,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Generic\KeyNotFoundException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Generic\KeyValuePair.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Generic\NonRandomizedStringEqualityComparer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Generic\ValueListBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Generic\List.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\HashHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\ICollection.cs" />

--- a/src/mscorlib/shared/System/Buffers/ValueListBuilder.cs
+++ b/src/mscorlib/shared/System/Buffers/ValueListBuilder.cs
@@ -22,16 +22,11 @@ namespace System.Buffers
         public void Append(T item)
         {
             int pos = _pos;
-            if (pos < _span.Length)
-            {
-                _span[pos] = item;
-                _pos = pos + 1;
-            }
-            else
-            {
+            if (pos >= _span.Length)
                 Grow();
-                Append(item);
-            }
+
+            _span[pos] = item;
+            _pos = pos + 1;
         }
 
         public ReadOnlySpan<T> AsReadOnlySpan()

--- a/src/mscorlib/shared/System/Buffers/ValueListBuilder.cs
+++ b/src/mscorlib/shared/System/Buffers/ValueListBuilder.cs
@@ -1,0 +1,66 @@
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System.Buffers
+{
+    internal ref struct ValueListBuilder<T>
+    {
+        private Span<T> _span;
+        private T[] _arrayFromPool;
+        private int _pos;
+
+        public ValueListBuilder(Span<T> initialSpan)
+        {
+            _span = initialSpan;
+            _arrayFromPool = null;
+            _pos = 0;
+        }
+
+        public int Length => _pos;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(T item)
+        {
+            int pos = _pos;
+            if (pos < _span.Length)
+            {
+                _span[pos] = item;
+                _pos = pos + 1;
+            }
+            else
+            {
+                Grow();
+                Append(item);
+            }
+        }
+
+        public ReadOnlySpan<T> AsReadOnlySpan()
+        {
+            return _span.Slice(0, _pos);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Dispose()
+        {
+            if (_arrayFromPool != null)
+            {
+                ArrayPool<T>.Shared.Return(_arrayFromPool);
+            }
+        }
+
+        private void Grow()
+        {
+            T[] array = ArrayPool<T>.Shared.Rent(_span.Length * 2);
+
+            bool success = _span.TryCopyTo(array);
+            Debug.Assert(success);
+
+            T[] toReturn = _arrayFromPool;
+            _span = _arrayFromPool = array;
+            if (toReturn != null)
+            {
+                ArrayPool<T>.Shared.Return(toReturn);
+            }
+        }
+    }
+}

--- a/src/mscorlib/shared/System/Collections/Generic/ValueListBuilder.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/ValueListBuilder.cs
@@ -1,7 +1,12 @@
-﻿using System.Diagnostics;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
-namespace System.Buffers
+namespace System.Collections.Generic
 {
     internal ref struct ValueListBuilder<T>
     {
@@ -40,6 +45,7 @@ namespace System.Buffers
             if (_arrayFromPool != null)
             {
                 ArrayPool<T>.Shared.Return(_arrayFromPool);
+                _arrayFromPool = null;
             }
         }
 

--- a/src/mscorlib/src/System/String.Manipulation.cs
+++ b/src/mscorlib/src/System/String.Manipulation.cs
@@ -14,7 +14,7 @@ namespace System
 {
     public partial class String
     {
-        private const int StackallocStringLengthLimit = 512;
+        private const int StackallocIntBufferSizeLimit = 512;
 
         unsafe private static void FillStringChecked(String dest, int destPos, String src)
         {
@@ -1163,7 +1163,7 @@ namespace System
                 return new string[] { this };
             }
 
-            Span<int> initialSpan = stackalloc int[StackallocStringLengthLimit];
+            Span<int> initialSpan = stackalloc int[StackallocIntBufferSizeLimit];
             var sepListBuilder = new ValueListBuilder<int>(initialSpan);
 
             MakeSeparatorList(separators, ref sepListBuilder);
@@ -1241,10 +1241,10 @@ namespace System
                 return SplitInternal(separator, count, options);
             }
             
-            Span<int> sepListInitialSpan = stackalloc int[StackallocStringLengthLimit];
+            Span<int> sepListInitialSpan = stackalloc int[StackallocIntBufferSizeLimit];
             var sepListBuilder = new ValueListBuilder<int>(sepListInitialSpan);
 
-            Span<int> lengthListInitialSpan = stackalloc int[StackallocStringLengthLimit];
+            Span<int> lengthListInitialSpan = stackalloc int[StackallocIntBufferSizeLimit];
             var lengthListBuilder = new ValueListBuilder<int>(lengthListInitialSpan);
 
             MakeSeparatorList(separators, ref sepListBuilder, ref lengthListBuilder);
@@ -1269,7 +1269,7 @@ namespace System
 
         private string[] SplitInternal(string separator, int count, StringSplitOptions options)
         {
-            Span<int> sepListInitialSpan = stackalloc int[StackallocStringLengthLimit];
+            Span<int> sepListInitialSpan = stackalloc int[StackallocIntBufferSizeLimit];
             var sepListBuilder = new ValueListBuilder<int>(sepListInitialSpan);
 
             MakeSeparatorList(separator, ref sepListBuilder);


### PR DESCRIPTION
Adds usage of Span and stackalloc for strings that are not large. Allows to avoid allocations of int arrays.

Benchmarks:
```
|                    Method | Mean after | Mean before |  Mean diff |  Allocated after | Allocated before | Allocated diff |
|-------------------------- |-----------:|------------:|-----------:|-----------------:|-----------------:|---------------:|
|         SplitCharLength20 |   201.6 us |  213.80 us  |    5.71%   |     210.94 KB    |     312.50 KB    |     32.50%     |
|        SplitCharLength200 | 1,199.6 us | 1194.10 us  |   -0.46%   |    1546.88 KB    |    2351.56 KB    |     34.21%     |
|        SplitCharLength600 | 3,367.1 us | 3276.00 us  |   -2.78%   |    6882.81 KB    |    6882.81 KB    |       0%       |
|       SplitStringLength20 |   159.4 us |  181.80 us  |   12.32%   |     132.81 KB    |     234.38 KB    |     43.34%     |
|      SplitStringLength200 |   767.9 us |  844.40 us  |    9.06%   |     835.94 KB    |    1640.63 KB    |     49.05%     |
|      SplitStringLength600 | 2,160.8 us | 2253.70 us  |    4.12%   |    4765.63 KB    |    4765.63 KB    |       0%       |
|  SplitStringArrayLength20 |   308.5 us |  347.90 us  |   11.33%   |     210.94 KB    |     414.06 KB    |     49.06%     |
| SplitStringArrayLength200 | 1,838.7 us | 1848.60 us  |    0.54%   |    1195.31 KB    |    2804.69 KB    |     57.38%     |
| SplitStringArrayLength600 | 5,171.7 us | 5155.00 us  |   -0.32%   |    8117.19 KB    |    8117.19 KB    |       0%       |
```

Benchmark code:
https://gist.github.com/cod7alex/f123c3e662d21c3327399aa71d338485

Closes https://github.com/dotnet/coreclr/issues/6136

@danmosemsft @stephentoub 