### PR TITLE
Allow COMPlus_JitHalt to display a pop-up on ARM/ARM64

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -5803,8 +5803,8 @@ void Compiler::compCompileFinish()
     {
         if (compJitHaltMethod())
         {
-#if !defined(_TARGET_ARMARCH_) && !defined(_HOST_UNIX_)
-            // TODO-ARM-NYI: re-enable this when we have an OS that supports a pop-up dialog
+#if !defined(_HOST_UNIX_)
+            // TODO-UNIX: re-enable this when we have an OS that supports a pop-up dialog
 
             // Don't do an assert, but just put up the dialog box so we get just-in-time debugger
             // launching.  When you hit 'retry' it will continue and naturally stop at the INT 3


### PR DESCRIPTION
Note that you need to `set COMPlus_NoGuiOnAssert=0` for the
pop-up to be displayed.