### PR TITLE
Jit: fix long shift helper for overly long shift counts

### DIFF
--- a/src/vm/i386/jithelp.asm
+++ b/src/vm/i386/jithelp.asm
@@ -483,6 +483,8 @@ ret
         ALIGN 16
 PUBLIC JIT_LLsh
 JIT_LLsh PROC
+; Reduce shift amount mod 64
+        and     ecx, 63
 ; Handle shifts of between bits 0 and 31
         cmp     ecx, 32
         jae     short LLshMORE32

--- a/tests/src/JIT/Regression/JitBlue/GitHub_15291/GitHub_15291.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_15291/GitHub_15291.ilproj
@@ -8,7 +8,6 @@
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_15319/GitHub_15319_1.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_15319/GitHub_15319_1.il
@@ -17,6 +17,7 @@
        ldarg.s      0x0
        clt         
        shl         
+       conv.i4
        ret 
   }
 

--- a/tests/src/JIT/Regression/JitBlue/GitHub_15319/GitHub_15319_1.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_15319/GitHub_15319_1.ilproj
@@ -8,7 +8,6 @@
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>


### PR DESCRIPTION
Reduce shift amount modulo 64 to match behavior on other platforms and the
jit optimizer.

Also, fix IL in related test case so it is valid for 32 bits too.

Also, make these two tests pri-0 so they get run with regular CI testing.

Fixes #15442.