### PR TITLE
Disable GetGeneration from GCStress runs

### DIFF
--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -60921,7 +60921,7 @@ RelativePath=GC\API\GC\GetGeneration\GetGeneration.cmd
 WorkingDir=GC\API\GC\GetGeneration
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=EXPECTED_FAIL;GCSTRESS_EXCLUDE
 HostStyle=0
 
 [OpCodeOperandType.cmd_7644]

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -21177,7 +21177,7 @@ RelativePath=GC\API\GC\GetGeneration\GetGeneration.cmd
 WorkingDir=GC\API\GC\GetGeneration
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS
+Categories=EXPECTED_PASS;GCSTRESS_EXCLUDE
 HostStyle=0
 
 [GetGeneration_box.cmd_2871]

--- a/tests/src/GC/API/GC/GetGeneration.csproj
+++ b/tests/src/GC/API/GC/GetGeneration.csproj
@@ -10,7 +10,7 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
This test has exhibited "random" failures during GCStress runs
(which are believed to be due to the test itself, not some
product issue). So, disable it from GCStress runs.