### PR TITLE
Use string.Contains(char) instead of Contains(string)

### DIFF
--- a/src/mscorlib/shared/System/Globalization/CultureData.Unix.cs
+++ b/src/mscorlib/shared/System/Globalization/CultureData.Unix.cs
@@ -33,7 +33,7 @@ namespace System.Globalization
             string realNameBuffer = _sRealName;
 
             // Basic validation
-            if (realNameBuffer.Contains("@"))
+            if (realNameBuffer.Contains('@'))
             {
                 return false; // don't allow ICU variants to come in directly
             }
@@ -43,7 +43,7 @@ namespace System.Globalization
             if (index > 0)
             {
                 if (index >= (realNameBuffer.Length - 1) // must have characters after _
-                    || realNameBuffer.Substring(index + 1).Contains("_")) // only one _ allowed
+                    || realNameBuffer.Substring(index + 1).Contains('_')) // only one _ allowed
                 {
                     return false; // fail
                 }

--- a/src/mscorlib/shared/System/Reflection/AssemblyNameFormatter.cs
+++ b/src/mscorlib/shared/System/Reflection/AssemblyNameFormatter.cs
@@ -95,7 +95,7 @@ namespace System.Reflection
 
             //@todo: App-compat: You can use double or single quotes to quote a name, and Fusion (or rather the IdentityAuthority) picks one
             // by some algorithm. Rather than guess at it, I'll just use double-quote consistently.
-            if (s != s.Trim() || s.Contains("\"") || s.Contains("\'"))
+            if (s != s.Trim() || s.Contains('\"') || s.Contains('\''))
                 needsQuoting = true;
 
             if (needsQuoting)

--- a/src/mscorlib/src/System/TimeZoneInfo.Unix.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.Unix.cs
@@ -564,7 +564,7 @@ namespace System
             {
                 throw new ArgumentNullException(nameof(id));
             }
-            else if (id.Length == 0 || id.Contains("\0"))
+            else if (id.Length == 0 || id.Contains('\0'))
             {
                 throw new TimeZoneNotFoundException(SR.Format(SR.TimeZoneNotFound_MissingData, id));
             }

--- a/src/mscorlib/src/System/TimeZoneInfo.Win32.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.Win32.cs
@@ -348,7 +348,7 @@ namespace System
             {
                 throw new ArgumentNullException(nameof(id));
             }
-            else if (id.Length == 0 || id.Length > MaxKeyLength || id.Contains("\0"))
+            else if (id.Length == 0 || id.Length > MaxKeyLength || id.Contains('\0'))
             {
                 throw new TimeZoneNotFoundException(SR.Format(SR.TimeZoneNotFound_MissingData, id));
             }


### PR DESCRIPTION
Now that `string.Contains(char)` exists, use it in corelib.