### PR TITLE
WIP NoMerge System.Runtime.Intrinsics.Arm.Arm64.Simd api draft for early feedback

### DIFF
--- a/Documentation/design-docs/arm64-intrinsics.md
+++ b/Documentation/design-docs/arm64-intrinsics.md
@@ -33,25 +33,18 @@ correspond to a single assembly instruction.
 
 ## Logical Sets of Intrinsics
 
-Individual CPU instantiate a specific set of instructions.  For various reasons, an
-individual CPU will have a specific set of supported instructions.  for `ARM64` the
+For various reasons, an individual CPU will have a specific set of supported instructions.  For `ARM64` the
 set of supported instructions is identified by various `ID_* System registers`.
 While these feature registers are only available for the OS to access, they provide
-a logical grouping of instructions which are enable/disabled to gether.
+a logical grouping of instructions which are enabled/disabled together.
 
 ### API Logical Set grouping & `IsSupported`
 
 The C# API must provide a mechanism to determine which sets of instructions are supported.
-
 Existing design uses a separate `static class` to group the methods which correspond to each
-logical set of instructions.
-
-A single `IsSupported` property is included in each `static class` to allow client code to alter
-control flow.
-
-The `IsSupported` properties are design so that JIT can remove code on unused paths.
-
-`ARM64` will use an identical approach.
+logical set of instructions.  A single `IsSupported` property is included in each `static class`
+to allow client code to alter control flow.  The `IsSupported` properties are designed so that JIT
+can remove code on unused paths.  `ARM64` will use an identical approach.
 
 ### API `PlatformNotSupported` Exception
 
@@ -68,7 +61,7 @@ means must provide for setting the flags.
 
 PAL must provide an OS abstraction layer.
 
-Each OS must provide mechanism for determining which sets of instructions are supported.
+Each OS must provide a mechanism for determining which sets of instructions are supported.
 
 + Linux provides the HWCAP detection mechanism which is able to detect current set of exposed
 features
@@ -86,7 +79,7 @@ NOTE: Exceptions might be where:
 
 ### Intrinsics & Crossgen
 
-For any intrinsic which may not be supported on all variants of a platform.  Crossgen Method
+For any intrinsic which may not be supported on all variants of a platform, crossgen method
 compilation must be trapped, so that the JIT is forced to generate optimal platform dependent
 code at runtime.
 
@@ -99,8 +92,8 @@ code at runtime.
 + `System.Runtime.Intrinsics` is used for type definitions useful across multiple platforms
 + `System.Runtime.Intrinsics.Arm` is used type definitions shared across `ARM32` and `ARM64` platforms
 + `System.Runtime.Intrinsics.Arm.Arm64` is used for type definitions for the `ARM64` platform
-  + The primary implementation of `ARM64` intrinsics wil occur within this namespace
-  + While `x86` and `x64` share a common namespace.  This document is recommending a separate namespace
+  + The primary implementation of `ARM64` intrinsics will occur within this namespace
+  + While `x86` and `x64` share a common namespace, this document is recommending a separate namespace
   for `ARM32` and `ARM64`.  This is because `AARCH64` is a separate `ISA` from the `AARCH32` `Arm` & `Thumb`
   instruction sets.  It is not an `ISA` extension, but rather a new `ISA`.  This is different from `x64`
   which could be viewed as a superset of `x86`.
@@ -116,38 +109,38 @@ platform specific functionality.  These API's are currently out of scope of this
 Within the `System.Runtime.Intrinsics.Arm.Arm64` namespace there will be a separate `static class` for each
 logical set of instructions
 
-The sets will be chosen to match the granularity if the `ARM64` `ID_*` register fields.
+The sets will be chosen to match the granularity of the `ARM64` `ID_*` register fields.
 
 #### Specific Class Names
 
 The table below documents the set of known extensions, their identification, and their recommended intrinsic
 class names.
 
-| ID Register      | Field   | Values   | Intrinsic `static class` name | Ext. type  |
-| ---------------- | ------- | -------- | ----------------------------- | ---------- |
-| N/A              | N/A     | N/A      | All                           | Baseline   |
-| ID_AA64ISAR0_EL1 | AES     | (1b, 10b)| Aes                           | Crypto     |
-| ID_AA64ISAR0_EL1 | Atomic  | (10b)    | Atomics                       | Ordering   |
-| ID_AA64ISAR0_EL1 | CRC32   | (1b)     | Crc32                         | Crypto     |
-| ID_AA64ISAR1_EL1 | DPB     | (1b)     | Dcpop                         | Ordering   |
-| ID_AA64ISAR0_EL1 | DP      | (1b)     | Dp                            | SIMD       |
-| ID_AA64ISAR1_EL1 | FCMA    | (1b)     | Fcma                          | SIMD       |
-| ID_AA64PFR0_EL1  | FP      | (0b, 1b) | Fp                            | FP         |
-| ID_AA64PFR0_EL1  | FP      | (1b)     | Fp16                          | FP, Half   |
-| ID_AA64ISAR1_EL1 | JSCVT   | (1b)     | Jscvt                         | SIMD       |
-| ID_AA64ISAR1_EL1 | LRCPC   | (1b)     | Lrcpc                         | Ordering   |
-| ID_AA64ISAR0_EL1 | AES     | (10b)    | Pmull                         | SIMD       |
-| ID_AA64PFR0_EL1  | RAS     | (1b)     | Ras                           | Ordering   |
-| ID_AA64ISAR0_EL1 | SHA1    | (1b)     | Sha1                          | Crypto     |
-| ID_AA64ISAR0_EL1 | SHA2    | (1b, 10b)| Sha2                          | Crypto     |
-| ID_AA64ISAR0_EL1 | SHA3    | (1b)     | Sha3                          | Crypto     |
-| ID_AA64ISAR0_EL1 | SHA2    | (10b)    | Sha512                        | Crypto     |
-| ID_AA64PFR0_EL1  | AdvSIMD | (0b, 1b) | Simd                          | SIMD       |
-| ID_AA64PFR0_EL1  | AdvSIMD | (1b)     | SimdFp16                      | SIMD,Half  |
-| ID_AA64ISAR0_EL1 | RDM     | (1b)     | SimdV81                       | SIMD       |
-| ID_AA64ISAR0_EL1 | SM3     | (1b)     | Sm3                           | Crypto     |
-| ID_AA64ISAR0_EL1 | SM4     | (1b)     | Sm4                           | Crypto     |
-| ID_AA64PFR0_EL1  | SVE     | (1b)     | Sve                           | SIMD,SVE   |
+| ID Register      | Field   | Values   | Intrinsic `static class` name |
+| ---------------- | ------- | -------- | ----------------------------- |
+| N/A              | N/A     | N/A      | All                           |
+| ID_AA64ISAR0_EL1 | AES     | (1b, 10b)| Aes                           |
+| ID_AA64ISAR0_EL1 | Atomic  | (10b)    | Atomics                       |
+| ID_AA64ISAR0_EL1 | CRC32   | (1b)     | Crc32                         |
+| ID_AA64ISAR1_EL1 | DPB     | (1b)     | Dcpop                         |
+| ID_AA64ISAR0_EL1 | DP      | (1b)     | Dp                            |
+| ID_AA64ISAR1_EL1 | FCMA    | (1b)     | Fcma                          |
+| ID_AA64PFR0_EL1  | FP      | (0b, 1b) | Fp                            |
+| ID_AA64PFR0_EL1  | FP      | (1b)     | Fp16                          |
+| ID_AA64ISAR1_EL1 | JSCVT   | (1b)     | Jscvt                         |
+| ID_AA64ISAR1_EL1 | LRCPC   | (1b)     | Lrcpc                         |
+| ID_AA64ISAR0_EL1 | AES     | (10b)    | Pmull                         |
+| ID_AA64PFR0_EL1  | RAS     | (1b)     | Ras                           |
+| ID_AA64ISAR0_EL1 | SHA1    | (1b)     | Sha1                          |
+| ID_AA64ISAR0_EL1 | SHA2    | (1b, 10b)| Sha2                          |
+| ID_AA64ISAR0_EL1 | SHA3    | (1b)     | Sha3                          |
+| ID_AA64ISAR0_EL1 | SHA2    | (10b)    | Sha512                        |
+| ID_AA64PFR0_EL1  | AdvSIMD | (0b, 1b) | Simd                          |
+| ID_AA64PFR0_EL1  | AdvSIMD | (1b)     | SimdFp16                      |
+| ID_AA64ISAR0_EL1 | RDM     | (1b)     | SimdV81                       |
+| ID_AA64ISAR0_EL1 | SM3     | (1b)     | Sm3                           |
+| ID_AA64ISAR0_EL1 | SM4     | (1b)     | Sm4                           |
+| ID_AA64PFR0_EL1  | SVE     | (1b)     | Sve                           |
 
 The `All`, `Simd`, and `Fp` classes will together contain the bulk of the `ARM64` intrinsics.  Most other extensions
 will only add a few instruction so they should be simpler to review.
@@ -163,7 +156,7 @@ As further extensions are released, this set of intrinsics will grow.
 Intrinsics will be named to describe functionality.  Names will not correspond to specific named
 assembly instructions.
 
-Where precedence exists within the `System.Runtime.Intrinsics.X86` namespace, identical method names will be
+Where precedent exists within the `System.Runtime.Intrinsics.X86` namespace, identical method names will be
 chosen: `Add`, `Multiply`, `Load`, `Store` ...
 
 It is also worth noting `System.Runtime.Intrinsics.X86` naming conventions will include the suffix `Scalar` for
@@ -214,7 +207,10 @@ As rough guidelines for order of implementation:
 
 Intrinsics will extend the API of CoreCLR.  They will need to follow standard API review practices.
 
-#### API review of a new intrinsic `static class`es
+XArch intrinsics are being added to the NetStandard API https://github.com/dotnet/corefx/issues/24346.  ARM64 intrinsics should be
+treated identically.
+
+#### API review of a new intrinsic `static class`
 
 Review will be facilitated by GitHub Pull requests to amend the Approved API section of this document.
 
@@ -229,7 +225,7 @@ Implementation will be kept separate from from API review.
 
 ### Partial implementation of intrinsic `static class`
 
-+ `IsSupported` must represents the state of an entire intrinsic `static class`
++ `IsSupported` must represent the state of an entire intrinsic `static class`
 + Once API review is complete and approved, it is acceptable to implement approved methods in any order provided tests are added
 + The approved API must be completed before the intrinsic `static class` is included in a release
 
@@ -244,7 +240,7 @@ This document will refer to half precision floating point as `Half`.
 + Machine learning and Artificial intelligence often use `Half` type to simplify storage and improve processing time.
 + CoreCLR and `CIL` in general do not have general support for a `Half` type
 + There is an open request to expose `Half` intrinsics
-+ There is an outstanding proposal to add `System.Half` to support this request
++ There is an outstanding proposal to add `System.Half` to support this request https://github.com/dotnet/corefx/issues/25702
 + Implementation of `Half` features will be adjusted based on
   + Implementation of the `System.Half` proposal
   + Availability of supporting hardware (extensions)
@@ -259,7 +255,7 @@ ARMv8 baseline support for `Half` is limited.  The following operations are supp
 + Widening from `Vector128<Half>` to two `Vector128<Float>`
 + Narrowing from two `Vector128<Float>` to `Vector128<Half>`
 
-Recent extension add support for
+Recent extensions add support for
 
 + General operations on `Half` types
 + Vector operations on `Half` types
@@ -281,15 +277,23 @@ Test cases must be written and conformance must be demonstrated.
 `SVE`, the Scalable Vector Extension introduces its own complexity.
 
 The extension
-+ Creates a new set of SVE registers
-+ Each register has a platform specific length
-  + Any multiple of 128 bits
+
++ Creates a set of `Z0-Z31` scalable vector registers.  These overlay existing vector registers.  Each scalar vector register has a platform specific length
+  + Any multiple of 128 bits up to 2048 bits
++ Creates a new set of `P0-P15` predicate registers.  Each predicate register has a platform specific length which is 1/8th of the scalar vector length.
++ Add an extensive set of instructions including complex load and store operations.
++ Modifies the ARM64 ABI.
 
 Therefore implementation will not be trivial.
 
-+ Register allocator may need changes
++ Register allocator will need changes to support predicate allocation
 + SIMD support will face similar issues
-+ Open issue: Should we use `Vector<T>` or SVE<T> in user interface design?
++ Open issue: Should we use `Vector<T>`, `Vector128<t>, Vector256<t>, ... Vector2048<T>`, `SVE<T>` ... in user interface design?
+  + Use of `Vector128<t>, Vector256<t>, ... Vector2048<T>` is current default proposal.
+Having 16 forms of every API may create issues for framework and client developers.
+However generics may provide some/sufficient relief to make this acceptable.
+  + Use of `Vector<T>` may be preferred if SVE will not be used for `FEATURE_SIMD`
+  + Use of `SVE<T>` may be preferred if SVE will not be used for `FEATURE_SIMD`
 
 Given lack of available hardware and a lack of thorough understanding of the specification:
 

--- a/Documentation/design-docs/arm64-intrinsics.md
+++ b/Documentation/design-docs/arm64-intrinsics.md
@@ -203,9 +203,7 @@ Intrinsics will extend the API of CoreCLR.  They will need to follow standard AP
 
 #### API review of a new intrinsic `static class`es
 
-Review will be facilitated by GitHub Issues requests.
-
-API reviews will be completed within the CoreFX project.
+Review will be facilitated by GitHub Pull requests to amend the Approved API section of this document.
 
 A separate GitHub Issue will be created for the review of each intrinsic `static class`.  This allows design and review team to
 review separately.  This allows review complexity to be kept manageable.  The O(N^2) nature of the review process will be kept to
@@ -296,3 +294,65 @@ Deprecation of instructions should be relatively rare
 + In event an assembly instruction is deprecated
   1. Prefer emulation using alternate instructions if practical
   2. Add `SetThrowOnDeprecated()` interface to allow developers to find these issues
+
+## Approved APIs
+
+The following sections document APIs which have completed the API review process.
+
+Until each API is approved it shall be marked "TBD Not Approved"
+
+### `Required`
+
+TBD Not approved
+
+### `Aes`
+
+TBD Not approved
+
+### `Atomics`
+
+TBD Not approved
+
+### `Crc32`
+
+TBD Not approved
+
+### `Esb`
+
+TBD Not approved
+
+### `Fp`
+
+TBD Not approved
+
+### `Fp16`
+
+TBD Not approved
+
+### `Pmull64`
+
+TBD Not approved
+
+### `Ras`
+
+TBD Not approved
+
+### `Sha1`
+
+TBD Not approved
+
+### `Sha2`
+
+TBD Not approved
+
+### `Simd`
+
+TBD Not approved
+
+### `SimdFp16`
+
+TBD Not approved
+
+### `Sve`
+
+TBD Not approved

--- a/Documentation/design-docs/arm64-intrinsics.md
+++ b/Documentation/design-docs/arm64-intrinsics.md
@@ -1,0 +1,217 @@
+## Arm64 Intrinsics
+
+This document is intended to document proposed design decision related to the introduction
+of Arm64 Intrinsics
+
+### Intrinsics in general
+
+Use of intrinsics in general is a CoreCLR design decision to allow low level platform
+specific optimizations.  
+
+At first glance, such a decision seems to violate the fundamental principles of .NET
+code running on any platform.  However, the intent is not for the vast majority of
+apps to use such optimizations.  The intended usage model is to allow library
+developers access to low level functions which enable optimization of key
+functions.  As such the use is expected to be limited, but performance critical.
+
+#### Intrinsic `IsSupported` granularity
+
+The existing implementation is using `IsSupported` to determine whether an existing
+namespace is supported on a given platform.
+
+The granularity is kept at a large scale to have large blocks of functionality controlled
+by a single `IsSupported`.
+
+#### Intrinsic granularity
+
+In general individual intrinsic will be chosen to be fine grained.  These will generally correspond to a single assembly instruction.
+
+#### Intrinsics & Crossgen
+
+For any intrinsic which may not be supported on all variants of a platform.  Crossgen
+Method compilation must be trapped, so that the JIT is forced to generate optimal platform dependent 
+code at runtime.
+
+#### API review
+
+Intrinsics will extend the API of CoreCLR.  They will need to follow standard API review practices.
+
+### Choice of Arm64 naming conventions
+
+#### Namespaces
+
+`ARM32` and `ARM64` will follow similar namespace conventions.
+
++ `System.Runtime.Intrinsics` is used for type definitions useful across multiple platforms
++ `System.Runtime.Intrinsics.Arm` is used for enumerations shared across `ARM32` and `ARM64` platforms
++ `System.Runtime.Intrinsics.Arm.Base` is recommended for functionality included in all `ARM32` and `ARM64` platforms
+  + Do we need this or could we assume `ARMv8` is minimum supported platform?
+  + Should we assume `ARMv7` or `ARMv5` is minimum supported platform?
++ `System.Runtime.Intrinsics.Arm.ARMv8` is used for `ARMv8` added functionality included in both `ARM32` and `ARM64` platforms 
++ `System.Runtime.Intrinsics.Arm.ARMv8.Arm64` is used for `ARMv8` functionality only included in `ARM64` platform
++ `System.Runtime.Intrinsics.Arm.ARMv8_1....` is used for `ARMv8.1` functionality.  
+  + Use similar sub namespace names for only included in `ARM64` platform ...
++ `System.Runtime.Intrinsics.Arm.XXX` is used for optional features `CRC32`, `AES`, `SHA1` ... 
+  + All extensions which were not required when they were initially introduced
+  + For example, `CRC32` became required with `ARMv8.1`, but since it was introduced as optional in `ARMv8` it would go in its own namespace
+  
+If an extension is only supported on `Arm32`, there is no reason to add a sub namespace.
+
++ `System.Runtime.Intrinsics.Arm.ARMv7` is used for `ARMv7` added functionality not included in `Base`
+
+If an extension is only supported on `Arm64`, there is no reason to add a sub namespace.  Hypothetically:
+
++ `System.Runtime.Intrinsics.Arm.ARMv10` is used for `ARMv10` added functionality (Hypothetically `Arm64` only)
+
+Namespace is chosen based on what could be implemented, not on what is or will be implemented.
+
+#### Names
+
+Intrinsics will be named to describe functionality.  Names will not correspond to specific named assembly instructions.
+
+`IsSupported` will be used in any namespace which may not be implemented on all CoreCLR platforms
+
+### Intrinsic Interface Documentation
+
++ Documentation will be minimal preferring the underlying ARM documentation
++ Namespaces will briefly document corresponding specification
++ Intrinsic methods will briefly document corresponding assembly instruction(s) for each platform
+
+### Test coverage
+
+As intrinsic support is added test coverage must be extended to provide basic testing
+
+### Phased Implementation
+
+#### Implementation Priorities
+
+As guidelines:
+
++ Baseline functionality will be prioritized over architectural extensions
++ Architectural extensions will typically be prioritized in age order.  Earlier extensions will be added first
++ `ARM64` only and `ARM*` features will have equal priority
++ Priorities will be driven by optimization efforts and requests
++ Priority will be given to intrinsics which have already been implemented for other platforms
++ Priority will be given to intrinsics which are equivalent/similar to those actively used in libraries for other platforms
+
+#### Addition of new intrinsics namespaces
+When an intrinsic namespace is introduced code will likely be implemented on different platforms at different times.
+
+It is explicitly OK for ARM64 to implement a namespace which may be implemented on `ARM32` w/o `ARM32` implementation.
+The opposite is also true.
+
+Any platform which does not implement a namespace, must:
+
++ Return `false` for `IsSupported`
++ `throw` on any unimplemented function
+
+#### Partial implementation of intrinsic namespace
+
++ It is preferred that `IsSupported` represents the state of an entire namespace
++ It is certainly required at time of a release, `IsSupported` represents the state of an entire namespace
++ Allow for writing tests and implementing code, `IsSupported == false` may be used when namespace is partially implemented
+
+#### Addition of new intrinsics to existing namespace
+When an intrinsic namespace is introduced, a best guess will be made about the set of useful intrinsics.
+However, the intrinsics will be added as needed or requested for various optimization efforts.
+
++ The set of intrinsics instructions supported by a namespace should only be allowed
+if all platforms reporting `IsSupported` are supported (at least at time of release)
++ It may be preferable to add new namespaces in cases where this creates significant burden
+
+### Half precision floating point
+
+This document will refer to half precision floating point as `Half`.
+
++ Machine learning and Artificial intelligence often use `Half` type to simplify storage and improve processing time.
++ CoreCLR and `CIL` in general do not have general support for a `Half` type
++ There is an open request to expose `Half` intrinsics
++ ARM64 will introduce `System.Runtime.Intrinsics.Half` to support this request 
++ `Half` will be defined as:
+
+```
+    [StructLayout(LayoutKind.Sequential, Size = 2)]
+    public struct Half : struct {}
+``` 
+
+#### ARMv8 Half precision support
+
+ARMv8 baseline support for `Half` is limited.  The following operations are supported
+
++ Loads and Stores
++ Conversion to/from `Float`
++ Widening from `Vector128<Half>` to two `Vector128<Float>`
++ Narrowing from two `Vector128<Float>` to `Vector128<Float>`
+
+It is presumed that even this minimal support could be helpful
+
+Optional `Half` extensions add more complete support
+
+#### `Half` and ARM64 ABI
+
+The proposed `Half` implementation will treat `Half` as raw bits.  
+It is likely therefore that this will not conform to the ARM64 ABI specifically with respect to the HFA
+calling convention.  This will hinder use of `Half` in `PInvoke` calls.  Resolving this ABI issue will
+be a low priority.
+
+### Scalable Vector Extension Support
+
+`SVE`, the Scalable Vector Extension introduces its own complexity.  
+
+The extension 
++ Creates a new set of SVE registers 
++ Each register has a platform specific length
+  + Any multiple of 128 bits
+
+Therefore implementation will not be trivial.
+
++ Register allocator may need changes
++ Crossgen of SVE intrinsics must be delayed until runtime JIT
++ SIMD support will face similar issues
++ Open issue: Should we use `Vector<T>` or SVE<T> in user interface design?
++ SVE probably requires a separate design
+
+### Miscellaneous
+#### Choice of Arm64 naming conventions -- Rationale
+
+##### Naming conventions
+
++ Namespaces are generally using Pascal case
++ Namespaces and Names must not start with a number
++ Names are descriptive.  Therefore intrinsics are generally named to describe functionality
+
+`ARMv8` is assumed to be an abbreviation for `ARM Reference Manual Version 8`
+
+##### Reference x86 & x64 choice of namespaces
+
++ `System.Runtime.Intrinsics` is used for type definitions useful across multiple platforms
++ `System.Runtime.Intrinsics.X86` is used for enumerations shared across both platforms
++ `System.Runtime.Intrinsics.AVX` is used for the instructions which are included in a specific hardware extension
+
+##### ARM Version history
+
+Looking at `ARM` version history, 
+
++ The `ARM` instruction set is regularly extended: `ARMv5`, `ARMv7`, `ARMv8`
++ New version are generally supersets of prior versions
+  + Deprecated features are preserved for at least one generation
+  + Deprecated features are eventually completely removed
++ `ARMv8` was the first version to introduce 64-bit support
+  + Legacy ARMv7 was extended to become `ARMv8` `AARCH32` 
+  + `ARMv8` `AARCH64` was introduced
+  + `AARCH64` used similar but distinctly different instruction set
+  + `AARCH64` naming convention varied slightly from `AARCH32`
++ `ARMv8.1` & `ARMv8.2` extensions have been introduced
++ New instructions introduced by extensions have generally been asymmetric.  New `AARCH64` instructions ARMv8New extensions have generally made It is not uncommon for an extensions to include new instructions for 
+`AARCH64`
+....  With the introduction of `ARMv8`, `aarch64` (`ARM64`) and `aarch32` were
+split.  The legacy ARMv7 instruction encodings were only supported in `aarch32`
+
+#### Handling Instruction Deprecation
+
+Deprecation of instructions should be relatively rare
+
++ Do not introduce an intrinsic for a feature that is currently deprecated
++ In event an assembly instruction is deprecated
+  1. Prefer emulation using alternate instructions if practical
+  2. Add `SetThrowOnDeprecated()` interface to allow developpers to find these issues

--- a/Documentation/design-docs/arm64-intrinsics.md
+++ b/Documentation/design-docs/arm64-intrinsics.md
@@ -63,7 +63,8 @@ exception must be thrown.
 The JIT must use a set of flags corresponding to logical sets of instructions to alter code
 generation.
 
-The VM must query the OS to populate the set of JIT flags.
+The VM must query the OS to populate the set of JIT flags.  For the special altJit case, a
+means must provide for setting the flags.
 
 Each OS must provide mechanism for determining which sets of instructions are supported.
 
@@ -122,26 +123,28 @@ class names.
 
 | ID Register      | Field   | Values   | Intrinsic `static class` name |
 | ---------------- | ------- | -------- | ----------------------------- |
-| N/A              | N/A     | N/A      | Required                      |
+| N/A              | N/A     | N/A      | All                           |
 | ID_AA64ISAR0_EL1 | AES     | (1b, 10b)| Aes                           |
-| ID_AA64ISAR0_EL1 | AES     | (10b)    | Pmull64                       |
-| ID_AA64ISAR0_EL1 | SHA1    | (1b)     | Sha1                          |
-| ID_AA64ISAR0_EL1 | SHA2    | (1b)     | Sha2                          |
-| ID_AA64ISAR0_EL1 | CRC32   | (1b)     | Crc32                         |
 | ID_AA64ISAR0_EL1 | Atomic  | (10b)    | Atomics                       |
-| ID_AA64ISAR0_EL1 | RDM     | (1b)     | SimdV81                       |
-| ID_AA64MMFR2_EL1 | IESB    | (1b)     | Esb                           |
+| ID_AA64ISAR0_EL1 | CRC32   | (1b)     | Crc32                         |
+| ID_AA64ISAR0_EL1 | DP      | (1b)     | Dp                            |
 | ID_AA64PFR0_EL1  | FP      | (0b, 1b) | Fp                            |
 | ID_AA64PFR0_EL1  | FP      | (1b)     | Fp16                          |
+| ID_AA64ISAR0_EL1 | AES     | (10b)    | Pmull                         |
+| ID_AA64PFR0_EL1  | RAS     | (1b)     | Ras                           |
+| ID_AA64ISAR0_EL1 | SHA1    | (1b)     | Sha1                          |
+| ID_AA64ISAR0_EL1 | SHA2    | (1b, 10b)| Sha2                          |
+| ID_AA64ISAR0_EL1 | SHA3    | (1b)     | Sha3                          |
+| ID_AA64ISAR0_EL1 | SHA2    | (10b)    | Sha512                        |
 | ID_AA64PFR0_EL1  | AdvSIMD | (0b, 1b) | Simd                          |
 | ID_AA64PFR0_EL1  | AdvSIMD | (1b)     | SimdFp16                      |
-| ID_AA64PFR0_EL1  | RAS     | (1b)     | Ras                           |
+| ID_AA64ISAR0_EL1 | RDM     | (1b)     | SimdV81                       |
+| ID_AA64ISAR0_EL1 | SM3     | (1b)     | Sm3                           |
+| ID_AA64ISAR0_EL1 | SM4     | (1b)     | Sm4                           |
 | ID_AA64PFR0_EL1  | SVE     | (1b)     | Sve                           |
 
 The `Required` `static class` is used to represent any intrinsic which is guaranteed to be implemented on all
 `ARM64` platforms.  Investigation is needed to determine if this is an empty set.
-
-It is also possible the `ESB` or `RAS` may not need intrinsics.
 
 As further extensions are released, this set of intrinsics will grow.
 
@@ -205,7 +208,7 @@ Intrinsics will extend the API of CoreCLR.  They will need to follow standard AP
 
 Review will be facilitated by GitHub Pull requests to amend the Approved API section of this document.
 
-A separate GitHub Issue will be created for the review of each intrinsic `static class`.  This allows design and review team to
+A separate GitHub Issue will typically created for the review of each intrinsic `static class`.  This allows design and review team to
 review separately.  This allows review complexity to be kept manageable.  The O(N^2) nature of the review process will be kept to
 reasonable levels and iterations will be finite.
 
@@ -223,8 +226,6 @@ Implementation will be kept separate from from API review.
 ### Test coverage
 
 As intrinsic support is added test coverage must be extended to provide basic testing
-
-Tests
 
 ## Half precision floating point
 
@@ -301,7 +302,7 @@ The following sections document APIs which have completed the API review process
 
 Until each API is approved it shall be marked "TBD Not Approved"
 
-### `Required`
+### `All`
 
 TBD Not approved
 
@@ -317,7 +318,7 @@ TBD Not approved
 
 TBD Not approved
 
-### `Esb`
+### `Dp`
 
 TBD Not approved
 
@@ -329,7 +330,7 @@ TBD Not approved
 
 TBD Not approved
 
-### `Pmull64`
+### `Pmull`
 
 TBD Not approved
 
@@ -345,11 +346,31 @@ TBD Not approved
 
 TBD Not approved
 
+### `Sha3`
+
+TBD Not approved
+
+### `Sha512`
+
+TBD Not approved
+
 ### `Simd`
 
 TBD Not approved
 
 ### `SimdFp16`
+
+TBD Not approved
+
+### `SimdV81`
+
+TBD Not approved
+
+### `Sm3`
+
+TBD Not approved
+
+### `Sm4`
 
 TBD Not approved
 

--- a/Documentation/design-docs/arm64-intrinsics.md
+++ b/Documentation/design-docs/arm64-intrinsics.md
@@ -1,12 +1,24 @@
-## Arm64 Intrinsics
+# Arm64 Intrinsics
 
-This document is intended to document proposed design decision related to the introduction
+This document is intended to document proposed design decisions related to the introduction
 of Arm64 Intrinsics
 
-### Intrinsics in general
+## Document Goals
+
++ Discuss design options
+  + Document existing design pattern
+  + Draft initial design decisions which are least likely to cause extensive rework
++ Decouple `X86`, `X64`, `ARM32` and `ARM64` development
+  + Make some minimal decisions which encourage API similarity between platforms
+  + Make some additional minimal decisions which allow `ARM32` and `ARM64` API's to be similar
++ Decouple CoreCLR implementation and testing from API design
++ Allow for best API design
++ Keep implementation simple
+
+## Intrinsics in general
 
 Use of intrinsics in general is a CoreCLR design decision to allow low level platform
-specific optimizations.  
+specific optimizations.
 
 At first glance, such a decision seems to violate the fundamental principles of .NET
 code running on any platform.  However, the intent is not for the vast majority of
@@ -14,204 +26,244 @@ apps to use such optimizations.  The intended usage model is to allow library
 developers access to low level functions which enable optimization of key
 functions.  As such the use is expected to be limited, but performance critical.
 
-#### Intrinsic `IsSupported` granularity
+## Intrinsic granularity
 
-The existing implementation is using `IsSupported` to determine whether an existing
-namespace is supported on a given platform.
+In general individual intrinsic will be chosen to be fine grained.  These will generally
+correspond to a single assembly instruction.
 
-The granularity is kept at a large scale to have large blocks of functionality controlled
-by a single `IsSupported`.
+## Logical Sets of Intrinsics
 
-#### Intrinsic granularity
+Individual CPU instantiate a specific set of instructions.  For various reasons, an
+individual CPU will have a specific set of supported instructions.  for `ARM64` the
+set of supported instructions is identified by various `ID_* System registers`.
+While these feature registers are only available for the OS to access, they provide
+a logical grouping of instructions which are enable/disabled to gether.
 
-In general individual intrinsic will be chosen to be fine grained.  These will generally correspond to a single assembly instruction.
+### API Logical Set grouping & `IsSupported`
 
-#### Intrinsics & Crossgen
+The C# API must provide a mechanism to determine which sets of instructions are supported.
 
-For any intrinsic which may not be supported on all variants of a platform.  Crossgen
-Method compilation must be trapped, so that the JIT is forced to generate optimal platform dependent 
+Existing design uses a separate `static class` to group the methods which correspond to each
+logical set of instructions.
+
+A single `IsSupported` property is included in each `static class` to allow client code to alter
+control flow.
+
+The `IsSupported` properties are design so that JIT can remove code on unused paths.
+
+`ARM64` will use an identical approach.
+
+### API `PlatformNotSupported` Exception
+
+If client code calls an intrinsic which is not supported by the platform a `PlatformNotSupported`
+exception must be thrown.
+
+### JIT, VM & OS requirements
+
+The JIT must use a set of flags corresponding to logical sets of instructions to alter code
+generation.
+
+The VM must query the OS to populate the set of JIT flags.
+
+Each OS must provide mechanism for determining which sets of instructions are supported.
+
++ Linux provides the HWCAP detection mechanism which is able to detect current set of exposed
+features
++ Arm64 MAC OS and Arm64 Windows OS must provide an equally capable detection mechanism.
+
+In the event the OS fails to provides a means to detect a support for an instruction set extension
+it must be treated as unsupported.
+
+NOTE: Exceptions might be where :
+
++ CoreCLR is distributed as source and CMake build configuration test is used  detect these features
++ Installer detects features and sets appropriate configuration knobs
++ VM runs code inside safe try/catch blocks to test for instruction support
++ Platform requires a specific minimum set of instructions
+
+### Intrinsics & Crossgen
+
+For any intrinsic which may not be supported on all variants of a platform.  Crossgen Method
+compilation must be trapped, so that the JIT is forced to generate optimal platform dependent
 code at runtime.
 
-#### API review
+## Choice of Arm64 naming conventions
+
+`x86`, `x64`, `ARM32` and `ARM64` will follow similar naming conventions.
+
+### Namespaces
+
++ `System.Runtime.Intrinsics` is used for type definitions useful across multiple platforms
++ `System.Runtime.Intrinsics.Arm` is used type definitions shared across `ARM32` and `ARM64` platforms
++ `System.Runtime.Intrinsics.Arm.Arm64` is used for type definitions for the `ARM64` platform
+  + The primary implementation of `ARM64` intrinsics wil occur within this namespace
+  + While `x86` and `x64` share a common namespace.  This document is recommending a separate namespace
+  for `ARM32` and `ARM64`.  This is because `AARCH64` is a separate `ISA` from the `AARCH32` `Arm` & `Thumb`
+  instruction sets.  It is not an `ISA` extension, but rather a new `ISA`.  This is different from `x64`
+  which could be viewed as a superset of `x86`.
+  + The logical grouping of `ARM64` and `ARM32` instruction sets is different.  It is controlled by
+  different sets of `System Registers`.
+
+For the convenience of the end user, it may be useful to add convenience API's which expose functionality
+which is common across platforms and sets of platforms.  These could be implemented in terms of the
+platform specific functionality.  These API's are currently out of scope of this initial design document.
+
+### Logical Set Class Names
+
+Within the `System.Runtime.Intrinsics.Arm.Arm64` namespace there will be a separate `static class` for each
+logical set of instructions
+
+The sets will be chosen to match the granularity if the `ARM64` `ID_*` register fields.
+
+#### Specific Class Names
+
+TBD Add table to document each known extension and recommended `static class` name.
+
+### Intrinsic Method Names
+
+Intrinsics will be named to describe functionality.  Names will not correspond to specific named
+assembly instructions.
+
+Where precedence exists within the `System.Runtime.Intrinsics.X86` namespace, identical method names will be
+chosen: `Add`, `Multiply`, `Load`, `Store` ...
+
+### Intinsic Method Argument Types
+
+Intrinsic methods will typically use a standard set of argument types:
++ Integer type: `byte`, `sbyte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`
++ Floating types: `double`, `single`, `System.Half`
++ Vector types: Vector128<T>
++ SVE will add new vector types: TBD
+
+## Intrinsic Interface Documentation
+
++ Namespace
++ Each `static class` will
+  + Briefly document corresponding `System Register Field and Value` from ARM specification.
+  + Document use of IsSupported property
+  + Optionally summarize set of methods enabled by the extension
++ Each intrinsic method will
+  + Document underlying `ARM64` assembly instruction
+  + Optionally, briefly summarize operation performed
+    + In many cases this may be unnecessary: `Add`, `Multiply`, `Load`, `Store`
+    + In some cases this may be difficult to do correctly. (Crypto instructions)
+
+## Phased Implementation
+
+### Implementation Priorities
+
+As rough guidelines for order of implementation:
+
++ Baseline functionality will be prioritized over architectural extensions
++ Architectural extensions will typically be prioritized in age order.  Earlier extensions will be added first
+  + This is primarily driven by availability of hardware.  Features released in earlier will be prevalent in
+  more hardware.
++ Priorities will be driven by optimization efforts and requests
+  + Priority will be given to intrinsics which are equivalent/similar to those actively used in libraries for other platforms
+  + Priority will be given to intrinsics which have already been implemented for other platforms
+
+### API review
 
 Intrinsics will extend the API of CoreCLR.  They will need to follow standard API review practices.
 
-### Choice of Arm64 naming conventions
+#### API review of a new intrinsic `static class`es
 
-#### Namespaces
+Review will be facilitated by GitHub Issues requests.
 
-`ARM32` and `ARM64` will follow similar namespace conventions.
+API reviews will be completed within the CoreFX project.
 
-+ `System.Runtime.Intrinsics` is used for type definitions useful across multiple platforms
-+ `System.Runtime.Intrinsics.Arm` is used for enumerations shared across `ARM32` and `ARM64` platforms
-+ `System.Runtime.Intrinsics.Arm.Base` is recommended for functionality included in all `ARM32` and `ARM64` platforms
-  + Do we need this or could we assume `ARMv8` is minimum supported platform?
-  + Should we assume `ARMv7` or `ARMv5` is minimum supported platform?
-+ `System.Runtime.Intrinsics.Arm.ARMv8` is used for `ARMv8` added functionality included in both `ARM32` and `ARM64` platforms 
-+ `System.Runtime.Intrinsics.Arm.ARMv8.Arm64` is used for `ARMv8` functionality only included in `ARM64` platform
-+ `System.Runtime.Intrinsics.Arm.ARMv8_1....` is used for `ARMv8.1` functionality.  
-  + Use similar sub namespace names for only included in `ARM64` platform ...
-+ `System.Runtime.Intrinsics.Arm.XXX` is used for optional features `CRC32`, `AES`, `SHA1` ... 
-  + All extensions which were not required when they were initially introduced
-  + For example, `CRC32` became required with `ARMv8.1`, but since it was introduced as optional in `ARMv8` it would go in its own namespace
-  
-If an extension is only supported on `Arm32`, there is no reason to add a sub namespace.
+A separate GitHub Issue will be created for the review of each intrinsic `static class`.  This allows design and review team to
+review separately.  This allows reviw complexity to be kept manageable.  The O(N^2) nature of the review process will be kept to 
+reasonable levels and iterations will be finite.
 
-+ `System.Runtime.Intrinsics.Arm.ARMv7` is used for `ARMv7` added functionality not included in `Base`
+Every effort will be made to completely elaborate all the methods of the intrinsic `static class` for each review.  This will 
+help minimize reopening the same classes for review.
 
-If an extension is only supported on `Arm64`, there is no reason to add a sub namespace.  Hypothetically:
+Implementation will be kept separate from from API review.
 
-+ `System.Runtime.Intrinsics.Arm.ARMv10` is used for `ARMv10` added functionality (Hypothetically `Arm64` only)
+### Partial implementation of intrinsic `static class`
 
-Namespace is chosen based on what could be implemented, not on what is or will be implemented.
++ `IsSupported` must represents the state of an entire intrinsic `static class`
++ Once API review is complete and approved, it is acceptable to implement approved methods in any order provided tests
 
-#### Names
+### Addition of new intrinsics methods to an existing `static class`
 
-Intrinsics will be named to describe functionality.  Names will not correspond to specific named assembly instructions.
+Since each `ARM64` intrinsic `static class` only supports a single platform, adding new instructions is not
+inherently problematic.  New methods can be added without undue complexity.
 
-`IsSupported` will be used in any namespace which may not be implemented on all CoreCLR platforms
-
-### Intrinsic Interface Documentation
-
-+ Documentation will be minimal preferring the underlying ARM documentation
-+ Namespaces will briefly document corresponding specification
-+ Intrinsic methods will briefly document corresponding assembly instruction(s) for each platform
+The primary problem would be the API review process
 
 ### Test coverage
 
 As intrinsic support is added test coverage must be extended to provide basic testing
 
-### Phased Implementation
+Tests 
 
-#### Implementation Priorities
-
-As guidelines:
-
-+ Baseline functionality will be prioritized over architectural extensions
-+ Architectural extensions will typically be prioritized in age order.  Earlier extensions will be added first
-+ `ARM64` only and `ARM*` features will have equal priority
-+ Priorities will be driven by optimization efforts and requests
-+ Priority will be given to intrinsics which have already been implemented for other platforms
-+ Priority will be given to intrinsics which are equivalent/similar to those actively used in libraries for other platforms
-
-#### Addition of new intrinsics namespaces
-When an intrinsic namespace is introduced code will likely be implemented on different platforms at different times.
-
-It is explicitly OK for ARM64 to implement a namespace which may be implemented on `ARM32` w/o `ARM32` implementation.
-The opposite is also true.
-
-Any platform which does not implement a namespace, must:
-
-+ Return `false` for `IsSupported`
-+ `throw` on any unimplemented function
-
-#### Partial implementation of intrinsic namespace
-
-+ It is preferred that `IsSupported` represents the state of an entire namespace
-+ It is certainly required at time of a release, `IsSupported` represents the state of an entire namespace
-+ Allow for writing tests and implementing code, `IsSupported == false` may be used when namespace is partially implemented
-
-#### Addition of new intrinsics to existing namespace
-When an intrinsic namespace is introduced, a best guess will be made about the set of useful intrinsics.
-However, the intrinsics will be added as needed or requested for various optimization efforts.
-
-+ The set of intrinsics instructions supported by a namespace should only be allowed
-if all platforms reporting `IsSupported` are supported (at least at time of release)
-+ It may be preferable to add new namespaces in cases where this creates significant burden
-
-### Half precision floating point
+## Half precision floating point
 
 This document will refer to half precision floating point as `Half`.
 
 + Machine learning and Artificial intelligence often use `Half` type to simplify storage and improve processing time.
 + CoreCLR and `CIL` in general do not have general support for a `Half` type
 + There is an open request to expose `Half` intrinsics
-+ ARM64 will introduce `System.Runtime.Intrinsics.Half` to support this request 
-+ `Half` will be defined as:
++ There is an outstanding proposal to add `System.Half` to support this request
++ Implementation of `Half` features will be adjusted based on
+  + Implementation of the `System.Half` proposal
+  + Availability of supporting hardware (extensions)
+  + General language extensions supporting `Half`
 
-```
-    [StructLayout(LayoutKind.Sequential, Size = 2)]
-    public struct Half : struct {}
-``` 
-
-#### ARMv8 Half precision support
+### ARMv8 Half precision support
 
 ARMv8 baseline support for `Half` is limited.  The following operations are supported
 
 + Loads and Stores
 + Conversion to/from `Float`
 + Widening from `Vector128<Half>` to two `Vector128<Float>`
-+ Narrowing from two `Vector128<Float>` to `Vector128<Float>`
++ Narrowing from two `Vector128<Float>` to `Vector128<Half>`
 
-It is presumed that even this minimal support could be helpful
+Recent extension add support for
 
-Optional `Half` extensions add more complete support
++ General operations on `Half` types
++ Vector operations on `Half` types
 
-#### `Half` and ARM64 ABI
+### `Half` and ARM64 ABI
 
-The proposed `Half` implementation will treat `Half` as raw bits.  
-It is likely therefore that this will not conform to the ARM64 ABI specifically with respect to the HFA
-calling convention.  This will hinder use of `Half` in `PInvoke` calls.  Resolving this ABI issue will
-be a low priority.
+Any complete `Half` implementation must conform to the `ARM64 ABI`.
 
-### Scalable Vector Extension Support
+The proposed `System.Half` type must be treated as a floating point type for purposes of the ARM64 ABI
 
-`SVE`, the Scalable Vector Extension introduces its own complexity.  
+As an argument it must be passed in a floating point register.
 
-The extension 
-+ Creates a new set of SVE registers 
+As a structure member, it must be treated as a floating point type and enter into the HFA determination logic.
+
+Test cases must be written and conformance must be demonstrated.
+
+## Scalable Vector Extension Support
+
+`SVE`, the Scalable Vector Extension introduces its own complexity.
+
+The extension
++ Creates a new set of SVE registers
 + Each register has a platform specific length
   + Any multiple of 128 bits
 
 Therefore implementation will not be trivial.
 
 + Register allocator may need changes
-+ Crossgen of SVE intrinsics must be delayed until runtime JIT
 + SIMD support will face similar issues
 + Open issue: Should we use `Vector<T>` or SVE<T> in user interface design?
-+ SVE probably requires a separate design
 
-### Miscellaneous
-#### Choice of Arm64 naming conventions -- Rationale
+Given lack of available hardware and a lack of thorough understanding of the specification:
 
-##### Naming conventions
++ SVE will require a separate design
++ SVE is considered out of scope for this document
 
-+ Namespaces are generally using Pascal case
-+ Namespaces and Names must not start with a number
-+ Names are descriptive.  Therefore intrinsics are generally named to describe functionality
-
-`ARMv8` is assumed to be an abbreviation for `ARM Reference Manual Version 8`
-
-##### Reference x86 & x64 choice of namespaces
-
-+ `System.Runtime.Intrinsics` is used for type definitions useful across multiple platforms
-+ `System.Runtime.Intrinsics.X86` is used for enumerations shared across both platforms
-+ `System.Runtime.Intrinsics.AVX` is used for the instructions which are included in a specific hardware extension
-
-##### ARM Version history
-
-Looking at `ARM` version history, 
-
-+ The `ARM` instruction set is regularly extended: `ARMv5`, `ARMv7`, `ARMv8`
-+ New version are generally supersets of prior versions
-  + Deprecated features are preserved for at least one generation
-  + Deprecated features are eventually completely removed
-+ `ARMv8` was the first version to introduce 64-bit support
-  + Legacy ARMv7 was extended to become `ARMv8` `AARCH32` 
-  + `ARMv8` `AARCH64` was introduced
-  + `AARCH64` used similar but distinctly different instruction set
-  + `AARCH64` naming convention varied slightly from `AARCH32`
-+ `ARMv8.1` & `ARMv8.2` extensions have been introduced
-+ New instructions introduced by extensions have generally been asymmetric.  New `AARCH64` instructions ARMv8New extensions have generally made It is not uncommon for an extensions to include new instructions for 
-`AARCH64`
-....  With the introduction of `ARMv8`, `aarch64` (`ARM64`) and `aarch32` were
-split.  The legacy ARMv7 instruction encodings were only supported in `aarch32`
-
-#### Handling Instruction Deprecation
+## Miscellaneous
+### Handling Instruction Deprecation
 
 Deprecation of instructions should be relatively rare
 
 + Do not introduce an intrinsic for a feature that is currently deprecated
 + In event an assembly instruction is deprecated
   1. Prefer emulation using alternate instructions if practical
-  2. Add `SetThrowOnDeprecated()` interface to allow developpers to find these issues
+  2. Add `SetThrowOnDeprecated()` interface to allow developers to find these issues

--- a/Documentation/design-docs/arm64-intrinsics.md
+++ b/Documentation/design-docs/arm64-intrinsics.md
@@ -58,13 +58,15 @@ The `IsSupported` properties are design so that JIT can remove code on unused pa
 If client code calls an intrinsic which is not supported by the platform a `PlatformNotSupported`
 exception must be thrown.
 
-### JIT, VM & OS requirements
+### JIT, VM, PAL & OS requirements
 
 The JIT must use a set of flags corresponding to logical sets of instructions to alter code
 generation.
 
 The VM must query the OS to populate the set of JIT flags.  For the special altJit case, a
 means must provide for setting the flags.
+
+PAL must provide an OS abstraction layer.
 
 Each OS must provide mechanism for determining which sets of instructions are supported.
 
@@ -121,30 +123,38 @@ The sets will be chosen to match the granularity if the `ARM64` `ID_*` register 
 The table below documents the set of known extensions, their identification, and their recommended intrinsic
 class names.
 
-| ID Register      | Field   | Values   | Intrinsic `static class` name |
-| ---------------- | ------- | -------- | ----------------------------- |
-| N/A              | N/A     | N/A      | All                           |
-| ID_AA64ISAR0_EL1 | AES     | (1b, 10b)| Aes                           |
-| ID_AA64ISAR0_EL1 | Atomic  | (10b)    | Atomics                       |
-| ID_AA64ISAR0_EL1 | CRC32   | (1b)     | Crc32                         |
-| ID_AA64ISAR0_EL1 | DP      | (1b)     | Dp                            |
-| ID_AA64PFR0_EL1  | FP      | (0b, 1b) | Fp                            |
-| ID_AA64PFR0_EL1  | FP      | (1b)     | Fp16                          |
-| ID_AA64ISAR0_EL1 | AES     | (10b)    | Pmull                         |
-| ID_AA64PFR0_EL1  | RAS     | (1b)     | Ras                           |
-| ID_AA64ISAR0_EL1 | SHA1    | (1b)     | Sha1                          |
-| ID_AA64ISAR0_EL1 | SHA2    | (1b, 10b)| Sha2                          |
-| ID_AA64ISAR0_EL1 | SHA3    | (1b)     | Sha3                          |
-| ID_AA64ISAR0_EL1 | SHA2    | (10b)    | Sha512                        |
-| ID_AA64PFR0_EL1  | AdvSIMD | (0b, 1b) | Simd                          |
-| ID_AA64PFR0_EL1  | AdvSIMD | (1b)     | SimdFp16                      |
-| ID_AA64ISAR0_EL1 | RDM     | (1b)     | SimdV81                       |
-| ID_AA64ISAR0_EL1 | SM3     | (1b)     | Sm3                           |
-| ID_AA64ISAR0_EL1 | SM4     | (1b)     | Sm4                           |
-| ID_AA64PFR0_EL1  | SVE     | (1b)     | Sve                           |
+| ID Register      | Field   | Values   | Intrinsic `static class` name | Ext. type  |
+| ---------------- | ------- | -------- | ----------------------------- | ---------- |
+| N/A              | N/A     | N/A      | All                           | Baseline   |
+| ID_AA64ISAR0_EL1 | AES     | (1b, 10b)| Aes                           | Crypto     |
+| ID_AA64ISAR0_EL1 | Atomic  | (10b)    | Atomics                       | Ordering   |
+| ID_AA64ISAR0_EL1 | CRC32   | (1b)     | Crc32                         | Crypto     |
+| ID_AA64ISAR1_EL1 | DPB     | (1b)     | Dcpop                         | Ordering   |
+| ID_AA64ISAR0_EL1 | DP      | (1b)     | Dp                            | SIMD       |
+| ID_AA64ISAR1_EL1 | FCMA    | (1b)     | Fcma                          | SIMD       |
+| ID_AA64PFR0_EL1  | FP      | (0b, 1b) | Fp                            | FP         |
+| ID_AA64PFR0_EL1  | FP      | (1b)     | Fp16                          | FP, Half   |
+| ID_AA64ISAR1_EL1 | JSCVT   | (1b)     | Jscvt                         | SIMD       |
+| ID_AA64ISAR1_EL1 | LRCPC   | (1b)     | Lrcpc                         | Ordering   |
+| ID_AA64ISAR0_EL1 | AES     | (10b)    | Pmull                         | SIMD       |
+| ID_AA64PFR0_EL1  | RAS     | (1b)     | Ras                           | Ordering   |
+| ID_AA64ISAR0_EL1 | SHA1    | (1b)     | Sha1                          | Crypto     |
+| ID_AA64ISAR0_EL1 | SHA2    | (1b, 10b)| Sha2                          | Crypto     |
+| ID_AA64ISAR0_EL1 | SHA3    | (1b)     | Sha3                          | Crypto     |
+| ID_AA64ISAR0_EL1 | SHA2    | (10b)    | Sha512                        | Crypto     |
+| ID_AA64PFR0_EL1  | AdvSIMD | (0b, 1b) | Simd                          | SIMD       |
+| ID_AA64PFR0_EL1  | AdvSIMD | (1b)     | SimdFp16                      | SIMD,Half  |
+| ID_AA64ISAR0_EL1 | RDM     | (1b)     | SimdV81                       | SIMD       |
+| ID_AA64ISAR0_EL1 | SM3     | (1b)     | Sm3                           | Crypto     |
+| ID_AA64ISAR0_EL1 | SM4     | (1b)     | Sm4                           | Crypto     |
+| ID_AA64PFR0_EL1  | SVE     | (1b)     | Sve                           | SIMD,SVE   |
 
-The `Required` `static class` is used to represent any intrinsic which is guaranteed to be implemented on all
-`ARM64` platforms.  Investigation is needed to determine if this is an empty set.
+The `All`, `Simd`, and `Fp` classes will together contain the bulk of the `ARM64` intrinsics.  Most other extensions
+will only add a few instruction so they should be simpler to review.
+
+The `Baseline` `All` `static class` is used to represent any intrinsic which is guaranteed to be implemented on all
+`ARM64` platforms.  This set will include general purpose instructions.  Investigation is needed to determine if
+any of these need intrinsics or whether this is an empty set.
 
 As further extensions are released, this set of intrinsics will grow.
 
@@ -318,7 +328,15 @@ TBD Not approved
 
 TBD Not approved
 
+### `Dcpop`
+
+TBD Not approved
+
 ### `Dp`
+
+TBD Not approved
+
+### `Fcma`
 
 TBD Not approved
 
@@ -327,6 +345,14 @@ TBD Not approved
 TBD Not approved
 
 ### `Fp16`
+
+TBD Not approved
+
+### `Jscvt`
+
+TBD Not approved
+
+### `Lrcpc`
 
 TBD Not approved
 

--- a/Documentation/design-docs/arm64-intrinsics.md
+++ b/Documentation/design-docs/arm64-intrinsics.md
@@ -386,7 +386,125 @@ TBD Not approved
 
 ### `Simd`
 
-TBD Not approved
+```C#
+namespace System.Runtime.Intrinsics.Arm.Arm64
+{
+    /// <summary>
+    /// This class provides access to the Arm64 AdvSIMD intrinsics
+    ///
+    /// Arm64 CPU indicate support for this feature by setting
+    /// ID_AA64PFR0_EL1.AdvSIMD == 0 or better.
+    /// </summary>
+    [CLSCompliant(false)]
+    public static class Simd
+    {
+        /// <summary>
+        /// IsSupported property indicates whether any method provided 
+        /// by this class is supported by the current runtime.
+        /// </summary>
+        public static bool IsSupported { get; }
+
+        /// <summary>
+        /// Vector absolute value
+        /// Corresponds to vector forms of ARM64 ABS & FABS
+        /// </summary>
+        public static Vector64<byte>    Abs(Vector64<sbyte>   value);
+        public static Vector64<ushort>  Abs(Vector64<short>   value);
+        public static Vector64<uint>    Abs(Vector64<int>     value);
+        public static Vector64<ulong>   Abs(Vector64<long>    value);
+        public static Vector64<float>   Abs(Vector64<float>   value);
+        public static Vector128<byte>   Abs(Vector128<sbyte>  value);
+        public static Vector128<ushort> Abs(Vector128<short>  value);
+        public static Vector128<uint>   Abs(Vector128<int>    value);
+        public static Vector128<ulong>  Abs(Vector128<long>   value);
+        public static Vector128<float>  Abs(Vector128<float>  value);
+        public static Vector128<double> Abs(Vector128<double> value);
+
+        /// <summary>
+        /// Vector add
+        /// Corresponds to vector forms of ARM64 ADD & FADD
+        /// </summary>
+        public static Vector64<byte>    Add(Vector64<byte>    left, Vector64<byte>    right);
+        public static Vector64<sbyte>   Add(Vector64<sbyte>   left, Vector64<sbyte>   right);
+        public static Vector64<ushort>  Add(Vector64<ushort>  left, Vector64<ushort>  right);
+        public static Vector64<short>   Add(Vector64<short>   left, Vector64<short>   right);
+        public static Vector64<uint>    Add(Vector64<uint>    left, Vector64<uint>    right);
+        public static Vector64<int>     Add(Vector64<int>     left, Vector64<int>     right);
+        public static Vector64<ulong>   Add(Vector64<ulong>   left, Vector64<ulong>   right);
+        public static Vector64<long>    Add(Vector64<long>    left, Vector64<long>    right);
+        public static Vector64<float>   Add(Vector64<float>   left, Vector64<float>   right);
+        public static Vector128<byte>   Add(Vector128<byte>   left, Vector128<byte>   right);
+        public static Vector128<sbyte>  Add(Vector128<sbyte>  left, Vector128<sbyte>  right);
+        public static Vector128<ushort> Add(Vector128<ushort> left, Vector128<ushort> right);
+        public static Vector128<short>  Add(Vector128<short>  left, Vector128<short>  right);
+        public static Vector128<uint>   Add(Vector128<uint>   left, Vector128<uint>   right);
+        public static Vector128<int>    Add(Vector128<int>    left, Vector128<int>    right);
+        public static Vector128<ulong>  Add(Vector128<ulong>  left, Vector128<ulong>  right);
+        public static Vector128<long>   Add(Vector128<long>   left, Vector128<long>   right);
+        public static Vector128<float>  Add(Vector128<float>  left, Vector128<float>  right);
+        public static Vector128<double> Add(Vector128<double> left, Vector128<double> right);
+
+        /// <summary>
+        /// Vector add high narrow lower
+        ///
+        /// Add vector elements, narrow result register, and store in lower half of destination
+        /// Zero upper half of destination
+        ///
+        /// Corresponds to vector forms of ARM64 ADDHN
+        /// </summary>
+        public static Vector128<byte>   AddHighNarrowLower(Vector128<ushort> left, Vector128<ushort> right);
+        public static Vector128<sbyte>  AddHighNarrowLower(Vector128<short>  left, Vector128<short>  right);
+        public static Vector128<ushort> AddHighNarrowLower(Vector128<uint>   left, Vector128<uint>   right);
+        public static Vector128<short>  AddHighNarrowLower(Vector128<int>    left, Vector128<int>    right);
+        public static Vector128<uint>   AddHighNarrowLower(Vector128<ulong>  left, Vector128<ulong>  right);
+        public static Vector128<int>    AddHighNarrowLower(Vector128<long>   left, Vector128<long>   right);
+
+        /// <summary>
+        /// Vector add high narrow upper
+        ///
+        /// Add vector elements, narrow result register, and store in upper half of destination
+        /// Or with lower half of destination
+        ///
+        /// Corresponds to vector forms of ARM64 ADDHN2
+        /// </summary>
+        public static Vector128<byte>   AddHighNarrowUpper(Vector128<ushort> left, Vector128<ushort> right, Vector128<ushort> lower);
+        public static Vector128<sbyte>  AddHighNarrowUpper(Vector128<short>  left, Vector128<short>  right, Vector128<short>  lower);
+        public static Vector128<ushort> AddHighNarrowUpper(Vector128<uint>   left, Vector128<uint>   right, Vector128<uint>   lower);
+        public static Vector128<short>  AddHighNarrowUpper(Vector128<int>    left, Vector128<int>    right, Vector128<int>    lower);
+        public static Vector128<uint>   AddHighNarrowUpper(Vector128<ulong>  left, Vector128<ulong>  right, Vector128<ulong>  lower);
+        public static Vector128<int>    AddHighNarrowUpper(Vector128<long>   left, Vector128<long>   right, Vector128<long>   lower);
+
+        /// <summary>
+        /// Vector add pairwise
+        ///
+        /// Concatenate left and right to form a vector with twice as many element.
+        /// For each pair of elements in the concatenated vector, add to produce a single element
+        /// Store the result of the pairwise addition in a vector of the original length
+        /// Pairs formed from the right operand will form the lower half to the result.  Left will form the upper
+        ///
+        /// Corresponds to vector forms of ARM64 ADDP & FADDP
+        /// </summary>
+        public static Vector64<byte>    AddPairwise(Vector64<byte>    left, Vector64<byte>    right);
+        public static Vector64<sbyte>   AddPairwise(Vector64<sbyte>   left, Vector64<sbyte>   right);
+        public static Vector64<ushort>  AddPairwise(Vector64<ushort>  left, Vector64<ushort>  right);
+        public static Vector64<short>   AddPairwise(Vector64<short>   left, Vector64<short>   right);
+        public static Vector64<uint>    AddPairwise(Vector64<uint>    left, Vector64<uint>    right);
+        public static Vector64<int>     AddPairwise(Vector64<int>     left, Vector64<int>     right);
+        public static Vector64<ulong>   AddPairwise(Vector64<ulong>   left, Vector64<ulong>   right);
+        public static Vector64<long>    AddPairwise(Vector64<long>    left, Vector64<long>    right);
+        public static Vector64<float>   AddPairwise(Vector64<float>   left, Vector64<float>   right);
+        public static Vector128<byte>   AddPairwise(Vector128<byte>   left, Vector128<byte>   right);
+        public static Vector128<sbyte>  AddPairwise(Vector128<sbyte>  left, Vector128<sbyte>  right);
+        public static Vector128<ushort> AddPairwise(Vector128<ushort> left, Vector128<ushort> right);
+        public static Vector128<short>  AddPairwise(Vector128<short>  left, Vector128<short>  right);
+        public static Vector128<uint>   AddPairwise(Vector128<uint>   left, Vector128<uint>   right);
+        public static Vector128<int>    AddPairwise(Vector128<int>    left, Vector128<int>    right);
+        public static Vector128<ulong>  AddPairwise(Vector128<ulong>  left, Vector128<ulong>  right);
+        public static Vector128<long>   AddPairwise(Vector128<long>   left, Vector128<long>   right);
+        public static Vector128<float>  AddPairwise(Vector128<float>  left, Vector128<float>  right);
+        public static Vector128<double> AddPairwise(Vector128<double> left, Vector128<double> right);
+    }
+```
 
 ### `SimdFp16`
 

--- a/Documentation/design-docs/arm64-intrinsics.md
+++ b/Documentation/design-docs/arm64-intrinsics.md
@@ -74,9 +74,9 @@ features
 In the event the OS fails to provides a means to detect a support for an instruction set extension
 it must be treated as unsupported.
 
-NOTE: Exceptions might be where :
+NOTE: Exceptions might be where:
 
-+ CoreCLR is distributed as source and CMake build configuration test is used  detect these features
++ CoreCLR is distributed as source and CMake build configuration test is used to detect these features
 + Installer detects features and sets appropriate configuration knobs
 + VM runs code inside safe try/catch blocks to test for instruction support
 + Platform requires a specific minimum set of instructions
@@ -117,7 +117,33 @@ The sets will be chosen to match the granularity if the `ARM64` `ID_*` register 
 
 #### Specific Class Names
 
-TBD Add table to document each known extension and recommended `static class` name.
+The table below documents the set of known extensions, their identification, and their recommended intrinsic
+class names.
+
+| ID Register      | Field   | Values   | Intrinsic `static class` name |
+| ---------------- | ------- | -------- | ----------------------------- |
+| N/A              | N/A     | N/A      | Required                      |
+| ID_AA64ISAR0_EL1 | AES     | (1b, 10b)| Aes                           |
+| ID_AA64ISAR0_EL1 | AES     | (10b)    | Pmull64                       |
+| ID_AA64ISAR0_EL1 | SHA1    | (1b)     | Sha1                          |
+| ID_AA64ISAR0_EL1 | SHA2    | (1b)     | Sha2                          |
+| ID_AA64ISAR0_EL1 | CRC32   | (1b)     | Crc32                         |
+| ID_AA64ISAR0_EL1 | Atomic  | (10b)    | Atomics                       |
+| ID_AA64ISAR0_EL1 | RDM     | (1b)     | SimdV81                       |
+| ID_AA64MMFR2_EL1 | IESB    | (1b)     | Esb                           |
+| ID_AA64PFR0_EL1  | FP      | (0b, 1b) | Fp                            |
+| ID_AA64PFR0_EL1  | FP      | (1b)     | Fp16                          |
+| ID_AA64PFR0_EL1  | AdvSIMD | (0b, 1b) | Simd                          |
+| ID_AA64PFR0_EL1  | AdvSIMD | (1b)     | SimdFp16                      |
+| ID_AA64PFR0_EL1  | RAS     | (1b)     | Ras                           |
+| ID_AA64PFR0_EL1  | SVE     | (1b)     | Sve                           |
+
+The `Required` `static class` is used to represent any intrinsic which is guaranteed to be implemented on all
+`ARM64` platforms.  Investigation is needed to determine if this is an empty set.
+
+It is also possible the `ESB` or `RAS` may not need intrinsics.
+
+As further extensions are released, this set of intrinsics will grow.
 
 ### Intrinsic Method Names
 
@@ -126,6 +152,10 @@ assembly instructions.
 
 Where precedence exists within the `System.Runtime.Intrinsics.X86` namespace, identical method names will be
 chosen: `Add`, `Multiply`, `Load`, `Store` ...
+
+It is also worth noting `System.Runtime.Intrinsics.X86` naming conventions will include the suffix `Scalar` for
+operations which take vector argument(s), but contain an implicit cast(s) to the base type and therefore operate only
+on the first item of the argument vector(s).
 
 ### Intinsic Method Argument Types
 
@@ -147,6 +177,11 @@ Intrinsic methods will typically use a standard set of argument types:
   + Optionally, briefly summarize operation performed
     + In many cases this may be unnecessary: `Add`, `Multiply`, `Load`, `Store`
     + In some cases this may be difficult to do correctly. (Crypto instructions)
+  + Optionally mention corresponding compiler gcc, clang, and/or MSVC intrinsics
+    + Review of existing documentation shows `ARM64` intrinsics are mostly absent or undocumented so
+    initially this will not be necessary for `ARM64`
+    + See gcc manual "AArch64 Built-in Functions"
+    + MSVC ARM64 documentation has not been publically released
 
 ## Phased Implementation
 
@@ -173,10 +208,10 @@ Review will be facilitated by GitHub Issues requests.
 API reviews will be completed within the CoreFX project.
 
 A separate GitHub Issue will be created for the review of each intrinsic `static class`.  This allows design and review team to
-review separately.  This allows reviw complexity to be kept manageable.  The O(N^2) nature of the review process will be kept to 
+review separately.  This allows review complexity to be kept manageable.  The O(N^2) nature of the review process will be kept to
 reasonable levels and iterations will be finite.
 
-Every effort will be made to completely elaborate all the methods of the intrinsic `static class` for each review.  This will 
+Every effort will be made to completely elaborate all the methods of the intrinsic `static class` for each review.  This will
 help minimize reopening the same classes for review.
 
 Implementation will be kept separate from from API review.
@@ -184,20 +219,14 @@ Implementation will be kept separate from from API review.
 ### Partial implementation of intrinsic `static class`
 
 + `IsSupported` must represents the state of an entire intrinsic `static class`
-+ Once API review is complete and approved, it is acceptable to implement approved methods in any order provided tests
-
-### Addition of new intrinsics methods to an existing `static class`
-
-Since each `ARM64` intrinsic `static class` only supports a single platform, adding new instructions is not
-inherently problematic.  New methods can be added without undue complexity.
-
-The primary problem would be the API review process
++ Once API review is complete and approved, it is acceptable to implement approved methods in any order provided tests are added
++ The approved API must be completed before the intrinsic `static class` is included in a release
 
 ### Test coverage
 
 As intrinsic support is added test coverage must be extended to provide basic testing
 
-Tests 
+Tests
 
 ## Half precision floating point
 


### PR DESCRIPTION
I am starting to draft the System.Runtime.Intrinsics.Arm.Arm64.Simd api.

I wanted to upload an early preview so I do not go too far down the wrong path.

Please take a quick look at the final patch in the series.  (The previous patches are under review in #15343).

Questions:

+ Are the comments structured appropriately?
+ Is is reasonable to only comment one of each set of overloaded methods?
+ My intention based on current design discussion is for this API to be an exhaustive set of AdvSIMD intrinsics corresponding to all supported assembly instructions.  The API could easily get very large.  The first 8 `Arm64` instructions created 61 static intrinsic methods.  There could be 2K methods here....  Is that OK?
+ Is there a better or preferable way
   + Could generics help?  
   + Could an instruction enumeration be better?
   + Simulate inline assembly using strings?  Probably too ugly.
   + Other approaches?


@dotnet/jit-contrib @dotnet/arm64-contrib @CarolEidt @4creators @tannergooding Please take a quick look.
@jkotas Please take a quick look and add anyone else who should be involved in an early API review.
