### PR TITLE
Fix Windows-Specific EventPipe Bugs

### DIFF
--- a/src/vm/sampleprofiler.cpp
+++ b/src/vm/sampleprofiler.cpp
@@ -15,8 +15,7 @@
 #include <mmsystem.h>
 #endif //FEATURE_PAL
 
-// To avoid counting zeros in conversions
-#define MILLION * 1000000
+#define NUM_NANOSECONDS_IN_1_MS (1000000)
 
 Volatile<BOOL> SampleProfiler::s_profilingEnabled = false;
 Thread* SampleProfiler::s_pSamplingThread = NULL;
@@ -26,7 +25,7 @@ EventPipeEvent* SampleProfiler::s_pThreadTimeEvent = NULL;
 BYTE* SampleProfiler::s_pPayloadExternal = NULL;
 BYTE* SampleProfiler::s_pPayloadManaged = NULL;
 CLREventStatic SampleProfiler::s_threadShutdownEvent;
-unsigned long SampleProfiler::s_samplingRateInNs = 1 MILLION; // 1ms
+unsigned long SampleProfiler::s_samplingRateInNs = NUM_NANOSECONDS_IN_1_MS; // 1ms
 bool SampleProfiler::s_timePeriodIsSet = FALSE;
 
 #ifndef FEATURE_PAL
@@ -256,7 +255,7 @@ void SampleProfiler::PlatformSleep(unsigned long nanoseconds)
 #ifdef FEATURE_PAL
     PAL_nanosleep(nanoseconds);
 #else //FEATURE_PAL
-    ClrSleepEx(s_samplingRateInNs / 1 MILLION, FALSE);
+    ClrSleepEx(s_samplingRateInNs / NUM_NANOSECONDS_IN_1_MS, FALSE);
 #endif //FEATURE_PAL
 }
 
@@ -278,7 +277,7 @@ void SampleProfiler::SetTimeGranularity()
     // the OS is on-CPU, decreasing overall system performance and increasing power consumption
     if(s_timeBeginPeriodFn != NULL)
     {
-        if(((TimePeriodFnPtr) s_timeBeginPeriodFn)(s_samplingRateInNs / 1 MILLION) == TIMERR_NOERROR)
+        if(((TimePeriodFnPtr) s_timeBeginPeriodFn)(s_samplingRateInNs / NUM_NANOSECONDS_IN_1_MS) == TIMERR_NOERROR)
         {
             s_timePeriodIsSet = TRUE;
         }
@@ -300,7 +299,7 @@ void SampleProfiler::ResetTimeGranularity()
     // End the modifications we had to the timer period in Enable
     if(s_timeEndPeriodFn != NULL)
     {
-        if(((TimePeriodFnPtr) s_timeEndPeriodFn)(s_samplingRateInNs / 1 MILLION) == TIMERR_NOERROR)
+        if(((TimePeriodFnPtr) s_timeEndPeriodFn)(s_samplingRateInNs / NUM_NANOSECONDS_IN_1_MS) == TIMERR_NOERROR)
         {
             s_timePeriodIsSet = FALSE;
         }


### PR DESCRIPTION
1. Any events that are gated by the ETW "IsEnabled" macros will not be emitted to the EventPipe unless they are also enabled for ETW.
2. An arithmetic order of operations error caused SampleProfiler to sleep for a very long period of time between samples.