### PR TITLE
Fixes so that COMPLUS_PerformanceTracing works on windows.

### DIFF
--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -268,12 +268,6 @@ void EventPipe::Enable(
         return;
     }
 
-    // If the state or aurguments are invalid, bail
-    if(pProviders == NULL || numProviders <= 0)
-    {
-        return;
-    }
-
     // Take the lock before enabling tracing.
     CrstHolder _crst(GetLock());
 

--- a/src/vm/sampleprofiler.cpp
+++ b/src/vm/sampleprofiler.cpp
@@ -256,7 +256,7 @@ void SampleProfiler::PlatformSleep(unsigned long nanoseconds)
 #ifdef FEATURE_PAL
     PAL_nanosleep(nanoseconds);
 #else //FEATURE_PAL
-    ClrSleepEx(s_samplingRateInNs / 1 MILLION, FALSE);
+    ClrSleepEx(s_samplingRateInNs / (1 MILLION), FALSE);
 #endif //FEATURE_PAL
 }
 
@@ -278,7 +278,7 @@ void SampleProfiler::SetTimeGranularity()
     // the OS is on-CPU, decreasing overall system performance and increasing power consumption
     if(s_timeBeginPeriodFn != NULL)
     {
-        if(((TimePeriodFnPtr) s_timeBeginPeriodFn)(s_samplingRateInNs / 1 MILLION) == TIMERR_NOERROR)
+        if(((TimePeriodFnPtr) s_timeBeginPeriodFn)(s_samplingRateInNs / (1 MILLION)) == TIMERR_NOERROR)
         {
             s_timePeriodIsSet = TRUE;
         }

--- a/src/vm/sampleprofiler.cpp
+++ b/src/vm/sampleprofiler.cpp
@@ -16,7 +16,7 @@
 #endif //FEATURE_PAL
 
 // To avoid counting zeros in conversions
-#define MILLION * 1000000
+#define MILLION 1000000
 
 Volatile<BOOL> SampleProfiler::s_profilingEnabled = false;
 Thread* SampleProfiler::s_pSamplingThread = NULL;
@@ -26,7 +26,7 @@ EventPipeEvent* SampleProfiler::s_pThreadTimeEvent = NULL;
 BYTE* SampleProfiler::s_pPayloadExternal = NULL;
 BYTE* SampleProfiler::s_pPayloadManaged = NULL;
 CLREventStatic SampleProfiler::s_threadShutdownEvent;
-unsigned long SampleProfiler::s_samplingRateInNs = 1 MILLION; // 1ms
+unsigned long SampleProfiler::s_samplingRateInNs = 1 * MILLION; // 1ms
 bool SampleProfiler::s_timePeriodIsSet = FALSE;
 
 #ifndef FEATURE_PAL
@@ -256,7 +256,7 @@ void SampleProfiler::PlatformSleep(unsigned long nanoseconds)
 #ifdef FEATURE_PAL
     PAL_nanosleep(nanoseconds);
 #else //FEATURE_PAL
-    ClrSleepEx(s_samplingRateInNs / (1 MILLION), FALSE);
+    ClrSleepEx(s_samplingRateInNs / (1 * MILLION), FALSE);
 #endif //FEATURE_PAL
 }
 
@@ -278,7 +278,7 @@ void SampleProfiler::SetTimeGranularity()
     // the OS is on-CPU, decreasing overall system performance and increasing power consumption
     if(s_timeBeginPeriodFn != NULL)
     {
-        if(((TimePeriodFnPtr) s_timeBeginPeriodFn)(s_samplingRateInNs / (1 MILLION)) == TIMERR_NOERROR)
+        if(((TimePeriodFnPtr) s_timeBeginPeriodFn)(s_samplingRateInNs / (1* MILLION)) == TIMERR_NOERROR)
         {
             s_timePeriodIsSet = TRUE;
         }
@@ -300,7 +300,7 @@ void SampleProfiler::ResetTimeGranularity()
     // End the modifications we had to the timer period in Enable
     if(s_timeEndPeriodFn != NULL)
     {
-        if(((TimePeriodFnPtr) s_timeEndPeriodFn)(s_samplingRateInNs / 1 MILLION) == TIMERR_NOERROR)
+        if(((TimePeriodFnPtr) s_timeEndPeriodFn)(s_samplingRateInNs / (1 * MILLION) == TIMERR_NOERROR)
         {
             s_timePeriodIsSet = FALSE;
         }

--- a/src/vm/sampleprofiler.cpp
+++ b/src/vm/sampleprofiler.cpp
@@ -278,7 +278,7 @@ void SampleProfiler::SetTimeGranularity()
     // the OS is on-CPU, decreasing overall system performance and increasing power consumption
     if(s_timeBeginPeriodFn != NULL)
     {
-        if(((TimePeriodFnPtr) s_timeBeginPeriodFn)(s_samplingRateInNs / (1* MILLION)) == TIMERR_NOERROR)
+        if(((TimePeriodFnPtr) s_timeBeginPeriodFn)(s_samplingRateInNs / (1 * MILLION)) == TIMERR_NOERROR)
         {
             s_timePeriodIsSet = TRUE;
         }
@@ -300,7 +300,7 @@ void SampleProfiler::ResetTimeGranularity()
     // End the modifications we had to the timer period in Enable
     if(s_timeEndPeriodFn != NULL)
     {
-        if(((TimePeriodFnPtr) s_timeEndPeriodFn)(s_samplingRateInNs / (1 * MILLION) == TIMERR_NOERROR)
+        if(((TimePeriodFnPtr) s_timeEndPeriodFn)(s_samplingRateInNs / (1 * MILLION)) == TIMERR_NOERROR)
         {
             s_timePeriodIsSet = FALSE;
         }


### PR DESCRIPTION
There are two fixes here. 

First we have a #define that called MILLION defined as * 1000000.   We are trying to be a bit too smart, here and it bit us.   Basically we used  X / 1 MILLION but that turns into X / 1 * 100000 which does not divide by 1 million but multiplies by 1 million.   We need () but I also make MILLION just equal to 1000000 so it is obvious that such parentheses are needed.

There is also some code that checks for an empty provider list and early outs.  This does not seem necessary, but in particular causes problem because the COMPLUS_PerformanceTracing variable does PRECISELY those arguments and thus does not do anything (COMPLUS_PerformanceTracing does not need a provider list because hooks logic to force all providers on).     Since having an empty list is not really an error, I simply removed the quick-out.   

With these change in place setting COMPLUS_PerformanceTracing=1 will cause a Process*.netperf file to be generated on shutdown (so it is useful).  

@nategraf  @brianrob @adamsitnik 

I wanted to get this fix in but there are two things I would like to do quickly after this. 

1. Currently setting this environment variable does NOT emit any EventSources (just the native providers).    The reason is that currently we don't plumb the EventPIpe enabling logic to call back to the EventSource (should be easy, it just has not been done).   

2. There is no control over anything (file name, size of file, or providers enabled).   I know that we want to make a REST API for this, but I think it is quick and easy to change this Environment Variable (or make a new one) that has a very simple syntax for specifying this.   I propose the following

COMPLUS_PerformanceTrace= Path=FILE_PATH;CircularMB=SIZE;Provider=NAME:Keyword:Level 

That is it is a semicolon separated list of key-value pairs and we define Path, CircularMB and Provider (Provider can be repeated, and they accumulate.     This is easy to parse.  

Vance