### PR TITLE
Do fast GC stress on some extreme tests

### DIFF
--- a/tests/src/CoreMangLib/cti/system/string/StringConcat4.csproj
+++ b/tests/src/CoreMangLib/cti/system/string/StringConcat4.csproj
@@ -27,6 +27,16 @@
     <!-- Add Compile Object Here -->
     <Compile Include="stringconcat4.cs" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_FastGCStress=1
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_FastGCStress=1
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>

--- a/tests/src/CoreMangLib/cti/system/string/StringConcat8.csproj
+++ b/tests/src/CoreMangLib/cti/system/string/StringConcat8.csproj
@@ -27,6 +27,16 @@
     <!-- Add Compile Object Here -->
     <Compile Include="stringconcat8.cs" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_FastGCStress=1
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_FastGCStress=1
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>

--- a/tests/src/baseservices/threading/regressions/269336/objmonhelper.csproj
+++ b/tests/src/baseservices/threading/regressions/269336/objmonhelper.csproj
@@ -21,6 +21,16 @@
       <Visible>False</Visible>
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_FastGCStress=1
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_FastGCStress=1
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
   <ItemGroup>
     <!-- Add Compile Object Here -->
     <Compile Include="objmonhelper.cs" />


### PR DESCRIPTION
Set COMPlus_FastGCStress=1 to avoid GC in the
`CoreCLR!JIT_Stelem_Ref => CoreCLR!ArrayStoreCheck` path.