### PR TITLE
Small changes around stack levels.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4954,7 +4954,10 @@ private:
     bool fgIsCodeAdded();
 
     bool fgIsThrowHlpBlk(BasicBlock* block);
+
+#if !FEATURE_FIXED_OUT_ARGS
     unsigned fgThrowHlpBlkStkLevel(BasicBlock* block);
+#endif // !FEATURE_FIXED_OUT_ARGS
 
     unsigned fgBigOffsetMorphingTemps[TYP_COUNT];
 

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -3033,6 +3033,8 @@ inline bool Compiler::fgIsThrowHlpBlk(BasicBlock* block)
     return false;
 }
 
+#if !FEATURE_FIXED_OUT_ARGS
+
 /*****************************************************************************
  *
  *  Return the stackLevel of the inserted block that throws exception
@@ -3065,6 +3067,8 @@ inline unsigned Compiler::fgThrowHlpBlkStkLevel(BasicBlock* block)
 
     return 0;
 }
+
+#endif // !FEATURE_FIXED_OUT_ARGS
 
 /*
     Small inline function to change a given block to a throw block.

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -18393,6 +18393,7 @@ BasicBlock* Compiler::fgAddCodeRef(BasicBlock* srcBlk, unsigned refData, Special
 
 Compiler::AddCodeDsc* Compiler::fgFindExcptnTarget(SpecialCodeKind kind, unsigned refData)
 {
+    assert(!opts.compDbgCode);
     if (!(fgExcptnTargetCache[kind] && // Try the cached value first
           fgExcptnTargetCache[kind]->acdData == refData))
     {


### PR DESCRIPTION
As the comment in flowgraph says:
```
    // For debuggable code, genJumpToThrowHlpBlk() will generate the 'throw'
    // code inline. It has to be kept consistent with fgAddCodeRef()
    if (opts.compDbgCode)
    {
        return nullptr;
    }
```
so check that we do not ask for these blocks when compile dbg code.

and an additional `ifdef` for x86 only function.