### PR TITLE
Fix typo in docstring

### DIFF
--- a/src/mscorlib/src/System/Collections/Hashtable.cs
+++ b/src/mscorlib/src/System/Collections/Hashtable.cs
@@ -74,7 +74,7 @@ namespace System.Collections
           fixes here probably need to be made to the generic Dictionary as well.
     
           This Hashtable uses double hashing.  There are hashsize buckets in the 
-          table, and each bucket can contain 0 or 1 element.  We a bit to mark
+          table, and each bucket can contain 0 or 1 element.  We use a bit to mark
           whether there's been a collision when we inserted multiple elements
           (ie, an inserted item was hashed at least a second time and we probed 
           this bucket, but it was already in use).  Using the collision bit, we


### PR DESCRIPTION
Fix missing word in the HashTable docstring.