### PR TITLE
Add ETL flags for ReadyToRun

### DIFF
--- a/src/inc/eventtracebase.h
+++ b/src/inc/eventtracebase.h
@@ -491,6 +491,7 @@ namespace ETW
                 DynamicAssembly=0x2,
                 NativeAssembly=0x4,
                 CollectibleAssembly=0x8,
+                ReadyToRunAssembly=0x10,
             }AssemblyFlags;
 
             typedef enum _ModuleFlags
@@ -499,7 +500,8 @@ namespace ETW
                 NativeModule=0x2,
                 DynamicModule=0x4,
                 ManifestModule=0x8,
-                IbcOptimized=0x10
+                IbcOptimized=0x10,
+                ReadyToRunModule=0x20,
             }ModuleFlags;
 
             typedef enum _RangeFlags
@@ -548,7 +550,7 @@ namespace ETW
         static VOID SendEventsForNgenMethods(Module *pModule, DWORD dwEventOptions);
         static VOID SendMethodJitStartEvent(MethodDesc *pMethodDesc, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL);
         static VOID SendMethodILToNativeMapEvent(MethodDesc * pMethodDesc, DWORD dwEventOptions, SIZE_T pCode, ReJITID rejitID);
-        static VOID SendMethodEvent(MethodDesc *pMethodDesc, DWORD dwEventOptions, BOOL bIsJit, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL, SIZE_T pCode = 0, ReJITID rejitID = 0);
+        static VOID SendMethodEvent(MethodDesc *pMethodDesc, DWORD dwEventOptions, BOOL bIsJit, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL, SIZE_T pCode = 0, ReJITID rejitID = 0, BOOL bProfilerRejectedPrecompiledCode = FALSE, BOOL bReadyToRunRejectedPrecompiledCode = FALSE);
         static VOID SendHelperEvent(ULONGLONG ullHelperStartAddress, ULONG ulHelperSize, LPCWSTR pHelperName);
     public:
         typedef union _MethodStructs
@@ -559,7 +561,9 @@ namespace ETW
                 GenericMethod=0x2,
                 SharedGenericCode=0x4,
                 JittedMethod=0x8,
-                JitHelperMethod=0x10
+                JitHelperMethod=0x10,
+                ProfilerRejectedPrecompiledCode=0x20,
+                ReadyToRunRejectedPrecompiledCode=0x40,
             }MethodFlags;
 
             typedef enum _MethodExtent
@@ -571,7 +575,7 @@ namespace ETW
         }MethodStructs;
 
         static VOID MethodJitting(MethodDesc *pMethodDesc, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL);
-        static VOID MethodJitted(MethodDesc *pMethodDesc, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL, SIZE_T pCode = 0, ReJITID rejitID = 0);
+        static VOID MethodJitted(MethodDesc *pMethodDesc, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL, SIZE_T pCode = 0, ReJITID rejitID = 0, BOOL bProfilerRejectedPrecompiledCode = FALSE, BOOL bReadyToRunRejectedPrecompiledCode = FALSE);
         static VOID StubInitialized(ULONGLONG ullHelperStartAddress, LPCWSTR pHelperName);
         static VOID StubsInitialized(PVOID *pHelperStartAddresss, PVOID *pHelperNames, LONG ulNoOfHelpers);
         static VOID MethodRestored(MethodDesc * pMethodDesc);

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -5225,7 +5225,7 @@ HRESULT ETW::CodeSymbolLog::ReadInMemorySymbols(
 /*******************************************************/
 /* This is called by the runtime when a method is jitted completely */
 /*******************************************************/
-VOID ETW::MethodLog::MethodJitted(MethodDesc *pMethodDesc, SString *namespaceOrClassName, SString *methodName, SString *methodSignature, SIZE_T pCode, ReJITID rejitID)
+VOID ETW::MethodLog::MethodJitted(MethodDesc *pMethodDesc, SString *namespaceOrClassName, SString *methodName, SString *methodSignature, SIZE_T pCode, ReJITID rejitID, BOOL bProfilerRejectedPrecompiledCode, BOOL bReadyToRunRejectedPrecompiledCode)
 {
     CONTRACTL {
         NOTHROW;
@@ -5238,7 +5238,7 @@ VOID ETW::MethodLog::MethodJitted(MethodDesc *pMethodDesc, SString *namespaceOrC
                                         TRACE_LEVEL_INFORMATION, 
                                         CLR_JIT_KEYWORD))
         {
-            ETW::MethodLog::SendMethodEvent(pMethodDesc, ETW::EnumerationLog::EnumerationStructs::JitMethodLoad, TRUE, namespaceOrClassName, methodName, methodSignature, pCode, rejitID);
+            ETW::MethodLog::SendMethodEvent(pMethodDesc, ETW::EnumerationLog::EnumerationStructs::JitMethodLoad, TRUE, namespaceOrClassName, methodName, methodSignature, pCode, rejitID, bProfilerRejectedPrecompiledCode, bReadyToRunRejectedPrecompiledCode); 
         }
 
         if(ETW_TRACING_CATEGORY_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_Context, 
@@ -5751,6 +5751,7 @@ VOID ETW::LoaderLog::SendAssemblyEvent(Assembly *pAssembly, DWORD dwEventOptions
     BOOL bIsCollectibleAssembly = pAssembly->IsCollectible();
     BOOL bIsDomainNeutral = pAssembly->IsDomainNeutral() ;
     BOOL bHasNativeImage = pAssembly->GetManifestFile()->HasNativeImage();
+    BOOL bIsReadyToRun = pAssembly->GetManifestFile()->IsILImageReadyToRun();
 
     ULONGLONG ullAssemblyId = (ULONGLONG)pAssembly;
     ULONGLONG ullDomainId = (ULONGLONG)pAssembly->GetDomain();
@@ -5758,7 +5759,8 @@ VOID ETW::LoaderLog::SendAssemblyEvent(Assembly *pAssembly, DWORD dwEventOptions
     ULONG ulAssemblyFlags = ((bIsDomainNeutral ? ETW::LoaderLog::LoaderStructs::DomainNeutralAssembly : 0) |
                              (bIsDynamicAssembly ? ETW::LoaderLog::LoaderStructs::DynamicAssembly : 0) |
                              (bHasNativeImage ? ETW::LoaderLog::LoaderStructs::NativeAssembly : 0) |
-                             (bIsCollectibleAssembly ? ETW::LoaderLog::LoaderStructs::CollectibleAssembly : 0));
+                             (bIsCollectibleAssembly ? ETW::LoaderLog::LoaderStructs::CollectibleAssembly : 0) |
+                             (bIsReadyToRun ? ETW::LoaderLog::LoaderStructs::ReadyToRunAssembly : 0));
 
     SString sAssemblyPath;
     pAssembly->GetDisplayName(sAssemblyPath);
@@ -6075,12 +6077,14 @@ VOID ETW::LoaderLog::SendModuleEvent(Module *pModule, DWORD dwEventOptions, BOOL
     {
         bIsIbcOptimized = pModule->IsIbcOptimized();
     }
+    BOOL bIsReadyToRun = pModule->IsReadyToRun();
     ULONG ulReservedFlags = 0;
     ULONG ulFlags = ((bIsDomainNeutral ? ETW::LoaderLog::LoaderStructs::DomainNeutralModule : 0) |
                      (bHasNativeImage ? ETW::LoaderLog::LoaderStructs::NativeModule : 0) |
                      (bIsDynamicAssembly ? ETW::LoaderLog::LoaderStructs::DynamicModule : 0) |
                      (bIsManifestModule ? ETW::LoaderLog::LoaderStructs::ManifestModule : 0) |
-                     (bIsIbcOptimized ? ETW::LoaderLog::LoaderStructs::IbcOptimized : 0));
+                     (bIsIbcOptimized ? ETW::LoaderLog::LoaderStructs::IbcOptimized : 0) |
+                     (bIsReadyToRun ? ETW::LoaderLog::LoaderStructs::ReadyToRunModule : 0));
 
     // Grab PDB path, guid, and age for managed PDB and native (NGEN) PDB when
     // available.  Any failures are not fatal.  The corresponding PDB info will remain
@@ -6266,7 +6270,7 @@ VOID ETW::MethodLog::SendMethodJitStartEvent(MethodDesc *pMethodDesc, SString *n
 /****************************************************************************/
 /* This routine is used to send a method load/unload or rundown event                              */
 /****************************************************************************/
-VOID ETW::MethodLog::SendMethodEvent(MethodDesc *pMethodDesc, DWORD dwEventOptions, BOOL bIsJit, SString *namespaceOrClassName, SString *methodName, SString *methodSignature, SIZE_T pCode, ReJITID rejitID)
+VOID ETW::MethodLog::SendMethodEvent(MethodDesc *pMethodDesc, DWORD dwEventOptions, BOOL bIsJit, SString *namespaceOrClassName, SString *methodName, SString *methodSignature, SIZE_T pCode, ReJITID rejitID, BOOL bProfilerRejectedPrecompiledCode, BOOL bReadyToRunRejectedPrecompiledCode)
 {
     CONTRACTL {
         THROWS;
@@ -6340,7 +6344,9 @@ VOID ETW::MethodLog::SendMethodEvent(MethodDesc *pMethodDesc, DWORD dwEventOptio
         (bHasSharedGenericCode ? ETW::MethodLog::MethodStructs::SharedGenericCode : 0) |
         (bIsGenericMethod ? ETW::MethodLog::MethodStructs::GenericMethod : 0) |
         (bIsDynamicMethod ? ETW::MethodLog::MethodStructs::DynamicMethod : 0) |
-        (bIsJit ? ETW::MethodLog::MethodStructs::JittedMethod : 0)));
+        (bIsJit ? ETW::MethodLog::MethodStructs::JittedMethod : 0) |
+        (bProfilerRejectedPrecompiledCode ? ETW::MethodLog::MethodStructs::ProfilerRejectedPrecompiledCode : 0) |
+        (bReadyToRunRejectedPrecompiledCode ? ETW::MethodLog::MethodStructs::ReadyToRunRejectedPrecompiledCode : 0)));
 
     // Intentionally set the extent flags (cold vs. hot) only after all the other common
     // flags (above) have been set.

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -1865,8 +1865,8 @@ public:
 private:
     PCODE PrepareILBasedCode(PrepareCodeConfig* pConfig);
     PCODE GetPrecompiledCode(PrepareCodeConfig* pConfig);
-    PCODE GetPrecompiledNgenCode();
-    PCODE GetPrecompiledR2RCode();
+    PCODE GetPrecompiledNgenCode(PrepareCodeConfig* pConfig);
+    PCODE GetPrecompiledR2RCode(PrepareCodeConfig* pConfig);
     PCODE GetMulticoreJitCode();
     COR_ILMETHOD_DECODER* GetAndVerifyILHeader(PrepareCodeConfig* pConfig, COR_ILMETHOD_DECODER* pIlDecoderMemory);
     COR_ILMETHOD_DECODER* GetAndVerifyMetadataILHeader(PrepareCodeConfig* pConfig, COR_ILMETHOD_DECODER* pIlDecoderMemory);
@@ -1891,12 +1891,18 @@ public:
     virtual BOOL SetNativeCode(PCODE pCode, PCODE * ppAlternateCodeToUse);
     virtual COR_ILMETHOD* GetILHeader();
     virtual CORJIT_FLAGS GetJitCompilationFlags();
+    BOOL ProfilerRejectedPrecompiledCode();
+    BOOL ReadyToRunRejectedPrecompiledCode();
+    void SetProfilerRejectedPrecompiledCode();
+    void SetReadyToRunRejectedPrecompiledCode();
     
 protected:
     MethodDesc* m_pMethodDesc;
     NativeCodeVersion m_nativeCodeVersion;
     BOOL m_needsMulticoreJitNotification;
     BOOL m_mayUsePrecompiledCode;
+    BOOL m_ProfilerRejectedPrecompiledCode;
+    BOOL m_ReadyToRunRejectedPrecompiledCode;
 };
 
 #ifdef FEATURE_CODE_VERSIONING

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -319,13 +319,13 @@ PCODE MethodDesc::GetPrecompiledCode(PrepareCodeConfig* pConfig)
     PCODE pCode = NULL;
 
 #ifdef FEATURE_PREJIT 
-    pCode = GetPrecompiledNgenCode();
+    pCode = GetPrecompiledNgenCode(pConfig);
 #endif
 
 #ifdef FEATURE_READYTORUN
     if (pCode == NULL)
     {
-        pCode = GetPrecompiledR2RCode();
+        pCode = GetPrecompiledR2RCode(pConfig);
         if (pCode != NULL)
         {
             pConfig->SetNativeCode(pCode, &pCode);
@@ -336,7 +336,7 @@ PCODE MethodDesc::GetPrecompiledCode(PrepareCodeConfig* pConfig)
     return pCode;
 }
 
-PCODE MethodDesc::GetPrecompiledNgenCode()
+PCODE MethodDesc::GetPrecompiledNgenCode(PrepareCodeConfig* pConfig)
 {
     STANDARD_VM_CONTRACT;
     PCODE pCode = NULL;
@@ -371,6 +371,7 @@ PCODE MethodDesc::GetPrecompiledNgenCode()
         {
             SetNativeCodeInterlocked(NULL, pCode);
             _ASSERTE(!IsPreImplemented());
+            pConfig->SetProfilerRejectedPrecompiledCode();
             pCode = NULL;
         }
     }
@@ -423,7 +424,7 @@ PCODE MethodDesc::GetPrecompiledNgenCode()
 }
 
 
-PCODE MethodDesc::GetPrecompiledR2RCode()
+PCODE MethodDesc::GetPrecompiledR2RCode(PrepareCodeConfig* pConfig)
 {
     STANDARD_VM_CONTRACT;
 
@@ -432,7 +433,7 @@ PCODE MethodDesc::GetPrecompiledR2RCode()
     Module * pModule = GetModule();
     if (pModule->IsReadyToRun())
     {
-        pCode = pModule->GetReadyToRunInfo()->GetEntryPoint(this);
+        pCode = pModule->GetReadyToRunInfo()->GetEntryPoint(this, pConfig);
     }
 #endif
     return pCode;
@@ -732,7 +733,9 @@ PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, J
                 &methodName,
                 &methodSignature,
                 pCode,
-                pConfig->GetCodeVersion().GetVersionId());
+                pConfig->GetCodeVersion().GetVersionId(),
+                pConfig->ProfilerRejectedPrecompiledCode(),
+                pConfig->ReadyToRunRejectedPrecompiledCode());
         }
 
     }
@@ -910,7 +913,9 @@ PrepareCodeConfig::PrepareCodeConfig(NativeCodeVersion codeVersion, BOOL needsMu
     m_pMethodDesc(codeVersion.GetMethodDesc()),
     m_nativeCodeVersion(codeVersion),
     m_needsMulticoreJitNotification(needsMulticoreJitNotification),
-    m_mayUsePrecompiledCode(mayUsePrecompiledCode)
+    m_mayUsePrecompiledCode(mayUsePrecompiledCode),
+    m_ProfilerRejectedPrecompiledCode(FALSE),
+    m_ReadyToRunRejectedPrecompiledCode(FALSE)
 {}
 
 MethodDesc* PrepareCodeConfig::GetMethodDesc()
@@ -929,6 +934,30 @@ BOOL PrepareCodeConfig::NeedsMulticoreJitNotification()
 {
     LIMITED_METHOD_CONTRACT;
     return m_needsMulticoreJitNotification;
+}
+
+BOOL PrepareCodeConfig::ProfilerRejectedPrecompiledCode()
+{
+    LIMITED_METHOD_CONTRACT;
+    return m_ProfilerRejectedPrecompiledCode;
+}
+
+void PrepareCodeConfig::SetProfilerRejectedPrecompiledCode()
+{
+    LIMITED_METHOD_CONTRACT;
+    m_ProfilerRejectedPrecompiledCode = TRUE;
+}
+
+BOOL PrepareCodeConfig::ReadyToRunRejectedPrecompiledCode()
+{
+    LIMITED_METHOD_CONTRACT;
+    return m_ReadyToRunRejectedPrecompiledCode;
+}
+
+void PrepareCodeConfig::SetReadyToRunRejectedPrecompiledCode()
+{
+    LIMITED_METHOD_CONTRACT;
+    m_ReadyToRunRejectedPrecompiledCode = TRUE;
 }
 
 NativeCodeVersion PrepareCodeConfig::GetCodeVersion()

--- a/src/vm/readytoruninfo.h
+++ b/src/vm/readytoruninfo.h
@@ -17,6 +17,8 @@
 
 typedef DPTR(struct READYTORUN_SECTION) PTR_READYTORUN_SECTION;
 
+class PrepareCodeConfig;
+
 typedef DPTR(class ReadyToRunInfo) PTR_ReadyToRunInfo;
 class ReadyToRunInfo
 {
@@ -50,7 +52,7 @@ public:
 
     static PTR_ReadyToRunInfo Initialize(Module * pModule, AllocMemTracker *pamTracker);
 
-    PCODE GetEntryPoint(MethodDesc * pMD, BOOL fFixups = TRUE);
+    PCODE GetEntryPoint(MethodDesc * pMD, PrepareCodeConfig* pConfig, BOOL fFixups = TRUE);
 
     MethodDesc * GetMethodDescForEntryPoint(PCODE entryPoint);
 


### PR DESCRIPTION
Add flags to track the presence of ReadyToRun codegen in an assembly
and module.

Add jitting flags to indicate when a method is jitted because the
precompiled code was rejected, either by a profiler or by ReadyToRun
dependence tracking.

Together these can be used to distingish between
* methods jitted because their assemblies were not precompiled
* methods jitted because they were not precompiled in an otherwise
precompiled assembly