### PR TITLE
Address ReflectionTypeLoadException feedback

### DIFF
--- a/src/mscorlib/shared/System/Reflection/ReflectionTypeLoadException.cs
+++ b/src/mscorlib/shared/System/Reflection/ReflectionTypeLoadException.cs
@@ -44,12 +44,15 @@ namespace System.Reflection
 
         public Exception[] LoaderExceptions { get; }
 
-        public override string Message => CreateString(base.Message, LoaderExceptions, e => e.Message);
+        public override string Message => CreateString(isMessage: true);
 
-        public override string ToString() => CreateString(base.ToString(), LoaderExceptions, e => e.ToString());
+        public override string ToString() => CreateString(isMessage: false);
 
-        private static string CreateString(string baseValue, Exception[] exceptions, Func<Exception, string> selector)
+        private string CreateString(bool isMessage)
         {
+            string baseValue = isMessage ? base.Message : base.ToString();
+
+            Exception[] exceptions = LoaderExceptions;
             if (exceptions == null || exceptions.Length == 0)
             {
                 return baseValue;
@@ -61,7 +64,7 @@ namespace System.Reflection
                 if (e != null)
                 {
                     text.AppendLine();
-                    text.Append(selector(e));
+                    text.Append(isMessage ? e.Message : e.ToString());
                 }
             }
             return text.ToString();

--- a/src/mscorlib/shared/System/Reflection/ReflectionTypeLoadException.cs
+++ b/src/mscorlib/shared/System/Reflection/ReflectionTypeLoadException.cs
@@ -27,7 +27,7 @@ namespace System.Reflection
             HResult = HResults.COR_E_REFLECTIONTYPELOAD;
         }
 
-        private ReflectionTypeLoadException(SerializationInfo info, StreamingContext context) 
+        private ReflectionTypeLoadException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
             LoaderExceptions = (Exception[])(info.GetValue("Exceptions", typeof(Exception[])));
@@ -40,48 +40,31 @@ namespace System.Reflection
             info.AddValue("Exceptions", LoaderExceptions, typeof(Exception[]));
         }
 
-        public override string Message
-        {
-            get
-            {
-                if (LoaderExceptions == null || LoaderExceptions.Length == 0)
-                {
-                    return base.Message;
-                }
-
-                StringBuilder text = new StringBuilder();
-                text.AppendLine(base.Message);
-                foreach (Exception e in LoaderExceptions)
-                {
-                    if (e != null)
-                    {
-                        text.AppendLine(e.Message);
-                    }
-                }
-                return text.ToString();
-            }
-        }
-
-        public override string ToString()
-        {
-            StringBuilder text = new StringBuilder();
-            text.AppendLine(base.ToString());
-            if (LoaderExceptions != null)
-            {
-                foreach (Exception e in LoaderExceptions)
-                {
-                    if (e != null)
-                    {
-                        text.AppendLine(e.ToString());
-                    }
-                }
-            }
-
-            return text.ToString();
-        }
-
         public Type[] Types { get; }
 
         public Exception[] LoaderExceptions { get; }
+
+        public override string Message => CreateString(base.Message, LoaderExceptions, e => e.Message);
+
+        public override string ToString() => CreateString(base.ToString(), LoaderExceptions, e => e.ToString());
+
+        private static string CreateString(string baseValue, Exception[] exceptions, Func<Exception, string> selector)
+        {
+            if (exceptions == null || exceptions.Length == 0)
+            {
+                return baseValue;
+            }
+
+            var text = new StringBuilder(baseValue);
+            foreach (Exception e in exceptions)
+            {
+                if (e != null)
+                {
+                    text.AppendLine();
+                    text.Append(selector(e));
+                }
+            }
+            return text.ToString();
+        }
     }
 }


### PR DESCRIPTION
Address additional minor feedback from #15711:

 - Share the code for `Message` and `ToString`
 - Remove trailing `NewLine` from resulting string
 - Pass initial base string to `StringBuilder..ctor`
 - Cache the exceptions array in a local (passed-in as a parameter)
 - Move methods below properties
 - Remove trailing whitespace

cc: @wtgodbe, @danmosemsft