### PR TITLE
Fix size-on-disk benchmark to handle new CLI behavior

### DIFF
--- a/tests/src/sizeondisk/sodbench/SoDBench.cs
+++ b/tests/src/sizeondisk/sodbench/SoDBench.cs
@@ -370,6 +370,7 @@ namespace SoDBench
                     ProcessStartInfo dotnetPublish = new ProcessStartInfo()
                     {
                         FileName = s_dotnetExe.FullName,
+                        // The UserSharedCompiler flag is set to false to prevent hnadles from being held that will later cause deletion of the installed SDK to fail.
                         Arguments = $"publish -c Release --runtime {os} --output {publishDir.FullName} /p:UseSharedCompilation=false",
                         UseShellExecute = false,
                         WorkingDirectory = deploymentSandbox.FullName

--- a/tests/src/sizeondisk/sodbench/SoDBench.cs
+++ b/tests/src/sizeondisk/sodbench/SoDBench.cs
@@ -370,7 +370,7 @@ namespace SoDBench
                     ProcessStartInfo dotnetPublish = new ProcessStartInfo()
                     {
                         FileName = s_dotnetExe.FullName,
-                        // The UserSharedCompiler flag is set to false to prevent hnadles from being held that will later cause deletion of the installed SDK to fail.
+                        // The UserSharedCompiler flag is set to false to prevent handles from being held that will later cause deletion of the installed SDK to fail.
                         Arguments = $"publish -c Release --runtime {os} --output {publishDir.FullName} /p:UseSharedCompilation=false",
                         UseShellExecute = false,
                         WorkingDirectory = deploymentSandbox.FullName

--- a/tests/src/sizeondisk/sodbench/SoDBench.cs
+++ b/tests/src/sizeondisk/sodbench/SoDBench.cs
@@ -223,7 +223,7 @@ namespace SoDBench
                         Console.WriteLine($"** Using core libraries found at {options.CoreLibariesDirectory}");
                         s_corelibsDir = new DirectoryInfo(options.CoreLibariesDirectory);
                     }
-                    else 
+                    else
                     {
                         var coreroot = Environment.GetEnvironmentVariable("CORE_ROOT");
                         if (!String.IsNullOrEmpty(coreroot) && Directory.Exists(coreroot))
@@ -237,7 +237,7 @@ namespace SoDBench
                         }
                     }
 
-                    PrintHeader("Installing Dotnet CLI");
+                    PrintHeader("** Installing Dotnet CLI");
                     s_dotnetExe = SetupDotnet();
                 }
 
@@ -248,11 +248,11 @@ namespace SoDBench
                 }
 
                 Console.WriteLine($"** Path to dotnet executable: {s_dotnetExe.FullName}");
-                
-                PrintHeader("Starting acquisition size test");
+
+                PrintHeader("** Starting acquisition size test");
                 var acquisition = GetAcquisitionSize();
 
-                PrintHeader("Running deployment size test");
+                PrintHeader("** Running deployment size test");
                 var deployment = GetDeploymentSize();
 
                 var root = new SizeReportingNode("Dotnet Total");
@@ -260,7 +260,7 @@ namespace SoDBench
                 root.AddChild(deployment);
 
                 var formattedStr = root.FormatAsCsv();
-               
+
                 File.WriteAllText(options.OutputFilename, formattedStr);
 
                 if (options.Verbose)
@@ -270,8 +270,8 @@ namespace SoDBench
             {
                 if (!s_keepArtifacts && s_sandboxDir != null)
                 {
-                    PrintHeader("Cleaning up sandbox directory");
-                    s_sandboxDir.Delete(true);
+                    PrintHeader("** Cleaning up sandbox directory");
+                    DeleteDirectory(s_sandboxDir);
                     s_sandboxDir = null;
                 }
             }
@@ -328,7 +328,7 @@ namespace SoDBench
 
             return result;
         }
-        
+
         private static SizeReportingNode GetDeploymentSize()
         {
             // Write the NuGet.Config file
@@ -370,7 +370,7 @@ namespace SoDBench
                     ProcessStartInfo dotnetPublish = new ProcessStartInfo()
                     {
                         FileName = s_dotnetExe.FullName,
-                        Arguments = $"publish -c Release --runtime {os} --output {publishDir.FullName}", // "out" is an arbitrary project name
+                        Arguments = $"publish -c Release --runtime {os} --output {publishDir.FullName} /p:UseSharedCompilation=false",
                         UseShellExecute = false,
                         WorkingDirectory = deploymentSandbox.FullName
                     };
@@ -676,6 +676,56 @@ namespace SoDBench
             private string _dotnetExe;
             private string _corelibsDir;
             private string _outputFilename = "measurement.csv";
+        }
+
+        private static void DeleteDirectory(DirectoryInfo dir, uint maxWait=10000)
+        {
+            foreach (var subdir in dir.GetDirectories())
+            {
+                DeleteDirectory(subdir);
+            }
+
+            // Give it time to actually delete all the files
+            var files = dir.GetFiles();
+            bool wait = true;
+            uint waitTime = 0;
+            while (wait)
+            {
+                wait = false;
+
+                foreach (var f in files)
+                {
+                    if (File.Exists(f.FullName))
+                    {
+                        try
+                        {
+                            File.Delete(f.FullName);
+                        }
+                        catch (IOException) { if (waitTime > maxWait) throw; }
+                        catch (UnauthorizedAccessException) { if (waitTime > maxWait) throw; }
+
+                        if (File.Exists(f.FullName))
+                        {
+                            wait = true;
+
+                            // Print a message every 3 seconds if the thread is stuck
+                            if (waitTime != 0 && waitTime % 3000 == 0)
+                            {
+                                Console.WriteLine($"Waiting to delete {f.FullName}");
+                            }
+                        }
+                    }
+                }
+
+                // Try again in 100ms
+                if (wait)
+                {
+                    Thread.Sleep(100);
+                    waitTime += 100;
+                }
+            }
+
+            Directory.Delete(dir.FullName);
         }
     }
 


### PR DESCRIPTION
Around Dec 20, the dotnet cli added the use of compiler server which lives beyond the life of the cli command. [More info](https://github.com/dotnet/cli/issues/8299)

This PR adds the flag `/p:UseSharedCompilation=false` to disable this new behavior for the purposes of testing and to ensure smooth cleanup. Additionally this PR changes to use a more resilient directory deletion strategy to address more intermittent failures seen on my developer machine.