### PR TITLE
Fix non-Windows R2R testing in CI

### DIFF
--- a/tests/skipCrossGenFiles.arm.txt
+++ b/tests/skipCrossGenFiles.arm.txt
@@ -1,3 +1,4 @@
 mscorlib.dll
 System.Runtime.WindowsRuntime.UI.Xaml.dll
 System.Private.CoreLib.dll
+xunit.performance.api.dll

--- a/tests/skipCrossGenFiles.arm64.txt
+++ b/tests/skipCrossGenFiles.arm64.txt
@@ -4,3 +4,4 @@ System.Net.NameResolution.dll
 System.Net.Sockets.dll
 System.Net.Primitives.dll
 System.Private.CoreLib.dll
+xunit.performance.api.dll

--- a/tests/skipCrossGenFiles.x64.txt
+++ b/tests/skipCrossGenFiles.x64.txt
@@ -1,3 +1,4 @@
 mscorlib.dll
 System.Runtime.WindowsRuntime.UI.Xaml.dll
 System.Private.CoreLib.dll
+xunit.performance.api.dll

--- a/tests/skipCrossGenFiles.x86.txt
+++ b/tests/skipCrossGenFiles.x86.txt
@@ -1,3 +1,4 @@
 mscorlib.dll
 System.Runtime.WindowsRuntime.UI.Xaml.dll
 System.Private.CoreLib.dll
+xunit.performance.api.dll


### PR DESCRIPTION
The xunit.performance.api.dll assembly depends on
Microsoft.3rdpartytools.MarkdownLog, which cannot
be found. Add xunit.performance.api.dll to the
list of assemblies that are not crossgen'ed
during R2R testing.

Fixes #15845 (or at least works around it)
