### PR TITLE
Stop treating all calls to instance interface methods as callvirt

### DIFF
--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -5397,7 +5397,8 @@ void CEEInfo::getCallInfo(
         directCall = true;
     }
     else
-    if (pTargetMD->GetMethodTable()->IsInterface() && pTargetMD->IsVirtual())
+    // Backwards compat: calls to abstract interface methods are treated as callvirt
+    if (pTargetMD->IsAbstract() && pTargetMD->GetMethodTable()->IsInterface())
     {
         directCall = false;
     }
@@ -5439,6 +5440,12 @@ void CEEInfo::getCallInfo(
         }
         else
 #endif
+        if (pTargetMD->GetMethodTable()->IsInterface())
+        {
+            // Handle interface methods specially because the Sealed bit has no meaning on interfaces.
+            devirt = !IsMdVirtual(pTargetMD->GetAttrs());
+        }
+        else
         {
             DWORD dwMethodAttrs = pTargetMD->GetAttrs();
             devirt = !IsMdVirtual(dwMethodAttrs) || IsMdFinal(dwMethodAttrs) || pTargetMD->GetMethodTable()->IsSealed();

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -5398,7 +5398,7 @@ void CEEInfo::getCallInfo(
     }
     else
     // Backwards compat: calls to abstract interface methods are treated as callvirt
-    if (pTargetMD->IsAbstract() && pTargetMD->GetMethodTable()->IsInterface())
+    if (pTargetMD->GetMethodTable()->IsInterface() && pTargetMD->IsAbstract())
     {
         directCall = false;
     }

--- a/tests/src/Regressions/coreclr/15827/nonvirtualcall.il
+++ b/tests/src/Regressions/coreclr/15827/nonvirtualcall.il
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//
+// Verifies that we're able to call virtual interface methods non-virtually.
+// Corresponds to the C# "base(IFoo).Frob()" syntax.
+//
+
+.assembly extern System.Runtime { }
+
+.assembly nonvirtualcall { }
+
+.class interface private abstract auto ansi IFoo
+{
+  .method public hidebysig newslot virtual instance int32 Frob() cil managed
+  {
+    ldc.i4 99
+    ret
+  }
+}
+
+.class interface private abstract auto ansi IBar
+       implements IFoo
+{
+  .method public hidebysig newslot virtual final instance int32 Frob() cil managed
+  {
+    .override IFoo::Frob
+    ldarg.0
+    call instance int32 class IFoo::Frob()
+    ldc.i4.1
+    add
+    ret
+  }
+}
+
+.class private auto ansi beforefieldinit Fooer
+       extends [System.Runtime]System.Object
+       implements IBar
+{
+  .method public hidebysig specialname rtspecialname 
+          instance void .ctor() cil managed
+  {
+    ldarg.0
+    call instance void [System.Runtime]System.Object::.ctor()
+    ret
+  }
+}
+
+.method public hidebysig static int32 RunTest() cil managed
+{
+  newobj instance void Fooer::.ctor()
+  callvirt instance int32 IFoo::Frob()
+  ret
+}
+
+.method public hidebysig static int32 Main() cil managed
+{
+  .entrypoint
+
+  ldstr "DefaultImplementationsOfInterfaces"
+  call bool [System.Runtime]System.Runtime.CompilerServices.RuntimeFeature::IsSupported(string)
+
+  // If default interfaces are not supported, consider the test successful.
+  brtrue DoRunTest
+  ldc.i4 100
+  ret
+
+DoRunTest:
+  call int32 RunTest()
+  ret
+}

--- a/tests/src/Regressions/coreclr/15827/nonvirtualcall.ilproj
+++ b/tests/src/Regressions/coreclr/15827/nonvirtualcall.ilproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>nonvirtualcall</AssemblyName>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{85DFC527-4DB1-595E-A7D7-E94EE1F8140D}</ProjectGuid>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="nonvirtualcall.il" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
Fixes #15827.

I made the test check for `DefaultImplementationsOfInterfaces` RuntimeFeature so that we don't need to go and disable it in the release branches.