### PR TITLE
Improve Dictionary Initialize CQ

### DIFF
--- a/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
@@ -376,10 +376,15 @@ namespace System.Collections.Generic
         private void Initialize(int capacity)
         {
             int size = HashHelpers.GetPrime(capacity);
-            _buckets = new int[size];
-            for (int i = 0; i < _buckets.Length; i++) _buckets[i] = -1;
-            _entries = new Entry[size];
+            int[] buckets = new int[size];
+            for (int i = 0; i < buckets.Length; i++)
+            {
+                buckets[i] = -1;
+            }
+
             _freeList = -1;
+            _buckets = buckets;
+            _entries = new Entry[size];
         }
 
         private bool TryInsert(TKey key, TValue value, InsertionBehavior behavior)
@@ -470,10 +475,7 @@ namespace System.Collections.Generic
 
             if (hashsize != 0)
             {
-                _buckets = new int[hashsize];
-                for (int i = 0; i < _buckets.Length; i++) _buckets[i] = -1;
-                _entries = new Entry[hashsize];
-                _freeList = -1;
+                Initialize(hashsize);
 
                 KeyValuePair<TKey, TValue>[] array = (KeyValuePair<TKey, TValue>[])
                     siInfo.GetValue(KeyValuePairsName, typeof(KeyValuePair<TKey, TValue>[]));


### PR DESCRIPTION
```
Total bytes of diff: -3316 (-0.10% of base)
    diff is an improvement.

Total byte diff includes 0 bytes from reconciling methods
        Base had    0 unique methods,        0 unique bytes
        Diff had    0 unique methods,        0 unique bytes

Top file improvements by size (bytes):
       -3316 : System.Private.CoreLib.dasm (-0.10% of base)

1 total files with size differences (1 improved, 0 regressed), 0 unchanged.

Top method improvements by size (bytes):
       -3142 : System.Private.CoreLib.dasm - Dictionary`2:OnDeserialization(ref):this (29 methods)
        -174 : System.Private.CoreLib.dasm - Dictionary`2:Initialize(int):this (29 methods)

2 total methods with size differences (2 improved, 0 regressed), 16743 unchanged.
```