### PR TITLE
Fix 64 bit shift inconsistencies (on 32 bit targets)

### DIFF
--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -408,13 +408,27 @@ T ValueNumStore::EvalOpIntegral(VNFunc vnf, T v0, T v1, ValueNum* pExcSet)
         case GT_AND:
             return v0 & v1;
         case GT_LSH:
-            return v0 << v1;
+            if (sizeof(T) == 8)
+            {
+                return v0 << (v1 & 0x3F);
+            }
+            else
+            {
+                return v0 << v1;
+            }
         case GT_RSH:
-            return v0 >> v1;
+            if (sizeof(T) == 8)
+            {
+                return v0 >> (v1 & 0x3F);
+            }
+            else
+            {
+                return v0 >> v1;
+            }
         case GT_RSZ:
             if (sizeof(T) == 8)
             {
-                return UINT64(v0) >> v1;
+                return UINT64(v0) >> (v1 & 0x3F);
             }
             else
             {

--- a/src/vm/i386/jithelp.asm
+++ b/src/vm/i386/jithelp.asm
@@ -520,6 +520,8 @@ JIT_LLsh ENDP
         ALIGN 16
 PUBLIC JIT_LRsh
 JIT_LRsh PROC
+; Reduce shift amount mod 64
+        and     ecx, 63
 ; Handle shifts of between bits 0 and 31
         cmp     ecx, 32
         jae     short LRshMORE32
@@ -554,6 +556,8 @@ JIT_LRsh ENDP
         ALIGN 16
 PUBLIC JIT_LRsz
 JIT_LRsz PROC
+; Reduce shift amount mod 64
+        and     ecx, 63
 ; Handle shifts of between bits 0 and 31
         cmp     ecx, 32
         jae     short LRszMORE32

--- a/src/vm/jithelpers.cpp
+++ b/src/vm/jithelpers.cpp
@@ -464,7 +464,7 @@ HCIMPLEND
 HCIMPL2_VV(INT64, JIT_LRsh, INT64 num, int shift)
 {
     FCALL_CONTRACT;
-    return num >> shift;
+    return num >> (shift & 0x3F);
 }
 HCIMPLEND
 
@@ -472,7 +472,7 @@ HCIMPLEND
 HCIMPL2_VV(UINT64, JIT_LRsz, UINT64 num, int shift)
 {
     FCALL_CONTRACT;
-    return num >> shift;
+    return num >> (shift & 0x3F);
 }
 HCIMPLEND
 #endif // !BIT64 && !_TARGET_X86_

--- a/tests/src/JIT/Regression/JitBlue/GitHub_15949/GitHub_15949.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_15949/GitHub_15949.il
@@ -1,0 +1,235 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib { auto }
+.assembly extern System.Console { auto }
+.assembly GitHub_15949 { }
+
+// Ensure that shifting a 64 bit value by 64 bits produces the same value. The ECMA spec doesn't specify
+// what should happen in this case but it would be preferable to have the same behavior for all shift
+// instructions (use only the lowest 6 bits of the shift count).
+
+// This test is intended for 32 bit targets where RyuJIT has 4 different code paths that are of interest:
+// helper call, decomposition, constant folding via gtFoldExpr and constant folding via VN's EvalOpIntegral.
+// But it also works on the current 64 bit targets (ARM64 & x64) because they too have the same behavior.
+
+.class private auto ansi Program extends [mscorlib]System.Object
+{
+    .method static int32 Main() cil managed
+    {
+        .entrypoint
+        .maxstack 8
+        .locals(int64)
+
+        ldc.i8 0x1020304050607080
+        ldc.i4 64
+        ldc.i4 1
+        call int64 Program::Test_Shl_Helper(int64, int32, bool)
+        stloc.0
+
+        ldc.i8 0x1020304050607080
+        ldc.i4 64
+        ldc.i4 1
+        call int64 Program::Test_Shr_Helper(int64, int32, bool)
+        ldloc.0
+        bne.un FAIL
+
+        ldc.i8 0x1020304050607080
+        ldc.i4 64
+        ldc.i4 1
+        call int64 Program::Test_ShrUn_Helper(int64, int32, bool)
+        ldloc.0
+        bne.un FAIL
+
+        ldc.i8 0x1020304050607080
+        ldc.i4 64
+        ldc.i4 1
+        call int64 Program::Test_Shl_Decompose(int64, int32, bool)
+        ldloc.0
+        bne.un FAIL
+
+        ldc.i8 0x1020304050607080
+        ldc.i4 64
+        ldc.i4 1
+        call int64 Program::Test_Shr_Decompose(int64, int32, bool)
+        ldloc.0
+        bne.un FAIL
+
+        ldc.i8 0x1020304050607080
+        ldc.i4 64
+        ldc.i4 1
+        call int64 Program::Test_ShrUn_Decompose(int64, int32, bool)
+        ldloc.0
+        bne.un FAIL
+
+        ldc.i8 0x1020304050607080
+        ldc.i4 64
+        ldc.i4 1
+        call int64 Program::Test_Shl_gtFoldExpr(int64, int32, bool)
+        ldloc.0
+        bne.un FAIL
+
+        ldc.i8 0x1020304050607080
+        ldc.i4 64
+        ldc.i4 1
+        call int64 Program::Test_Shr_gtFoldExpr(int64, int32, bool)
+        ldloc.0
+        bne.un FAIL
+
+        ldc.i8 0x1020304050607080
+        ldc.i4 64
+        ldc.i4 1
+        call int64 Program::Test_ShrUn_gtFoldExpr(int64, int32, bool)
+        ldloc.0
+        bne.un FAIL
+
+        ldc.i8 0x1020304050607080
+        ldc.i4 64
+        ldc.i4 1
+        call int64 Program::Test_Shl_EvalOpIntegral(int64, int32, bool)
+        ldloc.0
+        bne.un FAIL
+
+        ldc.i8 0x1020304050607080
+        ldc.i4 64
+        ldc.i4 1
+        call int64 Program::Test_Shr_EvalOpIntegral(int64, int32, bool)
+        ldloc.0
+        bne.un FAIL
+
+        ldc.i8 0x1020304050607080
+        ldc.i4 64
+        ldc.i4 1
+        call int64 Program::Test_ShrUn_EvalOpIntegral(int64, int32, bool)
+        ldloc.0
+        bne.un FAIL
+
+        ldc.i4 100
+        ret
+
+    FAIL:
+        ldc.i4 1
+        ret
+    }
+
+    .method static int64 Test_Shl_Helper(int64, int32, bool) cil managed noinlining
+    {
+        .maxstack 2
+        ldarg.0
+        ldarg.1
+        shl
+        ret
+    }
+
+    .method static int64 Test_Shr_Helper(int64, int32, bool) cil managed noinlining
+    {
+        .maxstack 2
+        ldarg.0
+        ldarg.1
+        shr
+        ret
+    }
+
+    .method static int64 Test_ShrUn_Helper(int64, int32, bool) cil managed noinlining
+    {
+        .maxstack 2
+        ldarg.0
+        ldarg.1
+        shr.un
+        ret
+    }
+
+    .method static int64 Test_Shl_Decompose(int64, int32, bool) cil managed noinlining
+    {
+        .maxstack 2
+        ldarg.0
+        ldc.i4 64
+        shl
+        ret
+    }
+
+    .method static int64 Test_Shr_Decompose(int64, int32, bool) cil managed noinlining
+    {
+        .maxstack 2
+        ldarg.0
+        ldc.i4 64
+        shr
+        ret
+    }
+
+    .method static int64 Test_ShrUn_Decompose(int64, int32, bool) cil managed noinlining
+    {
+        .maxstack 2
+        ldarg.0
+        ldc.i4 64
+        shr.un
+        ret
+    }
+
+    .method static int64 Test_Shl_gtFoldExpr(int64, int32, bool) cil managed noinlining
+    {
+        .maxstack 2
+        ldc.i8 0x1020304050607080
+        ldc.i4 64
+        shl
+        ret
+    }
+
+    .method static int64 Test_Shr_gtFoldExpr(int64, int32, bool) cil managed noinlining
+    {
+        .maxstack 2
+        ldc.i8 0x1020304050607080
+        ldc.i4 64
+        shr
+        ret
+    }
+
+    .method static int64 Test_ShrUn_gtFoldExpr(int64, int32, bool) cil managed noinlining
+    {
+        .maxstack 2
+        ldc.i8 0x1020304050607080
+        ldc.i4 64
+        shr.un
+        ret
+    }
+
+    .method static int64 Test_Shl_EvalOpIntegral(int64, int32, bool) cil managed noinlining
+    {
+        .maxstack 2
+        ldc.i8 0x1020304050607080
+        ldarg.2
+        brtrue L1
+        ldc.i4 64
+        br L2
+    L1: ldc.i4 64
+    L2: shl
+        ret
+    }
+
+    .method static int64 Test_Shr_EvalOpIntegral(int64, int32, bool) cil managed noinlining
+    {
+        .maxstack 2
+        ldc.i8 0x1020304050607080
+        ldarg.2
+        brtrue L1
+        ldc.i4 64
+        br L2
+    L1: ldc.i4 64
+    L2: shr
+        ret
+    }
+
+    .method static int64 Test_ShrUn_EvalOpIntegral(int64, int32, bool) cil managed noinlining
+    {
+        .maxstack 2
+        ldc.i8 0x1020304050607080
+        ldarg.2
+        brtrue L1
+        ldc.i4 64
+        br L2
+    L1: ldc.i4 64
+    L2: shr.un
+        ret
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_15949/GitHub_15949.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_15949/GitHub_15949.ilproj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_15949.il" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Recent shift changes made the `JIT_LLsh` helper mask the shift count to 6 bits. The other 2 helpers (`JIT_LRsh` and `JIT_LRsz`) so now we get inconsistencies such as `(x >> 64) != (x << 64)`.

The ECMA spec says that "the return value is unspecified if shiftAmount is greater than or equal to the width of value" so the JIT has no obligation to implement a particular behavior. But it seems preferable to have all shift instructions behave similarly, it avoids complications and reduces risks.

This also changes `ValueNumStore::EvalOpIntegral` to mask the shift count for 64 bit shifts so it matches `gtFoldExprConst`. Otherwise the produced value depends on the C/C++ compiler's behavior.