### PR TITLE
Updates `Vector64<T>`, `Vector128<T>`, and `Vector256<T>` to have the appropriate packing.

### DIFF
--- a/src/vm/classnames.h
+++ b/src/vm/classnames.h
@@ -72,6 +72,15 @@
 #define g_DecimalClassName "System.Decimal"
 #define g_DecimalName "Decimal"
 
+#define g_Vector64ClassName "System.Runtime.Intrinsics.Vector64`1"
+#define g_Vector64Name "Vector64`1"
+
+#define g_Vector128ClassName "System.Runtime.Intrinsics.Vector128`1"
+#define g_Vector128Name "Vector128`1"
+
+#define g_Vector256ClassName "System.Runtime.Intrinsics.Vector256`1"
+#define g_Vector256Name "Vector256`1"
+
 #ifdef FEATURE_COMINTEROP
 
 #define g_WindowsFoundationActivatableAttributeClassName      "Windows.Foundation.Metadata.ActivatableAttribute"

--- a/src/vm/fieldmarshaler.cpp
+++ b/src/vm/fieldmarshaler.cpp
@@ -1669,7 +1669,9 @@ VOID EEClassLayoutInfo::CollectLayoutFieldMetadataThrowing(
             if (!(alignmentRequirement == 1 ||
                      alignmentRequirement == 2 ||
                      alignmentRequirement == 4 ||
-                  alignmentRequirement == 8))
+                  alignmentRequirement == 8 ||
+                  alignmentRequirement == 16 ||
+                  alignmentRequirement == 32))
             {
                 COMPlusThrowHR(COR_E_INVALIDPROGRAM, BFA_METADATA_CORRUPT);
             }
@@ -1680,7 +1682,7 @@ VOID EEClassLayoutInfo::CollectLayoutFieldMetadataThrowing(
     
             // This assert means I forgot to special-case some NFT in the
             // above switch.
-            _ASSERTE(alignmentRequirement <= 8);
+            _ASSERTE(alignmentRequirement <= 32);
     
             // Check if this field is overlapped with other(s)
             pfwalk->m_fIsOverlapped = FALSE;
@@ -1806,7 +1808,9 @@ VOID EEClassLayoutInfo::CollectLayoutFieldMetadataThrowing(
             if (!(alignmentRequirement == 1 ||
                      alignmentRequirement == 2 ||
                      alignmentRequirement == 4 ||
-                  alignmentRequirement == 8))
+                  alignmentRequirement == 8 ||
+                  alignmentRequirement == 16 ||
+                  alignmentRequirement == 32))
             {
                 COMPlusThrowHR(COR_E_INVALIDPROGRAM, BFA_METADATA_CORRUPT);
             }
@@ -1815,7 +1819,7 @@ VOID EEClassLayoutInfo::CollectLayoutFieldMetadataThrowing(
             
             LargestAlignmentRequirement = max(LargestAlignmentRequirement, alignmentRequirement);
             
-            _ASSERTE(alignmentRequirement <= 8);
+            _ASSERTE(alignmentRequirement <= 32);
             
             // Insert enough padding to align the current data member.
             while (cbCurOffset % alignmentRequirement)

--- a/src/vm/fieldmarshaler.h
+++ b/src/vm/fieldmarshaler.h
@@ -88,7 +88,7 @@ enum NStructFieldType
 // Currently we set this to the packing size of the largest supported
 // fundamental type and let the field marshaller downsize where needed.
 //=======================================================================
-#define DEFAULT_PACKING_SIZE 8
+#define DEFAULT_PACKING_SIZE 32
 
 
 //=======================================================================

--- a/src/vm/fieldmarshaler.h
+++ b/src/vm/fieldmarshaler.h
@@ -84,13 +84,11 @@ enum NStructFieldType
 
 //=======================================================================
 // Magic number for default struct packing size.
+//
+// Currently we set this to the packing size of the largest supported
+// fundamental type and let the field marshaller downsize where needed.
 //=======================================================================
-#if defined(_TARGET_X86_) && defined(UNIX_X86_ABI)
-// A double is 4-byte aligned on GCC (without -malign-dobule)
-#define DEFAULT_PACKING_SIZE 4
-#else // _TARGET_X86_ && UNIX_X86_ABI
 #define DEFAULT_PACKING_SIZE 8
-#endif // !_TARGET_X86_ || !UNIX_X86_ABI
 
 
 //=======================================================================

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -9684,6 +9684,9 @@ void MethodTableBuilder::CheckForSystemTypes()
                     pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 4;
                     break;
                 }
+
+                default:
+                    break;
             }
 #endif // _TARGET_X86_ && UNIX_X86_ABI
 

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -9535,42 +9535,118 @@ void MethodTableBuilder::CheckForSystemTypes()
 {
     STANDARD_VM_CONTRACT;
 
+    LPCUTF8 name, nameSpace;
+
     MethodTable * pMT = GetHalfBakedMethodTable();
     EEClass * pClass = GetHalfBakedClass();
 
     // We can exit early for generic types - there are just a few cases to check for.
-    if (bmtGenerics->HasInstantiation() && g_pNullableClass != NULL)
+    if (bmtGenerics->HasInstantiation())
     {
-        _ASSERTE(g_pByReferenceClass != NULL);
-        _ASSERTE(g_pByReferenceClass->IsByRefLike());
+        if (pClass->HasLayout())
+        {
+            if (FAILED(GetMDImport()->GetNameOfTypeDef(GetCl(), &name, &nameSpace)))
+            {
+                BuildMethodTableThrowException(IDS_CLASSLOAD_BADFORMAT);
+            }
+
+            if (strcmp(nameSpace, g_IntrinsicsNS) == 0)
+            {
+                EEClassLayoutInfo * pLayout = pClass->GetLayoutInfo();
+
+                // The SIMD Hardware Intrinsic types correspond to fundamental data types in the underlying ABIs:
+                // * Vector64<T>:  __m64
+                // * Vector128<T>: __m128
+                // * Vector256<T>: __m256
+
+                // These __m128 and __m256 types, among other requirements, are special in that they must always
+                // be aligned properly.
+
+                if (strcmp(name, g_Vector64Name) == 0)
+                {
+                    // The System V ABI for i386 defaults to 8-byte alignment for __m64, except for parameter passing,
+                    // where it has an alignment of 4.
+
+                    pLayout->m_LargestAlignmentRequirementOfAllMembers        = 8; // sizeof(__m64)
+                    pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 8; // sizeof(__m64)
+                }
+                else if (strcmp(name, g_Vector128Name) == 0)
+                {
+    #ifdef _TARGET_ARM_
+                    // The Procedure Call Standard for ARM defaults to 8-byte alignment for __m128
+
+                    pLayout->m_LargestAlignmentRequirementOfAllMembers        = 8;
+                    pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 8;
+    #else
+                    pLayout->m_LargestAlignmentRequirementOfAllMembers        = 16; // sizeof(__m128)
+                    pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 16; // sizeof(__m128)
+    #endif // _TARGET_ARM_
+                }
+                else if (strcmp(name, g_Vector256Name) == 0)
+                {
+    #ifdef _TARGET_ARM_
+                    // No such type exists for the Procedure Call Standard for ARM. We will default
+                    // to the same alignment as __m128, which is supported by the ABI.
+
+                    pLayout->m_LargestAlignmentRequirementOfAllMembers        = 8;
+                    pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 8;
+    #elif defined(_TARGET_ARM64_)
+                    // The Procedure Call Standard for ARM 64-bit (with SVE support) defaults to
+                    // 16-byte alignment for __m256.
+
+                    pLayout->m_LargestAlignmentRequirementOfAllMembers        = 16;
+                    pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 16;
+    #else
+                    pLayout->m_LargestAlignmentRequirementOfAllMembers        = 32; // sizeof(__m256)
+                    pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 32; // sizeof(__m256)
+    #endif // _TARGET_ARM_ elif _TARGET_ARM64_
+                }
+                else
+                {
+                    // These types should be handled or explicitly skipped below to ensure that we don't
+                    // miss adding required ABI support for future types.
+
+                    _ASSERTE_MSG((strcmp(name, "Vector64DebugView`1") == 0) ||
+                                 (strcmp(name, "Vector128DebugView`1") == 0) ||
+                                 (strcmp(name, "Vector256DebugView`1") == 0),
+                                 "Unhandled Hardware Intrinsic Type.");
+                }
+
+                return;
+            }
+        }
+
+        if (g_pNullableClass != NULL)
+        {
+            _ASSERTE(g_pByReferenceClass != NULL);
+            _ASSERTE(g_pByReferenceClass->IsByRefLike());
 
 #ifdef _TARGET_X86_
-        if (GetCl() == g_pByReferenceClass->GetCl())
-        {
-            // x86 by default treats the type of ByReference<T> as the actual type of its IntPtr field, see calls to
-            // ComputeInternalCorElementTypeForValueType in this file. This is a special case where the struct needs to be
-            // treated as a value type so that its field can be considered as a by-ref pointer.
-            _ASSERTE(pMT->GetFlag(MethodTable::enum_flag_Category_Mask) == MethodTable::enum_flag_Category_PrimitiveValueType);
-            pMT->ClearFlag(MethodTable::enum_flag_Category_Mask);
-            pMT->SetInternalCorElementType(ELEMENT_TYPE_VALUETYPE);
-            return;
-        }
+            if (GetCl() == g_pByReferenceClass->GetCl())
+            {
+                // x86 by default treats the type of ByReference<T> as the actual type of its IntPtr field, see calls to
+                // ComputeInternalCorElementTypeForValueType in this file. This is a special case where the struct needs to be
+                // treated as a value type so that its field can be considered as a by-ref pointer.
+                _ASSERTE(pMT->GetFlag(MethodTable::enum_flag_Category_Mask) == MethodTable::enum_flag_Category_PrimitiveValueType);
+                pMT->ClearFlag(MethodTable::enum_flag_Category_Mask);
+                pMT->SetInternalCorElementType(ELEMENT_TYPE_VALUETYPE);
+                return;
+            }
 #endif
 
-        _ASSERTE(g_pNullableClass->IsNullable());
+            _ASSERTE(g_pNullableClass->IsNullable());
 
-        // Pre-compute whether the class is a Nullable<T> so that code:Nullable::IsNullableType is efficient
-        // This is useful to the performance of boxing/unboxing a Nullable
-        if (GetCl() == g_pNullableClass->GetCl())
-            pMT->SetIsNullable();
+            // Pre-compute whether the class is a Nullable<T> so that code:Nullable::IsNullableType is efficient
+            // This is useful to the performance of boxing/unboxing a Nullable
+            if (GetCl() == g_pNullableClass->GetCl())
+                pMT->SetIsNullable();
 
-        return;
+            return;
+        }
     }
 
     if (IsNested() || IsEnum())
         return;
-      
-    LPCUTF8 name, nameSpace;
 
     if (FAILED(GetMDImport()->GetNameOfTypeDef(GetCl(), &name, &nameSpace)))
     {

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -9594,6 +9594,23 @@ void MethodTableBuilder::CheckForSystemTypes()
             pMT->SetInternalCorElementType(type);
             pMT->SetIsTruePrimitive();
 
+#if defined(_TARGET_X86_) && defined(UNIX_X86_ABI)
+            switch (type)
+            {
+                // The System V ABI for i386 defines different packing for these types.
+
+                case ELEMENT_TYPE_I8:
+                case ELEMENT_TYPE_U8:
+                case ELEMENT_TYPE_R8:
+                {
+                    EEClassLayoutInfo * pLayout = pClass->GetLayoutInfo();
+                    pLayout->m_LargestAlignmentRequirementOfAllMembers        = 4;
+                    pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 4;
+                    break;
+                }
+            }
+#endif // _TARGET_X86_ && UNIX_X86_ABI
+
 #ifdef _DEBUG 
             if (FAILED(GetMDImport()->GetNameOfTypeDef(GetCl(), &name, &nameSpace)))
             {

--- a/src/vm/namespace.h
+++ b/src/vm/namespace.h
@@ -33,6 +33,8 @@
 #define g_WinRTNS           g_InteropNS ".WindowsRuntime"
 #endif // FEATURE_COMINTEROP
 
+#define g_IntrinsicsNS g_RuntimeNS ".Intrinsics"
+
 #define g_InternalCompilerServicesNS "Internal.Runtime.CompilerServices"
 #define g_CompilerServicesNS g_RuntimeNS ".CompilerServices"
 

--- a/tests/src/Interop/StructPacking/StructPacking.cs
+++ b/tests/src/Interop/StructPacking/StructPacking.cs
@@ -1208,28 +1208,53 @@ unsafe class Program
     {
         bool succeeded = true;
 
-        succeeded &= Test<DefaultLayoutDefaultPacking<Vector128<byte>>>(
-            expectedSize: 24,
-            expectedOffsetByte: 0,
-            expectedOffsetValue: 8
-        );
+        if (RuntimeInformation.OSArchitecture == Architecture.Arm)
+        {
+            // The Procedure Call Standard for ARM defines this type as having 8-byte alignment
 
-        succeeded &= Test<SequentialLayoutDefaultPacking<Vector128<byte>>>(
-            expectedSize: 24,
-            expectedOffsetByte: 0,
-            expectedOffsetValue: 8
-        );
+            succeeded &= Test<DefaultLayoutDefaultPacking<Vector128<byte>>>(
+                expectedSize: 24,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<SequentialLayoutDefaultPacking<Vector128<byte>>>(
+                expectedSize: 24,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<SequentialLayoutMaxPacking<Vector128<byte>>>(
+                expectedSize: 24,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+        }
+        else
+        {
+            succeeded &= Test<DefaultLayoutDefaultPacking<Vector128<byte>>>(
+                expectedSize: 32,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 16
+            );
+
+            succeeded &= Test<SequentialLayoutDefaultPacking<Vector128<byte>>>(
+                expectedSize: 32,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 16
+            );
+
+            succeeded &= Test<SequentialLayoutMaxPacking<Vector128<byte>>>(
+                expectedSize: 32,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 16
+            );
+        }
 
         succeeded &= Test<SequentialLayoutMinPacking<Vector128<byte>>>(
             expectedSize: 17,
             expectedOffsetByte: 0,
             expectedOffsetValue: 1
-        );
-
-        succeeded &= Test<SequentialLayoutMaxPacking<Vector128<byte>>>(
-            expectedSize: 24,
-            expectedOffsetByte: 0,
-            expectedOffsetValue: 8
         );
 
         if (Environment.Is64BitProcess)
@@ -1280,28 +1305,75 @@ unsafe class Program
     {
         bool succeeded = true;
 
-        succeeded &= Test<DefaultLayoutDefaultPacking<Vector256<byte>>>(
-            expectedSize: 40,
-            expectedOffsetByte: 0,
-            expectedOffsetValue: 8
-        );
+        if (RuntimeInformation.OSArchitecture == Architecture.Arm)
+        {
+            // The Procedure Call Standard for ARM defines this type as having 8-byte alignment
 
-        succeeded &= Test<SequentialLayoutDefaultPacking<Vector256<byte>>>(
-            expectedSize: 40,
-            expectedOffsetByte: 0,
-            expectedOffsetValue: 8
-        );
+            succeeded &= Test<DefaultLayoutDefaultPacking<Vector256<byte>>>(
+                expectedSize: 40,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<SequentialLayoutDefaultPacking<Vector256<byte>>>(
+                expectedSize: 40,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<SequentialLayoutMaxPacking<Vector256<byte>>>(
+                expectedSize: 40,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+        }
+        else if (RuntimeInformation.OSArchitecture == Architecture.Arm64)
+        {
+            // The Procedure Call Standard for ARM64 defines this type as having 16-byte alignment
+
+            succeeded &= Test<DefaultLayoutDefaultPacking<Vector256<byte>>>(
+                expectedSize: 48,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 16
+            );
+
+            succeeded &= Test<SequentialLayoutDefaultPacking<Vector256<byte>>>(
+                expectedSize: 48,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 16
+            );
+
+            succeeded &= Test<SequentialLayoutMaxPacking<Vector256<byte>>>(
+                expectedSize: 48,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 16
+            );
+        }
+        else
+        {
+            succeeded &= Test<DefaultLayoutDefaultPacking<Vector256<byte>>>(
+                expectedSize: 64,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 32
+            );
+
+            succeeded &= Test<SequentialLayoutDefaultPacking<Vector256<byte>>>(
+                expectedSize: 64,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 32
+            );
+
+            succeeded &= Test<SequentialLayoutMaxPacking<Vector256<byte>>>(
+                expectedSize: 64,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 32
+            );
+        }
 
         succeeded &= Test<SequentialLayoutMinPacking<Vector256<byte>>>(
             expectedSize: 33,
             expectedOffsetByte: 0,
             expectedOffsetValue: 1
-        );
-
-        succeeded &= Test<SequentialLayoutMaxPacking<Vector256<byte>>>(
-            expectedSize: 40,
-            expectedOffsetByte: 0,
-            expectedOffsetValue: 8
         );
 
         if (Environment.Is64BitProcess)

--- a/tests/src/Interop/StructPacking/StructPacking.cs
+++ b/tests/src/Interop/StructPacking/StructPacking.cs
@@ -1,0 +1,1608 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+
+[StructLayout(LayoutKind.Sequential, Pack = 8, Size = 8)]
+struct MyVector64<T> where T : struct { }
+
+[StructLayout(LayoutKind.Sequential, Pack = 16, Size = 16)]
+struct MyVector128<T> where T : struct { }
+
+[StructLayout(LayoutKind.Sequential, Pack = 32, Size = 32)]
+struct MyVector256<T> where T : struct { }
+
+interface ITestStructure
+{
+    int Size { get; }
+    int OffsetOfByte { get; }
+    int OffsetOfValue { get; }
+}
+
+struct DefaultLayoutDefaultPacking<T> : ITestStructure
+{
+    public byte _byte;
+    public T _value;
+
+    public int Size => Unsafe.SizeOf<DefaultLayoutDefaultPacking<T>>();
+    public int OffsetOfByte => Program.OffsetOf(ref this, ref _byte);
+    public int OffsetOfValue => Program.OffsetOf(ref this, ref _value);
+}
+
+[StructLayout(LayoutKind.Sequential)]
+struct SequentialLayoutDefaultPacking<T> : ITestStructure
+{
+    public byte _byte;
+    public T _value;
+
+    public int Size => Unsafe.SizeOf<SequentialLayoutDefaultPacking<T>>();
+    public int OffsetOfByte => Program.OffsetOf(ref this, ref _byte);
+    public int OffsetOfValue => Program.OffsetOf(ref this, ref _value);
+}
+
+[StructLayout(LayoutKind.Sequential, Pack = 1)]
+struct SequentialLayoutMinPacking<T> : ITestStructure
+{
+    public byte _byte;
+    public T _value;
+
+    public int Size => Unsafe.SizeOf<SequentialLayoutMinPacking<T>>();
+    public int OffsetOfByte => Program.OffsetOf(ref this, ref _byte);
+    public int OffsetOfValue => Program.OffsetOf(ref this, ref _value);
+}
+
+[StructLayout(LayoutKind.Sequential, Pack = 128)]
+struct SequentialLayoutMaxPacking<T> : ITestStructure
+{
+    public byte _byte;
+    public T _value;
+
+    public int Size => Unsafe.SizeOf<SequentialLayoutMaxPacking<T>>();
+    public int OffsetOfByte => Program.OffsetOf(ref this, ref _byte);
+    public int OffsetOfValue => Program.OffsetOf(ref this, ref _value);
+}
+
+[StructLayout(LayoutKind.Auto)]
+struct AutoLayoutDefaultPacking<T> : ITestStructure
+{
+    public byte _byte;
+    public T _value;
+
+    public int Size => Unsafe.SizeOf<AutoLayoutDefaultPacking<T>>();
+    public int OffsetOfByte => Program.OffsetOf(ref this, ref _byte);
+    public int OffsetOfValue => Program.OffsetOf(ref this, ref _value);
+}
+
+[StructLayout(LayoutKind.Auto, Pack = 1)]
+struct AutoLayoutMinPacking<T> : ITestStructure
+{
+    public byte _byte;
+    public T _value;
+
+    public int Size => Unsafe.SizeOf<AutoLayoutMinPacking<T>>();
+    public int OffsetOfByte => Program.OffsetOf(ref this, ref _byte);
+    public int OffsetOfValue => Program.OffsetOf(ref this, ref _value);
+}
+
+[StructLayout(LayoutKind.Auto, Pack = 128)]
+struct AutoLayoutMaxPacking<T> : ITestStructure
+{
+    public byte _byte;
+    public T _value;
+
+    public int Size => Unsafe.SizeOf<AutoLayoutMaxPacking<T>>();
+    public int OffsetOfByte => Program.OffsetOf(ref this, ref _byte);
+    public int OffsetOfValue => Program.OffsetOf(ref this, ref _value);
+}
+
+unsafe class Program
+{
+    const int Pass = 100;
+    const int Fail = 0;
+
+    static int Main(string[] args)
+    {
+        bool succeeded = true;
+
+        // Test fundamental data types
+        succeeded &= TestBoolean();
+        succeeded &= TestByte();
+        succeeded &= TestChar();
+        succeeded &= TestDouble();
+        succeeded &= TestInt16();
+        succeeded &= TestInt32();
+        succeeded &= TestInt64();
+        succeeded &= TestIntPtr();
+        succeeded &= TestSByte();
+        succeeded &= TestSingle();
+        succeeded &= TestUInt16();
+        succeeded &= TestUInt32();
+        succeeded &= TestUInt64();
+        succeeded &= TestUIntPtr();
+        succeeded &= TestVector64();
+        succeeded &= TestVector128();
+        succeeded &= TestVector256();
+
+        // Test custom data types with explicit size/packing 
+        succeeded &= TestMyVector64();
+        succeeded &= TestMyVector128();
+        succeeded &= TestMyVector256();
+
+        return succeeded ? Pass : Fail;
+    }
+
+    static bool TestBoolean()
+    {
+        bool succeeded = true;
+
+        succeeded &= Test<DefaultLayoutDefaultPacking<bool>>(
+            expectedSize: 2,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<SequentialLayoutDefaultPacking<bool>>(
+            expectedSize: 2,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<SequentialLayoutMinPacking<bool>>(
+            expectedSize: 2,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<SequentialLayoutMaxPacking<bool>>(
+            expectedSize: 2,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<AutoLayoutDefaultPacking<bool>>(
+            expectedSize: 2,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<AutoLayoutMinPacking<bool>>(
+            expectedSize: 2,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<AutoLayoutMaxPacking<bool>>(
+            expectedSize: 2,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        return succeeded;
+    }
+
+    static bool TestByte()
+    {
+        bool succeeded = true;
+
+        succeeded &= Test<DefaultLayoutDefaultPacking<byte>>(
+            expectedSize: 2,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<SequentialLayoutDefaultPacking<byte>>(
+            expectedSize: 2,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<SequentialLayoutMinPacking<byte>>(
+            expectedSize: 2,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<SequentialLayoutMaxPacking<byte>>(
+            expectedSize: 2,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<AutoLayoutDefaultPacking<byte>>(
+            expectedSize: 2,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<AutoLayoutMinPacking<byte>>(
+            expectedSize: 2,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<AutoLayoutMaxPacking<byte>>(
+            expectedSize: 2,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        return succeeded;
+    }
+
+    static bool TestChar()
+    {
+        bool succeeded = true;
+
+        succeeded &= Test<DefaultLayoutDefaultPacking<char>>(
+            expectedSize: 4,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 2
+        );
+
+        succeeded &= Test<SequentialLayoutDefaultPacking<char>>(
+            expectedSize: 4,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 2
+        );
+
+        succeeded &= Test<SequentialLayoutMinPacking<char>>(
+            expectedSize: 3,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<SequentialLayoutMaxPacking<char>>(
+            expectedSize: 4,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 2
+        );
+
+        succeeded &= Test<AutoLayoutDefaultPacking<char>>(
+            expectedSize: 4,
+            expectedOffsetByte: 2,
+            expectedOffsetValue: 0
+        );
+
+        succeeded &= Test<AutoLayoutMinPacking<char>>(
+            expectedSize: 4,
+            expectedOffsetByte: 2,
+            expectedOffsetValue: 0
+        );
+
+        succeeded &= Test<AutoLayoutMaxPacking<char>>(
+            expectedSize: 4,
+            expectedOffsetByte: 2,
+            expectedOffsetValue: 0
+        );
+
+        return succeeded;
+    }
+
+    static bool TestDouble()
+    {
+        bool succeeded = true;
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || (RuntimeInformation.OSArchitecture != Architecture.X86))
+        {
+            succeeded &= Test<DefaultLayoutDefaultPacking<double>>(
+                expectedSize: 16,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<SequentialLayoutDefaultPacking<double>>(
+                expectedSize: 16,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<SequentialLayoutMinPacking<double>>(
+                expectedSize: 9,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 1
+            );
+
+            succeeded &= Test<SequentialLayoutMaxPacking<double>>(
+                expectedSize: 16,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            if (Environment.Is64BitProcess)
+            {
+                succeeded &= Test<AutoLayoutDefaultPacking<double>>(
+                    expectedSize: 16,
+                    expectedOffsetByte: 8,
+                    expectedOffsetValue: 0
+                );
+
+                succeeded &= Test<AutoLayoutMinPacking<double>>(
+                    expectedSize: 16,
+                    expectedOffsetByte: 8,
+                    expectedOffsetValue: 0
+                );
+
+                succeeded &= Test<AutoLayoutMaxPacking<double>>(
+                    expectedSize: 16,
+                    expectedOffsetByte: 8,
+                    expectedOffsetValue: 0
+                );
+            }
+            else
+            {
+                succeeded &= Test<AutoLayoutDefaultPacking<double>>(
+                    expectedSize: 12,
+                    expectedOffsetByte: 8,
+                    expectedOffsetValue: 0
+                );
+
+                succeeded &= Test<AutoLayoutMinPacking<double>>(
+                    expectedSize: 12,
+                    expectedOffsetByte: 8,
+                    expectedOffsetValue: 0
+                );
+
+                succeeded &= Test<AutoLayoutMaxPacking<double>>(
+                    expectedSize: 12,
+                    expectedOffsetByte: 8,
+                    expectedOffsetValue: 0
+                );
+            }
+        }
+        else
+        {
+            // The System V ABI for i386 defines this type as having 4-byte alignment
+
+            succeeded &= Test<DefaultLayoutDefaultPacking<double>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<SequentialLayoutDefaultPacking<double>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<SequentialLayoutMinPacking<double>>(
+                expectedSize: 9,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 1
+            );
+
+            succeeded &= Test<SequentialLayoutMaxPacking<double>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<AutoLayoutDefaultPacking<double>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<AutoLayoutMinPacking<double>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<AutoLayoutMaxPacking<double>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+        }
+
+        return succeeded;
+    }
+
+    static bool TestInt16()
+    {
+        bool succeeded = true;
+
+        succeeded &= Test<DefaultLayoutDefaultPacking<short>>(
+            expectedSize: 4,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 2
+        );
+
+        succeeded &= Test<SequentialLayoutDefaultPacking<short>>(
+            expectedSize: 4,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 2
+        );
+
+        succeeded &= Test<SequentialLayoutMinPacking<short>>(
+            expectedSize: 3,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<SequentialLayoutMaxPacking<short>>(
+            expectedSize: 4,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 2
+        );
+
+        succeeded &= Test<AutoLayoutDefaultPacking<short>>(
+            expectedSize: 4,
+            expectedOffsetByte: 2,
+            expectedOffsetValue: 0
+        );
+
+        succeeded &= Test<AutoLayoutMinPacking<short>>(
+            expectedSize: 4,
+            expectedOffsetByte: 2,
+            expectedOffsetValue: 0
+        );
+
+        succeeded &= Test<AutoLayoutMaxPacking<short>>(
+            expectedSize: 4,
+            expectedOffsetByte: 2,
+            expectedOffsetValue: 0
+        );
+
+        return succeeded;
+    }
+
+    static bool TestInt32()
+    {
+        bool succeeded = true;
+
+        succeeded &= Test<DefaultLayoutDefaultPacking<int>>(
+            expectedSize: 8,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 4
+        );
+
+        succeeded &= Test<SequentialLayoutDefaultPacking<int>>(
+            expectedSize: 8,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 4
+        );
+
+        succeeded &= Test<SequentialLayoutMinPacking<int>>(
+            expectedSize: 5,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<SequentialLayoutMaxPacking<int>>(
+            expectedSize: 8,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 4
+        );
+
+        succeeded &= Test<AutoLayoutDefaultPacking<int>>(
+            expectedSize: 8,
+            expectedOffsetByte: 4,
+            expectedOffsetValue: 0
+        );
+
+        succeeded &= Test<AutoLayoutMinPacking<int>>(
+            expectedSize: 8,
+            expectedOffsetByte: 4,
+            expectedOffsetValue: 0
+        );
+
+        succeeded &= Test<AutoLayoutMaxPacking<int>>(
+            expectedSize: 8,
+            expectedOffsetByte: 4,
+            expectedOffsetValue: 0
+        );
+
+        return succeeded;
+    }
+
+    static bool TestInt64()
+    {
+        bool succeeded = true;
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || (RuntimeInformation.OSArchitecture != Architecture.X86))
+        {
+            succeeded &= Test<DefaultLayoutDefaultPacking<long>>(
+                expectedSize: 16,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<SequentialLayoutDefaultPacking<long>>(
+                expectedSize: 16,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<SequentialLayoutMinPacking<long>>(
+                expectedSize: 9,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 1
+            );
+
+            succeeded &= Test<SequentialLayoutMaxPacking<long>>(
+                expectedSize: 16,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            if (Environment.Is64BitProcess)
+            {
+                succeeded &= Test<AutoLayoutDefaultPacking<long>>(
+                    expectedSize: 16,
+                    expectedOffsetByte: 8,
+                    expectedOffsetValue: 0
+                );
+
+                succeeded &= Test<AutoLayoutMinPacking<long>>(
+                    expectedSize: 16,
+                    expectedOffsetByte: 8,
+                    expectedOffsetValue: 0
+                );
+
+                succeeded &= Test<AutoLayoutMaxPacking<long>>(
+                    expectedSize: 16,
+                    expectedOffsetByte: 8,
+                    expectedOffsetValue: 0
+                );
+            }
+            else
+            {
+                succeeded &= Test<AutoLayoutDefaultPacking<long>>(
+                    expectedSize: 12,
+                    expectedOffsetByte: 8,
+                    expectedOffsetValue: 0
+                );
+
+                succeeded &= Test<AutoLayoutMinPacking<long>>(
+                    expectedSize: 12,
+                    expectedOffsetByte: 8,
+                    expectedOffsetValue: 0
+                );
+
+                succeeded &= Test<AutoLayoutMaxPacking<long>>(
+                    expectedSize: 12,
+                    expectedOffsetByte: 8,
+                    expectedOffsetValue: 0
+                );
+            }
+        }
+        else
+        {
+            // The System V ABI for i386 defines this type as having 4-byte alignment
+
+            succeeded &= Test<DefaultLayoutDefaultPacking<long>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<SequentialLayoutDefaultPacking<long>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<SequentialLayoutMinPacking<long>>(
+                expectedSize: 9,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 1
+            );
+
+            succeeded &= Test<SequentialLayoutMaxPacking<long>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<AutoLayoutDefaultPacking<long>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<AutoLayoutMinPacking<long>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<AutoLayoutMaxPacking<long>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+        }
+
+        return succeeded;
+    }
+
+    static bool TestIntPtr()
+    {
+        bool succeeded = true;
+
+        if (Environment.Is64BitProcess)
+        {
+            succeeded &= Test<DefaultLayoutDefaultPacking<IntPtr>>(
+                expectedSize: 16,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<SequentialLayoutDefaultPacking<IntPtr>>(
+                expectedSize: 16,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<SequentialLayoutMinPacking<IntPtr>>(
+                expectedSize: 9,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 1
+            );
+
+            succeeded &= Test<SequentialLayoutMaxPacking<IntPtr>>(
+                expectedSize: 16,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<AutoLayoutDefaultPacking<IntPtr>>(
+                expectedSize: 16,
+                expectedOffsetByte: 8,
+                expectedOffsetValue: 0
+            );
+
+            succeeded &= Test<AutoLayoutMinPacking<IntPtr>>(
+                expectedSize: 16,
+                expectedOffsetByte: 8,
+                expectedOffsetValue: 0
+            );
+
+            succeeded &= Test<AutoLayoutMaxPacking<IntPtr>>(
+                expectedSize: 16,
+                expectedOffsetByte: 8,
+                expectedOffsetValue: 0
+            );
+        }
+        else
+        {
+            succeeded &= Test<DefaultLayoutDefaultPacking<IntPtr>>(
+                expectedSize: 8,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<SequentialLayoutDefaultPacking<IntPtr>>(
+                expectedSize: 8,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<SequentialLayoutMinPacking<IntPtr>>(
+                expectedSize: 5,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 1
+            );
+
+            succeeded &= Test<SequentialLayoutMaxPacking<IntPtr>>(
+                expectedSize: 8,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<AutoLayoutDefaultPacking<IntPtr>>(
+                expectedSize: 8,
+                expectedOffsetByte: 4,
+                expectedOffsetValue: 0
+            );
+
+            succeeded &= Test<AutoLayoutMinPacking<IntPtr>>(
+                expectedSize: 8,
+                expectedOffsetByte: 4,
+                expectedOffsetValue: 0
+            );
+
+            succeeded &= Test<AutoLayoutMaxPacking<IntPtr>>(
+                expectedSize: 8,
+                expectedOffsetByte: 4,
+                expectedOffsetValue: 0
+            );
+        }
+
+        return succeeded;
+    }
+
+    static bool TestSByte()
+    {
+        bool succeeded = true;
+
+        succeeded &= Test<DefaultLayoutDefaultPacking<sbyte>>(
+            expectedSize: 2,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<SequentialLayoutDefaultPacking<sbyte>>(
+            expectedSize: 2,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<SequentialLayoutMinPacking<sbyte>>(
+            expectedSize: 2,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<SequentialLayoutMaxPacking<sbyte>>(
+            expectedSize: 2,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<AutoLayoutDefaultPacking<sbyte>>(
+            expectedSize: 2,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<AutoLayoutMinPacking<sbyte>>(
+            expectedSize: 2,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<AutoLayoutMaxPacking<sbyte>>(
+            expectedSize: 2,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        return succeeded;
+    }
+
+    static bool TestSingle()
+    {
+        bool succeeded = true;
+
+        succeeded &= Test<DefaultLayoutDefaultPacking<float>>(
+            expectedSize: 8,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 4
+        );
+
+        succeeded &= Test<SequentialLayoutDefaultPacking<float>>(
+            expectedSize: 8,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 4
+        );
+
+        succeeded &= Test<SequentialLayoutMinPacking<float>>(
+            expectedSize: 5,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<SequentialLayoutMaxPacking<float>>(
+            expectedSize: 8,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 4
+        );
+
+        succeeded &= Test<AutoLayoutDefaultPacking<float>>(
+            expectedSize: 8,
+            expectedOffsetByte: 4,
+            expectedOffsetValue: 0
+        );
+
+        succeeded &= Test<AutoLayoutMinPacking<float>>(
+            expectedSize: 8,
+            expectedOffsetByte: 4,
+            expectedOffsetValue: 0
+        );
+
+        succeeded &= Test<AutoLayoutMaxPacking<float>>(
+            expectedSize: 8,
+            expectedOffsetByte: 4,
+            expectedOffsetValue: 0
+        );
+
+        return succeeded;
+    }
+
+    static bool TestUInt16()
+    {
+        bool succeeded = true;
+
+        succeeded &= Test<DefaultLayoutDefaultPacking<ushort>>(
+            expectedSize: 4,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 2
+        );
+
+        succeeded &= Test<SequentialLayoutDefaultPacking<ushort>>(
+            expectedSize: 4,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 2
+        );
+
+        succeeded &= Test<SequentialLayoutMinPacking<ushort>>(
+            expectedSize: 3,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<SequentialLayoutMaxPacking<ushort>>(
+            expectedSize: 4,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 2
+        );
+
+        succeeded &= Test<AutoLayoutDefaultPacking<ushort>>(
+            expectedSize: 4,
+            expectedOffsetByte: 2,
+            expectedOffsetValue: 0
+        );
+
+        succeeded &= Test<AutoLayoutMinPacking<ushort>>(
+            expectedSize: 4,
+            expectedOffsetByte: 2,
+            expectedOffsetValue: 0
+        );
+
+        succeeded &= Test<AutoLayoutMaxPacking<ushort>>(
+            expectedSize: 4,
+            expectedOffsetByte: 2,
+            expectedOffsetValue: 0
+        );
+
+        return succeeded;
+    }
+
+    static bool TestUInt32()
+    {
+        bool succeeded = true;
+
+        succeeded &= Test<DefaultLayoutDefaultPacking<uint>>(
+            expectedSize: 8,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 4
+        );
+
+        succeeded &= Test<SequentialLayoutDefaultPacking<uint>>(
+            expectedSize: 8,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 4
+        );
+
+        succeeded &= Test<SequentialLayoutMinPacking<uint>>(
+            expectedSize: 5,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<SequentialLayoutMaxPacking<uint>>(
+            expectedSize: 8,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 4
+        );
+
+        succeeded &= Test<AutoLayoutDefaultPacking<uint>>(
+            expectedSize: 8,
+            expectedOffsetByte: 4,
+            expectedOffsetValue: 0
+        );
+
+        succeeded &= Test<AutoLayoutMinPacking<uint>>(
+            expectedSize: 8,
+            expectedOffsetByte: 4,
+            expectedOffsetValue: 0
+        );
+
+        succeeded &= Test<AutoLayoutMaxPacking<uint>>(
+            expectedSize: 8,
+            expectedOffsetByte: 4,
+            expectedOffsetValue: 0
+        );
+
+        return succeeded;
+    }
+
+    static bool TestUInt64()
+    {
+        bool succeeded = true;
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || (RuntimeInformation.OSArchitecture != Architecture.X86))
+        {
+            succeeded &= Test<DefaultLayoutDefaultPacking<double>>(
+                expectedSize: 16,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<SequentialLayoutDefaultPacking<double>>(
+                expectedSize: 16,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<SequentialLayoutMinPacking<double>>(
+                expectedSize: 9,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 1
+            );
+
+            succeeded &= Test<SequentialLayoutMaxPacking<double>>(
+                expectedSize: 16,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            if (Environment.Is64BitProcess)
+            {
+                succeeded &= Test<AutoLayoutDefaultPacking<double>>(
+                    expectedSize: 16,
+                    expectedOffsetByte: 8,
+                    expectedOffsetValue: 0
+                );
+
+                succeeded &= Test<AutoLayoutMinPacking<double>>(
+                    expectedSize: 16,
+                    expectedOffsetByte: 8,
+                    expectedOffsetValue: 0
+                );
+
+                succeeded &= Test<AutoLayoutMaxPacking<double>>(
+                    expectedSize: 16,
+                    expectedOffsetByte: 8,
+                    expectedOffsetValue: 0
+                );
+            }
+            else
+            {
+                succeeded &= Test<AutoLayoutDefaultPacking<double>>(
+                    expectedSize: 12,
+                    expectedOffsetByte: 8,
+                    expectedOffsetValue: 0
+                );
+
+                succeeded &= Test<AutoLayoutMinPacking<double>>(
+                    expectedSize: 12,
+                    expectedOffsetByte: 8,
+                    expectedOffsetValue: 0
+                );
+
+                succeeded &= Test<AutoLayoutMaxPacking<double>>(
+                    expectedSize: 12,
+                    expectedOffsetByte: 8,
+                    expectedOffsetValue: 0
+                );
+            }
+        }
+        else
+        {
+            // The System V ABI for i386 defines this type as having 4-byte alignment
+
+            succeeded &= Test<DefaultLayoutDefaultPacking<double>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<SequentialLayoutDefaultPacking<double>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<SequentialLayoutMinPacking<double>>(
+                expectedSize: 9,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 1
+            );
+
+            succeeded &= Test<SequentialLayoutMaxPacking<double>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<AutoLayoutDefaultPacking<double>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<AutoLayoutMinPacking<double>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<AutoLayoutMaxPacking<double>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+        }
+
+        return succeeded;
+    }
+
+    static bool TestUIntPtr()
+    {
+        bool succeeded = true;
+
+        if (Environment.Is64BitProcess)
+        {
+            succeeded &= Test<DefaultLayoutDefaultPacking<UIntPtr>>(
+                expectedSize: 16,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<SequentialLayoutDefaultPacking<UIntPtr>>(
+                expectedSize: 16,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<SequentialLayoutMinPacking<UIntPtr>>(
+                expectedSize: 9,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 1
+            );
+
+            succeeded &= Test<SequentialLayoutMaxPacking<UIntPtr>>(
+                expectedSize: 16,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<AutoLayoutDefaultPacking<UIntPtr>>(
+                expectedSize: 16,
+                expectedOffsetByte: 8,
+                expectedOffsetValue: 0
+            );
+
+            succeeded &= Test<AutoLayoutMinPacking<UIntPtr>>(
+                expectedSize: 16,
+                expectedOffsetByte: 8,
+                expectedOffsetValue: 0
+            );
+
+            succeeded &= Test<AutoLayoutMaxPacking<UIntPtr>>(
+                expectedSize: 16,
+                expectedOffsetByte: 8,
+                expectedOffsetValue: 0
+            );
+        }
+        else
+        {
+            succeeded &= Test<DefaultLayoutDefaultPacking<UIntPtr>>(
+                expectedSize: 8,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<SequentialLayoutDefaultPacking<UIntPtr>>(
+                expectedSize: 8,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<SequentialLayoutMinPacking<UIntPtr>>(
+                expectedSize: 5,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 1
+            );
+
+            succeeded &= Test<SequentialLayoutMaxPacking<UIntPtr>>(
+                expectedSize: 8,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<AutoLayoutDefaultPacking<UIntPtr>>(
+                expectedSize: 8,
+                expectedOffsetByte: 4,
+                expectedOffsetValue: 0
+            );
+
+            succeeded &= Test<AutoLayoutMinPacking<UIntPtr>>(
+                expectedSize: 8,
+                expectedOffsetByte: 4,
+                expectedOffsetValue: 0
+            );
+
+            succeeded &= Test<AutoLayoutMaxPacking<UIntPtr>>(
+                expectedSize: 8,
+                expectedOffsetByte: 4,
+                expectedOffsetValue: 0
+            );
+        }
+
+        return succeeded;
+    }
+
+    static bool TestVector64()
+    {
+        bool succeeded = true;
+
+        succeeded &= Test<DefaultLayoutDefaultPacking<Vector64<byte>>>(
+            expectedSize: 16,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 8
+        );
+        
+        succeeded &= Test<SequentialLayoutDefaultPacking<Vector64<byte>>>(
+            expectedSize: 16,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 8
+        );
+        
+        succeeded &= Test<SequentialLayoutMinPacking<Vector64<byte>>>(
+            expectedSize: 9,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+        
+        succeeded &= Test<SequentialLayoutMaxPacking<Vector64<byte>>>(
+            expectedSize: 16,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 8
+        );
+        
+        if (Environment.Is64BitProcess)
+        {
+            succeeded &= Test<AutoLayoutDefaultPacking<Vector64<byte>>>(
+                expectedSize: 16,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+        
+            succeeded &= Test<AutoLayoutMinPacking<Vector64<byte>>>(
+                expectedSize: 16,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+        
+            succeeded &= Test<AutoLayoutMaxPacking<Vector64<byte>>>(
+                expectedSize: 16,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+        }
+        else
+        {
+            succeeded &= Test<AutoLayoutDefaultPacking<Vector64<byte>>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+        
+            succeeded &= Test<AutoLayoutMinPacking<Vector64<byte>>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+        
+            succeeded &= Test<AutoLayoutMaxPacking<Vector64<byte>>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+        }
+
+        return succeeded;
+    }
+
+    static bool TestVector128()
+    {
+        bool succeeded = true;
+
+        succeeded &= Test<DefaultLayoutDefaultPacking<Vector128<byte>>>(
+            expectedSize: 24,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 8
+        );
+
+        succeeded &= Test<SequentialLayoutDefaultPacking<Vector128<byte>>>(
+            expectedSize: 24,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 8
+        );
+
+        succeeded &= Test<SequentialLayoutMinPacking<Vector128<byte>>>(
+            expectedSize: 17,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<SequentialLayoutMaxPacking<Vector128<byte>>>(
+            expectedSize: 24,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 8
+        );
+
+        if (Environment.Is64BitProcess)
+        {
+            succeeded &= Test<AutoLayoutDefaultPacking<Vector128<byte>>>(
+                expectedSize: 24,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<AutoLayoutMinPacking<Vector128<byte>>>(
+                expectedSize: 24,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<AutoLayoutMaxPacking<Vector128<byte>>>(
+                expectedSize: 24,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+        }
+        else
+        {
+            succeeded &= Test<AutoLayoutDefaultPacking<Vector128<byte>>>(
+                expectedSize: 20,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<AutoLayoutMinPacking<Vector128<byte>>>(
+                expectedSize: 20,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<AutoLayoutMaxPacking<Vector128<byte>>>(
+                expectedSize: 20,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+        }
+
+        return succeeded;
+    }
+
+    static bool TestVector256()
+    {
+        bool succeeded = true;
+
+        succeeded &= Test<DefaultLayoutDefaultPacking<Vector256<byte>>>(
+            expectedSize: 40,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 8
+        );
+
+        succeeded &= Test<SequentialLayoutDefaultPacking<Vector256<byte>>>(
+            expectedSize: 40,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 8
+        );
+
+        succeeded &= Test<SequentialLayoutMinPacking<Vector256<byte>>>(
+            expectedSize: 33,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<SequentialLayoutMaxPacking<Vector256<byte>>>(
+            expectedSize: 40,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 8
+        );
+
+        if (Environment.Is64BitProcess)
+        {
+            succeeded &= Test<AutoLayoutDefaultPacking<Vector256<byte>>>(
+                expectedSize: 40,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<AutoLayoutMinPacking<Vector256<byte>>>(
+                expectedSize: 40,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<AutoLayoutMaxPacking<Vector256<byte>>>(
+                expectedSize: 40,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+        }
+        else
+        {
+            succeeded &= Test<AutoLayoutDefaultPacking<Vector256<byte>>>(
+                expectedSize: 36,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<AutoLayoutMinPacking<Vector256<byte>>>(
+                expectedSize: 36,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<AutoLayoutMaxPacking<Vector256<byte>>>(
+                expectedSize: 36,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+        }
+
+        return succeeded;
+    }
+
+    static bool TestMyVector64()
+    {
+        bool succeeded = true;
+
+        succeeded &= Test<DefaultLayoutDefaultPacking<MyVector64<byte>>>(
+            expectedSize: 9,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+        
+        succeeded &= Test<SequentialLayoutDefaultPacking<MyVector64<byte>>>(
+            expectedSize: 9,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+        
+        succeeded &= Test<SequentialLayoutMinPacking<MyVector64<byte>>>(
+            expectedSize: 9,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+        
+        succeeded &= Test<SequentialLayoutMaxPacking<MyVector64<byte>>>(
+            expectedSize: 9,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+        
+        if (Environment.Is64BitProcess)
+        {
+            succeeded &= Test<AutoLayoutDefaultPacking<MyVector64<byte>>>(
+                expectedSize: 16,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+        
+            succeeded &= Test<AutoLayoutMinPacking<MyVector64<byte>>>(
+                expectedSize: 16,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+        
+            succeeded &= Test<AutoLayoutMaxPacking<MyVector64<byte>>>(
+                expectedSize: 16,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+        }
+        else
+        {
+            succeeded &= Test<AutoLayoutDefaultPacking<MyVector64<byte>>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+        
+            succeeded &= Test<AutoLayoutMinPacking<MyVector64<byte>>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+        
+            succeeded &= Test<AutoLayoutMaxPacking<MyVector64<byte>>>(
+                expectedSize: 12,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+        }
+
+        return succeeded;
+    }
+
+    static bool TestMyVector128()
+    {
+        bool succeeded = true;
+
+        succeeded &= Test<DefaultLayoutDefaultPacking<MyVector128<byte>>>(
+            expectedSize: 17,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<SequentialLayoutDefaultPacking<MyVector128<byte>>>(
+            expectedSize: 17,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<SequentialLayoutMinPacking<MyVector128<byte>>>(
+            expectedSize: 17,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<SequentialLayoutMaxPacking<MyVector128<byte>>>(
+            expectedSize: 17,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        if (Environment.Is64BitProcess)
+        {
+            succeeded &= Test<AutoLayoutDefaultPacking<MyVector128<byte>>>(
+                expectedSize: 24,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<AutoLayoutMinPacking<MyVector128<byte>>>(
+                expectedSize: 24,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<AutoLayoutMaxPacking<MyVector128<byte>>>(
+                expectedSize: 24,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+        }
+        else
+        {
+            succeeded &= Test<AutoLayoutDefaultPacking<MyVector128<byte>>>(
+                expectedSize: 20,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<AutoLayoutMinPacking<MyVector128<byte>>>(
+                expectedSize: 20,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<AutoLayoutMaxPacking<MyVector128<byte>>>(
+                expectedSize: 20,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+        }
+
+        return succeeded;
+    }
+
+    static bool TestMyVector256()
+    {
+        bool succeeded = true;
+
+        succeeded &= Test<DefaultLayoutDefaultPacking<MyVector256<byte>>>(
+            expectedSize: 33,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<SequentialLayoutDefaultPacking<MyVector256<byte>>>(
+            expectedSize: 33,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<SequentialLayoutMinPacking<MyVector256<byte>>>(
+            expectedSize: 33,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        succeeded &= Test<SequentialLayoutMaxPacking<MyVector256<byte>>>(
+            expectedSize: 33,
+            expectedOffsetByte: 0,
+            expectedOffsetValue: 1
+        );
+
+        if (Environment.Is64BitProcess)
+        {
+            succeeded &= Test<AutoLayoutDefaultPacking<MyVector256<byte>>>(
+                expectedSize: 40,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<AutoLayoutMinPacking<MyVector256<byte>>>(
+                expectedSize: 40,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+
+            succeeded &= Test<AutoLayoutMaxPacking<MyVector256<byte>>>(
+                expectedSize: 40,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 8
+            );
+        }
+        else
+        {
+            succeeded &= Test<AutoLayoutDefaultPacking<MyVector256<byte>>>(
+                expectedSize: 36,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<AutoLayoutMinPacking<MyVector256<byte>>>(
+                expectedSize: 36,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+
+            succeeded &= Test<AutoLayoutMaxPacking<MyVector256<byte>>>(
+                expectedSize: 36,
+                expectedOffsetByte: 0,
+                expectedOffsetValue: 4
+            );
+        }
+
+        return succeeded;
+    }
+
+    static bool Test<T>(int expectedSize, int expectedOffsetByte, int expectedOffsetValue) where T : ITestStructure
+    {
+        bool succeeded = true;
+        var testStructure = default(T);
+
+        int size = testStructure.Size;
+        if (size != expectedSize)
+        {
+            Console.WriteLine($"Unexpected Size for {testStructure.GetType()}.");
+            Console.WriteLine($"     Expected: {expectedSize}; Actual: {size}");
+            succeeded = false;
+        }
+
+        int offsetByte = testStructure.OffsetOfByte;
+        if (offsetByte != expectedOffsetByte)
+        {
+            Console.WriteLine($"Unexpected Offset for {testStructure.GetType()}.Byte.");
+            Console.WriteLine($"     Expected: {expectedOffsetByte}; Actual: {offsetByte}");
+            succeeded = false;
+        }
+
+        int offsetValue = testStructure.OffsetOfValue;
+        if (offsetValue != expectedOffsetValue)
+        {
+            Console.WriteLine($"Unexpected Offset for {testStructure.GetType()}.Value.");
+            Console.WriteLine($"     Expected: {expectedOffsetValue}; Actual: {offsetValue}");
+            succeeded = false;
+        }
+
+        if (!succeeded)
+        {
+            Console.WriteLine();
+        }
+
+        return succeeded;
+    }
+
+    internal static int OffsetOf<T, U>(ref T origin, ref U target)
+    {
+        return Unsafe.ByteOffset(ref origin, ref Unsafe.As<U, T>(ref target)).ToInt32();
+    }
+}

--- a/tests/src/Interop/StructPacking/StructPacking.csproj
+++ b/tests/src/Interop/StructPacking/StructPacking.csproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="StructPacking.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
As per the discussion in https://github.com/dotnet/coreclr/issues/15943.

This updates the VM to specially handle `Vector64<T>`, `Vector128<T>`, and `Vector256<T>` so that they have the requisite packing levels as described in the various ABI specifications.

Unlike several of the other fundamental data types, these types are required to have a specific packing and are expected to use that packing regardless of the packing of the parent structure.

`LayoutKind.Auto` hasn't been handled yet as that is a bit more complicated.