### PR TITLE
Archive the obj directory for arm builds

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1820,7 +1820,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                     --testDirFile=./tests/testsRunningInsideARM.txt"""
 
                     // Basic archiving of the build, no pal tests
-                    Utilities.addArchival(newJob, "bin/Product/**", "bin/Product/**/.nuget/**")
+                    Utilities.addArchival(newJob, "bin/Product/**,bin/obj/*/tests/**/*.dylib,bin/obj/*/tests/**/*.so", "bin/Product/**/.nuget/**")
                     break
                 default:
                     println("Unknown architecture: ${architecture}");


### PR DESCRIPTION
This will allow us to correctly populate the core_root for eventual
arm linux testing.