### PR TITLE
Resolving a few issues with the HWIntrinsic code

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -7319,7 +7319,11 @@ void Compiler::gtBlockOpInit(GenTreePtr result, GenTreePtr dst, GenTreePtr srcOr
         {
             src = src->AsIndir()->Addr()->gtGetOp1();
         }
+#ifdef FEATURE_HW_INTRINSICS
+        if ((src->OperGet() == GT_SIMD) || (src->OperGet() == GT_HWIntrinsic))
+#else
         if (src->OperGet() == GT_SIMD)
+#endif // FEATURE_HW_INTRINSICS
         {
             if (dst->OperIsBlk() && (dst->AsIndir()->Addr()->OperGet() == GT_ADDR))
             {
@@ -17850,10 +17854,7 @@ GenTreeSIMD* Compiler::gtNewSIMDNode(
 {
     assert(op1 != nullptr);
     SetOpLclRelatedToSIMDIntrinsic(op1);
-    if (op2 != nullptr)
-    {
-        SetOpLclRelatedToSIMDIntrinsic(op2);
-    }
+    SetOpLclRelatedToSIMDIntrinsic(op2);
 
     return new (this, GT_SIMD) GenTreeSIMD(type, op1, op2, simdIntrinsicID, baseType, size);
 }
@@ -17867,14 +17868,17 @@ GenTreeSIMD* Compiler::gtNewSIMDNode(
 //
 void Compiler::SetOpLclRelatedToSIMDIntrinsic(GenTreePtr op)
 {
-    if (op->OperIsLocal())
+    if (op != nullptr)
     {
-        setLclRelatedToSIMDIntrinsic(op);
-    }
-    else if ((op->OperGet() == GT_OBJ) && (op->gtOp.gtOp1->OperGet() == GT_ADDR) &&
-             op->gtOp.gtOp1->gtOp.gtOp1->OperIsLocal())
-    {
-        setLclRelatedToSIMDIntrinsic(op->gtOp.gtOp1->gtOp.gtOp1);
+        if (op->OperIsLocal())
+        {
+            setLclRelatedToSIMDIntrinsic(op);
+        }
+        else if ((op->OperGet() == GT_OBJ) && (op->gtOp.gtOp1->OperGet() == GT_ADDR) &&
+                 op->gtOp.gtOp1->gtOp.gtOp1->OperIsLocal())
+        {
+            setLclRelatedToSIMDIntrinsic(op->gtOp.gtOp1->gtOp.gtOp1);
+        }
     }
 }
 
@@ -17912,12 +17916,17 @@ GenTreeHWIntrinsic* Compiler::gtNewSimdHWIntrinsicNode(var_types      type,
 GenTreeHWIntrinsic* Compiler::gtNewSimdHWIntrinsicNode(
     var_types type, GenTree* op1, NamedIntrinsic hwIntrinsicID, var_types baseType, unsigned size)
 {
+    SetOpLclRelatedToSIMDIntrinsic(op1);
+
     return new (this, GT_HWIntrinsic) GenTreeHWIntrinsic(type, op1, hwIntrinsicID, baseType, size);
 }
 
 GenTreeHWIntrinsic* Compiler::gtNewSimdHWIntrinsicNode(
     var_types type, GenTree* op1, GenTree* op2, NamedIntrinsic hwIntrinsicID, var_types baseType, unsigned size)
 {
+    SetOpLclRelatedToSIMDIntrinsic(op1);
+    SetOpLclRelatedToSIMDIntrinsic(op2);
+
     return new (this, GT_HWIntrinsic) GenTreeHWIntrinsic(type, op1, op2, hwIntrinsicID, baseType, size);
 }
 
@@ -17929,6 +17938,10 @@ GenTreeHWIntrinsic* Compiler::gtNewSimdHWIntrinsicNode(var_types      type,
                                                        var_types      baseType,
                                                        unsigned       size)
 {
+    SetOpLclRelatedToSIMDIntrinsic(op1);
+    SetOpLclRelatedToSIMDIntrinsic(op2);
+    SetOpLclRelatedToSIMDIntrinsic(op3);
+
     return new (this, GT_HWIntrinsic)
         GenTreeHWIntrinsic(type, gtNewArgList(op1, op2, op3), hwIntrinsicID, baseType, size);
 }
@@ -17942,12 +17955,19 @@ GenTreeHWIntrinsic* Compiler::gtNewSimdHWIntrinsicNode(var_types      type,
                                                        var_types      baseType,
                                                        unsigned       size)
 {
+    SetOpLclRelatedToSIMDIntrinsic(op1);
+    SetOpLclRelatedToSIMDIntrinsic(op2);
+    SetOpLclRelatedToSIMDIntrinsic(op3);
+    SetOpLclRelatedToSIMDIntrinsic(op4);
+
     return new (this, GT_HWIntrinsic)
         GenTreeHWIntrinsic(type, gtNewArgList(op1, op2, op3, op4), hwIntrinsicID, baseType, size);
 }
 
 GenTreeHWIntrinsic* Compiler::gtNewScalarHWIntrinsicNode(var_types type, GenTree* op1, NamedIntrinsic hwIntrinsicID)
 {
+    SetOpLclRelatedToSIMDIntrinsic(op1);
+
     return new (this, GT_HWIntrinsic) GenTreeHWIntrinsic(type, op1, hwIntrinsicID, TYP_UNKNOWN, 0);
 }
 
@@ -17956,6 +17976,9 @@ GenTreeHWIntrinsic* Compiler::gtNewScalarHWIntrinsicNode(var_types      type,
                                                          GenTree*       op2,
                                                          NamedIntrinsic hwIntrinsicID)
 {
+    SetOpLclRelatedToSIMDIntrinsic(op1);
+    SetOpLclRelatedToSIMDIntrinsic(op2);
+
     return new (this, GT_HWIntrinsic) GenTreeHWIntrinsic(type, op1, op2, hwIntrinsicID, TYP_UNKNOWN, 0);
 }
 

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -19127,7 +19127,8 @@ bool Compiler::IsTargetIntrinsic(CorInfoIntrinsics intrinsicId)
         case CORINFO_INTRINSIC_Round:
         case CORINFO_INTRINSIC_Ceiling:
         case CORINFO_INTRINSIC_Floor:
-            return compSupports(InstructionSet_SSE41);
+            // TODO-XArch-CQ: Update to work on non-AVX machines: https://github.com/dotnet/coreclr/issues/15908
+            return compSupports(InstructionSet_SSE41) && canUseVexEncoding();
 
         default:
             return false;

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/LoadAlignedVector128.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/LoadAlignedVector128.cs
@@ -22,7 +22,8 @@ namespace IntelHardwareIntrinsicTest
 
             if (Sse.IsSupported)
             {
-                float* inArray = stackalloc float[4];
+                byte* inBuffer = stackalloc byte[32];
+                float* inArray = Align(inBuffer, 16);
                 float* outArray = stackalloc float[4];
 
                 var vf = Sse.LoadAlignedVector128(inArray);
@@ -46,6 +47,16 @@ namespace IntelHardwareIntrinsicTest
             }
 
             return testResult;
+        }
+
+        static unsafe float* Align(byte* buffer, byte expectedAlignment)
+        {
+            // Compute how bad the misalignment is, which is at most (expectedAlignment - 1).
+            // Then subtract that from the expectedAlignment and add it to the original address
+            // to compute the aligned address.
+
+            var misalignment = expectedAlignment - ((ulong)(buffer) % expectedAlignment);
+            return (float*)(buffer + misalignment);
         }
     }
 }


### PR DESCRIPTION
Bad merge between two of my PRs (https://github.com/dotnet/coreclr/pull/15538) and (https://github.com/dotnet/coreclr/pull/14736) that resulted in the `System.Math.Round`, `System.Math.Floor`, and `System.Math.Ceiling` functions asserting in `Debug`/`Checked` builds on non-AVX enabled machines.

`roundss` and `roundsd` go down these code paths and are SSE4.1 instructions, and will fail the `IsThreeOperandAVXInstruction` check,

Also fixing the `LoadAlignedVector128` test, which was sometimes failing due to the stack not guaranteeing 16-byte alignment.

Also marking TYP_SIMD nodes to not undergo struct promotion if they are part of a GT_HWIntrinsic node.