### PR TITLE
Fix some tests under GCStress

### DIFF
--- a/tests/src/CoreMangLib/system/span/SlowTailCallArgs.csproj
+++ b/tests/src/CoreMangLib/system/span/SlowTailCallArgs.csproj
@@ -12,6 +12,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>

--- a/tests/src/baseservices/compilerservices/dynamicobjectproperties/dev10_535767.cs
+++ b/tests/src/baseservices/compilerservices/dynamicobjectproperties/dev10_535767.cs
@@ -238,6 +238,7 @@ class TestSet
         // which nodes were collected).
         GC.Collect();
         GC.WaitForPendingFinalizers();
+        GC.WaitForPendingFinalizers(); // the above call may correspond to a GC prior to the Collect above, call it again
 
         // Calculate our own view of which nodes should be alive or dead. Use a simple mark array for this.
         // Once the algorithm is complete a true value at a given index in the array indicates a node that


### PR DESCRIPTION
- Disabled one test, it takes far too long under GCStress
- For another, added a second call to WaitForPendingFinalizers() to ensure correspondence with a GC.Collect() call