### PR TITLE
Refactor minRegCount and eliminate auto

### DIFF
--- a/src/jit/jitstd/list.h
+++ b/src/jit/jitstd/list.h
@@ -177,6 +177,8 @@ public:
 
     reference back();
     const_reference back() const;
+    iterator backPosition();
+    const_iterator backPosition() const;
 
     iterator begin();
     const_iterator begin() const;
@@ -364,6 +366,18 @@ template <typename T, typename Allocator>
 typename list<T, Allocator>::const_reference list<T, Allocator>::back() const
 {
     return m_pTail->m_value;
+}
+
+template <typename T, typename Allocator>
+typename list<T, Allocator>::iterator list<T, Allocator>::backPosition()
+{
+    return iterator(m_pTail);
+}
+
+template <typename T, typename Allocator>
+typename list<T, Allocator>::const_iterator list<T, Allocator>::backPosition() const
+{
+    return const_iterator(m_pTail);
 }
 
 template <typename T, typename Allocator>

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -396,8 +396,10 @@ public:
 typedef ListElementAllocator<Interval, CMK_LSRA_Interval>       LinearScanMemoryAllocatorInterval;
 typedef ListElementAllocator<RefPosition, CMK_LSRA_RefPosition> LinearScanMemoryAllocatorRefPosition;
 
-typedef jitstd::list<Interval, LinearScanMemoryAllocatorInterval>       IntervalList;
-typedef jitstd::list<RefPosition, LinearScanMemoryAllocatorRefPosition> RefPositionList;
+typedef jitstd::list<Interval, LinearScanMemoryAllocatorInterval>                         IntervalList;
+typedef jitstd::list<RefPosition, LinearScanMemoryAllocatorRefPosition>                   RefPositionList;
+typedef jitstd::list<RefPosition, LinearScanMemoryAllocatorRefPosition>::iterator         RefPositionIterator;
+typedef jitstd::list<RefPosition, LinearScanMemoryAllocatorRefPosition>::reverse_iterator RefPositionReverseIterator;
 
 class Referenceable
 {
@@ -1050,18 +1052,11 @@ private:
 
     var_types getDefType(GenTree* tree);
 
-    RefPosition* defineNewInternalTemp(GenTree*     tree,
-                                       RegisterType regType,
-                                       regMaskTP regMask DEBUGARG(unsigned minRegCandidateCount));
+    RefPosition* defineNewInternalTemp(GenTree* tree, RegisterType regType, regMaskTP regMask);
 
-    int buildInternalRegisterDefsForNode(GenTree*      tree,
-                                         TreeNodeInfo* info,
-                                         RefPosition* defs[] DEBUGARG(unsigned minRegCandidateCount));
+    int buildInternalRegisterDefsForNode(GenTree* tree, TreeNodeInfo* info, RefPosition* defs[]);
 
-    void buildInternalRegisterUsesForNode(GenTree*      tree,
-                                          TreeNodeInfo* info,
-                                          RefPosition*  defs[],
-                                          int total DEBUGARG(unsigned minRegCandidateCount));
+    void buildInternalRegisterUsesForNode(GenTree* tree, TreeNodeInfo* info, RefPosition* defs[], int total);
 
     void resolveLocalRef(BasicBlock* block, GenTree* treeNode, RefPosition* currentRefPosition);
 
@@ -1118,7 +1113,7 @@ private:
                                 RefType      theRefType,
                                 GenTree*     theTreeNode,
                                 regMaskTP    mask,
-                                unsigned multiRegIdx = 0 DEBUGARG(unsigned minRegCandidateCount = 1));
+                                unsigned     multiRegIdx = 0);
 
     RefPosition* newRefPosition(
         regNumber reg, LsraLocation theLocation, RefType theRefType, GenTree* theTreeNode, regMaskTP mask);


### PR DESCRIPTION
When building `RefPosition`s in the `TreeNodeInfoInit` methods, it is very complex and messy to have the setting of the (debug-only) `minRegCandidateCount` spread all over. Instead, set them for all the `RefPosition`s for a given node after they have been created.

This required the ability to create an iterator marking the end of the list, prior to creating the new ones.

In the process, eliminated the use of `auto` from lsra.cpp in the interest of strong typing, as well as avoiding the confusion of having things with `RefPosition` in their name that are actually iterators.