### PR TITLE
Adding basic containment analysis support for hardware intrinsics.

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -262,6 +262,12 @@ GenTree* Lowering::LowerNode(GenTree* node)
             break;
 #endif //
 
+#ifdef FEATURE_HW_INTRINSICS
+        case GT_HWIntrinsic:
+            LowerHWIntrinsic(node->AsHWIntrinsic());
+            break;
+#endif // FEATURE_HW_INTRINSICS
+
         case GT_LCL_VAR:
             WidenSIMD12IfNecessary(node->AsLclVarCommon());
             break;
@@ -5857,6 +5863,11 @@ void Lowering::ContainCheckNode(GenTree* node)
             ContainCheckSIMD(node->AsSIMD());
             break;
 #endif // FEATURE_SIMD
+#ifdef FEATURE_HW_INTRINSICS
+        case GT_HWIntrinsic:
+            ContainCheckHWIntrinsic(node->AsHWIntrinsic());
+            break;
+#endif // FEATURE_HW_INTRINSICS
         default:
             break;
     }

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -120,6 +120,9 @@ private:
 #ifdef FEATURE_SIMD
     void ContainCheckSIMD(GenTreeSIMD* simdNode);
 #endif // FEATURE_SIMD
+#ifdef FEATURE_HW_INTRINSICS
+    void ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node);
+#endif // FEATURE_HW_INTRINSICS
 
 #ifdef DEBUG
     static void CheckCallArg(GenTree* arg);
@@ -306,6 +309,9 @@ private:
 #ifdef FEATURE_SIMD
     void LowerSIMD(GenTreeSIMD* simdNode);
 #endif // FEATURE_SIMD
+#ifdef FEATURE_HW_INTRINSICS
+    void LowerHWIntrinsic(GenTreeHWIntrinsic* node);
+#endif // FEATURE_HW_INTRINSICS
 
     // Utility functions
     void MorphBlkIntoHelperCall(GenTreePtr pTree, GenTreePtr treeStmt);

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -867,6 +867,19 @@ void Lowering::LowerSIMD(GenTreeSIMD* simdNode)
 }
 #endif // FEATURE_SIMD
 
+#ifdef FEATURE_HW_INTRINSICS
+//----------------------------------------------------------------------------------------------
+// Lowering::LowerHWIntrinsic: Perform containment analysis for a hardware intrinsic node.
+//
+//  Arguments:
+//     node - The hardware intrinsic node.
+//
+void Lowering::LowerHWIntrinsic(GenTreeHWIntrinsic* node)
+{
+    ContainCheckHWIntrinsic(node);
+}
+#endif // FEATURE_HW_INTRINSICS
+
 //----------------------------------------------------------------------------------------------
 // Lowering::IsRMWIndirCandidate:
 //    Returns true if the given operand is a candidate indirection for a read-modify-write
@@ -2277,6 +2290,28 @@ void Lowering::ContainCheckSIMD(GenTreeSIMD* simdNode)
     }
 }
 #endif // FEATURE_SIMD
+
+#ifdef FEATURE_HW_INTRINSICS
+//----------------------------------------------------------------------------------------------
+// ContainCheckHWIntrinsic: Perform containment analysis for a hardware intrinsic node.
+//
+//  Arguments:
+//     node - The hardware intrinsic node.
+//
+void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
+{
+    NamedIntrinsic intrinsicID = node->gtHWIntrinsicId;
+    GenTree*       op1         = node->gtOp.gtOp1;
+    GenTree*       op2         = node->gtOp.gtOp2;
+
+    switch (node->gtHWIntrinsicId)
+    {
+        default:
+            assert((intrinsicID > NI_HW_INTRINSIC_START) && (intrinsicID < NI_HW_INTRINSIC_END));
+            break;
+    }
+}
+#endif // FEATURE_HW_INTRINSICS
 
 //------------------------------------------------------------------------
 // ContainCheckFloatBinary: determine whether the sources of a floating point binary node should be contained.


### PR DESCRIPTION
Adds the basic support to lowerxarch so we can begin marking `gtOp`s for containment.