### PR TITLE
Mark emitIns_R_A and emitIns_R_R_A to be not defined for legacy backend

### DIFF
--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -3891,6 +3891,7 @@ void emitter::emitIns_R_R_I(instruction ins, emitAttr attr, regNumber reg1, regN
     emitCurIGsize += sz;
 }
 
+#ifndef LEGACY_BACKEND
 void emitter::emitIns_R_A(instruction ins, emitAttr attr, regNumber reg1, GenTreeIndir* indir, insFormat fmt)
 {
     ssize_t    offs = indir->Offset();
@@ -3929,6 +3930,7 @@ void emitter::emitIns_R_R_A(
     dispIns(id);
     emitCurIGsize += sz;
 }
+#endif // !LEGACY_BACKEND
 
 void emitter::emitIns_R_R_C(
     instruction ins, emitAttr attr, regNumber reg1, regNumber reg2, CORINFO_FIELD_HANDLE fldHnd, int offs)

--- a/src/jit/emitxarch.h
+++ b/src/jit/emitxarch.h
@@ -365,9 +365,11 @@ void emitIns_R_R(instruction ins, emitAttr attr, regNumber reg1, regNumber reg2)
 
 void emitIns_R_R_I(instruction ins, emitAttr attr, regNumber reg1, regNumber reg2, int ival);
 
+#ifndef LEGACY_BACKEND
 void emitIns_R_A(instruction ins, emitAttr attr, regNumber reg1, GenTreeIndir* indir, insFormat fmt);
 
 void emitIns_R_R_A(instruction ins, emitAttr attr, regNumber reg1, regNumber reg2, GenTreeIndir* indir, insFormat fmt);
+#endif // !LEGACY_BACKEND
 
 void emitIns_R_R_C(
     instruction ins, emitAttr attr, regNumber reg1, regNumber reg2, CORINFO_FIELD_HANDLE fldHnd, int offs);


### PR DESCRIPTION
Resolves https://github.com/dotnet/coreclr/pull/15804#issuecomment-358077239

FYI. @sandreenko, @CarolEidt 