### PR TITLE
ReadOnlySpan GetReference returns ref instead of ref readonly

### DIFF
--- a/src/mscorlib/shared/System/Runtime/InteropServices/MemoryMarshal.cs
+++ b/src/mscorlib/shared/System/Runtime/InteropServices/MemoryMarshal.cs
@@ -28,7 +28,7 @@ namespace System.Runtime.InteropServices
 
         public static ref T GetReference<T>(Span<T> span) => ref span._pointer.Value;
 
-        public static ref readonly T GetReference<T>(ReadOnlySpan<T> span) => ref span._pointer.Value;
+        public static ref T GetReference<T>(ReadOnlySpan<T> span) => ref span._pointer.Value;
 
         public static bool TryGetArray<T>(ReadOnlyMemory<T> readOnlyMemory, out ArraySegment<T> arraySegment)
         {


### PR DESCRIPTION
From: https://github.com/dotnet/coreclr/pull/15532#issuecomment-352141138

It was added here: https://github.com/dotnet/coreclr/pull/15417

I want to isolate this change and have it round-trip between corefx/coreclr to unblock this PR: https://github.com/dotnet/coreclr/pull/15532

cc @jkotas, @VSadov 