### PR TITLE
Fix timezone lookup to be consistently case insensitive

### DIFF
--- a/src/mscorlib/shared/System/TimeZoneInfo.cs
+++ b/src/mscorlib/shared/System/TimeZoneInfo.cs
@@ -1894,7 +1894,7 @@ namespace System
             if (result == TimeZoneInfoResult.Success)
             {
                 if (cachedData._systemTimeZones == null)
-                    cachedData._systemTimeZones = new Dictionary<string, TimeZoneInfo>();
+                    cachedData._systemTimeZones = new Dictionary<string, TimeZoneInfo>(StringComparer.OrdinalIgnoreCase);
 
                 cachedData._systemTimeZones.Add(id, match);
 


### PR DESCRIPTION
The timezone ids used case insensitive comparisons everywhere, except in the dictionary used to cache timezones.

Fixes dotnet/corefx#26479