### PR TITLE
Fix for 15671

### DIFF
--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -6935,6 +6935,15 @@ void Compiler::fgValueNumberTree(GenTreePtr tree, bool evalAsgLhsInd)
                         ValueNumPair op1VNPx = ValueNumStore::VNPForEmptyExcSet();
                         vnStore->VNPUnpackExc(tree->gtOp.gtOp1->gtVNPair, &op1VNP, &op1VNPx);
 
+                        // If we are fetching the array length for an array ref that came from global memory
+                        // then for CSE safety we must use the conservative value number for both
+                        //
+                        if ((tree->OperGet() == GT_ARR_LENGTH) && ((tree->gtOp.gtOp1->gtFlags & GTF_GLOB_REF) != 0))
+                        {
+                            // use the conservative value number for both when computing the VN for the ARR_LENGTH
+                            op1VNP.SetBoth(op1VNP.GetConservative());
+                        }
+
                         tree->gtVNPair =
                             vnStore->VNPWithExc(vnStore->VNPairForFunc(tree->TypeGet(),
                                                                        GetVNFuncForOper(oper, (tree->gtFlags &


### PR DESCRIPTION
If we are fetching an Array Length for an array ref that came from global memory
then for CSE safety we must use the conservative value number for both