### PR TITLE
Disable the prerelease flag

### DIFF
--- a/clrdefinitions.cmake
+++ b/clrdefinitions.cmake
@@ -2,7 +2,7 @@ include(clrfeatures.cmake)
 
 # If set, indicates that this is not an officially supported release
 # Keep in sync with IsPrerelease in dir.props
-set(PRERELEASE 1)
+set(PRERELEASE 0)
 
 # Features we're currently flighting, but don't intend to ship in officially supported releases
 if (PRERELEASE)

--- a/dir.props
+++ b/dir.props
@@ -142,7 +142,7 @@
     <!-- If true, indicates that this is not an officially supported release -->
     <!-- It is important to flip this to false in official release branches -->
     <!-- Keep it in sync with PRERELEASE in clrdefinitions.cmake -->
-    <IsPrerelease>true</IsPrerelease>
+    <IsPrerelease>false</IsPrerelease>
 
     <!-- This should be kept in sync with package details in src/.nuget/init/project.json -->
     <RuntimeIdGraphDefinitionVersion>1.0.2-beta-24224-02</RuntimeIdGraphDefinitionVersion>


### PR DESCRIPTION
Do not merge. Just testing if disabling default interfaces will work when we need to do this in the release branch.

Expecting test failures for the default interface feature, but nothing else.