### PR TITLE
Reset lvIsStructField when removing promoted struct vars

### DIFF
--- a/src/jit/regalloc.cpp
+++ b/src/jit/regalloc.cpp
@@ -841,6 +841,7 @@ void Compiler::raAssignVars()
                  varNum++)
             {
                 noway_assert(lvaTable[varNum].lvRefCnt == 0);
+                lvaTable[varNum].lvIsStructField = false;
             }
         }
         else

--- a/tests/src/JIT/Regression/JitBlue/GitHub_15718/GitHub_15718.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_15718/GitHub_15718.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    static int Main()
+    {
+        var map = new Dictionary<string, bool?> { { "foo", true } };
+        return (Test(map) == true) ? 100 : 1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool? Test(Dictionary<string, bool?> map)
+    {
+        return map["foo"];
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_15718/GitHub_15718.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_15718/GitHub_15718.csproj
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_15718.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
There's a bug in `Compiler::raAssignVars`
https://github.com/dotnet/coreclr/blob/66b31aab41996565ef02893cfdf12db485b7c07d/src/jit/regalloc.cpp#L834-L861
It attempts to get rid of unused promoted lclvars and changes various lclvar properties (e.g. it resets  `lvOnFrame`) but fails to reset `lvIsStructField` on the promoted fields. Later `lvaAssignFrameOffsetsToPromotedStructs` finds the fields and asserts because the parent lclvar has `lvOnFrame == false`.

This happens independently from the `GT_BOX` change, for example in the `Dictionary<string, bool?>` there's no `GT_BOX` in the IR.

In the case of the XUnit assert the `GT_BOX` change resulted in some dead code elimination that in turn produced some unused lclvars that `raAssignVars` now tries to eliminate.

Fixes #15718