### PR TITLE
Fix thread unhijacking in tail call corner case

### DIFF
--- a/tests/testsFailingOnArm64.txt
+++ b/tests/testsFailingOnArm64.txt
@@ -5,4 +5,3 @@ JIT/jit64/opt/cse/HugeField1/HugeField1.sh
 JIT/jit64/opt/cse/HugeField2/HugeField2.sh
 CoreMangLib/cti/system/string/StringFormat1/StringFormat1.sh
 CoreMangLib/cti/system/string/StringFormat2/StringFormat2.sh
-JIT/Methodical/tailcall_v4/hijacking/hijacking.sh

--- a/tests/testsUnsupportedOnARM32.txt
+++ b/tests/testsUnsupportedOnARM32.txt
@@ -1,6 +1,5 @@
 CoreMangLib/cti/system/reflection/emit/DynMethodJumpStubTests/DynMethodJumpStubTests/DynMethodJumpStubTests.sh
 JIT/Directed/tailcall/tailcall/tailcall.sh
-JIT/Methodical/tailcall_v4/hijacking/hijacking.sh
 JIT/Methodical/tailcall_v4/smallFrame/smallFrame.sh
 JIT/Methodical/xxobj/sizeof/_il_dbgsizeof/_il_dbgsizeof.sh
 JIT/Methodical/xxobj/sizeof/_il_dbgsizeof32/_il_dbgsizeof32.sh


### PR DESCRIPTION
On ARM architectures, the return address is sometimes not stored on the
stack, but it is only in the LR register. In a corner case when
a function tail calls another one, there is a small window when
the hijacked address is temporarily not on the stack (after the LR is
poped from the stack in the epilog of the caller and before it is
stored back to the stack in the the prolog of the callee).

This change fixes that and also re-enables the JIT\Methodical\tailcall_v4
test that was failing due to this issue on ARM and ARM64.