### PR TITLE
[Local GC] FEATURE_EVENT_TRACE 2/n: Scaffolding for emitting known events 

### DIFF
--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -82,6 +82,7 @@ public:
     static bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name);
     static void WalkAsyncPinnedForPromotion(Object* object, ScanContext* sc, promote_func* callback);
     static void WalkAsyncPinned(Object* object, void* context, void(*callback)(Object*, Object*, void*));
+    static IGCToCLREventSink* EventSink();
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -270,4 +270,10 @@ inline void GCToEEInterface::WalkAsyncPinned(Object* object, void* context, void
     return g_theGCToCLR->WalkAsyncPinned(object, context, callback);
 }
 
+inline IGCToCLREventSink* GCToEEInterface::EventSink()
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->EventSink();
+}
+
 #endif // __GCTOENV_EE_STANDALONE_INL__

--- a/src/gc/gcevents.h
+++ b/src/gc/gcevents.h
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+#ifndef KNOWN_EVENT
+ #define KNOWN_EVENT(name, provider, level, keyword)
+#endif // KNOWN_EVENT
+
+#ifndef DYNAMIC_EVENT
+ #define DYNAMIC_EVENT(name, provider, level, keyword, ...)
+#endif // DYNAMIC_EVENT
+
+#undef KNOWN_EVENT
+#undef DYNAMIC_EVENT

--- a/src/gc/gceventstatus.cpp
+++ b/src/gc/gceventstatus.cpp
@@ -7,3 +7,7 @@
 
 Volatile<GCEventLevel> GCEventStatus::enabledLevels[2] = {GCEventLevel_None, GCEventLevel_None};
 Volatile<GCEventKeyword> GCEventStatus::enabledKeywords[2] = {GCEventKeyword_None, GCEventKeyword_None};
+
+#define KNOWN_EVENT(name, provider, level, keyword) \
+  GCKnownEvent name##EventDescriptor(#name, provider, level, keyword);
+#include "gcevents.h"

--- a/src/gc/gceventstatus.cpp
+++ b/src/gc/gceventstatus.cpp
@@ -7,7 +7,3 @@
 
 Volatile<GCEventLevel> GCEventStatus::enabledLevels[2] = {GCEventLevel_None, GCEventLevel_None};
 Volatile<GCEventKeyword> GCEventStatus::enabledKeywords[2] = {GCEventKeyword_None, GCEventKeyword_None};
-
-#define KNOWN_EVENT(name, provider, level, keyword) \
-  GCKnownEvent name##EventDescriptor(#name, provider, level, keyword);
-#include "gcevents.h"

--- a/src/gc/gceventstatus.h
+++ b/src/gc/gceventstatus.h
@@ -187,4 +187,59 @@ private:
     GCEventStatus() = delete;
 };
 
+class GCEventBase
+{
+private:
+    const char *m_name;
+    GCEventProvider m_provider;
+    GCEventLevel m_level;
+    GCEventKeyword m_keyword;
+
+public:
+    GCEventBase(const char *name, GCEventProvider provider, GCEventLevel level, GCEventKeyword keyword)
+        : m_name(name), m_provider(provider), m_level(level), m_keyword(keyword)
+    {}
+
+    GCEventProvider Provider() const { return m_provider; }
+
+    GCEventLevel Level() const { return m_level; }
+
+    GCEventKeyword Keyword() const { return m_keyword; }
+
+    __forceinline bool IsEnabled() const
+    {
+        return GCEventStatus::IsEnabled(m_provider, m_keyword, m_level);
+    }
+};
+
+class GCKnownEvent : public GCEventBase
+{
+public:
+    GCKnownEvent(const char *name, GCEventProvider provider, GCEventLevel level, GCEventKeyword keyword)
+        : GCEventBase(name, provider, level, keyword)
+    {}
+};
+
+class GCDynamicEvent : public GCEventBase
+{
+    /* TODO(segilles) - Not Yet Implemented */
+};
+
+#if FEATURE_EVENT_TRACE
+#define KNOWN_EVENT(name, _provider, _level, _keyword)   \
+  extern gc_events::GCKnownEvent name##EventDescriptor;
+#include "gcevents.h"
+
+#define EVENT_ENABLED(name) name##EventDescriptor.IsEnabled()
+#define FIRE_EVENT(name, ...) \
+  do {                                                      \
+    IGCToCLREventSink* sink = GCToEEInterface::EventSink(); \
+    assert(sink != nullptr);                                \
+    sink->Fire##name(__VA_ARGS__);                          \
+  } while(0)
+#else
+#define EVENT_ENABLED(name) false
+#define FIRE_EVENT(name, ...) 0
+#endif // FEATURE_EVENT_TRACE
+
 #endif // __GCEVENTSTATUS_H__

--- a/src/gc/gceventstatus.h
+++ b/src/gc/gceventstatus.h
@@ -187,50 +187,17 @@ private:
     GCEventStatus() = delete;
 };
 
-class GCEventBase
-{
-private:
-    const char *m_name;
-    GCEventProvider m_provider;
-    GCEventLevel m_level;
-    GCEventKeyword m_keyword;
-
-public:
-    GCEventBase(const char *name, GCEventProvider provider, GCEventLevel level, GCEventKeyword keyword)
-        : m_name(name), m_provider(provider), m_level(level), m_keyword(keyword)
-    {}
-
-    GCEventProvider Provider() const { return m_provider; }
-
-    GCEventLevel Level() const { return m_level; }
-
-    GCEventKeyword Keyword() const { return m_keyword; }
-
-    __forceinline bool IsEnabled() const
-    {
-        return GCEventStatus::IsEnabled(m_provider, m_keyword, m_level);
-    }
-};
-
-class GCKnownEvent : public GCEventBase
-{
-public:
-    GCKnownEvent(const char *name, GCEventProvider provider, GCEventLevel level, GCEventKeyword keyword)
-        : GCEventBase(name, provider, level, keyword)
-    {}
-};
-
-class GCDynamicEvent : public GCEventBase
+class GCDynamicEvent
 {
     /* TODO(segilles) - Not Yet Implemented */
 };
 
 #if FEATURE_EVENT_TRACE
 #define KNOWN_EVENT(name, _provider, _level, _keyword)   \
-  extern gc_events::GCKnownEvent name##EventDescriptor;
+  inline bool GCEventEnabled##name() { return GCEventStatus::IsEnabled(_provider, _level, _keyword); }
 #include "gcevents.h"
 
-#define EVENT_ENABLED(name) name##EventDescriptor.IsEnabled()
+#define EVENT_ENABLED(name) GCEventEnabled##name()
 #define FIRE_EVENT(name, ...) \
   do {                                                      \
     IGCToCLREventSink* sink = GCToEEInterface::EventSink(); \

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -5,6 +5,20 @@
 #ifndef _GCINTERFACE_EE_H_
 #define _GCINTERFACE_EE_H_
 
+
+// This interface provides functions that the GC can use to fire events.
+// Events fired on this interface are split into two categories: "known"
+// events and "dynamic" events. Known events are events that are baked-in
+// to the hosting runtime's event manifest and are part of the GC/EE interface.
+// There is one callback on IGCToCLREventSink for each known event.
+//
+// Dynamic events are constructed at runtime by the GC and are not known
+// to the EE. ([LOCALGC TODO dynamic event implementation])
+class IGCToCLREventSink
+{
+    /* [LOCALGC TODO] This will be filled with events as they get ported */
+};
+
 // This interface provides the interface that the GC will use to speak to the rest
 // of the execution engine. Everything that the GC does that requires the EE
 // to be informed or that requires EE action must go through this interface.
@@ -251,6 +265,10 @@ public:
     // This function is a no-op if "object" is not an OverlappedData object.
     virtual
     void WalkAsyncPinned(Object* object, void* context, void(*callback)(Object*, Object*, void*)) = 0;
+
+    // Returns an IGCToCLREventSink instance that can be used to fire events.
+    virtual
+    IGCToCLREventSink* EventSink() = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -69,6 +69,7 @@ set(VM_SOURCES_DAC_AND_WKS_COMMON
     formattype.cpp
     fptrstubs.cpp
     frames.cpp
+    gctoclreventsink.cpp
     gcheaputilities.cpp
     gchandleutilities.cpp
     genericdict.cpp

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1384,3 +1384,10 @@ void GCToEEInterface::WalkAsyncPinned(Object* object, void* context, void (*call
         }
     }
 }
+
+IGCToCLREventSink* GCToEEInterface::EventSink()
+{
+    LIMITED_METHOD_CONTRACT;
+
+    return &g_gcToClrEventSink;
+}

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -62,6 +62,7 @@ public:
     bool CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name);
     void WalkAsyncPinnedForPromotion(Object* object, ScanContext* sc, promote_func* callback);
     void WalkAsyncPinned(Object* object, void* context, void(*callback)(Object*, Object*, void*));
+    IGCToCLREventSink* EventSink();
 };
 
 } // namespace standalone

--- a/src/vm/gcenv.ee.standalone.cpp
+++ b/src/vm/gcenv.ee.standalone.cpp
@@ -14,6 +14,8 @@
 #include "comcallablewrapper.h"
 #endif // FEATURE_COMINTEROP
 
+#include "gctoclreventsink.h"
+
 // the method table for the WeakReference class
 extern MethodTable* pWeakReferenceMT;
 

--- a/src/vm/gcenv.ee.static.cpp
+++ b/src/vm/gcenv.ee.static.cpp
@@ -14,6 +14,8 @@
 #include "comcallablewrapper.h"
 #endif // FEATURE_COMINTEROP
 
+#include "gctoclreventsink.h"
+
 // the method table for the WeakReference class
 extern MethodTable* pWeakReferenceMT;
 

--- a/src/vm/gctoclreventsink.cpp
+++ b/src/vm/gctoclreventsink.cpp
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "common.h"
+#include "gctoclreventsink.h"
+
+GCToCLREventSink g_gcToClrEventSink;

--- a/src/vm/gctoclreventsink.h
+++ b/src/vm/gctoclreventsink.h
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef __GCTOCLREVENTSINK_H__
+#define __GCTOCLREVENTSINK_H__
+
+#include "gcinterface.h"
+
+class GCToCLREventSink : public IGCToCLREventSink
+{
+    /* [LOCALGC TODO] This will be filled with events as they get ported */
+};
+
+extern GCToCLREventSink g_gcToClrEventSink;
+
+#endif // __GCTOCLREVENTSINK_H__
+


### PR DESCRIPTION
Non-WIP version of https://github.com/dotnet/coreclr/pull/15905, with the code porting `GCAllocationTick_V3` removed and the branch renamed. This PR still depends on https://github.com/dotnet/coreclr/pull/15873 and currently branches off that branch.