### PR TITLE
Improve Dictionary TryInsert CQ

### DIFF
--- a/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
@@ -402,8 +402,14 @@ namespace System.Collections.Generic
 
             int i = _buckets[targetBucket];
             Entry[] entries = _entries;
-            while (i >= 0)
+            do
             {
+                if ((uint)i >= (uint)entries.Length)
+                {
+                    // Test uint in if rather than loop condition to drop range check for following array access
+                    break;
+                }
+
                 if (entries[i].hashCode == hashCode && comparer.Equals(entries[i].key, key))
                 {
                     if (behavior == InsertionBehavior.OverwriteExisting)
@@ -423,7 +429,7 @@ namespace System.Collections.Generic
 
                 i = entries[i].next;
                 collisionCount++;
-            }
+            } while (true);
 
             int index;
             if (_freeCount > 0)


### PR DESCRIPTION
```
Total bytes of diff: -6455 (-0.19% of base)
    diff is an improvement.

Total byte diff includes 1389 bytes from reconciling methods
        Base had    0 unique methods,        0 unique bytes
        Diff had    2 unique methods,     1389 unique bytes

Top file improvements by size (bytes):
       -6455 : System.Private.CoreLib.dasm (-0.19% of base)

1 total files with size differences (1 improved, 0 regressed), 0 unchanged.

Top method regessions by size (bytes):
        1287 : System.Private.CoreLib.dasm - Dictionary`2:Rehash():this (0/11 methods)
         102 : System.Private.CoreLib.dasm - HashHelpers:ResizeDictionaryArrays(ref,ref,int,int):ref (0/1 methods)

Top method improvements by size (bytes):
       -3749 : System.Private.CoreLib.dasm - Dictionary`2:Resize(int,bool):this (29 methods)
        -671 : System.Private.CoreLib.dasm - Dictionary`2:TryInsert(ref,struct,ubyte):bool:this (4 methods)
        -462 : System.Private.CoreLib.dasm - Dictionary`2:TryInsert(ref,int,ubyte):bool:this (3 methods)
        -452 : System.Private.CoreLib.dasm - Dictionary`2:TryInsert(struct,ref,ubyte):bool:this (3 methods)
        -360 : System.Private.CoreLib.dasm - Dictionary`2:TryInsert(int,ref,ubyte):bool:this (3 methods)
        -296 : System.Private.CoreLib.dasm - Dictionary`2:TryInsert(struct,struct,ubyte):bool:this (2 methods)
        -240 : System.Private.CoreLib.dasm - Dictionary`2:TryInsert(long,ref,ubyte):bool:this (2 methods)
        -156 : System.Private.CoreLib.dasm - Dictionary`2:TryInsert(ref,ref,ubyte):bool:this
        -156 : System.Private.CoreLib.dasm - Dictionary`2:TryInsert(ref,long,ubyte):bool:this
        -154 : System.Private.CoreLib.dasm - Dictionary`2:TryInsert(ref,bool,ubyte):bool:this
        -154 : System.Private.CoreLib.dasm - Dictionary`2:TryInsert(ref,char,ubyte):bool:this
        -146 : System.Private.CoreLib.dasm - Dictionary`2:TryInsert(struct,int,ubyte):bool:this
        -146 : System.Private.CoreLib.dasm - Dictionary`2:TryInsert(struct,ubyte,ubyte):bool:this
        -128 : System.Private.CoreLib.dasm - Dictionary`2:TryInsert(short,long,ubyte):bool:this
        -115 : System.Private.CoreLib.dasm - Dictionary`2:TryInsert(long,short,ubyte):bool:this
        -115 : System.Private.CoreLib.dasm - Dictionary`2:TryInsert(int,ubyte,ubyte):bool:this
        -115 : System.Private.CoreLib.dasm - Dictionary`2:TryInsert(int,int,ubyte):bool:this
        -115 : System.Private.CoreLib.dasm - Dictionary`2:TryInsert(long,bool,ubyte):bool:this
        -114 : System.Private.CoreLib.dasm - Dictionary`2:TryInsert(char,ref,ubyte):bool:this

21 total methods with size differences (19 improved, 2 regressed), 16724 unchanged.
```
3 range checks rather than 6
2 are mod Length based (1 of them is conditional) https://github.com/dotnet/coreclr/issues/15472
1 can't be helped