### PR TITLE
Use Lzcnt for arraypool buckets

### DIFF
--- a/src/mscorlib/shared/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
+++ b/src/mscorlib/shared/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
@@ -158,7 +158,11 @@ namespace System.Buffers
             }
 
             // Determine with what bucket this array length is associated
+#if !CORERT && !ARM && !ARM64
             int bucketIndex = Lzcnt.IsSupported ? Utilities.SelectBucketIndexIntrinsic(array.Length) : Utilities.SelectBucketIndex(array.Length);
+#else
+            int bucketIndex = Utilities.SelectBucketIndex(array.Length);
+#endif
 
             // If we can tell that the buffer was allocated (or empty), drop it. Otherwise, check if we have space in the pool.
             if (bucketIndex < _buckets.Length)

--- a/src/mscorlib/shared/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
+++ b/src/mscorlib/shared/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.Win32;
 using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.X86;
 using System.Threading;
 
 namespace System.Buffers
@@ -87,7 +88,11 @@ namespace System.Buffers
             T[] buffer;
 
             // Get the bucket number for the array length
+#if !CORERT && !ARM && !ARM64
+            int bucketIndex = Lzcnt.IsSupported ? Utilities.SelectBucketIndexIntrinsic(minimumLength) : Utilities.SelectBucketIndex(minimumLength);
+#else
             int bucketIndex = Utilities.SelectBucketIndex(minimumLength);
+#endif
 
             // If the array could come from a bucket...
             if (bucketIndex < _buckets.Length)
@@ -153,7 +158,7 @@ namespace System.Buffers
             }
 
             // Determine with what bucket this array length is associated
-            int bucketIndex = Utilities.SelectBucketIndex(array.Length);
+            int bucketIndex = Lzcnt.IsSupported ? Utilities.SelectBucketIndexIntrinsic(array.Length) : Utilities.SelectBucketIndex(array.Length);
 
             // If we can tell that the buffer was allocated (or empty), drop it. Otherwise, check if we have space in the pool.
             if (bucketIndex < _buckets.Length)

--- a/src/mscorlib/shared/System/Buffers/Utilities.cs
+++ b/src/mscorlib/shared/System/Buffers/Utilities.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.X86;
 
 namespace System.Buffers
 {
@@ -23,6 +24,14 @@ namespace System.Buffers
 
             return poolIndex + (int)bitsRemaining;
         }
+
+#if !CORERT && !ARM && !ARM64
+        internal static int SelectBucketIndexIntrinsic(int bufferSize)
+        {
+            Debug.Assert(Lzcnt.IsSupported);
+            return (31 - (int)Lzcnt.LeadingZeroCount((uint)(bufferSize - 1) >> 3));
+        }
+#endif
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetMaxSizeForBucket(int binIndex)


### PR DESCRIPTION
Changes
```asm
       E8B3F5A85F           call     CORINFO_HELP_GETSHARED_GCSTATIC_BASE
       488B9878030000       mov      rbx, gword ptr [rax+888]
       8D4FFF               lea      ecx, [rdi-1]
       C1E904               shr      ecx, 4
       33D2                 xor      edx, edx
       81F9FFFF0000         cmp      ecx, 0xFFFF
       7608                 jbe      SHORT G_M6594_IG06
       C1E910               shr      ecx, 16
       BA10000000           mov      edx, 16

G_M6594_IG06:
       81F9FF000000         cmp      ecx, 255
       7606                 jbe      SHORT G_M6594_IG07
       C1E908               shr      ecx, 8
       83C208               add      edx, 8

G_M6594_IG07:
       83F90F               cmp      ecx, 15
       7606                 jbe      SHORT G_M6594_IG08
       C1E904               shr      ecx, 4
       83C204               add      edx, 4

G_M6594_IG08:
       83F903               cmp      ecx, 3
       7606                 jbe      SHORT G_M6594_IG09
       C1E902               shr      ecx, 2
       83C202               add      edx, 2

G_M6594_IG09:
       83F901               cmp      ecx, 1
       7604                 jbe      SHORT G_M6594_IG10
       D1E9                 shr      ecx, 1
       FFC2                 inc      edx

G_M6594_IG10:
       8D2C0A               lea      ebp, [rdx+rcx]
       488B4E10             mov      rcx, gword ptr [rsi+16]
       448B7108             mov      r14d, dword ptr [rcx+8]
```
To:
```asm
       E8B3F5A85F           call     CORINFO_HELP_GETSHARED_GCSTATIC_BASE
       488B9878030000       mov      rbx, gword ptr [rax+888]
       8D4FFF               lea      ecx, [rdi-1]
       C1E903               shr      ecx, 3
       F30FBDC9             lzcnt    ecx, ecx
       F7D9                 neg      ecx
       8D691F               lea      ebp, [rcx+31]
       488B4E10             mov      rcx, gword ptr [rsi+16]
       448B7108             mov      r14d, dword ptr [rcx+8]
```

/cc @fiigii