### PR TITLE
Delete unused SSA_FEATURE_USEDEF ifdefs

### DIFF
--- a/src/jit/ssabuilder.cpp
+++ b/src/jit/ssabuilder.cpp
@@ -150,10 +150,6 @@ SsaBuilder::SsaBuilder(Compiler* pCompiler)
     , m_pDomPreOrder(nullptr)
     , m_pDomPostOrder(nullptr)
 #endif
-#ifdef SSA_FEATURE_USEDEF
-    , m_uses(&m_allocator)
-    , m_defs(&m_allocator)
-#endif
 {
 }
 
@@ -840,29 +836,6 @@ void SsaBuilder::InsertPhiFunctions(BasicBlock** postOrder, int count)
     EndPhase(PHASE_BUILD_SSA_INSERT_PHIS);
 }
 
-#ifdef SSA_FEATURE_USEDEF
-/**
- * Record a use point of a variable.
- *
- * The use point is just the tree that is a local variable use.
- *
- * @param tree Tree node where an SSA variable is used.
- *
- * @remarks The result is in the m_uses map :: [lclNum, ssaNum] -> tree.
- */
-void SsaBuilder::AddUsePoint(GenTree* tree)
-{
-    assert(tree->IsLocal());
-    SsaVarName          key(tree->gtLclVarCommon.gtLclNum, tree->gtLclVarCommon.gtSsaNum);
-    VarToUses::iterator iter = m_uses.find(key);
-    if (iter == m_uses.end())
-    {
-        iter = m_uses.insert(key, VarToUses::mapped_type(m_uses.get_allocator()));
-    }
-    (*iter).second.push_back(tree);
-}
-#endif // !SSA_FEATURE_USEDEF
-
 /**
  * Record a def point of a variable.
  *
@@ -900,18 +873,6 @@ void SsaBuilder::AddDefPoint(GenTree* tree, BasicBlock* blk)
     LclSsaVarDsc* ssaDef    = m_pCompiler->lvaTable[lclNum].GetPerSsaData(defSsaNum);
     ssaDef->m_defLoc.m_blk  = blk;
     ssaDef->m_defLoc.m_tree = tree;
-
-#ifdef SSA_FEATURE_USEDEF
-    SsaVarName         key(lclNum, defSsaNum);
-    VarToDef::iterator iter = m_defs.find(key);
-    if (iter == m_defs.end())
-    {
-        iter = m_defs.insert(key, tree);
-        return;
-    }
-    // There can only be a single definition for an SSA var.
-    unreached();
-#endif
 }
 
 bool SsaBuilder::IsIndirectAssign(GenTreePtr tree, Compiler::IndirectAssignmentAnnotation** ppIndirAssign)
@@ -1056,9 +1017,6 @@ void SsaBuilder::TreeRenameVariables(GenTree* tree, BasicBlock* block, SsaRename
                 // name of the use, we record it in a map reserved for that purpose.
                 unsigned count = pRenameState->CountForUse(lclNum);
                 tree->gtLclVarCommon.SetSsaNum(count);
-#ifdef SSA_FEATURE_USEDEF
-                AddUsePoint(tree);
-#endif
             }
 
             // Give a count and increment.
@@ -1105,9 +1063,6 @@ void SsaBuilder::TreeRenameVariables(GenTree* tree, BasicBlock* block, SsaRename
             // Give the count as top of stack.
             unsigned count = pRenameState->CountForUse(lclNum);
             tree->gtLclVarCommon.SetSsaNum(count);
-#ifdef SSA_FEATURE_USEDEF
-            AddUsePoint(tree);
-#endif
         }
     }
 }

--- a/src/jit/ssabuilder.h
+++ b/src/jit/ssabuilder.h
@@ -5,7 +5,6 @@
 #pragma once
 #pragma warning(disable : 4503) // 'identifier' : decorated name length exceeded, name was truncated
 
-#undef SSA_FEATURE_USEDEF
 #undef SSA_FEATURE_DOMARR
 
 #include "compiler.h"
@@ -20,24 +19,6 @@ typedef jitstd::pair<LclVarNum, int> SsaVarName;
 class SsaBuilder
 {
 private:
-    struct SsaVarNameHasher
-    {
-        /**
-         * Hash functor used in maps to hash a given key.
-         *
-         * @params key SsaVarName which is a pair of lclNum and ssaNum which defines a variable.
-         * @return Hash value corresponding to a key.
-         */
-        size_t operator()(const SsaVarName& key) const
-        {
-            return jitstd::hash<__int64>()((((__int64)key.first) << sizeof(int)) | key.second);
-        }
-    };
-
-    // Used to maintain a map of a given SSA numbering to its use or def.
-    typedef jitstd::unordered_map<SsaVarName, jitstd::vector<GenTree*>, SsaVarNameHasher> VarToUses;
-    typedef jitstd::unordered_map<SsaVarName, GenTree*, SsaVarNameHasher>                 VarToDef;
-
     inline void EndPhase(Phases phase)
     {
         m_pCompiler->EndPhase(phase);
@@ -157,11 +138,6 @@ private:
     // Requires "tree" to be a local variable node. Maintains a map of <lclNum, ssaNum> -> tree
     // information in m_defs.
     void AddDefPoint(GenTree* tree, BasicBlock* blk);
-#ifdef SSA_FEATURE_USEDEF
-    // Requires "tree" to be a local variable node. Maintains a map of <lclNum, ssaNum> -> tree
-    // information in m_uses.
-    void AddUsePoint(GenTree* tree);
-#endif
 
     // Returns true, and sets "*ppIndirAssign", if "tree" has been recorded as an indirect assignment.
     // (If the tree is an assignment, it's a definition only if it's labeled as an indirect definition, where
@@ -185,13 +161,5 @@ private:
     // Do not move these outside of this class, use accessors/interface methods.
     int* m_pDomPreOrder;
     int* m_pDomPostOrder;
-#endif
-
-#ifdef SSA_FEATURE_USEDEF
-    // Use Def information after SSA. To query the uses and def of a given ssa var,
-    // probe these data structures.
-    // Do not move these outside of this class, use accessors/interface methods.
-    VarToUses m_uses;
-    VarToDef  m_defs;
 #endif
 };


### PR DESCRIPTION
I don't see any point in keeping this code around. Keeping track of SSA uses could be useful but this implementation is not efficient and probably predates the `PerSsaArray` from `LclVarDsc` (we could add a vector of uses to `LclSsaVarDsc` if we need to).