### PR TITLE
mark `call->fgArgInfo` with `hasStackArgs` for arm split args

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -1475,12 +1475,14 @@ void fgArgInfo::SplitArg(unsigned argNum, unsigned numRegs, unsigned numSlots)
         assert(curArgTabEntry->isSplit == true);
         assert(curArgTabEntry->numRegs == numRegs);
         assert(curArgTabEntry->numSlots == numSlots);
+        assert(hasStackArgs == true);
     }
     else
     {
         curArgTabEntry->isSplit  = true;
         curArgTabEntry->numRegs  = numRegs;
         curArgTabEntry->numSlots = numSlots;
+        hasStackArgs             = true;
     }
     nextSlotNum += numSlots;
 }


### PR DESCRIPTION
As the comment says: `bool              hasStackArgs; // true if we have one or more stack arguments`
we should have this flag set on for `GT_PUTARG_SPLIT`.

No arm32 asm diffs on  System.Private.CoreLib.dll.

I need this change for #15597.