### PR TITLE
Split Dictionary Resize -> Expand and Rehash

### DIFF
--- a/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
@@ -370,8 +370,13 @@ namespace System.Collections.Generic
         private void Initialize(int capacity)
         {
             int size = HashHelpers.GetPrime(capacity);
-            _buckets = new int[size];
-            for (int i = 0; i < _buckets.Length; i++) _buckets[i] = -1;
+            int[] buckets = new int[size];
+            for (int i = 0; i < buckets.Length; i++)
+            {
+                buckets[i] = -1;
+            }
+
+            _buckets = buckets;
             _entries = new Entry[size];
             _freeList = -1;
         }
@@ -464,10 +469,7 @@ namespace System.Collections.Generic
 
             if (hashsize != 0)
             {
-                _buckets = new int[hashsize];
-                for (int i = 0; i < _buckets.Length; i++) _buckets[i] = -1;
-                _entries = new Entry[hashsize];
-                _freeList = -1;
+                Initialize(hashsize);
 
                 KeyValuePair<TKey, TValue>[] array = (KeyValuePair<TKey, TValue>[])
                     siInfo.GetValue(KeyValuePairsName, typeof(KeyValuePair<TKey, TValue>[]));


### PR DESCRIPTION
Unify `OnDeserialization` initialization with .ctor `Initialize`

Split `Resize` -> `Expand` and `Rehash`

Rehashing is only used in `string` key variant so it doesn't need to be compiled in every Expand
Rehashing doesn't expand the Dictionary so it can reuse the existing arrays
Expand doesn't need the extra param and loop that it always skips
Loop CQ improvements

Shrinks the generic Resize (as Expand) from 497 bytes to 265 bytes

PTAL @jkotas 