### PR TITLE
Updating emitIns_R_R_A_I to not be defined for the legacy backend.

### DIFF
--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -4124,6 +4124,7 @@ void emitter::emitIns_R_R_S(instruction ins, emitAttr attr, regNumber reg1, regN
     emitCurIGsize += sz;
 }
 
+#ifndef LEGACY_BACKEND
 void emitter::emitIns_R_R_A_I(
     instruction ins, emitAttr attr, regNumber reg1, regNumber reg2, GenTreeIndir* indir, int ival, insFormat fmt)
 {
@@ -4145,6 +4146,7 @@ void emitter::emitIns_R_R_A_I(
     dispIns(id);
     emitCurIGsize += sz;
 }
+#endif // !LEGACY_BACKEND
 
 void emitter::emitIns_R_R_C_I(
     instruction ins, emitAttr attr, regNumber reg1, regNumber reg2, CORINFO_FIELD_HANDLE fldHnd, int offs, int ival)

--- a/src/jit/emitxarch.h
+++ b/src/jit/emitxarch.h
@@ -386,8 +386,10 @@ void emitIns_R_R_S(instruction ins, emitAttr attr, regNumber reg1, regNumber reg
 
 void emitIns_R_R_R(instruction ins, emitAttr attr, regNumber reg1, regNumber reg2, regNumber reg3);
 
+#ifndef LEGACY_BACKEND
 void emitIns_R_R_A_I(
     instruction ins, emitAttr attr, regNumber reg1, regNumber reg2, GenTreeIndir* indir, int ival, insFormat fmt);
+#endif // !LEGACY_BACKEND
 
 void emitIns_R_R_C_I(
     instruction ins, emitAttr attr, regNumber reg1, regNumber reg2, CORINFO_FIELD_HANDLE fldHnd, int offs, int ival);


### PR DESCRIPTION
Resolves https://github.com/dotnet/coreclr/pull/15538#issuecomment-358218278