### PR TITLE
Disable 3 failing ARM tests on Windows

### DIFF
--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -625,7 +625,7 @@ RelativePath=readytorun\tests\mainv1\mainv1.cmd
 WorkingDir=readytorun\tests\mainv1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS
+Categories=EXPECTED_PASS;PROTOJIT_JITSTRESS_FAIL;15150
 HostStyle=0
 
 [ComparerCompare2.cmd_80]
@@ -881,7 +881,7 @@ RelativePath=GC\Scenarios\DoublinkList\dlstack\dlstack.cmd
 WorkingDir=GC\Scenarios\DoublinkList\dlstack
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS
+Categories=EXPECTED_PASS;PROTOJIT_JITSTRESS_FAIL;15156
 HostStyle=0
 
 [Generated1222.cmd_112]
@@ -85153,7 +85153,7 @@ RelativePath=readytorun\tests\mainv2\mainv2.cmd
 WorkingDir=readytorun\tests\mainv2
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS
+Categories=EXPECTED_PASS;PROTOJIT_JITSTRESS_FAIL;15150
 HostStyle=0
 
 [Generated1463.cmd_10690]


### PR DESCRIPTION
mainv1, mainv2 against #15150 (JitStressRegs=1; JitStressRegs=8)
dlstack against #15156 (JitStress=2 + JitStressRegs=3)