### PR TITLE
small ref around stack levels setting methods.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1412,33 +1412,32 @@ public:
     }
 #endif // FEATURE_FIXED_OUT_ARGS
 
+#if defined(UNIX_X86_ABI)
     void ComputeStackAlignment(unsigned curStackLevelInBytes)
     {
-#if defined(UNIX_X86_ABI)
         padStkAlign = AlignmentPad(curStackLevelInBytes, STACK_ALIGN);
-#endif // defined(UNIX_X86_ABI)
     }
 
-    void SetStkSizeBytes(unsigned newStkSizeBytes)
-    {
-#if defined(UNIX_X86_ABI)
-        stkSizeBytes = newStkSizeBytes;
-#endif // defined(UNIX_X86_ABI)
-    }
-
-#if defined(UNIX_X86_ABI)
     unsigned GetStkAlign()
     {
         return padStkAlign;
     }
+
+    void SetStkSizeBytes(unsigned newStkSizeBytes)
+    {
+        stkSizeBytes = newStkSizeBytes;
+    }
+
     unsigned GetStkSizeBytes() const
     {
         return stkSizeBytes;
     }
+
     bool IsStkAlignmentDone() const
     {
         return alignmentDone;
     }
+
     void SetStkAlignmentDone()
     {
         alignmentDone = true;

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -4498,7 +4498,9 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
     }
 
     assert(fgPtrArgCntCur >= genPtrArgCntSav);
+#if defined(UNIX_X86_ABI)
     call->fgArgInfo->SetStkSizeBytes((fgPtrArgCntCur - genPtrArgCntSav) * TARGET_POINTER_SIZE);
+#endif // UNIX_X86_ABI
 
     /* The call will pop all the arguments we pushed */
 
@@ -5889,31 +5891,31 @@ BasicBlock* Compiler::fgSetRngChkTargetInner(SpecialCodeKind kind, bool delay, u
     {
         delay = false;
 
-#ifdef _TARGET_X86_
+#if !FEATURE_FIXED_OUT_ARGS
         // we need to initialize this field
         if (fgGlobalMorph && (stkDepth != nullptr))
         {
             *stkDepth = fgPtrArgCntCur;
         }
-#endif // _TARGET_X86_
+#endif // !FEATURE_FIXED_OUT_ARGS
     }
 
     if (!opts.compDbgCode)
     {
         if (delay || compIsForInlining())
         {
-#ifdef _TARGET_X86_
+#if !FEATURE_FIXED_OUT_ARGS
             // We delay this until after loop-oriented range check analysis. For now we merely store the current stack
             // level in the tree node.
             if (stkDepth != nullptr)
             {
                 *stkDepth = fgPtrArgCntCur;
             }
-#endif // _TARGET_X86_
+#endif // !FEATURE_FIXED_OUT_ARGS
         }
         else
         {
-#ifdef _TARGET_X86_
+#if !FEATURE_FIXED_OUT_ARGS
             // fgPtrArgCntCur is only valid for global morph or if we walk full stmt.
             noway_assert(fgGlobalMorph || (stkDepth != nullptr));
             const unsigned theStkDepth = fgGlobalMorph ? fgPtrArgCntCur : *stkDepth;


### PR DESCRIPTION
If a getter is under a define, then the setter should be under the same define.

Move `ComputeStackAlignment` where `GetStkAlign` is.
The same for `SetStkSizeBytes`.

Also change `_TARGET_X86_` to `!FEATURE_FIXED_OUT_ARGS` where we do stack settings.