### PR TITLE
Enable gdbjit while NI file exist

### DIFF
--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -2576,11 +2576,25 @@ void NotifyGdb::OnMethodPrepared(MethodDesc* methodDescPtr)
     }
 #endif
 
+    // remove '.ni.dll' or '.ni.exe' suffix from wszModuleFile
+    LPWSTR pNIExt = const_cast<LPWSTR>(wcsstr(wszModuleFile, W(".ni.exe"))); // where '.ni.exe' start at 
+    if (!pNIExt)
+    {
+      pNIExt = const_cast<LPWSTR>(wcsstr(wszModuleFile, W(".ni.dll"))); // where '.ni.dll' start at 
+    }
+
+    if (pNIExt)
+    {
+      wcscpy(pNIExt, W(".dll"));
+    }
+
     if (isListedModule(wszModuleFile))
     {
         bool bEmitted = EmitDebugInfo(elfBuilder, methodDescPtr, pCode, codeSize);
         bNotify = bNotify || bEmitted;
     }
+
+
 #ifdef FEATURE_GDBJIT_SYMTAB
     else
     {


### PR DESCRIPTION
Current gdbjit does not work with NI files.
This patch allows breakpoint to work with NI files when COMPlus_ZapDisable=1