### PR TITLE
[RyuJit][Armel] Do not lose type information

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -4963,11 +4963,17 @@ GenTreePtr Compiler::fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr f
         objClass           = argObj->gtClass;
         structSize         = info.compCompHnd->getClassSize(objClass);
 
-        // If we have a GT_OBJ of a GT_ADDR then we set argValue to the child node of the GT_ADDR
-        //
-        if (argObj->gtOp1->OperGet() == GT_ADDR)
+        // If we have a GT_OBJ of a GT_ADDR then we set argValue to the child node of the GT_ADDR.
+        GenTree* op1 = argObj->gtOp1;
+        if (op1->OperGet() == GT_ADDR)
         {
-            argValue = argObj->gtOp1->gtOp.gtOp1;
+            GenTree* underlyingTree = op1->gtOp.gtOp1;
+
+            // Only update to the same type.
+            if (underlyingTree->TypeGet() == argValue->TypeGet())
+            {
+                argValue = underlyingTree;
+            }
         }
     }
     else if (arg->OperGet() == GT_LCL_VAR)

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -5356,7 +5356,9 @@ GenTreePtr Compiler::fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr f
                 {
                     GenTreeLclVarCommon* varNode = addrTaken->AsLclVarCommon();
                     unsigned             varNum  = varNode->gtLclNum;
-                    lvaSetVarDoNotEnregister(varNum DEBUGARG(DNER_IsStruct));
+                    // We access non-struct type (for example, long) as a struct type.
+                    // Make sure lclVar lives on stack to make sure its fields are accessible by address.
+                    lvaSetVarDoNotEnregister(varNum DEBUGARG(DNER_LocalField));
                 }
             }
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -5349,12 +5349,15 @@ GenTreePtr Compiler::fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr f
             GenTreePtr  baseAddr = argObj->gtOp1;
             var_types   addrType = baseAddr->TypeGet();
 
-            GenTree* addrTaken = baseAddr->gtOp.gtOp1;
-            if (addrTaken->IsLocal())
+            if (baseAddr->OperGet() == GT_ADDR)
             {
-                GenTreeLclVarCommon* varNode = addrTaken->AsLclVarCommon();
-                unsigned             varNum  = varNode->gtLclNum;
-                lvaSetVarDoNotEnregister(varNum DEBUGARG(DNER_IsStruct));
+                GenTree* addrTaken = baseAddr->gtOp.gtOp1;
+                if (addrTaken->IsLocal())
+                {
+                    GenTreeLclVarCommon* varNode = addrTaken->AsLclVarCommon();
+                    unsigned             varNum  = varNode->gtLclNum;
+                    lvaSetVarDoNotEnregister(varNum DEBUGARG(DNER_IsStruct));
+                }
             }
 
             // Create a new tree for 'arg'

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -4970,7 +4970,8 @@ GenTreePtr Compiler::fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr f
             GenTree* underlyingTree = op1->gtOp.gtOp1;
 
             // Only update to the same type.
-            if ((underlyingTree->TypeGet() == argValue->TypeGet()) && (objClass == gtGetStructHandleIfPresent(underlyingTree)))
+            if ((underlyingTree->TypeGet() == argValue->TypeGet()) &&
+                (objClass == gtGetStructHandleIfPresent(underlyingTree)))
             {
                 argValue = underlyingTree;
             }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -4973,6 +4973,7 @@ GenTreePtr Compiler::fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr f
             if (underlyingTree->TypeGet() == argValue->TypeGet())
             {
                 argValue = underlyingTree;
+                assert(objClass == gtGetStructHandleIfPresent(underlyingTree));
             }
         }
     }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -4970,10 +4970,9 @@ GenTreePtr Compiler::fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr f
             GenTree* underlyingTree = op1->gtOp.gtOp1;
 
             // Only update to the same type.
-            if (underlyingTree->TypeGet() == argValue->TypeGet())
+            if ((underlyingTree->TypeGet() == argValue->TypeGet()) && (objClass == gtGetStructHandleIfPresent(underlyingTree)))
             {
                 argValue = underlyingTree;
-                assert(objClass == gtGetStructHandleIfPresent(underlyingTree));
             }
         }
     }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -5349,6 +5349,14 @@ GenTreePtr Compiler::fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr f
             GenTreePtr  baseAddr = argObj->gtOp1;
             var_types   addrType = baseAddr->TypeGet();
 
+            GenTree* addrTaken = baseAddr->gtOp.gtOp1;
+            if (addrTaken->IsLocal())
+            {
+                GenTreeLclVarCommon* varNode = addrTaken->AsLclVarCommon();
+                unsigned             varNum  = varNode->gtLclNum;
+                lvaSetVarDoNotEnregister(varNum DEBUGARG(DNER_IsStruct));
+            }
+
             // Create a new tree for 'arg'
             //    replace the existing LDOBJ(EXPR)
             //    with a FIELD_LIST(IND(EXPR), FIELD_LIST(IND(EXPR+8), nullptr) ...)

--- a/tests/src/JIT/Methodical/tailcall/_il_dbgtest_3b.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_dbgtest_3b.ilproj
@@ -10,7 +10,6 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>

--- a/tests/testsRunningInsideARM.txt
+++ b/tests/testsRunningInsideARM.txt
@@ -1,5 +1,6 @@
 JIT/Directed/coverage/importer/ldelemnullarr2/
 JIT/Methodical/Coverage/b39946/
+JIT/Methodical/tailcall/_il_dbgtest_3b/
 JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b26863/b26863/
 JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b28037/b28037/
 JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b29068/b29068/


### PR DESCRIPTION
fgMorphMultiregStructArg could lose type information when replaced smth like this:
 GT_OBJ - TYP_STRUCT     <== arg
 +GT_ADDR - TYP_I_IMPL
 ++GT_LCL_VAR - TYP_BLK  <== argValue

Fix #14955.

So after the change we do not replace argValue with anything that has different type.
