### PR TITLE
Add "CLRJitAttachState" global export from coreclr.dll that contains the CLR_DEBUGGING_PROCESS_FLAGS.

### DIFF
--- a/src/debug/ee/debugger.h
+++ b/src/debug/ee/debugger.h
@@ -110,6 +110,7 @@ typedef DPTR(struct DebuggerIPCControlBlock) PTR_DebuggerIPCControlBlock;
 
 GPTR_DECL(Debugger,         g_pDebugger);
 GPTR_DECL(EEDebugInterface, g_pEEInterface);
+GVAL_DECL(ULONG,            CLRJitAttachState);
 #ifndef FEATURE_PAL
 GVAL_DECL(HANDLE,           g_hContinueStartupEvent);
 #endif
@@ -2849,13 +2850,7 @@ private:
 #endif
     LONG                  m_threadsAtUnsafePlaces;
     Volatile<BOOL>        m_jitAttachInProgress;
-
-    // True if after the jit attach we plan to send a managed non-catchup
-    // debug event
-    BOOL                  m_attachingForManagedEvent;
     BOOL                  m_launchingDebugger;
-    BOOL                  m_userRequestedDebuggerLaunch;
-
     BOOL                  m_LoggingEnabled;
     AppDomainEnumerationIPCBlock    *m_pAppDomainCB;
 

--- a/src/dlls/mscoree/mscorwks_ntdef.src
+++ b/src/dlls/mscoree/mscorwks_ntdef.src
@@ -15,6 +15,9 @@ EXPORTS
         ; This cannot change, or else CoreCLR debugging will not work.
         ; See clr\src\DLLS\dbgshim\dbgshim.cpp.
         g_CLREngineMetrics                                  @2 data
+
+        ; VS depends on CLRJitAttachState having a ordinal of 3. This cannot change.
+        CLRJitAttachState                                   @3 data
         
         ; Unix hosting API
         coreclr_create_delegate

--- a/src/inc/dacvars.h
+++ b/src/inc/dacvars.h
@@ -212,12 +212,12 @@ DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE, dac__g_pDebugger, ::g_pDebugger)
 DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE, dac__g_pDebugInterface, ::g_pDebugInterface)
 DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE, dac__g_pEEDbgInterfaceImpl, ::g_pEEDbgInterfaceImpl)
 DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE, dac__g_pEEInterface, ::g_pEEInterface)
+DEFINE_DACVAR(ULONG, ULONG, dac__CLRJitAttachState, ::CLRJitAttachState)
 
 DEFINE_DACVAR(ULONG, BOOL, Debugger__s_fCanChangeNgenFlags, Debugger::s_fCanChangeNgenFlags)
 
 DEFINE_DACVAR(ULONG, PTR_DebuggerPatchTable, DebuggerController__g_patches, DebuggerController::g_patches)
 DEFINE_DACVAR(ULONG, BOOL, DebuggerController__g_patchTableValid, DebuggerController::g_patchTableValid)
-
 
 DEFINE_DACVAR(ULONG, SIZE_T, dac__gLowestFCall, ::gLowestFCall)
 DEFINE_DACVAR(ULONG, SIZE_T, dac__gHighestFCall, ::gHighestFCall)
@@ -256,8 +256,6 @@ DEFINE_DACVAR(ULONG, HRESULT, dac__g_hrFatalError, ::g_hrFatalError)
 #if defined(DEBUGGING_SUPPORTED) && defined (FEATURE_PREJIT)
     DEFINE_DACVAR(ULONG, DWORD, PEFile__s_NGENDebugFlags, PEFile::s_NGENDebugFlags)
 #endif //defined(DEBUGGING_SUPPORTED) && defined (FEATURE_PREJIT)
-
-
 
 #ifdef FEATURE_MINIMETADATA_IN_TRIAGEDUMPS
 DEFINE_DACVAR(ULONG, DWORD, dac__g_MiniMetaDataBuffMaxSize, ::g_MiniMetaDataBuffMaxSize)


### PR DESCRIPTION
This will allow VS to implement JIT debugging for .NET Core.

Issue #12074