### PR TITLE
Add missing config.h.in entry for HAVE_LIBINTL_H

### DIFF
--- a/src/pal/src/config.h.in
+++ b/src/pal/src/config.h.in
@@ -24,6 +24,7 @@
 #cmakedefine01 HAVE_NUMA_H
 #cmakedefine01 HAVE_PTHREAD_NP_H
 #cmakedefine01 HAVE_AUXV_HWCAP_H
+#cmakedefine01 HAVE_LIBINTL_H
 
 #cmakedefine01 HAVE_KQUEUE
 #cmakedefine01 HAVE_PTHREAD_SUSPEND


### PR DESCRIPTION
In my change yesterday, I have added HAVE_LIBINTL_H to the
configure.cmake file, but forgotten to add the corresponding define to
the config.h.in file. This fixes it.