### PR TITLE
Updating hardware intrinsics codegen to be table driven

### DIFF
--- a/src/jit/hwintrinsiccodegenxarch.cpp
+++ b/src/jit/hwintrinsiccodegenxarch.cpp
@@ -116,6 +116,7 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
 {
     NamedIntrinsic intrinsicID = node->gtHWIntrinsicId;
     InstructionSet isa         = compiler->isaOfHWIntrinsic(intrinsicID);
+
     switch (isa)
     {
         case InstructionSet_SSE:
@@ -178,23 +179,23 @@ void CodeGen::genSSEIntrinsic(GenTreeHWIntrinsic* node)
     var_types      targetType  = node->TypeGet();
     var_types      baseType    = node->gtSIMDBaseType;
 
-    regNumber op1Reg = op1->gtRegNum;
-    regNumber op2Reg = REG_NA;
-    emitter*  emit   = getEmitter();
-
+    instruction ins  = INS_invalid;
+    emitter*    emit = getEmitter();
     genConsumeOperands(node);
 
     switch (intrinsicID)
     {
         case NI_SSE_Add:
-            assert(baseType == TYP_FLOAT);
-            op2Reg = op2->gtRegNum;
-            emit->emitIns_SIMD_R_R_R(INS_addps, targetReg, op1Reg, op2Reg, TYP_SIMD16);
+            assert(ivalOfHWIntrinsic(intrinsicID) == -1);
+            ins = insOfHWIntrinsic(intrinsicID, baseType);
+            emit->emitIns_SIMD_R_R_R(ins, targetReg, op1->gtRegNum, op2->gtRegNum, TYP_SIMD16);
             break;
+
         default:
             unreached();
             break;
     }
+
     genProduceReg(node);
 }
 
@@ -207,52 +208,23 @@ void CodeGen::genSSE2Intrinsic(GenTreeHWIntrinsic* node)
     var_types      targetType  = node->TypeGet();
     var_types      baseType    = node->gtSIMDBaseType;
 
-    regNumber op1Reg = op1->gtRegNum;
-    regNumber op2Reg = REG_NA;
-    emitter*  emit   = getEmitter();
-
+    instruction ins  = INS_invalid;
+    emitter*    emit = getEmitter();
     genConsumeOperands(node);
 
     switch (intrinsicID)
     {
         case NI_SSE2_Add:
-        {
-            op2Reg = op2->gtRegNum;
-
-            instruction ins;
-            switch (baseType)
-            {
-                case TYP_DOUBLE:
-                    ins = INS_addpd;
-                    break;
-                case TYP_INT:
-                case TYP_UINT:
-                    ins = INS_paddd;
-                    break;
-                case TYP_LONG:
-                case TYP_ULONG:
-                    ins = INS_paddq;
-                    break;
-                case TYP_BYTE:
-                case TYP_UBYTE:
-                    ins = INS_paddb;
-                    break;
-                case TYP_SHORT:
-                case TYP_USHORT:
-                    ins = INS_paddw;
-                    break;
-                default:
-                    unreached();
-                    break;
-            }
-
-            emit->emitIns_SIMD_R_R_R(ins, targetReg, op1Reg, op2Reg, TYP_SIMD16);
+            assert(ivalOfHWIntrinsic(intrinsicID) == -1);
+            ins = insOfHWIntrinsic(intrinsicID, baseType);
+            emit->emitIns_SIMD_R_R_R(ins, targetReg, op1->gtRegNum, op2->gtRegNum, TYP_SIMD16);
             break;
-        }
+
         default:
             unreached();
             break;
     }
+
     genProduceReg(node);
 }
 
@@ -277,39 +249,34 @@ void CodeGen::genSSE42Intrinsic(GenTreeHWIntrinsic* node)
     GenTree*       op1         = node->gtGetOp1();
     GenTree*       op2         = node->gtGetOp2();
     regNumber      targetReg   = node->gtRegNum;
-    assert(targetReg != REG_NA);
-    var_types targetType = node->TypeGet();
-    var_types baseType   = node->gtSIMDBaseType;
+    var_types      targetType  = node->TypeGet();
+    var_types      baseType    = node->gtSIMDBaseType;
 
-    regNumber op1Reg = op1->gtRegNum;
-    regNumber op2Reg = op2->gtRegNum;
+    instruction ins = INS_invalid;
     genConsumeOperands(node);
 
     switch (intrinsicID)
     {
         case NI_SSE42_Crc32:
+        {
+            assert(ivalOfHWIntrinsic(intrinsicID) == -1);
+            regNumber op1Reg = op1->gtRegNum;
+
             if (op1Reg != targetReg)
             {
                 inst_RV_RV(INS_mov, targetReg, op1Reg, targetType, emitTypeSize(targetType));
             }
 
-            if (baseType == TYP_UBYTE || baseType == TYP_USHORT) // baseType is the type of the second argument
-            {
-                assert(targetType == TYP_INT);
-                inst_RV_RV(INS_crc32, targetReg, op2Reg, baseType, emitTypeSize(baseType));
-            }
-            else
-            {
-                assert(op1->TypeGet() == op2->TypeGet());
-                assert(targetType == TYP_INT || targetType == TYP_LONG);
-                inst_RV_RV(INS_crc32, targetReg, op2Reg, targetType, emitTypeSize(targetType));
-            }
-
+            ins = insOfHWIntrinsic(intrinsicID, baseType);
+            inst_RV_RV(ins, targetReg, op2->gtRegNum, baseType, emitTypeSize(baseType));
             break;
+        }
+
         default:
             unreached();
             break;
     }
+
     genProduceReg(node);
 }
 
@@ -322,39 +289,23 @@ void CodeGen::genAVXIntrinsic(GenTreeHWIntrinsic* node)
     var_types      targetType  = node->TypeGet();
     var_types      baseType    = node->gtSIMDBaseType;
 
-    regNumber op1Reg = op1->gtRegNum;
-    regNumber op2Reg = REG_NA;
-
+    instruction ins  = INS_invalid;
+    emitter*    emit = getEmitter();
     genConsumeOperands(node);
 
-    emitter* emit = getEmitter();
     switch (intrinsicID)
     {
         case NI_AVX_Add:
-        {
-            op2Reg = op2->gtRegNum;
-
-            instruction ins;
-            switch (baseType)
-            {
-                case TYP_DOUBLE:
-                    ins = INS_addpd;
-                    break;
-                case TYP_FLOAT:
-                    ins = INS_addps;
-                    break;
-                default:
-                    unreached();
-                    break;
-            }
-
-            emit->emitIns_R_R_R(ins, emitTypeSize(TYP_SIMD32), targetReg, op1Reg, op2Reg);
+            assert(ivalOfHWIntrinsic(intrinsicID) == -1);
+            ins = insOfHWIntrinsic(intrinsicID, baseType);
+            emit->emitIns_R_R_R(ins, emitTypeSize(TYP_SIMD32), targetReg, op1->gtRegNum, op2->gtRegNum);
             break;
-        }
+
         default:
             unreached();
             break;
     }
+
     genProduceReg(node);
 }
 
@@ -367,49 +318,24 @@ void CodeGen::genAVX2Intrinsic(GenTreeHWIntrinsic* node)
     var_types      targetType  = node->TypeGet();
     var_types      baseType    = node->gtSIMDBaseType;
 
-    regNumber op1Reg = op1->gtRegNum;
-    regNumber op2Reg = REG_NA;
+    instruction ins  = INS_invalid;
+    emitter*    emit = getEmitter();
 
     genConsumeOperands(node);
 
-    emitter* emit = getEmitter();
     switch (intrinsicID)
     {
         case NI_AVX2_Add:
-        {
-            op2Reg = op2->gtRegNum;
-
-            instruction ins;
-            switch (baseType)
-            {
-                case TYP_INT:
-                case TYP_UINT:
-                    ins = INS_paddd;
-                    break;
-                case TYP_LONG:
-                case TYP_ULONG:
-                    ins = INS_paddq;
-                    break;
-                case TYP_BYTE:
-                case TYP_UBYTE:
-                    ins = INS_paddb;
-                    break;
-                case TYP_SHORT:
-                case TYP_USHORT:
-                    ins = INS_paddw;
-                    break;
-                default:
-                    unreached();
-                    break;
-            }
-
-            emit->emitIns_R_R_R(ins, emitTypeSize(TYP_SIMD32), targetReg, op1Reg, op2Reg);
+            assert(ivalOfHWIntrinsic(intrinsicID) == -1);
+            ins = insOfHWIntrinsic(intrinsicID, baseType);
+            emit->emitIns_R_R_R(ins, emitTypeSize(TYP_SIMD32), targetReg, op1->gtRegNum, op2->gtRegNum);
             break;
-        }
+
         default:
             unreached();
             break;
     }
+
     genProduceReg(node);
 }
 
@@ -435,18 +361,13 @@ void CodeGen::genFMAIntrinsic(GenTreeHWIntrinsic* node)
 
 void CodeGen::genLZCNTIntrinsic(GenTreeHWIntrinsic* node)
 {
-    NamedIntrinsic intrinsicID = node->gtHWIntrinsicId;
-    GenTree*       op1         = node->gtGetOp1();
-    regNumber      targetReg   = node->gtRegNum;
-    assert(targetReg != REG_NA);
+    assert(node->gtHWIntrinsicId == NI_LZCNT_LeadingZeroCount);
+    assert(node->gtRegNum != REG_NA);
+
     var_types targetType = node->TypeGet();
-    regNumber op1Reg     = op1->gtRegNum;
     genConsumeOperands(node);
 
-    assert(intrinsicID == NI_LZCNT_LeadingZeroCount);
-
-    inst_RV_RV(INS_lzcnt, targetReg, op1Reg, targetType, emitTypeSize(targetType));
-
+    inst_RV_RV(INS_lzcnt, node->gtRegNum, node->gtGetOp1()->gtRegNum, targetType, emitTypeSize(targetType));
     genProduceReg(node);
 }
 
@@ -457,18 +378,13 @@ void CodeGen::genPCLMULQDQIntrinsic(GenTreeHWIntrinsic* node)
 
 void CodeGen::genPOPCNTIntrinsic(GenTreeHWIntrinsic* node)
 {
-    NamedIntrinsic intrinsicID = node->gtHWIntrinsicId;
-    GenTree*       op1         = node->gtGetOp1();
-    regNumber      targetReg   = node->gtRegNum;
-    assert(targetReg != REG_NA);
+    assert(node->gtHWIntrinsicId == NI_POPCNT_PopCount);
+    assert(node->gtRegNum != REG_NA);
+
     var_types targetType = node->TypeGet();
-    regNumber op1Reg     = op1->gtRegNum;
     genConsumeOperands(node);
 
-    assert(intrinsicID == NI_POPCNT_PopCount);
-
-    inst_RV_RV(INS_popcnt, targetReg, op1Reg, targetType, emitTypeSize(targetType));
-
+    inst_RV_RV(INS_popcnt, node->gtRegNum, node->gtGetOp1()->gtRegNum, targetType, emitTypeSize(targetType));
     genProduceReg(node);
 }
 

--- a/src/jit/hwintrinsiclistxarch.h
+++ b/src/jit/hwintrinsiclistxarch.h
@@ -11,58 +11,139 @@
 // clang-format off
 
 #if FEATURE_HW_INTRINSICS
-//                 Intrinsic ID                         Function name                   ISA             Instructions (flt, dbl, i8, i16, i32, i64)                                          ival
-//  SSE Intrinsics 
-HARDWARE_INTRINSIC(SSE_IsSupported,                     "get_IsSupported",              SSE,            {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
-HARDWARE_INTRINSIC(SSE_Add,                             "Add",                          SSE,            {INS_addps,   INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
+//                 Intrinsic ID                                     Function name                               ISA         Instructions (flt, dbl, i8, i16, i32, i64)                                                  ival
+//  SSE Intrinsics
+HARDWARE_INTRINSIC(SSE_IsSupported,                                 "get_IsSupported",                          SSE,        {INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_Add,                                         "Add",                                      SSE,        {INS_addps,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_AddScalar,                                   "AddScalar",                                SSE,        {INS_addss,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_And,                                         "And",                                      SSE,        {INS_andps,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_AndNot,                                      "AndNot",                                   SSE,        {INS_andnps,    INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_CompareEqual,                                "CompareEqual",                             SSE,        {INS_cmpps,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    0)
+HARDWARE_INTRINSIC(SSE_CompareEqualOrderedScalar,                   "CompareEqualOrderedScalar",                SSE,        {INS_comiss,    INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_CompareEqualScalar,                          "CompareEqualScalar",                       SSE,        {INS_cmpss,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    0)
+HARDWARE_INTRINSIC(SSE_CompareEqualUnorderedScalar,                 "CompareEqualUnorderedScalar",              SSE,        {INS_ucomiss,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_CompareGreaterThan,                          "CompareGreaterThan",                       SSE,        {INS_cmpps,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    6)
+HARDWARE_INTRINSIC(SSE_CompareGreaterThanOrderedScalar,             "CompareGreaterThanOrderedScalar",          SSE,        {INS_comiss,    INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_CompareGreaterThanScalar,                    "CompareGreaterThanScalar",                 SSE,        {INS_cmpss,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    6)
+HARDWARE_INTRINSIC(SSE_CompareGreaterThanUnorderedScalar,           "CompareGreaterThanUnorderedScalar",        SSE,        {INS_ucomiss,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_CompareGreaterThanOrEqual,                   "CompareGreaterThanOrEqual",                SSE,        {INS_cmpps,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    5)
+HARDWARE_INTRINSIC(SSE_CompareGreaterThanOrEqualOrderedScalar,      "CompareGreaterThanOrEqualOrderedScalar",   SSE,        {INS_comiss,    INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_CompareGreaterThanOrEqualScalar,             "CompareGreaterThanOrEqualScalar",          SSE,        {INS_cmpss,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    5)
+HARDWARE_INTRINSIC(SSE_CompareGreaterThanOrEqualUnorderedScalar,    "CompareGreaterThanOrEqualUnorderedScalar", SSE,        {INS_ucomiss,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_CompareLessThan,                             "CompareLessThan",                          SSE,        {INS_cmpps,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    1)
+HARDWARE_INTRINSIC(SSE_CompareLessThanOrderedScalar,                "CompareLessThanOrderedScalar",             SSE,        {INS_comiss,    INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_CompareLessThanScalar,                       "CompareLessThanScalar",                    SSE,        {INS_cmpss,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    1)
+HARDWARE_INTRINSIC(SSE_CompareLessThanUnorderedScalar,              "CompareLessThanUnorderedScalar",           SSE,        {INS_ucomiss,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_CompareLessThanOrEqual,                      "CompareLessThanOrEqual",                   SSE,        {INS_cmpps,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    2)
+HARDWARE_INTRINSIC(SSE_CompareLessThanOrEqualOrderedScalar,         "CompareLessThanOrEqualOrderedScalar",      SSE,        {INS_comiss,    INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_CompareLessThanOrEqualScalar,                "CompareLessThanOrEqualScalar",             SSE,        {INS_cmpss,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    2)
+HARDWARE_INTRINSIC(SSE_CompareLessThanOrEqualUnorderedScalar,       "CompareLessThanOrEqualUnorderedScalar",    SSE,        {INS_ucomiss,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_CompareNotEqual,                             "CompareNotEqual",                          SSE,        {INS_cmpps,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    4)
+HARDWARE_INTRINSIC(SSE_CompareNotEqualOrderedScalar,                "CompareNotEqualOrderedScalar",             SSE,        {INS_comiss,    INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_CompareNotEqualScalar,                       "CompareNotEqualScalar",                    SSE,        {INS_cmpss,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    4)
+HARDWARE_INTRINSIC(SSE_CompareNotEqualUnorderedScalar,              "CompareNotEqualUnorderedScalar",           SSE,        {INS_ucomiss,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_CompareNotGreaterThan,                       "CompareNotGreaterThan",                    SSE,        {INS_cmpps,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    2)
+HARDWARE_INTRINSIC(SSE_CompareNotGreaterThanScalar,                 "CompareNotGreaterThanScalar",              SSE,        {INS_cmpss,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    2)
+HARDWARE_INTRINSIC(SSE_CompareNotGreaterThanOrEqual,                "CompareNotGreaterThanOrEqual",             SSE,        {INS_cmpps,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    1)
+HARDWARE_INTRINSIC(SSE_CompareNotGreaterThanOrEqualScalar,          "CompareNotGreaterThanOrEqualScalar",       SSE,        {INS_cmpss,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    1)
+HARDWARE_INTRINSIC(SSE_CompareNotLessThan,                          "CompareNotLessThan",                       SSE,        {INS_cmpps,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    5)
+HARDWARE_INTRINSIC(SSE_CompareNotLessThanScalar,                    "CompareNotLessThanScalar",                 SSE,        {INS_cmpss,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    5)
+HARDWARE_INTRINSIC(SSE_CompareNotLessThanOrEqual,                   "CompareNotLessThanOrEqual",                SSE,        {INS_cmpps,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    6)
+HARDWARE_INTRINSIC(SSE_CompareNotLessThanOrEqualScalar,             "CompareNotLessThanOrEqualScalar",          SSE,        {INS_cmpss,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    6)
+HARDWARE_INTRINSIC(SSE_CompareOrdered,                              "CompareOrdered",                           SSE,        {INS_cmpps,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    7)
+HARDWARE_INTRINSIC(SSE_CompareOrderedScalar,                        "CompareOrderedScalar",                     SSE,        {INS_cmpss,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    7)
+HARDWARE_INTRINSIC(SSE_CompareUnordered,                            "CompareUnordered",                         SSE,        {INS_cmpps,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    3)
+HARDWARE_INTRINSIC(SSE_CompareUnorderedScalar,                      "CompareUnorderedScalar",                   SSE,        {INS_cmpss,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},    3)
+HARDWARE_INTRINSIC(SSE_ConvertToInt32,                              "ConvertToInt32",                           SSE,        {INS_cvtss2si,  INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_ConvertToInt64,                              "ConvertToInt64",                           SSE,        {INS_cvtss2si,  INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_ConvertToSingle,                             "ConvertToSingle",                          SSE,        {INS_movss,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_ConvertToVector128SingleScalar,              "ConvertToVector128SingleScalar",           SSE,        {INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_cvtsi2ss,  INS_cvtsi2ss},  -1)
+HARDWARE_INTRINSIC(SSE_ConvertToInt32WithTruncation,                "ConvertToInt32WithTruncation",             SSE,        {INS_cvttss2si, INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_ConvertToInt64WithTruncation,                "ConvertToInt64WithTruncation",             SSE,        {INS_cvttss2si, INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_Divide,                                      "Divide",                                   SSE,        {INS_divps,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_DivideScalar,                                "DivideScalar",                             SSE,        {INS_divss,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_Load,                                        "Load",                                     SSE,        {INS_movups,    INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_LoadAligned,                                 "LoadAligned",                              SSE,        {INS_movaps,    INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_LoadScalar,                                  "LoadScalar",                               SSE,        {INS_movss,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_Max,                                         "Max",                                      SSE,        {INS_maxps,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_MaxScalar,                                   "MaxScalar",                                SSE,        {INS_maxss,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_Min,                                         "Min",                                      SSE,        {INS_minps,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_MinScalar,                                   "MinScalar",                                SSE,        {INS_minss,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_MoveHighToLow,                               "MoveHighToLow",                            SSE,        {INS_movhlps,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_MoveLowToHigh,                               "MoveLowToHigh",                            SSE,        {INS_movlhps,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_MoveScalar,                                  "MoveScalar",                               SSE,        {INS_movss,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_Multiply,                                    "Multiply",                                 SSE,        {INS_mulps,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_MultiplyScalar,                              "MultiplyScalar",                           SSE,        {INS_mulss,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_Or,                                          "Or",                                       SSE,        {INS_orps,      INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_Reciprocal,                                  "Reciprocal",                               SSE,        {INS_rcpps,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_ReciprocalScalar,                            "ReciprocalScalar",                         SSE,        {INS_rcpss,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_ReciprocalSqrt,                              "ReciprocalSqrt",                           SSE,        {INS_rsqrtps,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_ReciprocalSqrtScalar,                        "ReciprocalSqrtScalar",                     SSE,        {INS_rsqrtss,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_Set,                                         "Set",                                      SSE,        {INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_SetAll,                                      "Set1",                                     SSE,        {INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_SetScalar,                                   "SetScalar",                                SSE,        {INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_SetZero,                                     "SetZero",                                  SSE,        {INS_xorps,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_Shuffle,                                     "Shuffle",                                  SSE,        {INS_shufps,    INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_Sqrt,                                        "Sqrt",                                     SSE,        {INS_sqrtps,    INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_SqrtScalar,                                  "SqrtScalar",                               SSE,        {INS_sqrtss,    INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_StaticCast,                                  "StaticCast",                               SSE,        {INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_Store,                                       "Store",                                    SSE,        {INS_movups,    INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_StoreAligned,                                "StoreAligned",                             SSE,        {INS_movaps,    INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_StoreAlignedNonTemporal,                     "StoreAlignedNonTemporal",                  SSE,        {INS_movntps,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_StoreScalar,                                 "StoreScalar",                              SSE,        {INS_movss,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_Subtract,                                    "Subtract",                                 SSE,        {INS_subps,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_SubtractScalar,                              "SubtractScalar",                           SSE,        {INS_subss,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_UnpackHigh,                                  "UnpackHigh",                               SSE,        {INS_unpckhps,  INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_UnpackLow,                                   "UnpackLow",                                SSE,        {INS_unpcklps,  INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE_Xor,                                         "Xor",                                      SSE,        {INS_xorps,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
 
-//  SSE2 Intrinsics 
-HARDWARE_INTRINSIC(SSE2_IsSupported,                    "get_IsSupported",              SSE2,           {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
-HARDWARE_INTRINSIC(SSE2_Add,                            "Add",                          SSE2,           {INS_invalid, INS_addpd,   INS_paddb,   INS_paddw,   INS_paddd,   INS_paddq},       -1)
+//  SSE2 Intrinsics
+HARDWARE_INTRINSIC(SSE2_IsSupported,                                "get_IsSupported",                          SSE2,       {INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE2_Add,                                        "Add",                                      SSE2,       {INS_invalid,   INS_addpd,     INS_paddb,     INS_paddw,     INS_paddd,     INS_paddq},     -1)
 
-//  SSE3 Intrinsics 
-HARDWARE_INTRINSIC(SSE3_IsSupported,                    "get_IsSupported",              SSE3,           {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
+//  SSE3 Intrinsics
+HARDWARE_INTRINSIC(SSE3_IsSupported,                                "get_IsSupported",                          SSE3,       {INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
 
-//  SSSE3 Intrinsics 
-HARDWARE_INTRINSIC(SSSE3_IsSupported,                   "get_IsSupported",              SSSE3,          {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
+//  SSSE3 Intrinsics
+HARDWARE_INTRINSIC(SSSE3_IsSupported,                               "get_IsSupported",                          SSSE3,      {INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
 
-//  SSE41 Intrinsics 
-HARDWARE_INTRINSIC(SSE41_IsSupported,                   "get_IsSupported",              SSE41,          {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
+//  SSE41 Intrinsics
+HARDWARE_INTRINSIC(SSE41_IsSupported,                               "get_IsSupported",                          SSE41,      {INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
 
-//  SSE42 Intrinsics 
-HARDWARE_INTRINSIC(SSE42_IsSupported,                   "get_IsSupported",              SSE42,          {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
-HARDWARE_INTRINSIC(SSE42_Crc32,                         "Crc32",                        SSE42,          {INS_invalid, INS_invalid, INS_crc32,   INS_crc32,   INS_crc32,   INS_crc32},       -1)
+//  SSE42 Intrinsics
+HARDWARE_INTRINSIC(SSE42_IsSupported,                               "get_IsSupported",                          SSE42,      {INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(SSE42_Crc32,                                     "Crc32",                                    SSE42,      {INS_invalid,   INS_invalid,   INS_crc32,     INS_crc32,     INS_crc32,     INS_crc32},     -1)
 
-//  AVX Intrinsics 
-HARDWARE_INTRINSIC(AVX_IsSupported,                     "get_IsSupported",              AVX,            {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
-HARDWARE_INTRINSIC(AVX_Add,                             "Add",                          AVX,            {INS_addps,   INS_addpd,   INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
+//  AVX Intrinsics
+HARDWARE_INTRINSIC(AVX_IsSupported,                                 "get_IsSupported",                          AVX,        {INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(AVX_Add,                                         "Add",                                      AVX,        {INS_addps,     INS_addpd,     INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
 
-//  AVX2 Intrinsics 
-HARDWARE_INTRINSIC(AVX2_IsSupported,                    "get_IsSupported",              AVX2,           {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
-HARDWARE_INTRINSIC(AVX2_Add,                            "Add",                          AVX2,           {INS_invalid, INS_invalid, INS_paddb,   INS_paddw,   INS_paddd,   INS_paddq},       -1)
+//  AVX2 Intrinsics
+HARDWARE_INTRINSIC(AVX2_IsSupported,                                "get_IsSupported",                          AVX2,       {INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(AVX2_Add,                                        "Add",                                      AVX2,       {INS_invalid,   INS_invalid,   INS_paddb,     INS_paddw,     INS_paddd,     INS_paddq},     -1)
 
-//  AES Intrinsics 
-HARDWARE_INTRINSIC(AES_IsSupported,                     "get_IsSupported",              AES,            {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
+//  AES Intrinsics
+HARDWARE_INTRINSIC(AES_IsSupported,                                 "get_IsSupported",                          AES,        {INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
 
-//  BMI1 Intrinsics 
-HARDWARE_INTRINSIC(BMI1_IsSupported,                    "get_IsSupported",              BMI1,           {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
+//  BMI1 Intrinsics
+HARDWARE_INTRINSIC(BMI1_IsSupported,                                "get_IsSupported",                          BMI1,       {INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
 
-//  BMI2 Intrinsics 
-HARDWARE_INTRINSIC(BMI2_IsSupported,                    "get_IsSupported",              BMI2,           {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
+//  BMI2 Intrinsics
+HARDWARE_INTRINSIC(BMI2_IsSupported,                                "get_IsSupported",                          BMI2,       {INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
 
-//  FMA Intrinsics 
-HARDWARE_INTRINSIC(FMA_IsSupported,                     "get_IsSupported",              FMA,            {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
+//  FMA Intrinsics
+HARDWARE_INTRINSIC(FMA_IsSupported,                                 "get_IsSupported",                          FMA,        {INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
 
-//  LZCNT Intrinsics 
-HARDWARE_INTRINSIC(LZCNT_IsSupported,                   "get_IsSupported",              LZCNT,          {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
-HARDWARE_INTRINSIC(LZCNT_LeadingZeroCount,              "LeadingZeroCount",             LZCNT,          {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_lzcnt,   INS_lzcnt},       -1)
+//  LZCNT Intrinsics
+HARDWARE_INTRINSIC(LZCNT_IsSupported,                               "get_IsSupported",                          LZCNT,      {INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(LZCNT_LeadingZeroCount,                          "LeadingZeroCount",                         LZCNT,      {INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_lzcnt,     INS_lzcnt},     -1)
 
-//  PCLMULQDQ Intrinsics 
-HARDWARE_INTRINSIC(PCLMULQDQ_IsSupported,               "get_IsSupported",              PCLMULQDQ,      {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
+//  PCLMULQDQ Intrinsics
+HARDWARE_INTRINSIC(PCLMULQDQ_IsSupported,                           "get_IsSupported",                          PCLMULQDQ,  {INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
 
-//  POPCNT Intrinsics 
-HARDWARE_INTRINSIC(POPCNT_IsSupported,                  "get_IsSupported",              POPCNT,         {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
-HARDWARE_INTRINSIC(POPCNT_PopCount,                     "PopCount",                     POPCNT,         {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_popcnt,  INS_popcnt},      -1)
+//  POPCNT Intrinsics
+HARDWARE_INTRINSIC(POPCNT_IsSupported,                              "get_IsSupported",                          POPCNT,     {INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid},   -1)
+HARDWARE_INTRINSIC(POPCNT_PopCount,                                 "PopCount",                                 POPCNT,     {INS_invalid,   INS_invalid,   INS_invalid,   INS_invalid,   INS_popcnt,    INS_popcnt},    -1)
 #endif // FEATURE_HW_INTRINSICS
 
 #undef HARDWARE_INTRINSIC

--- a/src/jit/hwintrinsiclistxarch.h
+++ b/src/jit/hwintrinsiclistxarch.h
@@ -11,58 +11,58 @@
 // clang-format off
 
 #if FEATURE_HW_INTRINSICS
-//                  Intrinsic ID                   Function name                ISA   
-//  SSE Intrinsics          
-HARDWARE_INTRINSIC(SSE_IsSupported,             "get_IsSupported",              SSE)
-HARDWARE_INTRINSIC(SSE_Add,                     "Add",                          SSE)
+//                 Intrinsic ID                         Function name                   ISA             Instructions (flt, dbl, i8, i16, i32, i64)                                          ival
+//  SSE Intrinsics 
+HARDWARE_INTRINSIC(SSE_IsSupported,                     "get_IsSupported",              SSE,            {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
+HARDWARE_INTRINSIC(SSE_Add,                             "Add",                          SSE,            {INS_addps,   INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
 
 //  SSE2 Intrinsics 
-HARDWARE_INTRINSIC(SSE2_IsSupported,            "get_IsSupported",              SSE2)
-HARDWARE_INTRINSIC(SSE2_Add,                    "Add",                          SSE2)
+HARDWARE_INTRINSIC(SSE2_IsSupported,                    "get_IsSupported",              SSE2,           {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
+HARDWARE_INTRINSIC(SSE2_Add,                            "Add",                          SSE2,           {INS_invalid, INS_addpd,   INS_paddb,   INS_paddw,   INS_paddd,   INS_paddq},       -1)
 
 //  SSE3 Intrinsics 
-HARDWARE_INTRINSIC(SSE3_IsSupported,            "get_IsSupported",              SSE3)
+HARDWARE_INTRINSIC(SSE3_IsSupported,                    "get_IsSupported",              SSE3,           {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
 
 //  SSSE3 Intrinsics 
-HARDWARE_INTRINSIC(SSSE3_IsSupported,           "get_IsSupported",              SSSE3)
+HARDWARE_INTRINSIC(SSSE3_IsSupported,                   "get_IsSupported",              SSSE3,          {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
 
 //  SSE41 Intrinsics 
-HARDWARE_INTRINSIC(SSE41_IsSupported,           "get_IsSupported",              SSE41)
+HARDWARE_INTRINSIC(SSE41_IsSupported,                   "get_IsSupported",              SSE41,          {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
 
 //  SSE42 Intrinsics 
-HARDWARE_INTRINSIC(SSE42_IsSupported,           "get_IsSupported",              SSE42)
-HARDWARE_INTRINSIC(SSE42_Crc32,                 "Crc32",                        SSE42)
+HARDWARE_INTRINSIC(SSE42_IsSupported,                   "get_IsSupported",              SSE42,          {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
+HARDWARE_INTRINSIC(SSE42_Crc32,                         "Crc32",                        SSE42,          {INS_invalid, INS_invalid, INS_crc32,   INS_crc32,   INS_crc32,   INS_crc32},       -1)
 
 //  AVX Intrinsics 
-HARDWARE_INTRINSIC(AVX_IsSupported,             "get_IsSupported",              AVX)
-HARDWARE_INTRINSIC(AVX_Add,                     "Add",                          AVX)
+HARDWARE_INTRINSIC(AVX_IsSupported,                     "get_IsSupported",              AVX,            {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
+HARDWARE_INTRINSIC(AVX_Add,                             "Add",                          AVX,            {INS_addps,   INS_addpd,   INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
 
 //  AVX2 Intrinsics 
-HARDWARE_INTRINSIC(AVX2_IsSupported,            "get_IsSupported",              AVX2)
-HARDWARE_INTRINSIC(AVX2_Add,                    "Add",                          AVX2)
+HARDWARE_INTRINSIC(AVX2_IsSupported,                    "get_IsSupported",              AVX2,           {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
+HARDWARE_INTRINSIC(AVX2_Add,                            "Add",                          AVX2,           {INS_invalid, INS_invalid, INS_paddb,   INS_paddw,   INS_paddd,   INS_paddq},       -1)
 
 //  AES Intrinsics 
-HARDWARE_INTRINSIC(AES_IsSupported,             "get_IsSupported",              AES)
+HARDWARE_INTRINSIC(AES_IsSupported,                     "get_IsSupported",              AES,            {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
 
 //  BMI1 Intrinsics 
-HARDWARE_INTRINSIC(BMI1_IsSupported,            "get_IsSupported",              BMI1)
+HARDWARE_INTRINSIC(BMI1_IsSupported,                    "get_IsSupported",              BMI1,           {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
 
 //  BMI2 Intrinsics 
-HARDWARE_INTRINSIC(BMI2_IsSupported,            "get_IsSupported",              BMI2)
+HARDWARE_INTRINSIC(BMI2_IsSupported,                    "get_IsSupported",              BMI2,           {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
 
 //  FMA Intrinsics 
-HARDWARE_INTRINSIC(FMA_IsSupported,             "get_IsSupported",              FMA)
+HARDWARE_INTRINSIC(FMA_IsSupported,                     "get_IsSupported",              FMA,            {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
 
 //  LZCNT Intrinsics 
-HARDWARE_INTRINSIC(LZCNT_IsSupported,           "get_IsSupported",              LZCNT)
-HARDWARE_INTRINSIC(LZCNT_LeadingZeroCount,      "LeadingZeroCount",             LZCNT)
+HARDWARE_INTRINSIC(LZCNT_IsSupported,                   "get_IsSupported",              LZCNT,          {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
+HARDWARE_INTRINSIC(LZCNT_LeadingZeroCount,              "LeadingZeroCount",             LZCNT,          {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_lzcnt,   INS_lzcnt},       -1)
 
 //  PCLMULQDQ Intrinsics 
-HARDWARE_INTRINSIC(PCLMULQDQ_IsSupported,       "get_IsSupported",              PCLMULQDQ)
+HARDWARE_INTRINSIC(PCLMULQDQ_IsSupported,               "get_IsSupported",              PCLMULQDQ,      {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
 
 //  POPCNT Intrinsics 
-HARDWARE_INTRINSIC(POPCNT_IsSupported,          "get_IsSupported",              POPCNT)
-HARDWARE_INTRINSIC(POPCNT_PopCount,              "PopCount",                    POPCNT)
+HARDWARE_INTRINSIC(POPCNT_IsSupported,                  "get_IsSupported",              POPCNT,         {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_invalid},     -1)
+HARDWARE_INTRINSIC(POPCNT_PopCount,                     "PopCount",                     POPCNT,         {INS_invalid, INS_invalid, INS_invalid, INS_invalid, INS_popcnt,  INS_popcnt},      -1)
 #endif // FEATURE_HW_INTRINSICS
 
 #undef HARDWARE_INTRINSIC

--- a/src/jit/hwintrinsicxarch.cpp
+++ b/src/jit/hwintrinsicxarch.cpp
@@ -14,7 +14,8 @@ struct HWIntrinsicInfo
 }
 
 static const hwIntrinsicInfoArray[] = {
-#define HARDWARE_INTRINSIC(id, name, isa) {NI_##id, name, InstructionSet_##isa},
+#define HARDWARE_INTRINSIC(id, name, isa, ins1, ins2, ins3, ins4, ins5, ins6, ival)                                    \
+    {NI_##id, name, InstructionSet_##isa},
 #include "hwintrinsiclistxarch.h"
 };
 

--- a/src/jit/instrsxarch.h
+++ b/src/jit/instrsxarch.h
@@ -204,7 +204,11 @@ INST3( movapd,      "movapd"      , 0, IUM_WR, 0, 0, PCKDBL(0x29), BAD_CODE, PCK
 INST3( movaps,      "movaps"      , 0, IUM_WR, 0, 0, PCKFLT(0x29), BAD_CODE, PCKFLT(0x28))
 INST3( movupd,      "movupd"      , 0, IUM_WR, 0, 0, PCKDBL(0x11), BAD_CODE, PCKDBL(0x10))
 INST3( movups,      "movups"      , 0, IUM_WR, 0, 0, PCKFLT(0x11), BAD_CODE, PCKFLT(0x10))
+INST3( movhlps,     "movhlps"     , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, PCKFLT(0x12))
 INST3( movlhps,     "movlhps"     , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, PCKFLT(0x16))
+INST3( movntps,     "movntps"     , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, PCKFLT(0x2B))
+INST3( unpckhps,    "unpckhps"    , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, PCKFLT(0x15)) 
+INST3( unpcklps,    "unpcklps"    , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, PCKFLT(0x14)) 
 
 INST3( shufps,      "shufps"      , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, PCKFLT(0xC6))
 INST3( shufpd,      "shufpd"      , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, PCKDBL(0xC6))
@@ -249,6 +253,12 @@ INST3( orps,   "orps",   0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, PCKFLT(0x56))    /
 INST3( orpd,   "orpd",   0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, PCKDBL(0x56))    // Or packed doubles
 INST3( haddpd, "haddpd", 0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, PCKDBL(0x7C))    // Horizontal add packed doubles
 
+// SSE 2 approx arith 
+INST3( rcpps,   "rcpps",   0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, PCKFLT(0x53))    // Reciprocal of packed singles 
+INST3( rcpss,   "rcpss",   0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, SSEFLT(0x53))    // Reciprocal of scalar single 
+INST3( rsqrtps, "rsqrtps", 0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, PCKFLT(0x52))    // Reciprocal Sqrt of packed singles 
+INST3( rsqrtss, "rsqrtss", 0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, SSEFLT(0x52))    // Reciprocal Sqrt of scalar single 
+
 // SSE2 conversions
 INST3( cvtpi2ps,  "cvtpi2ps",   0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, PCKFLT(0x2A))   // cvt packed DWORDs to singles
 INST3( cvtsi2ss,  "cvtsi2ss",   0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, SSEFLT(0x2A))   // cvt DWORD to scalar single
@@ -273,6 +283,8 @@ INST3( cvttpd2dq, "cvttpd2dq",  0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, PCKDBL(0xE6
 INST3( cvtdq2pd,  "cvtdq2pd",   0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, SSEFLT(0xE6))   // cvt packed DWORDs to doubles
 
 // SSE2 comparison instructions
+INST3( comiss,    "comiss",     0, IUM_RD, 0, 0, BAD_CODE, BAD_CODE, PCKFLT(0x2F))    // ordered compare singles
+INST3( comisd,    "comisd",     0, IUM_RD, 0, 0, BAD_CODE, BAD_CODE, PCKDBL(0x2F))    // ordered compare doubles
 INST3( ucomiss,   "ucomiss",    0, IUM_RD, 0, 0, BAD_CODE, BAD_CODE, PCKFLT(0x2E))    // unordered compare singles
 INST3( ucomisd,   "ucomisd",    0, IUM_RD, 0, 0, BAD_CODE, BAD_CODE, PCKDBL(0x2E))    // unordered compare doubles
 
@@ -280,6 +292,8 @@ INST3( ucomisd,   "ucomisd",    0, IUM_RD, 0, 0, BAD_CODE, BAD_CODE, PCKDBL(0x2E
 // Note that these instructions not only compare but also overwrite the first source.
 INST3( cmpps,     "cmpps",      0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, PCKFLT(0xC2))    // compare packed singles
 INST3( cmppd,     "cmppd",      0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, PCKDBL(0xC2))    // compare packed doubles
+INST3( cmpss,     "cmpss",      0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, SSEFLT(0xC2))    // compare scalar singles
+INST3( cmpsd,     "cmpsd",      0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, SSEDBL(0xC2))    // compare scalar doubles
 
 //SSE2 packed integer operations
 INST3( paddb,       "paddb"       , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE,      PCKDBL(0xFC))   // Add packed byte integers

--- a/src/jit/namedintrinsiclist.h
+++ b/src/jit/namedintrinsiclist.h
@@ -16,7 +16,7 @@ enum NamedIntrinsic : unsigned int
     NI_System_Collections_Generic_EqualityComparer_get_Default = 4,
 #if FEATURE_HW_INTRINSICS
     NI_HW_INTRINSIC_START,
-#define HARDWARE_INTRINSIC(id, name, isa) NI_##id,
+#define HARDWARE_INTRINSIC(id, name, isa, ins1, ins2, ins3, ins4, ins5, ins6, ival) NI_##id,
 #include "hwintrinsiclistxarch.h"
     NI_HW_INTRINSIC_END
 #endif


### PR DESCRIPTION
This just updates the HardwareIntrinsicInfo struct to also carry the instruction per base type and an ival per instruction.

This makes it really easy to remove the duplicated code for most basic instructions.

It isn't quite a constant-time lookup, due to multiple overloads mapping to the same intrinsic, but it should still be much improved.