### PR TITLE
fix pointer in ILCodeVersionNode so it uses PTR_COR_ILMETHOD instead of COR_IL_METHOD *, which was causing a crash in the DAC

### DIFF
--- a/src/vm/codeversion.cpp
+++ b/src/vm/codeversion.cpp
@@ -518,9 +518,11 @@ ILCodeVersionNode::ILCodeVersionNode() :
     m_rejitId(0),
     m_pNextILVersionNode(dac_cast<PTR_ILCodeVersionNode>(nullptr)),
     m_rejitState(ILCodeVersion::kStateRequested),
-    m_pIL(dac_cast<PTR_COR_ILMETHOD>(nullptr)),
+    m_pIL(),
     m_jitFlags(0)
-{}
+{
+    m_pIL.Store(dac_cast<PTR_COR_ILMETHOD>(nullptr));
+}
 
 #ifndef DACCESS_COMPILE
 ILCodeVersionNode::ILCodeVersionNode(Module* pModule, mdMethodDef methodDef, ReJITID id) :

--- a/src/vm/codeversion.h
+++ b/src/vm/codeversion.h
@@ -340,7 +340,7 @@ private:
     ReJITID m_rejitId;
     PTR_ILCodeVersionNode m_pNextILVersionNode;
     Volatile<ILCodeVersion::RejitFlags> m_rejitState;
-    VolatilePtr<COR_ILMETHOD> m_pIL;
+    VolatilePtr<COR_ILMETHOD, PTR_COR_ILMETHOD> m_pIL;
     Volatile<DWORD> m_jitFlags;
     InstrumentedILOffsetMapping m_instrumentedILMap;
 };


### PR DESCRIPTION
Fix for #15423 