### PR TITLE
Improve Dictionary.Clear CQ

### DIFF
--- a/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
@@ -48,9 +48,9 @@ namespace System.Collections.Generic
         private int[] _buckets;
         private Entry[] _entries;
         private int _count;
-        private int _version;
         private int _freeList;
         private int _freeCount;
+        private int _version;
         private IEqualityComparer<TKey> _comparer;
         private KeyCollection _keys;
         private ValueCollection _values;
@@ -256,14 +256,20 @@ namespace System.Collections.Generic
 
         public void Clear()
         {
-            if (_count > 0)
+            int count = _count;
+            if (count > 0)
             {
-                for (int i = 0; i < _buckets.Length; i++) _buckets[i] = -1;
-                Array.Clear(_entries, 0, _count);
-                _freeList = -1;
+                int[] buckets = _buckets;
+                for (int i = 0; i < buckets.Length; i++)
+                {
+                    buckets[i] = -1;
+                }
+
                 _count = 0;
+                _freeList = -1;
                 _freeCount = 0;
                 _version++;
+                Array.Clear(_entries, 0, count);
             }
         }
 


### PR DESCRIPTION
11 byes less asm (92 => 81 asm bytes)
One less instruction per loop
No stack push + pop
Tail call into Array:Clear
Total bytes of diff: -319 (-0.01% of base)

PTAL @jkotas 