### PR TITLE
Adding failing string to Boolean and TimeSpan parse failure exceptions

### DIFF
--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -2297,7 +2297,7 @@
     <value>Invalid length for a Base-64 char array or string.</value>
   </data>
   <data name="Format_BadBoolean" xml:space="preserve">
-    <value>String was not recognized as a valid Boolean.</value>
+    <value>String '{0}' was not recognized as a valid Boolean.</value>
   </data>
   <data name="Format_BadDatePattern" xml:space="preserve">
     <value>Could not determine the order of year, month, and date from '{0}'.</value>
@@ -2321,7 +2321,7 @@
     <value>Cannot find a matching quote character for the character '{0}'.</value>
   </data>
   <data name="Format_BadTimeSpan" xml:space="preserve">
-    <value>String was not recognized as a valid TimeSpan.</value>
+    <value>String '{0}' was not recognized as a valid TimeSpan.</value>
   </data>
   <data name="Format_DateOutOfRange" xml:space="preserve">
     <value>The DateTime represented by the string '{0}' is out of range.</value>
@@ -3203,7 +3203,7 @@
     <value>Value was either too large or too small for a Single.</value>
   </data>
   <data name="Overflow_TimeSpanElementTooLarge" xml:space="preserve">
-    <value>The TimeSpan could not be parsed because at least one of the numeric components is out of range or contains too many digits.</value>
+    <value>The TimeSpan string '{0}' could not be parsed because at least one of the numeric components is out of range or contains too many digits.</value>
   </data>
   <data name="Overflow_TimeSpanTooLong" xml:space="preserve">
     <value>TimeSpan overflowed because the duration is too long.</value>

--- a/src/mscorlib/shared/System/Boolean.cs
+++ b/src/mscorlib/shared/System/Boolean.cs
@@ -184,7 +184,7 @@ namespace System
         }
 
         public static bool Parse(ReadOnlySpan<char> value) =>
-            TryParse(value, out bool result) ? result : throw new FormatException(SR.Format_BadBoolean);
+            TryParse(value, out bool result) ? result : throw new FormatException(SR.Format(SR.Format_BadBoolean, new string(value)));
 
         // Determines whether a String represents true or false.
         // 

--- a/src/mscorlib/shared/System/Globalization/TimeSpanParse.cs
+++ b/src/mscorlib/shared/System/Globalization/TimeSpanParse.cs
@@ -67,8 +67,7 @@ namespace System.Globalization
             None = 0,
             ArgumentNull = 1,
             Format = 2,
-            FormatWithParameter = 3,
-            Overflow = 4,
+            FormatWithParameter = 3
         }
 
         [Flags]
@@ -513,6 +512,16 @@ namespace System.Globalization
                 }
 
                 throw new FormatException(SR.Format(SR.GetResourceString(nameof(SR.Format_BadTimeSpan)), new string(_originalTimeSpanString)));
+            }
+
+            internal bool SetBadFormatSpecifierFailure(char? formatSpecifierCharacter = null)
+            {
+                if (!_throwOnFailure)
+                {
+                    return false;
+                }
+
+                throw new FormatException(SR.Format(SR.GetResourceString(nameof(SR.Format_BadFormatSpecifier)), formatSpecifierCharacter));
             }
         }
 
@@ -1193,7 +1202,7 @@ namespace System.Globalization
         {
             if (format.Length == 0)
             {
-                return result.SetFailure(ParseFailureKind.FormatWithParameter, nameof(SR.Format_BadFormatSpecifier));
+                return result.SetBadFormatSpecifierFailure();
             }
 
             if (format.Length == 1)
@@ -1212,7 +1221,7 @@ namespace System.Globalization
                         return TryParseTimeSpan(input, TimeSpanStandardStyles.Localized | TimeSpanStandardStyles.RequireFull, formatProvider, ref result);
 
                     default:
-                        return result.SetFailure(ParseFailureKind.FormatWithParameter, nameof(SR.Format_BadFormatSpecifier), format[0]);
+                        return result.SetBadFormatSpecifierFailure(format[0]);
                 }
             }
 
@@ -1666,7 +1675,7 @@ namespace System.Globalization
             {
                 if (formats[i] == null || formats[i].Length == 0)
                 {
-                    return result.SetFailure(ParseFailureKind.FormatWithParameter, nameof(SR.Format_BadFormatSpecifier));
+                    return result.SetBadFormatSpecifierFailure();
                 }
 
                 // Create a new non-throwing result each time to ensure the runs are independent.

--- a/src/mscorlib/shared/System/Globalization/TimeSpanParse.cs
+++ b/src/mscorlib/shared/System/Globalization/TimeSpanParse.cs
@@ -501,7 +501,7 @@ namespace System.Globalization
                     return false;
                 }
 
-                throw new OverflowException(SR.Format(SR.GetResourceString(nameof(SR.Overflow_TimeSpanElementTooLarge)), new string(_originalTimeSpanString)));
+                throw new OverflowException(SR.Format(SR.Overflow_TimeSpanElementTooLarge, new string(_originalTimeSpanString)));
             }
 
             internal bool SetBadTimeSpanFailure()
@@ -511,7 +511,7 @@ namespace System.Globalization
                     return false;
                 }
 
-                throw new FormatException(SR.Format(SR.GetResourceString(nameof(SR.Format_BadTimeSpan)), new string(_originalTimeSpanString)));
+                throw new FormatException(SR.Format(SR.Format_BadTimeSpan, new string(_originalTimeSpanString)));
             }
 
             internal bool SetBadFormatSpecifierFailure(char? formatSpecifierCharacter = null)
@@ -521,7 +521,7 @@ namespace System.Globalization
                     return false;
                 }
 
-                throw new FormatException(SR.Format(SR.GetResourceString(nameof(SR.Format_BadFormatSpecifier)), formatSpecifierCharacter));
+                throw new FormatException(SR.Format(SR.Format_BadFormatSpecifier, formatSpecifierCharacter));
             }
         }
 

--- a/src/mscorlib/shared/System/Globalization/TimeSpanParse.cs
+++ b/src/mscorlib/shared/System/Globalization/TimeSpanParse.cs
@@ -463,14 +463,34 @@ namespace System.Globalization
                 _originalTimeSpanString = originalTimeSpanString;
             }
 
-            internal bool SetFailure(string resourceKey, object messageArgument = null)
+            internal bool SetNoFormatSpecifierFailure()
             {
                 if (!_throwOnFailure)
                 {
                     return false;
                 }
 
-                throw new FormatException(SR.Format(SR.GetResourceString(resourceKey), messageArgument));
+                throw new FormatException(SR.Format_NoFormatSpecifier);
+            }
+
+            internal bool SetBadQuoteFailure(char failingCharacter)
+            {
+                if (!_throwOnFailure)
+                {
+                    return false;
+                }
+
+                throw new FormatException(SR.Format(SR.Format_BadQuote, failingCharacter));
+            }
+
+            internal bool SetInvalidStringFailure()
+            {
+                if (!_throwOnFailure)
+                {
+                    return false;
+                }
+
+                throw new FormatException(SR.Format_InvalidString);
             }
 
             internal bool SetArgumentNullFailure(string argumentName)
@@ -1248,7 +1268,7 @@ namespace System.Globalization
                         tokenLen = DateTimeFormat.ParseRepeatPattern(format, i, ch);
                         if (tokenLen > 2 || seenHH || !ParseExactDigits(ref tokenizer, tokenLen, out hh))
                         {
-                            return result.SetFailure(nameof(SR.Format_InvalidString));
+                            return result.SetInvalidStringFailure();
                         }
                         seenHH = true;
                         break;
@@ -1257,7 +1277,7 @@ namespace System.Globalization
                         tokenLen = DateTimeFormat.ParseRepeatPattern(format, i, ch);
                         if (tokenLen > 2 || seenMM || !ParseExactDigits(ref tokenizer, tokenLen, out mm))
                         {
-                            return result.SetFailure(nameof(SR.Format_InvalidString));
+                            return result.SetInvalidStringFailure();
                         }
                         seenMM = true;
                         break;
@@ -1266,7 +1286,7 @@ namespace System.Globalization
                         tokenLen = DateTimeFormat.ParseRepeatPattern(format, i, ch);
                         if (tokenLen > 2 || seenSS || !ParseExactDigits(ref tokenizer, tokenLen, out ss))
                         {
-                            return result.SetFailure(nameof(SR.Format_InvalidString));
+                            return result.SetInvalidStringFailure();
                         }
                         seenSS = true;
                         break;
@@ -1275,7 +1295,7 @@ namespace System.Globalization
                         tokenLen = DateTimeFormat.ParseRepeatPattern(format, i, ch);
                         if (tokenLen > DateTimeFormat.MaxSecondsFractionDigits || seenFF || !ParseExactDigits(ref tokenizer, tokenLen, tokenLen, out leadingZeroes, out ff))
                         {
-                            return result.SetFailure(nameof(SR.Format_InvalidString));
+                            return result.SetInvalidStringFailure();
                         }
                         seenFF = true;
                         break;
@@ -1284,7 +1304,7 @@ namespace System.Globalization
                         tokenLen = DateTimeFormat.ParseRepeatPattern(format, i, ch);
                         if (tokenLen > DateTimeFormat.MaxSecondsFractionDigits || seenFF)
                         {
-                            return result.SetFailure(nameof(SR.Format_InvalidString));
+                            return result.SetInvalidStringFailure();
                         }
                         ParseExactDigits(ref tokenizer, tokenLen, tokenLen, out leadingZeroes, out ff);
                         seenFF = true;
@@ -1295,7 +1315,7 @@ namespace System.Globalization
                         int tmp = 0;
                         if (tokenLen > 8 || seenDD || !ParseExactDigits(ref tokenizer, (tokenLen < 2) ? 1 : tokenLen, (tokenLen < 2) ? 8 : tokenLen, out tmp, out dd))
                         {
-                            return result.SetFailure(nameof(SR.Format_InvalidString));
+                            return result.SetInvalidStringFailure();
                         }
                         seenDD = true;
                         break;
@@ -1306,12 +1326,12 @@ namespace System.Globalization
                         if (!DateTimeParse.TryParseQuoteString(format, i, enquotedString, out tokenLen))
                         {
                             StringBuilderCache.Release(enquotedString);
-                            return result.SetFailure(nameof(SR.Format_BadQuote), ch);
+                            return result.SetBadQuoteFailure(ch);
                         }
                         if (!ParseExactLiteral(ref tokenizer, enquotedString))
                         {
                             StringBuilderCache.Release(enquotedString);
-                            return result.SetFailure(nameof(SR.Format_InvalidString));
+                            return result.SetInvalidStringFailure();
                         }
                         StringBuilderCache.Release(enquotedString);
                         break;
@@ -1333,7 +1353,7 @@ namespace System.Globalization
                         {
                             // This means that '%' is at the end of the format string or
                             // "%%" appears in the format string.
-                            return result.SetFailure(nameof(SR.Format_InvalidString));
+                            return result.SetInvalidStringFailure();
                         }
 
                     case '\\':
@@ -1348,12 +1368,12 @@ namespace System.Globalization
                         else
                         {
                             // This means that '\' is at the end of the format string or the literal match failed.
-                            return result.SetFailure(nameof(SR.Format_InvalidString));
+                            return result.SetInvalidStringFailure();
                         }
                         break;
 
                     default:
-                        return result.SetFailure(nameof(SR.Format_InvalidString));
+                        return result.SetInvalidStringFailure();
                 }
 
                 i += tokenLen;
@@ -1656,7 +1676,7 @@ namespace System.Globalization
 
             if (formats.Length == 0)
             {
-                return result.SetFailure(nameof(SR.Format_NoFormatSpecifier));
+                return result.SetNoFormatSpecifierFailure();
             }
 
             // Do a loop through the provided formats and see if we can parse succesfully in


### PR DESCRIPTION
Additional extensions to exception messages when `bool` and `TimeSpan` parsing fails. This PR also fixes an issue introduced by my previous PR (https://github.com/dotnet/coreclr/pull/15635). Namely that I changed `Format_BadFormatSpecifier` which was used by other parsing exceptions as well.

This PR is in response to Dan Moseley's comment:
https://github.com/dotnet/coreclr/pull/15635#issuecomment-354330528