### PR TITLE
[Port to Release/2.0.0] Fix uaf in DestroyThread function

### DIFF
--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -987,12 +987,6 @@ void DestroyThread(Thread *th)
 #endif // _TARGET_X86_
 #endif // WIN64EXCEPTIONS
 
-    if (g_fEEShutDown == 0) 
-    {
-        th->SetThreadState(Thread::TS_ReportDead);
-        th->OnThreadTerminate(FALSE);
-    }
-
 #ifdef FEATURE_PERFTRACING
     // Before the thread dies, mark its buffers as no longer owned
     // so that they can be cleaned up after the thread dies.
@@ -1002,6 +996,12 @@ void DestroyThread(Thread *th)
         pBufferList->SetOwnedByThread(false);
     }
 #endif // FEATURE_PERFTRACING
+
+    if (g_fEEShutDown == 0) 
+    {
+        th->SetThreadState(Thread::TS_ReportDead);
+        th->OnThreadTerminate(FALSE);
+    }
 }
 
 //-------------------------------------------------------------------------


### PR DESCRIPTION
Fixes a crash on Tizen in EventPipe.  From the commit:

Mark thread's buffers as no longer owned before calling Thread::OnThreadTerminate because thread can delete itself in this method.