### PR TITLE
Fix issue where the unsigned value used for the the VN map select budget could underflow

### DIFF
--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -282,11 +282,13 @@ CONFIG_METHODSET(JitOptRepeat, W("JitOptRepeat"))            // Runs optimizer m
 CONFIG_INTEGER(JitOptRepeatCount, W("JitOptRepeatCount"), 2) // Number of times to repeat opts when repeating
 #endif                                                       // defined(OPT_CONFIG)
 
-CONFIG_INTEGER(JitRegisterFP, W("JitRegisterFP"), 3)           // Control FP enregistration
-CONFIG_INTEGER(JitTelemetry, W("JitTelemetry"), 1)             // If non-zero, gather JIT telemetry data
-CONFIG_INTEGER(JitVNMapSelBudget, W("JitVNMapSelBudget"), 100) // Max # of MapSelect's considered for a particular
-                                                               // top-level invocation.
-CONFIG_INTEGER(TailCallLoopOpt, W("TailCallLoopOpt"), 1)       // Convert recursive tail calls to loops
+CONFIG_INTEGER(JitRegisterFP, W("JitRegisterFP"), 3) // Control FP enregistration
+CONFIG_INTEGER(JitTelemetry, W("JitTelemetry"), 1)   // If non-zero, gather JIT telemetry data
+
+// Max # of MapSelect's considered for a particular top-level invocation.
+CONFIG_INTEGER(JitVNMapSelBudget, W("JitVNMapSelBudget"), DEFAULT_MAP_SELECT_BUDGET)
+
+CONFIG_INTEGER(TailCallLoopOpt, W("TailCallLoopOpt"), 1) // Convert recursive tail calls to loops
 CONFIG_METHODSET(AltJit, W("AltJit")) // Enables AltJit and selectively limits it to the specified methods.
 CONFIG_METHODSET(AltJitNgen,
                  W("AltJitNgen")) // Enables AltJit for NGEN and selectively limits it to the specified methods.

--- a/src/jit/valuenum.h
+++ b/src/jit/valuenum.h
@@ -225,9 +225,12 @@ private:
     unsigned m_numMapSels;
 #endif
 
+// This is the constant value used for the default value of m_mapSelectBudget
+#define DEFAULT_MAP_SELECT_BUDGET 100 // used by JitVNMapSelBudget
+
     // This is the maximum number of MapSelect terms that can be "considered" as part of evaluation of a top-level
     // MapSelect application.
-    unsigned m_mapSelectBudget;
+    int m_mapSelectBudget;
 
 public:
     // Initializes any static variables of ValueNumStore.
@@ -406,7 +409,7 @@ public:
 
     // A method that does the work for VNForMapSelect and may call itself recursively.
     ValueNum VNForMapSelectWork(
-        ValueNumKind vnk, var_types typ, ValueNum op1VN, ValueNum op2VN, unsigned* pBudget, bool* pUsedRecursiveVN);
+        ValueNumKind vnk, var_types typ, ValueNum op1VN, ValueNum op2VN, int* pBudget, bool* pUsedRecursiveVN);
 
     // A specialized version of VNForFunc that is used for VNF_MapStore and provides some logging when verbose is set
     ValueNum VNForMapStore(var_types typ, ValueNum arg0VN, ValueNum arg1VN, ValueNum arg2VN);


### PR DESCRIPTION
This underflow results in an unlimited budget when proccessing some methods.
This results in excessive JIT compile times for such methods.

Changed m_mapSelectBudget and budget to be a signed integer
Added an assert that ensures that the remaining budget is between [0..m_mapSelectBudget]
Change the test for running out of budge to be a <= zero test instead of an equal zero test.

Fixed the bug in the handling of phiArgs in VNForMapSelectWork
by adding a check if we exceeded our budget when processing the first phiArg.