### PR TITLE
Fix GC.KeepAlive test case

### DIFF
--- a/tests/src/CoreMangLib/cti/system/gc/gckeepalive.cs
+++ b/tests/src/CoreMangLib/cti/system/gc/gckeepalive.cs
@@ -44,13 +44,13 @@ public class GCKeepAlive
             GC.WaitForPendingFinalizers();
             GC.Collect();
 
-            GC.KeepAlive(tc);
             if (TestClass.m_TestInt != 1)
             {
                 TestLibrary.TestFramework.LogError("001.1", "Calling KeepAlive can not prevent an object to be GCed");
                 TestLibrary.TestFramework.LogInformation("WARNING [LOCAL VARIABLE] TestClass.m_TestInt = " + TestClass.m_TestInt);
                 retVal = false;
             }
+            GC.KeepAlive(tc);
         }
         catch (Exception e)
         {


### PR DESCRIPTION
In the test, as written, a GC could sneak in between the GC.KeepAlive()
call and the subsequent line that checks whether the finalizer
has run, especially in GC stress modes. Simply move the GC.KeepAlive()
call down.