### PR TITLE
Added comment to explicit number

### DIFF
--- a/src/inc/gcinfodecoder.h
+++ b/src/inc/gcinfodecoder.h
@@ -240,7 +240,7 @@ public:
         _ASSERTE( pBuffer != NULL );
 
         m_pCurrent = m_pBuffer = dac_cast<PTR_size_t>((size_t)dac_cast<TADDR>(pBuffer) & ~((size_t)sizeof(size_t)-1));
-        m_RelPos = m_InitialRelPos = (int)((size_t)dac_cast<TADDR>(pBuffer) % sizeof(size_t)) * 8;
+        m_RelPos = m_InitialRelPos = (int)((size_t)dac_cast<TADDR>(pBuffer) % sizeof(size_t)) * 8/*BITS_PER_BYTE*/;
     }
 
     BitStreamReader(const BitStreamReader& other)


### PR DESCRIPTION
I spent about half of day trying to propagate ```BITS_PER_BYTE``` macro here, but it requires some refactoring in ```gc``` and ```jit``` components