### PR TITLE
Remove duplicate callback to AppDomainCreationFinished in profiler

### DIFF
--- a/src/vm/corhost.cpp
+++ b/src/vm/corhost.cpp
@@ -650,10 +650,6 @@ HRESULT CorHost2::_CreateAppDomain(
     if (dwFlags & APPDOMAIN_FORCE_TRIVIAL_WAIT_OPERATIONS)
         pDomain->SetForceTrivialWaitOperations();
 
-        
-#ifdef PROFILING_SUPPORTED
-    EX_TRY
-#endif    
     {
         GCX_COOP();
     
@@ -710,28 +706,6 @@ HRESULT CorHost2::_CreateAppDomain(
 
         m_fAppDomainCreated = TRUE;
     }
-#ifdef PROFILING_SUPPORTED
-    EX_HOOK
-    {
-        // Need the first assembly loaded in to get any data on an app domain.
-        {
-            BEGIN_PIN_PROFILER(CORProfilerTrackAppDomainLoads());
-            GCX_PREEMP();
-            g_profControlBlock.pProfInterface->AppDomainCreationFinished((AppDomainID)(AppDomain*) pDomain, GET_EXCEPTION()->GetHR());
-            END_PIN_PROFILER();
-        }
-    }
-    EX_END_HOOK;
-
-    // Need the first assembly loaded in to get any data on an app domain.
-    {
-        BEGIN_PIN_PROFILER(CORProfilerTrackAppDomainLoads());
-        GCX_PREEMP();
-        g_profControlBlock.pProfInterface->AppDomainCreationFinished((AppDomainID)(AppDomain*) pDomain, S_OK);
-        END_PIN_PROFILER();
-    }        
-#endif // PROFILING_SUPPORTED
-
     // DoneCreating releases ownership of AppDomain.  After this call, there should be no access to pDomain.
     pDomain.DoneCreating();
 


### PR DESCRIPTION
- This fix addresses issue #7599
- We're already making a call to AppDomainCreationFinished callback in SystemDomain::NotifyProfilerStartup (refer to https://github.com/dotnet/coreclr/blob/master/src/vm/appdomain.cpp#L3852), so I'm removing the duplicate call in CorHost2::_CreateAppDomain()
