### PR TITLE
Disable broken EventPipe tests at build time

### DIFF
--- a/tests/src/dirs.proj
+++ b/tests/src/dirs.proj
@@ -30,6 +30,8 @@
       <DisabledProjects Include="Performance\performance.csproj" />
       <DisabledProjects Include="Loader\classloader\generics\regressions\DD117522\Test.csproj" />
       <DisabledProjects Include="Loader\classloader\generics\GenericMethods\VSW491668.csproj" /> <!-- issue 5501 -->
+      <DisabledProjects Include="tracing\eventpipetrace\**" /> <!-- issue 15924 -->
+      <DisabledProjects Include="tracing\eventsource*\**" /> <!-- issue 15924 -->
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
Addresses #15924

Using a strategy I know works this time