### PR TITLE
Adding a DebugView for Vector64<T>, Vector128<T>, and Vector256<T>

### DIFF
--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -253,8 +253,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(BclSourcesRoot)\System\Runtime\Intrinsics\Vector64.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Runtime\Intrinsics\Vector64DebugView.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\Intrinsics\Vector128.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Runtime\Intrinsics\Vector128DebugView.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\Intrinsics\Vector256.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Runtime\Intrinsics\Vector256DebugView.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(BclSourcesRoot)\System\Runtime\Intrinsics\X86\Enums.cs" />

--- a/src/mscorlib/src/System/Runtime/Intrinsics/Vector128.cs
+++ b/src/mscorlib/src/System/Runtime/Intrinsics/Vector128.cs
@@ -2,12 +2,43 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Internal.Runtime.CompilerServices;
 
 namespace System.Runtime.Intrinsics
 {
     [Intrinsic]
+    [DebuggerDisplay("{DisplayString,nq}")]
+    [DebuggerTypeProxy(typeof(Vector128DebugView<>))]
     [StructLayout(LayoutKind.Sequential, Size = 16)]
-    public struct Vector128<T> where T : struct {}
+    public struct Vector128<T> where T : struct
+    {
+        // These fields exist to ensure the alignment is 8, rather than 1.
+        // This also allows the debug view to work https://github.com/dotnet/coreclr/issues/15694)
+        private ulong _00;
+        private ulong _01;
+
+        private unsafe string DisplayString
+        {
+            get
+            {
+                // The IsPrimitive check ends up working for `bool`, `char`, `IntPtr`, and `UIntPtr`
+                // which are not actually supported by any current architecture. This shouldn't be
+                // an issue however and greatly simplifies the check
+
+                if (typeof(T).IsPrimitive)
+                {
+                    var items = new T[16 / Unsafe.SizeOf<T>()];
+                    Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref items[0]), this);
+                    return $"({string.Join(", ", items)})";
+                }
+                else
+                {
+                    return SR.NotSupported_Type;
+                }
+            }
+        }
+    }
 }

--- a/src/mscorlib/src/System/Runtime/Intrinsics/Vector128DebugView.cs
+++ b/src/mscorlib/src/System/Runtime/Intrinsics/Vector128DebugView.cs
@@ -1,0 +1,118 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.Runtime.CompilerServices;
+
+namespace System.Runtime.Intrinsics
+{
+    internal struct Vector128DebugView<T> where T : struct
+    {
+        private Vector128<T> _value;
+
+        public Vector128DebugView(Vector128<T> value)
+        {
+            _value = value;
+        }
+
+        public byte[] ByteView
+        {
+            get
+            {
+                var items = new byte[16];
+                Unsafe.WriteUnaligned(ref items[0], _value);
+                return items;
+            }
+        }
+
+        public double[] DoubleView
+        {
+            get
+            {
+                var items = new double[2];
+                Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public short[] Int16View
+        {
+            get
+            {
+                var items = new short[8];
+                Unsafe.WriteUnaligned(ref Unsafe.As<short, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public int[] Int32View
+        {
+            get
+            {
+                var items = new int[4];
+                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public long[] Int64View
+        {
+            get
+            {
+                var items = new long[2];
+                Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public sbyte[] SByteView
+        {
+            get
+            {
+                var items = new sbyte[16];
+                Unsafe.WriteUnaligned(ref Unsafe.As<sbyte, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public float[] SingleView
+        {
+            get
+            {
+                var items = new float[4];
+                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public ushort[] UInt16View
+        {
+            get
+            {
+                var items = new ushort[8];
+                Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public uint[] UInt32View
+        {
+            get
+            {
+                var items = new uint[4];
+                Unsafe.WriteUnaligned(ref Unsafe.As<uint, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public ulong[] UInt64View
+        {
+            get
+            {
+                var items = new ulong[2];
+                Unsafe.WriteUnaligned(ref Unsafe.As<ulong, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+    }
+}

--- a/src/mscorlib/src/System/Runtime/Intrinsics/Vector256.cs
+++ b/src/mscorlib/src/System/Runtime/Intrinsics/Vector256.cs
@@ -2,12 +2,45 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Internal.Runtime.CompilerServices;
 
 namespace System.Runtime.Intrinsics
 {
     [Intrinsic]
+    [DebuggerDisplay("{DisplayString,nq}")]
+    [DebuggerTypeProxy(typeof(Vector256DebugView<>))]
     [StructLayout(LayoutKind.Sequential, Size = 32)]
-    public struct Vector256<T> where T : struct {}
+    public struct Vector256<T> where T : struct
+    {
+        // These fields exist to ensure the alignment is 8, rather than 1.
+        // This also allows the debug view to work https://github.com/dotnet/coreclr/issues/15694)
+        private ulong _00;
+        private ulong _01;
+        private ulong _02;
+        private ulong _03;
+
+        private unsafe string DisplayString
+        {
+            get
+            {
+                // The IsPrimitive check ends up working for `bool`, `char`, `IntPtr`, and `UIntPtr`
+                // which are not actually supported by any current architecture. This shouldn't be
+                // an issue however and greatly simplifies the check
+
+                if (typeof(T).IsPrimitive)
+                {
+                    var items = new T[32 / Unsafe.SizeOf<T>()];
+                    Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref items[0]), this);
+                    return $"({string.Join(", ", items)})";
+                }
+                else
+                {
+                    return SR.NotSupported_Type;
+                }
+            }
+        }
+    }
 }

--- a/src/mscorlib/src/System/Runtime/Intrinsics/Vector256DebugView.cs
+++ b/src/mscorlib/src/System/Runtime/Intrinsics/Vector256DebugView.cs
@@ -1,0 +1,118 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.Runtime.CompilerServices;
+
+namespace System.Runtime.Intrinsics
+{
+    internal struct Vector256DebugView<T> where T : struct
+    {
+        private Vector256<T> _value;
+
+        public Vector256DebugView(Vector256<T> value)
+        {
+            _value = value;
+        }
+
+        public byte[] ByteView
+        {
+            get
+            {
+                var items = new byte[32];
+                Unsafe.WriteUnaligned(ref items[0], _value);
+                return items;
+            }
+        }
+
+        public double[] DoubleView
+        {
+            get
+            {
+                var items = new double[4];
+                Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public short[] Int16View
+        {
+            get
+            {
+                var items = new short[16];
+                Unsafe.WriteUnaligned(ref Unsafe.As<short, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public int[] Int32View
+        {
+            get
+            {
+                var items = new int[8];
+                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public long[] Int64View
+        {
+            get
+            {
+                var items = new long[4];
+                Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public sbyte[] SByteView
+        {
+            get
+            {
+                var items = new sbyte[32];
+                Unsafe.WriteUnaligned(ref Unsafe.As<sbyte, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public float[] SingleView
+        {
+            get
+            {
+                var items = new float[8];
+                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public ushort[] UInt16View
+        {
+            get
+            {
+                var items = new ushort[16];
+                Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public uint[] UInt32View
+        {
+            get
+            {
+                var items = new uint[8];
+                Unsafe.WriteUnaligned(ref Unsafe.As<uint, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public ulong[] UInt64View
+        {
+            get
+            {
+                var items = new ulong[4];
+                Unsafe.WriteUnaligned(ref Unsafe.As<ulong, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+    }
+}

--- a/src/mscorlib/src/System/Runtime/Intrinsics/Vector64.cs
+++ b/src/mscorlib/src/System/Runtime/Intrinsics/Vector64.cs
@@ -2,12 +2,42 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Internal.Runtime.CompilerServices;
 
 namespace System.Runtime.Intrinsics
 {
     [Intrinsic]
+    [DebuggerDisplay("{DisplayString,nq}")]
+    [DebuggerTypeProxy(typeof(Vector64DebugView<>))]
     [StructLayout(LayoutKind.Sequential, Size = 8)]
-    public struct Vector64<T> where T : struct {}
+    public struct Vector64<T> where T : struct
+    {
+        // These fields exist to ensure the alignment is 8, rather than 1.
+        // This also allows the debug view to work https://github.com/dotnet/coreclr/issues/15694)
+        private ulong _00;
+
+        private unsafe string DisplayString
+        {
+            get
+            {
+                // The IsPrimitive check ends up working for `bool`, `char`, `IntPtr`, and `UIntPtr`
+                // which are not actually supported by any current architecture. This shouldn't be
+                // an issue however and greatly simplifies the check
+
+                if (typeof(T).IsPrimitive)
+                {
+                    var items = new T[8 / Unsafe.SizeOf<T>()];
+                    Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref items[0]), this);
+                    return $"({string.Join(", ", items)})";
+                }
+                else
+                {
+                    return SR.NotSupported_Type;
+                }
+            }
+        }
+    }
 }

--- a/src/mscorlib/src/System/Runtime/Intrinsics/Vector64DebugView.cs
+++ b/src/mscorlib/src/System/Runtime/Intrinsics/Vector64DebugView.cs
@@ -1,0 +1,118 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.Runtime.CompilerServices;
+
+namespace System.Runtime.Intrinsics
+{
+    internal struct Vector64DebugView<T> where T : struct
+    {
+        private Vector64<T> _value;
+
+        public Vector64DebugView(Vector64<T> value)
+        {
+            _value = value;
+        }
+
+        public byte[] ByteView
+        {
+            get
+            {
+                var items = new byte[8];
+                Unsafe.WriteUnaligned(ref items[0], _value);
+                return items;
+            }
+        }
+
+        public double[] DoubleView
+        {
+            get
+            {
+                var items = new double[1];
+                Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public short[] Int16View
+        {
+            get
+            {
+                var items = new short[4];
+                Unsafe.WriteUnaligned(ref Unsafe.As<short, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public int[] Int32View
+        {
+            get
+            {
+                var items = new int[2];
+                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public long[] Int64View
+        {
+            get
+            {
+                var items = new long[1];
+                Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public sbyte[] SByteView
+        {
+            get
+            {
+                var items = new sbyte[8];
+                Unsafe.WriteUnaligned(ref Unsafe.As<sbyte, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public float[] SingleView
+        {
+            get
+            {
+                var items = new float[2];
+                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public ushort[] UInt16View
+        {
+            get
+            {
+                var items = new ushort[4];
+                Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public uint[] UInt32View
+        {
+            get
+            {
+                var items = new uint[2];
+                Unsafe.WriteUnaligned(ref Unsafe.As<uint, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+
+        public ulong[] UInt64View
+        {
+            get
+            {
+                var items = new ulong[1];
+                Unsafe.WriteUnaligned(ref Unsafe.As<ulong, byte>(ref items[0]), _value);
+                return items;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This implements https://github.com/dotnet/coreclr/issues/15694