### PR TITLE
[WIP] Replace HashHelpers.Combine with HashCode.Combine

### DIFF
--- a/src/mscorlib/shared/System/ArraySegment.cs
+++ b/src/mscorlib/shared/System/ArraySegment.cs
@@ -93,22 +93,11 @@ namespace System
             return new Enumerator(this);
         }
 
-        public override int GetHashCode()
-        {
-            if (_array == null)
-            {
-                return 0;
-            }
-
-            int hash = 5381;
-            hash = System.Numerics.Hashing.HashHelpers.Combine(hash, _offset);
-            hash = System.Numerics.Hashing.HashHelpers.Combine(hash, _count);
-
-            // The array hash is expected to be an evenly-distributed mixture of bits,
-            // so rather than adding the cost of another rotation we just xor it.
-            hash ^= _array.GetHashCode();
-            return hash;
-        }
+        public override int GetHashCode() => HashCode.Combine(
+            _array,
+            _offset,
+            _count
+        );
 
         public void CopyTo(T[] destination) => CopyTo(destination, 0);
 

--- a/src/mscorlib/shared/System/Memory.cs
+++ b/src/mscorlib/shared/System/Memory.cs
@@ -327,20 +327,10 @@ namespace System
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override int GetHashCode()
-        {
-            return _object != null ? CombineHashCodes(_object.GetHashCode(), _index.GetHashCode(), _length.GetHashCode()) : 0;
-        }
-
-        private static int CombineHashCodes(int left, int right)
-        {
-            return ((left << 5) + left) ^ right;
-        }
-
-        private static int CombineHashCodes(int h1, int h2, int h3)
-        {
-            return CombineHashCodes(CombineHashCodes(h1, h2), h3);
-        }
-
+        public override int GetHashCode() => HashCode.Combine(
+            _object,
+            _index,
+            _length
+        );
     }
 }

--- a/src/mscorlib/shared/System/ReadOnlyMemory.cs
+++ b/src/mscorlib/shared/System/ReadOnlyMemory.cs
@@ -307,20 +307,11 @@ namespace System
 
         /// <summary>Returns the hash code for this <see cref="ReadOnlyMemory{T}"/></summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override int GetHashCode()
-        {
-            return _object != null ? CombineHashCodes(_object.GetHashCode(), _index.GetHashCode(), _length.GetHashCode()) : 0;
-        }
-        
-        private static int CombineHashCodes(int left, int right)
-        {
-            return ((left << 5) + left) ^ right;
-        }
-
-        private static int CombineHashCodes(int h1, int h2, int h3)
-        {
-            return CombineHashCodes(CombineHashCodes(h1, h2), h3);
-        }
+        public override int GetHashCode() => HashCode.Combine(
+            _object,
+            _index,
+            _length
+        );
 
         /// <summary>Gets the state of the memory as individual fields.</summary>
         /// <param name="start">The offset.</param>

--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -675,25 +675,18 @@ namespace System
             return true;
         }
 
-        // From System.Web.Util.HashCodeCombiner
-        internal static int CombineHashCodes(int h1, int h2)
-        {
-            return (((h1 << 5) + h1) ^ h2);
-        }
-
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
         {
             if (comparer == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.comparer);
 
-            int ret = 0;
-
+            var hashCode = new HashCode();
             for (int i = (this.Length >= 8 ? this.Length - 8 : 0); i < this.Length; i++)
             {
-                ret = CombineHashCodes(ret, comparer.GetHashCode(GetValue(i)));
+                hashCode.Add(comparer.GetHashCode(GetValue(i)));
             }
 
-            return ret;
+            return hashCode.ToHashCode();
         }
 
         // Searches an array for a given element using a binary search algorithm.


### PR DESCRIPTION
Fixes #15508

All instances of HashHelpers.Combine and NumericsHelpers.CombineHash have been replaced. Copied code has also been replaced as far as grep is concerned. The helpers have been deleted.