### PR TITLE
CharUnicodeInfo.GetUnicodeCategory(int codePoint)

### DIFF
--- a/src/mscorlib/shared/System/Char.cs
+++ b/src/mscorlib/shared/System/Char.cs
@@ -853,7 +853,7 @@ namespace System
             {
                 return (GetLatin1UnicodeCategory(c));
             }
-            return CharUnicodeInfo.InternalGetUnicodeCategory(c);
+            return CharUnicodeInfo.GetUnicodeCategory((int)c);
         }
 
         public static UnicodeCategory GetUnicodeCategory(String s, int index)

--- a/src/mscorlib/shared/System/Globalization/CharUnicodeInfo.cs
+++ b/src/mscorlib/shared/System/Globalization/CharUnicodeInfo.cs
@@ -276,7 +276,7 @@ namespace System.Globalization
 
         public static UnicodeCategory GetUnicodeCategory(char ch)
         {
-            return (InternalGetUnicodeCategory(ch));
+            return (GetUnicodeCategory((int)ch));
         }
 
         public static UnicodeCategory GetUnicodeCategory(String s, int index)
@@ -290,9 +290,9 @@ namespace System.Globalization
             return InternalGetUnicodeCategory(s, index);
         }
 
-        internal static unsafe UnicodeCategory InternalGetUnicodeCategory(int ch)
+        public static UnicodeCategory GetUnicodeCategory(int codePoint)
         {
-            return ((UnicodeCategory)InternalGetCategoryValue(ch, UNICODE_CATEGORY_OFFSET));
+            return ((UnicodeCategory)InternalGetCategoryValue(codePoint, UNICODE_CATEGORY_OFFSET));
         }
 
 
@@ -352,7 +352,7 @@ namespace System.Globalization
             Debug.Assert(value != null, "value can not be null");
             Debug.Assert(index < value.Length, "index < value.Length");
 
-            return (InternalGetUnicodeCategory(InternalConvertToUtf32(value, index)));
+            return (GetUnicodeCategory(InternalConvertToUtf32(value, index)));
         }
 
         internal static BidiCategory GetBidiCategory(String s, int index)
@@ -381,7 +381,7 @@ namespace System.Globalization
             Debug.Assert(str.Length > 0, "str.Length > 0"); ;
             Debug.Assert(index >= 0 && index < str.Length, "index >= 0 && index < str.Length");
 
-            return (InternalGetUnicodeCategory(InternalConvertToUtf32(str, index, out charLength)));
+            return (GetUnicodeCategory(InternalConvertToUtf32(str, index, out charLength)));
         }
 
         internal static bool IsCombiningCategory(UnicodeCategory uc)

--- a/src/mscorlib/src/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/src/System/Globalization/CompareInfo.Unix.cs
@@ -329,7 +329,7 @@ namespace System.Globalization
                     if (index == length - 1 || !Char.IsLowSurrogate(text[index+1]))
                         return false; // unpaired surrogate
 
-                    uc = CharUnicodeInfo.InternalGetUnicodeCategory(Char.ConvertToUtf32(text[index], text[index+1]));
+                    uc = CharUnicodeInfo.GetUnicodeCategory(Char.ConvertToUtf32(text[index], text[index+1]));
                     if (uc == UnicodeCategory.PrivateUse || uc == UnicodeCategory.OtherNotAssigned)
                         return false;
 


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/26173

- renamed UnicodeCategory.InternalGetUnicodeCategory to GetUnicodeCategory
- renamed its parameter ch to codePoint
- made it public