### PR TITLE
Do not throw IndexOutOfBounds when AM/PM designator is empty

### DIFF
--- a/src/mscorlib/shared/System/Globalization/DateTimeParse.cs
+++ b/src/mscorlib/shared/System/Globalization/DateTimeParse.cs
@@ -3607,12 +3607,15 @@ new DS[] { DS.ERROR, DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,  
             // change the code below.
             if (str.GetNext())
             {
-                if (dtfi.AMDesignator.Length > 0 && str.GetChar() == dtfi.AMDesignator[0])
+                string amDesignator = dtfi.AMDesignator;
+                if (amDesignator.Length > 0 && str.GetChar() == amDesignator[0])
                 {
                     result = TM.AM;
                     return true;
                 }
-                if (dtfi.PMDesignator.Length > 0 && str.GetChar() == dtfi.PMDesignator[0])
+
+                string pmDesignator = dtfi.PMDesignator;
+                if (pmDesignator.Length > 0 && str.GetChar() == pmDesignator[0])
                 {
                     result = TM.PM;
                     return true;

--- a/src/mscorlib/shared/System/Globalization/DateTimeParse.cs
+++ b/src/mscorlib/shared/System/Globalization/DateTimeParse.cs
@@ -3607,15 +3607,15 @@ new DS[] { DS.ERROR, DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,  
             // change the code below.
             if (str.GetNext())
             {
-                if (str.GetChar() == dtfi.AMDesignator[0])
+                if (dtfi.AMDesignator.Length > 0 && str.GetChar() == dtfi.AMDesignator[0])
                 {
                     result = TM.AM;
-                    return (true);
+                    return true;
                 }
-                if (str.GetChar() == dtfi.PMDesignator[0])
+                if (dtfi.PMDesignator.Length > 0 && str.GetChar() == dtfi.PMDesignator[0])
                 {
                     result = TM.PM;
-                    return (true);
+                    return true;
                 }
             }
             return false;


### PR DESCRIPTION
Fixes: https://github.com/dotnet/coreclr/issues/15896

Currently when AM/PM designator happens to be empty we throw IndexOutOfBounds exception.

testing in progress