### PR TITLE
Allow ArrayPool.Shared devirtualization

### DIFF
--- a/src/mscorlib/shared/System/Buffers/ArrayPool.cs
+++ b/src/mscorlib/shared/System/Buffers/ArrayPool.cs
@@ -3,10 +3,18 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
-using System.Threading;
 
 namespace System.Buffers
 {
+    internal static class ArrayPool
+    {
+        // Store the shared arraypool in a field of its derived type so the Jit can "see" it when inlining Shared
+        // and devirtualize its calls.
+        // Needs to be in a non-generic class as crossgen doesn't resolve generic types in generic types very well.
+        internal static TlsOverPerCoreLockedStacksArrayPool<byte> ByteArrayPool { get; } = new TlsOverPerCoreLockedStacksArrayPool<byte>();
+        internal static TlsOverPerCoreLockedStacksArrayPool<char> CharArrayPool { get; } = new TlsOverPerCoreLockedStacksArrayPool<char>();
+    }
+
     /// <summary>
     /// Provides a resource pool that enables reusing instances of type <see cref="T:T[]"/>. 
     /// </summary>
@@ -24,7 +32,8 @@ namespace System.Buffers
     {
         // Store the shared arraypool in a field of its derived type so the Jit can "see" it when inlining Shared
         // and devirtualize its calls.
-        private static TlsOverPerCoreLockedStacksArrayPool<T> s_arrayPool = new TlsOverPerCoreLockedStacksArrayPool<T>();
+        private readonly static TlsOverPerCoreLockedStacksArrayPool<T> s_arrayPool
+            = (typeof(T) == typeof(byte) || typeof(T) == typeof(char)) ? null : new TlsOverPerCoreLockedStacksArrayPool<T>();
 
         /// <summary>
         /// Retrieves a shared <see cref="ArrayPool{T}"/> instance.
@@ -40,7 +49,25 @@ namespace System.Buffers
         /// optimized for very fast access speeds, at the expense of more memory consumption.
         /// The shared pool instance is created lazily on first access.
         /// </remarks>
-        public static ArrayPool<T> Shared => s_arrayPool;
+        public static ArrayPool<T> Shared
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                if (typeof(T) == typeof(byte))
+                {
+                    return (ArrayPool<T>)(object)ArrayPool.ByteArrayPool;
+                }
+                else if (typeof(T) == typeof(char))
+                {
+                    return (ArrayPool<T>)(object)ArrayPool.CharArrayPool;
+                }
+                else
+                {
+                    return s_arrayPool;
+                }
+            }
+        }
 
         /// <summary>
         /// Creates a new <see cref="ArrayPool{T}"/> instance using default configuration options.

--- a/src/mscorlib/shared/System/Buffers/ArrayPool.cs
+++ b/src/mscorlib/shared/System/Buffers/ArrayPool.cs
@@ -24,16 +24,7 @@ namespace System.Buffers
     {
         // Store the shared arraypool in a field of its derived type so the Jit can "see" it when inlining Shared
         // and devirtualize its calls.
-        private static TlsOverPerCoreLockedStacksArrayPool<T> s_arrayPool;
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static TlsOverPerCoreLockedStacksArrayPool<T> InitalizeArrayPool()
-        {
-            TlsOverPerCoreLockedStacksArrayPool<T> newPool = new TlsOverPerCoreLockedStacksArrayPool<T>();
-            TlsOverPerCoreLockedStacksArrayPool<T> currentPool = Interlocked.CompareExchange(ref s_arrayPool, newPool, null);
-
-            return currentPool ?? newPool;
-        }
+        private static TlsOverPerCoreLockedStacksArrayPool<T> s_arrayPool = new TlsOverPerCoreLockedStacksArrayPool<T>();
 
         /// <summary>
         /// Retrieves a shared <see cref="ArrayPool{T}"/> instance.
@@ -49,14 +40,7 @@ namespace System.Buffers
         /// optimized for very fast access speeds, at the expense of more memory consumption.
         /// The shared pool instance is created lazily on first access.
         /// </remarks>
-        public static ArrayPool<T> Shared
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                return s_arrayPool ?? InitalizeArrayPool();
-            }
-        }
+        public static ArrayPool<T> Shared => s_arrayPool;
 
         /// <summary>
         /// Creates a new <see cref="ArrayPool{T}"/> instance using default configuration options.

--- a/src/mscorlib/shared/System/Collections/Generic/ValueListBuilder.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/ValueListBuilder.cs
@@ -62,7 +62,7 @@ namespace System.Collections.Generic
         {
             // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
             // https://github.com/dotnet/coreclr/issues/15783
-            var length = _span.Length * 2;
+            int length = _span.Length * 2;
             T[] array = ArrayPool<T>.Shared.Rent(length);
 
             bool success = _span.TryCopyTo(array);

--- a/src/mscorlib/shared/System/Collections/Generic/ValueListBuilder.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/ValueListBuilder.cs
@@ -60,6 +60,8 @@ namespace System.Collections.Generic
 
         private void Grow()
         {
+            // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
+            // https://github.com/dotnet/coreclr/issues/15783
             var length = _span.Length * 2;
             T[] array = ArrayPool<T>.Shared.Rent(length);
 

--- a/src/mscorlib/shared/System/Collections/Generic/ValueListBuilder.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/ValueListBuilder.cs
@@ -60,7 +60,8 @@ namespace System.Collections.Generic
 
         private void Grow()
         {
-            T[] array = ArrayPool<T>.Shared.Rent(_span.Length * 2);
+            var length = _span.Length * 2;
+            T[] array = ArrayPool<T>.Shared.Rent(length);
 
             bool success = _span.TryCopyTo(array);
             Debug.Assert(success);

--- a/src/mscorlib/shared/System/Globalization/CompareInfo.cs
+++ b/src/mscorlib/shared/System/Globalization/CompareInfo.cs
@@ -1230,6 +1230,8 @@ namespace System.Globalization
             }
 
             char[] borrowedArr = null;
+            // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
+            // https://github.com/dotnet/coreclr/issues/15783
             int length = source.Length;
             Span<char> span = length <= 255 ?
                 stackalloc char[255] :

--- a/src/mscorlib/shared/System/Globalization/CompareInfo.cs
+++ b/src/mscorlib/shared/System/Globalization/CompareInfo.cs
@@ -1230,9 +1230,10 @@ namespace System.Globalization
             }
 
             char[] borrowedArr = null;
-            Span<char> span = source.Length <= 255 ?
+            int length = source.Length;
+            Span<char> span = length <= 255 ?
                 stackalloc char[255] :
-                (borrowedArr = ArrayPool<char>.Shared.Rent(source.Length));
+                (borrowedArr = ArrayPool<char>.Shared.Rent(length));
 
             int charsWritten = source.AsSpan().ToUpperInvariant(span);
 

--- a/src/mscorlib/shared/System/IO/BinaryWriter.cs
+++ b/src/mscorlib/shared/System/IO/BinaryWriter.cs
@@ -398,11 +398,12 @@ namespace System.IO
             }
             else
             {
-                byte[] array = ArrayPool<byte>.Shared.Rent(buffer.Length);
+                int length = buffer.Length;
+                byte[] array = ArrayPool<byte>.Shared.Rent(length);
                 try
                 {
                     buffer.CopyTo(array);
-                    Write(array, 0, buffer.Length);
+                    Write(array, 0, length);
                 }
                 finally
                 {
@@ -413,7 +414,8 @@ namespace System.IO
 
         public virtual void Write(ReadOnlySpan<char> chars)
         {
-            byte[] bytes = ArrayPool<byte>.Shared.Rent(_encoding.GetMaxByteCount(chars.Length));
+            int length = _encoding.GetMaxByteCount(chars.Length);
+            byte[] bytes = ArrayPool<byte>.Shared.Rent(length);
             try
             {
                 int bytesWritten = _encoding.GetBytes(chars, bytes);

--- a/src/mscorlib/shared/System/IO/BinaryWriter.cs
+++ b/src/mscorlib/shared/System/IO/BinaryWriter.cs
@@ -398,6 +398,8 @@ namespace System.IO
             }
             else
             {
+                // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
+                // https://github.com/dotnet/coreclr/issues/15783
                 int length = buffer.Length;
                 byte[] array = ArrayPool<byte>.Shared.Rent(length);
                 try
@@ -414,6 +416,8 @@ namespace System.IO
 
         public virtual void Write(ReadOnlySpan<char> chars)
         {
+            // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
+            // https://github.com/dotnet/coreclr/issues/15783
             int length = _encoding.GetMaxByteCount(chars.Length);
             byte[] bytes = ArrayPool<byte>.Shared.Rent(length);
             try

--- a/src/mscorlib/shared/System/IO/TextReader.cs
+++ b/src/mscorlib/shared/System/IO/TextReader.cs
@@ -104,12 +104,13 @@ namespace System.IO
         //
         public virtual int Read(Span<char> buffer)
         {
-            char[] array = ArrayPool<char>.Shared.Rent(buffer.Length);
+            int length = buffer.Length;
+            char[] array = ArrayPool<char>.Shared.Rent(length);
 
             try
             {
-                int numRead = Read(array, 0, buffer.Length);
-                if ((uint)numRead > buffer.Length)
+                int numRead = Read(array, 0, length);
+                if ((uint)numRead > (uint)length)
                 {
                     throw new IOException(SR.IO_InvalidReadLength);
                 }
@@ -154,12 +155,13 @@ namespace System.IO
         //
         public virtual int ReadBlock(Span<char> buffer)
         {
-            char[] array = ArrayPool<char>.Shared.Rent(buffer.Length);
+            int length = buffer.Length;
+            char[] array = ArrayPool<char>.Shared.Rent(length);
 
             try
             {
-                int numRead = ReadBlock(array, 0, buffer.Length);
-                if ((uint)numRead > buffer.Length)
+                int numRead = ReadBlock(array, 0, length);
+                if ((uint)numRead > (uint)length)
                 {
                     throw new IOException(SR.IO_InvalidReadLength);
                 }

--- a/src/mscorlib/shared/System/IO/TextReader.cs
+++ b/src/mscorlib/shared/System/IO/TextReader.cs
@@ -104,6 +104,8 @@ namespace System.IO
         //
         public virtual int Read(Span<char> buffer)
         {
+            // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
+            // https://github.com/dotnet/coreclr/issues/15783
             int length = buffer.Length;
             char[] array = ArrayPool<char>.Shared.Rent(length);
 
@@ -155,6 +157,8 @@ namespace System.IO
         //
         public virtual int ReadBlock(Span<char> buffer)
         {
+            // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
+            // https://github.com/dotnet/coreclr/issues/15783
             int length = buffer.Length;
             char[] array = ArrayPool<char>.Shared.Rent(length);
 

--- a/src/mscorlib/shared/System/IO/TextWriter.cs
+++ b/src/mscorlib/shared/System/IO/TextWriter.cs
@@ -170,12 +170,13 @@ namespace System.IO
         //
         public virtual void Write(ReadOnlySpan<char> buffer)
         {
-            char[] array = ArrayPool<char>.Shared.Rent(buffer.Length);
+            int length = buffer.Length;
+            char[] array = ArrayPool<char>.Shared.Rent(length);
 
             try
             {
                 buffer.CopyTo(new Span<char>(array));
-                Write(array, 0, buffer.Length);
+                Write(array, 0, length);
             }
             finally
             {
@@ -352,12 +353,13 @@ namespace System.IO
 
         public virtual void WriteLine(ReadOnlySpan<char> buffer)
         {
-            char[] array = ArrayPool<char>.Shared.Rent(buffer.Length);
+            int length = buffer.Length;
+            char[] array = ArrayPool<char>.Shared.Rent(length);
 
             try
             {
                 buffer.CopyTo(new Span<char>(array));
-                WriteLine(array, 0, buffer.Length);
+                WriteLine(array, 0, length);
             }
             finally
             {

--- a/src/mscorlib/shared/System/IO/TextWriter.cs
+++ b/src/mscorlib/shared/System/IO/TextWriter.cs
@@ -170,6 +170,8 @@ namespace System.IO
         //
         public virtual void Write(ReadOnlySpan<char> buffer)
         {
+            // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
+            // https://github.com/dotnet/coreclr/issues/15783
             int length = buffer.Length;
             char[] array = ArrayPool<char>.Shared.Rent(length);
 
@@ -353,6 +355,8 @@ namespace System.IO
 
         public virtual void WriteLine(ReadOnlySpan<char> buffer)
         {
+            // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
+            // https://github.com/dotnet/coreclr/issues/15783
             int length = buffer.Length;
             char[] array = ArrayPool<char>.Shared.Rent(length);
 

--- a/src/mscorlib/shared/System/Text/ValueStringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/ValueStringBuilder.cs
@@ -231,6 +231,8 @@ namespace System.Text
         {
             Debug.Assert(requiredAdditionalCapacity > 0);
 
+            // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
+            // https://github.com/dotnet/coreclr/issues/15783
             int length = Math.Max(_pos + requiredAdditionalCapacity, _chars.Length * 2);
             char[] poolArray = ArrayPool<char>.Shared.Rent(length);
 

--- a/src/mscorlib/shared/System/Text/ValueStringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/ValueStringBuilder.cs
@@ -231,7 +231,8 @@ namespace System.Text
         {
             Debug.Assert(requiredAdditionalCapacity > 0);
 
-            char[] poolArray = ArrayPool<char>.Shared.Rent(Math.Max(_pos + requiredAdditionalCapacity, _chars.Length * 2));
+            int length = Math.Max(_pos + requiredAdditionalCapacity, _chars.Length * 2);
+            char[] poolArray = ArrayPool<char>.Shared.Rent(length);
 
             _chars.CopyTo(poolArray);
 

--- a/src/mscorlib/src/Microsoft/Win32/RegistryKey.cs
+++ b/src/mscorlib/src/Microsoft/Win32/RegistryKey.cs
@@ -317,6 +317,8 @@ namespace Microsoft.Win32
             EnsureNotDisposed();
 
             var names = new List<string>();
+            // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
+            // https://github.com/dotnet/coreclr/issues/15783
             int length = MaxKeyLength + 1;
             char[] name = ArrayPool<char>.Shared.Rent(length);
 
@@ -412,6 +414,8 @@ namespace Microsoft.Win32
                             else
                             {
                                 char[] oldName = name;
+                                // Use simple variables to call ArrayPool.Shared.Rent to allow devirtualization
+                                // https://github.com/dotnet/coreclr/issues/15783
                                 int oldLength = oldName.Length;
                                 name = null;
                                 ArrayPool<char>.Shared.Return(oldName);

--- a/src/mscorlib/src/Microsoft/Win32/RegistryKey.cs
+++ b/src/mscorlib/src/Microsoft/Win32/RegistryKey.cs
@@ -317,7 +317,8 @@ namespace Microsoft.Win32
             EnsureNotDisposed();
 
             var names = new List<string>();
-            char[] name = ArrayPool<char>.Shared.Rent(MaxKeyLength + 1);
+            int length = MaxKeyLength + 1;
+            char[] name = ArrayPool<char>.Shared.Rent(length);
 
             try
             {
@@ -414,7 +415,8 @@ namespace Microsoft.Win32
                                 int oldLength = oldName.Length;
                                 name = null;
                                 ArrayPool<char>.Shared.Return(oldName);
-                                name = ArrayPool<char>.Shared.Rent(checked(oldLength * 2));
+                                int length = checked(oldLength * 2);
+                                name = ArrayPool<char>.Shared.Rent(length);
                             }
                             break;
                         default:

--- a/src/mscorlib/src/System/IO/Stream.cs
+++ b/src/mscorlib/src/System/IO/Stream.cs
@@ -382,8 +382,9 @@ namespace System.IO
             }
             else
             {
-                byte[] sharedBuffer = ArrayPool<byte>.Shared.Rent(buffer.Length);
-                return FinishReadAsync(ReadAsync(sharedBuffer, 0, buffer.Length, cancellationToken), sharedBuffer, buffer);
+                int length = buffer.Length;
+                byte[] sharedBuffer = ArrayPool<byte>.Shared.Rent(length);
+                return FinishReadAsync(ReadAsync(sharedBuffer, 0, length, cancellationToken), sharedBuffer, buffer);
 
                 async ValueTask<int> FinishReadAsync(Task<int> readTask, byte[] localBuffer, Memory<byte> localDestination)
                 {
@@ -691,9 +692,10 @@ namespace System.IO
             }
             else
             {
-                byte[] sharedBuffer = ArrayPool<byte>.Shared.Rent(buffer.Length);
+                int length = buffer.Length;
+                byte[] sharedBuffer = ArrayPool<byte>.Shared.Rent(length);
                 buffer.Span.CopyTo(sharedBuffer);
-                return new ValueTask(FinishWriteAsync(WriteAsync(sharedBuffer, 0, buffer.Length, cancellationToken), sharedBuffer));
+                return new ValueTask(FinishWriteAsync(WriteAsync(sharedBuffer, 0, length, cancellationToken), sharedBuffer));
             }
         }
 
@@ -740,11 +742,12 @@ namespace System.IO
 
         public virtual int Read(Span<byte> buffer)
         {
-            byte[] sharedBuffer = ArrayPool<byte>.Shared.Rent(buffer.Length);
+            int length = buffer.Length;
+            byte[] sharedBuffer = ArrayPool<byte>.Shared.Rent(length);
             try
             {
-                int numRead = Read(sharedBuffer, 0, buffer.Length);
-                if ((uint)numRead > buffer.Length)
+                int numRead = Read(sharedBuffer, 0, length);
+                if ((uint)numRead > (uint)length)
                 {
                     throw new IOException(SR.IO_StreamTooLong);
                 }
@@ -773,11 +776,12 @@ namespace System.IO
 
         public virtual void Write(ReadOnlySpan<byte> buffer)
         {
-            byte[] sharedBuffer = ArrayPool<byte>.Shared.Rent(buffer.Length);
+            int length = buffer.Length;
+            byte[] sharedBuffer = ArrayPool<byte>.Shared.Rent(length);
             try
             {
                 buffer.CopyTo(sharedBuffer);
-                Write(sharedBuffer, 0, buffer.Length);
+                Write(sharedBuffer, 0, length);
             }
             finally { ArrayPool<byte>.Shared.Return(sharedBuffer); }
         }

--- a/src/mscorlib/src/System/IO/Stream.cs
+++ b/src/mscorlib/src/System/IO/Stream.cs
@@ -382,6 +382,8 @@ namespace System.IO
             }
             else
             {
+                // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
+                // https://github.com/dotnet/coreclr/issues/15783
                 int length = buffer.Length;
                 byte[] sharedBuffer = ArrayPool<byte>.Shared.Rent(length);
                 return FinishReadAsync(ReadAsync(sharedBuffer, 0, length, cancellationToken), sharedBuffer, buffer);
@@ -692,6 +694,8 @@ namespace System.IO
             }
             else
             {
+                // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
+                // https://github.com/dotnet/coreclr/issues/15783
                 int length = buffer.Length;
                 byte[] sharedBuffer = ArrayPool<byte>.Shared.Rent(length);
                 buffer.Span.CopyTo(sharedBuffer);
@@ -742,6 +746,8 @@ namespace System.IO
 
         public virtual int Read(Span<byte> buffer)
         {
+            // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
+            // https://github.com/dotnet/coreclr/issues/15783
             int length = buffer.Length;
             byte[] sharedBuffer = ArrayPool<byte>.Shared.Rent(length);
             try
@@ -776,6 +782,8 @@ namespace System.IO
 
         public virtual void Write(ReadOnlySpan<byte> buffer)
         {
+            // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
+            // https://github.com/dotnet/coreclr/issues/15783
             int length = buffer.Length;
             byte[] sharedBuffer = ArrayPool<byte>.Shared.Rent(length);
             try


### PR DESCRIPTION
Every call to ArrayPool in crossgen'd System.Private.CoreLib is now devitualized to
```asm
call     TlsOverPerCoreLockedStacksArrayPool`1:Rent(int):ref:this
call     TlsOverPerCoreLockedStacksArrayPool`1:Return(ref,bool):this
```
Slight size regression
```asm
Total bytes of diff: 180 (0.01% of base)
    diff is a regression.

Total byte diff includes 178 bytes from reconciling methods
        Base had    0 unique methods,        0 unique bytes
        Diff had    3 unique methods,      178 unique bytes

Top file regressions by size (bytes):
         180 : System.Private.CoreLib.dasm (0.01% of base)

1 total files with size differences (0 improved, 1 regressed), 0 unchanged.

Top method regessions by size (bytes):
         110 : System.Private.CoreLib.dasm - ArrayPool:.cctor() (0/1 methods)
          34 : System.Private.CoreLib.dasm - ArrayPool:get_ByteArrayPool():ref (0/1 methods)
          34 : System.Private.CoreLib.dasm - ArrayPool:get_CharArrayPool():ref (0/1 methods)
          16 : System.Private.CoreLib.dasm - BinaryWriter:Write(struct):this (3 methods)
          13 : System.Private.CoreLib.dasm - ValueListBuilder`1:Grow():this (2 methods)

Top method improvements by size (bytes):
         -62 : System.Private.CoreLib.dasm - ArrayPool`1:.cctor() (4 methods)
         -21 : System.Private.CoreLib.dasm - Stream:ReadAsync(struct,struct):struct:this
         -13 : System.Private.CoreLib.dasm - Stream:Read(struct):int:this
         -13 : System.Private.CoreLib.dasm - TextReader:Read(struct):int:this
         -13 : System.Private.CoreLib.dasm - TextReader:ReadBlock(struct):int:this

36 total methods with size differences (5 improved, 31 regressed), 17261 unchanged.
```
Enabled by https://github.com/dotnet/coreclr/pull/15766

@stephentoub @jkotas PTAL
  
  