### PR TITLE
[WIP] Dictionary - magic remainder

### DIFF
--- a/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
@@ -408,17 +408,27 @@ namespace System.Collections.Generic
             }
 
             if (_buckets == null) Initialize(0);
-            int hashCode = _comparer.GetHashCode(key) & 0x7FFFFFFF;
-            int targetBucket = hashCode % _buckets.Length;
+            IEqualityComparer<TKey> comparer = _comparer;
+            int hashCode = comparer.GetHashCode(key) & 0x7FFFFFFF;
             int collisionCount = 0;
 
-            for (int i = _buckets[targetBucket]; i >= 0; i = _entries[i].next)
+            ref int bucket = ref _buckets[hashCode % _buckets.Length];
+            int i = bucket;
+            Entry[] entries = _entries;
+            do
             {
-                if (_entries[i].hashCode == hashCode && _comparer.Equals(_entries[i].key, key))
+                // Should be a while loop https://github.com/dotnet/coreclr/issues/15476
+                // Test uint in if rather than loop condition to drop range check for following array access
+                if ((uint)i >= (uint)entries.Length)
+                {
+                    break;
+                }
+
+                if (entries[i].hashCode == hashCode && comparer.Equals(entries[i].key, key))
                 {
                     if (behavior == InsertionBehavior.OverwriteExisting)
                     {
-                        _entries[i].value = value;
+                        entries[i].value = value;
                         _version++;
                         return true;
                     }
@@ -430,41 +440,56 @@ namespace System.Collections.Generic
 
                     return false;
                 }
-                collisionCount++;
-            }
 
+                i = entries[i].next;
+                collisionCount++;
+            } while (true);
+
+            // Can be improved with "Ref Local Reassignment"
+            // https://github.com/dotnet/csharplang/blob/master/proposals/ref-local-reassignment.md
+            bool resized = false;
+            bool updateFreeList = false;
             int index;
             if (_freeCount > 0)
             {
                 index = _freeList;
-                _freeList = _entries[index].next;
+                updateFreeList = true;
                 _freeCount--;
             }
             else
             {
-                if (_count == _entries.Length)
+                int count = _count;
+                if (count == entries.Length)
                 {
                     Resize();
-                    targetBucket = hashCode % _buckets.Length;
+                    resized = true;
                 }
-                index = _count;
-                _count++;
+                index = count;
+                _count = count + 1;
+                entries = _entries;
             }
 
-            _entries[index].hashCode = hashCode;
-            _entries[index].next = _buckets[targetBucket];
-            _entries[index].key = key;
-            _entries[index].value = value;
-            _buckets[targetBucket] = index;
+            ref int targetBucket = ref resized ? ref _buckets[hashCode % _buckets.Length] : ref bucket;
+            ref Entry entry = ref entries[index];
+
+            if (updateFreeList)
+            {
+                _freeList = entry.next;
+            }
+            entry.hashCode = hashCode;
+            entry.next = targetBucket;
+            entry.key = key;
+            entry.value = value;
+            targetBucket = index;
             _version++;
 
-            // If we hit the collision threshold we'll need to switch to the comparer which is using randomized string hashing
-            // i.e. EqualityComparer<string>.Default.
-
-            if (collisionCount > HashHelpers.HashCollisionThreshold && _comparer is NonRandomizedStringEqualityComparer)
+            // Value types never rehash
+            if (default(TKey) == null && collisionCount > HashHelpers.HashCollisionThreshold && _comparer is NonRandomizedStringEqualityComparer)
             {
+                // If we hit the collision threshold we'll need to switch to the comparer which is using randomized string hashing
+                // i.e. EqualityComparer<string>.Default.
                 _comparer = (IEqualityComparer<TKey>)EqualityComparer<string>.Default;
-                Resize(_entries.Length, true);
+                Resize(entries.Length, true);
             }
 
             return true;
@@ -523,6 +548,8 @@ namespace System.Collections.Generic
 
         private void Resize(int newSize, bool forceNewHashCodes)
         {
+            // Value types never rehash
+            Debug.Assert(!forceNewHashCodes || default(TKey) == null);
             Debug.Assert(newSize >= _entries.Length);
 
             int[] buckets = new int[newSize];
@@ -535,7 +562,7 @@ namespace System.Collections.Generic
             int count = _count;
             Array.Copy(_entries, 0, entries, 0, count);
 
-            if (forceNewHashCodes)
+            if (default(TKey) == null && forceNewHashCodes)
             {
                 for (int i = 0; i < count; i++)
                 {

--- a/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
@@ -362,15 +362,28 @@ namespace System.Collections.Generic
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
             }
 
-            if (_buckets != null)
+            int[] buckets = _buckets;
+            int i = -1;
+            if (buckets != null)
             {
-                int hashCode = _comparer.GetHashCode(key) & 0x7FFFFFFF;
-                for (int i = _buckets[hashCode % _buckets.Length]; i >= 0; i = _entries[i].next)
+                IEqualityComparer<TKey> comparer = _comparer;
+                int hashCode = comparer.GetHashCode(key) & 0x7FFFFFFF;
+                i = buckets[hashCode % buckets.Length];
+
+                Entry[] entries = _entries;
+                do
                 {
-                    if (_entries[i].hashCode == hashCode && _comparer.Equals(_entries[i].key, key)) return i;
-                }
+                    // Should be a while loop https://github.com/dotnet/coreclr/issues/15476
+                    // Test in if to drop range check for following array access
+                    if ((uint)i >= (uint)entries.Length || (entries[i].hashCode == hashCode && comparer.Equals(entries[i].key, key)))
+                    {
+                        break;
+                    }
+
+                    i = entries[i].next;
+                } while (true);
             }
-            return -1;
+            return i;
         }
 
         private void Initialize(int capacity)

--- a/src/mscorlib/shared/System/Collections/HashHelpers.cs
+++ b/src/mscorlib/shared/System/Collections/HashHelpers.cs
@@ -4,8 +4,10 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Threading;
+using Internal.Runtime.CompilerServices;
 
 namespace System.Collections
 {
@@ -32,6 +34,92 @@ namespace System.Collections
             17519, 21023, 25229, 30293, 36353, 43627, 52361, 62851, 75431, 90523, 108631, 130363, 156437,
             187751, 225307, 270371, 324449, 389357, 467237, 560689, 672827, 807403, 968897, 1162687, 1395263,
             1674319, 2009191, 2411033, 2893249, 3471899, 4166287, 4999559, 5999471, 7199369};
+
+        public static readonly uint[] PrimeMagicShift =
+        {
+            // prime, magic multiplier, magic shift
+            3, 0x55555556, 32,
+            7, 0x92492493, 34,
+            11, 0x2e8ba2e9, 33,
+            17, 0x78787879, 35,
+            23, 0xb21642c9, 36,
+            29, 0x8d3dcb09, 36,
+            37, 0xdd67c8a7, 37,
+            47, 0xae4c415d, 37,
+            59, 0x22b63cbf, 35,
+            71, 0xe6c2b449, 38,
+            89, 0xb81702e1, 38,
+            107, 0x4c8f8d29, 37,
+            131, 0x3e88cb3d, 37,
+            163, 0x0c907da5, 35,
+            197, 0x532ae21d, 38,
+            239, 0x891ac73b, 39,
+            293, 0xdfac1f75, 40,
+            353, 0xb9a7862b, 40,
+            431, 0x980e4157, 40,
+            521, 0x3ee4f99d, 39,
+            631, 0x33ee2623, 39,
+            761, 0x561e46a5, 40,
+            919, 0x8e9fe543, 41,
+            1103, 0x1db54401, 39,
+            1327, 0xc58bdd47, 42,
+            1597, 0xa425d4b9, 42,
+            1931, 0x10f82d9b, 39,
+            2333, 0x705d0d0f, 42,
+            2801, 0x2ecb7285, 41,
+            3371, 0x9b876783, 43,
+            4049, 0x817c5d53, 43,
+            4861, 0x35ed914d, 42,
+            5839, 0x0b394d8f, 40,
+            7013, 0x9584d635, 44,
+            8419, 0x7c8c7b75, 44,
+            10103, 0x33e4f01d, 43,
+            12143, 0x565a3073, 44,
+            14591, 0x23eeaa5d, 43,
+            17519, 0x77b510e9, 45,
+            21023, 0x63c14fe5, 45,
+            25229, 0x531fe999, 45,
+            30293, 0x8a75366b, 46,
+            36353, 0xe6c11447, 47,
+            43627, 0xc047bac3, 47,
+            52361, 0x0a035099, 43,
+            62851, 0x42bbed05, 46,
+            75431, 0x379ac159, 46,
+            90523, 0x05cab127, 43,
+            108631, 0x9a713743, 48,
+            130363, 0x80b236c9, 48,
+            156437, 0x6b3eeec1, 48,
+            187751, 0xb2b7bcf9, 49,
+            225307, 0x4a76bbc7, 48,
+            270371, 0x7c1aeabf, 49,
+            324449, 0x676b743d, 49,
+            389357, 0x2b16ec6d, 48,
+            467237, 0x8fa1117f, 50,
+            560689, 0x77b0a38f, 50,
+            672827, 0x63bddbb1, 50,
+            807403, 0x0531def9, 46,
+            968897, 0x8a86bc61, 51,
+            1162687, 0x737002ad, 51,
+            1395263, 0x180c7f9f, 49,
+            1674319, 0x140a67af, 49,
+            2009191, 0x42cd47bf, 51,
+            2411033, 0x37ab0b5f, 51,
+            2893249, 0x5cc7a9dd, 52,
+            3471899, 0x4d510d43, 52,
+            4166287, 0x080dc5ad, 49,
+            4999559, 0x035b11b9, 48,
+            5999471, 0xb2f90627, 54,
+            7199369, 0x9524d54d, 54,
+            14398753, 0x4a92658f, 54,
+            28797523, 0x4a9262ad, 55,
+            57595063, 0x9524c277, 57,
+            115190149, 0x9524c083, 58,
+            230380307, 0x4a926011, 58,
+            460760623, 0x9524bff1, 60,
+            921521257, 0x9524bfd3, 61,
+            1843042529, 0x4a925fdf, 61,
+            2146435069, 0x20040081, 60
+        };
 
         public static bool IsPrime(int candidate)
         {
@@ -103,6 +191,77 @@ namespace System.Collections
 
                 return s_serializationInfoTable;
             }
+        }
+
+        // To implement magic-number divide with a 32-bit magic number,
+        // multiply by the magic number, take the top 64 bits, and shift that
+        // by the amount given in the table.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint MagicNumberDivide(uint numerator, uint magic, int shift)
+        {
+            return (uint)((numerator * (ulong)magic) >> shift);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int MagicNumberRemainder(int numerator, int divisor, uint magic, int shift)
+        {
+            Debug.Assert(numerator >= 0);
+            uint product = MagicNumberDivide((uint)numerator, magic, shift);
+            Debug.Assert(product == numerator / divisor);
+            int result = (int)(numerator - (product * divisor));
+            Debug.Assert(result == numerator % divisor);
+            return result;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public readonly struct PrimeInfo
+        {
+            public readonly int Prime;
+            public readonly uint Magic;
+            public readonly int Shift;
+        }
+
+        public static void NearestPrimeInfo(int min, out int prime, out uint magic, out int shift)
+        {
+            if (min < 0)
+            {
+                throw new ArgumentException(SR.Arg_HTCapacityOverflow);
+            }
+
+            uint[] primeMagicShift = PrimeMagicShift;
+            for (int i = 0; i < primeMagicShift.Length; i += 3)
+            {
+                ref uint primeRef = ref primeMagicShift[i];
+                if (primeRef >= min)
+                {
+                    PrimeInfo primeInfo = Unsafe.As<uint, PrimeInfo>(ref primeRef);
+                    prime = primeInfo.Prime;
+                    magic = primeInfo.Magic;
+                    shift = primeInfo.Shift;
+                    return;
+                }
+            }
+
+            throw new ArgumentException(SR.Arg_HTCapacityOverflow);
+        }
+
+        public static void ExpandPrimeInfo(int oldSize, out int prime, out uint magic, out int shift)
+        {
+            int newSize = 2 * oldSize;
+            // Allow the hashtables to grow to maximum possible size (~2G elements) before encoutering capacity overflow.
+            // Note that this check works even when _items.Length overflowed thanks to the (uint) cast
+            if ((uint)newSize > MaxPrimeArrayLength && MaxPrimeArrayLength > oldSize)
+            {
+                Debug.Assert(MaxPrimeArrayLength == GetPrime(MaxPrimeArrayLength), "Invalid MaxPrimeArrayLength");
+
+                PrimeInfo primeInfo = Unsafe.As<uint, PrimeInfo>(ref PrimeMagicShift[PrimeMagicShift.Length - 3]);
+                prime = primeInfo.Prime;
+                magic = primeInfo.Magic;
+                shift = primeInfo.Shift;
+                return;
+            }
+
+            NearestPrimeInfo(newSize, out prime, out magic, out shift);
         }
     }
 }


### PR DESCRIPTION
Split Resize -> Expand and Rehash

Rehashing is only used in `string` key variant so it doesn't need to be compiled in every Expand
Rehashing doesn't expand the Dictionary so it can reuse the existing arrays
Use MagicNumberRemainder rather than `idiv` in `Expand` and `Rehash`