### PR TITLE
Delete Ptr typedefs from jit src.

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -556,7 +556,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
     unsigned argOffsetOut = treeNode->gtSlotNum * TARGET_POINTER_SIZE;
 
 #ifdef DEBUG
-    fgArgTabEntryPtr curArgTabEntry = compiler->gtArgEntryByNode(treeNode->gtCall, treeNode);
+    fgArgTabEntry* curArgTabEntry = compiler->gtArgEntryByNode(treeNode->gtCall, treeNode);
     assert(curArgTabEntry);
     assert(argOffsetOut == (curArgTabEntry->slotNum * TARGET_POINTER_SIZE));
 #endif // DEBUG
@@ -2194,7 +2194,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
 
         GenTreePtr argNode = list->Current();
 
-        fgArgTabEntryPtr curArgTabEntry = compiler->gtArgEntryByNode(call, argNode);
+        fgArgTabEntry* curArgTabEntry = compiler->gtArgEntryByNode(call, argNode);
         assert(curArgTabEntry);
 
         // GT_RELOAD/GT_COPY use the child node

--- a/src/jit/codegenclassic.h
+++ b/src/jit/codegenclassic.h
@@ -331,18 +331,18 @@ size_t genPushArgList(GenTreeCall* call);
 //       allocates a register, uses it, and sets "*pRegTmp" to the allocated register.
 //
 // Returns "true" iff it filled two slots with an 8-byte value.
-bool genFillSlotFromPromotedStruct(GenTreePtr       arg,
-                                   fgArgTabEntryPtr curArgTabEntry,
-                                   LclVarDsc*       promotedStructLocalVarDesc,
-                                   emitAttr         fieldSize,
-                                   unsigned*        pNextPromotedStructFieldVar,         // IN/OUT
-                                   unsigned*        pBytesOfNextSlotOfCurPromotedStruct, // IN/OUT
-                                   regNumber*       pCurRegNum,                          // IN/OUT
-                                   int              argOffset,
-                                   int              fieldOffsetOfFirstStackSlot,
-                                   int              argOffsetOfFirstStackSlot,
-                                   regMaskTP*       deadFieldVarRegs, // OUT
-                                   regNumber*       pRegTmp);         // IN/OUT
+bool genFillSlotFromPromotedStruct(GenTreePtr     arg,
+                                   fgArgTabEntry* curArgTabEntry,
+                                   LclVarDsc*     promotedStructLocalVarDesc,
+                                   emitAttr       fieldSize,
+                                   unsigned*      pNextPromotedStructFieldVar,         // IN/OUT
+                                   unsigned*      pBytesOfNextSlotOfCurPromotedStruct, // IN/OUT
+                                   regNumber*     pCurRegNum,                          // IN/OUT
+                                   int            argOffset,
+                                   int            fieldOffsetOfFirstStackSlot,
+                                   int            argOffsetOfFirstStackSlot,
+                                   regMaskTP*     deadFieldVarRegs, // OUT
+                                   regNumber*     pRegTmp);         // IN/OUT
 
 #endif // _TARGET_ARM_
 // Requires that "curr" is a cpblk.  If the RHS is a promoted struct local,
@@ -354,7 +354,7 @@ regMaskTP genFindDeadFieldRegs(GenTreePtr cpBlk);
 void SetupLateArgs(GenTreeCall* call);
 
 #ifdef _TARGET_ARM_
-void PushMkRefAnyArg(GenTreePtr mkRefAnyTree, fgArgTabEntryPtr curArgTabEntry, regMaskTP regNeedMask);
+void PushMkRefAnyArg(GenTreePtr mkRefAnyTree, fgArgTabEntry* curArgTabEntry, regMaskTP regNeedMask);
 #endif // _TARGET_ARM_
 
 regMaskTP genLoadIndirectCallTarget(GenTreeCall* call);

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -16431,7 +16431,7 @@ size_t CodeGen::genPushArgList(GenTreeCall* call)
 
         assert(!curr->IsArgPlaceHolderNode()); // No place holders nodes are in the late args
 
-        fgArgTabEntryPtr curArgTabEntry = compiler->gtArgEntryByNode(call, curr);
+        fgArgTabEntry* curArgTabEntry = compiler->gtArgEntryByNode(call, curr);
         assert(curArgTabEntry);
         regNumber regNum = curArgTabEntry->regNum;
 
@@ -16541,7 +16541,7 @@ size_t CodeGen::genPushArgList(GenTreeCall* call)
         /* Get hold of the next argument value */
         curr = args->Current();
 
-        fgArgTabEntryPtr curArgTabEntry = compiler->gtArgEntryByNode(call, curr);
+        fgArgTabEntry* curArgTabEntry = compiler->gtArgEntryByNode(call, curr);
         assert(curArgTabEntry);
         regNumber regNum    = curArgTabEntry->regNum;
         int       argOffset = curArgTabEntry->slotNum * TARGET_POINTER_SIZE;
@@ -16958,18 +16958,18 @@ size_t CodeGen::genPushArgList(GenTreeCall* call)
 }
 
 #ifdef _TARGET_ARM_
-bool CodeGen::genFillSlotFromPromotedStruct(GenTreePtr       arg,
-                                            fgArgTabEntryPtr curArgTabEntry,
-                                            LclVarDsc*       promotedStructLocalVarDesc,
-                                            emitAttr         fieldSize,
-                                            unsigned*        pNextPromotedStructFieldVar,
-                                            unsigned*        pBytesOfNextSlotOfCurPromotedStruct,
-                                            regNumber*       pCurRegNum,
-                                            int              argOffset,
-                                            int              fieldOffsetOfFirstStackSlot,
-                                            int              argOffsetOfFirstStackSlot,
-                                            regMaskTP*       deadFieldVarRegs,
-                                            regNumber*       pRegTmp)
+bool CodeGen::genFillSlotFromPromotedStruct(GenTreePtr     arg,
+                                            fgArgTabEntry* curArgTabEntry,
+                                            LclVarDsc*     promotedStructLocalVarDesc,
+                                            emitAttr       fieldSize,
+                                            unsigned*      pNextPromotedStructFieldVar,
+                                            unsigned*      pBytesOfNextSlotOfCurPromotedStruct,
+                                            regNumber*     pCurRegNum,
+                                            int            argOffset,
+                                            int            fieldOffsetOfFirstStackSlot,
+                                            int            argOffsetOfFirstStackSlot,
+                                            regMaskTP*     deadFieldVarRegs,
+                                            regNumber*     pRegTmp)
 {
     unsigned nextPromotedStructFieldVar = *pNextPromotedStructFieldVar;
     unsigned limitPromotedStructFieldVar =
@@ -17497,7 +17497,7 @@ void CodeGen::SetupLateArgs(GenTreeCall* call)
         curr = lateArgs->Current();
         assert(curr);
 
-        fgArgTabEntryPtr curArgTabEntry = compiler->gtArgEntryByNode(call, curr);
+        fgArgTabEntry* curArgTabEntry = compiler->gtArgEntryByNode(call, curr);
         assert(curArgTabEntry);
         regNumber regNum    = curArgTabEntry->regNum;
         unsigned  argOffset = curArgTabEntry->slotNum * TARGET_POINTER_SIZE;
@@ -18084,7 +18084,7 @@ void CodeGen::SetupLateArgs(GenTreeCall* call)
 // been pushed onto the stack, but *no* registers have been marked
 // as 'in-use', that is the responsibility of the caller.
 //
-void CodeGen::PushMkRefAnyArg(GenTreePtr mkRefAnyTree, fgArgTabEntryPtr curArgTabEntry, regMaskTP regNeedMask)
+void CodeGen::PushMkRefAnyArg(GenTreePtr mkRefAnyTree, fgArgTabEntry* curArgTabEntry, regMaskTP regNeedMask)
 {
     regNumber regNum = curArgTabEntry->regNum;
     regNumber regNum2;

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -5101,7 +5101,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
 
         GenTreePtr argNode = list->Current();
 
-        fgArgTabEntryPtr curArgTabEntry = compiler->gtArgEntryByNode(call, argNode->gtSkipReloadOrCopy());
+        fgArgTabEntry* curArgTabEntry = compiler->gtArgEntryByNode(call, argNode->gtSkipReloadOrCopy());
         assert(curArgTabEntry);
 
         if (curArgTabEntry->regNum == REG_STK)
@@ -5186,7 +5186,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
                 unsigned size   = arg->AsPutArgStk()->getArgSize();
                 stackArgBytes += size;
 #ifdef DEBUG
-                fgArgTabEntryPtr curArgTabEntry = compiler->gtArgEntryByNode(call, arg);
+                fgArgTabEntry* curArgTabEntry = compiler->gtArgEntryByNode(call, arg);
                 assert(curArgTabEntry);
                 assert(size == (curArgTabEntry->numSlots * TARGET_POINTER_SIZE));
 #ifdef FEATURE_PUT_STRUCT_ARG_STK
@@ -8051,10 +8051,10 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* putArgStk)
         // Get argument offset on stack.
         // Here we cross check that argument offset hasn't changed from lowering to codegen since
         // we are storing arg slot number in GT_PUTARG_STK node in lowering phase.
-        int              argOffset      = putArgStk->getArgOffset();
+        int            argOffset      = putArgStk->getArgOffset();
 
 #ifdef DEBUG
-        fgArgTabEntryPtr curArgTabEntry = compiler->gtArgEntryByNode(putArgStk->gtCall, putArgStk);
+        fgArgTabEntry* curArgTabEntry = compiler->gtArgEntryByNode(putArgStk->gtCall, putArgStk);
         assert(curArgTabEntry);
         assert(argOffset == (int)curArgTabEntry->slotNum * TARGET_POINTER_SIZE);
 #endif

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1293,7 +1293,6 @@ struct fgArgTabEntry
     void Dump();
 #endif
 };
-typedef struct fgArgTabEntry* fgArgTabEntryPtr;
 
 //-------------------------------------------------------------------------
 //
@@ -1322,44 +1321,43 @@ class fgArgInfo
     unsigned outArgSize; // Size of the out arg area for the call, will be at least MIN_ARG_AREA_FOR_CALL
 #endif
 
-    unsigned          argTableSize; // size of argTable array (equal to the argCount when done with fgMorphArgs)
-    bool              hasRegArgs;   // true if we have one or more register arguments
-    bool              hasStackArgs; // true if we have one or more stack arguments
-    bool              argsComplete; // marker for state
-    bool              argsSorted;   // marker for state
-    fgArgTabEntryPtr* argTable;     // variable sized array of per argument descrption: (i.e. argTable[argTableSize])
+    unsigned        argTableSize; // size of argTable array (equal to the argCount when done with fgMorphArgs)
+    bool            hasRegArgs;   // true if we have one or more register arguments
+    bool            hasStackArgs; // true if we have one or more stack arguments
+    bool            argsComplete; // marker for state
+    bool            argsSorted;   // marker for state
+    fgArgTabEntry** argTable;     // variable sized array of per argument descrption: (i.e. argTable[argTableSize])
 
 private:
-    void AddArg(fgArgTabEntryPtr curArgTabEntry);
+    void AddArg(fgArgTabEntry* curArgTabEntry);
 
 public:
     fgArgInfo(Compiler* comp, GenTreeCall* call, unsigned argCount);
     fgArgInfo(GenTreeCall* newCall, GenTreeCall* oldCall);
 
-    fgArgTabEntryPtr AddRegArg(
+    fgArgTabEntry* AddRegArg(
         unsigned argNum, GenTreePtr node, GenTreePtr parent, regNumber regNum, unsigned numRegs, unsigned alignment);
 
 #ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
-    fgArgTabEntryPtr AddRegArg(
-        unsigned                                                         argNum,
-        GenTreePtr                                                       node,
-        GenTreePtr                                                       parent,
-        regNumber                                                        regNum,
-        unsigned                                                         numRegs,
-        unsigned                                                         alignment,
-        const bool                                                       isStruct,
-        const regNumber                                                  otherRegNum   = REG_NA,
-        const SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR* const structDescPtr = nullptr);
+    fgArgTabEntry* AddRegArg(unsigned                                                         argNum,
+                             GenTreePtr                                                       node,
+                             GenTreePtr                                                       parent,
+                             regNumber                                                        regNum,
+                             unsigned                                                         numRegs,
+                             unsigned                                                         alignment,
+                             const bool                                                       isStruct,
+                             const regNumber                                                  otherRegNum   = REG_NA,
+                             const SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR* const structDescPtr = nullptr);
 #endif // FEATURE_UNIX_AMD64_STRUCT_PASSING
 
-    fgArgTabEntryPtr AddStkArg(unsigned   argNum,
-                               GenTreePtr node,
-                               GenTreePtr parent,
-                               unsigned   numSlots,
-                               unsigned alignment FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY_ARG(const bool isStruct));
+    fgArgTabEntry* AddStkArg(unsigned   argNum,
+                             GenTreePtr node,
+                             GenTreePtr parent,
+                             unsigned   numSlots,
+                             unsigned alignment FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY_ARG(const bool isStruct));
 
-    void             RemorphReset();
-    fgArgTabEntryPtr RemorphRegArg(
+    void           RemorphReset();
+    fgArgTabEntry* RemorphRegArg(
         unsigned argNum, GenTreePtr node, GenTreePtr parent, regNumber regNum, unsigned numRegs, unsigned alignment);
 
     void RemorphStkArg(unsigned argNum, GenTreePtr node, GenTreePtr parent, unsigned numSlots, unsigned alignment);
@@ -1381,7 +1379,7 @@ public:
     {
         return argCount;
     }
-    fgArgTabEntryPtr* ArgTable()
+    fgArgTabEntry** ArgTable()
     {
         return argTable;
     }
@@ -2109,10 +2107,10 @@ public:
     GenTreeArgList* gtNewArgList(GenTreePtr op1, GenTreePtr op2, GenTreePtr op3);
     GenTreeArgList* gtNewArgList(GenTreePtr op1, GenTreePtr op2, GenTreePtr op3, GenTreePtr op4);
 
-    static fgArgTabEntryPtr gtArgEntryByArgNum(GenTreeCall* call, unsigned argNum);
-    static fgArgTabEntryPtr gtArgEntryByNode(GenTreeCall* call, GenTreePtr node);
-    fgArgTabEntryPtr gtArgEntryByLateArgIndex(GenTreeCall* call, unsigned lateArgInx);
-    bool gtArgIsThisPtr(fgArgTabEntryPtr argEntry);
+    static fgArgTabEntry* gtArgEntryByArgNum(GenTreeCall* call, unsigned argNum);
+    static fgArgTabEntry* gtArgEntryByNode(GenTreeCall* call, GenTreePtr node);
+    fgArgTabEntry* gtArgEntryByLateArgIndex(GenTreeCall* call, unsigned lateArgInx);
+    bool gtArgIsThisPtr(fgArgTabEntry* argEntry);
 
     GenTreePtr gtNewAssignNode(GenTreePtr dst, GenTreePtr src);
 
@@ -4918,12 +4916,12 @@ private:
     bool fgCheckStmtAfterTailCall();
     void fgMorphTailCall(GenTreeCall* call);
     void fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCall* recursiveTailCall);
-    GenTreePtr fgAssignRecursiveCallArgToCallerParam(GenTreePtr       arg,
-                                                     fgArgTabEntryPtr argTabEntry,
-                                                     BasicBlock*      block,
-                                                     IL_OFFSETX       callILOffset,
-                                                     GenTreePtr       tmpAssignmentInsertionPoint,
-                                                     GenTreePtr       paramAssignmentInsertionPoint);
+    GenTreePtr fgAssignRecursiveCallArgToCallerParam(GenTreePtr     arg,
+                                                     fgArgTabEntry* argTabEntry,
+                                                     BasicBlock*    block,
+                                                     IL_OFFSETX     callILOffset,
+                                                     GenTreePtr     tmpAssignmentInsertionPoint,
+                                                     GenTreePtr     paramAssignmentInsertionPoint);
     static int fgEstimateCallStackSize(GenTreeCall* call);
     GenTreePtr fgMorphCall(GenTreeCall* call);
     void fgMorphCallInline(GenTreeCall* call, InlineResult* result);
@@ -9678,7 +9676,7 @@ public:
 #endif // defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
 
     void fgMorphMultiregStructArgs(GenTreeCall* call);
-    GenTreePtr fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr fgEntryPtr);
+    GenTreePtr fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntry* fgEntryPtr);
 
     bool killGCRefs(GenTreePtr tree);
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5670,8 +5670,6 @@ protected:
         BasicBlock*  tslBlock; // block containing the statement
     };
 
-    typedef struct treeStmtLst* treeStmtLstPtr;
-
     // The following logic keeps track of expressions via a simple hash table.
 
     struct CSEdsc
@@ -5693,8 +5691,8 @@ protected:
         GenTreePtr  csdStmt;  // stmt containing the 1st occurance
         BasicBlock* csdBlock; // block containing the 1st occurance
 
-        treeStmtLstPtr csdTreeList; // list of matching tree nodes: head
-        treeStmtLstPtr csdTreeLast; // list of matching tree nodes: tail
+        treeStmtLst* csdTreeList; // list of matching tree nodes: head
+        treeStmtLst* csdTreeLast; // list of matching tree nodes: tail
 
         ValueNum defConservativeVN; // if all def occurrences share the same conservative value
                                     // number, this will reflect it; otherwise, NoVN.

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5662,8 +5662,6 @@ protected:
         GenTreePtr tlTree;
     };
 
-    typedef struct treeLst* treeLstPtr;
-
     struct treeStmtLst
     {
         treeStmtLst* tslNext;

--- a/src/jit/earlyprop.cpp
+++ b/src/jit/earlyprop.cpp
@@ -123,7 +123,7 @@ GenTreePtr Compiler::getObjectHandleNodeFromAllocation(GenTreePtr tree)
                 call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_NEWARR_1_ALIGN8))
             {
                 // This is an object allocation site. Return the runtime type handle node.
-                fgArgTabEntryPtr argTabEntry = gtArgEntryByArgNum(call, 0);
+                fgArgTabEntry* argTabEntry = gtArgEntryByArgNum(call, 0);
                 return argTabEntry->node;
             }
         }

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -3316,8 +3316,7 @@ Compiler::SwitchUniqueSuccSet Compiler::GetDescriptorForSwitch(BasicBlock* switc
         // Now we have a set of unique successors.
         unsigned numNonDups = BitVecOps::Count(&blockVecTraits, uniqueSuccBlocks);
 
-        typedef BasicBlock* BasicBlockPtr;
-        BasicBlockPtr*      nonDups = new (getAllocator()) BasicBlockPtr[numNonDups];
+        BasicBlock** nonDups = new (getAllocator()) BasicBlock*[numNonDups];
 
         unsigned nonDupInd = 0;
         // At this point, all unique targets are in "uniqueSuccBlocks".  As we encounter each,
@@ -3385,8 +3384,7 @@ void Compiler::SwitchUniqueSuccSet::UpdateTarget(CompAllocator* alloc,
     else if (fromStillPresent && !toAlreadyPresent)
     {
         // reallocate to add an entry
-        typedef BasicBlock* BasicBlockPtr;
-        BasicBlockPtr*      newNonDups = new (alloc) BasicBlockPtr[numDistinctSuccs + 1];
+        BasicBlock** newNonDups = new (alloc) BasicBlock*[numDistinctSuccs + 1];
         memcpy(newNonDups, nonDuplicates, numDistinctSuccs * sizeof(BasicBlock*));
         newNonDups[numDistinctSuccs] = to;
         numDistinctSuccs++;

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -1160,7 +1160,7 @@ void GenTreeCall::ReplaceCallOperand(GenTree** useEdge, GenTree* replacement)
         {
             assert((replacement->gtFlags & GTF_LATE_ARG) == 0);
 
-            fgArgTabEntryPtr fp = Compiler::gtArgEntryByNode(this, originalOperand);
+            fgArgTabEntry* fp = Compiler::gtArgEntryByNode(this, originalOperand);
             assert(fp->node == originalOperand);
             fp->node = replacement;
         }
@@ -6814,14 +6814,14 @@ GenTreeArgList* Compiler::gtNewArgList(GenTreePtr arg1, GenTreePtr arg2, GenTree
  *  that has the matching argNum and return the fgArgTableEntryPtr
  */
 
-fgArgTabEntryPtr Compiler::gtArgEntryByArgNum(GenTreeCall* call, unsigned argNum)
+fgArgTabEntry* Compiler::gtArgEntryByArgNum(GenTreeCall* call, unsigned argNum)
 {
     fgArgInfo* argInfo = call->fgArgInfo;
     noway_assert(argInfo != nullptr);
 
-    unsigned          argCount       = argInfo->ArgCount();
-    fgArgTabEntryPtr* argTable       = argInfo->ArgTable();
-    fgArgTabEntryPtr  curArgTabEntry = nullptr;
+    unsigned        argCount       = argInfo->ArgCount();
+    fgArgTabEntry** argTable       = argInfo->ArgTable();
+    fgArgTabEntry*  curArgTabEntry = nullptr;
 
     for (unsigned i = 0; i < argCount; i++)
     {
@@ -6841,14 +6841,14 @@ fgArgTabEntryPtr Compiler::gtArgEntryByArgNum(GenTreeCall* call, unsigned argNum
  *  that has the matching node and return the fgArgTableEntryPtr
  */
 
-fgArgTabEntryPtr Compiler::gtArgEntryByNode(GenTreeCall* call, GenTreePtr node)
+fgArgTabEntry* Compiler::gtArgEntryByNode(GenTreeCall* call, GenTreePtr node)
 {
     fgArgInfo* argInfo = call->fgArgInfo;
     noway_assert(argInfo != nullptr);
 
-    unsigned          argCount       = argInfo->ArgCount();
-    fgArgTabEntryPtr* argTable       = argInfo->ArgTable();
-    fgArgTabEntryPtr  curArgTabEntry = nullptr;
+    unsigned        argCount       = argInfo->ArgCount();
+    fgArgTabEntry** argTable       = argInfo->ArgTable();
+    fgArgTabEntry*  curArgTabEntry = nullptr;
 
     for (unsigned i = 0; i < argCount; i++)
     {
@@ -6883,14 +6883,14 @@ fgArgTabEntryPtr Compiler::gtArgEntryByNode(GenTreeCall* call, GenTreePtr node)
  *  Find and return the entry with the given "lateArgInx".  Requires that one is found
  *  (asserts this).
  */
-fgArgTabEntryPtr Compiler::gtArgEntryByLateArgIndex(GenTreeCall* call, unsigned lateArgInx)
+fgArgTabEntry* Compiler::gtArgEntryByLateArgIndex(GenTreeCall* call, unsigned lateArgInx)
 {
     fgArgInfo* argInfo = call->fgArgInfo;
     noway_assert(argInfo != nullptr);
 
-    unsigned          argCount       = argInfo->ArgCount();
-    fgArgTabEntryPtr* argTable       = argInfo->ArgTable();
-    fgArgTabEntryPtr  curArgTabEntry = nullptr;
+    unsigned        argCount       = argInfo->ArgCount();
+    fgArgTabEntry** argTable       = argInfo->ArgTable();
+    fgArgTabEntry*  curArgTabEntry = nullptr;
 
     for (unsigned i = 0; i < argCount; i++)
     {
@@ -6906,9 +6906,9 @@ fgArgTabEntryPtr Compiler::gtArgEntryByLateArgIndex(GenTreeCall* call, unsigned 
 
 /*****************************************************************************
  *
- *  Given an fgArgTabEntryPtr, return true if it is the 'this' pointer argument.
+ *  Given an fgArgTabEntry*, return true if it is the 'this' pointer argument.
  */
-bool Compiler::gtArgIsThisPtr(fgArgTabEntryPtr argEntry)
+bool Compiler::gtArgIsThisPtr(fgArgTabEntry* argEntry)
 {
     return (argEntry->parent == nullptr);
 }
@@ -8602,10 +8602,10 @@ GenTreePtr Compiler::gtGetThisArg(GenTreeCall* call)
 
         if (call->gtCallLateArgs)
         {
-            regNumber        thisReg         = REG_ARG_0;
-            unsigned         argNum          = 0;
-            fgArgTabEntryPtr thisArgTabEntry = gtArgEntryByArgNum(call, argNum);
-            GenTreePtr       result          = thisArgTabEntry->node;
+            regNumber      thisReg         = REG_ARG_0;
+            unsigned       argNum          = 0;
+            fgArgTabEntry* thisArgTabEntry = gtArgEntryByArgNum(call, argNum);
+            GenTreePtr     result          = thisArgTabEntry->node;
 
 #if !FEATURE_FIXED_OUT_ARGS
             GenTreePtr lateArgs = call->gtCallLateArgs;
@@ -11889,7 +11889,7 @@ void Compiler::gtGetArgMsg(
 {
     if (call->gtCallLateArgs != nullptr)
     {
-        fgArgTabEntryPtr curArgTabEntry = gtArgEntryByArgNum(call, argNum);
+        fgArgTabEntry* curArgTabEntry = gtArgEntryByArgNum(call, argNum);
         assert(curArgTabEntry);
 
         if (arg->gtFlags & GTF_LATE_ARG)
@@ -12007,7 +12007,7 @@ void Compiler::gtGetLateArgMsg(
 {
     assert(!argx->IsArgPlaceHolderNode()); // No place holders nodes are in gtCallLateArgs;
 
-    fgArgTabEntryPtr curArgTabEntry = gtArgEntryByLateArgIndex(call, lateArgIndex);
+    fgArgTabEntry* curArgTabEntry = gtArgEntryByLateArgIndex(call, lateArgIndex);
     assert(curArgTabEntry);
     regNumber argReg = curArgTabEntry->regNum;
 
@@ -12301,7 +12301,7 @@ void Compiler::gtDispLIRNode(GenTree* node, const char* prefixMsg /* = nullptr *
             }
             else
             {
-                fgArgTabEntryPtr curArgTabEntry = gtArgEntryByNode(call, operand);
+                fgArgTabEntry* curArgTabEntry = gtArgEntryByNode(call, operand);
                 assert(curArgTabEntry);
 
                 if (operand->OperGet() == GT_LIST)

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -6816,7 +6816,7 @@ GenTreeArgList* Compiler::gtNewArgList(GenTreePtr arg1, GenTreePtr arg2, GenTree
 
 fgArgTabEntryPtr Compiler::gtArgEntryByArgNum(GenTreeCall* call, unsigned argNum)
 {
-    fgArgInfoPtr argInfo = call->fgArgInfo;
+    fgArgInfo* argInfo = call->fgArgInfo;
     noway_assert(argInfo != nullptr);
 
     unsigned          argCount       = argInfo->ArgCount();
@@ -6843,7 +6843,7 @@ fgArgTabEntryPtr Compiler::gtArgEntryByArgNum(GenTreeCall* call, unsigned argNum
 
 fgArgTabEntryPtr Compiler::gtArgEntryByNode(GenTreeCall* call, GenTreePtr node)
 {
-    fgArgInfoPtr argInfo = call->fgArgInfo;
+    fgArgInfo* argInfo = call->fgArgInfo;
     noway_assert(argInfo != nullptr);
 
     unsigned          argCount       = argInfo->ArgCount();
@@ -6885,7 +6885,7 @@ fgArgTabEntryPtr Compiler::gtArgEntryByNode(GenTreeCall* call, GenTreePtr node)
  */
 fgArgTabEntryPtr Compiler::gtArgEntryByLateArgIndex(GenTreeCall* call, unsigned lateArgInx)
 {
-    fgArgInfoPtr argInfo = call->fgArgInfo;
+    fgArgInfo* argInfo = call->fgArgInfo;
     noway_assert(argInfo != nullptr);
 
     unsigned          argCount       = argInfo->ArgCount();

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -3178,7 +3178,6 @@ struct GenTreeColon : public GenTreeOp
 };
 
 // gtCall   -- method call      (GT_CALL)
-typedef class fgArgInfo* fgArgInfoPtr;
 enum class InlineObservation;
 
 // Return type descriptor of a GT_CALL node.
@@ -3324,6 +3323,8 @@ public:
     regMaskTP GetABIReturnRegs();
 };
 
+class fgArgInfo;
+
 struct GenTreeCall final : public GenTree
 {
     GenTreePtr      gtCallObjp;     // The instance argument ('this' pointer)
@@ -3331,7 +3332,7 @@ struct GenTreeCall final : public GenTree
     GenTreeArgList* gtCallLateArgs; // On x86:     The register arguments in an optimal order
                                     // On ARM/x64: - also includes any outgoing arg space arguments
                                     //             - that were evaluated into a temp LclVar
-    fgArgInfoPtr fgArgInfo;
+    fgArgInfo* fgArgInfo;
 
 #if !FEATURE_FIXED_OUT_ARGS
     int     regArgListCount;

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -986,7 +986,7 @@ void Lowering::ReplaceArgWithPutArgOrBitcast(GenTree** argSlot, GenTree* putArgO
 //    layout object, so the codegen of the GT_PUTARG_STK could use this for optimizing copying to the stack by value.
 //    (using block copy primitives for non GC pointers and a single TARGET_POINTER_SIZE copy with recording GC info.)
 //
-GenTreePtr Lowering::NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntryPtr info, var_types type)
+GenTreePtr Lowering::NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntry* info, var_types type)
 {
     assert(call != nullptr);
     assert(arg != nullptr);
@@ -1393,7 +1393,7 @@ void Lowering::LowerArg(GenTreeCall* call, GenTreePtr* ppArg)
         return;
     }
 
-    fgArgTabEntryPtr info = comp->gtArgEntryByNode(call, arg);
+    fgArgTabEntry* info = comp->gtArgEntryByNode(call, arg);
     assert(info->node == arg);
     var_types type = arg->TypeGet();
 
@@ -2109,7 +2109,7 @@ void Lowering::LowerFastTailCall(GenTreeCall* call)
         // stack slots required for both Caller and Callee for passing params
         // and allow fast tail call only if stack slots required by Caller >=
         // Callee.
-        fgArgTabEntryPtr argTabEntry = comp->gtArgEntryByNode(call, putArgStkNode);
+        fgArgTabEntry* argTabEntry = comp->gtArgEntryByNode(call, putArgStkNode);
         assert(argTabEntry);
         unsigned callerArgNum = argTabEntry->argNum - calleeNonStandardArgCount;
         noway_assert(callerArgNum < comp->info.compArgsCount);
@@ -3224,8 +3224,8 @@ GenTree* Lowering::LowerDelegateInvoke(GenTreeCall* call)
         const unsigned argNum  = 2;
 #endif // !_TARGET_X86_
 
-        fgArgTabEntryPtr thisArgTabEntry = comp->gtArgEntryByArgNum(call, argNum);
-        thisArgNode                      = thisArgTabEntry->node;
+        fgArgTabEntry* thisArgTabEntry = comp->gtArgEntryByArgNum(call, argNum);
+        thisArgNode                    = thisArgTabEntry->node;
     }
     else
     {

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -159,7 +159,7 @@ private:
     GenTree* LowerVirtualStubCall(GenTreeCall* call);
     void LowerArgsForCall(GenTreeCall* call);
     void ReplaceArgWithPutArgOrBitcast(GenTreePtr* ppChild, GenTreePtr newNode);
-    GenTree* NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntryPtr info, var_types type);
+    GenTree* NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntry* info, var_types type);
     void LowerArg(GenTreeCall* call, GenTreePtr* ppTree);
 #ifdef _TARGET_ARMARCH_
     GenTree* LowerFloatArg(GenTree** pArg, fgArgTabEntry* info);

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -480,8 +480,8 @@ void LinearScan::TreeNodeInfoInitCall(GenTreeCall* call, TreeNodeInfo* info)
 #ifdef DEBUG
         // During TreeNodeInfoInit, we only use the ArgTabEntry for validation,
         // as getting it is rather expensive.
-        fgArgTabEntryPtr curArgTabEntry = compiler->gtArgEntryByNode(call, argNode);
-        regNumber        argReg         = curArgTabEntry->regNum;
+        fgArgTabEntry* curArgTabEntry = compiler->gtArgEntryByNode(call, argNode);
+        regNumber      argReg         = curArgTabEntry->regNum;
         assert(curArgTabEntry);
 #endif
 
@@ -587,7 +587,7 @@ void LinearScan::TreeNodeInfoInitCall(GenTreeCall* call, TreeNodeInfo* info)
         if (!(args->gtFlags & GTF_LATE_ARG))
         {
 #ifdef DEBUG
-            fgArgTabEntryPtr curArgTabEntry = compiler->gtArgEntryByNode(call, arg);
+            fgArgTabEntry* curArgTabEntry = compiler->gtArgEntryByNode(call, arg);
             assert(curArgTabEntry);
 #endif
 #ifdef _TARGET_ARM_

--- a/src/jit/lsraxarch.cpp
+++ b/src/jit/lsraxarch.cpp
@@ -1305,7 +1305,7 @@ void LinearScan::TreeNodeInfoInitCall(GenTreeCall* call, TreeNodeInfo* info)
 #ifdef DEBUG
         // In DEBUG only, check validity with respect to the arg table entry.
 
-        fgArgTabEntryPtr curArgTabEntry = compiler->gtArgEntryByNode(call, argNode);
+        fgArgTabEntry* curArgTabEntry = compiler->gtArgEntryByNode(call, argNode);
         assert(curArgTabEntry);
 
         if (curArgTabEntry->regNum == REG_STK)

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -982,7 +982,7 @@ fgArgInfo::fgArgInfo(Compiler* comp, GenTreeCall* call, unsigned numArgs)
     }
     else
     {
-        argTable = new (compiler, CMK_fgArgInfoPtrArr) fgArgTabEntryPtr[argTableSize];
+        argTable = new (compiler, CMK_fgArgInfoPtrArr) fgArgTabEntry*[argTableSize];
     }
 }
 
@@ -1019,7 +1019,7 @@ fgArgInfo::fgArgInfo(GenTreeCall* newCall, GenTreeCall* oldCall)
     argTable     = nullptr;
     if (argTableSize > 0)
     {
-        argTable = new (compiler, CMK_fgArgInfoPtrArr) fgArgTabEntryPtr[argTableSize];
+        argTable = new (compiler, CMK_fgArgInfoPtrArr) fgArgTabEntry*[argTableSize];
         for (unsigned inx = 0; inx < argTableSize; inx++)
         {
             argTable[inx] = nullptr;
@@ -1051,12 +1051,12 @@ fgArgInfo::fgArgInfo(GenTreeCall* newCall, GenTreeCall* oldCall)
         oldArgs              = &oldArgObjp;
     }
 
-    GenTreePtr        newCurr;
-    GenTreePtr        oldCurr;
-    GenTreeArgList*   newParent   = nullptr;
-    GenTreeArgList*   oldParent   = nullptr;
-    fgArgTabEntryPtr* oldArgTable = oldArgInfo->argTable;
-    bool              scanRegArgs = false;
+    GenTreePtr      newCurr;
+    GenTreePtr      oldCurr;
+    GenTreeArgList* newParent   = nullptr;
+    GenTreeArgList* oldParent   = nullptr;
+    fgArgTabEntry** oldArgTable = oldArgInfo->argTable;
+    bool            scanRegArgs = false;
 
     while (newArgs)
     {
@@ -1076,8 +1076,8 @@ fgArgInfo::fgArgInfo(GenTreeCall* newCall, GenTreeCall* oldCall)
         newArgs = newArgs->Rest();
         oldArgs = oldArgs->Rest();
 
-        fgArgTabEntryPtr oldArgTabEntry = nullptr;
-        fgArgTabEntryPtr newArgTabEntry = nullptr;
+        fgArgTabEntry* oldArgTabEntry = nullptr;
+        fgArgTabEntry* newArgTabEntry = nullptr;
 
         for (unsigned inx = 0; inx < argTableSize; inx++)
         {
@@ -1148,8 +1148,8 @@ fgArgInfo::fgArgInfo(GenTreeCall* newCall, GenTreeCall* oldCall)
             oldCurr = oldArgs->Current();
             oldArgs = oldArgs->Rest();
 
-            fgArgTabEntryPtr oldArgTabEntry = nullptr;
-            fgArgTabEntryPtr newArgTabEntry = nullptr;
+            fgArgTabEntry* oldArgTabEntry = nullptr;
+            fgArgTabEntry* newArgTabEntry = nullptr;
 
             for (unsigned inx = 0; inx < argTableSize; inx++)
             {
@@ -1181,17 +1181,17 @@ fgArgInfo::fgArgInfo(GenTreeCall* newCall, GenTreeCall* oldCall)
     argsSorted   = true;
 }
 
-void fgArgInfo::AddArg(fgArgTabEntryPtr curArgTabEntry)
+void fgArgInfo::AddArg(fgArgTabEntry* curArgTabEntry)
 {
     assert(argCount < argTableSize);
     argTable[argCount] = curArgTabEntry;
     argCount++;
 }
 
-fgArgTabEntryPtr fgArgInfo::AddRegArg(
+fgArgTabEntry* fgArgInfo::AddRegArg(
     unsigned argNum, GenTreePtr node, GenTreePtr parent, regNumber regNum, unsigned numRegs, unsigned alignment)
 {
-    fgArgTabEntryPtr curArgTabEntry = new (compiler, CMK_fgArgInfo) fgArgTabEntry;
+    fgArgTabEntry* curArgTabEntry = new (compiler, CMK_fgArgInfo) fgArgTabEntry;
 
     curArgTabEntry->argNum        = argNum;
     curArgTabEntry->node          = node;
@@ -1218,17 +1218,17 @@ fgArgTabEntryPtr fgArgInfo::AddRegArg(
 }
 
 #if defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
-fgArgTabEntryPtr fgArgInfo::AddRegArg(unsigned                                                         argNum,
-                                      GenTreePtr                                                       node,
-                                      GenTreePtr                                                       parent,
-                                      regNumber                                                        regNum,
-                                      unsigned                                                         numRegs,
-                                      unsigned                                                         alignment,
-                                      const bool                                                       isStruct,
-                                      const regNumber                                                  otherRegNum,
-                                      const SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR* const structDescPtr)
+fgArgTabEntry* fgArgInfo::AddRegArg(unsigned                                                         argNum,
+                                    GenTreePtr                                                       node,
+                                    GenTreePtr                                                       parent,
+                                    regNumber                                                        regNum,
+                                    unsigned                                                         numRegs,
+                                    unsigned                                                         alignment,
+                                    const bool                                                       isStruct,
+                                    const regNumber                                                  otherRegNum,
+                                    const SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR* const structDescPtr)
 {
-    fgArgTabEntryPtr curArgTabEntry = AddRegArg(argNum, node, parent, regNum, numRegs, alignment);
+    fgArgTabEntry* curArgTabEntry = AddRegArg(argNum, node, parent, regNum, numRegs, alignment);
     assert(curArgTabEntry != nullptr);
 
     // The node of the ArgTabEntry could change after remorphing - it could be rewritten to a cpyblk or a
@@ -1248,14 +1248,13 @@ fgArgTabEntryPtr fgArgInfo::AddRegArg(unsigned                                  
 }
 #endif // defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
 
-fgArgTabEntryPtr fgArgInfo::AddStkArg(unsigned   argNum,
-                                      GenTreePtr node,
-                                      GenTreePtr parent,
-                                      unsigned   numSlots,
-                                      unsigned   alignment
-                                          FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY_ARG(const bool isStruct))
+fgArgTabEntry* fgArgInfo::AddStkArg(unsigned   argNum,
+                                    GenTreePtr node,
+                                    GenTreePtr parent,
+                                    unsigned   numSlots,
+                                    unsigned alignment FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY_ARG(const bool isStruct))
 {
-    fgArgTabEntryPtr curArgTabEntry = new (compiler, CMK_fgArgInfo) fgArgTabEntry;
+    fgArgTabEntry* curArgTabEntry = new (compiler, CMK_fgArgInfo) fgArgTabEntry;
 
     nextSlotNum = (unsigned)roundUp(nextSlotNum, alignment);
 
@@ -1302,9 +1301,9 @@ void fgArgInfo::RemorphReset()
 fgArgTabEntry* fgArgInfo::RemorphRegArg(
     unsigned argNum, GenTreePtr node, GenTreePtr parent, regNumber regNum, unsigned numRegs, unsigned alignment)
 {
-    fgArgTabEntryPtr curArgTabEntry = nullptr;
-    unsigned         regArgInx      = 0;
-    unsigned         inx;
+    fgArgTabEntry* curArgTabEntry = nullptr;
+    unsigned       regArgInx      = 0;
+    unsigned       inx;
 
     for (inx = 0; inx < argCount; inx++)
     {
@@ -1373,11 +1372,11 @@ fgArgTabEntry* fgArgInfo::RemorphRegArg(
 void fgArgInfo::RemorphStkArg(
     unsigned argNum, GenTreePtr node, GenTreePtr parent, unsigned numSlots, unsigned alignment)
 {
-    fgArgTabEntryPtr curArgTabEntry = nullptr;
-    bool             isRegArg       = false;
-    unsigned         regArgInx      = 0;
-    GenTreePtr       argx;
-    unsigned         inx;
+    fgArgTabEntry* curArgTabEntry = nullptr;
+    bool           isRegArg       = false;
+    unsigned       regArgInx      = 0;
+    GenTreePtr     argx;
+    unsigned       inx;
 
     for (inx = 0; inx < argCount; inx++)
     {
@@ -1456,7 +1455,7 @@ void fgArgInfo::RemorphStkArg(
 
 void fgArgInfo::SplitArg(unsigned argNum, unsigned numRegs, unsigned numSlots)
 {
-    fgArgTabEntryPtr curArgTabEntry = nullptr;
+    fgArgTabEntry* curArgTabEntry = nullptr;
     assert(argNum < argCount);
     for (unsigned inx = 0; inx < argCount; inx++)
     {
@@ -1489,7 +1488,7 @@ void fgArgInfo::SplitArg(unsigned argNum, unsigned numRegs, unsigned numSlots)
 
 void fgArgInfo::EvalToTmp(unsigned argNum, unsigned tmpNum, GenTreePtr newNode)
 {
-    fgArgTabEntryPtr curArgTabEntry = nullptr;
+    fgArgTabEntry* curArgTabEntry = nullptr;
     assert(argNum < argCount);
     for (unsigned inx = 0; inx < argCount; inx++)
     {
@@ -1513,7 +1512,7 @@ void fgArgInfo::ArgsComplete()
 
     for (unsigned curInx = 0; curInx < argCount; curInx++)
     {
-        fgArgTabEntryPtr curArgTabEntry = argTable[curInx];
+        fgArgTabEntry* curArgTabEntry = argTable[curInx];
         assert(curArgTabEntry != nullptr);
         GenTreePtr argx = curArgTabEntry->node;
 
@@ -1574,7 +1573,7 @@ void fgArgInfo::ArgsComplete()
             //  we require that they be evaluated into temps
             for (unsigned prevInx = 0; prevInx < curInx; prevInx++)
             {
-                fgArgTabEntryPtr prevArgTabEntry = argTable[prevInx];
+                fgArgTabEntry* prevArgTabEntry = argTable[prevInx];
                 assert(prevArgTabEntry->argNum < curArgTabEntry->argNum);
 
                 assert(prevArgTabEntry->node);
@@ -1635,7 +1634,7 @@ void fgArgInfo::ArgsComplete()
             // All previous arguments may need to be evaluated into temps
             for (unsigned prevInx = 0; prevInx < curInx; prevInx++)
             {
-                fgArgTabEntryPtr prevArgTabEntry = argTable[prevInx];
+                fgArgTabEntry* prevArgTabEntry = argTable[prevInx];
                 assert(prevArgTabEntry->argNum < curArgTabEntry->argNum);
                 assert(prevArgTabEntry->node);
 
@@ -1786,7 +1785,7 @@ void fgArgInfo::ArgsComplete()
     {
         for (unsigned curInx = 0; curInx < argCount; curInx++)
         {
-            fgArgTabEntryPtr curArgTabEntry = argTable[curInx];
+            fgArgTabEntry* curArgTabEntry = argTable[curInx];
             assert(curArgTabEntry != nullptr);
             GenTreePtr argx = curArgTabEntry->node;
 
@@ -1887,7 +1886,7 @@ void fgArgInfo::SortArgs()
     {
         curInx--;
 
-        fgArgTabEntryPtr curArgTabEntry = argTable[curInx];
+        fgArgTabEntry* curArgTabEntry = argTable[curInx];
 
         if (curArgTabEntry->regNum != REG_STK)
         {
@@ -1929,7 +1928,7 @@ void fgArgInfo::SortArgs()
         //
         for (curInx = begTab; curInx <= endTab; curInx++)
         {
-            fgArgTabEntryPtr curArgTabEntry = argTable[curInx];
+            fgArgTabEntry* curArgTabEntry = argTable[curInx];
 
             // Skip any already processed args
             //
@@ -1969,7 +1968,7 @@ void fgArgInfo::SortArgs()
         //
         for (curInx = begTab; curInx <= endTab; curInx++)
         {
-            fgArgTabEntryPtr curArgTabEntry = argTable[curInx];
+            fgArgTabEntry* curArgTabEntry = argTable[curInx];
 
             // Skip any already processed args
             //
@@ -2005,7 +2004,7 @@ void fgArgInfo::SortArgs()
         {
             curInx--;
 
-            fgArgTabEntryPtr curArgTabEntry = argTable[curInx];
+            fgArgTabEntry* curArgTabEntry = argTable[curInx];
 
             // Skip any already processed args
             //
@@ -2041,15 +2040,15 @@ void fgArgInfo::SortArgs()
     {
         /* Find the most expensive arg remaining and evaluate it next */
 
-        fgArgTabEntryPtr expensiveArgTabEntry = nullptr;
-        unsigned         expensiveArg         = UINT_MAX;
-        unsigned         expensiveArgCost     = 0;
+        fgArgTabEntry* expensiveArgTabEntry = nullptr;
+        unsigned       expensiveArg         = UINT_MAX;
+        unsigned       expensiveArgCost     = 0;
 
         // [We use a forward iterator pattern]
         //
         for (curInx = begTab; curInx <= endTab; curInx++)
         {
-            fgArgTabEntryPtr curArgTabEntry = argTable[curInx];
+            fgArgTabEntry* curArgTabEntry = argTable[curInx];
 
             // Skip any already processed args
             //
@@ -2126,7 +2125,7 @@ void fgArgInfo::SortArgs()
     unsigned regInx = 0;
     for (curInx = 0; curInx < argCount; curInx++)
     {
-        fgArgTabEntryPtr curArgTabEntry = argTable[curInx];
+        fgArgTabEntry* curArgTabEntry = argTable[curInx];
 
         if (curArgTabEntry->regNum != REG_STK)
         {
@@ -2146,7 +2145,7 @@ void fgArgInfo::Dump(Compiler* compiler)
 {
     for (unsigned curInx = 0; curInx < ArgCount(); curInx++)
     {
-        fgArgTabEntryPtr curArgEntry = ArgTable()[curInx];
+        fgArgTabEntry* curArgEntry = ArgTable()[curInx];
         curArgEntry->Dump();
     }
 }
@@ -2283,7 +2282,7 @@ void fgArgInfo::EvalArgsToTemps()
     GenTreeArgList* tmpRegArgNext = nullptr;
     for (unsigned curInx = 0; curInx < argCount; curInx++)
     {
-        fgArgTabEntryPtr curArgTabEntry = argTable[curInx];
+        fgArgTabEntry* curArgTabEntry = argTable[curInx];
 
         GenTreePtr argx     = curArgTabEntry->node;
         GenTreePtr setupArg = nullptr;
@@ -2593,7 +2592,7 @@ void fgArgInfo::EvalArgsToTemps()
         printf("\nShuffled argument table:    ");
         for (unsigned curInx = 0; curInx < argCount; curInx++)
         {
-            fgArgTabEntryPtr curArgTabEntry = argTable[curInx];
+            fgArgTabEntry* curArgTabEntry = argTable[curInx];
 
             if (curArgTabEntry->regNum != REG_STK)
             {
@@ -3365,7 +3364,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
         bool                 isNonStandard = false;
         regNumber            nonStdRegNum  = REG_NA;
 
-        fgArgTabEntryPtr argEntry = nullptr;
+        fgArgTabEntry* argEntry = nullptr;
 
         if (reMorphing)
         {
@@ -3470,7 +3469,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
         {
 #if defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
             // Get the struct description for the already completed struct argument.
-            fgArgTabEntryPtr fgEntryPtr = gtArgEntryByNode(call, argx);
+            fgArgTabEntry* fgEntryPtr = gtArgEntryByNode(call, argx);
             assert(fgEntryPtr != nullptr);
 
             // As described in few other places, this can happen when the argx was morphed
@@ -4235,7 +4234,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
 #endif
 #endif
 
-            fgArgTabEntryPtr newArgEntry;
+            fgArgTabEntry* newArgEntry;
             if (reMorphing)
             {
                 // This is a register argument - possibly update it in the table
@@ -4370,9 +4369,9 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                 GenTreeFieldList(argx->gtOp.gtOp1, offsetof(CORINFO_RefAny, dataPtr), TYP_BYREF, nullptr);
             (void)new (this, GT_FIELD_LIST)
                 GenTreeFieldList(argx->gtOp.gtOp2, offsetof(CORINFO_RefAny, type), TYP_I_IMPL, fieldList);
-            fgArgTabEntryPtr fp = Compiler::gtArgEntryByNode(call, argx);
-            fp->node            = fieldList;
-            args->gtOp.gtOp1    = fieldList;
+            fgArgTabEntry* fp = Compiler::gtArgEntryByNode(call, argx);
+            fp->node          = fieldList;
+            args->gtOp.gtOp1  = fieldList;
 
 #else  // !_TARGET_X86_
 
@@ -4426,9 +4425,9 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                         lcl->gtType = fieldVarDsc->lvType;
                         fieldList   = new (this, GT_FIELD_LIST)
                             GenTreeFieldList(lcl, fieldVarDsc->lvFldOffset, fieldVarDsc->lvType, nullptr);
-                        fgArgTabEntryPtr fp = Compiler::gtArgEntryByNode(call, argx);
-                        fp->node            = fieldList;
-                        args->gtOp.gtOp1    = fieldList;
+                        fgArgTabEntry* fp = Compiler::gtArgEntryByNode(call, argx);
+                        fp->node          = fieldList;
+                        args->gtOp.gtOp1  = fieldList;
                     }
                     else
                     {
@@ -4640,8 +4639,8 @@ void Compiler::fgMorphSystemVStructArgs(GenTreeCall* call, bool hasStructArgumen
             // The tree from the gtCallLateArgs list is passed to the callee. The fgArgEntry node contains the mapping
             // between the nodes in both lists. If the arg is not a late arg, the fgArgEntry->node points to itself,
             // otherwise points to the list in the late args list.
-            bool             isLateArg  = (args->gtOp.gtOp1->gtFlags & GTF_LATE_ARG) != 0;
-            fgArgTabEntryPtr fgEntryPtr = gtArgEntryByNode(call, args->gtOp.gtOp1);
+            bool           isLateArg  = (args->gtOp.gtOp1->gtFlags & GTF_LATE_ARG) != 0;
+            fgArgTabEntry* fgEntryPtr = gtArgEntryByNode(call, args->gtOp.gtOp1);
             assert(fgEntryPtr != nullptr);
             GenTreePtr argx     = fgEntryPtr->node;
             GenTreePtr lateList = nullptr;
@@ -4759,8 +4758,8 @@ void Compiler::fgMorphSystemVStructArgs(GenTreeCall* call, bool hasStructArgumen
 
             if (argx != arg)
             {
-                bool             isLateArg  = (args->gtOp.gtOp1->gtFlags & GTF_LATE_ARG) != 0;
-                fgArgTabEntryPtr fgEntryPtr = gtArgEntryByNode(call, args->gtOp.gtOp1);
+                bool           isLateArg  = (args->gtOp.gtOp1->gtFlags & GTF_LATE_ARG) != 0;
+                fgArgTabEntry* fgEntryPtr = gtArgEntryByNode(call, args->gtOp.gtOp1);
                 assert(fgEntryPtr != nullptr);
                 GenTreePtr argx     = fgEntryPtr->node;
                 GenTreePtr lateList = nullptr;
@@ -4842,8 +4841,8 @@ void Compiler::fgMorphMultiregStructArgs(GenTreeCall* call)
         // The tree from the gtCallLateArgs list is passed to the callee. The fgArgEntry node contains the mapping
         // between the nodes in both lists. If the arg is not a late arg, the fgArgEntry->node points to itself,
         // otherwise points to the list in the late args list.
-        bool             isLateArg  = (args->gtOp.gtOp1->gtFlags & GTF_LATE_ARG) != 0;
-        fgArgTabEntryPtr fgEntryPtr = gtArgEntryByNode(call, args->gtOp.gtOp1);
+        bool           isLateArg  = (args->gtOp.gtOp1->gtFlags & GTF_LATE_ARG) != 0;
+        fgArgTabEntry* fgEntryPtr = gtArgEntryByNode(call, args->gtOp.gtOp1);
         assert(fgEntryPtr != nullptr);
         GenTreePtr argx     = fgEntryPtr->node;
         GenTreePtr lateList = nullptr;
@@ -4921,7 +4920,7 @@ void Compiler::fgMorphMultiregStructArgs(GenTreeCall* call)
 //    indirections.
 //    Currently the implementation handles ARM64/ARM and will NYI for other architectures.
 //
-GenTreePtr Compiler::fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr fgEntryPtr)
+GenTreePtr Compiler::fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntry* fgEntryPtr)
 {
     assert(varTypeIsStruct(arg->TypeGet()));
 
@@ -5485,10 +5484,10 @@ void Compiler::fgMakeOutgoingStructArgCopy(
             // struct parameters if they are passed as arguments to a tail call.
             if (!call->IsTailCallViaHelper() && (varDsc->lvRefCnt == 1) && !fgMightHaveLoop())
             {
-                varDsc->lvRefCnt    = 0;
-                args->gtOp.gtOp1    = lcl;
-                fgArgTabEntryPtr fp = Compiler::gtArgEntryByNode(call, argx);
-                fp->node            = lcl;
+                varDsc->lvRefCnt  = 0;
+                args->gtOp.gtOp1  = lcl;
+                fgArgTabEntry* fp = Compiler::gtArgEntryByNode(call, argx);
+                fp->node          = lcl;
 
                 JITDUMP("did not have to make outgoing copy for V%2d", varNum);
                 return;
@@ -8163,8 +8162,8 @@ void Compiler::fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCa
             else
             {
                 // This is an actual argument that needs to be assigned to the corresponding caller parameter.
-                fgArgTabEntryPtr curArgTabEntry = gtArgEntryByArgNum(recursiveTailCall, earlyArgIndex);
-                GenTreePtr       paramAssignStmt =
+                fgArgTabEntry* curArgTabEntry = gtArgEntryByArgNum(recursiveTailCall, earlyArgIndex);
+                GenTreePtr     paramAssignStmt =
                     fgAssignRecursiveCallArgToCallerParam(earlyArg, curArgTabEntry, block, callILOffset,
                                                           tmpAssignmentInsertionPoint, paramAssignmentInsertionPoint);
                 if ((tmpAssignmentInsertionPoint == last) && (paramAssignStmt != nullptr))
@@ -8182,9 +8181,9 @@ void Compiler::fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCa
          (lateArgIndex++, lateArgs = lateArgs->Rest()))
     {
         // A late argument is an actual argument that needs to be assigned to the corresponding caller's parameter.
-        GenTreePtr       lateArg        = lateArgs->Current();
-        fgArgTabEntryPtr curArgTabEntry = gtArgEntryByLateArgIndex(recursiveTailCall, lateArgIndex);
-        GenTreePtr       paramAssignStmt =
+        GenTreePtr     lateArg        = lateArgs->Current();
+        fgArgTabEntry* curArgTabEntry = gtArgEntryByLateArgIndex(recursiveTailCall, lateArgIndex);
+        GenTreePtr     paramAssignStmt =
             fgAssignRecursiveCallArgToCallerParam(lateArg, curArgTabEntry, block, callILOffset,
                                                   tmpAssignmentInsertionPoint, paramAssignmentInsertionPoint);
 
@@ -8275,12 +8274,12 @@ void Compiler::fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCa
 // Return Value:
 //    parameter assignment statement if one was inserted; nullptr otherwise.
 
-GenTreePtr Compiler::fgAssignRecursiveCallArgToCallerParam(GenTreePtr       arg,
-                                                           fgArgTabEntryPtr argTabEntry,
-                                                           BasicBlock*      block,
-                                                           IL_OFFSETX       callILOffset,
-                                                           GenTreePtr       tmpAssignmentInsertionPoint,
-                                                           GenTreePtr       paramAssignmentInsertionPoint)
+GenTreePtr Compiler::fgAssignRecursiveCallArgToCallerParam(GenTreePtr     arg,
+                                                           fgArgTabEntry* argTabEntry,
+                                                           BasicBlock*    block,
+                                                           IL_OFFSETX     callILOffset,
+                                                           GenTreePtr     tmpAssignmentInsertionPoint,
+                                                           GenTreePtr     paramAssignmentInsertionPoint)
 {
     // Call arguments should be assigned to temps first and then the temps should be assigned to parameters because
     // some argument trees may reference parameters directly.

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -999,7 +999,7 @@ fgArgInfo::fgArgInfo(Compiler* comp, GenTreeCall* call, unsigned numArgs)
  */
 fgArgInfo::fgArgInfo(GenTreeCall* newCall, GenTreeCall* oldCall)
 {
-    fgArgInfoPtr oldArgInfo = oldCall->gtCall.fgArgInfo;
+    fgArgInfo* oldArgInfo = oldCall->gtCall.fgArgInfo;
 
     compiler    = oldArgInfo->compiler;
     callTree    = newCall;
@@ -4631,7 +4631,7 @@ void Compiler::fgMorphSystemVStructArgs(GenTreeCall* call, bool hasStructArgumen
 
     if (hasStructArgument)
     {
-        fgArgInfoPtr allArgInfo = call->fgArgInfo;
+        fgArgInfo* allArgInfo = call->fgArgInfo;
 
         for (args = call->gtCallArgs; args != nullptr; args = args->gtOp.gtOp2)
         {
@@ -4815,10 +4815,10 @@ void Compiler::fgMorphSystemVStructArgs(GenTreeCall* call, bool hasStructArgumen
 //
 void Compiler::fgMorphMultiregStructArgs(GenTreeCall* call)
 {
-    bool         foundStructArg = false;
-    unsigned     initialFlags   = call->gtFlags;
-    unsigned     flagsSummary   = 0;
-    fgArgInfoPtr allArgInfo     = call->fgArgInfo;
+    bool       foundStructArg = false;
+    unsigned   initialFlags   = call->gtFlags;
+    unsigned   flagsSummary   = 0;
+    fgArgInfo* allArgInfo     = call->fgArgInfo;
 
     // Currently ARM64/ARM is using this method to morph the MultiReg struct args
     //  in the future AMD64_UNIX will also use this method

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -544,7 +544,7 @@ unsigned Compiler::optValnumCSE_Index(GenTreePtr tree, GenTreePtr stmt)
     {
         if (hashDsc->csdHashValue == key)
         {
-            treeStmtLstPtr newElem;
+            treeStmtLst* newElem;
 
             /* Have we started the list of matching nodes? */
 
@@ -912,9 +912,9 @@ void Compiler::optValnumCSE_InitDataFlow()
     //
     for (unsigned cnt = 0; cnt < optCSECandidateCount; cnt++)
     {
-        CSEdsc*        dsc      = optCSEtab[cnt];
-        unsigned       CSEindex = dsc->csdIndex;
-        treeStmtLstPtr lst      = dsc->csdTreeList;
+        CSEdsc*      dsc      = optCSEtab[cnt];
+        unsigned     CSEindex = dsc->csdIndex;
+        treeStmtLst* lst      = dsc->csdTreeList;
         noway_assert(lst);
 
         while (lst != nullptr)
@@ -1912,7 +1912,7 @@ public:
             We also unmark nested CSE's for all uses.
         */
 
-        Compiler::treeStmtLstPtr lst;
+        Compiler::treeStmtLst* lst;
         lst = successfulCandidate->CseDsc()->csdTreeList;
         noway_assert(lst);
 

--- a/src/jit/regalloc.cpp
+++ b/src/jit/regalloc.cpp
@@ -4611,7 +4611,7 @@ regMaskTP Compiler::rpPredictTreeRegUse(GenTreePtr   tree,
 
                 assert(!args->IsArgPlaceHolderNode()); // No place holders nodes are in gtCallLateArgs;
 
-                fgArgTabEntryPtr curArgTabEntry = gtArgEntryByNode(tree->AsCall(), args);
+                fgArgTabEntry* curArgTabEntry = gtArgEntryByNode(tree->AsCall(), args);
                 assert(curArgTabEntry);
 
                 regNumber regNum = curArgTabEntry->regNum; // first register use to pass this argument


### PR DESCRIPTION
Based on discussion in https://github.com/dotnet/coreclr/pull/12395#pullrequestreview-45330973 we want to delete `GenTreePtr` and other `*Ptr` types.
Because:
1. They are inconsistent;
2. They confuse intellisense, so if you have a function declaration with `GenTreePtr` and the imdlementation is declared with `GenTree*` it won't allow you to go to definition/declaration e.g. compiler.h:
`bool gtHasRef(GenTree* tree, ssize_t lclNum, bool defOnly);`
compiler.cpp:
`bool Compiler::gtHasRef(GenTreePtr tree, ssize_t lclNum, bool defOnly)`
 Vs doesn't see this implementation.


This PR deletes all *Ptr types except `GenTreePtr`.
