### PR TITLE
Avoid calling overloaded equality operators when checking for null

### DIFF
--- a/src/mscorlib/shared/System/Convert.cs
+++ b/src/mscorlib/shared/System/Convert.cs
@@ -256,7 +256,7 @@ namespace System
         internal static Object DefaultToType(IConvertible value, Type targetType, IFormatProvider provider)
         {
             Debug.Assert(value != null, "[Convert.DefaultToType]value!=null");
-            if (targetType == null)
+            if (targetType is null)
             {
                 throw new ArgumentNullException(nameof(targetType));
             }

--- a/src/mscorlib/shared/System/DefaultBinder.cs
+++ b/src/mscorlib/shared/System/DefaultBinder.cs
@@ -102,7 +102,7 @@ namespace System
                 paramArrayType = null;
 
                 // If we have named parameters then we may have a hole in the candidates array.
-                if (candidates[i] == null)
+                if (candidates[i] is null)
                     continue;
 
                 // Validate the parameters.
@@ -186,7 +186,7 @@ namespace System
 #endregion
 
                 Type pCls = null;
-                int argsToCheck = (paramArrayType != null) ? par.Length - 1 : args.Length;
+                int argsToCheck = ((object)paramArrayType != null) ? par.Length - 1 : args.Length;
 
 #region Match method by parameter type
                 for (j = 0; j < argsToCheck; j++)
@@ -217,14 +217,14 @@ namespace System
                     // now do a "classic" type check
                     if (pCls.IsPrimitive)
                     {
-                        if (argTypes[paramOrder[i][j]] == null || !CanChangePrimitiveObjectToType(args[paramOrder[i][j]], pCls))
+                        if (argTypes[paramOrder[i][j]] is null || !CanChangePrimitiveObjectToType(args[paramOrder[i][j]], pCls))
                         {
                             break;
                         }
                     }
                     else
                     {
-                        if (argTypes[paramOrder[i][j]] == null)
+                        if (argTypes[paramOrder[i][j]] is null)
                             continue;
 
                         if (!pCls.IsAssignableFrom(argTypes[paramOrder[i][j]]))
@@ -240,19 +240,19 @@ namespace System
 #endregion
                 }
 
-                if (paramArrayType != null && j == par.Length - 1)
+                if ((object)paramArrayType != null && j == par.Length - 1)
                 {
 #region Check that excess arguments can be placed in the param array
                     for (; j < args.Length; j++)
                     {
                         if (paramArrayType.IsPrimitive)
                         {
-                            if (argTypes[j] == null || !CanChangePrimitiveObjectToType(args[j], paramArrayType))
+                            if (argTypes[j] is null || !CanChangePrimitiveObjectToType(args[j], paramArrayType))
                                 break;
                         }
                         else
                         {
-                            if (argTypes[j] == null)
+                            if (argTypes[j] is null)
                                 continue;
 
                             if (!paramArrayType.IsAssignableFrom(argTypes[j]))
@@ -291,7 +291,7 @@ namespace System
 #region Found only one method
                 if (names != null)
                 {
-                    state = new BinderState((int[])paramOrder[0].Clone(), args.Length, paramArrayTypes[0] != null);
+                    state = new BinderState((int[])paramOrder[0].Clone(), args.Length, (object)paramArrayTypes[0] != null);
                     ReorderParams(paramOrder[0], args);
                 }
 
@@ -301,7 +301,7 @@ namespace System
 
                 if (parms.Length == args.Length)
                 {
-                    if (paramArrayTypes[0] != null)
+                    if ((object)paramArrayTypes[0] != null)
                     {
                         object[] objs = new object[parms.Length];
                         int lastPos = parms.Length - 1;
@@ -321,7 +321,7 @@ namespace System
                     for (; i < parms.Length - 1; i++)
                         objs[i] = parms[i].DefaultValue;
 
-                    if (paramArrayTypes[0] != null)
+                    if ((object)paramArrayTypes[0] != null)
                         objs[i] = Array.CreateInstance(paramArrayTypes[0], 0); // create an empty array for the 
 
                     else
@@ -372,7 +372,7 @@ namespace System
             // Reorder (if needed)
             if (names != null)
             {
-                state = new BinderState((int[])paramOrder[currentMin].Clone(), args.Length, paramArrayTypes[currentMin] != null);
+                state = new BinderState((int[])paramOrder[currentMin].Clone(), args.Length, (object)paramArrayTypes[currentMin] != null);
                 ReorderParams(paramOrder[currentMin], args);
             }
 
@@ -381,7 +381,7 @@ namespace System
             ParameterInfo[] parameters = candidates[currentMin].GetParametersNoCopy();
             if (parameters.Length == args.Length)
             {
-                if (paramArrayTypes[currentMin] != null)
+                if ((object)paramArrayTypes[currentMin] != null)
                 {
                     object[] objs = new object[parameters.Length];
                     int lastPos = parameters.Length - 1;
@@ -401,7 +401,7 @@ namespace System
                 for (; i < parameters.Length - 1; i++)
                     objs[i] = parameters[i].DefaultValue;
 
-                if (paramArrayTypes[currentMin] != null)
+                if ((object)paramArrayTypes[currentMin] != null)
                 {
                     objs[i] = Array.CreateInstance(paramArrayTypes[currentMin], 0);
                 }
@@ -563,7 +563,7 @@ namespace System
                         if (!(candidates[i] is MethodInfo methodInfo))
                             break;
                         type = signatureType.TryResolveAgainstGenericMethod(methodInfo);
-                        if (type == null)
+                        if (type is null)
                             break;
                     }
 
@@ -622,7 +622,7 @@ namespace System
             {
                 foreach (Type index in indexes)
                 {
-                    if (index == null)
+                    if (index is null)
                         throw new ArgumentNullException(nameof(indexes));
                 }
             }
@@ -671,7 +671,7 @@ namespace System
 
                 if (j == indexesLength)
                 {
-                    if (returnType != null)
+                    if ((object)returnType != null)
                     {
                         if (candidates[i].PropertyType.IsPrimitive)
                         {
@@ -835,10 +835,10 @@ namespace System
                 }
                 if (j < typesLength)
                     continue;
-                if (returnType != null && returnType != match[i].PropertyType)
+                if ((object)returnType != null && returnType != match[i].PropertyType)
                     continue;
 
-                if (bestMatch != null)
+                if ((object)bestMatch != null)
                     throw new AmbiguousMatchException(SR.Arg_AmbiguousMatchException);
 
                 bestMatch = match[i];
@@ -851,8 +851,8 @@ namespace System
                                             Type[] types, object[] args)
         {
             // A method using params is always less specific than one not using params
-            if (paramArrayType1 != null && paramArrayType2 == null) return 2;
-            if (paramArrayType2 != null && paramArrayType1 == null) return 1;
+            if ((object)paramArrayType1 != null && paramArrayType2 is null) return 2;
+            if ((object)paramArrayType2 != null && paramArrayType1 is null) return 1;
 
             // now either p1 and p2 both use params or neither does.
 
@@ -876,12 +876,12 @@ namespace System
                 //          the paramOrder array could contain indexes larger than p.Length - 1 (see VSW 577286)
                 //          so any index >= p.Length - 1 is being put in the param array
 
-                if (paramArrayType1 != null && paramOrder1[i] >= p1.Length - 1)
+                if ((object)paramArrayType1 != null && paramOrder1[i] >= p1.Length - 1)
                     c1 = paramArrayType1;
                 else
                     c1 = p1[paramOrder1[i]].ParameterType;
 
-                if (paramArrayType2 != null && paramOrder2[i] >= p2.Length - 1)
+                if ((object)paramArrayType2 != null && paramOrder2[i] >= p2.Length - 1)
                     c2 = paramArrayType2;
                 else
                     c2 = p2[paramOrder2[i]].ParameterType;
@@ -1107,7 +1107,7 @@ namespace System
             {
                 depth++;
                 currentType = currentType.BaseType;
-            } while (currentType != null);
+            } while ((object)currentType != null);
 
             return depth;
         }

--- a/src/mscorlib/shared/System/Diagnostics/DebuggerDisplayAttribute.cs
+++ b/src/mscorlib/shared/System/Diagnostics/DebuggerDisplayAttribute.cs
@@ -36,7 +36,7 @@ namespace System.Diagnostics
             get => _target;
             set
             {
-                if (value == null)
+                if (value is null)
                 {
                     throw new ArgumentNullException(nameof(value));
                 }

--- a/src/mscorlib/shared/System/Diagnostics/DebuggerTypeProxyAttribute.cs
+++ b/src/mscorlib/shared/System/Diagnostics/DebuggerTypeProxyAttribute.cs
@@ -11,7 +11,7 @@ namespace System.Diagnostics
 
         public DebuggerTypeProxyAttribute(Type type)
         {
-            if (type == null)
+            if (type is null)
             {
                 throw new ArgumentNullException(nameof(type));
             }
@@ -31,7 +31,7 @@ namespace System.Diagnostics
             get => _target;
             set
             {
-                if (value == null)
+                if (value is null)
                 {
                     throw new ArgumentNullException(nameof(value));
                 }

--- a/src/mscorlib/shared/System/Diagnostics/DebuggerVisualizerAttribute.cs
+++ b/src/mscorlib/shared/System/Diagnostics/DebuggerVisualizerAttribute.cs
@@ -26,7 +26,7 @@ namespace System.Diagnostics
 
         public DebuggerVisualizerAttribute(string visualizerTypeName, Type visualizerObjectSource)
         {
-            if (visualizerObjectSource == null)
+            if (visualizerObjectSource is null)
             {
                 throw new ArgumentNullException(nameof(visualizerObjectSource));
             }
@@ -37,7 +37,7 @@ namespace System.Diagnostics
 
         public DebuggerVisualizerAttribute(Type visualizer)
         {
-            if (visualizer == null)
+            if (visualizer is null)
             {
                 throw new ArgumentNullException(nameof(visualizer));
             }
@@ -47,11 +47,11 @@ namespace System.Diagnostics
 
         public DebuggerVisualizerAttribute(Type visualizer, Type visualizerObjectSource)
         {
-            if (visualizer == null)
+            if (visualizer is null)
             {
                 throw new ArgumentNullException(nameof(visualizer));
             }
-            if (visualizerObjectSource == null)
+            if (visualizerObjectSource is null)
             {
                 throw new ArgumentNullException(nameof(visualizerObjectSource));
             }
@@ -62,7 +62,7 @@ namespace System.Diagnostics
 
         public DebuggerVisualizerAttribute(Type visualizer, string visualizerObjectSourceTypeName)
         {
-            if (visualizer == null)
+            if (visualizer is null)
             {
                 throw new ArgumentNullException(nameof(visualizer));
             }
@@ -82,7 +82,7 @@ namespace System.Diagnostics
             get => _target;
             set
             {
-                if (value == null)
+                if (value is null)
                 {
                     throw new ArgumentNullException(nameof(value));
                 }

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -403,7 +403,7 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         public static Guid GetGuid(Type eventSourceType)
         {
-            if (eventSourceType == null)
+            if (eventSourceType is null)
                 throw new ArgumentNullException(nameof(eventSourceType));
 
             EventSourceAttribute attrib = (EventSourceAttribute)GetCustomAttributeHelper(eventSourceType, typeof(EventSourceAttribute));
@@ -470,7 +470,7 @@ namespace System.Diagnostics.Tracing
         /// <returns>The XML data string or null</returns>
         public static string GenerateManifest(Type eventSourceType, string assemblyPathToIncludeInManifest, EventManifestOptions flags)
         {
-            if (eventSourceType == null)
+            if (eventSourceType is null)
                 throw new ArgumentNullException(nameof(eventSourceType));
 
             byte[] manifestBytes = EventSource.CreateManifestAndDescriptors(eventSourceType, assemblyPathToIncludeInManifest, null, flags);
@@ -1619,7 +1619,7 @@ namespace System.Diagnostics.Tracing
 
         private static string GetName(Type eventSourceType, EventManifestOptions flags)
         {
-            if (eventSourceType == null)
+            if (eventSourceType is null)
                 throw new ArgumentNullException(nameof(eventSourceType));
 
             EventSourceAttribute attrib = (EventSourceAttribute)GetCustomAttributeHelper(eventSourceType, typeof(EventSourceAttribute), flags);
@@ -2179,7 +2179,7 @@ namespace System.Diagnostics.Tracing
                 // Checking to see if the Parameter types (from the Event method) match the supplied argument types.
                 // Fail if one of two things hold : either the argument type is not equal to the parameter type, or the 
                 // argument is null and the parameter type is non-nullable.
-                if ((args[i] != null && (args[i].GetType() != pType))
+                if ((args[i] != null && ((object)args[i].GetType() != pType))
                     || (args[i] == null && (!(pType.IsGenericType && pType.GetGenericTypeDefinition() == typeof(Nullable<>))))
                     )
                 {
@@ -3380,7 +3380,7 @@ namespace System.Diagnostics.Tracing
         private static Type GetEventSourceBaseType(Type eventSourceType, bool allowEventSourceOverride, bool reflectionOnly)
         {
             // return false for "object" and interfaces
-            if (eventSourceType.BaseType() == null)
+            if (eventSourceType.BaseType() is null)
                 return null;
 
             // now go up the inheritance chain until hitting a concrete type ("object" at worse)
@@ -3388,9 +3388,9 @@ namespace System.Diagnostics.Tracing
             {
                 eventSourceType = eventSourceType.BaseType();
             }
-            while (eventSourceType != null && eventSourceType.IsAbstract());
+            while ((object)eventSourceType != null && eventSourceType.IsAbstract());
 
-            if (eventSourceType != null)
+            if ((object)eventSourceType != null)
             {
                 if (!allowEventSourceOverride)
                 {
@@ -3459,7 +3459,7 @@ namespace System.Diagnostics.Tracing
                 // eventSourceType must be sealed and must derive from this EventSource
                 if ((flags & EventManifestOptions.Strict) != 0)
                 {
-                    bool typeMatch = GetEventSourceBaseType(eventSourceType, (flags & EventManifestOptions.AllowEventSourceOverride) != 0, eventSourceType.Assembly().ReflectionOnly()) != null;
+                    bool typeMatch = (object)GetEventSourceBaseType(eventSourceType, (flags & EventManifestOptions.AllowEventSourceOverride) != 0, eventSourceType.Assembly().ReflectionOnly()) != null;
 
                     if (!typeMatch)
                     {
@@ -3479,7 +3479,7 @@ namespace System.Diagnostics.Tracing
 #endif
                 {
                     Type nestedType = eventSourceType.GetNestedType(providerEnumKind);
-                    if (nestedType != null)
+                    if ((object)nestedType != null)
                     {
                         if (eventSourceType.IsAbstract())
                         {

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/Statics.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/Statics.cs
@@ -491,7 +491,7 @@ namespace System.Diagnostics.Tracing
                     }
 #endif
 
-                    if (elementType != null)
+                    if ((object)elementType != null)
                     {
                         // ambiguous match. report no match at all.
                         elementType = null;
@@ -709,7 +709,7 @@ namespace System.Diagnostics.Tracing
                 else
                 {
                     var elementType = FindEnumerableElementType(dataType);
-                    if (elementType != null)
+                    if ((object)elementType != null)
                     {
                         result = new EnumerableTypeInfo(dataType, TraceLoggingTypeInfo.GetInstance(elementType, recursionCheck));
                     }

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingTypeInfo.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingTypeInfo.cs
@@ -34,7 +34,7 @@ namespace System.Diagnostics.Tracing
 
         internal TraceLoggingTypeInfo(Type dataType)
         {
-            if (dataType == null)
+            if (dataType is null)
             {
                 throw new ArgumentNullException(nameof(dataType));
             }
@@ -52,7 +52,7 @@ namespace System.Diagnostics.Tracing
             EventKeywords keywords,
             EventTags tags)
         {
-            if (dataType == null)
+            if (dataType is null)
             {
                 throw new ArgumentNullException(nameof(dataType));
             }

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/TypeAnalysis.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/TypeAnalysis.cs
@@ -47,7 +47,7 @@ namespace System.Diagnostics.Tracing
                 }
 
                 MethodInfo getterInfo = Statics.GetGetMethod(propertyInfo);
-                if (getterInfo == null)
+                if (getterInfo is null)
                 {
                     continue;
                 }

--- a/src/mscorlib/shared/System/Globalization/CompareInfo.cs
+++ b/src/mscorlib/shared/System/Globalization/CompareInfo.cs
@@ -98,7 +98,7 @@ namespace System.Globalization
         public static CompareInfo GetCompareInfo(int culture, Assembly assembly)
         {
             // Parameter checking.
-            if (assembly == null)
+            if (assembly is null)
             {
                 throw new ArgumentNullException(nameof(assembly));
             }
@@ -124,7 +124,7 @@ namespace System.Globalization
         // Assembly constructor should be deprecated, we don't act on the assembly information any more
         public static CompareInfo GetCompareInfo(string name, Assembly assembly)
         {
-            if (name == null || assembly == null)
+            if (name == null || assembly is null)
             {
                 throw new ArgumentNullException(name == null ? nameof(name) : nameof(assembly));
             }
@@ -1280,7 +1280,7 @@ namespace System.Globalization
         {
             get
             {
-                if (m_SortVersion == null)
+                if (m_SortVersion is null)
                 {
                     if (_invariantMode)
                     {

--- a/src/mscorlib/shared/System/Globalization/SortVersion.cs
+++ b/src/mscorlib/shared/System/Globalization/SortVersion.cs
@@ -51,23 +51,15 @@ namespace System.Globalization
 
         public override bool Equals(object obj)
         {
-            SortVersion n = obj as SortVersion;
-            if (n != null)
-            {
-                return this.Equals(n);
-            }
-
-            return false;
+            return obj is SortVersion n && Equals(n);
         }
 
         public bool Equals(SortVersion other)
         {
-            if (other == null)
-            {
-                return false;
-            }
-
-            return m_NlsVersion == other.m_NlsVersion && m_SortId == other.m_SortId;
+            return
+                (object)other != null &&
+                m_NlsVersion == other.m_NlsVersion &&
+                m_SortId == other.m_SortId;
         }
 
         public override int GetHashCode()

--- a/src/mscorlib/shared/System/Reflection/Assembly.cs
+++ b/src/mscorlib/shared/System/Reflection/Assembly.cs
@@ -24,7 +24,7 @@ namespace System.Reflection
                 for (int i = 0; i < types.Length; i++)
                 {
                     TypeInfo typeinfo = types[i].GetTypeInfo();
-                    if (typeinfo == null)
+                    if (typeinfo is null)
                         throw new NotSupportedException(SR.Format(SR.NotSupported_NoTypeInfo, types[i].FullName));
 
                     typeinfos[i] = typeinfo;
@@ -99,7 +99,7 @@ namespace System.Reflection
         public virtual object CreateInstance(string typeName, bool ignoreCase, BindingFlags bindingAttr, Binder binder, object[] args, CultureInfo culture, object[] activationAttributes)
         {
             Type t = GetType(typeName, throwOnError: false, ignoreCase: ignoreCase);
-            if (t == null)
+            if (t is null)
                 return null;
 
             return Activator.CreateInstance(t, bindingAttr, binder, args, culture, activationAttributes);
@@ -166,11 +166,11 @@ namespace System.Reflection
 
         public static Assembly GetAssembly(Type type)
         {
-            if (type == null)
+            if (type is null)
                 throw new ArgumentNullException(nameof(type));
 
             Module m = type.Module;
-            if (m == null)
+            if (m is null)
                 return null;
             else
                 return m.Assembly;

--- a/src/mscorlib/shared/System/Reflection/AssemblyNameFormatter.cs
+++ b/src/mscorlib/shared/System/Reflection/AssemblyNameFormatter.cs
@@ -24,7 +24,7 @@ namespace System.Reflection
                 sb.AppendQuoted(name);
             }
 
-            if (version != null)
+            if ((object)version != null)
             {
                 Version canonicalizedVersion = version.CanonicalizeVersion();
                 if (canonicalizedVersion.Major != ushort.MaxValue)

--- a/src/mscorlib/shared/System/Reflection/EventInfo.cs
+++ b/src/mscorlib/shared/System/Reflection/EventInfo.cs
@@ -67,7 +67,7 @@ namespace System.Reflection
         {
             MethodInfo addMethod = GetAddMethod(nonPublic: false);
 
-            if (addMethod == null)
+            if (addMethod is null)
                 throw new InvalidOperationException(SR.InvalidOperation_NoPublicAddMethod);
 
 #if FEATURE_COMINTEROP
@@ -84,7 +84,7 @@ namespace System.Reflection
         {
             MethodInfo removeMethod = GetRemoveMethod(nonPublic: false);
 
-            if (removeMethod == null)
+            if (removeMethod is null)
                 throw new InvalidOperationException(SR.InvalidOperation_NoPublicRemoveMethod);
 
 #if FEATURE_COMINTEROP

--- a/src/mscorlib/shared/System/Reflection/IntrospectionExtensions.cs
+++ b/src/mscorlib/shared/System/Reflection/IntrospectionExtensions.cs
@@ -10,7 +10,7 @@ namespace System.Reflection
     {
         public static TypeInfo GetTypeInfo(this Type type)
         {
-            if (type == null)
+            if (type is null)
                 throw new ArgumentNullException(nameof(type));
 
             if (type is IReflectableType reflectableType)

--- a/src/mscorlib/shared/System/Reflection/MemberInfo.cs
+++ b/src/mscorlib/shared/System/Reflection/MemberInfo.cs
@@ -22,8 +22,7 @@ namespace System.Reflection
                 // This check is necessary because for some reason, Type adds a new "Module" property that hides the inherited one instead 
                 // of overriding.
 
-                Type type = this as Type;
-                if (type != null)
+                if (this is Type type)
                     return type.Module;
 
                 throw NotImplemented.ByDesign;
@@ -52,21 +51,15 @@ namespace System.Reflection
             if ((object)left == null || (object)right == null)
                 return false;
 
-            Type type1, type2;
-            MethodBase method1, method2;
-            FieldInfo field1, field2;
-            EventInfo event1, event2;
-            PropertyInfo property1, property2;
-
-            if ((type1 = left as Type) != null && (type2 = right as Type) != null)
+            if (left is Type type1 && right is Type type2)
                 return type1 == type2;
-            else if ((method1 = left as MethodBase) != null && (method2 = right as MethodBase) != null)
+            else if (left is MethodBase method1 && right is MethodBase method2)
                 return method1 == method2;
-            else if ((field1 = left as FieldInfo) != null && (field2 = right as FieldInfo) != null)
+            else if (left is FieldInfo field1 && right is FieldInfo field2)
                 return field1 == field2;
-            else if ((event1 = left as EventInfo) != null && (event2 = right as EventInfo) != null)
+            else if (left is EventInfo event1 && right is EventInfo event2)
                 return event1 == event2;
-            else if ((property1 = left as PropertyInfo) != null && (property2 = right as PropertyInfo) != null)
+            else if (left is PropertyInfo property1 && right is PropertyInfo property2)
                 return property1 == property2;
 
             return false;

--- a/src/mscorlib/shared/System/Reflection/MethodBase.cs
+++ b/src/mscorlib/shared/System/Reflection/MethodBase.cs
@@ -70,12 +70,9 @@ namespace System.Reflection
             if ((object)left == null || (object)right == null)
                 return false;
 
-            MethodInfo method1, method2;
-            ConstructorInfo constructor1, constructor2;
-
-            if ((method1 = left as MethodInfo) != null && (method2 = right as MethodInfo) != null)
+            if (left is MethodInfo method1 && right is MethodInfo method2)
                 return method1 == method2;
-            else if ((constructor1 = left as ConstructorInfo) != null && (constructor2 = right as ConstructorInfo) != null)
+            else if (left is ConstructorInfo constructor1 && right is ConstructorInfo constructor2)
                 return constructor1 == constructor2;
 
             return false;

--- a/src/mscorlib/shared/System/Reflection/Module.cs
+++ b/src/mscorlib/shared/System/Reflection/Module.cs
@@ -46,7 +46,7 @@ namespace System.Reflection
                 throw new ArgumentNullException(nameof(types));
             for (int i = 0; i < types.Length; i++)
             {
-                if (types[i] == null)
+                if (types[i] is null)
                     throw new ArgumentNullException(nameof(types));
             }
             return GetMethodImpl(name, bindingAttr, binder, callConvention, types, modifiers);
@@ -87,7 +87,7 @@ namespace System.Reflection
             cnt = 0;
             for (int i = 0; i < c.Length; i++)
             {
-                if (c[i] != null)
+                if ((object)c[i] != null)
                     ret[cnt++] = c[i];
             }
             return ret;

--- a/src/mscorlib/shared/System/Reflection/ParameterInfo.cs
+++ b/src/mscorlib/shared/System/Reflection/ParameterInfo.cs
@@ -29,7 +29,7 @@ namespace System.Reflection
 
         public virtual bool IsDefined(Type attributeType, bool inherit)
         {
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             return false;
@@ -41,7 +41,7 @@ namespace System.Reflection
         public virtual object[] GetCustomAttributes(bool inherit) => Array.Empty<object>();
         public virtual object[] GetCustomAttributes(Type attributeType, bool inherit)
         {
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             return Array.Empty<object>();
@@ -57,7 +57,7 @@ namespace System.Reflection
             // Once all the serializable fields have come in we can set up the real
             // instance based on just two of them (MemberImpl and PositionImpl).
 
-            if (MemberImpl == null)
+            if (MemberImpl is null)
                 throw new SerializationException(SR.Serialization_InsufficientState);
 
             ParameterInfo[] args = null;

--- a/src/mscorlib/shared/System/Reflection/Pointer.cs
+++ b/src/mscorlib/shared/System/Reflection/Pointer.cs
@@ -23,7 +23,7 @@ namespace System.Reflection
 
         public static object Box(void* ptr, Type type)
         {
-            if (type == null)
+            if (type is null)
                 throw new ArgumentNullException(nameof(type));
             if (!type.IsPointer)
                 throw new ArgumentException(SR.Arg_MustBePointer, nameof(ptr));

--- a/src/mscorlib/shared/System/Reflection/SignatureTypeExtensions.cs
+++ b/src/mscorlib/shared/System/Reflection/SignatureTypeExtensions.cs
@@ -141,7 +141,7 @@ namespace System.Reflection
                     if (genericTypeArgument is SignatureType signatureGenericTypeArgument)
                     {
                         newGenericTypeArguments[i] = signatureGenericTypeArgument.TryResolve(genericMethodParameters);
-                        if (newGenericTypeArguments[i] == null)
+                        if (newGenericTypeArguments[i] is null)
                             return null;
                     }
                     else

--- a/src/mscorlib/shared/System/Reflection/TypeDelegator.cs
+++ b/src/mscorlib/shared/System/Reflection/TypeDelegator.cs
@@ -14,7 +14,7 @@ namespace System.Reflection
     {
         public override bool IsAssignableFrom(TypeInfo typeInfo)
         {
-            if (typeInfo == null)
+            if (typeInfo is null)
                 return false;
             return IsAssignableFrom(typeInfo.AsType());
         }
@@ -25,7 +25,7 @@ namespace System.Reflection
 
         public TypeDelegator(Type delegatingType)
         {
-            if (delegatingType == null)
+            if (delegatingType is null)
                 throw new ArgumentNullException(nameof(delegatingType));
 
             typeImpl = delegatingType;
@@ -84,7 +84,7 @@ namespace System.Reflection
         protected override PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr, Binder binder,
                         Type returnType, Type[] types, ParameterModifier[] modifiers)
         {
-            if (returnType == null && types == null)
+            if (returnType is null && types == null)
                 return typeImpl.GetProperty(name, bindingAttr);
             else
                 return typeImpl.GetProperty(name, bindingAttr, binder, returnType, types, modifiers);

--- a/src/mscorlib/shared/System/Reflection/TypeInfo.cs
+++ b/src/mscorlib/shared/System/Reflection/TypeInfo.cs
@@ -52,7 +52,7 @@ namespace System.Reflection
         //a re-implementation of ISAF from Type, skipping the use of UnderlyingType
         public virtual bool IsAssignableFrom(TypeInfo typeInfo)
         {
-            if (typeInfo == null)
+            if (typeInfo is null)
                 return false;
 
             if (this == typeInfo)

--- a/src/mscorlib/shared/System/Type.Helpers.cs
+++ b/src/mscorlib/shared/System/Type.Helpers.cs
@@ -30,7 +30,7 @@ namespace System
 
                         underlyingType = underlyingType.BaseType;
                     }
-                    while (underlyingType != null);
+                    while ((object)underlyingType != null);
                 }
 
                 return false;
@@ -77,7 +77,7 @@ namespace System
             {
 #if CORECLR
                 RuntimeType rt = this as RuntimeType;
-                if (rt != null)
+                if ((object)rt != null)
                     return RuntimeTypeHandle.IsVisible(rt);
 #endif //CORECLR
 
@@ -135,7 +135,7 @@ namespace System
             cnt = 0;
             for (int i = 0; i < c.Length; i++)
             {
-                if (c[i] != null)
+                if ((object)c[i] != null)
                     ret[cnt++] = c[i];
             }
             return ret;
@@ -270,7 +270,7 @@ namespace System
             if (m != null)
             {
                 for (i = 0; i < m.Length; i++)
-                    if (m[i] != null)
+                    if ((object)m[i] != null)
                         ret[cnt++] = m[i];
             }
 
@@ -278,7 +278,7 @@ namespace System
             if (c != null)
             {
                 for (i = 0; i < c.Length; i++)
-                    if (c[i] != null)
+                    if ((object)c[i] != null)
                         ret[cnt++] = c[i];
             }
 
@@ -286,7 +286,7 @@ namespace System
             if (f != null)
             {
                 for (i = 0; i < f.Length; i++)
-                    if (f[i] != null)
+                    if ((object)f[i] != null)
                         ret[cnt++] = f[i];
             }
 
@@ -294,7 +294,7 @@ namespace System
             if (p != null)
             {
                 for (i = 0; i < p.Length; i++)
-                    if (p[i] != null)
+                    if ((object)p[i] != null)
                         ret[cnt++] = p[i];
             }
 
@@ -302,7 +302,7 @@ namespace System
             if (e != null)
             {
                 for (i = 0; i < e.Length; i++)
-                    if (e[i] != null)
+                    if ((object)e[i] != null)
                         ret[cnt++] = e[i];
             }
 
@@ -310,7 +310,7 @@ namespace System
             if (t != null)
             {
                 for (i = 0; i < t.Length; i++)
-                    if (t[i] != null)
+                    if ((object)t[i] != null)
                         ret[cnt++] = t[i];
             }
 
@@ -322,7 +322,7 @@ namespace System
             Type p = this;
             if (p == c)
                 return false;
-            while (p != null)
+            while ((object)p != null)
             {
                 if (p == c)
                     return true;
@@ -333,7 +333,7 @@ namespace System
 
         public virtual bool IsAssignableFrom(Type c)
         {
-            if (c == null)
+            if (c is null)
                 return false;
 
             if (this == c)
@@ -369,17 +369,16 @@ namespace System
         internal bool ImplementInterface(Type ifaceType)
         {
             Type t = this;
-            while (t != null)
+            while ((object)t != null)
             {
                 Type[] interfaces = t.GetInterfaces();
                 if (interfaces != null)
                 {
-                    for (int i = 0; i < interfaces.Length; i++)
+                    foreach (Type iface in interfaces)
                     {
                         // Interfaces don't derive from other interfaces, they implement them.
                         // So instead of IsSubclassOf, we should use ImplementInterface instead.
-                        if (interfaces[i] == ifaceType ||
-                            (interfaces[i] != null && interfaces[i].ImplementInterface(ifaceType)))
+                        if (iface == ifaceType || iface?.ImplementInterface(ifaceType) == true)
                             return true;
                     }
                 }

--- a/src/mscorlib/shared/System/Type.cs
+++ b/src/mscorlib/shared/System/Type.cs
@@ -25,7 +25,7 @@ namespace System
         public abstract Assembly Assembly { get; }
         public abstract new Module Module { get; }
 
-        public bool IsNested => DeclaringType != null;
+        public bool IsNested => (object)DeclaringType != null;
         public override Type DeclaringType => null;
         public virtual MethodBase DeclaringMethod => null;
 
@@ -41,8 +41,8 @@ namespace System
         protected abstract bool IsPointerImpl();
         public virtual bool IsConstructedGenericType { get { throw NotImplemented.ByDesign; } }
         public virtual bool IsGenericParameter => false;
-        public virtual bool IsGenericTypeParameter => IsGenericParameter && DeclaringMethod == null;
-        public virtual bool IsGenericMethodParameter => IsGenericParameter && DeclaringMethod != null;
+        public virtual bool IsGenericTypeParameter => IsGenericParameter && DeclaringMethod is null;
+        public virtual bool IsGenericMethodParameter => IsGenericParameter && (object)DeclaringMethod != null;
         public virtual bool IsGenericType => false;
         public virtual bool IsGenericTypeDefinition => false;
 
@@ -129,7 +129,7 @@ namespace System
                 throw new ArgumentNullException(nameof(types));
             for (int i = 0; i < types.Length; i++)
             {
-                if (types[i] == null)
+                if (types[i] is null)
                     throw new ArgumentNullException(nameof(types));
             }
             return GetConstructorImpl(bindingAttr, binder, callConvention, types, modifiers);
@@ -177,7 +177,7 @@ namespace System
                 throw new ArgumentNullException(nameof(types));
             for (int i = 0; i < types.Length; i++)
             {
-                if (types[i] == null)
+                if (types[i] is null)
                     throw new ArgumentNullException(nameof(types));
             }
             return GetMethodImpl(name, bindingAttr, binder, callConvention, types, modifiers);
@@ -198,7 +198,7 @@ namespace System
                 throw new ArgumentNullException(nameof(types));
             for (int i = 0; i < types.Length; i++)
             {
-                if (types[i] == null)
+                if (types[i] is null)
                     throw new ArgumentNullException(nameof(types));
             }
             return GetMethodImpl(name, genericParameterCount, bindingAttr, binder, callConvention, types, modifiers);
@@ -227,7 +227,7 @@ namespace System
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
-            if (returnType == null)
+            if (returnType is null)
                 throw new ArgumentNullException(nameof(returnType));
             return GetPropertyImpl(name, Type.DefaultLookup, null, returnType, null, null);
         }
@@ -277,13 +277,13 @@ namespace System
 
         public static TypeCode GetTypeCode(Type type)
         {
-            if (type == null)
+            if (type is null)
                 return TypeCode.Empty;
             return type.GetTypeCodeImpl();
         }
         protected virtual TypeCode GetTypeCodeImpl()
         {
-            if (this != UnderlyingSystemType && UnderlyingSystemType != null)
+            if (this != UnderlyingSystemType && (object)UnderlyingSystemType != null)
                 return Type.GetTypeCode(UnderlyingSystemType);
 
             return TypeCode.Object;
@@ -363,7 +363,7 @@ namespace System
                 return systemType.GetHashCode();
             return base.GetHashCode();
         }
-        public virtual bool Equals(Type o) => o == null ? false : object.ReferenceEquals(this.UnderlyingSystemType, o.UnderlyingSystemType);
+        public virtual bool Equals(Type o) => o is null ? false : object.ReferenceEquals(this.UnderlyingSystemType, o.UnderlyingSystemType);
 
         public static Type ReflectionOnlyGetType(string typeName, bool throwIfNotFound, bool ignoreCase) { throw new PlatformNotSupportedException(SR.PlatformNotSupported_ReflectionOnly); }
 

--- a/src/mscorlib/shared/System/Version.cs
+++ b/src/mscorlib/shared/System/Version.cs
@@ -134,20 +134,19 @@ namespace System
             get { return (short)(_Revision & 0xFFFF); }
         }
 
-        public int CompareTo(Object version)
+        public int CompareTo(object version)
         {
             if (version == null)
             {
                 return 1;
             }
 
-            Version v = version as Version;
-            if (v == null)
+            if (version is Version v)
             {
-                throw new ArgumentException(SR.Arg_MustBeVersion);
+                return CompareTo(v);
             }
 
-            return CompareTo(v);
+            throw new ArgumentException(SR.Arg_MustBeVersion);
         }
 
         public int CompareTo(Version value)
@@ -314,11 +313,11 @@ namespace System
                 return false;
             }
 
-            return (result = ParseVersion(input.AsReadOnlySpan(), throwOnFailure: false)) != null;
+            return (object)(result = ParseVersion(input.AsReadOnlySpan(), throwOnFailure: false)) != null;
         }
 
         public static bool TryParse(ReadOnlySpan<char> input, out Version result) =>
-            (result = ParseVersion(input, throwOnFailure: false)) != null;
+            (object)(result = ParseVersion(input, throwOnFailure: false)) != null;
 
         private static Version ParseVersion(ReadOnlySpan<char> input, bool throwOnFailure)
         {

--- a/src/mscorlib/src/Microsoft/Win32/OAVariantLib.cs
+++ b/src/mscorlib/src/Microsoft/Win32/OAVariantLib.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Win32
          */
         internal static Variant ChangeType(Variant source, Type targetClass, short options, CultureInfo culture)
         {
-            if (targetClass == null)
+            if (targetClass is null)
                 throw new ArgumentNullException(nameof(targetClass));
             if (culture == null)
                 throw new ArgumentNullException(nameof(culture));

--- a/src/mscorlib/src/System/AppDomain.cs
+++ b/src/mscorlib/src/System/AppDomain.cs
@@ -438,7 +438,7 @@ namespace System
             {
                 Assembly asm = handler(this, args);
                 RuntimeAssembly ret = GetRuntimeAssembly(asm);
-                if (ret != null)
+                if ((object)ret != null)
                     return ret;
             }
 
@@ -465,7 +465,7 @@ namespace System
         private static RuntimeAssembly GetRuntimeAssembly(Assembly asm)
         {
             return
-                asm == null ? null :
+                asm is null ? null :
                 asm is RuntimeAssembly rtAssembly ? rtAssembly :
                 asm is AssemblyBuilder ab ? ab.InternalAssembly :
                 null;

--- a/src/mscorlib/src/System/AppDomainManager.cs
+++ b/src/mscorlib/src/System/AppDomainManager.cs
@@ -36,7 +36,7 @@ namespace System
                 // AppDomain is a manifest application domain or not. In the first case, we parse
                 // the application manifest to find out the entry point assembly and return that assembly.
                 // In the second case, we maintain the old behavior by calling GetEntryAssembly().
-                if (m_entryAssembly == null)
+                if (m_entryAssembly is null)
                 {
                     {
                         RuntimeAssembly entryAssembly = null;

--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -73,7 +73,7 @@ namespace System
                 ThrowHelper.ThrowLengthArgumentOutOfRange_ArgumentOutOfRange_NeedNonNegNum();
 
             RuntimeType t = elementType.UnderlyingSystemType as RuntimeType;
-            if (t == null)
+            if (t is null)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_MustBeType, ExceptionArgument.elementType);
             return InternalCreate((void*)t.TypeHandle.Value, 1, &length, null);
         }
@@ -88,7 +88,7 @@ namespace System
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length2, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
 
             RuntimeType t = elementType.UnderlyingSystemType as RuntimeType;
-            if (t == null)
+            if (t is null)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_MustBeType, ExceptionArgument.elementType);
             int* pLengths = stackalloc int[2];
             pLengths[0] = length1;
@@ -108,7 +108,7 @@ namespace System
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length3, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
 
             RuntimeType t = elementType.UnderlyingSystemType as RuntimeType;
-            if (t == null)
+            if (t is null)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_MustBeType, ExceptionArgument.elementType);
             int* pLengths = stackalloc int[3];
             pLengths[0] = length1;
@@ -127,7 +127,7 @@ namespace System
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_NeedAtLeast1Rank);
 
             RuntimeType t = elementType.UnderlyingSystemType as RuntimeType;
-            if (t == null)
+            if (t is null)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_MustBeType, ExceptionArgument.elementType);
 
             // Check to make sure the lenghts are all positive. Note that we check this here to give
@@ -167,7 +167,7 @@ namespace System
 
         public unsafe static Array CreateInstance(Type elementType, int[] lengths, int[] lowerBounds)
         {
-            if (elementType == null)
+            if (elementType is null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.elementType);
             if (lengths == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.lengths);
@@ -179,7 +179,7 @@ namespace System
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_NeedAtLeast1Rank);
 
             RuntimeType t = elementType.UnderlyingSystemType as RuntimeType;
-            if (t == null)
+            if (t is null)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_MustBeType, ExceptionArgument.elementType);
 
             // Check to make sure the lenghts are all positive. Note that we check this here to give

--- a/src/mscorlib/src/System/Attribute.cs
+++ b/src/mscorlib/src/System/Attribute.cs
@@ -46,7 +46,7 @@ namespace System
 
 
             PropertyInfo baseProp = GetParentDefinition(element, indexParamTypes);
-            while (baseProp != null)
+            while ((object)baseProp != null)
             {
                 attributes = GetCustomAttributes(baseProp, type, false);
                 AddAttributesToList(attributeList, attributes, types);
@@ -75,7 +75,7 @@ namespace System
 
                 PropertyInfo baseProp = GetParentDefinition(element, indexParamTypes);
 
-                while (baseProp != null)
+                while ((object)baseProp != null)
                 {
                     if (baseProp.IsDefined(attributeType, false))
                         return true;
@@ -95,16 +95,14 @@ namespace System
             // note that this only works for RuntimeMethodInfo
             MethodInfo propAccessor = property.GetGetMethod(true);
 
-            if (propAccessor == null)
+            if (propAccessor is null)
                 propAccessor = property.GetSetMethod(true);
 
-            RuntimeMethodInfo rtPropAccessor = propAccessor as RuntimeMethodInfo;
-
-            if (rtPropAccessor != null)
+            if (propAccessor is RuntimeMethodInfo rtPropAccessor)
             {
                 rtPropAccessor = rtPropAccessor.GetParentDefinition();
 
-                if (rtPropAccessor != null)
+                if ((object)rtPropAccessor != null)
                 {
                     // There is a public overload of Type.GetProperty that takes both a BingingFlags enum and a return type.
                     // However, we cannot use that because it doesn't accept null for "types".
@@ -141,7 +139,7 @@ namespace System
                 CopyToArrayList(attributeList, attributes, types);
 
                 EventInfo baseEvent = GetParentDefinition(element);
-                while (baseEvent != null)
+                while ((object)baseEvent != null)
                 {
                     attributes = GetCustomAttributes(baseEvent, type, false);
                     AddAttributesToList(attributeList, attributes, types);
@@ -162,12 +160,10 @@ namespace System
             // note that this only works for RuntimeMethodInfo
             MethodInfo add = ev.GetAddMethod(true);
 
-            RuntimeMethodInfo rtAdd = add as RuntimeMethodInfo;
-
-            if (rtAdd != null)
+            if (add is RuntimeMethodInfo rtAdd)
             {
                 rtAdd = rtAdd.GetParentDefinition();
-                if (rtAdd != null)
+                if ((object)rtAdd != null)
                     return rtAdd.DeclaringType.GetEvent(ev.Name);
             }
             return null;
@@ -190,7 +186,7 @@ namespace System
 
                 EventInfo baseEvent = GetParentDefinition(element);
 
-                while (baseEvent != null)
+                while ((object)baseEvent != null)
                 {
                     if (baseEvent.IsDefined(attributeType, false))
                         return true;
@@ -209,13 +205,11 @@ namespace System
             Debug.Assert(param != null);
 
             // note that this only works for RuntimeMethodInfo
-            RuntimeMethodInfo rtMethod = param.Member as RuntimeMethodInfo;
-
-            if (rtMethod != null)
+            if (param.Member is RuntimeMethodInfo rtMethod)
             {
                 rtMethod = rtMethod.GetParentDefinition();
 
-                if (rtMethod != null)
+                if ((object)rtMethod != null)
                 {
                     // Find the ParameterInfo on this method
                     int position = param.Position;
@@ -247,7 +241,7 @@ namespace System
             List<Type> disAllowMultiple = new List<Type>();
             Object[] objAttr;
 
-            if (type == null)
+            if (type is null)
                 type = typeof(Attribute);
 
             objAttr = param.GetCustomAttributes(type, false);
@@ -267,7 +261,7 @@ namespace System
             else
                 ret = (Attribute[])objAttr;
 
-            if (param.Member.DeclaringType == null) // This is an interface so we are done.
+            if (param.Member.DeclaringType is null) // This is an interface so we are done.
                 return ret;
 
             if (!inherit)
@@ -337,7 +331,7 @@ namespace System
             if (param.IsDefined(type, false))
                 return true;
 
-            if (param.Member.DeclaringType == null || !inherit) // This is an interface so we are done.
+            if (param.Member.DeclaringType is null || !inherit) // This is an interface so we are done.
                 return false;
 
             ParameterInfo baseParam = GetParentDefinition(param);
@@ -452,10 +446,10 @@ namespace System
 
         public static Attribute[] GetCustomAttributes(MemberInfo element, Type type, bool inherit)
         {
-            if (element == null)
+            if (element is null)
                 throw new ArgumentNullException(nameof(element));
 
-            if (type == null)
+            if (type is null)
                 throw new ArgumentNullException(nameof(type));
 
             if (!type.IsSubclassOf(typeof(Attribute)) && type != typeof(Attribute))
@@ -481,7 +475,7 @@ namespace System
 
         public static Attribute[] GetCustomAttributes(MemberInfo element, bool inherit)
         {
-            if (element == null)
+            if (element is null)
                 throw new ArgumentNullException(nameof(element));
 
             switch (element.MemberType)
@@ -505,10 +499,10 @@ namespace System
         public static bool IsDefined(MemberInfo element, Type attributeType, bool inherit)
         {
             // Returns true if a custom attribute subclass of attributeType class/interface with inheritance walk
-            if (element == null)
+            if (element is null)
                 throw new ArgumentNullException(nameof(element));
 
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             if (!attributeType.IsSubclassOf(typeof(Attribute)) && attributeType != typeof(Attribute))
@@ -563,13 +557,13 @@ namespace System
             if (element == null)
                 throw new ArgumentNullException(nameof(element));
 
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             if (!attributeType.IsSubclassOf(typeof(Attribute)) && attributeType != typeof(Attribute))
                 throw new ArgumentException(SR.Argument_MustHaveAttributeBaseClass);
 
-            if (element.Member == null)
+            if (element.Member is null)
                 throw new ArgumentException(SR.Argument_InvalidParameterInfo, nameof(element));
 
 
@@ -585,7 +579,7 @@ namespace System
             if (element == null)
                 throw new ArgumentNullException(nameof(element));
 
-            if (element.Member == null)
+            if (element.Member is null)
                 throw new ArgumentException(SR.Argument_InvalidParameterInfo, nameof(element));
 
 
@@ -607,7 +601,7 @@ namespace System
             if (element == null)
                 throw new ArgumentNullException(nameof(element));
 
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             if (!attributeType.IsSubclassOf(typeof(Attribute)) && attributeType != typeof(Attribute))
@@ -670,7 +664,7 @@ namespace System
 
         public static Attribute[] GetCustomAttributes(Module element, bool inherit)
         {
-            if (element == null)
+            if (element is null)
                 throw new ArgumentNullException(nameof(element));
 
             return (Attribute[])element.GetCustomAttributes(typeof(Attribute), inherit);
@@ -678,10 +672,10 @@ namespace System
 
         public static Attribute[] GetCustomAttributes(Module element, Type attributeType, bool inherit)
         {
-            if (element == null)
+            if (element is null)
                 throw new ArgumentNullException(nameof(element));
 
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             if (!attributeType.IsSubclassOf(typeof(Attribute)) && attributeType != typeof(Attribute))
@@ -698,10 +692,10 @@ namespace System
         public static bool IsDefined(Module element, Type attributeType, bool inherit)
         {
             // Returns true is a custom attribute subclass of attributeType class/interface with no inheritance walk
-            if (element == null)
+            if (element is null)
                 throw new ArgumentNullException(nameof(element));
 
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             if (!attributeType.IsSubclassOf(typeof(Attribute)) && attributeType != typeof(Attribute))
@@ -740,10 +734,10 @@ namespace System
 
         public static Attribute[] GetCustomAttributes(Assembly element, Type attributeType, bool inherit)
         {
-            if (element == null)
+            if (element is null)
                 throw new ArgumentNullException(nameof(element));
 
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             if (!attributeType.IsSubclassOf(typeof(Attribute)) && attributeType != typeof(Attribute))
@@ -759,7 +753,7 @@ namespace System
 
         public static Attribute[] GetCustomAttributes(Assembly element, bool inherit)
         {
-            if (element == null)
+            if (element is null)
                 throw new ArgumentNullException(nameof(element));
 
             return (Attribute[])element.GetCustomAttributes(typeof(Attribute), inherit);
@@ -773,10 +767,10 @@ namespace System
         public static bool IsDefined(Assembly element, Type attributeType, bool inherit)
         {
             // Returns true is a custom attribute subclass of attributeType class/interface with no inheritance walk
-            if (element == null)
+            if (element is null)
                 throw new ArgumentNullException(nameof(element));
 
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             if (!attributeType.IsSubclassOf(typeof(Attribute)) && attributeType != typeof(Attribute))

--- a/src/mscorlib/src/System/Delegate.cs
+++ b/src/mscorlib/src/System/Delegate.cs
@@ -62,7 +62,7 @@ namespace System
         // for the class defining the method.
         protected unsafe Delegate(Type target, String method)
         {
-            if (target == null)
+            if (target is null)
                 throw new ArgumentNullException(nameof(target));
 
             if (target.ContainsGenericParameters)
@@ -72,7 +72,7 @@ namespace System
                 throw new ArgumentNullException(nameof(method));
 
             RuntimeType rtTarget = target as RuntimeType;
-            if (rtTarget == null)
+            if (rtTarget is null)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(target));
 
             // This API existed in v1/v1.1 and only expected to create open
@@ -243,7 +243,7 @@ namespace System
                             // walking won't be we compare using the generic type definition forms instead.
                             Type currentType = _target.GetType();
                             Type targetType = declaringType.GetGenericTypeDefinition();
-                            while (currentType != null)
+                            while ((object)currentType != null)
                             {
                                 if (currentType.IsGenericType &&
                                     currentType.GetGenericTypeDefinition() == targetType)
@@ -340,7 +340,7 @@ namespace System
         // V1 API.
         public static Delegate CreateDelegate(Type type, Object target, String method, bool ignoreCase, bool throwOnBindFailure)
         {
-            if (type == null)
+            if (type is null)
                 throw new ArgumentNullException(nameof(type));
             if (target == null)
                 throw new ArgumentNullException(nameof(target));
@@ -348,7 +348,7 @@ namespace System
                 throw new ArgumentNullException(nameof(method));
 
             RuntimeType rtType = type as RuntimeType;
-            if (rtType == null)
+            if (rtType is null)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(type));
             if (!rtType.IsDelegate())
                 throw new ArgumentException(SR.Arg_MustBeDelegate, nameof(type));
@@ -390,9 +390,9 @@ namespace System
         // V1 API.
         public static Delegate CreateDelegate(Type type, Type target, String method, bool ignoreCase, bool throwOnBindFailure)
         {
-            if (type == null)
+            if (type is null)
                 throw new ArgumentNullException(nameof(type));
-            if (target == null)
+            if (target is null)
                 throw new ArgumentNullException(nameof(target));
             if (target.ContainsGenericParameters)
                 throw new ArgumentException(SR.Arg_UnboundGenParam, nameof(target));
@@ -401,9 +401,9 @@ namespace System
 
             RuntimeType rtType = type as RuntimeType;
             RuntimeType rtTarget = target as RuntimeType;
-            if (rtType == null)
+            if (rtType is null)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(type));
-            if (rtTarget == null)
+            if (rtTarget is null)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(target));
             if (!rtType.IsDelegate())
                 throw new ArgumentException(SR.Arg_MustBeDelegate, nameof(type));
@@ -431,17 +431,17 @@ namespace System
         public static Delegate CreateDelegate(Type type, MethodInfo method, bool throwOnBindFailure)
         {
             // Validate the parameters.
-            if (type == null)
+            if (type is null)
                 throw new ArgumentNullException(nameof(type));
-            if (method == null)
+            if (method is null)
                 throw new ArgumentNullException(nameof(method));
 
             RuntimeType rtType = type as RuntimeType;
-            if (rtType == null)
+            if (rtType is null)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(type));
 
             RuntimeMethodInfo rmi = method as RuntimeMethodInfo;
-            if (rmi == null)
+            if (rmi is null)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeMethodInfo, nameof(method));
 
             if (!rtType.IsDelegate())
@@ -480,17 +480,17 @@ namespace System
         public static Delegate CreateDelegate(Type type, Object firstArgument, MethodInfo method, bool throwOnBindFailure)
         {
             // Validate the parameters.
-            if (type == null)
+            if (type is null)
                 throw new ArgumentNullException(nameof(type));
-            if (method == null)
+            if (method is null)
                 throw new ArgumentNullException(nameof(method));
 
             RuntimeType rtType = type as RuntimeType;
-            if (rtType == null)
+            if (rtType is null)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(type));
 
             RuntimeMethodInfo rmi = method as RuntimeMethodInfo;
-            if (rmi == null)
+            if (rmi is null)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeMethodInfo, nameof(method));
 
             if (!rtType.IsDelegate())
@@ -549,14 +549,14 @@ namespace System
         internal unsafe static Delegate CreateDelegateNoSecurityCheck(Type type, Object target, RuntimeMethodHandle method)
         {
             // Validate the parameters.
-            if (type == null)
+            if (type is null)
                 throw new ArgumentNullException(nameof(type));
 
             if (method.IsNullHandle())
                 throw new ArgumentNullException(nameof(method));
 
             RuntimeType rtType = type as RuntimeType;
-            if (rtType == null)
+            if (rtType is null)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(type));
 
             if (!rtType.IsDelegate())
@@ -581,14 +581,14 @@ namespace System
         internal static Delegate CreateDelegateNoSecurityCheck(RuntimeType type, Object firstArgument, MethodInfo method)
         {
             // Validate the parameters.
-            if (type == null)
+            if (type is null)
                 throw new ArgumentNullException(nameof(type));
-            if (method == null)
+            if (method is null)
                 throw new ArgumentNullException(nameof(method));
 
 
             RuntimeMethodInfo rtMethod = method as RuntimeMethodInfo;
-            if (rtMethod == null)
+            if (rtMethod is null)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeMethodInfo, nameof(method));
 
             if (!type.IsDelegate())

--- a/src/mscorlib/src/System/Diagnostics/Contracts/ContractsBCL.cs
+++ b/src/mscorlib/src/System/Diagnostics/Contracts/ContractsBCL.cs
@@ -45,7 +45,7 @@ namespace System.Diagnostics.Contracts
                 }
             }
 
-            if (probablyNotRewritten == null)
+            if (probablyNotRewritten is null)
                 probablyNotRewritten = thisAssembly;
             String simpleName = probablyNotRewritten.GetName().Name;
             System.Runtime.CompilerServices.ContractHelper.TriggerFailure(kind, SR.Format(SR.MustUseCCRewrite, contractKind, simpleName), null, null, null);

--- a/src/mscorlib/src/System/Diagnostics/Eventing/FrameworkEventSource.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/FrameworkEventSource.cs
@@ -530,7 +530,7 @@ namespace System.Diagnostics.Tracing
 
         private static string GetName(Assembly assembly)
         {
-            if (assembly == null)
+            if (assembly is null)
                 return "<<NULL>>";
             else
                 return assembly.FullName;

--- a/src/mscorlib/src/System/Diagnostics/Stackframe.cs
+++ b/src/mscorlib/src/System/Diagnostics/Stackframe.cs
@@ -203,7 +203,7 @@ namespace System.Diagnostics
         {
             StringBuilder sb = new StringBuilder(255);
 
-            if (method != null)
+            if ((object)method != null)
             {
                 sb.Append(method.Name);
 

--- a/src/mscorlib/src/System/Diagnostics/Stacktrace.cs
+++ b/src/mscorlib/src/System/Diagnostics/Stacktrace.cs
@@ -106,17 +106,17 @@ namespace System.Diagnostics
             t_reentrancy++;
             try
             {
-                if (s_symbolsMethodInfo == null)
+                if (s_symbolsMethodInfo is null)
                 {
                     s_symbolsType = Type.GetType(
                         "System.Diagnostics.StackTraceSymbols, System.Diagnostics.StackTrace, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
                         throwOnError: false);
 
-                    if (s_symbolsType == null)
+                    if (s_symbolsType is null)
                         return;
 
                     s_symbolsMethodInfo = s_symbolsType.GetMethod("GetSourceLineInfo", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
-                    if (s_symbolsMethodInfo == null)
+                    if (s_symbolsMethodInfo is null)
                         return;
                 }
 
@@ -337,10 +337,10 @@ namespace System.Diagnostics
             for (int i = 0; i < iNumFrames; i++)
             {
                 MethodBase mb = StackF.GetMethodBase(i);
-                if (mb != null)
+                if ((object)mb != null)
                 {
                     Type t = mb.DeclaringType;
-                    if (t == null)
+                    if (t is null)
                         break;
                     String ns = t.Namespace;
                     if (ns == null)
@@ -487,7 +487,7 @@ namespace System.Diagnostics
             {
                 StackFrame sf = GetFrame(iFrameIndex);
                 MethodBase mb = sf.GetMethod();
-                if (mb != null && (ShowInStackTrace(mb) || 
+                if ((object)mb != null && (ShowInStackTrace(mb) || 
                                    (iFrameIndex == m_iNumOfFrames - 1))) // Don't filter last frame
                 {
                     // We want a newline at the end of every line except for the last
@@ -500,7 +500,7 @@ namespace System.Diagnostics
 
                     Type t = mb.DeclaringType;
                     // if there is a type (non global method) print it
-                    if (t != null)
+                    if ((object)t != null)
                     {
                         // Append t.FullName, replacing '+' with '.'
                         string fullName = t.FullName;
@@ -556,7 +556,7 @@ namespace System.Diagnostics
                                 fFirstParam = false;
 
                             String typeName = "<UnknownType>";
-                            if (pi[j].ParameterType != null)
+                            if ((object)pi[j].ParameterType != null)
                                 typeName = pi[j].ParameterType.Name;
                             sb.Append(typeName);
                             sb.Append(' ');

--- a/src/mscorlib/src/System/Enum.cs
+++ b/src/mscorlib/src/System/Enum.cs
@@ -407,11 +407,11 @@ namespace System
 
         private static bool TryParseEnum(Type enumType, String value, bool ignoreCase, ref EnumResult parseResult)
         {
-            if (enumType == null)
+            if (enumType is null)
                 throw new ArgumentNullException(nameof(enumType));
 
             RuntimeType rtType = enumType as RuntimeType;
-            if (rtType == null)
+            if (rtType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(enumType));
 
             if (!enumType.IsEnum)
@@ -542,7 +542,7 @@ namespace System
 
         public static Type GetUnderlyingType(Type enumType)
         {
-            if (enumType == null)
+            if (enumType is null)
                 throw new ArgumentNullException(nameof(enumType));
 
             return enumType.GetEnumUnderlyingType();
@@ -550,7 +550,7 @@ namespace System
 
         public static Array GetValues(Type enumType)
         {
-            if (enumType == null)
+            if (enumType is null)
                 throw new ArgumentNullException(nameof(enumType));
 
             return enumType.GetEnumValues();
@@ -564,7 +564,7 @@ namespace System
 
         public static String GetName(Type enumType, Object value)
         {
-            if (enumType == null)
+            if (enumType is null)
                 throw new ArgumentNullException(nameof(enumType));
 
             return enumType.GetEnumName(value);
@@ -572,7 +572,7 @@ namespace System
 
         public static String[] GetNames(Type enumType)
         {
-            if (enumType == null)
+            if (enumType is null)
                 throw new ArgumentNullException(nameof(enumType));
 
             return enumType.GetEnumNames();
@@ -632,7 +632,7 @@ namespace System
 
         public static bool IsDefined(Type enumType, Object value)
         {
-            if (enumType == null)
+            if (enumType is null)
                 throw new ArgumentNullException(nameof(enumType));
 
             return enumType.IsEnumDefined(value);
@@ -640,7 +640,7 @@ namespace System
 
         public static String Format(Type enumType, Object value, String format)
         {
-            if (enumType == null)
+            if (enumType is null)
                 throw new ArgumentNullException(nameof(enumType));
 
             if (!enumType.IsEnum)
@@ -653,7 +653,7 @@ namespace System
                 throw new ArgumentNullException(nameof(format));
 
             RuntimeType rtType = enumType as RuntimeType;
-            if (rtType == null)
+            if (rtType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(enumType));
 
             // Check if both of them are of the same type
@@ -1084,48 +1084,48 @@ namespace System
         [CLSCompliant(false)]
         public static Object ToObject(Type enumType, sbyte value)
         {
-            if (enumType == null)
+            if (enumType is null)
                 throw new ArgumentNullException(nameof(enumType));
             if (!enumType.IsEnum)
                 throw new ArgumentException(SR.Arg_MustBeEnum, nameof(enumType));
             RuntimeType rtType = enumType as RuntimeType;
-            if (rtType == null)
+            if (rtType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(enumType));
             return InternalBoxEnum(rtType, value);
         }
 
         public static Object ToObject(Type enumType, short value)
         {
-            if (enumType == null)
+            if (enumType is null)
                 throw new ArgumentNullException(nameof(enumType));
             if (!enumType.IsEnum)
                 throw new ArgumentException(SR.Arg_MustBeEnum, nameof(enumType));
             RuntimeType rtType = enumType as RuntimeType;
-            if (rtType == null)
+            if (rtType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(enumType));
             return InternalBoxEnum(rtType, value);
         }
 
         public static Object ToObject(Type enumType, int value)
         {
-            if (enumType == null)
+            if (enumType is null)
                 throw new ArgumentNullException(nameof(enumType));
             if (!enumType.IsEnum)
                 throw new ArgumentException(SR.Arg_MustBeEnum, nameof(enumType));
             RuntimeType rtType = enumType as RuntimeType;
-            if (rtType == null)
+            if (rtType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(enumType));
             return InternalBoxEnum(rtType, value);
         }
 
         public static Object ToObject(Type enumType, byte value)
         {
-            if (enumType == null)
+            if (enumType is null)
                 throw new ArgumentNullException(nameof(enumType));
             if (!enumType.IsEnum)
                 throw new ArgumentException(SR.Arg_MustBeEnum, nameof(enumType));
             RuntimeType rtType = enumType as RuntimeType;
-            if (rtType == null)
+            if (rtType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(enumType));
             return InternalBoxEnum(rtType, value);
         }
@@ -1133,12 +1133,12 @@ namespace System
         [CLSCompliant(false)]
         public static Object ToObject(Type enumType, ushort value)
         {
-            if (enumType == null)
+            if (enumType is null)
                 throw new ArgumentNullException(nameof(enumType));
             if (!enumType.IsEnum)
                 throw new ArgumentException(SR.Arg_MustBeEnum, nameof(enumType));
             RuntimeType rtType = enumType as RuntimeType;
-            if (rtType == null)
+            if (rtType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(enumType));
             return InternalBoxEnum(rtType, value);
         }
@@ -1146,24 +1146,24 @@ namespace System
         [CLSCompliant(false)]
         public static Object ToObject(Type enumType, uint value)
         {
-            if (enumType == null)
+            if (enumType is null)
                 throw new ArgumentNullException(nameof(enumType));
             if (!enumType.IsEnum)
                 throw new ArgumentException(SR.Arg_MustBeEnum, nameof(enumType));
             RuntimeType rtType = enumType as RuntimeType;
-            if (rtType == null)
+            if (rtType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(enumType));
             return InternalBoxEnum(rtType, value);
         }
 
         public static Object ToObject(Type enumType, long value)
         {
-            if (enumType == null)
+            if (enumType is null)
                 throw new ArgumentNullException(nameof(enumType));
             if (!enumType.IsEnum)
                 throw new ArgumentException(SR.Arg_MustBeEnum, nameof(enumType));
             RuntimeType rtType = enumType as RuntimeType;
-            if (rtType == null)
+            if (rtType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(enumType));
             return InternalBoxEnum(rtType, value);
         }
@@ -1171,36 +1171,36 @@ namespace System
         [CLSCompliant(false)]
         public static Object ToObject(Type enumType, ulong value)
         {
-            if (enumType == null)
+            if (enumType is null)
                 throw new ArgumentNullException(nameof(enumType));
             if (!enumType.IsEnum)
                 throw new ArgumentException(SR.Arg_MustBeEnum, nameof(enumType));
             RuntimeType rtType = enumType as RuntimeType;
-            if (rtType == null)
+            if (rtType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(enumType));
             return InternalBoxEnum(rtType, unchecked((long)value));
         }
 
         private static Object ToObject(Type enumType, char value)
         {
-            if (enumType == null)
+            if (enumType is null)
                 throw new ArgumentNullException(nameof(enumType));
             if (!enumType.IsEnum)
                 throw new ArgumentException(SR.Arg_MustBeEnum, nameof(enumType));
             RuntimeType rtType = enumType as RuntimeType;
-            if (rtType == null)
+            if (rtType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(enumType));
             return InternalBoxEnum(rtType, value);
         }
 
         private static Object ToObject(Type enumType, bool value)
         {
-            if (enumType == null)
+            if (enumType is null)
                 throw new ArgumentNullException(nameof(enumType));
             if (!enumType.IsEnum)
                 throw new ArgumentException(SR.Arg_MustBeEnum, nameof(enumType));
             RuntimeType rtType = enumType as RuntimeType;
-            if (rtType == null)
+            if (rtType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(enumType));
             return InternalBoxEnum(rtType, value ? 1 : 0);
         }

--- a/src/mscorlib/src/System/Exception.cs
+++ b/src/mscorlib/src/System/Exception.cs
@@ -283,7 +283,7 @@ namespace System
         // this function is provided as a private helper to avoid the security demand
         private MethodBase GetTargetSiteInternal()
         {
-            if (_exceptionMethod != null)
+            if ((object)_exceptionMethod != null)
             {
                 return _exceptionMethod;
             }
@@ -373,10 +373,10 @@ namespace System
 
                         RuntimeModule rtModule = module as RuntimeModule;
 
-                        if (rtModule == null)
+                        if (rtModule is null)
                         {
                             System.Reflection.Emit.ModuleBuilder moduleBuilder = module as System.Reflection.Emit.ModuleBuilder;
-                            if (moduleBuilder != null)
+                            if ((object)moduleBuilder != null)
                                 rtModule = moduleBuilder.InternalModule;
                             else
                                 throw new ArgumentException(SR.Argument_MustBeRuntimeReflectionObject);
@@ -446,7 +446,7 @@ namespace System
                 {
                     tempStackTraceString = Environment.GetStackTrace(this, true);
                 }
-                if (_exceptionMethod == null)
+                if (_exceptionMethod is null)
                 {
                     _exceptionMethod = GetExceptionMethodFromStackTrace();
                 }

--- a/src/mscorlib/src/System/Object.cs
+++ b/src/mscorlib/src/System/Object.cs
@@ -168,7 +168,7 @@ namespace System
             Debug.Assert(fieldName != null);
 
             Type t = GetType();
-            while (null != t)
+            while ((object)t != null)
             {
                 if (t.FullName.Equals(typeName))
                 {
@@ -178,7 +178,7 @@ namespace System
                 t = t.BaseType;
             }
 
-            if (null == t)
+            if (t is null)
             {
                 throw new ArgumentException();
             }
@@ -186,7 +186,7 @@ namespace System
             FieldInfo fldInfo = t.GetField(fieldName, BindingFlags.Public |
                                                       BindingFlags.Instance |
                                                       BindingFlags.IgnoreCase);
-            if (null == fldInfo)
+            if (fldInfo is null)
             {
                 throw new ArgumentException();
             }

--- a/src/mscorlib/src/System/Reflection/Assembly.CoreCLR.cs
+++ b/src/mscorlib/src/System/Reflection/Assembly.CoreCLR.cs
@@ -21,7 +21,7 @@ namespace System.Reflection
         private static Assembly LoadFromResolveHandler(object sender, ResolveEventArgs args)
         {
             Assembly requestingAssembly = args.RequestingAssembly;
-            if (requestingAssembly == null)
+            if (requestingAssembly is null)
             {
                 return null;
             }
@@ -134,7 +134,7 @@ namespace System.Reflection
                 assemblyString,
                 out assembly);
 
-            if (assembly == null)
+            if (assembly is null)
             {
                 if (assemblyName.ContentType == AssemblyContentType.WindowsRuntime)
                 {

--- a/src/mscorlib/src/System/Reflection/AssemblyName.cs
+++ b/src/mscorlib/src/System/Reflection/AssemblyName.cs
@@ -415,7 +415,7 @@ namespace System.Reflection
                 Array.Copy(publicKeyToken, _PublicKeyToken, publicKeyToken.Length);
             }
 
-            if (version != null)
+            if ((object)version != null)
                 _Version = (Version)version.Clone();
 
             _CultureInfo = cultureInfo;

--- a/src/mscorlib/src/System/Reflection/Associates.cs
+++ b/src/mscorlib/src/System/Reflection/Associates.cs
@@ -102,7 +102,7 @@ namespace System.Reflection
                 RuntimeType.GetMethodBase(reflectedType, associateMethodHandle) as RuntimeMethodInfo;
 
             // suppose a property was mapped to a method not in the derivation hierarchy of the reflectedTypeHandle
-            if (associateMethod == null)
+            if (associateMethod is null)
                 associateMethod = reflectedType.Module.ResolveMethod(tkMethod, null, null) as RuntimeMethodInfo;
 
             return associateMethod;
@@ -151,7 +151,7 @@ namespace System.Reflection
                 RuntimeMethodInfo associateMethod =
                     AssignAssociates(methodDefToken, declaringType, reflectedType);
 
-                if (associateMethod == null)
+                if (associateMethod is null)
                     continue;
 
                 MethodAttributes methAttr = associateMethod.Attributes;

--- a/src/mscorlib/src/System/Reflection/CustomAttribute.cs
+++ b/src/mscorlib/src/System/Reflection/CustomAttribute.cs
@@ -24,7 +24,7 @@ namespace System.Reflection
         #region Public Static Members
         public static IList<CustomAttributeData> GetCustomAttributes(MemberInfo target)
         {
-            if (target == null)
+            if (target is null)
                 throw new ArgumentNullException(nameof(target));
 
             return target.GetCustomAttributesData();
@@ -32,7 +32,7 @@ namespace System.Reflection
 
         public static IList<CustomAttributeData> GetCustomAttributes(Module target)
         {
-            if (target == null)
+            if (target is null)
                 throw new ArgumentNullException(nameof(target));
 
             return target.GetCustomAttributesData();
@@ -40,7 +40,7 @@ namespace System.Reflection
 
         public static IList<CustomAttributeData> GetCustomAttributes(Assembly target)
         {
-            if (target == null)
+            if (target is null)
                 throw new ArgumentNullException(nameof(target));
 
             return target.GetCustomAttributesData();
@@ -433,11 +433,11 @@ namespace System.Reflection
 
             int i = 3; // ArraySubType, SizeParamIndex, SizeConst
             if (marshalAs.MarshalType != null) i++;
-            if (marshalAs.MarshalTypeRef != null) i++;
+            if ((object)marshalAs.MarshalTypeRef != null) i++;
             if (marshalAs.MarshalCookie != null) i++;
             i++; // IidParameterIndex
             i++; // SafeArraySubType
-            if (marshalAs.SafeArrayUserDefinedSubType != null) i++;
+            if ((object)marshalAs.SafeArrayUserDefinedSubType != null) i++;
             CustomAttributeNamedArgument[] namedArgs = new CustomAttributeNamedArgument[i];
 
             // For compatibility with previous runtimes, we always include the following 5 attributes, regardless
@@ -450,11 +450,11 @@ namespace System.Reflection
             namedArgs[i++] = new CustomAttributeNamedArgument(type.GetField("SafeArraySubType"), marshalAs.SafeArraySubType);
             if (marshalAs.MarshalType != null)
                 namedArgs[i++] = new CustomAttributeNamedArgument(type.GetField("MarshalType"), marshalAs.MarshalType);
-            if (marshalAs.MarshalTypeRef != null)
+            if ((object)marshalAs.MarshalTypeRef != null)
                 namedArgs[i++] = new CustomAttributeNamedArgument(type.GetField("MarshalTypeRef"), marshalAs.MarshalTypeRef);
             if (marshalAs.MarshalCookie != null)
                 namedArgs[i++] = new CustomAttributeNamedArgument(type.GetField("MarshalCookie"), marshalAs.MarshalCookie);
-            if (marshalAs.SafeArrayUserDefinedSubType != null)
+            if ((object)marshalAs.SafeArrayUserDefinedSubType != null)
                 namedArgs[i++] = new CustomAttributeNamedArgument(type.GetField("SafeArrayUserDefinedSubType"), marshalAs.SafeArrayUserDefinedSubType);
 
             m_namedArgs = Array.AsReadOnly(namedArgs);
@@ -586,16 +586,14 @@ namespace System.Reflection
         #region Constructor
         public CustomAttributeNamedArgument(MemberInfo memberInfo, object value)
         {
-            if (memberInfo == null)
+            if (memberInfo is null)
                 throw new ArgumentNullException(nameof(memberInfo));
 
             Type type = null;
-            FieldInfo field = memberInfo as FieldInfo;
-            PropertyInfo property = memberInfo as PropertyInfo;
 
-            if (field != null)
+            if (memberInfo is FieldInfo field)
                 type = field.FieldType;
-            else if (property != null)
+            else if (memberInfo is PropertyInfo property)
                 type = property.PropertyType;
             else
                 throw new ArgumentException(SR.Argument_InvalidMemberForNamedArgument);
@@ -606,7 +604,7 @@ namespace System.Reflection
 
         public CustomAttributeNamedArgument(MemberInfo memberInfo, CustomAttributeTypedArgument typedArgument)
         {
-            if (memberInfo == null)
+            if (memberInfo is null)
                 throw new ArgumentNullException(nameof(memberInfo));
 
             m_memberInfo = memberInfo;
@@ -617,7 +615,7 @@ namespace System.Reflection
         #region Object Override
         public override string ToString()
         {
-            if (m_memberInfo == null)
+            if (m_memberInfo is null)
                 return base.ToString();
 
             return String.Format(CultureInfo.CurrentCulture, "{0} = {1}", MemberInfo.Name, TypedValue.ToString(ArgumentType != typeof(object)));
@@ -775,7 +773,7 @@ namespace System.Reflection
         {
             RuntimeType type = RuntimeTypeHandle.GetTypeByNameUsingCARules(typeName, scope);
 
-            if (type == null)
+            if (type is null)
                 throw new InvalidOperationException(
                     String.Format(CultureInfo.CurrentUICulture, SR.Arg_CATypeResolutionFailed, typeName));
 
@@ -792,7 +790,7 @@ namespace System.Reflection
         public CustomAttributeTypedArgument(Type argumentType, object value)
         {
             // value can be null.
-            if (argumentType == null)
+            if (argumentType is null)
                 throw new ArgumentNullException(nameof(argumentType));
 
             m_value = (value == null) ? null : CanonicalizeValue(value);
@@ -888,7 +886,7 @@ namespace System.Reflection
 
         internal string ToString(bool typed)
         {
-            if (m_argumentType == null)
+            if (m_argumentType is null)
                 return base.ToString();
 
             if (ArgumentType.IsEnum)
@@ -998,7 +996,7 @@ namespace System.Reflection
             ref CustomAttributeNamedParameter[] customAttributeNamedParameters,
             RuntimeModule customAttributeModule)
         {
-            if (customAttributeModule == null)
+            if (customAttributeModule is null)
                 throw new ArgumentNullException(nameof(customAttributeModule));
 
             Debug.Assert(customAttributeCtorParameters != null);
@@ -1129,7 +1127,7 @@ namespace System.Reflection
         {
             Debug.Assert(type != null);
 
-            if (type.GetElementType() != null)
+            if ((object)type.GetElementType() != null)
                 return false;
 
             if (PseudoCustomAttribute.IsDefined(type, caType))
@@ -1143,7 +1141,7 @@ namespace System.Reflection
 
             type = type.BaseType as RuntimeType;
 
-            while (type != null)
+            while ((object)type != null)
             {
                 if (IsCustomAttributeDefined(type.GetRuntimeModule(), type.MetadataToken, caType, 0, inherit))
                     return true;
@@ -1170,7 +1168,7 @@ namespace System.Reflection
 
             method = method.GetParentDefinition();
 
-            while (method != null)
+            while ((object)method != null)
             {
                 if (IsCustomAttributeDefined(method.GetRuntimeModule(), method.MetadataToken, caType, 0, inherit))
                     return true;
@@ -1263,7 +1261,7 @@ namespace System.Reflection
             Debug.Assert(type != null);
             Debug.Assert(caType != null);
 
-            if (type.GetElementType() != null)
+            if ((object)type.GetElementType() != null)
                 return (caType.IsValueType) ? Array.Empty<Object>() : CreateAttributeArrayHelper(caType, 0);
 
             if (type.IsGenericType && !type.IsGenericTypeDefinition)
@@ -1284,13 +1282,13 @@ namespace System.Reflection
 
             List<object> result = new List<object>();
             bool mustBeInheritable = false;
-            bool useObjectArray = (caType == null || caType.IsValueType || caType.ContainsGenericParameters);
+            bool useObjectArray = (caType is null || caType.IsValueType || caType.ContainsGenericParameters);
             Type arrayType = useObjectArray ? typeof(object) : caType;
 
             while (pcaCount > 0)
                 result.Add(pca[--pcaCount]);
 
-            while (type != (RuntimeType)typeof(object) && type != null)
+            while (type != (RuntimeType)typeof(object) && (object)type != null)
             {
                 object[] attributes = GetCustomAttributes(type.GetRuntimeModule(), type.MetadataToken, 0, caType, mustBeInheritable, result);
                 mustBeInheritable = true;
@@ -1328,13 +1326,13 @@ namespace System.Reflection
 
             List<object> result = new List<object>();
             bool mustBeInheritable = false;
-            bool useObjectArray = (caType == null || caType.IsValueType || caType.ContainsGenericParameters);
+            bool useObjectArray = (caType is null || caType.IsValueType || caType.ContainsGenericParameters);
             Type arrayType = useObjectArray ? typeof(object) : caType;
 
             while (pcaCount > 0)
                 result.Add(pca[--pcaCount]);
 
-            while (method != null)
+            while ((object)method != null)
             {
                 object[] attributes = GetCustomAttributes(method.GetRuntimeModule(), method.MetadataToken, 0, caType, mustBeInheritable, result);
                 mustBeInheritable = true;
@@ -1454,7 +1452,7 @@ namespace System.Reflection
 
             CustomAttributeRecord[] car = CustomAttributeData.GetCustomAttributeRecords(decoratedModule, decoratedMetadataToken);
 
-            if (attributeFilterType != null)
+            if ((object)attributeFilterType != null)
             {
                 Debug.Assert(attributeCtorToken == 0);
 
@@ -1510,10 +1508,10 @@ namespace System.Reflection
             MetadataImport scope = decoratedModule.MetadataImport;
             CustomAttributeRecord[] car = CustomAttributeData.GetCustomAttributeRecords(decoratedModule, decoratedMetadataToken);
 
-            bool useObjectArray = (attributeFilterType == null || attributeFilterType.IsValueType || attributeFilterType.ContainsGenericParameters);
+            bool useObjectArray = (attributeFilterType is null || attributeFilterType.IsValueType || attributeFilterType.ContainsGenericParameters);
             Type arrayType = useObjectArray ? typeof(object) : attributeFilterType;
 
-            if (attributeFilterType == null && car.Length == 0)
+            if (attributeFilterType is null && car.Length == 0)
                 return CreateAttributeArrayHelper(arrayType, 0);
 
             object[] attributes = CreateAttributeArrayHelper(arrayType, car.Length);
@@ -1596,7 +1594,7 @@ namespace System.Reflection
                         if (isProperty)
                         {
                             #region // Initialize property
-                            if (type == null && value != null)
+                            if (type is null && value != null)
                             {
                                 type = (RuntimeType)value.GetType();
                                 if (type == Type_RuntimeType)
@@ -1605,13 +1603,13 @@ namespace System.Reflection
 
                             RuntimePropertyInfo property = null;
 
-                            if (type == null)
+                            if (type is null)
                                 property = attributeType.GetProperty(name) as RuntimePropertyInfo;
                             else
                                 property = attributeType.GetProperty(name, type, Type.EmptyTypes) as RuntimePropertyInfo;
 
                             // Did we get a valid property reference?
-                            if (property == null)
+                            if (property is null)
                             {
                                 throw new CustomAttributeFormatException(
                                     String.Format(CultureInfo.CurrentUICulture, 
@@ -2302,7 +2300,7 @@ namespace System.Reflection
         {
             int fieldOffset;
 
-            if (field.DeclaringType != null &&
+            if ((object)field.DeclaringType != null &&
                 field.GetRuntimeModule().MetadataImport.GetFieldOffset(field.DeclaringType.MetadataToken, field.MetadataToken, out fieldOffset))
                 return new FieldOffsetAttribute(fieldOffset);
 

--- a/src/mscorlib/src/System/Reflection/Emit/AQNBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/AQNBuilder.cs
@@ -109,7 +109,7 @@ namespace System.Reflection.Emit
 
             // Append namespace + nesting + name
             List<Type> nestings = new List<Type>();
-            for (Type t = rootType; t != null; t = t.IsGenericParameter ? null : t.DeclaringType)
+            for (Type t = rootType; (object)t != null; t = t.IsGenericParameter ? null : t.DeclaringType)
                 nestings.Add(t);
 
             for (int i = nestings.Count - 1; i >= 0; i--)

--- a/src/mscorlib/src/System/Reflection/Emit/AssemblyBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/AssemblyBuilder.cs
@@ -433,10 +433,10 @@ namespace System.Reflection.Emit
 
             foreach (Type type in types)
             {
-                if (type == null)
+                if (type is null)
                     continue;
 
-                if (type.Module == null || type.Module.Assembly == null)
+                if (type.Module is null || type.Module.Assembly is null)
                     throw new ArgumentException(SR.Argument_TypeNotValid);
 
                 if (type.Module.Assembly == typeof(object).Module.Assembly)
@@ -688,7 +688,7 @@ namespace System.Reflection.Emit
         **********************************************/
         public void SetCustomAttribute(ConstructorInfo con, byte[] binaryAttribute)
         {
-            if (con == null)
+            if (con is null)
                 throw new ArgumentNullException(nameof(con));
             if (binaryAttribute == null)
                 throw new ArgumentNullException(nameof(binaryAttribute));

--- a/src/mscorlib/src/System/Reflection/Emit/CustomAttributeBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/CustomAttributeBuilder.cs
@@ -104,7 +104,7 @@ namespace System.Reflection.Emit
                                                  PropertyInfo[] namedProperties, Object[] propertyValues,
                                                  FieldInfo[] namedFields, Object[] fieldValues)
         {
-            if (con == null)
+            if (con is null)
                 throw new ArgumentNullException(nameof(con));
             if (constructorArgs == null)
                 throw new ArgumentNullException(nameof(constructorArgs));
@@ -182,7 +182,7 @@ namespace System.Reflection.Emit
             {
                 // Validate the property.
                 PropertyInfo property = namedProperties[i];
-                if (property == null)
+                if (property is null)
                     throw new ArgumentNullException("namedProperties[" + i + "]");
 
                 // Allow null for non-primitive types only.
@@ -240,7 +240,7 @@ namespace System.Reflection.Emit
             {
                 // Validate the field.
                 FieldInfo namedField = namedFields[i];
-                if (namedField == null)
+                if (namedField is null)
                     throw new ArgumentNullException("namedFields[" + i + "]");
 
                 // Allow null for non-primitive types only.

--- a/src/mscorlib/src/System/Reflection/Emit/DynamicILGenerator.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/DynamicILGenerator.cs
@@ -46,12 +46,12 @@ namespace System.Reflection.Emit
         public override LocalBuilder DeclareLocal(Type localType, bool pinned)
         {
             LocalBuilder localBuilder;
-            if (localType == null)
+            if (localType is null)
                 throw new ArgumentNullException(nameof(localType));
 
             RuntimeType rtType = localType as RuntimeType;
 
-            if (rtType == null)
+            if (rtType is null)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType);
 
             localBuilder = new LocalBuilder(m_localCount, localType, m_methodBuilder);
@@ -68,20 +68,20 @@ namespace System.Reflection.Emit
         //
         public override void Emit(OpCode opcode, MethodInfo meth)
         {
-            if (meth == null)
+            if (meth is null)
                 throw new ArgumentNullException(nameof(meth));
 
             int stackchange = 0;
             int token = 0;
             DynamicMethod dynMeth = meth as DynamicMethod;
-            if (dynMeth == null)
+            if (dynMeth is null)
             {
                 RuntimeMethodInfo rtMeth = meth as RuntimeMethodInfo;
-                if (rtMeth == null)
+                if (rtMeth is null)
                     throw new ArgumentException(SR.Argument_MustBeRuntimeMethodInfo, nameof(meth));
 
                 RuntimeType declaringType = rtMeth.GetRuntimeType();
-                if (declaringType != null && (declaringType.IsGenericType || declaringType.IsArray))
+                if ((object)declaringType != null && (declaringType.IsGenericType || declaringType.IsArray))
                     token = GetTokenFor(rtMeth, declaringType);
                 else
                     token = GetTokenFor(rtMeth);
@@ -123,17 +123,17 @@ namespace System.Reflection.Emit
 
         public override void Emit(OpCode opcode, ConstructorInfo con)
         {
-            if (con == null)
+            if (con is null)
                 throw new ArgumentNullException(nameof(con));
 
             RuntimeConstructorInfo rtConstructor = con as RuntimeConstructorInfo;
-            if (rtConstructor == null)
+            if (rtConstructor is null)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeMethodInfo, nameof(con));
 
             RuntimeType declaringType = rtConstructor.GetRuntimeType();
             int token;
 
-            if (declaringType != null && (declaringType.IsGenericType || declaringType.IsArray))
+            if ((object)declaringType != null && (declaringType.IsGenericType || declaringType.IsArray))
                 // need to sort out the stack size story
                 token = GetTokenFor(rtConstructor, declaringType);
             else
@@ -150,12 +150,12 @@ namespace System.Reflection.Emit
 
         public override void Emit(OpCode opcode, Type type)
         {
-            if (type == null)
+            if (type is null)
                 throw new ArgumentNullException(nameof(type));
 
             RuntimeType rtType = type as RuntimeType;
 
-            if (rtType == null)
+            if (rtType is null)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType);
 
             int token = GetTokenFor(rtType);
@@ -166,15 +166,15 @@ namespace System.Reflection.Emit
 
         public override void Emit(OpCode opcode, FieldInfo field)
         {
-            if (field == null)
+            if (field is null)
                 throw new ArgumentNullException(nameof(field));
 
             RuntimeFieldInfo runtimeField = field as RuntimeFieldInfo;
-            if (runtimeField == null)
+            if (runtimeField is null)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeFieldInfo, nameof(field));
 
             int token;
-            if (field.DeclaringType == null)
+            if (field.DeclaringType is null)
                 token = GetTokenFor(runtimeField);
             else
                 token = GetTokenFor(runtimeField, runtimeField.GetRuntimeType());
@@ -243,7 +243,7 @@ namespace System.Reflection.Emit
 
         public override void EmitCall(OpCode opcode, MethodInfo methodInfo, Type[] optionalParameterTypes)
         {
-            if (methodInfo == null)
+            if (methodInfo is null)
                 throw new ArgumentNullException(nameof(methodInfo));
 
             if (!(opcode.Equals(OpCodes.Call) || opcode.Equals(OpCodes.Callvirt) || opcode.Equals(OpCodes.Newobj)))
@@ -252,7 +252,7 @@ namespace System.Reflection.Emit
             if (methodInfo.ContainsGenericParameters)
                 throw new ArgumentException(SR.Argument_GenericsInvalid, nameof(methodInfo));
 
-            if (methodInfo.DeclaringType != null && methodInfo.DeclaringType.ContainsGenericParameters)
+            if (methodInfo.DeclaringType?.ContainsGenericParameters == true)
                 throw new ArgumentException(SR.Argument_GenericsInvalid, nameof(methodInfo));
 
             int tk;
@@ -341,7 +341,7 @@ namespace System.Reflection.Emit
 
             if (current.GetCurrentState() == __ExceptionInfo.State_Filter)
             {
-                if (exceptionType != null)
+                if ((object)exceptionType != null)
                 {
                     throw new ArgumentException(SR.Argument_ShouldNotSpecifyExceptionType);
                 }
@@ -353,10 +353,10 @@ namespace System.Reflection.Emit
             else
             {
                 // execute this branch if previous clause is Catch or Fault
-                if (exceptionType == null)
+                if (exceptionType is null)
                     throw new ArgumentNullException(nameof(exceptionType));
 
-                if (rtType == null)
+                if (rtType is null)
                     throw new ArgumentException(SR.Argument_MustBeRuntimeType);
 
                 Label endLabel = current.GetEndLabel();
@@ -413,7 +413,7 @@ namespace System.Reflection.Emit
             RuntimeMethodInfo rtMeth = methodInfo as RuntimeMethodInfo;
             DynamicMethod dm = methodInfo as DynamicMethod;
 
-            if (rtMeth == null && dm == null)
+            if (rtMeth is null && dm is null)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeMethodInfo, nameof(methodInfo));
 
             ParameterInfo[] paramInfo = methodInfo.GetParametersNoCopy();
@@ -433,7 +433,7 @@ namespace System.Reflection.Emit
                                                      parameterTypes,
                                                      optionalParameterTypes);
 
-            if (rtMeth != null)
+            if ((object)rtMeth != null)
                 return GetTokenForVarArgMethod(rtMeth, sig);
             else
                 return GetTokenForVarArgMethod(dm, sig);
@@ -590,7 +590,7 @@ namespace System.Reflection.Emit
         {
             DynamicMethod method = m_method;
 
-            if (method == null)
+            if (method is null)
                 return;
 
             if (method.m_methodHandle == null)
@@ -783,7 +783,7 @@ namespace System.Reflection.Emit
             }
 
             DynamicMethod dm = handle as DynamicMethod;
-            if (dm != null)
+            if ((object)dm != null)
             {
                 methodHandle = dm.GetMethodDescriptor().Value;
                 return;
@@ -808,7 +808,7 @@ namespace System.Reflection.Emit
             VarArgMethod vaMeth = handle as VarArgMethod;
             if (vaMeth != null)
             {
-                if (vaMeth.m_dynamicMethod == null)
+                if (vaMeth.m_dynamicMethod is null)
                 {
                     methodHandle = vaMeth.m_method.MethodHandle.Value;
                     typeHandle = vaMeth.m_method.GetDeclaringTypeInternal().GetTypeHandleInternal().Value;
@@ -934,7 +934,7 @@ namespace System.Reflection.Emit
             if (methodReal != null && !RuntimeMethodHandle.IsDynamicMethod(rmhi))
             {
                 RuntimeType type = RuntimeMethodHandle.GetDeclaringType(rmhi);
-                if ((type != null) && RuntimeTypeHandle.HasInstantiation(type))
+                if (((object)type != null) && RuntimeTypeHandle.HasInstantiation(type))
                 {
                     // Do we really need to retrieve this much info just to throw an exception?
                     MethodBase m = RuntimeType.GetMethodBase(methodReal);

--- a/src/mscorlib/src/System/Reflection/Emit/DynamicMethod.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/DynamicMethod.cs
@@ -93,7 +93,7 @@ namespace System.Reflection.Emit
                              Type[] parameterTypes,
                              Module m)
         {
-            if (m == null)
+            if (m is null)
                 throw new ArgumentNullException(nameof(m));
 
             Init(name,
@@ -113,7 +113,7 @@ namespace System.Reflection.Emit
                              Module m,
                              bool skipVisibility)
         {
-            if (m == null)
+            if (m is null)
                 throw new ArgumentNullException(nameof(m));
 
             Init(name,
@@ -135,7 +135,7 @@ namespace System.Reflection.Emit
                              Module m,
                              bool skipVisibility)
         {
-            if (m == null)
+            if (m is null)
                 throw new ArgumentNullException(nameof(m));
 
             Init(name,
@@ -154,7 +154,7 @@ namespace System.Reflection.Emit
                              Type[] parameterTypes,
                              Type owner)
         {
-            if (owner == null)
+            if (owner is null)
                 throw new ArgumentNullException(nameof(owner));
 
             Init(name,
@@ -174,7 +174,7 @@ namespace System.Reflection.Emit
                              Type owner,
                              bool skipVisibility)
         {
-            if (owner == null)
+            if (owner is null)
                 throw new ArgumentNullException(nameof(owner));
 
             Init(name,
@@ -196,7 +196,7 @@ namespace System.Reflection.Emit
                              Type owner,
                              bool skipVisibility)
         {
-            if (owner == null)
+            if (owner is null)
                 throw new ArgumentNullException(nameof(owner));
 
             Init(name,
@@ -234,12 +234,12 @@ namespace System.Reflection.Emit
         [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
         private static RuntimeModule GetDynamicMethodsModule()
         {
-            if (s_anonymouslyHostedDynamicMethodsModule != null)
+            if ((object)s_anonymouslyHostedDynamicMethodsModule != null)
                 return s_anonymouslyHostedDynamicMethodsModule;
 
             lock (s_anonymouslyHostedDynamicMethodsModuleLock)
             {
-                if (s_anonymouslyHostedDynamicMethodsModule != null)
+                if ((object)s_anonymouslyHostedDynamicMethodsModule != null)
                     return s_anonymouslyHostedDynamicMethodsModule;
 
                 ConstructorInfo transparencyCtor = typeof(SecurityTransparentAttribute).GetConstructor(Type.EmptyTypes);
@@ -283,10 +283,10 @@ namespace System.Reflection.Emit
                 m_parameterTypes = new RuntimeType[signature.Length];
                 for (int i = 0; i < signature.Length; i++)
                 {
-                    if (signature[i] == null)
+                    if (signature[i] is null)
                         throw new ArgumentException(SR.Arg_InvalidTypeInSignature);
                     m_parameterTypes[i] = signature[i].UnderlyingSystemType as RuntimeType;
-                    if (m_parameterTypes[i] == null || m_parameterTypes[i] == (RuntimeType)typeof(void))
+                    if (m_parameterTypes[i] is null || m_parameterTypes[i] == (RuntimeType)typeof(void))
                         throw new ArgumentException(SR.Arg_InvalidTypeInSignature);
                 }
             }
@@ -296,8 +296,8 @@ namespace System.Reflection.Emit
             }
 
             // check and store the return value
-            m_returnType = (returnType == null) ? (RuntimeType)typeof(void) : returnType.UnderlyingSystemType as RuntimeType;
-            if (m_returnType == null)
+            m_returnType = (returnType is null) ? (RuntimeType)typeof(void) : returnType.UnderlyingSystemType as RuntimeType;
+            if (m_returnType is null)
                 throw new NotSupportedException(SR.Arg_InvalidTypeInRetType);
 
             if (transparentMethod)
@@ -315,15 +315,15 @@ namespace System.Reflection.Emit
                 Debug.Assert(m == null || !m.Equals(s_anonymouslyHostedDynamicMethodsModule), "The user cannot explicitly use this assembly");
                 Debug.Assert(m == null || owner == null, "m and owner cannot both be set");
 
-                if (m != null)
+                if ((object)m != null)
                     m_module = m.ModuleHandle.GetRuntimeModule(); // this returns the underlying module for all RuntimeModule and ModuleBuilder objects.
                 else
                 {
                     RuntimeType rtOwner = null;
-                    if (owner != null)
+                    if ((object)owner != null)
                         rtOwner = owner.UnderlyingSystemType as RuntimeType;
 
-                    if (rtOwner != null)
+                    if ((object)rtOwner != null)
                     {
                         if (rtOwner.HasElementType || rtOwner.ContainsGenericParameters
                             || rtOwner.IsGenericParameter || rtOwner.IsInterface)
@@ -670,7 +670,7 @@ namespace System.Reflection.Emit
 
             public override Object[] GetCustomAttributes(Type attributeType, bool inherit)
             {
-                if (attributeType == null)
+                if (attributeType is null)
                     throw new ArgumentNullException(nameof(attributeType));
 
                 if (attributeType.IsAssignableFrom(typeof(MethodImplAttribute)))
@@ -687,7 +687,7 @@ namespace System.Reflection.Emit
 
             public override bool IsDefined(Type attributeType, bool inherit)
             {
-                if (attributeType == null)
+                if (attributeType is null)
                     throw new ArgumentNullException(nameof(attributeType));
 
                 if (attributeType.IsAssignableFrom(typeof(MethodImplAttribute)))

--- a/src/mscorlib/src/System/Reflection/Emit/EnumBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/EnumBuilder.cs
@@ -25,7 +25,7 @@ namespace System.Reflection.Emit
     {
         public override bool IsAssignableFrom(System.Reflection.TypeInfo typeInfo)
         {
-            if (typeInfo == null) return false;
+            if (typeInfo is null) return false;
             return IsAssignableFrom(typeInfo.AsType());
         }
 

--- a/src/mscorlib/src/System/Reflection/Emit/EventBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/EventBuilder.cs
@@ -54,7 +54,7 @@ namespace System.Reflection.Emit
 
         private void SetMethodSemantics(MethodBuilder mdBuilder, MethodSemanticsAttributes semantics)
         {
-            if (mdBuilder == null)
+            if (mdBuilder is null)
             {
                 throw new ArgumentNullException(nameof(mdBuilder));
             }
@@ -91,7 +91,7 @@ namespace System.Reflection.Emit
 
         public void SetCustomAttribute(ConstructorInfo con, byte[] binaryAttribute)
         {
-            if (con == null)
+            if (con is null)
                 throw new ArgumentNullException(nameof(con));
             if (binaryAttribute == null)
                 throw new ArgumentNullException(nameof(binaryAttribute));

--- a/src/mscorlib/src/System/Reflection/Emit/FieldBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/FieldBuilder.cs
@@ -35,7 +35,7 @@ namespace System.Reflection.Emit
             if (fieldName[0] == '\0')
                 throw new ArgumentException(SR.Argument_IllegalName, nameof(fieldName));
 
-            if (type == null)
+            if (type is null)
                 throw new ArgumentNullException(nameof(type));
 
             if (type == typeof(void))
@@ -184,7 +184,7 @@ namespace System.Reflection.Emit
 
         public void SetCustomAttribute(ConstructorInfo con, byte[] binaryAttribute)
         {
-            if (con == null)
+            if (con is null)
                 throw new ArgumentNullException(nameof(con));
 
             if (binaryAttribute == null)

--- a/src/mscorlib/src/System/Reflection/Emit/GenericTypeParameterBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/GenericTypeParameterBuilder.cs
@@ -16,7 +16,7 @@ namespace System.Reflection.Emit
     {
         public override bool IsAssignableFrom(System.Reflection.TypeInfo typeInfo)
         {
-            if (typeInfo == null) return false;
+            if (typeInfo is null) return false;
             return IsAssignableFrom(typeInfo.AsType());
         }
 
@@ -40,7 +40,7 @@ namespace System.Reflection.Emit
         {
             GenericTypeParameterBuilder g = o as GenericTypeParameterBuilder;
 
-            if (g == null)
+            if (g is null)
                 return false;
 
             return object.ReferenceEquals(g.m_type, m_type);

--- a/src/mscorlib/src/System/Reflection/Emit/ILGenerator.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/ILGenerator.cs
@@ -139,11 +139,8 @@ namespace System.Reflection.Emit
 
             // initialize local signature
             m_localCount = 0;
-            MethodBuilder mb = m_methodBuilder as MethodBuilder;
-            if (mb == null)
-                m_localSignature = SignatureHelper.GetLocalVarSigHelper(null);
-            else
-                m_localSignature = SignatureHelper.GetLocalVarSigHelper(mb.GetTypeBuilder().Module);
+            m_localSignature = SignatureHelper.GetLocalVarSigHelper(
+                m_methodBuilder is MethodBuilder mb ? mb.GetTypeBuilder().Module : null);
         }
 
         #endregion
@@ -460,7 +457,7 @@ namespace System.Reflection.Emit
 
         public virtual void Emit(OpCode opcode, MethodInfo meth)
         {
-            if (meth == null)
+            if (meth is null)
                 throw new ArgumentNullException(nameof(meth));
 
             if (opcode.Equals(OpCodes.Call) || opcode.Equals(OpCodes.Callvirt) || opcode.Equals(OpCodes.Newobj))
@@ -578,7 +575,7 @@ namespace System.Reflection.Emit
 
         public virtual void EmitCall(OpCode opcode, MethodInfo methodInfo, Type[] optionalParameterTypes)
         {
-            if (methodInfo == null)
+            if (methodInfo is null)
                 throw new ArgumentNullException(nameof(methodInfo));
 
             if (!(opcode.Equals(OpCodes.Call) || opcode.Equals(OpCodes.Callvirt) || opcode.Equals(OpCodes.Newobj)))
@@ -648,7 +645,7 @@ namespace System.Reflection.Emit
 
         public virtual void Emit(OpCode opcode, ConstructorInfo con)
         {
-            if (con == null)
+            if (con is null)
                 throw new ArgumentNullException(nameof(con));
 
             int stackchange = 0;
@@ -695,7 +692,7 @@ namespace System.Reflection.Emit
 
             int tempVal = 0;
             ModuleBuilder modBuilder = (ModuleBuilder)m_methodBuilder.Module;
-            if (opcode == OpCodes.Ldtoken && cls != null && cls.IsGenericTypeDefinition)
+            if (opcode == OpCodes.Ldtoken && cls?.IsGenericTypeDefinition == true)
             {
                 // This gets the token for the generic type definition if cls is one.
                 tempVal = modBuilder.GetTypeToken(cls).Token;
@@ -1032,7 +1029,7 @@ namespace System.Reflection.Emit
 
             if (current.GetCurrentState() == __ExceptionInfo.State_Filter)
             {
-                if (exceptionType != null)
+                if ((object)exceptionType != null)
                 {
                     throw new ArgumentException(SR.Argument_ShouldNotSpecifyExceptionType);
                 }
@@ -1042,7 +1039,7 @@ namespace System.Reflection.Emit
             else
             {
                 // execute this branch if previous clause is Catch or Fault
-                if (exceptionType == null)
+                if (exceptionType is null)
                 {
                     throw new ArgumentNullException(nameof(exceptionType));
                 }
@@ -1150,7 +1147,7 @@ namespace System.Reflection.Emit
         {
             // Emits the il to throw an exception
 
-            if (excType == null)
+            if (excType is null)
             {
                 throw new ArgumentNullException(nameof(excType));
             }
@@ -1160,7 +1157,7 @@ namespace System.Reflection.Emit
                 throw new ArgumentException(SR.Argument_NotExceptionType);
             }
             ConstructorInfo con = excType.GetConstructor(Type.EmptyTypes);
-            if (con == null)
+            if (con is null)
             {
                 throw new ArgumentException(SR.Argument_MissingDefaultConstructor);
             }
@@ -1194,7 +1191,7 @@ namespace System.Reflection.Emit
             // we do *not* call ToString on the locals.
 
             Object cls;
-            if (m_methodBuilder == null)
+            if (m_methodBuilder is null)
             {
                 throw new ArgumentException(SR.InvalidOperation_BadILGeneratorUsage);
             }
@@ -1210,7 +1207,7 @@ namespace System.Reflection.Emit
             }
             parameterTypes[0] = (Type)cls;
             MethodInfo mi = prop.ReturnType.GetMethod("WriteLine", parameterTypes);
-            if (mi == null)
+            if (mi is null)
             {
                 throw new ArgumentException(SR.Argument_EmitWriteLineType, nameof(localBuilder));
             }
@@ -1227,7 +1224,7 @@ namespace System.Reflection.Emit
 
             Object cls;
 
-            if (fld == null)
+            if (fld is null)
             {
                 throw new ArgumentNullException(nameof(fld));
             }
@@ -1252,7 +1249,7 @@ namespace System.Reflection.Emit
             }
             parameterTypes[0] = (Type)cls;
             MethodInfo mi = prop.ReturnType.GetMethod("WriteLine", parameterTypes);
-            if (mi == null)
+            if (mi is null)
             {
                 throw new ArgumentException(SR.Argument_EmitWriteLineType, nameof(fld));
             }
@@ -1275,7 +1272,7 @@ namespace System.Reflection.Emit
             LocalBuilder localBuilder;
 
             MethodBuilder methodBuilder = m_methodBuilder as MethodBuilder;
-            if (methodBuilder == null)
+            if (methodBuilder is null)
                 throw new NotSupportedException();
 
             if (methodBuilder.IsTypeCreated())
@@ -1284,7 +1281,7 @@ namespace System.Reflection.Emit
                 throw new InvalidOperationException(SR.InvalidOperation_TypeHasBeenCreated);
             }
 
-            if (localType == null)
+            if (localType is null)
             {
                 throw new ArgumentNullException(nameof(localType));
             }
@@ -1315,7 +1312,7 @@ namespace System.Reflection.Emit
 
             int index;
             MethodBuilder methodBuilder = m_methodBuilder as MethodBuilder;
-            if (methodBuilder == null)
+            if (methodBuilder is null)
                 throw new NotSupportedException();
 
             index = methodBuilder.GetILGenerator().m_ScopeTree.GetCurrentActiveScopeIndex();

--- a/src/mscorlib/src/System/Reflection/Emit/LocalBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/LocalBuilder.cs
@@ -69,7 +69,7 @@ namespace System.Reflection.Emit
             int index;
 
             MethodBuilder methodBuilder = m_methodBuilder as MethodBuilder;
-            if (methodBuilder == null)
+            if (methodBuilder is null)
                 // it's a light code gen entity
                 throw new NotSupportedException();
             dynMod = (ModuleBuilder)methodBuilder.Module;

--- a/src/mscorlib/src/System/Reflection/Emit/MethodBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/MethodBuilder.cs
@@ -88,14 +88,14 @@ namespace System.Reflection.Emit
             if (name[0] == '\0')
                 throw new ArgumentException(SR.Argument_IllegalName, nameof(name));
 
-            if (mod == null)
+            if (mod is null)
                 throw new ArgumentNullException(nameof(mod));
 
             if (parameterTypes != null)
             {
                 foreach (Type t in parameterTypes)
                 {
-                    if (t == null)
+                    if (t is null)
                         throw new ArgumentNullException(nameof(parameterTypes));
                 }
             }
@@ -212,7 +212,7 @@ namespace System.Reflection.Emit
                 throw new InvalidOperationException(SR.InvalidOperation_MethodHasBody);
             }
 
-            if (il.m_methodBuilder != this && il.m_methodBuilder != null)
+            if (il.m_methodBuilder != this && (object)il.m_methodBuilder != null)
             {
                 // you don't need to call DefineBody when you get your ILGenerator
                 // through MethodBuilder::GetILGenerator.
@@ -255,7 +255,7 @@ namespace System.Reflection.Emit
                     for (int j = 0; j < numCatch; j++)
                     {
                         int tkExceptionClass = 0;
-                        if (catchClass[j] != null)
+                        if ((object)catchClass[j] != null)
                         {
                             tkExceptionClass = dynMod.GetTypeTokenInternal(catchClass[j]).Token;
                         }
@@ -339,14 +339,11 @@ namespace System.Reflection.Emit
 
         internal static Type GetMethodBaseReturnType(MethodBase method)
         {
-            MethodInfo mi = null;
-            ConstructorInfo ci = null;
-
-            if ((mi = method as MethodInfo) != null)
+            if (method is MethodInfo mi)
             {
                 return mi.ReturnType;
             }
-            else if ((ci = method as ConstructorInfo) != null)
+            else if (method is ConstructorInfo ci)
             {
                 return ci.GetReturnType();
             }
@@ -375,7 +372,7 @@ namespace System.Reflection.Emit
                 m_parameterTypes = Array.Empty<Type>();
 
             m_signature = SignatureHelper.GetMethodSigHelper(m_module, m_callingConvention, m_inst != null ? m_inst.Length : 0,
-                m_returnType == null ? typeof(void) : m_returnType, m_returnTypeRequiredCustomModifiers, m_returnTypeOptionalCustomModifiers,
+                m_returnType is null ? typeof(void) : m_returnType, m_returnTypeRequiredCustomModifiers, m_returnTypeOptionalCustomModifiers,
                 m_parameterTypes, m_parameterTypeRequiredCustomModifiers, m_parameterTypeOptionalCustomModifiers);
 
             return m_signature;
@@ -444,7 +441,7 @@ namespace System.Reflection.Emit
 
         internal bool IsTypeCreated()
         {
-            return (m_containingType != null && m_containingType.IsCreated());
+            return m_containingType?.IsCreated() == true;
         }
 
         internal TypeBuilder GetTypeBuilder()
@@ -611,7 +608,7 @@ namespace System.Reflection.Emit
 
         public override ParameterInfo[] GetParameters()
         {
-            if (!m_bIsBaked || m_containingType == null || m_containingType.BakedRuntimeType == null)
+            if (!m_bIsBaked || m_containingType is null || m_containingType.BakedRuntimeType is null)
                 throw new NotSupportedException(SR.InvalidOperation_TypeNotCreated);
 
             MethodInfo rmi = m_containingType.GetMethod(m_strName, m_parameterTypes);
@@ -623,7 +620,7 @@ namespace System.Reflection.Emit
         {
             get
             {
-                if (!m_bIsBaked || m_containingType == null || m_containingType.BakedRuntimeType == null)
+                if (!m_bIsBaked || m_containingType is null || m_containingType.BakedRuntimeType is null)
                     throw new InvalidOperationException(SR.InvalidOperation_TypeNotCreated);
 
                 MethodInfo rmi = m_containingType.GetMethod(m_strName, m_parameterTypes);
@@ -798,7 +795,7 @@ namespace System.Reflection.Emit
 
             ThrowIfGeneric();
 
-            if (returnType != null)
+            if ((object)returnType != null)
             {
                 m_returnType = returnType;
             }
@@ -908,7 +905,7 @@ namespace System.Reflection.Emit
 
         public void SetCustomAttribute(ConstructorInfo con, byte[] binaryAttribute)
         {
-            if (con == null)
+            if (con is null)
                 throw new ArgumentNullException(nameof(con));
             if (binaryAttribute == null)
                 throw new ArgumentNullException(nameof(binaryAttribute));

--- a/src/mscorlib/src/System/Reflection/Emit/MethodBuilderInstantiation.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/MethodBuilderInstantiation.cs
@@ -76,7 +76,7 @@ namespace System.Reflection.Emit
                         return true;
                 }
 
-                if (DeclaringType != null && DeclaringType.ContainsGenericParameters)
+                if (DeclaringType?.ContainsGenericParameters == true)
                     return true;
 
                 return false;

--- a/src/mscorlib/src/System/Reflection/Emit/ParameterBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/ParameterBuilder.cs
@@ -35,7 +35,7 @@ namespace System.Reflection.Emit
 
         public void SetCustomAttribute(ConstructorInfo con, byte[] binaryAttribute)
         {
-            if (con == null)
+            if (con is null)
                 throw new ArgumentNullException(nameof(con));
             if (binaryAttribute == null)
                 throw new ArgumentNullException(nameof(binaryAttribute));

--- a/src/mscorlib/src/System/Reflection/Emit/PropertyBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/PropertyBuilder.cs
@@ -89,7 +89,7 @@ namespace System.Reflection.Emit
 
         private void SetMethodSemantics(MethodBuilder mdBuilder, MethodSemanticsAttributes semantics)
         {
-            if (mdBuilder == null)
+            if (mdBuilder is null)
             {
                 throw new ArgumentNullException(nameof(mdBuilder));
             }
@@ -123,7 +123,7 @@ namespace System.Reflection.Emit
 
         public void SetCustomAttribute(ConstructorInfo con, byte[] binaryAttribute)
         {
-            if (con == null)
+            if (con is null)
                 throw new ArgumentNullException(nameof(con));
             if (binaryAttribute == null)
                 throw new ArgumentNullException(nameof(binaryAttribute));
@@ -176,7 +176,7 @@ namespace System.Reflection.Emit
 
         public override MethodInfo GetGetMethod(bool nonPublic)
         {
-            if (nonPublic || m_getMethod == null)
+            if (nonPublic || m_getMethod is null)
                 return m_getMethod;
             // now check to see if m_getMethod is public
             if ((m_getMethod.Attributes & MethodAttributes.Public) == MethodAttributes.Public)
@@ -186,7 +186,7 @@ namespace System.Reflection.Emit
 
         public override MethodInfo GetSetMethod(bool nonPublic)
         {
-            if (nonPublic || m_setMethod == null)
+            if (nonPublic || m_setMethod is null)
                 return m_setMethod;
             // now check to see if m_setMethod is public
             if ((m_setMethod.Attributes & MethodAttributes.Public) == MethodAttributes.Public)
@@ -209,15 +209,9 @@ namespace System.Reflection.Emit
             get { return m_attributes; }
         }
 
-        public override bool CanRead
-        {
-            get { if (m_getMethod != null) return true; else return false; }
-        }
+        public override bool CanRead => (object)m_getMethod != null;
 
-        public override bool CanWrite
-        {
-            get { if (m_setMethod != null) return true; else return false; }
-        }
+        public override bool CanWrite => (object)m_setMethod != null;
 
         public override Object[] GetCustomAttributes(bool inherit)
         {

--- a/src/mscorlib/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/SignatureHelper.cs
@@ -62,7 +62,7 @@ namespace System.Reflection.Emit
             SignatureHelper sigHelp;
             MdSigCallingConvention intCall;
 
-            if (returnType == null)
+            if (returnType is null)
             {
                 returnType = typeof(void);
             }
@@ -92,7 +92,7 @@ namespace System.Reflection.Emit
             SignatureHelper sigHelp;
             MdSigCallingConvention intCall;
 
-            if (returnType == null)
+            if (returnType is null)
                 returnType = typeof(void);
 
             if (unmanagedCallConv == CallingConvention.Cdecl)
@@ -164,7 +164,7 @@ namespace System.Reflection.Emit
         {
             SignatureHelper sigHelp;
 
-            if (returnType == null)
+            if (returnType is null)
             {
                 returnType = typeof(void);
             }
@@ -183,10 +183,10 @@ namespace System.Reflection.Emit
 
         internal static SignatureHelper GetTypeSigToken(Module module, Type type)
         {
-            if (module == null)
+            if (module is null)
                 throw new ArgumentNullException(nameof(module));
 
-            if (type == null)
+            if (type is null)
                 throw new ArgumentNullException(nameof(type));
 
             return new SignatureHelper(module, type);
@@ -243,7 +243,7 @@ namespace System.Reflection.Emit
             m_sigDone = false;
             m_sizeLoc = NO_SIZE_IN_SIG;
 
-            if (m_module == null && mod != null)
+            if (m_module is null && (object)mod != null)
                 throw new ArgumentException(SR.NotSupported_MustBeModuleBuilder);
         }
 
@@ -297,7 +297,7 @@ namespace System.Reflection.Emit
                 {
                     Type t = optionalCustomModifiers[i];
 
-                    if (t == null)
+                    if (t is null)
                         throw new ArgumentNullException(nameof(optionalCustomModifiers));
 
                     if (t.HasElementType)
@@ -320,7 +320,7 @@ namespace System.Reflection.Emit
                 {
                     Type t = requiredCustomModifiers[i];
 
-                    if (t == null)
+                    if (t is null)
                         throw new ArgumentNullException(nameof(requiredCustomModifiers));
 
                     if (t.HasElementType)
@@ -345,7 +345,7 @@ namespace System.Reflection.Emit
         {
             if (clsArgument.IsGenericParameter)
             {
-                if (clsArgument.DeclaringMethod != null)
+                if ((object)clsArgument.DeclaringMethod != null)
                     AddElementType(CorElementType.MVar);
                 else
                     AddElementType(CorElementType.Var);
@@ -467,7 +467,7 @@ namespace System.Reflection.Emit
                 {
                     AddElementType(type);
                 }
-                else if (m_module == null)
+                else if (m_module is null)
                 {
                     InternalAddRuntimeType(clsArgument);
                 }
@@ -773,7 +773,7 @@ namespace System.Reflection.Emit
 
         public void AddArgument(Type argument, bool pinned)
         {
-            if (argument == null)
+            if (argument is null)
                 throw new ArgumentNullException(nameof(argument));
 
             IncrementArgCounts();
@@ -804,7 +804,7 @@ namespace System.Reflection.Emit
             if (m_sigDone)
                 throw new ArgumentException(SR.Argument_SigIsFinalized);
 
-            if (argument == null)
+            if (argument is null)
                 throw new ArgumentNullException(nameof(argument));
 
             IncrementArgCounts();

--- a/src/mscorlib/src/System/Reflection/Emit/SymbolType.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/SymbolType.cs
@@ -23,7 +23,7 @@ namespace System.Reflection.Emit
     {
         public override bool IsAssignableFrom(System.Reflection.TypeInfo typeInfo)
         {
-            if (typeInfo == null) return false;
+            if (typeInfo is null) return false;
             return IsAssignableFrom(typeInfo.AsType());
         }
 
@@ -231,7 +231,7 @@ namespace System.Reflection.Emit
         #region Internal Members
         internal void SetElementType(Type baseType)
         {
-            if (baseType == null)
+            if (baseType is null)
                 throw new ArgumentNullException(nameof(baseType));
 
             m_baseType = baseType;
@@ -547,7 +547,7 @@ namespace System.Reflection.Emit
 
         protected override bool HasElementTypeImpl()
         {
-            return m_baseType != null;
+            return (object)m_baseType != null;
         }
 
         public override Type UnderlyingSystemType

--- a/src/mscorlib/src/System/Reflection/Emit/TypeBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/TypeBuilder.cs
@@ -36,7 +36,7 @@ namespace System.Reflection.Emit
     {
         public override bool IsAssignableFrom(System.Reflection.TypeInfo typeInfo)
         {
-            if (typeInfo == null) return false;
+            if (typeInfo is null) return false;
             return IsAssignableFrom(typeInfo.AsType());
         }
 
@@ -49,7 +49,7 @@ namespace System.Reflection.Emit
 
             public CustAttr(ConstructorInfo con, byte[] binaryAttribute)
             {
-                if (con == null)
+                if (con is null)
                     throw new ArgumentNullException(nameof(con));
 
                 if (binaryAttribute == null)
@@ -98,7 +98,7 @@ namespace System.Reflection.Emit
             if (method.IsGenericMethod && !method.IsGenericMethodDefinition)
                 throw new ArgumentException(SR.Argument_NeedGenericMethodDefinition, nameof(method));
 
-            if (method.DeclaringType == null || !method.DeclaringType.IsGenericTypeDefinition)
+            if (method.DeclaringType is null || !method.DeclaringType.IsGenericTypeDefinition)
                 throw new ArgumentException(SR.Argument_MethodNeedGenericDeclaringType, nameof(method));
 
             if (type.GetGenericTypeDefinition() != method.DeclaringType)
@@ -278,11 +278,11 @@ namespace System.Reflection.Emit
             }
 
             // If the type builder view is eqaul then it is equal                
-            if (tb1 != null && tb2 != null && Object.ReferenceEquals(tb1, tb2))
+            if ((object)tb1 != null && (object)tb2 != null && Object.ReferenceEquals(tb1, tb2))
                 return true;
 
             // if the runtimetype view is eqaul than it is equal                
-            if (runtimeType1 != null && runtimeType2 != null && runtimeType1 == runtimeType2)
+            if ((object)runtimeType1 != null && (object)runtimeType2 != null && runtimeType1 == runtimeType2)
                 return true;
 
             return false;
@@ -317,9 +317,7 @@ namespace System.Reflection.Emit
                     // The above behaviors might not be the most consistent but we have to live with them.
 
                     Type underlyingType;
-                    EnumBuilder enumBldr;
-                    TypeBuilder typeBldr;
-                    if ((enumBldr = destType as EnumBuilder) != null)
+                    if (destType is EnumBuilder enumBldr)
                     {
                         underlyingType = enumBldr.GetEnumUnderlyingType();
 
@@ -328,13 +326,13 @@ namespace System.Reflection.Emit
                         if (type != enumBldr.m_typeBuilder.m_bakedRuntimeType && type != underlyingType)
                             throw new ArgumentException(SR.Argument_ConstantDoesntMatch);
                     }
-                    else if ((typeBldr = destType as TypeBuilder) != null)
+                    else if (destType is TypeBuilder typeBldr)
                     {
                         underlyingType = typeBldr.m_enumUnderlyingType;
 
                         // The constant value supplied should match either the baked enum type or its underlying type
                         // typeBldr.m_enumUnderlyingType is null if the user hasn't created a "value__" field on the enum
-                        if (underlyingType == null || (type != typeBldr.UnderlyingSystemType && type != underlyingType))
+                        if (underlyingType is null || (type != typeBldr.UnderlyingSystemType && type != underlyingType))
                             throw new ArgumentException(SR.Argument_ConstantDoesntMatch);
                     }
                     else // must be a runtime Enum Type
@@ -519,7 +517,7 @@ namespace System.Reflection.Emit
             // cannot have two types within the same assembly of the same name
             containingAssem.m_assemblyData.CheckTypeNameConflict(fullname, enclosingType);
 
-            if (enclosingType != null)
+            if ((object)enclosingType != null)
             {
                 // Nested Type should have nested attribute set.
                 // If we are renumbering TypeAttributes' bit, we need to change the logic here.
@@ -532,7 +530,7 @@ namespace System.Reflection.Emit
             {
                 for (i = 0; i < interfaces.Length; i++)
                 {
-                    if (interfaces[i] == null)
+                    if (interfaces[i] is null)
                     {
                         // cannot contain null in the interface list
                         throw new ArgumentNullException(nameof(interfaces));
@@ -571,11 +569,11 @@ namespace System.Reflection.Emit
             SetInterfaces(interfaces);
 
             int tkParent = 0;
-            if (m_typeParent != null)
+            if ((object)m_typeParent != null)
                 tkParent = m_module.GetTypeTokenInternal(m_typeParent).Token;
 
             int tkEnclosingType = 0;
-            if (enclosingType != null)
+            if ((object)enclosingType != null)
             {
                 tkEnclosingType = enclosingType.m_tdType.Token;
             }
@@ -619,7 +617,7 @@ namespace System.Reflection.Emit
             Type temp = m_module.FindTypeBuilderWithName(strValueClassName, false);
             valueClassType = temp as TypeBuilder;
 
-            if (valueClassType == null)
+            if (valueClassType is null)
             {
                 typeAttributes = TypeAttributes.Public | TypeAttributes.ExplicitLayout | TypeAttributes.Class | TypeAttributes.Sealed | TypeAttributes.AnsiClass;
 
@@ -638,7 +636,7 @@ namespace System.Reflection.Emit
         private void VerifyTypeAttributes(TypeAttributes attr)
         {
             // Verify attr consistency for Nesting or otherwise.
-            if (DeclaringType == null)
+            if (DeclaringType is null)
             {
                 // Not a nested class.
                 if (((attr & TypeAttributes.VisibilityMask) != TypeAttributes.NotPublic) && ((attr & TypeAttributes.VisibilityMask) != TypeAttributes.Public))
@@ -915,7 +913,7 @@ namespace System.Reflection.Emit
 
         public override Type[] GetInterfaces()
         {
-            if (m_bakedRuntimeType != null)
+            if ((object)m_bakedRuntimeType != null)
             {
                 return m_bakedRuntimeType.GetInterfaces();
             }
@@ -1014,15 +1012,15 @@ namespace System.Reflection.Emit
             Type fromRuntimeType = null;
             TypeBuilder fromTypeBuilder = c as TypeBuilder;
 
-            if (fromTypeBuilder != null)
+            if ((object)fromTypeBuilder != null)
                 fromRuntimeType = fromTypeBuilder.m_bakedRuntimeType;
             else
                 fromRuntimeType = c;
 
-            if (fromRuntimeType != null && fromRuntimeType is RuntimeType)
+            if ((object)fromRuntimeType != null && fromRuntimeType is RuntimeType)
             {
                 // fromType is baked. So if this type is not baked, it cannot be assignable to!
-                if (m_bakedRuntimeType == null)
+                if (m_bakedRuntimeType is null)
                     return false;
 
                 // since toType is also baked, delegate to the base
@@ -1031,7 +1029,7 @@ namespace System.Reflection.Emit
 
             // So if c is not a runtimeType nor TypeBuilder. We don't know how to deal with it. 
             // return false then.
-            if (fromTypeBuilder == null)
+            if (fromTypeBuilder is null)
                 return false;
 
             // If fromTypeBuilder is a subclass of this class, then c can be cast to this type.
@@ -1121,7 +1119,7 @@ namespace System.Reflection.Emit
 
             p = p.BaseType;
 
-            while (p != null)
+            while ((object)p != null)
             {
                 if (TypeBuilder.IsTypeEqual(p, c))
                     return true;
@@ -1136,12 +1134,12 @@ namespace System.Reflection.Emit
         {
             get
             {
-                if (m_bakedRuntimeType != null)
+                if ((object)m_bakedRuntimeType != null)
                     return m_bakedRuntimeType;
 
                 if (IsEnum)
                 {
-                    if (m_enumUnderlyingType == null)
+                    if (m_enumUnderlyingType is null)
                         throw new InvalidOperationException(SR.InvalidOperation_NoUnderlyingTypeOnEnum);
 
                     return m_enumUnderlyingType;
@@ -1204,12 +1202,12 @@ namespace System.Reflection.Emit
             if (!IsCreated())
                 throw new NotSupportedException(SR.NotSupported_TypeNotYetCreated);
 
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             RuntimeType attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
 
-            if (attributeRuntimeType == null)
+            if (attributeRuntimeType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.GetCustomAttributes(m_bakedRuntimeType, attributeRuntimeType, inherit);
@@ -1220,12 +1218,12 @@ namespace System.Reflection.Emit
             if (!IsCreated())
                 throw new NotSupportedException(SR.NotSupported_TypeNotYetCreated);
 
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             RuntimeType attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
 
-            if (attributeRuntimeType == null)
+            if (attributeRuntimeType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.IsDefined(m_bakedRuntimeType, attributeRuntimeType, inherit);
@@ -1290,7 +1288,7 @@ namespace System.Reflection.Emit
 
         public override int GenericParameterPosition { get { return m_genParamPos; } }
         public override MethodBase DeclaringMethod { get { return m_declMeth; } }
-        public override Type GetGenericTypeDefinition() { if (IsGenericTypeDefinition) return this; if (m_genTypeDef == null) throw new InvalidOperationException(); return m_genTypeDef; }
+        public override Type GetGenericTypeDefinition() { if (IsGenericTypeDefinition) return this; if (m_genTypeDef is null) throw new InvalidOperationException(); return m_genTypeDef; }
         #endregion
 
         #region Define Method
@@ -1304,10 +1302,10 @@ namespace System.Reflection.Emit
 
         private void DefineMethodOverrideNoLock(MethodInfo methodInfoBody, MethodInfo methodInfoDeclaration)
         {
-            if (methodInfoBody == null)
+            if (methodInfoBody is null)
                 throw new ArgumentNullException(nameof(methodInfoBody));
 
-            if (methodInfoDeclaration == null)
+            if (methodInfoDeclaration is null)
                 throw new ArgumentNullException(nameof(methodInfoDeclaration));
 
             ThrowIfCreated();
@@ -1468,7 +1466,7 @@ namespace System.Reflection.Emit
                 if (genericTypeDefinition is TypeBuilder)
                     genericTypeDefinition = ((TypeBuilder)genericTypeDefinition).m_bakedRuntimeType;
 
-                if (genericTypeDefinition == null)
+                if (genericTypeDefinition is null)
                     throw new NotSupportedException(SR.NotSupported_DynamicModule);
 
                 Type inst = genericTypeDefinition.MakeGenericType(m_typeParent.GetGenericArguments());
@@ -1481,12 +1479,12 @@ namespace System.Reflection.Emit
                         BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, Type.EmptyTypes, null);
             }
 
-            if (con == null)
+            if (con is null)
             {
                 con = m_typeParent.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, Type.EmptyTypes, null);
             }
 
-            if (con == null)
+            if (con is null)
                 throw new NotSupportedException(SR.NotSupported_NoParentDefaultConstructor);
 
             // Define the constructor Builder
@@ -1645,7 +1643,7 @@ namespace System.Reflection.Emit
             CheckContext(type);
             CheckContext(requiredCustomModifiers);
 
-            if (m_enumUnderlyingType == null && IsEnum == true)
+            if (m_enumUnderlyingType is null && IsEnum)
             {
                 if ((attributes & FieldAttributes.Static) == 0)
                 {
@@ -1866,14 +1864,14 @@ namespace System.Reflection.Emit
             }
 
             int tkParent = 0;
-            if (m_typeParent != null)
+            if ((object)m_typeParent != null)
                 tkParent = m_module.GetTypeTokenInternal(m_typeParent).Token;
 
             if (IsGenericParameter)
             {
                 int[] constraints; // Array of token constrains terminated by null token
 
-                if (m_typeParent != null)
+                if ((object)m_typeParent != null)
                 {
                     constraints = new int[m_typeInterfaces.Count + 2];
                     constraints[constraints.Length - 2] = tkParent;
@@ -1888,7 +1886,7 @@ namespace System.Reflection.Emit
                     constraints[i] = m_module.GetTypeTokenInternal(m_typeInterfaces[i]).Token;
                 }
 
-                int declMember = m_declMeth == null ? m_DeclaringType.m_tdType.Token : m_declMeth.GetToken().Token;
+                int declMember = m_declMeth is null ? m_DeclaringType.m_tdType.Token : m_declMeth.GetToken().Token;
                 m_tdType = new TypeToken(DefineGenericParam(m_module.GetNativeHandle(),
                     m_strName, declMember, m_genParamAttributes, m_genParamPos, constraints));
 
@@ -2017,7 +2015,7 @@ namespace System.Reflection.Emit
                 m_bakedRuntimeType = cls;
 
                 // if this type is a nested type, we need to invalidate the cached nested runtime type on the nesting type
-                if (m_DeclaringType != null && m_DeclaringType.m_bakedRuntimeType != null)
+                if ((object)m_DeclaringType?.m_bakedRuntimeType != null)
                 {
                     m_DeclaringType.m_bakedRuntimeType.InvalidateCachedNestedType();
                 }
@@ -2047,7 +2045,7 @@ namespace System.Reflection.Emit
         {
             ThrowIfCreated();
 
-            if (parent != null)
+            if ((object)parent != null)
             {
                 CheckContext(parent);
 
@@ -2075,7 +2073,7 @@ namespace System.Reflection.Emit
 
         public void AddInterfaceImplementation(Type interfaceType)
         {
-            if (interfaceType == null)
+            if (interfaceType is null)
             {
                 throw new ArgumentNullException(nameof(interfaceType));
             }
@@ -2104,7 +2102,7 @@ namespace System.Reflection.Emit
 
         public void SetCustomAttribute(ConstructorInfo con, byte[] binaryAttribute)
         {
-            if (con == null)
+            if (con is null)
                 throw new ArgumentNullException(nameof(con));
 
             if (binaryAttribute == null)

--- a/src/mscorlib/src/System/Reflection/Emit/TypeBuilderInstantiation.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/TypeBuilderInstantiation.cs
@@ -16,7 +16,7 @@ namespace System.Reflection.Emit
     {
         public override bool IsAssignableFrom(System.Reflection.TypeInfo typeInfo)
         {
-            if (typeInfo == null) return false;
+            if (typeInfo is null) return false;
             return IsAssignableFrom(typeInfo.AsType());
         }
 
@@ -33,7 +33,7 @@ namespace System.Reflection.Emit
 
             foreach (Type t in typeArguments)
             {
-                if (t == null)
+                if (t is null)
                     throw new ArgumentNullException(nameof(typeArguments));
             }
 
@@ -154,12 +154,12 @@ namespace System.Reflection.Emit
             {
                 Type typeBldrBase = m_type.BaseType;
 
-                if (typeBldrBase == null)
+                if (typeBldrBase is null)
                     return null;
 
                 TypeBuilderInstantiation typeBldrBaseAs = typeBldrBase as TypeBuilderInstantiation;
 
-                if (typeBldrBaseAs == null)
+                if (typeBldrBaseAs is null)
                     return typeBldrBase;
 
                 return typeBldrBaseAs.Substitute(GetGenericArguments());

--- a/src/mscorlib/src/System/Reflection/Emit/XXXOnTypeBuilderInstantiation.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/XXXOnTypeBuilderInstantiation.cs
@@ -133,9 +133,7 @@ namespace System.Reflection.Emit
         {
             get
             {
-                ConstructorBuilder cb = m_ctor as ConstructorBuilder;
-
-                if (cb != null)
+                if (m_ctor is ConstructorBuilder cb)
                     return cb.MetadataTokenInternal;
                 else
                 {
@@ -234,9 +232,7 @@ namespace System.Reflection.Emit
         {
             get
             {
-                FieldBuilder fb = m_field as FieldBuilder;
-
-                if (fb != null)
+                if (m_field is FieldBuilder fb)
                     return fb.MetadataTokenInternal;
                 else
                 {

--- a/src/mscorlib/src/System/Reflection/ExceptionHandlingClause.cs
+++ b/src/mscorlib/src/System/Reflection/ExceptionHandlingClause.cs
@@ -54,8 +54,8 @@ namespace System.Reflection
                 if (!MetadataToken.IsNullToken(m_catchMetadataToken))
                 {
                     Type declaringType = m_methodBody.m_methodBase.DeclaringType;
-                    Module module = (declaringType == null) ? m_methodBody.m_methodBase.Module : declaringType.Module;
-                    type = module.ResolveType(m_catchMetadataToken, (declaringType == null) ? null : declaringType.GetGenericArguments(),
+                    Module module = (declaringType is null) ? m_methodBody.m_methodBase.Module : declaringType.Module;
+                    type = module.ResolveType(m_catchMetadataToken, (declaringType is null) ? null : declaringType.GetGenericArguments(),
                         m_methodBody.m_methodBase is MethodInfo ? m_methodBody.m_methodBase.GetGenericArguments() : null);
                 }
 

--- a/src/mscorlib/src/System/Reflection/FieldInfo.CoreCLR.cs
+++ b/src/mscorlib/src/System/Reflection/FieldInfo.CoreCLR.cs
@@ -16,7 +16,7 @@ namespace System.Reflection
             FieldInfo f = RuntimeType.GetFieldInfo(handle.GetRuntimeFieldInfo());
 
             Type declaringType = f.DeclaringType;
-            if (declaringType != null && declaringType.IsGenericType)
+            if (declaringType?.IsGenericType == true)
                 throw new ArgumentException(String.Format(
                     CultureInfo.CurrentCulture, SR.Argument_FieldDeclaringTypeGeneric,
                     f.Name, declaringType.GetGenericTypeDefinition()));

--- a/src/mscorlib/src/System/Reflection/MdFieldInfo.cs
+++ b/src/mscorlib/src/System/Reflection/MdFieldInfo.cs
@@ -112,7 +112,7 @@ namespace System.Reflection
         {
             get
             {
-                if (m_fieldType == null)
+                if (m_fieldType is null)
                 {
                     ConstArray fieldMarshal = GetRuntimeModule().MetadataImport.GetSigOfFieldDef(m_tkField);
 

--- a/src/mscorlib/src/System/Reflection/MemberInfo.Internal.cs
+++ b/src/mscorlib/src/System/Reflection/MemberInfo.Internal.cs
@@ -10,7 +10,7 @@ namespace System.Reflection
 
         internal bool HasSameMetadataDefinitionAsCore<TOther>(MemberInfo other) where TOther : MemberInfo
         {
-            if (other == null)
+            if (other is null)
                 throw new ArgumentNullException(nameof(other));
 
             // Ensure that "other" is a runtime-implemented MemberInfo. Do this check before calling any methods on it!

--- a/src/mscorlib/src/System/Reflection/Metadata/AssemblyExtensions.cs
+++ b/src/mscorlib/src/System/Reflection/Metadata/AssemblyExtensions.cs
@@ -24,7 +24,7 @@ namespace System.Reflection.Metadata
         [CLSCompliant(false)] // out byte* blob
         public unsafe static bool TryGetRawMetadata(this Assembly assembly, out byte* blob, out int length)
         {
-            if (assembly == null)
+            if (assembly is null)
             {
                 throw new ArgumentNullException(nameof(assembly));
             }
@@ -33,7 +33,7 @@ namespace System.Reflection.Metadata
             length = 0;
 
             var runtimeAssembly = assembly as RuntimeAssembly;
-            if (runtimeAssembly == null)
+            if (runtimeAssembly is null)
             {
                 return false;
             }

--- a/src/mscorlib/src/System/Reflection/MethodBase.CoreCLR.cs
+++ b/src/mscorlib/src/System/Reflection/MethodBase.CoreCLR.cs
@@ -20,7 +20,7 @@ namespace System.Reflection
             MethodBase m = RuntimeType.GetMethodBase(handle.GetMethodInfo());
 
             Type declaringType = m.DeclaringType;
-            if (declaringType != null && declaringType.IsGenericType)
+            if (declaringType?.IsGenericType == true)
                 throw new ArgumentException(String.Format(
                     CultureInfo.CurrentCulture, SR.Argument_MethodDeclaringTypeGeneric,
                     m, declaringType.GetGenericTypeDefinition()));

--- a/src/mscorlib/src/System/Reflection/RtFieldInfo.cs
+++ b/src/mscorlib/src/System/Reflection/RtFieldInfo.cs
@@ -34,8 +34,8 @@ namespace System.Reflection
 
                     // first take care of all the NO_INVOKE cases
                     if (
-                        (declaringType != null && declaringType.ContainsGenericParameters) ||
-                        (declaringType == null && Module.Assembly.ReflectionOnly) ||
+                        (declaringType?.ContainsGenericParameters == true) ||
+                        (declaringType is null && Module.Assembly.ReflectionOnly) ||
                         (fIsReflectionOnlyType)
                        )
                     {
@@ -131,10 +131,10 @@ namespace System.Reflection
 
             if ((invocationFlags & INVOCATION_FLAGS.INVOCATION_FLAGS_NO_INVOKE) != 0)
             {
-                if (declaringType != null && declaringType.ContainsGenericParameters)
+                if (declaringType?.ContainsGenericParameters == true)
                     throw new InvalidOperationException(SR.Arg_UnboundGenField);
 
-                if ((declaringType == null && Module.Assembly.ReflectionOnly) || declaringType is ReflectionOnlyType)
+                if ((declaringType is null && Module.Assembly.ReflectionOnly) || declaringType is ReflectionOnlyType)
                     throw new InvalidOperationException(SR.Arg_ReflectionOnlyField);
 
                 throw new FieldAccessException();
@@ -146,7 +146,7 @@ namespace System.Reflection
             value = fieldType.CheckValue(value, binder, culture, invokeAttr);
 
             bool domainInitialized = false;
-            if (declaringType == null)
+            if (declaringType is null)
             {
                 RuntimeFieldHandle.SetValue(this, obj, value, fieldType, m_fieldAttributes, null, ref domainInitialized);
             }
@@ -173,7 +173,7 @@ namespace System.Reflection
             value = fieldType.CheckValue(value, binder, culture, invokeAttr);
 
             bool domainInitialized = false;
-            if (declaringType == null)
+            if (declaringType is null)
             {
                 RuntimeFieldHandle.SetValue(this, obj, value, fieldType, m_fieldAttributes, null, ref domainInitialized);
             }
@@ -194,10 +194,10 @@ namespace System.Reflection
 
             if ((invocationFlags & INVOCATION_FLAGS.INVOCATION_FLAGS_NO_INVOKE) != 0)
             {
-                if (declaringType != null && DeclaringType.ContainsGenericParameters)
+                if (declaringType?.ContainsGenericParameters == true)
                     throw new InvalidOperationException(SR.Arg_UnboundGenField);
 
-                if ((declaringType == null && Module.Assembly.ReflectionOnly) || declaringType is ReflectionOnlyType)
+                if ((declaringType is null && Module.Assembly.ReflectionOnly) || declaringType is ReflectionOnlyType)
                     throw new InvalidOperationException(SR.Arg_ReflectionOnlyField);
 
                 throw new FieldAccessException();
@@ -223,7 +223,7 @@ namespace System.Reflection
             RuntimeType fieldType = (RuntimeType)FieldType;
 
             bool domainInitialized = false;
-            if (declaringType == null)
+            if (declaringType is null)
             {
                 return RuntimeFieldHandle.GetValue(this, obj, fieldType, null, ref domainInitialized);
             }
@@ -320,7 +320,7 @@ namespace System.Reflection
             get
             {
                 Type declaringType = DeclaringType;
-                if ((declaringType == null && Module.Assembly.ReflectionOnly) || declaringType is ReflectionOnlyType)
+                if ((declaringType is null && Module.Assembly.ReflectionOnly) || declaringType is ReflectionOnlyType)
                     throw new InvalidOperationException(SR.InvalidOperation_NotAllowedInReflectionOnly);
                 return new RuntimeFieldHandle(this);
             }
@@ -343,7 +343,7 @@ namespace System.Reflection
         {
             get
             {
-                if (m_fieldType == null)
+                if (m_fieldType is null)
                     m_fieldType = new Signature(this, m_declaringType).FieldType;
 
                 return m_fieldType;

--- a/src/mscorlib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimeAssembly.cs
@@ -105,7 +105,7 @@ namespace System.Reflection
             ImageFileMachine ifm;
 
             Module manifestModule = ManifestModule;
-            if (manifestModule != null)
+            if ((object)manifestModule != null)
             {
                 if (manifestModule.MDStreamVersion > 0x10000)
                 {
@@ -239,12 +239,12 @@ namespace System.Reflection
 
         public override Object[] GetCustomAttributes(Type attributeType, bool inherit)
         {
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             RuntimeType attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
 
-            if (attributeRuntimeType == null)
+            if (attributeRuntimeType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType);
@@ -252,12 +252,12 @@ namespace System.Reflection
 
         public override bool IsDefined(Type attributeType, bool inherit)
         {
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             RuntimeType attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
 
-            if (attributeRuntimeType == null)
+            if (attributeRuntimeType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.IsDefined(this, attributeRuntimeType);
@@ -283,7 +283,7 @@ namespace System.Reflection
             RuntimeAssembly assembly;
             AssemblyName an = CreateAssemblyName(assemblyString, out assembly);
 
-            if (assembly != null)
+            if ((object)assembly != null)
             {
                 // The assembly was returned from ResolveAssemblyEvent
                 return assembly;
@@ -389,7 +389,7 @@ namespace System.Reflection
         public override FileStream GetFile(String name)
         {
             RuntimeModule m = (RuntimeModule)GetModule(name);
-            if (m == null)
+            if (m is null)
                 return null;
 
             return new FileStream(m.GetFullyQualifiedName(),
@@ -545,7 +545,7 @@ namespace System.Reflection
             ref StackCrawlMark stackMark)
         {
             StringBuilder sb = new StringBuilder();
-            if (type == null)
+            if (type is null)
             {
                 if (name == null)
                     throw new ArgumentNullException(nameof(type));
@@ -679,7 +679,7 @@ namespace System.Reflection
             foreach (ModuleResolveEventHandler handler in moduleResolve.GetInvocationList())
             {
                 RuntimeModule ret = (RuntimeModule)handler(this, new ResolveEventArgs(moduleName, this));
-                if (ret != null)
+                if ((object)ret != null)
                     return ret;
             }
 
@@ -726,7 +726,7 @@ namespace System.Reflection
             an.SetPublicKey(GetPublicKey());
             an.Flags = GetFlags() | AssemblyNameFlags.PublicKey;
 
-            if (version == null)
+            if (version is null)
                 an.Version = GetVersion();
             else
                 an.Version = version;
@@ -738,7 +738,7 @@ namespace System.Reflection
                                 IntPtr.Zero,
                                 throwOnFileNotFound);
 
-            if (retAssembly == this || (retAssembly == null && throwOnFileNotFound))
+            if (retAssembly == this || (retAssembly is null && throwOnFileNotFound))
             {
                 throw new FileNotFoundException(String.Format(culture, SR.IO_FileNotFound_FileName, an.Name));
             }
@@ -792,7 +792,7 @@ namespace System.Reflection
                 try
                 {
                     GetForwardedType(this, mdtExternalType, pType);
-                    if (type == null)
+                    if (type is null)
                         continue;  // mdtExternalType was not a forwarder entry.
                 }
                 catch (Exception e)
@@ -803,7 +803,7 @@ namespace System.Reflection
 
                 Debug.Assert((type != null) != (exception != null)); // Exactly one of these must be non-null.
 
-                if (type != null)
+                if ((object)type != null)
                 {
                     types.Add(type);
                     AddPublicNestedTypes(type, types, exceptions);

--- a/src/mscorlib/src/System/Reflection/RuntimeConstructorInfo.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimeConstructorInfo.cs
@@ -40,13 +40,13 @@ namespace System.Reflection
                     //
                     // first take care of all the NO_INVOKE cases. 
                     if (declaringType == typeof(void) ||
-                         (declaringType != null && declaringType.ContainsGenericParameters) ||
+                         (declaringType?.ContainsGenericParameters == true) ||
                          ((CallingConvention & CallingConventions.VarArgs) == CallingConventions.VarArgs))
                     {
                         // We don't need other flags if this method cannot be invoked
                         invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_NO_INVOKE;
                     }
-                    else if (IsStatic || declaringType != null && declaringType.IsAbstract)
+                    else if (IsStatic || declaringType?.IsAbstract == true)
                     {
                         invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_NO_CTOR_INVOKE;
                     }
@@ -155,12 +155,12 @@ namespace System.Reflection
 
         public override Object[] GetCustomAttributes(Type attributeType, bool inherit)
         {
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             RuntimeType attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
 
-            if (attributeRuntimeType == null)
+            if (attributeRuntimeType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType);
@@ -168,12 +168,12 @@ namespace System.Reflection
 
         public override bool IsDefined(Type attributeType, bool inherit)
         {
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             RuntimeType attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
 
-            if (attributeRuntimeType == null)
+            if (attributeRuntimeType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.IsDefined(this, attributeRuntimeType);
@@ -260,7 +260,7 @@ namespace System.Reflection
             get
             {
                 Type declaringType = DeclaringType;
-                if ((declaringType == null && Module.Assembly.ReflectionOnly) || declaringType is ReflectionOnlyType)
+                if ((declaringType is null && Module.Assembly.ReflectionOnly) || declaringType is ReflectionOnlyType)
                     throw new InvalidOperationException(SR.InvalidOperation_NotAllowedInReflectionOnly);
                 return new RuntimeMethodHandle(this);
             }
@@ -284,7 +284,7 @@ namespace System.Reflection
 
         internal static void CheckCanCreateInstance(Type declaringType, bool isVarArg)
         {
-            if (declaringType == null)
+            if (declaringType is null)
                 throw new ArgumentNullException(nameof(declaringType));
 
             // ctor is ReflectOnly
@@ -395,7 +395,7 @@ namespace System.Reflection
         {
             get
             {
-                return (DeclaringType != null && DeclaringType.ContainsGenericParameters);
+                return DeclaringType?.ContainsGenericParameters == true;
             }
         }
         #endregion

--- a/src/mscorlib/src/System/Reflection/RuntimeEventInfo.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimeEventInfo.cs
@@ -72,7 +72,7 @@ namespace System.Reflection
         #region Object Overrides
         public override String ToString()
         {
-            if (m_addMethod == null || m_addMethod.GetParametersNoCopy().Length == 0)
+            if (m_addMethod is null || m_addMethod.GetParametersNoCopy().Length == 0)
                 throw new InvalidOperationException(SR.InvalidOperation_NoPublicAddMethod);
 
             return m_addMethod.GetParametersNoCopy()[0].ParameterType.FormatTypeName() + " " + Name;
@@ -87,12 +87,12 @@ namespace System.Reflection
 
         public override Object[] GetCustomAttributes(Type attributeType, bool inherit)
         {
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             RuntimeType attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
 
-            if (attributeRuntimeType == null)
+            if (attributeRuntimeType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType);
@@ -100,12 +100,12 @@ namespace System.Reflection
 
         public override bool IsDefined(Type attributeType, bool inherit)
         {
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             RuntimeType attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
 
-            if (attributeRuntimeType == null)
+            if (attributeRuntimeType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.IsDefined(this, attributeRuntimeType);

--- a/src/mscorlib/src/System/Reflection/RuntimeFieldInfo.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimeFieldInfo.cs
@@ -85,12 +85,12 @@ namespace System.Reflection
 
         public override Object[] GetCustomAttributes(Type attributeType, bool inherit)
         {
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             RuntimeType attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
 
-            if (attributeRuntimeType == null)
+            if (attributeRuntimeType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType);
@@ -98,12 +98,12 @@ namespace System.Reflection
 
         public override bool IsDefined(Type attributeType, bool inherit)
         {
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             RuntimeType attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
 
-            if (attributeRuntimeType == null)
+            if (attributeRuntimeType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.IsDefined(this, attributeRuntimeType);

--- a/src/mscorlib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -42,7 +42,7 @@ namespace System.Reflection
                     // first take care of all the NO_INVOKE cases. 
                     if (ContainsGenericParameters ||
                          ReturnType.IsByRef ||
-                         (declaringType != null && declaringType.ContainsGenericParameters) ||
+                         (declaringType?.ContainsGenericParameters == true) ||
                          ((CallingConvention & CallingConventions.VarArgs) == CallingConventions.VarArgs))
                     {
                         // We don't need other flags if this method cannot be invoked
@@ -163,7 +163,7 @@ namespace System.Reflection
 
             RuntimeType parent = (RuntimeType)m_declaringType.BaseType;
 
-            if (parent == null)
+            if (parent is null)
                 return null;
 
             int slot = RuntimeMethodHandle.GetSlot(this);
@@ -212,7 +212,7 @@ namespace System.Reflection
 
             RuntimeMethodInfo mi = obj as RuntimeMethodInfo;
 
-            if (mi == null || !mi.IsGenericMethod)
+            if (mi is null || !mi.IsGenericMethod)
                 return false;
 
             // now we know that both operands are generic methods
@@ -252,12 +252,12 @@ namespace System.Reflection
 
         public override Object[] GetCustomAttributes(Type attributeType, bool inherit)
         {
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             RuntimeType attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
 
-            if (attributeRuntimeType == null)
+            if (attributeRuntimeType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType, inherit);
@@ -265,12 +265,12 @@ namespace System.Reflection
 
         public override bool IsDefined(Type attributeType, bool inherit)
         {
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             RuntimeType attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
 
-            if (attributeRuntimeType == null)
+            if (attributeRuntimeType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.IsDefined(this, attributeRuntimeType, inherit);
@@ -374,7 +374,7 @@ namespace System.Reflection
             get
             {
                 Type declaringType = DeclaringType;
-                if ((declaringType == null && Module.Assembly.ReflectionOnly) || declaringType is ReflectionOnlyType)
+                if ((declaringType is null && Module.Assembly.ReflectionOnly) || declaringType is ReflectionOnlyType)
                     throw new InvalidOperationException(SR.InvalidOperation_NotAllowedInReflectionOnly);
                 return new RuntimeMethodHandle(this);
             }
@@ -419,7 +419,7 @@ namespace System.Reflection
         {
             // method is ReflectionOnly
             Type declaringType = DeclaringType;
-            if ((declaringType == null && Module.Assembly.ReflectionOnly) || declaringType is ReflectionOnlyType)
+            if ((declaringType is null && Module.Assembly.ReflectionOnly) || declaringType is ReflectionOnlyType)
             {
                 throw new InvalidOperationException(SR.Arg_ReflectionOnlyInvoke);
             }
@@ -544,7 +544,7 @@ namespace System.Reflection
 
         public override MethodInfo GetBaseDefinition()
         {
-            if (!IsVirtual || IsStatic || m_declaringType == null || m_declaringType.IsInterface)
+            if (!IsVirtual || IsStatic || m_declaringType is null || m_declaringType.IsInterface)
                 return this;
 
             int slot = RuntimeMethodHandle.GetSlot(this);
@@ -563,7 +563,7 @@ namespace System.Reflection
                 baseDeclaringType = declaringType;
 
                 declaringType = (RuntimeType)declaringType.BaseType;
-            } while (declaringType != null);
+            } while ((object)declaringType != null);
 
             return (MethodInfo)RuntimeType.GetMethodBase(baseDeclaringType, baseMethodHandle);
         }
@@ -606,11 +606,11 @@ namespace System.Reflection
         private Delegate CreateDelegateInternal(Type delegateType, Object firstArgument, DelegateBindingFlags bindingFlags, ref StackCrawlMark stackMark)
         {
             // Validate the parameters.
-            if (delegateType == null)
+            if (delegateType is null)
                 throw new ArgumentNullException(nameof(delegateType));
 
             RuntimeType rtType = delegateType as RuntimeType;
-            if (rtType == null)
+            if (rtType is null)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(delegateType));
 
             if (!rtType.IsDelegate())
@@ -643,12 +643,12 @@ namespace System.Reflection
             {
                 Type methodInstantiationElem = methodInstantiation[i];
 
-                if (methodInstantiationElem == null)
+                if (methodInstantiationElem is null)
                     throw new ArgumentNullException();
 
                 RuntimeType rtMethodInstantiationElem = methodInstantiationElem as RuntimeType;
 
-                if (rtMethodInstantiationElem == null)
+                if (rtMethodInstantiationElem is null)
                 {
                     Type[] methodInstantiationCopy = new Type[methodInstantiation.Length];
                     for (int iCopy = 0; iCopy < methodInstantiation.Length; iCopy++)
@@ -718,7 +718,7 @@ namespace System.Reflection
         {
             get
             {
-                if (DeclaringType != null && DeclaringType.ContainsGenericParameters)
+                if (DeclaringType?.ContainsGenericParameters == true)
                     return true;
 
                 if (!IsGenericMethod)

--- a/src/mscorlib/src/System/Reflection/RuntimeModule.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimeModule.cs
@@ -51,10 +51,10 @@ namespace System.Reflection
             for (int i = 0; i < size; i++)
             {
                 Type typeArg = genericArguments[i];
-                if (typeArg == null)
+                if (typeArg is null)
                     throw new ArgumentException(SR.Argument_InvalidGenericInstArray);
                 typeArg = typeArg.UnderlyingSystemType;
-                if (typeArg == null)
+                if (typeArg is null)
                     throw new ArgumentException(SR.Argument_InvalidGenericInstArray);
                 if (!(typeArg is RuntimeType))
                     throw new ArgumentException(SR.Argument_InvalidGenericInstArray);
@@ -245,7 +245,7 @@ namespace System.Reflection
             {
                 Type t = GetModuleHandleImpl().ResolveTypeHandle(metadataToken, typeArgs, methodArgs).GetRuntimeType();
 
-                if (t == null)
+                if (t is null)
                     throw new ArgumentException(SR.Format(SR.Argument_ResolveType, tk, this), nameof(metadataToken));
 
                 return t;
@@ -356,7 +356,7 @@ namespace System.Reflection
         internal MethodInfo GetMethodInternal(String name, BindingFlags bindingAttr, Binder binder,
             CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
         {
-            if (RuntimeType == null)
+            if (RuntimeType is null)
                 return null;
 
             if (types == null)
@@ -375,7 +375,7 @@ namespace System.Reflection
         {
             get
             {
-                if (m_runtimeType == null)
+                if (m_runtimeType is null)
                     m_runtimeType = ModuleHandle.GetModuleType(GetNativeHandle());
 
                 return m_runtimeType;
@@ -407,12 +407,12 @@ namespace System.Reflection
 
         public override Object[] GetCustomAttributes(Type attributeType, bool inherit)
         {
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             RuntimeType attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
 
-            if (attributeRuntimeType == null)
+            if (attributeRuntimeType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType);
@@ -420,12 +420,12 @@ namespace System.Reflection
 
         public override bool IsDefined(Type attributeType, bool inherit)
         {
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             RuntimeType attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
 
-            if (attributeRuntimeType == null)
+            if (attributeRuntimeType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.IsDefined(this, attributeRuntimeType);
@@ -508,7 +508,7 @@ namespace System.Reflection
 
         public override FieldInfo[] GetFields(BindingFlags bindingFlags)
         {
-            if (RuntimeType == null)
+            if (RuntimeType is null)
                 return new FieldInfo[0];
 
             return RuntimeType.GetFields(bindingFlags);
@@ -519,7 +519,7 @@ namespace System.Reflection
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
 
-            if (RuntimeType == null)
+            if (RuntimeType is null)
                 return null;
 
             return RuntimeType.GetField(name, bindingAttr);
@@ -527,7 +527,7 @@ namespace System.Reflection
 
         public override MethodInfo[] GetMethods(BindingFlags bindingFlags)
         {
-            if (RuntimeType == null)
+            if (RuntimeType is null)
                 return new MethodInfo[0];
 
             return RuntimeType.GetMethods(bindingFlags);

--- a/src/mscorlib/src/System/Reflection/RuntimeParameterInfo.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimeParameterInfo.cs
@@ -131,7 +131,7 @@ namespace System.Reflection
         {
             get
             {
-                MethodBase result = m_originalMember != null ? m_originalMember : MemberImpl as MethodBase;
+                MethodBase result = m_originalMember ?? MemberImpl as MethodBase;
                 Debug.Assert(result != null);
                 return result;
             }
@@ -221,7 +221,7 @@ namespace System.Reflection
             get
             {
                 // only instance of ParameterInfo has ClassImpl, all its subclasses don't
-                if (ClassImpl == null)
+                if (ClassImpl is null)
                 {
                     RuntimeType parameterType;
                     if (PositionImpl == -1)
@@ -327,7 +327,7 @@ namespace System.Reflection
                         CustomAttributeData.Filter(
                             CustomAttributeData.GetCustomAttributes(this), typeof(DateTimeConstantAttribute), 0);
 
-                    if (value.ArgumentType != null)
+                    if ((object)value.ArgumentType != null)
                         return new DateTime((long)value.Value);
                 }
                 else
@@ -470,18 +470,12 @@ namespace System.Reflection
 
         internal RuntimeModule GetRuntimeModule()
         {
-            RuntimeMethodInfo method = Member as RuntimeMethodInfo;
-            RuntimeConstructorInfo constructor = Member as RuntimeConstructorInfo;
-            RuntimePropertyInfo property = Member as RuntimePropertyInfo;
-
-            if (method != null)
-                return method.GetRuntimeModule();
-            else if (constructor != null)
-                return constructor.GetRuntimeModule();
-            else if (property != null)
-                return property.GetRuntimeModule();
-            else
-                return null;
+            MemberInfo member = Member;
+            return
+                member is RuntimeMethodInfo m ? m.GetRuntimeModule() :
+                member is RuntimeConstructorInfo c ? c.GetRuntimeModule() :
+                member is RuntimePropertyInfo p ? p.GetRuntimeModule() :
+                null;
         }
 
         public override int MetadataToken
@@ -515,7 +509,7 @@ namespace System.Reflection
 
         public override Object[] GetCustomAttributes(Type attributeType, bool inherit)
         {
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             if (MdToken.IsNullToken(m_tkParamDef))
@@ -523,7 +517,7 @@ namespace System.Reflection
 
             RuntimeType attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
 
-            if (attributeRuntimeType == null)
+            if (attributeRuntimeType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType);
@@ -531,7 +525,7 @@ namespace System.Reflection
 
         public override bool IsDefined(Type attributeType, bool inherit)
         {
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             if (MdToken.IsNullToken(m_tkParamDef))
@@ -539,7 +533,7 @@ namespace System.Reflection
 
             RuntimeType attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
 
-            if (attributeRuntimeType == null)
+            if (attributeRuntimeType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.IsDefined(this, attributeRuntimeType);

--- a/src/mscorlib/src/System/Reflection/RuntimePropertyInfo.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimePropertyInfo.cs
@@ -152,12 +152,12 @@ namespace System.Reflection
 
         public override Object[] GetCustomAttributes(Type attributeType, bool inherit)
         {
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             RuntimeType attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
 
-            if (attributeRuntimeType == null)
+            if (attributeRuntimeType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType);
@@ -165,12 +165,12 @@ namespace System.Reflection
 
         public override bool IsDefined(Type attributeType, bool inherit)
         {
-            if (attributeType == null)
+            if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
             RuntimeType attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
 
-            if (attributeRuntimeType == null)
+            if (attributeRuntimeType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.IsDefined(this, attributeRuntimeType);
@@ -325,7 +325,7 @@ namespace System.Reflection
 
                 // First try to get the Get method.
                 MethodInfo m = GetGetMethod(true);
-                if (m != null)
+                if ((object)m != null)
                 {
                     // There is a Get method so use it.
                     methParams = m.GetParametersNoCopy();
@@ -336,7 +336,7 @@ namespace System.Reflection
                     // If there is no Get method then use the Set method.
                     m = GetSetMethod(true);
 
-                    if (m != null)
+                    if ((object)m != null)
                     {
                         methParams = m.GetParametersNoCopy();
                         numParams = methParams.Length - 1;
@@ -369,7 +369,7 @@ namespace System.Reflection
         {
             get
             {
-                return m_getterMethod != null;
+                return (object)m_getterMethod != null;
             }
         }
 
@@ -377,7 +377,7 @@ namespace System.Reflection
         {
             get
             {
-                return m_setterMethod != null;
+                return (object)m_setterMethod != null;
             }
         }
         #endregion
@@ -396,7 +396,7 @@ namespace System.Reflection
         public override Object GetValue(Object obj, BindingFlags invokeAttr, Binder binder, Object[] index, CultureInfo culture)
         {
             MethodInfo m = GetGetMethod(true);
-            if (m == null)
+            if (m is null)
                 throw new ArgumentException(System.SR.Arg_GetMethNotFnd);
             return m.Invoke(obj, invokeAttr, binder, index, null);
         }
@@ -419,7 +419,7 @@ namespace System.Reflection
         {
             MethodInfo m = GetSetMethod(true);
 
-            if (m == null)
+            if (m is null)
                 throw new ArgumentException(System.SR.Arg_SetMethNotFnd);
 
             Object[] args = null;

--- a/src/mscorlib/src/System/Resources/FileBasedResourceGroveler.cs
+++ b/src/mscorlib/src/System/Resources/FileBasedResourceGroveler.cs
@@ -61,7 +61,7 @@ namespace System.Resources
                     {
                         // We really don't think this should happen - we always
                         // expect the neutral locale's resources to be present.
-                        throw new MissingManifestResourceException(SR.MissingManifestResource_NoNeutralDisk + Environment.NewLine + "baseName: " + _mediator.BaseNameField + "  locationInfo: " + (_mediator.LocationInfo == null ? "<null>" : _mediator.LocationInfo.FullName) + "  fileName: " + _mediator.GetResourceFileName(culture));
+                        throw new MissingManifestResourceException(SR.MissingManifestResource_NoNeutralDisk + Environment.NewLine + "baseName: " + _mediator.BaseNameField + "  locationInfo: " + (_mediator.LocationInfo is null ? "<null>" : _mediator.LocationInfo.FullName) + "  fileName: " + _mediator.GetResourceFileName(culture));
                     }
                 }
             }
@@ -108,7 +108,7 @@ namespace System.Resources
         {
             Debug.Assert(file != null, "file shouldn't be null; check caller");
 
-            if (_mediator.UserResourceSet == null)
+            if (_mediator.UserResourceSet is null)
             {
                 return new RuntimeResourceSet(file);
             }

--- a/src/mscorlib/src/System/Resources/ManifestBasedResourceGroveler.cs
+++ b/src/mscorlib/src/System/Resources/ManifestBasedResourceGroveler.cs
@@ -80,7 +80,7 @@ namespace System.Resources
             {
                 satellite = GetSatelliteAssembly(lookForCulture, ref stackMark);
 
-                if (satellite == null)
+                if (satellite is null)
                 {
                     bool raiseException = (culture.HasInvariantCultureName && (_mediator.FallbackLoc == UltimateResourceFallbackLocation.Satellite));
                     // didn't find satellite, give error if necessary
@@ -96,7 +96,7 @@ namespace System.Resources
             String fileName = _mediator.GetResourceFileName(lookForCulture);
 
             // 3. If we identified an assembly to search; look in manifest resource stream for resource file
-            if (satellite != null)
+            if ((object)satellite != null)
             {
                 // Handle case in here where someone added a callback for assembly load events.
                 // While no other threads have called into GetResourceSet, our own thread can!
@@ -259,7 +259,7 @@ namespace System.Resources
                         resourceSetArgs[0] = reader;
 
                         Type resSetType;
-                        if (_mediator.UserResourceSet == null)
+                        if (_mediator.UserResourceSet is null)
                         {
                             Debug.Assert(resSetTypeName != null, "We should have a ResourceSet type name from the custom resource file here.");
                             resSetType = Type.GetType(resSetTypeName, true, false);
@@ -281,7 +281,7 @@ namespace System.Resources
                 }
             }
 
-            if (_mediator.UserResourceSet == null)
+            if (_mediator.UserResourceSet is null)
             {
                 return new RuntimeResourceSet(store);
             }
@@ -344,7 +344,7 @@ namespace System.Resources
             Debug.Assert(name != null, "name shouldn't be null; check caller");
 
             StringBuilder sb = new StringBuilder();
-            if (_mediator.LocationInfo != null)
+            if ((object)_mediator.LocationInfo != null)
             {
                 String nameSpace = _mediator.LocationInfo.Namespace;
                 if (nameSpace != null)
@@ -441,7 +441,7 @@ namespace System.Resources
             Debug.Assert(readerTypeName != null, "readerTypeName shouldn't be null; check caller");
             Debug.Assert(resSetTypeName != null, "resSetTypeName shouldn't be null; check caller");
 
-            if (_mediator.UserResourceSet != null)
+            if ((object)_mediator.UserResourceSet != null)
                 return false;
 
             // Ignore the actual version of the ResourceReader and 
@@ -474,7 +474,7 @@ namespace System.Resources
         private void HandleSatelliteMissing()
         {
             String satAssemName = _mediator.MainAssembly.GetSimpleName() + ".resources.dll";
-            if (_mediator.SatelliteContractVersion != null)
+            if ((object)_mediator.SatelliteContractVersion != null)
             {
                 satAssemName += ", Version=" + _mediator.SatelliteContractVersion.ToString();
             }
@@ -514,7 +514,7 @@ namespace System.Resources
             // We really don't think this should happen - we always
             // expect the neutral locale's resources to be present.
             String resName = String.Empty;
-            if (_mediator.LocationInfo != null && _mediator.LocationInfo.Namespace != null)
+            if (_mediator.LocationInfo?.Namespace != null)
                 resName = _mediator.LocationInfo.Namespace + Type.Delimiter;
             resName += fileName;
             throw new MissingManifestResourceException(SR.Format(SR.MissingManifestResource_NoNeutralAsm, resName, _mediator.MainAssembly.GetSimpleName()));

--- a/src/mscorlib/src/System/Resources/ResourceManager.cs
+++ b/src/mscorlib/src/System/Resources/ResourceManager.cs
@@ -274,7 +274,7 @@ namespace System.Resources
             if (null == baseName)
                 throw new ArgumentNullException(nameof(baseName));
 
-            if (null == assembly)
+            if (assembly is null)
                 throw new ArgumentNullException(nameof(assembly));
 
             if (!(assembly is RuntimeAssembly))
@@ -303,7 +303,7 @@ namespace System.Resources
         {
             if (null == baseName)
                 throw new ArgumentNullException(nameof(baseName));
-            if (null == assembly)
+            if (assembly is null)
                 throw new ArgumentNullException(nameof(assembly));
 
             if (!(assembly is RuntimeAssembly))
@@ -312,7 +312,7 @@ namespace System.Resources
             MainAssembly = assembly;
             BaseNameField = baseName;
 
-            if (usingResourceSet != null && (usingResourceSet != _minResourceSet) && !(usingResourceSet.IsSubclassOf(_minResourceSet)))
+            if ((object)usingResourceSet != null && (usingResourceSet != _minResourceSet) && !(usingResourceSet.IsSubclassOf(_minResourceSet)))
                 throw new ArgumentException(SR.Arg_ResMgrNotResSet, nameof(usingResourceSet));
             _userResourceSet = usingResourceSet;
 
@@ -329,7 +329,7 @@ namespace System.Resources
         [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
         public ResourceManager(Type resourceSource)
         {
-            if (null == resourceSource)
+            if (resourceSource is null)
                 throw new ArgumentNullException(nameof(resourceSource));
 
             if (!(resourceSource is RuntimeType))
@@ -387,7 +387,7 @@ namespace System.Resources
         // to construct ResourceSets.
         public virtual Type ResourceSetType
         {
-            get { return (_userResourceSet == null) ? typeof(RuntimeResourceSet) : _userResourceSet; }
+            get { return (_userResourceSet is null) ? typeof(RuntimeResourceSet) : _userResourceSet; }
         }
 
         protected UltimateResourceFallbackLocation FallbackLocation
@@ -666,7 +666,7 @@ namespace System.Resources
         protected static Version GetSatelliteContractVersion(Assembly a)
         {
             // Ensure that the assembly reference is not null
-            if (a == null)
+            if (a is null)
             {
                 throw new ArgumentNullException(nameof(a), SR.ArgumentNull_Assembly);
             }
@@ -839,10 +839,10 @@ namespace System.Resources
 
             RuntimeAssembly resourcesAssembly = (RuntimeAssembly)MainAssembly;
 
-            if (resourcesAssembly == null)
+            if (resourcesAssembly is null)
                 resourcesAssembly = _callingAssembly;
 
-            if (resourcesAssembly != null)
+            if ((object)resourcesAssembly != null)
             {
                 if (resourcesAssembly != typeof(Object).Assembly) // We are not loading resources for mscorlib
                 {
@@ -853,7 +853,7 @@ namespace System.Resources
                         s_IsAppXModel = true;
 
                         // If we have the type information from the ResourceManager(Type) constructor, we use it. Otherwise, we use BaseNameField.
-                        String reswFilename = _locationInfo == null ? BaseNameField : _locationInfo.FullName;
+                        String reswFilename = _locationInfo is null ? BaseNameField : _locationInfo.FullName;
 
                         // The only way this can happen is if a class inherited from ResourceManager and
                         // did not set the BaseNameField before calling the protected ResourceManager() constructor.

--- a/src/mscorlib/src/System/Resources/ResourceReader.cs
+++ b/src/mscorlib/src/System/Resources/ResourceReader.cs
@@ -942,7 +942,7 @@ namespace System.Resources
             {
                 throw new BadImageFormatException(SR.BadImageFormat_InvalidType);
             }
-            if (_typeTable[typeIndex] == null)
+            if (_typeTable[typeIndex] is null)
             {
                 long oldPos = _store.BaseStream.Position;
                 try

--- a/src/mscorlib/src/System/RtType.cs
+++ b/src/mscorlib/src/System/RtType.cs
@@ -449,7 +449,7 @@ namespace System
                                     int memberCount = m_allMembers.Length;
                                     while (memberCount > 0)
                                     {
-                                        if (m_allMembers[memberCount - 1] != null)
+                                        if ((object)m_allMembers[memberCount - 1] != null)
                                             break;
                                         memberCount--;
                                     }
@@ -498,7 +498,7 @@ namespace System
                         for (cachedIndex = 0; cachedIndex < cachedCount; cachedIndex++)
                         {
                             T cachedMemberInfo = cachedMembers[cachedIndex];
-                            if (cachedMemberInfo == null)
+                            if (cachedMemberInfo is null)
                                 break;
 
                             if (newMemberInfo.CacheEquals(cachedMemberInfo))
@@ -719,7 +719,7 @@ namespace System
                             }
 
                             declaringType = RuntimeTypeHandle.GetBaseType(declaringType);
-                        } while (declaringType != null);
+                        } while ((object)declaringType != null);
                         #endregion
                     }
 
@@ -792,7 +792,7 @@ namespace System
                     while (RuntimeTypeHandle.IsGenericVariable(declaringType))
                         declaringType = declaringType.GetBaseType();
 
-                    while (declaringType != null)
+                    while ((object)declaringType != null)
                     {
                         PopulateRtFields(filter, declaringType, ref list);
 
@@ -1141,7 +1141,7 @@ namespace System
                             declaringType = declaringType.GetBaseType();
 
                         // Populate associates off of the class hierarchy
-                        while (declaringType != null)
+                        while ((object)declaringType != null)
                         {
                             PopulateEvents(filter, declaringType, csEventInfos, ref list);
                             declaringType = RuntimeTypeHandle.GetBaseType(declaringType);
@@ -1245,7 +1245,7 @@ namespace System
                         {
                             PopulateProperties(filter, declaringType, csPropertyInfos, usedSlots, ref list);
                             declaringType = RuntimeTypeHandle.GetBaseType(declaringType);
-                        } while (declaringType != null);
+                        } while ((object)declaringType != null);
                     }
                     else
                     {
@@ -1325,14 +1325,14 @@ namespace System
                             // the getter/setter of the former.
 
                             MethodInfo associateMethod = propertyInfo.GetGetMethod();
-                            if (associateMethod == null)
+                            if (associateMethod is null)
                             {
                                 // We only need to examine the setter if a getter doesn't exist.
                                 // It is not logical for the getter to be virtual but not the setter.
                                 associateMethod = propertyInfo.GetSetMethod();
                             }
 
-                            if (associateMethod != null)
+                            if ((object)associateMethod != null)
                             {
                                 int slot = RuntimeMethodHandle.GetSlot((RuntimeMethodInfo)associateMethod);
 
@@ -1583,7 +1583,7 @@ namespace System
 
             internal unsafe RuntimeType GetEnclosingType()
             {
-                if (m_enclosingType == null)
+                if (m_enclosingType is null)
                 {
                     // Use void as a marker of null enclosing type
                     RuntimeType enclosingType = RuntimeTypeHandle.GetDeclaringType(GetRuntimeType());
@@ -1615,7 +1615,7 @@ namespace System
                 {
                     CustomAttributeData attr = null;
                     Type DefaultMemberAttrType = typeof(DefaultMemberAttribute);
-                    for (RuntimeType t = m_runtimeType; t != null; t = t.GetBaseType())
+                    for (RuntimeType t = m_runtimeType; (object)t != null; t = t.GetBaseType())
                     {
                         IList<CustomAttributeData> attrs = CustomAttributeData.GetCustomAttributes(t);
                         for (int i = 0; i < attrs.Count; i++)
@@ -1657,7 +1657,7 @@ namespace System
                 {
                     crmi = s_methodInstantiations[rmi];
                 }
-                if (crmi != null)
+                if ((object)crmi != null)
                     return crmi;
 
                 if (s_methodInstantiationsLock == null)
@@ -1672,14 +1672,14 @@ namespace System
                     if (la != null)
                     {
                         crmi = la.m_methodInstantiations[rmi];
-                        if (crmi != null)
+                        if ((object)crmi != null)
                             return crmi;
                         la.m_methodInstantiations[rmi] = rmi;
                     }
                     else
                     {
                         crmi = s_methodInstantiations[rmi];
-                        if (crmi != null)
+                        if ((object)crmi != null)
                             return crmi;
                         s_methodInstantiations[rmi] = rmi;
                     }
@@ -1801,7 +1801,7 @@ namespace System
 
             RuntimeType[] methodInstantiation = null;
 
-            if (reflectedType == null)
+            if (reflectedType is null)
                 reflectedType = declaredType as RuntimeType;
 
             if (reflectedType != declaredType && !reflectedType.IsSubclassOf(declaredType))
@@ -1840,7 +1840,7 @@ namespace System
 
                     RuntimeType baseType = reflectedType;
 
-                    while (baseType != null)
+                    while ((object)baseType != null)
                     {
                         RuntimeType baseDefinition = baseType;
 
@@ -1853,7 +1853,7 @@ namespace System
                         baseType = baseType.GetBaseType();
                     }
 
-                    if (baseType == null)
+                    if (baseType is null)
                     {
                         // ignoring instantiation is the ReflectedType is not a subtype of the DeclaringType
                         throw new ArgumentException(String.Format(
@@ -1934,7 +1934,7 @@ namespace System
             RuntimeFieldHandleInternal fieldHandle = field.Value;
 
             // verify the type/method relationship
-            if (reflectedType == null)
+            if (reflectedType is null)
             {
                 reflectedType = RuntimeFieldHandle.GetApproxDeclaringType(fieldHandle);
             }
@@ -1992,7 +1992,7 @@ namespace System
 
             for (int i = 0; i < genericArguments.Length; i++)
             {
-                if (genericArguments[i] == null)
+                if (genericArguments[i] is null)
                     throw new ArgumentNullException();
 
                 ThrowIfTypeNeverValidGenericArgument(genericArguments[i]);
@@ -2022,7 +2022,7 @@ namespace System
                 methodContext = genericArguments;
 
                 RuntimeType declaringType = (RuntimeType)genericMethodDefinition.DeclaringType;
-                if (declaringType != null)
+                if ((object)declaringType != null)
                 {
                     typeContext = declaringType.GetTypeHandleInternal().GetInstantiationInternal();
                 }
@@ -2240,7 +2240,7 @@ namespace System
             {
                 MethodInfo methodInfo = memberInfo as MethodInfo;
 
-                if (methodInfo == null)
+                if (methodInfo is null)
                     return false;
 
                 if (!methodInfo.IsVirtual && !methodInfo.IsAbstract)
@@ -2716,7 +2716,7 @@ namespace System
 
             RuntimeType ifaceRtType = ifaceType as RuntimeType;
 
-            if (ifaceRtType == null)
+            if (ifaceRtType is null)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(ifaceType));
 
             RuntimeTypeHandle ifaceRtTypeHandle = ifaceRtType.GetTypeHandleInternal();
@@ -2909,7 +2909,7 @@ namespace System
                 RuntimeEventInfo eventInfo = cache[i];
                 if ((bindingAttr & eventInfo.BindingFlags) == eventInfo.BindingFlags)
                 {
-                    if (match != null)
+                    if ((object)match != null)
                         throw new AmbiguousMatchException(SR.Arg_AmbiguousMatchException);
 
                     match = eventInfo;
@@ -2938,7 +2938,7 @@ namespace System
                 RuntimeFieldInfo fieldInfo = cache[i];
                 if ((bindingAttr & fieldInfo.BindingFlags) == fieldInfo.BindingFlags)
                 {
-                    if (match != null)
+                    if ((object)match != null)
                     {
                         if (Object.ReferenceEquals(fieldInfo.DeclaringType, match.DeclaringType))
                             throw new AmbiguousMatchException(SR.Arg_AmbiguousMatchException);
@@ -2947,7 +2947,7 @@ namespace System
                             multipleStaticFieldMatches = true;
                     }
 
-                    if (match == null || fieldInfo.DeclaringType.IsSubclassOf(match.DeclaringType) || match.DeclaringType.IsInterface)
+                    if (match is null || fieldInfo.DeclaringType.IsSubclassOf(match.DeclaringType) || match.DeclaringType.IsInterface)
                         match = fieldInfo;
                 }
             }
@@ -2983,7 +2983,7 @@ namespace System
                 RuntimeType iface = cache[i];
                 if (RuntimeType.FilterApplyType(iface, bindingAttr, name, false, ns))
                 {
-                    if (match != null)
+                    if ((object)match != null)
                         throw new AmbiguousMatchException(SR.Arg_AmbiguousMatchException);
 
                     match = iface;
@@ -3013,7 +3013,7 @@ namespace System
                 RuntimeType nestedType = cache[i];
                 if (RuntimeType.FilterApplyType(nestedType, bindingAttr, name, false, ns))
                 {
-                    if (match != null)
+                    if ((object)match != null)
                         throw new AmbiguousMatchException(SR.Arg_AmbiguousMatchException);
 
                     match = nestedType;
@@ -3237,12 +3237,12 @@ namespace System
             if ((object)type == null)
                 throw new ArgumentNullException(nameof(type));
             RuntimeType rtType = type as RuntimeType;
-            if (rtType == null)
+            if (rtType is null)
                 return false;
 
             RuntimeType baseType = GetBaseType();
 
-            while (baseType != null)
+            while ((object)baseType != null)
             {
                 if (baseType == rtType)
                     return true;
@@ -3261,7 +3261,7 @@ namespace System
 
         public override bool IsAssignableFrom(System.Reflection.TypeInfo typeInfo)
         {
-            if (typeInfo == null) return false;
+            if (typeInfo is null) return false;
             return IsAssignableFrom(typeInfo.AsType());
         }
 
@@ -3276,7 +3276,7 @@ namespace System
             RuntimeType fromType = c.UnderlyingSystemType as RuntimeType;
 
             // For runtime type, let the VM decide.
-            if (fromType != null)
+            if ((object)fromType != null)
             {
                 // both this and c (or their underlying system types) are runtime types
                 return RuntimeTypeHandle.CanCastTo(fromType, this);
@@ -3691,12 +3691,12 @@ namespace System
             for (int i = 0; i < instantiation.Length; i++)
             {
                 Type instantiationElem = instantiation[i];
-                if (instantiationElem == null)
+                if (instantiationElem is null)
                     throw new ArgumentNullException();
 
                 RuntimeType rtInstantiationElem = instantiationElem as RuntimeType;
 
-                if (rtInstantiationElem == null)
+                if (rtInstantiationElem is null)
                 {
                     foundNonRuntimeType = true;
                     if (instantiationElem.IsSignatureType)
@@ -4145,7 +4145,7 @@ namespace System
                 }
                 #endregion
 
-                if (selFld != null)
+                if ((object)selFld != null)
                 {
                     #region Invocation on a field
                     if (selFld.FieldType.IsArray || Object.ReferenceEquals(selFld.FieldType, typeof(System.Array)))
@@ -4292,7 +4292,7 @@ namespace System
                     if (!FilterApplyMethodInfo((RuntimeMethodInfo)semiFinalist, bindingFlags, CallingConventions.Any, new Type[argCnt]))
                         continue;
 
-                    if (finalist == null)
+                    if (finalist is null)
                     {
                         finalist = semiFinalist;
                     }
@@ -4321,7 +4321,7 @@ namespace System
             Debug.Assert(finalists == null || finalist != null);
 
             #region BindingFlags.GetProperty or BindingFlags.SetProperty
-            if (finalist == null && isGetProperty || isSetProperty)
+            if (finalist is null && isGetProperty || isSetProperty)
             {
                 #region Lookup Property
                 PropertyInfo[] semiFinalists = GetMember(name, MemberTypes.Property, bindingFlags) as PropertyInfo[];
@@ -4340,13 +4340,13 @@ namespace System
                         semiFinalist = semiFinalists[i].GetGetMethod(true);
                     }
 
-                    if (semiFinalist == null)
+                    if (semiFinalist is null)
                         continue;
 
                     if (!FilterApplyMethodInfo((RuntimeMethodInfo)semiFinalist, bindingFlags, CallingConventions.Any, new Type[argCnt]))
                         continue;
 
-                    if (finalist == null)
+                    if (finalist is null)
                     {
                         finalist = semiFinalist;
                     }
@@ -4372,7 +4372,7 @@ namespace System
             }
             #endregion
 
-            if (finalist != null)
+            if ((object)finalist != null)
             {
                 #region Invoke
                 if (finalists == null &&
@@ -4400,7 +4400,7 @@ namespace System
                 try { invokeMethod = binder.BindToMethod(bindingFlags, finalists, ref providedArgs, modifiers, culture, namedParams, out state); }
                 catch (MissingMethodException) { }
 
-                if (invokeMethod == null)
+                if (invokeMethod is null)
                     throw new MissingMethodException(FullName, name);
 
                 //if (useCache && argCnt == invokeMethod.GetParameters().Length)
@@ -4459,7 +4459,7 @@ namespace System
 
             RuntimeType attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
 
-            if (attributeRuntimeType == null)
+            if (attributeRuntimeType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType, inherit);
@@ -4472,7 +4472,7 @@ namespace System
 
             RuntimeType attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
 
-            if (attributeRuntimeType == null)
+            if (attributeRuntimeType is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.IsDefined(this, attributeRuntimeType, inherit);
@@ -4656,7 +4656,7 @@ namespace System
                 }
                 catch (MissingMethodException) { invokeMethod = null; }
 
-                if (invokeMethod == null)
+                if (invokeMethod is null)
                 {
                     throw new MissingMethodException(SR.Format(SR.MissingConstructor_Name, FullName));
                 }
@@ -4727,7 +4727,7 @@ namespace System
                 {
                     Debug.Assert(!ace.m_hCtorMethodHandle.IsNullHandle(), "Expected the default ctor method handle for a reference type.");
 
-                    if (delegateCtorInfo == null)
+                    if (delegateCtorInfo is null)
                         InitializeDelegateCreator();
 
                     // No synchronization needed here. In the worst case we create extra garbage

--- a/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
@@ -241,7 +241,7 @@ namespace System.Runtime.InteropServices
 
         public static int SizeOf(Type t)
         {
-            if (t == null)
+            if (t is null)
                 throw new ArgumentNullException(nameof(t));
             if (!(t is RuntimeType))
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(t));
@@ -264,14 +264,14 @@ namespace System.Runtime.InteropServices
         //====================================================================
         public static IntPtr OffsetOf(Type t, String fieldName)
         {
-            if (t == null)
+            if (t is null)
                 throw new ArgumentNullException(nameof(t));
 
             FieldInfo f = t.GetField(fieldName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-            if (f == null)
+            if (f is null)
                 throw new ArgumentException(SR.Format(SR.Argument_OffsetOfFieldNotFound, t.FullName), nameof(fieldName));
             RtFieldInfo rtField = f as RtFieldInfo;
-            if (rtField == null)
+            if (rtField is null)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeFieldInfo, nameof(fieldName));
 
             return OffsetOfHelper(rtField);
@@ -835,12 +835,12 @@ namespace System.Runtime.InteropServices
         //====================================================================
         public static void Prelink(MethodInfo m)
         {
-            if (m == null)
+            if (m is null)
                 throw new ArgumentNullException(nameof(m));
 
             RuntimeMethodInfo rmi = m as RuntimeMethodInfo;
 
-            if (rmi == null)
+            if (rmi is null)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeMethodInfo);
 
             InternalPrelink(rmi);
@@ -851,7 +851,7 @@ namespace System.Runtime.InteropServices
 
         public static void PrelinkAll(Type c)
         {
-            if (c == null)
+            if (c is null)
                 throw new ArgumentNullException(nameof(c));
 
             MethodInfo[] mi = c.GetMethods();
@@ -905,7 +905,7 @@ namespace System.Runtime.InteropServices
         {
             if (ptr == IntPtr.Zero) return null;
 
-            if (structureType == null)
+            if (structureType is null)
                 throw new ArgumentNullException(nameof(structureType));
 
             if (structureType.IsGenericType)
@@ -913,7 +913,7 @@ namespace System.Runtime.InteropServices
 
             RuntimeType rt = structureType.UnderlyingSystemType as RuntimeType;
 
-            if (rt == null)
+            if (rt is null)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(structureType));
 
             Object structure = rt.CreateInstanceDefaultCtor(false /*publicOnly*/, false /*skipCheckThis*/, false /*fillCache*/, true /*wrapExceptions*/);
@@ -953,18 +953,18 @@ namespace System.Runtime.InteropServices
         //====================================================================
         public static IntPtr GetHINSTANCE(Module m)
         {
-            if (m == null)
+            if (m is null)
                 throw new ArgumentNullException(nameof(m));
 
             RuntimeModule rtModule = m as RuntimeModule;
-            if (rtModule == null)
+            if (rtModule is null)
             {
                 ModuleBuilder mb = m as ModuleBuilder;
-                if (mb != null)
+                if ((object)mb != null)
                     rtModule = mb.InternalModule;
             }
 
-            if (rtModule == null)
+            if (rtModule is null)
                 throw new ArgumentNullException(nameof(m), SR.Argument_MustBeRuntimeModule);
 
             return GetHINSTANCE(rtModule.GetNativeHandle());
@@ -1529,7 +1529,7 @@ namespace System.Runtime.InteropServices
         public static Object CreateWrapperOfType(Object o, Type t)
         {
             // Validate the arguments.
-            if (t == null)
+            if (t is null)
                 throw new ArgumentNullException(nameof(t));
             if (!t.IsCOMObject)
                 throw new ArgumentException(SR.Argument_TypeNotComObject, nameof(t));
@@ -1654,7 +1654,7 @@ namespace System.Runtime.InteropServices
         //====================================================================
         public static String GenerateProgIdForType(Type type)
         {
-            if (type == null)
+            if (type is null)
                 throw new ArgumentNullException(nameof(type));
             if (type.IsImport)
                 throw new ArgumentException(SR.Argument_TypeMustNotBeComImport, nameof(type));
@@ -1721,7 +1721,7 @@ namespace System.Runtime.InteropServices
             Assembly sys = Assembly.Load("System, Version=" + ThisAssembly.Version +
                 ", Culture=neutral, PublicKeyToken=" + AssemblyRef.EcmaPublicKeyToken);
             Type t = sys.GetType("System.ComponentModel.LicenseManager");
-            if (t == null || !t.IsVisible)
+            if (t is null || !t.IsVisible)
                 return IntPtr.Zero;
             return t.TypeHandle.Value;
         }
@@ -1751,17 +1751,17 @@ namespace System.Runtime.InteropServices
             if (ptr == IntPtr.Zero)
                 throw new ArgumentNullException(nameof(ptr));
 
-            if (t == null)
+            if (t is null)
                 throw new ArgumentNullException(nameof(t));
 
-            if ((t as RuntimeType) == null)
+            if (!(t is RuntimeType))
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(t));
 
             if (t.IsGenericType)
                 throw new ArgumentException(SR.Argument_NeedNonGenericType, nameof(t));
 
             Type c = t.BaseType;
-            if (c == null || (c != typeof(Delegate) && c != typeof(MulticastDelegate)))
+            if (c is null || (c != typeof(Delegate) && c != typeof(MulticastDelegate)))
                 throw new ArgumentException(SR.Arg_MustBeDelegate, nameof(t));
 
             return GetDelegateForFunctionPointerInternal(ptr, t);

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/CustomPropertyImpl.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/CustomPropertyImpl.cs
@@ -28,7 +28,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         //
         public CustomPropertyImpl(PropertyInfo propertyInfo)
         {
-            if (propertyInfo == null)
+            if (propertyInfo is null)
                 throw new ArgumentNullException(nameof(propertyInfo));
 
             m_property = propertyInfo;
@@ -51,7 +51,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             get
             {
                 // Return false if the getter is not public
-                return m_property.GetGetMethod() != null;
+                return (object)m_property.GetGetMethod() != null;
             }
         }
 
@@ -60,7 +60,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             get
             {
                 // Return false if the setter is not public
-                return m_property.GetSetMethod() != null;
+                return (object)m_property.GetSetMethod() != null;
             }
         }
 
@@ -105,7 +105,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             // We get non-public accessors just so that we can throw the correct exception.
             MethodInfo accessor = getValue ? m_property.GetGetMethod(true) : m_property.GetSetMethod(true);
 
-            if (accessor == null)
+            if (accessor is null)
                 throw new ArgumentException(getValue ? SR.Arg_GetMethNotFnd : SR.Arg_SetMethNotFnd);
 
             if (!accessor.IsPublic)
@@ -117,7 +117,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
                         accessor.DeclaringType.FullName));
 
             RuntimeMethodInfo rtMethod = accessor as RuntimeMethodInfo;
-            if (rtMethod == null)
+            if (rtMethod is null)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeMethodInfo);
 
             // We can safely skip access check because this is only used in full trust scenarios.

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/ICustomPropertyProvider.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/ICustomPropertyProvider.cs
@@ -40,10 +40,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
                 propertyName,
                 BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public);
 
-            if (propertyInfo == null)
-                return null;
-            else
-                return new CustomPropertyImpl(propertyInfo);
+            return propertyInfo is null ? null : new CustomPropertyImpl(propertyInfo);
         }
 
         //
@@ -80,10 +77,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
                 null                                                                    // ignore type modifier
                 );
 
-            if (propertyInfo == null)
-                return null;
-            else
-                return new CustomPropertyImpl(propertyInfo);
+            return propertyInfo is null ? null : new CustomPropertyImpl(propertyInfo);
         }
 
         static internal unsafe void GetType(object target, TypeNameNative* pIndexedParamType)

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/ManagedActivationFactory.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/ManagedActivationFactory.cs
@@ -34,7 +34,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
         internal ManagedActivationFactory(Type type)
         {
-            if (type == null)
+            if (type is null)
                 throw new ArgumentNullException(nameof(type));
 
             // Check whether the type is "exported to WinRT", i.e. it is declared in a managed .winmd and is decorated

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeMarshal.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeMarshal.cs
@@ -1219,7 +1219,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         //
         public static IActivationFactory GetActivationFactory(Type type)
         {
-            if (type == null)
+            if (type is null)
                 throw new ArgumentNullException(nameof(type));
 
             if (type.IsWindowsRuntimeObject && type.IsImport)

--- a/src/mscorlib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/mscorlib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -196,7 +196,7 @@ namespace System.Runtime.Loader
                 foreach (Func<AssemblyLoadContext, AssemblyName, Assembly> handler in assemblyResolveHandler.GetInvocationList())
                 {
                     resolvedAssembly = handler(this, assemblyName);
-                    if (resolvedAssembly != null)
+                    if ((object)resolvedAssembly != null)
                     {
                         break;
                     }
@@ -215,7 +215,7 @@ namespace System.Runtime.Loader
             // which is a RuntimeAssembly instance. However, since Assembly type can be used build any other artifact (e.g. AssemblyBuilder),
             // we need to check for RuntimeAssembly.
             RuntimeAssembly rtLoadedAssembly = assembly as RuntimeAssembly;
-            if (rtLoadedAssembly != null)
+            if ((object)rtLoadedAssembly != null)
             {
                 loadedSimpleName = rtLoadedAssembly.GetSimpleName();
             }
@@ -232,7 +232,7 @@ namespace System.Runtime.Loader
             string simpleName = assemblyName.Name;
             Assembly assembly = Load(assemblyName);
 
-            if (assembly != null)
+            if ((object)assembly != null)
             {
                 assembly = ValidateAssemblyNameWithSimpleName(assembly, simpleName);
             }
@@ -246,14 +246,14 @@ namespace System.Runtime.Loader
 
             // Invoke the AssemblyResolve event callbacks if wired up
             Assembly assembly = GetFirstResolvedAssembly(assemblyName);
-            if (assembly != null)
+            if ((object)assembly != null)
             {
                 assembly = ValidateAssemblyNameWithSimpleName(assembly, simpleName);
             }
 
             // Since attempt to resolve the assembly via Resolving event is the last option,
             // throw an exception if we do not find any assembly.
-            if (assembly == null)
+            if (assembly is null)
             {
                 throw new FileNotFoundException(SR.IO_FileLoad, simpleName);
             }
@@ -350,7 +350,7 @@ namespace System.Runtime.Loader
         // Returns the load context in which the specified assembly has been loaded
         public static AssemblyLoadContext GetLoadContext(Assembly assembly)
         {
-            if (assembly == null)
+            if (assembly is null)
             {
                 throw new ArgumentNullException(nameof(assembly));
             }
@@ -360,7 +360,7 @@ namespace System.Runtime.Loader
             RuntimeAssembly rtAsm = assembly as RuntimeAssembly;
 
             // We only support looking up load context for runtime assemblies.
-            if (rtAsm != null)
+            if ((object)rtAsm != null)
             {
                 IntPtr ptrAssemblyLoadContext = GetLoadContextForAssembly(rtAsm);
                 if (ptrAssemblyLoadContext == IntPtr.Zero)

--- a/src/mscorlib/src/System/Runtime/Serialization/SerializationInfo.cs
+++ b/src/mscorlib/src/System/Runtime/Serialization/SerializationInfo.cs
@@ -440,13 +440,12 @@ namespace System.Runtime.Serialization
 
         public Object GetValue(String name, Type type)
         {
-            if ((object)type == null)
+            if (type is null)
             {
                 throw new ArgumentNullException(nameof(type));
             }
 
-            RuntimeType rt = type as RuntimeType;
-            if (rt == null)
+            if (!(type is RuntimeType))
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType);
 
             Type foundType;

--- a/src/mscorlib/src/System/RuntimeHandles.cs
+++ b/src/mscorlib/src/System/RuntimeHandles.cs
@@ -29,7 +29,7 @@ namespace System
         {
             // Create local copy to avoid a race condition
             RuntimeType type = m_type;
-            if (type == null)
+            if (type is null)
                 throw new ArgumentNullException(null, SR.Arg_InvalidHandle);
             return new RuntimeTypeHandle(type);
         }
@@ -39,7 +39,7 @@ namespace System
         {
             // Create local copy to avoid a race condition
             RuntimeType type = m_type;
-            if (type == null)
+            if (type is null)
                 throw new ArgumentNullException(null, SR.Arg_InvalidHandle);
             return type;
         }
@@ -92,7 +92,7 @@ namespace System
 
         public override int GetHashCode()
         {
-            return m_type != null ? m_type.GetHashCode() : 0;
+            return m_type?.GetHashCode() ?? 0;
         }
 
         public override bool Equals(object obj)
@@ -113,7 +113,7 @@ namespace System
         {
             get
             {
-                return m_type != null ? m_type.m_handle : IntPtr.Zero;
+                return m_type?.m_handle ?? IntPtr.Zero;
             }
         }
 
@@ -1216,17 +1216,12 @@ namespace System
 
         public override int GetHashCode()
         {
-            return m_ptr != null ? m_ptr.GetHashCode() : 0;
+            return m_ptr?.GetHashCode() ?? 0;
         }
 
         public override bool Equals(object obj)
         {
-            if (!(obj is ModuleHandle))
-                return false;
-
-            ModuleHandle handle = (ModuleHandle)obj;
-
-            return handle.m_ptr == m_ptr;
+            return obj is ModuleHandle handle && handle.m_ptr == m_ptr;
         }
 
         public unsafe bool Equals(ModuleHandle handle)
@@ -1253,7 +1248,7 @@ namespace System
         private static void ValidateModulePointer(RuntimeModule module)
         {
             // Make sure we have a valid Module to resolve against.
-            if (module == null)
+            if (module is null)
                 throw new InvalidOperationException(SR.InvalidOperation_NullModuleHandle);
         }
 

--- a/src/mscorlib/src/System/StubHelpers.cs
+++ b/src/mscorlib/src/System/StubHelpers.cs
@@ -1270,7 +1270,7 @@ namespace System.StubHelpers
         {
             if (pNativeHome != IntPtr.Zero)
             {
-                if (layoutType != null)
+                if ((object)layoutType != null)
                 {
                     // this must happen regardless of BackPropAction
                     Marshal.DestroyStructure(pNativeHome, layoutType);
@@ -1352,7 +1352,7 @@ namespace System.StubHelpers
             }
 
             string typeName;
-            if (managedType != null)
+            if ((object)managedType != null)
             {
                 if (managedType.GetType() != typeof(System.RuntimeType))
                 {   // The type should be exactly System.RuntimeType (and not its child System.ReflectionOnlyType, or other System.Type children)

--- a/src/mscorlib/src/System/Threading/SynchronizationContext.cs
+++ b/src/mscorlib/src/System/Threading/SynchronizationContext.cs
@@ -85,11 +85,11 @@ namespace System.Threading
             {
                 RuntimeHelpers.PrepareDelegate(new WaitDelegate(this.Wait));
 
-                if (s_cachedPreparedType1 == null) s_cachedPreparedType1 = type;
-                else if (s_cachedPreparedType2 == null) s_cachedPreparedType2 = type;
-                else if (s_cachedPreparedType3 == null) s_cachedPreparedType3 = type;
-                else if (s_cachedPreparedType4 == null) s_cachedPreparedType4 = type;
-                else if (s_cachedPreparedType5 == null) s_cachedPreparedType5 = type;
+                if (s_cachedPreparedType1 is null) s_cachedPreparedType1 = type;
+                else if (s_cachedPreparedType2 is null) s_cachedPreparedType2 = type;
+                else if (s_cachedPreparedType3 is null) s_cachedPreparedType3 = type;
+                else if (s_cachedPreparedType4 is null) s_cachedPreparedType4 = type;
+                else if (s_cachedPreparedType5 is null) s_cachedPreparedType5 = type;
             }
 
             _props |= SynchronizationContextProperties.RequireWaitNotification;

--- a/src/mscorlib/src/System/Type.CoreCLR.cs
+++ b/src/mscorlib/src/System/Type.CoreCLR.cs
@@ -14,10 +14,9 @@ namespace System
         {
             get
             {
-                RuntimeType rt = this as RuntimeType;
-                if (rt != null)
-                    return RuntimeTypeHandle.IsInterface(rt);
-                return ((GetAttributeFlagsImpl() & TypeAttributes.ClassSemanticsMask) == TypeAttributes.Interface);
+                return this is RuntimeType rt ?
+                    RuntimeTypeHandle.IsInterface(rt) :
+                    ((GetAttributeFlagsImpl() & TypeAttributes.ClassSemanticsMask) == TypeAttributes.Interface);
             }
         }
 

--- a/src/mscorlib/src/System/TypeNameParser.cs
+++ b/src/mscorlib/src/System/TypeNameParser.cs
@@ -123,7 +123,7 @@ namespace System
             {
                 assembly = ResolveAssembly(asmName, assemblyResolver, throwOnError, ref stackMark);
 
-                if (assembly == null)
+                if (assembly is null)
                 {
                     // Cannot resolve the assembly. If throwOnError is true we should have already thrown.
                     return null;
@@ -142,7 +142,7 @@ namespace System
 
             Type baseType = ResolveType(assembly, names, typeResolver, throwOnError, ignoreCase, ref stackMark);
 
-            if (baseType == null)
+            if (baseType is null)
             {
                 // Cannot resolve the type. If throwOnError is true we should have already thrown.
                 Debug.Assert(throwOnError == false);
@@ -164,7 +164,7 @@ namespace System
                         types[i] = argParser.ConstructType(assemblyResolver, typeResolver, throwOnError, ignoreCase, ref stackMark);
                     }
 
-                    if (types[i] == null)
+                    if (types[i] is null)
                     {
                         // If throwOnError is true argParser.ConstructType should have already thrown.
                         Debug.Assert(throwOnError == false);
@@ -211,7 +211,7 @@ namespace System
             else
             {
                 assembly = assemblyResolver(new AssemblyName(asmName));
-                if (assembly == null && throwOnError)
+                if (assembly is null && throwOnError)
                 {
                     throw new FileNotFoundException(SR.Format(SR.FileNotFound_ResolveAssembly, asmName));
                 }
@@ -234,9 +234,9 @@ namespace System
             {
                 type = typeResolver(assembly, OuterMostTypeName, ignoreCase);
 
-                if (type == null && throwOnError)
+                if (type is null && throwOnError)
                 {
-                    string errorString = assembly == null ?
+                    string errorString = assembly is null ?
                         SR.Format(SR.TypeLoad_ResolveType, OuterMostTypeName):
                         SR.Format(SR.TypeLoad_ResolveTypeFromAssembly, OuterMostTypeName, assembly.FullName);
 
@@ -245,7 +245,7 @@ namespace System
             }
             else
             {
-                if (assembly == null)
+                if (assembly is null)
                 {
                     type = RuntimeType.GetType(OuterMostTypeName, throwOnError, ignoreCase, false, ref stackMark);
                 }
@@ -256,7 +256,7 @@ namespace System
             }
 
             // Resolve nested types.
-            if (type != null)
+            if ((object)type != null)
             {
                 BindingFlags bindingFlags = BindingFlags.NonPublic | BindingFlags.Public;
                 if (ignoreCase)
@@ -266,7 +266,7 @@ namespace System
                 {
                     type = type.GetNestedType(names[i], bindingFlags);
 
-                    if (type == null)
+                    if (type is null)
                     {
                         if (throwOnError)
                             throw new TypeLoadException(SR.Format(SR.TypeLoad_ResolveNestedType, names[i], names[i - 1]));

--- a/src/mscorlib/src/System/TypedReference.cs
+++ b/src/mscorlib/src/System/TypedReference.cs
@@ -38,7 +38,7 @@ namespace System
             for (int i = 0; i < flds.Length; i++)
             {
                 RuntimeFieldInfo field = flds[i] as RuntimeFieldInfo;
-                if (field == null)
+                if (field is null)
                     throw new ArgumentException(SR.Argument_MustBeRuntimeFieldInfo);
 
                 if (field.IsInitOnly || field.IsStatic)


### PR DESCRIPTION
Along with some minor cleanup around the changed areas.

---

When checking for null against types in corelib with overloaded `==`/`!=` operators:
 - `foo == null` => `foo is null`
 - `foo != null` => `(object)foo != null` (I found this easier to read than `!(foo is null)`)

I did not bother changing calls inside `Debug.Assert`.