### PR TITLE
Convert BulkTypeLogger Allocations From Stack to Heap

### DIFF
--- a/src/vm/eventtracepriv.h
+++ b/src/vm/eventtracepriv.h
@@ -341,11 +341,8 @@ public:
         }
         CONTRACTL_END;
 
-        if(m_pBulkTypeEventBuffer != NULL)
-        {
-            delete[] m_pBulkTypeEventBuffer;
-            m_pBulkTypeEventBuffer = NULL;
-        }
+        delete[] m_pBulkTypeEventBuffer;
+        m_pBulkTypeEventBuffer = NULL;
     }
 #endif
 

--- a/src/vm/eventtracepriv.h
+++ b/src/vm/eventtracepriv.h
@@ -254,6 +254,11 @@ class BulkTypeEventLogger
 {
 private:
 
+#ifdef FEATURE_PAL
+    // The maximum event size, and the size of the buffer that we allocate to hold the event contents.
+    static const size_t kSizeOfEventBuffer = 65536;
+#endif
+
     // Estimate of how many bytes we can squeeze in the event data for the value struct
     // array.  (Intentionally overestimate the size of the non-array parts to keep it safe.)
     static const int kMaxBytesTypeValues = (cbMaxEtwEvent - 0x30);
@@ -295,7 +300,7 @@ private:
     BulkTypeValue m_rgBulkTypeValues[kMaxCountTypeValues];
 
 #ifdef FEATURE_PAL
-    BYTE m_BulkTypeEventBuffer[65536];
+    BYTE *m_pBulkTypeEventBuffer;
 #endif
 
 #ifdef FEATURE_REDHAWK
@@ -307,10 +312,42 @@ private:
 public:
     BulkTypeEventLogger() :
         m_nBulkTypeValueCount(0),
-        m_nBulkTypeValueByteCount(0)
+        m_nBulkTypeValueByteCount(0),
+#ifdef FEATURE_PAL
+        m_pBulkTypeEventBuffer(NULL)
+#endif
     {
-        LIMITED_METHOD_CONTRACT;
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_NOTRIGGER;
+            MODE_ANY;
+        }
+        CONTRACTL_END;
+
+#ifdef FEATURE_PAL
+        m_pBulkTypeEventBuffer = new (nothrow) BYTE[kSizeOfEventBuffer];
+#endif
     }
+
+#ifdef FEATURE_PAL
+    ~BulkTypeEventLogger()
+    {
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_NOTRIGGER;
+            MODE_ANY;
+        }
+        CONTRACTL_END;
+
+        if(m_pBulkTypeEventBuffer != NULL)
+        {
+            delete[] m_pBulkTypeEventBuffer;
+            m_pBulkTypeEventBuffer = NULL;
+        }
+    }
+#endif
 
     void LogTypeAndParameters(ULONGLONG thAsAddr, ETW::TypeSystemLog::TypeLogBehavior typeLogBehavior);
     void FireBulkTypeEvent();

--- a/src/vm/eventtracepriv.h
+++ b/src/vm/eventtracepriv.h
@@ -312,9 +312,9 @@ private:
 public:
     BulkTypeEventLogger() :
         m_nBulkTypeValueCount(0),
-        m_nBulkTypeValueByteCount(0),
+        m_nBulkTypeValueByteCount(0)
 #ifdef FEATURE_PAL
-        m_pBulkTypeEventBuffer(NULL)
+        , m_pBulkTypeEventBuffer(NULL)
 #endif
     {
         CONTRACTL


### PR DESCRIPTION
This solves an issue observed on Linux in which enabling tracing causes a stack overflow to occur and crash the process.  The underlying cause is that when tracing is on (COMPlus_EnableEventLog=1), allocation logging machinery is enabled which results in a BulkTypeEventLogger object being created on the stack. 
 BulkTypeEventLogger creates a stack-allocated 64KB buffer which represents the raw event - 64KB is the max event size.  On threads where stack space is constrained, or the stack size is small, this can result in a stack overflow.

To make this stack overflow much less likely to happen, we can allocate the buffer on the heap.  The rest of the BulkTypeEventLogger object is significantly smaller (less than 1KB).