### PR TITLE
[Local GC] FEATURE_EVENT_TRACE 1/n: Tracking Event State

### DIFF
--- a/src/gc/CMakeLists.txt
+++ b/src/gc/CMakeLists.txt
@@ -18,6 +18,7 @@ remove_definitions(-DWRITE_BARRIER_CHECK)
 add_definitions(-DFEATURE_REDHAWK)
 
 set( GC_SOURCES
+  gceventstatus.cpp
   gcconfig.cpp
   gccommon.cpp
   gcscan.cpp

--- a/src/gc/env/gcenv.h
+++ b/src/gc/env/gcenv.h
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+#ifndef __GCENV_H__
+#define __GCENV_H__
 
 #if defined(_DEBUG)
 #ifndef _DEBUG_IMPL
@@ -71,3 +73,5 @@
 
 #include "etmdummy.h"
 #define ETW_EVENT_ENABLED(e,f) false
+
+#endif // __GCENV_H__

--- a/src/gc/env/gcenv.object.h
+++ b/src/gc/env/gcenv.object.h
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#ifndef __GCENV_OBJECT_H__
+#define __GCENV_OBJECT_H__
+
 //-------------------------------------------------------------------------------------------------
 //
 // Low-level types describing GC object layouts.
@@ -168,3 +171,5 @@ public:
         return offsetof(ArrayBase, m_dwLength);
     }
 };
+
+#endif // __GCENV_OBJECT_H__

--- a/src/gc/env/gcenv.sync.h
+++ b/src/gc/env/gcenv.sync.h
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+#ifndef __GCENV_SYNC_H__
+#define __GCENV_SYNC_H__
 
 // -----------------------------------------------------------------------------------------------------------
 //
@@ -143,3 +145,5 @@ private:
     HANDLE  m_hEvent;
     bool    m_fInitialized;
 };
+
+#endif // __GCENV_SYNC_H__

--- a/src/gc/gcee.cpp
+++ b/src/gc/gcee.cpp
@@ -687,6 +687,15 @@ bool GCHeap::RuntimeStructuresValid()
     return GCScan::GetGcRuntimeStructuresValid();
 }
 
+void GCHeap::ControlEvents(GCEventKeyword keyword, GCEventLevel level)
+{
+    GCEventStatus::Set(GCEventProvider_Default, keyword, level);
+}
+
+void GCHeap::ControlPrivateEvents(GCEventKeyword keyword, GCEventLevel level)
+{
+    GCEventStatus::Set(GCEventProvider_Private, keyword, level);
+}
 
 #endif // !DACCESS_COMPILE
 

--- a/src/gc/gceesvr.cpp
+++ b/src/gc/gceesvr.cpp
@@ -13,6 +13,7 @@
 #include "gc.h"
 #include "gcscan.h"
 #include "gchandletableimpl.h"
+#include "gceventstatus.h"
 
 #define SERVER_GC 1
 

--- a/src/gc/gceventstatus.cpp
+++ b/src/gc/gceventstatus.cpp
@@ -2,23 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-
 #include "common.h"
-
-#include "gcenv.h"
-
-#include "gc.h"
-#include "gcscan.h"
-#include "gchandletableimpl.h"
 #include "gceventstatus.h"
 
-#ifdef SERVER_GC
-#undef SERVER_GC
-#endif
-
-namespace WKS { 
-#include "gcimpl.h"
-#include "gcee.cpp"
-}
-
+Volatile<GCEventLevel> GCEventStatus::enabledLevels[2] = {GCEventLevel_None, GCEventLevel_None};
+Volatile<GCEventKeyword> GCEventStatus::enabledKeywords[2] = {GCEventKeyword_None, GCEventKeyword_None};

--- a/src/gc/gceventstatus.h
+++ b/src/gc/gceventstatus.h
@@ -1,0 +1,187 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef __GCEVENTSTATUS_H__
+#define __GCEVENTSTATUS_H__
+
+
+/*
+ * gceventstatus.h - Eventing status for a standalone GC
+ *
+ * In order for a local GC to determine what events are enabled
+ * in an efficient manner, the GC maintains some local state about
+ * keywords and levels that are enabled for each eventing provider.
+ *
+ * The GC fires events from two providers: the "main" provider
+ * and the "private" provider. This file tracks keyword and level
+ * information for each provider separately.
+ *
+ * It is the responsibility of the EE to inform the GC of changes
+ * to eventing state. This is accomplished by invoking the
+ * `IGCHeap::ControlEvents` and `IGCHeap::ControlPrivateEvents` callbacks
+ * on the EE's heap instance, which ultimately will enable and disable keywords
+ * and levels within this file.
+ */
+
+#include "common.h"
+#include "gcenv.h"
+#include "gc.h"
+
+// Uncomment this define to print out event state changes to standard error.
+// #define TRACE_GC_EVENT_STATE 1
+
+/*
+ * GCEventProvider represents one of the two providers that the GC can
+ * fire events from: the default and private providers.
+ */
+enum GCEventProvider
+{
+    GCEventProvider_Default = 0,
+    GCEventProvider_Private = 1
+};
+
+/*
+ * GCEventStatus maintains all eventing state for the GC. It consists
+ * of a keyword bitmask and level for each provider that the GC can use
+ * to fire events.
+ *
+ * A level and event pair are considered to be "enabled" on a given provider
+ * if the given level is less than or equal to the current enabled level
+ * and if the keyword is present in the enabled keyword bitmask for that
+ * provider.
+ */
+class GCEventStatus
+{
+private:
+    /*
+     * The enabled level for each provider.
+     */
+    static Volatile<GCEventLevel> enabledLevels[2];
+
+    /*
+     * The bitmap of enabled keywords for each provider.
+     */
+    static Volatile<GCEventKeyword> enabledKeywords[2];
+
+public:
+    /*
+     * IsEnabled queries whether or not the given level and keyword are
+     * enabled on the given provider, returning true if they are.
+     */
+    __forceinline static bool IsEnabled(GCEventProvider provider, GCEventKeyword keyword, GCEventLevel level)
+    {
+        assert(level >= GCEventLevel_None && level < GCEventLevel_Max);
+
+        size_t index = static_cast<size_t>(provider);
+        return (enabledLevels[index] >= level) && (enabledKeywords[index] & keyword);
+    }
+
+    /*
+     * Set sets the eventing state (level and keyword bitmap) for a given
+     * provider to the provided values.
+     */
+    static void Set(GCEventProvider provider, GCEventKeyword keywords, GCEventLevel level)
+    {
+        assert(level >= GCEventLevel_None && level < GCEventLevel_Max);
+
+        size_t index = static_cast<size_t>(provider);
+
+        enabledLevels[index] = level;
+        enabledKeywords[index] = keywords;
+
+#if TRACE_GC_EVENT_STATE
+        fprintf(stderr, "event state change:\n");
+        DebugDumpState(provider);
+#endif // TRACE_GC_EVENT_STATE
+    }
+
+private:
+    static void DebugDumpState(GCEventProvider provider)
+    {
+        size_t index = static_cast<size_t>(provider);
+        GCEventLevel level = enabledLevels[index];
+        GCEventKeyword keyword = enabledKeywords[index];
+        if (provider == GCEventProvider_Default)
+        {
+            fprintf(stderr, "provider: default\n");
+        }
+        else
+        {
+            fprintf(stderr, "provider: private\n");
+        }
+
+        switch (level)
+        {
+        case GCEventLevel_None:
+            fprintf(stderr, "  level: None\n");
+            break;
+        case GCEventLevel_Fatal:
+            fprintf(stderr, "  level: Fatal\n");
+            break;
+        case GCEventLevel_Error:
+            fprintf(stderr, "  level: Error\n");
+            break;
+        case GCEventLevel_Warning:
+            fprintf(stderr, "  level: Warning\n");
+            break;
+        case GCEventLevel_Information:
+            fprintf(stderr, "  level: Information\n");
+            break;
+        case GCEventLevel_Verbose:
+            fprintf(stderr, "  level: Verbose\n");
+            break;
+        default:
+            fprintf(stderr, "  level: %d?\n", level);
+            break;
+        }
+
+        fprintf(stderr, "  keywords: ");
+        if (keyword & GCEventKeyword_GC)
+        {
+            fprintf(stderr, "GC ");
+        }
+
+        if (keyword & GCEventKeyword_GCHandle)
+        {
+            fprintf(stderr, "GCHandle ");
+        }
+
+        if (keyword & GCEventKeyword_GCHeapDump)
+        {
+            fprintf(stderr, "GCHeapDump ");
+        }
+
+        if (keyword & GCEventKeyword_GCSampledObjectAllocationHigh)
+        {
+            fprintf(stderr, "GCSampledObjectAllocationHigh ");
+        }
+
+        if (keyword & GCEventKeyword_GCHeapSurvivalAndMovement)
+        {
+            fprintf(stderr, "GCHeapSurvivalAndMovement ");
+        }
+
+        if (keyword & GCEventKeyword_GCHeapCollect)
+        {
+            fprintf(stderr, "GCHeapCollect ");
+        }
+
+        if (keyword & GCEventKeyword_GCHeapAndTypeNames)
+        {
+            fprintf(stderr, "GCHeapAndTypeNames ");
+        }
+
+        if (keyword & GCEventKeyword_GCSampledObjectAllocationLow)
+        {
+            fprintf(stderr, "GCSampledObjectAllocationLow ");
+        }
+
+        fprintf(stderr, "\n");
+    }
+
+    // This class is a singleton and can't be instantiated.
+    GCEventStatus() = delete;
+};
+
+#endif // __GCEVENTSTATUS_H__

--- a/src/gc/gceventstatus.h
+++ b/src/gc/gceventstatus.h
@@ -74,7 +74,8 @@ public:
         assert(level >= GCEventLevel_None && level < GCEventLevel_Max);
 
         size_t index = static_cast<size_t>(provider);
-        return (enabledLevels[index] >= level) && (enabledKeywords[index] & keyword);
+        return (enabledLevels[index].LoadWithoutBarrier() >= level)
+          && (enabledKeywords[index].LoadWithoutBarrier() & keyword);
     }
 
     /*
@@ -96,6 +97,7 @@ public:
 #endif // TRACE_GC_EVENT_STATE
     }
 
+#if TRACE_GC_EVENT_STATE
 private:
     static void DebugDumpState(GCEventProvider provider)
     {
@@ -179,6 +181,7 @@ private:
 
         fprintf(stderr, "\n");
     }
+#endif // TRACE_GC_EVENT_STATUS
 
     // This class is a singleton and can't be instantiated.
     GCEventStatus() = delete;

--- a/src/gc/gcimpl.h
+++ b/src/gc/gcimpl.h
@@ -230,6 +230,10 @@ public:	// FIX
     virtual segment_handle RegisterFrozenSegment(segment_info *pseginfo);
     virtual void UnregisterFrozenSegment(segment_handle seg);
 
+    // Event control functions
+    void ControlEvents(GCEventKeyword keyword, GCEventLevel level);
+    void ControlPrivateEvents(GCEventKeyword keyword, GCEventLevel level);
+
     void    WaitUntilConcurrentGCComplete ();                               // Use in managd threads
 #ifndef DACCESS_COMPILE    
     HRESULT WaitUntilConcurrentGCCompleteAsync(int millisecondsTimeout);    // Use in native threads. TRUE if succeed. FALSE if failed or timeout

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -205,6 +205,41 @@ extern uint8_t* g_shadow_lowest_address;
 // For low memory notification from host
 extern int32_t g_bLowMemoryFromHost;
 
+// Event levels corresponding to events that can be fired by the GC.
+enum GCEventLevel
+{
+    GCEventLevel_None = 0,
+    GCEventLevel_Fatal = 1,
+    GCEventLevel_Error = 2,
+    GCEventLevel_Warning = 3,
+    GCEventLevel_Information = 4,
+    GCEventLevel_Verbose = 5,
+    GCEventLevel_Max = 6
+};
+
+enum GCEventKeyword
+{
+    GCEventKeyword_None                          =       0x0,
+    GCEventKeyword_GC                            =       0x1,
+    GCEventKeyword_GCHandle                      =       0x2,
+    GCEventKeyword_GCHeapDump                    =  0x100000,
+    GCEventKeyword_GCSampledObjectAllocationHigh =  0x200000,
+    GCEventKeyword_GCHeapSurvivalAndMovement     =  0x400000,
+    GCEventKeyword_GCHeapCollect                 =  0x800000,
+    GCEventKeyword_GCHeapAndTypeNames            = 0x1000000,
+    GCEventKeyword_GCSampledObjectAllocationLow  = 0x2000000,
+    GCEventKeyword_All = GCEventKeyword_GC
+      | GCEventKeyword_GCHandle
+      | GCEventKeyword_GCHeapDump
+      | GCEventKeyword_GCSampledObjectAllocationHigh
+      | GCEventKeyword_GCHeapDump
+      | GCEventKeyword_GCSampledObjectAllocationHigh
+      | GCEventKeyword_GCHeapSurvivalAndMovement
+      | GCEventKeyword_GCHeapCollect
+      | GCEventKeyword_GCHeapAndTypeNames
+      | GCEventKeyword_GCSampledObjectAllocationLow
+};
+
 // !!!!!!!!!!!!!!!!!!!!!!!
 // make sure you change the def in bcl\system\gc.cs 
 // if you change this!
@@ -808,6 +843,18 @@ public:
 
     // Unregisters a frozen segment.
     virtual void UnregisterFrozenSegment(segment_handle seg) = 0;
+
+    /*
+    ===========================================================================
+    Routines for informing the GC about which events are enabled.
+    ===========================================================================
+    */
+
+    // Enables or disables the given keyword or level on the default event provider.
+    virtual void ControlEvents(GCEventKeyword keyword, GCEventLevel level) = 0;
+
+    // Enables or disables the given keyword or level on the private event provider.
+    virtual void ControlPrivateEvents(GCEventKeyword keyword, GCEventLevel level) = 0;
 
     IGCHeap() {}
     virtual ~IGCHeap() {}

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -217,6 +217,9 @@ enum GCEventLevel
     GCEventLevel_Max = 6
 };
 
+// Event keywords corresponding to events that can be fired by the GC. These
+// numbers come from the ETW manifest itself - please make changes to this enum
+// if you add, remove, or change keyword sets that are used by the GC!
 enum GCEventKeyword
 {
     GCEventKeyword_None                          =       0x0,

--- a/src/gc/sample/CMakeLists.txt
+++ b/src/gc/sample/CMakeLists.txt
@@ -10,6 +10,7 @@ add_definitions(-DFEATURE_REDHAWK)
 set(SOURCES
     GCSample.cpp
     gcenv.ee.cpp
+    ../gceventstatus.cpp
     ../gcconfig.cpp
     ../gccommon.cpp
     ../gceewks.cpp

--- a/src/gc/sample/gcenv.h
+++ b/src/gc/sample/gcenv.h
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+#ifndef __GCENV_H__
+#define __GCENV_H__
 
 // The sample is to be kept simple, so building the sample
 // in tandem with a standalone GC is currently not supported.
@@ -200,3 +202,5 @@ extern EEConfig * g_pConfig;
 
 #include "etmdummy.h"
 #define ETW_EVENT_ENABLED(e,f) false
+
+#endif // __GCENV_H__

--- a/src/inc/eventtracebase.h
+++ b/src/inc/eventtracebase.h
@@ -251,6 +251,42 @@ public:
 
 #if defined(FEATURE_EVENT_TRACE)
 
+VOID EventPipeEtwCallbackDotNETRuntimeStress(
+    _In_ LPCGUID SourceId,
+    _In_ ULONG ControlCode,
+    _In_ UCHAR Level,
+    _In_ ULONGLONG MatchAnyKeyword,
+    _In_ ULONGLONG MatchAllKeyword,
+    _In_opt_ PVOID FilterData,
+    _Inout_opt_ PVOID CallbackContext);
+
+VOID EventPipeEtwCallbackDotNETRuntime(
+    _In_ LPCGUID SourceId,
+    _In_ ULONG ControlCode,
+    _In_ UCHAR Level,
+    _In_ ULONGLONG MatchAnyKeyword,
+    _In_ ULONGLONG MatchAllKeyword,
+    _In_opt_ PVOID FilterData,
+    _Inout_opt_ PVOID CallbackContext);
+
+VOID EventPipeEtwCallbackDotNETRuntimeRundown(
+    _In_ LPCGUID SourceId,
+    _In_ ULONG ControlCode,
+    _In_ UCHAR Level,
+    _In_ ULONGLONG MatchAnyKeyword,
+    _In_ ULONGLONG MatchAllKeyword,
+    _In_opt_ PVOID FilterData,
+    _Inout_opt_ PVOID CallbackContext);
+
+VOID EventPipeEtwCallbackDotNETRuntimePrivate(
+    _In_ LPCGUID SourceId,
+    _In_ ULONG ControlCode,
+    _In_ UCHAR Level,
+    _In_ ULONGLONG MatchAnyKeyword,
+    _In_ ULONGLONG MatchAllKeyword,
+    _In_opt_ PVOID FilterData,
+    _Inout_opt_ PVOID CallbackContext);
+
 #ifndef  FEATURE_PAL
 // Callback and stack support
 #if !defined(DONOT_DEFINE_ETW_CALLBACK) && !defined(DACCESS_COMPILE)

--- a/src/scripts/genEventPipe.py
+++ b/src/scripts/genEventPipe.py
@@ -130,6 +130,7 @@ def generateClrEventPipeWriteEventsImpl(
         WriteEventImpl.append("\n    return ERROR_SUCCESS;\n}\n\n")
 
     # EventPipeProvider and EventPipeEvent initialization
+    callbackName = 'EventPipeEtwCallback' + providerPrettyName
     if extern: WriteEventImpl.append('extern "C" ')
     WriteEventImpl.append(
         "void Init" +
@@ -140,7 +141,7 @@ def generateClrEventPipeWriteEventsImpl(
         providerPrettyName +
         " = EventPipe::CreateProvider(SL(" +
         providerPrettyName +
-        "Name), EventPipeEtwCallback);\n")
+        "Name), " + callbackName + ");\n")
     for eventNode in eventNodes:
         eventName = eventNode.getAttribute('symbol')
         templateName = eventNode.getAttribute('template')
@@ -440,8 +441,6 @@ bool WriteToBuffer(const T &value, char *&buffer, size_t& offset, size_t& size, 
     offset += sizeof(T);
     return true;
 }}
-
-extern VOID EventPipeEtwCallback(LPCGUID, ULONG, UCHAR, ULONGLONG, ULONGLONG, PVOID, PVOID);
 
 """.format(root=src_dirname.replace('\\', '/'))
 

--- a/src/scripts/genEventPipe.py
+++ b/src/scripts/genEventPipe.py
@@ -140,7 +140,7 @@ def generateClrEventPipeWriteEventsImpl(
         providerPrettyName +
         " = EventPipe::CreateProvider(SL(" +
         providerPrettyName +
-        "Name));\n")
+        "Name), EventPipeEtwCallback);\n")
     for eventNode in eventNodes:
         eventName = eventNode.getAttribute('symbol')
         templateName = eventNode.getAttribute('template')
@@ -440,6 +440,8 @@ bool WriteToBuffer(const T &value, char *&buffer, size_t& offset, size_t& size, 
     offset += sizeof(T);
     return true;
 }}
+
+extern VOID EventPipeEtwCallback(LPCGUID, ULONG, UCHAR, ULONGLONG, ULONGLONG, PVOID, PVOID);
 
 """.format(root=src_dirname.replace('\\', '/'))
 

--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -259,6 +259,7 @@ set(VM_SOURCES_WKS
 
 set(GC_SOURCES_WKS
     ${GC_SOURCES_DAC_AND_WKS_COMMON}
+    ../gc/gceventstatus.cpp
     ../gc/gcconfig.cpp
     ../gc/gccommon.cpp
     ../gc/gcscan.cpp

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -4324,40 +4324,18 @@ VOID EventPipeEtwCallback(
 
 #if !defined(FEATURE_PAL)
     PMCGEN_TRACE_CONTEXT context = (PMCGEN_TRACE_CONTEXT)CallbackContext;
-    BOOLEAN bIsPublicTraceHandle = (context->RegistrationHandle==Microsoft_Windows_DotNETRuntimeHandle);
-    BOOLEAN bIsPrivateTraceHandle = (context->RegistrationHandle==Microsoft_Windows_DotNETRuntimePrivateHandle);
+    bool bIsPublicTraceHandle = context->RegistrationHandle == Microsoft_Windows_DotNETRuntimeHandle;
 
-    if (!g_fEEStarted || g_fEEShutDown)
-    {
-        return;
-    }
-
-    if (ControlCode == EVENT_CONTROL_CODE_ENABLE_PROVIDER || ControlCode == EVENT_CONTROL_CODE_DISABLE_PROVIDER)
-    {
-        static_assert(GCEventLevel_None == TRACE_LEVEL_NONE, "GCEventLevel_None value mismatch");
-        static_assert(GCEventLevel_Fatal == TRACE_LEVEL_FATAL, "GCEventLevel_Fatal value mismatch");
-        static_assert(GCEventLevel_Error == TRACE_LEVEL_ERROR, "GCEventLevel_Error value mismatch");
-        static_assert(GCEventLevel_Warning == TRACE_LEVEL_WARNING, "GCEventLevel_Warning mismatch");
-        static_assert(GCEventLevel_Information == TRACE_LEVEL_INFORMATION, "GCEventLevel_Information mismatch");
-        static_assert(GCEventLevel_Verbose == TRACE_LEVEL_VERBOSE, "GCEventLevel_Verbose mismatch");
-
-        // The GC also needs to be informed of changes to keywords and levels.
-        IGCHeap *heap = GCHeapUtilities::GetGCHeap();
-        GCEventKeyword keywords = static_cast<GCEventKeyword>(MatchAnyKeyword);
-        GCEventLevel level = static_cast<GCEventLevel>(Level);
-        if (bIsPublicTraceHandle)
-        {
-            heap->ControlEvents(keywords, level);
-        }
-        else if (bIsPrivateTraceHandle)
-        {
-            heap->ControlPrivateEvents(keywords, level);
-        }
-
-    }
+    static_assert(GCEventLevel_None == TRACE_LEVEL_NONE, "GCEventLevel_None value mismatch");
+    static_assert(GCEventLevel_Fatal == TRACE_LEVEL_FATAL, "GCEventLevel_Fatal value mismatch");
+    static_assert(GCEventLevel_Error == TRACE_LEVEL_ERROR, "GCEventLevel_Error value mismatch");
+    static_assert(GCEventLevel_Warning == TRACE_LEVEL_WARNING, "GCEventLevel_Warning mismatch");
+    static_assert(GCEventLevel_Information == TRACE_LEVEL_INFORMATION, "GCEventLevel_Information mismatch");
+    static_assert(GCEventLevel_Verbose == TRACE_LEVEL_VERBOSE, "GCEventLevel_Verbose mismatch");
+    GCEventKeyword keywords = static_cast<GCEventKeyword>(MatchAnyKeyword);
+    GCEventLevel level = static_cast<GCEventLevel>(Level);
+    GCHeapUtilities::RecordEventStateChange(bIsPublicTraceHandle, keywords, level);
 #endif // !defined(FEATURE_PAL)
-
-    // the GC doesn't use the runtime rundown provider.
 }
 
 #if !defined(FEATURE_PAL)

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -4441,12 +4441,40 @@ extern "C"
 
         BOOLEAN bIsRundownTraceHandle = (context->RegistrationHandle==Microsoft_Windows_DotNETRuntimeRundownHandle);
 
-		// TypeSystemLog needs a notification when certain keywords are modified, so
-		// give it a hook here.
-		if (g_fEEStarted && !g_fEEShutDown && bIsPublicTraceHandle)
-		{
-			ETW::TypeSystemLog::OnKeywordsChanged();
-		}
+        if (g_fEEStarted && !g_fEEShutDown)
+        {
+            // TypeSystemLog needs a notification when certain keywords are modified, so
+            // give it a hook here.
+            if (bIsPublicTraceHandle)
+            {
+                ETW::TypeSystemLog::OnKeywordsChanged();
+            }
+
+            if (ControlCode == EVENT_CONTROL_CODE_ENABLE_PROVIDER || ControlCode == EVENT_CONTROL_CODE_DISABLE_PROVIDER)
+            {
+                static_assert(GCEventLevel_None == TRACE_LEVEL_NONE, "GCEventLevel_None value mismatch");
+                static_assert(GCEventLevel_Fatal == TRACE_LEVEL_FATAL, "GCEventLevel_Fatal value mismatch");
+                static_assert(GCEventLevel_Error == TRACE_LEVEL_ERROR, "GCEventLevel_Error value mismatch");
+                static_assert(GCEventLevel_Warning == TRACE_LEVEL_WARNING, "GCEventLevel_Warning mismatch");
+                static_assert(GCEventLevel_Information == TRACE_LEVEL_INFORMATION, "GCEventLevel_Information mismatch");
+                static_assert(GCEventLevel_Verbose == TRACE_LEVEL_VERBOSE, "GCEventLevel_Verbose mismatch");
+
+                // The GC also needs to be informed of changes to keywords and levels.
+                IGCHeap *heap = GCHeapUtilities::GetGCHeap();
+                GCEventKeyword keywords = static_cast<GCEventKeyword>(MatchAnyKeyword);
+                GCEventLevel level = static_cast<GCEventLevel>(Level);
+                if (bIsPublicTraceHandle)
+                {
+                    heap->ControlEvents(keywords, level);
+                }
+                else if (bIsPrivateTraceHandle)
+                {
+                    heap->ControlPrivateEvents(keywords, level);
+                }
+
+                // the GC doesn't use the runtime rundown provider.
+            }
+        }
 
         // A manifest based provider can be enabled to multiple event tracing sessions
         // As long as there is atleast 1 enabled session, IsEnabled will be TRUE

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -4340,12 +4340,14 @@ VOID EtwCallbackCommon(
     LIMITED_METHOD_CONTRACT;
 
     bool bIsPublicTraceHandle = ProviderIndex == DotNETRuntime;
+#if !defined(FEATURE_PAL)
     static_assert(GCEventLevel_None == TRACE_LEVEL_NONE, "GCEventLevel_None value mismatch");
     static_assert(GCEventLevel_Fatal == TRACE_LEVEL_FATAL, "GCEventLevel_Fatal value mismatch");
     static_assert(GCEventLevel_Error == TRACE_LEVEL_ERROR, "GCEventLevel_Error value mismatch");
     static_assert(GCEventLevel_Warning == TRACE_LEVEL_WARNING, "GCEventLevel_Warning mismatch");
     static_assert(GCEventLevel_Information == TRACE_LEVEL_INFORMATION, "GCEventLevel_Information mismatch");
     static_assert(GCEventLevel_Verbose == TRACE_LEVEL_VERBOSE, "GCEventLevel_Verbose mismatch");
+#endif // !defined(FEATURE_PAL)
     GCEventKeyword keywords = static_cast<GCEventKeyword>(MatchAnyKeyword);
     GCEventLevel level = static_cast<GCEventLevel>(Level);
     GCHeapUtilities::RecordEventStateChange(bIsPublicTraceHandle, keywords, level);

--- a/src/vm/gcheaputilities.cpp
+++ b/src/vm/gcheaputilities.cpp
@@ -88,19 +88,14 @@ namespace
 // The below lock is taken by the "main" thread (the thread in EEStartup) and
 // the "ETW" thread, the one calling EtwCallback. EtwCallback may or may not
 // be called on the main thread.
-CRITICAL_SECTION g_eventStashLock;
+DangerousNonHostedSpinLock g_eventStashLock;
 
-// These two global fields are 64-bit integers so that loads and stores to them
-// can be atomic.
-LONG64 g_stashedKeywordAndLevel = 0;
-LONG64 g_stashedPrivateKeywordAndLevel = 0;
+GCEventLevel g_stashedLevel = GCEventLevel_None;
+GCEventKeyword g_stashedKeyword = GCEventKeyword_None;
+GCEventLevel g_stashedPrivateLevel = GCEventLevel_None;
+GCEventKeyword g_stashedPrivateKeyword = GCEventKeyword_None;
 
-// In order for loads and stores of the keyword and level state to be atomic,
-// these macros assist in packing and unpacking two 32-bit integer values into
-// a 64-bit value.
-#define STASH_KEY_AND_LEVEL(key, level) ((static_cast<LONG64>(key) << 32) | static_cast<LONG64>(level))
-#define UNSTASH_KEY(combined) (static_cast<GCEventKeyword>(combined >> 32))
-#define UNSTASH_VALUE(combined) (static_cast<GCEventLevel>(combined & 0xFFFFFFFF))
+BOOL g_gcEventTracingInitialized = FALSE;
 
 // FinalizeLoad is called by the main thread to complete initialization of the GC.
 // At this point, the GC has provided us with an IGCHeap instance and we are preparing
@@ -109,34 +104,17 @@ LONG64 g_stashedPrivateKeywordAndLevel = 0;
 // This function can proceed concurrently with StashKeywordAndLevel below.
 void FinalizeLoad(IGCHeap* gcHeap, IGCHandleManager* handleMgr, HMODULE gcModule)
 {
-    // at this point the GC has been initialized and is ready to go.
-    // the main thread is responsible for initializing the lock.
-    UnsafeInitializeCriticalSection(&g_eventStashLock);
-    UnsafeEnterCriticalSection(&g_eventStashLock);
-
-    // the compiler or hardware can't be allowed to reorder this write before
-    // the lock acquision. This is because StashKeywordAndLevel will acquire the
-    // lock if g_pGCHeap is not null and the lock must be initialized by that point.
-    VOLATILE_MEMORY_BARRIER();
     g_pGCHeap = gcHeap;
 
-    // despite holding the lock, the ETW callback thread may still write to the stashed
-    // values. All writes are atomic.
-    //
-    // the values we read here may not necessarily be the most up-to-date.
-    // Between the time we read these values and we call ControlEvents, an ETW callback
-    // may have been fired and overwrote these values with more up-to-date ones.
-    // However, if this is the case, the ETW callback is now blocked waiting to acquire
-    // g_eventStashLock, so it will have a chance to call ControlEvents itself later
-    // once we release the lock.
-    LONG64 keyAndLevel = InterlockedExchange64(&g_stashedKeywordAndLevel, 0);
-    LONG64 privateKeyAndLevel = InterlockedExchange64(&g_stashedPrivateKeywordAndLevel, 0);
+    {
+        DangerousNonHostedSpinLockHolder lockHolder(&g_eventStashLock);
 
-    // Ultimately, g_eventStashLock ensures that no two threads call ControlEvents at any
-    // point in time.
-    g_pGCHeap->ControlEvents(UNSTASH_KEY(keyAndLevel), UNSTASH_VALUE(keyAndLevel));
-    g_pGCHeap->ControlPrivateEvents(UNSTASH_KEY(privateKeyAndLevel), UNSTASH_VALUE(privateKeyAndLevel));
-    UnsafeLeaveCriticalSection(&g_eventStashLock);
+        // Ultimately, g_eventStashLock ensures that no two threads call ControlEvents at any
+        // point in time.
+        g_pGCHeap->ControlEvents(g_stashedKeyword, g_stashedLevel);
+        g_pGCHeap->ControlPrivateEvents(g_stashedPrivateKeyword, g_stashedPrivateLevel);
+        g_gcEventTracingInitialized = TRUE;
+    }
 
     g_pGCHandleManager = handleMgr;
     g_gcDacGlobals = &g_gc_dac_vars;
@@ -147,20 +125,22 @@ void FinalizeLoad(IGCHeap* gcHeap, IGCHandleManager* handleMgr, HMODULE gcModule
 
 void StashKeywordAndLevel(bool isPublicProvider, GCEventKeyword keywords, GCEventLevel level)
 {
-    volatile LONG64* stash = isPublicProvider ? &g_stashedKeywordAndLevel : &g_stashedPrivateKeywordAndLevel;
-    InterlockedExchange64(stash, STASH_KEY_AND_LEVEL(keywords, level));
-
-    VOLATILE_MEMORY_BARRIER();
-    if (g_pGCHeap != nullptr)
+    DangerousNonHostedSpinLockHolder lockHolder(&g_eventStashLock);
+    if (!g_gcEventTracingInitialized)
     {
-        // observing that g_pGCHeap is not null means that g_eventStashLock has been
-        // initialized. At this point either the GC is still being initialized
-        // (the main thread will hold the lock) or the GC has already been initialized
-        // (the lock will be uncontested).
-        //
-        // At any rate, once we grab the lock, we're free to inform the GC of our changes
-        // to the event state.
-        UnsafeEnterCriticalSection(&g_eventStashLock);
+        if (isPublicProvider)
+        {
+            g_stashedKeyword = keywords;
+            g_stashedLevel = level;
+        }
+        else
+        {
+            g_stashedPrivateKeyword = keywords;
+            g_stashedPrivateLevel = level;
+        }
+    }
+    else
+    {
         if (isPublicProvider)
         {
             g_pGCHeap->ControlEvents(keywords, level);
@@ -169,14 +149,7 @@ void StashKeywordAndLevel(bool isPublicProvider, GCEventKeyword keywords, GCEven
         {
             g_pGCHeap->ControlPrivateEvents(keywords, level);
         }
-
-        UnsafeLeaveCriticalSection(&g_eventStashLock);
     }
-
-    // note that we will do nothing if g_pGCHeap is null. The main thread will read our stashed
-    // event state when initializing the GC, so by virtue of writing to the event stash we
-    // will ensure that the initializing GC will see the event state that we were just informed
-    // of by an ETW callback.
 }
 
 // Loads and initializes a standalone GC, given the path to the GC

--- a/src/vm/gcheaputilities.h
+++ b/src/vm/gcheaputilities.h
@@ -202,6 +202,10 @@ public:
 
     // Loads (if using a standalone GC) and initializes the GC.
     static HRESULT LoadAndInitialize();
+
+    // Records a change in eventing state. This ultimately will inform the GC that it needs to be aware
+    // of new events being enabled.
+    static void RecordEventStateChange(bool isPublicProvider, GCEventKeyword keywords, GCEventLevel level);
 #endif // DACCESS_COMPILE
 
 private:


### PR DESCRIPTION
This PR is the first of several PRs implementing [this design](https://github.com/dotnet/coreclr/blob/master/Documentation/design-docs/standalone-gc-eventing.md) bringing FEATURE_EVENT_TRACE to standalone GCs. This PR implements the portion of the design that [keeps track of what events are enabled](https://github.com/dotnet/coreclr/blob/master/Documentation/design-docs/standalone-gc-eventing.md#querying-whether-events-are-enabled).

The approach taken in this PR is fundamentally the same as the one described in the design document, with some minor tweaks to `GCEventState`.

The `GCEventState` class described in the spec was simplified somewhat, based on some insights I had when experimenting with ETW. There is no need to draw any distinction between enabling
or disabling a provider, since the `EtwCallback` installed by the runtime receives the level and keyword state after applying the delta that a log enabler (e.g. logman) has created. For example, for the following sequence of events:

```
logman start trace1 -p {clr-provider-guid} 0x1 0x5 -ets
logman start trace2 -p {clr-provider-guid} 0x2 0x4 -ets
logman stop trace1 -ets
logman stop trace2 -ets
```

`EtwCallback` is invoked four times, with the following arguments:

```
EtwCallback(Level=5, Keyword=1, EVENT_CONTROL_CODE_ENABLE_PROVIDER)
EtwCallback(Level=5, Keyword=3, EVENT_CONTROL_CODE_ENABLE_PROVIDER)
EtwCallback(Level=4, Keyword=2, EVENT_CONTROL_CODE_ENABLE_PROVIDER)
EtwCallback(Level=0, Keyword=0, EVENT_CONTROL_CODE_DISABLE_PROVIDER)
```

We can pass the level and keyword information verbatim to the GC and no additional logic is
necessary; the ETW subsystem is already keeping track of which trace client has what level and keyword enabled so the GC doesn't need to do it. The GC doesn't even need to know if a provider
is being enabled or disabled since it can just take the information ETW gives it.

Instead of having separate `Enable` and `Disable` code paths on `GCEventState`, as written in the spec, this PR has a single `Set` entry point that sets the GC's level and keyword state for a provider to exactly what is given to `Set` as arguments, which in turn comes directly from ETW.