### PR TITLE
Use lower contention local TP queues

### DIFF
--- a/src/mscorlib/src/System/Runtime/CompilerServices/YieldAwaitable.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/YieldAwaitable.cs
@@ -100,11 +100,11 @@ namespace System.Runtime.CompilerServices
                     {
                         if (flowContext)
                         {
-                            ThreadPool.QueueUserWorkItem(s_waitCallbackRunAction, continuation);
+                            ThreadPool.QueueUserWorkItem(s_waitCallbackRunAction, continuation, preferLocal: true);
                         }
                         else
                         {
-                            ThreadPool.UnsafeQueueUserWorkItem(s_waitCallbackRunAction, continuation);
+                            ThreadPool.UnsafeQueueUserWorkItem(s_waitCallbackRunAction, continuation, preferLocal: true);
                         }
                     }
                     // We're targeting a custom scheduler, so queue a task.

--- a/src/mscorlib/src/System/Threading/ThreadPool.cs
+++ b/src/mscorlib/src/System/Threading/ThreadPool.cs
@@ -1293,7 +1293,10 @@ namespace System.Threading
             return true;
         }
 
-        public static bool UnsafeQueueUserWorkItem(WaitCallback callBack, Object state)
+        public static bool UnsafeQueueUserWorkItem(WaitCallback callBack, Object state) =>
+            UnsafeQueueUserWorkItem(callBack, state, preferLocal: false);
+
+        internal static bool UnsafeQueueUserWorkItem(WaitCallback callBack, Object state, bool preferLocal)
         {
             if (callBack == null)
             {
@@ -1304,7 +1307,7 @@ namespace System.Threading
 
             IThreadPoolWorkItem tpcallBack = new QueueUserWorkItemCallback(callBack, state, null);
 
-            ThreadPoolGlobals.workQueue.Enqueue(tpcallBack, forceGlobal: true);
+            ThreadPoolGlobals.workQueue.Enqueue(tpcallBack, forceGlobal: !preferLocal);
 
             return true;
         }


### PR DESCRIPTION
When fairness is not required, use lower contention local TP queues rather than the single global one

/cc @stephentoub 