### PR TITLE
Remove unused TYP_ARRAY/PTR/FUNC

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2341,7 +2341,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
     {
         assert(!varTypeIsStruct(call));
 
-        if (call->gtType == TYP_REF || call->gtType == TYP_ARRAY)
+        if (call->gtType == TYP_REF)
         {
             retSize = EA_GCREF;
         }

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -18476,7 +18476,7 @@ regMaskTP CodeGen::genCodeForCall(GenTreeCall* call, bool valUsed)
 
     if (valUsed)
     {
-        if (call->gtType == TYP_REF || call->gtType == TYP_ARRAY)
+        if (call->gtType == TYP_REF)
         {
             retSize = EA_GCREF;
         }
@@ -20037,7 +20037,6 @@ regMaskTP CodeGen::genCodeForCall(GenTreeCall* call, bool valUsed)
     switch (call->gtType)
     {
         case TYP_REF:
-        case TYP_ARRAY:
         case TYP_BYREF:
             gcInfo.gcMarkRegPtrVal(REG_INTRET, call->TypeGet());
 

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -5270,7 +5270,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
     {
         assert(!varTypeIsStruct(call));
 
-        if (call->gtType == TYP_REF || call->gtType == TYP_ARRAY)
+        if (call->gtType == TYP_REF)
         {
             retSize = EA_GCREF;
         }

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -551,7 +551,6 @@ inline bool genTypeCanRepresentValue(var_types type, TValue value)
             return FitsIn<INT64>(value);
         case TYP_REF:
         case TYP_BYREF:
-        case TYP_ARRAY:
             return FitsIn<UINT_PTR>(value);
         default:
             return false;
@@ -606,7 +605,6 @@ inline var_types genActualType(var_types type)
     /* Spot check to make certain the table is in synch with the enum */
 
     assert(genActualTypes[TYP_DOUBLE] == TYP_DOUBLE);
-    assert(genActualTypes[TYP_FNC] == TYP_FNC);
     assert(genActualTypes[TYP_REF] == TYP_REF);
 
     assert((unsigned)type < sizeof(genActualTypes));

--- a/src/jit/gcencode.cpp
+++ b/src/jit/gcencode.cpp
@@ -44,7 +44,6 @@ ReturnKind GCInfo::getReturnKind()
     switch (compiler->info.compRetType)
     {
         case TYP_REF:
-        case TYP_ARRAY:
             return RT_Object;
         case TYP_BYREF:
             return RT_ByRef;
@@ -55,9 +54,6 @@ ReturnKind GCInfo::getReturnKind()
 
             switch (retType)
             {
-                case TYP_ARRAY:
-                    _ASSERTE(false && "TYP_ARRAY unexpected from getReturnTypeForStruct()");
-                // fall through
                 case TYP_REF:
                     return RT_Object;
 

--- a/src/jit/regalloc.cpp
+++ b/src/jit/regalloc.cpp
@@ -382,12 +382,9 @@ inline regMaskTP Compiler::genReturnRegForTree(GenTreePtr tree)
         RBM_DOUBLERET, // TYP_DOUBLE,
         RBM_INTRET,    // TYP_REF,
         RBM_INTRET,    // TYP_BYREF,
-        RBM_INTRET,    // TYP_ARRAY,
         RBM_ILLEGAL,   // TYP_STRUCT,
         RBM_ILLEGAL,   // TYP_BLK,
         RBM_ILLEGAL,   // TYP_LCLBLK,
-        RBM_ILLEGAL,   // TYP_PTR,
-        RBM_ILLEGAL,   // TYP_FNC,
         RBM_ILLEGAL,   // TYP_UNKNOWN,
     };
 

--- a/src/jit/typelist.h
+++ b/src/jit/typelist.h
@@ -52,14 +52,10 @@ DEF_TP(DOUBLE  ,"double"  , TYP_DOUBLE,  TI_DOUBLE,8,  8,  8,   2, 8, VTF_FLT,  
 
 DEF_TP(REF     ,"ref"     , TYP_REF,     TI_REF,  PS,GCS,GCS, PST,PS, VTF_ANY|VTF_GCR|VTF_I,TYPE_REF_PTR)
 DEF_TP(BYREF   ,"byref"   , TYP_BYREF,   TI_ERROR,PS,BRS,BRS, PST,PS, VTF_ANY|VTF_BYR|VTF_I,TYPE_REF_BYR)
-DEF_TP(ARRAY   ,"array"   , TYP_REF,     TI_REF,  PS,GCS,GCS, PST,PS, VTF_ANY|VTF_GCR|VTF_I,TYPE_REF_PTR)
 DEF_TP(STRUCT  ,"struct"  , TYP_STRUCT,  TI_STRUCT,0,  0,  0,   1, 4, VTF_S,          TYPE_REF_STC)
 
 DEF_TP(BLK     ,"blk"     , TYP_BLK,     TI_ERROR, 0,  0,  0,   1, 4, VTF_ANY,        0           ) // blob of memory
 DEF_TP(LCLBLK  ,"lclBlk"  , TYP_LCLBLK,  TI_ERROR, 0,  0,  0,   1, 4, VTF_ANY,        0           ) // preallocated memory for locspace
-
-DEF_TP(PTR     ,"pointer" , TYP_PTR,     TI_ERROR,PS, PS, PS, PST,PS, VTF_ANY|VTF_I,  TYPE_REF_PTR) // (not currently used)
-DEF_TP(FNC     ,"function", TYP_FNC,     TI_ERROR, 0, PS, PS,   0, 0, VTF_ANY|VTF_I,  0           )
 
 #ifdef FEATURE_SIMD
 // Amd64: The size and alignment of SIMD vector varies at JIT time based on whether target arch supports AVX or SSE2.

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -918,7 +918,6 @@ ValueNum ValueNumStore::VNZeroForType(var_types typ)
         case TYP_DOUBLE:
             return VNForDoubleCon(0.0);
         case TYP_REF:
-        case TYP_ARRAY:
             return VNForNull();
         case TYP_BYREF:
             return VNForByrefCon(0);
@@ -3909,7 +3908,6 @@ void ValueNumStore::vnDump(Compiler* comp, ValueNum vn, bool isPtr)
                 printf("DblCns[%f]", ConstantValue<double>(vn));
                 break;
             case TYP_REF:
-            case TYP_ARRAY:
                 if (vn == VNForNull())
                 {
                     printf("null");


### PR DESCRIPTION
Not only that these clutter the code but they also waste memory because there are some arrays that are indexed by type. Together with the recently removed `TYP_CHAR` we get a 0.5% drop in `nraUsed`.