### PR TITLE
JIT: don't overlook strong nearby preference in LSRA

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -5286,8 +5286,8 @@ regNumber LinearScan::tryAllocateFreeReg(Interval* currentInterval, RefPosition*
             {
                 relatedInterval = nullptr;
             }
-            // Is the relatedInterval simply a copy to another relatedInterval?
-            else if ((relatedInterval->relatedInterval != nullptr) &&
+            // Is the relatedInterval not assigned and simply a copy to another relatedInterval?
+            else if ((relatedInterval->assignedReg == nullptr) && (relatedInterval->relatedInterval != nullptr) &&
                      (nextRelatedRefPosition->nextRefPosition != nullptr) &&
                      (nextRelatedRefPosition->nextRefPosition->nextRefPosition == nullptr) &&
                      (nextRelatedRefPosition->nextRefPosition->nodeLocation <


### PR DESCRIPTION
When allocating an interval, LSRA will look at related intervals
for preference hints.

LSRA may look past a related interval I1 to its related interval
I2 if I1 looks like a simple copy. But if I1 has been previously
allocated then it seems we are often better served using I1's
preferences instead of using I2's.

Addresses some issues seen in #11390.