### PR TITLE
Fix build-only test priority

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1460,7 +1460,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
     def lowerConfiguration = configuration.toLowerCase()
 
     def priority = '1'
-    if ((scenario == 'default' && isPR == true) || (scenario == 'default' && isBuildOnly == true)) {
+    if (scenario == 'default' && isPR == true) {
         priority = '0'
     }
 


### PR DESCRIPTION
Build-only jobs used to create non-Windows test assets were changed
undesirably to build only pri-0 tests.

Addresses #15569