### PR TITLE
Cleanup Alpine CI

### DIFF
--- a/buildpipeline/alpine.3.6.groovy
+++ b/buildpipeline/alpine.3.6.groovy
@@ -4,7 +4,6 @@
 // Note that the parameters will be set as env variables so we cannot use names that conflict
 // with the engineering system parameter names.
 // CGroup - Build configuration.
-// TestOuter - If true, runs outerloop, if false runs just innerloop
 
 simpleDockerNode('microsoft/dotnet-buildtools-prereqs:alpine-3.6-3148f11-20171119021156') {
     stage ('Checkout source') {
@@ -19,6 +18,6 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:alpine-3.6-3148f11-2017111
         sh "./sync.sh"
     }
     stage ('Build Product') {
-        sh "./build.sh -x64 -${params.CGroup} -skiprestore -stripSymbols -portablebuild=false"
+        sh "./build.sh -${params.AGroup} -${params.CGroup} -skiprestore -stripSymbols -portablebuild=false"
     }
 }

--- a/buildpipeline/pipelinejobs.groovy
+++ b/buildpipeline/pipelinejobs.groovy
@@ -17,7 +17,7 @@ def branch = GithubBranchName
 def alpine36Pipeline = Pipeline.createPipelineForGithub(this, project, branch, 'buildpipeline/alpine.3.6.groovy')
 
 def configurations = [
-    ['TGroup':"netcoreapp", 'Pipeline':alpine36Pipeline, 'Name':'Alpine.3.6' ,'ForPR':"Debug-x64", 'Arch':['x64']],
+    ['Pipeline':alpine36Pipeline, 'Name':'Alpine.3.6' ,'ForPR':"Debug-x64", 'Arch':['x64']],
 ]
 
 configurations.each { config ->
@@ -26,10 +26,8 @@ configurations.each { config ->
     def triggerName = "${config.Name} ${archGroup} ${configurationGroup} Build"
 
     def pipeline = config.Pipeline
-    def params = ['TGroup':config.TGroup,
-                  'CGroup':configurationGroup,
-                  'AGroup':archGroup,
-                  'TestOuter': false]
+    def params = ['CGroup':configurationGroup,
+                  'AGroup':archGroup]
 
     // Add default PR triggers for particular configurations but manual triggers for all
     if (config.ForPR.contains("${configurationGroup}-${archGroup}")) {
@@ -41,10 +39,6 @@ configurations.each { config ->
 
     // Add trigger for all configurations to run on merge
     pipeline.triggerPipelineOnGithubPush(params)
-
-    // Add optional PR trigger for Outerloop test runs
-    params.TestOuter = true
-    pipeline.triggerPipelineOnGithubPRComment("Outerloop ${triggerName}", params)
 }}}
 
 JobReport.Report.generateJobReport(out)


### PR DESCRIPTION
Remove unnecessary parameters that were an artefact of copying the
originals of these files from corefx and make the alpine groovy file use
AGroup instead of hardcoded x64 to make it future proof.