### PR TITLE
Ignore *.nuget.cache files in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,7 @@ publish/
 *.nupkg
 *.nuget.g.props
 *.nuget.g.targets
+*.nuget.cache
 **/packages/*
 project.lock.json
 project.assets.json


### PR DESCRIPTION
NuGet seems to be producing cache files of the form *.nuget.cache.  I've seen them in two places:

        .nuget/init/init.csproj.nuget.cache
        ToolBox/SOS/NETCore/SOS.NETCore.csproj.nuget.cache

Update the .gitignore file to include these files.