### PR TITLE
Update the version of the xUnit Performance Api

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -37,7 +37,7 @@
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>2.1.0-preview1-26020-03</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <XunitPackageVersion>2.2.0-beta2-build3300</XunitPackageVersion>
     <XunitConsoleNetcorePackageVersion>1.0.2-prerelease-00177</XunitConsoleNetcorePackageVersion>
-    <XunitPerformanceApiPackageVersion>1.0.0-beta-build0012</XunitPerformanceApiPackageVersion>
+    <XunitPerformanceApiPackageVersion>1.0.0-beta-build0015</XunitPerformanceApiPackageVersion>
     <MicrosoftDiagnosticsTracingTraceEventPackageVersion>1.0.3-alpha-experimental</MicrosoftDiagnosticsTracingTraceEventPackageVersion>
     <VCRuntimeVersion>1.2.0</VCRuntimeVersion>
   </PropertyGroup>

--- a/tests/src/Common/PerfHarness/PerfHarness.cs
+++ b/tests/src/Common/PerfHarness/PerfHarness.cs
@@ -1,16 +1,21 @@
-using System.IO;
-using System.Reflection;
-using System.Collections.Generic;
+using System;
 using Microsoft.Xunit.Performance.Api;
 
 public class PerfHarness
 {
-    public static void Main(string[] args)
+    public static int Main(string[] args)
     {
-        string assemblyName = args[0];
-        using (XunitPerformanceHarness harness = new XunitPerformanceHarness(args))
+        try
         {
-            harness.RunBenchmarks(assemblyName);
+            using (XunitPerformanceHarness harness = new XunitPerformanceHarness(args))
+                harness.RunBenchmarks(assemblyFileName: args[0]);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("[ERROR] Benchmark execution failed.");
+            Console.WriteLine($"  {ex.ToString()}");
+            return 1;
         }
     }
 }


### PR DESCRIPTION
- This version fail broken benchmarks, so we can catch bugs earlier.
- Changed the harness to exit with non-zero code when an exception is thrown.