### PR TITLE
[x86/Linux] Fix HelperMethodFrame::UpdateRegDisplay

### DIFF
--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -390,9 +390,11 @@ void HelperMethodFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
         pRD->pCurrentContext->Eip = pRD->ControlPC = pUnwoundState->GetRetAddr();
         pRD->pCurrentContext->Esp = pRD->SP        = pUnwoundState->esp();
 
-#define CALLEE_SAVED_REGISTER(regname) pRD->pCurrentContext->regname = *((DWORD*) pUnwoundState->p##regname());
-        ENUM_CALLEE_SAVED_REGISTERS();
-#undef CALLEE_SAVED_REGISTER
+        // Do not use pUnwoundState->p##regname() here because it returns NULL in this case
+        pRD->pCurrentContext->Edi = pUnwoundState->_edi;
+        pRD->pCurrentContext->Esi = pUnwoundState->_esi;
+        pRD->pCurrentContext->Ebx = pUnwoundState->_ebx;
+        pRD->pCurrentContext->Ebp = pUnwoundState->_ebp;
 
 #define CALLEE_SAVED_REGISTER(regname) pRD->pCurrentContextPointers->regname = (DWORD*) pUnwoundState->p##regname();
         ENUM_CALLEE_SAVED_REGISTERS();


### PR DESCRIPTION
For DAC after initialization MachState using `InsureInit` method, register pointers are NULL so we cannot use them to restore register values.