### PR TITLE
[WIP] write pointer size to event pipe file to make x86 working

### DIFF
--- a/src/vm/eventpipeconfiguration.cpp
+++ b/src/vm/eventpipeconfiguration.cpp
@@ -432,10 +432,11 @@ EventPipeEventInstance* EventPipeConfiguration::BuildEventMetadataEvent(EventPip
     const SString &providerName = sourceEvent.GetProvider()->GetProviderName();
     unsigned int eventID = sourceEvent.GetEventID();
     unsigned int eventVersion = sourceEvent.GetEventVersion();
+    INT64 keywords = sourceEvent.GetKeywords();
     BYTE *pPayloadData = sourceEvent.GetMetadata();
     unsigned int payloadLength = sourceEvent.GetMetadataLength();
     unsigned int providerNameLength = (providerName.GetCount() + 1) * sizeof(WCHAR);
-    unsigned int instancePayloadSize = providerNameLength + sizeof(eventID) + sizeof(eventVersion) + sizeof(payloadLength) + payloadLength;
+    unsigned int instancePayloadSize = providerNameLength + sizeof(eventID) + sizeof(eventVersion) + sizeof(keywords) + sizeof(payloadLength) + payloadLength;
 
     // Allocate the payload.
     BYTE *pInstancePayload = new BYTE[instancePayloadSize];
@@ -454,6 +455,10 @@ EventPipeEventInstance* EventPipeConfiguration::BuildEventMetadataEvent(EventPip
     // Write the event version.
     memcpy(currentPtr, &eventVersion, sizeof(eventVersion));
     currentPtr += sizeof(eventVersion);
+
+    // Write the event keywords.
+    memcpy(currentPtr, &keywords, sizeof(keywords));
+    currentPtr += sizeof(keywords);
 
     // Write the size of the metadata.
     memcpy(currentPtr, &payloadLength, sizeof(payloadLength));

--- a/src/vm/eventpipefile.cpp
+++ b/src/vm/eventpipefile.cpp
@@ -25,8 +25,8 @@ EventPipeFile::EventPipeFile(
     }
     CONTRACTL_END;
 
-    SetObjectVersion(2);
-    SetMinReaderVersion(1);
+    SetObjectVersion(3);
+    SetMinReaderVersion(0);
 
     m_pSerializer = new FastSerializer(outputFilePath, *this);
     m_serializationLock.Init(LOCK_TYPE_DEFAULT);
@@ -42,6 +42,8 @@ EventPipeFile::EventPipeFile(
     QueryPerformanceFrequency(&m_timeStampFrequency);
 
     m_pointerSize = TARGET_POINTER_SIZE;
+
+    m_currentProcessId = GetCurrentProcessId();
 
     SYSTEM_INFO sysinfo = {};
     GetSystemInfo(&sysinfo);
@@ -69,13 +71,14 @@ EventPipeFile::EventPipeFile(
     // Write ClockFrequency
     m_pSerializer->WriteBuffer((BYTE*)&m_timeStampFrequency, sizeof(m_timeStampFrequency));
 
-    // Write Pointer Size
+// the beginning of V3
     m_pSerializer->WriteBuffer((BYTE*)&m_pointerSize, sizeof(m_pointerSize));
 
-    // Write Number of Processors
+    m_pSerializer->WriteBuffer((BYTE*)&m_currentProcessId, sizeof(m_currentProcessId));
+
     m_pSerializer->WriteBuffer((BYTE*)&m_numberOfProcessors, sizeof(m_numberOfProcessors));
 
-    // define the start of the events
+    // define the start of the events stream
     StreamLabel currentLabel = m_pSerializer->GetStreamLabel();
     m_pSerializer->DefineForwardReference(m_beginEventsForwardReferenceIndex, currentLabel);
 }

--- a/src/vm/eventpipefile.cpp
+++ b/src/vm/eventpipefile.cpp
@@ -28,7 +28,7 @@ EventPipeFile::EventPipeFile(
     SetObjectVersion(3);
     SetMinReaderVersion(0);
 
-    m_pSerializer = new FastSerializer(outputFilePath, *this);
+    m_pSerializer = new FastSerializer(outputFilePath, *this); // it calls FastSerializer::WriteEntryObject()
     m_serializationLock.Init(LOCK_TYPE_DEFAULT);
     m_pMetadataLabels = new MapSHashWithRemove<EventPipeEvent*, StreamLabel>();
 
@@ -60,15 +60,10 @@ EventPipeFile::EventPipeFile(
     m_endEventsForwardReferenceIndex = m_pSerializer->AllocateForwardReference();
     m_pSerializer->WriteForwardReference(m_endEventsForwardReferenceIndex);
 
-    // Write the header information into the file.
-
-    // Write the current date and time.
     m_pSerializer->WriteBuffer((BYTE*)&m_fileOpenSystemTime, sizeof(m_fileOpenSystemTime));
 
-    // Write FileOpenTimeStamp
     m_pSerializer->WriteBuffer((BYTE*)&m_fileOpenTimeStamp, sizeof(m_fileOpenTimeStamp));
 
-    // Write ClockFrequency
     m_pSerializer->WriteBuffer((BYTE*)&m_timeStampFrequency, sizeof(m_timeStampFrequency));
 
 // the beginning of V3
@@ -77,6 +72,8 @@ EventPipeFile::EventPipeFile(
     m_pSerializer->WriteBuffer((BYTE*)&m_currentProcessId, sizeof(m_currentProcessId));
 
     m_pSerializer->WriteBuffer((BYTE*)&m_numberOfProcessors, sizeof(m_numberOfProcessors));
+
+    m_pSerializer->WriteTag(FastSerializerTags::EndObject); // the entry object is written in FastSerializer::WriteEntryObject()
 
     // define the start of the events stream
     StreamLabel currentLabel = m_pSerializer->GetStreamLabel();

--- a/src/vm/eventpipefile.cpp
+++ b/src/vm/eventpipefile.cpp
@@ -6,6 +6,7 @@
 #include "eventpipebuffer.h"
 #include "eventpipeconfiguration.h"
 #include "eventpipefile.h"
+#include "sampleprofiler.h"
 
 #ifdef FEATURE_PERFTRACING
 
@@ -49,6 +50,8 @@ EventPipeFile::EventPipeFile(
     GetSystemInfo(&sysinfo);
     m_numberOfProcessors = sysinfo.dwNumberOfProcessors;
 
+    m_samplingRateInNs = SampleProfiler::GetSamplingRate();
+
     // Write a forward reference to the beginning of the event stream.
     // This also allows readers to know where the event stream starts 
     // and skip new metadata from the begining of the file if needed
@@ -72,6 +75,8 @@ EventPipeFile::EventPipeFile(
     m_pSerializer->WriteBuffer((BYTE*)&m_currentProcessId, sizeof(m_currentProcessId));
 
     m_pSerializer->WriteBuffer((BYTE*)&m_numberOfProcessors, sizeof(m_numberOfProcessors));
+
+    m_pSerializer->WriteBuffer((BYTE*)&m_samplingRateInNs, sizeof(m_samplingRateInNs));
 
     m_pSerializer->WriteTag(FastSerializerTags::EndObject); // the entry object is written in FastSerializer::WriteEntryObject()
 

--- a/src/vm/eventpipefile.cpp
+++ b/src/vm/eventpipefile.cpp
@@ -25,12 +25,18 @@ EventPipeFile::EventPipeFile(
     }
     CONTRACTL_END;
 
-    SetObjectVersion(2);
+    SetObjectVersion(3);
     SetMinReaderVersion(0);
 
     m_pSerializer = new FastSerializer(outputFilePath, *this);
     m_serializationLock.Init(LOCK_TYPE_DEFAULT);
     m_pMetadataLabels = new MapSHashWithRemove<EventPipeEvent*, StreamLabel>();
+
+    m_pointerSize = TARGET_POINTER_SIZE;
+
+    SYSTEM_INFO sysinfo;
+    GetSystemInfo(&sysinfo);
+    m_numberOfProcessors = sysinfo.dwNumberOfProcessors;
 
 #ifdef _DEBUG
     m_lockOnWrite = lockOnWrite;
@@ -56,6 +62,12 @@ EventPipeFile::EventPipeFile(
 
     // Write ClockFrequency
     m_pSerializer->WriteBuffer((BYTE*)&m_timeStampFrequency, sizeof(m_timeStampFrequency));
+
+    // Write Pointer Size
+    m_pSerializer->WriteBuffer((BYTE*)&m_pointerSize, sizeof(m_pointerSize));
+
+    // Write Number of Processors
+    m_pSerializer->WriteBuffer((BYTE*)&m_numberOfProcessors, sizeof(m_numberOfProcessors));
 }
 
 EventPipeFile::~EventPipeFile()

--- a/src/vm/eventpipefile.h
+++ b/src/vm/eventpipefile.h
@@ -71,6 +71,8 @@ class EventPipeFile : public FastSerializableObject
 
         unsigned int m_numberOfProcessors;
 
+        unsigned int m_samplingRateInNs;
+
         // The forward reference index that marks the beginning of the event stream.
         unsigned int m_beginEventsForwardReferenceIndex;
 

--- a/src/vm/eventpipefile.h
+++ b/src/vm/eventpipefile.h
@@ -65,10 +65,10 @@ class EventPipeFile : public FastSerializableObject
         // The frequency of the timestamps used for this file.
         LARGE_INTEGER m_timeStampFrequency;
 
-        // The pointer Size
         unsigned int m_pointerSize;
 
-        // The number of processors
+        unsigned int m_currentProcessId;
+
         unsigned int m_numberOfProcessors;
 
         // The forward reference index that marks the beginning of the event stream.

--- a/src/vm/eventpipefile.h
+++ b/src/vm/eventpipefile.h
@@ -65,6 +65,12 @@ class EventPipeFile : public FastSerializableObject
         // The frequency of the timestamps used for this file.
         LARGE_INTEGER m_timeStampFrequency;
 
+        // The pointer Size
+        unsigned int m_pointerSize;
+
+        // The number of processors
+        unsigned int m_numberOfProcessors;
+
         // The forward reference index that marks the beginning of the event stream.
         unsigned int m_beginEventsForwardReferenceIndex;
 

--- a/src/vm/eventpipefile.h
+++ b/src/vm/eventpipefile.h
@@ -74,6 +74,9 @@ class EventPipeFile : public FastSerializableObject
         // The forward reference index that marks the beginning of the event stream.
         unsigned int m_beginEventsForwardReferenceIndex;
 
+        // The forward reference index that marks the end of the event stream.
+        unsigned int m_endEventsForwardReferenceIndex;
+
         // The serialization which is responsible for making sure only a single event
         // or block of events gets written to the file at once.
         SpinLock m_serializationLock;

--- a/src/vm/fastserializer.cpp
+++ b/src/vm/fastserializer.cpp
@@ -148,7 +148,7 @@ void FastSerializer::WriteEntryObject()
     CONTRACTL_END;
 
     // Write begin entry object tag.
-    WriteTag(FastSerializerTags::BeginObject);
+    WriteTag(FastSerializerTags::BeginObject); // the caller must write EndObject tag
 
     // Write the type information for the entry object.
     WriteSerializationType(m_pEntryObject);

--- a/src/vm/sampleprofiler.h
+++ b/src/vm/sampleprofiler.h
@@ -35,6 +35,13 @@ class SampleProfiler
         // Set the sampling rate.
         static void SetSamplingRate(unsigned long nanoseconds);
 
+        static unsigned long GetSamplingRate()
+        {
+            LIMITED_METHOD_CONTRACT;
+
+            return s_samplingRateInNs;
+        }
+
     private:
 
         // Iterate through all managed threads and walk all stacks.


### PR DESCRIPTION
Part of https://github.com/Microsoft/perfview/issues/470

Initially, the issue seemed to be trivial: one simple thing was missing in the file: pointer size.

I analyzed the code and realized, that the existing version of the consumer of Event Pipe was [assuming](https://github.com/Microsoft/perfview/blob/1447751e7a22d3caff15b630903ae88f132729e4/src/TraceEvent/EventPipe/EventPipeEventSourceV1.cs#L99) that right after the initial data (time, timestamp and frequency) there is always the beginning of the events stream.

So if I add a new field, the old serializer fails because it's going to try to deserialize it as the first event.

To make the solution more future proof I decided to add a forward reference to the beginning of the events stream.

So the reader knows where to jump after reading the fields it knows. If there are some new fields, it's going to ignore them. So no breaking changes by adding new fields in the future.

I had to bump the version of the object (2 => 3) in order to make the previous versions of the reader give users an easy to understand error message when they use new runtime with and old consumer lib.

The problem was that the old implementation was [ignoring](https://github.com/Microsoft/perfview/blob/1447751e7a22d3caff15b630903ae88f132729e4/src/TraceEvent/EventPipe/EventPipeEventSourceFactory.cs#L34) minimum reader version:

```cs
            var version = deserializer.ReadInt();

            // Read the minimum reader version.
            var minimumReaderVersion = deserializer.ReadInt(); <- NOT USED

            switch (version)
            {
                case 1:
                case 2: return new EventPipeEventSourceV1(deserializer, fileName, version);
                default: throw new NotSupportedException($"The version of {fileName} is {version} which is not yet supported.");
            }
``` 
It was a good time to add some other missing fields.

I have also added the number of processors and process Id (all available in the PAL).

OsVersion and Cpu Speed are still missing, because they are not a part of the PAL.
