### PR TITLE
improve DllImport library name variation trying

### DIFF
--- a/src/vm/dllimport.cpp
+++ b/src/vm/dllimport.cpp
@@ -6018,7 +6018,7 @@ HMODULE NDirect::LoadFromNativeDllSearchDirectories(AppDomain* pDomain, LPCWSTR 
     return hmod;
 }
 
-const int MAX_LIBNAME_VARIATIONS = 4;
+static const int MAX_LIBNAME_VARIATIONS = 4;
 
 static void AddLibNameVariation(const char** libNameVariations, int* numberOfVariations, const char* const variation)
 {

--- a/src/vm/dllimport.cpp
+++ b/src/vm/dllimport.cpp
@@ -6154,7 +6154,7 @@ HINSTANCE NDirect::LoadLibraryModule(NDirectMethodDesc * pMD, LoadLibErrorTracke
         currLibNameVariation.Printf(prefixSuffixCombinations[i], PAL_SHLIB_PREFIX, name, PAL_SHLIB_SUFFIX);
 #else
     {
-        SString& currLibNameVariation = wszLibName;
+        LPCWSTR currLibNameVariation = wszLibName;
 #endif
         if (hmod == NULL)
         {


### PR DESCRIPTION
Implements https://github.com/dotnet/coreclr/issues/15576

The dllName is first tried with _LoadFromNativeDllSearchDirectories_ and then with _LocalLoadLibraryHelper_, while variations are using the opposite order.

This PR uses the same order for the dllName and its variations.

When the dllName does not contain a suffix, first variations that include a suffix are tried.

CC @janvorli