### PR TITLE
fix CoreCLR build errors with clang5.0.

### DIFF
--- a/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -299,8 +299,6 @@ void MethodContext::MethodInitHelperFile(HANDLE hFile)
 
 void MethodContext::MethodInitHelper(unsigned char* buff2, unsigned int totalLen)
 {
-    MethodContext::MethodContext();
-
     unsigned int   buffIndex = 0;
     unsigned int   localsize = 0;
     unsigned char  canary    = 0xff;

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -5921,6 +5921,7 @@ public:
     EXCEPTION_DISPOSITION disposition = EXCEPTION_CONTINUE_EXECUTION;           \
     auto exceptionFilter = [&disposition, &__param](PAL_SEHException& ex)       \
     {                                                                           \
+        (void)__param;                                                          \
         disposition = dispositionExpression;                                    \
         _ASSERTE(disposition != EXCEPTION_CONTINUE_EXECUTION);                  \
         return disposition;                                                     \


### PR DESCRIPTION
The PR combines fix for the wrong spmi methodContext  explicit constructor and @janvorli's fix for an unused lambda parameter.

With this fixes I was able to build CoreCLR with clang 5.0 on Ubuntu 14.04.
Fix #14757  and #15197.