### PR TITLE
Fix metadata format error checking

### DIFF
--- a/src/md/runtime/mdinternaldisp.cpp
+++ b/src/md/runtime/mdinternaldisp.cpp
@@ -74,6 +74,11 @@ CheckFileFormat(
         }
         // Get next stream.
         PSTORAGESTREAM pNext = pStream->NextStream_Verify();
+        if (pNext == NULL)
+        {   // Stream header is corrupted.
+            Debug_ReportError("Invalid stream header - cannot get next stream header.");
+            IfFailGo(CLDB_E_FILE_CORRUPT);
+        }
         
         // Check that stream header is within the buffer.
         if (((LPBYTE)pStream >= ((LPBYTE)pData + cbData)) ||


### PR DESCRIPTION
NextStream_Verify can return NULL for invalid file. Report error for it instead of AVing.
Similar check is around the other calls to NextStream_Verify. It was missing here for some reason.