### PR TITLE
Rename Libraries.GlobalizationInterop to Libraries.GlobalizationNative

### DIFF
--- a/src/mscorlib/shared/Interop/Unix/Interop.Libraries.cs
+++ b/src/mscorlib/shared/Interop/Unix/Interop.Libraries.cs
@@ -6,7 +6,7 @@ internal static partial class Interop
 {
     internal static partial class Libraries
     {
-        internal const string GlobalizationInterop = "System.Globalization.Native";
+        internal const string GlobalizationNative = "System.Globalization.Native";
         internal const string SystemNative = "System.Native";
     }
 }

--- a/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.Calendar.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.Calendar.cs
@@ -9,25 +9,25 @@ using System.Text;
 
 internal static partial class Interop
 {
-    internal static partial class GlobalizationInterop
+    internal static partial class Globalization
     {
         internal delegate void EnumCalendarInfoCallback(
            [MarshalAs(UnmanagedType.LPWStr)] string calendarString,
            IntPtr context);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetCalendars")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetCalendars")]
         internal static extern int GetCalendars(string localeName, CalendarId[] calendars, int calendarsCapacity);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetCalendarInfo")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetCalendarInfo")]
         internal static extern ResultCode GetCalendarInfo(string localeName, CalendarId calendarId, CalendarDataType calendarDataType, [Out] StringBuilder result, int resultCapacity);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_EnumCalendarInfo")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_EnumCalendarInfo")]
         internal static extern bool EnumCalendarInfo(EnumCalendarInfoCallback callback, string localeName, CalendarId calendarId, CalendarDataType calendarDataType, IntPtr context);
 
-        [DllImport(Libraries.GlobalizationInterop, EntryPoint = "GlobalizationNative_GetLatestJapaneseEra")]
+        [DllImport(Libraries.GlobalizationNative, EntryPoint = "GlobalizationNative_GetLatestJapaneseEra")]
         internal static extern int GetLatestJapaneseEra();
 
-        [DllImport(Libraries.GlobalizationInterop, EntryPoint = "GlobalizationNative_GetJapaneseEraStartDate")]
+        [DllImport(Libraries.GlobalizationNative, EntryPoint = "GlobalizationNative_GetJapaneseEraStartDate")]
         internal static extern bool GetJapaneseEraStartDate(int era, out int startYear, out int startMonth, out int startDay);
     }
 }

--- a/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.Casing.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.Casing.cs
@@ -9,15 +9,15 @@ using System.Text;
 
 internal static partial class Interop
 {
-    internal static partial class GlobalizationInterop
+    internal static partial class Globalization
     {
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ChangeCase")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ChangeCase")]
         internal unsafe static extern void ChangeCase(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ChangeCaseInvariant")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ChangeCaseInvariant")]
         internal unsafe static extern void ChangeCaseInvariant(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ChangeCaseTurkish")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ChangeCaseTurkish")]
         internal unsafe static extern void ChangeCaseTurkish(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper);
     }
 }

--- a/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.Collation.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.Collation.cs
@@ -9,41 +9,41 @@ using System.Security;
 
 internal static partial class Interop
 {
-    internal static partial class GlobalizationInterop
+    internal static partial class Globalization
     {
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetSortHandle")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetSortHandle")]
         internal unsafe static extern ResultCode GetSortHandle(byte[] localeName, out SafeSortHandle sortHandle);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_CloseSortHandle")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_CloseSortHandle")]
         internal unsafe static extern void CloseSortHandle(IntPtr handle);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_CompareString")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_CompareString")]
         internal unsafe static extern int CompareString(SafeSortHandle sortHandle, char* lpStr1, int cwStr1Len, char* lpStr2, int cwStr2Len, CompareOptions options);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IndexOf")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IndexOf")]
         internal unsafe static extern int IndexOf(SafeSortHandle sortHandle, string target, int cwTargetLength, char* pSource, int cwSourceLength, CompareOptions options, int* matchLengthPtr);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_LastIndexOf")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_LastIndexOf")]
         internal unsafe static extern int LastIndexOf(SafeSortHandle sortHandle, string target, int cwTargetLength, char* pSource, int cwSourceLength, CompareOptions options);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IndexOfOrdinalIgnoreCase")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IndexOfOrdinalIgnoreCase")]
         internal unsafe static extern int IndexOfOrdinalIgnoreCase(string target, int cwTargetLength, char* pSource, int cwSourceLength, bool findLast);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_StartsWith")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_StartsWith")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool StartsWith(SafeSortHandle sortHandle, string target, int cwTargetLength, string source, int cwSourceLength, CompareOptions options);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_EndsWith")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_EndsWith")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool EndsWith(SafeSortHandle sortHandle, string target, int cwTargetLength, string source, int cwSourceLength, CompareOptions options);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetSortKey")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetSortKey")]
         internal unsafe static extern int GetSortKey(SafeSortHandle sortHandle, string str, int strLength, byte* sortKey, int sortKeyLength, CompareOptions options);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_CompareStringOrdinalIgnoreCase")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_CompareStringOrdinalIgnoreCase")]
         internal unsafe static extern int CompareStringOrdinalIgnoreCase(char* lpStr1, int cwStr1Len, char* lpStr2, int cwStr2Len);
 
-        [DllImport(Libraries.GlobalizationInterop, EntryPoint = "GlobalizationNative_GetSortVersion")]
+        [DllImport(Libraries.GlobalizationNative, EntryPoint = "GlobalizationNative_GetSortVersion")]
         internal static extern int GetSortVersion(SafeSortHandle sortHandle);
 
         internal class SafeSortHandle : SafeHandle

--- a/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.ICU.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.ICU.cs
@@ -8,9 +8,9 @@ using System.Runtime.CompilerServices;
 
 internal static partial class Interop
 {
-    internal static partial class GlobalizationInterop
+    internal static partial class Globalization
     {
-        [DllImport(Libraries.GlobalizationInterop, EntryPoint = "GlobalizationNative_LoadICU")]
+        [DllImport(Libraries.GlobalizationNative, EntryPoint = "GlobalizationNative_LoadICU")]
         internal static extern int LoadICU();
     }
 }

--- a/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.Idna.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.Idna.cs
@@ -7,15 +7,15 @@ using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
-    internal static partial class GlobalizationInterop
+    internal static partial class Globalization
     {
         internal const int AllowUnassigned = 0x1;
         internal const int UseStd3AsciiRules = 0x2;
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ToAscii")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ToAscii")]
         internal static unsafe extern int ToAscii(uint flags, char* src, int srcLen, char* dstBuffer, int dstBufferCapacity);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ToUnicode")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ToUnicode")]
         internal static unsafe extern int ToUnicode(uint flags, char* src, int srcLen, char* dstBuffer, int dstBufferCapacity);
     }
 }

--- a/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.Locale.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.Locale.cs
@@ -8,33 +8,33 @@ using System.Text;
 
 internal static partial class Interop
 {
-    internal static partial class GlobalizationInterop
+    internal static partial class Globalization
     {
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleName")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleName")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool GetLocaleName(string localeName, [Out] StringBuilder value, int valueLength);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleInfoString")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleInfoString")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool GetLocaleInfoString(string localeName, uint localeStringData, [Out] StringBuilder value, int valueLength);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetDefaultLocaleName")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetDefaultLocaleName")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool GetDefaultLocaleName([Out] StringBuilder value, int valueLength);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleTimeFormat")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleTimeFormat")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool GetLocaleTimeFormat(string localeName, bool shortFormat, [Out] StringBuilder value, int valueLength);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleInfoInt")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleInfoInt")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool GetLocaleInfoInt(string localeName, uint localeNumberData, ref int value);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleInfoGroupingSizes")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleInfoGroupingSizes")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool GetLocaleInfoGroupingSizes(string localeName, uint localeGroupingData, ref int primaryGroupSize, ref int secondaryGroupSize);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocales")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocales")]
         internal unsafe static extern int GetLocales([Out] Char[] value, int valueLength);
     }
 }

--- a/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.Normalization.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.Normalization.cs
@@ -8,12 +8,12 @@ using System.Text;
 
 internal static partial class Interop
 {
-    internal static partial class GlobalizationInterop
+    internal static partial class Globalization
     {
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IsNormalized")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IsNormalized")]
         internal static extern int IsNormalized(NormalizationForm normalizationForm, string src, int srcLen);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_NormalizeString")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_NormalizeString")]
         internal static extern int NormalizeString(NormalizationForm normalizationForm, string src, int srcLen, [Out] char[] dstBuffer, int dstBufferCapacity);
     }
 }

--- a/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.ResultCode.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.ResultCode.cs
@@ -4,7 +4,7 @@
 
 internal static partial class Interop
 {
-    internal static partial class GlobalizationInterop
+    internal static partial class Globalization
     {
         // needs to be kept in sync with ResultCode in System.Globalization.Native
         internal enum ResultCode

--- a/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.TimeZoneInfo.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.TimeZoneInfo.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 internal static partial class Interop
 {
-    internal static partial class GlobalizationInterop
+    internal static partial class Globalization
     {
         // needs to be kept in sync with TimeZoneDisplayNameType in System.Globalization.Native
         internal enum TimeZoneDisplayNameType
@@ -17,7 +17,7 @@ internal static partial class Interop
             DaylightSavings = 2,
         }
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetTimeZoneDisplayName")]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetTimeZoneDisplayName")]
         internal static extern ResultCode GetTimeZoneDisplayName(
             string localeName, 
             string timeZoneId, 

--- a/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.Utils.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.Utils.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
     /// increasing buffer until the size is big enough.
     /// </summary>
     internal static bool CallStringMethod<TArg1, TArg2, TArg3>(
-        Func<TArg1, TArg2, TArg3, StringBuilder, GlobalizationInterop.ResultCode> interopCall,
+        Func<TArg1, TArg2, TArg3, StringBuilder, Interop.Globalization.ResultCode> interopCall,
         TArg1 arg1,
         TArg2 arg2,
         TArg3 arg3,
@@ -26,14 +26,14 @@ internal static partial class Interop
 
         for (int i = 0; i < maxDoubleAttempts; i++)
         {
-            GlobalizationInterop.ResultCode resultCode = interopCall(arg1, arg2, arg3, stringBuilder);
+            Interop.Globalization.ResultCode resultCode = interopCall(arg1, arg2, arg3, stringBuilder);
 
-            if (resultCode == GlobalizationInterop.ResultCode.Success)
+            if (resultCode == Interop.Globalization.ResultCode.Success)
             {
                 result = StringBuilderCache.GetStringAndRelease(stringBuilder);
                 return true;
             }
-            else if (resultCode == GlobalizationInterop.ResultCode.InsufficentBuffer)
+            else if (resultCode == Interop.Globalization.ResultCode.InsufficentBuffer)
             {
                 // increase the string size and loop
                 stringBuilder.EnsureCapacity(stringBuilder.Capacity * 2);

--- a/src/mscorlib/shared/Interop/Unix/System.Native/Interop.PathConf.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Native/Interop.PathConf.cs
@@ -9,8 +9,6 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        internal static int DEFAULT_PC_NAME_MAX = 255;
-
         internal enum PathConfName : int
         {
             PC_LINK_MAX         = 1,

--- a/src/mscorlib/shared/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/mscorlib/shared/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -83,10 +83,7 @@ namespace Microsoft.Win32.SafeHandles
 
         private static bool DirectoryExists(string fullPath)
         {
-            int fileType = Interop.Sys.FileTypes.S_IFDIR;
-
             Interop.Sys.FileStatus fileinfo;
-            Interop.ErrorInfo errorInfo = default(Interop.ErrorInfo);
 
             // First use stat, as we want to follow symlinks.  If that fails, it could be because the symlink
             // is broken, we don't have permissions, etc., in which case fall back to using LStat to evaluate
@@ -94,16 +91,10 @@ namespace Microsoft.Win32.SafeHandles
             if (Interop.Sys.Stat(fullPath, out fileinfo) < 0 &&
                 Interop.Sys.LStat(fullPath, out fileinfo) < 0)
             {
-                errorInfo = Interop.Sys.GetLastErrorInfo();
                 return false;
             }
 
-            // Something exists at this path.  If the caller is asking for a directory, return true if it's
-            // a directory and false for everything else.  If the caller is asking for a file, return false for
-            // a directory and true for everything else.
-            return
-                (fileType == Interop.Sys.FileTypes.S_IFDIR) ==
-                ((fileinfo.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR);
+            return ((fileinfo.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR);
         }
 
         /// <summary>Opens a SafeFileHandle for a file descriptor created by a provided delegate.</summary>

--- a/src/mscorlib/shared/System/Globalization/CalendarData.Unix.cs
+++ b/src/mscorlib/shared/System/Globalization/CalendarData.Unix.cs
@@ -68,7 +68,7 @@ namespace System.Globalization
             Debug.Assert(!GlobalizationMode.Invariant);
 
             // NOTE: there are no 'user overrides' on Linux
-            int count = Interop.GlobalizationInterop.GetCalendars(localeName, calendars, calendars.Length);
+            int count = Interop.Globalization.GetCalendars(localeName, calendars, calendars.Length);
 
             // ensure there is at least 1 calendar returned
             if (count == 0 && calendars.Length > 0)
@@ -93,7 +93,7 @@ namespace System.Globalization
 
             return Interop.CallStringMethod(
                 (locale, calId, type, stringBuilder) =>
-                    Interop.GlobalizationInterop.GetCalendarInfo(
+                    Interop.Globalization.GetCalendarInfo(
                         locale,
                         calId,
                         type,
@@ -295,7 +295,7 @@ namespace System.Globalization
 
         private static unsafe bool EnumCalendarInfo(string localeName, CalendarId calendarId, CalendarDataType dataType, ref EnumCalendarsData callbackContext)
         {
-            return Interop.GlobalizationInterop.EnumCalendarInfo(EnumCalendarInfoCallback, localeName, calendarId, dataType, (IntPtr)Unsafe.AsPointer(ref callbackContext));
+            return Interop.Globalization.EnumCalendarInfo(EnumCalendarInfoCallback, localeName, calendarId, dataType, (IntPtr)Unsafe.AsPointer(ref callbackContext));
         }
 
         private static unsafe void EnumCalendarInfoCallback(string calendarString, IntPtr context)

--- a/src/mscorlib/shared/System/Globalization/CultureData.Unix.cs
+++ b/src/mscorlib/shared/System/Globalization/CultureData.Unix.cs
@@ -91,7 +91,7 @@ namespace System.Globalization
         {
             // Get the locale name from ICU
             StringBuilder sb = StringBuilderCache.Acquire(ICU_ULOC_FULLNAME_CAPACITY);
-            if (!Interop.GlobalizationInterop.GetLocaleName(localeName, sb, sb.Capacity))
+            if (!Interop.Globalization.GetLocaleName(localeName, sb, sb.Capacity))
             {
                 StringBuilderCache.Release(sb);
                 windowsName = null;
@@ -107,7 +107,7 @@ namespace System.Globalization
         {
             // Get the default (system) locale name from ICU
             StringBuilder sb = StringBuilderCache.Acquire(ICU_ULOC_FULLNAME_CAPACITY);
-            if (!Interop.GlobalizationInterop.GetDefaultLocaleName(sb, sb.Capacity))
+            if (!Interop.Globalization.GetDefaultLocaleName(sb, sb.Capacity))
             {
                 StringBuilderCache.Release(sb);
                 windowsName = null;
@@ -143,7 +143,7 @@ namespace System.Globalization
 
             StringBuilder sb = StringBuilderCache.Acquire(ICU_ULOC_KEYWORD_AND_VALUES_CAPACITY);
 
-            bool result = Interop.GlobalizationInterop.GetLocaleInfoString(localeName, (uint)type, sb, sb.Capacity);
+            bool result = Interop.Globalization.GetLocaleInfoString(localeName, (uint)type, sb, sb.Capacity);
             if (!result)
             {
                 // Failed, just use empty string
@@ -169,7 +169,7 @@ namespace System.Globalization
             
 
             int value = 0;
-            bool result = Interop.GlobalizationInterop.GetLocaleInfoInt(_sWindowsName, (uint)type, ref value);
+            bool result = Interop.Globalization.GetLocaleInfoInt(_sWindowsName, (uint)type, ref value);
             if (!result)
             {
                 // Failed, just use 0
@@ -185,7 +185,7 @@ namespace System.Globalization
 
             int primaryGroupingSize = 0;
             int secondaryGroupingSize = 0;
-            bool result = Interop.GlobalizationInterop.GetLocaleInfoGroupingSizes(_sWindowsName, (uint)type, ref primaryGroupingSize, ref secondaryGroupingSize);
+            bool result = Interop.Globalization.GetLocaleInfoGroupingSizes(_sWindowsName, (uint)type, ref primaryGroupingSize, ref secondaryGroupingSize);
             if (!result)
             {
                 Debug.Fail("[CultureData.GetLocaleInfo(LocaleGroupingData type)] failed");
@@ -210,7 +210,7 @@ namespace System.Globalization
 
             StringBuilder sb = StringBuilderCache.Acquire(ICU_ULOC_KEYWORD_AND_VALUES_CAPACITY);
 
-            bool result = Interop.GlobalizationInterop.GetLocaleTimeFormat(_sWindowsName, shortFormat, sb, sb.Capacity);
+            bool result = Interop.Globalization.GetLocaleTimeFormat(_sWindowsName, shortFormat, sb, sb.Capacity);
             if (!result)
             {
                 // Failed, just use empty string
@@ -365,7 +365,7 @@ namespace System.Globalization
                 return Array.Empty<CultureInfo>();
             }
             
-            int bufferLength = Interop.GlobalizationInterop.GetLocales(null, 0);
+            int bufferLength = Interop.Globalization.GetLocales(null, 0);
             if (bufferLength <= 0)
             {
                 return Array.Empty<CultureInfo>();
@@ -373,7 +373,7 @@ namespace System.Globalization
             
             Char [] chars = new Char[bufferLength];
             
-            bufferLength = Interop.GlobalizationInterop.GetLocales(chars, bufferLength);
+            bufferLength = Interop.Globalization.GetLocales(chars, bufferLength);
             if (bufferLength <= 0)
             {
                 return Array.Empty<CultureInfo>();

--- a/src/mscorlib/shared/System/Globalization/IdnMapping.Unix.cs
+++ b/src/mscorlib/shared/System/Globalization/IdnMapping.Unix.cs
@@ -23,7 +23,7 @@ namespace System.Globalization
             if (estimatedLength < StackallocThreshold)
             {
                 char* outputStack = stackalloc char[estimatedLength];
-                actualLength = Interop.GlobalizationInterop.ToAscii(flags, unicode, count, outputStack, estimatedLength);
+                actualLength = Interop.Globalization.ToAscii(flags, unicode, count, outputStack, estimatedLength);
                 if (actualLength > 0 && actualLength <= estimatedLength)
                 {
                     return new string(outputStack, 0, actualLength);
@@ -31,7 +31,7 @@ namespace System.Globalization
             }
             else
             {
-                actualLength = Interop.GlobalizationInterop.ToAscii(flags, unicode, count, null, 0);
+                actualLength = Interop.Globalization.ToAscii(flags, unicode, count, null, 0);
             }
             if (actualLength == 0)
             {
@@ -41,7 +41,7 @@ namespace System.Globalization
             char[] outputHeap = new char[actualLength];
             fixed (char* pOutputHeap = &outputHeap[0])
             {
-                actualLength = Interop.GlobalizationInterop.ToAscii(flags, unicode, count, pOutputHeap, actualLength);
+                actualLength = Interop.Globalization.ToAscii(flags, unicode, count, pOutputHeap, actualLength);
                 if (actualLength == 0 || actualLength > outputHeap.Length)
                 {
                     throw new ArgumentException(SR.Argument_IdnIllegalName, nameof(unicode));
@@ -77,7 +77,7 @@ namespace System.Globalization
         {
             Debug.Assert(!GlobalizationMode.Invariant);
 
-            int realLen = Interop.GlobalizationInterop.ToUnicode(flags, ascii, count, output, outputLength);
+            int realLen = Interop.Globalization.ToUnicode(flags, ascii, count, output, outputLength);
 
             if (realLen == 0)
             {
@@ -108,8 +108,8 @@ namespace System.Globalization
             get
             {
                 int flags =
-                    (AllowUnassigned ? Interop.GlobalizationInterop.AllowUnassigned : 0) |
-                    (UseStd3AsciiRules ? Interop.GlobalizationInterop.UseStd3AsciiRules : 0);
+                    (AllowUnassigned ? Interop.Globalization.AllowUnassigned : 0) |
+                    (UseStd3AsciiRules ? Interop.Globalization.UseStd3AsciiRules : 0);
                 return (uint)flags;
             }
         }
@@ -123,7 +123,7 @@ namespace System.Globalization
         /// </summary>
         private static unsafe void CheckInvalidIdnCharacters(char* s, int count, uint flags, string paramName)
         {
-            if ((flags & Interop.GlobalizationInterop.UseStd3AsciiRules) == 0)
+            if ((flags & Interop.Globalization.UseStd3AsciiRules) == 0)
             {
                 for (int i = 0; i < count; i++)
                 {

--- a/src/mscorlib/shared/System/Globalization/JapaneseCalendar.Unix.cs
+++ b/src/mscorlib/shared/System/Globalization/JapaneseCalendar.Unix.cs
@@ -31,7 +31,7 @@ namespace System.Globalization
             List<EraInfo> eras = new List<EraInfo>();
             int lastMaxYear = GregorianCalendar.MaxYear;
 
-            int latestEra = Interop.GlobalizationInterop.GetLatestJapaneseEra();
+            int latestEra = Interop.Globalization.GetLatestJapaneseEra();
             for (int i = latestEra; i >= 0; i--)
             {
                 DateTime dt;
@@ -79,7 +79,7 @@ namespace System.Globalization
             int startYear;
             int startMonth;
             int startDay;
-            bool result = Interop.GlobalizationInterop.GetJapaneseEraStartDate(
+            bool result = Interop.Globalization.GetJapaneseEraStartDate(
                 era,
                 out startYear,
                 out startMonth,

--- a/src/mscorlib/shared/System/Globalization/Normalization.Unix.cs
+++ b/src/mscorlib/shared/System/Globalization/Normalization.Unix.cs
@@ -20,7 +20,7 @@ namespace System.Globalization
 
             ValidateArguments(strInput, normalizationForm);
 
-            int ret = Interop.GlobalizationInterop.IsNormalized(normalizationForm, strInput, strInput.Length);
+            int ret = Interop.Globalization.IsNormalized(normalizationForm, strInput, strInput.Length);
 
             if (ret == -1)
             {
@@ -45,7 +45,7 @@ namespace System.Globalization
 
             for (int attempts = 2; attempts > 0; attempts--)
             {
-                int realLen = Interop.GlobalizationInterop.NormalizeString(normalizationForm, strInput, strInput.Length, buf, buf.Length);
+                int realLen = Interop.Globalization.NormalizeString(normalizationForm, strInput, strInput.Length, buf, buf.Length);
 
                 if (realLen == -1)
                 {

--- a/src/mscorlib/shared/System/Globalization/TextInfo.Unix.cs
+++ b/src/mscorlib/shared/System/Globalization/TextInfo.Unix.cs
@@ -94,7 +94,7 @@ namespace System.Globalization
 
             if (IsInvariant)
             {
-                Interop.GlobalizationInterop.ChangeCaseInvariant(src, srcLen, dstBuffer, dstBufferCapacity, bToUpper);
+                Interop.Globalization.ChangeCaseInvariant(src, srcLen, dstBuffer, dstBufferCapacity, bToUpper);
             }
             else
             {
@@ -104,11 +104,11 @@ namespace System.Globalization
                 }
                 if (_needsTurkishCasing == Tristate.True)
                 {
-                    Interop.GlobalizationInterop.ChangeCaseTurkish(src, srcLen, dstBuffer, dstBufferCapacity, bToUpper);
+                    Interop.Globalization.ChangeCaseTurkish(src, srcLen, dstBuffer, dstBufferCapacity, bToUpper);
                 }
                 else
                 {
-                    Interop.GlobalizationInterop.ChangeCase(src, srcLen, dstBuffer, dstBufferCapacity, bToUpper);
+                    Interop.Globalization.ChangeCase(src, srcLen, dstBuffer, dstBufferCapacity, bToUpper);
                 }
             }
         }

--- a/src/mscorlib/src/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/src/System/Globalization/CompareInfo.Unix.cs
@@ -12,7 +12,7 @@ namespace System.Globalization
     public partial class CompareInfo
     {
         [NonSerialized]
-        private Interop.GlobalizationInterop.SafeSortHandle _sortHandle;
+        private Interop.Globalization.SafeSortHandle _sortHandle;
 
         [NonSerialized]
         private bool _isAsciiEqualityOrdinal;
@@ -27,12 +27,12 @@ namespace System.Globalization
             }
             else
             {
-                Interop.GlobalizationInterop.ResultCode resultCode = Interop.GlobalizationInterop.GetSortHandle(GetNullTerminatedUtf8String(_sortName), out _sortHandle); 
-                if (resultCode != Interop.GlobalizationInterop.ResultCode.Success)
+                Interop.Globalization.ResultCode resultCode = Interop.Globalization.GetSortHandle(GetNullTerminatedUtf8String(_sortName), out _sortHandle); 
+                if (resultCode != Interop.Globalization.ResultCode.Success)
                 {
                     _sortHandle.Dispose();
                     
-                    if (resultCode == Interop.GlobalizationInterop.ResultCode.OutOfMemory)
+                    if (resultCode == Interop.Globalization.ResultCode.OutOfMemory)
                         throw new OutOfMemoryException();
                     
                     throw new ExternalException(SR.Arg_ExternalException);
@@ -62,7 +62,7 @@ namespace System.Globalization
             {
                 fixed (char* pSource = source)
                 {
-                    int index = Interop.GlobalizationInterop.IndexOfOrdinalIgnoreCase(value, value.Length, pSource + startIndex, count, findLast: false);
+                    int index = Interop.Globalization.IndexOfOrdinalIgnoreCase(value, value.Length, pSource + startIndex, count, findLast: false);
                     return index != -1 ?
                         startIndex + index :
                         -1;
@@ -113,7 +113,7 @@ namespace System.Globalization
             {
                 fixed (char* pSource = source)
                 {
-                    int lastIndex = Interop.GlobalizationInterop.IndexOfOrdinalIgnoreCase(value, value.Length, pSource + leftStartIndex, count, findLast: true);
+                    int lastIndex = Interop.Globalization.IndexOfOrdinalIgnoreCase(value, value.Length, pSource + leftStartIndex, count, findLast: true);
                     return lastIndex != -1 ?
                         leftStartIndex + lastIndex :
                         -1;
@@ -140,7 +140,7 @@ namespace System.Globalization
         {
             Debug.Assert(!GlobalizationMode.Invariant);
 
-            return Interop.GlobalizationInterop.CompareStringOrdinalIgnoreCase(string1, count1, string2, count2);
+            return Interop.Globalization.CompareStringOrdinalIgnoreCase(string1, count1, string2, count2);
         }
 
         // TODO https://github.com/dotnet/coreclr/issues/13827:
@@ -155,7 +155,7 @@ namespace System.Globalization
             fixed (char* pString1 = &MemoryMarshal.GetReference(string1))
             fixed (char* pString2 = &string2.GetRawStringData())
             {
-                return Interop.GlobalizationInterop.CompareString(_sortHandle, pString1, string1.Length, pString2, string2.Length, options);
+                return Interop.Globalization.CompareString(_sortHandle, pString1, string1.Length, pString2, string2.Length, options);
             }
         }
 
@@ -167,7 +167,7 @@ namespace System.Globalization
             fixed (char* pString1 = &MemoryMarshal.GetReference(string1))
             fixed (char* pString2 = &MemoryMarshal.GetReference(string2))
             {
-                return Interop.GlobalizationInterop.CompareString(_sortHandle, pString1, string1.Length, pString2, string2.Length, options);
+                return Interop.Globalization.CompareString(_sortHandle, pString1, string1.Length, pString2, string2.Length, options);
             }
         }
 
@@ -212,7 +212,7 @@ namespace System.Globalization
             
             fixed (char* pSource = source)
             {
-                index = Interop.GlobalizationInterop.IndexOf(_sortHandle, target, target.Length, pSource + startIndex, count, options, matchLengthPtr);
+                index = Interop.Globalization.IndexOf(_sortHandle, target, target.Length, pSource + startIndex, count, options, matchLengthPtr);
 
                 return index != -1 ? index + startIndex : -1;
             }
@@ -247,7 +247,7 @@ namespace System.Globalization
 
             fixed (char* pSource = source)
             {
-                int lastIndex = Interop.GlobalizationInterop.LastIndexOf(_sortHandle, target, target.Length, pSource + (startIndex - count + 1), count, options);
+                int lastIndex = Interop.Globalization.LastIndexOf(_sortHandle, target, target.Length, pSource + (startIndex - count + 1), count, options);
 
                 return lastIndex != -1 ? lastIndex + leftStartIndex : -1;
             }
@@ -266,7 +266,7 @@ namespace System.Globalization
                 return IsPrefix(source, prefix, GetOrdinalCompareOptions(options));
             }
 
-            return Interop.GlobalizationInterop.StartsWith(_sortHandle, prefix, prefix.Length, source, source.Length, options);
+            return Interop.Globalization.StartsWith(_sortHandle, prefix, prefix.Length, source, source.Length, options);
         }
 
         private bool EndsWith(string source, string suffix, CompareOptions options)
@@ -282,7 +282,7 @@ namespace System.Globalization
                 return IsSuffix(source, suffix, GetOrdinalCompareOptions(options));
             }
 
-            return Interop.GlobalizationInterop.EndsWith(_sortHandle, suffix, suffix.Length, source, source.Length, options);
+            return Interop.Globalization.EndsWith(_sortHandle, suffix, suffix.Length, source, source.Length, options);
         }
         
         private unsafe SortKey CreateSortKey(String source, CompareOptions options)
@@ -303,12 +303,12 @@ namespace System.Globalization
             }
             else
             {
-                int sortKeyLength = Interop.GlobalizationInterop.GetSortKey(_sortHandle, source, source.Length, null, 0, options);
+                int sortKeyLength = Interop.Globalization.GetSortKey(_sortHandle, source, source.Length, null, 0, options);
                 keyData = new byte[sortKeyLength];
 
                 fixed (byte* pSortKey = keyData)
                 {
-                    Interop.GlobalizationInterop.GetSortKey(_sortHandle, source, source.Length, pSortKey, sortKeyLength, options);
+                    Interop.Globalization.GetSortKey(_sortHandle, source, source.Length, pSortKey, sortKeyLength, options);
                 }
             }
 
@@ -370,13 +370,13 @@ namespace System.Globalization
                 return 0;
             }
 
-            int sortKeyLength = Interop.GlobalizationInterop.GetSortKey(_sortHandle, source, source.Length, null, 0, options);
+            int sortKeyLength = Interop.Globalization.GetSortKey(_sortHandle, source, source.Length, null, 0, options);
 
             // As an optimization, for small sort keys we allocate the buffer on the stack.
             if (sortKeyLength <= 256)
             {
                 byte* pSortKey = stackalloc byte[sortKeyLength];
-                Interop.GlobalizationInterop.GetSortKey(_sortHandle, source, source.Length, pSortKey, sortKeyLength, options);
+                Interop.Globalization.GetSortKey(_sortHandle, source, source.Length, pSortKey, sortKeyLength, options);
                 return InternalHashSortKey(pSortKey, sortKeyLength);
             }
 
@@ -384,7 +384,7 @@ namespace System.Globalization
 
             fixed (byte* pSortKey = sortKey)
             {
-                Interop.GlobalizationInterop.GetSortKey(_sortHandle, source, source.Length, pSortKey, sortKeyLength, options);
+                Interop.Globalization.GetSortKey(_sortHandle, source, source.Length, pSortKey, sortKeyLength, options);
                 return InternalHashSortKey(pSortKey, sortKeyLength);
             }
         }
@@ -428,7 +428,7 @@ namespace System.Globalization
         {
             Debug.Assert(!_invariantMode);
 
-            int sortVersion = Interop.GlobalizationInterop.GetSortVersion(_sortHandle);
+            int sortVersion = Interop.Globalization.GetSortVersion(_sortHandle);
             return new SortVersion(sortVersion, LCID, new Guid(sortVersion, 0, 0, 0, 0, 0, 0,
                                                              (byte) (LCID >> 24),
                                                              (byte) ((LCID  & 0x00FF0000) >> 16),

--- a/src/mscorlib/src/System/Globalization/GlobalizationMode.Unix.cs
+++ b/src/mscorlib/src/System/Globalization/GlobalizationMode.Unix.cs
@@ -11,7 +11,7 @@ namespace System.Globalization
             bool invariantEnabled = GetInvariantSwitchValue();
             if (!invariantEnabled)
             {
-                if (Interop.GlobalizationInterop.LoadICU() == 0)
+                if (Interop.Globalization.LoadICU() == 0)
                 {
                     string message = "Couldn't find a valid ICU package installed on the system. " +
                                     "Set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support.";

--- a/src/mscorlib/src/System/TimeZoneInfo.Unix.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.Unix.cs
@@ -74,9 +74,9 @@ namespace System
             }
             _displayName = _standardDisplayName;
 
-            GetDisplayName(Interop.GlobalizationInterop.TimeZoneDisplayNameType.Generic, ref _displayName);
-            GetDisplayName(Interop.GlobalizationInterop.TimeZoneDisplayNameType.Standard, ref _standardDisplayName);
-            GetDisplayName(Interop.GlobalizationInterop.TimeZoneDisplayNameType.DaylightSavings, ref _daylightDisplayName);
+            GetDisplayName(Interop.Globalization.TimeZoneDisplayNameType.Generic, ref _displayName);
+            GetDisplayName(Interop.Globalization.TimeZoneDisplayNameType.Standard, ref _standardDisplayName);
+            GetDisplayName(Interop.Globalization.TimeZoneDisplayNameType.DaylightSavings, ref _daylightDisplayName);
 
             // TZif supports seconds-level granularity with offsets but TimeZoneInfo only supports minutes since it aligns
             // with DateTimeOffset, SQL Server, and the W3C XML Specification
@@ -94,7 +94,7 @@ namespace System
             ValidateTimeZoneInfo(_id, _baseUtcOffset, _adjustmentRules, out _supportsDaylightSavingTime);
         }
 
-        private void GetDisplayName(Interop.GlobalizationInterop.TimeZoneDisplayNameType nameType, ref string displayName)
+        private void GetDisplayName(Interop.Globalization.TimeZoneDisplayNameType nameType, ref string displayName)
         {
             if (GlobalizationMode.Invariant)
             {
@@ -104,7 +104,7 @@ namespace System
 
             string timeZoneDisplayName;
             bool result = Interop.CallStringMethod(
-                (locale, id, type, stringBuilder) => Interop.GlobalizationInterop.GetTimeZoneDisplayName(
+                (locale, id, type, stringBuilder) => Interop.Globalization.GetTimeZoneDisplayName(
                     locale,
                     id,
                     type,


### PR DESCRIPTION
Consistency with CoreFX and coding conventions.

Also delete a few other pieces of unused code.