### PR TITLE
Do not optimize flags-setting add

### DIFF
--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -2392,7 +2392,7 @@ void emitter::emitIns_R_R_I(instruction ins,
             assert(insOptsNone(opt));
 
             // Is it just a mov?
-            if (imm == 0)
+            if ((imm == 0) && insDoesNotSetFlags(flags))
             {
                 // Is the mov even necessary?
                 // Fix 383915 ARM ILGEN


### PR DESCRIPTION
In minopts, we were attempting to generate "add r0,r0,0" and
optimizing it away completely. But it if needs to generate
the flags, for a subsequent overflow (flags) check, we can't do that.

Fixes #14860