### PR TITLE
Memory footprint gc latency level

### DIFF
--- a/src/gc/gccommon.cpp
+++ b/src/gc/gccommon.cpp
@@ -53,8 +53,6 @@ void record_global_mechanism (int mech_index)
 }
 #endif //GC_CONFIG_DRIVEN
 
-int32_t g_bLowMemoryFromHost = 0;
-
 #ifdef WRITE_BARRIER_CHECK
 
 #define INVALIDGCVALUE (void *)((size_t)0xcccccccd)

--- a/src/gc/gcconfig.h
+++ b/src/gc/gcconfig.h
@@ -83,7 +83,7 @@ public:
   INT_CONFIG(LatencyMode,   "GCLatencyMode", -1,                                               \
       "Specifies the GC latency mode - batch, interactive or low latency (note that the same " \
       "thing can be specified via API which is the supported way")                             \
-  INT_CONFIG(LatencyLevel,  "GCLatencyLevel", 2,                                               \
+  INT_CONFIG(LatencyLevel,  "GCLatencyLevel", 1,                                               \
       "Specifies the GC latency level that you want to optimize for. Must be a number from 0"  \
       "3. See documentation for more details on each level.")                                  \
   INT_CONFIG(LogFileSize,   "GCLogFileSize", 0, "Specifies the GC log file size")              \

--- a/src/gc/gcconfig.h
+++ b/src/gc/gcconfig.h
@@ -83,6 +83,9 @@ public:
   INT_CONFIG(LatencyMode,   "GCLatencyMode", -1,                                               \
       "Specifies the GC latency mode - batch, interactive or low latency (note that the same " \
       "thing can be specified via API which is the supported way")                             \
+  INT_CONFIG(LatencyLevel,  "GCLatencyLevel", 2,                                               \
+      "Specifies the GC latency level that you want to optimize for. Must be a number from 0"  \
+      "3. See documentation for more details on each level.")                                  \
   INT_CONFIG(LogFileSize,   "GCLogFileSize", 0, "Specifies the GC log file size")              \
   INT_CONFIG(CompactRatio,  "GCCompactRatio", 0,                                               \
       "Specifies the ratio compacting GCs vs sweeping")                                        \

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -202,9 +202,6 @@ extern uint8_t* g_GCShadowEnd;
 extern uint8_t* g_shadow_lowest_address;
 #endif
 
-// For low memory notification from host
-extern int32_t g_bLowMemoryFromHost;
-
 // Event levels corresponding to events that can be fired by the GC.
 enum GCEventLevel
 {

--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -295,6 +295,7 @@ RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_StatsUpdatePeriod, W("StatsUpdatePeriod"), 
 RETAIL_CONFIG_STRING_INFO(UNSUPPORTED_SuspendTimeLog, W("SuspendTimeLog"), "Specifies the name of the log file for suspension statistics")
 RETAIL_CONFIG_STRING_INFO(UNSUPPORTED_GCMixLog, W("GCMixLog"), "Specifies the name of the log file for GC mix statistics")
 CONFIG_DWORD_INFO_DIRECT_ACCESS(INTERNAL_GCLatencyMode, W("GCLatencyMode"), "Specifies the GC latency mode - batch, interactive or low latency (note that the same thing can be specified via API which is the supported way)")
+RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_GCLatencyLevel, W("GCLatencyLevel"), 2, "Specifies the GC latency level that you want to optimize for")
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_GCConfigLogEnabled, W("GCConfigLogEnabled"), 0, "Specifies if you want to turn on config logging in GC")
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_GCLogEnabled, W("GCLogEnabled"), 0, "Specifies if you want to turn on logging in GC")
 RETAIL_CONFIG_STRING_INFO(UNSUPPORTED_GCLogFile, W("GCLogFile"), "Specifies the name of the GC log file")

--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -295,7 +295,7 @@ RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_StatsUpdatePeriod, W("StatsUpdatePeriod"), 
 RETAIL_CONFIG_STRING_INFO(UNSUPPORTED_SuspendTimeLog, W("SuspendTimeLog"), "Specifies the name of the log file for suspension statistics")
 RETAIL_CONFIG_STRING_INFO(UNSUPPORTED_GCMixLog, W("GCMixLog"), "Specifies the name of the log file for GC mix statistics")
 CONFIG_DWORD_INFO_DIRECT_ACCESS(INTERNAL_GCLatencyMode, W("GCLatencyMode"), "Specifies the GC latency mode - batch, interactive or low latency (note that the same thing can be specified via API which is the supported way)")
-RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_GCLatencyLevel, W("GCLatencyLevel"), 2, "Specifies the GC latency level that you want to optimize for")
+RETAIL_CONFIG_DWORD_INFO(EXTERNAL_GCLatencyLevel, W("GCLatencyLevel"), 1, "Specifies the GC latency level that you want to optimize for")
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_GCConfigLogEnabled, W("GCConfigLogEnabled"), 0, "Specifies if you want to turn on config logging in GC")
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_GCLogEnabled, W("GCLogEnabled"), 0, "Specifies if you want to turn on logging in GC")
 RETAIL_CONFIG_STRING_INFO(UNSUPPORTED_GCLogFile, W("GCLogFile"), "Specifies the name of the GC log file")


### PR DESCRIPTION
This pull request adds memory footprint gc latency level.

This pull request is based on the commit by @Maoni0. Parameters for memory_consumption level are almost the same as for default balanced level (which is same as the base), except for gen1 min_size, which is set equal to gen0 min_size. Large heap compacting is not included in this pull request.

Tizen Xamarin GUI applications: (base is 97d9d593ae44438fab85044e2a189316e7f3cbc4)

Test|base GC heap (Kb), startup time (s)|"memory_consumption" level GC heap (Kb), startup time (s)
----|---------|----
HelloWorld.Tizen|368; 1.9825|368 (0); 1.99737 (+0.75%)
Settings.Tizen.Mobile|632; 2.5325|600 (-5.06%); 2.5935 (+2.41%)
VolumeController.Tizen.Mobile|512; 2.3705|472 (-6.99%); 2.4455 (+3.16%)
AppCommon.Tizen.Mobile|825.6; 3.851|784 (-5.04%); 3.94158 (+2.35%)
EmailUI.Tizen.Mobile|1384; 3.1215|1184 (-14.45%); 3.1425 (+0.67%)
ApplicationControl.Tizen.Mobile|705.2; 3.2575|643.1 (-8.81%); 3.31278 (+1.70%)
SNSUI.Tizen.Mobile|2306; 4.486|1904 (-17.43%); 4.601 (+2.56%)
ApplicationStoreUI.Tizen.Mobile|1205.6; 2.4305|956 (-20.70%); 2.515 (+3.48%)
Puzzle.Tizen.Mobile|970.4; 3.0165|923.2 (-4.86%); 3.0975 (+2.69%)
System_info.Tizen.Mobile|368; 2.3785|368 (0); 2.436 (+2.42%)
GalleryUI.Tizen.Mobile|368; 2.436|368 (0); 2.499 (+2.59%)
Calculator.Tizen.Mobile|2156; 4.8995|696 (-67.72%); 5.22105 (+6.56%)

average: GC heap size reduction 15.62%, startup time increase 2.6%

GC GUI benchmarks:

Test|base GC heap (Kb), startup time (s)|"memory_consumption" level GC heap (Kb), startup time (s)
----|---------|----
GC test 1|4932; 3.597|1570.74 (-68.15%); 3.87368 (+7.69%)
GC test 2|715.6; 10.474|464 (-35.16%); 10.4417 (-0.31%)
fasta|1955.6; 65.2105|520.4 (-73.39%); 73.7475 (+13.09%)
nbody|368; 21.2485|368 (0); 21.0194 (-1.08%)
spectral norm|408; 15.5615|380 (-6.86%); 15.4325 (-0.83%)

average: GC heap size reduction 44.81%, startup time increase 3.56%

@Maoni0

cc @kvochko @Dmitri-Botcharnikov 