### PR TITLE
Fix FreeBSD build and update build instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -587,6 +587,13 @@ if(WIN32)
   add_compile_options(/Zl) # omit default library name in .OBJ
 endif(WIN32)
 
+#------------------------------
+# Add Test Directory
+#------------------------------
+if(CLR_CMAKE_BUILD_TESTS)
+  add_subdirectory(tests)
+endif(CLR_CMAKE_BUILD_TESTS)
+
 #--------------------------------
 # Definition directives
 #  - all clr specific compile definitions should be included in this file
@@ -620,17 +627,5 @@ set(BuildToolsDir "${CLR_CMAKE_PACKAGES_DIR}/Microsoft.DotNet.BuildTools.CoreCLR
 # Add Product Directory
 #------------------------------
 add_subdirectory(src)
-
-#------------------------------
-# Add Test Directory
-#------------------------------
-if(CLR_CMAKE_BUILD_TESTS)
-  # remove some definitions for test build
-  remove_definitions(-D_SECURE_SCL=0)
-  remove_definitions(-DUNICODE)
-  remove_definitions(-D_UNICODE)
-
-  add_subdirectory(tests)
-endif(CLR_CMAKE_BUILD_TESTS)
 
 include(definitionsconsistencycheck.cmake)

--- a/Documentation/building/freebsd-instructions.md
+++ b/Documentation/building/freebsd-instructions.md
@@ -23,6 +23,9 @@ Install the following packages for the toolchain:
 - libunwind
 - gettext
 - icu
+- ninja (optional)
+- lttng-ust
+- python27
 
 To install the packages you need:
 

--- a/src/pal/src/exception/remote-unwind.cpp
+++ b/src/pal/src/exception/remote-unwind.cpp
@@ -63,6 +63,9 @@ SET_DEFAULT_DEBUG_CHANNEL(EXCEPT);
 #include <elf.h>
 #include <link.h>
 
+#ifndef ElfW
+#define ElfW(foo) Elf_ ## foo
+#endif
 #define Ehdr   ElfW(Ehdr)
 #define Phdr   ElfW(Phdr)
 #define Shdr   ElfW(Shdr)

--- a/src/pal/src/numa/numa.cpp
+++ b/src/pal/src/numa/numa.cpp
@@ -31,7 +31,11 @@ SET_DEFAULT_DEBUG_CHANNEL(NUMA);
 
 #include <pthread.h>
 #include <dlfcn.h>
+#ifdef __FreeBSD__
+#include <stdlib.h>
+#else
 #include <alloca.h>
+#endif
 
 #include <algorithm>
 


### PR DESCRIPTION
Move src/pal/inc/rt include from global CMakeLists to src/ to avoid
include conflict in test/ code (ForeignThreadExceptionsNative.cpp ->
thread -> functional -> memory -> cassert -> pal rt "assert.h").

Update build instructions to include needed components (ninja,
lttng-ust, python27).

Change int8_t definition to be explicitly signed to match FreeBSD
includes.

Add missing ElfW() definition when libunwind does not define it.

FreeBSD alloca() is defined in stdlib.h, so include that instead of
alloca.h on FreeBSD.