### PR TITLE
Fix Build Error When Using VS2015

### DIFF
--- a/src/vm/threads.h
+++ b/src/vm/threads.h
@@ -5284,7 +5284,7 @@ public:
     bool GetGCModeOnSuspension()
     {
         LIMITED_METHOD_CONTRACT;
-        return m_gcModeOnSuspension;
+        return m_gcModeOnSuspension != 0;
     }
 
     void SaveGCModeOnSuspension()


### PR DESCRIPTION
#14772 introduced a compilation error on VS2015.  I'm not sure why this doesn't occur in the CI - perhaps because we're compiling with VS2017.

```
c:\src\coreclr\src\vm\threads.h(5287): error C2220: warning treated as error - no 'object' file generated (compiling source file C:\src\coreclr\src\classlibnative\bcltype\currency.cpp) [C:\src\coreclr\bin\obj\W
indows_NT.x64.Debug\src\classlibnative\bcltype\bcltype.vcxproj]
c:\src\coreclr\src\vm\threads.h(5287): warning C4800: 'DWORD': forcing value to bool 'true' or 'false' (performance warning) (compiling source file C:\src\coreclr\src\classlibnative\bcltype\currency.cpp) [C:\sr
c\coreclr\bin\obj\Windows_NT.x64.Debug\src\classlibnative\bcltype\bcltype.vcxproj]
```