### PR TITLE
Remove CoreFX runtest dependency

### DIFF
--- a/Documentation/building/unix-test-instructions.md
+++ b/Documentation/building/unix-test-instructions.md
@@ -6,19 +6,24 @@ CoreCLR tests
 
 **Building**
 
-Build CoreCLR on [Unix](https://github.com/dotnet/coreclr/blob/master/Documentation/building/linux-instructions.md), and CoreFX on [Unix](https://github.com/dotnet/corefx/blob/master/Documentation/building/unix-instructions.md).
+Build CoreCLR on [Unix](https://github.com/dotnet/coreclr/blob/master/Documentation/building/linux-instructions.md).
 
 **Building the Tests**
 
+DotNet is required to build the tests, this can be done on any platform then copied over if the arch or os does not support DotNet. If DotNet is not supported, [CoreFX](https://github.com/dotnet/corefx/blob/master/Documentation/building/unix-instructions.md) is also required to be built.
+
 To build the tests on Unix:
 
-> `./build-test.sh -rebuild`
-
-As of [#11860](https://github.com/dotnet/coreclr/pull/11860) building the tests on unix works; however, it will take significantly more time than building on Windows.
+> `./build-test.sh`
 
 To build on Windows:
 
-> `C:\coreclr>build-test.cmd -rebuild`
+> `C:\coreclr>build-test.cmd`
+
+Please note that this builds the Priority 0 tests. To build priority 1:
+
+> `build-test.sh -priority 1`
+
 
 **Building Individual Tests**
 
@@ -83,41 +88,54 @@ sudo apt-get install libunwind8:armhf libunwind8-dev:armhf libicu-dev:armhf libl
 **Running tests**
 
 The following instructions assume that on the Unix machine:
-- The CoreCLR repo is cloned at `~/coreclr`
-- The CoreFX repo is cloned at `~/corefx`
-- The Windows clone of the CoreCLR repo is mounted at `/media/coreclr`
+- The CoreCLR repo is cloned at `/mnt/coreclr`
 
-Tests currently need to be built on Windows and copied over to the Unix machine for testing. Copy the test build over to the Unix machine:
+If DotNet is unsupported
+- The CoreFX repo is cloned at `/mnt/corefx`
+- The other platform's clone of the CoreCLR repo is mounted at `/media/coreclr`
 
-> `cp --recursive /media/coreclr/bin/tests/Windows_NT.x64.Debug ~/test/`
+The following steps are different if DotNet is supported or not on your arch and os.
+
+**DotNet is supported**
+
+build-test.sh will have setup the Core_Root directory correctly after the test build. If this was either skipped or needs to be regenerated use:
+
+>`build-test.sh generatelayoutonly`
+
+To run the tests run with the --coreOverlayDir path
+
+> ```bash
+> ~/coreclr$ tests/runtest.sh
+>     --testRootDir=/mnt/coreclr/bin/tests/Linux.x64.Debug
+>     --testNativeBinDir=/mnt/coreclr/bin/obj/Linux.x64.Debug/tests
+>     --coreOverlayDir=/mnt/coreclr/bin/tests/Tests/Core_Root
+>     --copyNativeTestBin
+> ```
+
+**DotNet is not supported**
+
+Tests need to be built on another platform and copied over to the Unix machine for testing. Copy the test build over to the Unix machine:
+
+> `cp --recursive /media/coreclr/bin/tests/Windows_NT.x64.Debug /mnt/test/`
 
 See runtest.sh usage information:
 
-> `~/coreclr$ tests/runtest.sh --help`
+> `/mnt/coreclr$ tests/runtest.sh --help`
 
 Run tests (`Debug` may be replaced with `Release` or `Checked`, depending on which Configuration you've built):
 
 > ```bash
-> ~/coreclr$ tests/runtest.sh
->     --testRootDir=~/test/Windows_NT.x64.Debug
->     --testNativeBinDir=~/coreclr/bin/obj/Linux.x64.Debug/tests
->     --coreClrBinDir=~/coreclr/bin/Product/Linux.x64.Debug
->     --mscorlibDir=~/coreclr/bin/Product/Linux.x64.Debug
->     --coreFxBinDir=~/corefx/bin/runtime/netcoreapp-Linux-Debug-x64
+> /mnt/coreclr$ tests/runtest.sh
+>     --testRootDir=/mnt/test/Windows_NT.x64.Debug
+>     --testNativeBinDir=/mnt/coreclr/bin/obj/Linux.x64.Debug/tests
+>     --coreClrBinDir=/mnt/coreclr/bin/Product/Linux.x64.Debug
+>     --mscorlibDir=/mnt/coreclr/bin/Product/Linux.x64.Debug
+>     --coreFxBinDir=/mnt/corefx/bin/runtime/netcoreapp-Linux-Debug-x64
 > ```
 
 The method above will copy dependencies from the set of directories provided to create an 'overlay' directory.
-If you already have an overlay directory prepared with the dependencies you need, you can specify `--coreOverlayDir`
-instead of `--coreClrBinDir`, `--mscorlibDir`, `--coreFxBinDir`, and `--coreFxNativeBinDir`. It would look something like:
 
-
-> ```bash
-> ~/coreclr$ tests/runtest.sh
->     --testRootDir=~/test/Windows_NT.x64.Debug
->     --testNativeBinDir=~/coreclr/bin/obj/Linux.x64.Debug/tests
->     --coreOverlayDir=/path/to/directory/containing/overlay
-> ```
-
+**Results**
 
 Test results will go into:
 

--- a/build-test.sh
+++ b/build-test.sh
@@ -3,29 +3,50 @@
 initHostDistroRid()
 {
     __HostDistroRid=""
+
+    # Some OS groups should default to use the portable packages
+    if [ "$__BuildOS" == "OSX" ]; then
+        __PortableBuild=1
+    fi
+
     if [ "$__HostOS" == "Linux" ]; then
-        if [ -e /etc/os-release ]; then
+        if [ -e /etc/redhat-release ]; then
+            local redhatRelease=$(</etc/redhat-release)
+            if [[ $redhatRelease == "CentOS release 6."* || $redhatRelease == "Red Hat Enterprise Linux Server release 6."* ]]; then
+                __HostDistroRid="rhel.6-$__HostArch"
+            else
+                __PortableBuild=1
+            fi
+        elif [ -e /etc/os-release ]; then
             source /etc/os-release
             if [[ $ID == "alpine" ]]; then
                 # remove the last version digit
                 VERSION_ID=${VERSION_ID%.*}
+            else
+                __PortableBuild=1
             fi
+
             __HostDistroRid="$ID.$VERSION_ID-$__HostArch"
-        elif [ -e /etc/redhat-release ]; then
-            local redhatRelease=$(</etc/redhat-release)
-            if [[ $redhatRelease == "CentOS release 6."* || $redhatRelease == "Red Hat Enterprise Linux Server release 6."* ]]; then
-               __HostDistroRid="rhel.6-$__HostArch"
-            fi
-        fi
-    fi
-    if [ "$__HostOS" == "FreeBSD" ]; then
+        fi        
+    elif [ "$__HostOS" == "FreeBSD" ]; then
         __freebsd_version=`sysctl -n kern.osrelease | cut -f1 -d'.'`
         __HostDistroRid="freebsd.$__freebsd_version-$__HostArch"
+    fi
+
+    # Portable builds target the base RID
+    if [ "$__PortableBuild" == 1 ]; then
+        if [ "$__BuildOS" == "OSX" ]; then
+            export __HostDistroRid="osx-$__BuildArch"
+        elif [ "$__BuildOS" == "Linux" ]; then
+            export __HostDistroRid="linux-$__BuildArch"
+        fi
     fi
 
     if [ "$__HostDistroRid" == "" ]; then
         echo "WARNING: Cannot determine runtime id for current distro."
     fi
+
+    echo "Setting __HostDistroRid to $__HostDistroRid"
 }
 
 initTargetDistroRid()
@@ -33,8 +54,13 @@ initTargetDistroRid()
     if [ $__CrossBuild == 1 ]; then
         if [ "$__BuildOS" == "Linux" ]; then
             if [ ! -e $ROOTFS_DIR/etc/os-release ]; then
-                echo "WARNING: Can not determine runtime id for current distro."
-                export __DistroRid=""
+                if [ -e $ROOTFS_DIR/android_platform ]; then
+                    source $ROOTFS_DIR/android_platform
+                    export __DistroRid="$RID"
+                else
+                    echo "WARNING: Cannot determine runtime id for current distro."
+                    export __DistroRid=""
+                fi
             else
                 source $ROOTFS_DIR/etc/os-release
                 export __DistroRid="$ID.$VERSION_ID-$__BuildArch"
@@ -44,24 +70,22 @@ initTargetDistroRid()
         export __DistroRid="$__HostDistroRid"
     fi
 
-    if [ "$__BuildOS" == "OSX" ]; then
-        __PortableBuild=1
+    if [ "$ID.$VERSION_ID" == "ubuntu.16.04" ]; then
+     export __DistroRid="ubuntu.14.04-$__BuildArch"
     fi
 
     # Portable builds target the base RID
     if [ "$__PortableBuild" == 1 ]; then
         if [ "$__BuildOS" == "Linux" ]; then
             export __DistroRid="linux-$__BuildArch"
+            export __RuntimeId="linux-$__BuildArch"
         elif [ "$__BuildOS" == "OSX" ]; then
             export __DistroRid="osx-$__BuildArch"
+            export __RuntimeId="osx-$__BuildArch"
         fi
     fi
 
-   if [ "$ID.$VERSION_ID" == "ubuntu.16.04" ]; then
-     export __DistroRid="ubuntu.14.04-$__BuildArch"
-   fi
-
-   echo "__DistroRid: " $__DistroRid
+    echo "__DistroRid: " $__DistroRid
 }
 
 isMSBuildOnNETCoreSupported()
@@ -89,6 +113,84 @@ isMSBuildOnNETCoreSupported()
     fi
 }
 
+generate_layout()
+{
+    __TestDir=$__ProjectDir/tests
+    __ProjectFilesDir=$__TestDir
+    __TestBinDir=$__TestWorkingDir
+
+    if [ $__RebuildTests -ne 0 ]; then
+        if [ -d "${__TestBinDir}" ]; then
+            echo "Removing tests build dir: ${__TestBinDir}"
+            rm -rf $__TestBinDir
+        fi
+    fi
+
+    __CMakeBinDir="${__TestBinDir}"
+
+    if [ -z "$__TestIntermediateDir" ]; then
+        __TestIntermediateDir="tests/obj/${__BuildOS}.${__BuildArch}.${__BuildType}"
+    fi
+
+    echo "__BuildOS: ${__BuildOS}"
+    echo "__BuildArch: ${__BuildArch}"
+    echo "__BuildType: ${__BuildType}"
+    echo "__TestIntermediateDir: ${__TestIntermediateDir}"
+
+    if [ ! -f "$__TestBinDir" ]; then
+        echo "Creating TestBinDir: ${__TestBinDir}"
+        mkdir -p $__TestBinDir
+    fi
+    if [ ! -f "$__LogsDir" ]; then
+        echo "Creating LogsDir: ${__LogsDir}"
+        mkdir -p $__LogsDir
+    fi
+
+    __BuildProperties="-p:OSGroup=${__BuildOS} -p:BuildOS=${__BuildOS} -p:BuildArch=${__BuildArch} -p:BuildType=${__BuildType}"
+
+    # =========================================================================================
+    # ===
+    # === Restore product binaries from packages
+    # ===
+    # =========================================================================================
+
+    build_Tests_internal "Restore_Packages" "${__ProjectDir}/tests/build.proj" " -BatchRestorePackages" "Restore product binaries (build tests)"
+
+    if [ -n "$__UpdateInvalidPackagesArg" ]; then
+        __up=-updateinvalidpackageversion
+    fi
+
+    echo "${__MsgPrefix}Creating test overlay..."
+
+    if [ -z "$xUnitTestBinBase" ]; then
+      xUnitTestBinBase=$__TestWorkingDir
+    fi
+
+    export CORE_ROOT=$xUnitTestBinBase/Tests/Core_Root
+
+    if [ -d "${CORE_ROOT}" ]; then
+      rm -rf $CORE_ROOT
+    fi
+
+    mkdir -p $CORE_ROOT
+
+    build_Tests_internal "Tests_Overlay_Managed" "${__ProjectDir}/tests/runtest.proj" "-testOverlay" "Creating test overlay"
+
+    chmod +x $__BinDir/corerun
+    chmod +x $__BinDir/crossgen
+
+    # Make sure to copy over the pulled down packages
+    cp -r $__BinDir/* $CORE_ROOT/ > /dev/null
+
+    # Work hardcoded path around
+    if [ ! -f "${__BuildToolsDir}/Microsoft.CSharp.Core.Targets" ]; then
+        ln -s "${__BuildToolsDir}/Microsoft.CSharp.Core.targets" "${__BuildToolsDir}/Microsoft.CSharp.Core.Targets"
+    fi
+    if [ ! -f "${__BuildToolsDir}/Microsoft.CSharp.targets" ]; then
+        ln -s "${__BuildToolsDir}/Microsoft.CSharp.Targets" "${__BuildToolsDir}/Microsoft.CSharp.targets"
+    fi
+}
+
 build_Tests()
 {
     __TestDir=$__ProjectDir/tests
@@ -108,10 +210,10 @@ build_Tests()
         __TestIntermediateDir="tests/obj/${__BuildOS}.${__BuildArch}.${__BuildType}"
     fi
 
-	echo "__BuildOS: ${__BuildOS}"
-	echo "__BuildArch: ${__BuildArch}"
-	echo "__BuildType: ${__BuildType}"
-	echo "__TestIntermediateDir: ${__TestIntermediateDir}"
+    echo "__BuildOS: ${__BuildOS}"
+    echo "__BuildArch: ${__BuildArch}"
+    echo "__BuildType: ${__BuildType}"
+    echo "__TestIntermediateDir: ${__TestIntermediateDir}"
 
     if [ ! -f "$__TestBinDir" ]; then
         echo "Creating TestBinDir: ${__TestBinDir}"
@@ -132,18 +234,8 @@ build_Tests()
 
     build_Tests_internal "Restore_Product" "${__ProjectDir}/tests/build.proj" " -BatchRestorePackages" "Restore product binaries (build tests)"
 
-    build_Tests_internal "Tests_GenerateRuntimeLayout" "${__ProjectDir}/tests/runtest.proj" "-BinPlaceRef -BinPlaceProduct -CopyCrossgenToProduct" "Restore product binaries (run tests)"
-
-    if [ -n "$__UpdateInvalidPackagesArg" ]; then
-        __up=-updateinvalidpackageversion
-    fi
-
-    # Work hardcoded path around
-    if [ ! -f "${__BuildToolsDir}/Microsoft.CSharp.Core.Targets" ]; then
-        ln -s "${__BuildToolsDir}/Microsoft.CSharp.Core.targets" "${__BuildToolsDir}/Microsoft.CSharp.Core.Targets"
-    fi
-    if [ ! -f "${__BuildToolsDir}/Microsoft.CSharp.targets" ]; then
-        ln -s "${__BuildToolsDir}/Microsoft.CSharp.Targets" "${__BuildToolsDir}/Microsoft.CSharp.targets"
+    if [ -n "$__BuildAgainstPackagesArg" ]; then
+        build_Tests_internal "Tests_GenerateRuntimeLayout" "${__ProjectDir}/tests/runtest.proj" "-BinPlaceRef -BinPlaceProduct -CopyCrossgenToProduct" "Restore product binaries (run tests)"
     fi
 
     echo "Starting the Managed Tests Build..."
@@ -152,7 +244,7 @@ build_Tests()
 
     if [ ! -f $__ManagedTestBuiltMarker ]; then
 
-	    build_Tests_internal "Tests_Managed" "$__ProjectDir/tests/build.proj" "$__up" "Managed tests build (build tests)"
+        build_Tests_internal "Tests_Managed" "$__ProjectDir/tests/build.proj" "$__up" "Managed tests build (build tests)"
 
         if [ $? -ne 0 ]; then
             echo "${__MsgPrefix}Error: build failed. Refer to the build log files for details (above)"
@@ -188,23 +280,13 @@ build_Tests()
         fi
     fi
 
+    if [ -n "$__UpdateInvalidPackagesArg" ]; then
+        __up=-updateinvalidpackageversion
+    fi
+
     echo "${__MsgPrefix}Creating test overlay..."
 
-    if [ -z "$XuintTestBinBase" ]; then
-      XuintTestBinBase=$__TestWorkingDir
-    fi
-
-    export CORE_ROOT=$XuintTestBinBase/Tests/Core_Root
-
-    if [ ! -f "${CORE_ROOT}" ]; then
-      mkdir -p $CORE_ROOT
-    else
-      rm -rf $CORE_ROOT/*
-    fi
-
-    cp -r $__BinDir/* $CORE_ROOT/ > /dev/null
-
-    build_Tests_internal "Tests_Overlay_Managed" "$__ProjectDir/tests/runtest.proj" "-testOverlay" "Creating test overlay"
+    generate_layout
 
     if [ $__ZipTests -ne 0 ]; then
         echo "${__MsgPrefix}ZIP tests packages..."
@@ -214,13 +296,13 @@ build_Tests()
 
 build_Tests_internal()
 {
-	subDirectoryName=$1
-	projectName=$2
-	extraBuildParameters=$3
-	stepName="$4"
+    subDirectoryName=$1
+    projectName=$2
+    extraBuildParameters=$3
+    stepName="$4"
 
-	# Set up directories and file names
-	__BuildLogRootName=$subDirectoryName
+    # Set up directories and file names
+    __BuildLogRootName=$subDirectoryName
     __BuildLog="$__LogsDir/${__BuildLogRootName}.${__BuildOS}.${__BuildArch}.${__BuildType}.log"
     __BuildWrn="$__LogsDir/${__BuildLogRootName}.${__BuildOS}.${__BuildArch}.${__BuildType}.wrn"
     __BuildErr="$__LogsDir/${__BuildLogRootName}.${__BuildOS}.${__BuildArch}.${__BuildType}.err"
@@ -262,8 +344,11 @@ usage()
     echo "crosscomponent - optional argument to build cross-architecture component,"
     echo "               - will use CAC_ROOTFS_DIR environment variable if set."
     echo "portableLinux - build for Portable Linux Distribution"
+    echo "portablebuild - Use portable build."
     echo "verbose - optional argument to enable verbose build output."
     echo "rebuild - if tests have already been built - rebuild them"
+    echo "generatelayoutonly - only pull down dependencies and build coreroot"
+    echo "buildagainstpackages - pull down and build using packages."
     echo "runtests - run tests after building them"
     echo "ziptests - zips CoreCLR tests & Core_Root for a Helix run"
     echo "bindir - output directory (defaults to $__ProjectRoot/bin)"
@@ -376,6 +461,7 @@ __ClangMajorVersion=0
 __ClangMinorVersion=0
 __NuGetPath="$__PackagesDir/NuGet.exe"
 __HostDistroRid=""
+__BuildAgainstPackagesArg=
 __DistroRid=""
 __cmakeargs=""
 __PortableLinux=0
@@ -385,8 +471,8 @@ __NativeTestIntermediatesDir=
 __RunTests=0
 __RebuildTests=0
 __BuildTestWrappers=0
+__GenerateLayoutOnly=
 CORE_ROOT=
-
 
 while :; do
     if [ $# -le 0 ]; then
@@ -438,6 +524,10 @@ while :; do
 
         cross)
             __CrossBuild=1
+            ;;
+
+        portableBuild)
+            __PortableBuild=1
             ;;
 
         portablelinux)
@@ -494,6 +584,14 @@ while :; do
             __ZipTests=1
             ;;
 
+        generatelayoutonly)
+            __GenerateLayoutOnly=1
+            ;;
+
+        buildagainstpackages)
+            __BuildAgainstPackagesArg=1
+            ;;
+
         bindir)
             if [ -n "$2" ]; then
                 __RootBinDir="$2"
@@ -527,7 +625,7 @@ __RunArgs="-BuildArch=$__BuildArch -BuildType=$__BuildType -BuildOS=$__BuildOS"
 # Configure environment if we are doing a verbose build
 if [ $__VerboseBuild == 1 ]; then
     export VERBOSE=1
-	__RunArgs="$__RunArgs -verbose"
+    __RunArgs="$__RunArgs -verbose"
 fi
 
 # Set default clang version
@@ -588,8 +686,9 @@ export __CMakeBinDir="$__BinDir"
 
 if [ ! -d "$__BinDir" ] || [ ! -d "$__BinDir/bin" ]; then
 
-    echo "Has not been found built CoreCLR instance"
-    echo "Please build it before tests using './build.sh $__BuildArch $__BuildType'"
+    echo "Cannot find build directory for the CoreCLR Product."
+    echo "Please make sure CoreCLR is built before building tests."
+    echo "Example use: './build.sh $__BuildArch $__BuildType'"
     exit 1
 fi
 
@@ -611,7 +710,11 @@ __sharedFxDir=$__BuildToolsDir/dotnetcli/shared/Microsoft.NETCore.App/$__CoreClr
 
 echo "Building Tests..."
 
-build_Tests
+if [ -z "$__GenerateLayoutOnly" ]; then
+    build_Tests
+else
+    generate_layout
+fi
 
 if [ $? -ne 0 ]; then
     echo "Failed to build tests"
@@ -638,6 +741,10 @@ else
     echo "    coreClrBinDir    = $__BinDir"
     echo "    coreFxBinDir     = $CORE_ROOT"
     echo "    testNativeBinDir = $__testNativeBinDir"
+    echo " -------------------------------------------------- "
+    echo " Example runtest.sh command"
+    echo ""
+    echo " ./tests/runtest.sh --coreOverlayDir=$CORE_ROOT --testNativeBinDir=$__testNativeBinDir --testRootDir=$__TestBinDir --copyNativeTestBin"
     echo " -------------------------------------------------- "
     echo "To run single test use the following command:"
     echo "    bash ${__TestBinDir}/__TEST_PATH__/__TEST_NAME__.sh -coreroot=${CORE_ROOT}"

--- a/netci.groovy
+++ b/netci.groovy
@@ -1408,7 +1408,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
     def lowerConfiguration = configuration.toLowerCase()
 
     def priority = '1'
-    if (scenario == 'default' && isPR == true) {
+    if ((scenario == 'default' && isPR == true) || (scenario == 'default' && isBuildOnly == true)) {
         priority = '0'
     }
 
@@ -1725,7 +1725,8 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                         // only on supported OS platforms.
                         def bootstrapRid = Utilities.getBoostrapPublishRid(os)
                         def bootstrapRidEnv = bootstrapRid != null ? "__PUBLISH_RID=${bootstrapRid} " : ''
-                        buildCommands += "${bootstrapRidEnv}./build.sh verbose ${lowerConfiguration} ${architecture}" 
+
+                        buildCommands += "${bootstrapRidEnv}./build.sh verbose ${lowerConfiguration} ${architecture}"
                         buildCommands += "src/pal/tests/palsuite/runpaltests.sh \${WORKSPACE}/bin/obj/${osGroup}.${architecture}.${configuration} \${WORKSPACE}/bin/paltestout"
 
                         setTestJobTimeOut(newJob, isPR, architecture, scenario)
@@ -2289,9 +2290,18 @@ Constants.allScenarios.each { scenario ->
                         inputWindowsTestBuildArch = "x64"
                     }
 
-                    def inputWindowTestsBuildName = projectFolder + '/' +
+                    def inputWindowTestsBuildName = ""
+
+                    if (isJitStressScenario(scenario)) {
+                        inputWindowTestsBuildName = projectFolder + '/' +
+                        Utilities.getFullJobName(project, getJobName(configuration, inputWindowsTestBuildArch, 'windows_nt', testBuildScenario, false), isPR)
+                    } else {
+                        inputWindowTestsBuildName = projectFolder + '/' +
                         Utilities.getFullJobName(project, getJobName(configuration, inputWindowsTestBuildArch, 'windows_nt', testBuildScenario, true), isPR)
 
+                    }
+
+                     
                     // Enable Server GC for Ubuntu PR builds
                     def serverGCString = ''
                     if (os == 'Ubuntu' && isPR) {
@@ -2408,7 +2418,7 @@ Constants.allScenarios.each { scenario ->
                             // Set up the copies
 
                             // Coreclr build containing the tests and mscorlib
-
+                            // pri1 jobs still need to copy windows_nt built tests
                             if (windowsArmJob != true) {
                                 copyArtifacts(inputWindowTestsBuildName) {
                                     excludePatterns('**/testResults.xml', '**/*.ni.dll')
@@ -2419,6 +2429,8 @@ Constants.allScenarios.each { scenario ->
                             }
 
                             // Coreclr build we are trying to test
+                            //
+                            //  ** NOTE ** This will, correctly, overwrite over the CORE_ROOT from the windows test archive
 
                             copyArtifacts(inputCoreCLRBuildName) {
                                 excludePatterns('**/testResults.xml', '**/*.ni.dll')
@@ -2434,32 +2446,6 @@ Constants.allScenarios.each { scenario ->
                             // because we do not have a unified runner
                             if (windowsArmJob != true) {
                                 def corefxFolder = Utilities.getFolderName('dotnet/corefx') + '/' + Utilities.getFolderName(branch)
-
-                                // Corefx components.  We now have full stack builds on all distros we test here, so we can copy straight from CoreFX jobs.
-                                def osJobName
-                                if (os == 'Ubuntu') {
-                                    osJobName = 'ubuntu14.04'
-                                }
-                                else if (architecture == 'x86') {
-                                    if (os == 'Ubuntu') {
-                                        // Linux/x86 corefx jobs does not build managed yet
-                                        // Clone linux/arm corefx managed packages and overwrite linux/x86 native
-                                        osJobName = "linux_arm_cross"
-                                    }
-                                }
-                                else {
-                                    osJobName = os.toLowerCase()
-                                }
-                                copyArtifacts("${corefxFolder}/${osJobName}_release") {
-                                    includePatterns('bin/build.tar.gz')
-                                    buildSelector {
-                                        latestSuccessful(true)
-                                    }
-                                }
-
-                                shell("mkdir ./bin/CoreFxBinDir")
-                                // Unpack the corefx binaries
-                                shell("tar -xf ./bin/build.tar.gz -C ./bin/CoreFxBinDir")
 
                                 // HACK -- Arm64 does not have corefx jobs yet.
                                 // Clone corefx and build the native packages overwriting the x64 packages.
@@ -2482,7 +2468,10 @@ Constants.allScenarios.each { scenario ->
                                 }
 
                                 // Unzip the tests first.  Exit with 0
-                                shell("unzip -q -o ./bin/tests/tests.zip -d ./bin/tests/Windows_NT.${architecture}.${configuration} || exit 0")
+                                shell("unzip -q -o ./bin/tests/tests.zip -d ./bin/tests/${osGroup}.${architecture}.${configuration} || exit 0")
+                                shell("rm -r ./bin/tests/${osGroup}.${architecture}.${configuration}/Tests/Core_Root || exit 0")
+
+                                shell("./build-test.sh ${architecture} ${configuration} generatelayoutonly")
 
                                 // Execute the tests
                                 def runDocker = isNeedDocker(architecture, os, false)
@@ -2508,12 +2497,10 @@ Constants.allScenarios.each { scenario ->
                                 }
 
                                 shell("""${dockerCmd}./tests/runtest.sh \\
-                --testRootDir=\"\${WORKSPACE}/bin/tests/Windows_NT.${architecture}.${configuration}\" \\
+                --testRootDir=\"\${WORKSPACE}/bin/tests/${osGroup}.${architecture}.${configuration}\" \\
+                --coreOverlayDir=\"\${WORKSPACE}/bin/tests/${osGroup}.${architecture}.${configuration}/Tests/Core_Root\" \\
                 --testNativeBinDir=\"\${WORKSPACE}/bin/obj/${osGroup}.${architecture}.${configuration}/tests\" \\
-                --coreClrBinDir=\"\${WORKSPACE}/bin/Product/${osGroup}.${architecture}.${configuration}\" \\
-                --mscorlibDir=\"\${WORKSPACE}/bin/Product/${osGroup}.${architecture}.${configuration}\" \\
-                --coreFxBinDir=\"\${WORKSPACE}/bin/CoreFxBinDir\" \\
-                --limitedDumpGeneration ${testEnvOpt} ${serverGCString} ${testOpts}""")
+                --copyNativeTestBin --limitedDumpGeneration ${testEnvOpt} ${serverGCString} ${testOpts}""")
 
                                 if (isGcReliabilityFramework(scenario)) {
                                     // runtest.sh doesn't actually execute the reliability framework - do it here.
@@ -2701,8 +2688,9 @@ Constants.allScenarios.each { scenario ->
                         // Do not create the flow job for RHEL jobs.
                         return
                     }
-
-                    if (windowsArmJob == true) {
+                    
+                    // For pri0 jobs we can build tests on unix
+                    if (windowsArmJob) {
                         // For Windows arm jobs there is no reason to build a parallel test job.
                         // The product build supports building and archiving the tests.
 

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -9,9 +9,8 @@ function print_usage {
     echo 'coreclr/tests/runtest.sh'
     echo '    --testRootDir="temp/Windows_NT.x64.Debug"'
     echo '    --testNativeBinDir="coreclr/bin/obj/Linux.x64.Debug/tests"'
-    echo '    --coreClrBinDir="coreclr/bin/Product/Linux.x64.Debug"'
-    echo '    --mscorlibDir="windows/coreclr/bin/Product/Linux.x64.Debug"'
-    echo '    --coreFxBinDir="corefx/bin/runtime/netcoreapp-Linux-Debug-x64'
+    echo '    --coreOverlayDir="coreclr/bin/tests/Linux.x64.Debug/Tests/Core_Root"'
+    echo '    --copyNativeTestBin'
     echo ''
     echo 'Required arguments:'
     echo '  --testRootDir=<path>             : Root directory of the test build (e.g. coreclr/bin/tests/Windows_NT.x64.Debug).'
@@ -44,6 +43,7 @@ function print_usage {
     echo '  -h|--help                        : Show usage information.'
     echo '  --useServerGC                    : Enable server GC for this test run'
     echo '  --test-env                       : Script to set environment variables for tests'
+    echo '  --copyNativeTestBin              : Explicitly copy native test components into the test dir'
     echo '  --crossgen                       : Precompiles the framework managed assemblies'
     echo '  --runcrossgentests               : Runs the ready to run tests' 
     echo '  --jitstress=<n>                  : Runs the tests with COMPlus_JitStress=n'
@@ -338,6 +338,11 @@ function create_core_overlay {
 
     if [ -n "$coreOverlayDir" ]; then
         export CORE_ROOT="$coreOverlayDir"
+
+        if [ -n "$copyNativeTestBin" ]; then
+            copy_test_native_bin_to_test_root $coreOverlayDir
+        fi
+
         return
     fi
 
@@ -380,7 +385,7 @@ function create_core_overlay {
         # Test dependencies come from a Windows build, and System.Private.CoreLib.ni.dll would be the one from Windows
         rm -f "$coreOverlayDir/System.Private.CoreLib.ni.dll"
     fi
-    copy_test_native_bin_to_test_root
+    copy_test_native_bin_to_test_root $coreOverlayDir
 }
 
 declare -a skipCrossGenFiles
@@ -438,6 +443,7 @@ function precompile_overlay_assemblies {
 
 function copy_test_native_bin_to_test_root {
     local errorSource='copy_test_native_bin_to_test_root'
+    local coreRootDir=$1
 
     if [ -z "$testNativeBinDir" ]; then
         exit_with_error "$errorSource" "--testNativeBinDir is required."
@@ -448,14 +454,10 @@ function copy_test_native_bin_to_test_root {
     fi
 
     # Copy native test components from the native test build into the respective test directory in the test root directory
-    find "$testNativeBinDir" -type f -iname '*.$libExtension' |
+    find "$testNativeBinDir" -type f -iname "*.$libExtension" |
         while IFS='' read -r filePath || [ -n "$filePath" ]; do
             local dirPath=$(dirname "$filePath")
-            local destinationDirPath=${testRootDir}${dirPath:${#testNativeBinDir}}
-            if [ ! -d "$destinationDirPath" ]; then
-                exit_with_error "$errorSource" "Cannot copy native test bin '$filePath' to '$destinationDirPath/', as the destination directory does not exist."
-            fi
-            cp -f "$filePath" "$destinationDirPath/"
+            cp -f "$filePath" "$coreRootDir"
         done
 }
 
@@ -1061,6 +1063,9 @@ do
             ;;
         --jitminopts)
             export COMPlus_JITMinOpts=1
+            ;;
+        --copyNativeTestBin)
+            export copyNativeTestBin=1
             ;;
         --jitforcerelocs)
             export COMPlus_ForceRelocs=1


### PR DESCRIPTION
This change will start using build-test.sh generatelayoutonly to build
the coreoverlay directory for use with runtest.sh.

Note that there are many small changes. The following are a short summary:

1. build-test.sh
    - Add a generate layout only step which will only setup the coreroot but not build tests
    - Fixes restore issues on CentOS 7, ubuntu 14.04, OSX 10.12, 10.13
2. netci.groovy
    - Use build-test.sh generate layout to setup the core_root
    - Change runtest to use coreoverlay (it no longer builds the coreoverlay).
3. runtest.sh
    - Copy all .dylib and .so dependencies for the tests **directly** into core_root instead of the tests path

This fixes #15096