### PR TITLE
Manually add arm/arm64 BenchmarksGame testing

### DIFF
--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -29172,12 +29172,12 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;Pri1
 HostStyle=0
 
-[revcomp.cmd_3664]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\revcomp\revcomp\revcomp.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\revcomp\revcomp
+[reverse-complement-1.cmd_3664]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\reverse-complement\reverse-complement-1\reverse-complement-1.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\reverse-complement\reverse-complement-1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [ConvertToUInt323.cmd_3665]
@@ -33164,12 +33164,12 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;Pri1
 HostStyle=0
 
-[pi-digits.cmd_4164]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\pidigits\pi-digits\pi-digits.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\pidigits\pi-digits
+[pidigits-3.cmd_4164]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\pidigits\pidigits-3\pidigits-3.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\pidigits\pidigits-3
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [TextReaderNull_PSC.cmd_4165]
@@ -33324,12 +33324,12 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;Pri1
 HostStyle=0
 
-[binarytrees3.cmd_4184]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\binarytrees\binarytrees3\binarytrees3.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\binarytrees\binarytrees3
+[binarytrees-2.cmd_4184]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\binarytrees\binarytrees-2\binarytrees-2.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\binarytrees\binarytrees-2
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b35354.cmd_4185]
@@ -40676,12 +40676,12 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS
 HostStyle=0
 
-[regexdna.cmd_5103]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\regexdna\regexdna\regexdna.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\regexdna\regexdna
+[regex-redux-1.cmd_5103]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\regex-redux\regex-redux-1\regex-redux-1.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\regex-redux\regex-redux-1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [_il_relrefarg_box_f8.cmd_5104]
@@ -58180,12 +58180,12 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;Pri1
 HostStyle=0
 
-[binarytrees.cmd_7301]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\binarytrees\binarytrees\binarytrees.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\binarytrees\binarytrees
+[binarytrees-5.cmd_7301]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\binarytrees\binarytrees-5\binarytrees-5.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\binarytrees\binarytrees-5
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated686.cmd_7302]
@@ -62076,12 +62076,12 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;Pri1
 HostStyle=0
 
-[spectralnorm.cmd_7789]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\spectralnorm\spectralnorm\spectralnorm.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\spectralnorm\spectralnorm
+[spectralnorm-1.cmd_7789]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\spectralnorm\spectralnorm-1\spectralnorm-1.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\spectralnorm\spectralnorm-1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [ArraySetValue1.cmd_7790]
@@ -80692,14 +80692,6 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;Pri1
 HostStyle=0
 
-[fastaredux.cmd_10129]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\fastaredux\fastaredux\fastaredux.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\fastaredux\fastaredux
-Expected=0
-MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
-HostStyle=0
-
 [MathTan.cmd_10130]
 RelativePath=CoreMangLib\cti\system\math\MathTan\MathTan.cmd
 WorkingDir=CoreMangLib\cti\system\math\MathTan
@@ -87940,12 +87932,12 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;Pri1
 HostStyle=0
 
-[fasta.cmd_11039]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\fasta\fasta\fasta.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\fasta\fasta
+[fasta-1.cmd_11039]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\fasta\fasta-1\fasta-1.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\fasta\fasta-1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [dev10_512868.cmd_11040]
@@ -88804,12 +88796,12 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;Pri1
 HostStyle=0
 
-[nbody.cmd_11148]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\nbody\nbody\nbody.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\nbody\nbody
+[n-body-3.cmd_11148]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\n-body\n-body-3\n-body-3.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\n-body\n-body-3
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [StringIConvertibleToChar.cmd_11149]
@@ -89732,12 +89724,12 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;Pri1
 HostStyle=0
 
-[k-nucleotide.cmd_11265]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\k-nucleotide\k-nucleotide\k-nucleotide.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\k-nucleotide\k-nucleotide
+[k-nucleotide-1.cmd_11265]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\k-nucleotide\k-nucleotide-1\k-nucleotide-1.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\k-nucleotide\k-nucleotide-1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1091.cmd_11266]
@@ -90660,12 +90652,12 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;NEW
 HostStyle=0
 
-[mandelbrot.cmd_11382]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\mandelbrot\mandelbrot\mandelbrot.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\mandelbrot\mandelbrot
+[mandelbrot-2.cmd_11382]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\mandelbrot\mandelbrot-2\mandelbrot-2.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\mandelbrot\mandelbrot-2
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [GitHub_13404.cmd_11383]
@@ -90692,12 +90684,12 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;Pri1;NEW
 HostStyle=0
 
-[fannkuch-redux.cmd_11386]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\fannkuch-redux\fannkuch-redux\fannkuch-redux.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\fannkuch-redux\fannkuch-redux
+[fannkuch-redux-2.cmd_11386]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\fannkuch-redux\fannkuch-redux-2\fannkuch-redux-2.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\fannkuch-redux\fannkuch-redux-2
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [GitHub_12949_4.cmd_11387]
@@ -90756,3 +90748,58 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;Pri1;NEW
 HostStyle=0
 
+[reverse-complement-6.cmd_11394]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\reverse-complement\reverse-complement-6\reverse-complement-6.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\reverse-complement\reverse-complement-6
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0
+
+[spectralnorm-3.cmd_11395]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\spectralnorm\spectralnorm-3\spectralnorm-3.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\spectralnorm\spectralnorm-3
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0
+
+[regex-redux-5.cmd_11396]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\regex-redux\regex-redux-5\regex-redux-5.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\regex-redux\regex-redux-5
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0
+
+[mandelbrot-7.cmd_11397]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\mandelbrot\mandelbrot-7\mandelbrot-7.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\mandelbrot\mandelbrot-7
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0
+
+[k-nucleotide-9.cmd_11398]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\k-nucleotide\k-nucleotide-9\k-nucleotide-9.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\k-nucleotide\k-nucleotide-9
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0
+
+[fasta-2.cmd_11399]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\fasta\fasta-2\fasta-2.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\fasta\fasta-2
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0
+
+[fannkuch-redux-5.cmd_11386]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\fannkuch-redux\fannkuch-redux-5\fannkuch-redux-5.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\fannkuch-redux\fannkuch-redux-5
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -61580,52 +61580,44 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS
 HostStyle=0
 
-[binarytrees.cmd_8015]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\binarytrees\binarytrees\binarytrees.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\binarytrees\binarytrees
+[binarytrees-2.cmd_8015]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\binarytrees\binarytrees-2\binarytrees-2.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\binarytrees\binarytrees-2
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=GCSTRESS_FAIL;LONG_RUNNING;ISSUE_6065;EXPECTED_FAIL
+Categories=EXPECTED_PASS
 HostStyle=0
 
-[fasta.cmd_8016]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\fasta\fasta\fasta.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\fasta\fasta
+[fasta-1.cmd_8016]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\fasta\fasta-1\fasta-1.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\fasta\fasta-1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=EXPECTED_PASS
 HostStyle=0
 
-[fastaredux.cmd_8017]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\fastaredux\fastaredux\fastaredux.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\fastaredux\fastaredux
+[n-body-3.cmd_8018]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\n-body\n-body-3\n-body-3.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\n-body\n-body-3
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=EXPECTED_PASS
 HostStyle=0
 
-[nbody.cmd_8018]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\nbody\nbody\nbody.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\nbody\nbody
+[pidigits-3.cmd_8019]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\pidigits\pidigits-3\pidigits-3.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\pidigits\pidigits-3
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=EXPECTED_PASS
 HostStyle=0
 
-[pi-digits.cmd_8019]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\pidigits\pi-digits\pi-digits.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\pidigits\pi-digits
+[spectralnorm-1.cmd_8020]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\spectralnorm\spectralnorm-1\spectralnorm-1.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\spectralnorm\spectralnorm-1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
-HostStyle=0
-
-[spectralnorm.cmd_8020]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\spectralnorm\spectralnorm\spectralnorm.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\spectralnorm\spectralnorm
-Expected=0
-MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Burgers.cmd_8021]
@@ -80292,12 +80284,12 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;NEW;Pri1
 HostStyle=0
 
-[revcomp.cmd_10394]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\revcomp\revcomp\revcomp.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\revcomp\revcomp
+[reverse-complement-1.cmd_10394]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\reverse-complement\reverse-complement-1\reverse-complement-1.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\reverse-complement\reverse-complement-1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_216571.cmd_10395]
@@ -82106,14 +82098,6 @@ WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1081\Generated
 Expected=0
 MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;NEW;Pri1
-HostStyle=0
-
-[regexdna.cmd_10623]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\regexdna\regexdna\regexdna.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\regexdna\regexdna
-Expected=0
-MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
 HostStyle=0
 
 [Generated504.cmd_10624]
@@ -86324,14 +86308,6 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;NEW;Pri1
 HostStyle=0
 
-[binarytrees3.cmd_11156]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\binarytrees\binarytrees3\binarytrees3.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\binarytrees\binarytrees3
-Expected=0
-MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
-HostStyle=0
-
 [Generated781.cmd_11157]
 RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest781\Generated781\Generated781.cmd
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest781\Generated781
@@ -90092,12 +90068,12 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;NEW;Pri1
 HostStyle=0
 
-[k-nucleotide.cmd_11628]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\k-nucleotide\k-nucleotide\k-nucleotide.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\k-nucleotide\k-nucleotide
+[k-nucleotide-1.cmd_11628]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\k-nucleotide\k-nucleotide-1\k-nucleotide-1.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\k-nucleotide\k-nucleotide-1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [ArrayObj.cmd_11629]
@@ -90460,12 +90436,12 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;Pri1;NEW
 HostStyle=0
 
-[mandelbrot.cmd_11675]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\mandelbrot\mandelbrot\mandelbrot.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\mandelbrot\mandelbrot
+[mandelbrot-2.cmd_11675]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\mandelbrot\mandelbrot-2\mandelbrot-2.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\mandelbrot\mandelbrot-2
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [ReadWriteObject.cmd_11676]
@@ -90596,12 +90572,12 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;Pri1;NEW
 HostStyle=0
 
-[fannkuch-redux.cmd_11692]
-RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\fannkuch-redux\fannkuch-redux\fannkuch-redux.cmd
-WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\fannkuch-redux\fannkuch-redux
+[fannkuch-redux-2.cmd_11692]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\fannkuch-redux\fannkuch-redux-2\fannkuch-redux-2.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\fannkuch-redux\fannkuch-redux-2
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [GitHub_11508.cmd_11693]
@@ -90756,3 +90732,74 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;Pri1;NEW
 HostStyle=0
 
+[binarytrees-5.cmd_11712]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\binarytrees\binarytrees-5\binarytrees-5.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\binarytrees\binarytrees-5
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0
+
+[fasta-2.cmd_11713]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\fasta\fasta-2\fasta-2.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\fasta\fasta-2
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0
+
+[spectralnorm-3.cmd_11714]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\spectralnorm\spectralnorm-3\spectralnorm-3.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\spectralnorm\spectralnorm-3
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0
+
+[reverse-complement-6.cmd_11715]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\reverse-complement\reverse-complement-6\reverse-complement-6.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\reverse-complement\reverse-complement-6
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0
+
+[k-nucleotide-9.cmd_11716]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\k-nucleotide\k-nucleotide-9\k-nucleotide-9.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\k-nucleotide\k-nucleotide-9
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0
+
+[mandelbrot-7.cmd_11717]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\mandelbrot\mandelbrot-7\mandelbrot-7.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\mandelbrot\mandelbrot-7
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0
+
+[fannkuch-redux-5.cmd_11718]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\fannkuch-redux\fannkuch-redux-5\fannkuch-redux-5.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\fannkuch-redux\fannkuch-redux-5
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0
+
+[regex-redux-1.cmd_11719]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\regex-redux\regex-redux-1\regex-redux-1.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\regex-redux\regex-redux-1
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0
+
+[regex-redux-5.cmd_11719]
+RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\regex-redux\regex-redux-5\regex-redux-5.cmd
+WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\regex-redux\regex-redux-5
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0


### PR DESCRIPTION
It was removed in #13994 when these benchmarks were updated, expecting
a tests.lst autogeneration would follow. I'm adding them manually now
to ensure we have test coverage for these.

Fixes #15503