### PR TITLE
Disable FP to Unsigned Vector Conversions

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -3771,10 +3771,8 @@ void CodeGen::genSIMDIntrinsic(GenTreeSIMD* simdNode)
         case SIMDIntrinsicCast:
         case SIMDIntrinsicConvertToSingle:
         case SIMDIntrinsicConvertToInt32:
-        case SIMDIntrinsicConvertToUInt32:
         case SIMDIntrinsicConvertToDouble:
         case SIMDIntrinsicConvertToInt64:
-        case SIMDIntrinsicConvertToUInt64:
             genSIMDIntrinsicUnOp(simdNode);
             break;
 
@@ -3917,10 +3915,6 @@ instruction CodeGen::getOpForSIMDIntrinsic(SIMDIntrinsicID intrinsicId, var_type
             case SIMDIntrinsicConvertToInt32:
             case SIMDIntrinsicConvertToInt64:
                 result = INS_fcvtns;
-                break;
-            case SIMDIntrinsicConvertToUInt32:
-            case SIMDIntrinsicConvertToUInt64:
-                result = INS_fcvtnu;
                 break;
             case SIMDIntrinsicDiv:
                 result = INS_fdiv;
@@ -4199,10 +4193,8 @@ void CodeGen::genSIMDIntrinsicUnOp(GenTreeSIMD* simdNode)
            simdNode->gtSIMDIntrinsicID == SIMDIntrinsicAbs ||
            simdNode->gtSIMDIntrinsicID == SIMDIntrinsicConvertToSingle ||
            simdNode->gtSIMDIntrinsicID == SIMDIntrinsicConvertToInt32 ||
-           simdNode->gtSIMDIntrinsicID == SIMDIntrinsicConvertToUInt32 ||
            simdNode->gtSIMDIntrinsicID == SIMDIntrinsicConvertToDouble ||
-           simdNode->gtSIMDIntrinsicID == SIMDIntrinsicConvertToInt64 ||
-           simdNode->gtSIMDIntrinsicID == SIMDIntrinsicConvertToUInt64);
+           simdNode->gtSIMDIntrinsicID == SIMDIntrinsicConvertToInt64);
 
     GenTree*  op1       = simdNode->gtGetOp1();
     var_types baseType  = simdNode->gtSIMDBaseType;

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -134,6 +134,7 @@ bool emitter::IsDstDstSrcAVXInstruction(instruction ins)
         case INS_pcmpgtq:
         case INS_pcmpgtw:
         case INS_phaddd:
+        case INS_pinsrw:
         case INS_pmaxsb:
         case INS_pmaxsd:
         case INS_pmaxsw:

--- a/src/jit/lsraarm64.cpp
+++ b/src/jit/lsraarm64.cpp
@@ -830,10 +830,8 @@ void LinearScan::TreeNodeInfoInitSIMD(GenTreeSIMD* simdTree, TreeNodeInfo* info)
         case SIMDIntrinsicAbs:
         case SIMDIntrinsicConvertToSingle:
         case SIMDIntrinsicConvertToInt32:
-        case SIMDIntrinsicConvertToUInt32:
         case SIMDIntrinsicConvertToDouble:
         case SIMDIntrinsicConvertToInt64:
-        case SIMDIntrinsicConvertToUInt64:
         case SIMDIntrinsicWidenLo:
         case SIMDIntrinsicWidenHi:
             assert(info->srcCount == 1);

--- a/src/jit/lsraxarch.cpp
+++ b/src/jit/lsraxarch.cpp
@@ -2395,7 +2395,6 @@ void LinearScan::TreeNodeInfoInitSIMD(GenTreeSIMD* simdTree, TreeNodeInfo* info)
             }
             break;
 
-        case SIMDIntrinsicConvertToUInt32:
         case SIMDIntrinsicConvertToInt32:
             assert(info->srcCount == 1);
             break;
@@ -2413,7 +2412,6 @@ void LinearScan::TreeNodeInfoInitSIMD(GenTreeSIMD* simdTree, TreeNodeInfo* info)
             break;
 
         case SIMDIntrinsicConvertToInt64:
-        case SIMDIntrinsicConvertToUInt64:
             assert(info->srcCount == 1);
             // We need an internal register different from targetReg.
             info->isInternalRegDelayFree = true;

--- a/src/jit/simd.cpp
+++ b/src/jit/simd.cpp
@@ -3051,14 +3051,6 @@ GenTreePtr Compiler::impSIMDIntrinsic(OPCODE                opcode,
         }
         break;
 
-        case SIMDIntrinsicConvertToUInt32:
-        case SIMDIntrinsicConvertToUInt64:
-        {
-            JITDUMP("SIMD Conversion to UInt32/UInt64 is not supported on this platform\n");
-            return nullptr;
-        }
-        break;
-
         case SIMDIntrinsicConvertToInt64:
         {
 #ifdef _TARGET_64BIT_

--- a/src/jit/simd.cpp
+++ b/src/jit/simd.cpp
@@ -3043,7 +3043,6 @@ GenTreePtr Compiler::impSIMDIntrinsic(OPCODE                opcode,
         case SIMDIntrinsicConvertToSingle:
         case SIMDIntrinsicConvertToDouble:
         case SIMDIntrinsicConvertToInt32:
-        case SIMDIntrinsicConvertToUInt32:
         {
             op1 = impSIMDPopStack(simdType, instMethod);
 
@@ -3052,8 +3051,15 @@ GenTreePtr Compiler::impSIMDIntrinsic(OPCODE                opcode,
         }
         break;
 
-        case SIMDIntrinsicConvertToInt64:
+        case SIMDIntrinsicConvertToUInt32:
         case SIMDIntrinsicConvertToUInt64:
+        {
+            JITDUMP("SIMD Conversion to UInt32/UInt64 is not supported on this platform\n");
+            return nullptr;
+        }
+        break;
+
+        case SIMDIntrinsicConvertToInt64:
         {
 #ifdef _TARGET_64BIT_
             op1 = impSIMDPopStack(simdType, instMethod);
@@ -3061,7 +3067,7 @@ GenTreePtr Compiler::impSIMDIntrinsic(OPCODE                opcode,
             simdTree = gtNewSIMDNode(simdType, op1, nullptr, simdIntrinsicID, baseType, size);
             retVal   = simdTree;
 #else
-            JITDUMP("SIMD Conversion to Int64/UInt64 is not supported on this platform\n");
+            JITDUMP("SIMD Conversion to Int64 is not supported on this platform\n");
             return nullptr;
 #endif
         }

--- a/src/jit/simdcodegenxarch.cpp
+++ b/src/jit/simdcodegenxarch.cpp
@@ -497,13 +497,11 @@ instruction CodeGen::getOpForSIMDIntrinsic(SIMDIntrinsicID intrinsicId, var_type
             break;
 
         case SIMDIntrinsicConvertToInt32:
-        case SIMDIntrinsicConvertToUInt32:
             assert(baseType == TYP_FLOAT);
             result = INS_cvttps2dq;
             break;
 
         case SIMDIntrinsicConvertToInt64:
-        case SIMDIntrinsicConvertToUInt64:
             assert(baseType == TYP_DOUBLE);
             result = INS_cvttsd2si;
             break;

--- a/src/jit/simdcodegenxarch.cpp
+++ b/src/jit/simdcodegenxarch.cpp
@@ -1060,8 +1060,7 @@ void CodeGen::genSIMDIntrinsicUnOp(GenTreeSIMD* simdNode)
 void CodeGen::genSIMDIntrinsic32BitConvert(GenTreeSIMD* simdNode)
 {
     SIMDIntrinsicID intrinsicID = simdNode->gtSIMDIntrinsicID;
-    assert((intrinsicID == SIMDIntrinsicConvertToSingle) || (intrinsicID == SIMDIntrinsicConvertToInt32) ||
-           (intrinsicID == SIMDIntrinsicConvertToUInt32));
+    assert((intrinsicID == SIMDIntrinsicConvertToSingle) || (intrinsicID == SIMDIntrinsicConvertToInt32));
 
     GenTree*  op1       = simdNode->gtGetOp1();
     var_types baseType  = simdNode->gtSIMDBaseType;
@@ -1196,8 +1195,7 @@ void CodeGen::genSIMDLo64BitConvert(SIMDIntrinsicID intrinsicID,
 void CodeGen::genSIMDIntrinsic64BitConvert(GenTreeSIMD* simdNode)
 {
     SIMDIntrinsicID intrinsicID = simdNode->gtSIMDIntrinsicID;
-    assert((intrinsicID == SIMDIntrinsicConvertToDouble) || (intrinsicID == SIMDIntrinsicConvertToInt64) ||
-           (intrinsicID == SIMDIntrinsicConvertToUInt64));
+    assert((intrinsicID == SIMDIntrinsicConvertToDouble) || (intrinsicID == SIMDIntrinsicConvertToInt64));
 
     GenTree*  op1       = simdNode->gtGetOp1();
     var_types baseType  = simdNode->gtSIMDBaseType;
@@ -3137,13 +3135,11 @@ void CodeGen::genSIMDIntrinsic(GenTreeSIMD* simdNode)
 
         case SIMDIntrinsicConvertToSingle:
         case SIMDIntrinsicConvertToInt32:
-        case SIMDIntrinsicConvertToUInt32:
             genSIMDIntrinsic32BitConvert(simdNode);
             break;
 
         case SIMDIntrinsicConvertToDouble:
         case SIMDIntrinsicConvertToInt64:
-        case SIMDIntrinsicConvertToUInt64:
             genSIMDIntrinsic64BitConvert(simdNode);
             break;
 

--- a/src/jit/simdintrinsiclist.h
+++ b/src/jit/simdintrinsiclist.h
@@ -137,12 +137,8 @@ SIMD_INTRINSIC("ConvertToSingle",           false,       ConvertToSingle,       
 SIMD_INTRINSIC("ConvertToDouble",           false,       ConvertToDouble,          "ConvertToDouble",        TYP_STRUCT,     1,      {TYP_STRUCT, TYP_UNDEF,  TYP_UNDEF},   {TYP_LONG, TYP_ULONG, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF})
 // Convert single to int
 SIMD_INTRINSIC("ConvertToInt32",            false,       ConvertToInt32,           "ConvertToInt32",         TYP_STRUCT,     1,      {TYP_STRUCT, TYP_UNDEF,  TYP_UNDEF},   {TYP_FLOAT, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF})
-// Convert single to uint
-SIMD_INTRINSIC("ConvertToUInt32",           false,       ConvertToUInt32,          "ConvertToUInt32",        TYP_STRUCT,     1,      {TYP_STRUCT, TYP_UNDEF,  TYP_UNDEF},   {TYP_FLOAT, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF})
 // Convert double to long
 SIMD_INTRINSIC("ConvertToInt64",            false,       ConvertToInt64,           "ConvertToInt64",         TYP_STRUCT,     1,      {TYP_STRUCT, TYP_UNDEF,  TYP_UNDEF},   {TYP_DOUBLE, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF})
-// Convert double to ulong
-SIMD_INTRINSIC("ConvertToUInt64",           false,       ConvertToUInt64,          "ConvertToUInt64",        TYP_STRUCT,     1,      {TYP_STRUCT, TYP_UNDEF,  TYP_UNDEF},   {TYP_DOUBLE, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF})
 // Narrow two input Vector<T>s to a single Vector<T>. The return value's lower elements are the elements from src1, and the upper elements are from src2.
 SIMD_INTRINSIC("Narrow",                    false,       Narrow,                   "Narrow",                 TYP_STRUCT,     2,      {TYP_STRUCT, TYP_STRUCT, TYP_UNDEF},   {TYP_INT, TYP_DOUBLE, TYP_LONG, TYP_USHORT, TYP_SHORT, TYP_UINT, TYP_ULONG, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF})
 // Widen one input Vector<T> to two Vector<T>s: dest1 contains the lower half of elements in src, and dest2 contains the upper half of elements in src.


### PR DESCRIPTION
The specific failure in #15848 was due to a problem with the AVX encoding of the `pinsrw` instruction that was exposed when AVX is enabled but AVX2 is not. The code generator generates the (SSE2) 2-operand form, but this is an instruction that needs to be encoded with the dst duplicated when using AVX encodings. So it needs to be added to `IsDstDstSrcAVXInstruction()`.

Investigating this (and adding additional test coverage) revealed that conversions to unsigned were not implemented correctly for out-of-range values, and providing the same behavior as scalar conversion is complex and costly, with unknown benefit, as this is not expected to be a common scenario. So, don't recognize these as intrinsics (revert to the IL implementation).

Also, fix the test to cover more cases.

Fix 15848