### PR TITLE
Enable Windows ARM32 corefx testing

### DIFF
--- a/tests/arm/corefx_test_exclusions.txt
+++ b/tests/arm/corefx_test_exclusions.txt
@@ -1,0 +1,7 @@
+System.Console.Tests
+System.Data.SqlClient.Tests
+System.Diagnostics.Process.Tests
+System.Drawing.Common.Tests
+System.IO.FileSystem.Tests
+System.IO.Ports.Tests
+System.Management.Tests

--- a/tests/scripts/run-corefx-tests.bat
+++ b/tests/scripts/run-corefx-tests.bat
@@ -1,0 +1,93 @@
+@echo off
+setlocal ENABLEDELAYEDEXPANSION
+goto start
+
+:usage
+echo Usage: run-corefx-tests.bat ^<runtime path^> ^<tests dir^> ^<test exclusion file^>
+echo.
+echo Runs the corefx tests on a Windows ARM device, by searching for all relevant corefx
+echo RunTests.cmd files in the ^<tests dir^> tree, and running each one in turn. This
+echo script is typically run on a Windows ARM machine after the run-corefx-test.py script
+echo is run on a Windows x64 machine with the `-no_run_tests` argument, to build the
+echo corefx tree, including tests, and then copying the built runtime layout and tests
+echo to the ARM machine.
+echo.
+echo Arguments:
+echo ^<runtime path^> -- Path to corefx-built runtime "layout", e.g. _\fx\bin\testhost\netcoreapp-Windows_NT-Release-arm
+echo ^<tests dir^> -- Path to corefx test tree, e.g., _\fx\bin\tests
+echo ^<test exclusion file^> -- Path to test exclusion file, e.g., C:\coreclr\tests\arm\corefx_test_exclusions.txt
+echo.
+echo The ^<test exclusion file^> is a file with a list of assemblies for which the
+echo tests should not be run. This allows excluding failing tests by excluding the
+echo entire assembly in which they live. This obviously does not provide fine-grained
+echo control, but is easy to implement. This file should be a list of assembly names,
+echo without filename extension, one per line, e.g.:
+echo.
+echo     System.Console.Tests
+echo     System.Data.SqlClient.Tests
+echo     System.Diagnostics.Process.Tests
+echo.
+echo This script only works for Windows ARM, but perhaps should be extended to work
+echo for Windows ARM64 as well.
+goto :eof
+
+:start
+if "%3"=="" goto usage
+if not "%4"=="" goto usage
+
+set _runtime_path=%1
+set _tests_dir=%2
+set _exclusion_file=%3
+
+echo Running CoreFX tests
+echo Using runtime: %_runtime_path%
+echo Using tests: %_tests_dir%
+echo Using test exclusion file: %_exclusion_file%
+
+set _pass=0
+set _fail=0
+set _skipped=0
+set _total=0
+
+pushd %_tests_dir%
+for /F %%i in ('dir /s /b /A:D netcoreapp-Windows_NT-Release-arm') do (
+    if exist %%i\RunTests.cmd call :one %%i
+)
+popd
+echo COREFX TEST PASS: %_pass%, FAIL: %_fail%, SKIPPED: %_skipped%, TOTAL: %_total%
+if %_fail% GTR 0 (
+    exit /b 1
+)
+exit /b 0
+
+:one
+set /A _total=_total + 1
+
+REM Extract out the test name from the path.
+REM The path looks like: e:\gh\corefx\bin\tests\System.Management.Tests\netcoreapp-Windows_NT-Release-arm
+REM From this, we want System.Management.Tests to compare against the exclusion file, which should be a list
+REM of test names to skip.
+
+set _t1=%1
+set _t2=%_t1:\netcoreapp-Windows_NT-Release-arm=%
+for /F %%j in ("%_t2%") do set _t3=%%~nxj
+findstr /i %_t3% %_exclusion_file% >nul
+if %errorlevel% EQU 0 (
+    echo COREFX TEST %_t3% EXCLUDED
+    set /A _skipped=_skipped + 1
+) else (
+    call :run %1\RunTests.cmd %_runtime_path%
+)
+goto :eof
+
+:run
+echo Running: %*
+call %*
+if %errorlevel% EQU 0 (
+    set /A _pass=_pass + 1
+    echo COREFX TEST PASSED
+) else (
+    set /A _fail=_fail + 1
+    echo COREFX TEST FAILED
+)
+goto :eof

--- a/tests/scripts/run-corefx-tests.py
+++ b/tests/scripts/run-corefx-tests.py
@@ -67,6 +67,7 @@ parser.add_argument('-fx_root', dest='fx_root', default=None)
 parser.add_argument('-fx_branch', dest='fx_branch', default='master')
 parser.add_argument('-fx_commit', dest='fx_commit', default=None)
 parser.add_argument('-env_script', dest='env_script', default=None)
+parser.add_argument('-no_run_tests', dest='no_run_tests', action="store_true", default=False)
 
 
 ##########################################################################
@@ -78,7 +79,7 @@ def validate_args(args):
     Args:
         args (argparser.ArgumentParser): Args parsed by the argument parser.
     Returns:
-        (arch, ci_arch, build_type, clr_root, fx_root, fx_branch, fx_commit, env_script)
+        (arch, ci_arch, build_type, clr_root, fx_root, fx_branch, fx_commit, env_script, no_run_tests)
             (str, str, str, str, str, str, str, str)
     Notes:
     If the arguments are valid then return them all in a tuple. If not, raise
@@ -93,6 +94,7 @@ def validate_args(args):
     fx_branch = args.fx_branch
     fx_commit = args.fx_commit
     env_script = args.env_script
+    no_run_tests = args.no_run_tests
 
     def validate_arg(arg, check):
         """ Validate an individual arg
@@ -138,7 +140,7 @@ def validate_args(args):
         validate_arg(env_script, lambda item: os.path.isfile(env_script))
         env_script = os.path.abspath(env_script)
 
-    args = (arch, ci_arch, build_type, clr_root, fx_root, fx_branch, fx_commit, env_script)
+    args = (arch, ci_arch, build_type, clr_root, fx_root, fx_branch, fx_commit, env_script, no_run_tests)
 
     log('Configuration:')
     log(' arch: %s' % arch)
@@ -149,6 +151,7 @@ def validate_args(args):
     log(' fx_branch: %s' % fx_branch)
     log(' fx_commit: %s' % fx_commit)
     log(' env_script: %s' % env_script)
+    log(' no_run_tests: %s' % no_run_tests)
 
     return args
 
@@ -188,7 +191,7 @@ def main(args):
 
     testing = False
 
-    arch, ci_arch, build_type, clr_root, fx_root, fx_branch, fx_commit, env_script = validate_args(
+    arch, ci_arch, build_type, clr_root, fx_root, fx_branch, fx_commit, env_script, no_run_tests = validate_args(
         args)
 
     clr_os = 'Windows_NT' if Is_windows else Unix_name_map[os.uname()[0]]
@@ -289,6 +292,7 @@ def main(args):
     command = ' '.join((
         command,
         config_args,
+        '-SkipTests' if no_run_tests else '',
         '--',
         without_categories
     ))


### PR DESCRIPTION
We create a flow job for each arm32 corefx mode, e.g.
arm_cross_checked_windows_nt_corefx_jitstress1_flow_prtest. This
depends on a build job that is specific to the stress mode, e.g.
arm_cross_checked_windows_nt_corefx_jitstress1_bld_prtest, which
(on x64) builds CoreCLR, then clones and builds CoreFX using run-corefx-tests.py.
In particular, it only builds the CoreFX tests; it doesn't run them.
Note that because the CoreFX test build embeds the stress mode environment
variables in its generated RunTests.cmd scripts, we need a different
corefx build dependency for each corefx test run; we can't share the
builds. The build script then ZIPs up the CoreFX tests and generated
CoreFX runtime (which will include the coreclr runtime because we built
CoreFX with the `/p:CoreCLROverridePath` argument), and archives these.

The test job, which runs on an arm64 machine, then copies the ZIPed
tests and runtime, unzips them, and runs a batch script to run each
RunTests.cmd file. Note that we don't use any existing mechanism to
run each test (such as msbuild), and I believe the CoreFX msbuild
harness doesn't have any mechanism to just run a previously built set of tests.

There is a very simple test exclusion mechanism: an entire test assembly
can be excluded by putting its name (e.g., System.IO.Ports.Tests), in
a file (e.g., tests\arm\corefx_test_exclusions.txt).

Note that this corefx testing mechanism is only enabled for arm
(aka arm32), not armlb or arm64.