### PR TITLE
fix COMPlus_JitHalt for arm32.

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -5780,8 +5780,8 @@ void Compiler::compCompileFinish()
     {
         if (compJitHaltMethod())
         {
-#if !defined(_TARGET_ARM64_) && !defined(_HOST_UNIX_)
-            // TODO-ARM64-NYI: re-enable this when we have an OS that supports a pop-up dialog
+#if !defined(_TARGET_ARMARCH_) && !defined(_HOST_UNIX_)
+            // TODO-ARM-NYI: re-enable this when we have an OS that supports a pop-up dialog
 
             // Don't do an assert, but just put up the dialog box so we get just-in-time debugger
             // launching.  When you hit 'retry' it will continue and naturally stop at the INT 3


### PR DESCRIPTION
arm and arm64 have the same Windows OS, that do not support a pop-up dialog.