### PR TITLE
Port #16003 to 2.1 preview1

### DIFF
--- a/src/vm/codeversion.cpp
+++ b/src/vm/codeversion.cpp
@@ -518,9 +518,11 @@ ILCodeVersionNode::ILCodeVersionNode() :
     m_rejitId(0),
     m_pNextILVersionNode(dac_cast<PTR_ILCodeVersionNode>(nullptr)),
     m_rejitState(ILCodeVersion::kStateRequested),
-    m_pIL(dac_cast<PTR_COR_ILMETHOD>(nullptr)),
+    m_pIL(),
     m_jitFlags(0)
-{}
+{
+    m_pIL.Store(dac_cast<PTR_COR_ILMETHOD>(nullptr));
+}
 
 #ifndef DACCESS_COMPILE
 ILCodeVersionNode::ILCodeVersionNode(Module* pModule, mdMethodDef methodDef, ReJITID id) :

--- a/src/vm/codeversion.h
+++ b/src/vm/codeversion.h
@@ -340,7 +340,7 @@ private:
     ReJITID m_rejitId;
     PTR_ILCodeVersionNode m_pNextILVersionNode;
     Volatile<ILCodeVersion::RejitFlags> m_rejitState;
-    VolatilePtr<COR_ILMETHOD> m_pIL;
+    VolatilePtr<COR_ILMETHOD, PTR_COR_ILMETHOD> m_pIL;
     Volatile<DWORD> m_jitFlags;
     InstrumentedILOffsetMapping m_instrumentedILMap;
 };


### PR DESCRIPTION
#16003 is the fix for #15423, and it would be good to have it in any 2.1 previews so we can get the best coverage for tiered jitting possible.