### PR TITLE
AggregateException: Use StringBuilder.AppendFormat

### DIFF
--- a/src/mscorlib/shared/System/AggregateException.cs
+++ b/src/mscorlib/shared/System/AggregateException.cs
@@ -453,12 +453,12 @@ namespace System
 
             for (int i = 0; i < m_innerExceptions.Count; i++)
             {
-                text.Append(Environment.NewLine);
+                text.AppendLine();
                 text.Append("---> ");
-                text.Append(string.Format(CultureInfo.InvariantCulture, SR.AggregateException_InnerException, i));
+                text.AppendFormat(CultureInfo.InvariantCulture, SR.AggregateException_InnerException, i);
                 text.Append(m_innerExceptions[i].ToString());
                 text.Append("<---");
-                text.Append(Environment.NewLine);
+                text.AppendLine();
             }
 
             return text.ToString();


### PR DESCRIPTION
Use `AppendFormat(...)` instead of `Append(string.Format(...))` and `AppendLine()` instead of `Append(Environment.NewLine)`.