### PR TITLE
Implement support for selecting test assemblies via runtest.{cmd|sh} command line switch

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <CL_MPCount>$(NumberOfCores)</CL_MPCount>
+    <VCPkgEnabled>false</VCPkgEnabled>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,41 @@
+ <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+ 
+  <!-- Verifies if targets are included into Visual Studio CoreCLR.sln in project which outputs 
+       *.dll or *.exe and sets ShouldCopyVSBuildArtifacts to true  -->
+  <Target Name="_ShouldCopyVSBuildArtifacts" BeforeTargets="CopyVSBuildArtifacts;PostBuildEvent">
+
+    <PropertyGroup>
+      <ShouldCopyVSBuildArtifacts>false</ShouldCopyVSBuildArtifacts>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="($(TargetFileName.EndsWith('.dll')) Or $(TargetFileName.EndsWith('.exe'))) And $(SolutionName) == 'CoreCLR'">
+      <ShouldCopyVSBuildArtifacts >true</ShouldCopyVSBuildArtifacts>
+    </PropertyGroup>
+  </Target>
+
+  <!-- Copies *.dll and *.exe files built in Visual Studio to output directory and test layout directory -->
+  <Target Name="CopyVSBuildArtifacts" 
+    DependsOnTargets="_ShouldCopyVSBuildArtifacts"
+    BeforeTargets="PostBuildEvent"
+    Condition="$(ShouldCopyVSBuildArtifacts)">
+
+    <Message Importance="High" Text="Copying build artifacts to output directory and test layout"/>
+        
+      <Copy SourceFiles="$(TargetPath)" 
+        Condition="Exists('$(MSBuildThisFileDirectory)bin\Product\$(OS).$(Platform).$(Configuration)')"
+        DestinationFiles="$(MSBuildThisFileDirectory)bin\Product\$(OS).$(Platform).$(Configuration)\$(TargetFileName)"/>
+
+      <Copy SourceFiles="$(TargetDir)\$(TargetName).pdb" 
+        Condition="Exists('$(MSBuildThisFileDirectory)bin\Product\$(OS).$(Platform).$(Configuration)\PDB')"
+        DestinationFiles="$(MSBuildThisFileDirectory)bin\Product\$(OS).$(Platform).$(Configuration)\PDB\$(TargetName).pdb"/>
+        
+      <Copy SourceFiles="$(TargetPath)" 
+        Condition="Exists('$(MSBuildThisFileDirectory)bin\tests\$(OS).$(Platform).$(Configuration)\Tests\Core_Root')"
+        DestinationFiles="$(MSBuildThisFileDirectory)bin\tests\$(OS).$(Platform).$(Configuration)\Tests\Core_Root\$(TargetFileName)"/>
+
+      <Copy SourceFiles="$(TargetDir)\$(TargetName).pdb" 
+        Condition="Exists('$(MSBuildThisFileDirectory)bin\tests\$(OS).$(Platform).$(Configuration)\Tests\Core_Root')"
+        DestinationFiles="$(MSBuildThisFileDirectory)bin\tests\$(OS).$(Platform).$(Configuration)\Tests\Core_Root\$(TargetName).pdb"/>
+
+  </Target>
+</Project>

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -68,6 +68,7 @@ set __IlasmRoundTrip=
 set __CollectDumps=
 set __DoCrossgen=
 set __CrossgenAltJit=
+set __UserTestAssemblies=
 
 :Arg_Loop
 if "%1" == "" goto ArgsDone
@@ -111,6 +112,7 @@ if /i "%1" == "link"                  (set DoLink=true&set ILLINK=%2&shift&shift
 if /i "%1" == "tieredcompilation"     (set COMPLUS_EXPERIMENTAL_TieredCompilation=1&shift&goto Arg_Loop)
 if /i "%1" == "gcname"                (set COMPlus_GCName=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "timeout"               (set __TestTimeout=%2&shift&shift&goto Arg_Loop)
+if /i "%1" == "userassemblies"        (set __UserTestAssemblies=%2&shift&shift&goto Arg_Loop) 
 
 REM change it to COMPlus_GCStress when we stop using xunit harness
 if /i "%1" == "gcstresslevel"         (set __GCSTRESSLEVEL=%2&set __TestTimeout=1800000&shift&shift&goto Arg_Loop)
@@ -481,6 +483,10 @@ echo VSVersion ^<vs_version^>    - VS2015 or VS2017 ^(default: VS2017^).
 echo TestEnv ^<test_env_script^> - Run a custom script before every test to set custom test environment settings.
 echo AgainstPackages           - This indicates that we are running tests that were built against packages.
 echo GenerateLayoutOnly        - If specified will not run the tests and will only create the Runtime Dependency Layout
+echo userassemblies            - If specified with test assembly name tests will be run only for assembly / assemblies specified after switch
+echo                             selected assembly should be specified by it's 2 first name parts separated by dot
+echo                             all MSBuild globbing operators are accepted i.e. specify "userassemblies JIT.*" to run all JIT tests
+echo                             only one assembly selection string can be specified
 echo sequential                - Run tests sequentially (no parallelism).
 echo crossgen                  - Precompile ^(crossgen^) the managed assemblies in CORE_ROOT before running the tests.
 echo crossgenaltjit ^<altjit^>   - Precompile ^(crossgen^) the managed assemblies in CORE_ROOT before running the tests, using the given altjit.

--- a/tests/tests.targets
+++ b/tests/tests.targets
@@ -11,10 +11,12 @@
       <TestAssemblyDir Condition="'$(TestAssemblyDir)' == ''">$(BaseOutputPathWithConfig)\tests\</TestAssemblyDir>
       <__TestRunHtmlLog Condition="'$(__TestRunHtmlLog)' == ''">$(__LogsDir)\TestRun.html</__TestRunHtmlLog>
       <__TestRunXmlLog Condition="'$(__TestRunXmlLog)' == ''">$(__LogsDir)\TestRun.xml</__TestRunXmlLog>
+      <UserTestAssemblies>$(__UserTestAssemblies)</UserTestAssemblies>
+      <UserTestAssemblies Condition="$(UserTestAssemblies) == ''">*</UserTestAssemblies>
   </PropertyGroup>
   <Target Name="FindTestDirectories">
     <ItemGroup>
-      <AllTestAssemblies Include="$(BaseOutputPathWithConfig)\**\*.XUnitWrapper.dll" />
+      <AllTestAssemblies Include="$(BaseOutputPathWithConfig)\**\$(UserTestAssemblies).XUnitWrapper.dll" />
       <TestAssemblies Include="@(AllTestAssemblies)" Exclude="@(_SkipTestAssemblies -> '$(TestAssemblyDir)%(Identity)\%(Identity).XUnitWrapper.dll')" />
     </ItemGroup>
     


### PR DESCRIPTION
 and let build handle copying of native assemblies to target directories (Product | Core_Root) when built from Visual Studio CoreCLR solution

Fixes #15697