### PR TITLE
Collected delegate diagnostic

### DIFF
--- a/src/inc/loaderheap.h
+++ b/src/inc/loaderheap.h
@@ -288,8 +288,7 @@ protected:
                        SIZE_T dwReservedRegionSize,
                        size_t *pPrivatePerfCounter_LoaderBytes = NULL,
                        RangeList *pRangeList = NULL,
-                       BOOL fMakeExecutable = FALSE,
-                       BOOL fZeroInit = TRUE);
+                       BOOL fMakeExecutable = FALSE);
 
     ~UnlockedLoaderHeap();
 #endif
@@ -400,8 +399,6 @@ public:
     }
 
     BOOL IsExecutable();
-    BOOL IsZeroInit();
-
 
 public:
 #ifdef _DEBUG
@@ -446,16 +443,14 @@ public:
                DWORD dwCommitBlockSize,
                size_t *pPrivatePerfCounter_LoaderBytes = NULL,
                RangeList *pRangeList = NULL,
-               BOOL fMakeExecutable = FALSE,
-               BOOL fZeroInit = TRUE
+               BOOL fMakeExecutable = FALSE
                )
       : UnlockedLoaderHeap(dwReserveBlockSize,
                            dwCommitBlockSize,
                            NULL, 0,
                            pPrivatePerfCounter_LoaderBytes,
                            pRangeList,
-                           fMakeExecutable,
-                           fZeroInit)
+                           fMakeExecutable)
     {
         WRAPPER_NO_CONTRACT;
         m_CriticalSection = NULL;
@@ -470,8 +465,7 @@ public:
                SIZE_T dwReservedRegionSize,
                size_t *pPrivatePerfCounter_LoaderBytes = NULL,
                RangeList *pRangeList = NULL,
-               BOOL fMakeExecutable = FALSE,
-               BOOL fZeroInit = TRUE
+               BOOL fMakeExecutable = FALSE
                )
       : UnlockedLoaderHeap(dwReserveBlockSize,
                            dwCommitBlockSize,
@@ -479,8 +473,7 @@ public:
                            dwReservedRegionSize,
                            pPrivatePerfCounter_LoaderBytes,
                            pRangeList,
-                           fMakeExecutable,
-                           fZeroInit)
+                           fMakeExecutable)
     {
         WRAPPER_NO_CONTRACT;
         m_CriticalSection = NULL;

--- a/src/vm/amd64/cgenamd64.cpp
+++ b/src/vm/amd64/cgenamd64.cpp
@@ -680,7 +680,18 @@ void UMEntryThunkCode::Poison()
     }
     CONTRACTL_END;
 
-    m_movR10[0] = X86_INSTR_INT3;
+    m_execstub    = (BYTE *)UMEntryThunk::ReportViolation;
+
+    m_movR10[0]  = REX_PREFIX_BASE | REX_OPERAND_SIZE_64BIT;
+#ifdef _WIN32
+    // mov rcx, pUMEntryThunk // 48 b9 xx xx xx xx xx xx xx xx
+    m_movR10[1]  = 0xB9;
+#else
+    // mov rdi, pUMEntryThunk // 48 bf xx xx xx xx xx xx xx xx
+    m_movR10[1]  = 0xBF;
+#endif
+
+    ClrFlushInstructionCache(&m_movR10[0], &m_jmpRAX[3]-&m_movR10[0]);
 }
 
 UMEntryThunk* UMEntryThunk::Decode(LPVOID pCallback)

--- a/src/vm/arm/stubs.cpp
+++ b/src/vm/arm/stubs.cpp
@@ -2483,11 +2483,21 @@ void UMEntryThunkCode::Encode(BYTE* pTargetCode, void* pvSecretParam)
     FlushInstructionCache(GetCurrentProcess(),&m_code,sizeof(m_code));
 }
 
+#ifndef DACCESS_COMPILE
+
 void UMEntryThunkCode::Poison()
 {
-    // Insert 'udf 0xff' at the entry point
-    m_code[0] = 0xdeff;
+    m_pTargetCode = (TADDR)UMEntryThunk::ReportViolation;
+
+    // ldr r0, [pc + 8]
+    m_code[0] = 0x4802;
+    // nop
+    m_code[1] = 0xbf00;
+
+    ClrFlushInstructionCache(&m_code,sizeof(m_code));
 }
+
+#endif // DACCESS_COMPILE
 
 ///////////////////////////// UNIMPLEMENTED //////////////////////////////////
 

--- a/src/vm/arm64/stubs.cpp
+++ b/src/vm/arm64/stubs.cpp
@@ -1268,11 +1268,19 @@ void UMEntryThunkCode::Encode(BYTE* pTargetCode, void* pvSecretParam)
     FlushInstructionCache(GetCurrentProcess(),&m_code,sizeof(m_code));
 }
 
+#ifndef DACCESS_COMPILE
+
 void UMEntryThunkCode::Poison()
 {
-    // Insert 'brk 0xbe' at the entry point
-    m_code[0] = 0xd42017c0;
+    m_pTargetCode = (TADDR)UMEntryThunk::ReportViolation;
+
+    // ldp x16, x0, [x12]
+    m_code[1] = 0xd42017c0;
+
+    ClrFlushInstructionCache(&m_code,sizeof(m_code));
 }
+
+#endif // DACCESS_COMPILE
 
 #ifdef PROFILING_SUPPORTED
 #include "proftoeeinterfaceimpl.h"

--- a/src/vm/dllimportcallback.cpp
+++ b/src/vm/dllimportcallback.cpp
@@ -1153,7 +1153,6 @@ void UMEntryThunk::Terminate()
     }
     CONTRACTL_END;
 
-    _ASSERTE(!SystemDomain::GetGlobalLoaderAllocator()->GetExecutableHeap()->IsZeroInit());
     m_code.Poison();
 
     s_thunkFreeList.AddToList(this);

--- a/src/vm/dllimportcallback.h
+++ b/src/vm/dllimportcallback.h
@@ -250,6 +250,7 @@ class UMEntryThunk
 {
     friend class CheckAsmOffsets;
     friend class NDirectStubLinker;
+    friend class UMEntryThunkFreeList;
 
 private:
 #ifdef _DEBUG
@@ -526,8 +527,13 @@ private:
     // Field is NULL for a static method.
     OBJECTHANDLE            m_pObjectHandle;
 
-    // Pointer to the shared structure containing everything else
-    PTR_UMThunkMarshInfo    m_pUMThunkMarshInfo;
+    union
+    {
+        // Pointer to the shared structure containing everything else
+        PTR_UMThunkMarshInfo    m_pUMThunkMarshInfo;
+        // Pointer to the next UMEntryThunk in the free list. Used when it is freed.
+        UMEntryThunk *m_pNextFreeThunk;
+    };
 
     ADID                    m_dwDomainId;   // appdomain of module (cached for fast access)
 #ifdef _DEBUG

--- a/src/vm/dllimportcallback.h
+++ b/src/vm/dllimportcallback.h
@@ -424,13 +424,7 @@ public:
             MODE_ANY;
             SUPPORTS_DAC;
             PRECONDITION(m_state == kRunTimeInited || m_state == kLoadTimeInited);
-#ifdef MDA_SUPPORTED
-            // We can return NULL here if the CollectedDelegate probe is on because
-            // a collected delegate will have set this field to NULL.
-            POSTCONDITION(g_pDebugInterface->ThisIsHelperThread() || MDA_GET_ASSISTANT(CallbackOnCollectedDelegate) || CheckPointer(RETVAL));
-#else
             POSTCONDITION(CheckPointer(RETVAL));
-#endif
         }
         CONTRACT_END;
     
@@ -502,15 +496,6 @@ public:
     }
 
     static UMEntryThunk* Decode(LPVOID pCallback);
-
-#ifdef MDA_SUPPORTED
-    BOOL IsCollected() const
-    {
-        LIMITED_METHOD_CONTRACT;
-        _ASSERTE(m_pMD != NULL && m_pMD->IsEEImpl());
-        return m_pObjectHandle == NULL;
-    }
-#endif
 
     static VOID __fastcall ReportViolation(UMEntryThunk* p);
 
@@ -612,9 +597,5 @@ EXTERN_C void UMThunkStub(void);
 #ifdef _DEBUG
 void STDCALL LogUMTransition(UMEntryThunk* thunk);
 #endif
-
-#ifdef MDA_SUPPORTED
-EXTERN_C void __fastcall CallbackOnCollectedDelegateHelper(UMEntryThunk *pEntryThunk);
-#endif // MDA_SUPPORTED
 
 #endif //__dllimportcallback_h__

--- a/src/vm/dllimportcallback.h
+++ b/src/vm/dllimportcallback.h
@@ -511,6 +511,8 @@ public:
     }
 #endif
 
+    static VOID __fastcall ReportViolation(UMEntryThunk* p);
+
 private:
     // The start of the managed code.
     // if m_pObjectHandle is non-NULL, this field is still set to help with diagnostic of call on collected delegate crashes

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -1614,7 +1614,12 @@ void UMEntryThunkCode::Poison()
 {
     LIMITED_METHOD_CONTRACT;
 
-    m_movEAX = X86_INSTR_INT3;
+    m_execstub = (BYTE*) ((BYTE*)UMEntryThunk::ReportViolation - (4+((BYTE*)&m_execstub)));
+
+    // mov ecx, imm32
+    m_movEAX = 0xb9;
+
+    ClrFlushInstructionCache(GetEntryPoint(),sizeof(UMEntryThunkCode));
 }
 
 UMEntryThunk* UMEntryThunk::Decode(LPVOID pCallback)

--- a/src/vm/loaderallocator.cpp
+++ b/src/vm/loaderallocator.cpp
@@ -1005,8 +1005,7 @@ void LoaderAllocator::Init(BaseDomain *pDomain, BYTE *pExecutableHeapMemory)
                                                                       dwExecutableHeapReserveSize,
                                                                       LOADERHEAP_PROFILE_COUNTER,
                                                                       NULL,
-                                                                      TRUE /* Make heap executable */,
-                                                                      FALSE /* Disable zero-initialization (needed by UMEntryThunkCode::Poison) */
+                                                                      TRUE /* Make heap executable */
                                                                       );
         initReservedMem += dwExecutableHeapReserveSize;
     }


### PR DESCRIPTION
Improve collected delegate calls diagnostic (https://github.com/dotnet/coreclr/issues/15465):
* Improve `UMEntryThunkCode::Poison` to produce diagnostic message
* Store freed thunks into FIFO free list, in this case it takes longer before the thunks get reused

Example:
```
$ ./corerun delegategc.dll
Press ESC to stop
register_callback:0x7f293afa316c ----
force GC!!!
upcall ----
FailFast: A callback was made on a garbage collected delegate of type 'delegategc!DelegateGC.Program+Callback::Invoke'.

   at DelegateGC.Program.upcall()
   at DelegateGC.Program.upcall()
   at DelegateGC.Program.MyView_KeyEvent(System.ConsoleKeyInfo)
   at DelegateGC.Program.Main(System.String[])
Aborted (core dumped)
```
