### PR TITLE
Fix method names of hardware intrinsic APIs

### DIFF
--- a/src/mscorlib/src/System/Runtime/Intrinsics/X86/Avx.PlatformNotSupported.cs
+++ b/src/mscorlib/src/System/Runtime/Intrinsics/X86/Avx.PlatformNotSupported.cs
@@ -121,19 +121,19 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __m128i _mm256_cvtpd_epi32 (__m256d a)
         /// </summary>
-        public static Vector128<int> ConvertToVector128Int(Vector256<double> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int> ConvertToVector128Int32(Vector256<double> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128 _mm256_cvtpd_ps (__m256d a)
         /// </summary>
-        public static Vector128<float> ConvertToVector128Float(Vector256<double> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> ConvertToVector128Single(Vector256<double> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_cvtps_epi32 (__m256 a)
         /// </summary>
-        public static Vector256<int> ConvertToVector256Int(Vector256<float> value) { throw new PlatformNotSupportedException(); }
+        public static Vector256<int> ConvertToVector256Int32(Vector256<float> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256 _mm256_cvtepi32_ps (__m256i a)
         /// </summary>
-        public static Vector256<float> ConvertToVector256Float(Vector256<int> value) { throw new PlatformNotSupportedException(); }
+        public static Vector256<float> ConvertToVector256Single(Vector256<int> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256d _mm256_cvtps_pd (__m128 a)
         /// </summary>
@@ -146,11 +146,11 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __m128i _mm256_cvttpd_epi32 (__m256d a)
         /// </summary>
-        public static Vector128<int> ConvertToVector128IntWithTruncation(Vector256<double> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int> ConvertToVector128Int32WithTruncation(Vector256<double> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_cvttps_epi32 (__m256 a)
         /// </summary>
-        public static Vector256<int> ConvertToVector256IntWithTruncation(Vector256<float> value) { throw new PlatformNotSupportedException(); }
+        public static Vector256<int> ConvertToVector256Int32WithTruncation(Vector256<float> value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m256 _mm256_div_ps (__m256 a, __m256 b)
@@ -183,7 +183,7 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __int8 _mm256_extract_epi8 (__m256i a, const int index)
         /// </summary>
-        public static sbyte ExtractSbyte<T>(Vector256<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static sbyte ExtractSByte<T>(Vector256<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __int8 _mm256_extract_epi8 (__m256i a, const int index)
         /// </summary>
@@ -191,27 +191,27 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __int16 _mm256_extract_epi16 (__m256i a, const int index)
         /// </summary>
-        public static short ExtractShort<T>(Vector256<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static short ExtractInt16<T>(Vector256<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __int16 _mm256_extract_epi16 (__m256i a, const int index)
         /// </summary>
-        public static ushort ExtractUshort<T>(Vector256<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static ushort ExtractUInt16<T>(Vector256<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __int32 _mm256_extract_epi32 (__m256i a, const int index)
         /// </summary>
-        public static int ExtractInt<T>(Vector256<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static int ExtractInt32<T>(Vector256<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __int32 _mm256_extract_epi32 (__m256i a, const int index)
         /// </summary>
-        public static uint ExtractUint<T>(Vector256<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static uint ExtractUInt32<T>(Vector256<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __int64 _mm256_extract_epi64 (__m256i a, const int index)
         /// </summary>
-        public static long ExtractLong<T>(Vector256<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static long ExtractInt64<T>(Vector256<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __int64 _mm256_extract_epi64 (__m256i a, const int index)
         /// </summary>
-        public static ulong ExtractUlong<T>(Vector256<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static ulong ExtractUInt64<T>(Vector256<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
         
         /// <summary>
         /// __m128 _mm256_extractf128_ps (__m256 a, const int imm8)
@@ -305,7 +305,7 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __m256i _mm256_insert_epi8 (__m256i a, __int8 i, const int index)
         /// </summary>
-        public static Vector256<T> InsertSbyte<T>(Vector256<T> value, sbyte data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector256<T> InsertSByte<T>(Vector256<T> value, sbyte data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_insert_epi8 (__m256i a, __int8 i, const int index)
         /// </summary>
@@ -313,27 +313,27 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __m256i _mm256_insert_epi16 (__m256i a, __int16 i, const int index)
         /// </summary>
-        public static Vector256<T> InsertShort<T>(Vector256<T> value, short data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector256<T> InsertInt16<T>(Vector256<T> value, short data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_insert_epi16 (__m256i a, __int16 i, const int index)
         /// </summary>
-        public static Vector256<T> InsertUshort<T>(Vector256<T> value, ushort data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector256<T> InsertUInt16<T>(Vector256<T> value, ushort data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_insert_epi32 (__m256i a, __int32 i, const int index)
         /// </summary>
-        public static Vector256<T> InsertInt<T>(Vector256<T> value, int data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector256<T> InsertInt32<T>(Vector256<T> value, int data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_insert_epi32 (__m256i a, __int32 i, const int index)
         /// </summary>
-        public static Vector256<T> InsertUint<T>(Vector256<T> value, uint data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector256<T> InsertUInt32<T>(Vector256<T> value, uint data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_insert_epi64 (__m256i a, __int64 i, const int index)
         /// </summary>
-        public static Vector256<T> InsertLong<T>(Vector256<T> value, long data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector256<T> InsertInt64<T>(Vector256<T> value, long data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_insert_epi64 (__m256i a, __int64 i, const int index)
         /// </summary>
-        public static Vector256<T> InsertUlong<T>(Vector256<T> value, ulong data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector256<T> InsertUInt64<T>(Vector256<T> value, ulong data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m256 _mm256_insertf128_ps (__m256 a, __m128 b, int imm8)
@@ -599,13 +599,11 @@ namespace System.Runtime.Intrinsics.X86
         
         /// <summary>
         /// __m256 _mm256_permute2f128_ps (__m256 a, __m256 b, int imm8)
-        /// </summary>
-        public static Vector256<float> Permute2x128(Vector256<float> left, Vector256<float> right, byte control) { throw new PlatformNotSupportedException(); }
-        /// <summary>
         /// __m256d _mm256_permute2f128_pd (__m256d a, __m256d b, int imm8)
+        /// __m256i _mm256_permute2f128_si256 (__m256i a, __m256i b, int imm8)
         /// </summary>
-        public static Vector256<double> Permute2x128(Vector256<double> left, Vector256<double> right, byte control) { throw new PlatformNotSupportedException(); }
-        
+        public static Vector256<T> Permute2x128<T>(Vector256<T> left, Vector256<T> right, byte control) where T : struct { throw new PlatformNotSupportedException(); }
+
         /// <summary>
         /// __m128 _mm_permutevar_ps (__m128 a, __m128i b)
         /// </summary>
@@ -733,7 +731,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256d _mm256_set_m128d (__m128d hi, __m128d lo)
         /// __m256i _mm256_set_m128i (__m128i hi, __m128i lo)
         /// </summary>
-        public static Vector256<T> SetHiLo<T>(Vector128<T> hi, Vector128<T> lo) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector256<T> SetHighLow<T>(Vector128<T> hi, Vector128<T> lo) where T : struct { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m256i _mm256_setzero_si256 (void)

--- a/src/mscorlib/src/System/Runtime/Intrinsics/X86/Avx.cs
+++ b/src/mscorlib/src/System/Runtime/Intrinsics/X86/Avx.cs
@@ -121,19 +121,19 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __m128i _mm256_cvtpd_epi32 (__m256d a)
         /// </summary>
-        public static Vector128<int> ConvertToVector128Int(Vector256<double> value) => ConvertToVector128Int(value);
+        public static Vector128<int> ConvertToVector128Int32(Vector256<double> value) => ConvertToVector128Int32(value);
         /// <summary>
         /// __m128 _mm256_cvtpd_ps (__m256d a)
         /// </summary>
-        public static Vector128<float> ConvertToVector128Float(Vector256<double> value) => ConvertToVector128Float(value);
+        public static Vector128<float> ConvertToVector128Single(Vector256<double> value) => ConvertToVector128Single(value);
         /// <summary>
         /// __m256i _mm256_cvtps_epi32 (__m256 a)
         /// </summary>
-        public static Vector256<int> ConvertToVector256Int(Vector256<float> value) => ConvertToVector256Int(value);
+        public static Vector256<int> ConvertToVector256Int32(Vector256<float> value) => ConvertToVector256Int32(value);
         /// <summary>
         /// __m256 _mm256_cvtepi32_ps (__m256i a)
         /// </summary>
-        public static Vector256<float> ConvertToVector256Float(Vector256<int> value) => ConvertToVector256Float(value);
+        public static Vector256<float> ConvertToVector256Single(Vector256<int> value) => ConvertToVector256Single(value);
         /// <summary>
         /// __m256d _mm256_cvtps_pd (__m128 a)
         /// </summary>
@@ -146,11 +146,11 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __m128i _mm256_cvttpd_epi32 (__m256d a)
         /// </summary>
-        public static Vector128<int> ConvertToVector128IntWithTruncation(Vector256<double> value) => ConvertToVector128IntWithTruncation(value);
+        public static Vector128<int> ConvertToVector128Int32WithTruncation(Vector256<double> value) => ConvertToVector128Int32WithTruncation(value);
         /// <summary>
         /// __m256i _mm256_cvttps_epi32 (__m256 a)
         /// </summary>
-        public static Vector256<int> ConvertToVector256IntWithTruncation(Vector256<float> value) => ConvertToVector256IntWithTruncation(value);
+        public static Vector256<int> ConvertToVector256Int32WithTruncation(Vector256<float> value) => ConvertToVector256Int32WithTruncation(value);
 
         /// <summary>
         /// __m256 _mm256_div_ps (__m256 a, __m256 b)
@@ -183,10 +183,10 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __int8 _mm256_extract_epi8 (__m256i a, const int index)
         /// </summary>
-        public static sbyte ExtractSbyte<T>(Vector256<T> value, byte index) where T : struct 
+        public static sbyte ExtractSByte<T>(Vector256<T> value, byte index) where T : struct 
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return ExtractSbyte<T>(value, index);
+            return ExtractSByte<T>(value, index);
         }
         /// <summary>
         /// __int8 _mm256_extract_epi8 (__m256i a, const int index)
@@ -199,50 +199,50 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __int16 _mm256_extract_epi16 (__m256i a, const int index)
         /// </summary>
-        public static short ExtractShort<T>(Vector256<T> value, byte index) where T : struct
+        public static short ExtractInt16<T>(Vector256<T> value, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return ExtractShort<T>(value, index);
+            return ExtractInt16<T>(value, index);
         }
         /// <summary>
         /// __int16 _mm256_extract_epi16 (__m256i a, const int index)
         /// </summary>
-        public static ushort ExtractUshort<T>(Vector256<T> value, byte index) where T : struct 
+        public static ushort ExtractUInt16<T>(Vector256<T> value, byte index) where T : struct 
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return ExtractUshort<T>(value, index);
+            return ExtractUInt16<T>(value, index);
         }
         /// <summary>
         /// __int32 _mm256_extract_epi32 (__m256i a, const int index)
         /// </summary>
-        public static int ExtractInt<T>(Vector256<T> value, byte index) where T : struct 
+        public static int ExtractInt32<T>(Vector256<T> value, byte index) where T : struct 
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return ExtractInt<T>(value, index);
+            return ExtractInt32<T>(value, index);
         }
         /// <summary>
         /// __int32 _mm256_extract_epi32 (__m256i a, const int index)
         /// </summary>
-        public static uint ExtractUint<T>(Vector256<T> value, byte index) where T : struct 
+        public static uint ExtractUInt32<T>(Vector256<T> value, byte index) where T : struct 
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return ExtractUint<T>(value, index);
+            return ExtractUInt32<T>(value, index);
         }
         /// <summary>
         /// __int64 _mm256_extract_epi64 (__m256i a, const int index)
         /// </summary>
-        public static long ExtractLong<T>(Vector256<T> value, byte index) where T : struct 
+        public static long ExtractInt64<T>(Vector256<T> value, byte index) where T : struct 
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return ExtractLong<T>(value, index);
+            return ExtractInt64<T>(value, index);
         }
         /// <summary>
         /// __int64 _mm256_extract_epi64 (__m256i a, const int index)
         /// </summary>
-        public static ulong ExtractUlong<T>(Vector256<T> value, byte index) where T : struct 
+        public static ulong ExtractUInt64<T>(Vector256<T> value, byte index) where T : struct 
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return ExtractUlong<T>(value, index);
+            return ExtractUInt64<T>(value, index);
         }
         
         /// <summary>
@@ -349,10 +349,10 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __m256i _mm256_insert_epi8 (__m256i a, __int8 i, const int index)
         /// </summary>
-        public static Vector256<T> InsertSbyte<T>(Vector256<T> value, sbyte data, byte index) where T : struct
+        public static Vector256<T> InsertSByte<T>(Vector256<T> value, sbyte data, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return InsertSbyte<T>(value, data, index);
+            return InsertSByte<T>(value, data, index);
         }
         /// <summary>
         /// __m256i _mm256_insert_epi8 (__m256i a, __int8 i, const int index)
@@ -365,50 +365,50 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __m256i _mm256_insert_epi16 (__m256i a, __int16 i, const int index)
         /// </summary>
-        public static Vector256<T> InsertShort<T>(Vector256<T> value, short data, byte index) where T : struct
+        public static Vector256<T> InsertInt16<T>(Vector256<T> value, short data, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return InsertShort<T>(value, data, index);
+            return InsertInt16<T>(value, data, index);
         }
         /// <summary>
         /// __m256i _mm256_insert_epi16 (__m256i a, __int16 i, const int index)
         /// </summary>
-        public static Vector256<T> InsertUshort<T>(Vector256<T> value, ushort data, byte index) where T : struct
+        public static Vector256<T> InsertUInt16<T>(Vector256<T> value, ushort data, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return InsertUshort<T>(value, data, index);
+            return InsertUInt16<T>(value, data, index);
         }
         /// <summary>
         /// __m256i _mm256_insert_epi32 (__m256i a, __int32 i, const int index)
         /// </summary>
-        public static Vector256<T> InsertInt<T>(Vector256<T> value, int data, byte index) where T : struct
+        public static Vector256<T> InsertInt32<T>(Vector256<T> value, int data, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return InsertInt<T>(value, data, index);
+            return InsertInt32<T>(value, data, index);
         }
         /// <summary>
         /// __m256i _mm256_insert_epi32 (__m256i a, __int32 i, const int index)
         /// </summary>
-        public static Vector256<T> InsertUint<T>(Vector256<T> value, uint data, byte index) where T : struct
+        public static Vector256<T> InsertUInt32<T>(Vector256<T> value, uint data, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return InsertUint<T>(value, data, index);
+            return InsertUInt32<T>(value, data, index);
         }
         /// <summary>
         /// __m256i _mm256_insert_epi64 (__m256i a, __int64 i, const int index)
         /// </summary>
-        public static Vector256<T> InsertLong<T>(Vector256<T> value, long data, byte index) where T : struct
+        public static Vector256<T> InsertInt64<T>(Vector256<T> value, long data, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return InsertLong<T>(value, data, index);
+            return InsertInt64<T>(value, data, index);
         }
         /// <summary>
         /// __m256i _mm256_insert_epi64 (__m256i a, __int64 i, const int index)
         /// </summary>
-        public static Vector256<T> InsertUlong<T>(Vector256<T> value, ulong data, byte index) where T : struct
+        public static Vector256<T> InsertUInt64<T>(Vector256<T> value, ulong data, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return InsertUlong<T>(value, data, index);
+            return InsertUInt64<T>(value, data, index);
         }
 
         /// <summary>
@@ -679,12 +679,14 @@ namespace System.Runtime.Intrinsics.X86
         
         /// <summary>
         /// __m256 _mm256_permute2f128_ps (__m256 a, __m256 b, int imm8)
-        /// </summary>
-        public static Vector256<float> Permute2x128(Vector256<float> left, Vector256<float> right, byte control) => Permute2x128(left, right, control);
-        /// <summary>
         /// __m256d _mm256_permute2f128_pd (__m256d a, __m256d b, int imm8)
+        /// __m256i _mm256_permute2f128_si256 (__m256i a, __m256i b, int imm8)
         /// </summary>
-        public static Vector256<double> Permute2x128(Vector256<double> left, Vector256<double> right, byte control) => Permute2x128(left, right, control);
+        public static Vector256<T> Permute2x128<T>(Vector256<T> left, Vector256<T> right, byte control) where T : struct
+        {
+            ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
+            return Permute2x128<T>(left, right, control);
+        }
         
         /// <summary>
         /// __m128 _mm_permutevar_ps (__m128 a, __m128i b)
@@ -817,10 +819,10 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256d _mm256_set_m128d (__m128d hi, __m128d lo)
         /// __m256i _mm256_set_m128i (__m128i hi, __m128i lo)
         /// </summary>
-        public static Vector256<T> SetHiLo<T>(Vector128<T> hi, Vector128<T> lo) where T : struct
+        public static Vector256<T> SetHighLow<T>(Vector128<T> hi, Vector128<T> lo) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return SetHiLo<T>(hi, lo);
+            return SetHighLow<T>(hi, lo);
         }
 
         /// <summary>

--- a/src/mscorlib/src/System/Runtime/Intrinsics/X86/Avx2.PlatformNotSupported.cs
+++ b/src/mscorlib/src/System/Runtime/Intrinsics/X86/Avx2.PlatformNotSupported.cs
@@ -298,51 +298,51 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __m256i _mm256_cvtepi8_epi16 (__m128i a)
         /// </summary>
-        public static Vector256<short> ConvertToVector256Short(Vector128<sbyte> value) { throw new PlatformNotSupportedException(); }
+        public static Vector256<short> ConvertToVector256Int16(Vector128<sbyte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_cvtepu8_epi16 (__m128i a)
         /// </summary>
-        public static Vector256<ushort> ConvertToVector256UShort(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
+        public static Vector256<ushort> ConvertToVector256UInt16(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_cvtepi8_epi32 (__m128i a)
         /// </summary>
-        public static Vector256<int> ConvertToVector256Int(Vector128<sbyte> value) { throw new PlatformNotSupportedException(); }
+        public static Vector256<int> ConvertToVector256Int32(Vector128<sbyte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_cvtepi16_epi32 (__m128i a)
         /// </summary>
-        public static Vector256<int> ConvertToVector256Int(Vector128<short> value) { throw new PlatformNotSupportedException(); }
+        public static Vector256<int> ConvertToVector256Int32(Vector128<short> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_cvtepu8_epi32 (__m128i a)
         /// </summary>
-        public static Vector256<uint> ConvertToVector256UInt(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
+        public static Vector256<uint> ConvertToVector256UInt32(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_cvtepu16_epi32 (__m128i a)
         /// </summary>
-        public static Vector256<uint> ConvertToVector256UInt(Vector128<ushort> value) { throw new PlatformNotSupportedException(); }
+        public static Vector256<uint> ConvertToVector256UInt32(Vector128<ushort> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_cvtepi8_epi64 (__m128i a)
         /// </summary>
-        public static Vector256<long> ConvertToVector256Long(Vector128<sbyte> value) { throw new PlatformNotSupportedException(); }
+        public static Vector256<long> ConvertToVector256Int64(Vector128<sbyte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_cvtepi16_epi64 (__m128i a)
         /// </summary>
-        public static Vector256<long> ConvertToVector256Long(Vector128<short> value) { throw new PlatformNotSupportedException(); }
+        public static Vector256<long> ConvertToVector256Int64(Vector128<short> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_cvtepi32_epi64 (__m128i a)
         /// </summary>
-        public static Vector256<long> ConvertToVector256Long(Vector128<int> value) { throw new PlatformNotSupportedException(); }
+        public static Vector256<long> ConvertToVector256Int64(Vector128<int> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_cvtepu8_epi64 (__m128i a)
         /// </summary>
-        public static Vector256<ulong> ConvertToVector256ULong(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
+        public static Vector256<ulong> ConvertToVector256UInt64(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_cvtepu16_epi64 (__m128i a)
         /// </summary>
-        public static Vector256<ulong> ConvertToVector256ULong(Vector128<ushort> value) { throw new PlatformNotSupportedException(); }
+        public static Vector256<ulong> ConvertToVector256UInt64(Vector128<ushort> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_cvtepu32_epi64 (__m128i a)
         /// </summary>
-        public static Vector256<ulong> ConvertToVector256ULong(Vector128<uint> value) { throw new PlatformNotSupportedException(); }
+        public static Vector256<ulong> ConvertToVector256UInt64(Vector128<uint> value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)

--- a/src/mscorlib/src/System/Runtime/Intrinsics/X86/Avx2.cs
+++ b/src/mscorlib/src/System/Runtime/Intrinsics/X86/Avx2.cs
@@ -306,51 +306,51 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __m256i _mm256_cvtepi8_epi16 (__m128i a)
         /// </summary>
-        public static Vector256<short> ConvertToVector256Short(Vector128<sbyte> value) => ConvertToVector256Short(value);
+        public static Vector256<short> ConvertToVector256Int16(Vector128<sbyte> value) => ConvertToVector256Int16(value);
         /// <summary>
         /// __m256i _mm256_cvtepu8_epi16 (__m128i a)
         /// </summary>
-        public static Vector256<ushort> ConvertToVector256UShort(Vector128<byte> value) => ConvertToVector256UShort(value);
+        public static Vector256<ushort> ConvertToVector256UInt16(Vector128<byte> value) => ConvertToVector256UInt16(value);
         /// <summary>
         /// __m256i _mm256_cvtepi8_epi32 (__m128i a)
         /// </summary>
-        public static Vector256<int> ConvertToVector256Int(Vector128<sbyte> value) => ConvertToVector256Int(value);
+        public static Vector256<int> ConvertToVector256Int32(Vector128<sbyte> value) => ConvertToVector256Int32(value);
         /// <summary>
         /// __m256i _mm256_cvtepi16_epi32 (__m128i a)
         /// </summary>
-        public static Vector256<int> ConvertToVector256Int(Vector128<short> value) => ConvertToVector256Int(value);
+        public static Vector256<int> ConvertToVector256Int32(Vector128<short> value) => ConvertToVector256Int32(value);
         /// <summary>
         /// __m256i _mm256_cvtepu8_epi32 (__m128i a)
         /// </summary>
-        public static Vector256<uint> ConvertToVector256UInt(Vector128<byte> value) => ConvertToVector256UInt(value);
+        public static Vector256<uint> ConvertToVector256UInt32(Vector128<byte> value) => ConvertToVector256UInt32(value);
         /// <summary>
         /// __m256i _mm256_cvtepu16_epi32 (__m128i a)
         /// </summary>
-        public static Vector256<uint> ConvertToVector256UInt(Vector128<ushort> value) => ConvertToVector256UInt(value);
+        public static Vector256<uint> ConvertToVector256UInt32(Vector128<ushort> value) => ConvertToVector256UInt32(value);
         /// <summary>
         /// __m256i _mm256_cvtepi8_epi64 (__m128i a)
         /// </summary>
-        public static Vector256<long> ConvertToVector256Long(Vector128<sbyte> value) => ConvertToVector256Long(value);
+        public static Vector256<long> ConvertToVector256Int64(Vector128<sbyte> value) => ConvertToVector256Int64(value);
         /// <summary>
         /// __m256i _mm256_cvtepi16_epi64 (__m128i a)
         /// </summary>
-        public static Vector256<long> ConvertToVector256Long(Vector128<short> value) => ConvertToVector256Long(value);
+        public static Vector256<long> ConvertToVector256Int64(Vector128<short> value) => ConvertToVector256Int64(value);
         /// <summary>
         /// __m256i _mm256_cvtepi32_epi64 (__m128i a)
         /// </summary>
-        public static Vector256<long> ConvertToVector256Long(Vector128<int> value) => ConvertToVector256Long(value);
+        public static Vector256<long> ConvertToVector256Int64(Vector128<int> value) => ConvertToVector256Int64(value);
         /// <summary>
         /// __m256i _mm256_cvtepu8_epi64 (__m128i a)
         /// </summary>
-        public static Vector256<ulong> ConvertToVector256ULong(Vector128<byte> value) => ConvertToVector256ULong(value);
+        public static Vector256<ulong> ConvertToVector256UInt64(Vector128<byte> value) => ConvertToVector256UInt64(value);
         /// <summary>
         /// __m256i _mm256_cvtepu16_epi64 (__m128i a)
         /// </summary>
-        public static Vector256<ulong> ConvertToVector256ULong(Vector128<ushort> value) => ConvertToVector256ULong(value);
+        public static Vector256<ulong> ConvertToVector256UInt64(Vector128<ushort> value) => ConvertToVector256UInt64(value);
         /// <summary>
         /// __m256i _mm256_cvtepu32_epi64 (__m128i a)
         /// </summary>
-        public static Vector256<ulong> ConvertToVector256ULong(Vector128<uint> value) => ConvertToVector256ULong(value);
+        public static Vector256<ulong> ConvertToVector256UInt64(Vector128<uint> value) => ConvertToVector256UInt64(value);
 
         /// <summary>
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)

--- a/src/mscorlib/src/System/Runtime/Intrinsics/X86/Sse.PlatformNotSupported.cs
+++ b/src/mscorlib/src/System/Runtime/Intrinsics/X86/Sse.PlatformNotSupported.cs
@@ -143,7 +143,7 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __m128 _mm_rsqrt_ps (__m128 a)
         /// </summary>
-        public static Vector128<float> ReciprocalSquareRoot(Vector128<float> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> ReciprocalSqrt(Vector128<float> value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128 _mm_set_ps (float e3, float e2, float e1, float e0)

--- a/src/mscorlib/src/System/Runtime/Intrinsics/X86/Sse.cs
+++ b/src/mscorlib/src/System/Runtime/Intrinsics/X86/Sse.cs
@@ -143,7 +143,7 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __m128 _mm_rsqrt_ps (__m128 a)
         /// </summary>
-        public static Vector128<float> ReciprocalSquareRoot(Vector128<float> value) => ReciprocalSquareRoot(value);
+        public static Vector128<float> ReciprocalSqrt(Vector128<float> value) => ReciprocalSqrt(value);
 
         /// <summary>
         /// __m128 _mm_set_ps (float e3, float e2, float e1, float e0)

--- a/src/mscorlib/src/System/Runtime/Intrinsics/X86/Sse2.PlatformNotSupported.cs
+++ b/src/mscorlib/src/System/Runtime/Intrinsics/X86/Sse2.PlatformNotSupported.cs
@@ -263,36 +263,36 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __m128i _mm_cvtps_epi32 (__m128 a)
         /// </summary>
-        public static Vector128<int> ConvertToInt(Vector128<float> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int> ConvertToVector128Int32(Vector128<float> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtpd_epi32 (__m128d a)
         /// </summary>
-        public static Vector128<int> ConvertToInt(Vector128<double> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int> ConvertToVector128Int32(Vector128<double> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128 _mm_cvtepi32_ps (__m128i a)
         /// </summary>
-        public static Vector128<float> ConvertToFloat(Vector128<int> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> ConvertToVector128Single(Vector128<int> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128 _mm_cvtpd_ps (__m128d a)
         /// </summary>
-        public static Vector128<float> ConvertToFloat(Vector128<double> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> ConvertToVector128Single(Vector128<double> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128d _mm_cvtepi32_pd (__m128i a)
         /// </summary>
-        public static Vector128<double> ConvertToDouble(Vector128<int> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> ConvertToVector128Double(Vector128<int> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128d _mm_cvtps_pd (__m128 a)
         /// </summary>
-        public static Vector128<double> ConvertToDouble(Vector128<float> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> ConvertToVector128Double(Vector128<float> value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm_cvttps_epi32 (__m128 a)
         /// </summary>
-        public static Vector128<int> ConvertToIntWithTruncation(Vector128<float> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int> ConvertToVector128Int32WithTruncation(Vector128<float> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvttpd_epi32 (__m128d a)
         /// </summary>
-        public static Vector128<int> ConvertToIntWithTruncation(Vector128<double> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int> ConvertToVector128Int32WithTruncation(Vector128<double> value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128d _mm_div_pd (__m128d a,  __m128d b)
@@ -302,20 +302,20 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// int _mm_extract_epi16 (__m128i a,  int immediate)
         /// </summary>
-        public static short ExtractShort<T>(Vector128<T> value,  byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static short ExtractInt16<T>(Vector128<T> value,  byte index) where T : struct { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// int _mm_extract_epi16 (__m128i a,  int immediate)
         /// </summary>
-        public static ushort ExtractUshort<T>(Vector128<T> value,  byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static ushort ExtractUInt16<T>(Vector128<T> value,  byte index) where T : struct { throw new PlatformNotSupportedException(); }
         
         /// <summary>
         /// __m128i _mm_insert_epi16 (__m128i a,  int i, int immediate)
         /// </summary>
-        public static Vector128<T> InsertShort<T>(Vector128<T> value,  short data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> InsertInt16<T>(Vector128<T> value,  short data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_insert_epi16 (__m128i a,  int i, int immediate)
         /// </summary>
-        public static Vector128<T> InsertUshort<T>(Vector128<T> value,  ushort data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> InsertUInt16<T>(Vector128<T> value,  ushort data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
         
         /// <summary>
         /// __m128i _mm_loadu_si128 (__m128i const* mem_address)
@@ -447,11 +447,11 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __m128i _mm_mulhi_epi16 (__m128i a,  __m128i b)
         /// </summary>
-        public static Vector128<short> MultiplyHi(Vector128<short> left,  Vector128<short> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<short> MultiplyHigh(Vector128<short> left,  Vector128<short> right) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_mulhi_epu16 (__m128i a,  __m128i b)
         /// </summary>
-        public static Vector128<ushort> MultiplyHi(Vector128<ushort> left,  Vector128<ushort> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<ushort> MultiplyHigh(Vector128<ushort> left,  Vector128<ushort> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm_madd_epi16 (__m128i a,  __m128i b)

--- a/src/mscorlib/src/System/Runtime/Intrinsics/X86/Sse2.cs
+++ b/src/mscorlib/src/System/Runtime/Intrinsics/X86/Sse2.cs
@@ -263,36 +263,36 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __m128i _mm_cvtps_epi32 (__m128 a)
         /// </summary>
-        public static Vector128<int> ConvertToInt(Vector128<float> value) => ConvertToInt(value);
+        public static Vector128<int> ConvertToVector128Int32(Vector128<float> value) => ConvertToVector128Int32(value);
         /// <summary>
         /// __m128i _mm_cvtpd_epi32 (__m128d a)
         /// </summary>
-        public static Vector128<int> ConvertToInt(Vector128<double> value) => ConvertToInt(value);
+        public static Vector128<int> ConvertToVector128Int32(Vector128<double> value) => ConvertToVector128Int32(value);
         /// <summary>
         /// __m128 _mm_cvtepi32_ps (__m128i a)
         /// </summary>
-        public static Vector128<float> ConvertToFloat(Vector128<int> value) => ConvertToFloat(value);
+        public static Vector128<float> ConvertToVector128Single(Vector128<int> value) => ConvertToVector128Single(value);
         /// <summary>
         /// __m128 _mm_cvtpd_ps (__m128d a)
         /// </summary>
-        public static Vector128<float> ConvertToFloat(Vector128<double> value) => ConvertToFloat(value);
+        public static Vector128<float> ConvertToVector128Single(Vector128<double> value) => ConvertToVector128Single(value);
         /// <summary>
         /// __m128d _mm_cvtepi32_pd (__m128i a)
         /// </summary>
-        public static Vector128<double> ConvertToDouble(Vector128<int> value) => ConvertToDouble(value);
+        public static Vector128<double> ConvertToVector128Double(Vector128<int> value) => ConvertToVector128Double(value);
         /// <summary>
         /// __m128d _mm_cvtps_pd (__m128 a)
         /// </summary>
-        public static Vector128<double> ConvertToDouble(Vector128<float> value) => ConvertToDouble(value);
+        public static Vector128<double> ConvertToVector128Double(Vector128<float> value) => ConvertToVector128Double(value);
 
         /// <summary>
         /// __m128i _mm_cvttps_epi32 (__m128 a)
         /// </summary>
-        public static Vector128<int> ConvertToIntWithTruncation(Vector128<float> value) => ConvertToIntWithTruncation(value);
+        public static Vector128<int> ConvertToVector128Int32WithTruncation(Vector128<float> value) => ConvertToVector128Int32WithTruncation(value);
         /// <summary>
         /// __m128i _mm_cvttpd_epi32 (__m128d a)
         /// </summary>
-        public static Vector128<int> ConvertToIntWithTruncation(Vector128<double> value) => ConvertToIntWithTruncation(value);
+        public static Vector128<int> ConvertToVector128Int32WithTruncation(Vector128<double> value) => ConvertToVector128Int32WithTruncation(value);
 
         /// <summary>
         /// __m128d _mm_div_pd (__m128d a,  __m128d b)
@@ -302,35 +302,35 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// int _mm_extract_epi16 (__m128i a,  int immediate)
         /// </summary>
-        public static short ExtractShort<T>(Vector128<T> value, byte index) where T : struct
+        public static short ExtractInt16<T>(Vector128<T> value, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return ExtractShort<T>(value, index);
+            return ExtractInt16<T>(value, index);
         }
         /// <summary>
         /// int _mm_extract_epi16 (__m128i a,  int immediate)
         /// </summary>
-        public static ushort ExtractUshort<T>(Vector128<T> value, byte index) where T : struct
+        public static ushort ExtractUInt16<T>(Vector128<T> value, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return ExtractUshort<T>(value, index);
+            return ExtractUInt16<T>(value, index);
         }
         
         /// <summary>
         /// __m128i _mm_insert_epi16 (__m128i a,  int i, int immediate)
         /// </summary>
-        public static Vector128<T> InsertShort<T>(Vector128<T> value, short data, byte index) where T : struct
+        public static Vector128<T> InsertInt16<T>(Vector128<T> value, short data, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return InsertShort<T>(value, data, index);
+            return InsertInt16<T>(value, data, index);
         }
         /// <summary>
         /// __m128i _mm_insert_epi16 (__m128i a,  int i, int immediate)
         /// </summary>
-        public static Vector128<T> InsertUshort<T>(Vector128<T> value, ushort data, byte index) where T : struct
+        public static Vector128<T> InsertUInt16<T>(Vector128<T> value, ushort data, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return InsertUshort<T>(value, data, index);
+            return InsertUInt16<T>(value, data, index);
         }
         
         /// <summary>
@@ -463,11 +463,11 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __m128i _mm_mulhi_epi16 (__m128i a,  __m128i b)
         /// </summary>
-        public static Vector128<short> MultiplyHi(Vector128<short> left, Vector128<short> right) => MultiplyHi(left, right);
+        public static Vector128<short> MultiplyHigh(Vector128<short> left, Vector128<short> right) => MultiplyHigh(left, right);
         /// <summary>
         /// __m128i _mm_mulhi_epu16 (__m128i a,  __m128i b)
         /// </summary>
-        public static Vector128<ushort> MultiplyHi(Vector128<ushort> left, Vector128<ushort> right) => MultiplyHi(left, right);
+        public static Vector128<ushort> MultiplyHigh(Vector128<ushort> left, Vector128<ushort> right) => MultiplyHigh(left, right);
 
         /// <summary>
         /// __m128i _mm_madd_epi16 (__m128i a,  __m128i b)

--- a/src/mscorlib/src/System/Runtime/Intrinsics/X86/Sse41.PlatformNotSupported.cs
+++ b/src/mscorlib/src/System/Runtime/Intrinsics/X86/Sse41.PlatformNotSupported.cs
@@ -73,51 +73,51 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __m128i _mm_cvtepi8_epi16 (__m128i a)
         /// </summary>
-        public static Vector128<short> ConvertToShort(Vector128<sbyte> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<short> ConvertToVector128Int16(Vector128<sbyte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtepu8_epi16 (__m128i a)
         /// </summary>
-        public static Vector128<short> ConvertToShort(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<short> ConvertToVector128Int16(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtepi8_epi32 (__m128i a)
         /// </summary>
-        public static Vector128<int> ConvertToInt(Vector128<sbyte> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int> ConvertToVector128Int32(Vector128<sbyte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtepu8_epi32 (__m128i a)
         /// </summary>
-        public static Vector128<int> ConvertToInt(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int> ConvertToVector128Int32(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtepi16_epi32 (__m128i a)
         /// </summary>
-        public static Vector128<int> ConvertToInt(Vector128<short> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int> ConvertToVector128Int32(Vector128<short> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtepu16_epi32 (__m128i a)
         /// </summary>
-        public static Vector128<int> ConvertToInt(Vector128<ushort> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int> ConvertToVector128Int32(Vector128<ushort> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtepi8_epi64 (__m128i a)
         /// </summary>
-        public static Vector128<long> ConvertToLong(Vector128<sbyte> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<long> ConvertToVector128Int64(Vector128<sbyte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtepu8_epi64 (__m128i a)
         /// </summary>
-        public static Vector128<long> ConvertToLong(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<long> ConvertToVector128Int64(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtepi16_epi64 (__m128i a)
         /// </summary>
-        public static Vector128<long> ConvertToLong(Vector128<short> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<long> ConvertToVector128Int64(Vector128<short> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtepu16_epi64 (__m128i a)
         /// </summary>
-        public static Vector128<long> ConvertToLong(Vector128<ushort> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<long> ConvertToVector128Int64(Vector128<ushort> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtepi32_epi64 (__m128i a)
         /// </summary>
-        public static Vector128<long> ConvertToLong(Vector128<int> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<long> ConvertToVector128Int64(Vector128<int> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtepu32_epi64 (__m128i a)
         /// </summary>
-        public static Vector128<long> ConvertToLong(Vector128<uint> value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<long> ConvertToVector128Int64(Vector128<uint> value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128 _mm_dp_ps (__m128 a, __m128 b, const int imm8)
@@ -131,7 +131,7 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// int _mm_extract_epi8 (__m128i a, const int imm8)
         /// </summary>
-        public static sbyte ExtractSbyte<T>(Vector128<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static sbyte ExtractSByte<T>(Vector128<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// int _mm_extract_epi8 (__m128i a, const int imm8)
         /// </summary>
@@ -140,27 +140,27 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// int _mm_extract_epi32 (__m128i a, const int imm8)
         /// </summary>
-        public static int ExtractInt<T>(Vector128<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static int ExtractInt32<T>(Vector128<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_extract_epi32 (__m128i a, const int imm8)
         /// </summary>
-        public static uint ExtractUint<T>(Vector128<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static uint ExtractUInt32<T>(Vector128<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __int64 _mm_extract_epi64 (__m128i a, const int imm8)
         /// </summary>
-        public static long ExtractLong<T>(Vector128<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static long ExtractInt64<T>(Vector128<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __int64 _mm_extract_epi64 (__m128i a, const int imm8)
         /// </summary>
-        public static ulong ExtractUlong<T>(Vector128<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static ulong ExtractUInt64<T>(Vector128<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_extract_ps (__m128 a, const int imm8)
         /// </summary>
-        public static float ExtractFloat<T>(Vector128<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static float ExtractSingle<T>(Vector128<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128 _mm_floor_ps (__m128 a)
@@ -174,7 +174,7 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __m128i _mm_insert_epi8 (__m128i a, int i, const int imm8)
         /// </summary>
-        public static Vector128<T> InsertSbyte<T>(Vector128<T> value, sbyte data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> InsertSByte<T>(Vector128<T> value, sbyte data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm_insert_epi8 (__m128i a, int i, const int imm8)
@@ -184,27 +184,27 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __m128i _mm_insert_epi32 (__m128i a, int i, const int imm8)
         /// </summary>
-        public static Vector128<T> InsertInt<T>(Vector128<T> value, int data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> InsertInt32<T>(Vector128<T> value, int data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm_insert_epi32 (__m128i a, int i, const int imm8)
         /// </summary>
-        public static Vector128<T> InsertUint<T>(Vector128<T> value, uint data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> InsertUInt32<T>(Vector128<T> value, uint data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm_insert_epi64 (__m128i a, __int64 i, const int imm8)
         /// </summary>
-        public static Vector128<T> InsertLong<T>(Vector128<T> value, long data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> InsertInt64<T>(Vector128<T> value, long data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm_insert_epi64 (__m128i a, __int64 i, const int imm8)
         /// </summary>
-        public static Vector128<T> InsertUlong<T>(Vector128<T> value, ulong data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> InsertUInt64<T>(Vector128<T> value, ulong data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128 _mm_insert_ps (__m128 a, __m128 b, const int imm8)
         /// </summary>
-        public static Vector128<T> InsertFloat<T>(Vector128<T> value, float data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> InsertSingle<T>(Vector128<T> value, float data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm_max_epi8 (__m128i a, __m128i b)

--- a/src/mscorlib/src/System/Runtime/Intrinsics/X86/Sse41.cs
+++ b/src/mscorlib/src/System/Runtime/Intrinsics/X86/Sse41.cs
@@ -73,51 +73,51 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __m128i _mm_cvtepi8_epi16 (__m128i a)
         /// </summary>
-        public static Vector128<short> ConvertToShort(Vector128<sbyte> value) => ConvertToShort(value);
+        public static Vector128<short> ConvertToVector128Int16(Vector128<sbyte> value) => ConvertToVector128Int16(value);
         /// <summary>
         /// __m128i _mm_cvtepu8_epi16 (__m128i a)
         /// </summary>
-        public static Vector128<short> ConvertToShort(Vector128<byte> value) => ConvertToShort(value);
+        public static Vector128<short> ConvertToVector128Int16(Vector128<byte> value) => ConvertToVector128Int16(value);
         /// <summary>
         /// __m128i _mm_cvtepi8_epi32 (__m128i a)
         /// </summary>
-        public static Vector128<int> ConvertToInt(Vector128<sbyte> value) => ConvertToInt(value);
+        public static Vector128<int> ConvertToVector128Int32(Vector128<sbyte> value) => ConvertToVector128Int32(value);
         /// <summary>
         /// __m128i _mm_cvtepu8_epi32 (__m128i a)
         /// </summary>
-        public static Vector128<int> ConvertToInt(Vector128<byte> value) => ConvertToInt(value);
+        public static Vector128<int> ConvertToVector128Int32(Vector128<byte> value) => ConvertToVector128Int32(value);
         /// <summary>
         /// __m128i _mm_cvtepi16_epi32 (__m128i a)
         /// </summary>
-        public static Vector128<int> ConvertToInt(Vector128<short> value) => ConvertToInt(value);
+        public static Vector128<int> ConvertToVector128Int32(Vector128<short> value) => ConvertToVector128Int32(value);
         /// <summary>
         /// __m128i _mm_cvtepu16_epi32 (__m128i a)
         /// </summary>
-        public static Vector128<int> ConvertToInt(Vector128<ushort> value) => ConvertToInt(value);
+        public static Vector128<int> ConvertToVector128Int32(Vector128<ushort> value) => ConvertToVector128Int32(value);
         /// <summary>
         /// __m128i _mm_cvtepi8_epi64 (__m128i a)
         /// </summary>
-        public static Vector128<long> ConvertToLong(Vector128<sbyte> value) => ConvertToLong(value);
+        public static Vector128<long> ConvertToVector128Int64(Vector128<sbyte> value) => ConvertToVector128Int64(value);
         /// <summary>
         /// __m128i _mm_cvtepu8_epi64 (__m128i a)
         /// </summary>
-        public static Vector128<long> ConvertToLong(Vector128<byte> value) => ConvertToLong(value);
+        public static Vector128<long> ConvertToVector128Int64(Vector128<byte> value) => ConvertToVector128Int64(value);
         /// <summary>
         /// __m128i _mm_cvtepi16_epi64 (__m128i a)
         /// </summary>
-        public static Vector128<long> ConvertToLong(Vector128<short> value) => ConvertToLong(value);
+        public static Vector128<long> ConvertToVector128Int64(Vector128<short> value) => ConvertToVector128Int64(value);
         /// <summary>
         /// __m128i _mm_cvtepu16_epi64 (__m128i a)
         /// </summary>
-        public static Vector128<long> ConvertToLong(Vector128<ushort> value) => ConvertToLong(value);
+        public static Vector128<long> ConvertToVector128Int64(Vector128<ushort> value) => ConvertToVector128Int64(value);
         /// <summary>
         /// __m128i _mm_cvtepi32_epi64 (__m128i a)
         /// </summary>
-        public static Vector128<long> ConvertToLong(Vector128<int> value) => ConvertToLong(value);
+        public static Vector128<long> ConvertToVector128Int64(Vector128<int> value) => ConvertToVector128Int64(value);
         /// <summary>
         /// __m128i _mm_cvtepu32_epi64 (__m128i a)
         /// </summary>
-        public static Vector128<long> ConvertToLong(Vector128<uint> value) => ConvertToLong(value);
+        public static Vector128<long> ConvertToVector128Int64(Vector128<uint> value) => ConvertToVector128Int64(value);
 
         /// <summary>
         /// __m128 _mm_dp_ps (__m128 a, __m128 b, const int imm8)
@@ -131,10 +131,10 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// int _mm_extract_epi8 (__m128i a, const int imm8)
         /// </summary>
-        public static sbyte ExtractSbyte<T>(Vector128<T> value, byte index) where T : struct
+        public static sbyte ExtractSByte<T>(Vector128<T> value, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return ExtractSbyte<T>(value, index);
+            return ExtractSByte<T>(value, index);
         }
         /// <summary>
         /// int _mm_extract_epi8 (__m128i a, const int imm8)
@@ -148,46 +148,46 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// int _mm_extract_epi32 (__m128i a, const int imm8)
         /// </summary>
-        public static int ExtractInt<T>(Vector128<T> value, byte index) where T : struct
+        public static int ExtractInt32<T>(Vector128<T> value, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return ExtractInt<T>(value, index);
+            return ExtractInt32<T>(value, index);
         }
 
         /// <summary>
         /// int _mm_extract_epi32 (__m128i a, const int imm8)
         /// </summary>
-        public static uint ExtractUint<T>(Vector128<T> value, byte index) where T : struct
+        public static uint ExtractUInt32<T>(Vector128<T> value, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return ExtractUint<T>(value, index);
+            return ExtractUInt32<T>(value, index);
         }
 
         /// <summary>
         /// __int64 _mm_extract_epi64 (__m128i a, const int imm8)
         /// </summary>
-        public static long ExtractLong<T>(Vector128<T> value, byte index) where T : struct
+        public static long ExtractInt64<T>(Vector128<T> value, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return ExtractLong<T>(value, index);
+            return ExtractInt64<T>(value, index);
         }
 
         /// <summary>
         /// __int64 _mm_extract_epi64 (__m128i a, const int imm8)
         /// </summary>
-        public static ulong ExtractUlong<T>(Vector128<T> value, byte index) where T : struct
+        public static ulong ExtractUInt64<T>(Vector128<T> value, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return ExtractUlong<T>(value, index);
+            return ExtractUInt64<T>(value, index);
         }
 
         /// <summary>
         /// int _mm_extract_ps (__m128 a, const int imm8)
         /// </summary>
-        public static float ExtractFloat<T>(Vector128<T> value, byte index) where T : struct
+        public static float ExtractSingle<T>(Vector128<T> value, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return ExtractFloat<T>(value, index);
+            return ExtractSingle<T>(value, index);
         }
 
         /// <summary>
@@ -202,10 +202,10 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __m128i _mm_insert_epi8 (__m128i a, int i, const int imm8)
         /// </summary>
-        public static Vector128<T> InsertSbyte<T>(Vector128<T> value, sbyte data, byte index) where T : struct
+        public static Vector128<T> InsertSByte<T>(Vector128<T> value, sbyte data, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return InsertSbyte<T>(value, data, index);
+            return InsertSByte<T>(value, data, index);
         }
 
         /// <summary>
@@ -220,46 +220,46 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __m128i _mm_insert_epi32 (__m128i a, int i, const int imm8)
         /// </summary>
-        public static Vector128<T> InsertInt<T>(Vector128<T> value, int data, byte index) where T : struct
+        public static Vector128<T> InsertInt32<T>(Vector128<T> value, int data, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return InsertInt<T>(value, data, index);
+            return InsertInt32<T>(value, data, index);
         }
 
         /// <summary>
         /// __m128i _mm_insert_epi32 (__m128i a, int i, const int imm8)
         /// </summary>
-        public static Vector128<T> InsertUint<T>(Vector128<T> value, uint data, byte index) where T : struct
+        public static Vector128<T> InsertUInt32<T>(Vector128<T> value, uint data, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return InsertUint<T>(value, data, index);
+            return InsertUInt32<T>(value, data, index);
         }
 
         /// <summary>
         /// __m128i _mm_insert_epi64 (__m128i a, __int64 i, const int imm8)
         /// </summary>
-        public static Vector128<T> InsertLong<T>(Vector128<T> value, long data, byte index) where T : struct
+        public static Vector128<T> InsertInt64<T>(Vector128<T> value, long data, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return InsertLong<T>(value, data, index);
+            return InsertInt64<T>(value, data, index);
         }
 
         /// <summary>
         /// __m128i _mm_insert_epi64 (__m128i a, __int64 i, const int imm8)
         /// </summary>
-        public static Vector128<T> InsertUlong<T>(Vector128<T> value, ulong data, byte index) where T : struct
+        public static Vector128<T> InsertUInt64<T>(Vector128<T> value, ulong data, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return InsertUlong<T>(value, data, index);
+            return InsertUInt64<T>(value, data, index);
         }
 
         /// <summary>
         /// __m128 _mm_insert_ps (__m128 a, __m128 b, const int imm8)
         /// </summary>
-        public static Vector128<T> InsertFloat<T>(Vector128<T> value, float data, byte index) where T : struct
+        public static Vector128<T> InsertSingle<T>(Vector128<T> value, float data, byte index) where T : struct
         {
             ThrowHelper.ThrowNotSupportedExceptionIfNonNumericType<T>();
-            return InsertFloat<T>(value, data, index);
+            return InsertSingle<T>(value, data, index);
         }
 
         /// <summary>


### PR DESCRIPTION
Avoid language-specific type names in hardware intrinsic APIs. Discussed in https://github.com/dotnet/coreclr/pull/15341#issuecomment-348659762

@tannergooding @jkotas 