### PR TITLE
Remove some unnecessary boxing 

### DIFF
--- a/src/mscorlib/src/System/Reflection/CustomAttribute.cs
+++ b/src/mscorlib/src/System/Reflection/CustomAttribute.cs
@@ -1644,7 +1644,7 @@ namespace System.Reflection
                     #endregion
                 }
 
-                if (!blobStart.Equals(blobEnd))
+                if (blobStart != blobEnd)
                     throw new CustomAttributeFormatException();
 
                 attributes[cAttributes++] = attribute;

--- a/src/mscorlib/src/System/Resources/ResourceManager.cs
+++ b/src/mscorlib/src/System/Resources/ResourceManager.cs
@@ -416,11 +416,9 @@ namespace System.Resources
 
             lock (localResourceSets)
             {
-                IDictionaryEnumerator setEnum = localResourceSets.GetEnumerator();
-
-                while (setEnum.MoveNext())
+                foreach ((_, ResourceSet resourceSet) in localResourceSets)
                 {
-                    ((ResourceSet)setEnum.Value).Close();
+                    resourceSet.Close();
                 }
             }
         }

--- a/src/mscorlib/src/System/RtType.cs
+++ b/src/mscorlib/src/System/RtType.cs
@@ -2441,12 +2441,7 @@ namespace System
         #region Private\Internal Members
         internal override bool CacheEquals(object o)
         {
-            RuntimeType m = o as RuntimeType;
-
-            if (m == null)
-                return false;
-
-            return m.m_handle.Equals(m_handle);
+            return (o is RuntimeType t) && (t.m_handle == m_handle);
         }
 
         private RuntimeTypeCache Cache


### PR DESCRIPTION
Remove 2 unnecessary uses of `IntPtr.Equals(object)` and an unnecessary cast to `IDictionaryEnumerator`.