### PR TITLE
Fix typo _TARGET_ARM to _TARGET_ARM_ in lsra.cpp

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -5397,7 +5397,7 @@ void CodeGen::genEnregisterIncomingStackArgs()
             otherReg          = genRegPairHi(regPair);
         }
         else
-#endif // _TARGET_ARM
+#endif // _TARGET_ARM_
         {
             regNum   = varDsc->lvArgInitReg;
             otherReg = REG_NA;

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1531,7 +1531,7 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE    typeHnd,
         // On ARM, we have a requirement on the struct alignment; see below.
         unsigned structAlignment =
             roundUp(info.compCompHnd->getClassAlignmentRequirement(typeHnd), TARGET_POINTER_SIZE);
-#endif // _TARGET_ARM
+#endif // _TARGET_ARM_
 
         bool isHole[MaxOffset]; // isHole[] is initialized to true for every valid offset in the struct and false for
                                 // the rest

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -6356,7 +6356,7 @@ regNumber LinearScan::allocateBusyReg(Interval* current, RefPosition* refPositio
                     // need to be spilled as they are already in memory and
                     // codegen considers them as contained memory operands.
                     CLANG_FORMAT_COMMENT_ANCHOR;
-#ifdef _TARGET_ARM
+#ifdef _TARGET_ARM_
                     // TODO-CQ-ARM: Just conservatively "and" two condition. We may implement better condision later.
                     isBetterLocation = true;
                     if (recentAssignedRef != nullptr)

--- a/src/jit/regalloc.cpp
+++ b/src/jit/regalloc.cpp
@@ -4392,7 +4392,7 @@ regMaskTP Compiler::rpPredictTreeRegUse(GenTreePtr   tree,
                 }
                 tree->gtUsedRegs = (regMaskSmall)(regMask | tmpMask);
                 goto RETURN_CHECK;
-#else  // !_TARGET_ARM
+#else  // !_TARGET_ARM_
                 goto GENERIC_UNARY;
 #endif // _TARGET_ARM_
             }

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -1837,7 +1837,7 @@ CLRUnwindStatus ExceptionTracker::ProcessOSExceptionNotification(
                     pICFForUnwindTarget = pFrame;
                 }
             }
-#endif // defined(_TARGET_ARM)
+#endif // defined(_TARGET_ARM_)
 
             cfThisFrame.CheckGSCookies();
 

--- a/src/zap/zapimage.cpp
+++ b/src/zap/zapimage.cpp
@@ -537,7 +537,7 @@ void ZapImage::AllocateVirtualSections()
 
         //ILMetadata/Resources sections are reported as a statically known warm ranges for now.
         m_pILMetaDataSection = NewVirtualSection(pTextSection, IBCProfiledSection | HotColdSortedRange | ILMetadataSection, sizeof(DWORD));
-#endif  // _TARGET_ARM
+#endif  // _TARGET_ARM_
 
 #if defined(_TARGET_ARM_)
         if (!bigResourceSection) // for ARM, put the resource section at the end if it's very large - see comment above


### PR DESCRIPTION
This replaces typo `_TARGET_ARM` with `_TARGET_ARM_` in lsra.cpp for RyuJIT/ARM32 and also in comments in other files. 
No assembly diffs introduced for RyuJIT/ARM32 cross-compiling altjit (protononjit.dll)