### PR TITLE
Disable LowerCompare optimizations in minopts

### DIFF
--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -137,7 +137,11 @@ private:
     // Call Lowering
     // ------------------------------
     void LowerCall(GenTree* call);
-    GenTree* LowerCompare(GenTree* tree);
+#ifndef _TARGET_64BIT_
+    GenTree* DecomposeLongCompare(GenTree* cmp);
+#endif
+    GenTree* OptimizeConstCompare(GenTree* cmp);
+    GenTree* LowerCompare(GenTree* cmp);
     GenTree* LowerJTrue(GenTreeOp* jtrue);
     void LowerJmpMethod(GenTree* jmp);
     void LowerRet(GenTree* ret);


### PR DESCRIPTION
Disables various optimizations performed by `LowerCompare` in minopts mode. Also split it into 3 separate functions to make the code more manageable: `DecomposeLongCompare`, `OptimizeConstCompare`, `LowerCompare`.

Diff best viewed with w=1 option due to changes in indentation.

This simply moves code around but there's a little difference that's worth highlighting - before this change, the code that recognizes the BT pattern and the "flag reuse" pattern was running on all compares. This is not necessary, in both cases the second operand of the original compare must be constant for the pattern match to succeed.