### PR TITLE
Do not devirtualize shared default interface methods

### DIFF
--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -8870,6 +8870,14 @@ CORINFO_METHOD_HANDLE CEEInfo::resolveVirtualMethodHelper(CORINFO_METHOD_HANDLE 
         {
             return nullptr;
         }
+
+        // If we devirtualized into a default interface method on a generic type, we should actually return an
+        // instantiating stub but this is not happening.
+        // Making this work is tracked by https://github.com/dotnet/coreclr/issues/15977
+        if (pDevirtMD->GetMethodTable()->IsInterface() && pDevirtMD->HasClassInstantiation())
+        {
+            return nullptr;
+        }
     }
     else
     {

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -169,9 +169,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\DefaultInterfaceMethods\diamondshape\diamondshape\*">
             <Issue>15591</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\DefaultInterfaceMethods\sharedgenerics\sharedgenerics\*">
-            <Issue>15591</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\DefaultInterfaceMethods\constrainedcall\constrainedcall\*">
             <Issue>15353</Issue>
         </ExcludeList>

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -72,7 +72,6 @@ GC/Features/LOHFragmentation/lohfragmentation/lohfragmentation.sh
 GC/Features/SustainedLowLatency/scenario/scenario.sh
 GC/Regressions/dev10bugs/536168/536168/536168.sh
 Loader/classloader/DefaultInterfaceMethods/diamondshape/diamondshape/diamondshape.sh
-Loader/classloader/DefaultInterfaceMethods/sharedgenerics/sharedgenerics/sharedgenerics.sh
 Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrainedcall/constrainedcall.sh
 Loader/classloader/TypeGeneratorTests/TypeGeneratorTest612/Generated612/Generated612.sh
 Loader/classloader/TypeGeneratorTests/TypeGeneratorTest613/Generated613/Generated613.sh


### PR DESCRIPTION
The result of the devirtualization for a method on a generic type should be an instantiating stub, but this doesn't seem to work right.

Fixing that is a perf issue (that can be triaged/punted - #15977). This commit is a correctness fix to avoid bad codegen for that case.

Resolves #15591.