### PR TITLE
Adding EnsureCapacity implementation for Dictionary

### DIFF
--- a/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
@@ -759,6 +759,24 @@ namespace System.Collections.Generic
             return new Enumerator(this, Enumerator.KeyValuePair);
         }
 
+        /// <summary>
+        /// Ensures that the capacity of this dictionary is at least the given minimum value
+        /// </summary>
+        /// <param name="capacity"></param>
+        /// <returns></returns>
+        public int EnsureCapacity(int capacity)
+        {
+            if (capacity < 0)
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.capacity);
+            if (_entries == null)
+                Initialize(0);
+            if (capacity <= _entries.Length)
+                return _entries.Length;
+            int newSize = HashHelpers.ExpandPrime(capacity);
+            Resize(newSize, false);
+            return newSize;
+        }
+
         bool ICollection.IsSynchronized
         {
             get { return false; }

--- a/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
@@ -373,7 +373,7 @@ namespace System.Collections.Generic
             return -1;
         }
 
-        private void Initialize(int capacity)
+        private int Initialize(int capacity)
         {
             int size = HashHelpers.GetPrime(capacity);
             int[] buckets = new int[size];
@@ -385,6 +385,8 @@ namespace System.Collections.Generic
             _freeList = -1;
             _buckets = buckets;
             _entries = new Entry[size];
+
+            return size;
         }
 
         private bool TryInsert(TKey key, TValue value, InsertionBehavior behavior)
@@ -760,20 +762,18 @@ namespace System.Collections.Generic
         }
 
         /// <summary>
-        /// Ensures that the capacity of this dictionary is at least the given minimum value
+        /// Ensures that the dictionary can hold up to 'capacity' entries without any further expansion of its backing storage
         /// </summary>
-        /// <param name="capacity"></param>
-        /// <returns></returns>
         public int EnsureCapacity(int capacity)
         {
             if (capacity < 0)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.capacity);
-            if (_entries == null)
-                Initialize(0);
-            if (capacity <= _entries.Length)
+            if (_entries != null && _entries.Length >= capacity)
                 return _entries.Length;
-            int newSize = HashHelpers.ExpandPrime(capacity);
-            Resize(newSize, false);
+            if (_buckets == null)
+                return Initialize(capacity);
+            int newSize = HashHelpers.GetPrime(capacity);
+            Resize(newSize, forceNewHashCodes: false);
             return newSize;
         }
 


### PR DESCRIPTION
Adding EnsureCapacity API to Dictionary and Adding Tests.
tests and the ref changes are made in a corefx PR separately here https://github.com/dotnet/corefx/pull/26158.

cc: @danmosemsft @benaadams 
 
TODO Next in a separate PR:
- Will add EnsureCapacity to SortedSet and HashSet 
- Will add TrimExcess to Dictionary, SortedSet 