### PR TITLE
Change just-in-time debugging registry keys.

### DIFF
--- a/src/ToolBox/superpmi/superpmi/jitdebugger.cpp
+++ b/src/ToolBox/superpmi/superpmi/jitdebugger.cpp
@@ -193,7 +193,7 @@ BOOL IsCurrentModuleFileNameInAutoExclusionList()
 {
     HKEY hKeyHolder;
 
-    // Look for "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug\\AutoExclusionList"
+    // Look for "HKLM\\SOFTWARE\\Microsoft\\.NETCore\\JITDebugging\\AutoExclusionList"
     DWORD ret = WszRegOpenKeyEx(HKEY_LOCAL_MACHINE, kUnmanagedDebuggerAutoExclusionListKey, 0, KEY_READ, &hKeyHolder);
 
     if (ret != ERROR_SUCCESS)
@@ -277,15 +277,15 @@ HRESULT GetDebuggerSettingInfoWorker(__out_ecount_part_opt(*pcchDebuggerString, 
 
     HKEY hKey;
 
-    // Look for "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug"
+    // Look for "HKLM\\SOFTWARE\\Microsoft\\.NETCore\\JITDebugging"
     DWORD ret = WszRegOpenKeyEx(HKEY_LOCAL_MACHINE, kUnmanagedDebuggerKey, 0, KEY_READ, &hKey);
 
     if (ret != ERROR_SUCCESS)
-    { // Wow, there's not even an AeDebug hive, so no native debugger, no auto.
+    { // Wow, there's not even an JITDebugging hive, so no native debugger, no auto.
         return S_OK;
     }
 
-    // Look in AeDebug key for "Debugger"; get the size of any value stored there.
+    // Look in JITDebugging key for "Debugger"; get the size of any value stored there.
     DWORD valueType, valueSize;
     ret = RegQueryValueExW(hKey, kUnmanagedDebuggerValue, 0, &valueType, 0, &valueSize);
 
@@ -337,7 +337,7 @@ HRESULT GetDebuggerSettingInfoWorker(__out_ecount_part_opt(*pcchDebuggerString, 
         }
         else
         {
-            // Look in AeDebug key for "Auto"; get the size of any value stored there.
+            // Look in JITDebugging key for "Auto"; get the size of any value stored there.
             ret = RegQueryValueExW(hKey, kUnmanagedDebuggerAutoValue, 0, &valueType, 0, &valueSize);
             if ((ret == ERROR_SUCCESS) && (valueType == REG_SZ) && (valueSize / sizeof(WCHAR) < MAX_PATH))
             {

--- a/src/inc/utilcode.h
+++ b/src/inc/utilcode.h
@@ -4248,10 +4248,10 @@ void  AdjustImageRuntimeVersion (SString* pVersion);
 SELECTANY const WCHAR kDebugApplicationsPoliciesKey[] = W("SOFTWARE\\Policies\\Microsoft\\Windows\\Windows Error Reporting\\DebugApplications");
 SELECTANY const WCHAR kDebugApplicationsKey[] = W("SOFTWARE\\Microsoft\\Windows\\Windows Error Reporting\\DebugApplications");
 
-SELECTANY const WCHAR kUnmanagedDebuggerKey[] = W("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug");
+SELECTANY const WCHAR kUnmanagedDebuggerKey[] = W("SOFTWARE\\Microsoft\\.NETCore\\JITDebugging");
 SELECTANY const WCHAR kUnmanagedDebuggerValue[] = W("Debugger");
 SELECTANY const WCHAR kUnmanagedDebuggerAutoValue[] = W("Auto");
-SELECTANY const WCHAR kUnmanagedDebuggerAutoExclusionListKey[] = W("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug\\AutoExclusionList");
+SELECTANY const WCHAR kUnmanagedDebuggerAutoExclusionListKey[] = W("SOFTWARE\\Microsoft\\.NETCore\\JITDebugging\\AutoExclusionList");
 
 BOOL GetRegistryLongValue(HKEY    hKeyParent,              // Parent key.
                           LPCWSTR szKey,                   // Key name to look at.

--- a/src/utilcode/util_nodependencies.cpp
+++ b/src/utilcode/util_nodependencies.cpp
@@ -353,7 +353,7 @@ BOOL IsCurrentModuleFileNameInAutoExclusionList()
 
     HKEYHolder hKeyHolder;
 
-    // Look for "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug\\AutoExclusionList"
+    // Look for "HKLM\\SOFTWARE\\Microsoft\\.NETCore\\JITDebugging\\AutoExclusionList"
     DWORD ret = WszRegOpenKeyEx(HKEY_LOCAL_MACHINE, kUnmanagedDebuggerAutoExclusionListKey, 0, KEY_READ, &hKeyHolder);
 
     if (ret != ERROR_SUCCESS)
@@ -484,15 +484,15 @@ HRESULT GetDebuggerSettingInfoWorker(__out_ecount_part_opt(*pcchDebuggerString, 
 
     HKEYHolder hKeyHolder;
 
-    // Look for "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug"
+    // Look for "HKLM\\SOFTWARE\\Microsoft\\.NETCore\\JITDebugging"
     DWORD ret = WszRegOpenKeyEx(HKEY_LOCAL_MACHINE, kUnmanagedDebuggerKey, 0, KEY_READ, &hKeyHolder);
 
     if (ret != ERROR_SUCCESS)
-    {   // Wow, there's not even an AeDebug hive, so no native debugger, no auto.
+    {   // Wow, there's not even an JITDebugging hive, so no native debugger, no auto.
         return S_OK;
     }
 
-    // Look in AeDebug key for "Debugger"; get the size of any value stored there.
+    // Look in JITDebugging key for "Debugger"; get the size of any value stored there.
     DWORD valueType, valueSize = 0;
     ret = WszRegQueryValueEx(hKeyHolder, kUnmanagedDebuggerValue, 0, &valueType, 0, &valueSize);   
 
@@ -547,7 +547,7 @@ HRESULT GetDebuggerSettingInfoWorker(__out_ecount_part_opt(*pcchDebuggerString, 
             }
             else
             {
-                // Look in AeDebug key for "Auto"; get the size of any value stored there.
+                // Look in JITDebugging key for "Auto"; get the size of any value stored there.
                 ret = WszRegQueryValueEx(hKeyHolder, kUnmanagedDebuggerAutoValue, 0, &valueType, 0, &valueSize);
                 if ((ret == ERROR_SUCCESS) && (valueType == REG_SZ) && (valueSize / sizeof(WCHAR) < MAX_LONGPATH))
                 {   


### PR DESCRIPTION
From "SOFTWARE\Microsoft\Windows NT\CurrentVersion\AeDebug" to "SOFTWARE\Microsoft\.NETCore\JITDebugging".