### PR TITLE
Disable GitHub_15291.cmd for x86

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -213,6 +213,9 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_255294\DevDiv_255294\DevDiv_255294.cmd">
             <Issue>11469, The test causes OutOfMemory exception in crossgen mode.</Issue> 
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\GitHub_15291\GitHub_15291\GitHub_15291.cmd">
+            <Issue>15566</Issue> 
+        </ExcludeList>
     </ItemGroup>
 
     <!-- The following are ARM32 failures -->


### PR DESCRIPTION
It fails under MinOpts. Disable until it is fixed.

Tracked with #15566.