### PR TITLE
Updated CreateMethodDesc to pass along the `IsJitIntrinsic` flag for generic methods.

### DIFF
--- a/src/vm/genmeth.cpp
+++ b/src/vm/genmeth.cpp
@@ -120,6 +120,10 @@ static MethodDesc* CreateMethodDesc(LoaderAllocator *pAllocator,
     {
         pMD->SetSynchronized();
     }
+    if (pTemplateMD->IsJitIntrinsic())
+    {
+        pMD->SetIsJitIntrinsic();
+    }
 
     pMD->SetMemberDef(token);
     pMD->SetSlot(pTemplateMD->GetSlot());


### PR DESCRIPTION
The flag was not being passed along, which caused some generic named intrinsics to not be recognized as such.