### PR TITLE
Replace a few for loops with foreach to avoid loop cloning

### DIFF
--- a/src/mscorlib/src/System/AppDomain.cs
+++ b/src/mscorlib/src/System/AppDomain.cs
@@ -511,58 +511,29 @@ namespace System
         // This method is called by the VM.
         private RuntimeAssembly OnResourceResolveEvent(RuntimeAssembly assembly, String resourceName)
         {
-            ResolveEventHandler eventHandler = _ResourceResolve;
-            if (eventHandler == null)
-                return null;
-
-            Delegate[] ds = eventHandler.GetInvocationList();
-            int len = ds.Length;
-            for (int i = 0; i < len; i++)
-            {
-                Assembly asm = ((ResolveEventHandler)ds[i])(this, new ResolveEventArgs(resourceName, assembly));
-                RuntimeAssembly ret = GetRuntimeAssembly(asm);
-                if (ret != null)
-                    return ret;
-            }
-
-            return null;
+            return InvokeResolveEvent(_ResourceResolve, assembly, resourceName);
         }
 
         // This method is called by the VM
         private RuntimeAssembly OnTypeResolveEvent(RuntimeAssembly assembly, String typeName)
         {
-            ResolveEventHandler eventHandler = _TypeResolve;
-            if (eventHandler == null)
-                return null;
-
-            Delegate[] ds = eventHandler.GetInvocationList();
-            int len = ds.Length;
-            for (int i = 0; i < len; i++)
-            {
-                Assembly asm = ((ResolveEventHandler)ds[i])(this, new ResolveEventArgs(typeName, assembly));
-                RuntimeAssembly ret = GetRuntimeAssembly(asm);
-                if (ret != null)
-                    return ret;
-            }
-
-            return null;
+            return InvokeResolveEvent(_TypeResolve, assembly, typeName);
         }
 
         // This method is called by the VM.
         private RuntimeAssembly OnAssemblyResolveEvent(RuntimeAssembly assembly, String assemblyFullName)
         {
-            ResolveEventHandler eventHandler = _AssemblyResolve;
+            return InvokeResolveEvent(_AssemblyResolve, assembly, assemblyFullName);
+        }
 
+        private RuntimeAssembly InvokeResolveEvent(ResolveEventHandler eventHandler, RuntimeAssembly assembly, string name)
+        {
             if (eventHandler == null)
-            {
                 return null;
-            }
 
-            Delegate[] ds = eventHandler.GetInvocationList();
-            int len = ds.Length;
-            for (int i = 0; i < len; i++)
+            foreach (ResolveEventHandler handler in eventHandler.GetInvocationList())
             {
-                Assembly asm = ((ResolveEventHandler)ds[i])(this, new ResolveEventArgs(assemblyFullName, assembly));
+                Assembly asm = handler(this, new ResolveEventArgs(name, assembly));
                 RuntimeAssembly ret = GetRuntimeAssembly(asm);
                 if (ret != null)
                     return ret;

--- a/src/mscorlib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimeAssembly.cs
@@ -676,11 +676,9 @@ namespace System.Reflection
             if (moduleResolve == null)
                 return null;
 
-            Delegate[] ds = moduleResolve.GetInvocationList();
-            int len = ds.Length;
-            for (int i = 0; i < len; i++)
+            foreach (ModuleResolveEventHandler handler in moduleResolve.GetInvocationList())
             {
-                RuntimeModule ret = (RuntimeModule)((ModuleResolveEventHandler)ds[i])(this, new ResolveEventArgs(moduleName, this));
+                RuntimeModule ret = (RuntimeModule)handler(this, new ResolveEventArgs(moduleName, this));
                 if (ret != null)
                     return ret;
             }

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeMetadata.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeMetadata.cs
@@ -24,13 +24,11 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             EventHandler<DesignerNamespaceResolveEventArgs> eventHandler = DesignerNamespaceResolve;
             if (eventHandler != null)
             {
-                Delegate[] ds = eventHandler.GetInvocationList();
-                int len = ds.Length;
-                for (int i = 0; i < len; i++)
+                foreach (EventHandler<DesignerNamespaceResolveEventArgs> handler in eventHandler.GetInvocationList())
                 {
                     DesignerNamespaceResolveEventArgs eventArgs = new DesignerNamespaceResolveEventArgs(namespaceName);
 
-                    ((EventHandler<DesignerNamespaceResolveEventArgs>)ds[i])(appDomain, eventArgs);
+                    handler(appDomain, eventArgs);
 
                     Collection<string> assemblyFilesCollection = eventArgs.ResolvedAssemblyFiles;
                     if (assemblyFilesCollection.Count > 0)

--- a/src/mscorlib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/mscorlib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -193,10 +193,9 @@ namespace System.Runtime.Loader
             if (assemblyResolveHandler != null)
             {
                 // Loop through the event subscribers and return the first non-null Assembly instance
-                Delegate[] arrSubscribers = assemblyResolveHandler.GetInvocationList();
-                for (int i = 0; i < arrSubscribers.Length; i++)
+                foreach (Func<AssemblyLoadContext, AssemblyName, Assembly> handler in assemblyResolveHandler.GetInvocationList())
                 {
-                    resolvedAssembly = ((Func<AssemblyLoadContext, AssemblyName, Assembly>)arrSubscribers[i])(this, assemblyName);
+                    resolvedAssembly = handler(this, assemblyName);
                     if (resolvedAssembly != null)
                     {
                         break;


### PR DESCRIPTION
A pattern like
```C#
int len = a.Length;
for (int i = 0; i < len; i++) { ... a[i] ... }
```
may result in unnecessary loop cloning.

Anyway, there's no real reason to use a for loop in any of these case. Avois the need for a cast too.

Also remove duplicated code related to AppDomain.OnXResolveEvent methods.