### PR TITLE
Fix desktop build break

### DIFF
--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -16022,7 +16022,7 @@ size_t CodeGen::genPushArgList(GenTreeCall* call)
                                 if (fieldVarDsc->lvStackAligned())
                                 {
                                     if (fieldVarDsc->lvExactSize != 2 * sizeof(unsigned) &&
-                                        fieldVarDsc->lvFldOffset + TARGET_POINTER_SIZE != bytesToBeCopied)
+                                        fieldVarDsc->lvFldOffset + (unsigned)TARGET_POINTER_SIZE != bytesToBeCopied)
                                     {
                                         // Might need 4-bytes paddings for fields other than LONG and DOUBLE.
                                         // Just push some junk (i.e EAX) on the stack.


### PR DESCRIPTION
Fix desktop build break
codegenlegacy.cpp(16025): warning C4389: '!=' : signed/unsigned mismatch
codegenlegacy.cpp(16025): error C2220: warning treated as error - no 'object' file generated

Introduced in #15524 