### PR TITLE
Link to the File Header Example for C# was broken.

### DIFF
--- a/Documentation/project-docs/contributing.md
+++ b/Documentation/project-docs/contributing.md
@@ -112,7 +112,7 @@ The following file header is the used for .NET Core. Please use it for new files
 ```
 
 - See [class.cpp](../../src/vm/class.cpp) for an example of the header in a C++ file.
-- See [List.cs](../../src/mscorlib/src/System/Collections/Generic/List.cs) for an example of the header in a C# file.
+- See [Comparer.cs](../../src/mscorlib/src/System/Collections/Generic/Comparer.cs) for an example of the header in a C# file.
 
 Contributing Ports
 ------------------


### PR DESCRIPTION
The File Header example for C# was redirecting to (../../src/mscorlib/src/System/Collections/Generic/List.cs) which was missing in the master repository. The example file has been changed to Comparer.cs which is another file in the same repo path.