### PR TITLE
Use Span to drop byte[1] allocations

### DIFF
--- a/src/mscorlib/shared/System/IO/PinnedBufferMemoryStream.cs
+++ b/src/mscorlib/shared/System/IO/PinnedBufferMemoryStream.cs
@@ -30,18 +30,12 @@ namespace System.IO
             Debug.Assert(array != null, "Array can't be null");
 
             int len = array.Length;
-            // Handle 0 length byte arrays specially.
-            if (len == 0)
-            {
-                array = new byte[1];
-                len = 0;
-            }
 
             _array = array;
             _pinningHandle = GCHandle.Alloc(array, GCHandleType.Pinned);
             // Now the byte[] is pinned for the lifetime of this instance.
             // But I also need to get a pointer to that block of memory...
-            fixed (byte* ptr = &_array[0])
+            fixed (byte* ptr = &MemoryMarshal.GetReference((Span<byte>)array))
                 Initialize(ptr, len, len, FileAccess.Read);
         }
 

--- a/src/mscorlib/shared/System/IO/PinnedBufferMemoryStream.cs
+++ b/src/mscorlib/shared/System/IO/PinnedBufferMemoryStream.cs
@@ -29,12 +29,11 @@ namespace System.IO
         {
             Debug.Assert(array != null, "Array can't be null");
 
-            int len = array.Length;
-
             _array = array;
             _pinningHandle = GCHandle.Alloc(array, GCHandleType.Pinned);
             // Now the byte[] is pinned for the lifetime of this instance.
             // But I also need to get a pointer to that block of memory...
+            int len = array.Length;
             fixed (byte* ptr = &MemoryMarshal.GetReference((Span<byte>)array))
                 Initialize(ptr, len, len, FileAccess.Read);
         }

--- a/src/mscorlib/src/System/IO/Stream.cs
+++ b/src/mscorlib/src/System/IO/Stream.cs
@@ -767,16 +767,17 @@ namespace System.IO
 
         // Reads one byte from the stream by calling Read(byte[], int, int). 
         // Will return an unsigned byte cast to an int or -1 on end of stream.
-        // This implementation should be overridden by any 
+        // This implementation does not perform well because it allocates a new
+        // byte[] each time you call it, and should be overridden by any 
         // subclass that maintains an internal buffer.  Then, it can help perf
         // significantly for people who are reading one byte at a time.
         public virtual int ReadByte()
         {
-            Span<byte> bytes = stackalloc byte[1];
-            int r = Read(bytes);
+            byte[] oneByteArray = new byte[1];
+            int r = Read(oneByteArray, 0, 1);
             if (r == 0)
                 return -1;
-            return bytes[0];
+            return oneByteArray[0];
         }
 
         public abstract void Write(byte[] buffer, int offset, int count);
@@ -793,14 +794,15 @@ namespace System.IO
         }
 
         // Writes one byte from the stream by calling Write(byte[], int, int).
-        // This implementation should be overridden by any 
+        // This implementation does not perform well because it allocates a new
+        // byte[] each time you call it, and should be overridden by any 
         // subclass that maintains an internal buffer.  Then, it can help perf
         // significantly for people who are writing one byte at a time.
         public virtual void WriteByte(byte value)
         {
-            Span<byte> bytes = stackalloc byte[1];
-            bytes[0] = value;
-            Write(bytes);
+            byte[] oneByteArray = new byte[1];
+            oneByteArray[0] = value;
+            Write(oneByteArray, 0, 1);
         }
 
         public static Stream Synchronized(Stream stream)

--- a/src/mscorlib/src/System/IO/Stream.cs
+++ b/src/mscorlib/src/System/IO/Stream.cs
@@ -767,17 +767,16 @@ namespace System.IO
 
         // Reads one byte from the stream by calling Read(byte[], int, int). 
         // Will return an unsigned byte cast to an int or -1 on end of stream.
-        // This implementation does not perform well because it allocates a new
-        // byte[] each time you call it, and should be overridden by any 
+        // This implementation should be overridden by any 
         // subclass that maintains an internal buffer.  Then, it can help perf
         // significantly for people who are reading one byte at a time.
         public virtual int ReadByte()
         {
-            byte[] oneByteArray = new byte[1];
-            int r = Read(oneByteArray, 0, 1);
+            Span<byte> bytes = stackalloc byte[1];
+            int r = Read(bytes);
             if (r == 0)
                 return -1;
-            return oneByteArray[0];
+            return bytes[0];
         }
 
         public abstract void Write(byte[] buffer, int offset, int count);
@@ -794,15 +793,14 @@ namespace System.IO
         }
 
         // Writes one byte from the stream by calling Write(byte[], int, int).
-        // This implementation does not perform well because it allocates a new
-        // byte[] each time you call it, and should be overridden by any 
+        // This implementation should be overridden by any 
         // subclass that maintains an internal buffer.  Then, it can help perf
         // significantly for people who are writing one byte at a time.
         public virtual void WriteByte(byte value)
         {
-            byte[] oneByteArray = new byte[1];
-            oneByteArray[0] = value;
-            Write(oneByteArray, 0, 1);
+            Span<byte> bytes = stackalloc byte[1];
+            bytes[0] = value;
+            Write(bytes);
         }
 
         public static Stream Synchronized(Stream stream)

--- a/src/mscorlib/src/System/StubHelpers.cs
+++ b/src/mscorlib/src/System/StubHelpers.cs
@@ -46,7 +46,7 @@ namespace System.StubHelpers
 
         static internal char ConvertToManaged(byte nativeChar)
         {
-            Span<byte> bytes = stackalloc byte[1];
+            Span<byte> bytes = new Span<byte>(ref nativeChar, 1);
             bytes[0] = nativeChar;
             string str = Encoding.Default.GetString(bytes);
             return str[0];

--- a/src/mscorlib/src/System/StubHelpers.cs
+++ b/src/mscorlib/src/System/StubHelpers.cs
@@ -46,7 +46,8 @@ namespace System.StubHelpers
 
         static internal char ConvertToManaged(byte nativeChar)
         {
-            byte[] bytes = new byte[1] { nativeChar };
+            Span<byte> bytes = stackalloc byte[1];
+            bytes[0] = nativeChar;
             string str = Encoding.Default.GetString(bytes);
             return str[0];
         }

--- a/src/mscorlib/src/System/StubHelpers.cs
+++ b/src/mscorlib/src/System/StubHelpers.cs
@@ -47,7 +47,6 @@ namespace System.StubHelpers
         static internal char ConvertToManaged(byte nativeChar)
         {
             Span<byte> bytes = new Span<byte>(ref nativeChar, 1);
-            bytes[0] = nativeChar;
             string str = Encoding.Default.GetString(bytes);
             return str[0];
         }


### PR DESCRIPTION
* PinnedBufferMemoryStream drop allocation for zero length array
* AnsiCharMarshaler ConvertToManaged use stackalloc'd `Span<byte>`
  