### PR TITLE
Updating Compiler::impIntrinsic to always expand hardware intrinsics.

### DIFF
--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Add.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Add.cs
@@ -30,11 +30,6 @@ namespace IntelHardwareIntrinsicTest
                     var vf3 = Avx.Add(vf1, vf2);
                     Unsafe.Write(floatTable.outArrayPtr, vf3);
 
-                    var vd1 = Unsafe.Read<Vector256<double>>(doubleTable.inArray1Ptr);
-                    var vd2 = Unsafe.Read<Vector256<double>>(doubleTable.inArray2Ptr);
-                    var vd3 = Avx.Add(vd1, vd2);
-                    Unsafe.Write(doubleTable.outArrayPtr, vd3);
-
                     if (!floatTable.CheckResult((x, y, z) => x + y == z))
                     {
                         Console.WriteLine("AVX Add failed on float:");
@@ -46,9 +41,42 @@ namespace IntelHardwareIntrinsicTest
                         testResult = Fail;
                     }
 
+                    vf3 = (Vector256<float>)typeof(Avx).GetMethod(nameof(Avx.Add), new Type[] { vf1.GetType(), vf2.GetType() }).Invoke(null, new object[] { vf1, vf2 });
+                    Unsafe.Write(floatTable.outArrayPtr, vf3);
+
+                    if (!floatTable.CheckResult((x, y, z) => x + y == z))
+                    {
+                        Console.WriteLine("AVX Add failed via reflection on float:");
+                        foreach (var item in floatTable.outArray)
+                        {
+                            Console.Write(item + ", ");
+                        }
+                        Console.WriteLine();
+                        testResult = Fail;
+                    }
+
+                    var vd1 = Unsafe.Read<Vector256<double>>(doubleTable.inArray1Ptr);
+                    var vd2 = Unsafe.Read<Vector256<double>>(doubleTable.inArray2Ptr);
+                    var vd3 = Avx.Add(vd1, vd2);
+                    Unsafe.Write(doubleTable.outArrayPtr, vd3);
+
                     if (!doubleTable.CheckResult((x, y, z) => x + y == z))
                     {
                         Console.WriteLine("AVX Add failed on double:");
+                        foreach (var item in doubleTable.outArray)
+                        {
+                            Console.Write(item + ", ");
+                        }
+                        Console.WriteLine();
+                        testResult = Fail;
+                    }
+
+                    vd3 = (Vector256<double>)typeof(Avx).GetMethod(nameof(Avx.Add), new Type[] { vd1.GetType(), vd2.GetType() }).Invoke(null, new object[] { vd1, vd2 });
+                    Unsafe.Write(doubleTable.outArrayPtr, vd3);
+
+                    if (!doubleTable.CheckResult((x, y, z) => x + y == z))
+                    {
+                        Console.WriteLine("AVX Add failed via reflection on double:");
                         foreach (var item in doubleTable.outArray)
                         {
                             Console.Write(item + ", ");

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/Add.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/Add.cs
@@ -37,41 +37,6 @@ namespace IntelHardwareIntrinsicTest
                     var vi3 = Avx2.Add(vi1, vi2);
                     Unsafe.Write(intTable.outArrayPtr, vi3);
 
-                    var vl1 = Unsafe.Read<Vector256<long>>(longTable.inArray1Ptr);
-                    var vl2 = Unsafe.Read<Vector256<long>>(longTable.inArray2Ptr);
-                    var vl3 = Avx2.Add(vl1, vl2);
-                    Unsafe.Write(longTable.outArrayPtr, vl3);
-
-                    var vui1 = Unsafe.Read<Vector256<uint>>(uintTable.inArray1Ptr);
-                    var vui2 = Unsafe.Read<Vector256<uint>>(uintTable.inArray2Ptr);
-                    var vui3 = Avx2.Add(vui1, vui2);
-                    Unsafe.Write(uintTable.outArrayPtr, vui3);
-
-                    var vul1 = Unsafe.Read<Vector256<ulong>>(ulongTable.inArray1Ptr);
-                    var vul2 = Unsafe.Read<Vector256<ulong>>(ulongTable.inArray2Ptr);
-                    var vul3 = Avx2.Add(vul1, vul2);
-                    Unsafe.Write(ulongTable.outArrayPtr, vul3);
-
-                    var vs1 = Unsafe.Read<Vector256<short>>(shortTable.inArray1Ptr);
-                    var vs2 = Unsafe.Read<Vector256<short>>(shortTable.inArray2Ptr);
-                    var vs3 = Avx2.Add(vs1, vs2);
-                    Unsafe.Write(shortTable.outArrayPtr, vs3);
-
-                    var vus1 = Unsafe.Read<Vector256<ushort>>(ushortTable.inArray1Ptr);
-                    var vus2 = Unsafe.Read<Vector256<ushort>>(ushortTable.inArray2Ptr);
-                    var vus3 = Avx2.Add(vus1, vus2);
-                    Unsafe.Write(ushortTable.outArrayPtr, vus3);
-
-                    var vsb1 = Unsafe.Read<Vector256<sbyte>>(sbyteTable.inArray1Ptr);
-                    var vsb2 = Unsafe.Read<Vector256<sbyte>>(sbyteTable.inArray2Ptr);
-                    var vsb3 = Avx2.Add(vsb1, vsb2);
-                    Unsafe.Write(sbyteTable.outArrayPtr, vsb3);
-
-                    var vb1 = Unsafe.Read<Vector256<byte>>(byteTable.inArray1Ptr);
-                    var vb2 = Unsafe.Read<Vector256<byte>>(byteTable.inArray2Ptr);
-                    var vb3 = Avx2.Add(vb1, vb2);
-                    Unsafe.Write(byteTable.outArrayPtr, vb3);
-
                     if (!intTable.CheckResult((x, y, z) => x + y == z))
                     {
                         Console.WriteLine("AVX2 Add failed on int:");
@@ -82,6 +47,25 @@ namespace IntelHardwareIntrinsicTest
                         Console.WriteLine();
                         testResult = Fail;
                     }
+
+                    vi3 = (Vector256<int>)typeof(Avx2).GetMethod(nameof(Avx2.Add), new Type[] { vi1.GetType(), vi2.GetType() }).Invoke(null, new object[] { vi1, vi2 });
+                    Unsafe.Write(intTable.outArrayPtr, vi3);
+
+                    if (!intTable.CheckResult((x, y, z) => x + y == z))
+                    {
+                        Console.WriteLine("AVX2 Add failed via reflection on int:");
+                        foreach (var item in intTable.outArray)
+                        {
+                            Console.Write(item + ", ");
+                        }
+                        Console.WriteLine();
+                        testResult = Fail;
+                    }
+
+                    var vl1 = Unsafe.Read<Vector256<long>>(longTable.inArray1Ptr);
+                    var vl2 = Unsafe.Read<Vector256<long>>(longTable.inArray2Ptr);
+                    var vl3 = Avx2.Add(vl1, vl2);
+                    Unsafe.Write(longTable.outArrayPtr, vl3);
 
                     if (!longTable.CheckResult((x, y, z) => x + y == z))
                     {
@@ -94,6 +78,25 @@ namespace IntelHardwareIntrinsicTest
                         testResult = Fail;
                     }
 
+                    vl3 = (Vector256<long>)typeof(Avx2).GetMethod(nameof(Avx2.Add), new Type[] { vl1.GetType(), vl2.GetType() }).Invoke(null, new object[] { vl1, vl2 });
+                    Unsafe.Write(longTable.outArrayPtr, vl3);
+
+                    if (!longTable.CheckResult((x, y, z) => x + y == z))
+                    {
+                        Console.WriteLine("AVX2 Add failed via reflection on long:");
+                        foreach (var item in longTable.outArray)
+                        {
+                            Console.Write(item + ", ");
+                        }
+                        Console.WriteLine();
+                        testResult = Fail;
+                    }
+
+                    var vui1 = Unsafe.Read<Vector256<uint>>(uintTable.inArray1Ptr);
+                    var vui2 = Unsafe.Read<Vector256<uint>>(uintTable.inArray2Ptr);
+                    var vui3 = Avx2.Add(vui1, vui2);
+                    Unsafe.Write(uintTable.outArrayPtr, vui3);
+
                     if (!uintTable.CheckResult((x, y, z) => x + y == z))
                     {
                         Console.WriteLine("AVX2 Add failed on uint:");
@@ -104,6 +107,25 @@ namespace IntelHardwareIntrinsicTest
                         Console.WriteLine();
                         testResult = Fail;
                     }
+
+                    vui3 = (Vector256<uint>)typeof(Avx2).GetMethod(nameof(Avx2.Add), new Type[] { vui1.GetType(), vui2.GetType() }).Invoke(null, new object[] { vui1, vui2 });
+                    Unsafe.Write(uintTable.outArrayPtr, vui3);
+
+                    if (!uintTable.CheckResult((x, y, z) => x + y == z))
+                    {
+                        Console.WriteLine("AVX2 Add failed via reflection on uint:");
+                        foreach (var item in uintTable.outArray)
+                        {
+                            Console.Write(item + ", ");
+                        }
+                        Console.WriteLine();
+                        testResult = Fail;
+                    }
+
+                    var vul1 = Unsafe.Read<Vector256<ulong>>(ulongTable.inArray1Ptr);
+                    var vul2 = Unsafe.Read<Vector256<ulong>>(ulongTable.inArray2Ptr);
+                    var vul3 = Avx2.Add(vul1, vul2);
+                    Unsafe.Write(ulongTable.outArrayPtr, vul3);
 
                     if (!ulongTable.CheckResult((x, y, z) => x + y == z))
                     {
@@ -116,6 +138,25 @@ namespace IntelHardwareIntrinsicTest
                         testResult = Fail;
                     }
 
+                    vul3 = (Vector256<ulong>)typeof(Avx2).GetMethod(nameof(Avx2.Add), new Type[] { vul1.GetType(), vul2.GetType() }).Invoke(null, new object[] { vul1, vul2 });
+                    Unsafe.Write(ulongTable.outArrayPtr, vul3);
+
+                    if (!ulongTable.CheckResult((x, y, z) => x + y == z))
+                    {
+                        Console.WriteLine("AVX2 Add failed via reflection on ulong:");
+                        foreach (var item in ulongTable.outArray)
+                        {
+                            Console.Write(item + ", ");
+                        }
+                        Console.WriteLine();
+                        testResult = Fail;
+                    }
+
+                    var vs1 = Unsafe.Read<Vector256<short>>(shortTable.inArray1Ptr);
+                    var vs2 = Unsafe.Read<Vector256<short>>(shortTable.inArray2Ptr);
+                    var vs3 = Avx2.Add(vs1, vs2);
+                    Unsafe.Write(shortTable.outArrayPtr, vs3);
+
                     if (!shortTable.CheckResult((x, y, z) => x + y == z))
                     {
                         Console.WriteLine("AVX2 Add failed on short:");
@@ -126,6 +167,25 @@ namespace IntelHardwareIntrinsicTest
                         Console.WriteLine();
                         testResult = Fail;
                     }
+
+                    vs3 = (Vector256<short>)typeof(Avx2).GetMethod(nameof(Avx2.Add), new Type[] { vs1.GetType(), vs2.GetType() }).Invoke(null, new object[] { vs1, vs2 });
+                    Unsafe.Write(shortTable.outArrayPtr, vs3);
+
+                    if (!shortTable.CheckResult((x, y, z) => x + y == z))
+                    {
+                        Console.WriteLine("AVX2 Add failed via reflection on short:");
+                        foreach (var item in shortTable.outArray)
+                        {
+                            Console.Write(item + ", ");
+                        }
+                        Console.WriteLine();
+                        testResult = Fail;
+                    }
+
+                    var vus1 = Unsafe.Read<Vector256<ushort>>(ushortTable.inArray1Ptr);
+                    var vus2 = Unsafe.Read<Vector256<ushort>>(ushortTable.inArray2Ptr);
+                    var vus3 = Avx2.Add(vus1, vus2);
+                    Unsafe.Write(ushortTable.outArrayPtr, vus3);
 
                     if (!ushortTable.CheckResult((x, y, z) => x + y == z))
                     {
@@ -138,6 +198,25 @@ namespace IntelHardwareIntrinsicTest
                         testResult = Fail;
                     }
 
+                    vus3 = (Vector256<ushort>)typeof(Avx2).GetMethod(nameof(Avx2.Add), new Type[] { vus1.GetType(), vus2.GetType() }).Invoke(null, new object[] { vus1, vus2 });
+                    Unsafe.Write(ushortTable.outArrayPtr, vus3);
+
+                    if (!ushortTable.CheckResult((x, y, z) => x + y == z))
+                    {
+                        Console.WriteLine("AVX2 Add failed via reflection on ushort:");
+                        foreach (var item in ushortTable.outArray)
+                        {
+                            Console.Write(item + ", ");
+                        }
+                        Console.WriteLine();
+                        testResult = Fail;
+                    }
+
+                    var vsb1 = Unsafe.Read<Vector256<sbyte>>(sbyteTable.inArray1Ptr);
+                    var vsb2 = Unsafe.Read<Vector256<sbyte>>(sbyteTable.inArray2Ptr);
+                    var vsb3 = Avx2.Add(vsb1, vsb2);
+                    Unsafe.Write(sbyteTable.outArrayPtr, vsb3);
+
                     if (!sbyteTable.CheckResult((x, y, z) => x + y == z))
                     {
                         Console.WriteLine("AVX2 Add failed on sbyte:");
@@ -149,6 +228,25 @@ namespace IntelHardwareIntrinsicTest
                         testResult = Fail;
                     }
 
+                    vsb3 = (Vector256<sbyte>)typeof(Avx2).GetMethod(nameof(Avx2.Add), new Type[] { vsb1.GetType(), vsb2.GetType() }).Invoke(null, new object[] { vsb1, vsb2 });
+                    Unsafe.Write(sbyteTable.outArrayPtr, vsb3);
+
+                    if (!sbyteTable.CheckResult((x, y, z) => x + y == z))
+                    {
+                        Console.WriteLine("AVX2 Add failed via reflection on sbyte:");
+                        foreach (var item in sbyteTable.outArray)
+                        {
+                            Console.Write(item + ", ");
+                        }
+                        Console.WriteLine();
+                        testResult = Fail;
+                    }
+
+                    var vb1 = Unsafe.Read<Vector256<byte>>(byteTable.inArray1Ptr);
+                    var vb2 = Unsafe.Read<Vector256<byte>>(byteTable.inArray2Ptr);
+                    var vb3 = Avx2.Add(vb1, vb2);
+                    Unsafe.Write(byteTable.outArrayPtr, vb3);
+
                     if (!byteTable.CheckResult((x, y, z) => x + y == z))
                     {
                         Console.WriteLine("AVX2 Add failed on byte:");
@@ -159,8 +257,21 @@ namespace IntelHardwareIntrinsicTest
                         Console.WriteLine();
                         testResult = Fail;
                     }
-                }
 
+                    vb3 = (Vector256<byte>)typeof(Avx2).GetMethod(nameof(Avx2.Add), new Type[] { vb1.GetType(), vb2.GetType() }).Invoke(null, new object[] { vb1, vb2 });
+                    Unsafe.Write(byteTable.outArrayPtr, vb3);
+
+                    if (!byteTable.CheckResult((x, y, z) => x + y == z))
+                    {
+                        Console.WriteLine("AVX2 Add failed via reflection on byte:");
+                        foreach (var item in byteTable.outArray)
+                        {
+                            Console.Write(item + ", ");
+                        }
+                        Console.WriteLine();
+                        testResult = Fail;
+                    }
+                }
             }
 
             return testResult;

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/Add.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/Add.cs
@@ -40,9 +40,22 @@ namespace IntelHardwareIntrinsicTest
                         Console.WriteLine();
                         testResult = Fail;
                     }
+
+                    vf3 = (Vector128<float>)typeof(Sse).GetMethod(nameof(Sse.Add), new Type[] { vf1.GetType(), vf2.GetType() }).Invoke(null, new object[] { vf1, vf2 });
+                    Unsafe.Write(floatTable.outArrayPtr, vf3);
+
+                    if (!floatTable.CheckResult((x, y, z) => x + y == z))
+                    {
+                        Console.WriteLine("SSE Add failed via reflection on float:");
+                        foreach (var item in floatTable.outArray)
+                        {
+                            Console.Write(item + ", ");
+                        }
+                        Console.WriteLine();
+                        testResult = Fail;
+                    }
                 }
             }
-
 
             return testResult;
         }

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Add.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Add.cs
@@ -37,45 +37,35 @@ namespace IntelHardwareIntrinsicTest
                     var vd3 = Sse2.Add(vd1, vd2);
                     Unsafe.Write(doubleTable.outArrayPtr, vd3);
 
+                    if (!doubleTable.CheckResult((x, y, z) => x + y == z))
+                    {
+                        Console.WriteLine("SSE2 Add failed on double:");
+                        foreach (var item in doubleTable.outArray)
+                        {
+                            Console.Write(item + ", ");
+                        }
+                        Console.WriteLine();
+                        testResult = Fail;
+                    }
+
+                    vd3 = (Vector128<double>)typeof(Sse2).GetMethod(nameof(Sse2.Add), new Type[] { vd1.GetType(), vd2.GetType() }).Invoke(null, new object[] { vd1, vd2 });
+                    Unsafe.Write(doubleTable.outArrayPtr, vd3);
+
+                    if (!doubleTable.CheckResult((x, y, z) => x + y == z))
+                    {
+                        Console.WriteLine("SSE2 Add failed via reflection on double:");
+                        foreach (var item in doubleTable.outArray)
+                        {
+                            Console.Write(item + ", ");
+                        }
+                        Console.WriteLine();
+                        testResult = Fail;
+                    }
+
                     var vi1 = Unsafe.Read<Vector128<int>>(intTable.inArray1Ptr);
                     var vi2 = Unsafe.Read<Vector128<int>>(intTable.inArray2Ptr);
                     var vi3 = Sse2.Add(vi1, vi2);
                     Unsafe.Write(intTable.outArrayPtr, vi3);
- 
-                    var vl1 = Unsafe.Read<Vector128<long>>(longTable.inArray1Ptr);
-                    var vl2 = Unsafe.Read<Vector128<long>>(longTable.inArray2Ptr);
-                    var vl3 = Sse2.Add(vl1, vl2);
-                    Unsafe.Write(longTable.outArrayPtr, vl3);
-
-                    var vui1 = Unsafe.Read<Vector128<uint>>(uintTable.inArray1Ptr);
-                    var vui2 = Unsafe.Read<Vector128<uint>>(uintTable.inArray2Ptr);
-                    var vui3 = Sse2.Add(vui1, vui2);
-                    Unsafe.Write(uintTable.outArrayPtr, vui3);
- 
-                    var vul1 = Unsafe.Read<Vector128<ulong>>(ulongTable.inArray1Ptr);
-                    var vul2 = Unsafe.Read<Vector128<ulong>>(ulongTable.inArray2Ptr);
-                    var vul3 = Sse2.Add(vul1, vul2);
-                    Unsafe.Write(ulongTable.outArrayPtr, vul3);
-
-                    var vs1 = Unsafe.Read<Vector128<short>>(shortTable.inArray1Ptr);
-                    var vs2 = Unsafe.Read<Vector128<short>>(shortTable.inArray2Ptr);
-                    var vs3 = Sse2.Add(vs1, vs2);
-                    Unsafe.Write(shortTable.outArrayPtr, vs3);
-
-                    var vus1 = Unsafe.Read<Vector128<ushort>>(ushortTable.inArray1Ptr);
-                    var vus2 = Unsafe.Read<Vector128<ushort>>(ushortTable.inArray2Ptr);
-                    var vus3 = Sse2.Add(vus1, vus2);
-                    Unsafe.Write(ushortTable.outArrayPtr, vus3);
-
-                    var vsb1 = Unsafe.Read<Vector128<sbyte>>(sbyteTable.inArray1Ptr);
-                    var vsb2 = Unsafe.Read<Vector128<sbyte>>(sbyteTable.inArray2Ptr);
-                    var vsb3 = Sse2.Add(vsb1, vsb2);
-                    Unsafe.Write(sbyteTable.outArrayPtr, vsb3);
-
-                    var vb1 = Unsafe.Read<Vector128<byte>>(byteTable.inArray1Ptr);
-                    var vb2 = Unsafe.Read<Vector128<byte>>(byteTable.inArray2Ptr);
-                    var vb3 = Sse2.Add(vb1, vb2);
-                    Unsafe.Write(byteTable.outArrayPtr, vb3);
 
                     if (!intTable.CheckResult((x, y, z) => x + y == z))
                     {
@@ -88,6 +78,25 @@ namespace IntelHardwareIntrinsicTest
                         testResult = Fail;
                     }
 
+                    vi3 = (Vector128<int>)typeof(Sse2).GetMethod(nameof(Sse2.Add), new Type[] { vi1.GetType(), vi2.GetType() }).Invoke(null, new object[] { vi1, vi2 });
+                    Unsafe.Write(intTable.outArrayPtr, vi3);
+
+                    if (!intTable.CheckResult((x, y, z) => x + y == z))
+                    {
+                        Console.WriteLine("SSE2 Add failed via reflection on int:");
+                        foreach (var item in intTable.outArray)
+                        {
+                            Console.Write(item + ", ");
+                        }
+                        Console.WriteLine();
+                        testResult = Fail;
+                    }
+
+                    var vl1 = Unsafe.Read<Vector128<long>>(longTable.inArray1Ptr);
+                    var vl2 = Unsafe.Read<Vector128<long>>(longTable.inArray2Ptr);
+                    var vl3 = Sse2.Add(vl1, vl2);
+                    Unsafe.Write(longTable.outArrayPtr, vl3);
+
                     if (!longTable.CheckResult((x, y, z) => x + y == z))
                     {
                         Console.WriteLine("SSE2 Add failed on long:");
@@ -98,6 +107,25 @@ namespace IntelHardwareIntrinsicTest
                         Console.WriteLine();
                         testResult = Fail;
                     }
+
+                    vl3 = (Vector128<long>)typeof(Sse2).GetMethod(nameof(Sse2.Add), new Type[] { vl1.GetType(), vl2.GetType() }).Invoke(null, new object[] { vl1, vl2 });
+                    Unsafe.Write(longTable.outArrayPtr, vl3);
+
+                    if (!longTable.CheckResult((x, y, z) => x + y == z))
+                    {
+                        Console.WriteLine("SSE2 Add failed via reflection on long:");
+                        foreach (var item in longTable.outArray)
+                        {
+                            Console.Write(item + ", ");
+                        }
+                        Console.WriteLine();
+                        testResult = Fail;
+                    }
+
+                    var vui1 = Unsafe.Read<Vector128<uint>>(uintTable.inArray1Ptr);
+                    var vui2 = Unsafe.Read<Vector128<uint>>(uintTable.inArray2Ptr);
+                    var vui3 = Sse2.Add(vui1, vui2);
+                    Unsafe.Write(uintTable.outArrayPtr, vui3);
 
                     if (!uintTable.CheckResult((x, y, z) => x + y == z))
                     {
@@ -110,6 +138,25 @@ namespace IntelHardwareIntrinsicTest
                         testResult = Fail;
                     }
 
+                    vui3 = (Vector128<uint>)typeof(Sse2).GetMethod(nameof(Sse2.Add), new Type[] { vui1.GetType(), vui2.GetType() }).Invoke(null, new object[] { vui1, vui2 });
+                    Unsafe.Write(uintTable.outArrayPtr, vui3);
+
+                    if (!uintTable.CheckResult((x, y, z) => x + y == z))
+                    {
+                        Console.WriteLine("SSE2 Add failed via reflection on uint:");
+                        foreach (var item in uintTable.outArray)
+                        {
+                            Console.Write(item + ", ");
+                        }
+                        Console.WriteLine();
+                        testResult = Fail;
+                    }
+
+                    var vul1 = Unsafe.Read<Vector128<ulong>>(ulongTable.inArray1Ptr);
+                    var vul2 = Unsafe.Read<Vector128<ulong>>(ulongTable.inArray2Ptr);
+                    var vul3 = Sse2.Add(vul1, vul2);
+                    Unsafe.Write(ulongTable.outArrayPtr, vul3);
+
                     if (!ulongTable.CheckResult((x, y, z) => x + y == z))
                     {
                         Console.WriteLine("SSE2 Add failed on ulong:");
@@ -120,6 +167,25 @@ namespace IntelHardwareIntrinsicTest
                         Console.WriteLine();
                         testResult = Fail;
                     }
+
+                    vul3 = (Vector128<ulong>)typeof(Sse2).GetMethod(nameof(Sse2.Add), new Type[] { vul1.GetType(), vul2.GetType() }).Invoke(null, new object[] { vul1, vul2 });
+                    Unsafe.Write(ulongTable.outArrayPtr, vul3);
+
+                    if (!ulongTable.CheckResult((x, y, z) => x + y == z))
+                    {
+                        Console.WriteLine("SSE2 Add failed via reflection on ulong:");
+                        foreach (var item in ulongTable.outArray)
+                        {
+                            Console.Write(item + ", ");
+                        }
+                        Console.WriteLine();
+                        testResult = Fail;
+                    }
+
+                    var vs1 = Unsafe.Read<Vector128<short>>(shortTable.inArray1Ptr);
+                    var vs2 = Unsafe.Read<Vector128<short>>(shortTable.inArray2Ptr);
+                    var vs3 = Sse2.Add(vs1, vs2);
+                    Unsafe.Write(shortTable.outArrayPtr, vs3);
 
                     if (!shortTable.CheckResult((x, y, z) => x + y == z))
                     {
@@ -132,6 +198,25 @@ namespace IntelHardwareIntrinsicTest
                         testResult = Fail;
                     }
 
+                    vs3 = (Vector128<short>)typeof(Sse2).GetMethod(nameof(Sse2.Add), new Type[] { vs1.GetType(), vs2.GetType() }).Invoke(null, new object[] { vs1, vs2 });
+                    Unsafe.Write(shortTable.outArrayPtr, vs3);
+
+                    if (!shortTable.CheckResult((x, y, z) => x + y == z))
+                    {
+                        Console.WriteLine("SSE2 Add failed via reflection on short:");
+                        foreach (var item in shortTable.outArray)
+                        {
+                            Console.Write(item + ", ");
+                        }
+                        Console.WriteLine();
+                        testResult = Fail;
+                    }
+
+                    var vus1 = Unsafe.Read<Vector128<ushort>>(ushortTable.inArray1Ptr);
+                    var vus2 = Unsafe.Read<Vector128<ushort>>(ushortTable.inArray2Ptr);
+                    var vus3 = Sse2.Add(vus1, vus2);
+                    Unsafe.Write(ushortTable.outArrayPtr, vus3);
+
                     if (!ushortTable.CheckResult((x, y, z) => x + y == z))
                     {
                         Console.WriteLine("SSE2 Add failed on ushort:");
@@ -143,16 +228,24 @@ namespace IntelHardwareIntrinsicTest
                         testResult = Fail;
                     }
 
-                    if (!doubleTable.CheckResult((x, y, z) => x + y == z))
+                    vus3 = (Vector128<ushort>)typeof(Sse2).GetMethod(nameof(Sse2.Add), new Type[] { vus1.GetType(), vus2.GetType() }).Invoke(null, new object[] { vus1, vus2 });
+                    Unsafe.Write(ushortTable.outArrayPtr, vus3);
+
+                    if (!ushortTable.CheckResult((x, y, z) => x + y == z))
                     {
-                        Console.WriteLine("SSE2 Add failed on double:");
-                        foreach (var item in doubleTable.outArray)
+                        Console.WriteLine("SSE2 Add failed via reflection on ushort:");
+                        foreach (var item in ushortTable.outArray)
                         {
                             Console.Write(item + ", ");
                         }
                         Console.WriteLine();
                         testResult = Fail;
                     }
+
+                    var vsb1 = Unsafe.Read<Vector128<sbyte>>(sbyteTable.inArray1Ptr);
+                    var vsb2 = Unsafe.Read<Vector128<sbyte>>(sbyteTable.inArray2Ptr);
+                    var vsb3 = Sse2.Add(vsb1, vsb2);
+                    Unsafe.Write(sbyteTable.outArrayPtr, vsb3);
 
                     if (!sbyteTable.CheckResult((x, y, z) => x + y == z))
                     {
@@ -165,6 +258,25 @@ namespace IntelHardwareIntrinsicTest
                         testResult = Fail;
                     }
 
+                    vsb3 = (Vector128<sbyte>)typeof(Sse2).GetMethod(nameof(Sse2.Add), new Type[] { vsb1.GetType(), vsb2.GetType() }).Invoke(null, new object[] { vsb1, vsb2 });
+                    Unsafe.Write(sbyteTable.outArrayPtr, vsb3);
+
+                    if (!sbyteTable.CheckResult((x, y, z) => x + y == z))
+                    {
+                        Console.WriteLine("SSE2 Add failed via reflection on sbyte:");
+                        foreach (var item in sbyteTable.outArray)
+                        {
+                            Console.Write(item + ", ");
+                        }
+                        Console.WriteLine();
+                        testResult = Fail;
+                    }
+
+                    var vb1 = Unsafe.Read<Vector128<byte>>(byteTable.inArray1Ptr);
+                    var vb2 = Unsafe.Read<Vector128<byte>>(byteTable.inArray2Ptr);
+                    var vb3 = Sse2.Add(vb1, vb2);
+                    Unsafe.Write(byteTable.outArrayPtr, vb3);
+
                     if (!byteTable.CheckResult((x, y, z) => x + y == z))
                     {
                         Console.WriteLine("SSE2 Add failed on byte:");
@@ -175,6 +287,21 @@ namespace IntelHardwareIntrinsicTest
                         Console.WriteLine();
                         testResult = Fail;
                     }
+
+                    vb3 = (Vector128<byte>)typeof(Sse2).GetMethod(nameof(Sse2.Add), new Type[] { vb1.GetType(), vb2.GetType() }).Invoke(null, new object[] { vb1, vb2 });
+                    Unsafe.Write(byteTable.outArrayPtr, vb3);
+
+                    if (!byteTable.CheckResult((x, y, z) => x + y == z))
+                    {
+                        Console.WriteLine("SSE2 Add failed via reflection on byte:");
+                        foreach (var item in byteTable.outArray)
+                        {
+                            Console.Write(item + ", ");
+                        }
+                        Console.WriteLine();
+                        testResult = Fail;
+                    }
+                
                 }
             }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse42/Crc32.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse42/Crc32.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using System.Reflection;
 using System.Runtime.Intrinsics.X86;
 
 namespace IntelHardwareIntrinsicTest
@@ -26,11 +27,22 @@ namespace IntelHardwareIntrinsicTest
                     Console.WriteLine("Intrinsic Sse42.Crc32 is called on non-supported hardware.");
                     Console.WriteLine("Sse42.IsSupported " + Sse42.IsSupported);
                     Console.WriteLine("Environment.Is64BitProcess " + Environment.Is64BitProcess);
-                    return Fail;
+                    testResult = Fail;
                 }
                 catch (PlatformNotSupportedException)
                 {
-                    testResult = Pass;
+                }
+
+                try
+                {
+                    resl = Convert.ToUInt64(typeof(Sse42).GetMethod(nameof(Sse42.Crc32), new Type[] { s1l.GetType(), s2l.GetType() }).Invoke(null, new object[] { s1l, s2l }));
+                    Console.WriteLine("Intrinsic Sse42.Crc32 is called via reflection on non-supported hardware.");
+                    Console.WriteLine("Sse42.IsSupported " + Sse42.IsSupported);
+                    Console.WriteLine("Environment.Is64BitProcess " + Environment.Is64BitProcess);
+                    testResult = Fail;
+                }
+                catch (TargetInvocationException e) when (e.InnerException is PlatformNotSupportedException)
+                {
                 }
             }
 
@@ -43,10 +55,19 @@ namespace IntelHardwareIntrinsicTest
                     {
                         s1l = longCrcTable[i].s1;
                         s2l = longCrcTable[i].s2;
+
                         resl = Sse42.Crc32(s1l, s2l);
                         if (resl != longCrcTable[i].res)
                         {
                             Console.WriteLine("{0}: Inputs: 0x{1,16:x}, 0x{2,16:x} Expected: 0x{3,16:x} actual: 0x{4,16:x}",
+                                i, s1l, s2l, longCrcTable[i].res, resl);
+                            testResult = Fail;
+                        }
+
+                        resl = Convert.ToUInt64(typeof(Sse42).GetMethod(nameof(Sse42.Crc32), new Type[] { s1l.GetType(), s2l.GetType() }).Invoke(null, new object[] { s1l, s2l }));
+                        if (resl != longCrcTable[i].res)
+                        {
+                            Console.WriteLine("{0}: Inputs: 0x{1,16:x}, 0x{2,16:x} Expected: 0x{3,16:x} actual: 0x{4,16:x} - Reflection",
                                 i, s1l, s2l, longCrcTable[i].res, resl);
                             testResult = Fail;
                         }
@@ -58,10 +79,19 @@ namespace IntelHardwareIntrinsicTest
                 {
                     s1i = intCrcTable[i].s1;
                     s2i = intCrcTable[i].s2;
+
                     resi = Sse42.Crc32(s1i, s2i);
                     if (resi != intCrcTable[i].res)
                     {
                         Console.WriteLine("{0}: Inputs: 0x{1,8:x}, 0x{2,8:x} Expected: 0x{3,8:x} actual: 0x{4,8:x}",
+                            i, s1i, s2i, intCrcTable[i].res, resi);
+                        testResult = Fail;
+                    }
+
+                    resi = Convert.ToUInt32(typeof(Sse42).GetMethod(nameof(Sse42.Crc32), new Type[] { s1i.GetType(), s2i.GetType() }).Invoke(null, new object[] { s1i, s2i }));
+                    if (resi != intCrcTable[i].res)
+                    {
+                        Console.WriteLine("{0}: Inputs: 0x{1,8:x}, 0x{2,8:x} Expected: 0x{3,8:x} actual: 0x{4,8:x} - Reflection",
                             i, s1i, s2i, intCrcTable[i].res, resi);
                         testResult = Fail;
                     }
@@ -72,10 +102,19 @@ namespace IntelHardwareIntrinsicTest
                 {
                     s1i = shortCrcTable[i].s1;
                     s2s = shortCrcTable[i].s2;
+
                     resi = Sse42.Crc32(s1i, s2s);
                     if (resi != shortCrcTable[i].res)
                     {
                         Console.WriteLine("{0}: Inputs: 0x{1,8:x}, 0x{2,8:x} Expected: 0x{3,8:x} actual: 0x{4,8:x}",
+                            i, s1i, s2s, shortCrcTable[i].res, resi);
+                        testResult = Fail;
+                    }
+
+                    resi = Convert.ToUInt32(typeof(Sse42).GetMethod(nameof(Sse42.Crc32), new Type[] { s1i.GetType(), s2s.GetType() }).Invoke(null, new object[] { s1i, s2s }));
+                    if (resi != shortCrcTable[i].res)
+                    {
+                        Console.WriteLine("{0}: Inputs: 0x{1,8:x}, 0x{2,8:x} Expected: 0x{3,8:x} actual: 0x{4,8:x} - Reflection",
                             i, s1i, s2s, shortCrcTable[i].res, resi);
                         testResult = Fail;
                     }
@@ -86,7 +125,16 @@ namespace IntelHardwareIntrinsicTest
                 {
                     s1i = byteCrcTable[i].s1;
                     s2b = byteCrcTable[i].s2;
+
                     resi = Sse42.Crc32(s1i, s2b);
+                    if (resi != byteCrcTable[i].res)
+                    {
+                        Console.WriteLine("{0}: Inputs: 0x{1,8:x}, 0x{2,8:x} Expected: 0x{3,8:x} actual: 0x{4,8:x}",
+                            i, s1i, s2b, byteCrcTable[i].res, resi);
+                        testResult = Fail;
+                    }
+
+                    resi = Convert.ToUInt32(typeof(Sse42).GetMethod(nameof(Sse42.Crc32), new Type[] { s1i.GetType(), s2b.GetType() }).Invoke(null, new object[] { s1i, s2b }));
                     if (resi != byteCrcTable[i].res)
                     {
                         Console.WriteLine("{0}: Inputs: 0x{1,8:x}, 0x{2,8:x} Expected: 0x{3,8:x} actual: 0x{4,8:x}",


### PR DESCRIPTION
### Issue
Hardware intrinsics are not currently expanded inline when `minopts` or `compDbgCode` is enabled.

This means that, rather than the raw instruction being emitted, a call to the hardware intrinsic method is emitted instead (ex: `Sse.Shuffle`).
The hardware intrinsic method itself is recursive and will be expanded when it is jitted.

Because of this, nodes that were originally `GT_CNS_*` are now `GT_LCL_VAR` and methods which require constant parameters fail codegen.

### Resolution

Hardware intrinsics should either always be expanded or have a software fallback implemented for the methods which require constant parameters.

This PR does the former, but it has some drawbacks.
* Reflection, delegates, or other forms of indirect calling will fail for intrinsics which require constant parameters
* Various external parts may need to be updated to work with hardware intrinsics, this includes
  * Debuggers
  * Profilers
  * IL Interpreters
  * JIT minopts
  * etc

NOTE: On the second bullet point above, it may be that the external parts will need to be updated to work with hardware intrinsics for when optimizations are enabled anyways.

The latter (software fallback/not always expanding intrinsics) has several concerns around the usability and performance of hardware intrinsics when optimizations are disabled.

Ex: While some performance degradation is normally expected, hardware intrinsics generally map to a single underlying hardware instructions. Not expanding the intrinsics will result in a call, plus stack spilling, per instruction. This causes the overhead to be significantly greater than a normal method, which will generally execute a series of instructions. This can also cause the hardware intrinsics to perform worse than a naively serial (non-vectorized) algorithm.

### Impacted Intrinsics

This will end up impacting all intrinsics which require a constant parameter for codegen to complete succesfully.

A non exhaustive list includes:
 `Extract`, `Insert`, `ShuffleHigh`, `ShuffleLow`, `ShiftLeftLogical`, `ShiftLeftLogical128BitLane`, `ShiftRightLogical`, `ShiftRightLogical128BitLane`, `ShiftRightArithmetic`, `Blend`, `MultiplySumAbsoluteDifferences`, `CompareImplicitLength`, `CompareExplicitLength`, `CompareImplicitLengthIndex`, `CompareExplicitLengthIndex`, `Compare`, etc...

These intrinsics are spread out across most of the exposed ISAs and several of them have multiple overloads. This means we are looking at a large number of intrinsics that will be impacted.

ARM/ARM64 is adding their own intrinsics as well and will also likely be impacted. I do not currently have a list of which of their intrinsics would be impacted. 
