### PR TITLE
Port S.N.Vector sources down to corelib

### DIFF
--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -283,6 +283,9 @@
   <data name="Arg_EHClauseNotFilter" xml:space="preserve">
     <value>This ExceptionHandlingClause is not a filter.</value>
   </data>
+  <data name="Arg_ElementsInSourceIsGreaterThanDestination" xml:space="preserve">
+    <value>Number of elements in source vector is greater than the destination array</value>
+  </data>
   <data name="Arg_EmptyArray" xml:space="preserve">
     <value>Array may not be empty.</value>
   </data>
@@ -618,6 +621,9 @@
   </data>
   <data name="Arg_NotSupportedException" xml:space="preserve">
     <value>Specified method is not supported.</value>
+  </data>
+  <data name="Arg_NullArgumentNullRef" xml:space="preserve">
+    <value>The method was called with a null array argument.</value>
   </data>
   <data name="Arg_NullIndex" xml:space="preserve">
     <value>Arrays indexes must be set to an object instance.</value>

--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -573,6 +573,21 @@
     <Compile Condition="'$(FeatureWin32Registry)' == 'true'" Include="$(BclSourcesRoot)\Microsoft\Win32\SafeHandles\SafeRegistryHandle.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(BclSourcesRoot)\System\Numerics\ConstantHelper.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Numerics\JitIntrinsicAttribute.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Numerics\Matrix3x2.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Numerics\Matrix4x4.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Numerics\Plane.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Numerics\Quaternion.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Numerics\Register.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Numerics\Vector.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Numerics\Vector_Operations.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Numerics\Vector2.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Numerics\Vector2_Intrinsics.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Numerics\Vector3.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Numerics\Vector3_Intrinsics.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Numerics\Vector4.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Numerics\Vector4_Intrinsics.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Numerics\Hashing\HashHelpers.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">

--- a/src/mscorlib/src/System/Numerics/ConstantHelper.cs
+++ b/src/mscorlib/src/System/Numerics/ConstantHelper.cs
@@ -1,0 +1,142 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Numerics
+{
+    internal class ConstantHelper
+    {
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Byte GetByteWithAllBitsSet()
+        {
+            Byte value = 0;
+            unsafe
+            {
+                unchecked
+                {
+                    *((Byte*)&value) = (Byte)0xff;
+                }
+            }
+            return value;
+        }
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static SByte GetSByteWithAllBitsSet()
+        {
+            SByte value = 0;
+            unsafe
+            {
+                unchecked
+                {
+                    *((SByte*)&value) = (SByte)0xff;
+                }
+            }
+            return value;
+        }
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static UInt16 GetUInt16WithAllBitsSet()
+        {
+            UInt16 value = 0;
+            unsafe
+            {
+                unchecked
+                {
+                    *((UInt16*)&value) = (UInt16)0xffff;
+                }
+            }
+            return value;
+        }
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Int16 GetInt16WithAllBitsSet()
+        {
+            Int16 value = 0;
+            unsafe
+            {
+                unchecked
+                {
+                    *((Int16*)&value) = (Int16)0xffff;
+                }
+            }
+            return value;
+        }
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static UInt32 GetUInt32WithAllBitsSet()
+        {
+            UInt32 value = 0;
+            unsafe
+            {
+                unchecked
+                {
+                    *((UInt32*)&value) = (UInt32)0xffffffff;
+                }
+            }
+            return value;
+        }
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Int32 GetInt32WithAllBitsSet()
+        {
+            Int32 value = 0;
+            unsafe
+            {
+                unchecked
+                {
+                    *((Int32*)&value) = (Int32)0xffffffff;
+                }
+            }
+            return value;
+        }
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static UInt64 GetUInt64WithAllBitsSet()
+        {
+            UInt64 value = 0;
+            unsafe
+            {
+                unchecked
+                {
+                    *((UInt64*)&value) = (UInt64)0xffffffffffffffff;
+                }
+            }
+            return value;
+        }
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Int64 GetInt64WithAllBitsSet()
+        {
+            Int64 value = 0;
+            unsafe
+            {
+                unchecked
+                {
+                    *((Int64*)&value) = (Int64)0xffffffffffffffff;
+                }
+            }
+            return value;
+        }
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Single GetSingleWithAllBitsSet()
+        {
+            Single value = 0;
+            unsafe
+            {
+                unchecked
+                {
+                    *((Int32*)&value) = (Int32)0xffffffff;
+                }
+            }
+            return value;
+        }
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Double GetDoubleWithAllBitsSet()
+        {
+            Double value = 0;
+            unsafe
+            {
+                unchecked
+                {
+                    *((Int64*)&value) = (Int64)0xffffffffffffffff;
+                }
+            }
+            return value;
+        }
+    }
+}

--- a/src/mscorlib/src/System/Numerics/JitIntrinsicAttribute.cs
+++ b/src/mscorlib/src/System/Numerics/JitIntrinsicAttribute.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Numerics
+{
+    /// <summary>
+    /// An attribute that can be attached to JIT Intrinsic methods/properties
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Property)]
+    internal class JitIntrinsicAttribute : Attribute
+    {
+    }
+}

--- a/src/mscorlib/src/System/Numerics/Matrix3x2.cs
+++ b/src/mscorlib/src/System/Numerics/Matrix3x2.cs
@@ -1,0 +1,810 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+
+namespace System.Numerics
+{
+    /// <summary>
+    /// A structure encapsulating a 3x2 matrix.
+    /// </summary>
+    public struct Matrix3x2 : IEquatable<Matrix3x2>
+    {
+        #region Public Fields
+        /// <summary>
+        /// The first element of the first row
+        /// </summary>
+        public float M11;
+        /// <summary>
+        /// The second element of the first row
+        /// </summary>
+        public float M12;
+        /// <summary>
+        /// The first element of the second row
+        /// </summary>
+        public float M21;
+        /// <summary>
+        /// The second element of the second row
+        /// </summary>
+        public float M22;
+        /// <summary>
+        /// The first element of the third row
+        /// </summary>
+        public float M31;
+        /// <summary>
+        /// The second element of the third row
+        /// </summary>
+        public float M32;
+        #endregion Public Fields
+
+        private static readonly Matrix3x2 _identity = new Matrix3x2
+        (
+            1f, 0f,
+            0f, 1f,
+            0f, 0f
+        );
+
+        /// <summary>
+        /// Returns the multiplicative identity matrix.
+        /// </summary>
+        public static Matrix3x2 Identity
+        {
+            get { return _identity; }
+        }
+
+        /// <summary>
+        /// Returns whether the matrix is the identity matrix.
+        /// </summary>
+        public bool IsIdentity
+        {
+            get
+            {
+                return M11 == 1f && M22 == 1f && // Check diagonal element first for early out.
+                                    M12 == 0f &&
+                       M21 == 0f &&
+                       M31 == 0f && M32 == 0f;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the translation component of this matrix.
+        /// </summary>
+        public Vector2 Translation
+        {
+            get
+            {
+                return new Vector2(M31, M32);
+            }
+
+            set
+            {
+                M31 = value.X;
+                M32 = value.Y;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a Matrix3x2 from the given components.
+        /// </summary>
+        public Matrix3x2(float m11, float m12,
+                         float m21, float m22,
+                         float m31, float m32)
+        {
+            this.M11 = m11;
+            this.M12 = m12;
+            this.M21 = m21;
+            this.M22 = m22;
+            this.M31 = m31;
+            this.M32 = m32;
+        }
+
+        /// <summary>
+        /// Creates a translation matrix from the given vector.
+        /// </summary>
+        /// <param name="position">The translation position.</param>
+        /// <returns>A translation matrix.</returns>
+        public static Matrix3x2 CreateTranslation(Vector2 position)
+        {
+            Matrix3x2 result;
+
+            result.M11 = 1.0f;
+            result.M12 = 0.0f;
+            result.M21 = 0.0f;
+            result.M22 = 1.0f;
+
+            result.M31 = position.X;
+            result.M32 = position.Y;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a translation matrix from the given X and Y components.
+        /// </summary>
+        /// <param name="xPosition">The X position.</param>
+        /// <param name="yPosition">The Y position.</param>
+        /// <returns>A translation matrix.</returns>
+        public static Matrix3x2 CreateTranslation(float xPosition, float yPosition)
+        {
+            Matrix3x2 result;
+
+            result.M11 = 1.0f;
+            result.M12 = 0.0f;
+            result.M21 = 0.0f;
+            result.M22 = 1.0f;
+
+            result.M31 = xPosition;
+            result.M32 = yPosition;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a scale matrix from the given X and Y components.
+        /// </summary>
+        /// <param name="xScale">Value to scale by on the X-axis.</param>
+        /// <param name="yScale">Value to scale by on the Y-axis.</param>
+        /// <returns>A scaling matrix.</returns>
+        public static Matrix3x2 CreateScale(float xScale, float yScale)
+        {
+            Matrix3x2 result;
+
+            result.M11 = xScale;
+            result.M12 = 0.0f;
+            result.M21 = 0.0f;
+            result.M22 = yScale;
+            result.M31 = 0.0f;
+            result.M32 = 0.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a scale matrix that is offset by a given center point.
+        /// </summary>
+        /// <param name="xScale">Value to scale by on the X-axis.</param>
+        /// <param name="yScale">Value to scale by on the Y-axis.</param>
+        /// <param name="centerPoint">The center point.</param>
+        /// <returns>A scaling matrix.</returns>
+        public static Matrix3x2 CreateScale(float xScale, float yScale, Vector2 centerPoint)
+        {
+            Matrix3x2 result;
+
+            float tx = centerPoint.X * (1 - xScale);
+            float ty = centerPoint.Y * (1 - yScale);
+
+            result.M11 = xScale;
+            result.M12 = 0.0f;
+            result.M21 = 0.0f;
+            result.M22 = yScale;
+            result.M31 = tx;
+            result.M32 = ty;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a scale matrix from the given vector scale.
+        /// </summary>
+        /// <param name="scales">The scale to use.</param>
+        /// <returns>A scaling matrix.</returns>
+        public static Matrix3x2 CreateScale(Vector2 scales)
+        {
+            Matrix3x2 result;
+
+            result.M11 = scales.X;
+            result.M12 = 0.0f;
+            result.M21 = 0.0f;
+            result.M22 = scales.Y;
+            result.M31 = 0.0f;
+            result.M32 = 0.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a scale matrix from the given vector scale with an offset from the given center point.
+        /// </summary>
+        /// <param name="scales">The scale to use.</param>
+        /// <param name="centerPoint">The center offset.</param>
+        /// <returns>A scaling matrix.</returns>
+        public static Matrix3x2 CreateScale(Vector2 scales, Vector2 centerPoint)
+        {
+            Matrix3x2 result;
+
+            float tx = centerPoint.X * (1 - scales.X);
+            float ty = centerPoint.Y * (1 - scales.Y);
+
+            result.M11 = scales.X;
+            result.M12 = 0.0f;
+            result.M21 = 0.0f;
+            result.M22 = scales.Y;
+            result.M31 = tx;
+            result.M32 = ty;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a scale matrix that scales uniformly with the given scale.
+        /// </summary>
+        /// <param name="scale">The uniform scale to use.</param>
+        /// <returns>A scaling matrix.</returns>
+        public static Matrix3x2 CreateScale(float scale)
+        {
+            Matrix3x2 result;
+
+            result.M11 = scale;
+            result.M12 = 0.0f;
+            result.M21 = 0.0f;
+            result.M22 = scale;
+            result.M31 = 0.0f;
+            result.M32 = 0.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a scale matrix that scales uniformly with the given scale with an offset from the given center.
+        /// </summary>
+        /// <param name="scale">The uniform scale to use.</param>
+        /// <param name="centerPoint">The center offset.</param>
+        /// <returns>A scaling matrix.</returns>
+        public static Matrix3x2 CreateScale(float scale, Vector2 centerPoint)
+        {
+            Matrix3x2 result;
+
+            float tx = centerPoint.X * (1 - scale);
+            float ty = centerPoint.Y * (1 - scale);
+
+            result.M11 = scale;
+            result.M12 = 0.0f;
+            result.M21 = 0.0f;
+            result.M22 = scale;
+            result.M31 = tx;
+            result.M32 = ty;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a skew matrix from the given angles in radians.
+        /// </summary>
+        /// <param name="radiansX">The X angle, in radians.</param>
+        /// <param name="radiansY">The Y angle, in radians.</param>
+        /// <returns>A skew matrix.</returns>
+        public static Matrix3x2 CreateSkew(float radiansX, float radiansY)
+        {
+            Matrix3x2 result;
+
+            float xTan = MathF.Tan(radiansX);
+            float yTan = MathF.Tan(radiansY);
+
+            result.M11 = 1.0f;
+            result.M12 = yTan;
+            result.M21 = xTan;
+            result.M22 = 1.0f;
+            result.M31 = 0.0f;
+            result.M32 = 0.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a skew matrix from the given angles in radians and a center point.
+        /// </summary>
+        /// <param name="radiansX">The X angle, in radians.</param>
+        /// <param name="radiansY">The Y angle, in radians.</param>
+        /// <param name="centerPoint">The center point.</param>
+        /// <returns>A skew matrix.</returns>
+        public static Matrix3x2 CreateSkew(float radiansX, float radiansY, Vector2 centerPoint)
+        {
+            Matrix3x2 result;
+
+            float xTan = MathF.Tan(radiansX);
+            float yTan = MathF.Tan(radiansY);
+
+            float tx = -centerPoint.Y * xTan;
+            float ty = -centerPoint.X * yTan;
+
+            result.M11 = 1.0f;
+            result.M12 = yTan;
+            result.M21 = xTan;
+            result.M22 = 1.0f;
+            result.M31 = tx;
+            result.M32 = ty;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a rotation matrix using the given rotation in radians.
+        /// </summary>
+        /// <param name="radians">The amount of rotation, in radians.</param>
+        /// <returns>A rotation matrix.</returns>
+        public static Matrix3x2 CreateRotation(float radians)
+        {
+            Matrix3x2 result;
+
+            radians = MathF.IEEERemainder(radians, MathF.PI * 2);
+
+            float c, s;
+
+            const float epsilon = 0.001f * MathF.PI / 180f;     // 0.1% of a degree
+
+            if (radians > -epsilon && radians < epsilon)
+            {
+                // Exact case for zero rotation.
+                c = 1;
+                s = 0;
+            }
+            else if (radians > MathF.PI / 2 - epsilon && radians < MathF.PI / 2 + epsilon)
+            {
+                // Exact case for 90 degree rotation.
+                c = 0;
+                s = 1;
+            }
+            else if (radians < -MathF.PI + epsilon || radians > MathF.PI - epsilon)
+            {
+                // Exact case for 180 degree rotation.
+                c = -1;
+                s = 0;
+            }
+            else if (radians > -MathF.PI / 2 - epsilon && radians < -MathF.PI / 2 + epsilon)
+            {
+                // Exact case for 270 degree rotation.
+                c = 0;
+                s = -1;
+            }
+            else
+            {
+                // Arbitrary rotation.
+                c = MathF.Cos(radians);
+                s = MathF.Sin(radians);
+            }
+
+            // [  c  s ]
+            // [ -s  c ]
+            // [  0  0 ]
+            result.M11 = c;
+            result.M12 = s;
+            result.M21 = -s;
+            result.M22 = c;
+            result.M31 = 0.0f;
+            result.M32 = 0.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a rotation matrix using the given rotation in radians and a center point.
+        /// </summary>
+        /// <param name="radians">The amount of rotation, in radians.</param>
+        /// <param name="centerPoint">The center point.</param>
+        /// <returns>A rotation matrix.</returns>
+        public static Matrix3x2 CreateRotation(float radians, Vector2 centerPoint)
+        {
+            Matrix3x2 result;
+
+            radians = MathF.IEEERemainder(radians, MathF.PI * 2);
+
+            float c, s;
+
+            const float epsilon = 0.001f * MathF.PI / 180f;     // 0.1% of a degree
+
+            if (radians > -epsilon && radians < epsilon)
+            {
+                // Exact case for zero rotation.
+                c = 1;
+                s = 0;
+            }
+            else if (radians > MathF.PI / 2 - epsilon && radians < MathF.PI / 2 + epsilon)
+            {
+                // Exact case for 90 degree rotation.
+                c = 0;
+                s = 1;
+            }
+            else if (radians < -MathF.PI + epsilon || radians > MathF.PI - epsilon)
+            {
+                // Exact case for 180 degree rotation.
+                c = -1;
+                s = 0;
+            }
+            else if (radians > -MathF.PI / 2 - epsilon && radians < -MathF.PI / 2 + epsilon)
+            {
+                // Exact case for 270 degree rotation.
+                c = 0;
+                s = -1;
+            }
+            else
+            {
+                // Arbitrary rotation.
+                c = MathF.Cos(radians);
+                s = MathF.Sin(radians);
+            }
+
+            float x = centerPoint.X * (1 - c) + centerPoint.Y * s;
+            float y = centerPoint.Y * (1 - c) - centerPoint.X * s;
+
+            // [  c  s ]
+            // [ -s  c ]
+            // [  x  y ]
+            result.M11 = c;
+            result.M12 = s;
+            result.M21 = -s;
+            result.M22 = c;
+            result.M31 = x;
+            result.M32 = y;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Calculates the determinant for this matrix. 
+        /// The determinant is calculated by expanding the matrix with a third column whose values are (0,0,1).
+        /// </summary>
+        /// <returns>The determinant.</returns>
+        public float GetDeterminant()
+        {
+            // There isn't actually any such thing as a determinant for a non-square matrix,
+            // but this 3x2 type is really just an optimization of a 3x3 where we happen to
+            // know the rightmost column is always (0, 0, 1). So we expand to 3x3 format:
+            //
+            //  [ M11, M12, 0 ]
+            //  [ M21, M22, 0 ]
+            //  [ M31, M32, 1 ]
+            //
+            // Sum the diagonal products:
+            //  (M11 * M22 * 1) + (M12 * 0 * M31) + (0 * M21 * M32)
+            //
+            // Subtract the opposite diagonal products:
+            //  (M31 * M22 * 0) + (M32 * 0 * M11) + (1 * M21 * M12)
+            //
+            // Collapse out the constants and oh look, this is just a 2x2 determinant!
+
+            return (M11 * M22) - (M21 * M12);
+        }
+
+        /// <summary>
+        /// Attempts to invert the given matrix. If the operation succeeds, the inverted matrix is stored in the result parameter.
+        /// </summary>
+        /// <param name="matrix">The source matrix.</param>
+        /// <param name="result">The output matrix.</param>
+        /// <returns>True if the operation succeeded, False otherwise.</returns>
+        public static bool Invert(Matrix3x2 matrix, out Matrix3x2 result)
+        {
+            float det = (matrix.M11 * matrix.M22) - (matrix.M21 * matrix.M12);
+
+            if (MathF.Abs(det) < float.Epsilon)
+            {
+                result = new Matrix3x2(float.NaN, float.NaN, float.NaN, float.NaN, float.NaN, float.NaN);
+                return false;
+            }
+
+            float invDet = 1.0f / det;
+
+            result.M11 = matrix.M22 * invDet;
+            result.M12 = -matrix.M12 * invDet;
+            result.M21 = -matrix.M21 * invDet;
+            result.M22 = matrix.M11 * invDet;
+            result.M31 = (matrix.M21 * matrix.M32 - matrix.M31 * matrix.M22) * invDet;
+            result.M32 = (matrix.M31 * matrix.M12 - matrix.M11 * matrix.M32) * invDet;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Linearly interpolates from matrix1 to matrix2, based on the third parameter.
+        /// </summary>
+        /// <param name="matrix1">The first source matrix.</param>
+        /// <param name="matrix2">The second source matrix.</param>
+        /// <param name="amount">The relative weighting of matrix2.</param>
+        /// <returns>The interpolated matrix.</returns>
+        public static Matrix3x2 Lerp(Matrix3x2 matrix1, Matrix3x2 matrix2, float amount)
+        {
+            Matrix3x2 result;
+
+            // First row
+            result.M11 = matrix1.M11 + (matrix2.M11 - matrix1.M11) * amount;
+            result.M12 = matrix1.M12 + (matrix2.M12 - matrix1.M12) * amount;
+
+            // Second row
+            result.M21 = matrix1.M21 + (matrix2.M21 - matrix1.M21) * amount;
+            result.M22 = matrix1.M22 + (matrix2.M22 - matrix1.M22) * amount;
+
+            // Third row
+            result.M31 = matrix1.M31 + (matrix2.M31 - matrix1.M31) * amount;
+            result.M32 = matrix1.M32 + (matrix2.M32 - matrix1.M32) * amount;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Negates the given matrix by multiplying all values by -1.
+        /// </summary>
+        /// <param name="value">The source matrix.</param>
+        /// <returns>The negated matrix.</returns>
+        public static Matrix3x2 Negate(Matrix3x2 value)
+        {
+            Matrix3x2 result;
+
+            result.M11 = -value.M11;
+            result.M12 = -value.M12;
+            result.M21 = -value.M21;
+            result.M22 = -value.M22;
+            result.M31 = -value.M31;
+            result.M32 = -value.M32;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Adds each matrix element in value1 with its corresponding element in value2.
+        /// </summary>
+        /// <param name="value1">The first source matrix.</param>
+        /// <param name="value2">The second source matrix.</param>
+        /// <returns>The matrix containing the summed values.</returns>
+        public static Matrix3x2 Add(Matrix3x2 value1, Matrix3x2 value2)
+        {
+            Matrix3x2 result;
+
+            result.M11 = value1.M11 + value2.M11;
+            result.M12 = value1.M12 + value2.M12;
+            result.M21 = value1.M21 + value2.M21;
+            result.M22 = value1.M22 + value2.M22;
+            result.M31 = value1.M31 + value2.M31;
+            result.M32 = value1.M32 + value2.M32;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Subtracts each matrix element in value2 from its corresponding element in value1.
+        /// </summary>
+        /// <param name="value1">The first source matrix.</param>
+        /// <param name="value2">The second source matrix.</param>
+        /// <returns>The matrix containing the resulting values.</returns>
+        public static Matrix3x2 Subtract(Matrix3x2 value1, Matrix3x2 value2)
+        {
+            Matrix3x2 result;
+
+            result.M11 = value1.M11 - value2.M11;
+            result.M12 = value1.M12 - value2.M12;
+            result.M21 = value1.M21 - value2.M21;
+            result.M22 = value1.M22 - value2.M22;
+            result.M31 = value1.M31 - value2.M31;
+            result.M32 = value1.M32 - value2.M32;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Multiplies two matrices together and returns the resulting matrix.
+        /// </summary>
+        /// <param name="value1">The first source matrix.</param>
+        /// <param name="value2">The second source matrix.</param>
+        /// <returns>The product matrix.</returns>
+        public static Matrix3x2 Multiply(Matrix3x2 value1, Matrix3x2 value2)
+        {
+            Matrix3x2 result;
+
+            // First row
+            result.M11 = value1.M11 * value2.M11 + value1.M12 * value2.M21;
+            result.M12 = value1.M11 * value2.M12 + value1.M12 * value2.M22;
+
+            // Second row
+            result.M21 = value1.M21 * value2.M11 + value1.M22 * value2.M21;
+            result.M22 = value1.M21 * value2.M12 + value1.M22 * value2.M22;
+
+            // Third row
+            result.M31 = value1.M31 * value2.M11 + value1.M32 * value2.M21 + value2.M31;
+            result.M32 = value1.M31 * value2.M12 + value1.M32 * value2.M22 + value2.M32;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Scales all elements in a matrix by the given scalar factor.
+        /// </summary>
+        /// <param name="value1">The source matrix.</param>
+        /// <param name="value2">The scaling value to use.</param>
+        /// <returns>The resulting matrix.</returns>
+        public static Matrix3x2 Multiply(Matrix3x2 value1, float value2)
+        {
+            Matrix3x2 result;
+
+            result.M11 = value1.M11 * value2;
+            result.M12 = value1.M12 * value2;
+            result.M21 = value1.M21 * value2;
+            result.M22 = value1.M22 * value2;
+            result.M31 = value1.M31 * value2;
+            result.M32 = value1.M32 * value2;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Negates the given matrix by multiplying all values by -1.
+        /// </summary>
+        /// <param name="value">The source matrix.</param>
+        /// <returns>The negated matrix.</returns>
+        public static Matrix3x2 operator -(Matrix3x2 value)
+        {
+            Matrix3x2 m;
+
+            m.M11 = -value.M11;
+            m.M12 = -value.M12;
+            m.M21 = -value.M21;
+            m.M22 = -value.M22;
+            m.M31 = -value.M31;
+            m.M32 = -value.M32;
+
+            return m;
+        }
+
+        /// <summary>
+        /// Adds each matrix element in value1 with its corresponding element in value2.
+        /// </summary>
+        /// <param name="value1">The first source matrix.</param>
+        /// <param name="value2">The second source matrix.</param>
+        /// <returns>The matrix containing the summed values.</returns>
+        public static Matrix3x2 operator +(Matrix3x2 value1, Matrix3x2 value2)
+        {
+            Matrix3x2 m;
+
+            m.M11 = value1.M11 + value2.M11;
+            m.M12 = value1.M12 + value2.M12;
+            m.M21 = value1.M21 + value2.M21;
+            m.M22 = value1.M22 + value2.M22;
+            m.M31 = value1.M31 + value2.M31;
+            m.M32 = value1.M32 + value2.M32;
+
+            return m;
+        }
+
+        /// <summary>
+        /// Subtracts each matrix element in value2 from its corresponding element in value1.
+        /// </summary>
+        /// <param name="value1">The first source matrix.</param>
+        /// <param name="value2">The second source matrix.</param>
+        /// <returns>The matrix containing the resulting values.</returns>
+        public static Matrix3x2 operator -(Matrix3x2 value1, Matrix3x2 value2)
+        {
+            Matrix3x2 m;
+
+            m.M11 = value1.M11 - value2.M11;
+            m.M12 = value1.M12 - value2.M12;
+            m.M21 = value1.M21 - value2.M21;
+            m.M22 = value1.M22 - value2.M22;
+            m.M31 = value1.M31 - value2.M31;
+            m.M32 = value1.M32 - value2.M32;
+
+            return m;
+        }
+
+        /// <summary>
+        /// Multiplies two matrices together and returns the resulting matrix.
+        /// </summary>
+        /// <param name="value1">The first source matrix.</param>
+        /// <param name="value2">The second source matrix.</param>
+        /// <returns>The product matrix.</returns>
+        public static Matrix3x2 operator *(Matrix3x2 value1, Matrix3x2 value2)
+        {
+            Matrix3x2 m;
+
+            // First row
+            m.M11 = value1.M11 * value2.M11 + value1.M12 * value2.M21;
+            m.M12 = value1.M11 * value2.M12 + value1.M12 * value2.M22;
+
+            // Second row
+            m.M21 = value1.M21 * value2.M11 + value1.M22 * value2.M21;
+            m.M22 = value1.M21 * value2.M12 + value1.M22 * value2.M22;
+
+            // Third row
+            m.M31 = value1.M31 * value2.M11 + value1.M32 * value2.M21 + value2.M31;
+            m.M32 = value1.M31 * value2.M12 + value1.M32 * value2.M22 + value2.M32;
+
+            return m;
+        }
+
+        /// <summary>
+        /// Scales all elements in a matrix by the given scalar factor.
+        /// </summary>
+        /// <param name="value1">The source matrix.</param>
+        /// <param name="value2">The scaling value to use.</param>
+        /// <returns>The resulting matrix.</returns>
+        public static Matrix3x2 operator *(Matrix3x2 value1, float value2)
+        {
+            Matrix3x2 m;
+
+            m.M11 = value1.M11 * value2;
+            m.M12 = value1.M12 * value2;
+            m.M21 = value1.M21 * value2;
+            m.M22 = value1.M22 * value2;
+            m.M31 = value1.M31 * value2;
+            m.M32 = value1.M32 * value2;
+
+            return m;
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the given matrices are equal.
+        /// </summary>
+        /// <param name="value1">The first source matrix.</param>
+        /// <param name="value2">The second source matrix.</param>
+        /// <returns>True if the matrices are equal; False otherwise.</returns>
+        public static bool operator ==(Matrix3x2 value1, Matrix3x2 value2)
+        {
+            return (value1.M11 == value2.M11 && value1.M22 == value2.M22 && // Check diagonal element first for early out.
+                                                value1.M12 == value2.M12 &&
+                    value1.M21 == value2.M21 &&
+                    value1.M31 == value2.M31 && value1.M32 == value2.M32);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the given matrices are not equal.
+        /// </summary>
+        /// <param name="value1">The first source matrix.</param>
+        /// <param name="value2">The second source matrix.</param>
+        /// <returns>True if the matrices are not equal; False if they are equal.</returns>
+        public static bool operator !=(Matrix3x2 value1, Matrix3x2 value2)
+        {
+            return (value1.M11 != value2.M11 || value1.M12 != value2.M12 ||
+                    value1.M21 != value2.M21 || value1.M22 != value2.M22 ||
+                    value1.M31 != value2.M31 || value1.M32 != value2.M32);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the matrix is equal to the other given matrix.
+        /// </summary>
+        /// <param name="other">The other matrix to test equality against.</param>
+        /// <returns>True if this matrix is equal to other; False otherwise.</returns>
+        public bool Equals(Matrix3x2 other)
+        {
+            return (M11 == other.M11 && M22 == other.M22 && // Check diagonal element first for early out.
+                                        M12 == other.M12 &&
+                    M21 == other.M21 &&
+                    M31 == other.M31 && M32 == other.M32);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the given Object is equal to this matrix instance.
+        /// </summary>
+        /// <param name="obj">The Object to compare against.</param>
+        /// <returns>True if the Object is equal to this matrix; False otherwise.</returns>
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix3x2)
+            {
+                return Equals((Matrix3x2)obj);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns a String representing this matrix instance.
+        /// </summary>
+        /// <returns>The string representation.</returns>
+        public override string ToString()
+        {
+            CultureInfo ci = CultureInfo.CurrentCulture;
+            return String.Format(ci, "{{ {{M11:{0} M12:{1}}} {{M21:{2} M22:{3}}} {{M31:{4} M32:{5}}} }}",
+                                 M11.ToString(ci), M12.ToString(ci),
+                                 M21.ToString(ci), M22.ToString(ci),
+                                 M31.ToString(ci), M32.ToString(ci));
+        }
+
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>The hash code.</returns>
+        public override int GetHashCode()
+        {
+            return unchecked(M11.GetHashCode() + M12.GetHashCode() +
+                             M21.GetHashCode() + M22.GetHashCode() +
+                             M31.GetHashCode() + M32.GetHashCode());
+        }
+    }
+}

--- a/src/mscorlib/src/System/Numerics/Matrix4x4.cs
+++ b/src/mscorlib/src/System/Numerics/Matrix4x4.cs
@@ -1,0 +1,2219 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+
+namespace System.Numerics
+{
+    /// <summary>
+    /// A structure encapsulating a 4x4 matrix.
+    /// </summary>
+    public struct Matrix4x4 : IEquatable<Matrix4x4>
+    {
+        #region Public Fields
+        /// <summary>
+        /// Value at row 1, column 1 of the matrix.
+        /// </summary>
+        public float M11;
+        /// <summary>
+        /// Value at row 1, column 2 of the matrix.
+        /// </summary>
+        public float M12;
+        /// <summary>
+        /// Value at row 1, column 3 of the matrix.
+        /// </summary>
+        public float M13;
+        /// <summary>
+        /// Value at row 1, column 4 of the matrix.
+        /// </summary>
+        public float M14;
+
+        /// <summary>
+        /// Value at row 2, column 1 of the matrix.
+        /// </summary>
+        public float M21;
+        /// <summary>
+        /// Value at row 2, column 2 of the matrix.
+        /// </summary>
+        public float M22;
+        /// <summary>
+        /// Value at row 2, column 3 of the matrix.
+        /// </summary>
+        public float M23;
+        /// <summary>
+        /// Value at row 2, column 4 of the matrix.
+        /// </summary>
+        public float M24;
+
+        /// <summary>
+        /// Value at row 3, column 1 of the matrix.
+        /// </summary>
+        public float M31;
+        /// <summary>
+        /// Value at row 3, column 2 of the matrix.
+        /// </summary>
+        public float M32;
+        /// <summary>
+        /// Value at row 3, column 3 of the matrix.
+        /// </summary>
+        public float M33;
+        /// <summary>
+        /// Value at row 3, column 4 of the matrix.
+        /// </summary>
+        public float M34;
+
+        /// <summary>
+        /// Value at row 4, column 1 of the matrix.
+        /// </summary>
+        public float M41;
+        /// <summary>
+        /// Value at row 4, column 2 of the matrix.
+        /// </summary>
+        public float M42;
+        /// <summary>
+        /// Value at row 4, column 3 of the matrix.
+        /// </summary>
+        public float M43;
+        /// <summary>
+        /// Value at row 4, column 4 of the matrix.
+        /// </summary>
+        public float M44;
+        #endregion Public Fields
+
+        private static readonly Matrix4x4 _identity = new Matrix4x4
+        (
+            1f, 0f, 0f, 0f,
+            0f, 1f, 0f, 0f,
+            0f, 0f, 1f, 0f,
+            0f, 0f, 0f, 1f
+        );
+
+        /// <summary>
+        /// Returns the multiplicative identity matrix.
+        /// </summary>
+        public static Matrix4x4 Identity
+        {
+            get { return _identity; }
+        }
+
+        /// <summary>
+        /// Returns whether the matrix is the identity matrix.
+        /// </summary>
+        public bool IsIdentity
+        {
+            get
+            {
+                return M11 == 1f && M22 == 1f && M33 == 1f && M44 == 1f && // Check diagonal element first for early out.
+                                    M12 == 0f && M13 == 0f && M14 == 0f &&
+                       M21 == 0f && M23 == 0f && M24 == 0f &&
+                       M31 == 0f && M32 == 0f && M34 == 0f &&
+                       M41 == 0f && M42 == 0f && M43 == 0f;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the translation component of this matrix.
+        /// </summary>
+        public Vector3 Translation
+        {
+            get
+            {
+                return new Vector3(M41, M42, M43);
+            }
+            set
+            {
+                M41 = value.X;
+                M42 = value.Y;
+                M43 = value.Z;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a Matrix4x4 from the given components.
+        /// </summary>
+        public Matrix4x4(float m11, float m12, float m13, float m14,
+                         float m21, float m22, float m23, float m24,
+                         float m31, float m32, float m33, float m34,
+                         float m41, float m42, float m43, float m44)
+        {
+            this.M11 = m11;
+            this.M12 = m12;
+            this.M13 = m13;
+            this.M14 = m14;
+
+            this.M21 = m21;
+            this.M22 = m22;
+            this.M23 = m23;
+            this.M24 = m24;
+
+            this.M31 = m31;
+            this.M32 = m32;
+            this.M33 = m33;
+            this.M34 = m34;
+
+            this.M41 = m41;
+            this.M42 = m42;
+            this.M43 = m43;
+            this.M44 = m44;
+        }
+
+        /// <summary>
+        /// Constructs a Matrix4x4 from the given Matrix3x2.
+        /// </summary>
+        /// <param name="value">The source Matrix3x2.</param>
+        public Matrix4x4(Matrix3x2 value)
+        {
+            M11 = value.M11;
+            M12 = value.M12;
+            M13 = 0f;
+            M14 = 0f;
+            M21 = value.M21;
+            M22 = value.M22;
+            M23 = 0f;
+            M24 = 0f;
+            M31 = 0f;
+            M32 = 0f;
+            M33 = 1f;
+            M34 = 0f;
+            M41 = value.M31;
+            M42 = value.M32;
+            M43 = 0f;
+            M44 = 1f;
+        }
+
+        /// <summary>
+        /// Creates a spherical billboard that rotates around a specified object position.
+        /// </summary>
+        /// <param name="objectPosition">Position of the object the billboard will rotate around.</param>
+        /// <param name="cameraPosition">Position of the camera.</param>
+        /// <param name="cameraUpVector">The up vector of the camera.</param>
+        /// <param name="cameraForwardVector">The forward vector of the camera.</param>
+        /// <returns>The created billboard matrix</returns>
+        public static Matrix4x4 CreateBillboard(Vector3 objectPosition, Vector3 cameraPosition, Vector3 cameraUpVector, Vector3 cameraForwardVector)
+        {
+            const float epsilon = 1e-4f;
+
+            Vector3 zaxis = new Vector3(
+                objectPosition.X - cameraPosition.X,
+                objectPosition.Y - cameraPosition.Y,
+                objectPosition.Z - cameraPosition.Z);
+
+            float norm = zaxis.LengthSquared();
+
+            if (norm < epsilon)
+            {
+                zaxis = -cameraForwardVector;
+            }
+            else
+            {
+                zaxis = Vector3.Multiply(zaxis, 1.0f / MathF.Sqrt(norm));
+            }
+
+            Vector3 xaxis = Vector3.Normalize(Vector3.Cross(cameraUpVector, zaxis));
+
+            Vector3 yaxis = Vector3.Cross(zaxis, xaxis);
+
+            Matrix4x4 result;
+
+            result.M11 = xaxis.X;
+            result.M12 = xaxis.Y;
+            result.M13 = xaxis.Z;
+            result.M14 = 0.0f;
+            result.M21 = yaxis.X;
+            result.M22 = yaxis.Y;
+            result.M23 = yaxis.Z;
+            result.M24 = 0.0f;
+            result.M31 = zaxis.X;
+            result.M32 = zaxis.Y;
+            result.M33 = zaxis.Z;
+            result.M34 = 0.0f;
+
+            result.M41 = objectPosition.X;
+            result.M42 = objectPosition.Y;
+            result.M43 = objectPosition.Z;
+            result.M44 = 1.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a cylindrical billboard that rotates around a specified axis.
+        /// </summary>
+        /// <param name="objectPosition">Position of the object the billboard will rotate around.</param>
+        /// <param name="cameraPosition">Position of the camera.</param>
+        /// <param name="rotateAxis">Axis to rotate the billboard around.</param>
+        /// <param name="cameraForwardVector">Forward vector of the camera.</param>
+        /// <param name="objectForwardVector">Forward vector of the object.</param>
+        /// <returns>The created billboard matrix.</returns>
+        public static Matrix4x4 CreateConstrainedBillboard(Vector3 objectPosition, Vector3 cameraPosition, Vector3 rotateAxis, Vector3 cameraForwardVector, Vector3 objectForwardVector)
+        {
+            const float epsilon = 1e-4f;
+            const float minAngle = 1.0f - (0.1f * (MathF.PI / 180.0f)); // 0.1 degrees
+
+            // Treat the case when object and camera positions are too close.
+            Vector3 faceDir = new Vector3(
+                objectPosition.X - cameraPosition.X,
+                objectPosition.Y - cameraPosition.Y,
+                objectPosition.Z - cameraPosition.Z);
+
+            float norm = faceDir.LengthSquared();
+
+            if (norm < epsilon)
+            {
+                faceDir = -cameraForwardVector;
+            }
+            else
+            {
+                faceDir = Vector3.Multiply(faceDir, (1.0f / MathF.Sqrt(norm)));
+            }
+
+            Vector3 yaxis = rotateAxis;
+            Vector3 xaxis;
+            Vector3 zaxis;
+
+            // Treat the case when angle between faceDir and rotateAxis is too close to 0.
+            float dot = Vector3.Dot(rotateAxis, faceDir);
+
+            if (MathF.Abs(dot) > minAngle)
+            {
+                zaxis = objectForwardVector;
+
+                // Make sure passed values are useful for compute.
+                dot = Vector3.Dot(rotateAxis, zaxis);
+
+                if (MathF.Abs(dot) > minAngle)
+                {
+                    zaxis = (MathF.Abs(rotateAxis.Z) > minAngle) ? new Vector3(1, 0, 0) : new Vector3(0, 0, -1);
+                }
+
+                xaxis = Vector3.Normalize(Vector3.Cross(rotateAxis, zaxis));
+                zaxis = Vector3.Normalize(Vector3.Cross(xaxis, rotateAxis));
+            }
+            else
+            {
+                xaxis = Vector3.Normalize(Vector3.Cross(rotateAxis, faceDir));
+                zaxis = Vector3.Normalize(Vector3.Cross(xaxis, yaxis));
+            }
+
+            Matrix4x4 result;
+
+            result.M11 = xaxis.X;
+            result.M12 = xaxis.Y;
+            result.M13 = xaxis.Z;
+            result.M14 = 0.0f;
+            result.M21 = yaxis.X;
+            result.M22 = yaxis.Y;
+            result.M23 = yaxis.Z;
+            result.M24 = 0.0f;
+            result.M31 = zaxis.X;
+            result.M32 = zaxis.Y;
+            result.M33 = zaxis.Z;
+            result.M34 = 0.0f;
+
+            result.M41 = objectPosition.X;
+            result.M42 = objectPosition.Y;
+            result.M43 = objectPosition.Z;
+            result.M44 = 1.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a translation matrix.
+        /// </summary>
+        /// <param name="position">The amount to translate in each axis.</param>
+        /// <returns>The translation matrix.</returns>
+        public static Matrix4x4 CreateTranslation(Vector3 position)
+        {
+            Matrix4x4 result;
+
+            result.M11 = 1.0f;
+            result.M12 = 0.0f;
+            result.M13 = 0.0f;
+            result.M14 = 0.0f;
+            result.M21 = 0.0f;
+            result.M22 = 1.0f;
+            result.M23 = 0.0f;
+            result.M24 = 0.0f;
+            result.M31 = 0.0f;
+            result.M32 = 0.0f;
+            result.M33 = 1.0f;
+            result.M34 = 0.0f;
+
+            result.M41 = position.X;
+            result.M42 = position.Y;
+            result.M43 = position.Z;
+            result.M44 = 1.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a translation matrix.
+        /// </summary>
+        /// <param name="xPosition">The amount to translate on the X-axis.</param>
+        /// <param name="yPosition">The amount to translate on the Y-axis.</param>
+        /// <param name="zPosition">The amount to translate on the Z-axis.</param>
+        /// <returns>The translation matrix.</returns>
+        public static Matrix4x4 CreateTranslation(float xPosition, float yPosition, float zPosition)
+        {
+            Matrix4x4 result;
+
+            result.M11 = 1.0f;
+            result.M12 = 0.0f;
+            result.M13 = 0.0f;
+            result.M14 = 0.0f;
+            result.M21 = 0.0f;
+            result.M22 = 1.0f;
+            result.M23 = 0.0f;
+            result.M24 = 0.0f;
+            result.M31 = 0.0f;
+            result.M32 = 0.0f;
+            result.M33 = 1.0f;
+            result.M34 = 0.0f;
+
+            result.M41 = xPosition;
+            result.M42 = yPosition;
+            result.M43 = zPosition;
+            result.M44 = 1.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a scaling matrix.
+        /// </summary>
+        /// <param name="xScale">Value to scale by on the X-axis.</param>
+        /// <param name="yScale">Value to scale by on the Y-axis.</param>
+        /// <param name="zScale">Value to scale by on the Z-axis.</param>
+        /// <returns>The scaling matrix.</returns>
+        public static Matrix4x4 CreateScale(float xScale, float yScale, float zScale)
+        {
+            Matrix4x4 result;
+
+            result.M11 = xScale;
+            result.M12 = 0.0f;
+            result.M13 = 0.0f;
+            result.M14 = 0.0f;
+            result.M21 = 0.0f;
+            result.M22 = yScale;
+            result.M23 = 0.0f;
+            result.M24 = 0.0f;
+            result.M31 = 0.0f;
+            result.M32 = 0.0f;
+            result.M33 = zScale;
+            result.M34 = 0.0f;
+            result.M41 = 0.0f;
+            result.M42 = 0.0f;
+            result.M43 = 0.0f;
+            result.M44 = 1.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a scaling matrix with a center point.
+        /// </summary>
+        /// <param name="xScale">Value to scale by on the X-axis.</param>
+        /// <param name="yScale">Value to scale by on the Y-axis.</param>
+        /// <param name="zScale">Value to scale by on the Z-axis.</param>
+        /// <param name="centerPoint">The center point.</param>
+        /// <returns>The scaling matrix.</returns>
+        public static Matrix4x4 CreateScale(float xScale, float yScale, float zScale, Vector3 centerPoint)
+        {
+            Matrix4x4 result;
+
+            float tx = centerPoint.X * (1 - xScale);
+            float ty = centerPoint.Y * (1 - yScale);
+            float tz = centerPoint.Z * (1 - zScale);
+
+            result.M11 = xScale;
+            result.M12 = 0.0f;
+            result.M13 = 0.0f;
+            result.M14 = 0.0f;
+            result.M21 = 0.0f;
+            result.M22 = yScale;
+            result.M23 = 0.0f;
+            result.M24 = 0.0f;
+            result.M31 = 0.0f;
+            result.M32 = 0.0f;
+            result.M33 = zScale;
+            result.M34 = 0.0f;
+            result.M41 = tx;
+            result.M42 = ty;
+            result.M43 = tz;
+            result.M44 = 1.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a scaling matrix.
+        /// </summary>
+        /// <param name="scales">The vector containing the amount to scale by on each axis.</param>
+        /// <returns>The scaling matrix.</returns>
+        public static Matrix4x4 CreateScale(Vector3 scales)
+        {
+            Matrix4x4 result;
+
+            result.M11 = scales.X;
+            result.M12 = 0.0f;
+            result.M13 = 0.0f;
+            result.M14 = 0.0f;
+            result.M21 = 0.0f;
+            result.M22 = scales.Y;
+            result.M23 = 0.0f;
+            result.M24 = 0.0f;
+            result.M31 = 0.0f;
+            result.M32 = 0.0f;
+            result.M33 = scales.Z;
+            result.M34 = 0.0f;
+            result.M41 = 0.0f;
+            result.M42 = 0.0f;
+            result.M43 = 0.0f;
+            result.M44 = 1.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a scaling matrix with a center point.
+        /// </summary>
+        /// <param name="scales">The vector containing the amount to scale by on each axis.</param>
+        /// <param name="centerPoint">The center point.</param>
+        /// <returns>The scaling matrix.</returns>
+        public static Matrix4x4 CreateScale(Vector3 scales, Vector3 centerPoint)
+        {
+            Matrix4x4 result;
+
+            float tx = centerPoint.X * (1 - scales.X);
+            float ty = centerPoint.Y * (1 - scales.Y);
+            float tz = centerPoint.Z * (1 - scales.Z);
+
+            result.M11 = scales.X;
+            result.M12 = 0.0f;
+            result.M13 = 0.0f;
+            result.M14 = 0.0f;
+            result.M21 = 0.0f;
+            result.M22 = scales.Y;
+            result.M23 = 0.0f;
+            result.M24 = 0.0f;
+            result.M31 = 0.0f;
+            result.M32 = 0.0f;
+            result.M33 = scales.Z;
+            result.M34 = 0.0f;
+            result.M41 = tx;
+            result.M42 = ty;
+            result.M43 = tz;
+            result.M44 = 1.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a uniform scaling matrix that scales equally on each axis.
+        /// </summary>
+        /// <param name="scale">The uniform scaling factor.</param>
+        /// <returns>The scaling matrix.</returns>
+        public static Matrix4x4 CreateScale(float scale)
+        {
+            Matrix4x4 result;
+
+            result.M11 = scale;
+            result.M12 = 0.0f;
+            result.M13 = 0.0f;
+            result.M14 = 0.0f;
+            result.M21 = 0.0f;
+            result.M22 = scale;
+            result.M23 = 0.0f;
+            result.M24 = 0.0f;
+            result.M31 = 0.0f;
+            result.M32 = 0.0f;
+            result.M33 = scale;
+            result.M34 = 0.0f;
+            result.M41 = 0.0f;
+            result.M42 = 0.0f;
+            result.M43 = 0.0f;
+            result.M44 = 1.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a uniform scaling matrix that scales equally on each axis with a center point.
+        /// </summary>
+        /// <param name="scale">The uniform scaling factor.</param>
+        /// <param name="centerPoint">The center point.</param>
+        /// <returns>The scaling matrix.</returns>
+        public static Matrix4x4 CreateScale(float scale, Vector3 centerPoint)
+        {
+            Matrix4x4 result;
+
+            float tx = centerPoint.X * (1 - scale);
+            float ty = centerPoint.Y * (1 - scale);
+            float tz = centerPoint.Z * (1 - scale);
+
+            result.M11 = scale;
+            result.M12 = 0.0f;
+            result.M13 = 0.0f;
+            result.M14 = 0.0f;
+            result.M21 = 0.0f;
+            result.M22 = scale;
+            result.M23 = 0.0f;
+            result.M24 = 0.0f;
+            result.M31 = 0.0f;
+            result.M32 = 0.0f;
+            result.M33 = scale;
+            result.M34 = 0.0f;
+            result.M41 = tx;
+            result.M42 = ty;
+            result.M43 = tz;
+            result.M44 = 1.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a matrix for rotating points around the X-axis.
+        /// </summary>
+        /// <param name="radians">The amount, in radians, by which to rotate around the X-axis.</param>
+        /// <returns>The rotation matrix.</returns>
+        public static Matrix4x4 CreateRotationX(float radians)
+        {
+            Matrix4x4 result;
+
+            float c = MathF.Cos(radians);
+            float s = MathF.Sin(radians);
+
+            // [  1  0  0  0 ]
+            // [  0  c  s  0 ]
+            // [  0 -s  c  0 ]
+            // [  0  0  0  1 ]
+            result.M11 = 1.0f;
+            result.M12 = 0.0f;
+            result.M13 = 0.0f;
+            result.M14 = 0.0f;
+            result.M21 = 0.0f;
+            result.M22 = c;
+            result.M23 = s;
+            result.M24 = 0.0f;
+            result.M31 = 0.0f;
+            result.M32 = -s;
+            result.M33 = c;
+            result.M34 = 0.0f;
+            result.M41 = 0.0f;
+            result.M42 = 0.0f;
+            result.M43 = 0.0f;
+            result.M44 = 1.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a matrix for rotating points around the X-axis, from a center point.
+        /// </summary>
+        /// <param name="radians">The amount, in radians, by which to rotate around the X-axis.</param>
+        /// <param name="centerPoint">The center point.</param>
+        /// <returns>The rotation matrix.</returns>
+        public static Matrix4x4 CreateRotationX(float radians, Vector3 centerPoint)
+        {
+            Matrix4x4 result;
+
+            float c = MathF.Cos(radians);
+            float s = MathF.Sin(radians);
+
+            float y = centerPoint.Y * (1 - c) + centerPoint.Z * s;
+            float z = centerPoint.Z * (1 - c) - centerPoint.Y * s;
+
+            // [  1  0  0  0 ]
+            // [  0  c  s  0 ]
+            // [  0 -s  c  0 ]
+            // [  0  y  z  1 ]
+            result.M11 = 1.0f;
+            result.M12 = 0.0f;
+            result.M13 = 0.0f;
+            result.M14 = 0.0f;
+            result.M21 = 0.0f;
+            result.M22 = c;
+            result.M23 = s;
+            result.M24 = 0.0f;
+            result.M31 = 0.0f;
+            result.M32 = -s;
+            result.M33 = c;
+            result.M34 = 0.0f;
+            result.M41 = 0.0f;
+            result.M42 = y;
+            result.M43 = z;
+            result.M44 = 1.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a matrix for rotating points around the Y-axis.
+        /// </summary>
+        /// <param name="radians">The amount, in radians, by which to rotate around the Y-axis.</param>
+        /// <returns>The rotation matrix.</returns>
+        public static Matrix4x4 CreateRotationY(float radians)
+        {
+            Matrix4x4 result;
+
+            float c = MathF.Cos(radians);
+            float s = MathF.Sin(radians);
+
+            // [  c  0 -s  0 ]
+            // [  0  1  0  0 ]
+            // [  s  0  c  0 ]
+            // [  0  0  0  1 ]
+            result.M11 = c;
+            result.M12 = 0.0f;
+            result.M13 = -s;
+            result.M14 = 0.0f;
+            result.M21 = 0.0f;
+            result.M22 = 1.0f;
+            result.M23 = 0.0f;
+            result.M24 = 0.0f;
+            result.M31 = s;
+            result.M32 = 0.0f;
+            result.M33 = c;
+            result.M34 = 0.0f;
+            result.M41 = 0.0f;
+            result.M42 = 0.0f;
+            result.M43 = 0.0f;
+            result.M44 = 1.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a matrix for rotating points around the Y-axis, from a center point.
+        /// </summary>
+        /// <param name="radians">The amount, in radians, by which to rotate around the Y-axis.</param>
+        /// <param name="centerPoint">The center point.</param>
+        /// <returns>The rotation matrix.</returns>
+        public static Matrix4x4 CreateRotationY(float radians, Vector3 centerPoint)
+        {
+            Matrix4x4 result;
+
+            float c = MathF.Cos(radians);
+            float s = MathF.Sin(radians);
+
+            float x = centerPoint.X * (1 - c) - centerPoint.Z * s;
+            float z = centerPoint.Z * (1 - c) + centerPoint.X * s;
+
+            // [  c  0 -s  0 ]
+            // [  0  1  0  0 ]
+            // [  s  0  c  0 ]
+            // [  x  0  z  1 ]
+            result.M11 = c;
+            result.M12 = 0.0f;
+            result.M13 = -s;
+            result.M14 = 0.0f;
+            result.M21 = 0.0f;
+            result.M22 = 1.0f;
+            result.M23 = 0.0f;
+            result.M24 = 0.0f;
+            result.M31 = s;
+            result.M32 = 0.0f;
+            result.M33 = c;
+            result.M34 = 0.0f;
+            result.M41 = x;
+            result.M42 = 0.0f;
+            result.M43 = z;
+            result.M44 = 1.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a matrix for rotating points around the Z-axis.
+        /// </summary>
+        /// <param name="radians">The amount, in radians, by which to rotate around the Z-axis.</param>
+        /// <returns>The rotation matrix.</returns>
+        public static Matrix4x4 CreateRotationZ(float radians)
+        {
+            Matrix4x4 result;
+
+            float c = MathF.Cos(radians);
+            float s = MathF.Sin(radians);
+
+            // [  c  s  0  0 ]
+            // [ -s  c  0  0 ]
+            // [  0  0  1  0 ]
+            // [  0  0  0  1 ]
+            result.M11 = c;
+            result.M12 = s;
+            result.M13 = 0.0f;
+            result.M14 = 0.0f;
+            result.M21 = -s;
+            result.M22 = c;
+            result.M23 = 0.0f;
+            result.M24 = 0.0f;
+            result.M31 = 0.0f;
+            result.M32 = 0.0f;
+            result.M33 = 1.0f;
+            result.M34 = 0.0f;
+            result.M41 = 0.0f;
+            result.M42 = 0.0f;
+            result.M43 = 0.0f;
+            result.M44 = 1.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a matrix for rotating points around the Z-axis, from a center point.
+        /// </summary>
+        /// <param name="radians">The amount, in radians, by which to rotate around the Z-axis.</param>
+        /// <param name="centerPoint">The center point.</param>
+        /// <returns>The rotation matrix.</returns>
+        public static Matrix4x4 CreateRotationZ(float radians, Vector3 centerPoint)
+        {
+            Matrix4x4 result;
+
+            float c = MathF.Cos(radians);
+            float s = MathF.Sin(radians);
+
+            float x = centerPoint.X * (1 - c) + centerPoint.Y * s;
+            float y = centerPoint.Y * (1 - c) - centerPoint.X * s;
+
+            // [  c  s  0  0 ]
+            // [ -s  c  0  0 ]
+            // [  0  0  1  0 ]
+            // [  x  y  0  1 ]
+            result.M11 = c;
+            result.M12 = s;
+            result.M13 = 0.0f;
+            result.M14 = 0.0f;
+            result.M21 = -s;
+            result.M22 = c;
+            result.M23 = 0.0f;
+            result.M24 = 0.0f;
+            result.M31 = 0.0f;
+            result.M32 = 0.0f;
+            result.M33 = 1.0f;
+            result.M34 = 0.0f;
+            result.M41 = x;
+            result.M42 = y;
+            result.M43 = 0.0f;
+            result.M44 = 1.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a matrix that rotates around an arbitrary vector.
+        /// </summary>
+        /// <param name="axis">The axis to rotate around.</param>
+        /// <param name="angle">The angle to rotate around the given axis, in radians.</param>
+        /// <returns>The rotation matrix.</returns>
+        public static Matrix4x4 CreateFromAxisAngle(Vector3 axis, float angle)
+        {
+            // a: angle
+            // x, y, z: unit vector for axis.
+            //
+            // Rotation matrix M can compute by using below equation.
+            //
+            //        T               T
+            //  M = uu + (cos a)( I-uu ) + (sin a)S
+            //
+            // Where:
+            //
+            //  u = ( x, y, z )
+            //
+            //      [  0 -z  y ]
+            //  S = [  z  0 -x ]
+            //      [ -y  x  0 ]
+            //
+            //      [ 1 0 0 ]
+            //  I = [ 0 1 0 ]
+            //      [ 0 0 1 ]
+            //
+            //
+            //     [  xx+cosa*(1-xx)   yx-cosa*yx-sina*z zx-cosa*xz+sina*y ]
+            // M = [ xy-cosa*yx+sina*z    yy+cosa(1-yy)  yz-cosa*yz-sina*x ]
+            //     [ zx-cosa*zx-sina*y zy-cosa*zy+sina*x   zz+cosa*(1-zz)  ]
+            //
+            float x = axis.X, y = axis.Y, z = axis.Z;
+            float sa = MathF.Sin(angle), ca = MathF.Cos(angle);
+            float xx = x * x, yy = y * y, zz = z * z;
+            float xy = x * y, xz = x * z, yz = y * z;
+
+            Matrix4x4 result;
+
+            result.M11 = xx + ca * (1.0f - xx);
+            result.M12 = xy - ca * xy + sa * z;
+            result.M13 = xz - ca * xz - sa * y;
+            result.M14 = 0.0f;
+            result.M21 = xy - ca * xy - sa * z;
+            result.M22 = yy + ca * (1.0f - yy);
+            result.M23 = yz - ca * yz + sa * x;
+            result.M24 = 0.0f;
+            result.M31 = xz - ca * xz + sa * y;
+            result.M32 = yz - ca * yz - sa * x;
+            result.M33 = zz + ca * (1.0f - zz);
+            result.M34 = 0.0f;
+            result.M41 = 0.0f;
+            result.M42 = 0.0f;
+            result.M43 = 0.0f;
+            result.M44 = 1.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a perspective projection matrix based on a field of view, aspect ratio, and near and far view plane distances. 
+        /// </summary>
+        /// <param name="fieldOfView">Field of view in the y direction, in radians.</param>
+        /// <param name="aspectRatio">Aspect ratio, defined as view space width divided by height.</param>
+        /// <param name="nearPlaneDistance">Distance to the near view plane.</param>
+        /// <param name="farPlaneDistance">Distance to the far view plane.</param>
+        /// <returns>The perspective projection matrix.</returns>
+        public static Matrix4x4 CreatePerspectiveFieldOfView(float fieldOfView, float aspectRatio, float nearPlaneDistance, float farPlaneDistance)
+        {
+            if (fieldOfView <= 0.0f || fieldOfView >= MathF.PI)
+                throw new ArgumentOutOfRangeException(nameof(fieldOfView));
+
+            if (nearPlaneDistance <= 0.0f)
+                throw new ArgumentOutOfRangeException(nameof(nearPlaneDistance));
+
+            if (farPlaneDistance <= 0.0f)
+                throw new ArgumentOutOfRangeException(nameof(farPlaneDistance));
+
+            if (nearPlaneDistance >= farPlaneDistance)
+                throw new ArgumentOutOfRangeException(nameof(nearPlaneDistance));
+
+            float yScale = 1.0f / MathF.Tan(fieldOfView * 0.5f);
+            float xScale = yScale / aspectRatio;
+
+            Matrix4x4 result;
+
+            result.M11 = xScale;
+            result.M12 = result.M13 = result.M14 = 0.0f;
+
+            result.M22 = yScale;
+            result.M21 = result.M23 = result.M24 = 0.0f;
+
+            result.M31 = result.M32 = 0.0f;
+            var negFarRange = float.IsPositiveInfinity(farPlaneDistance) ? -1.0f : farPlaneDistance / (nearPlaneDistance - farPlaneDistance);
+            result.M33 = negFarRange;
+            result.M34 = -1.0f;
+
+            result.M41 = result.M42 = result.M44 = 0.0f;
+            result.M43 = nearPlaneDistance * negFarRange;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a perspective projection matrix from the given view volume dimensions.
+        /// </summary>
+        /// <param name="width">Width of the view volume at the near view plane.</param>
+        /// <param name="height">Height of the view volume at the near view plane.</param>
+        /// <param name="nearPlaneDistance">Distance to the near view plane.</param>
+        /// <param name="farPlaneDistance">Distance to the far view plane.</param>
+        /// <returns>The perspective projection matrix.</returns>
+        public static Matrix4x4 CreatePerspective(float width, float height, float nearPlaneDistance, float farPlaneDistance)
+        {
+            if (nearPlaneDistance <= 0.0f)
+                throw new ArgumentOutOfRangeException(nameof(nearPlaneDistance));
+
+            if (farPlaneDistance <= 0.0f)
+                throw new ArgumentOutOfRangeException(nameof(farPlaneDistance));
+
+            if (nearPlaneDistance >= farPlaneDistance)
+                throw new ArgumentOutOfRangeException(nameof(nearPlaneDistance));
+
+            Matrix4x4 result;
+
+            result.M11 = 2.0f * nearPlaneDistance / width;
+            result.M12 = result.M13 = result.M14 = 0.0f;
+
+            result.M22 = 2.0f * nearPlaneDistance / height;
+            result.M21 = result.M23 = result.M24 = 0.0f;
+
+            var negFarRange = float.IsPositiveInfinity(farPlaneDistance) ? -1.0f : farPlaneDistance / (nearPlaneDistance - farPlaneDistance);
+            result.M33 = negFarRange;
+            result.M31 = result.M32 = 0.0f;
+            result.M34 = -1.0f;
+
+            result.M41 = result.M42 = result.M44 = 0.0f;
+            result.M43 = nearPlaneDistance * negFarRange;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a customized, perspective projection matrix.
+        /// </summary>
+        /// <param name="left">Minimum x-value of the view volume at the near view plane.</param>
+        /// <param name="right">Maximum x-value of the view volume at the near view plane.</param>
+        /// <param name="bottom">Minimum y-value of the view volume at the near view plane.</param>
+        /// <param name="top">Maximum y-value of the view volume at the near view plane.</param>
+        /// <param name="nearPlaneDistance">Distance to the near view plane.</param>
+        /// <param name="farPlaneDistance">Distance to of the far view plane.</param>
+        /// <returns>The perspective projection matrix.</returns>
+        public static Matrix4x4 CreatePerspectiveOffCenter(float left, float right, float bottom, float top, float nearPlaneDistance, float farPlaneDistance)
+        {
+            if (nearPlaneDistance <= 0.0f)
+                throw new ArgumentOutOfRangeException(nameof(nearPlaneDistance));
+
+            if (farPlaneDistance <= 0.0f)
+                throw new ArgumentOutOfRangeException(nameof(farPlaneDistance));
+
+            if (nearPlaneDistance >= farPlaneDistance)
+                throw new ArgumentOutOfRangeException(nameof(nearPlaneDistance));
+
+            Matrix4x4 result;
+
+            result.M11 = 2.0f * nearPlaneDistance / (right - left);
+            result.M12 = result.M13 = result.M14 = 0.0f;
+
+            result.M22 = 2.0f * nearPlaneDistance / (top - bottom);
+            result.M21 = result.M23 = result.M24 = 0.0f;
+
+            result.M31 = (left + right) / (right - left);
+            result.M32 = (top + bottom) / (top - bottom);
+            var negFarRange = float.IsPositiveInfinity(farPlaneDistance) ? -1.0f : farPlaneDistance / (nearPlaneDistance - farPlaneDistance);
+            result.M33 = negFarRange;
+            result.M34 = -1.0f;
+
+            result.M43 = nearPlaneDistance * negFarRange;
+            result.M41 = result.M42 = result.M44 = 0.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates an orthographic perspective matrix from the given view volume dimensions.
+        /// </summary>
+        /// <param name="width">Width of the view volume.</param>
+        /// <param name="height">Height of the view volume.</param>
+        /// <param name="zNearPlane">Minimum Z-value of the view volume.</param>
+        /// <param name="zFarPlane">Maximum Z-value of the view volume.</param>
+        /// <returns>The orthographic projection matrix.</returns>
+        public static Matrix4x4 CreateOrthographic(float width, float height, float zNearPlane, float zFarPlane)
+        {
+            Matrix4x4 result;
+
+            result.M11 = 2.0f / width;
+            result.M12 = result.M13 = result.M14 = 0.0f;
+
+            result.M22 = 2.0f / height;
+            result.M21 = result.M23 = result.M24 = 0.0f;
+
+            result.M33 = 1.0f / (zNearPlane - zFarPlane);
+            result.M31 = result.M32 = result.M34 = 0.0f;
+
+            result.M41 = result.M42 = 0.0f;
+            result.M43 = zNearPlane / (zNearPlane - zFarPlane);
+            result.M44 = 1.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Builds a customized, orthographic projection matrix.
+        /// </summary>
+        /// <param name="left">Minimum X-value of the view volume.</param>
+        /// <param name="right">Maximum X-value of the view volume.</param>
+        /// <param name="bottom">Minimum Y-value of the view volume.</param>
+        /// <param name="top">Maximum Y-value of the view volume.</param>
+        /// <param name="zNearPlane">Minimum Z-value of the view volume.</param>
+        /// <param name="zFarPlane">Maximum Z-value of the view volume.</param>
+        /// <returns>The orthographic projection matrix.</returns>
+        public static Matrix4x4 CreateOrthographicOffCenter(float left, float right, float bottom, float top, float zNearPlane, float zFarPlane)
+        {
+            Matrix4x4 result;
+
+            result.M11 = 2.0f / (right - left);
+            result.M12 = result.M13 = result.M14 = 0.0f;
+
+            result.M22 = 2.0f / (top - bottom);
+            result.M21 = result.M23 = result.M24 = 0.0f;
+
+            result.M33 = 1.0f / (zNearPlane - zFarPlane);
+            result.M31 = result.M32 = result.M34 = 0.0f;
+
+            result.M41 = (left + right) / (left - right);
+            result.M42 = (top + bottom) / (bottom - top);
+            result.M43 = zNearPlane / (zNearPlane - zFarPlane);
+            result.M44 = 1.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a view matrix.
+        /// </summary>
+        /// <param name="cameraPosition">The position of the camera.</param>
+        /// <param name="cameraTarget">The target towards which the camera is pointing.</param>
+        /// <param name="cameraUpVector">The direction that is "up" from the camera's point of view.</param>
+        /// <returns>The view matrix.</returns>
+        public static Matrix4x4 CreateLookAt(Vector3 cameraPosition, Vector3 cameraTarget, Vector3 cameraUpVector)
+        {
+            Vector3 zaxis = Vector3.Normalize(cameraPosition - cameraTarget);
+            Vector3 xaxis = Vector3.Normalize(Vector3.Cross(cameraUpVector, zaxis));
+            Vector3 yaxis = Vector3.Cross(zaxis, xaxis);
+
+            Matrix4x4 result;
+
+            result.M11 = xaxis.X;
+            result.M12 = yaxis.X;
+            result.M13 = zaxis.X;
+            result.M14 = 0.0f;
+            result.M21 = xaxis.Y;
+            result.M22 = yaxis.Y;
+            result.M23 = zaxis.Y;
+            result.M24 = 0.0f;
+            result.M31 = xaxis.Z;
+            result.M32 = yaxis.Z;
+            result.M33 = zaxis.Z;
+            result.M34 = 0.0f;
+            result.M41 = -Vector3.Dot(xaxis, cameraPosition);
+            result.M42 = -Vector3.Dot(yaxis, cameraPosition);
+            result.M43 = -Vector3.Dot(zaxis, cameraPosition);
+            result.M44 = 1.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a world matrix with the specified parameters.
+        /// </summary>
+        /// <param name="position">The position of the object; used in translation operations.</param>
+        /// <param name="forward">Forward direction of the object.</param>
+        /// <param name="up">Upward direction of the object; usually [0, 1, 0].</param>
+        /// <returns>The world matrix.</returns>
+        public static Matrix4x4 CreateWorld(Vector3 position, Vector3 forward, Vector3 up)
+        {
+            Vector3 zaxis = Vector3.Normalize(-forward);
+            Vector3 xaxis = Vector3.Normalize(Vector3.Cross(up, zaxis));
+            Vector3 yaxis = Vector3.Cross(zaxis, xaxis);
+
+            Matrix4x4 result;
+
+            result.M11 = xaxis.X;
+            result.M12 = xaxis.Y;
+            result.M13 = xaxis.Z;
+            result.M14 = 0.0f;
+            result.M21 = yaxis.X;
+            result.M22 = yaxis.Y;
+            result.M23 = yaxis.Z;
+            result.M24 = 0.0f;
+            result.M31 = zaxis.X;
+            result.M32 = zaxis.Y;
+            result.M33 = zaxis.Z;
+            result.M34 = 0.0f;
+            result.M41 = position.X;
+            result.M42 = position.Y;
+            result.M43 = position.Z;
+            result.M44 = 1.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a rotation matrix from the given Quaternion rotation value.
+        /// </summary>
+        /// <param name="quaternion">The source Quaternion.</param>
+        /// <returns>The rotation matrix.</returns>
+        public static Matrix4x4 CreateFromQuaternion(Quaternion quaternion)
+        {
+            Matrix4x4 result;
+
+            float xx = quaternion.X * quaternion.X;
+            float yy = quaternion.Y * quaternion.Y;
+            float zz = quaternion.Z * quaternion.Z;
+
+            float xy = quaternion.X * quaternion.Y;
+            float wz = quaternion.Z * quaternion.W;
+            float xz = quaternion.Z * quaternion.X;
+            float wy = quaternion.Y * quaternion.W;
+            float yz = quaternion.Y * quaternion.Z;
+            float wx = quaternion.X * quaternion.W;
+
+            result.M11 = 1.0f - 2.0f * (yy + zz);
+            result.M12 = 2.0f * (xy + wz);
+            result.M13 = 2.0f * (xz - wy);
+            result.M14 = 0.0f;
+            result.M21 = 2.0f * (xy - wz);
+            result.M22 = 1.0f - 2.0f * (zz + xx);
+            result.M23 = 2.0f * (yz + wx);
+            result.M24 = 0.0f;
+            result.M31 = 2.0f * (xz + wy);
+            result.M32 = 2.0f * (yz - wx);
+            result.M33 = 1.0f - 2.0f * (yy + xx);
+            result.M34 = 0.0f;
+            result.M41 = 0.0f;
+            result.M42 = 0.0f;
+            result.M43 = 0.0f;
+            result.M44 = 1.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a rotation matrix from the specified yaw, pitch, and roll.
+        /// </summary>
+        /// <param name="yaw">Angle of rotation, in radians, around the Y-axis.</param>
+        /// <param name="pitch">Angle of rotation, in radians, around the X-axis.</param>
+        /// <param name="roll">Angle of rotation, in radians, around the Z-axis.</param>
+        /// <returns>The rotation matrix.</returns>
+        public static Matrix4x4 CreateFromYawPitchRoll(float yaw, float pitch, float roll)
+        {
+            Quaternion q = Quaternion.CreateFromYawPitchRoll(yaw, pitch, roll);
+
+            return Matrix4x4.CreateFromQuaternion(q);
+        }
+
+        /// <summary>
+        /// Creates a Matrix that flattens geometry into a specified Plane as if casting a shadow from a specified light source.
+        /// </summary>
+        /// <param name="lightDirection">The direction from which the light that will cast the shadow is coming.</param>
+        /// <param name="plane">The Plane onto which the new matrix should flatten geometry so as to cast a shadow.</param>
+        /// <returns>A new Matrix that can be used to flatten geometry onto the specified plane from the specified direction.</returns>
+        public static Matrix4x4 CreateShadow(Vector3 lightDirection, Plane plane)
+        {
+            Plane p = Plane.Normalize(plane);
+
+            float dot = p.Normal.X * lightDirection.X + p.Normal.Y * lightDirection.Y + p.Normal.Z * lightDirection.Z;
+            float a = -p.Normal.X;
+            float b = -p.Normal.Y;
+            float c = -p.Normal.Z;
+            float d = -p.D;
+
+            Matrix4x4 result;
+
+            result.M11 = a * lightDirection.X + dot;
+            result.M21 = b * lightDirection.X;
+            result.M31 = c * lightDirection.X;
+            result.M41 = d * lightDirection.X;
+
+            result.M12 = a * lightDirection.Y;
+            result.M22 = b * lightDirection.Y + dot;
+            result.M32 = c * lightDirection.Y;
+            result.M42 = d * lightDirection.Y;
+
+            result.M13 = a * lightDirection.Z;
+            result.M23 = b * lightDirection.Z;
+            result.M33 = c * lightDirection.Z + dot;
+            result.M43 = d * lightDirection.Z;
+
+            result.M14 = 0.0f;
+            result.M24 = 0.0f;
+            result.M34 = 0.0f;
+            result.M44 = dot;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a Matrix that reflects the coordinate system about a specified Plane.
+        /// </summary>
+        /// <param name="value">The Plane about which to create a reflection.</param>
+        /// <returns>A new matrix expressing the reflection.</returns>
+        public static Matrix4x4 CreateReflection(Plane value)
+        {
+            value = Plane.Normalize(value);
+
+            float a = value.Normal.X;
+            float b = value.Normal.Y;
+            float c = value.Normal.Z;
+
+            float fa = -2.0f * a;
+            float fb = -2.0f * b;
+            float fc = -2.0f * c;
+
+            Matrix4x4 result;
+
+            result.M11 = fa * a + 1.0f;
+            result.M12 = fb * a;
+            result.M13 = fc * a;
+            result.M14 = 0.0f;
+
+            result.M21 = fa * b;
+            result.M22 = fb * b + 1.0f;
+            result.M23 = fc * b;
+            result.M24 = 0.0f;
+
+            result.M31 = fa * c;
+            result.M32 = fb * c;
+            result.M33 = fc * c + 1.0f;
+            result.M34 = 0.0f;
+
+            result.M41 = fa * value.D;
+            result.M42 = fb * value.D;
+            result.M43 = fc * value.D;
+            result.M44 = 1.0f;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Calculates the determinant of the matrix.
+        /// </summary>
+        /// <returns>The determinant of the matrix.</returns>
+        public float GetDeterminant()
+        {
+            // | a b c d |     | f g h |     | e g h |     | e f h |     | e f g |
+            // | e f g h | = a | j k l | - b | i k l | + c | i j l | - d | i j k |
+            // | i j k l |     | n o p |     | m o p |     | m n p |     | m n o |
+            // | m n o p |
+            //
+            //   | f g h |
+            // a | j k l | = a ( f ( kp - lo ) - g ( jp - ln ) + h ( jo - kn ) )
+            //   | n o p |
+            //
+            //   | e g h |     
+            // b | i k l | = b ( e ( kp - lo ) - g ( ip - lm ) + h ( io - km ) )
+            //   | m o p |     
+            //
+            //   | e f h |
+            // c | i j l | = c ( e ( jp - ln ) - f ( ip - lm ) + h ( in - jm ) )
+            //   | m n p |
+            //
+            //   | e f g |
+            // d | i j k | = d ( e ( jo - kn ) - f ( io - km ) + g ( in - jm ) )
+            //   | m n o |
+            //
+            // Cost of operation
+            // 17 adds and 28 muls.
+            //
+            // add: 6 + 8 + 3 = 17
+            // mul: 12 + 16 = 28
+
+            float a = M11, b = M12, c = M13, d = M14;
+            float e = M21, f = M22, g = M23, h = M24;
+            float i = M31, j = M32, k = M33, l = M34;
+            float m = M41, n = M42, o = M43, p = M44;
+
+            float kp_lo = k * p - l * o;
+            float jp_ln = j * p - l * n;
+            float jo_kn = j * o - k * n;
+            float ip_lm = i * p - l * m;
+            float io_km = i * o - k * m;
+            float in_jm = i * n - j * m;
+
+            return a * (f * kp_lo - g * jp_ln + h * jo_kn) -
+                   b * (e * kp_lo - g * ip_lm + h * io_km) +
+                   c * (e * jp_ln - f * ip_lm + h * in_jm) -
+                   d * (e * jo_kn - f * io_km + g * in_jm);
+        }
+
+        /// <summary>
+        /// Attempts to calculate the inverse of the given matrix. If successful, result will contain the inverted matrix.
+        /// </summary>
+        /// <param name="matrix">The source matrix to invert.</param>
+        /// <param name="result">If successful, contains the inverted matrix.</param>
+        /// <returns>True if the source matrix could be inverted; False otherwise.</returns>
+        public static bool Invert(Matrix4x4 matrix, out Matrix4x4 result)
+        {
+            //                                       -1
+            // If you have matrix M, inverse Matrix M   can compute
+            //
+            //     -1       1      
+            //    M   = --------- A
+            //            det(M)
+            //
+            // A is adjugate (adjoint) of M, where,
+            //
+            //      T
+            // A = C
+            //
+            // C is Cofactor matrix of M, where,
+            //           i + j
+            // C   = (-1)      * det(M  )
+            //  ij                    ij
+            //
+            //     [ a b c d ]
+            // M = [ e f g h ]
+            //     [ i j k l ]
+            //     [ m n o p ]
+            //
+            // First Row
+            //           2 | f g h |
+            // C   = (-1)  | j k l | = + ( f ( kp - lo ) - g ( jp - ln ) + h ( jo - kn ) )
+            //  11         | n o p |
+            //
+            //           3 | e g h |
+            // C   = (-1)  | i k l | = - ( e ( kp - lo ) - g ( ip - lm ) + h ( io - km ) )
+            //  12         | m o p |
+            //
+            //           4 | e f h |
+            // C   = (-1)  | i j l | = + ( e ( jp - ln ) - f ( ip - lm ) + h ( in - jm ) )
+            //  13         | m n p |
+            //
+            //           5 | e f g |
+            // C   = (-1)  | i j k | = - ( e ( jo - kn ) - f ( io - km ) + g ( in - jm ) )
+            //  14         | m n o |
+            //
+            // Second Row
+            //           3 | b c d |
+            // C   = (-1)  | j k l | = - ( b ( kp - lo ) - c ( jp - ln ) + d ( jo - kn ) )
+            //  21         | n o p |
+            //
+            //           4 | a c d |
+            // C   = (-1)  | i k l | = + ( a ( kp - lo ) - c ( ip - lm ) + d ( io - km ) )
+            //  22         | m o p |
+            //
+            //           5 | a b d |
+            // C   = (-1)  | i j l | = - ( a ( jp - ln ) - b ( ip - lm ) + d ( in - jm ) )
+            //  23         | m n p |
+            //
+            //           6 | a b c |
+            // C   = (-1)  | i j k | = + ( a ( jo - kn ) - b ( io - km ) + c ( in - jm ) )
+            //  24         | m n o |
+            //
+            // Third Row
+            //           4 | b c d |
+            // C   = (-1)  | f g h | = + ( b ( gp - ho ) - c ( fp - hn ) + d ( fo - gn ) )
+            //  31         | n o p |
+            //
+            //           5 | a c d |
+            // C   = (-1)  | e g h | = - ( a ( gp - ho ) - c ( ep - hm ) + d ( eo - gm ) )
+            //  32         | m o p |
+            //
+            //           6 | a b d |
+            // C   = (-1)  | e f h | = + ( a ( fp - hn ) - b ( ep - hm ) + d ( en - fm ) )
+            //  33         | m n p |
+            //
+            //           7 | a b c |
+            // C   = (-1)  | e f g | = - ( a ( fo - gn ) - b ( eo - gm ) + c ( en - fm ) )
+            //  34         | m n o |
+            //
+            // Fourth Row
+            //           5 | b c d |
+            // C   = (-1)  | f g h | = - ( b ( gl - hk ) - c ( fl - hj ) + d ( fk - gj ) )
+            //  41         | j k l |
+            //
+            //           6 | a c d |
+            // C   = (-1)  | e g h | = + ( a ( gl - hk ) - c ( el - hi ) + d ( ek - gi ) )
+            //  42         | i k l |
+            //
+            //           7 | a b d |
+            // C   = (-1)  | e f h | = - ( a ( fl - hj ) - b ( el - hi ) + d ( ej - fi ) )
+            //  43         | i j l |
+            //
+            //           8 | a b c |
+            // C   = (-1)  | e f g | = + ( a ( fk - gj ) - b ( ek - gi ) + c ( ej - fi ) )
+            //  44         | i j k |
+            //
+            // Cost of operation
+            // 53 adds, 104 muls, and 1 div.
+            float a = matrix.M11, b = matrix.M12, c = matrix.M13, d = matrix.M14;
+            float e = matrix.M21, f = matrix.M22, g = matrix.M23, h = matrix.M24;
+            float i = matrix.M31, j = matrix.M32, k = matrix.M33, l = matrix.M34;
+            float m = matrix.M41, n = matrix.M42, o = matrix.M43, p = matrix.M44;
+
+            float kp_lo = k * p - l * o;
+            float jp_ln = j * p - l * n;
+            float jo_kn = j * o - k * n;
+            float ip_lm = i * p - l * m;
+            float io_km = i * o - k * m;
+            float in_jm = i * n - j * m;
+
+            float a11 = +(f * kp_lo - g * jp_ln + h * jo_kn);
+            float a12 = -(e * kp_lo - g * ip_lm + h * io_km);
+            float a13 = +(e * jp_ln - f * ip_lm + h * in_jm);
+            float a14 = -(e * jo_kn - f * io_km + g * in_jm);
+
+            float det = a * a11 + b * a12 + c * a13 + d * a14;
+
+            if (MathF.Abs(det) < float.Epsilon)
+            {
+                result = new Matrix4x4(float.NaN, float.NaN, float.NaN, float.NaN,
+                                       float.NaN, float.NaN, float.NaN, float.NaN,
+                                       float.NaN, float.NaN, float.NaN, float.NaN,
+                                       float.NaN, float.NaN, float.NaN, float.NaN);
+                return false;
+            }
+
+            float invDet = 1.0f / det;
+
+            result.M11 = a11 * invDet;
+            result.M21 = a12 * invDet;
+            result.M31 = a13 * invDet;
+            result.M41 = a14 * invDet;
+
+            result.M12 = -(b * kp_lo - c * jp_ln + d * jo_kn) * invDet;
+            result.M22 = +(a * kp_lo - c * ip_lm + d * io_km) * invDet;
+            result.M32 = -(a * jp_ln - b * ip_lm + d * in_jm) * invDet;
+            result.M42 = +(a * jo_kn - b * io_km + c * in_jm) * invDet;
+
+            float gp_ho = g * p - h * o;
+            float fp_hn = f * p - h * n;
+            float fo_gn = f * o - g * n;
+            float ep_hm = e * p - h * m;
+            float eo_gm = e * o - g * m;
+            float en_fm = e * n - f * m;
+
+            result.M13 = +(b * gp_ho - c * fp_hn + d * fo_gn) * invDet;
+            result.M23 = -(a * gp_ho - c * ep_hm + d * eo_gm) * invDet;
+            result.M33 = +(a * fp_hn - b * ep_hm + d * en_fm) * invDet;
+            result.M43 = -(a * fo_gn - b * eo_gm + c * en_fm) * invDet;
+
+            float gl_hk = g * l - h * k;
+            float fl_hj = f * l - h * j;
+            float fk_gj = f * k - g * j;
+            float el_hi = e * l - h * i;
+            float ek_gi = e * k - g * i;
+            float ej_fi = e * j - f * i;
+
+            result.M14 = -(b * gl_hk - c * fl_hj + d * fk_gj) * invDet;
+            result.M24 = +(a * gl_hk - c * el_hi + d * ek_gi) * invDet;
+            result.M34 = -(a * fl_hj - b * el_hi + d * ej_fi) * invDet;
+            result.M44 = +(a * fk_gj - b * ek_gi + c * ej_fi) * invDet;
+
+            return true;
+        }
+
+
+        struct CanonicalBasis
+        {
+            public Vector3 Row0;
+            public Vector3 Row1;
+            public Vector3 Row2;
+        };
+
+
+        struct VectorBasis
+        {
+            public unsafe Vector3* Element0;
+            public unsafe Vector3* Element1;
+            public unsafe Vector3* Element2;
+        }
+
+        /// <summary>
+        /// Attempts to extract the scale, translation, and rotation components from the given scale/rotation/translation matrix.
+        /// If successful, the out parameters will contained the extracted values.
+        /// </summary>
+        /// <param name="matrix">The source matrix.</param>
+        /// <param name="scale">The scaling component of the transformation matrix.</param>
+        /// <param name="rotation">The rotation component of the transformation matrix.</param>
+        /// <param name="translation">The translation component of the transformation matrix</param>
+        /// <returns>True if the source matrix was successfully decomposed; False otherwise.</returns>
+        public static bool Decompose(Matrix4x4 matrix, out Vector3 scale, out Quaternion rotation, out Vector3 translation)
+        {
+            bool result = true;
+
+            unsafe
+            {
+                fixed (Vector3* scaleBase = &scale)
+                {
+                    float* pfScales = (float*)scaleBase;
+                    const float EPSILON = 0.0001f;
+                    float det;
+
+                    VectorBasis vectorBasis;
+                    Vector3** pVectorBasis = (Vector3**)&vectorBasis;
+
+                    Matrix4x4 matTemp = Matrix4x4.Identity;
+                    CanonicalBasis canonicalBasis = new CanonicalBasis();
+                    Vector3* pCanonicalBasis = &canonicalBasis.Row0;
+
+                    canonicalBasis.Row0 = new Vector3(1.0f, 0.0f, 0.0f);
+                    canonicalBasis.Row1 = new Vector3(0.0f, 1.0f, 0.0f);
+                    canonicalBasis.Row2 = new Vector3(0.0f, 0.0f, 1.0f);
+
+                    translation = new Vector3(
+                        matrix.M41,
+                        matrix.M42,
+                        matrix.M43);
+
+                    pVectorBasis[0] = (Vector3*)&matTemp.M11;
+                    pVectorBasis[1] = (Vector3*)&matTemp.M21;
+                    pVectorBasis[2] = (Vector3*)&matTemp.M31;
+
+                    *(pVectorBasis[0]) = new Vector3(matrix.M11, matrix.M12, matrix.M13);
+                    *(pVectorBasis[1]) = new Vector3(matrix.M21, matrix.M22, matrix.M23);
+                    *(pVectorBasis[2]) = new Vector3(matrix.M31, matrix.M32, matrix.M33);
+
+                    scale.X = pVectorBasis[0]->Length();
+                    scale.Y = pVectorBasis[1]->Length();
+                    scale.Z = pVectorBasis[2]->Length();
+
+                    uint a, b, c;
+                    #region Ranking
+                    float x = pfScales[0], y = pfScales[1], z = pfScales[2];
+                    if (x < y)
+                    {
+                        if (y < z)
+                        {
+                            a = 2;
+                            b = 1;
+                            c = 0;
+                        }
+                        else
+                        {
+                            a = 1;
+
+                            if (x < z)
+                            {
+                                b = 2;
+                                c = 0;
+                            }
+                            else
+                            {
+                                b = 0;
+                                c = 2;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        if (x < z)
+                        {
+                            a = 2;
+                            b = 0;
+                            c = 1;
+                        }
+                        else
+                        {
+                            a = 0;
+
+                            if (y < z)
+                            {
+                                b = 2;
+                                c = 1;
+                            }
+                            else
+                            {
+                                b = 1;
+                                c = 2;
+                            }
+                        }
+                    }
+                    #endregion
+
+                    if (pfScales[a] < EPSILON)
+                    {
+                        *(pVectorBasis[a]) = pCanonicalBasis[a];
+                    }
+
+                    *pVectorBasis[a] = Vector3.Normalize(*pVectorBasis[a]);
+
+                    if (pfScales[b] < EPSILON)
+                    {
+                        uint cc;
+                        float fAbsX, fAbsY, fAbsZ;
+
+                        fAbsX = MathF.Abs(pVectorBasis[a]->X);
+                        fAbsY = MathF.Abs(pVectorBasis[a]->Y);
+                        fAbsZ = MathF.Abs(pVectorBasis[a]->Z);
+
+                        #region Ranking
+                        if (fAbsX < fAbsY)
+                        {
+                            if (fAbsY < fAbsZ)
+                            {
+                                cc = 0;
+                            }
+                            else
+                            {
+                                if (fAbsX < fAbsZ)
+                                {
+                                    cc = 0;
+                                }
+                                else
+                                {
+                                    cc = 2;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (fAbsX < fAbsZ)
+                            {
+                                cc = 1;
+                            }
+                            else
+                            {
+                                if (fAbsY < fAbsZ)
+                                {
+                                    cc = 1;
+                                }
+                                else
+                                {
+                                    cc = 2;
+                                }
+                            }
+                        }
+                        #endregion
+
+                        *pVectorBasis[b] = Vector3.Cross(*pVectorBasis[a], *(pCanonicalBasis + cc));
+                    }
+
+                    *pVectorBasis[b] = Vector3.Normalize(*pVectorBasis[b]);
+
+                    if (pfScales[c] < EPSILON)
+                    {
+                        *pVectorBasis[c] = Vector3.Cross(*pVectorBasis[a], *pVectorBasis[b]);
+                    }
+
+                    *pVectorBasis[c] = Vector3.Normalize(*pVectorBasis[c]);
+
+                    det = matTemp.GetDeterminant();
+
+                    // use Kramer's rule to check for handedness of coordinate system
+                    if (det < 0.0f)
+                    {
+                        // switch coordinate system by negating the scale and inverting the basis vector on the x-axis
+                        pfScales[a] = -pfScales[a];
+                        *pVectorBasis[a] = -(*pVectorBasis[a]);
+
+                        det = -det;
+                    }
+
+                    det -= 1.0f;
+                    det *= det;
+
+                    if ((EPSILON < det))
+                    {
+                        // Non-SRT matrix encountered
+                        rotation = Quaternion.Identity;
+                        result = false;
+                    }
+                    else
+                    {
+                        // generate the quaternion from the matrix
+                        rotation = Quaternion.CreateFromRotationMatrix(matTemp);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Transforms the given matrix by applying the given Quaternion rotation.
+        /// </summary>
+        /// <param name="value">The source matrix to transform.</param>
+        /// <param name="rotation">The rotation to apply.</param>
+        /// <returns>The transformed matrix.</returns>
+        public static Matrix4x4 Transform(Matrix4x4 value, Quaternion rotation)
+        {
+            // Compute rotation matrix.
+            float x2 = rotation.X + rotation.X;
+            float y2 = rotation.Y + rotation.Y;
+            float z2 = rotation.Z + rotation.Z;
+
+            float wx2 = rotation.W * x2;
+            float wy2 = rotation.W * y2;
+            float wz2 = rotation.W * z2;
+            float xx2 = rotation.X * x2;
+            float xy2 = rotation.X * y2;
+            float xz2 = rotation.X * z2;
+            float yy2 = rotation.Y * y2;
+            float yz2 = rotation.Y * z2;
+            float zz2 = rotation.Z * z2;
+
+            float q11 = 1.0f - yy2 - zz2;
+            float q21 = xy2 - wz2;
+            float q31 = xz2 + wy2;
+
+            float q12 = xy2 + wz2;
+            float q22 = 1.0f - xx2 - zz2;
+            float q32 = yz2 - wx2;
+
+            float q13 = xz2 - wy2;
+            float q23 = yz2 + wx2;
+            float q33 = 1.0f - xx2 - yy2;
+
+            Matrix4x4 result;
+
+            // First row
+            result.M11 = value.M11 * q11 + value.M12 * q21 + value.M13 * q31;
+            result.M12 = value.M11 * q12 + value.M12 * q22 + value.M13 * q32;
+            result.M13 = value.M11 * q13 + value.M12 * q23 + value.M13 * q33;
+            result.M14 = value.M14;
+
+            // Second row
+            result.M21 = value.M21 * q11 + value.M22 * q21 + value.M23 * q31;
+            result.M22 = value.M21 * q12 + value.M22 * q22 + value.M23 * q32;
+            result.M23 = value.M21 * q13 + value.M22 * q23 + value.M23 * q33;
+            result.M24 = value.M24;
+
+            // Third row
+            result.M31 = value.M31 * q11 + value.M32 * q21 + value.M33 * q31;
+            result.M32 = value.M31 * q12 + value.M32 * q22 + value.M33 * q32;
+            result.M33 = value.M31 * q13 + value.M32 * q23 + value.M33 * q33;
+            result.M34 = value.M34;
+
+            // Fourth row
+            result.M41 = value.M41 * q11 + value.M42 * q21 + value.M43 * q31;
+            result.M42 = value.M41 * q12 + value.M42 * q22 + value.M43 * q32;
+            result.M43 = value.M41 * q13 + value.M42 * q23 + value.M43 * q33;
+            result.M44 = value.M44;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Transposes the rows and columns of a matrix.
+        /// </summary>
+        /// <param name="matrix">The source matrix.</param>
+        /// <returns>The transposed matrix.</returns>
+        public static Matrix4x4 Transpose(Matrix4x4 matrix)
+        {
+            Matrix4x4 result;
+
+            result.M11 = matrix.M11;
+            result.M12 = matrix.M21;
+            result.M13 = matrix.M31;
+            result.M14 = matrix.M41;
+            result.M21 = matrix.M12;
+            result.M22 = matrix.M22;
+            result.M23 = matrix.M32;
+            result.M24 = matrix.M42;
+            result.M31 = matrix.M13;
+            result.M32 = matrix.M23;
+            result.M33 = matrix.M33;
+            result.M34 = matrix.M43;
+            result.M41 = matrix.M14;
+            result.M42 = matrix.M24;
+            result.M43 = matrix.M34;
+            result.M44 = matrix.M44;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Linearly interpolates between the corresponding values of two matrices.
+        /// </summary>
+        /// <param name="matrix1">The first source matrix.</param>
+        /// <param name="matrix2">The second source matrix.</param>
+        /// <param name="amount">The relative weight of the second source matrix.</param>
+        /// <returns>The interpolated matrix.</returns>
+        public static Matrix4x4 Lerp(Matrix4x4 matrix1, Matrix4x4 matrix2, float amount)
+        {
+            Matrix4x4 result;
+
+            // First row
+            result.M11 = matrix1.M11 + (matrix2.M11 - matrix1.M11) * amount;
+            result.M12 = matrix1.M12 + (matrix2.M12 - matrix1.M12) * amount;
+            result.M13 = matrix1.M13 + (matrix2.M13 - matrix1.M13) * amount;
+            result.M14 = matrix1.M14 + (matrix2.M14 - matrix1.M14) * amount;
+
+            // Second row
+            result.M21 = matrix1.M21 + (matrix2.M21 - matrix1.M21) * amount;
+            result.M22 = matrix1.M22 + (matrix2.M22 - matrix1.M22) * amount;
+            result.M23 = matrix1.M23 + (matrix2.M23 - matrix1.M23) * amount;
+            result.M24 = matrix1.M24 + (matrix2.M24 - matrix1.M24) * amount;
+
+            // Third row
+            result.M31 = matrix1.M31 + (matrix2.M31 - matrix1.M31) * amount;
+            result.M32 = matrix1.M32 + (matrix2.M32 - matrix1.M32) * amount;
+            result.M33 = matrix1.M33 + (matrix2.M33 - matrix1.M33) * amount;
+            result.M34 = matrix1.M34 + (matrix2.M34 - matrix1.M34) * amount;
+
+            // Fourth row
+            result.M41 = matrix1.M41 + (matrix2.M41 - matrix1.M41) * amount;
+            result.M42 = matrix1.M42 + (matrix2.M42 - matrix1.M42) * amount;
+            result.M43 = matrix1.M43 + (matrix2.M43 - matrix1.M43) * amount;
+            result.M44 = matrix1.M44 + (matrix2.M44 - matrix1.M44) * amount;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Returns a new matrix with the negated elements of the given matrix.
+        /// </summary>
+        /// <param name="value">The source matrix.</param>
+        /// <returns>The negated matrix.</returns>
+        public static Matrix4x4 Negate(Matrix4x4 value)
+        {
+            Matrix4x4 result;
+
+            result.M11 = -value.M11;
+            result.M12 = -value.M12;
+            result.M13 = -value.M13;
+            result.M14 = -value.M14;
+            result.M21 = -value.M21;
+            result.M22 = -value.M22;
+            result.M23 = -value.M23;
+            result.M24 = -value.M24;
+            result.M31 = -value.M31;
+            result.M32 = -value.M32;
+            result.M33 = -value.M33;
+            result.M34 = -value.M34;
+            result.M41 = -value.M41;
+            result.M42 = -value.M42;
+            result.M43 = -value.M43;
+            result.M44 = -value.M44;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Adds two matrices together.
+        /// </summary>
+        /// <param name="value1">The first source matrix.</param>
+        /// <param name="value2">The second source matrix.</param>
+        /// <returns>The resulting matrix.</returns>
+        public static Matrix4x4 Add(Matrix4x4 value1, Matrix4x4 value2)
+        {
+            Matrix4x4 result;
+
+            result.M11 = value1.M11 + value2.M11;
+            result.M12 = value1.M12 + value2.M12;
+            result.M13 = value1.M13 + value2.M13;
+            result.M14 = value1.M14 + value2.M14;
+            result.M21 = value1.M21 + value2.M21;
+            result.M22 = value1.M22 + value2.M22;
+            result.M23 = value1.M23 + value2.M23;
+            result.M24 = value1.M24 + value2.M24;
+            result.M31 = value1.M31 + value2.M31;
+            result.M32 = value1.M32 + value2.M32;
+            result.M33 = value1.M33 + value2.M33;
+            result.M34 = value1.M34 + value2.M34;
+            result.M41 = value1.M41 + value2.M41;
+            result.M42 = value1.M42 + value2.M42;
+            result.M43 = value1.M43 + value2.M43;
+            result.M44 = value1.M44 + value2.M44;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Subtracts the second matrix from the first.
+        /// </summary>
+        /// <param name="value1">The first source matrix.</param>
+        /// <param name="value2">The second source matrix.</param>
+        /// <returns>The result of the subtraction.</returns>
+        public static Matrix4x4 Subtract(Matrix4x4 value1, Matrix4x4 value2)
+        {
+            Matrix4x4 result;
+
+            result.M11 = value1.M11 - value2.M11;
+            result.M12 = value1.M12 - value2.M12;
+            result.M13 = value1.M13 - value2.M13;
+            result.M14 = value1.M14 - value2.M14;
+            result.M21 = value1.M21 - value2.M21;
+            result.M22 = value1.M22 - value2.M22;
+            result.M23 = value1.M23 - value2.M23;
+            result.M24 = value1.M24 - value2.M24;
+            result.M31 = value1.M31 - value2.M31;
+            result.M32 = value1.M32 - value2.M32;
+            result.M33 = value1.M33 - value2.M33;
+            result.M34 = value1.M34 - value2.M34;
+            result.M41 = value1.M41 - value2.M41;
+            result.M42 = value1.M42 - value2.M42;
+            result.M43 = value1.M43 - value2.M43;
+            result.M44 = value1.M44 - value2.M44;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Multiplies a matrix by another matrix.
+        /// </summary>
+        /// <param name="value1">The first source matrix.</param>
+        /// <param name="value2">The second source matrix.</param>
+        /// <returns>The result of the multiplication.</returns>
+        public static Matrix4x4 Multiply(Matrix4x4 value1, Matrix4x4 value2)
+        {
+            Matrix4x4 result;
+
+            // First row
+            result.M11 = value1.M11 * value2.M11 + value1.M12 * value2.M21 + value1.M13 * value2.M31 + value1.M14 * value2.M41;
+            result.M12 = value1.M11 * value2.M12 + value1.M12 * value2.M22 + value1.M13 * value2.M32 + value1.M14 * value2.M42;
+            result.M13 = value1.M11 * value2.M13 + value1.M12 * value2.M23 + value1.M13 * value2.M33 + value1.M14 * value2.M43;
+            result.M14 = value1.M11 * value2.M14 + value1.M12 * value2.M24 + value1.M13 * value2.M34 + value1.M14 * value2.M44;
+
+            // Second row
+            result.M21 = value1.M21 * value2.M11 + value1.M22 * value2.M21 + value1.M23 * value2.M31 + value1.M24 * value2.M41;
+            result.M22 = value1.M21 * value2.M12 + value1.M22 * value2.M22 + value1.M23 * value2.M32 + value1.M24 * value2.M42;
+            result.M23 = value1.M21 * value2.M13 + value1.M22 * value2.M23 + value1.M23 * value2.M33 + value1.M24 * value2.M43;
+            result.M24 = value1.M21 * value2.M14 + value1.M22 * value2.M24 + value1.M23 * value2.M34 + value1.M24 * value2.M44;
+
+            // Third row
+            result.M31 = value1.M31 * value2.M11 + value1.M32 * value2.M21 + value1.M33 * value2.M31 + value1.M34 * value2.M41;
+            result.M32 = value1.M31 * value2.M12 + value1.M32 * value2.M22 + value1.M33 * value2.M32 + value1.M34 * value2.M42;
+            result.M33 = value1.M31 * value2.M13 + value1.M32 * value2.M23 + value1.M33 * value2.M33 + value1.M34 * value2.M43;
+            result.M34 = value1.M31 * value2.M14 + value1.M32 * value2.M24 + value1.M33 * value2.M34 + value1.M34 * value2.M44;
+
+            // Fourth row
+            result.M41 = value1.M41 * value2.M11 + value1.M42 * value2.M21 + value1.M43 * value2.M31 + value1.M44 * value2.M41;
+            result.M42 = value1.M41 * value2.M12 + value1.M42 * value2.M22 + value1.M43 * value2.M32 + value1.M44 * value2.M42;
+            result.M43 = value1.M41 * value2.M13 + value1.M42 * value2.M23 + value1.M43 * value2.M33 + value1.M44 * value2.M43;
+            result.M44 = value1.M41 * value2.M14 + value1.M42 * value2.M24 + value1.M43 * value2.M34 + value1.M44 * value2.M44;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Multiplies a matrix by a scalar value.
+        /// </summary>
+        /// <param name="value1">The source matrix.</param>
+        /// <param name="value2">The scaling factor.</param>
+        /// <returns>The scaled matrix.</returns>
+        public static Matrix4x4 Multiply(Matrix4x4 value1, float value2)
+        {
+            Matrix4x4 result;
+
+            result.M11 = value1.M11 * value2;
+            result.M12 = value1.M12 * value2;
+            result.M13 = value1.M13 * value2;
+            result.M14 = value1.M14 * value2;
+            result.M21 = value1.M21 * value2;
+            result.M22 = value1.M22 * value2;
+            result.M23 = value1.M23 * value2;
+            result.M24 = value1.M24 * value2;
+            result.M31 = value1.M31 * value2;
+            result.M32 = value1.M32 * value2;
+            result.M33 = value1.M33 * value2;
+            result.M34 = value1.M34 * value2;
+            result.M41 = value1.M41 * value2;
+            result.M42 = value1.M42 * value2;
+            result.M43 = value1.M43 * value2;
+            result.M44 = value1.M44 * value2;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Returns a new matrix with the negated elements of the given matrix.
+        /// </summary>
+        /// <param name="value">The source matrix.</param>
+        /// <returns>The negated matrix.</returns>
+        public static Matrix4x4 operator -(Matrix4x4 value)
+        {
+            Matrix4x4 m;
+
+            m.M11 = -value.M11;
+            m.M12 = -value.M12;
+            m.M13 = -value.M13;
+            m.M14 = -value.M14;
+            m.M21 = -value.M21;
+            m.M22 = -value.M22;
+            m.M23 = -value.M23;
+            m.M24 = -value.M24;
+            m.M31 = -value.M31;
+            m.M32 = -value.M32;
+            m.M33 = -value.M33;
+            m.M34 = -value.M34;
+            m.M41 = -value.M41;
+            m.M42 = -value.M42;
+            m.M43 = -value.M43;
+            m.M44 = -value.M44;
+
+            return m;
+        }
+
+        /// <summary>
+        /// Adds two matrices together.
+        /// </summary>
+        /// <param name="value1">The first source matrix.</param>
+        /// <param name="value2">The second source matrix.</param>
+        /// <returns>The resulting matrix.</returns>
+        public static Matrix4x4 operator +(Matrix4x4 value1, Matrix4x4 value2)
+        {
+            Matrix4x4 m;
+
+            m.M11 = value1.M11 + value2.M11;
+            m.M12 = value1.M12 + value2.M12;
+            m.M13 = value1.M13 + value2.M13;
+            m.M14 = value1.M14 + value2.M14;
+            m.M21 = value1.M21 + value2.M21;
+            m.M22 = value1.M22 + value2.M22;
+            m.M23 = value1.M23 + value2.M23;
+            m.M24 = value1.M24 + value2.M24;
+            m.M31 = value1.M31 + value2.M31;
+            m.M32 = value1.M32 + value2.M32;
+            m.M33 = value1.M33 + value2.M33;
+            m.M34 = value1.M34 + value2.M34;
+            m.M41 = value1.M41 + value2.M41;
+            m.M42 = value1.M42 + value2.M42;
+            m.M43 = value1.M43 + value2.M43;
+            m.M44 = value1.M44 + value2.M44;
+
+            return m;
+        }
+
+        /// <summary>
+        /// Subtracts the second matrix from the first.
+        /// </summary>
+        /// <param name="value1">The first source matrix.</param>
+        /// <param name="value2">The second source matrix.</param>
+        /// <returns>The result of the subtraction.</returns>
+        public static Matrix4x4 operator -(Matrix4x4 value1, Matrix4x4 value2)
+        {
+            Matrix4x4 m;
+
+            m.M11 = value1.M11 - value2.M11;
+            m.M12 = value1.M12 - value2.M12;
+            m.M13 = value1.M13 - value2.M13;
+            m.M14 = value1.M14 - value2.M14;
+            m.M21 = value1.M21 - value2.M21;
+            m.M22 = value1.M22 - value2.M22;
+            m.M23 = value1.M23 - value2.M23;
+            m.M24 = value1.M24 - value2.M24;
+            m.M31 = value1.M31 - value2.M31;
+            m.M32 = value1.M32 - value2.M32;
+            m.M33 = value1.M33 - value2.M33;
+            m.M34 = value1.M34 - value2.M34;
+            m.M41 = value1.M41 - value2.M41;
+            m.M42 = value1.M42 - value2.M42;
+            m.M43 = value1.M43 - value2.M43;
+            m.M44 = value1.M44 - value2.M44;
+
+            return m;
+        }
+
+        /// <summary>
+        /// Multiplies a matrix by another matrix.
+        /// </summary>
+        /// <param name="value1">The first source matrix.</param>
+        /// <param name="value2">The second source matrix.</param>
+        /// <returns>The result of the multiplication.</returns>
+        public static Matrix4x4 operator *(Matrix4x4 value1, Matrix4x4 value2)
+        {
+            Matrix4x4 m;
+
+            // First row
+            m.M11 = value1.M11 * value2.M11 + value1.M12 * value2.M21 + value1.M13 * value2.M31 + value1.M14 * value2.M41;
+            m.M12 = value1.M11 * value2.M12 + value1.M12 * value2.M22 + value1.M13 * value2.M32 + value1.M14 * value2.M42;
+            m.M13 = value1.M11 * value2.M13 + value1.M12 * value2.M23 + value1.M13 * value2.M33 + value1.M14 * value2.M43;
+            m.M14 = value1.M11 * value2.M14 + value1.M12 * value2.M24 + value1.M13 * value2.M34 + value1.M14 * value2.M44;
+
+            // Second row
+            m.M21 = value1.M21 * value2.M11 + value1.M22 * value2.M21 + value1.M23 * value2.M31 + value1.M24 * value2.M41;
+            m.M22 = value1.M21 * value2.M12 + value1.M22 * value2.M22 + value1.M23 * value2.M32 + value1.M24 * value2.M42;
+            m.M23 = value1.M21 * value2.M13 + value1.M22 * value2.M23 + value1.M23 * value2.M33 + value1.M24 * value2.M43;
+            m.M24 = value1.M21 * value2.M14 + value1.M22 * value2.M24 + value1.M23 * value2.M34 + value1.M24 * value2.M44;
+
+            // Third row
+            m.M31 = value1.M31 * value2.M11 + value1.M32 * value2.M21 + value1.M33 * value2.M31 + value1.M34 * value2.M41;
+            m.M32 = value1.M31 * value2.M12 + value1.M32 * value2.M22 + value1.M33 * value2.M32 + value1.M34 * value2.M42;
+            m.M33 = value1.M31 * value2.M13 + value1.M32 * value2.M23 + value1.M33 * value2.M33 + value1.M34 * value2.M43;
+            m.M34 = value1.M31 * value2.M14 + value1.M32 * value2.M24 + value1.M33 * value2.M34 + value1.M34 * value2.M44;
+
+            // Fourth row
+            m.M41 = value1.M41 * value2.M11 + value1.M42 * value2.M21 + value1.M43 * value2.M31 + value1.M44 * value2.M41;
+            m.M42 = value1.M41 * value2.M12 + value1.M42 * value2.M22 + value1.M43 * value2.M32 + value1.M44 * value2.M42;
+            m.M43 = value1.M41 * value2.M13 + value1.M42 * value2.M23 + value1.M43 * value2.M33 + value1.M44 * value2.M43;
+            m.M44 = value1.M41 * value2.M14 + value1.M42 * value2.M24 + value1.M43 * value2.M34 + value1.M44 * value2.M44;
+
+            return m;
+        }
+
+        /// <summary>
+        /// Multiplies a matrix by a scalar value.
+        /// </summary>
+        /// <param name="value1">The source matrix.</param>
+        /// <param name="value2">The scaling factor.</param>
+        /// <returns>The scaled matrix.</returns>
+        public static Matrix4x4 operator *(Matrix4x4 value1, float value2)
+        {
+            Matrix4x4 m;
+
+            m.M11 = value1.M11 * value2;
+            m.M12 = value1.M12 * value2;
+            m.M13 = value1.M13 * value2;
+            m.M14 = value1.M14 * value2;
+            m.M21 = value1.M21 * value2;
+            m.M22 = value1.M22 * value2;
+            m.M23 = value1.M23 * value2;
+            m.M24 = value1.M24 * value2;
+            m.M31 = value1.M31 * value2;
+            m.M32 = value1.M32 * value2;
+            m.M33 = value1.M33 * value2;
+            m.M34 = value1.M34 * value2;
+            m.M41 = value1.M41 * value2;
+            m.M42 = value1.M42 * value2;
+            m.M43 = value1.M43 * value2;
+            m.M44 = value1.M44 * value2;
+            return m;
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the given two matrices are equal.
+        /// </summary>
+        /// <param name="value1">The first matrix to compare.</param>
+        /// <param name="value2">The second matrix to compare.</param>
+        /// <returns>True if the given matrices are equal; False otherwise.</returns>
+        public static bool operator ==(Matrix4x4 value1, Matrix4x4 value2)
+        {
+            return (value1.M11 == value2.M11 && value1.M22 == value2.M22 && value1.M33 == value2.M33 && value1.M44 == value2.M44 && // Check diagonal element first for early out.
+                                                value1.M12 == value2.M12 && value1.M13 == value2.M13 && value1.M14 == value2.M14 &&
+                    value1.M21 == value2.M21 && value1.M23 == value2.M23 && value1.M24 == value2.M24 &&
+                    value1.M31 == value2.M31 && value1.M32 == value2.M32 && value1.M34 == value2.M34 &&
+                    value1.M41 == value2.M41 && value1.M42 == value2.M42 && value1.M43 == value2.M43);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the given two matrices are not equal.
+        /// </summary>
+        /// <param name="value1">The first matrix to compare.</param>
+        /// <param name="value2">The second matrix to compare.</param>
+        /// <returns>True if the given matrices are not equal; False if they are equal.</returns>
+        public static bool operator !=(Matrix4x4 value1, Matrix4x4 value2)
+        {
+            return (value1.M11 != value2.M11 || value1.M12 != value2.M12 || value1.M13 != value2.M13 || value1.M14 != value2.M14 ||
+                    value1.M21 != value2.M21 || value1.M22 != value2.M22 || value1.M23 != value2.M23 || value1.M24 != value2.M24 ||
+                    value1.M31 != value2.M31 || value1.M32 != value2.M32 || value1.M33 != value2.M33 || value1.M34 != value2.M34 ||
+                    value1.M41 != value2.M41 || value1.M42 != value2.M42 || value1.M43 != value2.M43 || value1.M44 != value2.M44);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether this matrix instance is equal to the other given matrix.
+        /// </summary>
+        /// <param name="other">The matrix to compare this instance to.</param>
+        /// <returns>True if the matrices are equal; False otherwise.</returns>
+        public bool Equals(Matrix4x4 other)
+        {
+            return (M11 == other.M11 && M22 == other.M22 && M33 == other.M33 && M44 == other.M44 && // Check diagonal element first for early out.
+                                        M12 == other.M12 && M13 == other.M13 && M14 == other.M14 &&
+                    M21 == other.M21 && M23 == other.M23 && M24 == other.M24 &&
+                    M31 == other.M31 && M32 == other.M32 && M34 == other.M34 &&
+                    M41 == other.M41 && M42 == other.M42 && M43 == other.M43);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the given Object is equal to this matrix instance.
+        /// </summary>
+        /// <param name="obj">The Object to compare against.</param>
+        /// <returns>True if the Object is equal to this matrix; False otherwise.</returns>
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix4x4)
+            {
+                return Equals((Matrix4x4)obj);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns a String representing this matrix instance.
+        /// </summary>
+        /// <returns>The string representation.</returns>
+        public override string ToString()
+        {
+            CultureInfo ci = CultureInfo.CurrentCulture;
+
+            return String.Format(ci, "{{ {{M11:{0} M12:{1} M13:{2} M14:{3}}} {{M21:{4} M22:{5} M23:{6} M24:{7}}} {{M31:{8} M32:{9} M33:{10} M34:{11}}} {{M41:{12} M42:{13} M43:{14} M44:{15}}} }}",
+                                 M11.ToString(ci), M12.ToString(ci), M13.ToString(ci), M14.ToString(ci),
+                                 M21.ToString(ci), M22.ToString(ci), M23.ToString(ci), M24.ToString(ci),
+                                 M31.ToString(ci), M32.ToString(ci), M33.ToString(ci), M34.ToString(ci),
+                                 M41.ToString(ci), M42.ToString(ci), M43.ToString(ci), M44.ToString(ci));
+        }
+
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>The hash code.</returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return M11.GetHashCode() + M12.GetHashCode() + M13.GetHashCode() + M14.GetHashCode() +
+                       M21.GetHashCode() + M22.GetHashCode() + M23.GetHashCode() + M24.GetHashCode() +
+                       M31.GetHashCode() + M32.GetHashCode() + M33.GetHashCode() + M34.GetHashCode() +
+                       M41.GetHashCode() + M42.GetHashCode() + M43.GetHashCode() + M44.GetHashCode();
+            }
+        }
+    }
+}

--- a/src/mscorlib/src/System/Numerics/Plane.cs
+++ b/src/mscorlib/src/System/Numerics/Plane.cs
@@ -1,0 +1,367 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Runtime.CompilerServices;
+
+namespace System.Numerics
+{
+    /// <summary>
+    /// A structure encapsulating a 3D Plane
+    /// </summary>
+    public struct Plane : IEquatable<Plane>
+    {
+        /// <summary>
+        /// The normal vector of the Plane.
+        /// </summary>
+        public Vector3 Normal;
+        /// <summary>
+        /// The distance of the Plane along its normal from the origin.
+        /// </summary>
+        public float D;
+
+        /// <summary>
+        /// Constructs a Plane from the X, Y, and Z components of its normal, and its distance from the origin on that normal.
+        /// </summary>
+        /// <param name="x">The X-component of the normal.</param>
+        /// <param name="y">The Y-component of the normal.</param>
+        /// <param name="z">The Z-component of the normal.</param>
+        /// <param name="d">The distance of the Plane along its normal from the origin.</param>
+        public Plane(float x, float y, float z, float d)
+        {
+            Normal = new Vector3(x, y, z);
+            this.D = d;
+        }
+
+        /// <summary>
+        /// Constructs a Plane from the given normal and distance along the normal from the origin.
+        /// </summary>
+        /// <param name="normal">The Plane's normal vector.</param>
+        /// <param name="d">The Plane's distance from the origin along its normal vector.</param>
+        public Plane(Vector3 normal, float d)
+        {
+            this.Normal = normal;
+            this.D = d;
+        }
+
+        /// <summary>
+        /// Constructs a Plane from the given Vector4.
+        /// </summary>
+        /// <param name="value">A vector whose first 3 elements describe the normal vector, 
+        /// and whose W component defines the distance along that normal from the origin.</param>
+        public Plane(Vector4 value)
+        {
+            Normal = new Vector3(value.X, value.Y, value.Z);
+            D = value.W;
+        }
+
+        /// <summary>
+        /// Creates a Plane that contains the three given points.
+        /// </summary>
+        /// <param name="point1">The first point defining the Plane.</param>
+        /// <param name="point2">The second point defining the Plane.</param>
+        /// <param name="point3">The third point defining the Plane.</param>
+        /// <returns>The Plane containing the three points.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Plane CreateFromVertices(Vector3 point1, Vector3 point2, Vector3 point3)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                Vector3 a = point2 - point1;
+                Vector3 b = point3 - point1;
+
+                // N = Cross(a, b)
+                Vector3 n = Vector3.Cross(a, b);
+                Vector3 normal = Vector3.Normalize(n);
+
+                // D = - Dot(N, point1)
+                float d = -Vector3.Dot(normal, point1);
+
+                return new Plane(normal, d);
+            }
+            else
+            {
+                float ax = point2.X - point1.X;
+                float ay = point2.Y - point1.Y;
+                float az = point2.Z - point1.Z;
+
+                float bx = point3.X - point1.X;
+                float by = point3.Y - point1.Y;
+                float bz = point3.Z - point1.Z;
+
+                // N=Cross(a,b)
+                float nx = ay * bz - az * by;
+                float ny = az * bx - ax * bz;
+                float nz = ax * by - ay * bx;
+
+                // Normalize(N)
+                float ls = nx * nx + ny * ny + nz * nz;
+                float invNorm = 1.0f / MathF.Sqrt(ls);
+
+                Vector3 normal = new Vector3(
+                    nx * invNorm,
+                    ny * invNorm,
+                    nz * invNorm);
+
+                return new Plane(
+                    normal,
+                    -(normal.X * point1.X + normal.Y * point1.Y + normal.Z * point1.Z));
+            }
+        }
+
+        /// <summary>
+        /// Creates a new Plane whose normal vector is the source Plane's normal vector normalized.
+        /// </summary>
+        /// <param name="value">The source Plane.</param>
+        /// <returns>The normalized Plane.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Plane Normalize(Plane value)
+        {
+            const float FLT_EPSILON = 1.192092896e-07f; // smallest such that 1.0+FLT_EPSILON != 1.0
+            if (Vector.IsHardwareAccelerated)
+            {
+                float normalLengthSquared = value.Normal.LengthSquared();
+                if (MathF.Abs(normalLengthSquared - 1.0f) < FLT_EPSILON)
+                {
+                    // It already normalized, so we don't need to farther process.
+                    return value;
+                }
+                float normalLength = MathF.Sqrt(normalLengthSquared);
+                return new Plane(
+                    value.Normal / normalLength,
+                    value.D / normalLength);
+            }
+            else
+            {
+                float f = value.Normal.X * value.Normal.X + value.Normal.Y * value.Normal.Y + value.Normal.Z * value.Normal.Z;
+
+                if (MathF.Abs(f - 1.0f) < FLT_EPSILON)
+                {
+                    return value; // It already normalized, so we don't need to further process.
+                }
+
+                float fInv = 1.0f / MathF.Sqrt(f);
+
+                return new Plane(
+                    value.Normal.X * fInv,
+                    value.Normal.Y * fInv,
+                    value.Normal.Z * fInv,
+                    value.D * fInv);
+            }
+        }
+
+        /// <summary>
+        /// Transforms a normalized Plane by a Matrix.
+        /// </summary>
+        /// <param name="plane"> The normalized Plane to transform. 
+        /// This Plane must already be normalized, so that its Normal vector is of unit length, before this method is called.</param>
+        /// <param name="matrix">The transformation matrix to apply to the Plane.</param>
+        /// <returns>The transformed Plane.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Plane Transform(Plane plane, Matrix4x4 matrix)
+        {
+            Matrix4x4 m;
+            Matrix4x4.Invert(matrix, out m);
+
+            float x = plane.Normal.X, y = plane.Normal.Y, z = plane.Normal.Z, w = plane.D;
+
+            return new Plane(
+                x * m.M11 + y * m.M12 + z * m.M13 + w * m.M14,
+                x * m.M21 + y * m.M22 + z * m.M23 + w * m.M24,
+                x * m.M31 + y * m.M32 + z * m.M33 + w * m.M34,
+                x * m.M41 + y * m.M42 + z * m.M43 + w * m.M44);
+        }
+
+        /// <summary>
+        ///  Transforms a normalized Plane by a Quaternion rotation.
+        /// </summary>
+        /// <param name="plane"> The normalized Plane to transform.
+        /// This Plane must already be normalized, so that its Normal vector is of unit length, before this method is called.</param>
+        /// <param name="rotation">The Quaternion rotation to apply to the Plane.</param>
+        /// <returns>A new Plane that results from applying the rotation.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Plane Transform(Plane plane, Quaternion rotation)
+        {
+            // Compute rotation matrix.
+            float x2 = rotation.X + rotation.X;
+            float y2 = rotation.Y + rotation.Y;
+            float z2 = rotation.Z + rotation.Z;
+
+            float wx2 = rotation.W * x2;
+            float wy2 = rotation.W * y2;
+            float wz2 = rotation.W * z2;
+            float xx2 = rotation.X * x2;
+            float xy2 = rotation.X * y2;
+            float xz2 = rotation.X * z2;
+            float yy2 = rotation.Y * y2;
+            float yz2 = rotation.Y * z2;
+            float zz2 = rotation.Z * z2;
+
+            float m11 = 1.0f - yy2 - zz2;
+            float m21 = xy2 - wz2;
+            float m31 = xz2 + wy2;
+
+            float m12 = xy2 + wz2;
+            float m22 = 1.0f - xx2 - zz2;
+            float m32 = yz2 - wx2;
+
+            float m13 = xz2 - wy2;
+            float m23 = yz2 + wx2;
+            float m33 = 1.0f - xx2 - yy2;
+
+            float x = plane.Normal.X, y = plane.Normal.Y, z = plane.Normal.Z;
+
+            return new Plane(
+                x * m11 + y * m21 + z * m31,
+                x * m12 + y * m22 + z * m32,
+                x * m13 + y * m23 + z * m33,
+                plane.D);
+        }
+
+        /// <summary>
+        /// Calculates the dot product of a Plane and Vector4.
+        /// </summary>
+        /// <param name="plane">The Plane.</param>
+        /// <param name="value">The Vector4.</param>
+        /// <returns>The dot product.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Dot(Plane plane, Vector4 value)
+        {
+            return plane.Normal.X * value.X +
+                   plane.Normal.Y * value.Y +
+                   plane.Normal.Z * value.Z +
+                   plane.D * value.W;
+        }
+
+        /// <summary>
+        /// Returns the dot product of a specified Vector3 and the normal vector of this Plane plus the distance (D) value of the Plane.
+        /// </summary>
+        /// <param name="plane">The plane.</param>
+        /// <param name="value">The Vector3.</param>
+        /// <returns>The resulting value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float DotCoordinate(Plane plane, Vector3 value)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                return Vector3.Dot(plane.Normal, value) + plane.D;
+            }
+            else
+            {
+                return plane.Normal.X * value.X +
+                       plane.Normal.Y * value.Y +
+                       plane.Normal.Z * value.Z +
+                       plane.D;
+            }
+        }
+
+        /// <summary>
+        /// Returns the dot product of a specified Vector3 and the Normal vector of this Plane.
+        /// </summary>
+        /// <param name="plane">The plane.</param>
+        /// <param name="value">The Vector3.</param>
+        /// <returns>The resulting dot product.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float DotNormal(Plane plane, Vector3 value)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                return Vector3.Dot(plane.Normal, value);
+            }
+            else
+            {
+                return plane.Normal.X * value.X +
+                       plane.Normal.Y * value.Y +
+                       plane.Normal.Z * value.Z;
+            }
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the two given Planes are equal.
+        /// </summary>
+        /// <param name="value1">The first Plane to compare.</param>
+        /// <param name="value2">The second Plane to compare.</param>
+        /// <returns>True if the Planes are equal; False otherwise.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator ==(Plane value1, Plane value2)
+        {
+            return (value1.Normal.X == value2.Normal.X &&
+                    value1.Normal.Y == value2.Normal.Y &&
+                    value1.Normal.Z == value2.Normal.Z &&
+                    value1.D == value2.D);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the two given Planes are not equal.
+        /// </summary>
+        /// <param name="value1">The first Plane to compare.</param>
+        /// <param name="value2">The second Plane to compare.</param>
+        /// <returns>True if the Planes are not equal; False if they are equal.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator !=(Plane value1, Plane value2)
+        {
+            return (value1.Normal.X != value2.Normal.X ||
+                    value1.Normal.Y != value2.Normal.Y ||
+                    value1.Normal.Z != value2.Normal.Z ||
+                    value1.D != value2.D);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the given Plane is equal to this Plane instance.
+        /// </summary>
+        /// <param name="other">The Plane to compare this instance to.</param>
+        /// <returns>True if the other Plane is equal to this instance; False otherwise.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Equals(Plane other)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                return this.Normal.Equals(other.Normal) && this.D == other.D;
+            }
+            else
+            {
+                return (Normal.X == other.Normal.X &&
+                        Normal.Y == other.Normal.Y &&
+                        Normal.Z == other.Normal.Z &&
+                        D == other.D);
+            }
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the given Object is equal to this Plane instance.
+        /// </summary>
+        /// <param name="obj">The Object to compare against.</param>
+        /// <returns>True if the Object is equal to this Plane; False otherwise.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override bool Equals(object obj)
+        {
+            if (obj is Plane)
+            {
+                return Equals((Plane)obj);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns a String representing this Plane instance.
+        /// </summary>
+        /// <returns>The string representation.</returns>
+        public override string ToString()
+        {
+            CultureInfo ci = CultureInfo.CurrentCulture;
+
+            return String.Format(ci, "{{Normal:{0} D:{1}}}", Normal.ToString(), D.ToString(ci));
+        }
+
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>The hash code.</returns>
+        public override int GetHashCode()
+        {
+            return Normal.GetHashCode() + D.GetHashCode();
+        }
+    }
+}

--- a/src/mscorlib/src/System/Numerics/Quaternion.cs
+++ b/src/mscorlib/src/System/Numerics/Quaternion.cs
@@ -1,0 +1,794 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+
+namespace System.Numerics
+{
+    /// <summary>
+    /// A structure encapsulating a four-dimensional vector (x,y,z,w), 
+    /// which is used to efficiently rotate an object about the (x,y,z) vector by the angle theta, where w = cos(theta/2).
+    /// </summary>
+    public struct Quaternion : IEquatable<Quaternion>
+    {
+        /// <summary>
+        /// Specifies the X-value of the vector component of the Quaternion.
+        /// </summary>
+        public float X;
+        /// <summary>
+        /// Specifies the Y-value of the vector component of the Quaternion.
+        /// </summary>
+        public float Y;
+        /// <summary>
+        /// Specifies the Z-value of the vector component of the Quaternion.
+        /// </summary>
+        public float Z;
+        /// <summary>
+        /// Specifies the rotation component of the Quaternion.
+        /// </summary>
+        public float W;
+
+        /// <summary>
+        /// Returns a Quaternion representing no rotation. 
+        /// </summary>
+        public static Quaternion Identity
+        {
+            get { return new Quaternion(0, 0, 0, 1); }
+        }
+
+        /// <summary>
+        /// Returns whether the Quaternion is the identity Quaternion.
+        /// </summary>
+        public bool IsIdentity
+        {
+            get { return X == 0f && Y == 0f && Z == 0f && W == 1f; }
+        }
+
+        /// <summary>
+        /// Constructs a Quaternion from the given components.
+        /// </summary>
+        /// <param name="x">The X component of the Quaternion.</param>
+        /// <param name="y">The Y component of the Quaternion.</param>
+        /// <param name="z">The Z component of the Quaternion.</param>
+        /// <param name="w">The W component of the Quaternion.</param>
+        public Quaternion(float x, float y, float z, float w)
+        {
+            this.X = x;
+            this.Y = y;
+            this.Z = z;
+            this.W = w;
+        }
+
+        /// <summary>
+        /// Constructs a Quaternion from the given vector and rotation parts.
+        /// </summary>
+        /// <param name="vectorPart">The vector part of the Quaternion.</param>
+        /// <param name="scalarPart">The rotation part of the Quaternion.</param>
+        public Quaternion(Vector3 vectorPart, float scalarPart)
+        {
+            X = vectorPart.X;
+            Y = vectorPart.Y;
+            Z = vectorPart.Z;
+            W = scalarPart;
+        }
+
+        /// <summary>
+        /// Calculates the length of the Quaternion.
+        /// </summary>
+        /// <returns>The computed length of the Quaternion.</returns>
+        public float Length()
+        {
+            float ls = X * X + Y * Y + Z * Z + W * W;
+
+            return MathF.Sqrt(ls);
+        }
+
+        /// <summary>
+        /// Calculates the length squared of the Quaternion. This operation is cheaper than Length().
+        /// </summary>
+        /// <returns>The length squared of the Quaternion.</returns>
+        public float LengthSquared()
+        {
+            return X * X + Y * Y + Z * Z + W * W;
+        }
+
+        /// <summary>
+        /// Divides each component of the Quaternion by the length of the Quaternion.
+        /// </summary>
+        /// <param name="value">The source Quaternion.</param>
+        /// <returns>The normalized Quaternion.</returns>
+        public static Quaternion Normalize(Quaternion value)
+        {
+            Quaternion ans;
+
+            float ls = value.X * value.X + value.Y * value.Y + value.Z * value.Z + value.W * value.W;
+
+            float invNorm = 1.0f / MathF.Sqrt(ls);
+
+            ans.X = value.X * invNorm;
+            ans.Y = value.Y * invNorm;
+            ans.Z = value.Z * invNorm;
+            ans.W = value.W * invNorm;
+
+            return ans;
+        }
+
+        /// <summary>
+        /// Creates the conjugate of a specified Quaternion.
+        /// </summary>
+        /// <param name="value">The Quaternion of which to return the conjugate.</param>
+        /// <returns>A new Quaternion that is the conjugate of the specified one.</returns>
+        public static Quaternion Conjugate(Quaternion value)
+        {
+            Quaternion ans;
+
+            ans.X = -value.X;
+            ans.Y = -value.Y;
+            ans.Z = -value.Z;
+            ans.W = value.W;
+
+            return ans;
+        }
+
+        /// <summary>
+        /// Returns the inverse of a Quaternion.
+        /// </summary>
+        /// <param name="value">The source Quaternion.</param>
+        /// <returns>The inverted Quaternion.</returns>
+        public static Quaternion Inverse(Quaternion value)
+        {
+            //  -1   (       a              -v       )
+            // q   = ( -------------   ------------- )
+            //       (  a^2 + |v|^2  ,  a^2 + |v|^2  )
+
+            Quaternion ans;
+
+            float ls = value.X * value.X + value.Y * value.Y + value.Z * value.Z + value.W * value.W;
+            float invNorm = 1.0f / ls;
+
+            ans.X = -value.X * invNorm;
+            ans.Y = -value.Y * invNorm;
+            ans.Z = -value.Z * invNorm;
+            ans.W = value.W * invNorm;
+
+            return ans;
+        }
+
+        /// <summary>
+        /// Creates a Quaternion from a normalized vector axis and an angle to rotate about the vector.
+        /// </summary>
+        /// <param name="axis">The unit vector to rotate around.
+        /// This vector must be normalized before calling this function or the resulting Quaternion will be incorrect.</param>
+        /// <param name="angle">The angle, in radians, to rotate around the vector.</param>
+        /// <returns>The created Quaternion.</returns>
+        public static Quaternion CreateFromAxisAngle(Vector3 axis, float angle)
+        {
+            Quaternion ans;
+
+            float halfAngle = angle * 0.5f;
+            float s = MathF.Sin(halfAngle);
+            float c = MathF.Cos(halfAngle);
+
+            ans.X = axis.X * s;
+            ans.Y = axis.Y * s;
+            ans.Z = axis.Z * s;
+            ans.W = c;
+
+            return ans;
+        }
+
+        /// <summary>
+        /// Creates a new Quaternion from the given yaw, pitch, and roll, in radians.
+        /// </summary>
+        /// <param name="yaw">The yaw angle, in radians, around the Y-axis.</param>
+        /// <param name="pitch">The pitch angle, in radians, around the X-axis.</param>
+        /// <param name="roll">The roll angle, in radians, around the Z-axis.</param>
+        /// <returns></returns>
+        public static Quaternion CreateFromYawPitchRoll(float yaw, float pitch, float roll)
+        {
+            //  Roll first, about axis the object is facing, then
+            //  pitch upward, then yaw to face into the new heading
+            float sr, cr, sp, cp, sy, cy;
+
+            float halfRoll = roll * 0.5f;
+            sr = MathF.Sin(halfRoll);
+            cr = MathF.Cos(halfRoll);
+
+            float halfPitch = pitch * 0.5f;
+            sp = MathF.Sin(halfPitch);
+            cp = MathF.Cos(halfPitch);
+
+            float halfYaw = yaw * 0.5f;
+            sy = MathF.Sin(halfYaw);
+            cy = MathF.Cos(halfYaw);
+
+            Quaternion result;
+
+            result.X = cy * sp * cr + sy * cp * sr;
+            result.Y = sy * cp * cr - cy * sp * sr;
+            result.Z = cy * cp * sr - sy * sp * cr;
+            result.W = cy * cp * cr + sy * sp * sr;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a Quaternion from the given rotation matrix.
+        /// </summary>
+        /// <param name="matrix">The rotation matrix.</param>
+        /// <returns>The created Quaternion.</returns>
+        public static Quaternion CreateFromRotationMatrix(Matrix4x4 matrix)
+        {
+            float trace = matrix.M11 + matrix.M22 + matrix.M33;
+
+            Quaternion q = new Quaternion();
+
+            if (trace > 0.0f)
+            {
+                float s = MathF.Sqrt(trace + 1.0f);
+                q.W = s * 0.5f;
+                s = 0.5f / s;
+                q.X = (matrix.M23 - matrix.M32) * s;
+                q.Y = (matrix.M31 - matrix.M13) * s;
+                q.Z = (matrix.M12 - matrix.M21) * s;
+            }
+            else
+            {
+                if (matrix.M11 >= matrix.M22 && matrix.M11 >= matrix.M33)
+                {
+                    float s = MathF.Sqrt(1.0f + matrix.M11 - matrix.M22 - matrix.M33);
+                    float invS = 0.5f / s;
+                    q.X = 0.5f * s;
+                    q.Y = (matrix.M12 + matrix.M21) * invS;
+                    q.Z = (matrix.M13 + matrix.M31) * invS;
+                    q.W = (matrix.M23 - matrix.M32) * invS;
+                }
+                else if (matrix.M22 > matrix.M33)
+                {
+                    float s = MathF.Sqrt(1.0f + matrix.M22 - matrix.M11 - matrix.M33);
+                    float invS = 0.5f / s;
+                    q.X = (matrix.M21 + matrix.M12) * invS;
+                    q.Y = 0.5f * s;
+                    q.Z = (matrix.M32 + matrix.M23) * invS;
+                    q.W = (matrix.M31 - matrix.M13) * invS;
+                }
+                else
+                {
+                    float s = MathF.Sqrt(1.0f + matrix.M33 - matrix.M11 - matrix.M22);
+                    float invS = 0.5f / s;
+                    q.X = (matrix.M31 + matrix.M13) * invS;
+                    q.Y = (matrix.M32 + matrix.M23) * invS;
+                    q.Z = 0.5f * s;
+                    q.W = (matrix.M12 - matrix.M21) * invS;
+                }
+            }
+
+            return q;
+        }
+
+        /// <summary>
+        /// Calculates the dot product of two Quaternions.
+        /// </summary>
+        /// <param name="quaternion1">The first source Quaternion.</param>
+        /// <param name="quaternion2">The second source Quaternion.</param>
+        /// <returns>The dot product of the Quaternions.</returns>
+        public static float Dot(Quaternion quaternion1, Quaternion quaternion2)
+        {
+            return quaternion1.X * quaternion2.X +
+                   quaternion1.Y * quaternion2.Y +
+                   quaternion1.Z * quaternion2.Z +
+                   quaternion1.W * quaternion2.W;
+        }
+
+        /// <summary>
+        /// Interpolates between two quaternions, using spherical linear interpolation.
+        /// </summary>
+        /// <param name="quaternion1">The first source Quaternion.</param>
+        /// <param name="quaternion2">The second source Quaternion.</param>
+        /// <param name="amount">The relative weight of the second source Quaternion in the interpolation.</param>
+        /// <returns>The interpolated Quaternion.</returns>
+        public static Quaternion Slerp(Quaternion quaternion1, Quaternion quaternion2, float amount)
+        {
+            const float epsilon = 1e-6f;
+
+            float t = amount;
+
+            float cosOmega = quaternion1.X * quaternion2.X + quaternion1.Y * quaternion2.Y +
+                             quaternion1.Z * quaternion2.Z + quaternion1.W * quaternion2.W;
+
+            bool flip = false;
+
+            if (cosOmega < 0.0f)
+            {
+                flip = true;
+                cosOmega = -cosOmega;
+            }
+
+            float s1, s2;
+
+            if (cosOmega > (1.0f - epsilon))
+            {
+                // Too close, do straight linear interpolation.
+                s1 = 1.0f - t;
+                s2 = (flip) ? -t : t;
+            }
+            else
+            {
+                float omega = MathF.Acos(cosOmega);
+                float invSinOmega = 1 / MathF.Sin(omega);
+
+                s1 = MathF.Sin((1.0f - t) * omega) * invSinOmega;
+                s2 = (flip)
+                    ? -MathF.Sin(t * omega) * invSinOmega
+                    : MathF.Sin(t * omega) * invSinOmega;
+            }
+
+            Quaternion ans;
+
+            ans.X = s1 * quaternion1.X + s2 * quaternion2.X;
+            ans.Y = s1 * quaternion1.Y + s2 * quaternion2.Y;
+            ans.Z = s1 * quaternion1.Z + s2 * quaternion2.Z;
+            ans.W = s1 * quaternion1.W + s2 * quaternion2.W;
+
+            return ans;
+        }
+
+        /// <summary>
+        ///  Linearly interpolates between two quaternions.
+        /// </summary>
+        /// <param name="quaternion1">The first source Quaternion.</param>
+        /// <param name="quaternion2">The second source Quaternion.</param>
+        /// <param name="amount">The relative weight of the second source Quaternion in the interpolation.</param>
+        /// <returns>The interpolated Quaternion.</returns>
+        public static Quaternion Lerp(Quaternion quaternion1, Quaternion quaternion2, float amount)
+        {
+            float t = amount;
+            float t1 = 1.0f - t;
+
+            Quaternion r = new Quaternion();
+
+            float dot = quaternion1.X * quaternion2.X + quaternion1.Y * quaternion2.Y +
+                        quaternion1.Z * quaternion2.Z + quaternion1.W * quaternion2.W;
+
+            if (dot >= 0.0f)
+            {
+                r.X = t1 * quaternion1.X + t * quaternion2.X;
+                r.Y = t1 * quaternion1.Y + t * quaternion2.Y;
+                r.Z = t1 * quaternion1.Z + t * quaternion2.Z;
+                r.W = t1 * quaternion1.W + t * quaternion2.W;
+            }
+            else
+            {
+                r.X = t1 * quaternion1.X - t * quaternion2.X;
+                r.Y = t1 * quaternion1.Y - t * quaternion2.Y;
+                r.Z = t1 * quaternion1.Z - t * quaternion2.Z;
+                r.W = t1 * quaternion1.W - t * quaternion2.W;
+            }
+
+            // Normalize it.
+            float ls = r.X * r.X + r.Y * r.Y + r.Z * r.Z + r.W * r.W;
+            float invNorm = 1.0f / MathF.Sqrt(ls);
+
+            r.X *= invNorm;
+            r.Y *= invNorm;
+            r.Z *= invNorm;
+            r.W *= invNorm;
+
+            return r;
+        }
+
+        /// <summary>
+        /// Concatenates two Quaternions; the result represents the value1 rotation followed by the value2 rotation.
+        /// </summary>
+        /// <param name="value1">The first Quaternion rotation in the series.</param>
+        /// <param name="value2">The second Quaternion rotation in the series.</param>
+        /// <returns>A new Quaternion representing the concatenation of the value1 rotation followed by the value2 rotation.</returns>
+        public static Quaternion Concatenate(Quaternion value1, Quaternion value2)
+        {
+            Quaternion ans;
+
+            // Concatenate rotation is actually q2 * q1 instead of q1 * q2.
+            // So that's why value2 goes q1 and value1 goes q2.
+            float q1x = value2.X;
+            float q1y = value2.Y;
+            float q1z = value2.Z;
+            float q1w = value2.W;
+
+            float q2x = value1.X;
+            float q2y = value1.Y;
+            float q2z = value1.Z;
+            float q2w = value1.W;
+
+            // cross(av, bv)
+            float cx = q1y * q2z - q1z * q2y;
+            float cy = q1z * q2x - q1x * q2z;
+            float cz = q1x * q2y - q1y * q2x;
+
+            float dot = q1x * q2x + q1y * q2y + q1z * q2z;
+
+            ans.X = q1x * q2w + q2x * q1w + cx;
+            ans.Y = q1y * q2w + q2y * q1w + cy;
+            ans.Z = q1z * q2w + q2z * q1w + cz;
+            ans.W = q1w * q2w - dot;
+
+            return ans;
+        }
+
+        /// <summary>
+        /// Flips the sign of each component of the quaternion.
+        /// </summary>
+        /// <param name="value">The source Quaternion.</param>
+        /// <returns>The negated Quaternion.</returns>
+        public static Quaternion Negate(Quaternion value)
+        {
+            Quaternion ans;
+
+            ans.X = -value.X;
+            ans.Y = -value.Y;
+            ans.Z = -value.Z;
+            ans.W = -value.W;
+
+            return ans;
+        }
+
+        /// <summary>
+        /// Adds two Quaternions element-by-element.
+        /// </summary>
+        /// <param name="value1">The first source Quaternion.</param>
+        /// <param name="value2">The second source Quaternion.</param>
+        /// <returns>The result of adding the Quaternions.</returns>
+        public static Quaternion Add(Quaternion value1, Quaternion value2)
+        {
+            Quaternion ans;
+
+            ans.X = value1.X + value2.X;
+            ans.Y = value1.Y + value2.Y;
+            ans.Z = value1.Z + value2.Z;
+            ans.W = value1.W + value2.W;
+
+            return ans;
+        }
+
+        /// <summary>
+        /// Subtracts one Quaternion from another.
+        /// </summary>
+        /// <param name="value1">The first source Quaternion.</param>
+        /// <param name="value2">The second Quaternion, to be subtracted from the first.</param>
+        /// <returns>The result of the subtraction.</returns>
+        public static Quaternion Subtract(Quaternion value1, Quaternion value2)
+        {
+            Quaternion ans;
+
+            ans.X = value1.X - value2.X;
+            ans.Y = value1.Y - value2.Y;
+            ans.Z = value1.Z - value2.Z;
+            ans.W = value1.W - value2.W;
+
+            return ans;
+        }
+
+        /// <summary>
+        /// Multiplies two Quaternions together.
+        /// </summary>
+        /// <param name="value1">The Quaternion on the left side of the multiplication.</param>
+        /// <param name="value2">The Quaternion on the right side of the multiplication.</param>
+        /// <returns>The result of the multiplication.</returns>
+        public static Quaternion Multiply(Quaternion value1, Quaternion value2)
+        {
+            Quaternion ans;
+
+            float q1x = value1.X;
+            float q1y = value1.Y;
+            float q1z = value1.Z;
+            float q1w = value1.W;
+
+            float q2x = value2.X;
+            float q2y = value2.Y;
+            float q2z = value2.Z;
+            float q2w = value2.W;
+
+            // cross(av, bv)
+            float cx = q1y * q2z - q1z * q2y;
+            float cy = q1z * q2x - q1x * q2z;
+            float cz = q1x * q2y - q1y * q2x;
+
+            float dot = q1x * q2x + q1y * q2y + q1z * q2z;
+
+            ans.X = q1x * q2w + q2x * q1w + cx;
+            ans.Y = q1y * q2w + q2y * q1w + cy;
+            ans.Z = q1z * q2w + q2z * q1w + cz;
+            ans.W = q1w * q2w - dot;
+
+            return ans;
+        }
+
+        /// <summary>
+        /// Multiplies a Quaternion by a scalar value.
+        /// </summary>
+        /// <param name="value1">The source Quaternion.</param>
+        /// <param name="value2">The scalar value.</param>
+        /// <returns>The result of the multiplication.</returns>
+        public static Quaternion Multiply(Quaternion value1, float value2)
+        {
+            Quaternion ans;
+
+            ans.X = value1.X * value2;
+            ans.Y = value1.Y * value2;
+            ans.Z = value1.Z * value2;
+            ans.W = value1.W * value2;
+
+            return ans;
+        }
+
+        /// <summary>
+        /// Divides a Quaternion by another Quaternion.
+        /// </summary>
+        /// <param name="value1">The source Quaternion.</param>
+        /// <param name="value2">The divisor.</param>
+        /// <returns>The result of the division.</returns>
+        public static Quaternion Divide(Quaternion value1, Quaternion value2)
+        {
+            Quaternion ans;
+
+            float q1x = value1.X;
+            float q1y = value1.Y;
+            float q1z = value1.Z;
+            float q1w = value1.W;
+
+            //-------------------------------------
+            // Inverse part.
+            float ls = value2.X * value2.X + value2.Y * value2.Y +
+                       value2.Z * value2.Z + value2.W * value2.W;
+            float invNorm = 1.0f / ls;
+
+            float q2x = -value2.X * invNorm;
+            float q2y = -value2.Y * invNorm;
+            float q2z = -value2.Z * invNorm;
+            float q2w = value2.W * invNorm;
+
+            //-------------------------------------
+            // Multiply part.
+
+            // cross(av, bv)
+            float cx = q1y * q2z - q1z * q2y;
+            float cy = q1z * q2x - q1x * q2z;
+            float cz = q1x * q2y - q1y * q2x;
+
+            float dot = q1x * q2x + q1y * q2y + q1z * q2z;
+
+            ans.X = q1x * q2w + q2x * q1w + cx;
+            ans.Y = q1y * q2w + q2y * q1w + cy;
+            ans.Z = q1z * q2w + q2z * q1w + cz;
+            ans.W = q1w * q2w - dot;
+
+            return ans;
+        }
+
+        /// <summary>
+        /// Flips the sign of each component of the quaternion.
+        /// </summary>
+        /// <param name="value">The source Quaternion.</param>
+        /// <returns>The negated Quaternion.</returns>
+        public static Quaternion operator -(Quaternion value)
+        {
+            Quaternion ans;
+
+            ans.X = -value.X;
+            ans.Y = -value.Y;
+            ans.Z = -value.Z;
+            ans.W = -value.W;
+
+            return ans;
+        }
+
+        /// <summary>
+        /// Adds two Quaternions element-by-element.
+        /// </summary>
+        /// <param name="value1">The first source Quaternion.</param>
+        /// <param name="value2">The second source Quaternion.</param>
+        /// <returns>The result of adding the Quaternions.</returns>
+        public static Quaternion operator +(Quaternion value1, Quaternion value2)
+        {
+            Quaternion ans;
+
+            ans.X = value1.X + value2.X;
+            ans.Y = value1.Y + value2.Y;
+            ans.Z = value1.Z + value2.Z;
+            ans.W = value1.W + value2.W;
+
+            return ans;
+        }
+
+        /// <summary>
+        /// Subtracts one Quaternion from another.
+        /// </summary>
+        /// <param name="value1">The first source Quaternion.</param>
+        /// <param name="value2">The second Quaternion, to be subtracted from the first.</param>
+        /// <returns>The result of the subtraction.</returns>
+        public static Quaternion operator -(Quaternion value1, Quaternion value2)
+        {
+            Quaternion ans;
+
+            ans.X = value1.X - value2.X;
+            ans.Y = value1.Y - value2.Y;
+            ans.Z = value1.Z - value2.Z;
+            ans.W = value1.W - value2.W;
+
+            return ans;
+        }
+
+        /// <summary>
+        /// Multiplies two Quaternions together.
+        /// </summary>
+        /// <param name="value1">The Quaternion on the left side of the multiplication.</param>
+        /// <param name="value2">The Quaternion on the right side of the multiplication.</param>
+        /// <returns>The result of the multiplication.</returns>
+        public static Quaternion operator *(Quaternion value1, Quaternion value2)
+        {
+            Quaternion ans;
+
+            float q1x = value1.X;
+            float q1y = value1.Y;
+            float q1z = value1.Z;
+            float q1w = value1.W;
+
+            float q2x = value2.X;
+            float q2y = value2.Y;
+            float q2z = value2.Z;
+            float q2w = value2.W;
+
+            // cross(av, bv)
+            float cx = q1y * q2z - q1z * q2y;
+            float cy = q1z * q2x - q1x * q2z;
+            float cz = q1x * q2y - q1y * q2x;
+
+            float dot = q1x * q2x + q1y * q2y + q1z * q2z;
+
+            ans.X = q1x * q2w + q2x * q1w + cx;
+            ans.Y = q1y * q2w + q2y * q1w + cy;
+            ans.Z = q1z * q2w + q2z * q1w + cz;
+            ans.W = q1w * q2w - dot;
+
+            return ans;
+        }
+
+        /// <summary>
+        /// Multiplies a Quaternion by a scalar value.
+        /// </summary>
+        /// <param name="value1">The source Quaternion.</param>
+        /// <param name="value2">The scalar value.</param>
+        /// <returns>The result of the multiplication.</returns>
+        public static Quaternion operator *(Quaternion value1, float value2)
+        {
+            Quaternion ans;
+
+            ans.X = value1.X * value2;
+            ans.Y = value1.Y * value2;
+            ans.Z = value1.Z * value2;
+            ans.W = value1.W * value2;
+
+            return ans;
+        }
+
+        /// <summary>
+        /// Divides a Quaternion by another Quaternion.
+        /// </summary>
+        /// <param name="value1">The source Quaternion.</param>
+        /// <param name="value2">The divisor.</param>
+        /// <returns>The result of the division.</returns>
+        public static Quaternion operator /(Quaternion value1, Quaternion value2)
+        {
+            Quaternion ans;
+
+            float q1x = value1.X;
+            float q1y = value1.Y;
+            float q1z = value1.Z;
+            float q1w = value1.W;
+
+            //-------------------------------------
+            // Inverse part.
+            float ls = value2.X * value2.X + value2.Y * value2.Y +
+                       value2.Z * value2.Z + value2.W * value2.W;
+            float invNorm = 1.0f / ls;
+
+            float q2x = -value2.X * invNorm;
+            float q2y = -value2.Y * invNorm;
+            float q2z = -value2.Z * invNorm;
+            float q2w = value2.W * invNorm;
+
+            //-------------------------------------
+            // Multiply part.
+
+            // cross(av, bv)
+            float cx = q1y * q2z - q1z * q2y;
+            float cy = q1z * q2x - q1x * q2z;
+            float cz = q1x * q2y - q1y * q2x;
+
+            float dot = q1x * q2x + q1y * q2y + q1z * q2z;
+
+            ans.X = q1x * q2w + q2x * q1w + cx;
+            ans.Y = q1y * q2w + q2y * q1w + cy;
+            ans.Z = q1z * q2w + q2z * q1w + cz;
+            ans.W = q1w * q2w - dot;
+
+            return ans;
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the two given Quaternions are equal.
+        /// </summary>
+        /// <param name="value1">The first Quaternion to compare.</param>
+        /// <param name="value2">The second Quaternion to compare.</param>
+        /// <returns>True if the Quaternions are equal; False otherwise.</returns>
+        public static bool operator ==(Quaternion value1, Quaternion value2)
+        {
+            return (value1.X == value2.X &&
+                    value1.Y == value2.Y &&
+                    value1.Z == value2.Z &&
+                    value1.W == value2.W);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the two given Quaternions are not equal.
+        /// </summary>
+        /// <param name="value1">The first Quaternion to compare.</param>
+        /// <param name="value2">The second Quaternion to compare.</param>
+        /// <returns>True if the Quaternions are not equal; False if they are equal.</returns>
+        public static bool operator !=(Quaternion value1, Quaternion value2)
+        {
+            return (value1.X != value2.X ||
+                    value1.Y != value2.Y ||
+                    value1.Z != value2.Z ||
+                    value1.W != value2.W);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the given Quaternion is equal to this Quaternion instance.
+        /// </summary>
+        /// <param name="other">The Quaternion to compare this instance to.</param>
+        /// <returns>True if the other Quaternion is equal to this instance; False otherwise.</returns>
+        public bool Equals(Quaternion other)
+        {
+            return (X == other.X &&
+                    Y == other.Y &&
+                    Z == other.Z &&
+                    W == other.W);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the given Object is equal to this Quaternion instance.
+        /// </summary>
+        /// <param name="obj">The Object to compare against.</param>
+        /// <returns>True if the Object is equal to this Quaternion; False otherwise.</returns>
+        public override bool Equals(object obj)
+        {
+            if (obj is Quaternion)
+            {
+                return Equals((Quaternion)obj);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns a String representing this Quaternion instance.
+        /// </summary>
+        /// <returns>The string representation.</returns>
+        public override string ToString()
+        {
+            CultureInfo ci = CultureInfo.CurrentCulture;
+
+            return String.Format(ci, "{{X:{0} Y:{1} Z:{2} W:{3}}}", X.ToString(ci), Y.ToString(ci), Z.ToString(ci), W.ToString(ci));
+        }
+
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>The hash code.</returns>
+        public override int GetHashCode()
+        {
+            return unchecked(X.GetHashCode() + Y.GetHashCode() + Z.GetHashCode() + W.GetHashCode());
+        }
+    }
+}

--- a/src/mscorlib/src/System/Numerics/Register.cs
+++ b/src/mscorlib/src/System/Numerics/Register.cs
@@ -1,0 +1,172 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Numerics
+{
+    /// <summary>
+    /// A structure describing the layout of an SSE2-sized register.
+    /// Contains overlapping fields representing the set of valid numeric types.
+    /// Allows the generic Vector'T struct to contain an explicit field layout.
+    /// </summary>
+    [StructLayout(LayoutKind.Explicit)]
+    internal struct Register
+    {
+        #region Internal Storage Fields
+        // Internal System.Byte Fields
+        [FieldOffset(0)]
+        internal Byte byte_0;
+        [FieldOffset(1)]
+        internal Byte byte_1;
+        [FieldOffset(2)]
+        internal Byte byte_2;
+        [FieldOffset(3)]
+        internal Byte byte_3;
+        [FieldOffset(4)]
+        internal Byte byte_4;
+        [FieldOffset(5)]
+        internal Byte byte_5;
+        [FieldOffset(6)]
+        internal Byte byte_6;
+        [FieldOffset(7)]
+        internal Byte byte_7;
+        [FieldOffset(8)]
+        internal Byte byte_8;
+        [FieldOffset(9)]
+        internal Byte byte_9;
+        [FieldOffset(10)]
+        internal Byte byte_10;
+        [FieldOffset(11)]
+        internal Byte byte_11;
+        [FieldOffset(12)]
+        internal Byte byte_12;
+        [FieldOffset(13)]
+        internal Byte byte_13;
+        [FieldOffset(14)]
+        internal Byte byte_14;
+        [FieldOffset(15)]
+        internal Byte byte_15;
+
+        // Internal System.SByte Fields
+        [FieldOffset(0)]
+        internal SByte sbyte_0;
+        [FieldOffset(1)]
+        internal SByte sbyte_1;
+        [FieldOffset(2)]
+        internal SByte sbyte_2;
+        [FieldOffset(3)]
+        internal SByte sbyte_3;
+        [FieldOffset(4)]
+        internal SByte sbyte_4;
+        [FieldOffset(5)]
+        internal SByte sbyte_5;
+        [FieldOffset(6)]
+        internal SByte sbyte_6;
+        [FieldOffset(7)]
+        internal SByte sbyte_7;
+        [FieldOffset(8)]
+        internal SByte sbyte_8;
+        [FieldOffset(9)]
+        internal SByte sbyte_9;
+        [FieldOffset(10)]
+        internal SByte sbyte_10;
+        [FieldOffset(11)]
+        internal SByte sbyte_11;
+        [FieldOffset(12)]
+        internal SByte sbyte_12;
+        [FieldOffset(13)]
+        internal SByte sbyte_13;
+        [FieldOffset(14)]
+        internal SByte sbyte_14;
+        [FieldOffset(15)]
+        internal SByte sbyte_15;
+
+        // Internal System.UInt16 Fields
+        [FieldOffset(0)]
+        internal UInt16 uint16_0;
+        [FieldOffset(2)]
+        internal UInt16 uint16_1;
+        [FieldOffset(4)]
+        internal UInt16 uint16_2;
+        [FieldOffset(6)]
+        internal UInt16 uint16_3;
+        [FieldOffset(8)]
+        internal UInt16 uint16_4;
+        [FieldOffset(10)]
+        internal UInt16 uint16_5;
+        [FieldOffset(12)]
+        internal UInt16 uint16_6;
+        [FieldOffset(14)]
+        internal UInt16 uint16_7;
+
+        // Internal System.Int16 Fields
+        [FieldOffset(0)]
+        internal Int16 int16_0;
+        [FieldOffset(2)]
+        internal Int16 int16_1;
+        [FieldOffset(4)]
+        internal Int16 int16_2;
+        [FieldOffset(6)]
+        internal Int16 int16_3;
+        [FieldOffset(8)]
+        internal Int16 int16_4;
+        [FieldOffset(10)]
+        internal Int16 int16_5;
+        [FieldOffset(12)]
+        internal Int16 int16_6;
+        [FieldOffset(14)]
+        internal Int16 int16_7;
+
+        // Internal System.UInt32 Fields
+        [FieldOffset(0)]
+        internal UInt32 uint32_0;
+        [FieldOffset(4)]
+        internal UInt32 uint32_1;
+        [FieldOffset(8)]
+        internal UInt32 uint32_2;
+        [FieldOffset(12)]
+        internal UInt32 uint32_3;
+
+        // Internal System.Int32 Fields
+        [FieldOffset(0)]
+        internal Int32 int32_0;
+        [FieldOffset(4)]
+        internal Int32 int32_1;
+        [FieldOffset(8)]
+        internal Int32 int32_2;
+        [FieldOffset(12)]
+        internal Int32 int32_3;
+
+        // Internal System.UInt64 Fields
+        [FieldOffset(0)]
+        internal UInt64 uint64_0;
+        [FieldOffset(8)]
+        internal UInt64 uint64_1;
+
+        // Internal System.Int64 Fields
+        [FieldOffset(0)]
+        internal Int64 int64_0;
+        [FieldOffset(8)]
+        internal Int64 int64_1;
+
+        // Internal System.Single Fields
+        [FieldOffset(0)]
+        internal Single single_0;
+        [FieldOffset(4)]
+        internal Single single_1;
+        [FieldOffset(8)]
+        internal Single single_2;
+        [FieldOffset(12)]
+        internal Single single_3;
+
+        // Internal System.Double Fields
+        [FieldOffset(0)]
+        internal Double double_0;
+        [FieldOffset(8)]
+        internal Double double_1;
+
+        #endregion Internal Storage Fields
+    }
+}

--- a/src/mscorlib/src/System/Numerics/Vector.cs
+++ b/src/mscorlib/src/System/Numerics/Vector.cs
@@ -1,0 +1,5548 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Numerics.Hashing;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace System.Numerics
+{
+    /* Note: The following patterns are used throughout the code here and are described here
+    *
+    * PATTERN:
+    *    if (typeof(T) == typeof(Int32)) { ... }
+    *    else if (typeof(T) == typeof(Single)) { ... }
+    * EXPLANATION:
+    *    At runtime, each instantiation of Vector<T> will be type-specific, and each of these typeof blocks will be eliminated,
+    *    as typeof(T) is a (JIT) compile-time constant for each instantiation. This design was chosen to eliminate any overhead from
+    *    delegates and other patterns.
+    *
+    * PATTERN:
+    *    if (Vector.IsHardwareAccelerated) { ... }
+    *    else { ... }
+    * EXPLANATION
+    *    This pattern solves two problems:
+    *        1. Allows us to unroll loops when we know the size (when no hardware acceleration is present)
+    *        2. Allows reflection to work:
+    *            - If a method is called via reflection, it will not be "intrinsified", which would cause issues if we did
+    *              not provide an implementation for that case (i.e. if it only included a case which assumed 16-byte registers)
+    *    (NOTE: It is assumed that Vector.IsHardwareAccelerated will be a compile-time constant, eliminating these checks
+    *        from the JIT'd code.)
+    *
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+    /// <summary>
+    /// A structure that represents a single Vector. The count of this Vector is fixed but CPU register dependent.
+    /// This struct only supports numerical types. This type is intended to be used as a building block for vectorizing
+    /// large algorithms. This type is immutable, individual elements cannot be modified.
+    /// </summary>
+    public struct Vector<T> : IEquatable<Vector<T>>, IFormattable where T : struct
+    {
+        #region Fields
+        private Register register;
+        #endregion Fields
+
+        #region Static Members
+        /// <summary>
+        /// Returns the number of elements stored in the vector. This value is hardware dependent.
+        /// </summary>
+        [JitIntrinsic]
+        public static int Count
+        {
+            get
+            {
+                return s_count;
+            }
+        }
+        private static readonly int s_count = InitializeCount();
+
+        /// <summary>
+        /// Returns a vector containing all zeroes.
+        /// </summary>
+        [JitIntrinsic]
+        public static Vector<T> Zero { get { return zero; } }
+        private static readonly Vector<T> zero = new Vector<T>(GetZeroValue());
+
+        /// <summary>
+        /// Returns a vector containing all ones.
+        /// </summary>
+        [JitIntrinsic]
+        public static Vector<T> One { get { return one; } }
+        private static readonly Vector<T> one = new Vector<T>(GetOneValue());
+
+        internal static Vector<T> AllOnes { get { return allOnes; } }
+        private static readonly Vector<T> allOnes = new Vector<T>(GetAllBitsSetValue());
+        #endregion Static Members
+
+        #region Static Initialization
+        private struct VectorSizeHelper
+        {
+            internal Vector<T> _placeholder;
+            internal byte _byte;
+        }
+
+		// Calculates the size of this struct in bytes, by computing the offset of a field in a structure
+        private static unsafe int InitializeCount()
+        {
+            VectorSizeHelper vsh;
+            byte* vectorBase = &vsh._placeholder.register.byte_0;
+            byte* byteBase = &vsh._byte;
+            int vectorSizeInBytes = (int)(byteBase - vectorBase);
+
+            int typeSizeInBytes = -1;
+            if (typeof(T) == typeof(Byte))
+            {
+                typeSizeInBytes = sizeof(Byte);
+            }
+            else if (typeof(T) == typeof(SByte))
+            {
+                typeSizeInBytes = sizeof(SByte);
+            }
+            else if (typeof(T) == typeof(UInt16))
+            {
+                typeSizeInBytes = sizeof(UInt16);
+            }
+            else if (typeof(T) == typeof(Int16))
+            {
+                typeSizeInBytes = sizeof(Int16);
+            }
+            else if (typeof(T) == typeof(UInt32))
+            {
+                typeSizeInBytes = sizeof(UInt32);
+            }
+            else if (typeof(T) == typeof(Int32))
+            {
+                typeSizeInBytes = sizeof(Int32);
+            }
+            else if (typeof(T) == typeof(UInt64))
+            {
+                typeSizeInBytes = sizeof(UInt64);
+            }
+            else if (typeof(T) == typeof(Int64))
+            {
+                typeSizeInBytes = sizeof(Int64);
+            }
+            else if (typeof(T) == typeof(Single))
+            {
+                typeSizeInBytes = sizeof(Single);
+            }
+            else if (typeof(T) == typeof(Double))
+            {
+                typeSizeInBytes = sizeof(Double);
+            }
+            else
+            {
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
+            }
+
+            return vectorSizeInBytes / typeSizeInBytes;
+        }
+        #endregion Static Initialization
+
+        #region Constructors
+        /// <summary>
+        /// Constructs a vector whose components are all <code>value</code>
+        /// </summary>
+        [JitIntrinsic]
+        public unsafe Vector(T value)
+            : this()
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                if (typeof(T) == typeof(Byte))
+                {
+                    fixed (Byte* basePtr = &this.register.byte_0)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            *(basePtr + g) = (Byte)(object)value;
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(SByte))
+                {
+                    fixed (SByte* basePtr = &this.register.sbyte_0)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            *(basePtr + g) = (SByte)(object)value;
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(UInt16))
+                {
+                    fixed (UInt16* basePtr = &this.register.uint16_0)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            *(basePtr + g) = (UInt16)(object)value;
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    fixed (Int16* basePtr = &this.register.int16_0)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            *(basePtr + g) = (Int16)(object)value;
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(UInt32))
+                {
+                    fixed (UInt32* basePtr = &this.register.uint32_0)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            *(basePtr + g) = (UInt32)(object)value;
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    fixed (Int32* basePtr = &this.register.int32_0)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            *(basePtr + g) = (Int32)(object)value;
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(UInt64))
+                {
+                    fixed (UInt64* basePtr = &this.register.uint64_0)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            *(basePtr + g) = (UInt64)(object)value;
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    fixed (Int64* basePtr = &this.register.int64_0)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            *(basePtr + g) = (Int64)(object)value;
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    fixed (Single* basePtr = &this.register.single_0)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            *(basePtr + g) = (Single)(object)value;
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    fixed (Double* basePtr = &this.register.double_0)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            *(basePtr + g) = (Double)(object)value;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                if (typeof(T) == typeof(Byte))
+                {
+                    register.byte_0 = (Byte)(object)value;
+                    register.byte_1 = (Byte)(object)value;
+                    register.byte_2 = (Byte)(object)value;
+                    register.byte_3 = (Byte)(object)value;
+                    register.byte_4 = (Byte)(object)value;
+                    register.byte_5 = (Byte)(object)value;
+                    register.byte_6 = (Byte)(object)value;
+                    register.byte_7 = (Byte)(object)value;
+                    register.byte_8 = (Byte)(object)value;
+                    register.byte_9 = (Byte)(object)value;
+                    register.byte_10 = (Byte)(object)value;
+                    register.byte_11 = (Byte)(object)value;
+                    register.byte_12 = (Byte)(object)value;
+                    register.byte_13 = (Byte)(object)value;
+                    register.byte_14 = (Byte)(object)value;
+                    register.byte_15 = (Byte)(object)value;
+                }
+                else if (typeof(T) == typeof(SByte))
+                {
+                    register.sbyte_0 = (SByte)(object)value;
+                    register.sbyte_1 = (SByte)(object)value;
+                    register.sbyte_2 = (SByte)(object)value;
+                    register.sbyte_3 = (SByte)(object)value;
+                    register.sbyte_4 = (SByte)(object)value;
+                    register.sbyte_5 = (SByte)(object)value;
+                    register.sbyte_6 = (SByte)(object)value;
+                    register.sbyte_7 = (SByte)(object)value;
+                    register.sbyte_8 = (SByte)(object)value;
+                    register.sbyte_9 = (SByte)(object)value;
+                    register.sbyte_10 = (SByte)(object)value;
+                    register.sbyte_11 = (SByte)(object)value;
+                    register.sbyte_12 = (SByte)(object)value;
+                    register.sbyte_13 = (SByte)(object)value;
+                    register.sbyte_14 = (SByte)(object)value;
+                    register.sbyte_15 = (SByte)(object)value;
+                }
+                else if (typeof(T) == typeof(UInt16))
+                {
+                    register.uint16_0 = (UInt16)(object)value;
+                    register.uint16_1 = (UInt16)(object)value;
+                    register.uint16_2 = (UInt16)(object)value;
+                    register.uint16_3 = (UInt16)(object)value;
+                    register.uint16_4 = (UInt16)(object)value;
+                    register.uint16_5 = (UInt16)(object)value;
+                    register.uint16_6 = (UInt16)(object)value;
+                    register.uint16_7 = (UInt16)(object)value;
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    register.int16_0 = (Int16)(object)value;
+                    register.int16_1 = (Int16)(object)value;
+                    register.int16_2 = (Int16)(object)value;
+                    register.int16_3 = (Int16)(object)value;
+                    register.int16_4 = (Int16)(object)value;
+                    register.int16_5 = (Int16)(object)value;
+                    register.int16_6 = (Int16)(object)value;
+                    register.int16_7 = (Int16)(object)value;
+                }
+                else if (typeof(T) == typeof(UInt32))
+                {
+                    register.uint32_0 = (UInt32)(object)value;
+                    register.uint32_1 = (UInt32)(object)value;
+                    register.uint32_2 = (UInt32)(object)value;
+                    register.uint32_3 = (UInt32)(object)value;
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    register.int32_0 = (Int32)(object)value;
+                    register.int32_1 = (Int32)(object)value;
+                    register.int32_2 = (Int32)(object)value;
+                    register.int32_3 = (Int32)(object)value;
+                }
+                else if (typeof(T) == typeof(UInt64))
+                {
+                    register.uint64_0 = (UInt64)(object)value;
+                    register.uint64_1 = (UInt64)(object)value;
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    register.int64_0 = (Int64)(object)value;
+                    register.int64_1 = (Int64)(object)value;
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    register.single_0 = (Single)(object)value;
+                    register.single_1 = (Single)(object)value;
+                    register.single_2 = (Single)(object)value;
+                    register.single_3 = (Single)(object)value;
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    register.double_0 = (Double)(object)value;
+                    register.double_1 = (Double)(object)value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Constructs a vector from the given array. The size of the given array must be at least Vector'T.Count.
+        /// </summary>
+        [JitIntrinsic]
+        public unsafe Vector(T[] values) : this(values, 0) { }
+
+        /// <summary>
+        /// Constructs a vector from the given array, starting from the given index.
+        /// The array must contain at least Vector'T.Count from the given index.
+        /// </summary>
+        public unsafe Vector(T[] values, int index)
+            : this()
+        {
+            if (values == null)
+            {
+                // Match the JIT's exception type here. For perf, a NullReference is thrown instead of an ArgumentNull.
+                throw new NullReferenceException(SR.Arg_NullArgumentNullRef);
+            }
+            if (index < 0 || (values.Length - index) < Count)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            if (Vector.IsHardwareAccelerated)
+            {
+                if (typeof(T) == typeof(Byte))
+                {
+                    fixed (Byte* basePtr = &this.register.byte_0)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            *(basePtr + g) = (Byte)(object)values[g + index];
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(SByte))
+                {
+                    fixed (SByte* basePtr = &this.register.sbyte_0)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            *(basePtr + g) = (SByte)(object)values[g + index];
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(UInt16))
+                {
+                    fixed (UInt16* basePtr = &this.register.uint16_0)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            *(basePtr + g) = (UInt16)(object)values[g + index];
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    fixed (Int16* basePtr = &this.register.int16_0)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            *(basePtr + g) = (Int16)(object)values[g + index];
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(UInt32))
+                {
+                    fixed (UInt32* basePtr = &this.register.uint32_0)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            *(basePtr + g) = (UInt32)(object)values[g + index];
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    fixed (Int32* basePtr = &this.register.int32_0)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            *(basePtr + g) = (Int32)(object)values[g + index];
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(UInt64))
+                {
+                    fixed (UInt64* basePtr = &this.register.uint64_0)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            *(basePtr + g) = (UInt64)(object)values[g + index];
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    fixed (Int64* basePtr = &this.register.int64_0)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            *(basePtr + g) = (Int64)(object)values[g + index];
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    fixed (Single* basePtr = &this.register.single_0)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            *(basePtr + g) = (Single)(object)values[g + index];
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    fixed (Double* basePtr = &this.register.double_0)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            *(basePtr + g) = (Double)(object)values[g + index];
+                        }
+                    }
+                }
+            }
+            else
+            {
+                if (typeof(T) == typeof(Byte))
+                {
+                    fixed (Byte* basePtr = &this.register.byte_0)
+                    {
+                        *(basePtr + 0) = (Byte)(object)values[0 + index];
+                        *(basePtr + 1) = (Byte)(object)values[1 + index];
+                        *(basePtr + 2) = (Byte)(object)values[2 + index];
+                        *(basePtr + 3) = (Byte)(object)values[3 + index];
+                        *(basePtr + 4) = (Byte)(object)values[4 + index];
+                        *(basePtr + 5) = (Byte)(object)values[5 + index];
+                        *(basePtr + 6) = (Byte)(object)values[6 + index];
+                        *(basePtr + 7) = (Byte)(object)values[7 + index];
+                        *(basePtr + 8) = (Byte)(object)values[8 + index];
+                        *(basePtr + 9) = (Byte)(object)values[9 + index];
+                        *(basePtr + 10) = (Byte)(object)values[10 + index];
+                        *(basePtr + 11) = (Byte)(object)values[11 + index];
+                        *(basePtr + 12) = (Byte)(object)values[12 + index];
+                        *(basePtr + 13) = (Byte)(object)values[13 + index];
+                        *(basePtr + 14) = (Byte)(object)values[14 + index];
+                        *(basePtr + 15) = (Byte)(object)values[15 + index];
+                    }
+                }
+                else if (typeof(T) == typeof(SByte))
+                {
+                    fixed (SByte* basePtr = &this.register.sbyte_0)
+                    {
+                        *(basePtr + 0) = (SByte)(object)values[0 + index];
+                        *(basePtr + 1) = (SByte)(object)values[1 + index];
+                        *(basePtr + 2) = (SByte)(object)values[2 + index];
+                        *(basePtr + 3) = (SByte)(object)values[3 + index];
+                        *(basePtr + 4) = (SByte)(object)values[4 + index];
+                        *(basePtr + 5) = (SByte)(object)values[5 + index];
+                        *(basePtr + 6) = (SByte)(object)values[6 + index];
+                        *(basePtr + 7) = (SByte)(object)values[7 + index];
+                        *(basePtr + 8) = (SByte)(object)values[8 + index];
+                        *(basePtr + 9) = (SByte)(object)values[9 + index];
+                        *(basePtr + 10) = (SByte)(object)values[10 + index];
+                        *(basePtr + 11) = (SByte)(object)values[11 + index];
+                        *(basePtr + 12) = (SByte)(object)values[12 + index];
+                        *(basePtr + 13) = (SByte)(object)values[13 + index];
+                        *(basePtr + 14) = (SByte)(object)values[14 + index];
+                        *(basePtr + 15) = (SByte)(object)values[15 + index];
+                    }
+                }
+                else if (typeof(T) == typeof(UInt16))
+                {
+                    fixed (UInt16* basePtr = &this.register.uint16_0)
+                    {
+                        *(basePtr + 0) = (UInt16)(object)values[0 + index];
+                        *(basePtr + 1) = (UInt16)(object)values[1 + index];
+                        *(basePtr + 2) = (UInt16)(object)values[2 + index];
+                        *(basePtr + 3) = (UInt16)(object)values[3 + index];
+                        *(basePtr + 4) = (UInt16)(object)values[4 + index];
+                        *(basePtr + 5) = (UInt16)(object)values[5 + index];
+                        *(basePtr + 6) = (UInt16)(object)values[6 + index];
+                        *(basePtr + 7) = (UInt16)(object)values[7 + index];
+                    }
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    fixed (Int16* basePtr = &this.register.int16_0)
+                    {
+                        *(basePtr + 0) = (Int16)(object)values[0 + index];
+                        *(basePtr + 1) = (Int16)(object)values[1 + index];
+                        *(basePtr + 2) = (Int16)(object)values[2 + index];
+                        *(basePtr + 3) = (Int16)(object)values[3 + index];
+                        *(basePtr + 4) = (Int16)(object)values[4 + index];
+                        *(basePtr + 5) = (Int16)(object)values[5 + index];
+                        *(basePtr + 6) = (Int16)(object)values[6 + index];
+                        *(basePtr + 7) = (Int16)(object)values[7 + index];
+                    }
+                }
+                else if (typeof(T) == typeof(UInt32))
+                {
+                    fixed (UInt32* basePtr = &this.register.uint32_0)
+                    {
+                        *(basePtr + 0) = (UInt32)(object)values[0 + index];
+                        *(basePtr + 1) = (UInt32)(object)values[1 + index];
+                        *(basePtr + 2) = (UInt32)(object)values[2 + index];
+                        *(basePtr + 3) = (UInt32)(object)values[3 + index];
+                    }
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    fixed (Int32* basePtr = &this.register.int32_0)
+                    {
+                        *(basePtr + 0) = (Int32)(object)values[0 + index];
+                        *(basePtr + 1) = (Int32)(object)values[1 + index];
+                        *(basePtr + 2) = (Int32)(object)values[2 + index];
+                        *(basePtr + 3) = (Int32)(object)values[3 + index];
+                    }
+                }
+                else if (typeof(T) == typeof(UInt64))
+                {
+                    fixed (UInt64* basePtr = &this.register.uint64_0)
+                    {
+                        *(basePtr + 0) = (UInt64)(object)values[0 + index];
+                        *(basePtr + 1) = (UInt64)(object)values[1 + index];
+                    }
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    fixed (Int64* basePtr = &this.register.int64_0)
+                    {
+                        *(basePtr + 0) = (Int64)(object)values[0 + index];
+                        *(basePtr + 1) = (Int64)(object)values[1 + index];
+                    }
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    fixed (Single* basePtr = &this.register.single_0)
+                    {
+                        *(basePtr + 0) = (Single)(object)values[0 + index];
+                        *(basePtr + 1) = (Single)(object)values[1 + index];
+                        *(basePtr + 2) = (Single)(object)values[2 + index];
+                        *(basePtr + 3) = (Single)(object)values[3 + index];
+                    }
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    fixed (Double* basePtr = &this.register.double_0)
+                    {
+                        *(basePtr + 0) = (Double)(object)values[0 + index];
+                        *(basePtr + 1) = (Double)(object)values[1 + index];
+                    }
+                }
+            }
+        }
+
+#pragma warning disable 3001 // void* is not a CLS-Compliant argument type
+        internal unsafe Vector(void* dataPointer) : this(dataPointer, 0) { }
+#pragma warning restore 3001 // void* is not a CLS-Compliant argument type
+
+#pragma warning disable 3001 // void* is not a CLS-Compliant argument type
+        // Implemented with offset if this API ever becomes public; an offset of 0 is used internally.
+        internal unsafe Vector(void* dataPointer, int offset)
+            : this()
+        {
+            if (typeof(T) == typeof(Byte))
+            {
+                Byte* castedPtr = (Byte*)dataPointer;
+                castedPtr += offset;
+                fixed (Byte* registerBase = &this.register.byte_0)
+                {
+                    for (int g = 0; g < Count; g++)
+                    {
+                        registerBase[g] = castedPtr[g];
+                    }
+                }
+            }
+            else if (typeof(T) == typeof(SByte))
+            {
+                SByte* castedPtr = (SByte*)dataPointer;
+                castedPtr += offset;
+                fixed (SByte* registerBase = &this.register.sbyte_0)
+                {
+                    for (int g = 0; g < Count; g++)
+                    {
+                        registerBase[g] = castedPtr[g];
+                    }
+                }
+            }
+            else if (typeof(T) == typeof(UInt16))
+            {
+                UInt16* castedPtr = (UInt16*)dataPointer;
+                castedPtr += offset;
+                fixed (UInt16* registerBase = &this.register.uint16_0)
+                {
+                    for (int g = 0; g < Count; g++)
+                    {
+                        registerBase[g] = castedPtr[g];
+                    }
+                }
+            }
+            else if (typeof(T) == typeof(Int16))
+            {
+                Int16* castedPtr = (Int16*)dataPointer;
+                castedPtr += offset;
+                fixed (Int16* registerBase = &this.register.int16_0)
+                {
+                    for (int g = 0; g < Count; g++)
+                    {
+                        registerBase[g] = castedPtr[g];
+                    }
+                }
+            }
+            else if (typeof(T) == typeof(UInt32))
+            {
+                UInt32* castedPtr = (UInt32*)dataPointer;
+                castedPtr += offset;
+                fixed (UInt32* registerBase = &this.register.uint32_0)
+                {
+                    for (int g = 0; g < Count; g++)
+                    {
+                        registerBase[g] = castedPtr[g];
+                    }
+                }
+            }
+            else if (typeof(T) == typeof(Int32))
+            {
+                Int32* castedPtr = (Int32*)dataPointer;
+                castedPtr += offset;
+                fixed (Int32* registerBase = &this.register.int32_0)
+                {
+                    for (int g = 0; g < Count; g++)
+                    {
+                        registerBase[g] = castedPtr[g];
+                    }
+                }
+            }
+            else if (typeof(T) == typeof(UInt64))
+            {
+                UInt64* castedPtr = (UInt64*)dataPointer;
+                castedPtr += offset;
+                fixed (UInt64* registerBase = &this.register.uint64_0)
+                {
+                    for (int g = 0; g < Count; g++)
+                    {
+                        registerBase[g] = castedPtr[g];
+                    }
+                }
+            }
+            else if (typeof(T) == typeof(Int64))
+            {
+                Int64* castedPtr = (Int64*)dataPointer;
+                castedPtr += offset;
+                fixed (Int64* registerBase = &this.register.int64_0)
+                {
+                    for (int g = 0; g < Count; g++)
+                    {
+                        registerBase[g] = castedPtr[g];
+                    }
+                }
+            }
+            else if (typeof(T) == typeof(Single))
+            {
+                Single* castedPtr = (Single*)dataPointer;
+                castedPtr += offset;
+                fixed (Single* registerBase = &this.register.single_0)
+                {
+                    for (int g = 0; g < Count; g++)
+                    {
+                        registerBase[g] = castedPtr[g];
+                    }
+                }
+            }
+            else if (typeof(T) == typeof(Double))
+            {
+                Double* castedPtr = (Double*)dataPointer;
+                castedPtr += offset;
+                fixed (Double* registerBase = &this.register.double_0)
+                {
+                    for (int g = 0; g < Count; g++)
+                    {
+                        registerBase[g] = castedPtr[g];
+                    }
+                }
+            }
+            else
+            {
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
+            }
+        }
+#pragma warning restore 3001 // void* is not a CLS-Compliant argument type
+
+        private Vector(ref Register existingRegister)
+        {
+            this.register = existingRegister;
+        }
+        #endregion Constructors
+
+        #region Public Instance Methods
+        /// <summary>
+        /// Copies the vector to the given destination array. The destination array must be at least size Vector'T.Count.
+        /// </summary>
+        /// <param name="destination">The destination array which the values are copied into</param>
+        /// <exception cref="ArgumentNullException">If the destination array is null</exception>
+        /// <exception cref="ArgumentException">If number of elements in source vector is greater than those available in destination array</exception>
+        [JitIntrinsic]
+        public unsafe void CopyTo(T[] destination)
+        {
+            CopyTo(destination, 0);
+        }
+
+        /// <summary>
+        /// Copies the vector to the given destination array. The destination array must be at least size Vector'T.Count.
+        /// </summary>
+        /// <param name="destination">The destination array which the values are copied into</param>
+        /// <param name="startIndex">The index to start copying to</param>
+        /// <exception cref="ArgumentNullException">If the destination array is null</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If index is greater than end of the array or index is less than zero</exception>
+        /// <exception cref="ArgumentException">If number of elements in source vector is greater than those available in destination array</exception>
+        [JitIntrinsic]
+        public unsafe void CopyTo(T[] destination, int startIndex)
+        {
+            if (destination == null)
+            {
+                // Match the JIT's exception type here. For perf, a NullReference is thrown instead of an ArgumentNull.
+                throw new NullReferenceException(SR.Arg_NullArgumentNullRef);
+            }
+            if (startIndex < 0 || startIndex >= destination.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(startIndex), SR.Format(SR.Arg_ArgumentOutOfRangeException, startIndex));
+            }
+            if ((destination.Length - startIndex) < Count)
+            {
+                throw new ArgumentException(SR.Format(SR.Arg_ElementsInSourceIsGreaterThanDestination, startIndex));
+            }
+
+            if (Vector.IsHardwareAccelerated)
+            {
+                if (typeof(T) == typeof(Byte))
+                {
+                    Byte[] byteArray = (Byte[])(object)destination;
+                    fixed (Byte* destinationBase = byteArray)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            destinationBase[startIndex + g] = (Byte)(object)this[g];
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(SByte))
+                {
+                    SByte[] sbyteArray = (SByte[])(object)destination;
+                    fixed (SByte* destinationBase = sbyteArray)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            destinationBase[startIndex + g] = (SByte)(object)this[g];
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(UInt16))
+                {
+                    UInt16[] uint16Array = (UInt16[])(object)destination;
+                    fixed (UInt16* destinationBase = uint16Array)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            destinationBase[startIndex + g] = (UInt16)(object)this[g];
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    Int16[] int16Array = (Int16[])(object)destination;
+                    fixed (Int16* destinationBase = int16Array)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            destinationBase[startIndex + g] = (Int16)(object)this[g];
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(UInt32))
+                {
+                    UInt32[] uint32Array = (UInt32[])(object)destination;
+                    fixed (UInt32* destinationBase = uint32Array)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            destinationBase[startIndex + g] = (UInt32)(object)this[g];
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    Int32[] int32Array = (Int32[])(object)destination;
+                    fixed (Int32* destinationBase = int32Array)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            destinationBase[startIndex + g] = (Int32)(object)this[g];
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(UInt64))
+                {
+                    UInt64[] uint64Array = (UInt64[])(object)destination;
+                    fixed (UInt64* destinationBase = uint64Array)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            destinationBase[startIndex + g] = (UInt64)(object)this[g];
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    Int64[] int64Array = (Int64[])(object)destination;
+                    fixed (Int64* destinationBase = int64Array)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            destinationBase[startIndex + g] = (Int64)(object)this[g];
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    Single[] singleArray = (Single[])(object)destination;
+                    fixed (Single* destinationBase = singleArray)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            destinationBase[startIndex + g] = (Single)(object)this[g];
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    Double[] doubleArray = (Double[])(object)destination;
+                    fixed (Double* destinationBase = doubleArray)
+                    {
+                        for (int g = 0; g < Count; g++)
+                        {
+                            destinationBase[startIndex + g] = (Double)(object)this[g];
+                        }
+                    }
+                }
+            }
+            else
+            {
+                if (typeof(T) == typeof(Byte))
+                {
+                    Byte[] byteArray = (Byte[])(object)destination;
+                    fixed (Byte* destinationBase = byteArray)
+                    {
+                        destinationBase[startIndex + 0] = this.register.byte_0;
+                        destinationBase[startIndex + 1] = this.register.byte_1;
+                        destinationBase[startIndex + 2] = this.register.byte_2;
+                        destinationBase[startIndex + 3] = this.register.byte_3;
+                        destinationBase[startIndex + 4] = this.register.byte_4;
+                        destinationBase[startIndex + 5] = this.register.byte_5;
+                        destinationBase[startIndex + 6] = this.register.byte_6;
+                        destinationBase[startIndex + 7] = this.register.byte_7;
+                        destinationBase[startIndex + 8] = this.register.byte_8;
+                        destinationBase[startIndex + 9] = this.register.byte_9;
+                        destinationBase[startIndex + 10] = this.register.byte_10;
+                        destinationBase[startIndex + 11] = this.register.byte_11;
+                        destinationBase[startIndex + 12] = this.register.byte_12;
+                        destinationBase[startIndex + 13] = this.register.byte_13;
+                        destinationBase[startIndex + 14] = this.register.byte_14;
+                        destinationBase[startIndex + 15] = this.register.byte_15;
+                    }
+                }
+                else if (typeof(T) == typeof(SByte))
+                {
+                    SByte[] sbyteArray = (SByte[])(object)destination;
+                    fixed (SByte* destinationBase = sbyteArray)
+                    {
+                        destinationBase[startIndex + 0] = this.register.sbyte_0;
+                        destinationBase[startIndex + 1] = this.register.sbyte_1;
+                        destinationBase[startIndex + 2] = this.register.sbyte_2;
+                        destinationBase[startIndex + 3] = this.register.sbyte_3;
+                        destinationBase[startIndex + 4] = this.register.sbyte_4;
+                        destinationBase[startIndex + 5] = this.register.sbyte_5;
+                        destinationBase[startIndex + 6] = this.register.sbyte_6;
+                        destinationBase[startIndex + 7] = this.register.sbyte_7;
+                        destinationBase[startIndex + 8] = this.register.sbyte_8;
+                        destinationBase[startIndex + 9] = this.register.sbyte_9;
+                        destinationBase[startIndex + 10] = this.register.sbyte_10;
+                        destinationBase[startIndex + 11] = this.register.sbyte_11;
+                        destinationBase[startIndex + 12] = this.register.sbyte_12;
+                        destinationBase[startIndex + 13] = this.register.sbyte_13;
+                        destinationBase[startIndex + 14] = this.register.sbyte_14;
+                        destinationBase[startIndex + 15] = this.register.sbyte_15;
+                    }
+                }
+                else if (typeof(T) == typeof(UInt16))
+                {
+                    UInt16[] uint16Array = (UInt16[])(object)destination;
+                    fixed (UInt16* destinationBase = uint16Array)
+                    {
+                        destinationBase[startIndex + 0] = this.register.uint16_0;
+                        destinationBase[startIndex + 1] = this.register.uint16_1;
+                        destinationBase[startIndex + 2] = this.register.uint16_2;
+                        destinationBase[startIndex + 3] = this.register.uint16_3;
+                        destinationBase[startIndex + 4] = this.register.uint16_4;
+                        destinationBase[startIndex + 5] = this.register.uint16_5;
+                        destinationBase[startIndex + 6] = this.register.uint16_6;
+                        destinationBase[startIndex + 7] = this.register.uint16_7;
+                    }
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    Int16[] int16Array = (Int16[])(object)destination;
+                    fixed (Int16* destinationBase = int16Array)
+                    {
+                        destinationBase[startIndex + 0] = this.register.int16_0;
+                        destinationBase[startIndex + 1] = this.register.int16_1;
+                        destinationBase[startIndex + 2] = this.register.int16_2;
+                        destinationBase[startIndex + 3] = this.register.int16_3;
+                        destinationBase[startIndex + 4] = this.register.int16_4;
+                        destinationBase[startIndex + 5] = this.register.int16_5;
+                        destinationBase[startIndex + 6] = this.register.int16_6;
+                        destinationBase[startIndex + 7] = this.register.int16_7;
+                    }
+                }
+                else if (typeof(T) == typeof(UInt32))
+                {
+                    UInt32[] uint32Array = (UInt32[])(object)destination;
+                    fixed (UInt32* destinationBase = uint32Array)
+                    {
+                        destinationBase[startIndex + 0] = this.register.uint32_0;
+                        destinationBase[startIndex + 1] = this.register.uint32_1;
+                        destinationBase[startIndex + 2] = this.register.uint32_2;
+                        destinationBase[startIndex + 3] = this.register.uint32_3;
+                    }
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    Int32[] int32Array = (Int32[])(object)destination;
+                    fixed (Int32* destinationBase = int32Array)
+                    {
+                        destinationBase[startIndex + 0] = this.register.int32_0;
+                        destinationBase[startIndex + 1] = this.register.int32_1;
+                        destinationBase[startIndex + 2] = this.register.int32_2;
+                        destinationBase[startIndex + 3] = this.register.int32_3;
+                    }
+                }
+                else if (typeof(T) == typeof(UInt64))
+                {
+                    UInt64[] uint64Array = (UInt64[])(object)destination;
+                    fixed (UInt64* destinationBase = uint64Array)
+                    {
+                        destinationBase[startIndex + 0] = this.register.uint64_0;
+                        destinationBase[startIndex + 1] = this.register.uint64_1;
+                    }
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    Int64[] int64Array = (Int64[])(object)destination;
+                    fixed (Int64* destinationBase = int64Array)
+                    {
+                        destinationBase[startIndex + 0] = this.register.int64_0;
+                        destinationBase[startIndex + 1] = this.register.int64_1;
+                    }
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    Single[] singleArray = (Single[])(object)destination;
+                    fixed (Single* destinationBase = singleArray)
+                    {
+                        destinationBase[startIndex + 0] = this.register.single_0;
+                        destinationBase[startIndex + 1] = this.register.single_1;
+                        destinationBase[startIndex + 2] = this.register.single_2;
+                        destinationBase[startIndex + 3] = this.register.single_3;
+                    }
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    Double[] doubleArray = (Double[])(object)destination;
+                    fixed (Double* destinationBase = doubleArray)
+                    {
+                        destinationBase[startIndex + 0] = this.register.double_0;
+                        destinationBase[startIndex + 1] = this.register.double_1;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns the element at the given index.
+        /// </summary>
+        [JitIntrinsic]
+        public unsafe T this[int index]
+        {
+            get
+            {
+                if (index >= Count || index < 0)
+                {
+                    throw new IndexOutOfRangeException(SR.Format(SR.Arg_ArgumentOutOfRangeException, index));
+                }
+                if (typeof(T) == typeof(Byte))
+                {
+                    fixed (Byte* basePtr = &this.register.byte_0)
+                    {
+                        return (T)(object)*(basePtr + index);
+                    }
+                }
+                else if (typeof(T) == typeof(SByte))
+                {
+                    fixed (SByte* basePtr = &this.register.sbyte_0)
+                    {
+                        return (T)(object)*(basePtr + index);
+                    }
+                }
+                else if (typeof(T) == typeof(UInt16))
+                {
+                    fixed (UInt16* basePtr = &this.register.uint16_0)
+                    {
+                        return (T)(object)*(basePtr + index);
+                    }
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    fixed (Int16* basePtr = &this.register.int16_0)
+                    {
+                        return (T)(object)*(basePtr + index);
+                    }
+                }
+                else if (typeof(T) == typeof(UInt32))
+                {
+                    fixed (UInt32* basePtr = &this.register.uint32_0)
+                    {
+                        return (T)(object)*(basePtr + index);
+                    }
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    fixed (Int32* basePtr = &this.register.int32_0)
+                    {
+                        return (T)(object)*(basePtr + index);
+                    }
+                }
+                else if (typeof(T) == typeof(UInt64))
+                {
+                    fixed (UInt64* basePtr = &this.register.uint64_0)
+                    {
+                        return (T)(object)*(basePtr + index);
+                    }
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    fixed (Int64* basePtr = &this.register.int64_0)
+                    {
+                        return (T)(object)*(basePtr + index);
+                    }
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    fixed (Single* basePtr = &this.register.single_0)
+                    {
+                        return (T)(object)*(basePtr + index);
+                    }
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    fixed (Double* basePtr = &this.register.double_0)
+                    {
+                        return (T)(object)*(basePtr + index);
+                    }
+                }
+                else
+                {
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the given Object is equal to this vector instance.
+        /// </summary>
+        /// <param name="obj">The Object to compare against.</param>
+        /// <returns>True if the Object is equal to this vector; False otherwise.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public override bool Equals(object obj)
+        {
+            if (!(obj is Vector<T>))
+            {
+                return false;
+            }
+            return Equals((Vector<T>)obj);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the given vector is equal to this vector instance.
+        /// </summary>
+        /// <param name="other">The vector to compare this instance to.</param>
+        /// <returns>True if the other vector is equal to this instance; False otherwise.</returns>
+        [JitIntrinsic]
+        public bool Equals(Vector<T> other)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                for (int g = 0; g < Count; g++)
+                {
+                    if (!ScalarEquals(this[g], other[g]))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            else
+            {
+                if (typeof(T) == typeof(Byte))
+                {
+                    return
+                        this.register.byte_0 == other.register.byte_0
+                        && this.register.byte_1 == other.register.byte_1
+                        && this.register.byte_2 == other.register.byte_2
+                        && this.register.byte_3 == other.register.byte_3
+                        && this.register.byte_4 == other.register.byte_4
+                        && this.register.byte_5 == other.register.byte_5
+                        && this.register.byte_6 == other.register.byte_6
+                        && this.register.byte_7 == other.register.byte_7
+                        && this.register.byte_8 == other.register.byte_8
+                        && this.register.byte_9 == other.register.byte_9
+                        && this.register.byte_10 == other.register.byte_10
+                        && this.register.byte_11 == other.register.byte_11
+                        && this.register.byte_12 == other.register.byte_12
+                        && this.register.byte_13 == other.register.byte_13
+                        && this.register.byte_14 == other.register.byte_14
+                        && this.register.byte_15 == other.register.byte_15;
+                }
+                else if (typeof(T) == typeof(SByte))
+                {
+                    return
+                        this.register.sbyte_0 == other.register.sbyte_0
+                        && this.register.sbyte_1 == other.register.sbyte_1
+                        && this.register.sbyte_2 == other.register.sbyte_2
+                        && this.register.sbyte_3 == other.register.sbyte_3
+                        && this.register.sbyte_4 == other.register.sbyte_4
+                        && this.register.sbyte_5 == other.register.sbyte_5
+                        && this.register.sbyte_6 == other.register.sbyte_6
+                        && this.register.sbyte_7 == other.register.sbyte_7
+                        && this.register.sbyte_8 == other.register.sbyte_8
+                        && this.register.sbyte_9 == other.register.sbyte_9
+                        && this.register.sbyte_10 == other.register.sbyte_10
+                        && this.register.sbyte_11 == other.register.sbyte_11
+                        && this.register.sbyte_12 == other.register.sbyte_12
+                        && this.register.sbyte_13 == other.register.sbyte_13
+                        && this.register.sbyte_14 == other.register.sbyte_14
+                        && this.register.sbyte_15 == other.register.sbyte_15;
+                }
+                else if (typeof(T) == typeof(UInt16))
+                {
+                    return
+                        this.register.uint16_0 == other.register.uint16_0
+                        && this.register.uint16_1 == other.register.uint16_1
+                        && this.register.uint16_2 == other.register.uint16_2
+                        && this.register.uint16_3 == other.register.uint16_3
+                        && this.register.uint16_4 == other.register.uint16_4
+                        && this.register.uint16_5 == other.register.uint16_5
+                        && this.register.uint16_6 == other.register.uint16_6
+                        && this.register.uint16_7 == other.register.uint16_7;
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    return
+                        this.register.int16_0 == other.register.int16_0
+                        && this.register.int16_1 == other.register.int16_1
+                        && this.register.int16_2 == other.register.int16_2
+                        && this.register.int16_3 == other.register.int16_3
+                        && this.register.int16_4 == other.register.int16_4
+                        && this.register.int16_5 == other.register.int16_5
+                        && this.register.int16_6 == other.register.int16_6
+                        && this.register.int16_7 == other.register.int16_7;
+                }
+                else if (typeof(T) == typeof(UInt32))
+                {
+                    return
+                        this.register.uint32_0 == other.register.uint32_0
+                        && this.register.uint32_1 == other.register.uint32_1
+                        && this.register.uint32_2 == other.register.uint32_2
+                        && this.register.uint32_3 == other.register.uint32_3;
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    return
+                        this.register.int32_0 == other.register.int32_0
+                        && this.register.int32_1 == other.register.int32_1
+                        && this.register.int32_2 == other.register.int32_2
+                        && this.register.int32_3 == other.register.int32_3;
+                }
+                else if (typeof(T) == typeof(UInt64))
+                {
+                    return
+                        this.register.uint64_0 == other.register.uint64_0
+                        && this.register.uint64_1 == other.register.uint64_1;
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    return
+                        this.register.int64_0 == other.register.int64_0
+                        && this.register.int64_1 == other.register.int64_1;
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    return
+                        this.register.single_0 == other.register.single_0
+                        && this.register.single_1 == other.register.single_1
+                        && this.register.single_2 == other.register.single_2
+                        && this.register.single_3 == other.register.single_3;
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    return
+                        this.register.double_0 == other.register.double_0
+                        && this.register.double_1 == other.register.double_1;
+                }
+                else
+                {
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>The hash code.</returns>
+        public override int GetHashCode()
+        {
+            int hash = 0;
+
+            if (Vector.IsHardwareAccelerated)
+            {
+                if (typeof(T) == typeof(Byte))
+                {
+                    for (int g = 0; g < Count; g++)
+                    {
+                        hash = HashHelpers.Combine(hash, ((Byte)(object)this[g]).GetHashCode());
+                    }
+                    return hash;
+                }
+                else if (typeof(T) == typeof(SByte))
+                {
+                    for (int g = 0; g < Count; g++)
+                    {
+                        hash = HashHelpers.Combine(hash, ((SByte)(object)this[g]).GetHashCode());
+                    }
+                    return hash;
+                }
+                else if (typeof(T) == typeof(UInt16))
+                {
+                    for (int g = 0; g < Count; g++)
+                    {
+                        hash = HashHelpers.Combine(hash, ((UInt16)(object)this[g]).GetHashCode());
+                    }
+                    return hash;
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    for (int g = 0; g < Count; g++)
+                    {
+                        hash = HashHelpers.Combine(hash, ((Int16)(object)this[g]).GetHashCode());
+                    }
+                    return hash;
+                }
+                else if (typeof(T) == typeof(UInt32))
+                {
+                    for (int g = 0; g < Count; g++)
+                    {
+                        hash = HashHelpers.Combine(hash, ((UInt32)(object)this[g]).GetHashCode());
+                    }
+                    return hash;
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    for (int g = 0; g < Count; g++)
+                    {
+                        hash = HashHelpers.Combine(hash, ((Int32)(object)this[g]).GetHashCode());
+                    }
+                    return hash;
+                }
+                else if (typeof(T) == typeof(UInt64))
+                {
+                    for (int g = 0; g < Count; g++)
+                    {
+                        hash = HashHelpers.Combine(hash, ((UInt64)(object)this[g]).GetHashCode());
+                    }
+                    return hash;
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    for (int g = 0; g < Count; g++)
+                    {
+                        hash = HashHelpers.Combine(hash, ((Int64)(object)this[g]).GetHashCode());
+                    }
+                    return hash;
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    for (int g = 0; g < Count; g++)
+                    {
+                        hash = HashHelpers.Combine(hash, ((Single)(object)this[g]).GetHashCode());
+                    }
+                    return hash;
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    for (int g = 0; g < Count; g++)
+                    {
+                        hash = HashHelpers.Combine(hash, ((Double)(object)this[g]).GetHashCode());
+                    }
+                    return hash;
+                }
+                else
+                {
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                }
+            }
+            else
+            {
+                if (typeof(T) == typeof(Byte))
+                {
+                    hash = HashHelpers.Combine(hash, this.register.byte_0.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.byte_1.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.byte_2.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.byte_3.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.byte_4.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.byte_5.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.byte_6.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.byte_7.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.byte_8.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.byte_9.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.byte_10.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.byte_11.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.byte_12.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.byte_13.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.byte_14.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.byte_15.GetHashCode());
+                    return hash;
+                }
+                else if (typeof(T) == typeof(SByte))
+                {
+                    hash = HashHelpers.Combine(hash, this.register.sbyte_0.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.sbyte_1.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.sbyte_2.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.sbyte_3.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.sbyte_4.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.sbyte_5.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.sbyte_6.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.sbyte_7.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.sbyte_8.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.sbyte_9.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.sbyte_10.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.sbyte_11.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.sbyte_12.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.sbyte_13.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.sbyte_14.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.sbyte_15.GetHashCode());
+                    return hash;
+                }
+                else if (typeof(T) == typeof(UInt16))
+                {
+                    hash = HashHelpers.Combine(hash, this.register.uint16_0.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.uint16_1.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.uint16_2.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.uint16_3.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.uint16_4.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.uint16_5.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.uint16_6.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.uint16_7.GetHashCode());
+                    return hash;
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    hash = HashHelpers.Combine(hash, this.register.int16_0.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.int16_1.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.int16_2.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.int16_3.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.int16_4.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.int16_5.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.int16_6.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.int16_7.GetHashCode());
+                    return hash;
+                }
+                else if (typeof(T) == typeof(UInt32))
+                {
+                    hash = HashHelpers.Combine(hash, this.register.uint32_0.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.uint32_1.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.uint32_2.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.uint32_3.GetHashCode());
+                    return hash;
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    hash = HashHelpers.Combine(hash, this.register.int32_0.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.int32_1.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.int32_2.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.int32_3.GetHashCode());
+                    return hash;
+                }
+                else if (typeof(T) == typeof(UInt64))
+                {
+                    hash = HashHelpers.Combine(hash, this.register.uint64_0.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.uint64_1.GetHashCode());
+                    return hash;
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    hash = HashHelpers.Combine(hash, this.register.int64_0.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.int64_1.GetHashCode());
+                    return hash;
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    hash = HashHelpers.Combine(hash, this.register.single_0.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.single_1.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.single_2.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.single_3.GetHashCode());
+                    return hash;
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    hash = HashHelpers.Combine(hash, this.register.double_0.GetHashCode());
+                    hash = HashHelpers.Combine(hash, this.register.double_1.GetHashCode());
+                    return hash;
+                }
+                else
+                {
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns a String representing this vector.
+        /// </summary>
+        /// <returns>The string representation.</returns>
+        public override string ToString()
+        {
+            return ToString("G", CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Returns a String representing this vector, using the specified format string to format individual elements.
+        /// </summary>
+        /// <param name="format">The format of individual elements.</param>
+        /// <returns>The string representation.</returns>
+        public string ToString(string format)
+        {
+            return ToString(format, CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Returns a String representing this vector, using the specified format string to format individual elements
+        /// and the given IFormatProvider.
+        /// </summary>
+        /// <param name="format">The format of individual elements.</param>
+        /// <param name="formatProvider">The format provider to use when formatting elements.</param>
+        /// <returns>The string representation.</returns>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            StringBuilder sb = new StringBuilder();
+            string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;
+            sb.Append('<');
+            for (int g = 0; g < Count - 1; g++)
+            {
+                sb.Append(((IFormattable)this[g]).ToString(format, formatProvider));
+                sb.Append(separator);
+                sb.Append(' ');
+            }
+            // Append last element w/out separator
+            sb.Append(((IFormattable)this[Count - 1]).ToString(format, formatProvider));
+            sb.Append('>');
+            return sb.ToString();
+        }
+        #endregion Public Instance Methods
+
+        #region Arithmetic Operators
+        /// <summary>
+        /// Adds two vectors together.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The summed vector.</returns>
+        public static unsafe Vector<T> operator +(Vector<T> left, Vector<T> right)
+        {
+            unchecked
+            {
+                if (Vector.IsHardwareAccelerated)
+                {
+                    if (typeof(T) == typeof(Byte))
+                    {
+                        Byte* dataPtr = stackalloc Byte[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Byte)(object)ScalarAdd(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(SByte))
+                    {
+                        SByte* dataPtr = stackalloc SByte[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (SByte)(object)ScalarAdd(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(UInt16))
+                    {
+                        UInt16* dataPtr = stackalloc UInt16[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (UInt16)(object)ScalarAdd(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(Int16))
+                    {
+                        Int16* dataPtr = stackalloc Int16[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Int16)(object)ScalarAdd(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(UInt32))
+                    {
+                        UInt32* dataPtr = stackalloc UInt32[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (UInt32)(object)ScalarAdd(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(Int32))
+                    {
+                        Int32* dataPtr = stackalloc Int32[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Int32)(object)ScalarAdd(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(UInt64))
+                    {
+                        UInt64* dataPtr = stackalloc UInt64[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (UInt64)(object)ScalarAdd(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(Int64))
+                    {
+                        Int64* dataPtr = stackalloc Int64[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Int64)(object)ScalarAdd(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(Single))
+                    {
+                        Single* dataPtr = stackalloc Single[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Single)(object)ScalarAdd(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(Double))
+                    {
+                        Double* dataPtr = stackalloc Double[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Double)(object)ScalarAdd(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else
+                    {
+                        throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                    }
+                }
+                else
+                {
+                    Vector<T> sum = new Vector<T>();
+                    if (typeof(T) == typeof(Byte))
+                    {
+                        sum.register.byte_0 = (Byte)(left.register.byte_0 + right.register.byte_0);
+                        sum.register.byte_1 = (Byte)(left.register.byte_1 + right.register.byte_1);
+                        sum.register.byte_2 = (Byte)(left.register.byte_2 + right.register.byte_2);
+                        sum.register.byte_3 = (Byte)(left.register.byte_3 + right.register.byte_3);
+                        sum.register.byte_4 = (Byte)(left.register.byte_4 + right.register.byte_4);
+                        sum.register.byte_5 = (Byte)(left.register.byte_5 + right.register.byte_5);
+                        sum.register.byte_6 = (Byte)(left.register.byte_6 + right.register.byte_6);
+                        sum.register.byte_7 = (Byte)(left.register.byte_7 + right.register.byte_7);
+                        sum.register.byte_8 = (Byte)(left.register.byte_8 + right.register.byte_8);
+                        sum.register.byte_9 = (Byte)(left.register.byte_9 + right.register.byte_9);
+                        sum.register.byte_10 = (Byte)(left.register.byte_10 + right.register.byte_10);
+                        sum.register.byte_11 = (Byte)(left.register.byte_11 + right.register.byte_11);
+                        sum.register.byte_12 = (Byte)(left.register.byte_12 + right.register.byte_12);
+                        sum.register.byte_13 = (Byte)(left.register.byte_13 + right.register.byte_13);
+                        sum.register.byte_14 = (Byte)(left.register.byte_14 + right.register.byte_14);
+                        sum.register.byte_15 = (Byte)(left.register.byte_15 + right.register.byte_15);
+                    }
+                    else if (typeof(T) == typeof(SByte))
+                    {
+                        sum.register.sbyte_0 = (SByte)(left.register.sbyte_0 + right.register.sbyte_0);
+                        sum.register.sbyte_1 = (SByte)(left.register.sbyte_1 + right.register.sbyte_1);
+                        sum.register.sbyte_2 = (SByte)(left.register.sbyte_2 + right.register.sbyte_2);
+                        sum.register.sbyte_3 = (SByte)(left.register.sbyte_3 + right.register.sbyte_3);
+                        sum.register.sbyte_4 = (SByte)(left.register.sbyte_4 + right.register.sbyte_4);
+                        sum.register.sbyte_5 = (SByte)(left.register.sbyte_5 + right.register.sbyte_5);
+                        sum.register.sbyte_6 = (SByte)(left.register.sbyte_6 + right.register.sbyte_6);
+                        sum.register.sbyte_7 = (SByte)(left.register.sbyte_7 + right.register.sbyte_7);
+                        sum.register.sbyte_8 = (SByte)(left.register.sbyte_8 + right.register.sbyte_8);
+                        sum.register.sbyte_9 = (SByte)(left.register.sbyte_9 + right.register.sbyte_9);
+                        sum.register.sbyte_10 = (SByte)(left.register.sbyte_10 + right.register.sbyte_10);
+                        sum.register.sbyte_11 = (SByte)(left.register.sbyte_11 + right.register.sbyte_11);
+                        sum.register.sbyte_12 = (SByte)(left.register.sbyte_12 + right.register.sbyte_12);
+                        sum.register.sbyte_13 = (SByte)(left.register.sbyte_13 + right.register.sbyte_13);
+                        sum.register.sbyte_14 = (SByte)(left.register.sbyte_14 + right.register.sbyte_14);
+                        sum.register.sbyte_15 = (SByte)(left.register.sbyte_15 + right.register.sbyte_15);
+                    }
+                    else if (typeof(T) == typeof(UInt16))
+                    {
+                        sum.register.uint16_0 = (UInt16)(left.register.uint16_0 + right.register.uint16_0);
+                        sum.register.uint16_1 = (UInt16)(left.register.uint16_1 + right.register.uint16_1);
+                        sum.register.uint16_2 = (UInt16)(left.register.uint16_2 + right.register.uint16_2);
+                        sum.register.uint16_3 = (UInt16)(left.register.uint16_3 + right.register.uint16_3);
+                        sum.register.uint16_4 = (UInt16)(left.register.uint16_4 + right.register.uint16_4);
+                        sum.register.uint16_5 = (UInt16)(left.register.uint16_5 + right.register.uint16_5);
+                        sum.register.uint16_6 = (UInt16)(left.register.uint16_6 + right.register.uint16_6);
+                        sum.register.uint16_7 = (UInt16)(left.register.uint16_7 + right.register.uint16_7);
+                    }
+                    else if (typeof(T) == typeof(Int16))
+                    {
+                        sum.register.int16_0 = (Int16)(left.register.int16_0 + right.register.int16_0);
+                        sum.register.int16_1 = (Int16)(left.register.int16_1 + right.register.int16_1);
+                        sum.register.int16_2 = (Int16)(left.register.int16_2 + right.register.int16_2);
+                        sum.register.int16_3 = (Int16)(left.register.int16_3 + right.register.int16_3);
+                        sum.register.int16_4 = (Int16)(left.register.int16_4 + right.register.int16_4);
+                        sum.register.int16_5 = (Int16)(left.register.int16_5 + right.register.int16_5);
+                        sum.register.int16_6 = (Int16)(left.register.int16_6 + right.register.int16_6);
+                        sum.register.int16_7 = (Int16)(left.register.int16_7 + right.register.int16_7);
+                    }
+                    else if (typeof(T) == typeof(UInt32))
+                    {
+                        sum.register.uint32_0 = (UInt32)(left.register.uint32_0 + right.register.uint32_0);
+                        sum.register.uint32_1 = (UInt32)(left.register.uint32_1 + right.register.uint32_1);
+                        sum.register.uint32_2 = (UInt32)(left.register.uint32_2 + right.register.uint32_2);
+                        sum.register.uint32_3 = (UInt32)(left.register.uint32_3 + right.register.uint32_3);
+                    }
+                    else if (typeof(T) == typeof(Int32))
+                    {
+                        sum.register.int32_0 = (Int32)(left.register.int32_0 + right.register.int32_0);
+                        sum.register.int32_1 = (Int32)(left.register.int32_1 + right.register.int32_1);
+                        sum.register.int32_2 = (Int32)(left.register.int32_2 + right.register.int32_2);
+                        sum.register.int32_3 = (Int32)(left.register.int32_3 + right.register.int32_3);
+                    }
+                    else if (typeof(T) == typeof(UInt64))
+                    {
+                        sum.register.uint64_0 = (UInt64)(left.register.uint64_0 + right.register.uint64_0);
+                        sum.register.uint64_1 = (UInt64)(left.register.uint64_1 + right.register.uint64_1);
+                    }
+                    else if (typeof(T) == typeof(Int64))
+                    {
+                        sum.register.int64_0 = (Int64)(left.register.int64_0 + right.register.int64_0);
+                        sum.register.int64_1 = (Int64)(left.register.int64_1 + right.register.int64_1);
+                    }
+                    else if (typeof(T) == typeof(Single))
+                    {
+                        sum.register.single_0 = (Single)(left.register.single_0 + right.register.single_0);
+                        sum.register.single_1 = (Single)(left.register.single_1 + right.register.single_1);
+                        sum.register.single_2 = (Single)(left.register.single_2 + right.register.single_2);
+                        sum.register.single_3 = (Single)(left.register.single_3 + right.register.single_3);
+                    }
+                    else if (typeof(T) == typeof(Double))
+                    {
+                        sum.register.double_0 = (Double)(left.register.double_0 + right.register.double_0);
+                        sum.register.double_1 = (Double)(left.register.double_1 + right.register.double_1);
+                    }
+                    return sum;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Subtracts the second vector from the first.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The difference vector.</returns>
+        public static unsafe Vector<T> operator -(Vector<T> left, Vector<T> right)
+        {
+            unchecked
+            {
+                if (Vector.IsHardwareAccelerated)
+                {
+                    if (typeof(T) == typeof(Byte))
+                    {
+                        Byte* dataPtr = stackalloc Byte[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Byte)(object)ScalarSubtract(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(SByte))
+                    {
+                        SByte* dataPtr = stackalloc SByte[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (SByte)(object)ScalarSubtract(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(UInt16))
+                    {
+                        UInt16* dataPtr = stackalloc UInt16[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (UInt16)(object)ScalarSubtract(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(Int16))
+                    {
+                        Int16* dataPtr = stackalloc Int16[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Int16)(object)ScalarSubtract(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(UInt32))
+                    {
+                        UInt32* dataPtr = stackalloc UInt32[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (UInt32)(object)ScalarSubtract(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(Int32))
+                    {
+                        Int32* dataPtr = stackalloc Int32[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Int32)(object)ScalarSubtract(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(UInt64))
+                    {
+                        UInt64* dataPtr = stackalloc UInt64[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (UInt64)(object)ScalarSubtract(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(Int64))
+                    {
+                        Int64* dataPtr = stackalloc Int64[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Int64)(object)ScalarSubtract(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(Single))
+                    {
+                        Single* dataPtr = stackalloc Single[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Single)(object)ScalarSubtract(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(Double))
+                    {
+                        Double* dataPtr = stackalloc Double[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Double)(object)ScalarSubtract(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else
+                    {
+                        throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                    }
+                }
+                else
+                {
+                    Vector<T> difference = new Vector<T>();
+                    if (typeof(T) == typeof(Byte))
+                    {
+                        difference.register.byte_0 = (Byte)(left.register.byte_0 - right.register.byte_0);
+                        difference.register.byte_1 = (Byte)(left.register.byte_1 - right.register.byte_1);
+                        difference.register.byte_2 = (Byte)(left.register.byte_2 - right.register.byte_2);
+                        difference.register.byte_3 = (Byte)(left.register.byte_3 - right.register.byte_3);
+                        difference.register.byte_4 = (Byte)(left.register.byte_4 - right.register.byte_4);
+                        difference.register.byte_5 = (Byte)(left.register.byte_5 - right.register.byte_5);
+                        difference.register.byte_6 = (Byte)(left.register.byte_6 - right.register.byte_6);
+                        difference.register.byte_7 = (Byte)(left.register.byte_7 - right.register.byte_7);
+                        difference.register.byte_8 = (Byte)(left.register.byte_8 - right.register.byte_8);
+                        difference.register.byte_9 = (Byte)(left.register.byte_9 - right.register.byte_9);
+                        difference.register.byte_10 = (Byte)(left.register.byte_10 - right.register.byte_10);
+                        difference.register.byte_11 = (Byte)(left.register.byte_11 - right.register.byte_11);
+                        difference.register.byte_12 = (Byte)(left.register.byte_12 - right.register.byte_12);
+                        difference.register.byte_13 = (Byte)(left.register.byte_13 - right.register.byte_13);
+                        difference.register.byte_14 = (Byte)(left.register.byte_14 - right.register.byte_14);
+                        difference.register.byte_15 = (Byte)(left.register.byte_15 - right.register.byte_15);
+                    }
+                    else if (typeof(T) == typeof(SByte))
+                    {
+                        difference.register.sbyte_0 = (SByte)(left.register.sbyte_0 - right.register.sbyte_0);
+                        difference.register.sbyte_1 = (SByte)(left.register.sbyte_1 - right.register.sbyte_1);
+                        difference.register.sbyte_2 = (SByte)(left.register.sbyte_2 - right.register.sbyte_2);
+                        difference.register.sbyte_3 = (SByte)(left.register.sbyte_3 - right.register.sbyte_3);
+                        difference.register.sbyte_4 = (SByte)(left.register.sbyte_4 - right.register.sbyte_4);
+                        difference.register.sbyte_5 = (SByte)(left.register.sbyte_5 - right.register.sbyte_5);
+                        difference.register.sbyte_6 = (SByte)(left.register.sbyte_6 - right.register.sbyte_6);
+                        difference.register.sbyte_7 = (SByte)(left.register.sbyte_7 - right.register.sbyte_7);
+                        difference.register.sbyte_8 = (SByte)(left.register.sbyte_8 - right.register.sbyte_8);
+                        difference.register.sbyte_9 = (SByte)(left.register.sbyte_9 - right.register.sbyte_9);
+                        difference.register.sbyte_10 = (SByte)(left.register.sbyte_10 - right.register.sbyte_10);
+                        difference.register.sbyte_11 = (SByte)(left.register.sbyte_11 - right.register.sbyte_11);
+                        difference.register.sbyte_12 = (SByte)(left.register.sbyte_12 - right.register.sbyte_12);
+                        difference.register.sbyte_13 = (SByte)(left.register.sbyte_13 - right.register.sbyte_13);
+                        difference.register.sbyte_14 = (SByte)(left.register.sbyte_14 - right.register.sbyte_14);
+                        difference.register.sbyte_15 = (SByte)(left.register.sbyte_15 - right.register.sbyte_15);
+                    }
+                    else if (typeof(T) == typeof(UInt16))
+                    {
+                        difference.register.uint16_0 = (UInt16)(left.register.uint16_0 - right.register.uint16_0);
+                        difference.register.uint16_1 = (UInt16)(left.register.uint16_1 - right.register.uint16_1);
+                        difference.register.uint16_2 = (UInt16)(left.register.uint16_2 - right.register.uint16_2);
+                        difference.register.uint16_3 = (UInt16)(left.register.uint16_3 - right.register.uint16_3);
+                        difference.register.uint16_4 = (UInt16)(left.register.uint16_4 - right.register.uint16_4);
+                        difference.register.uint16_5 = (UInt16)(left.register.uint16_5 - right.register.uint16_5);
+                        difference.register.uint16_6 = (UInt16)(left.register.uint16_6 - right.register.uint16_6);
+                        difference.register.uint16_7 = (UInt16)(left.register.uint16_7 - right.register.uint16_7);
+                    }
+                    else if (typeof(T) == typeof(Int16))
+                    {
+                        difference.register.int16_0 = (Int16)(left.register.int16_0 - right.register.int16_0);
+                        difference.register.int16_1 = (Int16)(left.register.int16_1 - right.register.int16_1);
+                        difference.register.int16_2 = (Int16)(left.register.int16_2 - right.register.int16_2);
+                        difference.register.int16_3 = (Int16)(left.register.int16_3 - right.register.int16_3);
+                        difference.register.int16_4 = (Int16)(left.register.int16_4 - right.register.int16_4);
+                        difference.register.int16_5 = (Int16)(left.register.int16_5 - right.register.int16_5);
+                        difference.register.int16_6 = (Int16)(left.register.int16_6 - right.register.int16_6);
+                        difference.register.int16_7 = (Int16)(left.register.int16_7 - right.register.int16_7);
+                    }
+                    else if (typeof(T) == typeof(UInt32))
+                    {
+                        difference.register.uint32_0 = (UInt32)(left.register.uint32_0 - right.register.uint32_0);
+                        difference.register.uint32_1 = (UInt32)(left.register.uint32_1 - right.register.uint32_1);
+                        difference.register.uint32_2 = (UInt32)(left.register.uint32_2 - right.register.uint32_2);
+                        difference.register.uint32_3 = (UInt32)(left.register.uint32_3 - right.register.uint32_3);
+                    }
+                    else if (typeof(T) == typeof(Int32))
+                    {
+                        difference.register.int32_0 = (Int32)(left.register.int32_0 - right.register.int32_0);
+                        difference.register.int32_1 = (Int32)(left.register.int32_1 - right.register.int32_1);
+                        difference.register.int32_2 = (Int32)(left.register.int32_2 - right.register.int32_2);
+                        difference.register.int32_3 = (Int32)(left.register.int32_3 - right.register.int32_3);
+                    }
+                    else if (typeof(T) == typeof(UInt64))
+                    {
+                        difference.register.uint64_0 = (UInt64)(left.register.uint64_0 - right.register.uint64_0);
+                        difference.register.uint64_1 = (UInt64)(left.register.uint64_1 - right.register.uint64_1);
+                    }
+                    else if (typeof(T) == typeof(Int64))
+                    {
+                        difference.register.int64_0 = (Int64)(left.register.int64_0 - right.register.int64_0);
+                        difference.register.int64_1 = (Int64)(left.register.int64_1 - right.register.int64_1);
+                    }
+                    else if (typeof(T) == typeof(Single))
+                    {
+                        difference.register.single_0 = (Single)(left.register.single_0 - right.register.single_0);
+                        difference.register.single_1 = (Single)(left.register.single_1 - right.register.single_1);
+                        difference.register.single_2 = (Single)(left.register.single_2 - right.register.single_2);
+                        difference.register.single_3 = (Single)(left.register.single_3 - right.register.single_3);
+                    }
+                    else if (typeof(T) == typeof(Double))
+                    {
+                        difference.register.double_0 = (Double)(left.register.double_0 - right.register.double_0);
+                        difference.register.double_1 = (Double)(left.register.double_1 - right.register.double_1);
+                    }
+                    return difference;
+                }
+            }
+        }
+
+        // This method is intrinsic only for certain types. It cannot access fields directly unless we are sure the context is unaccelerated.
+        /// <summary>
+        /// Multiplies two vectors together.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The product vector.</returns>
+        public static unsafe Vector<T> operator *(Vector<T> left, Vector<T> right)
+        {
+            unchecked
+            {
+                if (Vector.IsHardwareAccelerated)
+                {
+                    if (typeof(T) == typeof(Byte))
+                    {
+                        Byte* dataPtr = stackalloc Byte[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Byte)(object)ScalarMultiply(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(SByte))
+                    {
+                        SByte* dataPtr = stackalloc SByte[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (SByte)(object)ScalarMultiply(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(UInt16))
+                    {
+                        UInt16* dataPtr = stackalloc UInt16[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (UInt16)(object)ScalarMultiply(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(Int16))
+                    {
+                        Int16* dataPtr = stackalloc Int16[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Int16)(object)ScalarMultiply(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(UInt32))
+                    {
+                        UInt32* dataPtr = stackalloc UInt32[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (UInt32)(object)ScalarMultiply(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(Int32))
+                    {
+                        Int32* dataPtr = stackalloc Int32[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Int32)(object)ScalarMultiply(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(UInt64))
+                    {
+                        UInt64* dataPtr = stackalloc UInt64[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (UInt64)(object)ScalarMultiply(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(Int64))
+                    {
+                        Int64* dataPtr = stackalloc Int64[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Int64)(object)ScalarMultiply(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(Single))
+                    {
+                        Single* dataPtr = stackalloc Single[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Single)(object)ScalarMultiply(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(Double))
+                    {
+                        Double* dataPtr = stackalloc Double[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Double)(object)ScalarMultiply(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else
+                    {
+                        throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                    }
+                }
+                else
+                {
+                    Vector<T> product = new Vector<T>();
+                    if (typeof(T) == typeof(Byte))
+                    {
+                        product.register.byte_0 = (Byte)(left.register.byte_0 * right.register.byte_0);
+                        product.register.byte_1 = (Byte)(left.register.byte_1 * right.register.byte_1);
+                        product.register.byte_2 = (Byte)(left.register.byte_2 * right.register.byte_2);
+                        product.register.byte_3 = (Byte)(left.register.byte_3 * right.register.byte_3);
+                        product.register.byte_4 = (Byte)(left.register.byte_4 * right.register.byte_4);
+                        product.register.byte_5 = (Byte)(left.register.byte_5 * right.register.byte_5);
+                        product.register.byte_6 = (Byte)(left.register.byte_6 * right.register.byte_6);
+                        product.register.byte_7 = (Byte)(left.register.byte_7 * right.register.byte_7);
+                        product.register.byte_8 = (Byte)(left.register.byte_8 * right.register.byte_8);
+                        product.register.byte_9 = (Byte)(left.register.byte_9 * right.register.byte_9);
+                        product.register.byte_10 = (Byte)(left.register.byte_10 * right.register.byte_10);
+                        product.register.byte_11 = (Byte)(left.register.byte_11 * right.register.byte_11);
+                        product.register.byte_12 = (Byte)(left.register.byte_12 * right.register.byte_12);
+                        product.register.byte_13 = (Byte)(left.register.byte_13 * right.register.byte_13);
+                        product.register.byte_14 = (Byte)(left.register.byte_14 * right.register.byte_14);
+                        product.register.byte_15 = (Byte)(left.register.byte_15 * right.register.byte_15);
+                    }
+                    else if (typeof(T) == typeof(SByte))
+                    {
+                        product.register.sbyte_0 = (SByte)(left.register.sbyte_0 * right.register.sbyte_0);
+                        product.register.sbyte_1 = (SByte)(left.register.sbyte_1 * right.register.sbyte_1);
+                        product.register.sbyte_2 = (SByte)(left.register.sbyte_2 * right.register.sbyte_2);
+                        product.register.sbyte_3 = (SByte)(left.register.sbyte_3 * right.register.sbyte_3);
+                        product.register.sbyte_4 = (SByte)(left.register.sbyte_4 * right.register.sbyte_4);
+                        product.register.sbyte_5 = (SByte)(left.register.sbyte_5 * right.register.sbyte_5);
+                        product.register.sbyte_6 = (SByte)(left.register.sbyte_6 * right.register.sbyte_6);
+                        product.register.sbyte_7 = (SByte)(left.register.sbyte_7 * right.register.sbyte_7);
+                        product.register.sbyte_8 = (SByte)(left.register.sbyte_8 * right.register.sbyte_8);
+                        product.register.sbyte_9 = (SByte)(left.register.sbyte_9 * right.register.sbyte_9);
+                        product.register.sbyte_10 = (SByte)(left.register.sbyte_10 * right.register.sbyte_10);
+                        product.register.sbyte_11 = (SByte)(left.register.sbyte_11 * right.register.sbyte_11);
+                        product.register.sbyte_12 = (SByte)(left.register.sbyte_12 * right.register.sbyte_12);
+                        product.register.sbyte_13 = (SByte)(left.register.sbyte_13 * right.register.sbyte_13);
+                        product.register.sbyte_14 = (SByte)(left.register.sbyte_14 * right.register.sbyte_14);
+                        product.register.sbyte_15 = (SByte)(left.register.sbyte_15 * right.register.sbyte_15);
+                    }
+                    else if (typeof(T) == typeof(UInt16))
+                    {
+                        product.register.uint16_0 = (UInt16)(left.register.uint16_0 * right.register.uint16_0);
+                        product.register.uint16_1 = (UInt16)(left.register.uint16_1 * right.register.uint16_1);
+                        product.register.uint16_2 = (UInt16)(left.register.uint16_2 * right.register.uint16_2);
+                        product.register.uint16_3 = (UInt16)(left.register.uint16_3 * right.register.uint16_3);
+                        product.register.uint16_4 = (UInt16)(left.register.uint16_4 * right.register.uint16_4);
+                        product.register.uint16_5 = (UInt16)(left.register.uint16_5 * right.register.uint16_5);
+                        product.register.uint16_6 = (UInt16)(left.register.uint16_6 * right.register.uint16_6);
+                        product.register.uint16_7 = (UInt16)(left.register.uint16_7 * right.register.uint16_7);
+                    }
+                    else if (typeof(T) == typeof(Int16))
+                    {
+                        product.register.int16_0 = (Int16)(left.register.int16_0 * right.register.int16_0);
+                        product.register.int16_1 = (Int16)(left.register.int16_1 * right.register.int16_1);
+                        product.register.int16_2 = (Int16)(left.register.int16_2 * right.register.int16_2);
+                        product.register.int16_3 = (Int16)(left.register.int16_3 * right.register.int16_3);
+                        product.register.int16_4 = (Int16)(left.register.int16_4 * right.register.int16_4);
+                        product.register.int16_5 = (Int16)(left.register.int16_5 * right.register.int16_5);
+                        product.register.int16_6 = (Int16)(left.register.int16_6 * right.register.int16_6);
+                        product.register.int16_7 = (Int16)(left.register.int16_7 * right.register.int16_7);
+                    }
+                    else if (typeof(T) == typeof(UInt32))
+                    {
+                        product.register.uint32_0 = (UInt32)(left.register.uint32_0 * right.register.uint32_0);
+                        product.register.uint32_1 = (UInt32)(left.register.uint32_1 * right.register.uint32_1);
+                        product.register.uint32_2 = (UInt32)(left.register.uint32_2 * right.register.uint32_2);
+                        product.register.uint32_3 = (UInt32)(left.register.uint32_3 * right.register.uint32_3);
+                    }
+                    else if (typeof(T) == typeof(Int32))
+                    {
+                        product.register.int32_0 = (Int32)(left.register.int32_0 * right.register.int32_0);
+                        product.register.int32_1 = (Int32)(left.register.int32_1 * right.register.int32_1);
+                        product.register.int32_2 = (Int32)(left.register.int32_2 * right.register.int32_2);
+                        product.register.int32_3 = (Int32)(left.register.int32_3 * right.register.int32_3);
+                    }
+                    else if (typeof(T) == typeof(UInt64))
+                    {
+                        product.register.uint64_0 = (UInt64)(left.register.uint64_0 * right.register.uint64_0);
+                        product.register.uint64_1 = (UInt64)(left.register.uint64_1 * right.register.uint64_1);
+                    }
+                    else if (typeof(T) == typeof(Int64))
+                    {
+                        product.register.int64_0 = (Int64)(left.register.int64_0 * right.register.int64_0);
+                        product.register.int64_1 = (Int64)(left.register.int64_1 * right.register.int64_1);
+                    }
+                    else if (typeof(T) == typeof(Single))
+                    {
+                        product.register.single_0 = (Single)(left.register.single_0 * right.register.single_0);
+                        product.register.single_1 = (Single)(left.register.single_1 * right.register.single_1);
+                        product.register.single_2 = (Single)(left.register.single_2 * right.register.single_2);
+                        product.register.single_3 = (Single)(left.register.single_3 * right.register.single_3);
+                    }
+                    else if (typeof(T) == typeof(Double))
+                    {
+                        product.register.double_0 = (Double)(left.register.double_0 * right.register.double_0);
+                        product.register.double_1 = (Double)(left.register.double_1 * right.register.double_1);
+                    }
+                    return product;
+                }
+            }
+        }
+
+        // This method is intrinsic only for certain types. It cannot access fields directly unless we are sure the context is unaccelerated.
+        /// <summary>
+        /// Multiplies a vector by the given scalar.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <param name="factor">The scalar value.</param>
+        /// <returns>The scaled vector.</returns>
+        public static Vector<T> operator *(Vector<T> value, T factor)
+        {
+            unchecked
+            {
+                if (Vector.IsHardwareAccelerated)
+                {
+                    return new Vector<T>(factor) * value;
+                }
+                else
+                {
+                    Vector<T> product = new Vector<T>();
+                    if (typeof(T) == typeof(Byte))
+                    {
+                        product.register.byte_0 = (Byte)(value.register.byte_0 * (Byte)(object)factor);
+                        product.register.byte_1 = (Byte)(value.register.byte_1 * (Byte)(object)factor);
+                        product.register.byte_2 = (Byte)(value.register.byte_2 * (Byte)(object)factor);
+                        product.register.byte_3 = (Byte)(value.register.byte_3 * (Byte)(object)factor);
+                        product.register.byte_4 = (Byte)(value.register.byte_4 * (Byte)(object)factor);
+                        product.register.byte_5 = (Byte)(value.register.byte_5 * (Byte)(object)factor);
+                        product.register.byte_6 = (Byte)(value.register.byte_6 * (Byte)(object)factor);
+                        product.register.byte_7 = (Byte)(value.register.byte_7 * (Byte)(object)factor);
+                        product.register.byte_8 = (Byte)(value.register.byte_8 * (Byte)(object)factor);
+                        product.register.byte_9 = (Byte)(value.register.byte_9 * (Byte)(object)factor);
+                        product.register.byte_10 = (Byte)(value.register.byte_10 * (Byte)(object)factor);
+                        product.register.byte_11 = (Byte)(value.register.byte_11 * (Byte)(object)factor);
+                        product.register.byte_12 = (Byte)(value.register.byte_12 * (Byte)(object)factor);
+                        product.register.byte_13 = (Byte)(value.register.byte_13 * (Byte)(object)factor);
+                        product.register.byte_14 = (Byte)(value.register.byte_14 * (Byte)(object)factor);
+                        product.register.byte_15 = (Byte)(value.register.byte_15 * (Byte)(object)factor);
+                    }
+                    else if (typeof(T) == typeof(SByte))
+                    {
+                        product.register.sbyte_0 = (SByte)(value.register.sbyte_0 * (SByte)(object)factor);
+                        product.register.sbyte_1 = (SByte)(value.register.sbyte_1 * (SByte)(object)factor);
+                        product.register.sbyte_2 = (SByte)(value.register.sbyte_2 * (SByte)(object)factor);
+                        product.register.sbyte_3 = (SByte)(value.register.sbyte_3 * (SByte)(object)factor);
+                        product.register.sbyte_4 = (SByte)(value.register.sbyte_4 * (SByte)(object)factor);
+                        product.register.sbyte_5 = (SByte)(value.register.sbyte_5 * (SByte)(object)factor);
+                        product.register.sbyte_6 = (SByte)(value.register.sbyte_6 * (SByte)(object)factor);
+                        product.register.sbyte_7 = (SByte)(value.register.sbyte_7 * (SByte)(object)factor);
+                        product.register.sbyte_8 = (SByte)(value.register.sbyte_8 * (SByte)(object)factor);
+                        product.register.sbyte_9 = (SByte)(value.register.sbyte_9 * (SByte)(object)factor);
+                        product.register.sbyte_10 = (SByte)(value.register.sbyte_10 * (SByte)(object)factor);
+                        product.register.sbyte_11 = (SByte)(value.register.sbyte_11 * (SByte)(object)factor);
+                        product.register.sbyte_12 = (SByte)(value.register.sbyte_12 * (SByte)(object)factor);
+                        product.register.sbyte_13 = (SByte)(value.register.sbyte_13 * (SByte)(object)factor);
+                        product.register.sbyte_14 = (SByte)(value.register.sbyte_14 * (SByte)(object)factor);
+                        product.register.sbyte_15 = (SByte)(value.register.sbyte_15 * (SByte)(object)factor);
+                    }
+                    else if (typeof(T) == typeof(UInt16))
+                    {
+                        product.register.uint16_0 = (UInt16)(value.register.uint16_0 * (UInt16)(object)factor);
+                        product.register.uint16_1 = (UInt16)(value.register.uint16_1 * (UInt16)(object)factor);
+                        product.register.uint16_2 = (UInt16)(value.register.uint16_2 * (UInt16)(object)factor);
+                        product.register.uint16_3 = (UInt16)(value.register.uint16_3 * (UInt16)(object)factor);
+                        product.register.uint16_4 = (UInt16)(value.register.uint16_4 * (UInt16)(object)factor);
+                        product.register.uint16_5 = (UInt16)(value.register.uint16_5 * (UInt16)(object)factor);
+                        product.register.uint16_6 = (UInt16)(value.register.uint16_6 * (UInt16)(object)factor);
+                        product.register.uint16_7 = (UInt16)(value.register.uint16_7 * (UInt16)(object)factor);
+                    }
+                    else if (typeof(T) == typeof(Int16))
+                    {
+                        product.register.int16_0 = (Int16)(value.register.int16_0 * (Int16)(object)factor);
+                        product.register.int16_1 = (Int16)(value.register.int16_1 * (Int16)(object)factor);
+                        product.register.int16_2 = (Int16)(value.register.int16_2 * (Int16)(object)factor);
+                        product.register.int16_3 = (Int16)(value.register.int16_3 * (Int16)(object)factor);
+                        product.register.int16_4 = (Int16)(value.register.int16_4 * (Int16)(object)factor);
+                        product.register.int16_5 = (Int16)(value.register.int16_5 * (Int16)(object)factor);
+                        product.register.int16_6 = (Int16)(value.register.int16_6 * (Int16)(object)factor);
+                        product.register.int16_7 = (Int16)(value.register.int16_7 * (Int16)(object)factor);
+                    }
+                    else if (typeof(T) == typeof(UInt32))
+                    {
+                        product.register.uint32_0 = (UInt32)(value.register.uint32_0 * (UInt32)(object)factor);
+                        product.register.uint32_1 = (UInt32)(value.register.uint32_1 * (UInt32)(object)factor);
+                        product.register.uint32_2 = (UInt32)(value.register.uint32_2 * (UInt32)(object)factor);
+                        product.register.uint32_3 = (UInt32)(value.register.uint32_3 * (UInt32)(object)factor);
+                    }
+                    else if (typeof(T) == typeof(Int32))
+                    {
+                        product.register.int32_0 = (Int32)(value.register.int32_0 * (Int32)(object)factor);
+                        product.register.int32_1 = (Int32)(value.register.int32_1 * (Int32)(object)factor);
+                        product.register.int32_2 = (Int32)(value.register.int32_2 * (Int32)(object)factor);
+                        product.register.int32_3 = (Int32)(value.register.int32_3 * (Int32)(object)factor);
+                    }
+                    else if (typeof(T) == typeof(UInt64))
+                    {
+                        product.register.uint64_0 = (UInt64)(value.register.uint64_0 * (UInt64)(object)factor);
+                        product.register.uint64_1 = (UInt64)(value.register.uint64_1 * (UInt64)(object)factor);
+                    }
+                    else if (typeof(T) == typeof(Int64))
+                    {
+                        product.register.int64_0 = (Int64)(value.register.int64_0 * (Int64)(object)factor);
+                        product.register.int64_1 = (Int64)(value.register.int64_1 * (Int64)(object)factor);
+                    }
+                    else if (typeof(T) == typeof(Single))
+                    {
+                        product.register.single_0 = (Single)(value.register.single_0 * (Single)(object)factor);
+                        product.register.single_1 = (Single)(value.register.single_1 * (Single)(object)factor);
+                        product.register.single_2 = (Single)(value.register.single_2 * (Single)(object)factor);
+                        product.register.single_3 = (Single)(value.register.single_3 * (Single)(object)factor);
+                    }
+                    else if (typeof(T) == typeof(Double))
+                    {
+                        product.register.double_0 = (Double)(value.register.double_0 * (Double)(object)factor);
+                        product.register.double_1 = (Double)(value.register.double_1 * (Double)(object)factor);
+                    }
+                    return product;
+                }
+            }
+        }
+
+        // This method is intrinsic only for certain types. It cannot access fields directly unless we are sure the context is unaccelerated.
+        /// <summary>
+        /// Multiplies a vector by the given scalar.
+        /// </summary>
+        /// <param name="factor">The scalar value.</param>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The scaled vector.</returns>
+        public static Vector<T> operator *(T factor, Vector<T> value)
+        {
+            unchecked
+            {
+                if (Vector.IsHardwareAccelerated)
+                {
+                    return new Vector<T>(factor) * value;
+                }
+                else
+                {
+                    Vector<T> product = new Vector<T>();
+                    if (typeof(T) == typeof(Byte))
+                    {
+                        product.register.byte_0 = (Byte)(value.register.byte_0 * (Byte)(object)factor);
+                        product.register.byte_1 = (Byte)(value.register.byte_1 * (Byte)(object)factor);
+                        product.register.byte_2 = (Byte)(value.register.byte_2 * (Byte)(object)factor);
+                        product.register.byte_3 = (Byte)(value.register.byte_3 * (Byte)(object)factor);
+                        product.register.byte_4 = (Byte)(value.register.byte_4 * (Byte)(object)factor);
+                        product.register.byte_5 = (Byte)(value.register.byte_5 * (Byte)(object)factor);
+                        product.register.byte_6 = (Byte)(value.register.byte_6 * (Byte)(object)factor);
+                        product.register.byte_7 = (Byte)(value.register.byte_7 * (Byte)(object)factor);
+                        product.register.byte_8 = (Byte)(value.register.byte_8 * (Byte)(object)factor);
+                        product.register.byte_9 = (Byte)(value.register.byte_9 * (Byte)(object)factor);
+                        product.register.byte_10 = (Byte)(value.register.byte_10 * (Byte)(object)factor);
+                        product.register.byte_11 = (Byte)(value.register.byte_11 * (Byte)(object)factor);
+                        product.register.byte_12 = (Byte)(value.register.byte_12 * (Byte)(object)factor);
+                        product.register.byte_13 = (Byte)(value.register.byte_13 * (Byte)(object)factor);
+                        product.register.byte_14 = (Byte)(value.register.byte_14 * (Byte)(object)factor);
+                        product.register.byte_15 = (Byte)(value.register.byte_15 * (Byte)(object)factor);
+                    }
+                    else if (typeof(T) == typeof(SByte))
+                    {
+                        product.register.sbyte_0 = (SByte)(value.register.sbyte_0 * (SByte)(object)factor);
+                        product.register.sbyte_1 = (SByte)(value.register.sbyte_1 * (SByte)(object)factor);
+                        product.register.sbyte_2 = (SByte)(value.register.sbyte_2 * (SByte)(object)factor);
+                        product.register.sbyte_3 = (SByte)(value.register.sbyte_3 * (SByte)(object)factor);
+                        product.register.sbyte_4 = (SByte)(value.register.sbyte_4 * (SByte)(object)factor);
+                        product.register.sbyte_5 = (SByte)(value.register.sbyte_5 * (SByte)(object)factor);
+                        product.register.sbyte_6 = (SByte)(value.register.sbyte_6 * (SByte)(object)factor);
+                        product.register.sbyte_7 = (SByte)(value.register.sbyte_7 * (SByte)(object)factor);
+                        product.register.sbyte_8 = (SByte)(value.register.sbyte_8 * (SByte)(object)factor);
+                        product.register.sbyte_9 = (SByte)(value.register.sbyte_9 * (SByte)(object)factor);
+                        product.register.sbyte_10 = (SByte)(value.register.sbyte_10 * (SByte)(object)factor);
+                        product.register.sbyte_11 = (SByte)(value.register.sbyte_11 * (SByte)(object)factor);
+                        product.register.sbyte_12 = (SByte)(value.register.sbyte_12 * (SByte)(object)factor);
+                        product.register.sbyte_13 = (SByte)(value.register.sbyte_13 * (SByte)(object)factor);
+                        product.register.sbyte_14 = (SByte)(value.register.sbyte_14 * (SByte)(object)factor);
+                        product.register.sbyte_15 = (SByte)(value.register.sbyte_15 * (SByte)(object)factor);
+                    }
+                    else if (typeof(T) == typeof(UInt16))
+                    {
+                        product.register.uint16_0 = (UInt16)(value.register.uint16_0 * (UInt16)(object)factor);
+                        product.register.uint16_1 = (UInt16)(value.register.uint16_1 * (UInt16)(object)factor);
+                        product.register.uint16_2 = (UInt16)(value.register.uint16_2 * (UInt16)(object)factor);
+                        product.register.uint16_3 = (UInt16)(value.register.uint16_3 * (UInt16)(object)factor);
+                        product.register.uint16_4 = (UInt16)(value.register.uint16_4 * (UInt16)(object)factor);
+                        product.register.uint16_5 = (UInt16)(value.register.uint16_5 * (UInt16)(object)factor);
+                        product.register.uint16_6 = (UInt16)(value.register.uint16_6 * (UInt16)(object)factor);
+                        product.register.uint16_7 = (UInt16)(value.register.uint16_7 * (UInt16)(object)factor);
+                    }
+                    else if (typeof(T) == typeof(Int16))
+                    {
+                        product.register.int16_0 = (Int16)(value.register.int16_0 * (Int16)(object)factor);
+                        product.register.int16_1 = (Int16)(value.register.int16_1 * (Int16)(object)factor);
+                        product.register.int16_2 = (Int16)(value.register.int16_2 * (Int16)(object)factor);
+                        product.register.int16_3 = (Int16)(value.register.int16_3 * (Int16)(object)factor);
+                        product.register.int16_4 = (Int16)(value.register.int16_4 * (Int16)(object)factor);
+                        product.register.int16_5 = (Int16)(value.register.int16_5 * (Int16)(object)factor);
+                        product.register.int16_6 = (Int16)(value.register.int16_6 * (Int16)(object)factor);
+                        product.register.int16_7 = (Int16)(value.register.int16_7 * (Int16)(object)factor);
+                    }
+                    else if (typeof(T) == typeof(UInt32))
+                    {
+                        product.register.uint32_0 = (UInt32)(value.register.uint32_0 * (UInt32)(object)factor);
+                        product.register.uint32_1 = (UInt32)(value.register.uint32_1 * (UInt32)(object)factor);
+                        product.register.uint32_2 = (UInt32)(value.register.uint32_2 * (UInt32)(object)factor);
+                        product.register.uint32_3 = (UInt32)(value.register.uint32_3 * (UInt32)(object)factor);
+                    }
+                    else if (typeof(T) == typeof(Int32))
+                    {
+                        product.register.int32_0 = (Int32)(value.register.int32_0 * (Int32)(object)factor);
+                        product.register.int32_1 = (Int32)(value.register.int32_1 * (Int32)(object)factor);
+                        product.register.int32_2 = (Int32)(value.register.int32_2 * (Int32)(object)factor);
+                        product.register.int32_3 = (Int32)(value.register.int32_3 * (Int32)(object)factor);
+                    }
+                    else if (typeof(T) == typeof(UInt64))
+                    {
+                        product.register.uint64_0 = (UInt64)(value.register.uint64_0 * (UInt64)(object)factor);
+                        product.register.uint64_1 = (UInt64)(value.register.uint64_1 * (UInt64)(object)factor);
+                    }
+                    else if (typeof(T) == typeof(Int64))
+                    {
+                        product.register.int64_0 = (Int64)(value.register.int64_0 * (Int64)(object)factor);
+                        product.register.int64_1 = (Int64)(value.register.int64_1 * (Int64)(object)factor);
+                    }
+                    else if (typeof(T) == typeof(Single))
+                    {
+                        product.register.single_0 = (Single)(value.register.single_0 * (Single)(object)factor);
+                        product.register.single_1 = (Single)(value.register.single_1 * (Single)(object)factor);
+                        product.register.single_2 = (Single)(value.register.single_2 * (Single)(object)factor);
+                        product.register.single_3 = (Single)(value.register.single_3 * (Single)(object)factor);
+                    }
+                    else if (typeof(T) == typeof(Double))
+                    {
+                        product.register.double_0 = (Double)(value.register.double_0 * (Double)(object)factor);
+                        product.register.double_1 = (Double)(value.register.double_1 * (Double)(object)factor);
+                    }
+                    return product;
+                }
+            }
+        }
+
+        // This method is intrinsic only for certain types. It cannot access fields directly unless we are sure the context is unaccelerated.
+        /// <summary>
+        /// Divides the first vector by the second.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The vector resulting from the division.</returns>
+        public static unsafe Vector<T> operator /(Vector<T> left, Vector<T> right)
+        {
+            unchecked
+            {
+                if (Vector.IsHardwareAccelerated)
+                {
+                    if (typeof(T) == typeof(Byte))
+                    {
+                        Byte* dataPtr = stackalloc Byte[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Byte)(object)ScalarDivide(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(SByte))
+                    {
+                        SByte* dataPtr = stackalloc SByte[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (SByte)(object)ScalarDivide(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(UInt16))
+                    {
+                        UInt16* dataPtr = stackalloc UInt16[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (UInt16)(object)ScalarDivide(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(Int16))
+                    {
+                        Int16* dataPtr = stackalloc Int16[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Int16)(object)ScalarDivide(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(UInt32))
+                    {
+                        UInt32* dataPtr = stackalloc UInt32[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (UInt32)(object)ScalarDivide(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(Int32))
+                    {
+                        Int32* dataPtr = stackalloc Int32[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Int32)(object)ScalarDivide(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(UInt64))
+                    {
+                        UInt64* dataPtr = stackalloc UInt64[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (UInt64)(object)ScalarDivide(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(Int64))
+                    {
+                        Int64* dataPtr = stackalloc Int64[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Int64)(object)ScalarDivide(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(Single))
+                    {
+                        Single* dataPtr = stackalloc Single[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Single)(object)ScalarDivide(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else if (typeof(T) == typeof(Double))
+                    {
+                        Double* dataPtr = stackalloc Double[Count];
+                        for (int g = 0; g < Count; g++)
+                        {
+                            dataPtr[g] = (Double)(object)ScalarDivide(left[g], right[g]);
+                        }
+                        return new Vector<T>(dataPtr);
+                    }
+                    else
+                    {
+                        throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                    }
+                }
+                else
+                {
+                    Vector<T> quotient = new Vector<T>();
+                    if (typeof(T) == typeof(Byte))
+                    {
+                        quotient.register.byte_0 = (Byte)(left.register.byte_0 / right.register.byte_0);
+                        quotient.register.byte_1 = (Byte)(left.register.byte_1 / right.register.byte_1);
+                        quotient.register.byte_2 = (Byte)(left.register.byte_2 / right.register.byte_2);
+                        quotient.register.byte_3 = (Byte)(left.register.byte_3 / right.register.byte_3);
+                        quotient.register.byte_4 = (Byte)(left.register.byte_4 / right.register.byte_4);
+                        quotient.register.byte_5 = (Byte)(left.register.byte_5 / right.register.byte_5);
+                        quotient.register.byte_6 = (Byte)(left.register.byte_6 / right.register.byte_6);
+                        quotient.register.byte_7 = (Byte)(left.register.byte_7 / right.register.byte_7);
+                        quotient.register.byte_8 = (Byte)(left.register.byte_8 / right.register.byte_8);
+                        quotient.register.byte_9 = (Byte)(left.register.byte_9 / right.register.byte_9);
+                        quotient.register.byte_10 = (Byte)(left.register.byte_10 / right.register.byte_10);
+                        quotient.register.byte_11 = (Byte)(left.register.byte_11 / right.register.byte_11);
+                        quotient.register.byte_12 = (Byte)(left.register.byte_12 / right.register.byte_12);
+                        quotient.register.byte_13 = (Byte)(left.register.byte_13 / right.register.byte_13);
+                        quotient.register.byte_14 = (Byte)(left.register.byte_14 / right.register.byte_14);
+                        quotient.register.byte_15 = (Byte)(left.register.byte_15 / right.register.byte_15);
+                    }
+                    else if (typeof(T) == typeof(SByte))
+                    {
+                        quotient.register.sbyte_0 = (SByte)(left.register.sbyte_0 / right.register.sbyte_0);
+                        quotient.register.sbyte_1 = (SByte)(left.register.sbyte_1 / right.register.sbyte_1);
+                        quotient.register.sbyte_2 = (SByte)(left.register.sbyte_2 / right.register.sbyte_2);
+                        quotient.register.sbyte_3 = (SByte)(left.register.sbyte_3 / right.register.sbyte_3);
+                        quotient.register.sbyte_4 = (SByte)(left.register.sbyte_4 / right.register.sbyte_4);
+                        quotient.register.sbyte_5 = (SByte)(left.register.sbyte_5 / right.register.sbyte_5);
+                        quotient.register.sbyte_6 = (SByte)(left.register.sbyte_6 / right.register.sbyte_6);
+                        quotient.register.sbyte_7 = (SByte)(left.register.sbyte_7 / right.register.sbyte_7);
+                        quotient.register.sbyte_8 = (SByte)(left.register.sbyte_8 / right.register.sbyte_8);
+                        quotient.register.sbyte_9 = (SByte)(left.register.sbyte_9 / right.register.sbyte_9);
+                        quotient.register.sbyte_10 = (SByte)(left.register.sbyte_10 / right.register.sbyte_10);
+                        quotient.register.sbyte_11 = (SByte)(left.register.sbyte_11 / right.register.sbyte_11);
+                        quotient.register.sbyte_12 = (SByte)(left.register.sbyte_12 / right.register.sbyte_12);
+                        quotient.register.sbyte_13 = (SByte)(left.register.sbyte_13 / right.register.sbyte_13);
+                        quotient.register.sbyte_14 = (SByte)(left.register.sbyte_14 / right.register.sbyte_14);
+                        quotient.register.sbyte_15 = (SByte)(left.register.sbyte_15 / right.register.sbyte_15);
+                    }
+                    else if (typeof(T) == typeof(UInt16))
+                    {
+                        quotient.register.uint16_0 = (UInt16)(left.register.uint16_0 / right.register.uint16_0);
+                        quotient.register.uint16_1 = (UInt16)(left.register.uint16_1 / right.register.uint16_1);
+                        quotient.register.uint16_2 = (UInt16)(left.register.uint16_2 / right.register.uint16_2);
+                        quotient.register.uint16_3 = (UInt16)(left.register.uint16_3 / right.register.uint16_3);
+                        quotient.register.uint16_4 = (UInt16)(left.register.uint16_4 / right.register.uint16_4);
+                        quotient.register.uint16_5 = (UInt16)(left.register.uint16_5 / right.register.uint16_5);
+                        quotient.register.uint16_6 = (UInt16)(left.register.uint16_6 / right.register.uint16_6);
+                        quotient.register.uint16_7 = (UInt16)(left.register.uint16_7 / right.register.uint16_7);
+                    }
+                    else if (typeof(T) == typeof(Int16))
+                    {
+                        quotient.register.int16_0 = (Int16)(left.register.int16_0 / right.register.int16_0);
+                        quotient.register.int16_1 = (Int16)(left.register.int16_1 / right.register.int16_1);
+                        quotient.register.int16_2 = (Int16)(left.register.int16_2 / right.register.int16_2);
+                        quotient.register.int16_3 = (Int16)(left.register.int16_3 / right.register.int16_3);
+                        quotient.register.int16_4 = (Int16)(left.register.int16_4 / right.register.int16_4);
+                        quotient.register.int16_5 = (Int16)(left.register.int16_5 / right.register.int16_5);
+                        quotient.register.int16_6 = (Int16)(left.register.int16_6 / right.register.int16_6);
+                        quotient.register.int16_7 = (Int16)(left.register.int16_7 / right.register.int16_7);
+                    }
+                    else if (typeof(T) == typeof(UInt32))
+                    {
+                        quotient.register.uint32_0 = (UInt32)(left.register.uint32_0 / right.register.uint32_0);
+                        quotient.register.uint32_1 = (UInt32)(left.register.uint32_1 / right.register.uint32_1);
+                        quotient.register.uint32_2 = (UInt32)(left.register.uint32_2 / right.register.uint32_2);
+                        quotient.register.uint32_3 = (UInt32)(left.register.uint32_3 / right.register.uint32_3);
+                    }
+                    else if (typeof(T) == typeof(Int32))
+                    {
+                        quotient.register.int32_0 = (Int32)(left.register.int32_0 / right.register.int32_0);
+                        quotient.register.int32_1 = (Int32)(left.register.int32_1 / right.register.int32_1);
+                        quotient.register.int32_2 = (Int32)(left.register.int32_2 / right.register.int32_2);
+                        quotient.register.int32_3 = (Int32)(left.register.int32_3 / right.register.int32_3);
+                    }
+                    else if (typeof(T) == typeof(UInt64))
+                    {
+                        quotient.register.uint64_0 = (UInt64)(left.register.uint64_0 / right.register.uint64_0);
+                        quotient.register.uint64_1 = (UInt64)(left.register.uint64_1 / right.register.uint64_1);
+                    }
+                    else if (typeof(T) == typeof(Int64))
+                    {
+                        quotient.register.int64_0 = (Int64)(left.register.int64_0 / right.register.int64_0);
+                        quotient.register.int64_1 = (Int64)(left.register.int64_1 / right.register.int64_1);
+                    }
+                    else if (typeof(T) == typeof(Single))
+                    {
+                        quotient.register.single_0 = (Single)(left.register.single_0 / right.register.single_0);
+                        quotient.register.single_1 = (Single)(left.register.single_1 / right.register.single_1);
+                        quotient.register.single_2 = (Single)(left.register.single_2 / right.register.single_2);
+                        quotient.register.single_3 = (Single)(left.register.single_3 / right.register.single_3);
+                    }
+                    else if (typeof(T) == typeof(Double))
+                    {
+                        quotient.register.double_0 = (Double)(left.register.double_0 / right.register.double_0);
+                        quotient.register.double_1 = (Double)(left.register.double_1 / right.register.double_1);
+                    }
+                    return quotient;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Negates a given vector.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The negated vector.</returns>
+        public static Vector<T> operator -(Vector<T> value)
+        {
+            return Zero - value;
+        }
+        #endregion Arithmetic Operators
+
+        #region Bitwise Operators
+        /// <summary>
+        /// Returns a new vector by performing a bitwise-and operation on each of the elements in the given vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The resultant vector.</returns>
+        [JitIntrinsic]
+        public static unsafe Vector<T> operator &(Vector<T> left, Vector<T> right)
+        {
+            Vector<T> result = new Vector<T>();
+            unchecked
+            {
+                if (Vector.IsHardwareAccelerated)
+                {
+                    Int64* resultBase = &result.register.int64_0;
+                    Int64* leftBase = &left.register.int64_0;
+                    Int64* rightBase = &right.register.int64_0;
+                    for (int g = 0; g < Vector<Int64>.Count; g++)
+                    {
+                        resultBase[g] = leftBase[g] & rightBase[g];
+                    }
+                }
+                else
+                {
+                    result.register.int64_0 = left.register.int64_0 & right.register.int64_0;
+                    result.register.int64_1 = left.register.int64_1 & right.register.int64_1;
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Returns a new vector by performing a bitwise-or operation on each of the elements in the given vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The resultant vector.</returns>
+        [JitIntrinsic]
+        public static unsafe Vector<T> operator |(Vector<T> left, Vector<T> right)
+        {
+            Vector<T> result = new Vector<T>();
+            unchecked
+            {
+                if (Vector.IsHardwareAccelerated)
+                {
+                    Int64* resultBase = &result.register.int64_0;
+                    Int64* leftBase = &left.register.int64_0;
+                    Int64* rightBase = &right.register.int64_0;
+                    for (int g = 0; g < Vector<Int64>.Count; g++)
+                    {
+                        resultBase[g] = leftBase[g] | rightBase[g];
+                    }
+                }
+                else
+                {
+                    result.register.int64_0 = left.register.int64_0 | right.register.int64_0;
+                    result.register.int64_1 = left.register.int64_1 | right.register.int64_1;
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Returns a new vector by performing a bitwise-exclusive-or operation on each of the elements in the given vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The resultant vector.</returns>
+        [JitIntrinsic]
+        public static unsafe Vector<T> operator ^(Vector<T> left, Vector<T> right)
+        {
+            Vector<T> result = new Vector<T>();
+            unchecked
+            {
+                if (Vector.IsHardwareAccelerated)
+                {
+                    Int64* resultBase = &result.register.int64_0;
+                    Int64* leftBase = &left.register.int64_0;
+                    Int64* rightBase = &right.register.int64_0;
+                    for (int g = 0; g < Vector<Int64>.Count; g++)
+                    {
+                        resultBase[g] = leftBase[g] ^ rightBase[g];
+                    }
+                }
+                else
+                {
+                    result.register.int64_0 = left.register.int64_0 ^ right.register.int64_0;
+                    result.register.int64_1 = left.register.int64_1 ^ right.register.int64_1;
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Returns a new vector whose elements are obtained by taking the one's complement of the given vector's elements.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The one's complement vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<T> operator ~(Vector<T> value)
+        {
+            return allOnes ^ value;
+        }
+        #endregion Bitwise Operators
+
+        #region Logical Operators
+        /// <summary>
+        /// Returns a boolean indicating whether each pair of elements in the given vectors are equal.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The first vector to compare.</param>
+        /// <returns>True if all elements are equal; False otherwise.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static bool operator ==(Vector<T> left, Vector<T> right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether any single pair of elements in the given vectors are not equal.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>True if left and right are not equal; False otherwise.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static bool operator !=(Vector<T> left, Vector<T> right)
+        {
+            return !(left == right);
+        }
+        #endregion Logical Operators
+
+        #region Conversions
+        /// <summary>
+        /// Reinterprets the bits of the given vector into those of another type.
+        /// </summary>
+        /// <param name="value">The source vector</param>
+        /// <returns>The reinterpreted vector.</returns>
+        [JitIntrinsic]
+        public static explicit operator Vector<Byte>(Vector<T> value)
+        {
+            return new Vector<Byte>(ref value.register);
+        }
+
+        /// <summary>
+        /// Reinterprets the bits of the given vector into those of another type.
+        /// </summary>
+        /// <param name="value">The source vector</param>
+        /// <returns>The reinterpreted vector.</returns>
+        [CLSCompliant(false)]
+        [JitIntrinsic]
+        public static explicit operator Vector<SByte>(Vector<T> value)
+        {
+            return new Vector<SByte>(ref value.register);
+        }
+
+        /// <summary>
+        /// Reinterprets the bits of the given vector into those of another type.
+        /// </summary>
+        /// <param name="value">The source vector</param>
+        /// <returns>The reinterpreted vector.</returns>
+        [CLSCompliant(false)]
+        [JitIntrinsic]
+        public static explicit operator Vector<UInt16>(Vector<T> value)
+        {
+            return new Vector<UInt16>(ref value.register);
+        }
+
+        /// <summary>
+        /// Reinterprets the bits of the given vector into those of another type.
+        /// </summary>
+        /// <param name="value">The source vector</param>
+        /// <returns>The reinterpreted vector.</returns>
+        [JitIntrinsic]
+        public static explicit operator Vector<Int16>(Vector<T> value)
+        {
+            return new Vector<Int16>(ref value.register);
+        }
+
+        /// <summary>
+        /// Reinterprets the bits of the given vector into those of another type.
+        /// </summary>
+        /// <param name="value">The source vector</param>
+        /// <returns>The reinterpreted vector.</returns>
+        [CLSCompliant(false)]
+        [JitIntrinsic]
+        public static explicit operator Vector<UInt32>(Vector<T> value)
+        {
+            return new Vector<UInt32>(ref value.register);
+        }
+
+        /// <summary>
+        /// Reinterprets the bits of the given vector into those of another type.
+        /// </summary>
+        /// <param name="value">The source vector</param>
+        /// <returns>The reinterpreted vector.</returns>
+        [JitIntrinsic]
+        public static explicit operator Vector<Int32>(Vector<T> value)
+        {
+            return new Vector<Int32>(ref value.register);
+        }
+
+        /// <summary>
+        /// Reinterprets the bits of the given vector into those of another type.
+        /// </summary>
+        /// <param name="value">The source vector</param>
+        /// <returns>The reinterpreted vector.</returns>
+        [CLSCompliant(false)]
+        [JitIntrinsic]
+        public static explicit operator Vector<UInt64>(Vector<T> value)
+        {
+            return new Vector<UInt64>(ref value.register);
+        }
+
+        /// <summary>
+        /// Reinterprets the bits of the given vector into those of another type.
+        /// </summary>
+        /// <param name="value">The source vector</param>
+        /// <returns>The reinterpreted vector.</returns>
+        [JitIntrinsic]
+        public static explicit operator Vector<Int64>(Vector<T> value)
+        {
+            return new Vector<Int64>(ref value.register);
+        }
+
+        /// <summary>
+        /// Reinterprets the bits of the given vector into those of another type.
+        /// </summary>
+        /// <param name="value">The source vector</param>
+        /// <returns>The reinterpreted vector.</returns>
+        [JitIntrinsic]
+        public static explicit operator Vector<Single>(Vector<T> value)
+        {
+            return new Vector<Single>(ref value.register);
+        }
+
+        /// <summary>
+        /// Reinterprets the bits of the given vector into those of another type.
+        /// </summary>
+        /// <param name="value">The source vector</param>
+        /// <returns>The reinterpreted vector.</returns>
+        [JitIntrinsic]
+        public static explicit operator Vector<Double>(Vector<T> value)
+        {
+            return new Vector<Double>(ref value.register);
+        }
+
+        #endregion Conversions
+
+        #region Internal Comparison Methods
+        [JitIntrinsic]
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        internal static unsafe Vector<T> Equals(Vector<T> left, Vector<T> right)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                if (typeof(T) == typeof(Byte))
+                {
+                    Byte* dataPtr = stackalloc Byte[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarEquals(left[g], right[g]) ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(SByte))
+                {
+                    SByte* dataPtr = stackalloc SByte[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarEquals(left[g], right[g]) ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(UInt16))
+                {
+                    UInt16* dataPtr = stackalloc UInt16[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarEquals(left[g], right[g]) ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    Int16* dataPtr = stackalloc Int16[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarEquals(left[g], right[g]) ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(UInt32))
+                {
+                    UInt32* dataPtr = stackalloc UInt32[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarEquals(left[g], right[g]) ? ConstantHelper.GetUInt32WithAllBitsSet() : (UInt32)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    Int32* dataPtr = stackalloc Int32[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarEquals(left[g], right[g]) ? ConstantHelper.GetInt32WithAllBitsSet() : (Int32)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(UInt64))
+                {
+                    UInt64* dataPtr = stackalloc UInt64[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarEquals(left[g], right[g]) ? ConstantHelper.GetUInt64WithAllBitsSet() : (UInt64)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    Int64* dataPtr = stackalloc Int64[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarEquals(left[g], right[g]) ? ConstantHelper.GetInt64WithAllBitsSet() : (Int64)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    Single* dataPtr = stackalloc Single[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarEquals(left[g], right[g]) ? ConstantHelper.GetSingleWithAllBitsSet() : (Single)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    Double* dataPtr = stackalloc Double[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarEquals(left[g], right[g]) ? ConstantHelper.GetDoubleWithAllBitsSet() : (Double)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else
+                {
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                }
+            }
+            else
+            {
+                Register register = new Register();
+                if (typeof(T) == typeof(Byte))
+                {
+                    register.byte_0 = left.register.byte_0 == right.register.byte_0 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_1 = left.register.byte_1 == right.register.byte_1 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_2 = left.register.byte_2 == right.register.byte_2 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_3 = left.register.byte_3 == right.register.byte_3 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_4 = left.register.byte_4 == right.register.byte_4 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_5 = left.register.byte_5 == right.register.byte_5 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_6 = left.register.byte_6 == right.register.byte_6 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_7 = left.register.byte_7 == right.register.byte_7 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_8 = left.register.byte_8 == right.register.byte_8 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_9 = left.register.byte_9 == right.register.byte_9 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_10 = left.register.byte_10 == right.register.byte_10 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_11 = left.register.byte_11 == right.register.byte_11 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_12 = left.register.byte_12 == right.register.byte_12 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_13 = left.register.byte_13 == right.register.byte_13 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_14 = left.register.byte_14 == right.register.byte_14 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_15 = left.register.byte_15 == right.register.byte_15 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(SByte))
+                {
+                    register.sbyte_0 = left.register.sbyte_0 == right.register.sbyte_0 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_1 = left.register.sbyte_1 == right.register.sbyte_1 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_2 = left.register.sbyte_2 == right.register.sbyte_2 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_3 = left.register.sbyte_3 == right.register.sbyte_3 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_4 = left.register.sbyte_4 == right.register.sbyte_4 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_5 = left.register.sbyte_5 == right.register.sbyte_5 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_6 = left.register.sbyte_6 == right.register.sbyte_6 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_7 = left.register.sbyte_7 == right.register.sbyte_7 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_8 = left.register.sbyte_8 == right.register.sbyte_8 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_9 = left.register.sbyte_9 == right.register.sbyte_9 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_10 = left.register.sbyte_10 == right.register.sbyte_10 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_11 = left.register.sbyte_11 == right.register.sbyte_11 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_12 = left.register.sbyte_12 == right.register.sbyte_12 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_13 = left.register.sbyte_13 == right.register.sbyte_13 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_14 = left.register.sbyte_14 == right.register.sbyte_14 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_15 = left.register.sbyte_15 == right.register.sbyte_15 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(UInt16))
+                {
+                    register.uint16_0 = left.register.uint16_0 == right.register.uint16_0 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    register.uint16_1 = left.register.uint16_1 == right.register.uint16_1 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    register.uint16_2 = left.register.uint16_2 == right.register.uint16_2 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    register.uint16_3 = left.register.uint16_3 == right.register.uint16_3 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    register.uint16_4 = left.register.uint16_4 == right.register.uint16_4 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    register.uint16_5 = left.register.uint16_5 == right.register.uint16_5 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    register.uint16_6 = left.register.uint16_6 == right.register.uint16_6 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    register.uint16_7 = left.register.uint16_7 == right.register.uint16_7 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    register.int16_0 = left.register.int16_0 == right.register.int16_0 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    register.int16_1 = left.register.int16_1 == right.register.int16_1 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    register.int16_2 = left.register.int16_2 == right.register.int16_2 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    register.int16_3 = left.register.int16_3 == right.register.int16_3 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    register.int16_4 = left.register.int16_4 == right.register.int16_4 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    register.int16_5 = left.register.int16_5 == right.register.int16_5 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    register.int16_6 = left.register.int16_6 == right.register.int16_6 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    register.int16_7 = left.register.int16_7 == right.register.int16_7 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(UInt32))
+                {
+                    register.uint32_0 = left.register.uint32_0 == right.register.uint32_0 ? ConstantHelper.GetUInt32WithAllBitsSet() : (UInt32)0;
+                    register.uint32_1 = left.register.uint32_1 == right.register.uint32_1 ? ConstantHelper.GetUInt32WithAllBitsSet() : (UInt32)0;
+                    register.uint32_2 = left.register.uint32_2 == right.register.uint32_2 ? ConstantHelper.GetUInt32WithAllBitsSet() : (UInt32)0;
+                    register.uint32_3 = left.register.uint32_3 == right.register.uint32_3 ? ConstantHelper.GetUInt32WithAllBitsSet() : (UInt32)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    register.int32_0 = left.register.int32_0 == right.register.int32_0 ? ConstantHelper.GetInt32WithAllBitsSet() : (Int32)0;
+                    register.int32_1 = left.register.int32_1 == right.register.int32_1 ? ConstantHelper.GetInt32WithAllBitsSet() : (Int32)0;
+                    register.int32_2 = left.register.int32_2 == right.register.int32_2 ? ConstantHelper.GetInt32WithAllBitsSet() : (Int32)0;
+                    register.int32_3 = left.register.int32_3 == right.register.int32_3 ? ConstantHelper.GetInt32WithAllBitsSet() : (Int32)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(UInt64))
+                {
+                    register.uint64_0 = left.register.uint64_0 == right.register.uint64_0 ? ConstantHelper.GetUInt64WithAllBitsSet() : (UInt64)0;
+                    register.uint64_1 = left.register.uint64_1 == right.register.uint64_1 ? ConstantHelper.GetUInt64WithAllBitsSet() : (UInt64)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    register.int64_0 = left.register.int64_0 == right.register.int64_0 ? ConstantHelper.GetInt64WithAllBitsSet() : (Int64)0;
+                    register.int64_1 = left.register.int64_1 == right.register.int64_1 ? ConstantHelper.GetInt64WithAllBitsSet() : (Int64)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    register.single_0 = left.register.single_0 == right.register.single_0 ? ConstantHelper.GetSingleWithAllBitsSet() : (Single)0;
+                    register.single_1 = left.register.single_1 == right.register.single_1 ? ConstantHelper.GetSingleWithAllBitsSet() : (Single)0;
+                    register.single_2 = left.register.single_2 == right.register.single_2 ? ConstantHelper.GetSingleWithAllBitsSet() : (Single)0;
+                    register.single_3 = left.register.single_3 == right.register.single_3 ? ConstantHelper.GetSingleWithAllBitsSet() : (Single)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    register.double_0 = left.register.double_0 == right.register.double_0 ? ConstantHelper.GetDoubleWithAllBitsSet() : (Double)0;
+                    register.double_1 = left.register.double_1 == right.register.double_1 ? ConstantHelper.GetDoubleWithAllBitsSet() : (Double)0;
+                    return new Vector<T>(ref register);
+                }
+                else
+                {
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                }
+            }
+        }
+
+        [JitIntrinsic]
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        internal static unsafe Vector<T> LessThan(Vector<T> left, Vector<T> right)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                if (typeof(T) == typeof(Byte))
+                {
+                    Byte* dataPtr = stackalloc Byte[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(SByte))
+                {
+                    SByte* dataPtr = stackalloc SByte[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(UInt16))
+                {
+                    UInt16* dataPtr = stackalloc UInt16[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    Int16* dataPtr = stackalloc Int16[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(UInt32))
+                {
+                    UInt32* dataPtr = stackalloc UInt32[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? ConstantHelper.GetUInt32WithAllBitsSet() : (UInt32)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    Int32* dataPtr = stackalloc Int32[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? ConstantHelper.GetInt32WithAllBitsSet() : (Int32)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(UInt64))
+                {
+                    UInt64* dataPtr = stackalloc UInt64[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? ConstantHelper.GetUInt64WithAllBitsSet() : (UInt64)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    Int64* dataPtr = stackalloc Int64[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? ConstantHelper.GetInt64WithAllBitsSet() : (Int64)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    Single* dataPtr = stackalloc Single[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? ConstantHelper.GetSingleWithAllBitsSet() : (Single)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    Double* dataPtr = stackalloc Double[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? ConstantHelper.GetDoubleWithAllBitsSet() : (Double)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else
+                {
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                }
+            }
+            else
+            {
+                Register register = new Register();
+                if (typeof(T) == typeof(Byte))
+                {
+                    register.byte_0 = left.register.byte_0 < right.register.byte_0 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_1 = left.register.byte_1 < right.register.byte_1 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_2 = left.register.byte_2 < right.register.byte_2 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_3 = left.register.byte_3 < right.register.byte_3 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_4 = left.register.byte_4 < right.register.byte_4 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_5 = left.register.byte_5 < right.register.byte_5 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_6 = left.register.byte_6 < right.register.byte_6 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_7 = left.register.byte_7 < right.register.byte_7 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_8 = left.register.byte_8 < right.register.byte_8 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_9 = left.register.byte_9 < right.register.byte_9 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_10 = left.register.byte_10 < right.register.byte_10 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_11 = left.register.byte_11 < right.register.byte_11 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_12 = left.register.byte_12 < right.register.byte_12 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_13 = left.register.byte_13 < right.register.byte_13 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_14 = left.register.byte_14 < right.register.byte_14 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_15 = left.register.byte_15 < right.register.byte_15 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(SByte))
+                {
+                    register.sbyte_0 = left.register.sbyte_0 < right.register.sbyte_0 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_1 = left.register.sbyte_1 < right.register.sbyte_1 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_2 = left.register.sbyte_2 < right.register.sbyte_2 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_3 = left.register.sbyte_3 < right.register.sbyte_3 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_4 = left.register.sbyte_4 < right.register.sbyte_4 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_5 = left.register.sbyte_5 < right.register.sbyte_5 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_6 = left.register.sbyte_6 < right.register.sbyte_6 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_7 = left.register.sbyte_7 < right.register.sbyte_7 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_8 = left.register.sbyte_8 < right.register.sbyte_8 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_9 = left.register.sbyte_9 < right.register.sbyte_9 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_10 = left.register.sbyte_10 < right.register.sbyte_10 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_11 = left.register.sbyte_11 < right.register.sbyte_11 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_12 = left.register.sbyte_12 < right.register.sbyte_12 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_13 = left.register.sbyte_13 < right.register.sbyte_13 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_14 = left.register.sbyte_14 < right.register.sbyte_14 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_15 = left.register.sbyte_15 < right.register.sbyte_15 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(UInt16))
+                {
+                    register.uint16_0 = left.register.uint16_0 < right.register.uint16_0 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    register.uint16_1 = left.register.uint16_1 < right.register.uint16_1 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    register.uint16_2 = left.register.uint16_2 < right.register.uint16_2 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    register.uint16_3 = left.register.uint16_3 < right.register.uint16_3 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    register.uint16_4 = left.register.uint16_4 < right.register.uint16_4 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    register.uint16_5 = left.register.uint16_5 < right.register.uint16_5 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    register.uint16_6 = left.register.uint16_6 < right.register.uint16_6 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    register.uint16_7 = left.register.uint16_7 < right.register.uint16_7 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    register.int16_0 = left.register.int16_0 < right.register.int16_0 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    register.int16_1 = left.register.int16_1 < right.register.int16_1 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    register.int16_2 = left.register.int16_2 < right.register.int16_2 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    register.int16_3 = left.register.int16_3 < right.register.int16_3 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    register.int16_4 = left.register.int16_4 < right.register.int16_4 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    register.int16_5 = left.register.int16_5 < right.register.int16_5 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    register.int16_6 = left.register.int16_6 < right.register.int16_6 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    register.int16_7 = left.register.int16_7 < right.register.int16_7 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(UInt32))
+                {
+                    register.uint32_0 = left.register.uint32_0 < right.register.uint32_0 ? ConstantHelper.GetUInt32WithAllBitsSet() : (UInt32)0;
+                    register.uint32_1 = left.register.uint32_1 < right.register.uint32_1 ? ConstantHelper.GetUInt32WithAllBitsSet() : (UInt32)0;
+                    register.uint32_2 = left.register.uint32_2 < right.register.uint32_2 ? ConstantHelper.GetUInt32WithAllBitsSet() : (UInt32)0;
+                    register.uint32_3 = left.register.uint32_3 < right.register.uint32_3 ? ConstantHelper.GetUInt32WithAllBitsSet() : (UInt32)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    register.int32_0 = left.register.int32_0 < right.register.int32_0 ? ConstantHelper.GetInt32WithAllBitsSet() : (Int32)0;
+                    register.int32_1 = left.register.int32_1 < right.register.int32_1 ? ConstantHelper.GetInt32WithAllBitsSet() : (Int32)0;
+                    register.int32_2 = left.register.int32_2 < right.register.int32_2 ? ConstantHelper.GetInt32WithAllBitsSet() : (Int32)0;
+                    register.int32_3 = left.register.int32_3 < right.register.int32_3 ? ConstantHelper.GetInt32WithAllBitsSet() : (Int32)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(UInt64))
+                {
+                    register.uint64_0 = left.register.uint64_0 < right.register.uint64_0 ? ConstantHelper.GetUInt64WithAllBitsSet() : (UInt64)0;
+                    register.uint64_1 = left.register.uint64_1 < right.register.uint64_1 ? ConstantHelper.GetUInt64WithAllBitsSet() : (UInt64)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    register.int64_0 = left.register.int64_0 < right.register.int64_0 ? ConstantHelper.GetInt64WithAllBitsSet() : (Int64)0;
+                    register.int64_1 = left.register.int64_1 < right.register.int64_1 ? ConstantHelper.GetInt64WithAllBitsSet() : (Int64)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    register.single_0 = left.register.single_0 < right.register.single_0 ? ConstantHelper.GetSingleWithAllBitsSet() : (Single)0;
+                    register.single_1 = left.register.single_1 < right.register.single_1 ? ConstantHelper.GetSingleWithAllBitsSet() : (Single)0;
+                    register.single_2 = left.register.single_2 < right.register.single_2 ? ConstantHelper.GetSingleWithAllBitsSet() : (Single)0;
+                    register.single_3 = left.register.single_3 < right.register.single_3 ? ConstantHelper.GetSingleWithAllBitsSet() : (Single)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    register.double_0 = left.register.double_0 < right.register.double_0 ? ConstantHelper.GetDoubleWithAllBitsSet() : (Double)0;
+                    register.double_1 = left.register.double_1 < right.register.double_1 ? ConstantHelper.GetDoubleWithAllBitsSet() : (Double)0;
+                    return new Vector<T>(ref register);
+                }
+                else
+                {
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                }
+            }
+        }
+
+        [JitIntrinsic]
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        internal static unsafe Vector<T> GreaterThan(Vector<T> left, Vector<T> right)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                if (typeof(T) == typeof(Byte))
+                {
+                    Byte* dataPtr = stackalloc Byte[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(SByte))
+                {
+                    SByte* dataPtr = stackalloc SByte[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(UInt16))
+                {
+                    UInt16* dataPtr = stackalloc UInt16[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    Int16* dataPtr = stackalloc Int16[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(UInt32))
+                {
+                    UInt32* dataPtr = stackalloc UInt32[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? ConstantHelper.GetUInt32WithAllBitsSet() : (UInt32)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    Int32* dataPtr = stackalloc Int32[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? ConstantHelper.GetInt32WithAllBitsSet() : (Int32)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(UInt64))
+                {
+                    UInt64* dataPtr = stackalloc UInt64[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? ConstantHelper.GetUInt64WithAllBitsSet() : (UInt64)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    Int64* dataPtr = stackalloc Int64[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? ConstantHelper.GetInt64WithAllBitsSet() : (Int64)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    Single* dataPtr = stackalloc Single[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? ConstantHelper.GetSingleWithAllBitsSet() : (Single)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    Double* dataPtr = stackalloc Double[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? ConstantHelper.GetDoubleWithAllBitsSet() : (Double)0;
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else
+                {
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                }
+            }
+            else
+            {
+                Register register = new Register();
+                if (typeof(T) == typeof(Byte))
+                {
+                    register.byte_0 = left.register.byte_0 > right.register.byte_0 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_1 = left.register.byte_1 > right.register.byte_1 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_2 = left.register.byte_2 > right.register.byte_2 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_3 = left.register.byte_3 > right.register.byte_3 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_4 = left.register.byte_4 > right.register.byte_4 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_5 = left.register.byte_5 > right.register.byte_5 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_6 = left.register.byte_6 > right.register.byte_6 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_7 = left.register.byte_7 > right.register.byte_7 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_8 = left.register.byte_8 > right.register.byte_8 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_9 = left.register.byte_9 > right.register.byte_9 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_10 = left.register.byte_10 > right.register.byte_10 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_11 = left.register.byte_11 > right.register.byte_11 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_12 = left.register.byte_12 > right.register.byte_12 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_13 = left.register.byte_13 > right.register.byte_13 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_14 = left.register.byte_14 > right.register.byte_14 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    register.byte_15 = left.register.byte_15 > right.register.byte_15 ? ConstantHelper.GetByteWithAllBitsSet() : (Byte)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(SByte))
+                {
+                    register.sbyte_0 = left.register.sbyte_0 > right.register.sbyte_0 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_1 = left.register.sbyte_1 > right.register.sbyte_1 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_2 = left.register.sbyte_2 > right.register.sbyte_2 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_3 = left.register.sbyte_3 > right.register.sbyte_3 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_4 = left.register.sbyte_4 > right.register.sbyte_4 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_5 = left.register.sbyte_5 > right.register.sbyte_5 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_6 = left.register.sbyte_6 > right.register.sbyte_6 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_7 = left.register.sbyte_7 > right.register.sbyte_7 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_8 = left.register.sbyte_8 > right.register.sbyte_8 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_9 = left.register.sbyte_9 > right.register.sbyte_9 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_10 = left.register.sbyte_10 > right.register.sbyte_10 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_11 = left.register.sbyte_11 > right.register.sbyte_11 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_12 = left.register.sbyte_12 > right.register.sbyte_12 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_13 = left.register.sbyte_13 > right.register.sbyte_13 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_14 = left.register.sbyte_14 > right.register.sbyte_14 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    register.sbyte_15 = left.register.sbyte_15 > right.register.sbyte_15 ? ConstantHelper.GetSByteWithAllBitsSet() : (SByte)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(UInt16))
+                {
+                    register.uint16_0 = left.register.uint16_0 > right.register.uint16_0 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    register.uint16_1 = left.register.uint16_1 > right.register.uint16_1 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    register.uint16_2 = left.register.uint16_2 > right.register.uint16_2 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    register.uint16_3 = left.register.uint16_3 > right.register.uint16_3 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    register.uint16_4 = left.register.uint16_4 > right.register.uint16_4 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    register.uint16_5 = left.register.uint16_5 > right.register.uint16_5 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    register.uint16_6 = left.register.uint16_6 > right.register.uint16_6 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    register.uint16_7 = left.register.uint16_7 > right.register.uint16_7 ? ConstantHelper.GetUInt16WithAllBitsSet() : (UInt16)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    register.int16_0 = left.register.int16_0 > right.register.int16_0 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    register.int16_1 = left.register.int16_1 > right.register.int16_1 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    register.int16_2 = left.register.int16_2 > right.register.int16_2 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    register.int16_3 = left.register.int16_3 > right.register.int16_3 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    register.int16_4 = left.register.int16_4 > right.register.int16_4 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    register.int16_5 = left.register.int16_5 > right.register.int16_5 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    register.int16_6 = left.register.int16_6 > right.register.int16_6 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    register.int16_7 = left.register.int16_7 > right.register.int16_7 ? ConstantHelper.GetInt16WithAllBitsSet() : (Int16)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(UInt32))
+                {
+                    register.uint32_0 = left.register.uint32_0 > right.register.uint32_0 ? ConstantHelper.GetUInt32WithAllBitsSet() : (UInt32)0;
+                    register.uint32_1 = left.register.uint32_1 > right.register.uint32_1 ? ConstantHelper.GetUInt32WithAllBitsSet() : (UInt32)0;
+                    register.uint32_2 = left.register.uint32_2 > right.register.uint32_2 ? ConstantHelper.GetUInt32WithAllBitsSet() : (UInt32)0;
+                    register.uint32_3 = left.register.uint32_3 > right.register.uint32_3 ? ConstantHelper.GetUInt32WithAllBitsSet() : (UInt32)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    register.int32_0 = left.register.int32_0 > right.register.int32_0 ? ConstantHelper.GetInt32WithAllBitsSet() : (Int32)0;
+                    register.int32_1 = left.register.int32_1 > right.register.int32_1 ? ConstantHelper.GetInt32WithAllBitsSet() : (Int32)0;
+                    register.int32_2 = left.register.int32_2 > right.register.int32_2 ? ConstantHelper.GetInt32WithAllBitsSet() : (Int32)0;
+                    register.int32_3 = left.register.int32_3 > right.register.int32_3 ? ConstantHelper.GetInt32WithAllBitsSet() : (Int32)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(UInt64))
+                {
+                    register.uint64_0 = left.register.uint64_0 > right.register.uint64_0 ? ConstantHelper.GetUInt64WithAllBitsSet() : (UInt64)0;
+                    register.uint64_1 = left.register.uint64_1 > right.register.uint64_1 ? ConstantHelper.GetUInt64WithAllBitsSet() : (UInt64)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    register.int64_0 = left.register.int64_0 > right.register.int64_0 ? ConstantHelper.GetInt64WithAllBitsSet() : (Int64)0;
+                    register.int64_1 = left.register.int64_1 > right.register.int64_1 ? ConstantHelper.GetInt64WithAllBitsSet() : (Int64)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    register.single_0 = left.register.single_0 > right.register.single_0 ? ConstantHelper.GetSingleWithAllBitsSet() : (Single)0;
+                    register.single_1 = left.register.single_1 > right.register.single_1 ? ConstantHelper.GetSingleWithAllBitsSet() : (Single)0;
+                    register.single_2 = left.register.single_2 > right.register.single_2 ? ConstantHelper.GetSingleWithAllBitsSet() : (Single)0;
+                    register.single_3 = left.register.single_3 > right.register.single_3 ? ConstantHelper.GetSingleWithAllBitsSet() : (Single)0;
+                    return new Vector<T>(ref register);
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    register.double_0 = left.register.double_0 > right.register.double_0 ? ConstantHelper.GetDoubleWithAllBitsSet() : (Double)0;
+                    register.double_1 = left.register.double_1 > right.register.double_1 ? ConstantHelper.GetDoubleWithAllBitsSet() : (Double)0;
+                    return new Vector<T>(ref register);
+                }
+                else
+                {
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                }
+            }
+        }
+
+        [JitIntrinsic]
+        internal static Vector<T> GreaterThanOrEqual(Vector<T> left, Vector<T> right)
+        {
+            return Equals(left, right) | GreaterThan(left, right);
+        }
+
+        [JitIntrinsic]
+        internal static Vector<T> LessThanOrEqual(Vector<T> left, Vector<T> right)
+        {
+            return Equals(left, right) | LessThan(left, right);
+        }
+
+        [JitIntrinsic]
+        internal static Vector<T> ConditionalSelect(Vector<T> condition, Vector<T> left, Vector<T> right)
+        {
+            return (left & condition) | (Vector.AndNot(right, condition));
+        }
+        #endregion Comparison Methods
+
+        #region Internal Math Methods
+        [JitIntrinsic]
+        internal static unsafe Vector<T> Abs(Vector<T> value)
+        {
+            if (typeof(T) == typeof(Byte))
+            {
+                return value;
+            }
+            else if (typeof(T) == typeof(UInt16))
+            {
+                return value;
+            }
+            else if (typeof(T) == typeof(UInt32))
+            {
+                return value;
+            }
+            else if (typeof(T) == typeof(UInt64))
+            {
+                return value;
+            }
+            if (Vector.IsHardwareAccelerated)
+            {
+                if (typeof(T) == typeof(SByte))
+                {
+                    SByte* dataPtr = stackalloc SByte[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = (SByte)(object)(Math.Abs((SByte)(object)value[g]));
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    Int16* dataPtr = stackalloc Int16[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = (Int16)(object)(Math.Abs((Int16)(object)value[g]));
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    Int32* dataPtr = stackalloc Int32[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = (Int32)(object)(Math.Abs((Int32)(object)value[g]));
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    Int64* dataPtr = stackalloc Int64[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = (Int64)(object)(Math.Abs((Int64)(object)value[g]));
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    Single* dataPtr = stackalloc Single[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = (Single)(object)(Math.Abs((Single)(object)value[g]));
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    Double* dataPtr = stackalloc Double[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = (Double)(object)(Math.Abs((Double)(object)value[g]));
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else
+                {
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                }
+            }
+            else
+            {
+                if (typeof(T) == typeof(SByte))
+                {
+                    value.register.sbyte_0 = (SByte)(Math.Abs(value.register.sbyte_0));
+                    value.register.sbyte_1 = (SByte)(Math.Abs(value.register.sbyte_1));
+                    value.register.sbyte_2 = (SByte)(Math.Abs(value.register.sbyte_2));
+                    value.register.sbyte_3 = (SByte)(Math.Abs(value.register.sbyte_3));
+                    value.register.sbyte_4 = (SByte)(Math.Abs(value.register.sbyte_4));
+                    value.register.sbyte_5 = (SByte)(Math.Abs(value.register.sbyte_5));
+                    value.register.sbyte_6 = (SByte)(Math.Abs(value.register.sbyte_6));
+                    value.register.sbyte_7 = (SByte)(Math.Abs(value.register.sbyte_7));
+                    value.register.sbyte_8 = (SByte)(Math.Abs(value.register.sbyte_8));
+                    value.register.sbyte_9 = (SByte)(Math.Abs(value.register.sbyte_9));
+                    value.register.sbyte_10 = (SByte)(Math.Abs(value.register.sbyte_10));
+                    value.register.sbyte_11 = (SByte)(Math.Abs(value.register.sbyte_11));
+                    value.register.sbyte_12 = (SByte)(Math.Abs(value.register.sbyte_12));
+                    value.register.sbyte_13 = (SByte)(Math.Abs(value.register.sbyte_13));
+                    value.register.sbyte_14 = (SByte)(Math.Abs(value.register.sbyte_14));
+                    value.register.sbyte_15 = (SByte)(Math.Abs(value.register.sbyte_15));
+                    return value;
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    value.register.int16_0 = (Int16)(Math.Abs(value.register.int16_0));
+                    value.register.int16_1 = (Int16)(Math.Abs(value.register.int16_1));
+                    value.register.int16_2 = (Int16)(Math.Abs(value.register.int16_2));
+                    value.register.int16_3 = (Int16)(Math.Abs(value.register.int16_3));
+                    value.register.int16_4 = (Int16)(Math.Abs(value.register.int16_4));
+                    value.register.int16_5 = (Int16)(Math.Abs(value.register.int16_5));
+                    value.register.int16_6 = (Int16)(Math.Abs(value.register.int16_6));
+                    value.register.int16_7 = (Int16)(Math.Abs(value.register.int16_7));
+                    return value;
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    value.register.int32_0 = (Int32)(Math.Abs(value.register.int32_0));
+                    value.register.int32_1 = (Int32)(Math.Abs(value.register.int32_1));
+                    value.register.int32_2 = (Int32)(Math.Abs(value.register.int32_2));
+                    value.register.int32_3 = (Int32)(Math.Abs(value.register.int32_3));
+                    return value;
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    value.register.int64_0 = (Int64)(Math.Abs(value.register.int64_0));
+                    value.register.int64_1 = (Int64)(Math.Abs(value.register.int64_1));
+                    return value;
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    value.register.single_0 = (Single)(Math.Abs(value.register.single_0));
+                    value.register.single_1 = (Single)(Math.Abs(value.register.single_1));
+                    value.register.single_2 = (Single)(Math.Abs(value.register.single_2));
+                    value.register.single_3 = (Single)(Math.Abs(value.register.single_3));
+                    return value;
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    value.register.double_0 = (Double)(Math.Abs(value.register.double_0));
+                    value.register.double_1 = (Double)(Math.Abs(value.register.double_1));
+                    return value;
+                }
+                else
+                {
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                }
+            }
+        }
+
+        [JitIntrinsic]
+        internal static unsafe Vector<T> Min(Vector<T> left, Vector<T> right)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                if (typeof(T) == typeof(Byte))
+                {
+                    Byte* dataPtr = stackalloc Byte[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? (Byte)(object)left[g] : (Byte)(object)right[g];
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(SByte))
+                {
+                    SByte* dataPtr = stackalloc SByte[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? (SByte)(object)left[g] : (SByte)(object)right[g];
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(UInt16))
+                {
+                    UInt16* dataPtr = stackalloc UInt16[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? (UInt16)(object)left[g] : (UInt16)(object)right[g];
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    Int16* dataPtr = stackalloc Int16[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? (Int16)(object)left[g] : (Int16)(object)right[g];
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(UInt32))
+                {
+                    UInt32* dataPtr = stackalloc UInt32[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? (UInt32)(object)left[g] : (UInt32)(object)right[g];
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    Int32* dataPtr = stackalloc Int32[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? (Int32)(object)left[g] : (Int32)(object)right[g];
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(UInt64))
+                {
+                    UInt64* dataPtr = stackalloc UInt64[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? (UInt64)(object)left[g] : (UInt64)(object)right[g];
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    Int64* dataPtr = stackalloc Int64[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? (Int64)(object)left[g] : (Int64)(object)right[g];
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    Single* dataPtr = stackalloc Single[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? (Single)(object)left[g] : (Single)(object)right[g];
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    Double* dataPtr = stackalloc Double[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? (Double)(object)left[g] : (Double)(object)right[g];
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else
+                {
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                }
+            }
+            else
+            {
+                Vector<T> vec = new Vector<T>();
+                if (typeof(T) == typeof(Byte))
+                {
+                    vec.register.byte_0 = left.register.byte_0 < right.register.byte_0 ? left.register.byte_0 : right.register.byte_0;
+                    vec.register.byte_1 = left.register.byte_1 < right.register.byte_1 ? left.register.byte_1 : right.register.byte_1;
+                    vec.register.byte_2 = left.register.byte_2 < right.register.byte_2 ? left.register.byte_2 : right.register.byte_2;
+                    vec.register.byte_3 = left.register.byte_3 < right.register.byte_3 ? left.register.byte_3 : right.register.byte_3;
+                    vec.register.byte_4 = left.register.byte_4 < right.register.byte_4 ? left.register.byte_4 : right.register.byte_4;
+                    vec.register.byte_5 = left.register.byte_5 < right.register.byte_5 ? left.register.byte_5 : right.register.byte_5;
+                    vec.register.byte_6 = left.register.byte_6 < right.register.byte_6 ? left.register.byte_6 : right.register.byte_6;
+                    vec.register.byte_7 = left.register.byte_7 < right.register.byte_7 ? left.register.byte_7 : right.register.byte_7;
+                    vec.register.byte_8 = left.register.byte_8 < right.register.byte_8 ? left.register.byte_8 : right.register.byte_8;
+                    vec.register.byte_9 = left.register.byte_9 < right.register.byte_9 ? left.register.byte_9 : right.register.byte_9;
+                    vec.register.byte_10 = left.register.byte_10 < right.register.byte_10 ? left.register.byte_10 : right.register.byte_10;
+                    vec.register.byte_11 = left.register.byte_11 < right.register.byte_11 ? left.register.byte_11 : right.register.byte_11;
+                    vec.register.byte_12 = left.register.byte_12 < right.register.byte_12 ? left.register.byte_12 : right.register.byte_12;
+                    vec.register.byte_13 = left.register.byte_13 < right.register.byte_13 ? left.register.byte_13 : right.register.byte_13;
+                    vec.register.byte_14 = left.register.byte_14 < right.register.byte_14 ? left.register.byte_14 : right.register.byte_14;
+                    vec.register.byte_15 = left.register.byte_15 < right.register.byte_15 ? left.register.byte_15 : right.register.byte_15;
+                    return vec;
+                }
+                else if (typeof(T) == typeof(SByte))
+                {
+                    vec.register.sbyte_0 = left.register.sbyte_0 < right.register.sbyte_0 ? left.register.sbyte_0 : right.register.sbyte_0;
+                    vec.register.sbyte_1 = left.register.sbyte_1 < right.register.sbyte_1 ? left.register.sbyte_1 : right.register.sbyte_1;
+                    vec.register.sbyte_2 = left.register.sbyte_2 < right.register.sbyte_2 ? left.register.sbyte_2 : right.register.sbyte_2;
+                    vec.register.sbyte_3 = left.register.sbyte_3 < right.register.sbyte_3 ? left.register.sbyte_3 : right.register.sbyte_3;
+                    vec.register.sbyte_4 = left.register.sbyte_4 < right.register.sbyte_4 ? left.register.sbyte_4 : right.register.sbyte_4;
+                    vec.register.sbyte_5 = left.register.sbyte_5 < right.register.sbyte_5 ? left.register.sbyte_5 : right.register.sbyte_5;
+                    vec.register.sbyte_6 = left.register.sbyte_6 < right.register.sbyte_6 ? left.register.sbyte_6 : right.register.sbyte_6;
+                    vec.register.sbyte_7 = left.register.sbyte_7 < right.register.sbyte_7 ? left.register.sbyte_7 : right.register.sbyte_7;
+                    vec.register.sbyte_8 = left.register.sbyte_8 < right.register.sbyte_8 ? left.register.sbyte_8 : right.register.sbyte_8;
+                    vec.register.sbyte_9 = left.register.sbyte_9 < right.register.sbyte_9 ? left.register.sbyte_9 : right.register.sbyte_9;
+                    vec.register.sbyte_10 = left.register.sbyte_10 < right.register.sbyte_10 ? left.register.sbyte_10 : right.register.sbyte_10;
+                    vec.register.sbyte_11 = left.register.sbyte_11 < right.register.sbyte_11 ? left.register.sbyte_11 : right.register.sbyte_11;
+                    vec.register.sbyte_12 = left.register.sbyte_12 < right.register.sbyte_12 ? left.register.sbyte_12 : right.register.sbyte_12;
+                    vec.register.sbyte_13 = left.register.sbyte_13 < right.register.sbyte_13 ? left.register.sbyte_13 : right.register.sbyte_13;
+                    vec.register.sbyte_14 = left.register.sbyte_14 < right.register.sbyte_14 ? left.register.sbyte_14 : right.register.sbyte_14;
+                    vec.register.sbyte_15 = left.register.sbyte_15 < right.register.sbyte_15 ? left.register.sbyte_15 : right.register.sbyte_15;
+                    return vec;
+                }
+                else if (typeof(T) == typeof(UInt16))
+                {
+                    vec.register.uint16_0 = left.register.uint16_0 < right.register.uint16_0 ? left.register.uint16_0 : right.register.uint16_0;
+                    vec.register.uint16_1 = left.register.uint16_1 < right.register.uint16_1 ? left.register.uint16_1 : right.register.uint16_1;
+                    vec.register.uint16_2 = left.register.uint16_2 < right.register.uint16_2 ? left.register.uint16_2 : right.register.uint16_2;
+                    vec.register.uint16_3 = left.register.uint16_3 < right.register.uint16_3 ? left.register.uint16_3 : right.register.uint16_3;
+                    vec.register.uint16_4 = left.register.uint16_4 < right.register.uint16_4 ? left.register.uint16_4 : right.register.uint16_4;
+                    vec.register.uint16_5 = left.register.uint16_5 < right.register.uint16_5 ? left.register.uint16_5 : right.register.uint16_5;
+                    vec.register.uint16_6 = left.register.uint16_6 < right.register.uint16_6 ? left.register.uint16_6 : right.register.uint16_6;
+                    vec.register.uint16_7 = left.register.uint16_7 < right.register.uint16_7 ? left.register.uint16_7 : right.register.uint16_7;
+                    return vec;
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    vec.register.int16_0 = left.register.int16_0 < right.register.int16_0 ? left.register.int16_0 : right.register.int16_0;
+                    vec.register.int16_1 = left.register.int16_1 < right.register.int16_1 ? left.register.int16_1 : right.register.int16_1;
+                    vec.register.int16_2 = left.register.int16_2 < right.register.int16_2 ? left.register.int16_2 : right.register.int16_2;
+                    vec.register.int16_3 = left.register.int16_3 < right.register.int16_3 ? left.register.int16_3 : right.register.int16_3;
+                    vec.register.int16_4 = left.register.int16_4 < right.register.int16_4 ? left.register.int16_4 : right.register.int16_4;
+                    vec.register.int16_5 = left.register.int16_5 < right.register.int16_5 ? left.register.int16_5 : right.register.int16_5;
+                    vec.register.int16_6 = left.register.int16_6 < right.register.int16_6 ? left.register.int16_6 : right.register.int16_6;
+                    vec.register.int16_7 = left.register.int16_7 < right.register.int16_7 ? left.register.int16_7 : right.register.int16_7;
+                    return vec;
+                }
+                else if (typeof(T) == typeof(UInt32))
+                {
+                    vec.register.uint32_0 = left.register.uint32_0 < right.register.uint32_0 ? left.register.uint32_0 : right.register.uint32_0;
+                    vec.register.uint32_1 = left.register.uint32_1 < right.register.uint32_1 ? left.register.uint32_1 : right.register.uint32_1;
+                    vec.register.uint32_2 = left.register.uint32_2 < right.register.uint32_2 ? left.register.uint32_2 : right.register.uint32_2;
+                    vec.register.uint32_3 = left.register.uint32_3 < right.register.uint32_3 ? left.register.uint32_3 : right.register.uint32_3;
+                    return vec;
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    vec.register.int32_0 = left.register.int32_0 < right.register.int32_0 ? left.register.int32_0 : right.register.int32_0;
+                    vec.register.int32_1 = left.register.int32_1 < right.register.int32_1 ? left.register.int32_1 : right.register.int32_1;
+                    vec.register.int32_2 = left.register.int32_2 < right.register.int32_2 ? left.register.int32_2 : right.register.int32_2;
+                    vec.register.int32_3 = left.register.int32_3 < right.register.int32_3 ? left.register.int32_3 : right.register.int32_3;
+                    return vec;
+                }
+                else if (typeof(T) == typeof(UInt64))
+                {
+                    vec.register.uint64_0 = left.register.uint64_0 < right.register.uint64_0 ? left.register.uint64_0 : right.register.uint64_0;
+                    vec.register.uint64_1 = left.register.uint64_1 < right.register.uint64_1 ? left.register.uint64_1 : right.register.uint64_1;
+                    return vec;
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    vec.register.int64_0 = left.register.int64_0 < right.register.int64_0 ? left.register.int64_0 : right.register.int64_0;
+                    vec.register.int64_1 = left.register.int64_1 < right.register.int64_1 ? left.register.int64_1 : right.register.int64_1;
+                    return vec;
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    vec.register.single_0 = left.register.single_0 < right.register.single_0 ? left.register.single_0 : right.register.single_0;
+                    vec.register.single_1 = left.register.single_1 < right.register.single_1 ? left.register.single_1 : right.register.single_1;
+                    vec.register.single_2 = left.register.single_2 < right.register.single_2 ? left.register.single_2 : right.register.single_2;
+                    vec.register.single_3 = left.register.single_3 < right.register.single_3 ? left.register.single_3 : right.register.single_3;
+                    return vec;
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    vec.register.double_0 = left.register.double_0 < right.register.double_0 ? left.register.double_0 : right.register.double_0;
+                    vec.register.double_1 = left.register.double_1 < right.register.double_1 ? left.register.double_1 : right.register.double_1;
+                    return vec;
+                }
+                else
+                {
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                }
+            }
+        }
+
+        [JitIntrinsic]
+        internal static unsafe Vector<T> Max(Vector<T> left, Vector<T> right)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                if (typeof(T) == typeof(Byte))
+                {
+                    Byte* dataPtr = stackalloc Byte[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? (Byte)(object)left[g] : (Byte)(object)right[g];
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(SByte))
+                {
+                    SByte* dataPtr = stackalloc SByte[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? (SByte)(object)left[g] : (SByte)(object)right[g];
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(UInt16))
+                {
+                    UInt16* dataPtr = stackalloc UInt16[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? (UInt16)(object)left[g] : (UInt16)(object)right[g];
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    Int16* dataPtr = stackalloc Int16[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? (Int16)(object)left[g] : (Int16)(object)right[g];
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(UInt32))
+                {
+                    UInt32* dataPtr = stackalloc UInt32[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? (UInt32)(object)left[g] : (UInt32)(object)right[g];
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    Int32* dataPtr = stackalloc Int32[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? (Int32)(object)left[g] : (Int32)(object)right[g];
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(UInt64))
+                {
+                    UInt64* dataPtr = stackalloc UInt64[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? (UInt64)(object)left[g] : (UInt64)(object)right[g];
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    Int64* dataPtr = stackalloc Int64[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? (Int64)(object)left[g] : (Int64)(object)right[g];
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    Single* dataPtr = stackalloc Single[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? (Single)(object)left[g] : (Single)(object)right[g];
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    Double* dataPtr = stackalloc Double[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? (Double)(object)left[g] : (Double)(object)right[g];
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else
+                {
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                }
+            }
+            else
+            {
+                Vector<T> vec = new Vector<T>();
+                if (typeof(T) == typeof(Byte))
+                {
+                    vec.register.byte_0 = left.register.byte_0 > right.register.byte_0 ? left.register.byte_0 : right.register.byte_0;
+                    vec.register.byte_1 = left.register.byte_1 > right.register.byte_1 ? left.register.byte_1 : right.register.byte_1;
+                    vec.register.byte_2 = left.register.byte_2 > right.register.byte_2 ? left.register.byte_2 : right.register.byte_2;
+                    vec.register.byte_3 = left.register.byte_3 > right.register.byte_3 ? left.register.byte_3 : right.register.byte_3;
+                    vec.register.byte_4 = left.register.byte_4 > right.register.byte_4 ? left.register.byte_4 : right.register.byte_4;
+                    vec.register.byte_5 = left.register.byte_5 > right.register.byte_5 ? left.register.byte_5 : right.register.byte_5;
+                    vec.register.byte_6 = left.register.byte_6 > right.register.byte_6 ? left.register.byte_6 : right.register.byte_6;
+                    vec.register.byte_7 = left.register.byte_7 > right.register.byte_7 ? left.register.byte_7 : right.register.byte_7;
+                    vec.register.byte_8 = left.register.byte_8 > right.register.byte_8 ? left.register.byte_8 : right.register.byte_8;
+                    vec.register.byte_9 = left.register.byte_9 > right.register.byte_9 ? left.register.byte_9 : right.register.byte_9;
+                    vec.register.byte_10 = left.register.byte_10 > right.register.byte_10 ? left.register.byte_10 : right.register.byte_10;
+                    vec.register.byte_11 = left.register.byte_11 > right.register.byte_11 ? left.register.byte_11 : right.register.byte_11;
+                    vec.register.byte_12 = left.register.byte_12 > right.register.byte_12 ? left.register.byte_12 : right.register.byte_12;
+                    vec.register.byte_13 = left.register.byte_13 > right.register.byte_13 ? left.register.byte_13 : right.register.byte_13;
+                    vec.register.byte_14 = left.register.byte_14 > right.register.byte_14 ? left.register.byte_14 : right.register.byte_14;
+                    vec.register.byte_15 = left.register.byte_15 > right.register.byte_15 ? left.register.byte_15 : right.register.byte_15;
+                    return vec;
+                }
+                else if (typeof(T) == typeof(SByte))
+                {
+                    vec.register.sbyte_0 = left.register.sbyte_0 > right.register.sbyte_0 ? left.register.sbyte_0 : right.register.sbyte_0;
+                    vec.register.sbyte_1 = left.register.sbyte_1 > right.register.sbyte_1 ? left.register.sbyte_1 : right.register.sbyte_1;
+                    vec.register.sbyte_2 = left.register.sbyte_2 > right.register.sbyte_2 ? left.register.sbyte_2 : right.register.sbyte_2;
+                    vec.register.sbyte_3 = left.register.sbyte_3 > right.register.sbyte_3 ? left.register.sbyte_3 : right.register.sbyte_3;
+                    vec.register.sbyte_4 = left.register.sbyte_4 > right.register.sbyte_4 ? left.register.sbyte_4 : right.register.sbyte_4;
+                    vec.register.sbyte_5 = left.register.sbyte_5 > right.register.sbyte_5 ? left.register.sbyte_5 : right.register.sbyte_5;
+                    vec.register.sbyte_6 = left.register.sbyte_6 > right.register.sbyte_6 ? left.register.sbyte_6 : right.register.sbyte_6;
+                    vec.register.sbyte_7 = left.register.sbyte_7 > right.register.sbyte_7 ? left.register.sbyte_7 : right.register.sbyte_7;
+                    vec.register.sbyte_8 = left.register.sbyte_8 > right.register.sbyte_8 ? left.register.sbyte_8 : right.register.sbyte_8;
+                    vec.register.sbyte_9 = left.register.sbyte_9 > right.register.sbyte_9 ? left.register.sbyte_9 : right.register.sbyte_9;
+                    vec.register.sbyte_10 = left.register.sbyte_10 > right.register.sbyte_10 ? left.register.sbyte_10 : right.register.sbyte_10;
+                    vec.register.sbyte_11 = left.register.sbyte_11 > right.register.sbyte_11 ? left.register.sbyte_11 : right.register.sbyte_11;
+                    vec.register.sbyte_12 = left.register.sbyte_12 > right.register.sbyte_12 ? left.register.sbyte_12 : right.register.sbyte_12;
+                    vec.register.sbyte_13 = left.register.sbyte_13 > right.register.sbyte_13 ? left.register.sbyte_13 : right.register.sbyte_13;
+                    vec.register.sbyte_14 = left.register.sbyte_14 > right.register.sbyte_14 ? left.register.sbyte_14 : right.register.sbyte_14;
+                    vec.register.sbyte_15 = left.register.sbyte_15 > right.register.sbyte_15 ? left.register.sbyte_15 : right.register.sbyte_15;
+                    return vec;
+                }
+                else if (typeof(T) == typeof(UInt16))
+                {
+                    vec.register.uint16_0 = left.register.uint16_0 > right.register.uint16_0 ? left.register.uint16_0 : right.register.uint16_0;
+                    vec.register.uint16_1 = left.register.uint16_1 > right.register.uint16_1 ? left.register.uint16_1 : right.register.uint16_1;
+                    vec.register.uint16_2 = left.register.uint16_2 > right.register.uint16_2 ? left.register.uint16_2 : right.register.uint16_2;
+                    vec.register.uint16_3 = left.register.uint16_3 > right.register.uint16_3 ? left.register.uint16_3 : right.register.uint16_3;
+                    vec.register.uint16_4 = left.register.uint16_4 > right.register.uint16_4 ? left.register.uint16_4 : right.register.uint16_4;
+                    vec.register.uint16_5 = left.register.uint16_5 > right.register.uint16_5 ? left.register.uint16_5 : right.register.uint16_5;
+                    vec.register.uint16_6 = left.register.uint16_6 > right.register.uint16_6 ? left.register.uint16_6 : right.register.uint16_6;
+                    vec.register.uint16_7 = left.register.uint16_7 > right.register.uint16_7 ? left.register.uint16_7 : right.register.uint16_7;
+                    return vec;
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    vec.register.int16_0 = left.register.int16_0 > right.register.int16_0 ? left.register.int16_0 : right.register.int16_0;
+                    vec.register.int16_1 = left.register.int16_1 > right.register.int16_1 ? left.register.int16_1 : right.register.int16_1;
+                    vec.register.int16_2 = left.register.int16_2 > right.register.int16_2 ? left.register.int16_2 : right.register.int16_2;
+                    vec.register.int16_3 = left.register.int16_3 > right.register.int16_3 ? left.register.int16_3 : right.register.int16_3;
+                    vec.register.int16_4 = left.register.int16_4 > right.register.int16_4 ? left.register.int16_4 : right.register.int16_4;
+                    vec.register.int16_5 = left.register.int16_5 > right.register.int16_5 ? left.register.int16_5 : right.register.int16_5;
+                    vec.register.int16_6 = left.register.int16_6 > right.register.int16_6 ? left.register.int16_6 : right.register.int16_6;
+                    vec.register.int16_7 = left.register.int16_7 > right.register.int16_7 ? left.register.int16_7 : right.register.int16_7;
+                    return vec;
+                }
+                else if (typeof(T) == typeof(UInt32))
+                {
+                    vec.register.uint32_0 = left.register.uint32_0 > right.register.uint32_0 ? left.register.uint32_0 : right.register.uint32_0;
+                    vec.register.uint32_1 = left.register.uint32_1 > right.register.uint32_1 ? left.register.uint32_1 : right.register.uint32_1;
+                    vec.register.uint32_2 = left.register.uint32_2 > right.register.uint32_2 ? left.register.uint32_2 : right.register.uint32_2;
+                    vec.register.uint32_3 = left.register.uint32_3 > right.register.uint32_3 ? left.register.uint32_3 : right.register.uint32_3;
+                    return vec;
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    vec.register.int32_0 = left.register.int32_0 > right.register.int32_0 ? left.register.int32_0 : right.register.int32_0;
+                    vec.register.int32_1 = left.register.int32_1 > right.register.int32_1 ? left.register.int32_1 : right.register.int32_1;
+                    vec.register.int32_2 = left.register.int32_2 > right.register.int32_2 ? left.register.int32_2 : right.register.int32_2;
+                    vec.register.int32_3 = left.register.int32_3 > right.register.int32_3 ? left.register.int32_3 : right.register.int32_3;
+                    return vec;
+                }
+                else if (typeof(T) == typeof(UInt64))
+                {
+                    vec.register.uint64_0 = left.register.uint64_0 > right.register.uint64_0 ? left.register.uint64_0 : right.register.uint64_0;
+                    vec.register.uint64_1 = left.register.uint64_1 > right.register.uint64_1 ? left.register.uint64_1 : right.register.uint64_1;
+                    return vec;
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    vec.register.int64_0 = left.register.int64_0 > right.register.int64_0 ? left.register.int64_0 : right.register.int64_0;
+                    vec.register.int64_1 = left.register.int64_1 > right.register.int64_1 ? left.register.int64_1 : right.register.int64_1;
+                    return vec;
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    vec.register.single_0 = left.register.single_0 > right.register.single_0 ? left.register.single_0 : right.register.single_0;
+                    vec.register.single_1 = left.register.single_1 > right.register.single_1 ? left.register.single_1 : right.register.single_1;
+                    vec.register.single_2 = left.register.single_2 > right.register.single_2 ? left.register.single_2 : right.register.single_2;
+                    vec.register.single_3 = left.register.single_3 > right.register.single_3 ? left.register.single_3 : right.register.single_3;
+                    return vec;
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    vec.register.double_0 = left.register.double_0 > right.register.double_0 ? left.register.double_0 : right.register.double_0;
+                    vec.register.double_1 = left.register.double_1 > right.register.double_1 ? left.register.double_1 : right.register.double_1;
+                    return vec;
+                }
+                else
+                {
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                }
+            }
+        }
+
+        [JitIntrinsic]
+        internal static T DotProduct(Vector<T> left, Vector<T> right)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                T product = GetZeroValue();
+                for (int g = 0; g < Count; g++)
+                {
+                    product = ScalarAdd(product, ScalarMultiply(left[g], right[g]));
+                }
+                return product;
+            }
+            else
+            {
+                if (typeof(T) == typeof(Byte))
+                {
+                    Byte product = 0;
+                    product += (Byte)(left.register.byte_0 * right.register.byte_0);
+                    product += (Byte)(left.register.byte_1 * right.register.byte_1);
+                    product += (Byte)(left.register.byte_2 * right.register.byte_2);
+                    product += (Byte)(left.register.byte_3 * right.register.byte_3);
+                    product += (Byte)(left.register.byte_4 * right.register.byte_4);
+                    product += (Byte)(left.register.byte_5 * right.register.byte_5);
+                    product += (Byte)(left.register.byte_6 * right.register.byte_6);
+                    product += (Byte)(left.register.byte_7 * right.register.byte_7);
+                    product += (Byte)(left.register.byte_8 * right.register.byte_8);
+                    product += (Byte)(left.register.byte_9 * right.register.byte_9);
+                    product += (Byte)(left.register.byte_10 * right.register.byte_10);
+                    product += (Byte)(left.register.byte_11 * right.register.byte_11);
+                    product += (Byte)(left.register.byte_12 * right.register.byte_12);
+                    product += (Byte)(left.register.byte_13 * right.register.byte_13);
+                    product += (Byte)(left.register.byte_14 * right.register.byte_14);
+                    product += (Byte)(left.register.byte_15 * right.register.byte_15);
+                    return (T)(object)product;
+                }
+                else if (typeof(T) == typeof(SByte))
+                {
+                    SByte product = 0;
+                    product += (SByte)(left.register.sbyte_0 * right.register.sbyte_0);
+                    product += (SByte)(left.register.sbyte_1 * right.register.sbyte_1);
+                    product += (SByte)(left.register.sbyte_2 * right.register.sbyte_2);
+                    product += (SByte)(left.register.sbyte_3 * right.register.sbyte_3);
+                    product += (SByte)(left.register.sbyte_4 * right.register.sbyte_4);
+                    product += (SByte)(left.register.sbyte_5 * right.register.sbyte_5);
+                    product += (SByte)(left.register.sbyte_6 * right.register.sbyte_6);
+                    product += (SByte)(left.register.sbyte_7 * right.register.sbyte_7);
+                    product += (SByte)(left.register.sbyte_8 * right.register.sbyte_8);
+                    product += (SByte)(left.register.sbyte_9 * right.register.sbyte_9);
+                    product += (SByte)(left.register.sbyte_10 * right.register.sbyte_10);
+                    product += (SByte)(left.register.sbyte_11 * right.register.sbyte_11);
+                    product += (SByte)(left.register.sbyte_12 * right.register.sbyte_12);
+                    product += (SByte)(left.register.sbyte_13 * right.register.sbyte_13);
+                    product += (SByte)(left.register.sbyte_14 * right.register.sbyte_14);
+                    product += (SByte)(left.register.sbyte_15 * right.register.sbyte_15);
+                    return (T)(object)product;
+                }
+                else if (typeof(T) == typeof(UInt16))
+                {
+                    UInt16 product = 0;
+                    product += (UInt16)(left.register.uint16_0 * right.register.uint16_0);
+                    product += (UInt16)(left.register.uint16_1 * right.register.uint16_1);
+                    product += (UInt16)(left.register.uint16_2 * right.register.uint16_2);
+                    product += (UInt16)(left.register.uint16_3 * right.register.uint16_3);
+                    product += (UInt16)(left.register.uint16_4 * right.register.uint16_4);
+                    product += (UInt16)(left.register.uint16_5 * right.register.uint16_5);
+                    product += (UInt16)(left.register.uint16_6 * right.register.uint16_6);
+                    product += (UInt16)(left.register.uint16_7 * right.register.uint16_7);
+                    return (T)(object)product;
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    Int16 product = 0;
+                    product += (Int16)(left.register.int16_0 * right.register.int16_0);
+                    product += (Int16)(left.register.int16_1 * right.register.int16_1);
+                    product += (Int16)(left.register.int16_2 * right.register.int16_2);
+                    product += (Int16)(left.register.int16_3 * right.register.int16_3);
+                    product += (Int16)(left.register.int16_4 * right.register.int16_4);
+                    product += (Int16)(left.register.int16_5 * right.register.int16_5);
+                    product += (Int16)(left.register.int16_6 * right.register.int16_6);
+                    product += (Int16)(left.register.int16_7 * right.register.int16_7);
+                    return (T)(object)product;
+                }
+                else if (typeof(T) == typeof(UInt32))
+                {
+                    UInt32 product = 0;
+                    product += (UInt32)(left.register.uint32_0 * right.register.uint32_0);
+                    product += (UInt32)(left.register.uint32_1 * right.register.uint32_1);
+                    product += (UInt32)(left.register.uint32_2 * right.register.uint32_2);
+                    product += (UInt32)(left.register.uint32_3 * right.register.uint32_3);
+                    return (T)(object)product;
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    Int32 product = 0;
+                    product += (Int32)(left.register.int32_0 * right.register.int32_0);
+                    product += (Int32)(left.register.int32_1 * right.register.int32_1);
+                    product += (Int32)(left.register.int32_2 * right.register.int32_2);
+                    product += (Int32)(left.register.int32_3 * right.register.int32_3);
+                    return (T)(object)product;
+                }
+                else if (typeof(T) == typeof(UInt64))
+                {
+                    UInt64 product = 0;
+                    product += (UInt64)(left.register.uint64_0 * right.register.uint64_0);
+                    product += (UInt64)(left.register.uint64_1 * right.register.uint64_1);
+                    return (T)(object)product;
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    Int64 product = 0;
+                    product += (Int64)(left.register.int64_0 * right.register.int64_0);
+                    product += (Int64)(left.register.int64_1 * right.register.int64_1);
+                    return (T)(object)product;
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    Single product = 0;
+                    product += (Single)(left.register.single_0 * right.register.single_0);
+                    product += (Single)(left.register.single_1 * right.register.single_1);
+                    product += (Single)(left.register.single_2 * right.register.single_2);
+                    product += (Single)(left.register.single_3 * right.register.single_3);
+                    return (T)(object)product;
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    Double product = 0;
+                    product += (Double)(left.register.double_0 * right.register.double_0);
+                    product += (Double)(left.register.double_1 * right.register.double_1);
+                    return (T)(object)product;
+                }
+                else
+                {
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                }
+            }
+        }
+
+        [JitIntrinsic]
+        internal static unsafe Vector<T> SquareRoot(Vector<T> value)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                if (typeof(T) == typeof(Byte))
+                {
+                    Byte* dataPtr = stackalloc Byte[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = unchecked((Byte)Math.Sqrt((Byte)(object)value[g]));
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(SByte))
+                {
+                    SByte* dataPtr = stackalloc SByte[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = unchecked((SByte)Math.Sqrt((SByte)(object)value[g]));
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(UInt16))
+                {
+                    UInt16* dataPtr = stackalloc UInt16[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = unchecked((UInt16)Math.Sqrt((UInt16)(object)value[g]));
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    Int16* dataPtr = stackalloc Int16[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = unchecked((Int16)Math.Sqrt((Int16)(object)value[g]));
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(UInt32))
+                {
+                    UInt32* dataPtr = stackalloc UInt32[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = unchecked((UInt32)Math.Sqrt((UInt32)(object)value[g]));
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    Int32* dataPtr = stackalloc Int32[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = unchecked((Int32)Math.Sqrt((Int32)(object)value[g]));
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(UInt64))
+                {
+                    UInt64* dataPtr = stackalloc UInt64[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = unchecked((UInt64)Math.Sqrt((UInt64)(object)value[g]));
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    Int64* dataPtr = stackalloc Int64[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = unchecked((Int64)Math.Sqrt((Int64)(object)value[g]));
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    Single* dataPtr = stackalloc Single[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = unchecked((Single)Math.Sqrt((Single)(object)value[g]));
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    Double* dataPtr = stackalloc Double[Count];
+                    for (int g = 0; g < Count; g++)
+                    {
+                        dataPtr[g] = unchecked((Double)Math.Sqrt((Double)(object)value[g]));
+                    }
+                    return new Vector<T>(dataPtr);
+                }
+                else
+                {
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                }
+            }
+            else
+            {
+                if (typeof(T) == typeof(Byte))
+                {
+                    value.register.byte_0 = (Byte)Math.Sqrt(value.register.byte_0);
+                    value.register.byte_1 = (Byte)Math.Sqrt(value.register.byte_1);
+                    value.register.byte_2 = (Byte)Math.Sqrt(value.register.byte_2);
+                    value.register.byte_3 = (Byte)Math.Sqrt(value.register.byte_3);
+                    value.register.byte_4 = (Byte)Math.Sqrt(value.register.byte_4);
+                    value.register.byte_5 = (Byte)Math.Sqrt(value.register.byte_5);
+                    value.register.byte_6 = (Byte)Math.Sqrt(value.register.byte_6);
+                    value.register.byte_7 = (Byte)Math.Sqrt(value.register.byte_7);
+                    value.register.byte_8 = (Byte)Math.Sqrt(value.register.byte_8);
+                    value.register.byte_9 = (Byte)Math.Sqrt(value.register.byte_9);
+                    value.register.byte_10 = (Byte)Math.Sqrt(value.register.byte_10);
+                    value.register.byte_11 = (Byte)Math.Sqrt(value.register.byte_11);
+                    value.register.byte_12 = (Byte)Math.Sqrt(value.register.byte_12);
+                    value.register.byte_13 = (Byte)Math.Sqrt(value.register.byte_13);
+                    value.register.byte_14 = (Byte)Math.Sqrt(value.register.byte_14);
+                    value.register.byte_15 = (Byte)Math.Sqrt(value.register.byte_15);
+                    return value;
+                }
+                else if (typeof(T) == typeof(SByte))
+                {
+                    value.register.sbyte_0 = (SByte)Math.Sqrt(value.register.sbyte_0);
+                    value.register.sbyte_1 = (SByte)Math.Sqrt(value.register.sbyte_1);
+                    value.register.sbyte_2 = (SByte)Math.Sqrt(value.register.sbyte_2);
+                    value.register.sbyte_3 = (SByte)Math.Sqrt(value.register.sbyte_3);
+                    value.register.sbyte_4 = (SByte)Math.Sqrt(value.register.sbyte_4);
+                    value.register.sbyte_5 = (SByte)Math.Sqrt(value.register.sbyte_5);
+                    value.register.sbyte_6 = (SByte)Math.Sqrt(value.register.sbyte_6);
+                    value.register.sbyte_7 = (SByte)Math.Sqrt(value.register.sbyte_7);
+                    value.register.sbyte_8 = (SByte)Math.Sqrt(value.register.sbyte_8);
+                    value.register.sbyte_9 = (SByte)Math.Sqrt(value.register.sbyte_9);
+                    value.register.sbyte_10 = (SByte)Math.Sqrt(value.register.sbyte_10);
+                    value.register.sbyte_11 = (SByte)Math.Sqrt(value.register.sbyte_11);
+                    value.register.sbyte_12 = (SByte)Math.Sqrt(value.register.sbyte_12);
+                    value.register.sbyte_13 = (SByte)Math.Sqrt(value.register.sbyte_13);
+                    value.register.sbyte_14 = (SByte)Math.Sqrt(value.register.sbyte_14);
+                    value.register.sbyte_15 = (SByte)Math.Sqrt(value.register.sbyte_15);
+                    return value;
+                }
+                else if (typeof(T) == typeof(UInt16))
+                {
+                    value.register.uint16_0 = (UInt16)Math.Sqrt(value.register.uint16_0);
+                    value.register.uint16_1 = (UInt16)Math.Sqrt(value.register.uint16_1);
+                    value.register.uint16_2 = (UInt16)Math.Sqrt(value.register.uint16_2);
+                    value.register.uint16_3 = (UInt16)Math.Sqrt(value.register.uint16_3);
+                    value.register.uint16_4 = (UInt16)Math.Sqrt(value.register.uint16_4);
+                    value.register.uint16_5 = (UInt16)Math.Sqrt(value.register.uint16_5);
+                    value.register.uint16_6 = (UInt16)Math.Sqrt(value.register.uint16_6);
+                    value.register.uint16_7 = (UInt16)Math.Sqrt(value.register.uint16_7);
+                    return value;
+                }
+                else if (typeof(T) == typeof(Int16))
+                {
+                    value.register.int16_0 = (Int16)Math.Sqrt(value.register.int16_0);
+                    value.register.int16_1 = (Int16)Math.Sqrt(value.register.int16_1);
+                    value.register.int16_2 = (Int16)Math.Sqrt(value.register.int16_2);
+                    value.register.int16_3 = (Int16)Math.Sqrt(value.register.int16_3);
+                    value.register.int16_4 = (Int16)Math.Sqrt(value.register.int16_4);
+                    value.register.int16_5 = (Int16)Math.Sqrt(value.register.int16_5);
+                    value.register.int16_6 = (Int16)Math.Sqrt(value.register.int16_6);
+                    value.register.int16_7 = (Int16)Math.Sqrt(value.register.int16_7);
+                    return value;
+                }
+                else if (typeof(T) == typeof(UInt32))
+                {
+                    value.register.uint32_0 = (UInt32)Math.Sqrt(value.register.uint32_0);
+                    value.register.uint32_1 = (UInt32)Math.Sqrt(value.register.uint32_1);
+                    value.register.uint32_2 = (UInt32)Math.Sqrt(value.register.uint32_2);
+                    value.register.uint32_3 = (UInt32)Math.Sqrt(value.register.uint32_3);
+                    return value;
+                }
+                else if (typeof(T) == typeof(Int32))
+                {
+                    value.register.int32_0 = (Int32)Math.Sqrt(value.register.int32_0);
+                    value.register.int32_1 = (Int32)Math.Sqrt(value.register.int32_1);
+                    value.register.int32_2 = (Int32)Math.Sqrt(value.register.int32_2);
+                    value.register.int32_3 = (Int32)Math.Sqrt(value.register.int32_3);
+                    return value;
+                }
+                else if (typeof(T) == typeof(UInt64))
+                {
+                    value.register.uint64_0 = (UInt64)Math.Sqrt(value.register.uint64_0);
+                    value.register.uint64_1 = (UInt64)Math.Sqrt(value.register.uint64_1);
+                    return value;
+                }
+                else if (typeof(T) == typeof(Int64))
+                {
+                    value.register.int64_0 = (Int64)Math.Sqrt(value.register.int64_0);
+                    value.register.int64_1 = (Int64)Math.Sqrt(value.register.int64_1);
+                    return value;
+                }
+                else if (typeof(T) == typeof(Single))
+                {
+                    value.register.single_0 = (Single)Math.Sqrt(value.register.single_0);
+                    value.register.single_1 = (Single)Math.Sqrt(value.register.single_1);
+                    value.register.single_2 = (Single)Math.Sqrt(value.register.single_2);
+                    value.register.single_3 = (Single)Math.Sqrt(value.register.single_3);
+                    return value;
+                }
+                else if (typeof(T) == typeof(Double))
+                {
+                    value.register.double_0 = (Double)Math.Sqrt(value.register.double_0);
+                    value.register.double_1 = (Double)Math.Sqrt(value.register.double_1);
+                    return value;
+                }
+                else
+                {
+                    throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                }
+            }
+        }
+        #endregion Internal Math Methods
+
+        #region Helper Methods
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        private static bool ScalarEquals(T left, T right)
+        {
+            if (typeof(T) == typeof(Byte))
+            {
+                return (Byte)(object)left == (Byte)(object)right;
+            }
+            else if (typeof(T) == typeof(SByte))
+            {
+                return (SByte)(object)left == (SByte)(object)right;
+            }
+            else if (typeof(T) == typeof(UInt16))
+            {
+                return (UInt16)(object)left == (UInt16)(object)right;
+            }
+            else if (typeof(T) == typeof(Int16))
+            {
+                return (Int16)(object)left == (Int16)(object)right;
+            }
+            else if (typeof(T) == typeof(UInt32))
+            {
+                return (UInt32)(object)left == (UInt32)(object)right;
+            }
+            else if (typeof(T) == typeof(Int32))
+            {
+                return (Int32)(object)left == (Int32)(object)right;
+            }
+            else if (typeof(T) == typeof(UInt64))
+            {
+                return (UInt64)(object)left == (UInt64)(object)right;
+            }
+            else if (typeof(T) == typeof(Int64))
+            {
+                return (Int64)(object)left == (Int64)(object)right;
+            }
+            else if (typeof(T) == typeof(Single))
+            {
+                return (Single)(object)left == (Single)(object)right;
+            }
+            else if (typeof(T) == typeof(Double))
+            {
+                return (Double)(object)left == (Double)(object)right;
+            }
+            else
+            {
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
+            }
+        }
+
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        private static bool ScalarLessThan(T left, T right)
+        {
+            if (typeof(T) == typeof(Byte))
+            {
+                return (Byte)(object)left < (Byte)(object)right;
+            }
+            else if (typeof(T) == typeof(SByte))
+            {
+                return (SByte)(object)left < (SByte)(object)right;
+            }
+            else if (typeof(T) == typeof(UInt16))
+            {
+                return (UInt16)(object)left < (UInt16)(object)right;
+            }
+            else if (typeof(T) == typeof(Int16))
+            {
+                return (Int16)(object)left < (Int16)(object)right;
+            }
+            else if (typeof(T) == typeof(UInt32))
+            {
+                return (UInt32)(object)left < (UInt32)(object)right;
+            }
+            else if (typeof(T) == typeof(Int32))
+            {
+                return (Int32)(object)left < (Int32)(object)right;
+            }
+            else if (typeof(T) == typeof(UInt64))
+            {
+                return (UInt64)(object)left < (UInt64)(object)right;
+            }
+            else if (typeof(T) == typeof(Int64))
+            {
+                return (Int64)(object)left < (Int64)(object)right;
+            }
+            else if (typeof(T) == typeof(Single))
+            {
+                return (Single)(object)left < (Single)(object)right;
+            }
+            else if (typeof(T) == typeof(Double))
+            {
+                return (Double)(object)left < (Double)(object)right;
+            }
+            else
+            {
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
+            }
+        }
+
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        private static bool ScalarGreaterThan(T left, T right)
+        {
+            if (typeof(T) == typeof(Byte))
+            {
+                return (Byte)(object)left > (Byte)(object)right;
+            }
+            else if (typeof(T) == typeof(SByte))
+            {
+                return (SByte)(object)left > (SByte)(object)right;
+            }
+            else if (typeof(T) == typeof(UInt16))
+            {
+                return (UInt16)(object)left > (UInt16)(object)right;
+            }
+            else if (typeof(T) == typeof(Int16))
+            {
+                return (Int16)(object)left > (Int16)(object)right;
+            }
+            else if (typeof(T) == typeof(UInt32))
+            {
+                return (UInt32)(object)left > (UInt32)(object)right;
+            }
+            else if (typeof(T) == typeof(Int32))
+            {
+                return (Int32)(object)left > (Int32)(object)right;
+            }
+            else if (typeof(T) == typeof(UInt64))
+            {
+                return (UInt64)(object)left > (UInt64)(object)right;
+            }
+            else if (typeof(T) == typeof(Int64))
+            {
+                return (Int64)(object)left > (Int64)(object)right;
+            }
+            else if (typeof(T) == typeof(Single))
+            {
+                return (Single)(object)left > (Single)(object)right;
+            }
+            else if (typeof(T) == typeof(Double))
+            {
+                return (Double)(object)left > (Double)(object)right;
+            }
+            else
+            {
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
+            }
+        }
+
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        private static T ScalarAdd(T left, T right)
+        {
+            if (typeof(T) == typeof(Byte))
+            {
+                return (T)(object)unchecked((Byte)((Byte)(object)left + (Byte)(object)right));
+            }
+            else if (typeof(T) == typeof(SByte))
+            {
+                return (T)(object)unchecked((SByte)((SByte)(object)left + (SByte)(object)right));
+            }
+            else if (typeof(T) == typeof(UInt16))
+            {
+                return (T)(object)unchecked((UInt16)((UInt16)(object)left + (UInt16)(object)right));
+            }
+            else if (typeof(T) == typeof(Int16))
+            {
+                return (T)(object)unchecked((Int16)((Int16)(object)left + (Int16)(object)right));
+            }
+            else if (typeof(T) == typeof(UInt32))
+            {
+                return (T)(object)unchecked((UInt32)((UInt32)(object)left + (UInt32)(object)right));
+            }
+            else if (typeof(T) == typeof(Int32))
+            {
+                return (T)(object)unchecked((Int32)((Int32)(object)left + (Int32)(object)right));
+            }
+            else if (typeof(T) == typeof(UInt64))
+            {
+                return (T)(object)unchecked((UInt64)((UInt64)(object)left + (UInt64)(object)right));
+            }
+            else if (typeof(T) == typeof(Int64))
+            {
+                return (T)(object)unchecked((Int64)((Int64)(object)left + (Int64)(object)right));
+            }
+            else if (typeof(T) == typeof(Single))
+            {
+                return (T)(object)unchecked((Single)((Single)(object)left + (Single)(object)right));
+            }
+            else if (typeof(T) == typeof(Double))
+            {
+                return (T)(object)unchecked((Double)((Double)(object)left + (Double)(object)right));
+            }
+            else
+            {
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
+            }
+        }
+
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        private static T ScalarSubtract(T left, T right)
+        {
+            if (typeof(T) == typeof(Byte))
+            {
+                return (T)(object)(Byte)((Byte)(object)left - (Byte)(object)right);
+            }
+            else if (typeof(T) == typeof(SByte))
+            {
+                return (T)(object)(SByte)((SByte)(object)left - (SByte)(object)right);
+            }
+            else if (typeof(T) == typeof(UInt16))
+            {
+                return (T)(object)(UInt16)((UInt16)(object)left - (UInt16)(object)right);
+            }
+            else if (typeof(T) == typeof(Int16))
+            {
+                return (T)(object)(Int16)((Int16)(object)left - (Int16)(object)right);
+            }
+            else if (typeof(T) == typeof(UInt32))
+            {
+                return (T)(object)(UInt32)((UInt32)(object)left - (UInt32)(object)right);
+            }
+            else if (typeof(T) == typeof(Int32))
+            {
+                return (T)(object)(Int32)((Int32)(object)left - (Int32)(object)right);
+            }
+            else if (typeof(T) == typeof(UInt64))
+            {
+                return (T)(object)(UInt64)((UInt64)(object)left - (UInt64)(object)right);
+            }
+            else if (typeof(T) == typeof(Int64))
+            {
+                return (T)(object)(Int64)((Int64)(object)left - (Int64)(object)right);
+            }
+            else if (typeof(T) == typeof(Single))
+            {
+                return (T)(object)(Single)((Single)(object)left - (Single)(object)right);
+            }
+            else if (typeof(T) == typeof(Double))
+            {
+                return (T)(object)(Double)((Double)(object)left - (Double)(object)right);
+            }
+            else
+            {
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
+            }
+        }
+
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        private static T ScalarMultiply(T left, T right)
+        {
+            if (typeof(T) == typeof(Byte))
+            {
+                return (T)(object)unchecked((Byte)((Byte)(object)left * (Byte)(object)right));
+            }
+            else if (typeof(T) == typeof(SByte))
+            {
+                return (T)(object)unchecked((SByte)((SByte)(object)left * (SByte)(object)right));
+            }
+            else if (typeof(T) == typeof(UInt16))
+            {
+                return (T)(object)unchecked((UInt16)((UInt16)(object)left * (UInt16)(object)right));
+            }
+            else if (typeof(T) == typeof(Int16))
+            {
+                return (T)(object)unchecked((Int16)((Int16)(object)left * (Int16)(object)right));
+            }
+            else if (typeof(T) == typeof(UInt32))
+            {
+                return (T)(object)unchecked((UInt32)((UInt32)(object)left * (UInt32)(object)right));
+            }
+            else if (typeof(T) == typeof(Int32))
+            {
+                return (T)(object)unchecked((Int32)((Int32)(object)left * (Int32)(object)right));
+            }
+            else if (typeof(T) == typeof(UInt64))
+            {
+                return (T)(object)unchecked((UInt64)((UInt64)(object)left * (UInt64)(object)right));
+            }
+            else if (typeof(T) == typeof(Int64))
+            {
+                return (T)(object)unchecked((Int64)((Int64)(object)left * (Int64)(object)right));
+            }
+            else if (typeof(T) == typeof(Single))
+            {
+                return (T)(object)unchecked((Single)((Single)(object)left * (Single)(object)right));
+            }
+            else if (typeof(T) == typeof(Double))
+            {
+                return (T)(object)unchecked((Double)((Double)(object)left * (Double)(object)right));
+            }
+            else
+            {
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
+            }
+        }
+
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        private static T ScalarDivide(T left, T right)
+        {
+            if (typeof(T) == typeof(Byte))
+            {
+                return (T)(object)(Byte)((Byte)(object)left / (Byte)(object)right);
+            }
+            else if (typeof(T) == typeof(SByte))
+            {
+                return (T)(object)(SByte)((SByte)(object)left / (SByte)(object)right);
+            }
+            else if (typeof(T) == typeof(UInt16))
+            {
+                return (T)(object)(UInt16)((UInt16)(object)left / (UInt16)(object)right);
+            }
+            else if (typeof(T) == typeof(Int16))
+            {
+                return (T)(object)(Int16)((Int16)(object)left / (Int16)(object)right);
+            }
+            else if (typeof(T) == typeof(UInt32))
+            {
+                return (T)(object)(UInt32)((UInt32)(object)left / (UInt32)(object)right);
+            }
+            else if (typeof(T) == typeof(Int32))
+            {
+                return (T)(object)(Int32)((Int32)(object)left / (Int32)(object)right);
+            }
+            else if (typeof(T) == typeof(UInt64))
+            {
+                return (T)(object)(UInt64)((UInt64)(object)left / (UInt64)(object)right);
+            }
+            else if (typeof(T) == typeof(Int64))
+            {
+                return (T)(object)(Int64)((Int64)(object)left / (Int64)(object)right);
+            }
+            else if (typeof(T) == typeof(Single))
+            {
+                return (T)(object)(Single)((Single)(object)left / (Single)(object)right);
+            }
+            else if (typeof(T) == typeof(Double))
+            {
+                return (T)(object)(Double)((Double)(object)left / (Double)(object)right);
+            }
+            else
+            {
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
+            }
+        }
+
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        private static T GetZeroValue()
+        {
+            if (typeof(T) == typeof(Byte))
+            {
+                Byte value = 0;
+                return (T)(object)value;
+            }
+            else if (typeof(T) == typeof(SByte))
+            {
+                SByte value = 0;
+                return (T)(object)value;
+            }
+            else if (typeof(T) == typeof(UInt16))
+            {
+                UInt16 value = 0;
+                return (T)(object)value;
+            }
+            else if (typeof(T) == typeof(Int16))
+            {
+                Int16 value = 0;
+                return (T)(object)value;
+            }
+            else if (typeof(T) == typeof(UInt32))
+            {
+                UInt32 value = 0;
+                return (T)(object)value;
+            }
+            else if (typeof(T) == typeof(Int32))
+            {
+                Int32 value = 0;
+                return (T)(object)value;
+            }
+            else if (typeof(T) == typeof(UInt64))
+            {
+                UInt64 value = 0;
+                return (T)(object)value;
+            }
+            else if (typeof(T) == typeof(Int64))
+            {
+                Int64 value = 0;
+                return (T)(object)value;
+            }
+            else if (typeof(T) == typeof(Single))
+            {
+                Single value = 0;
+                return (T)(object)value;
+            }
+            else if (typeof(T) == typeof(Double))
+            {
+                Double value = 0;
+                return (T)(object)value;
+            }
+            else
+            {
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
+            }
+        }
+
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        private static T GetOneValue()
+        {
+            if (typeof(T) == typeof(Byte))
+            {
+                Byte value = 1;
+                return (T)(object)value;
+            }
+            else if (typeof(T) == typeof(SByte))
+            {
+                SByte value = 1;
+                return (T)(object)value;
+            }
+            else if (typeof(T) == typeof(UInt16))
+            {
+                UInt16 value = 1;
+                return (T)(object)value;
+            }
+            else if (typeof(T) == typeof(Int16))
+            {
+                Int16 value = 1;
+                return (T)(object)value;
+            }
+            else if (typeof(T) == typeof(UInt32))
+            {
+                UInt32 value = 1;
+                return (T)(object)value;
+            }
+            else if (typeof(T) == typeof(Int32))
+            {
+                Int32 value = 1;
+                return (T)(object)value;
+            }
+            else if (typeof(T) == typeof(UInt64))
+            {
+                UInt64 value = 1;
+                return (T)(object)value;
+            }
+            else if (typeof(T) == typeof(Int64))
+            {
+                Int64 value = 1;
+                return (T)(object)value;
+            }
+            else if (typeof(T) == typeof(Single))
+            {
+                Single value = 1;
+                return (T)(object)value;
+            }
+            else if (typeof(T) == typeof(Double))
+            {
+                Double value = 1;
+                return (T)(object)value;
+            }
+            else
+            {
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
+            }
+        }
+
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        private static T GetAllBitsSetValue()
+        {
+            if (typeof(T) == typeof(Byte))
+            {
+                return (T)(object)ConstantHelper.GetByteWithAllBitsSet();
+            }
+            else if (typeof(T) == typeof(SByte))
+            {
+                return (T)(object)ConstantHelper.GetSByteWithAllBitsSet();
+            }
+            else if (typeof(T) == typeof(UInt16))
+            {
+                return (T)(object)ConstantHelper.GetUInt16WithAllBitsSet();
+            }
+            else if (typeof(T) == typeof(Int16))
+            {
+                return (T)(object)ConstantHelper.GetInt16WithAllBitsSet();
+            }
+            else if (typeof(T) == typeof(UInt32))
+            {
+                return (T)(object)ConstantHelper.GetUInt32WithAllBitsSet();
+            }
+            else if (typeof(T) == typeof(Int32))
+            {
+                return (T)(object)ConstantHelper.GetInt32WithAllBitsSet();
+            }
+            else if (typeof(T) == typeof(UInt64))
+            {
+                return (T)(object)ConstantHelper.GetUInt64WithAllBitsSet();
+            }
+            else if (typeof(T) == typeof(Int64))
+            {
+                return (T)(object)ConstantHelper.GetInt64WithAllBitsSet();
+            }
+            else if (typeof(T) == typeof(Single))
+            {
+                return (T)(object)ConstantHelper.GetSingleWithAllBitsSet();
+            }
+            else if (typeof(T) == typeof(Double))
+            {
+                return (T)(object)ConstantHelper.GetDoubleWithAllBitsSet();
+            }
+            else
+            {
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
+            }
+        }
+        #endregion
+    }
+
+    public static partial class Vector
+    {
+        #region Widen/Narrow
+        /// <summary>
+        /// Widens a Vector{Byte} into two Vector{UInt16}'s.
+        /// <param name="source">The source vector whose elements are widened into the outputs.</param>
+        /// <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+        /// <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+        /// </summary>
+        [CLSCompliant(false)]
+        [JitIntrinsic]
+        public static unsafe void Widen(Vector<Byte> source, out Vector<UInt16> low, out Vector<UInt16> high)
+        {
+            int elements = Vector<Byte>.Count;
+            UInt16* lowPtr = stackalloc UInt16[elements / 2];
+            for (int i = 0; i < elements / 2; i++)
+            {
+                lowPtr[i] = (UInt16)source[i];
+            }
+            UInt16* highPtr = stackalloc UInt16[elements / 2];
+            for (int i = 0; i < elements / 2; i++)
+            {
+                highPtr[i] = (UInt16)source[i + (elements / 2)];
+            }
+
+            low = new Vector<UInt16>(lowPtr);
+            high = new Vector<UInt16>(highPtr);
+        }
+
+        /// <summary>
+        /// Widens a Vector{UInt16} into two Vector{UInt32}'s.
+        /// <param name="source">The source vector whose elements are widened into the outputs.</param>
+        /// <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+        /// <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+        /// </summary>
+        [CLSCompliant(false)]
+        [JitIntrinsic]
+        public static unsafe void Widen(Vector<UInt16> source, out Vector<UInt32> low, out Vector<UInt32> high)
+        {
+            int elements = Vector<UInt16>.Count;
+            UInt32* lowPtr = stackalloc UInt32[elements / 2];
+            for (int i = 0; i < elements / 2; i++)
+            {
+                lowPtr[i] = (UInt32)source[i];
+            }
+            UInt32* highPtr = stackalloc UInt32[elements / 2];
+            for (int i = 0; i < elements / 2; i++)
+            {
+                highPtr[i] = (UInt32)source[i + (elements / 2)];
+            }
+
+            low = new Vector<UInt32>(lowPtr);
+            high = new Vector<UInt32>(highPtr);
+        }
+
+        /// <summary>
+        /// Widens a Vector{UInt32} into two Vector{UInt64}'s.
+        /// <param name="source">The source vector whose elements are widened into the outputs.</param>
+        /// <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+        /// <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+        /// </summary>
+        [CLSCompliant(false)]
+        [JitIntrinsic]
+        public static unsafe void Widen(Vector<UInt32> source, out Vector<UInt64> low, out Vector<UInt64> high)
+        {
+            int elements = Vector<UInt32>.Count;
+            UInt64* lowPtr = stackalloc UInt64[elements / 2];
+            for (int i = 0; i < elements / 2; i++)
+            {
+                lowPtr[i] = (UInt64)source[i];
+            }
+            UInt64* highPtr = stackalloc UInt64[elements / 2];
+            for (int i = 0; i < elements / 2; i++)
+            {
+                highPtr[i] = (UInt64)source[i + (elements / 2)];
+            }
+
+            low = new Vector<UInt64>(lowPtr);
+            high = new Vector<UInt64>(highPtr);
+        }
+
+        /// <summary>
+        /// Widens a Vector{SByte} into two Vector{Int16}'s.
+        /// <param name="source">The source vector whose elements are widened into the outputs.</param>
+        /// <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+        /// <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+        /// </summary>
+        [CLSCompliant(false)]
+        [JitIntrinsic]
+        public static unsafe void Widen(Vector<SByte> source, out Vector<Int16> low, out Vector<Int16> high)
+        {
+            int elements = Vector<SByte>.Count;
+            Int16* lowPtr = stackalloc Int16[elements / 2];
+            for (int i = 0; i < elements / 2; i++)
+            {
+                lowPtr[i] = (Int16)source[i];
+            }
+            Int16* highPtr = stackalloc Int16[elements / 2];
+            for (int i = 0; i < elements / 2; i++)
+            {
+                highPtr[i] = (Int16)source[i + (elements / 2)];
+            }
+
+            low = new Vector<Int16>(lowPtr);
+            high = new Vector<Int16>(highPtr);
+        }
+
+        /// <summary>
+        /// Widens a Vector{Int16} into two Vector{Int32}'s.
+        /// <param name="source">The source vector whose elements are widened into the outputs.</param>
+        /// <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+        /// <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+        /// </summary>
+        [JitIntrinsic]
+        public static unsafe void Widen(Vector<Int16> source, out Vector<Int32> low, out Vector<Int32> high)
+        {
+            int elements = Vector<Int16>.Count;
+            Int32* lowPtr = stackalloc Int32[elements / 2];
+            for (int i = 0; i < elements / 2; i++)
+            {
+                lowPtr[i] = (Int32)source[i];
+            }
+            Int32* highPtr = stackalloc Int32[elements / 2];
+            for (int i = 0; i < elements / 2; i++)
+            {
+                highPtr[i] = (Int32)source[i + (elements / 2)];
+            }
+
+            low = new Vector<Int32>(lowPtr);
+            high = new Vector<Int32>(highPtr);
+        }
+
+        /// <summary>
+        /// Widens a Vector{Int32} into two Vector{Int64}'s.
+        /// <param name="source">The source vector whose elements are widened into the outputs.</param>
+        /// <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+        /// <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+        /// </summary>
+        [JitIntrinsic]
+        public static unsafe void Widen(Vector<Int32> source, out Vector<Int64> low, out Vector<Int64> high)
+        {
+            int elements = Vector<Int32>.Count;
+            Int64* lowPtr = stackalloc Int64[elements / 2];
+            for (int i = 0; i < elements / 2; i++)
+            {
+                lowPtr[i] = (Int64)source[i];
+            }
+            Int64* highPtr = stackalloc Int64[elements / 2];
+            for (int i = 0; i < elements / 2; i++)
+            {
+                highPtr[i] = (Int64)source[i + (elements / 2)];
+            }
+
+            low = new Vector<Int64>(lowPtr);
+            high = new Vector<Int64>(highPtr);
+        }
+
+        /// <summary>
+        /// Widens a Vector{Single} into two Vector{Double}'s.
+        /// <param name="source">The source vector whose elements are widened into the outputs.</param>
+        /// <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+        /// <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+        /// </summary>
+        [JitIntrinsic]
+        public static unsafe void Widen(Vector<Single> source, out Vector<Double> low, out Vector<Double> high)
+        {
+            int elements = Vector<Single>.Count;
+            Double* lowPtr = stackalloc Double[elements / 2];
+            for (int i = 0; i < elements / 2; i++)
+            {
+                lowPtr[i] = (Double)source[i];
+            }
+            Double* highPtr = stackalloc Double[elements / 2];
+            for (int i = 0; i < elements / 2; i++)
+            {
+                highPtr[i] = (Double)source[i + (elements / 2)];
+            }
+
+            low = new Vector<Double>(lowPtr);
+            high = new Vector<Double>(highPtr);
+        }
+
+        /// <summary>
+        /// Narrows two Vector{UInt16}'s into one Vector{Byte}.
+        /// <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+        /// <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+        /// <returns>A Vector{Byte} containing elements narrowed from the source vectors.</returns>
+        /// </summary>
+        [CLSCompliant(false)]
+        [JitIntrinsic]
+        public static unsafe Vector<Byte> Narrow(Vector<UInt16> low, Vector<UInt16> high)
+        {
+		    unchecked
+		    {
+				int elements = Vector<Byte>.Count;
+				Byte* retPtr = stackalloc Byte[elements];
+				for (int i = 0; i < elements / 2; i++)
+				{
+					retPtr[i] = (Byte)low[i];
+				}
+				for (int i = 0; i < elements / 2; i++)
+				{
+					retPtr[i + (elements / 2)] = (Byte)high[i];
+				}
+
+				return new Vector<Byte>(retPtr);
+		    }
+        }
+
+        /// <summary>
+        /// Narrows two Vector{UInt32}'s into one Vector{UInt16}.
+        /// <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+        /// <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+        /// <returns>A Vector{UInt16} containing elements narrowed from the source vectors.</returns>
+        /// </summary>
+        [CLSCompliant(false)]
+        [JitIntrinsic]
+        public static unsafe Vector<UInt16> Narrow(Vector<UInt32> low, Vector<UInt32> high)
+        {
+		    unchecked
+		    {
+				int elements = Vector<UInt16>.Count;
+				UInt16* retPtr = stackalloc UInt16[elements];
+				for (int i = 0; i < elements / 2; i++)
+				{
+					retPtr[i] = (UInt16)low[i];
+				}
+				for (int i = 0; i < elements / 2; i++)
+				{
+					retPtr[i + (elements / 2)] = (UInt16)high[i];
+				}
+
+				return new Vector<UInt16>(retPtr);
+		    }
+        }
+
+        /// <summary>
+        /// Narrows two Vector{UInt64}'s into one Vector{UInt32}.
+        /// <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+        /// <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+        /// <returns>A Vector{UInt32} containing elements narrowed from the source vectors.</returns>
+        /// </summary>
+        [CLSCompliant(false)]
+        [JitIntrinsic]
+        public static unsafe Vector<UInt32> Narrow(Vector<UInt64> low, Vector<UInt64> high)
+        {
+		    unchecked
+		    {
+				int elements = Vector<UInt32>.Count;
+				UInt32* retPtr = stackalloc UInt32[elements];
+				for (int i = 0; i < elements / 2; i++)
+				{
+					retPtr[i] = (UInt32)low[i];
+				}
+				for (int i = 0; i < elements / 2; i++)
+				{
+					retPtr[i + (elements / 2)] = (UInt32)high[i];
+				}
+
+				return new Vector<UInt32>(retPtr);
+		    }
+        }
+
+        /// <summary>
+        /// Narrows two Vector{Int16}'s into one Vector{SByte}.
+        /// <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+        /// <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+        /// <returns>A Vector{SByte} containing elements narrowed from the source vectors.</returns>
+        /// </summary>
+        [CLSCompliant(false)]
+        [JitIntrinsic]
+        public static unsafe Vector<SByte> Narrow(Vector<Int16> low, Vector<Int16> high)
+        {
+		    unchecked
+		    {
+				int elements = Vector<SByte>.Count;
+				SByte* retPtr = stackalloc SByte[elements];
+				for (int i = 0; i < elements / 2; i++)
+				{
+					retPtr[i] = (SByte)low[i];
+				}
+				for (int i = 0; i < elements / 2; i++)
+				{
+					retPtr[i + (elements / 2)] = (SByte)high[i];
+				}
+
+				return new Vector<SByte>(retPtr);
+		    }
+        }
+
+        /// <summary>
+        /// Narrows two Vector{Int32}'s into one Vector{Int16}.
+        /// <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+        /// <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+        /// <returns>A Vector{Int16} containing elements narrowed from the source vectors.</returns>
+        /// </summary>
+        [JitIntrinsic]
+        public static unsafe Vector<Int16> Narrow(Vector<Int32> low, Vector<Int32> high)
+        {
+		    unchecked
+		    {
+				int elements = Vector<Int16>.Count;
+				Int16* retPtr = stackalloc Int16[elements];
+				for (int i = 0; i < elements / 2; i++)
+				{
+					retPtr[i] = (Int16)low[i];
+				}
+				for (int i = 0; i < elements / 2; i++)
+				{
+					retPtr[i + (elements / 2)] = (Int16)high[i];
+				}
+
+				return new Vector<Int16>(retPtr);
+		    }
+        }
+
+        /// <summary>
+        /// Narrows two Vector{Int64}'s into one Vector{Int32}.
+        /// <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+        /// <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+        /// <returns>A Vector{Int32} containing elements narrowed from the source vectors.</returns>
+        /// </summary>
+        [JitIntrinsic]
+        public static unsafe Vector<Int32> Narrow(Vector<Int64> low, Vector<Int64> high)
+        {
+		    unchecked
+		    {
+				int elements = Vector<Int32>.Count;
+				Int32* retPtr = stackalloc Int32[elements];
+				for (int i = 0; i < elements / 2; i++)
+				{
+					retPtr[i] = (Int32)low[i];
+				}
+				for (int i = 0; i < elements / 2; i++)
+				{
+					retPtr[i + (elements / 2)] = (Int32)high[i];
+				}
+
+				return new Vector<Int32>(retPtr);
+		    }
+        }
+
+        /// <summary>
+        /// Narrows two Vector{Double}'s into one Vector{Single}.
+        /// <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+        /// <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+        /// <returns>A Vector{Single} containing elements narrowed from the source vectors.</returns>
+        /// </summary>
+        [JitIntrinsic]
+        public static unsafe Vector<Single> Narrow(Vector<Double> low, Vector<Double> high)
+        {
+		    unchecked
+		    {
+				int elements = Vector<Single>.Count;
+				Single* retPtr = stackalloc Single[elements];
+				for (int i = 0; i < elements / 2; i++)
+				{
+					retPtr[i] = (Single)low[i];
+				}
+				for (int i = 0; i < elements / 2; i++)
+				{
+					retPtr[i + (elements / 2)] = (Single)high[i];
+				}
+
+				return new Vector<Single>(retPtr);
+		    }
+        }
+
+        #endregion Widen/Narrow
+
+        #region Same-Size Conversion
+        /// <summary>
+        /// Converts a Vector{Int32} to a Vector{Single}.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The converted vector.</returns>
+        [JitIntrinsic]
+        public static unsafe Vector<Single> ConvertToSingle(Vector<Int32> value)
+        {
+			unchecked
+			{
+				int elements = Vector<Single>.Count;
+				Single* retPtr = stackalloc Single[elements];
+				for (int i = 0; i < elements; i++)
+				{
+					retPtr[i] = (Single)value[i];
+				}
+
+				return new Vector<Single>(retPtr);
+			}
+        }
+
+        /// <summary>
+        /// Converts a Vector{UInt32} to a Vector{Single}.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The converted vector.</returns>
+        [CLSCompliant(false)]
+        [JitIntrinsic]
+        public static unsafe Vector<Single> ConvertToSingle(Vector<UInt32> value)
+        {
+			unchecked
+			{
+				int elements = Vector<Single>.Count;
+				Single* retPtr = stackalloc Single[elements];
+				for (int i = 0; i < elements; i++)
+				{
+					retPtr[i] = (Single)value[i];
+				}
+
+				return new Vector<Single>(retPtr);
+			}
+        }
+
+        /// <summary>
+        /// Converts a Vector{Int64} to a Vector{Double}.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The converted vector.</returns>
+        [JitIntrinsic]
+        public static unsafe Vector<Double> ConvertToDouble(Vector<Int64> value)
+        {
+			unchecked
+			{
+				int elements = Vector<Double>.Count;
+				Double* retPtr = stackalloc Double[elements];
+				for (int i = 0; i < elements; i++)
+				{
+					retPtr[i] = (Double)value[i];
+				}
+
+				return new Vector<Double>(retPtr);
+			}
+        }
+
+        /// <summary>
+        /// Converts a Vector{UInt64} to a Vector{Double}.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The converted vector.</returns>
+        [CLSCompliant(false)]
+        [JitIntrinsic]
+        public static unsafe Vector<Double> ConvertToDouble(Vector<UInt64> value)
+        {
+			unchecked
+			{
+				int elements = Vector<Double>.Count;
+				Double* retPtr = stackalloc Double[elements];
+				for (int i = 0; i < elements; i++)
+				{
+					retPtr[i] = (Double)value[i];
+				}
+
+				return new Vector<Double>(retPtr);
+			}
+        }
+
+        /// <summary>
+        /// Converts a Vector{Single} to a Vector{Int32}.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The converted vector.</returns>
+        [JitIntrinsic]
+        public static unsafe Vector<Int32> ConvertToInt32(Vector<Single> value)
+        {
+			unchecked
+			{
+				int elements = Vector<Int32>.Count;
+				Int32* retPtr = stackalloc Int32[elements];
+				for (int i = 0; i < elements; i++)
+				{
+					retPtr[i] = (Int32)value[i];
+				}
+
+				return new Vector<Int32>(retPtr);
+			}
+        }
+
+        /// <summary>
+        /// Converts a Vector{Single} to a Vector{UInt32}.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The converted vector.</returns>
+        [CLSCompliant(false)]
+        [JitIntrinsic]
+        public static unsafe Vector<UInt32> ConvertToUInt32(Vector<Single> value)
+        {
+			unchecked
+			{
+				int elements = Vector<UInt32>.Count;
+				UInt32* retPtr = stackalloc UInt32[elements];
+				for (int i = 0; i < elements; i++)
+				{
+					retPtr[i] = (UInt32)value[i];
+				}
+
+				return new Vector<UInt32>(retPtr);
+			}
+        }
+
+        /// <summary>
+        /// Converts a Vector{Double} to a Vector{Int64}.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The converted vector.</returns>
+        [JitIntrinsic]
+        public static unsafe Vector<Int64> ConvertToInt64(Vector<Double> value)
+        {
+			unchecked
+			{
+				int elements = Vector<Int64>.Count;
+				Int64* retPtr = stackalloc Int64[elements];
+				for (int i = 0; i < elements; i++)
+				{
+					retPtr[i] = (Int64)value[i];
+				}
+
+				return new Vector<Int64>(retPtr);
+			}
+        }
+
+        /// <summary>
+        /// Converts a Vector{Double} to a Vector{UInt64}.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The converted vector.</returns>
+        [CLSCompliant(false)]
+        [JitIntrinsic]
+        public static unsafe Vector<UInt64> ConvertToUInt64(Vector<Double> value)
+        {
+			unchecked
+			{
+				int elements = Vector<UInt64>.Count;
+				UInt64* retPtr = stackalloc UInt64[elements];
+				for (int i = 0; i < elements; i++)
+				{
+					retPtr[i] = (UInt64)value[i];
+				}
+
+				return new Vector<UInt64>(retPtr);
+			}
+        }
+
+        #endregion Same-Size Conversion
+    }
+}

--- a/src/mscorlib/src/System/Numerics/Vector2.cs
+++ b/src/mscorlib/src/System/Numerics/Vector2.cs
@@ -1,0 +1,453 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Numerics.Hashing;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace System.Numerics
+{
+    /// <summary>
+    /// A structure encapsulating two single precision floating point values and provides hardware accelerated methods.
+    /// </summary>
+    public partial struct Vector2 : IEquatable<Vector2>, IFormattable
+    {
+        #region Public Static Properties
+        /// <summary>
+        /// Returns the vector (0,0).
+        /// </summary>
+        public static Vector2 Zero { get { return new Vector2(); } }
+        /// <summary>
+        /// Returns the vector (1,1).
+        /// </summary>
+        public static Vector2 One { get { return new Vector2(1.0f, 1.0f); } }
+        /// <summary>
+        /// Returns the vector (1,0).
+        /// </summary>
+        public static Vector2 UnitX { get { return new Vector2(1.0f, 0.0f); } }
+        /// <summary>
+        /// Returns the vector (0,1).
+        /// </summary>
+        public static Vector2 UnitY { get { return new Vector2(0.0f, 1.0f); } }
+        #endregion Public Static Properties
+
+        #region Public instance methods
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>The hash code.</returns>
+        public override int GetHashCode()
+        {
+            int hash = this.X.GetHashCode();
+            hash = HashHelpers.Combine(hash, this.Y.GetHashCode());
+            return hash;
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the given Object is equal to this Vector2 instance.
+        /// </summary>
+        /// <param name="obj">The Object to compare against.</param>
+        /// <returns>True if the Object is equal to this Vector2; False otherwise.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override bool Equals(object obj)
+        {
+            if (!(obj is Vector2))
+                return false;
+            return Equals((Vector2)obj);
+        }
+
+        /// <summary>
+        /// Returns a String representing this Vector2 instance.
+        /// </summary>
+        /// <returns>The string representation.</returns>
+        public override string ToString()
+        {
+            return ToString("G", CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Returns a String representing this Vector2 instance, using the specified format to format individual elements.
+        /// </summary>
+        /// <param name="format">The format of individual elements.</param>
+        /// <returns>The string representation.</returns>
+        public string ToString(string format)
+        {
+            return ToString(format, CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Returns a String representing this Vector2 instance, using the specified format to format individual elements 
+        /// and the given IFormatProvider.
+        /// </summary>
+        /// <param name="format">The format of individual elements.</param>
+        /// <param name="formatProvider">The format provider to use when formatting elements.</param>
+        /// <returns>The string representation.</returns>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            StringBuilder sb = new StringBuilder();
+            string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;
+            sb.Append('<');
+            sb.Append(this.X.ToString(format, formatProvider));
+            sb.Append(separator);
+            sb.Append(' ');
+            sb.Append(this.Y.ToString(format, formatProvider));
+            sb.Append('>');
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns the length of the vector.
+        /// </summary>
+        /// <returns>The vector's length.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float Length()
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                float ls = Vector2.Dot(this, this);
+                return MathF.Sqrt(ls);
+            }
+            else
+            {
+                float ls = X * X + Y * Y;
+                return MathF.Sqrt(ls);
+            }
+        }
+
+        /// <summary>
+        /// Returns the length of the vector squared. This operation is cheaper than Length().
+        /// </summary>
+        /// <returns>The vector's length squared.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float LengthSquared()
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                return Vector2.Dot(this, this);
+            }
+            else
+            {
+                return X * X + Y * Y;
+            }
+        }
+        #endregion Public Instance Methods
+
+        #region Public Static Methods
+        /// <summary>
+        /// Returns the Euclidean distance between the two given points.
+        /// </summary>
+        /// <param name="value1">The first point.</param>
+        /// <param name="value2">The second point.</param>
+        /// <returns>The distance.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Distance(Vector2 value1, Vector2 value2)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                Vector2 difference = value1 - value2;
+                float ls = Vector2.Dot(difference, difference);
+                return MathF.Sqrt(ls);
+            }
+            else
+            {
+                float dx = value1.X - value2.X;
+                float dy = value1.Y - value2.Y;
+
+                float ls = dx * dx + dy * dy;
+
+                return MathF.Sqrt(ls);
+            }
+        }
+
+        /// <summary>
+        /// Returns the Euclidean distance squared between the two given points.
+        /// </summary>
+        /// <param name="value1">The first point.</param>
+        /// <param name="value2">The second point.</param>
+        /// <returns>The distance squared.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float DistanceSquared(Vector2 value1, Vector2 value2)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                Vector2 difference = value1 - value2;
+                return Vector2.Dot(difference, difference);
+            }
+            else
+            {
+                float dx = value1.X - value2.X;
+                float dy = value1.Y - value2.Y;
+
+                return dx * dx + dy * dy;
+            }
+        }
+
+        /// <summary>
+        /// Returns a vector with the same direction as the given vector, but with a length of 1.
+        /// </summary>
+        /// <param name="value">The vector to normalize.</param>
+        /// <returns>The normalized vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 Normalize(Vector2 value)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                float length = value.Length();
+                return value / length;
+            }
+            else
+            {
+                float ls = value.X * value.X + value.Y * value.Y;
+                float invNorm = 1.0f / MathF.Sqrt(ls);
+
+                return new Vector2(
+                    value.X * invNorm,
+                    value.Y * invNorm);
+            }
+        }
+
+        /// <summary>
+        /// Returns the reflection of a vector off a surface that has the specified normal.
+        /// </summary>
+        /// <param name="vector">The source vector.</param>
+        /// <param name="normal">The normal of the surface being reflected off.</param>
+        /// <returns>The reflected vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 Reflect(Vector2 vector, Vector2 normal)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                float dot = Vector2.Dot(vector, normal);
+                return vector - (2 * dot * normal);
+            }
+            else
+            {
+                float dot = vector.X * normal.X + vector.Y * normal.Y;
+
+                return new Vector2(
+                    vector.X - 2.0f * dot * normal.X,
+                    vector.Y - 2.0f * dot * normal.Y);
+            }
+        }
+
+        /// <summary>
+        /// Restricts a vector between a min and max value.
+        /// </summary>
+        /// <param name="value1">The source vector.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 Clamp(Vector2 value1, Vector2 min, Vector2 max)
+        {
+            // This compare order is very important!!!
+            // We must follow HLSL behavior in the case user specified min value is bigger than max value.
+            float x = value1.X;
+            x = (x > max.X) ? max.X : x;
+            x = (x < min.X) ? min.X : x;
+
+            float y = value1.Y;
+            y = (y > max.Y) ? max.Y : y;
+            y = (y < min.Y) ? min.Y : y;
+
+            return new Vector2(x, y);
+        }
+
+        /// <summary>
+        /// Linearly interpolates between two vectors based on the given weighting.
+        /// </summary>
+        /// <param name="value1">The first source vector.</param>
+        /// <param name="value2">The second source vector.</param>
+        /// <param name="amount">Value between 0 and 1 indicating the weight of the second source vector.</param>
+        /// <returns>The interpolated vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 Lerp(Vector2 value1, Vector2 value2, float amount)
+        {
+            return new Vector2(
+                value1.X + (value2.X - value1.X) * amount,
+                value1.Y + (value2.Y - value1.Y) * amount);
+        }
+
+        /// <summary>
+        /// Transforms a vector by the given matrix.
+        /// </summary>
+        /// <param name="position">The source vector.</param>
+        /// <param name="matrix">The transformation matrix.</param>
+        /// <returns>The transformed vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 Transform(Vector2 position, Matrix3x2 matrix)
+        {
+            return new Vector2(
+                position.X * matrix.M11 + position.Y * matrix.M21 + matrix.M31,
+                position.X * matrix.M12 + position.Y * matrix.M22 + matrix.M32);
+        }
+
+        /// <summary>
+        /// Transforms a vector by the given matrix.
+        /// </summary>
+        /// <param name="position">The source vector.</param>
+        /// <param name="matrix">The transformation matrix.</param>
+        /// <returns>The transformed vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 Transform(Vector2 position, Matrix4x4 matrix)
+        {
+            return new Vector2(
+                position.X * matrix.M11 + position.Y * matrix.M21 + matrix.M41,
+                position.X * matrix.M12 + position.Y * matrix.M22 + matrix.M42);
+        }
+
+        /// <summary>
+        /// Transforms a vector normal by the given matrix.
+        /// </summary>
+        /// <param name="normal">The source vector.</param>
+        /// <param name="matrix">The transformation matrix.</param>
+        /// <returns>The transformed vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 TransformNormal(Vector2 normal, Matrix3x2 matrix)
+        {
+            return new Vector2(
+                normal.X * matrix.M11 + normal.Y * matrix.M21,
+                normal.X * matrix.M12 + normal.Y * matrix.M22);
+        }
+
+        /// <summary>
+        /// Transforms a vector normal by the given matrix.
+        /// </summary>
+        /// <param name="normal">The source vector.</param>
+        /// <param name="matrix">The transformation matrix.</param>
+        /// <returns>The transformed vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 TransformNormal(Vector2 normal, Matrix4x4 matrix)
+        {
+            return new Vector2(
+                normal.X * matrix.M11 + normal.Y * matrix.M21,
+                normal.X * matrix.M12 + normal.Y * matrix.M22);
+        }
+
+        /// <summary>
+        /// Transforms a vector by the given Quaternion rotation value.
+        /// </summary>
+        /// <param name="value">The source vector to be rotated.</param>
+        /// <param name="rotation">The rotation to apply.</param>
+        /// <returns>The transformed vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 Transform(Vector2 value, Quaternion rotation)
+        {
+            float x2 = rotation.X + rotation.X;
+            float y2 = rotation.Y + rotation.Y;
+            float z2 = rotation.Z + rotation.Z;
+
+            float wz2 = rotation.W * z2;
+            float xx2 = rotation.X * x2;
+            float xy2 = rotation.X * y2;
+            float yy2 = rotation.Y * y2;
+            float zz2 = rotation.Z * z2;
+
+            return new Vector2(
+                value.X * (1.0f - yy2 - zz2) + value.Y * (xy2 - wz2),
+                value.X * (xy2 + wz2) + value.Y * (1.0f - xx2 - zz2));
+        }
+        #endregion Public Static Methods
+
+        #region Public operator methods
+        // all the below methods should be inlined as they are 
+        // implemented over JIT intrinsics
+
+        /// <summary>
+        /// Adds two vectors together.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The summed vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 Add(Vector2 left, Vector2 right)
+        {
+            return left + right;
+        }
+
+        /// <summary>
+        /// Subtracts the second vector from the first.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The difference vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 Subtract(Vector2 left, Vector2 right)
+        {
+            return left - right;
+        }
+
+        /// <summary>
+        /// Multiplies two vectors together.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The product vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 Multiply(Vector2 left, Vector2 right)
+        {
+            return left * right;
+        }
+
+        /// <summary>
+        /// Multiplies a vector by the given scalar.
+        /// </summary>
+        /// <param name="left">The source vector.</param>
+        /// <param name="right">The scalar value.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 Multiply(Vector2 left, Single right)
+        {
+            return left * right;
+        }
+
+        /// <summary>
+        /// Multiplies a vector by the given scalar.
+        /// </summary>
+        /// <param name="left">The scalar value.</param>
+        /// <param name="right">The source vector.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 Multiply(Single left, Vector2 right)
+        {
+            return left * right;
+        }
+
+        /// <summary>
+        /// Divides the first vector by the second.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The vector resulting from the division.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 Divide(Vector2 left, Vector2 right)
+        {
+            return left / right;
+        }
+
+        /// <summary>
+        /// Divides the vector by the given scalar.
+        /// </summary>
+        /// <param name="left">The source vector.</param>
+        /// <param name="divisor">The scalar value.</param>
+        /// <returns>The result of the division.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 Divide(Vector2 left, Single divisor)
+        {
+            return left / divisor;
+        }
+
+        /// <summary>
+        /// Negates a given vector.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The negated vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 Negate(Vector2 value)
+        {
+            return -value;
+        }
+        #endregion Public operator methods
+    }
+}

--- a/src/mscorlib/src/System/Numerics/Vector2_Intrinsics.cs
+++ b/src/mscorlib/src/System/Numerics/Vector2_Intrinsics.cs
@@ -1,0 +1,297 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Numerics
+{
+    // This file contains the definitions for all of the JIT intrinsic methods and properties that are recognized by the current x64 JIT compiler.
+    // The implementation defined here is used in any circumstance where the JIT fails to recognize these members as intrinsic.
+    // The JIT recognizes these methods and properties by name and signature: if either is changed, the JIT will no longer recognize the member.
+    // Some methods declared here are not strictly intrinsic, but delegate to an intrinsic method. For example, only one overload of CopyTo() 
+
+    public partial struct Vector2
+    {
+        /// <summary>
+        /// The X component of the vector.
+        /// </summary>
+        public Single X;
+        /// <summary>
+        /// The Y component of the vector.
+        /// </summary>
+        public Single Y;
+
+        #region Constructors
+        /// <summary>
+        /// Constructs a vector whose elements are all the single specified value.
+        /// </summary>
+        /// <param name="value">The element to fill the vector with.</param>
+        [JitIntrinsic]
+        public Vector2(Single value) : this(value, value) { }
+
+        /// <summary>
+        /// Constructs a vector with the given individual elements.
+        /// </summary>
+        /// <param name="x">The X component.</param>
+        /// <param name="y">The Y component.</param>
+        [JitIntrinsic]
+        public Vector2(Single x, Single y)
+        {
+            X = x;
+            Y = y;
+        }
+        #endregion Constructors
+
+        #region Public Instance Methods
+        /// <summary>
+        /// Copies the contents of the vector into the given array.
+        /// </summary>
+        /// <param name="array">The destination array.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void CopyTo(Single[] array)
+        {
+            CopyTo(array, 0);
+        }
+
+        /// <summary>
+        /// Copies the contents of the vector into the given array, starting from the given index.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">If array is null.</exception>
+        /// <exception cref="RankException">If array is multidimensional.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If index is greater than end of the array or index is less than zero.</exception>
+        /// <exception cref="ArgumentException">If number of elements in source vector is greater than those available in destination array
+        /// or if there are not enough elements to copy.</exception>
+        public void CopyTo(Single[] array, int index)
+        {
+            if (array == null)
+            {
+                // Match the JIT's exception type here. For perf, a NullReference is thrown instead of an ArgumentNull.
+                throw new NullReferenceException(SR.Arg_NullArgumentNullRef);
+            }
+            if (index < 0 || index >= array.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index), SR.Format(SR.Arg_ArgumentOutOfRangeException, index));
+            }
+            if ((array.Length - index) < 2)
+            {
+                throw new ArgumentException(SR.Format(SR.Arg_ElementsInSourceIsGreaterThanDestination, index));
+            }
+            array[index] = X;
+            array[index + 1] = Y;
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the given Vector2 is equal to this Vector2 instance.
+        /// </summary>
+        /// <param name="other">The Vector2 to compare this instance to.</param>
+        /// <returns>True if the other Vector2 is equal to this instance; False otherwise.</returns>
+        [JitIntrinsic]
+        public bool Equals(Vector2 other)
+        {
+            return this.X == other.X && this.Y == other.Y;
+        }
+        #endregion Public Instance Methods
+
+        #region Public Static Methods
+        /// <summary>
+        /// Returns the dot product of two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <returns>The dot product.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Dot(Vector2 value1, Vector2 value2)
+        {
+            return value1.X * value2.X +
+                   value1.Y * value2.Y;
+        }
+
+        /// <summary>
+        /// Returns a vector whose elements are the minimum of each of the pairs of elements in the two source vectors.
+        /// </summary>
+        /// <param name="value1">The first source vector.</param>
+        /// <param name="value2">The second source vector.</param>
+        /// <returns>The minimized vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 Min(Vector2 value1, Vector2 value2)
+        {
+            return new Vector2(
+                (value1.X < value2.X) ? value1.X : value2.X,
+                (value1.Y < value2.Y) ? value1.Y : value2.Y);
+        }
+
+        /// <summary>
+        /// Returns a vector whose elements are the maximum of each of the pairs of elements in the two source vectors
+        /// </summary>
+        /// <param name="value1">The first source vector</param>
+        /// <param name="value2">The second source vector</param>
+        /// <returns>The maximized vector</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 Max(Vector2 value1, Vector2 value2)
+        {
+            return new Vector2(
+                (value1.X > value2.X) ? value1.X : value2.X,
+                (value1.Y > value2.Y) ? value1.Y : value2.Y);
+        }
+
+        /// <summary>
+        /// Returns a vector whose elements are the absolute values of each of the source vector's elements.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The absolute value vector.</returns>        
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 Abs(Vector2 value)
+        {
+            return new Vector2(MathF.Abs(value.X), MathF.Abs(value.Y));
+        }
+
+        /// <summary>
+        /// Returns a vector whose elements are the square root of each of the source vector's elements.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The square root vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 SquareRoot(Vector2 value)
+        {
+            return new Vector2(MathF.Sqrt(value.X), MathF.Sqrt(value.Y));
+        }
+        #endregion Public Static Methods
+
+        #region Public Static Operators
+        /// <summary>
+        /// Adds two vectors together.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The summed vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 operator +(Vector2 left, Vector2 right)
+        {
+            return new Vector2(left.X + right.X, left.Y + right.Y);
+        }
+
+        /// <summary>
+        /// Subtracts the second vector from the first.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The difference vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 operator -(Vector2 left, Vector2 right)
+        {
+            return new Vector2(left.X - right.X, left.Y - right.Y);
+        }
+
+        /// <summary>
+        /// Multiplies two vectors together.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The product vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 operator *(Vector2 left, Vector2 right)
+        {
+            return new Vector2(left.X * right.X, left.Y * right.Y);
+        }
+
+        /// <summary>
+        /// Multiplies a vector by the given scalar.
+        /// </summary>
+        /// <param name="left">The scalar value.</param>
+        /// <param name="right">The source vector.</param>
+        /// <returns>The scaled vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 operator *(Single left, Vector2 right)
+        {
+            return new Vector2(left, left) * right;
+        }
+
+        /// <summary>
+        /// Multiplies a vector by the given scalar.
+        /// </summary>
+        /// <param name="left">The source vector.</param>
+        /// <param name="right">The scalar value.</param>
+        /// <returns>The scaled vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 operator *(Vector2 left, Single right)
+        {
+            return left * new Vector2(right, right);
+        }
+
+        /// <summary>
+        /// Divides the first vector by the second.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The vector resulting from the division.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 operator /(Vector2 left, Vector2 right)
+        {
+            return new Vector2(left.X / right.X, left.Y / right.Y);
+        }
+
+        /// <summary>
+        /// Divides the vector by the given scalar.
+        /// </summary>
+        /// <param name="value1">The source vector.</param>
+        /// <param name="value2">The scalar value.</param>
+        /// <returns>The result of the division.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 operator /(Vector2 value1, float value2)
+        {
+            float invDiv = 1.0f / value2;
+            return new Vector2(
+                value1.X * invDiv,
+                value1.Y * invDiv);
+        }
+
+        /// <summary>
+        /// Negates a given vector.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The negated vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector2 operator -(Vector2 value)
+        {
+            return Zero - value;
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the two given vectors are equal.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>True if the vectors are equal; False otherwise.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator ==(Vector2 left, Vector2 right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the two given vectors are not equal.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>True if the vectors are not equal; False if they are equal.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator !=(Vector2 left, Vector2 right)
+        {
+            return !(left == right);
+        }
+        #endregion Public Static Operators
+    }
+}

--- a/src/mscorlib/src/System/Numerics/Vector3.cs
+++ b/src/mscorlib/src/System/Numerics/Vector3.cs
@@ -1,0 +1,473 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Numerics.Hashing;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace System.Numerics
+{
+    /// <summary>
+    /// A structure encapsulating three single precision floating point values and provides hardware accelerated methods.
+    /// </summary>
+    public partial struct Vector3 : IEquatable<Vector3>, IFormattable
+    {
+        #region Public Static Properties
+        /// <summary>
+        /// Returns the vector (0,0,0).
+        /// </summary>
+        public static Vector3 Zero { get { return new Vector3(); } }
+        /// <summary>
+        /// Returns the vector (1,1,1).
+        /// </summary>
+        public static Vector3 One { get { return new Vector3(1.0f, 1.0f, 1.0f); } }
+        /// <summary>
+        /// Returns the vector (1,0,0).
+        /// </summary>
+        public static Vector3 UnitX { get { return new Vector3(1.0f, 0.0f, 0.0f); } }
+        /// <summary>
+        /// Returns the vector (0,1,0).
+        /// </summary>
+        public static Vector3 UnitY { get { return new Vector3(0.0f, 1.0f, 0.0f); } }
+        /// <summary>
+        /// Returns the vector (0,0,1).
+        /// </summary>
+        public static Vector3 UnitZ { get { return new Vector3(0.0f, 0.0f, 1.0f); } }
+        #endregion Public Static Properties
+
+        #region Public Instance Methods
+
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>The hash code.</returns>
+        public override int GetHashCode()
+        {
+            int hash = this.X.GetHashCode();
+            hash = HashHelpers.Combine(hash, this.Y.GetHashCode());
+            hash = HashHelpers.Combine(hash, this.Z.GetHashCode());
+            return hash;
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the given Object is equal to this Vector3 instance.
+        /// </summary>
+        /// <param name="obj">The Object to compare against.</param>
+        /// <returns>True if the Object is equal to this Vector3; False otherwise.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override bool Equals(object obj)
+        {
+            if (!(obj is Vector3))
+                return false;
+            return Equals((Vector3)obj);
+        }
+
+        /// <summary>
+        /// Returns a String representing this Vector3 instance.
+        /// </summary>
+        /// <returns>The string representation.</returns>
+        public override string ToString()
+        {
+            return ToString("G", CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Returns a String representing this Vector3 instance, using the specified format to format individual elements.
+        /// </summary>
+        /// <param name="format">The format of individual elements.</param>
+        /// <returns>The string representation.</returns>
+        public string ToString(string format)
+        {
+            return ToString(format, CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Returns a String representing this Vector3 instance, using the specified format to format individual elements 
+        /// and the given IFormatProvider.
+        /// </summary>
+        /// <param name="format">The format of individual elements.</param>
+        /// <param name="formatProvider">The format provider to use when formatting elements.</param>
+        /// <returns>The string representation.</returns>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            StringBuilder sb = new StringBuilder();
+            string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;
+            sb.Append('<');
+            sb.Append(((IFormattable)this.X).ToString(format, formatProvider));
+            sb.Append(separator);
+            sb.Append(' ');
+            sb.Append(((IFormattable)this.Y).ToString(format, formatProvider));
+            sb.Append(separator);
+            sb.Append(' ');
+            sb.Append(((IFormattable)this.Z).ToString(format, formatProvider));
+            sb.Append('>');
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns the length of the vector.
+        /// </summary>
+        /// <returns>The vector's length.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float Length()
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                float ls = Vector3.Dot(this, this);
+                return MathF.Sqrt(ls);
+            }
+            else
+            {
+                float ls = X * X + Y * Y + Z * Z;
+                return MathF.Sqrt(ls);
+            }
+        }
+
+        /// <summary>
+        /// Returns the length of the vector squared. This operation is cheaper than Length().
+        /// </summary>
+        /// <returns>The vector's length squared.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float LengthSquared()
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                return Vector3.Dot(this, this);
+            }
+            else
+            {
+                return X * X + Y * Y + Z * Z;
+            }
+        }
+        #endregion Public Instance Methods
+
+        #region Public Static Methods
+        /// <summary>
+        /// Returns the Euclidean distance between the two given points.
+        /// </summary>
+        /// <param name="value1">The first point.</param>
+        /// <param name="value2">The second point.</param>
+        /// <returns>The distance.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Distance(Vector3 value1, Vector3 value2)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                Vector3 difference = value1 - value2;
+                float ls = Vector3.Dot(difference, difference);
+                return MathF.Sqrt(ls);
+            }
+            else
+            {
+                float dx = value1.X - value2.X;
+                float dy = value1.Y - value2.Y;
+                float dz = value1.Z - value2.Z;
+
+                float ls = dx * dx + dy * dy + dz * dz;
+
+                return MathF.Sqrt(ls);
+            }
+        }
+
+        /// <summary>
+        /// Returns the Euclidean distance squared between the two given points.
+        /// </summary>
+        /// <param name="value1">The first point.</param>
+        /// <param name="value2">The second point.</param>
+        /// <returns>The distance squared.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float DistanceSquared(Vector3 value1, Vector3 value2)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                Vector3 difference = value1 - value2;
+                return Vector3.Dot(difference, difference);
+            }
+            else
+            {
+                float dx = value1.X - value2.X;
+                float dy = value1.Y - value2.Y;
+                float dz = value1.Z - value2.Z;
+
+                return dx * dx + dy * dy + dz * dz;
+            }
+        }
+
+        /// <summary>
+        /// Returns a vector with the same direction as the given vector, but with a length of 1.
+        /// </summary>
+        /// <param name="value">The vector to normalize.</param>
+        /// <returns>The normalized vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 Normalize(Vector3 value)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                float length = value.Length();
+                return value / length;
+            }
+            else
+            {
+                float ls = value.X * value.X + value.Y * value.Y + value.Z * value.Z;
+                float length = MathF.Sqrt(ls);
+                return new Vector3(value.X / length, value.Y / length, value.Z / length);
+            }
+        }
+
+        /// <summary>
+        /// Computes the cross product of two vectors.
+        /// </summary>
+        /// <param name="vector1">The first vector.</param>
+        /// <param name="vector2">The second vector.</param>
+        /// <returns>The cross product.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 Cross(Vector3 vector1, Vector3 vector2)
+        {
+            return new Vector3(
+                vector1.Y * vector2.Z - vector1.Z * vector2.Y,
+                vector1.Z * vector2.X - vector1.X * vector2.Z,
+                vector1.X * vector2.Y - vector1.Y * vector2.X);
+        }
+
+        /// <summary>
+        /// Returns the reflection of a vector off a surface that has the specified normal.
+        /// </summary>
+        /// <param name="vector">The source vector.</param>
+        /// <param name="normal">The normal of the surface being reflected off.</param>
+        /// <returns>The reflected vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 Reflect(Vector3 vector, Vector3 normal)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                float dot = Vector3.Dot(vector, normal);
+                Vector3 temp = normal * dot * 2f;
+                return vector - temp;
+            }
+            else
+            {
+                float dot = vector.X * normal.X + vector.Y * normal.Y + vector.Z * normal.Z;
+                float tempX = normal.X * dot * 2f;
+                float tempY = normal.Y * dot * 2f;
+                float tempZ = normal.Z * dot * 2f;
+                return new Vector3(vector.X - tempX, vector.Y - tempY, vector.Z - tempZ);
+            }
+        }
+
+        /// <summary>
+        /// Restricts a vector between a min and max value.
+        /// </summary>
+        /// <param name="value1">The source vector.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <returns>The restricted vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 Clamp(Vector3 value1, Vector3 min, Vector3 max)
+        {
+            // This compare order is very important!!!
+            // We must follow HLSL behavior in the case user specified min value is bigger than max value.
+
+            float x = value1.X;
+            x = (x > max.X) ? max.X : x;
+            x = (x < min.X) ? min.X : x;
+
+            float y = value1.Y;
+            y = (y > max.Y) ? max.Y : y;
+            y = (y < min.Y) ? min.Y : y;
+
+            float z = value1.Z;
+            z = (z > max.Z) ? max.Z : z;
+            z = (z < min.Z) ? min.Z : z;
+
+            return new Vector3(x, y, z);
+        }
+
+        /// <summary>
+        /// Linearly interpolates between two vectors based on the given weighting.
+        /// </summary>
+        /// <param name="value1">The first source vector.</param>
+        /// <param name="value2">The second source vector.</param>
+        /// <param name="amount">Value between 0 and 1 indicating the weight of the second source vector.</param>
+        /// <returns>The interpolated vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 Lerp(Vector3 value1, Vector3 value2, float amount)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                Vector3 firstInfluence = value1 * (1f - amount);
+                Vector3 secondInfluence = value2 * amount;
+                return firstInfluence + secondInfluence;
+            }
+            else
+            {
+                return new Vector3(
+                    value1.X + (value2.X - value1.X) * amount,
+                    value1.Y + (value2.Y - value1.Y) * amount,
+                    value1.Z + (value2.Z - value1.Z) * amount);
+            }
+        }
+
+        /// <summary>
+        /// Transforms a vector by the given matrix.
+        /// </summary>
+        /// <param name="position">The source vector.</param>
+        /// <param name="matrix">The transformation matrix.</param>
+        /// <returns>The transformed vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 Transform(Vector3 position, Matrix4x4 matrix)
+        {
+            return new Vector3(
+                position.X * matrix.M11 + position.Y * matrix.M21 + position.Z * matrix.M31 + matrix.M41,
+                position.X * matrix.M12 + position.Y * matrix.M22 + position.Z * matrix.M32 + matrix.M42,
+                position.X * matrix.M13 + position.Y * matrix.M23 + position.Z * matrix.M33 + matrix.M43);
+        }
+
+        /// <summary>
+        /// Transforms a vector normal by the given matrix.
+        /// </summary>
+        /// <param name="normal">The source vector.</param>
+        /// <param name="matrix">The transformation matrix.</param>
+        /// <returns>The transformed vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 TransformNormal(Vector3 normal, Matrix4x4 matrix)
+        {
+            return new Vector3(
+                normal.X * matrix.M11 + normal.Y * matrix.M21 + normal.Z * matrix.M31,
+                normal.X * matrix.M12 + normal.Y * matrix.M22 + normal.Z * matrix.M32,
+                normal.X * matrix.M13 + normal.Y * matrix.M23 + normal.Z * matrix.M33);
+        }
+
+        /// <summary>
+        /// Transforms a vector by the given Quaternion rotation value.
+        /// </summary>
+        /// <param name="value">The source vector to be rotated.</param>
+        /// <param name="rotation">The rotation to apply.</param>
+        /// <returns>The transformed vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 Transform(Vector3 value, Quaternion rotation)
+        {
+            float x2 = rotation.X + rotation.X;
+            float y2 = rotation.Y + rotation.Y;
+            float z2 = rotation.Z + rotation.Z;
+
+            float wx2 = rotation.W * x2;
+            float wy2 = rotation.W * y2;
+            float wz2 = rotation.W * z2;
+            float xx2 = rotation.X * x2;
+            float xy2 = rotation.X * y2;
+            float xz2 = rotation.X * z2;
+            float yy2 = rotation.Y * y2;
+            float yz2 = rotation.Y * z2;
+            float zz2 = rotation.Z * z2;
+
+            return new Vector3(
+                value.X * (1.0f - yy2 - zz2) + value.Y * (xy2 - wz2) + value.Z * (xz2 + wy2),
+                value.X * (xy2 + wz2) + value.Y * (1.0f - xx2 - zz2) + value.Z * (yz2 - wx2),
+                value.X * (xz2 - wy2) + value.Y * (yz2 + wx2) + value.Z * (1.0f - xx2 - yy2));
+        }
+        #endregion Public Static Methods
+
+        #region Public operator methods
+
+        // All these methods should be inlined as they are implemented
+        // over JIT intrinsics
+
+        /// <summary>
+        /// Adds two vectors together.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The summed vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 Add(Vector3 left, Vector3 right)
+        {
+            return left + right;
+        }
+
+        /// <summary>
+        /// Subtracts the second vector from the first.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The difference vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 Subtract(Vector3 left, Vector3 right)
+        {
+            return left - right;
+        }
+
+        /// <summary>
+        /// Multiplies two vectors together.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The product vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 Multiply(Vector3 left, Vector3 right)
+        {
+            return left * right;
+        }
+
+        /// <summary>
+        /// Multiplies a vector by the given scalar.
+        /// </summary>
+        /// <param name="left">The source vector.</param>
+        /// <param name="right">The scalar value.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 Multiply(Vector3 left, Single right)
+        {
+            return left * right;
+        }
+
+        /// <summary>
+        /// Multiplies a vector by the given scalar.
+        /// </summary>
+        /// <param name="left">The scalar value.</param>
+        /// <param name="right">The source vector.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 Multiply(Single left, Vector3 right)
+        {
+            return left * right;
+        }
+
+        /// <summary>
+        /// Divides the first vector by the second.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The vector resulting from the division.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 Divide(Vector3 left, Vector3 right)
+        {
+            return left / right;
+        }
+
+        /// <summary>
+        /// Divides the vector by the given scalar.
+        /// </summary>
+        /// <param name="left">The source vector.</param>
+        /// <param name="divisor">The scalar value.</param>
+        /// <returns>The result of the division.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 Divide(Vector3 left, Single divisor)
+        {
+            return left / divisor;
+        }
+
+        /// <summary>
+        /// Negates a given vector.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The negated vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 Negate(Vector3 value)
+        {
+            return -value;
+        }
+        #endregion Public operator methods
+    }
+}

--- a/src/mscorlib/src/System/Numerics/Vector3_Intrinsics.cs
+++ b/src/mscorlib/src/System/Numerics/Vector3_Intrinsics.cs
@@ -1,0 +1,323 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Numerics
+{
+    // This file contains the definitions for all of the JIT intrinsic methods and properties that are recognized by the current x64 JIT compiler.
+    // The implementation defined here is used in any circumstance where the JIT fails to recognize these members as intrinsic.
+    // The JIT recognizes these methods and properties by name and signature: if either is changed, the JIT will no longer recognize the member.
+    // Some methods declared here are not strictly intrinsic, but delegate to an intrinsic method. For example, only one overload of CopyTo()
+    // is actually recognized by the JIT, but both are here for simplicity.
+
+    public partial struct Vector3
+    {
+        /// <summary>
+        /// The X component of the vector.
+        /// </summary>
+        public Single X;
+        /// <summary>
+        /// The Y component of the vector.
+        /// </summary>
+        public Single Y;
+        /// <summary>
+        /// The Z component of the vector.
+        /// </summary>
+        public Single Z;
+
+        #region Constructors
+        /// <summary>
+        /// Constructs a vector whose elements are all the single specified value.
+        /// </summary>
+        /// <param name="value">The element to fill the vector with.</param>
+        [JitIntrinsic]
+        public Vector3(Single value) : this(value, value, value) { }
+
+        /// <summary>
+        /// Constructs a Vector3 from the given Vector2 and a third value.
+        /// </summary>
+        /// <param name="value">The Vector to extract X and Y components from.</param>
+        /// <param name="z">The Z component.</param>
+        public Vector3(Vector2 value, float z) : this(value.X, value.Y, z) { }
+
+        /// <summary>
+        /// Constructs a vector with the given individual elements.
+        /// </summary>
+        /// <param name="x">The X component.</param>
+        /// <param name="y">The Y component.</param>
+        /// <param name="z">The Z component.</param>
+        [JitIntrinsic]
+        public Vector3(Single x, Single y, Single z)
+        {
+            X = x;
+            Y = y;
+            Z = z;
+        }
+        #endregion Constructors
+
+        #region Public Instance Methods
+        /// <summary>
+        /// Copies the contents of the vector into the given array.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void CopyTo(Single[] array)
+        {
+            CopyTo(array, 0);
+        }
+
+        /// <summary>
+        /// Copies the contents of the vector into the given array, starting from index.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">If array is null.</exception>
+        /// <exception cref="RankException">If array is multidimensional.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If index is greater than end of the array or index is less than zero.</exception>
+        /// <exception cref="ArgumentException">If number of elements in source vector is greater than those available in destination array.</exception>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void CopyTo(Single[] array, int index)
+        {
+            if (array == null)
+            {
+                // Match the JIT's exception type here. For perf, a NullReference is thrown instead of an ArgumentNull.
+                throw new NullReferenceException(SR.Arg_NullArgumentNullRef);
+            }
+            if (index < 0 || index >= array.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index), SR.Format(SR.Arg_ArgumentOutOfRangeException, index));
+            }
+            if ((array.Length - index) < 3)
+            {
+                throw new ArgumentException(SR.Format(SR.Arg_ElementsInSourceIsGreaterThanDestination, index));
+            }
+            array[index] = X;
+            array[index + 1] = Y;
+            array[index + 2] = Z;
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the given Vector3 is equal to this Vector3 instance.
+        /// </summary>
+        /// <param name="other">The Vector3 to compare this instance to.</param>
+        /// <returns>True if the other Vector3 is equal to this instance; False otherwise.</returns>
+        [JitIntrinsic]
+        public bool Equals(Vector3 other)
+        {
+            return X == other.X &&
+                   Y == other.Y &&
+                   Z == other.Z;
+        }
+        #endregion Public Instance Methods
+
+        #region Public Static Methods
+        /// <summary>
+        /// Returns the dot product of two vectors.
+        /// </summary>
+        /// <param name="vector1">The first vector.</param>
+        /// <param name="vector2">The second vector.</param>
+        /// <returns>The dot product.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Dot(Vector3 vector1, Vector3 vector2)
+        {
+            return vector1.X * vector2.X +
+                   vector1.Y * vector2.Y +
+                   vector1.Z * vector2.Z;
+        }
+
+        /// <summary>
+        /// Returns a vector whose elements are the minimum of each of the pairs of elements in the two source vectors.
+        /// </summary>
+        /// <param name="value1">The first source vector.</param>
+        /// <param name="value2">The second source vector.</param>
+        /// <returns>The minimized vector.</returns>
+        [JitIntrinsic]
+        public static Vector3 Min(Vector3 value1, Vector3 value2)
+        {
+            return new Vector3(
+                (value1.X < value2.X) ? value1.X : value2.X,
+                (value1.Y < value2.Y) ? value1.Y : value2.Y,
+                (value1.Z < value2.Z) ? value1.Z : value2.Z);
+        }
+
+        /// <summary>
+        /// Returns a vector whose elements are the maximum of each of the pairs of elements in the two source vectors.
+        /// </summary>
+        /// <param name="value1">The first source vector.</param>
+        /// <param name="value2">The second source vector.</param>
+        /// <returns>The maximized vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 Max(Vector3 value1, Vector3 value2)
+        {
+            return new Vector3(
+                (value1.X > value2.X) ? value1.X : value2.X,
+                (value1.Y > value2.Y) ? value1.Y : value2.Y,
+                (value1.Z > value2.Z) ? value1.Z : value2.Z);
+        }
+
+        /// <summary>
+        /// Returns a vector whose elements are the absolute values of each of the source vector's elements.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The absolute value vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 Abs(Vector3 value)
+        {
+            return new Vector3(MathF.Abs(value.X), MathF.Abs(value.Y), MathF.Abs(value.Z));
+        }
+
+        /// <summary>
+        /// Returns a vector whose elements are the square root of each of the source vector's elements.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The square root vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 SquareRoot(Vector3 value)
+        {
+            return new Vector3(MathF.Sqrt(value.X), MathF.Sqrt(value.Y), MathF.Sqrt(value.Z));
+        }
+        #endregion Public Static Methods
+
+        #region Public Static Operators
+        /// <summary>
+        /// Adds two vectors together.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The summed vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 operator +(Vector3 left, Vector3 right)
+        {
+            return new Vector3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
+        }
+
+        /// <summary>
+        /// Subtracts the second vector from the first.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The difference vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 operator -(Vector3 left, Vector3 right)
+        {
+            return new Vector3(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
+        }
+
+        /// <summary>
+        /// Multiplies two vectors together.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The product vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 operator *(Vector3 left, Vector3 right)
+        {
+            return new Vector3(left.X * right.X, left.Y * right.Y, left.Z * right.Z);
+        }
+
+        /// <summary>
+        /// Multiplies a vector by the given scalar.
+        /// </summary>
+        /// <param name="left">The source vector.</param>
+        /// <param name="right">The scalar value.</param>
+        /// <returns>The scaled vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 operator *(Vector3 left, Single right)
+        {
+            return left * new Vector3(right);
+        }
+
+        /// <summary>
+        /// Multiplies a vector by the given scalar.
+        /// </summary>
+        /// <param name="left">The scalar value.</param>
+        /// <param name="right">The source vector.</param>
+        /// <returns>The scaled vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 operator *(Single left, Vector3 right)
+        {
+            return new Vector3(left) * right;
+        }
+
+        /// <summary>
+        /// Divides the first vector by the second.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The vector resulting from the division.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 operator /(Vector3 left, Vector3 right)
+        {
+            return new Vector3(left.X / right.X, left.Y / right.Y, left.Z / right.Z);
+        }
+
+        /// <summary>
+        /// Divides the vector by the given scalar.
+        /// </summary>
+        /// <param name="value1">The source vector.</param>
+        /// <param name="value2">The scalar value.</param>
+        /// <returns>The result of the division.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 operator /(Vector3 value1, float value2)
+        {
+            float invDiv = 1.0f / value2;
+
+            return new Vector3(
+                value1.X * invDiv,
+                value1.Y * invDiv,
+                value1.Z * invDiv);
+        }
+
+        /// <summary>
+        /// Negates a given vector.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The negated vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 operator -(Vector3 value)
+        {
+            return Zero - value;
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the two given vectors are equal.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>True if the vectors are equal; False otherwise.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator ==(Vector3 left, Vector3 right)
+        {
+            return (left.X == right.X &&
+                    left.Y == right.Y &&
+                    left.Z == right.Z);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the two given vectors are not equal.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>True if the vectors are not equal; False if they are equal.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator !=(Vector3 left, Vector3 right)
+        {
+            return (left.X != right.X ||
+                    left.Y != right.Y ||
+                    left.Z != right.Z);
+        }
+        #endregion Public Static Operators
+    }
+}

--- a/src/mscorlib/src/System/Numerics/Vector4.cs
+++ b/src/mscorlib/src/System/Numerics/Vector4.cs
@@ -1,0 +1,522 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Numerics.Hashing;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace System.Numerics
+{
+    /// <summary>
+    /// A structure encapsulating four single precision floating point values and provides hardware accelerated methods.
+    /// </summary>
+    public partial struct Vector4 : IEquatable<Vector4>, IFormattable
+    {
+        #region Public Static Properties
+        /// <summary>
+        /// Returns the vector (0,0,0,0).
+        /// </summary>
+        public static Vector4 Zero { get { return new Vector4(); } }
+        /// <summary>
+        /// Returns the vector (1,1,1,1).
+        /// </summary>
+        public static Vector4 One { get { return new Vector4(1.0f, 1.0f, 1.0f, 1.0f); } }
+        /// <summary>
+        /// Returns the vector (1,0,0,0).
+        /// </summary>
+        public static Vector4 UnitX { get { return new Vector4(1.0f, 0.0f, 0.0f, 0.0f); } }
+        /// <summary>
+        /// Returns the vector (0,1,0,0).
+        /// </summary>
+        public static Vector4 UnitY { get { return new Vector4(0.0f, 1.0f, 0.0f, 0.0f); } }
+        /// <summary>
+        /// Returns the vector (0,0,1,0).
+        /// </summary>
+        public static Vector4 UnitZ { get { return new Vector4(0.0f, 0.0f, 1.0f, 0.0f); } }
+        /// <summary>
+        /// Returns the vector (0,0,0,1).
+        /// </summary>
+        public static Vector4 UnitW { get { return new Vector4(0.0f, 0.0f, 0.0f, 1.0f); } }
+        #endregion Public Static Properties
+
+        #region Public instance methods
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>The hash code.</returns>
+        public override int GetHashCode()
+        {
+            int hash = this.X.GetHashCode();
+            hash = HashHelpers.Combine(hash, this.Y.GetHashCode());
+            hash = HashHelpers.Combine(hash, this.Z.GetHashCode());
+            hash = HashHelpers.Combine(hash, this.W.GetHashCode());
+            return hash;
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the given Object is equal to this Vector4 instance.
+        /// </summary>
+        /// <param name="obj">The Object to compare against.</param>
+        /// <returns>True if the Object is equal to this Vector4; False otherwise.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override bool Equals(object obj)
+        {
+            if (!(obj is Vector4))
+                return false;
+            return Equals((Vector4)obj);
+        }
+
+        /// <summary>
+        /// Returns a String representing this Vector4 instance.
+        /// </summary>
+        /// <returns>The string representation.</returns>
+        public override string ToString()
+        {
+            return ToString("G", CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Returns a String representing this Vector4 instance, using the specified format to format individual elements.
+        /// </summary>
+        /// <param name="format">The format of individual elements.</param>
+        /// <returns>The string representation.</returns>
+        public string ToString(string format)
+        {
+            return ToString(format, CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Returns a String representing this Vector4 instance, using the specified format to format individual elements 
+        /// and the given IFormatProvider.
+        /// </summary>
+        /// <param name="format">The format of individual elements.</param>
+        /// <param name="formatProvider">The format provider to use when formatting elements.</param>
+        /// <returns>The string representation.</returns>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            StringBuilder sb = new StringBuilder();
+            string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;
+            sb.Append('<');
+            sb.Append(this.X.ToString(format, formatProvider));
+            sb.Append(separator);
+            sb.Append(' ');
+            sb.Append(this.Y.ToString(format, formatProvider));
+            sb.Append(separator);
+            sb.Append(' ');
+            sb.Append(this.Z.ToString(format, formatProvider));
+            sb.Append(separator);
+            sb.Append(' ');
+            sb.Append(this.W.ToString(format, formatProvider));
+            sb.Append('>');
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns the length of the vector. This operation is cheaper than Length().
+        /// </summary>
+        /// <returns>The vector's length.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float Length()
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                float ls = Vector4.Dot(this, this);
+                return MathF.Sqrt(ls);
+            }
+            else
+            {
+                float ls = X * X + Y * Y + Z * Z + W * W;
+
+                return MathF.Sqrt(ls);
+            }
+        }
+
+        /// <summary>
+        /// Returns the length of the vector squared.
+        /// </summary>
+        /// <returns>The vector's length squared.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float LengthSquared()
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                return Vector4.Dot(this, this);
+            }
+            else
+            {
+                return X * X + Y * Y + Z * Z + W * W;
+            }
+        }
+        #endregion Public Instance Methods
+
+        #region Public Static Methods
+        /// <summary>
+        /// Returns the Euclidean distance between the two given points.
+        /// </summary>
+        /// <param name="value1">The first point.</param>
+        /// <param name="value2">The second point.</param>
+        /// <returns>The distance.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Distance(Vector4 value1, Vector4 value2)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                Vector4 difference = value1 - value2;
+                float ls = Vector4.Dot(difference, difference);
+                return MathF.Sqrt(ls);
+            }
+            else
+            {
+                float dx = value1.X - value2.X;
+                float dy = value1.Y - value2.Y;
+                float dz = value1.Z - value2.Z;
+                float dw = value1.W - value2.W;
+
+                float ls = dx * dx + dy * dy + dz * dz + dw * dw;
+
+                return MathF.Sqrt(ls);
+            }
+        }
+
+        /// <summary>
+        /// Returns the Euclidean distance squared between the two given points.
+        /// </summary>
+        /// <param name="value1">The first point.</param>
+        /// <param name="value2">The second point.</param>
+        /// <returns>The distance squared.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float DistanceSquared(Vector4 value1, Vector4 value2)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                Vector4 difference = value1 - value2;
+                return Vector4.Dot(difference, difference);
+            }
+            else
+            {
+                float dx = value1.X - value2.X;
+                float dy = value1.Y - value2.Y;
+                float dz = value1.Z - value2.Z;
+                float dw = value1.W - value2.W;
+
+                return dx * dx + dy * dy + dz * dz + dw * dw;
+            }
+        }
+
+        /// <summary>
+        /// Returns a vector with the same direction as the given vector, but with a length of 1.
+        /// </summary>
+        /// <param name="vector">The vector to normalize.</param>
+        /// <returns>The normalized vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 Normalize(Vector4 vector)
+        {
+            if (Vector.IsHardwareAccelerated)
+            {
+                float length = vector.Length();
+                return vector / length;
+            }
+            else
+            {
+                float ls = vector.X * vector.X + vector.Y * vector.Y + vector.Z * vector.Z + vector.W * vector.W;
+                float invNorm = 1.0f / MathF.Sqrt(ls);
+
+                return new Vector4(
+                    vector.X * invNorm,
+                    vector.Y * invNorm,
+                    vector.Z * invNorm,
+                    vector.W * invNorm);
+            }
+        }
+
+        /// <summary>
+        /// Restricts a vector between a min and max value.
+        /// </summary>
+        /// <param name="value1">The source vector.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <returns>The restricted vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 Clamp(Vector4 value1, Vector4 min, Vector4 max)
+        {
+            // This compare order is very important!!!
+            // We must follow HLSL behavior in the case user specified min value is bigger than max value.
+
+            float x = value1.X;
+            x = (x > max.X) ? max.X : x;
+            x = (x < min.X) ? min.X : x;
+
+            float y = value1.Y;
+            y = (y > max.Y) ? max.Y : y;
+            y = (y < min.Y) ? min.Y : y;
+
+            float z = value1.Z;
+            z = (z > max.Z) ? max.Z : z;
+            z = (z < min.Z) ? min.Z : z;
+
+            float w = value1.W;
+            w = (w > max.W) ? max.W : w;
+            w = (w < min.W) ? min.W : w;
+
+            return new Vector4(x, y, z, w);
+        }
+
+        /// <summary>
+        /// Linearly interpolates between two vectors based on the given weighting.
+        /// </summary>
+        /// <param name="value1">The first source vector.</param>
+        /// <param name="value2">The second source vector.</param>
+        /// <param name="amount">Value between 0 and 1 indicating the weight of the second source vector.</param>
+        /// <returns>The interpolated vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 Lerp(Vector4 value1, Vector4 value2, float amount)
+        {
+            return new Vector4(
+                value1.X + (value2.X - value1.X) * amount,
+                value1.Y + (value2.Y - value1.Y) * amount,
+                value1.Z + (value2.Z - value1.Z) * amount,
+                value1.W + (value2.W - value1.W) * amount);
+        }
+
+        /// <summary>
+        /// Transforms a vector by the given matrix.
+        /// </summary>
+        /// <param name="position">The source vector.</param>
+        /// <param name="matrix">The transformation matrix.</param>
+        /// <returns>The transformed vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 Transform(Vector2 position, Matrix4x4 matrix)
+        {
+            return new Vector4(
+                position.X * matrix.M11 + position.Y * matrix.M21 + matrix.M41,
+                position.X * matrix.M12 + position.Y * matrix.M22 + matrix.M42,
+                position.X * matrix.M13 + position.Y * matrix.M23 + matrix.M43,
+                position.X * matrix.M14 + position.Y * matrix.M24 + matrix.M44);
+        }
+
+        /// <summary>
+        /// Transforms a vector by the given matrix.
+        /// </summary>
+        /// <param name="position">The source vector.</param>
+        /// <param name="matrix">The transformation matrix.</param>
+        /// <returns>The transformed vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 Transform(Vector3 position, Matrix4x4 matrix)
+        {
+            return new Vector4(
+                position.X * matrix.M11 + position.Y * matrix.M21 + position.Z * matrix.M31 + matrix.M41,
+                position.X * matrix.M12 + position.Y * matrix.M22 + position.Z * matrix.M32 + matrix.M42,
+                position.X * matrix.M13 + position.Y * matrix.M23 + position.Z * matrix.M33 + matrix.M43,
+                position.X * matrix.M14 + position.Y * matrix.M24 + position.Z * matrix.M34 + matrix.M44);
+        }
+
+        /// <summary>
+        /// Transforms a vector by the given matrix.
+        /// </summary>
+        /// <param name="vector">The source vector.</param>
+        /// <param name="matrix">The transformation matrix.</param>
+        /// <returns>The transformed vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 Transform(Vector4 vector, Matrix4x4 matrix)
+        {
+            return new Vector4(
+                vector.X * matrix.M11 + vector.Y * matrix.M21 + vector.Z * matrix.M31 + vector.W * matrix.M41,
+                vector.X * matrix.M12 + vector.Y * matrix.M22 + vector.Z * matrix.M32 + vector.W * matrix.M42,
+                vector.X * matrix.M13 + vector.Y * matrix.M23 + vector.Z * matrix.M33 + vector.W * matrix.M43,
+                vector.X * matrix.M14 + vector.Y * matrix.M24 + vector.Z * matrix.M34 + vector.W * matrix.M44);
+        }
+
+        /// <summary>
+        /// Transforms a vector by the given Quaternion rotation value.
+        /// </summary>
+        /// <param name="value">The source vector to be rotated.</param>
+        /// <param name="rotation">The rotation to apply.</param>
+        /// <returns>The transformed vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 Transform(Vector2 value, Quaternion rotation)
+        {
+            float x2 = rotation.X + rotation.X;
+            float y2 = rotation.Y + rotation.Y;
+            float z2 = rotation.Z + rotation.Z;
+
+            float wx2 = rotation.W * x2;
+            float wy2 = rotation.W * y2;
+            float wz2 = rotation.W * z2;
+            float xx2 = rotation.X * x2;
+            float xy2 = rotation.X * y2;
+            float xz2 = rotation.X * z2;
+            float yy2 = rotation.Y * y2;
+            float yz2 = rotation.Y * z2;
+            float zz2 = rotation.Z * z2;
+
+            return new Vector4(
+                value.X * (1.0f - yy2 - zz2) + value.Y * (xy2 - wz2),
+                value.X * (xy2 + wz2) + value.Y * (1.0f - xx2 - zz2),
+                value.X * (xz2 - wy2) + value.Y * (yz2 + wx2),
+                1.0f);
+        }
+
+        /// <summary>
+        /// Transforms a vector by the given Quaternion rotation value.
+        /// </summary>
+        /// <param name="value">The source vector to be rotated.</param>
+        /// <param name="rotation">The rotation to apply.</param>
+        /// <returns>The transformed vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 Transform(Vector3 value, Quaternion rotation)
+        {
+            float x2 = rotation.X + rotation.X;
+            float y2 = rotation.Y + rotation.Y;
+            float z2 = rotation.Z + rotation.Z;
+
+            float wx2 = rotation.W * x2;
+            float wy2 = rotation.W * y2;
+            float wz2 = rotation.W * z2;
+            float xx2 = rotation.X * x2;
+            float xy2 = rotation.X * y2;
+            float xz2 = rotation.X * z2;
+            float yy2 = rotation.Y * y2;
+            float yz2 = rotation.Y * z2;
+            float zz2 = rotation.Z * z2;
+
+            return new Vector4(
+                value.X * (1.0f - yy2 - zz2) + value.Y * (xy2 - wz2) + value.Z * (xz2 + wy2),
+                value.X * (xy2 + wz2) + value.Y * (1.0f - xx2 - zz2) + value.Z * (yz2 - wx2),
+                value.X * (xz2 - wy2) + value.Y * (yz2 + wx2) + value.Z * (1.0f - xx2 - yy2),
+                1.0f);
+        }
+
+        /// <summary>
+        /// Transforms a vector by the given Quaternion rotation value.
+        /// </summary>
+        /// <param name="value">The source vector to be rotated.</param>
+        /// <param name="rotation">The rotation to apply.</param>
+        /// <returns>The transformed vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 Transform(Vector4 value, Quaternion rotation)
+        {
+            float x2 = rotation.X + rotation.X;
+            float y2 = rotation.Y + rotation.Y;
+            float z2 = rotation.Z + rotation.Z;
+
+            float wx2 = rotation.W * x2;
+            float wy2 = rotation.W * y2;
+            float wz2 = rotation.W * z2;
+            float xx2 = rotation.X * x2;
+            float xy2 = rotation.X * y2;
+            float xz2 = rotation.X * z2;
+            float yy2 = rotation.Y * y2;
+            float yz2 = rotation.Y * z2;
+            float zz2 = rotation.Z * z2;
+
+            return new Vector4(
+                value.X * (1.0f - yy2 - zz2) + value.Y * (xy2 - wz2) + value.Z * (xz2 + wy2),
+                value.X * (xy2 + wz2) + value.Y * (1.0f - xx2 - zz2) + value.Z * (yz2 - wx2),
+                value.X * (xz2 - wy2) + value.Y * (yz2 + wx2) + value.Z * (1.0f - xx2 - yy2),
+                value.W);
+        }
+        #endregion Public Static Methods
+
+        #region Public operator methods
+        // All these methods should be inlines as they are implemented
+        // over JIT intrinsics
+
+        /// <summary>
+        /// Adds two vectors together.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The summed vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 Add(Vector4 left, Vector4 right)
+        {
+            return left + right;
+        }
+
+        /// <summary>
+        /// Subtracts the second vector from the first.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The difference vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 Subtract(Vector4 left, Vector4 right)
+        {
+            return left - right;
+        }
+
+        /// <summary>
+        /// Multiplies two vectors together.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The product vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 Multiply(Vector4 left, Vector4 right)
+        {
+            return left * right;
+        }
+
+        /// <summary>
+        /// Multiplies a vector by the given scalar.
+        /// </summary>
+        /// <param name="left">The source vector.</param>
+        /// <param name="right">The scalar value.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 Multiply(Vector4 left, Single right)
+        {
+            return left * new Vector4(right, right, right, right);
+        }
+
+        /// <summary>
+        /// Multiplies a vector by the given scalar.
+        /// </summary>
+        /// <param name="left">The scalar value.</param>
+        /// <param name="right">The source vector.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 Multiply(Single left, Vector4 right)
+        {
+            return new Vector4(left, left, left, left) * right;
+        }
+
+        /// <summary>
+        /// Divides the first vector by the second.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The vector resulting from the division.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 Divide(Vector4 left, Vector4 right)
+        {
+            return left / right;
+        }
+
+        /// <summary>
+        /// Divides the vector by the given scalar.
+        /// </summary>
+        /// <param name="left">The source vector.</param>
+        /// <param name="divisor">The scalar value.</param>
+        /// <returns>The result of the division.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 Divide(Vector4 left, Single divisor)
+        {
+            return left / divisor;
+        }
+
+        /// <summary>
+        /// Negates a given vector.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The negated vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 Negate(Vector4 value)
+        {
+            return -value;
+        }
+        #endregion Public operator methods
+    }
+}

--- a/src/mscorlib/src/System/Numerics/Vector4_Intrinsics.cs
+++ b/src/mscorlib/src/System/Numerics/Vector4_Intrinsics.cs
@@ -1,0 +1,354 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Numerics
+{
+    // This file contains the definitions for all of the JIT intrinsic methods and properties that are recognized by the current x64 JIT compiler.
+    // The implementation defined here is used in any circumstance where the JIT fails to recognize these members as intrinsic.
+    // The JIT recognizes these methods and properties by name and signature: if either is changed, the JIT will no longer recognize the member.
+    // Some methods declared here are not strictly intrinsic, but delegate to an intrinsic method. For example, only one overload of CopyTo() 
+
+    public partial struct Vector4
+    {
+        /// <summary>
+        /// The X component of the vector.
+        /// </summary>
+        public Single X;
+        /// <summary>
+        /// The Y component of the vector.
+        /// </summary>
+        public Single Y;
+        /// <summary>
+        /// The Z component of the vector.
+        /// </summary>
+        public Single Z;
+        /// <summary>
+        /// The W component of the vector.
+        /// </summary>
+        public Single W;
+
+        #region Constructors
+
+        /// <summary>
+        /// Constructs a vector whose elements are all the single specified value.
+        /// </summary>
+        /// <param name="value">The element to fill the vector with.</param>
+        [JitIntrinsic]
+        public Vector4(Single value)
+            : this(value, value, value, value)
+        {
+        }
+        /// <summary>
+        /// Constructs a vector with the given individual elements.
+        /// </summary>
+        /// <param name="w">W component.</param>
+        /// <param name="x">X component.</param>
+        /// <param name="y">Y component.</param>
+        /// <param name="z">Z component.</param>
+        [JitIntrinsic]
+        public Vector4(Single x, Single y, Single z, Single w)
+        {
+            W = w;
+            X = x;
+            Y = y;
+            Z = z;
+        }
+
+        /// <summary>
+        /// Constructs a Vector4 from the given Vector2 and a Z and W component.
+        /// </summary>
+        /// <param name="value">The vector to use as the X and Y components.</param>
+        /// <param name="z">The Z component.</param>
+        /// <param name="w">The W component.</param>
+        public Vector4(Vector2 value, Single z, Single w)
+        {
+            X = value.X;
+            Y = value.Y;
+            Z = z;
+            W = w;
+        }
+
+        /// <summary>
+        /// Constructs a Vector4 from the given Vector3 and a W component.
+        /// </summary>
+        /// <param name="value">The vector to use as the X, Y, and Z components.</param>
+        /// <param name="w">The W component.</param>
+        public Vector4(Vector3 value, Single w)
+        {
+            X = value.X;
+            Y = value.Y;
+            Z = value.Z;
+            W = w;
+        }
+        #endregion Constructors
+
+        #region Public Instance Methods
+        /// <summary>
+        /// Copies the contents of the vector into the given array.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void CopyTo(Single[] array)
+        {
+            CopyTo(array, 0);
+        }
+
+        /// <summary>
+        /// Copies the contents of the vector into the given array, starting from index.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">If array is null.</exception>
+        /// <exception cref="RankException">If array is multidimensional.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If index is greater than end of the array or index is less than zero.</exception>
+        /// <exception cref="ArgumentException">If number of elements in source vector is greater than those available in destination array.</exception>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void CopyTo(Single[] array, int index)
+        {
+            if (array == null)
+            {
+                // Match the JIT's exception type here. For perf, a NullReference is thrown instead of an ArgumentNull.
+                throw new NullReferenceException(SR.Arg_NullArgumentNullRef);
+            }
+            if (index < 0 || index >= array.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index), SR.Format(SR.Arg_ArgumentOutOfRangeException, index));
+            }
+            if ((array.Length - index) < 4)
+            {
+                throw new ArgumentException(SR.Format(SR.Arg_ElementsInSourceIsGreaterThanDestination, index));
+            }
+            array[index] = X;
+            array[index + 1] = Y;
+            array[index + 2] = Z;
+            array[index + 3] = W;
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the given Vector4 is equal to this Vector4 instance.
+        /// </summary>
+        /// <param name="other">The Vector4 to compare this instance to.</param>
+        /// <returns>True if the other Vector4 is equal to this instance; False otherwise.</returns>
+        [JitIntrinsic]
+        public bool Equals(Vector4 other)
+        {
+            return this.X == other.X
+                && this.Y == other.Y
+                && this.Z == other.Z
+                && this.W == other.W;
+        }
+        #endregion Public Instance Methods
+
+        #region Public Static Methods
+        /// <summary>
+        /// Returns the dot product of two vectors.
+        /// </summary>
+        /// <param name="vector1">The first vector.</param>
+        /// <param name="vector2">The second vector.</param>
+        /// <returns>The dot product.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Dot(Vector4 vector1, Vector4 vector2)
+        {
+            return vector1.X * vector2.X +
+                   vector1.Y * vector2.Y +
+                   vector1.Z * vector2.Z +
+                   vector1.W * vector2.W;
+        }
+
+        /// <summary>
+        /// Returns a vector whose elements are the minimum of each of the pairs of elements in the two source vectors.
+        /// </summary>
+        /// <param name="value1">The first source vector.</param>
+        /// <param name="value2">The second source vector.</param>
+        /// <returns>The minimized vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 Min(Vector4 value1, Vector4 value2)
+        {
+            return new Vector4(
+                (value1.X < value2.X) ? value1.X : value2.X,
+                (value1.Y < value2.Y) ? value1.Y : value2.Y,
+                (value1.Z < value2.Z) ? value1.Z : value2.Z,
+                (value1.W < value2.W) ? value1.W : value2.W);
+        }
+
+        /// <summary>
+        /// Returns a vector whose elements are the maximum of each of the pairs of elements in the two source vectors.
+        /// </summary>
+        /// <param name="value1">The first source vector.</param>
+        /// <param name="value2">The second source vector.</param>
+        /// <returns>The maximized vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 Max(Vector4 value1, Vector4 value2)
+        {
+            return new Vector4(
+                (value1.X > value2.X) ? value1.X : value2.X,
+                (value1.Y > value2.Y) ? value1.Y : value2.Y,
+                (value1.Z > value2.Z) ? value1.Z : value2.Z,
+                (value1.W > value2.W) ? value1.W : value2.W);
+        }
+
+        /// <summary>
+        /// Returns a vector whose elements are the absolute values of each of the source vector's elements.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The absolute value vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 Abs(Vector4 value)
+        {
+            return new Vector4(MathF.Abs(value.X), MathF.Abs(value.Y), MathF.Abs(value.Z), MathF.Abs(value.W));
+        }
+
+        /// <summary>
+        /// Returns a vector whose elements are the square root of each of the source vector's elements.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The square root vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 SquareRoot(Vector4 value)
+        {
+            return new Vector4(MathF.Sqrt(value.X), MathF.Sqrt(value.Y), MathF.Sqrt(value.Z), MathF.Sqrt(value.W));
+        }
+        #endregion Public Static Methods
+
+        #region Public static operators
+        /// <summary>
+        /// Adds two vectors together.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The summed vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 operator +(Vector4 left, Vector4 right)
+        {
+            return new Vector4(left.X + right.X, left.Y + right.Y, left.Z + right.Z, left.W + right.W);
+        }
+
+        /// <summary>
+        /// Subtracts the second vector from the first.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The difference vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 operator -(Vector4 left, Vector4 right)
+        {
+            return new Vector4(left.X - right.X, left.Y - right.Y, left.Z - right.Z, left.W - right.W);
+        }
+
+        /// <summary>
+        /// Multiplies two vectors together.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The product vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 operator *(Vector4 left, Vector4 right)
+        {
+            return new Vector4(left.X * right.X, left.Y * right.Y, left.Z * right.Z, left.W * right.W);
+        }
+
+        /// <summary>
+        /// Multiplies a vector by the given scalar.
+        /// </summary>
+        /// <param name="left">The source vector.</param>
+        /// <param name="right">The scalar value.</param>
+        /// <returns>The scaled vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 operator *(Vector4 left, Single right)
+        {
+            return left * new Vector4(right);
+        }
+
+        /// <summary>
+        /// Multiplies a vector by the given scalar.
+        /// </summary>
+        /// <param name="left">The scalar value.</param>
+        /// <param name="right">The source vector.</param>
+        /// <returns>The scaled vector.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 operator *(Single left, Vector4 right)
+        {
+            return new Vector4(left) * right;
+        }
+
+        /// <summary>
+        /// Divides the first vector by the second.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The vector resulting from the division.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 operator /(Vector4 left, Vector4 right)
+        {
+            return new Vector4(left.X / right.X, left.Y / right.Y, left.Z / right.Z, left.W / right.W);
+        }
+
+        /// <summary>
+        /// Divides the vector by the given scalar.
+        /// </summary>
+        /// <param name="value1">The source vector.</param>
+        /// <param name="value2">The scalar value.</param>
+        /// <returns>The result of the division.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 operator /(Vector4 value1, float value2)
+        {
+            float invDiv = 1.0f / value2;
+
+            return new Vector4(
+                value1.X * invDiv,
+                value1.Y * invDiv,
+                value1.Z * invDiv,
+                value1.W * invDiv);
+        }
+
+        /// <summary>
+        /// Negates a given vector.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The negated vector.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector4 operator -(Vector4 value)
+        {
+            return Zero - value;
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the two given vectors are equal.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>True if the vectors are equal; False otherwise.</returns>
+        [JitIntrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator ==(Vector4 left, Vector4 right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether the two given vectors are not equal.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>True if the vectors are not equal; False if they are equal.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator !=(Vector4 left, Vector4 right)
+        {
+            return !(left == right);
+        }
+        #endregion Public static operators
+    }
+}

--- a/src/mscorlib/src/System/Numerics/Vector_Operations.cs
+++ b/src/mscorlib/src/System/Numerics/Vector_Operations.cs
@@ -1,0 +1,865 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Numerics
+{
+    /// <summary>
+    /// Contains various methods useful for creating, manipulating, combining, and converting generic vectors with one another.
+    /// </summary>
+    public static partial class Vector
+    {
+        // JIT is not looking at the Vector class methods
+        // all methods here should be inlined and they must be implemented in terms of Vector<T> intrinsics
+        #region Select Methods
+        /// <summary>
+        /// Creates a new vector with elements selected between the two given source vectors, and based on a mask vector.
+        /// </summary>
+        /// <param name="condition">The integral mask vector used to drive selection.</param>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The new vector with elements selected based on the mask.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<Single> ConditionalSelect(Vector<int> condition, Vector<Single> left, Vector<Single> right)
+        {
+            return (Vector<Single>)Vector<Single>.ConditionalSelect((Vector<Single>)condition, left, right);
+        }
+
+        /// <summary>
+        /// Creates a new vector with elements selected between the two given source vectors, and based on a mask vector.
+        /// </summary>
+        /// <param name="condition">The integral mask vector used to drive selection.</param>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The new vector with elements selected based on the mask.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<double> ConditionalSelect(Vector<long> condition, Vector<double> left, Vector<double> right)
+        {
+            return (Vector<double>)Vector<double>.ConditionalSelect((Vector<double>)condition, left, right);
+        }
+
+        /// <summary>
+        /// Creates a new vector with elements selected between the two given source vectors, and based on a mask vector.
+        /// </summary>
+        /// <param name="condition">The mask vector used to drive selection.</param>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The new vector with elements selected based on the mask.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<T> ConditionalSelect<T>(Vector<T> condition, Vector<T> left, Vector<T> right) where T : struct
+        {
+            return Vector<T>.ConditionalSelect(condition, left, right);
+        }
+        #endregion Select Methods
+
+        #region Comparison methods
+        #region Equals methods
+        /// <summary>
+        /// Returns a new vector whose elements signal whether the elements in left and right were equal.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<T> Equals<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            return Vector<T>.Equals(left, right);
+        }
+
+        /// <summary>
+        /// Returns an integral vector whose elements signal whether elements in the left and right floating point vectors were equal.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<int> Equals(Vector<Single> left, Vector<Single> right)
+        {
+            return (Vector<int>)Vector<Single>.Equals(left, right);
+        }
+
+        /// <summary>
+        /// Returns a new vector whose elements signal whether the elements in left and right were equal.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<int> Equals(Vector<int> left, Vector<int> right)
+        {
+            return Vector<int>.Equals(left, right);
+        }
+
+        /// <summary>
+        /// Returns an integral vector whose elements signal whether elements in the left and right floating point vectors were equal.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<long> Equals(Vector<double> left, Vector<double> right)
+        {
+            return (Vector<long>)Vector<double>.Equals(left, right);
+        }
+
+        /// <summary>
+        /// Returns a new vector whose elements signal whether the elements in left and right were equal.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<long> Equals(Vector<long> left, Vector<long> right)
+        {
+            return Vector<long>.Equals(left, right);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether each pair of elements in the given vectors are equal.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The first vector to compare.</param>
+        /// <returns>True if all elements are equal; False otherwise.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static bool EqualsAll<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            return left == right;
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether any single pair of elements in the given vectors are equal.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>True if any element pairs are equal; False if no element pairs are equal.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static bool EqualsAny<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            return !Vector<T>.Equals(left, right).Equals(Vector<T>.Zero);
+        }
+        #endregion Equals methods
+
+        #region Lessthan Methods
+        /// <summary>
+        /// Returns a new vector whose elements signal whether the elements in left were less than their
+        /// corresponding elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<T> LessThan<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            return Vector<T>.LessThan(left, right);
+        }
+
+        /// <summary>
+        /// Returns an integral vector whose elements signal whether the elements in left were less than their
+        /// corresponding elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant integral vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<int> LessThan(Vector<Single> left, Vector<Single> right)
+        {
+            return (Vector<int>)Vector<Single>.LessThan(left, right);
+        }
+
+        /// <summary>
+        /// Returns a new vector whose elements signal whether the elements in left were less than their
+        /// corresponding elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<int> LessThan(Vector<int> left, Vector<int> right)
+        {
+            return Vector<int>.LessThan(left, right);
+        }
+
+        /// <summary>
+        /// Returns an integral vector whose elements signal whether the elements in left were less than their
+        /// corresponding elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant integral vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<long> LessThan(Vector<double> left, Vector<double> right)
+        {
+            return (Vector<long>)Vector<double>.LessThan(left, right);
+        }
+
+        /// <summary>
+        /// Returns a new vector whose elements signal whether the elements in left were less than their
+        /// corresponding elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<long> LessThan(Vector<long> left, Vector<long> right)
+        {
+            return Vector<long>.LessThan(left, right);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether all of the elements in left are less than their corresponding elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>True if all elements in left are less than their corresponding elements in right; False otherwise.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static bool LessThanAll<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            Vector<int> cond = (Vector<int>)Vector<T>.LessThan(left, right);
+            return cond.Equals(Vector<int>.AllOnes);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether any element in left is less than its corresponding element in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>True if any elements in left are less than their corresponding elements in right; False otherwise.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static bool LessThanAny<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            Vector<int> cond = (Vector<int>)Vector<T>.LessThan(left, right);
+            return !cond.Equals(Vector<int>.Zero);
+        }
+        #endregion LessthanMethods
+
+        #region Lessthanorequal methods
+        /// <summary>
+        /// Returns a new vector whose elements signal whether the elements in left were less than or equal to their
+        /// corresponding elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<T> LessThanOrEqual<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            return Vector<T>.LessThanOrEqual(left, right);
+        }
+
+        /// <summary>
+        /// Returns an integral vector whose elements signal whether the elements in left were less than or equal to their
+        /// corresponding elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant integral vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<int> LessThanOrEqual(Vector<Single> left, Vector<Single> right)
+        {
+            return (Vector<int>)Vector<Single>.LessThanOrEqual(left, right);
+        }
+
+        /// <summary>
+        /// Returns a new vector whose elements signal whether the elements in left were less than or equal to their
+        /// corresponding elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<int> LessThanOrEqual(Vector<int> left, Vector<int> right)
+        {
+            return Vector<int>.LessThanOrEqual(left, right);
+        }
+
+        /// <summary>
+        /// Returns a new vector whose elements signal whether the elements in left were less than or equal to their
+        /// corresponding elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<long> LessThanOrEqual(Vector<long> left, Vector<long> right)
+        {
+            return Vector<long>.LessThanOrEqual(left, right);
+        }
+
+        /// <summary>
+        /// Returns an integral vector whose elements signal whether the elements in left were less than or equal to their
+        /// corresponding elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant integral vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<long> LessThanOrEqual(Vector<double> left, Vector<double> right)
+        {
+            return (Vector<long>)Vector<double>.LessThanOrEqual(left, right);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether all elements in left are less than or equal to their corresponding elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>True if all elements in left are less than or equal to their corresponding elements in right; False otherwise.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static bool LessThanOrEqualAll<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            Vector<int> cond = (Vector<int>)Vector<T>.LessThanOrEqual(left, right);
+            return cond.Equals(Vector<int>.AllOnes);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether any element in left is less than or equal to its corresponding element in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>True if any elements in left are less than their corresponding elements in right; False otherwise.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static bool LessThanOrEqualAny<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            Vector<int> cond = (Vector<int>)Vector<T>.LessThanOrEqual(left, right);
+            return !cond.Equals(Vector<int>.Zero);
+        }
+        #endregion Lessthanorequal methods
+
+        #region Greaterthan methods
+        /// <summary>
+        /// Returns a new vector whose elements signal whether the elements in left were greater than their
+        /// corresponding elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<T> GreaterThan<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            return Vector<T>.GreaterThan(left, right);
+        }
+
+        /// <summary>
+        /// Returns an integral vector whose elements signal whether the elements in left were greater than their
+        /// corresponding elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant integral vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<int> GreaterThan(Vector<Single> left, Vector<Single> right)
+        {
+            return (Vector<int>)Vector<Single>.GreaterThan(left, right);
+        }
+
+        /// <summary>
+        /// Returns a new vector whose elements signal whether the elements in left were greater than their
+        /// corresponding elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<int> GreaterThan(Vector<int> left, Vector<int> right)
+        {
+            return Vector<int>.GreaterThan(left, right);
+        }
+
+        /// <summary>
+        /// Returns an integral vector whose elements signal whether the elements in left were greater than their
+        /// corresponding elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant integral vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<long> GreaterThan(Vector<double> left, Vector<double> right)
+        {
+            return (Vector<long>)Vector<double>.GreaterThan(left, right);
+        }
+
+        /// <summary>
+        /// Returns a new vector whose elements signal whether the elements in left were greater than their
+        /// corresponding elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<long> GreaterThan(Vector<long> left, Vector<long> right)
+        {
+            return Vector<long>.GreaterThan(left, right);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether all elements in left are greater than the corresponding elements in right.
+        /// elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>True if all elements in left are greater than their corresponding elements in right; False otherwise.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static bool GreaterThanAll<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            Vector<int> cond = (Vector<int>)Vector<T>.GreaterThan(left, right);
+            return cond.Equals(Vector<int>.AllOnes);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether any element in left is greater than its corresponding element in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>True if any elements in left are greater than their corresponding elements in right; False otherwise.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static bool GreaterThanAny<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            Vector<int> cond = (Vector<int>)Vector<T>.GreaterThan(left, right);
+            return !cond.Equals(Vector<int>.Zero);
+        }
+        #endregion Greaterthan methods
+
+        #region Greaterthanorequal methods
+        /// <summary>
+        /// Returns a new vector whose elements signal whether the elements in left were greater than or equal to their
+        /// corresponding elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<T> GreaterThanOrEqual<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            return Vector<T>.GreaterThanOrEqual(left, right);
+        }
+
+        /// <summary>
+        /// Returns an integral vector whose elements signal whether the elements in left were greater than or equal to their
+        /// corresponding elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant integral vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<int> GreaterThanOrEqual(Vector<Single> left, Vector<Single> right)
+        {
+            return (Vector<int>)Vector<Single>.GreaterThanOrEqual(left, right);
+        }
+
+        /// <summary>
+        /// Returns a new vector whose elements signal whether the elements in left were greater than or equal to their
+        /// corresponding elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<int> GreaterThanOrEqual(Vector<int> left, Vector<int> right)
+        {
+            return Vector<int>.GreaterThanOrEqual(left, right);
+        }
+
+        /// <summary>
+        /// Returns a new vector whose elements signal whether the elements in left were greater than or equal to their
+        /// corresponding elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<long> GreaterThanOrEqual(Vector<long> left, Vector<long> right)
+        {
+            return Vector<long>.GreaterThanOrEqual(left, right);
+        }
+
+        /// <summary>
+        /// Returns an integral vector whose elements signal whether the elements in left were greater than or equal to 
+        /// their corresponding elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>The resultant integral vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<long> GreaterThanOrEqual(Vector<double> left, Vector<double> right)
+        {
+            return (Vector<long>)Vector<double>.GreaterThanOrEqual(left, right);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether all of the elements in left are greater than or equal to 
+        /// their corresponding elements in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>True if all elements in left are greater than or equal to their corresponding elements in right; False otherwise.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static bool GreaterThanOrEqualAll<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            Vector<int> cond = (Vector<int>)Vector<T>.GreaterThanOrEqual(left, right);
+            return cond.Equals(Vector<int>.AllOnes);
+        }
+
+        /// <summary>
+        /// Returns a boolean indicating whether any element in left is greater than or equal to its corresponding element in right.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>True if any elements in left are greater than or equal to their corresponding elements in right; False otherwise.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static bool GreaterThanOrEqualAny<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            Vector<int> cond = (Vector<int>)Vector<T>.GreaterThanOrEqual(left, right);
+            return !cond.Equals(Vector<int>.Zero);
+        }
+        #endregion Greaterthanorequal methods
+        #endregion Comparison methods
+
+        #region Vector Math Methods
+        // Every operation must either be a JIT intrinsic or implemented over a JIT intrinsic
+        // as a thin wrapper
+        // Operations implemented over a JIT intrinsic should be inlined
+        // Methods that do not have a <T> type parameter are recognized as intrinsics
+        /// <summary>
+        /// Returns whether or not vector operations are subject to hardware acceleration through JIT intrinsic support.
+        /// </summary>
+        [JitIntrinsic]
+        public static bool IsHardwareAccelerated
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        // Vector<T>
+        // Basic Math
+        // All Math operations for Vector<T> are aggressively inlined here
+
+        /// <summary>
+        /// Returns a new vector whose elements are the absolute values of the given vector's elements.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The absolute value vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<T> Abs<T>(Vector<T> value) where T : struct
+        {
+            return Vector<T>.Abs(value);
+        }
+
+        /// <summary>
+        /// Returns a new vector whose elements are the minimum of each pair of elements in the two given vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The minimum vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<T> Min<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            return Vector<T>.Min(left, right);
+        }
+
+        /// <summary>
+        /// Returns a new vector whose elements are the maximum of each pair of elements in the two given vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The maximum vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<T> Max<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            return Vector<T>.Max(left, right);
+        }
+
+        // Specialized vector operations
+
+        /// <summary>
+        /// Returns the dot product of two vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The dot product.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static T Dot<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            return Vector<T>.DotProduct(left, right);
+        }
+
+        /// <summary>
+        /// Returns a new vector whose elements are the square roots of the given vector's elements.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The square root vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<T> SquareRoot<T>(Vector<T> value) where T : struct
+        {
+            return Vector<T>.SquareRoot(value);
+        }
+        #endregion Vector Math Methods
+
+        #region Named Arithmetic Operators
+        /// <summary>
+        /// Creates a new vector whose values are the sum of each pair of elements from the two given vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The summed vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<T> Add<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            return left + right;
+        }
+
+        /// <summary>
+        /// Creates a new vector whose values are the difference between each pairs of elements in the given vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The difference vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<T> Subtract<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            return left - right;
+        }
+
+        /// <summary>
+        /// Creates a new vector whose values are the product of each pair of elements from the two given vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The summed vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<T> Multiply<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            return left * right;
+        }
+
+        /// <summary>
+        /// Returns a new vector whose values are the values of the given vector each multiplied by a scalar value.
+        /// </summary>
+        /// <param name="left">The source vector.</param>
+        /// <param name="right">The scalar factor.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<T> Multiply<T>(Vector<T> left, T right) where T : struct
+        {
+            return left * right;
+        }
+
+        /// <summary>
+        /// Returns a new vector whose values are the values of the given vector each multiplied by a scalar value.
+        /// </summary>
+        /// <param name="left">The scalar factor.</param>
+        /// <param name="right">The source vector.</param>
+        /// <returns>The scaled vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<T> Multiply<T>(T left, Vector<T> right) where T : struct
+        {
+            return left * right;
+        }
+
+        /// <summary>
+        /// Returns a new vector whose values are the result of dividing the first vector's elements 
+        /// by the corresponding elements in the second vector.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The divided vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<T> Divide<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            return left / right;
+        }
+
+        /// <summary>
+        /// Returns a new vector whose elements are the given vector's elements negated.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The negated vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<T> Negate<T>(Vector<T> value) where T : struct
+        {
+            return -value;
+        }
+        #endregion Named Arithmetic Operators
+
+        #region Named Bitwise Operators
+        /// <summary>
+        /// Returns a new vector by performing a bitwise-and operation on each of the elements in the given vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The resultant vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<T> BitwiseAnd<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            return left & right;
+        }
+
+        /// <summary>
+        /// Returns a new vector by performing a bitwise-or operation on each of the elements in the given vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The resultant vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<T> BitwiseOr<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            return left | right;
+        }
+
+        /// <summary>
+        /// Returns a new vector whose elements are obtained by taking the one's complement of the given vector's elements.
+        /// </summary>
+        /// <param name="value">The source vector.</param>
+        /// <returns>The one's complement vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<T> OnesComplement<T>(Vector<T> value) where T : struct
+        {
+            return ~value;
+        }
+
+        /// <summary>
+        /// Returns a new vector by performing a bitwise-exclusive-or operation on each of the elements in the given vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The resultant vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<T> Xor<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            return left ^ right;
+        }
+
+        /// <summary>
+        /// Returns a new vector by performing a bitwise-and-not operation on each of the elements in the given vectors.
+        /// </summary>
+        /// <param name="left">The first source vector.</param>
+        /// <param name="right">The second source vector.</param>
+        /// <returns>The resultant vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<T> AndNot<T>(Vector<T> left, Vector<T> right) where T : struct
+        {
+            return left & ~right;
+        }
+        #endregion Named Bitwise Operators
+
+        #region Conversion Methods
+        /// <summary>
+        /// Reinterprets the bits of the given vector into those of a vector of unsigned bytes.
+        /// </summary>
+        /// <param name="value">The source vector</param>
+        /// <returns>The reinterpreted vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<Byte> AsVectorByte<T>(Vector<T> value) where T : struct
+        {
+            return (Vector<Byte>)value;
+        }
+
+        /// <summary>
+        /// Reinterprets the bits of the given vector into those of a vector of signed bytes.
+        /// </summary>
+        /// <param name="value">The source vector</param>
+        /// <returns>The reinterpreted vector.</returns>
+        [CLSCompliant(false)]
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<SByte> AsVectorSByte<T>(Vector<T> value) where T : struct
+        {
+            return (Vector<SByte>)value;
+        }
+
+        /// <summary>
+        /// Reinterprets the bits of the given vector into those of a vector of 16-bit integers.
+        /// </summary>
+        /// <param name="value">The source vector</param>
+        /// <returns>The reinterpreted vector.</returns>
+        [CLSCompliant(false)]
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<UInt16> AsVectorUInt16<T>(Vector<T> value) where T : struct
+        {
+            return (Vector<UInt16>)value;
+        }
+
+        /// <summary>
+        /// Reinterprets the bits of the given vector into those of a vector of signed 16-bit integers.
+        /// </summary>
+        /// <param name="value">The source vector</param>
+        /// <returns>The reinterpreted vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<Int16> AsVectorInt16<T>(Vector<T> value) where T : struct
+        {
+            return (Vector<Int16>)value;
+        }
+
+        /// <summary>
+        /// Reinterprets the bits of the given vector into those of a vector of unsigned 32-bit integers.
+        /// </summary>
+        /// <param name="value">The source vector</param>
+        /// <returns>The reinterpreted vector.</returns>
+        [CLSCompliant(false)]
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<UInt32> AsVectorUInt32<T>(Vector<T> value) where T : struct
+        {
+            return (Vector<UInt32>)value;
+        }
+
+        /// <summary>
+        /// Reinterprets the bits of the given vector into those of a vector of signed 32-bit integers.
+        /// </summary>
+        /// <param name="value">The source vector</param>
+        /// <returns>The reinterpreted vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<Int32> AsVectorInt32<T>(Vector<T> value) where T : struct
+        {
+            return (Vector<Int32>)value;
+        }
+
+        /// <summary>
+        /// Reinterprets the bits of the given vector into those of a vector of unsigned 64-bit integers.
+        /// </summary>
+        /// <param name="value">The source vector</param>
+        /// <returns>The reinterpreted vector.</returns>
+        [CLSCompliant(false)]
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<UInt64> AsVectorUInt64<T>(Vector<T> value) where T : struct
+        {
+            return (Vector<UInt64>)value;
+        }
+
+
+        /// <summary>
+        /// Reinterprets the bits of the given vector into those of a vector of signed 64-bit integers.
+        /// </summary>
+        /// <param name="value">The source vector</param>
+        /// <returns>The reinterpreted vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<Int64> AsVectorInt64<T>(Vector<T> value) where T : struct
+        {
+            return (Vector<Int64>)value;
+        }
+
+        /// <summary>
+        /// Reinterprets the bits of the given vector into those of a vector of 32-bit floating point numbers.
+        /// </summary>
+        /// <param name="value">The source vector</param>
+        /// <returns>The reinterpreted vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<Single> AsVectorSingle<T>(Vector<T> value) where T : struct
+        {
+            return (Vector<Single>)value;
+        }
+
+        /// <summary>
+        /// Reinterprets the bits of the given vector into those of a vector of 64-bit floating point numbers.
+        /// </summary>
+        /// <param name="value">The source vector</param>
+        /// <returns>The reinterpreted vector.</returns>
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public static Vector<Double> AsVectorDouble<T>(Vector<T> value) where T : struct
+        {
+            return (Vector<Double>)value;
+        }
+        #endregion Conversion Methods
+    }
+}


### PR DESCRIPTION
As part of https://github.com/dotnet/corefx/issues/25182#issuecomment-343614677, moving `Vector<T>` and friends down to CoreLib.

I didn't copy over the .tt files. Are they necessary at this point?

We should attempt to keep these in sync with https://github.com/dotnet/corefx/tree/master/src/System.Numerics.Vectors/src/System/Numerics

Related PR: https://github.com/dotnet/corefx/pull/26266

cc @jkotas, @KrzysztofCwalina, @safern, @ViktorHofer, @eerhardt 