### PR TITLE
Adds StringBuilder.Equals(ReadOnlySpan<char>) Api

### DIFF
--- a/src/mscorlib/shared/System/Text/StringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.cs
@@ -1656,19 +1656,22 @@ namespace System.Text
 
             StringBuilder thisChunk = this;
             int thisChunkIndex = thisChunk.m_ChunkLength;
+            var chunkChars = thisChunk.m_ChunkChars;
 
             for (int i = Length - 1; i >= 0; i--)
             {
-                --thisChunkIndex;
-                while (thisChunkIndex < 0)
+                thisChunkIndex--;
+                if (thisChunkIndex < 0)
                 {
                     thisChunk = thisChunk.m_ChunkPrevious;
                     if (thisChunk == null)
-                        break;
-                    thisChunkIndex = thisChunk.m_ChunkLength + thisChunkIndex;
+                        return false;
+
+                    thisChunkIndex += thisChunk.m_ChunkLength;
+                    chunkChars = thisChunk.m_ChunkChars;
                 }
 
-                if (thisChunk.m_ChunkChars[thisChunkIndex] != value[i])
+                if (chunkChars[thisChunkIndex] != value[i])
                     return false;
             }
 

--- a/src/mscorlib/shared/System/Text/StringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.cs
@@ -1648,28 +1648,29 @@ namespace System.Text
         /// <summary>
         /// Determines if the contents of this builder are equal to the contents of ReadOnlySpan<char>.
         /// </summary>
-        /// <param name="value">The ReadOnlySpan<char>.</param>
+        /// <param name="value">The ReadOnlySpan{char}.</param>
         public bool Equals(ReadOnlySpan<char> value)
         {
             if (value.Length != Length)
                 return false;
 
-            StringBuilder thisChunk = this;
+            StringBuilder sbChunk = this;
             int offset = 0;
-            int chunk_length = -1;
-            
-            
-            while (thisChunk != null)
+
+            do
             {
-                chunk_length = thisChunk.m_ChunkLength;                 
+                int chunk_length = sbChunk.m_ChunkLength;
                 offset += chunk_length;
 
-                if(!StringSpanHelpers.Equals(thisChunk.m_ChunkChars, value.Slice(value.Length - offset, chunk_length)))
+                ReadOnlySpan<char> chunk = new ReadOnlySpan<char>(sbChunk.m_ChunkChars, 0, chunk_length);
+
+                if (!StringSpanHelpers.Equals(chunk, value.Slice(value.Length - offset, chunk_length)))
                     return false;
 
-                thisChunk = thisChunk.m_ChunkPrevious;
-            }
-            
+                sbChunk = sbChunk.m_ChunkPrevious;
+            } while (sbChunk != null);
+
+            Debug.Assert(offset == Length);
             return true;
         }
 

--- a/src/mscorlib/shared/System/Text/StringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.cs
@@ -1655,26 +1655,21 @@ namespace System.Text
                 return false;
 
             StringBuilder thisChunk = this;
-            int thisChunkIndex = thisChunk.m_ChunkLength;
-            var chunkChars = thisChunk.m_ChunkChars;
-
-            for (int i = Length - 1; i >= 0; i--)
+            int offset = 0;
+            int chunk_length = -1;
+            
+            
+            while (thisChunk != null)
             {
-                thisChunkIndex--;
-                if (thisChunkIndex < 0)
-                {
-                    thisChunk = thisChunk.m_ChunkPrevious;
-                    if (thisChunk == null)
-                        return false;
+                chunk_length = thisChunk.m_ChunkLength;                 
+                offset += chunk_length;
 
-                    thisChunkIndex += thisChunk.m_ChunkLength;
-                    chunkChars = thisChunk.m_ChunkChars;
-                }
-
-                if (chunkChars[thisChunkIndex] != value[i])
+                if(!StringSpanHelpers.Equals(thisChunk.m_ChunkChars, value.Slice(value.Length - offset, chunk_length)))
                     return false;
-            }
 
+                thisChunk = thisChunk.m_ChunkPrevious;
+            }
+            
             return true;
         }
 

--- a/src/mscorlib/shared/System/Text/StringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.cs
@@ -1664,7 +1664,7 @@ namespace System.Text
 
                 ReadOnlySpan<char> chunk = new ReadOnlySpan<char>(sbChunk.m_ChunkChars, 0, chunk_length);
 
-                if (!StringSpanHelpers.Equals(chunk, value.Slice(value.Length - offset, chunk_length)))
+                if (!chunk.Equals(value.Slice(value.Length - offset, chunk_length)))
                     return false;
 
                 sbChunk = sbChunk.m_ChunkPrevious;

--- a/src/mscorlib/shared/System/Text/StringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.cs
@@ -1646,6 +1646,36 @@ namespace System.Text
         }
 
         /// <summary>
+        /// Determines if the contents of this builder are equal to the contents of ReadOnlySpan<char>.
+        /// </summary>
+        /// <param name="value">The ReadOnlySpan<char>.</param>
+        public bool Equals(ReadOnlySpan<char> value)
+        {
+            if (value.Length != Length)
+                return false;
+
+            StringBuilder thisChunk = this;
+            int thisChunkIndex = thisChunk.m_ChunkLength;
+
+            for (int i = Length - 1; i >= 0; i--)
+            {
+                --thisChunkIndex;
+                while (thisChunkIndex < 0)
+                {
+                    thisChunk = thisChunk.m_ChunkPrevious;
+                    if (thisChunk == null)
+                        break;
+                    thisChunkIndex = thisChunk.m_ChunkLength + thisChunkIndex;
+                }
+
+                if (thisChunk.m_ChunkChars[thisChunkIndex] != value[i])
+                    return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
         /// Replaces all instances of one string with another in part of this builder.
         /// </summary>
         /// <param name="oldValue">The string to replace.</param>


### PR DESCRIPTION
This overload can be used to efficiently compare StringBuilders with ReadOnlySpan and strings.
Fixes- https://github.com/dotnet/corefx/issues/25846
Tests PR - https://github.com/dotnet/corefx/pull/26189
  