### PR TITLE
Improve Dictionary FindEntry CQ

### DIFF
--- a/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
@@ -371,15 +371,17 @@ namespace System.Collections.Generic
                 i = buckets[hashCode % buckets.Length];
 
                 Entry[] entries = _entries;
-                while (i >= 0)
+                do
                 {
-                    if (entries[i].hashCode == hashCode && comparer.Equals(entries[i].key, key))
+                    // Should be a while loop https://github.com/dotnet/coreclr/issues/15476
+                    // Test in if to drop range check for following array access
+                    if ((uint)i >= (uint)entries.Length || (entries[i].hashCode == hashCode && comparer.Equals(entries[i].key, key)))
                     {
                         break;
                     }
 
                     i = entries[i].next;
-                }
+                } while (true);
             }
             return i;
         }

--- a/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
@@ -362,15 +362,26 @@ namespace System.Collections.Generic
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
             }
 
-            if (_buckets != null)
+            int[] buckets = _buckets;
+            int i = -1;
+            if (buckets != null)
             {
-                int hashCode = _comparer.GetHashCode(key) & 0x7FFFFFFF;
-                for (int i = _buckets[hashCode % _buckets.Length]; i >= 0; i = _entries[i].next)
+                IEqualityComparer<TKey> comparer = _comparer;
+                int hashCode = comparer.GetHashCode(key) & 0x7FFFFFFF;
+                i = buckets[hashCode % buckets.Length];
+
+                Entry[] entries = _entries;
+                while (i >= 0)
                 {
-                    if (_entries[i].hashCode == hashCode && _comparer.Equals(_entries[i].key, key)) return i;
+                    if (entries[i].hashCode == hashCode && comparer.Equals(entries[i].key, key))
+                    {
+                        break;
+                    }
+
+                    i = entries[i].next;
                 }
             }
-            return -1;
+            return i;
         }
 
         private void Initialize(int capacity)


### PR DESCRIPTION
```
Total bytes of diff: -1249 (-0.04% of base)
    diff is an improvement.

Total byte diff includes 0 bytes from reconciling methods
        Base had    0 unique methods,        0 unique bytes
        Diff had    0 unique methods,        0 unique bytes

Top file improvements by size (bytes):
       -1249 : System.Private.CoreLib.dasm (-0.04% of base)

1 total files with size differences (1 improved, 0 regressed), 0 unchanged.

Top method improvements by size (bytes):
        -683 : System.Private.CoreLib.dasm - Dictionary`2:FindEntry(ref):int:this (11 methods)
        -235 : System.Private.CoreLib.dasm - Dictionary`2:FindEntry(struct):int:this (7 methods)
        -158 : System.Private.CoreLib.dasm - Dictionary`2:FindEntry(int):int:this (5 methods)
        -124 : System.Private.CoreLib.dasm - Dictionary`2:FindEntry(long):int:this (4 methods)
         -32 : System.Private.CoreLib.dasm - Dictionary`2:FindEntry(short):int:this

6 total methods with size differences (6 improved, 0 regressed), 16739 unchanged.
```