### PR TITLE
fix jit_std::unordered_map::operator[]

### DIFF
--- a/src/jit/jitstd/unordered_map.h
+++ b/src/jit/jitstd/unordered_map.h
@@ -147,7 +147,7 @@ unordered_map<Key, Value, Hash, Pred, Alloc>& unordered_map<Key, Value, Hash, Pr
 template<typename Key, typename Value, typename Hash, typename Pred, typename Alloc>
 Value& unordered_map<Key, Value, Hash, Pred, Alloc>::operator[](const Key& key)
 {
-    iterator<Key, Value> iter = base_type::find(key, this->key_eq());
+    typename unordered_map<Key, Value, Hash, Pred, Alloc>::iterator iter = base_type::find(key, this->key_eq());
     if (iter == this->end())
     {
         iter = base_type::insert(jitstd::pair<const Key, mapped_type>(key, mapped_type())).first;
@@ -158,7 +158,7 @@ Value& unordered_map<Key, Value, Hash, Pred, Alloc>::operator[](const Key& key)
 template<typename Key, typename Value, typename Hash, typename Pred, typename Alloc>
 Value& unordered_map<Key, Value, Hash, Pred, Alloc>::operator[](key_type&& key)
 {
-    iterator<Key, Value> iter = base_type::find(key, this->key_eq());
+    typename unordered_map<Key, Value, Hash, Pred, Alloc>::iterator iter = base_type::find(key, this->key_eq());
     if (iter == this->end())
     {
         iter = base_type::insert(jitstd::pair<const Key, mapped_type>(key, mapped_type())).first;


### PR DESCRIPTION
Because they are template methods they were not instantiated without users. But if you try to call it you will see compilation errors. The right variant was copied from the `insert` method.

Found during local experiments.