### PR TITLE
Link to THIRD-PARTY-NOTICES is fixed

### DIFF
--- a/Documentation/project-docs/contributing.md
+++ b/Documentation/project-docs/contributing.md
@@ -145,9 +145,9 @@ The following rules must be followed for PRs that include files from another pro
 
 - The license of the file is [permissive](https://en.wikipedia.org/wiki/Permissive_free_software_licence).
 - The license of the file is left in-tact.
-- The contribution is correctly attributed in the [3rd party notices](../../THIRD-PARTY-NOTICES) file in the repository, as needed.
+- The contribution is correctly attributed in the [3rd party notices](../../THIRD-PARTY-NOTICES.TXT) file in the repository, as needed.
 
-See [IdnMapping.cs](../../src/mscorlib/src/System/Globalization/IdnMapping.cs) for an example of a file copied from another project and attributed in the [CoreCLR 3rd party notices](../../THIRD-PARTY-NOTICES) file. 
+See [IdnMapping.cs](../../src/mscorlib/src/System/Globalization/IdnMapping.cs) for an example of a file copied from another project and attributed in the [CoreCLR 3rd party notices](../../THIRD-PARTY-NOTICES.TXT) file. 
 
 Porting Files from Other Projects
 ---------------------------------


### PR DESCRIPTION
The link to the THIRD-PARTY-NOTICES page is broken in contributing.md [https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/contributing.md]

The current link is [https://github.com/dotnet/coreclr/blob/master/THIRD-PARTY-NOTICES]

Seems it is missing a '.TXT' at the end of the URL. The correct link should be [https://github.com/dotnet/coreclr/blob/master/THIRD-PARTY-NOTICES.TXT] which is working fine.

Issue #15664