### PR TITLE
Change monitor test

### DIFF
--- a/tests/src/baseservices/threading/generics/Monitor/EnterExit02.cs
+++ b/tests/src/baseservices/threading/generics/Monitor/EnterExit02.cs
@@ -47,7 +47,7 @@ class Gen<T>
 			if(myHelper.Error == true || myHelper2.Error == true)
 				break;
 		}
-		Test.Eval(!(myHelper.Error && myHelper2.Error));
+		Test.Eval(!(myHelper.Error || myHelper2.Error));
 	}
 }
 

--- a/tests/src/baseservices/threading/generics/Monitor/EnterExit04.cs
+++ b/tests/src/baseservices/threading/generics/Monitor/EnterExit04.cs
@@ -52,7 +52,7 @@ struct Gen<T>
 			if(myHelper.Error == true || myHelper2.Error == true)
 				break;
 		}
-		Test.Eval(!(myHelper.Error && myHelper2.Error));
+		Test.Eval(!(myHelper.Error || myHelper2.Error));
 	}	
 }
 

--- a/tests/src/baseservices/threading/generics/Monitor/EnterExit06.cs
+++ b/tests/src/baseservices/threading/generics/Monitor/EnterExit06.cs
@@ -50,7 +50,7 @@ class Gen<T>
 			if(myHelper.Error == true || myHelper2.Error == true)
 				break;
 		}
-		Test.Eval(!(myHelper.Error && myHelper2.Error));
+		Test.Eval(!(myHelper.Error || myHelper2.Error));
 	}
 	
 }

--- a/tests/src/baseservices/threading/generics/Monitor/EnterExit08.cs
+++ b/tests/src/baseservices/threading/generics/Monitor/EnterExit08.cs
@@ -50,7 +50,7 @@ struct Gen<T>
 			if(myHelper.Error == true || myHelper2.Error == true)
 				break;
 		}
-		Test.Eval(!(myHelper.Error && myHelper2.Error));
+		Test.Eval(!(myHelper.Error || myHelper2.Error));
 	}
 	
 }

--- a/tests/src/baseservices/threading/generics/Monitor/EnterExit10.cs
+++ b/tests/src/baseservices/threading/generics/Monitor/EnterExit10.cs
@@ -50,7 +50,7 @@ class Gen<T>
 			if(myHelper.Error == true || myHelper2.Error == true)
 				break;
 		}
-		Test.Eval(!(myHelper.Error && myHelper2.Error));
+		Test.Eval(!(myHelper.Error || myHelper2.Error));
 	}
 
 }

--- a/tests/src/baseservices/threading/generics/Monitor/EnterExit12.cs
+++ b/tests/src/baseservices/threading/generics/Monitor/EnterExit12.cs
@@ -55,7 +55,7 @@ class Gen<T>
 			if(myHelper.Error == true || myHelper2.Error == true)
 				break;
 		}
-		Test.Eval(!(myHelper.Error && myHelper2.Error));
+		Test.Eval(!(myHelper.Error || myHelper2.Error));
 	}
 
 

--- a/tests/src/baseservices/threading/generics/Monitor/EnterExit14.cs
+++ b/tests/src/baseservices/threading/generics/Monitor/EnterExit14.cs
@@ -54,7 +54,7 @@ struct Gen<T>
 			if(myHelper.Error == true || myHelper2.Error == true)
 				break;
 		}
-		Test.Eval(!(myHelper.Error && myHelper2.Error));
+		Test.Eval(!(myHelper.Error || myHelper2.Error));
 	}
 
 

--- a/tests/src/baseservices/threading/generics/Monitor/MonitorHelper.cs
+++ b/tests/src/baseservices/threading/generics/Monitor/MonitorHelper.cs
@@ -54,7 +54,8 @@ class TestHelper
         }
         if(m_iSharedData == m_iRequestedEntries)
             m_Event.Set();
-    }    
+    }
+
     public void Consumer(object monitor)
     {
         lock(monitor)
@@ -62,19 +63,21 @@ class TestHelper
             DoWork();
         }    
     }
-    public void ConsumerTryEnter(object monitor,int timeout)
+
+    public void ConsumerTryEnter(object monitor, int timeout)
     {
+        bool tookLock = false;
+
+        Monitor.TryEnter(monitor, timeout, ref tookLock);
+
+        while (!tookLock)
+        {
+            Thread.Sleep(0);
+            Monitor.TryEnter(monitor, timeout, ref tookLock);
+        }
+
         try
         {
-            bool tookLock = false;
-            
-            Monitor.TryEnter(monitor,timeout, ref tookLock);
-
-            while(!tookLock) {                
-                Thread.Sleep(0);
-                Monitor.TryEnter(monitor,timeout, ref tookLock);
-            }
-
             DoWork();
         }
         finally

--- a/tests/src/baseservices/threading/generics/Monitor/TryEnter03.cs
+++ b/tests/src/baseservices/threading/generics/Monitor/TryEnter03.cs
@@ -44,7 +44,7 @@ class Gen<T>
 			if(myHelper.Error == true || myHelper2.Error == true)
 				break;
 		}
-		Test.Eval(!(myHelper.Error && myHelper2.Error));
+		Test.Eval(!(myHelper.Error || myHelper2.Error));
 		
 	}
 

--- a/tests/src/baseservices/threading/generics/Monitor/TryEnter06.cs
+++ b/tests/src/baseservices/threading/generics/Monitor/TryEnter06.cs
@@ -44,7 +44,7 @@ struct Gen<T>
 			if(myHelper.Error == true || myHelper2.Error == true)
 				break;
 		}
-		Test.Eval(!(myHelper.Error && myHelper2.Error));
+		Test.Eval(!(myHelper.Error || myHelper2.Error));
 		
 	}
 


### PR DESCRIPTION
Relevant to https://github.com/dotnet/coreclr/issues/15592:
- Not sure what is actually happening, guessing there is an exception during TryEnter() and the exception from Exit() from the finally block is hiding the actual exception
- Moved TryEnter() to before the try block
- Fixed pass/fail condition for some similar monitor tests