### PR TITLE
Reduce Execution Context Save+Restore

### DIFF
--- a/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
@@ -357,6 +357,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Resources\SatelliteContractVersionAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Resources\UltimateResourceFallbackLocation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AccessedThroughPropertyAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncMethodBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncMethodBuilderAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncStateMachineAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncValueTaskMethodBuilder.cs" />

--- a/src/mscorlib/shared/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/mscorlib/shared/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace System.Runtime.CompilerServices
+{
+    internal static partial class AsyncMethodBuilder
+    {
+        /// <summary>Initiates the builder's execution with the associated state machine.</summary>
+        /// <typeparam name="TStateMachine">Specifies the type of the state machine.</typeparam>
+        /// <param name="stateMachine">The state machine instance, passed by reference.</param>
+        [DebuggerStepThrough]
+        public static void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine
+        {
+            if (stateMachine == null) // TStateMachines are generally non-nullable value types, so this check will be elided
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.stateMachine);
+            }
+
+            // enregistrer variables with 0 post-fix so they can be used in registers without EH forcing them to stack
+            // Capture references to Thread Contexts
+            Thread currentThread0 = Thread.CurrentThread;
+            Thread currentThread = currentThread0;
+            ExecutionContext previousExecutionCtx0 = currentThread0.ExecutionContext;
+
+            // Store current ExecutionContext and SynchronizationContext as "previousXxx".
+            // This allows us to restore them and undo any Context changes made in stateMachine.MoveNext
+            // so that they won't "leak" out of the first await.
+            ExecutionContext previousExecutionCtx = previousExecutionCtx0;
+            SynchronizationContext previousSyncCtx = currentThread0.SynchronizationContext;
+
+            try
+            {
+                stateMachine.MoveNext();
+            }
+            finally
+            {
+                // Re-enregistrer variables post EH with 1 post-fix so they can be used in registers rather than from stack
+                SynchronizationContext previousSyncCtx1 = previousSyncCtx;
+                Thread currentThread1 = currentThread;
+                // The common case is that these have not changed, so avoid the cost of a write barrier if not needed.
+                if (previousSyncCtx1 != currentThread1.SynchronizationContext)
+                {
+                    // Restore changed SynchronizationContext back to previous
+                    currentThread1.SynchronizationContext = previousSyncCtx1;
+                }
+
+                ExecutionContext previousExecutionCtx1 = previousExecutionCtx;
+                ExecutionContext currentExecutionCtx1 = currentThread1.ExecutionContext;
+                if (previousExecutionCtx1 != currentExecutionCtx1)
+                {
+                    // Restore changed ExecutionContext back to previous
+                    currentThread1.ExecutionContext = previousExecutionCtx1;
+                    if ((currentExecutionCtx1 != null && currentExecutionCtx1.HasChangeNotifications) ||
+                        (previousExecutionCtx1 != null && previousExecutionCtx1.HasChangeNotifications))
+                    {
+                        // There are change notifications; trigger any affected
+                        ExecutionContext.OnValuesChanged(currentExecutionCtx1, previousExecutionCtx1);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/mscorlib/shared/System/Runtime/CompilerServices/AsyncValueTaskMethodBuilder.cs
+++ b/src/mscorlib/shared/System/Runtime/CompilerServices/AsyncValueTaskMethodBuilder.cs
@@ -38,8 +38,9 @@ namespace System.Runtime.CompilerServices
         /// <summary>Begins running the builder with the associated state machine.</summary>
         /// <typeparam name="TStateMachine">The type of the state machine.</typeparam>
         /// <param name="stateMachine">The state machine instance, passed by reference.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine =>
-            _methodBuilder.Start(ref stateMachine); // will provide the right ExecutionContext semantics
+            AsyncMethodBuilder.Start(ref stateMachine); // will provide the right ExecutionContext semantics
 
         /// <summary>Associates the builder with the specified state machine.</summary>
         /// <param name="stateMachine">The state machine instance to associate with the builder.</param>

--- a/src/mscorlib/shared/System/Threading/AsyncLocal.cs
+++ b/src/mscorlib/shared/System/Threading/AsyncLocal.cs
@@ -125,7 +125,7 @@ namespace System.Threading
         public static IAsyncLocalValueMap Empty { get; } = new EmptyAsyncLocalValueMap();
 
         // Instance without any key/value pairs.  Used as a singleton/
-        private sealed class EmptyAsyncLocalValueMap : IAsyncLocalValueMap
+        internal sealed class EmptyAsyncLocalValueMap : IAsyncLocalValueMap
         {
             public IAsyncLocalValueMap Set(IAsyncLocal key, object value)
             {

--- a/src/mscorlib/shared/System/Threading/AsyncLocal.cs
+++ b/src/mscorlib/shared/System/Threading/AsyncLocal.cs
@@ -144,7 +144,7 @@ namespace System.Threading
         }
 
         // Instance with one key/value pair.
-        private sealed class OneElementAsyncLocalValueMap : IAsyncLocalValueMap
+        internal sealed class OneElementAsyncLocalValueMap : IAsyncLocalValueMap
         {
             private readonly IAsyncLocal _key1;
             private readonly object _value1;

--- a/src/mscorlib/shared/System/Threading/ExecutionContext.cs
+++ b/src/mscorlib/shared/System/Threading/ExecutionContext.cs
@@ -70,7 +70,8 @@ namespace System.Threading
             {
                 return null; // implies the default context
             }
-            return new ExecutionContext(m_localValues, m_localChangeNotifications, isFlowSuppressed);
+            // Flow suppressing a Default context will have null values, set them to Empty
+            return new ExecutionContext(m_localValues ?? AsyncLocalValueMap.Empty, m_localChangeNotifications ?? Array.Empty<IAsyncLocal>(), isFlowSuppressed);
         }
 
         public static AsyncFlowControl SuppressFlow()

--- a/src/mscorlib/shared/System/Threading/ExecutionContext.cs
+++ b/src/mscorlib/shared/System/Threading/ExecutionContext.cs
@@ -151,7 +151,7 @@ namespace System.Threading
                 if ((executionContext != null && executionContext.HasChangeNotifications) ||
                     (previousExecutionCtx0 != null && previousExecutionCtx0.HasChangeNotifications))
                 {
-                    // Are change notifications; trigger any effected
+                    // There are change notifications; trigger any affected
                     OnValuesChanged(previousExecutionCtx0, executionContext);
                 }
             }
@@ -188,14 +188,13 @@ namespace System.Threading
                 if ((currentExecutionCtx1 != null && currentExecutionCtx1.HasChangeNotifications) ||
                     (previousExecutionCtx1 != null && previousExecutionCtx1.HasChangeNotifications))
                 {
-                    // Are change notifications; trigger any effected
+                    // There are change notifications; trigger any affected
                     OnValuesChanged(currentExecutionCtx1, previousExecutionCtx1);
                 }
             }
-            // Enregistrer edi to edi1
-            ExceptionDispatchInfo edi1 = edi;
+
             // If exception was thrown by callback, rethrow it now original contexts are restored
-            edi1?.Throw();
+            edi?.Throw();
         }
 
         internal static void OnValuesChanged(ExecutionContext previousExecutionCtx, ExecutionContext nextExecutionCtx)
@@ -225,7 +224,7 @@ namespace System.Threading
 
                         if (previousValue != currentValue)
                         {
-                            local.OnValueChanged(previousValue, currentValue, true);
+                            local.OnValueChanged(previousValue, currentValue, contextChanged: true);
                         }
                     }
 
@@ -241,7 +240,7 @@ namespace System.Threading
                                 nextExecutionCtx.m_localValues.TryGetValue(local, out object currentValue);
                                 if (previousValue != currentValue)
                                 {
-                                    local.OnValueChanged(previousValue, currentValue, true);
+                                    local.OnValueChanged(previousValue, currentValue, contextChanged: true);
                                 }
                             }
                         }
@@ -257,7 +256,7 @@ namespace System.Threading
                         previousExecutionCtx.m_localValues.TryGetValue(local, out object previousValue);
                         if (previousValue != null)
                         {
-                            local.OnValueChanged(previousValue, null, true);
+                            local.OnValueChanged(previousValue, null, contextChanged: true);
                         }
                     }
                 }
@@ -271,7 +270,7 @@ namespace System.Threading
                         nextExecutionCtx.m_localValues.TryGetValue(local, out object currentValue);
                         if (currentValue != null)
                         {
-                            local.OnValueChanged(null, currentValue, true);
+                            local.OnValueChanged(null, currentValue, contextChanged: true);
                         }
                     }
                 }
@@ -345,8 +344,7 @@ namespace System.Threading
                 }
                 else if (newChangeNotifications == null)
                 {
-                    newChangeNotifications = new IAsyncLocal[1];
-                    newChangeNotifications[0] = local;
+                    newChangeNotifications = new IAsyncLocal[1] { local };
                 }
                 else
                 {
@@ -361,7 +359,7 @@ namespace System.Threading
 
             if (needChangeNotifications)
             {
-                local.OnValueChanged(previousValue, newValue, false);
+                local.OnValueChanged(previousValue, newValue, contextChanged: false);
             }
         }
 

--- a/src/mscorlib/shared/System/Threading/ExecutionContext.cs
+++ b/src/mscorlib/shared/System/Threading/ExecutionContext.cs
@@ -23,16 +23,22 @@ namespace System.Threading
 
     public sealed class ExecutionContext : IDisposable, ISerializable
     {
-        internal static readonly ExecutionContext Default = new ExecutionContext();
+        internal static readonly ExecutionContext Default = new ExecutionContext(isDefault: true);
 
         private readonly IAsyncLocalValueMap m_localValues;
         private readonly IAsyncLocal[] m_localChangeNotifications;
         private readonly bool m_isFlowSuppressed;
+        private readonly bool m_isDefault;
 
         private ExecutionContext()
         {
             m_localValues = AsyncLocalValueMap.Empty;
             m_localChangeNotifications = Array.Empty<IAsyncLocal>();
+        }
+
+        private ExecutionContext(bool isDefault) : base()
+        {
+            m_isDefault = true;
         }
 
         private ExecutionContext(
@@ -129,7 +135,7 @@ namespace System.Threading
             ExecutionContext previousExecutionCtx = previousExecutionCtx0;
             SynchronizationContext previousSyncCtx = currentThread0.SynchronizationContext;
 
-            if (executionContext == Default)
+            if (executionContext.m_isDefault)
             {
                 // Default is a null ExecutionContext internally
                 executionContext = null;

--- a/src/mscorlib/shared/System/Threading/ExecutionContext.cs
+++ b/src/mscorlib/shared/System/Threading/ExecutionContext.cs
@@ -64,8 +64,9 @@ namespace System.Threading
             Debug.Assert(isFlowSuppressed != m_isFlowSuppressed);
 
             if (!isFlowSuppressed &&
-                m_localValues == null &&
-                m_localChangeNotifications == null)
+                (m_localValues == null ||
+                 m_localValues.GetType() == typeof(AsyncLocalValueMap.EmptyAsyncLocalValueMap))
+               )
             {
                 return null; // implies the default context
             }
@@ -356,7 +357,9 @@ namespace System.Threading
                 }
             }
 
-            Thread.CurrentThread.ExecutionContext =
+            Thread.CurrentThread.ExecutionContext = 
+                (!isFlowSuppressed && newValues.GetType() == typeof(AsyncLocalValueMap.EmptyAsyncLocalValueMap)) ?
+                null : // No values, return to Default context
                 new ExecutionContext(newValues, newChangeNotifications, isFlowSuppressed);
 
             if (needChangeNotifications)

--- a/src/mscorlib/shared/System/Threading/ExecutionContext.cs
+++ b/src/mscorlib/shared/System/Threading/ExecutionContext.cs
@@ -138,7 +138,7 @@ namespace System.Threading
             ExecutionContext previousExecutionCtx = previousExecutionCtx0;
             SynchronizationContext previousSyncCtx = currentThread0.SynchronizationContext;
 
-            if (executionContext.m_isDefault)
+            if (executionContext != null && executionContext.m_isDefault)
             {
                 // Default is a null ExecutionContext internally
                 executionContext = null;

--- a/src/mscorlib/shared/System/Threading/ExecutionContext.cs
+++ b/src/mscorlib/shared/System/Threading/ExecutionContext.cs
@@ -21,28 +21,6 @@ namespace System.Threading
 {
     public delegate void ContextCallback(Object state);
 
-    internal struct ExecutionContextSwitcher
-    {
-        internal ExecutionContext m_ec;
-        internal SynchronizationContext m_sc;
-
-        internal void Undo(Thread currentThread)
-        {
-            Debug.Assert(currentThread == Thread.CurrentThread);
-
-            // The common case is that these have not changed, so avoid the cost of a write if not needed.
-            if (currentThread.SynchronizationContext != m_sc)
-            {
-                currentThread.SynchronizationContext = m_sc;
-            }
-
-            if (currentThread.ExecutionContext != m_ec)
-            {
-                ExecutionContext.Restore(currentThread, m_ec);
-            }
-        }
-    }
-
     public sealed class ExecutionContext : IDisposable, ISerializable
     {
         internal static readonly ExecutionContext Default = new ExecutionContext();
@@ -128,133 +106,238 @@ namespace System.Threading
             return executionContext != null && executionContext.m_isFlowSuppressed;
         }
 
+        internal bool HasChangeNotifications => m_localChangeNotifications != null;
+
         public static void Run(ExecutionContext executionContext, ContextCallback callback, Object state)
         {
+            // Note: ExecutionContext.Run is an extremely hot function and used by every await, ThreadPool execution, etc.
             if (executionContext == null)
-                throw new InvalidOperationException(SR.InvalidOperation_NullContext);
+            {
+                ThrowNullContext();
+            }
 
-            Thread currentThread = Thread.CurrentThread;
-            ExecutionContextSwitcher ecsw = default(ExecutionContextSwitcher);
+            // enregistrer variables with 0 post-fix so they can be used in registers without EH forcing them to stack
+            // Capture references to Thread Contexts
+            Thread currentThread0 = Thread.CurrentThread;
+            Thread currentThread = currentThread0;
+            ExecutionContext previousExecutionCtx0 = currentThread0.ExecutionContext;
+
+            // Store current ExecutionContext and SynchronizationContext as "previousXxx".
+            // This allows us to restore them and undo any Context changes made in callback.Invoke
+            // so that they won't "leak" back into caller.
+            // These variables will cross EH so be forced to stack
+            ExecutionContext previousExecutionCtx = previousExecutionCtx0;
+            SynchronizationContext previousSyncCtx = currentThread0.SynchronizationContext;
+
+            if (executionContext == Default)
+            {
+                // Default is a null ExecutionContext internally
+                executionContext = null;
+            }
+
+            if (previousExecutionCtx0 != executionContext)
+            {
+                // Restore changed ExecutionContext
+                currentThread0.ExecutionContext = executionContext;
+                if ((executionContext != null && executionContext.HasChangeNotifications) ||
+                    (previousExecutionCtx0 != null && previousExecutionCtx0.HasChangeNotifications))
+                {
+                    // Are change notifications; trigger any effected
+                    OnValuesChanged(previousExecutionCtx0, executionContext);
+                }
+            }
+
+            ExceptionDispatchInfo edi = null;
             try
             {
-                EstablishCopyOnWriteScope(currentThread, ref ecsw);
-                ExecutionContext.Restore(currentThread, executionContext);
-                callback(state);
+                callback.Invoke(state);
             }
-            catch
+            catch (Exception ex)
             {
                 // Note: we have a "catch" rather than a "finally" because we want
                 // to stop the first pass of EH here.  That way we can restore the previous
-                // context before any of our callers' EH filters run.  That means we need to
-                // end the scope separately in the non-exceptional case below.
-                ecsw.Undo(currentThread);
-                throw;
-            }
-            ecsw.Undo(currentThread);
-        }
-
-        internal static void Restore(Thread currentThread, ExecutionContext executionContext)
-        {
-            Debug.Assert(currentThread == Thread.CurrentThread);
-
-            ExecutionContext previous = currentThread.ExecutionContext ?? Default;
-            currentThread.ExecutionContext = executionContext;
-
-            // New EC could be null if that's what ECS.Undo saved off.
-            // For the purposes of dealing with context change, treat this as the default EC
-            executionContext = executionContext ?? Default;
-
-            if (previous != executionContext)
-            {
-                OnContextChanged(previous, executionContext);
-            }
-        }
-
-        internal static void EstablishCopyOnWriteScope(Thread currentThread, ref ExecutionContextSwitcher ecsw)
-        {
-            Debug.Assert(currentThread == Thread.CurrentThread);
-
-            ecsw.m_ec = currentThread.ExecutionContext;
-            ecsw.m_sc = currentThread.SynchronizationContext;
-        }
-
-        private static void OnContextChanged(ExecutionContext previous, ExecutionContext current)
-        {
-            Debug.Assert(previous != null);
-            Debug.Assert(current != null);
-            Debug.Assert(previous != current);
-
-            foreach (IAsyncLocal local in previous.m_localChangeNotifications)
-            {
-                object previousValue;
-                object currentValue;
-                previous.m_localValues.TryGetValue(local, out previousValue);
-                current.m_localValues.TryGetValue(local, out currentValue);
-
-                if (previousValue != currentValue)
-                    local.OnValueChanged(previousValue, currentValue, true);
+                // context before any of our callers' EH filters run.
+                edi = ExceptionDispatchInfo.Capture(ex);
             }
 
-            if (current.m_localChangeNotifications != previous.m_localChangeNotifications)
+            // Re-enregistrer variables post EH with 1 post-fix so they can be used in registers rather than from stack
+            SynchronizationContext previousSyncCtx1 = previousSyncCtx;
+            Thread currentThread1 = currentThread;
+            // The common case is that these have not changed, so avoid the cost of a write barrier if not needed.
+            if (currentThread1.SynchronizationContext != previousSyncCtx1)
             {
-                try
+                // Restore changed SynchronizationContext back to previous
+                currentThread1.SynchronizationContext = previousSyncCtx1;
+            }
+
+            ExecutionContext previousExecutionCtx1 = previousExecutionCtx;
+            ExecutionContext currentExecutionCtx1 = currentThread1.ExecutionContext;
+            if (currentExecutionCtx1 != previousExecutionCtx1)
+            {
+                // Restore changed ExecutionContext back to previous
+                currentThread1.ExecutionContext = previousExecutionCtx1;
+                if ((currentExecutionCtx1 != null && currentExecutionCtx1.HasChangeNotifications) ||
+                    (previousExecutionCtx1 != null && previousExecutionCtx1.HasChangeNotifications))
                 {
-                    foreach (IAsyncLocal local in current.m_localChangeNotifications)
-                    {
-                        // If the local has a value in the previous context, we already fired the event for that local
-                        // in the code above.
-                        object previousValue;
-                        if (!previous.m_localValues.TryGetValue(local, out previousValue))
-                        {
-                            object currentValue;
-                            current.m_localValues.TryGetValue(local, out currentValue);
+                    // Are change notifications; trigger any effected
+                    OnValuesChanged(currentExecutionCtx1, previousExecutionCtx1);
+                }
+            }
+            // Enregistrer edi to edi1
+            ExceptionDispatchInfo edi1 = edi;
+            // If exception was thrown by callback, rethrow it now original contexts are restored
+            edi1?.Throw();
+        }
 
-                            if (previousValue != currentValue)
-                                local.OnValueChanged(previousValue, currentValue, true);
+        internal static void OnValuesChanged(ExecutionContext previousExecutionCtx, ExecutionContext nextExecutionCtx)
+        {
+            Debug.Assert(previousExecutionCtx != nextExecutionCtx);
+
+            // Collect Change Notifications 
+            IAsyncLocal[] previousChangeNotifications = previousExecutionCtx?.m_localChangeNotifications;
+            IAsyncLocal[] nextChangeNotifications = nextExecutionCtx?.m_localChangeNotifications;
+
+            // At least one side must have notifications
+            Debug.Assert(previousChangeNotifications != null || nextChangeNotifications != null);
+
+            // Fire Change Notifications
+            try
+            {
+                if (previousChangeNotifications != null && nextChangeNotifications != null)
+                {
+                    // Notifications can't exist without values
+                    Debug.Assert(previousExecutionCtx.m_localValues != null);
+                    Debug.Assert(nextExecutionCtx.m_localValues != null);
+                    // Both contexts have change notifications, check previousExecutionCtx first
+                    foreach (IAsyncLocal local in previousChangeNotifications)
+                    {
+                        previousExecutionCtx.m_localValues.TryGetValue(local, out object previousValue);
+                        nextExecutionCtx.m_localValues.TryGetValue(local, out object currentValue);
+
+                        if (previousValue != currentValue)
+                        {
+                            local.OnValueChanged(previousValue, currentValue, true);
+                        }
+                    }
+
+                    if (nextChangeNotifications != previousChangeNotifications)
+                    {
+                        // Check for additional notifications in nextExecutionCtx
+                        foreach (IAsyncLocal local in nextChangeNotifications)
+                        {
+                            // If the local has a value in the previous context, we already fired the event 
+                            // for that local in the code above.
+                            if (!previousExecutionCtx.m_localValues.TryGetValue(local, out object previousValue))
+                            {
+                                nextExecutionCtx.m_localValues.TryGetValue(local, out object currentValue);
+                                if (previousValue != currentValue)
+                                {
+                                    local.OnValueChanged(previousValue, currentValue, true);
+                                }
+                            }
                         }
                     }
                 }
-                catch (Exception ex)
+                else if (previousChangeNotifications != null)
                 {
-                    Environment.FailFast(
-                        SR.ExecutionContext_ExceptionInAsyncLocalNotification,
-                        ex);
+                    // Notifications can't exist without values
+                    Debug.Assert(previousExecutionCtx.m_localValues != null);
+                    // No current values, so just check previous against null
+                    foreach (IAsyncLocal local in previousChangeNotifications)
+                    {
+                        previousExecutionCtx.m_localValues.TryGetValue(local, out object previousValue);
+                        if (previousValue != null)
+                        {
+                            local.OnValueChanged(previousValue, null, true);
+                        }
+                    }
+                }
+                else // Implied: nextChangeNotifications != null
+                {
+                    // Notifications can't exist without values
+                    Debug.Assert(nextExecutionCtx.m_localValues != null);
+                    // No previous values, so just check current against null
+                    foreach (IAsyncLocal local in nextChangeNotifications)
+                    {
+                        nextExecutionCtx.m_localValues.TryGetValue(local, out object currentValue);
+                        if (currentValue != null)
+                        {
+                            local.OnValueChanged(null, currentValue, true);
+                        }
+                    }
                 }
             }
+            catch (Exception ex)
+            {
+                Environment.FailFast(
+                    SR.ExecutionContext_ExceptionInAsyncLocalNotification,
+                    ex);
+            }
+        }
+
+        [StackTraceHidden]
+        private static void ThrowNullContext()
+        {
+            throw new InvalidOperationException(SR.InvalidOperation_NullContext);
         }
 
         internal static object GetLocalValue(IAsyncLocal local)
         {
             ExecutionContext current = Thread.CurrentThread.ExecutionContext;
             if (current == null)
+            {
                 return null;
+            }
 
-            object value;
-            current.m_localValues.TryGetValue(local, out value);
+            current.m_localValues.TryGetValue(local, out object value);
             return value;
         }
 
         internal static void SetLocalValue(IAsyncLocal local, object newValue, bool needChangeNotifications)
         {
-            ExecutionContext current = Thread.CurrentThread.ExecutionContext ?? ExecutionContext.Default;
+            ExecutionContext current = Thread.CurrentThread.ExecutionContext;
 
-            object previousValue;
-            bool hadPreviousValue = current.m_localValues.TryGetValue(local, out previousValue);
+            object previousValue = null;
+            bool hadPreviousValue = false;
+            if (current != null)
+            {
+                hadPreviousValue = current.m_localValues.TryGetValue(local, out previousValue);
+            }
 
             if (previousValue == newValue)
+            {
                 return;
+            }
 
-            IAsyncLocalValueMap newValues = current.m_localValues.Set(local, newValue);
+            IAsyncLocal[] newChangeNotifications = null;
+            IAsyncLocalValueMap newValues;
+            bool isFlowSuppressed = false;
+            if (current != null)
+            {
+                isFlowSuppressed = current.m_isFlowSuppressed;
+                newValues = current.m_localValues.Set(local, newValue);
+                newChangeNotifications = current.m_localChangeNotifications;
+            }
+            else
+            {
+                // First AsyncLocal
+                newValues = new AsyncLocalValueMap.OneElementAsyncLocalValueMap(local, newValue);
+            }
 
             //
             // Either copy the change notification array, or create a new one, depending on whether we need to add a new item.
             //
-            IAsyncLocal[] newChangeNotifications = current.m_localChangeNotifications;
             if (needChangeNotifications)
             {
                 if (hadPreviousValue)
                 {
+                    Debug.Assert(newChangeNotifications != null);
                     Debug.Assert(Array.IndexOf(newChangeNotifications, local) >= 0);
+                }
+                else if (newChangeNotifications == null)
+                {
+                    newChangeNotifications = new IAsyncLocal[1];
+                    newChangeNotifications[0] = local;
                 }
                 else
                 {
@@ -265,7 +348,7 @@ namespace System.Threading
             }
 
             Thread.CurrentThread.ExecutionContext =
-                new ExecutionContext(newValues, newChangeNotifications, current.m_isFlowSuppressed);
+                new ExecutionContext(newValues, newChangeNotifications, isFlowSuppressed);
 
             if (needChangeNotifications)
             {

--- a/src/mscorlib/shared/System/Threading/ExecutionContext.cs
+++ b/src/mscorlib/shared/System/Threading/ExecutionContext.cs
@@ -124,6 +124,8 @@ namespace System.Threading
         internal static void RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
         {
             // Note: ExecutionContext.RunInternal is an extremely hot function and used by every await, ThreadPool execution, etc.
+            // Note: Manual enregistering may be addressed by "Exception Handling Write Through Optimization"
+            //       https://github.com/dotnet/coreclr/blob/master/Documentation/design-docs/eh-writethru.md
 
             // Enregister variables with 0 post-fix so they can be used in registers without EH forcing them to stack
             // Capture references to Thread Contexts

--- a/src/mscorlib/src/System/IO/Stream.cs
+++ b/src/mscorlib/src/System/IO/Stream.cs
@@ -673,7 +673,7 @@ namespace System.IO
                     var invokeAsyncCallback = s_invokeAsyncCallback;
                     if (invokeAsyncCallback == null) s_invokeAsyncCallback = invokeAsyncCallback = InvokeAsyncCallback; // benign race condition
 
-                    ExecutionContext.Run(context, invokeAsyncCallback, this);
+                    ExecutionContext.RunInternal(context, invokeAsyncCallback, this);
                 }
             }
 

--- a/src/mscorlib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -575,13 +575,14 @@ namespace System.Runtime.CompilerServices
             /// <summary>Calls MoveNext on <see cref="StateMachine"/></summary>
             public void MoveNext()
             {
-                if (Context == null)
+                ExecutionContext context = Context;
+                if (context == null)
                 {
                     StateMachine.MoveNext();
                 }
                 else
                 {
-                    ExecutionContext.Run(Context, s_callback, this);
+                    ExecutionContext.RunInternal(context, s_callback, this);
                 }
 
                 // In case this is a state machine box with a finalizer, suppress its finalization

--- a/src/mscorlib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -356,7 +356,7 @@ namespace System.Runtime.CompilerServices
                     if ((currentExecutionCtx1 != null && currentExecutionCtx1.HasChangeNotifications) ||
                         (previousExecutionCtx1 != null && previousExecutionCtx1.HasChangeNotifications))
                     {
-                        // Are change notifications; trigger any effected
+                        // There are change notifications; trigger any affected
                         ExecutionContext.OnValuesChanged(currentExecutionCtx1, previousExecutionCtx1);
                     }
                 }

--- a/src/mscorlib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -49,8 +49,9 @@ namespace System.Runtime.CompilerServices
         /// <param name="stateMachine">The state machine instance, passed by reference.</param>
         /// <exception cref="System.ArgumentNullException">The <paramref name="stateMachine"/> argument was null (Nothing in Visual Basic).</exception>
         [DebuggerStepThrough]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine =>
-            _builder.Start(ref stateMachine);
+            AsyncMethodBuilder.Start(ref stateMachine);
 
         /// <summary>Associates the builder with the state machine it represents.</summary>
         /// <param name="stateMachine">The heap-allocated state machine object.</param>
@@ -198,8 +199,9 @@ namespace System.Runtime.CompilerServices
         /// <typeparam name="TStateMachine">Specifies the type of the state machine.</typeparam>
         /// <param name="stateMachine">The state machine instance, passed by reference.</param>
         [DebuggerStepThrough]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine =>
-            m_builder.Start(ref stateMachine);
+            AsyncMethodBuilder.Start(ref stateMachine);
 
         /// <summary>Associates the builder with the state machine it represents.</summary>
         /// <param name="stateMachine">The heap-allocated state machine object.</param>
@@ -312,56 +314,9 @@ namespace System.Runtime.CompilerServices
         /// <typeparam name="TStateMachine">Specifies the type of the state machine.</typeparam>
         /// <param name="stateMachine">The state machine instance, passed by reference.</param>
         [DebuggerStepThrough]
-        public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine
-        {
-            if (stateMachine == null) // TStateMachines are generally non-nullable value types, so this check will be elided
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.stateMachine);
-            }
-
-            // enregistrer variables with 0 post-fix so they can be used in registers without EH forcing them to stack
-            // Capture references to Thread Contexts
-            Thread currentThread0 = Thread.CurrentThread;
-            Thread currentThread = currentThread0;
-            ExecutionContext previousExecutionCtx0 = currentThread0.ExecutionContext;
-
-            // Store current ExecutionContext and SynchronizationContext as "previousXxx".
-            // This allows us to restore them and undo any Context changes made in stateMachine.MoveNext
-            // so that they won't "leak" out of the first await.
-            ExecutionContext previousExecutionCtx = previousExecutionCtx0;
-            SynchronizationContext previousSyncCtx = currentThread0.SynchronizationContext;
-
-            try
-            {
-                stateMachine.MoveNext();
-            }
-            finally
-            {
-                // Re-enregistrer variables post EH with 1 post-fix so they can be used in registers rather than from stack
-                SynchronizationContext previousSyncCtx1 = previousSyncCtx;
-                Thread currentThread1 = currentThread;
-                // The common case is that these have not changed, so avoid the cost of a write barrier if not needed.
-                if (previousSyncCtx1 != currentThread1.SynchronizationContext)
-                {
-                    // Restore changed SynchronizationContext back to previous
-                    currentThread1.SynchronizationContext = previousSyncCtx1;
-                }
-
-                ExecutionContext previousExecutionCtx1 = previousExecutionCtx;
-                ExecutionContext currentExecutionCtx1 = currentThread1.ExecutionContext;
-                if (previousExecutionCtx1 != currentExecutionCtx1)
-                {
-                    // Restore changed ExecutionContext back to previous
-                    currentThread1.ExecutionContext = previousExecutionCtx1;
-                    if ((currentExecutionCtx1 != null && currentExecutionCtx1.HasChangeNotifications) ||
-                        (previousExecutionCtx1 != null && previousExecutionCtx1.HasChangeNotifications))
-                    {
-                        // There are change notifications; trigger any affected
-                        ExecutionContext.OnValuesChanged(currentExecutionCtx1, previousExecutionCtx1);
-                    }
-                }
-            }
-        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine =>
+            AsyncMethodBuilder.Start(ref stateMachine);
 
         /// <summary>Associates the builder with the state machine it represents.</summary>
         /// <param name="stateMachine">The heap-allocated state machine object.</param>

--- a/src/mscorlib/src/System/Threading/CancellationTokenSource.cs
+++ b/src/mscorlib/src/System/Threading/CancellationTokenSource.cs
@@ -924,9 +924,10 @@ namespace System.Threading
 
             public void ExecuteCallback()
             {
-                if (ExecutionContext != null)
+                ExecutionContext context = ExecutionContext;
+                if (context != null)
                 {
-                    ExecutionContext.Run(ExecutionContext, s =>
+                    ExecutionContext.RunInternal(context, s =>
                     {
                         CallbackNode n = (CallbackNode)s;
                         n.Callback(n.CallbackState);

--- a/src/mscorlib/src/System/Threading/Overlapped.cs
+++ b/src/mscorlib/src/System/Threading/Overlapped.cs
@@ -94,7 +94,8 @@ namespace System.Threading
                 overlapped = OverlappedData.GetOverlappedFromNative(pOVERLAP).m_overlapped;
                 helper = overlapped.iocbHelper;
 
-                if (helper == null || helper._executionContext == null || helper._executionContext == ExecutionContext.Default)
+                ExecutionContext context = helper?._executionContext;
+                if (context == null || context.IsDefault)
                 {
                     // We got here because of UnsafePack (or) Pack with EC flow supressed
                     IOCompletionCallback callback = overlapped.UserCallback;
@@ -106,7 +107,7 @@ namespace System.Threading
                     helper._errorCode = errorCode;
                     helper._numBytes = numBytes;
                     helper._pOVERLAP = pOVERLAP;
-                    ExecutionContext.Run(helper._executionContext, _ccb, helper);
+                    ExecutionContext.RunInternal(context, _ccb, helper);
                 }
 
                 //Quickly check the VM again, to see if a packet has arrived.

--- a/src/mscorlib/src/System/Threading/Overlapped.cs
+++ b/src/mscorlib/src/System/Threading/Overlapped.cs
@@ -94,8 +94,7 @@ namespace System.Threading
                 overlapped = OverlappedData.GetOverlappedFromNative(pOVERLAP).m_overlapped;
                 helper = overlapped.iocbHelper;
 
-                ExecutionContext context = helper?._executionContext;
-                if (context == null || context.IsDefault)
+                if (helper == null || helper._executionContext == null || helper._executionContext.IsDefault)
                 {
                     // We got here because of UnsafePack (or) Pack with EC flow supressed
                     IOCompletionCallback callback = overlapped.UserCallback;
@@ -107,7 +106,7 @@ namespace System.Threading
                     helper._errorCode = errorCode;
                     helper._numBytes = numBytes;
                     helper._pOVERLAP = pOVERLAP;
-                    ExecutionContext.RunInternal(context, _ccb, helper);
+                    ExecutionContext.RunInternal(helper._executionContext, _ccb, helper);
                 }
 
                 //Quickly check the VM again, to see if a packet has arrived.

--- a/src/mscorlib/src/System/Threading/Tasks/Task.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/Task.cs
@@ -2437,7 +2437,7 @@ namespace System.Threading.Tasks
                     else
                     {
                         // Invoke it under the captured ExecutionContext
-                        ExecutionContext.Run(ec, s_ecCallback, this);
+                        ExecutionContext.RunInternal(ec, s_ecCallback, this);
                     }
                 }
                 catch (Exception exn)

--- a/src/mscorlib/src/System/Threading/Thread.cs
+++ b/src/mscorlib/src/System/Threading/Thread.cs
@@ -65,9 +65,10 @@ namespace System.Threading
         internal void ThreadStart(object obj)
         {
             _startArg = obj;
-            if (_executionContext != null)
+            ExecutionContext context = _executionContext;
+            if (context != null)
             {
-                ExecutionContext.Run(_executionContext, _ccb, (Object)this);
+                ExecutionContext.RunInternal(context, _ccb, (Object)this);
             }
             else
             {
@@ -78,9 +79,10 @@ namespace System.Threading
         // call back helper
         internal void ThreadStart()
         {
-            if (_executionContext != null)
+            ExecutionContext context = _executionContext;
+            if (context != null)
             {
-                ExecutionContext.Run(_executionContext, _ccb, (Object)this);
+                ExecutionContext.RunInternal(context, _ccb, (Object)this);
             }
             else
             {

--- a/src/mscorlib/src/System/Threading/ThreadPool.cs
+++ b/src/mscorlib/src/System/Threading/ThreadPool.cs
@@ -1287,9 +1287,9 @@ namespace System.Threading
 
             ExecutionContext context = ExecutionContext.Capture();
 
-            IThreadPoolWorkItem tpcallBack = (context == null || !context.IsDefault) ?
-                new QueueUserWorkItemCallback(callBack, state, context) :
-                (IThreadPoolWorkItem)new QueueUserWorkItemCallbackDefaultContext(callBack, state);
+            IThreadPoolWorkItem tpcallBack = (context != null && context.IsDefault) ?
+                new QueueUserWorkItemCallbackDefaultContext(callBack, state) :
+                (IThreadPoolWorkItem)new QueueUserWorkItemCallback(callBack, state, context);
 
             ThreadPoolGlobals.workQueue.Enqueue(tpcallBack, forceGlobal: !preferLocal);
 

--- a/src/mscorlib/src/System/Threading/ThreadPool.cs
+++ b/src/mscorlib/src/System/Threading/ThreadPool.cs
@@ -1000,7 +1000,8 @@ namespace System.Threading
 #if DEBUG
             MarkExecuted(aborted: false);
 #endif
-            ExecutionContext.RunInternal(ExecutionContext.Default, ccb, this);
+            // null executionContext on RunInternal is Default context
+            ExecutionContext.RunInternal(executionContext: null, ccb, this);
         }
 
         void IThreadPoolWorkItem.MarkAborted(ThreadAbortException tae)

--- a/src/mscorlib/src/System/Threading/ThreadPool.cs
+++ b/src/mscorlib/src/System/Threading/ThreadPool.cs
@@ -896,9 +896,9 @@ namespace System.Threading
 
     internal sealed class QueueUserWorkItemCallback : IThreadPoolWorkItem
     {
-        private WaitCallback callback;
-        private readonly ExecutionContext context;
-        private readonly Object state;
+        private WaitCallback _callback;
+        private readonly ExecutionContext _context;
+        private readonly Object _state;
 
 #if DEBUG
         private volatile int executed;
@@ -921,9 +921,9 @@ namespace System.Threading
 
         internal QueueUserWorkItemCallback(WaitCallback waitCallback, Object stateObj, ExecutionContext ec)
         {
-            callback = waitCallback;
-            state = stateObj;
-            context = ec;
+            _callback = waitCallback;
+            _state = stateObj;
+            _context = ec;
         }
 
         void IThreadPoolWorkItem.ExecuteWorkItem()
@@ -932,15 +932,16 @@ namespace System.Threading
             MarkExecuted(aborted: false);
 #endif
             // call directly if it is an unsafe call OR EC flow is suppressed
+            ExecutionContext context = _context;
             if (context == null)
             {
-                WaitCallback cb = callback;
-                callback = null;
-                cb(state);
+                WaitCallback cb = _callback;
+                _callback = null;
+                cb(_state);
             }
             else
             {
-                ExecutionContext.Run(context, ccb, this);
+                ExecutionContext.RunInternal(context, ccb, this);
             }
         }
 
@@ -958,9 +959,9 @@ namespace System.Threading
         private static void WaitCallback_Context(Object state)
         {
             QueueUserWorkItemCallback obj = (QueueUserWorkItemCallback)state;
-            WaitCallback wc = obj.callback;
+            WaitCallback wc = obj._callback;
             Debug.Assert(null != wc);
-            wc(obj.state);
+            wc(obj._state);
         }
     }
 
@@ -999,7 +1000,7 @@ namespace System.Threading
 #if DEBUG
             MarkExecuted(aborted: false);
 #endif
-            ExecutionContext.Run(ExecutionContext.Default, ccb, this);
+            ExecutionContext.RunInternal(ExecutionContext.Default, ccb, this);
         }
 
         void IThreadPoolWorkItem.MarkAborted(ThreadAbortException tae)
@@ -1061,14 +1062,15 @@ namespace System.Threading
             _ThreadPoolWaitOrTimerCallback helper = (_ThreadPoolWaitOrTimerCallback)state;
             Debug.Assert(helper != null, "Null state passed to PerformWaitOrTimerCallback!");
             // call directly if it is an unsafe call OR EC flow is suppressed
-            if (helper._executionContext == null)
+            ExecutionContext context = helper._executionContext;
+            if (context == null)
             {
                 WaitOrTimerCallback callback = helper._waitOrTimerCallback;
                 callback(helper._state, timedOut);
             }
             else
             {
-                ExecutionContext.Run(helper._executionContext, timedOut ? _ccbt : _ccbf, helper);
+                ExecutionContext.Run(context, timedOut ? _ccbt : _ccbf, helper);
             }
         }
     }
@@ -1284,9 +1286,9 @@ namespace System.Threading
 
             ExecutionContext context = ExecutionContext.Capture();
 
-            IThreadPoolWorkItem tpcallBack = context == ExecutionContext.Default ?
-                new QueueUserWorkItemCallbackDefaultContext(callBack, state) :
-                (IThreadPoolWorkItem)new QueueUserWorkItemCallback(callBack, state, context);
+            IThreadPoolWorkItem tpcallBack = (context == null || !context.IsDefault) ?
+                new QueueUserWorkItemCallback(callBack, state, context) :
+                (IThreadPoolWorkItem)new QueueUserWorkItemCallbackDefaultContext(callBack, state);
 
             ThreadPoolGlobals.workQueue.Enqueue(tpcallBack, forceGlobal: !preferLocal);
 

--- a/src/mscorlib/src/System/Threading/Timer.cs
+++ b/src/mscorlib/src/System/Threading/Timer.cs
@@ -600,13 +600,14 @@ namespace System.Threading
                 FrameworkEventSource.Log.ThreadTransferReceiveObj(this, 1, string.Empty);
 
             // call directly if EC flow is suppressed
-            if (m_executionContext == null)
+            ExecutionContext context = m_executionContext;
+            if (context == null)
             {
                 m_timerCallback(m_state);
             }
             else
             {
-                ExecutionContext.Run(m_executionContext, s_callCallbackInContext, this);
+                ExecutionContext.RunInternal(context, s_callCallbackInContext, this);
             }
         }
 


### PR DESCRIPTION
x 1.94 speed up for `ExecutionContext.Run(ec, (o) => { }, null);` where `ec == Default`
x 1.57 speed up for `ExecutionContext.Run(ec, (o) => { }, null);` with `AsyncLocal`s (no notifications)

Results https://github.com/dotnet/coreclr/pull/15629#issuecomment-355708318

Alternative approach to https://github.com/dotnet/coreclr/pull/11100 as suggested by @kouvel https://github.com/dotnet/coreclr/pull/11100#discussion_r113028941

When `Default` context is used in `Run` use it as `null`; which also counts as Default - rather than having two forms of `Default` context internally (Thread starts will null) and saving and restoring between them.

```
                Method |   Current |       New |    Change |
---------------------- |----------:|----------:|----------:|
        Run Default EC | 14.134 ns |  7.303 ns |    x 1.94 |
 Run w/ AsyncLocals EC | 11.986 ns |  7.631 ns |    x 1.57 | 
                 await |  3.152 ns |  3.158 ns |    x 1.00 | 
```

ASP.NET Kestrel Plaintext call counts

**Pre**
![image](https://user-images.githubusercontent.com/1142958/35485603-fbb48a50-0459-11e8-851a-7c1aa3c54564.png)

**Post**
![image](https://user-images.githubusercontent.com/1142958/35485607-09e47914-045a-11e8-950b-9fc04383e2d0.png)


Resolves #11126 
  