### PR TITLE
Enabling temporarily disabled tests that call ReadOnlySpan indexer

### DIFF
--- a/tests/src/CoreMangLib/system/span/BasicSpanTest.cs
+++ b/tests/src/CoreMangLib/system/span/BasicSpanTest.cs
@@ -740,9 +740,9 @@ class My
     static void AssertEqualContent(string text, ReadOnlySpan<char> span)
     {
         AssertEqual(text.Length, span.Length);
-        /*for (int i = 0; i < text.Length; i++)
+        for (int i = 0; i < text.Length; i++)
         {
             AssertEqual(text[i], span[i]);
-        }*/
+        }
     }
 }

--- a/tests/src/JIT/CheckProjects/CheckProjects.cs
+++ b/tests/src/JIT/CheckProjects/CheckProjects.cs
@@ -24,8 +24,6 @@ internal class ScanProjectFiles
 
     private static int Main(string[] args)
     {
-        // TEMPORARILY DISABLING - see issue #15089
-        return 100;
         // If invoked w/o args, locate jit test project dir from
         // CORE_ROOT, and scan only.
         //

--- a/tests/src/JIT/Performance/CodeQuality/Span/Indexer.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Span/Indexer.cs
@@ -917,8 +917,6 @@ namespace Span
 
         public static int Main(string[] args)
         {
-            // TEMPORARILY DISABLING - see issue #15089
-            return 100;
             if (args.Length > 0)
             {
                 if (args[0].Equals("-bench"))

--- a/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
@@ -1053,8 +1053,6 @@ namespace Span
 
         public static int Main(string[] args)
         {
-            // TEMPORARILY DISABLING - see issue #15089
-            return 100;
             // When we call into Invoke, it'll need to know this isn't xunit-perf running
             IsXunitInvocation = false;
 

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_461649/DevDiv_461649.cs
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_461649/DevDiv_461649.cs
@@ -24,8 +24,7 @@ namespace XSLTest
             string inputXml = "Input.xml";
             string inputXsl = "Transform.xsl";
 
-            // TEMPORARILY DISABLING - see issue #15089
-            return 100; //DotNetXslCompiledTransform(inputXml, inputXsl);
+            return DotNetXslCompiledTransform(inputXml, inputXsl);
         }
 
         private static int DotNetXslCompiledTransform(string inputXml, string inputXsl)

--- a/tests/src/JIT/superpmi/superpmicollect.cs
+++ b/tests/src/JIT/superpmi/superpmicollect.cs
@@ -657,9 +657,6 @@ namespace SuperPMICollection
             string runProgramArguments = null;
             string tempPath = null;
 
-            // TEMPORARILY DISABLING - see issue #15089
-            return 100;
-
             // Parse arguments
             if (args.Length > 0)
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/15089

Re-enable the tests disabled in https://github.com/dotnet/coreclr/pull/14727 after the change to ReadOnlySpan indexer propagates to corefx.

cc @ektrah, @VSadov, @jkotas, @KrzysztofCwalina 