### PR TITLE
[Local GC] FEATURE_EVENT_TRACE 3/n: Defining and Firing Dynamic Events 

### DIFF
--- a/src/gc/gcevent_serializers.h
+++ b/src/gc/gcevent_serializers.h
@@ -1,0 +1,141 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef __GCEVENT_SERIALIZERS_H__
+#define __GCEVENT_SERIALIZERS_H__
+
+/*
+ * gcevent_serializers.h - Serialization traits and plumbing for
+ * serializing dynamic events.
+ *
+ * Dynamic events are events that can be fired by the GC without prior
+ * knowledge of the EE. In order to accomplish this, the GC sends raw
+ * bytes to the EE using the `IGCToCLR::FireDynamicEvent` callback, which
+ * the EE will then fire as its own event.
+ *
+ * In order to keep the friction of adding new dynamic events low, this
+ * file defines a simple ETW-style binary serialization format that
+ * is efficient and easy to both serialize and deserialize.
+ *
+ * ## Serializing Types
+ *
+ * This file makes use of `EventSerializationTraits` to serialize
+ * types. A type can opt-in to serialization using the mechanisms
+ * in this file by specializing the `EventSerializationTraits` template,
+ * providing implementations of `Serialize` and `SerializedSize`.
+ * 
+ * If you attempt to serialize a type that does not implement this trait,
+ * you will receive an error message like this:
+ *
+ * bool gc_event::EventSerializationTraits<Head>::Serialize(const T&,uint8_t **)': attempting to reference a deleted function
+ * with
+ *  [
+ *      Head=<your type you tried to serialize>,
+ *      T=<your type you tried to serialize>
+ *  ] 
+ * 
+ * If you get this message, you will need to specialize `EventSerializationTraits`
+ * for the type you want to serialize.
+ */ 
+
+#ifdef _MSC_VER
+#define ByteSwap32 _byteswap_ulong
+#define ByteSwap64 _byteswap_uint64
+#else
+#define ByteSwap32 __bulitin_bswap32
+#define ByteSwap64 __builtin_bswap64
+#endif // MSC_VER
+
+namespace gc_event
+{
+
+/*
+ * `EventSerializatonTraits` is a trait implemented by types that
+ * can be serialized to the payload of a dynamic event.
+ */
+template<class T>
+struct EventSerializationTraits
+{
+    /*
+     * Serializes the value `value` to the buffer `buffer`, incrementing
+     * the buffer double-pointer to point to the next byte to be written.
+     * 
+     * It is the responsibility of the caller to ensure that the buffer is
+     * large enough to accomodate the serialized form of T.
+     */
+    static void Serialize(const T& value, uint8_t** buffer) = delete;
+
+    /*
+     * Returns the size of the value `value` if it were to be serialized.
+     */
+    static size_t SerializedSize(const T& value) = delete;
+};
+
+/*
+ * EventSerializationTraits implementation for uint32_t. Other integral types
+ * can follow this pattern.
+ *
+ * The convention here is that integral types are always serialized as
+ * little-endian.
+ */
+template<>
+struct EventSerializationTraits<uint32_t>
+{
+    static void Serialize(const uint32_t& value, uint8_t** buffer)
+    {
+#if defined(BIGENDIAN)
+        **((uint32_t**)buffer) = ByteSwap32(value);
+#else
+        **((uint32_t**)buffer) = value;
+#endif // BIGENDIAN
+        *buffer += sizeof(uint32_t);
+    }
+
+    static size_t SerializedSize(const uint32_t& value)
+    {
+        return sizeof(uint32_t);
+    }
+};
+
+/*
+ * Helper routines for serializing lists of arguments.
+ */
+
+/*
+ * Given a list of arguments , returns the total size of
+ * the buffer required to fully serialize the list of arguments.
+ */
+template<class Head, class... Tail>
+size_t SerializedSize(Head head, Tail... tail)
+{
+    return EventSerializationTraits<Head>::SerializedSize(head) + SerializedSize(tail...);
+}
+
+template<class Head>
+size_t SerializedSize(Head head)
+{
+    return EventSerializationTraits<Head>::SerializedSize(head);
+}
+
+/*
+ * Given a list of arguments and a list of actual parameters, serialize
+ * the arguments into the buffer that's given to us.
+ */
+template<class Head, class... Tail>
+void Serialize(uint8_t** buf, Head head, Tail... tail)
+{
+    EventSerializationTraits<Head>::Serialize(head, buf);
+    Serialize(buf, tail...);
+}
+
+template<class Head>
+void Serialize(uint8_t** buf, Head head)
+{
+    EventSerializationTraits<Head>::Serialize(head, buf);
+}
+
+} // namespace gc_event
+
+#endif // __GCEVENT_SERIALIZERS_H__
+

--- a/src/gc/gcevents.h
+++ b/src/gc/gcevents.h
@@ -6,7 +6,7 @@
 #endif // KNOWN_EVENT
 
 #ifndef DYNAMIC_EVENT
- #define DYNAMIC_EVENT(name, provider, level, keyword, ...)
+ #define DYNAMIC_EVENT(name, level, keyword, ...)
 #endif // DYNAMIC_EVENT
 
 #undef KNOWN_EVENT

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -16,7 +16,15 @@
 // to the EE. ([LOCALGC TODO dynamic event implementation])
 class IGCToCLREventSink
 {
-    /* [LOCALGC TODO] This will be filled with events as they get ported */
+public:
+    // Fires a dynamic event with the given event name and payload. Dynamic
+    // events are not known to the EE and are fired as an unschematized event
+    // to the underlying eventing implementation.
+    virtual
+    void FireDynamicEvent(
+        const char* eventName,
+        void* payload,
+        uint32_t payloadSize) = 0;
 };
 
 // This interface provides the interface that the GC will use to speak to the rest

--- a/src/gc/gcsvr.cpp
+++ b/src/gc/gcsvr.cpp
@@ -17,6 +17,7 @@
 #include "handletable.h"
 #include "handletable.inl"
 #include "gcenv.inl"
+#include "gceventstatus.h"
 
 #define SERVER_GC 1
 

--- a/src/gc/gcwks.cpp
+++ b/src/gc/gcwks.cpp
@@ -15,6 +15,7 @@
 #include "handletable.h"
 #include "handletable.inl"
 #include "gcenv.inl"
+#include "gceventstatus.h"
 
 #ifdef SERVER_GC
 #undef SERVER_GC

--- a/src/vm/ClrEtwAll.man
+++ b/src/vm/ClrEtwAll.man
@@ -116,6 +116,7 @@
                             <opcode name="GCBulkRootCCW" message="$(string.RuntimePublisher.GCBulkRootCCWOpcodeMessage)" symbol="CLR_GC_BULKROOTCCW_OPCODE" value="38"> </opcode>
                             <opcode name="GCBulkRCW" message="$(string.RuntimePublisher.GCBulkRCWOpcodeMessage)" symbol="CLR_GC_BULKRCW_OPCODE" value="39"> </opcode>
                             <opcode name="GCBulkRootStaticVar" message="$(string.RuntimePublisher.GCBulkRootStaticVarOpcodeMessage)" symbol="CLR_GC_BULKROOTSTATICVAR_OPCODE" value="40"> </opcode>
+                            <opcode name="GCDynamicEvent" message="$(string.RuntimePublisher.GCDynamicEventOpcodeMessage)" symbol="CLR_GC_DYNAMICEVENT_OPCODE" value="41"> </opcode>
                             <opcode name="IncreaseMemoryPressure" message="$(string.RuntimePublisher.IncreaseMemoryPressureOpcodeMessage)" symbol="CLR_GC_INCREASEMEMORYPRESSURE_OPCODE" value="200"> </opcode>
                             <opcode name="DecreaseMemoryPressure" message="$(string.RuntimePublisher.DecreaseMemoryPressureOpcodeMessage)" symbol="CLR_GC_DECREASEMEMORYPRESSURE_OPCODE" value="201"> </opcode>
                             <opcode name="GCMarkWithType" message="$(string.RuntimePublisher.GCMarkOpcodeMessage)" symbol="CLR_GC_MARK_OPCODE" value="202"> </opcode>
@@ -1184,6 +1185,13 @@
                         <data name="ObjectID" inType="win:Pointer" />
                         <data name="ObjectSize" inType="win:UInt64" />
                         <data name="TypeName" inType="win:UnicodeString" />
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                    </template>
+
+                    <template tid="GCDynamicEvent">
+                        <data name="Name" inType="win:UnicodeString" />
+                        <data name="DataSize" inType="win:UInt32" />
+                        <data name="Data" inType="win:Binary" length="DataSize" />
                         <data name="ClrInstanceID" inType="win:UInt16" />
                     </template>
                     
@@ -2566,6 +2574,12 @@
                            keywords ="GCHeapDumpKeyword"  opcode="GCBulkRootStaticVar"
                            task="GarbageCollection"
                            symbol="GCBulkRootStaticVar" message="$(string.RuntimePublisher.GCBulkRootStaticVarEventMessage)"/>
+
+                    <event value="39" version="0" level="win:LogAlways" template="GCDynamicEvent"
+                           keywords= "GCKeyword GCHandleKeyword GCHeapDumpKeyword GCSampledObjectAllocationHighKeyword GCHeapSurvivalAndMovementKeyword GCHeapCollectKeyword GCHeapAndTypeNamesKeyword GCSampledObjectAllocationLowKeyword"
+                           opcode="GCDynamicEvent"
+                           task="GarbageCollection"
+                           symbol="GCDynamicEvent"/>
 
                     <!-- CLR Threading events, value reserved from 40 to 79 -->
                     <event value="40" version="0" level="win:Informational"  template="ClrWorkerThread"
@@ -6194,6 +6208,7 @@
                 <string id="RuntimePublisher.GCBulkRootCCWEventMessage" value="ClrInstanceID=%1;%nIndex=%2;%nCount=%3" />
                 <string id="RuntimePublisher.GCBulkRCWEventMessage" value="ClrInstanceID=%1;%nIndex=%2;%nCount=%3" />
                 <string id="RuntimePublisher.GCBulkRootStaticVarEventMessage" value="ClrInstanceID=%1;%nIndex=%2;%nCount=%3" />
+                <string id="RuntimePublisher.GCDynamicEventMessage" value="ClrInstanceID=%1;Data=%2;Size=%3" />
                 <string id="RuntimePublisher.GCBulkRootConditionalWeakTableElementEdgeEventMessage" value="ClrInstanceID=%1;%nIndex=%2;%nCount=%3" />
                 <string id="RuntimePublisher.GCBulkNodeEventMessage" value="ClrInstanceID=%1;%nIndex=%2;%nCount=%3" />
                 <string id="RuntimePublisher.GCBulkEdgeEventMessage" value="ClrInstanceID=%1;%nIndex=%2;%nCount=%3" />
@@ -6788,6 +6803,7 @@
                 <string id="RuntimePublisher.GCBulkRootCCWOpcodeMessage" value="GCBulkRootCCW" />
                 <string id="RuntimePublisher.GCBulkRCWOpcodeMessage" value="GCBulkRCW" />
                 <string id="RuntimePublisher.GCBulkRootStaticVarOpcodeMessage" value="GCBulkRootStaticVar" />
+                <string id="RuntimePublisher.GCDynamicEventOpcodeMessage" value="GCDynamicEvent" />
                 <string id="RuntimePublisher.GCBulkRootConditionalWeakTableElementEdgeOpcodeMessage" value="GCBulkRootConditionalWeakTableElementEdge" />
                 <string id="RuntimePublisher.GCBulkNodeOpcodeMessage" value="GCBulkNode" />
                 <string id="RuntimePublisher.GCBulkEdgeOpcodeMessage" value="GCBulkEdge" />

--- a/src/vm/gctoclreventsink.cpp
+++ b/src/vm/gctoclreventsink.cpp
@@ -6,3 +6,18 @@
 #include "gctoclreventsink.h"
 
 GCToCLREventSink g_gcToClrEventSink;
+
+void GCToCLREventSink::FireDynamicEvent(const char* eventName, void* payload, uint32_t payloadSize)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    const size_t EventNameMaxSize = 255;
+
+    WCHAR wideEventName[EventNameMaxSize];
+    if (MultiByteToWideChar(CP_ACP, 0, eventName, -1, wideEventName, EventNameMaxSize) == 0)
+    {
+        return;
+    }
+
+    FireEtwGCDynamicEvent(wideEventName, payloadSize, (const BYTE*)payload, GetClrInstanceId());
+}

--- a/src/vm/gctoclreventsink.h
+++ b/src/vm/gctoclreventsink.h
@@ -9,7 +9,8 @@
 
 class GCToCLREventSink : public IGCToCLREventSink
 {
-    /* [LOCALGC TODO] This will be filled with events as they get ported */
+public:
+    void FireDynamicEvent(const char* eventName, void* payload, uint32_t payloadSize);
 };
 
 extern GCToCLREventSink g_gcToClrEventSink;


### PR DESCRIPTION
This PR implements the [Defining and Firing Dynamic Events](https://github.com/dotnet/coreclr/blob/master/Documentation/design-docs/standalone-gc-eventing.md#defining-and-firing-dynamic-events) portion of the standalone GC eventing spec.

## Defining Events

Under this scheme, a new dynamic event can be added by adding a macro describing it to `src\gc\gcevents.h`. For example, this macro invocation defines a new dynamic event `GCMyNewDynamicEvent` has a level of Verbose, has the single keyword GC, and has a payload consisting of two `uint32_t`s:

```c++
DYNAMIC_EVENT(GCEvent2, GCEventLevel_Verbose, GCEventKeyword_GC, uint32_t, uint32_t)
```

The general syntax for `DYNAMIC_EVENT` is

```
DYNAMIC_EVENT(<event name>, <level>, <keyword>, ...<arguments>)
```

Where `arguments` are zero or more types that form the payload of the dynamic event. Dynamic events are always associated with the default ETW provider and not the private one.

Under the hood, the definition macro invocation results in two functions being generated. In
the above example, these two functions are generated:

```c++
inline bool GCEventEnabledGCEvent2()
{
    return GCEventStatus::IsEnabled(GCEventProvider_Default, GCEventKeyword_GC, GCEventLevel_Verbose);
}

template<typename... EventActualArguments>
inline void GCEventFireGCEvent2(EventActualArguments... arguments)
{
    FireDynamicEvent<uint32_t, uint32_t>("GCEvent2", arguments...);
}
```

`FireDynamicEvent` is a helper templated method that 1) serializes the event payload into a binary format and 2) sends the binary payload across the GC/EE interface via `IGCToCLREventSink::FireDynamicEvent`, where the event is handed off to the platform logger(s). `FireDynamicEvent` is a variadic template whose template arguments are the types of the event payload specified in the declaration and whose actual arguments are the values that will form the payload of the event.

## Firing Events

The above two auto-generated functions allow us to hide the template complexity between the two macros used in https://github.com/dotnet/coreclr/pull/15957: `EVENT_ENABLED` and `FIRE_EVENT`.

For example, the following code would check if the above dynamic event is enabled and, if it is, fires the event:

```c++
if (EVENT_ENABLED(GCEvent2))
{
    FIRE_EVENT(GCEvent2, 11, 88);
}
```

Note that this exactly the syntax for firing a known event - at the call site there is no distinction between a known event and a dynamic one.

On the EE side of the GC/EE interface, the EE defines a single event for dynamic events called `GCDynamicEvent`, whose level is `LogAlways` and whose keyword consists of all keywords that are used by the GC to fire events. This ensures that the `GCDynamicEvent` will always be enabled on the underlying ETW provider if there ever is a dynamic event that is enabled.

This is an example ETW payload that I received when testing this feature with the above dynamic event:

```
<Event MSec=  "3345.6193" PID="271000" PName="Process(271000)" TID="271064" EventName="EventID(39)"
  TimeStamp="01/23/18 16:33:31.171744" ID="39" Version="0" Keywords="0x03F00003" TimeStampQPC="624,394,476,297"
  Level="Always" ProviderName="Microsoft-Windows-DotNETRuntime" ProviderGuid="e13c0d23-ccbc-4e12-931b-d9cc2eee27e4" ClassicProvider="False"
  Opcode="41" Task="1" Channel="0" PointerSize="8"
  CPU="4" EventIndex="67" TemplateType="UnhandledTraceEvent">
  <Payload Length="32">
       0:  47  0 43  0 45  0 76  0 | 65  0 6e  0 74  0 32  0   G.C.E.v. e.n.t.2.
      10:   0  0  8  0  0  0  b  0 |  0  0 58  0  0  0  2  0   ........ ..X.....
  </Payload>
</Event>
```

(note that PerfView, which produced this event dump, is not aware what this event is because I haven't installed the manifest that I built - the payload is the most interesting part of this snippet.)

## Serializing Event Payloads

Payload serialization is driven by the `EventSerializationTraits` in `src\gc\gcevent_serializers.h`. It should be implemented for all types that will be serialized as event payloads. This PR provides only one such implementation, for `uint32_t`, but new implementations can be added as they are needed for new dynamic events.

The serialization scheme is extremely simple and doesn't preclude more sophisticated serialization schemes in the future. The provided implementation of `EventSerializationTraits` for `uint32_t` serializes a `uint32_t` as a four-byte little-endian integer, but the code in this file is not opinionated at all about how things are serialized.