### PR TITLE
Disable jitdiff jobs

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -136,7 +136,7 @@ class Constants {
                'longgc',
                'formatting',
                'gcsimulator',
-               'jitdiff',
+               // 'jitdiff', // jitdiff is currently disabled, until someone spends the effort to make it fully work
                'standalone_gc',
                'gc_reliability_framework',
                'illink']


### PR DESCRIPTION
They are failing now. Disable them until someone puts the effort
in to make them fully work.