### PR TITLE
Move FP DIV/MUL handling to genCodeForBinary

### DIFF
--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -764,7 +764,7 @@ protected:
 
     void genSetRegToConst(regNumber targetReg, var_types targetType, GenTree* tree);
     void genCodeForTreeNode(GenTree* treeNode);
-    void genCodeForBinary(GenTree* treeNode);
+    void genCodeForBinary(GenTreeOp* treeNode);
 
 #if defined(_TARGET_X86_)
     void genCodeForLongUMod(GenTreeOp* node);

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -206,7 +206,7 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
 //    Mul and div are not handled here.
 //    See the assert below for the operators that are handled.
 
-void CodeGen::genCodeForBinary(GenTree* treeNode)
+void CodeGen::genCodeForBinary(GenTreeOp* treeNode)
 {
     const genTreeOps oper       = treeNode->OperGet();
     regNumber        targetReg  = treeNode->gtRegNum;

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -1540,7 +1540,7 @@ void CodeGen::genCodeForMulHi(GenTreeOp* treeNode)
 
 // Generate code for ADD, SUB, MUL, DIV, UDIV, AND, OR and XOR
 // This method is expected to have called genConsumeOperands() before calling it.
-void CodeGen::genCodeForBinary(GenTree* treeNode)
+void CodeGen::genCodeForBinary(GenTreeOp* treeNode)
 {
     const genTreeOps oper       = treeNode->OperGet();
     regNumber        targetReg  = treeNode->gtRegNum;

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -124,7 +124,7 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
         case GT_SUB:
         case GT_MUL:
             genConsumeOperands(treeNode->AsOp());
-            genCodeForBinary(treeNode);
+            genCodeForBinary(treeNode->AsOp());
             break;
 
         case GT_LSH:

--- a/src/jit/instr.cpp
+++ b/src/jit/instr.cpp
@@ -1821,12 +1821,6 @@ instruction CodeGen::ins_MathOp(genTreeOps oper, var_types type)
             return type == TYP_DOUBLE ? INS_mulsd : INS_mulss;
         case GT_DIV:
             return type == TYP_DOUBLE ? INS_divsd : INS_divss;
-        case GT_AND:
-            return type == TYP_DOUBLE ? INS_andpd : INS_andps;
-        case GT_OR:
-            return type == TYP_DOUBLE ? INS_orpd : INS_orps;
-        case GT_XOR:
-            return type == TYP_DOUBLE ? INS_xorpd : INS_xorps;
         default:
             unreached();
     }

--- a/src/jit/lowerarmarch.cpp
+++ b/src/jit/lowerarmarch.cpp
@@ -674,6 +674,19 @@ void Lowering::ContainCheckMul(GenTreeOp* node)
 }
 
 //------------------------------------------------------------------------
+// ContainCheckDivOrMod: determine which operands of a div/mod should be contained.
+//
+// Arguments:
+//    node - the node we care about
+//
+void Lowering::ContainCheckDivOrMod(GenTreeOp* node)
+{
+    assert(node->OperIs(GT_DIV, GT_UDIV));
+
+    // ARM doesn't have a div instruction with an immediate operand
+}
+
+//------------------------------------------------------------------------
 // ContainCheckShiftRotate: Determine whether a mul op's operands should be contained.
 //
 // Arguments:

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -1550,60 +1550,19 @@ void Lowering::ContainCheckMul(GenTreeOp* node)
 #else
     assert(node->OperIs(GT_MUL, GT_MULHI));
 #endif
+
+    // Case of float/double mul.
+    if (varTypeIsFloating(node->TypeGet()))
+    {
+        ContainCheckFloatBinary(node);
+        return;
+    }
+
     GenTree* op1 = node->gtOp.gtOp1;
     GenTree* op2 = node->gtOp.gtOp2;
 
     bool isSafeToContainOp1 = true;
     bool isSafeToContainOp2 = true;
-
-    // Case of float/double mul.
-    if (varTypeIsFloating(node->TypeGet()))
-    {
-        assert(node->OperGet() == GT_MUL);
-
-        if (op2->IsCnsNonZeroFltOrDbl())
-        {
-            MakeSrcContained(node, op2);
-        }
-        else if (IsContainableMemoryOp(op2))
-        {
-            isSafeToContainOp2 = IsSafeToContainMem(node, op2);
-            if (isSafeToContainOp2)
-            {
-                MakeSrcContained(node, op2);
-            }
-        }
-
-        if (!op2->isContained())
-        {
-            // Since  GT_MUL is commutative, we will try to re-order operands if it is safe to
-            // generate more efficient code sequence for the case of GT_MUL(op1=memOp, op2=non-memOp)
-            if (op1->IsCnsNonZeroFltOrDbl())
-            {
-                MakeSrcContained(node, op1);
-            }
-            else if (IsContainableMemoryOp(op1))
-            {
-                isSafeToContainOp1 = IsSafeToContainMem(node, op1);
-                if (isSafeToContainOp1)
-                {
-                    MakeSrcContained(node, op1);
-                }
-            }
-        }
-
-        if (!op1->isContained() && !op2->isContained())
-        {
-            // If there are no containable operands, we can make an operand reg optional.
-            // IsSafeToContainMem is expensive so we call it at most once for each operand
-            // in this method. If we already called IsSafeToContainMem, it must have returned false;
-            // otherwise, the corresponding operand (op1 or op2) would be contained.
-            isSafeToContainOp1 = isSafeToContainOp1 && IsSafeToContainMem(node, op1);
-            isSafeToContainOp2 = isSafeToContainOp2 && IsSafeToContainMem(node, op2);
-            SetRegOptionalForBinOp(node, isSafeToContainOp1, isSafeToContainOp2);
-        }
-        return;
-    }
 
     bool     isUnsignedMultiply    = ((node->gtFlags & GTF_UNSIGNED) != 0);
     bool     requiresOverflowCheck = node->gtOverflowEx();
@@ -1743,6 +1702,47 @@ void Lowering::ContainCheckMul(GenTreeOp* node)
             }
             SetRegOptionalForBinOp(node, isSafeToContainOp1, isSafeToContainOp2);
         }
+    }
+}
+
+//------------------------------------------------------------------------
+// ContainCheckDivOrMod: determine which operands of a div/mod should be contained.
+//
+// Arguments:
+//    node - pointer to the node
+//
+void Lowering::ContainCheckDivOrMod(GenTreeOp* node)
+{
+    assert(node->OperIs(GT_DIV, GT_MOD, GT_UDIV, GT_UMOD));
+
+    if (varTypeIsFloating(node->TypeGet()))
+    {
+        ContainCheckFloatBinary(node);
+        return;
+    }
+
+    GenTree* dividend = node->gtGetOp1();
+    GenTree* divisor  = node->gtGetOp2();
+
+    bool divisorCanBeRegOptional = true;
+#ifdef _TARGET_X86_
+    if (dividend->OperGet() == GT_LONG)
+    {
+        divisorCanBeRegOptional = false;
+        MakeSrcContained(node, dividend);
+    }
+#endif
+
+    // divisor can be an r/m, but the memory indirection must be of the same size as the divide
+    if (IsContainableMemoryOp(divisor) && (divisor->TypeGet() == node->TypeGet()))
+    {
+        MakeSrcContained(node, divisor);
+    }
+    else if (divisorCanBeRegOptional)
+    {
+        // If there are no containable operands, we can make an operand reg optional.
+        // Div instruction allows only divisor to be a memory op.
+        divisor->SetRegOptional();
     }
 }
 
@@ -3144,10 +3144,10 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
 //
 void Lowering::ContainCheckFloatBinary(GenTreeOp* node)
 {
-    assert(node->OperIsBinary() && varTypeIsFloating(node));
+    assert(node->OperIs(GT_ADD, GT_SUB, GT_MUL, GT_DIV) && varTypeIsFloating(node));
 
     // overflow operations aren't supported on float/double types.
-    assert(!node->gtOverflow());
+    assert(!node->gtOverflowEx());
 
     GenTree* op1 = node->gtGetOp1();
     GenTree* op2 = node->gtGetOp2();


### PR DESCRIPTION
Floating point (SSE) MUL/DIV instructions have the same formats as ADD/SUB but they're handled by genCodeForMul and genCodeForDivMod. At least in the case of division, this results in duplicated logic being required in genCodeForDivMod.

No diffs.