### PR TITLE
Fix manual GC_PROTECTs around StackTraceArray

### DIFF
--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -3110,15 +3110,9 @@ public:
     void CopyFrom(StackTraceArray const & src);
     
 private:
-    StackTraceArray(StackTraceArray const & rhs);
+    StackTraceArray(StackTraceArray const & rhs) = delete;
 
-    StackTraceArray & operator=(StackTraceArray const & rhs)
-    {
-        WRAPPER_NO_CONTRACT;
-        StackTraceArray copy(rhs);
-        this->Swap(copy);
-        return *this;
-    }
+    StackTraceArray & operator=(StackTraceArray const & rhs) = delete;
 
     void Grow(size_t size);
     void EnsureThreadAffinity();


### PR DESCRIPTION
StackTraceArray wraps GC reference that needs to be GC_PROTECTED exactly once accross all GC triggering points. The calls from copy constructor and assignment operator were violating this invariant. I have fixed this by deleting the copy constructor and assignment operator, and replaced their use by explicit CopyFrom method.

Fixes #15537