### PR TITLE
Fix Android build

### DIFF
--- a/cross/build-android-rootfs.sh
+++ b/cross/build-android-rootfs.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 __NDK_Version=r14
 
 usage()
@@ -101,35 +102,35 @@ rm -rf $__Android_Cross_Dir/tmp
 
 mkdir -p $__Android_Cross_Dir/deb/
 mkdir -p $__Android_Cross_Dir/tmp/$arch/
-wget -nv -nc http://termux.net/dists/stable/main/binary-$__AndroidArch/libicu_59.1-1_$__AndroidArch.deb -O $__Android_Cross_Dir/deb/libicu_59.1-1_$__AndroidArch.deb
-wget -nv -nc http://termux.net/dists/stable/main/binary-$__AndroidArch/libicu-dev_59.1-1_$__AndroidArch.deb -O $__Android_Cross_Dir/deb/libicu-dev_59.1-1_$__AndroidArch.deb
+wget -nv -nc http://termux.net/dists/stable/main/binary-$__AndroidArch/libicu_60.2_$__AndroidArch.deb -O $__Android_Cross_Dir/deb/libicu_60.2_$__AndroidArch.deb
+wget -nv -nc http://termux.net/dists/stable/main/binary-$__AndroidArch/libicu-dev_60.2_$__AndroidArch.deb -O $__Android_Cross_Dir/deb/libicu-dev_60.2_$__AndroidArch.deb
 
 if [ "$__AndroidArch" == "arm" ]; then
-    wget -nv -nc http://termux.net/dists/stable/main/binary-$__AndroidArch/libuuid-dev-1.0.3_$__AndroidArch.deb -O $__Android_Cross_Dir/deb/libuuid-dev_1.0.3_$__AndroidArch.deb
-    wget -nv -nc http://termux.net/dists/stable/main/binary-$__AndroidArch/libuuid-1.0.3_$__AndroidArch.deb -O $__Android_Cross_Dir/deb/libuuid_1.0.3_$__AndroidArch.deb
+    wget -nv -nc http://termux.net/dists/stable/main/binary-$__AndroidArch/libuuid-dev-1.0.3-1_$__AndroidArch.deb -O $__Android_Cross_Dir/deb/libuuid-dev_1.0.3-1_$__AndroidArch.deb
+    wget -nv -nc http://termux.net/dists/stable/main/binary-$__AndroidArch/libuuid-1.0.3-1_$__AndroidArch.deb -O $__Android_Cross_Dir/deb/libuuid_1.0.3-1_$__AndroidArch.deb
 else
-    wget -nv -nc http://termux.net/dists/stable/main/binary-$__AndroidArch/libuuid-dev_1.0.3_$__AndroidArch.deb -O $__Android_Cross_Dir/deb/libuuid-dev_1.0.3_$__AndroidArch.deb
-    wget -nv -nc http://termux.net/dists/stable/main/binary-$__AndroidArch/libuuid_1.0.3_$__AndroidArch.deb -O $__Android_Cross_Dir/deb/libuuid_1.0.3_$__AndroidArch.deb
+    wget -nv -nc http://termux.net/dists/stable/main/binary-$__AndroidArch/libuuid-dev_1.0.3-1_$__AndroidArch.deb -O $__Android_Cross_Dir/deb/libuuid-dev_1.0.3-1_$__AndroidArch.deb
+    wget -nv -nc http://termux.net/dists/stable/main/binary-$__AndroidArch/libuuid_1.0.3-1_$__AndroidArch.deb -O $__Android_Cross_Dir/deb/libuuid_1.0.3-1_$__AndroidArch.deb
 fi
 
 wget -nv -nc http://termux.net/dists/stable/main/binary-$__AndroidArch/libandroid-glob-dev_0.4_$__AndroidArch.deb -O $__Android_Cross_Dir/deb/libandroid-glob-dev_0.4_$__AndroidArch.deb
 wget -nv -nc http://termux.net/dists/stable/main/binary-$__AndroidArch/libandroid-glob_0.4_$__AndroidArch.deb -O $__Android_Cross_Dir/deb/libandroid-glob_0.4_$__AndroidArch.deb
-wget -nv -nc http://termux.net/dists/stable/main/binary-$__AndroidArch/libandroid-support-dev_20_$__AndroidArch.deb -O $__Android_Cross_Dir/deb/libandroid-support-dev_20_$__AndroidArch.deb
-wget -nv -nc http://termux.net/dists/stable/main/binary-$__AndroidArch/libandroid-support_20_$__AndroidArch.deb -O $__Android_Cross_Dir/deb/libandroid-support_20_$__AndroidArch.deb
+wget -nv -nc http://termux.net/dists/stable/main/binary-$__AndroidArch/libandroid-support-dev_22_$__AndroidArch.deb -O $__Android_Cross_Dir/deb/libandroid-support-dev_22_$__AndroidArch.deb
+wget -nv -nc http://termux.net/dists/stable/main/binary-$__AndroidArch/libandroid-support_22_$__AndroidArch.deb -O $__Android_Cross_Dir/deb/libandroid-support_22_$__AndroidArch.deb
 wget -nv -nc http://termux.net/dists/stable/main/binary-$__AndroidArch/liblzma-dev_5.2.3_$__AndroidArch.deb  -O $__Android_Cross_Dir/deb/liblzma-dev_5.2.3_$__AndroidArch.deb
 wget -nv -nc http://termux.net/dists/stable/main/binary-$__AndroidArch/liblzma_5.2.3_$__AndroidArch.deb -O $__Android_Cross_Dir/deb/liblzma_5.2.3_$__AndroidArch.deb
 wget -nv -nc http://termux.net/dists/stable/main/binary-$__AndroidArch/libunwind-dev_1.2.20170304_$__AndroidArch.deb  -O $__Android_Cross_Dir/deb/libunwind-dev_1.2.20170304_$__AndroidArch.deb
 wget -nv -nc http://termux.net/dists/stable/main/binary-$__AndroidArch/libunwind_1.2.20170304_$__AndroidArch.deb -O $__Android_Cross_Dir/deb/libunwind_1.2.20170304_$__AndroidArch.deb
 
 echo Unpacking Termux packages
-dpkg -x $__Android_Cross_Dir/deb/libicu_59.1-1_$__AndroidArch.deb $__Android_Cross_Dir/tmp/$__AndroidArch/
-dpkg -x $__Android_Cross_Dir/deb/libicu-dev_59.1-1_$__AndroidArch.deb $__Android_Cross_Dir/tmp/$__AndroidArch/
-dpkg -x $__Android_Cross_Dir/deb/libuuid-dev_1.0.3_$__AndroidArch.deb $__Android_Cross_Dir/tmp/$__AndroidArch/
-dpkg -x $__Android_Cross_Dir/deb/libuuid_1.0.3_$__AndroidArch.deb $__Android_Cross_Dir/tmp/$__AndroidArch/
+dpkg -x $__Android_Cross_Dir/deb/libicu_60.2_$__AndroidArch.deb $__Android_Cross_Dir/tmp/$__AndroidArch/
+dpkg -x $__Android_Cross_Dir/deb/libicu-dev_60.2_$__AndroidArch.deb $__Android_Cross_Dir/tmp/$__AndroidArch/
+dpkg -x $__Android_Cross_Dir/deb/libuuid-dev_1.0.3-1_$__AndroidArch.deb $__Android_Cross_Dir/tmp/$__AndroidArch/
+dpkg -x $__Android_Cross_Dir/deb/libuuid_1.0.3-1_$__AndroidArch.deb $__Android_Cross_Dir/tmp/$__AndroidArch/
 dpkg -x $__Android_Cross_Dir/deb/libandroid-glob-dev_0.4_$__AndroidArch.deb $__Android_Cross_Dir/tmp/$__AndroidArch/
 dpkg -x $__Android_Cross_Dir/deb/libandroid-glob_0.4_$__AndroidArch.deb $__Android_Cross_Dir/tmp/$__AndroidArch/
-dpkg -x $__Android_Cross_Dir/deb/libandroid-support-dev_20_$__AndroidArch.deb $__Android_Cross_Dir/tmp/$__AndroidArch/
-dpkg -x $__Android_Cross_Dir/deb/libandroid-support_20_$__AndroidArch.deb $__Android_Cross_Dir/tmp/$__AndroidArch/
+dpkg -x $__Android_Cross_Dir/deb/libandroid-support-dev_22_$__AndroidArch.deb $__Android_Cross_Dir/tmp/$__AndroidArch/
+dpkg -x $__Android_Cross_Dir/deb/libandroid-support_22_$__AndroidArch.deb $__Android_Cross_Dir/tmp/$__AndroidArch/
 dpkg -x $__Android_Cross_Dir/deb/liblzma-dev_5.2.3_$__AndroidArch.deb $__Android_Cross_Dir/tmp/$__AndroidArch/
 dpkg -x $__Android_Cross_Dir/deb/liblzma_5.2.3_$__AndroidArch.deb $__Android_Cross_Dir/tmp/$__AndroidArch/
 dpkg -x $__Android_Cross_Dir/deb/libunwind-dev_1.2.20170304_$__AndroidArch.deb $__Android_Cross_Dir/tmp/$__AndroidArch/

--- a/src/corefx/System.Globalization.Native/configure.cmake
+++ b/src/corefx/System.Globalization.Native/configure.cmake
@@ -1,5 +1,5 @@
 include(CheckCXXSourceCompiles)
-include(CheckSymbolExists)
+include(CheckCXXSymbolExists)
 
 set(CMAKE_REQUIRED_INCLUDES ${UTYPES_H} ${ICU_HOMEBREW_INC_PATH})
 
@@ -14,7 +14,7 @@ else()
     set(CMAKE_REQUIRED_LIBRARIES ${ICUCORE})
 endif()
 
-check_symbol_exists(
+check_cxx_symbol_exists(
     ucol_setMaxVariable
     "unicode/ucol.h"
     HAVE_SET_MAX_VARIABLE)

--- a/src/gc/unix/cgroup.cpp
+++ b/src/gc/unix/cgroup.cpp
@@ -25,7 +25,10 @@ Abstract:
 #include <sys/resource.h>
 #include <errno.h>
 
+#ifndef SIZE_T_MAX
 #define SIZE_T_MAX (~(size_t)0)
+#endif
+
 #define PROC_MOUNTINFO_FILENAME "/proc/self/mountinfo"
 #define PROC_CGROUP_FILENAME "/proc/self/cgroup"
 #define PROC_STATM_FILENAME "/proc/self/statm"

--- a/src/pal/src/configure.cmake
+++ b/src/pal/src/configure.cmake
@@ -38,6 +38,7 @@ check_include_files(sys/prctl.h HAVE_PRCTL_H)
 check_include_files(numa.h HAVE_NUMA_H)
 check_include_files(pthread_np.h HAVE_PTHREAD_NP_H)
 check_include_files("sys/auxv.h;asm/hwcap.h" HAVE_AUXV_HWCAP_H)
+check_include_files("libintl.h" HAVE_LIBINTL_H)
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD AND NOT CMAKE_SYSTEM_NAME STREQUAL NetBSD)
   set(CMAKE_REQUIRED_FLAGS "-ldl")
@@ -421,7 +422,7 @@ int main()
   exit(ret);
 }" HAVE_CLOCK_MONOTONIC)
 
-check_library_exists(pthread pthread_condattr_setclock "" HAVE_PTHREAD_CONDATTR_SETCLOCK)
+check_library_exists(${PTHREAD_LIBRARY} pthread_condattr_setclock "" HAVE_PTHREAD_CONDATTR_SETCLOCK)
 
 check_cxx_source_runs("
 #include <stdlib.h>

--- a/src/pal/src/locale/unicode.cpp
+++ b/src/pal/src/locale/unicode.cpp
@@ -37,9 +37,9 @@ Revision History:
 
 #include <pthread.h>
 #include <locale.h>
-#ifndef __APPLE__
+#if HAVE_LIBINTL_H
 #include <libintl.h>
-#endif // __APPLE__
+#endif // HAVE_LIBINTL_H
 #include <errno.h>
 #if HAVE_COREFOUNDATION
 #include <CoreFoundation/CoreFoundation.h>
@@ -915,7 +915,7 @@ BOOL
 PALAPI
 PAL_BindResources(IN LPCSTR lpDomain)
 {
-#ifndef __APPLE__
+#if HAVE_LIBINTL_H
     _ASSERTE(g_szCoreCLRPath != NULL);
     char * coreCLRDirectoryPath;
     PathCharString coreCLRDirectoryPathPS;
@@ -931,10 +931,10 @@ PAL_BindResources(IN LPCSTR lpDomain)
     LPCSTR boundPath = bindtextdomain(lpDomain, coreCLRDirectoryPath);
 
     return boundPath != NULL;
-#else // __APPLE__
-    // UNIXTODO: Implement for OSX if necessary
+#else // HAVE_LIBINTL_H
+    // UNIXTODO: Implement for Unixes without libintl if necessary
     return TRUE;
-#endif // __APPLE__
+#endif // HAVE_LIBINTL_H
 }
 
 /*++
@@ -955,16 +955,16 @@ PAL_GetResourceString(
         IN int cchWideChar
       )
 {
-#ifndef __APPLE__
+#if HAVE_LIBINTL_H
     // NOTE: dgettext returns the key if it fails to locate the appropriate
     // resource. In our case, that will be the English string.
     LPCSTR resourceString = dgettext(lpDomain, lpResourceStr);
-#else // __APPLE__
+#else // HAVE_LIBINTL_H
     // UNIXTODO: Implement for OSX using the native localization API 
 
     // This is a temporary solution until we add the real native resource support.
     LPCSTR resourceString = lpResourceStr;
-#endif // __APPLE__
+#endif // HAVE_LIBINTL_H
 
     int length = strlen(resourceString);
     return UTF8ToUnicode(lpResourceStr, length + 1, lpWideCharStr, cchWideChar, 0);


### PR DESCRIPTION
There were the following issues:
* The current versions of packages available at the termux site were obsolete.
* The libintl.h was removed from the Android SDK, so the dgettext and bindtextdomain
  are not available. But they were dummy implementations before anyways, so we can remove
  their usage on Android.
* The detection of the ucol_setMaxVariable needs to be done using the
  check_cxx_symbol_exists instead of check_symbol_exists, since on Android, the
  ICU libraries now depend on C++ runtime.
* The SIZE_T_MAX is already defined in Android headers, so the definition in cgroup.cpp was
  colliding with it.
* The pthread_condattr_setclock detection was using pthread library, but on Android, it is
  located in the "c" library instead. So it was not being detected.