### PR TITLE
Remove hardcoded paths in linkbench scripts

### DIFF
--- a/buildpipeline/perf-pipeline.groovy
+++ b/buildpipeline/perf-pipeline.groovy
@@ -88,7 +88,8 @@ def windowsPerf(String arch, String config, String uploadString, String runType,
         }
         else if (scenario == 'illink') {
             String runXUnitPerfCommonArgs = "${runXUnitCommonArgs} -scenarioTest"
-            bat "py tests\\scripts\\run-xunit-perf.py ${runXUnitPerfCommonArgs} -testBinLoc bin\\tests\\${os}.${arch}.${config}\\performance\\linkbench\\linkbench -group ILLink -nowarmup"
+            bat "\"%VS140COMNTOOLS%\\..\\..\\VC\\vcvarsall.bat x86_amd64\"\n" +
+                "py tests\\scripts\\run-xunit-perf.py ${runXUnitPerfCommonArgs} -testBinLoc bin\\tests\\${os}.${arch}.${config}\\performance\\linkbench\\linkbench -group ILLink -nowarmup"
         }
         archiveArtifacts allowEmptyArchive: false, artifacts:'bin/sandbox_logs/**,machinedata.json'
     }

--- a/buildpipeline/perf-pipeline.groovy
+++ b/buildpipeline/perf-pipeline.groovy
@@ -88,7 +88,7 @@ def windowsPerf(String arch, String config, String uploadString, String runType,
         }
         else if (scenario == 'illink') {
             String runXUnitPerfCommonArgs = "${runXUnitCommonArgs} -scenarioTest"
-            bat "\"%VS140COMNTOOLS%\\..\\..\\VC\\vcvarsall.bat x86_amd64\"\n" +
+            bat "\"%VS140COMNTOOLS%\\..\\..\\VC\\vcvarsall.bat\" x86_amd64\n" +
                 "py tests\\scripts\\run-xunit-perf.py ${runXUnitPerfCommonArgs} -testBinLoc bin\\tests\\${os}.${arch}.${config}\\performance\\linkbench\\linkbench -group ILLink -nowarmup"
         }
         archiveArtifacts allowEmptyArchive: false, artifacts:'bin/sandbox_logs/**,machinedata.json'

--- a/perf.groovy
+++ b/perf.groovy
@@ -782,7 +782,7 @@ parallel(
                             def runXUnitPerfCommonArgs = "-arch ${arch} -configuration ${configuration} -generateBenchviewData \"%WORKSPACE%\\Microsoft.Benchview.JSONFormat\\tools\" ${uploadString} -runtype ${runType} ${testEnv} -optLevel ${opt_level} -jitName ${jit} -outputdir \"%WORKSPACE%\\bin\\sandbox_logs\" -scenarioTest"
 
                             // Scenario: ILLink
-                            batchFile("\"%VS140COMNTOOLS%\\..\\..\\VC\\vcvarsall.bat x86_amd64\"\n" +
+                            batchFile("\"%VS140COMNTOOLS%\\..\\..\\VC\\vcvarsall.bat\" x86_amd64\n" +
                             "py tests\\scripts\\run-xunit-perf.py ${runXUnitPerfCommonArgs} -testBinLoc bin\\tests\\${os}.${architecture}.${configuration}\\performance\\linkbench\\linkbench -group ILLink -nowarmup")
                         }
                     }

--- a/perf.groovy
+++ b/perf.groovy
@@ -782,7 +782,8 @@ parallel(
                             def runXUnitPerfCommonArgs = "-arch ${arch} -configuration ${configuration} -generateBenchviewData \"%WORKSPACE%\\Microsoft.Benchview.JSONFormat\\tools\" ${uploadString} -runtype ${runType} ${testEnv} -optLevel ${opt_level} -jitName ${jit} -outputdir \"%WORKSPACE%\\bin\\sandbox_logs\" -scenarioTest"
 
                             // Scenario: ILLink
-                            batchFile("py tests\\scripts\\run-xunit-perf.py ${runXUnitPerfCommonArgs} -testBinLoc bin\\tests\\${os}.${architecture}.${configuration}\\performance\\linkbench\\linkbench -group ILLink -nowarmup")
+                            batchFile("""\"%VS140COMNTOOLS%\\..\\..\\VC\\vcvarsall.bat x86_x64\"\n" +
+                            "py tests\\scripts\\run-xunit-perf.py ${runXUnitPerfCommonArgs} -testBinLoc bin\\tests\\${os}.${architecture}.${configuration}\\performance\\linkbench\\linkbench -group ILLink -nowarmup""")
                         }
                     }
 

--- a/perf.groovy
+++ b/perf.groovy
@@ -782,8 +782,8 @@ parallel(
                             def runXUnitPerfCommonArgs = "-arch ${arch} -configuration ${configuration} -generateBenchviewData \"%WORKSPACE%\\Microsoft.Benchview.JSONFormat\\tools\" ${uploadString} -runtype ${runType} ${testEnv} -optLevel ${opt_level} -jitName ${jit} -outputdir \"%WORKSPACE%\\bin\\sandbox_logs\" -scenarioTest"
 
                             // Scenario: ILLink
-                            batchFile("""\"%VS140COMNTOOLS%\\..\\..\\VC\\vcvarsall.bat x86_amd64\"\n" +
-                            "py tests\\scripts\\run-xunit-perf.py ${runXUnitPerfCommonArgs} -testBinLoc bin\\tests\\${os}.${architecture}.${configuration}\\performance\\linkbench\\linkbench -group ILLink -nowarmup""")
+                            batchFile("\"%VS140COMNTOOLS%\\..\\..\\VC\\vcvarsall.bat x86_amd64\"\n" +
+                            "py tests\\scripts\\run-xunit-perf.py ${runXUnitPerfCommonArgs} -testBinLoc bin\\tests\\${os}.${architecture}.${configuration}\\performance\\linkbench\\linkbench -group ILLink -nowarmup")
                         }
                     }
 

--- a/perf.groovy
+++ b/perf.groovy
@@ -782,7 +782,7 @@ parallel(
                             def runXUnitPerfCommonArgs = "-arch ${arch} -configuration ${configuration} -generateBenchviewData \"%WORKSPACE%\\Microsoft.Benchview.JSONFormat\\tools\" ${uploadString} -runtype ${runType} ${testEnv} -optLevel ${opt_level} -jitName ${jit} -outputdir \"%WORKSPACE%\\bin\\sandbox_logs\" -scenarioTest"
 
                             // Scenario: ILLink
-                            batchFile("""\"%VS140COMNTOOLS%\\..\\..\\VC\\vcvarsall.bat x86_x64\"\n" +
+                            batchFile("""\"%VS140COMNTOOLS%\\..\\..\\VC\\vcvarsall.bat x86_amd64\"\n" +
                             "py tests\\scripts\\run-xunit-perf.py ${runXUnitPerfCommonArgs} -testBinLoc bin\\tests\\${os}.${architecture}.${configuration}\\performance\\linkbench\\linkbench -group ILLink -nowarmup""")
                         }
                     }

--- a/tests/src/performance/linkbench/scripts/build.cmd
+++ b/tests/src/performance/linkbench/scripts/build.cmd
@@ -8,11 +8,7 @@ set AssetDir=%1
 set ExitCode=0
 pushd %LinkBenchRoot%
 
-set __CORFLAGS="%VS140COMNTOOLS%\..\..\..\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.1 Tools\CorFlags.exe"
-if not exist %__CORFLAGS% (
-    echo corflags.exe not found
-    exit /b -1
-)
+where.exe /Q CorFlags.exe || (echo [Error] CorFlags.exe is not on the environment & exit /b 1)
 
 if defined __test_HelloWorld call :HelloWorld
 if defined __test_WebAPI call :WebAPI
@@ -88,7 +84,7 @@ copy ..\..\..\..\..\..\crossgen.exe
 FOR /F %%I IN ('dir /b *.dll ^| find /V /I ".ni.dll"  ^| find /V /I "System.Private.CoreLib" ^| find /V /I "mscorlib.dll"') DO (
     REM Don't crossgen Corlib, since the native image already exists.
     REM For all other MSIL files (corflags returns 0), run crossgen
-    %__CORFLAGS% %%I 
+    CorFlags.exe %%I 
     if not errorlevel 1 (
         crossgen.exe /Platform_Assemblies_Paths . %%I 
         if errorlevel 1 (

--- a/tests/src/performance/linkbench/scripts/getcert.cmd
+++ b/tests/src/performance/linkbench/scripts/getcert.cmd
@@ -1,2 +1,5 @@
 @echo off
-"%VS140COMNTOOLS%\..\..\VC\bin\amd64\dumpbin.exe" /headers %1 | findstr /C:"Certificates Directory
+
+where.exe /Q dumpbin.exe || (echo [Error] dumpbin.exe is not on the environment & exit /b 1)
+
+dumpbin.exe /headers %1 | findstr /C:"Certificates Directory


### PR DESCRIPTION
Linkbench has hardcoded paths based off of VS140COMNTOOLS, which not all
machines will have (ie, machines with only VS2017 installed). This
change removes the hardcoded paths, and replaces them with checks to
make sure the tool is on the path (which they will be if we are in a VS
environment of any kind - which we would have been in if
VS140COMNTOOLS was already set).