### PR TITLE
Fix side effect flags setting after expression cloning.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2164,7 +2164,9 @@ public:
 
     void gtUpdateStmtSideEffects(GenTree* stmt);
 
-    void gtResetNodeSideEffects(GenTree* tree);
+    void gtUpdateNodeSideEffects(GenTree* tree);
+
+    void gtUpdateNodeOperSideEffects(GenTree* tree);
 
     // Returns "true" iff the complexity (not formally defined, but first interpretation
     // is #of nodes in subtree) of "tree" is greater than "limit".


### PR DESCRIPTION
Side effect flags need to be recomputed after cloning
an expression, since cloning may involve some simplifications
(e.g., replacing a local with a const).

I also did some minor refactoring and renaming of the side-effect-updating helpers
and made one of them more robust by checking whether a child is null before accessing
its flags.

This fixes VSO 543054 where this problem was encountered in a PMI ARM32 JitStress=2 run.