### PR TITLE
[Local GC] [WIP] FEATURE_EVENT_TRACE 2/n: Scaffolding for emitting known events

### DIFF
--- a/src/gc/CMakeLists.txt
+++ b/src/gc/CMakeLists.txt
@@ -18,6 +18,7 @@ remove_definitions(-DWRITE_BARRIER_CHECK)
 add_definitions(-DFEATURE_REDHAWK)
 
 set( GC_SOURCES
+  gceventstatus.cpp
   gcconfig.cpp
   gccommon.cpp
   gcscan.cpp

--- a/src/gc/CMakeLists.txt
+++ b/src/gc/CMakeLists.txt
@@ -18,6 +18,7 @@ remove_definitions(-DWRITE_BARRIER_CHECK)
 add_definitions(-DFEATURE_REDHAWK)
 
 set( GC_SOURCES
+  gcevents.cpp
   gceventstatus.cpp
   gcconfig.cpp
   gccommon.cpp

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -82,6 +82,7 @@ public:
     static bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name);
     static void WalkAsyncPinnedForPromotion(Object* object, ScanContext* sc, promote_func* callback);
     static void WalkAsyncPinned(Object* object, void* context, void(*callback)(Object*, Object*, void*));
+    static IGCToCLREventSink* EventSink();
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/env/gcenv.h
+++ b/src/gc/env/gcenv.h
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+#ifndef __GCENV_H__
+#define __GCENV_H__
 
 #if defined(_DEBUG)
 #ifndef _DEBUG_IMPL
@@ -71,3 +73,5 @@
 
 #include "etmdummy.h"
 #define ETW_EVENT_ENABLED(e,f) false
+
+#endif // __GCENV_H__

--- a/src/gc/env/gcenv.object.h
+++ b/src/gc/env/gcenv.object.h
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#ifndef __GCENV_OBJECT_H__
+#define __GCENV_OBJECT_H__
+
 //-------------------------------------------------------------------------------------------------
 //
 // Low-level types describing GC object layouts.
@@ -168,3 +171,5 @@ public:
         return offsetof(ArrayBase, m_dwLength);
     }
 };
+
+#endif // __GCENV_OBJECT_H__

--- a/src/gc/env/gcenv.sync.h
+++ b/src/gc/env/gcenv.sync.h
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+#ifndef __GCENV_SYNC_H__
+#define __GCENV_SYNC_H__
 
 // -----------------------------------------------------------------------------------------------------------
 //
@@ -143,3 +145,5 @@ private:
     HANDLE  m_hEvent;
     bool    m_fInitialized;
 };
+
+#endif // __GCENV_SYNC_H__

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -13235,12 +13235,15 @@ int gc_heap::try_allocate_more_space (alloc_context* acontext, size_t size,
 #else
             // Unfortunately some of the ETW macros do not check whether the ETW feature is enabled.
             // The ones that do are much less efficient.
-#if defined(FEATURE_EVENT_TRACE)
-            if (EventEnabledGCAllocationTick_V3())
+            if (EVENT_ENABLED(GCAllocationTick_V3))
             {
-                fire_etw_allocation_event (etw_allocation_running_amount[etw_allocation_index], gen_number, acontext->alloc_ptr);
+                AllocationKind allocation_kind = gen_number == 0 ? AllocationKind_Small : AllocationKind_Large;
+                FIRE_EVENT(GCAllocationTick_V3,
+                    etw_allocation_running_amount[etw_allocation_index],
+                    allocation_kind,
+                    heap_number,
+                    acontext->alloc_ptr);
             }
-#endif //FEATURE_EVENT_TRACE
 #endif //FEATURE_REDHAWK
             etw_allocation_running_amount[etw_allocation_index] = 0;
         }

--- a/src/gc/gcee.cpp
+++ b/src/gc/gcee.cpp
@@ -687,6 +687,15 @@ bool GCHeap::RuntimeStructuresValid()
     return GCScan::GetGcRuntimeStructuresValid();
 }
 
+void GCHeap::ControlEvents(GCEventKeyword keyword, GCEventLevel level)
+{
+    GCEventStatus::Set(GCEventProvider_Default, keyword, level);
+}
+
+void GCHeap::ControlPrivateEvents(GCEventKeyword keyword, GCEventLevel level)
+{
+    GCEventStatus::Set(GCEventProvider_Private, keyword, level);
+}
 
 #endif // !DACCESS_COMPILE
 

--- a/src/gc/gcee.cpp
+++ b/src/gc/gcee.cpp
@@ -456,43 +456,6 @@ bool GCHeap::IsConcurrentGCInProgress()
 }
 
 #ifdef FEATURE_EVENT_TRACE
-void gc_heap::fire_etw_allocation_event (size_t allocation_amount, int gen_number, uint8_t* object_address)
-{
-    void * typeId = nullptr;
-    const WCHAR * name = nullptr;
-#ifdef FEATURE_REDHAWK
-    typeId = RedhawkGCInterface::GetLastAllocEEType();
-#else
-    InlineSString<MAX_CLASSNAME_LENGTH> strTypeName;
-
-    EX_TRY
-    {
-        TypeHandle th = GCToEEInterface::GetThread()->GetTHAllocContextObj();
-
-        if (th != 0)
-        {
-            th.GetName(strTypeName);
-            name = strTypeName.GetUnicode();
-            typeId = th.GetMethodTable();
-        }
-    }
-    EX_CATCH {}
-    EX_END_CATCH(SwallowAllExceptions)
-#endif
-
-    if (typeId != nullptr)
-    {
-        FireEtwGCAllocationTick_V3((uint32_t)allocation_amount,
-                                   ((gen_number == 0) ? ETW::GCLog::ETW_GC_INFO::AllocationSmall : ETW::GCLog::ETW_GC_INFO::AllocationLarge), 
-                                   GetClrInstanceId(),
-                                   allocation_amount,
-                                   typeId, 
-                                   name,
-                                   heap_number,
-                                   object_address
-                                   );
-    }
-}
 void gc_heap::fire_etw_pin_object_event (uint8_t* object, uint8_t** ppObject)
 {
 #ifdef FEATURE_REDHAWK

--- a/src/gc/gceesvr.cpp
+++ b/src/gc/gceesvr.cpp
@@ -13,6 +13,7 @@
 #include "gc.h"
 #include "gcscan.h"
 #include "gchandletableimpl.h"
+#include "gceventstatus.h"
 
 #define SERVER_GC 1
 

--- a/src/gc/gceesvr.cpp
+++ b/src/gc/gceesvr.cpp
@@ -14,6 +14,7 @@
 #include "gcscan.h"
 #include "gchandletableimpl.h"
 #include "gceventstatus.h"
+#include "gcevents.h"
 
 #define SERVER_GC 1
 

--- a/src/gc/gceewks.cpp
+++ b/src/gc/gceewks.cpp
@@ -12,6 +12,7 @@
 #include "gcscan.h"
 #include "gchandletableimpl.h"
 #include "gceventstatus.h"
+#include "gcevents.h"
 
 #ifdef SERVER_GC
 #undef SERVER_GC

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -270,4 +270,10 @@ inline void GCToEEInterface::WalkAsyncPinned(Object* object, void* context, void
     return g_theGCToCLR->WalkAsyncPinned(object, context, callback);
 }
 
+inline IGCToCLREventSink* GCToEEInterface::EventSink()
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->EventSink();
+}
+
 #endif // __GCTOENV_EE_STANDALONE_INL__

--- a/src/gc/gcevents.cpp
+++ b/src/gc/gcevents.cpp
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "common.h"
+#include "gcevents.h"
+
+#define KNOWN_EVENT(name, provider, level, keyword) \
+  gc_events::GCKnownEvent name##EventDescriptor(#name, provider, level, keyword);
+#include "gcevents.def"

--- a/src/gc/gcevents.def
+++ b/src/gc/gcevents.def
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+#ifndef KNOWN_EVENT
+ #define KNOWN_EVENT(name, provider, level, keyword)
+#endif // KNOWN_EVENT
+
+#ifndef DYNAMIC_EVENT
+ #define DYNAMIC_EVENT(name, provider, level, keyword, ...)
+#endif // DYNAMIC_EVENT
+
+#undef KNOWN_EVENT
+#undef DYNAMIC_EVENT

--- a/src/gc/gcevents.def
+++ b/src/gc/gcevents.def
@@ -5,6 +5,8 @@
  #define KNOWN_EVENT(name, provider, level, keyword)
 #endif // KNOWN_EVENT
 
+KNOWN_EVENT(GCAllocationTick_V3, GCEventProvider_Default, GCEventLevel_Verbose, GCEventKeyword_GC)
+
 #ifndef DYNAMIC_EVENT
  #define DYNAMIC_EVENT(name, provider, level, keyword, ...)
 #endif // DYNAMIC_EVENT

--- a/src/gc/gcevents.h
+++ b/src/gc/gcevents.h
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef __GCEVENTS_H__
+#define __GCEVENTS_H__
+
+#include "common.h"
+#include "gcenv.h"
+#include "gc.h"
+#include "gceventstatus.h"
+
+namespace gc_events
+{
+
+class GCEventBase
+{
+private:
+    const char *m_name;
+    GCEventProvider m_provider;
+    GCEventLevel m_level;
+    GCEventKeyword m_keyword;
+
+public:
+    GCEventBase(const char *name, GCEventProvider provider, GCEventLevel level, GCEventKeyword keyword)
+        : m_name(name), m_provider(provider), m_level(level), m_keyword(keyword)
+    {}
+
+    GCEventProvider Provider() const { return m_provider; }
+
+    GCEventLevel Level() const { return m_level; }
+
+    GCEventKeyword Keyword() const { return m_keyword; }
+
+    __forceinline bool IsEnabled() const
+    {
+        return GCEventStatus::IsEnabled(m_provider, m_keyword, m_level);
+    }
+};
+
+class GCKnownEvent : public GCEventBase
+{
+public:
+    GCKnownEvent(const char *name, GCEventProvider provider, GCEventLevel level, GCEventKeyword keyword)
+        : GCEventBase(name, provider, level, keyword)
+    {}
+};
+
+class GCDynamicEvent : public GCEventBase
+{
+    /* TODO(segilles) - Not Yet Implemented */
+};
+
+} // namespace gc_events
+
+#define KNOWN_EVENT(name, _provider, _level, _keyword)   \
+  extern gc_events::GCKnownEvent name##EventDescriptor;
+#include "gcevents.def"
+
+#define EVENT_ENABLED(name) \
+  name##EventDescriptor.IsEnabled()
+
+#endif // __GCEVENTS_H__

--- a/src/gc/gcevents.h
+++ b/src/gc/gcevents.h
@@ -53,11 +53,23 @@ class GCDynamicEvent : public GCEventBase
 
 } // namespace gc_events
 
+#if FEATURE_EVENT_TRACE
 #define KNOWN_EVENT(name, _provider, _level, _keyword)   \
   extern gc_events::GCKnownEvent name##EventDescriptor;
 #include "gcevents.def"
 
-#define EVENT_ENABLED(name) \
-  name##EventDescriptor.IsEnabled()
+#define EVENT_ENABLED(name) name##EventDescriptor.IsEnabled()
+#define FIRE_EVENT(name, ...)                               \
+  do {                                                      \
+    IGCToCLREventSink* sink = GCToEEInterface::EventSink(); \
+    assert(sink != nullptr);                                \
+    sink->Fire##name(__VA_ARGS__);                          \
+  } while(0)
+
+#else
+#define EVENT_ENABLED(name) false
+#define FIRE_EVENT(name, ...) 0
+#endif // FEATURE_EVENT_TRACE
+
 
 #endif // __GCEVENTS_H__

--- a/src/gc/gceventstatus.cpp
+++ b/src/gc/gceventstatus.cpp
@@ -2,23 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-
 #include "common.h"
-
-#include "gcenv.h"
-
-#include "gc.h"
-#include "gcscan.h"
-#include "gchandletableimpl.h"
 #include "gceventstatus.h"
 
-#ifdef SERVER_GC
-#undef SERVER_GC
-#endif
-
-namespace WKS { 
-#include "gcimpl.h"
-#include "gcee.cpp"
-}
-
+Volatile<GCEventLevel> GCEventStatus::enabledLevels[2] = {GCEventLevel_None, GCEventLevel_None};
+Volatile<GCEventKeyword> GCEventStatus::enabledKeywords[2] = {GCEventKeyword_None, GCEventKeyword_None};

--- a/src/gc/gceventstatus.h
+++ b/src/gc/gceventstatus.h
@@ -29,7 +29,7 @@
 #include "gc.h"
 
 // Uncomment this define to print out event state changes to standard error.
-// #define TRACE_GC_EVENT_STATE 1
+#define TRACE_GC_EVENT_STATE 1
 
 /*
  * GCEventProvider represents one of the two providers that the GC can

--- a/src/gc/gceventstatus.h
+++ b/src/gc/gceventstatus.h
@@ -1,0 +1,187 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef __GCEVENTSTATUS_H__
+#define __GCEVENTSTATUS_H__
+
+
+/*
+ * gceventstatus.h - Eventing status for a standalone GC
+ *
+ * In order for a local GC to determine what events are enabled
+ * in an efficient manner, the GC maintains some local state about
+ * keywords and levels that are enabled for each eventing provider.
+ *
+ * The GC fires events from two providers: the "main" provider
+ * and the "private" provider. This file tracks keyword and level
+ * information for each provider separately.
+ *
+ * It is the responsibility of the EE to inform the GC of changes
+ * to eventing state. This is accomplished by invoking the
+ * `IGCHeap::ControlEvents` and `IGCHeap::ControlPrivateEvents` callbacks
+ * on the EE's heap instance, which ultimately will enable and disable keywords
+ * and levels within this file.
+ */
+
+#include "common.h"
+#include "gcenv.h"
+#include "gc.h"
+
+// Uncomment this define to print out event state changes to standard error.
+// #define TRACE_GC_EVENT_STATE 1
+
+/*
+ * GCEventProvider represents one of the two providers that the GC can
+ * fire events from: the default and private providers.
+ */
+enum GCEventProvider
+{
+    GCEventProvider_Default = 0,
+    GCEventProvider_Private = 1
+};
+
+/*
+ * GCEventStatus maintains all eventing state for the GC. It consists
+ * of a keyword bitmask and level for each provider that the GC can use
+ * to fire events.
+ *
+ * A level and event pair are considered to be "enabled" on a given provider
+ * if the given level is less than or equal to the current enabled level
+ * and if the keyword is present in the enabled keyword bitmask for that
+ * provider.
+ */
+class GCEventStatus
+{
+private:
+    /*
+     * The enabled level for each provider.
+     */
+    static Volatile<GCEventLevel> enabledLevels[2];
+
+    /*
+     * The bitmap of enabled keywords for each provider.
+     */
+    static Volatile<GCEventKeyword> enabledKeywords[2];
+
+public:
+    /*
+     * IsEnabled queries whether or not the given level and keyword are
+     * enabled on the given provider, returning true if they are.
+     */
+    __forceinline static bool IsEnabled(GCEventProvider provider, GCEventKeyword keyword, GCEventLevel level)
+    {
+        assert(level >= GCEventLevel_None && level < GCEventLevel_Max);
+
+        size_t index = static_cast<size_t>(provider);
+        return (enabledLevels[index] >= level) && (enabledKeywords[index] & keyword);
+    }
+
+    /*
+     * Set sets the eventing state (level and keyword bitmap) for a given
+     * provider to the provided values.
+     */
+    static void Set(GCEventProvider provider, GCEventKeyword keywords, GCEventLevel level)
+    {
+        assert(level >= GCEventLevel_None && level < GCEventLevel_Max);
+
+        size_t index = static_cast<size_t>(provider);
+
+        enabledLevels[index] = level;
+        enabledKeywords[index] = keywords;
+
+#if TRACE_GC_EVENT_STATE
+        fprintf(stderr, "event state change:\n");
+        DebugDumpState(provider);
+#endif // TRACE_GC_EVENT_STATE
+    }
+
+private:
+    static void DebugDumpState(GCEventProvider provider)
+    {
+        size_t index = static_cast<size_t>(provider);
+        GCEventLevel level = enabledLevels[index];
+        GCEventKeyword keyword = enabledKeywords[index];
+        if (provider == GCEventProvider_Default)
+        {
+            fprintf(stderr, "provider: default\n");
+        }
+        else
+        {
+            fprintf(stderr, "provider: private\n");
+        }
+
+        switch (level)
+        {
+        case GCEventLevel_None:
+            fprintf(stderr, "  level: None\n");
+            break;
+        case GCEventLevel_Fatal:
+            fprintf(stderr, "  level: Fatal\n");
+            break;
+        case GCEventLevel_Error:
+            fprintf(stderr, "  level: Error\n");
+            break;
+        case GCEventLevel_Warning:
+            fprintf(stderr, "  level: Warning\n");
+            break;
+        case GCEventLevel_Information:
+            fprintf(stderr, "  level: Information\n");
+            break;
+        case GCEventLevel_Verbose:
+            fprintf(stderr, "  level: Verbose\n");
+            break;
+        default:
+            fprintf(stderr, "  level: %d?\n", level);
+            break;
+        }
+
+        fprintf(stderr, "  keywords: ");
+        if (keyword & GCEventKeyword_GC)
+        {
+            fprintf(stderr, "GC ");
+        }
+
+        if (keyword & GCEventKeyword_GCHandle)
+        {
+            fprintf(stderr, "GCHandle ");
+        }
+
+        if (keyword & GCEventKeyword_GCHeapDump)
+        {
+            fprintf(stderr, "GCHeapDump ");
+        }
+
+        if (keyword & GCEventKeyword_GCSampledObjectAllocationHigh)
+        {
+            fprintf(stderr, "GCSampledObjectAllocationHigh ");
+        }
+
+        if (keyword & GCEventKeyword_GCHeapSurvivalAndMovement)
+        {
+            fprintf(stderr, "GCHeapSurvivalAndMovement ");
+        }
+
+        if (keyword & GCEventKeyword_GCHeapCollect)
+        {
+            fprintf(stderr, "GCHeapCollect ");
+        }
+
+        if (keyword & GCEventKeyword_GCHeapAndTypeNames)
+        {
+            fprintf(stderr, "GCHeapAndTypeNames ");
+        }
+
+        if (keyword & GCEventKeyword_GCSampledObjectAllocationLow)
+        {
+            fprintf(stderr, "GCSampledObjectAllocationLow ");
+        }
+
+        fprintf(stderr, "\n");
+    }
+
+    // This class is a singleton and can't be instantiated.
+    GCEventStatus() = delete;
+};
+
+#endif // __GCEVENTSTATUS_H__

--- a/src/gc/gceventstatus.h
+++ b/src/gc/gceventstatus.h
@@ -74,7 +74,8 @@ public:
         assert(level >= GCEventLevel_None && level < GCEventLevel_Max);
 
         size_t index = static_cast<size_t>(provider);
-        return (enabledLevels[index] >= level) && (enabledKeywords[index] & keyword);
+        return (enabledLevels[index].LoadWithoutBarrier() >= level)
+          && (enabledKeywords[index].LoadWithoutBarrier() & keyword);
     }
 
     /*
@@ -96,6 +97,7 @@ public:
 #endif // TRACE_GC_EVENT_STATE
     }
 
+#if TRACE_GC_EVENT_STATE
 private:
     static void DebugDumpState(GCEventProvider provider)
     {
@@ -179,6 +181,7 @@ private:
 
         fprintf(stderr, "\n");
     }
+#endif // TRACE_GC_EVENT_STATUS
 
     // This class is a singleton and can't be instantiated.
     GCEventStatus() = delete;

--- a/src/gc/gcimpl.h
+++ b/src/gc/gcimpl.h
@@ -230,6 +230,10 @@ public:	// FIX
     virtual segment_handle RegisterFrozenSegment(segment_info *pseginfo);
     virtual void UnregisterFrozenSegment(segment_handle seg);
 
+    // Event control functions
+    void ControlEvents(GCEventKeyword keyword, GCEventLevel level);
+    void ControlPrivateEvents(GCEventKeyword keyword, GCEventLevel level);
+
     void    WaitUntilConcurrentGCComplete ();                               // Use in managd threads
 #ifndef DACCESS_COMPILE    
     HRESULT WaitUntilConcurrentGCCompleteAsync(int millisecondsTimeout);    // Use in native threads. TRUE if succeed. FALSE if failed or timeout

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -5,9 +5,31 @@
 #ifndef _GCINTERFACE_EE_H_
 #define _GCINTERFACE_EE_H_
 
+// AllocationKind for GCAllocationTick series of events,
+// indicating what kind of allocation occured (LOH or SOH).
+enum AllocationKind
+{
+    AllocationKind_Small = 0,
+    AllocationKind_Large = 1
+};
+
+// This interface provides functions that the GC can use to fire events.
+// Events fired on this interface are split into two categories: "known"
+// events and "dynamic" events. Known events are events that are baked-in
+// to the hosting runtime's event manifest and are part of the GC/EE interface.
+// There is one callback on IGCToCLREventSink for each known event.
+//
+// Dynamic events are constructed at runtime by the GC and are not known
+// to the EE. ([LOCALGC TODO dynamic event implementation])
 class IGCToCLREventSink
 {
-    /* [LOCALGC TODO] This will be filled with events as they get ported */
+public:
+    // Fires the GCAllocationTick_V3 event.
+    virtual void FireGCAllocationTick_V3(
+        uint64_t allocationAmount,
+        AllocationKind kind,
+        uint32_t heapIndex,
+        void* address) = 0;
 };
 
 // This interface provides the interface that the GC will use to speak to the rest

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -5,6 +5,11 @@
 #ifndef _GCINTERFACE_EE_H_
 #define _GCINTERFACE_EE_H_
 
+class IGCToCLREventSink
+{
+    /* [LOCALGC TODO] This will be filled with events as they get ported */
+};
+
 // This interface provides the interface that the GC will use to speak to the rest
 // of the execution engine. Everything that the GC does that requires the EE
 // to be informed or that requires EE action must go through this interface.
@@ -251,6 +256,10 @@ public:
     // This function is a no-op if "object" is not an OverlappedData object.
     virtual
     void WalkAsyncPinned(Object* object, void* context, void(*callback)(Object*, Object*, void*)) = 0;
+
+    // Returns an IGCToCLREventSink instance that can be used to fire events.
+    virtual
+    IGCToCLREventSink* EventSink() = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -205,6 +205,41 @@ extern uint8_t* g_shadow_lowest_address;
 // For low memory notification from host
 extern int32_t g_bLowMemoryFromHost;
 
+// Event levels corresponding to events that can be fired by the GC.
+enum GCEventLevel
+{
+    GCEventLevel_None = 0,
+    GCEventLevel_Fatal = 1,
+    GCEventLevel_Error = 2,
+    GCEventLevel_Warning = 3,
+    GCEventLevel_Information = 4,
+    GCEventLevel_Verbose = 5,
+    GCEventLevel_Max = 6
+};
+
+enum GCEventKeyword
+{
+    GCEventKeyword_None                          =       0x0,
+    GCEventKeyword_GC                            =       0x1,
+    GCEventKeyword_GCHandle                      =       0x2,
+    GCEventKeyword_GCHeapDump                    =  0x100000,
+    GCEventKeyword_GCSampledObjectAllocationHigh =  0x200000,
+    GCEventKeyword_GCHeapSurvivalAndMovement     =  0x400000,
+    GCEventKeyword_GCHeapCollect                 =  0x800000,
+    GCEventKeyword_GCHeapAndTypeNames            = 0x1000000,
+    GCEventKeyword_GCSampledObjectAllocationLow  = 0x2000000,
+    GCEventKeyword_All = GCEventKeyword_GC
+      | GCEventKeyword_GCHandle
+      | GCEventKeyword_GCHeapDump
+      | GCEventKeyword_GCSampledObjectAllocationHigh
+      | GCEventKeyword_GCHeapDump
+      | GCEventKeyword_GCSampledObjectAllocationHigh
+      | GCEventKeyword_GCHeapSurvivalAndMovement
+      | GCEventKeyword_GCHeapCollect
+      | GCEventKeyword_GCHeapAndTypeNames
+      | GCEventKeyword_GCSampledObjectAllocationLow
+};
+
 // !!!!!!!!!!!!!!!!!!!!!!!
 // make sure you change the def in bcl\system\gc.cs 
 // if you change this!
@@ -808,6 +843,18 @@ public:
 
     // Unregisters a frozen segment.
     virtual void UnregisterFrozenSegment(segment_handle seg) = 0;
+
+    /*
+    ===========================================================================
+    Routines for informing the GC about which events are enabled.
+    ===========================================================================
+    */
+
+    // Enables or disables the given keyword or level on the default event provider.
+    virtual void ControlEvents(GCEventKeyword keyword, GCEventLevel level) = 0;
+
+    // Enables or disables the given keyword or level on the private event provider.
+    virtual void ControlPrivateEvents(GCEventKeyword keyword, GCEventLevel level) = 0;
 
     IGCHeap() {}
     virtual ~IGCHeap() {}

--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -1355,9 +1355,6 @@ protected:
     void handle_failure_for_no_gc();
 
     PER_HEAP
-    void fire_etw_allocation_event (size_t allocation_amount, int gen_number, uint8_t* object_address);
-
-    PER_HEAP
     void fire_etw_pin_object_event (uint8_t* object, uint8_t** ppObject);
 
     PER_HEAP

--- a/src/gc/gcsvr.cpp
+++ b/src/gc/gcsvr.cpp
@@ -17,6 +17,7 @@
 #include "handletable.h"
 #include "handletable.inl"
 #include "gcenv.inl"
+#include "gcevents.h"
 
 #define SERVER_GC 1
 

--- a/src/gc/gcwks.cpp
+++ b/src/gc/gcwks.cpp
@@ -15,6 +15,7 @@
 #include "handletable.h"
 #include "handletable.inl"
 #include "gcenv.inl"
+#include "gcevents.h"
 
 #ifdef SERVER_GC
 #undef SERVER_GC

--- a/src/gc/sample/CMakeLists.txt
+++ b/src/gc/sample/CMakeLists.txt
@@ -10,6 +10,7 @@ add_definitions(-DFEATURE_REDHAWK)
 set(SOURCES
     GCSample.cpp
     gcenv.ee.cpp
+    ../gceventstatus.cpp
     ../gcconfig.cpp
     ../gccommon.cpp
     ../gceewks.cpp

--- a/src/gc/sample/gcenv.h
+++ b/src/gc/sample/gcenv.h
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+#ifndef __GCENV_H__
+#define __GCENV_H__
 
 // The sample is to be kept simple, so building the sample
 // in tandem with a standalone GC is currently not supported.
@@ -200,3 +202,5 @@ extern EEConfig * g_pConfig;
 
 #include "etmdummy.h"
 #define ETW_EVENT_ENABLED(e,f) false
+
+#endif // __GCENV_H__

--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -259,6 +259,7 @@ set(VM_SOURCES_WKS
 
 set(GC_SOURCES_WKS
     ${GC_SOURCES_DAC_AND_WKS_COMMON}
+    ../gc/gceventstatus.cpp
     ../gc/gcconfig.cpp
     ../gc/gccommon.cpp
     ../gc/gcscan.cpp

--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -69,6 +69,7 @@ set(VM_SOURCES_DAC_AND_WKS_COMMON
     formattype.cpp
     fptrstubs.cpp
     frames.cpp
+    gctoclreventsink.cpp
     gcheaputilities.cpp
     gchandleutilities.cpp
     genericdict.cpp
@@ -259,6 +260,7 @@ set(VM_SOURCES_WKS
 
 set(GC_SOURCES_WKS
     ${GC_SOURCES_DAC_AND_WKS_COMMON}
+    ../gc/gcevents.cpp
     ../gc/gceventstatus.cpp
     ../gc/gcconfig.cpp
     ../gc/gccommon.cpp

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -4441,12 +4441,40 @@ extern "C"
 
         BOOLEAN bIsRundownTraceHandle = (context->RegistrationHandle==Microsoft_Windows_DotNETRuntimeRundownHandle);
 
-		// TypeSystemLog needs a notification when certain keywords are modified, so
-		// give it a hook here.
-		if (g_fEEStarted && !g_fEEShutDown && bIsPublicTraceHandle)
-		{
-			ETW::TypeSystemLog::OnKeywordsChanged();
-		}
+        if (g_fEEStarted && !g_fEEShutDown)
+        {
+            // TypeSystemLog needs a notification when certain keywords are modified, so
+            // give it a hook here.
+            if (bIsPublicTraceHandle)
+            {
+                ETW::TypeSystemLog::OnKeywordsChanged();
+            }
+
+            if (ControlCode == EVENT_CONTROL_CODE_ENABLE_PROVIDER || ControlCode == EVENT_CONTROL_CODE_DISABLE_PROVIDER)
+            {
+                static_assert(GCEventLevel_None == TRACE_LEVEL_NONE, "GCEventLevel_None value mismatch");
+                static_assert(GCEventLevel_Fatal == TRACE_LEVEL_FATAL, "GCEventLevel_Fatal value mismatch");
+                static_assert(GCEventLevel_Error == TRACE_LEVEL_ERROR, "GCEventLevel_Error value mismatch");
+                static_assert(GCEventLevel_Warning == TRACE_LEVEL_WARNING, "GCEventLevel_Warning mismatch");
+                static_assert(GCEventLevel_Information == TRACE_LEVEL_INFORMATION, "GCEventLevel_Information mismatch");
+                static_assert(GCEventLevel_Verbose == TRACE_LEVEL_VERBOSE, "GCEventLevel_Verbose mismatch");
+
+                // The GC also needs to be informed of changes to keywords and levels.
+                IGCHeap *heap = GCHeapUtilities::GetGCHeap();
+                GCEventKeyword keywords = static_cast<GCEventKeyword>(MatchAnyKeyword);
+                GCEventLevel level = static_cast<GCEventLevel>(Level);
+                if (bIsPublicTraceHandle)
+                {
+                    heap->ControlEvents(keywords, level);
+                }
+                else if (bIsPrivateTraceHandle)
+                {
+                    heap->ControlPrivateEvents(keywords, level);
+                }
+
+                // the GC doesn't use the runtime rundown provider.
+            }
+        }
 
         // A manifest based provider can be enabled to multiple event tracing sessions
         // As long as there is atleast 1 enabled session, IsEnabled will be TRUE

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1384,3 +1384,10 @@ void GCToEEInterface::WalkAsyncPinned(Object* object, void* context, void (*call
         }
     }
 }
+
+IGCToCLREventSink* GCToEEInterface::EventSink()
+{
+    LIMITED_METHOD_CONTRACT;
+
+    return &g_gcToClrEventSink;
+}

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -62,6 +62,7 @@ public:
     bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name);
     void WalkAsyncPinnedForPromotion(Object* object, ScanContext* sc, promote_func* callback);
     void WalkAsyncPinned(Object* object, void* context, void(*callback)(Object*, Object*, void*));
+    IGCToCLREventSink* EventSink();
 };
 
 } // namespace standalone

--- a/src/vm/gcenv.ee.standalone.cpp
+++ b/src/vm/gcenv.ee.standalone.cpp
@@ -14,6 +14,8 @@
 #include "comcallablewrapper.h"
 #endif // FEATURE_COMINTEROP
 
+#include "gctoclreventsink.h"
+
 // the method table for the WeakReference class
 extern MethodTable* pWeakReferenceMT;
 

--- a/src/vm/gcenv.ee.static.cpp
+++ b/src/vm/gcenv.ee.static.cpp
@@ -14,6 +14,8 @@
 #include "comcallablewrapper.h"
 #endif // FEATURE_COMINTEROP
 
+#include "gctoclreventsink.h"
+
 // the method table for the WeakReference class
 extern MethodTable* pWeakReferenceMT;
 

--- a/src/vm/gctoclreventsink.cpp
+++ b/src/vm/gctoclreventsink.cpp
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "common.h"
+#include "gctoclreventsink.h"
+
+GCToCLREventSink g_gcToClrEventSink;

--- a/src/vm/gctoclreventsink.cpp
+++ b/src/vm/gctoclreventsink.cpp
@@ -6,3 +6,41 @@
 #include "gctoclreventsink.h"
 
 GCToCLREventSink g_gcToClrEventSink;
+
+void GCToCLREventSink::FireGCAllocationTick_V3(
+    uint64_t allocationAmount,
+    AllocationKind kind,
+    uint32_t heapIndex,
+    void* address)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    InlineSString<MAX_CLASSNAME_LENGTH> strTypeName;
+    EX_TRY
+    {
+        TypeHandle th = GetThread()->GetTHAllocContextObj();
+
+        void* typeId = nullptr;
+        const WCHAR * name = nullptr;
+        if (th != 0)
+        {
+            th.GetName(strTypeName);
+            name = strTypeName.GetUnicode();
+            typeId = th.GetMethodTable();
+        }
+
+        if (typeId != nullptr)
+        {
+            FireEtwGCAllocationTick_V3(static_cast<uint32_t>(allocationAmount),
+                                   static_cast<uint32_t>(kind),
+                                   GetClrInstanceId(),
+                                   allocationAmount,
+                                   typeId,
+                                   name,
+                                   heapIndex,
+                                   address);
+        }
+    }
+    EX_CATCH {}
+    EX_END_CATCH(SwallowAllExceptions)
+}

--- a/src/vm/gctoclreventsink.h
+++ b/src/vm/gctoclreventsink.h
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef __GCTOCLREVENTSINK_H__
+#define __GCTOCLREVENTSINK_H__
+
+#include "gcinterface.h"
+
+class GCToCLREventSink : public IGCToCLREventSink
+{
+    /* [LOCALGC TODO] This will be filled with events as they get ported */
+};
+
+extern GCToCLREventSink g_gcToClrEventSink;
+
+#endif // __GCTOCLREVENTSINK_H__
+

--- a/src/vm/gctoclreventsink.h
+++ b/src/vm/gctoclreventsink.h
@@ -9,7 +9,12 @@
 
 class GCToCLREventSink : public IGCToCLREventSink
 {
-    /* [LOCALGC TODO] This will be filled with events as they get ported */
+public:
+    void FireGCAllocationTick_V3(
+        uint64_t allocationAmount,
+        AllocationKind kind,
+        uint32_t heapIndex,
+        void* address);
 };
 
 extern GCToCLREventSink g_gcToClrEventSink;


### PR DESCRIPTION
This PR is marked WIP because it depends on https://github.com/dotnet/coreclr/pull/15873. This branch is branched off of `swgillespie/event-spec-foundation` so you can ignore the first two commits of this PR (they are from https://github.com/dotnet/coreclr/pull/15873).

This PR implements the [Firing Events section of the standalone GC eventing spec](https://github.com/dotnet/coreclr/blob/master/Documentation/design-docs/standalone-gc-eventing.md#firing-events) and verifies that it works by porting the `GCAllocationTick_V3` event to travel across the GC/EE interface.

This PR elaborates on a couple of ideas from the spec:

1. Events known to the GC are listed in the new `src\gc\gcevents.def` file, where the `KNOWN_EVENT` xmacro is used to describe the event, its provider, its level, and its keyword set, like here: https://github.com/swgillespie/coreclr/blob/557fcb67cd64ba845732c22ea0c39201ea236781/src/gc/gcevents.def#L8
2. From the information supplied in the `KNOWN_EVENT` xmacro, an "event descriptor" is generated that describes the known event - it's name, provider, level, and keywords. The `EVENT_ENABLED` macro can be used to query whether or not an event is enabled, like this usage in gc.cpp:

```c++
            // Unfortunately some of the ETW macros do not check whether the ETW feature is enabled.
            // The ones that do are much less efficient.
            if (EVENT_ENABLED(GCAllocationTick_V3))
            {
                AllocationKind allocation_kind = gen_number == 0 ? AllocationKind_Small : AllocationKind_Large;
                FIRE_EVENT(GCAllocationTick_V3,
                    etw_allocation_running_amount[etw_allocation_index],
                    allocation_kind,
                    heap_number,
                    acontext->alloc_ptr);
            }
```

3. The `FIRE_EVENT` macro accepts the name of the event and any parameters that the event accepts. `FIRE_EVENT` ultimately fires the event by invoking the GC/EE interface to send the event across the interface boundary.

I chose not to re-use the existing `FireEtw*Event` and `ETW_EVENT_ENABLED` macros because I am hoping for the upcoming series of changes (porting events to use this new system) to be done incrementally. It would be difficult to be in a "half and half" situation where one macro delegates to ETW or `GCEventState` depending on the event. I think that it is very reasonable to convert all usages of `EVENT_ENABLED` and `FIRE_EVENT` to `FireEtw*Event` and `ETW_EVENT_ENABLED` in the future once everything has moved over to the new system.