### PR TITLE
Use EventSource guid ctor for ArrayPoolEventSource

### DIFF
--- a/src/mscorlib/shared/System/Buffers/ArrayPoolEventSource.cs
+++ b/src/mscorlib/shared/System/Buffers/ArrayPoolEventSource.cs
@@ -6,7 +6,7 @@ using System.Diagnostics.Tracing;
 
 namespace System.Buffers
 {
-    [EventSource(Name = "System.Buffers.ArrayPoolEventSource")]
+    [EventSource(Guid = "0866B2B8-5CEF-5DB9-2612-0C0FFD814A44", Name = "System.Buffers.ArrayPoolEventSource")]
     internal sealed class ArrayPoolEventSource : EventSource
     {
         internal readonly static ArrayPoolEventSource Log = new ArrayPoolEventSource();
@@ -21,6 +21,9 @@ namespace System.Buffers
             /// <summary>The pool has already allocated for pooling as many buffers of a particular size as it's allowed.</summary>
             PoolExhausted
         }
+
+        // The ArrayPoolEventSource GUID is {0866b2b8-5cef-5db9-2612-0c0ffd814a44}
+        private ArrayPoolEventSource() : base(new Guid(0x0866b2b8, 0x5cef, 0x5db9, 0x26, 0x12, 0x0c, 0x0f, 0xfd, 0x81, 0x4a, 0x44), "System.Buffers.ArrayPoolEventSourc") { }
 
         /// <summary>
         /// Event for when a buffer is rented.  This is invoked once for every successful call to Rent,

--- a/src/mscorlib/shared/System/Buffers/ArrayPoolEventSource.cs
+++ b/src/mscorlib/shared/System/Buffers/ArrayPoolEventSource.cs
@@ -23,7 +23,7 @@ namespace System.Buffers
         }
 
         // The ArrayPoolEventSource GUID is {0866b2b8-5cef-5db9-2612-0c0ffd814a44}
-        private ArrayPoolEventSource() : base(new Guid(0x0866b2b8, 0x5cef, 0x5db9, 0x26, 0x12, 0x0c, 0x0f, 0xfd, 0x81, 0x4a, 0x44), "System.Buffers.ArrayPoolEventSourc") { }
+        private ArrayPoolEventSource() : base(new Guid(0x0866b2b8, 0x5cef, 0x5db9, 0x26, 0x12, 0x0c, 0x0f, 0xfd, 0x81, 0x4a, 0x44), "System.Buffers.ArrayPoolEventSource") { }
 
         /// <summary>
         /// Event for when a buffer is rented.  This is invoked once for every successful call to Rent,


### PR DESCRIPTION
Generated the Guid `0866b2b8-5cef-5db9-2612-0c0ffd814a44` by adding a `Console.WriteLine(Guid.ToString)` to the `ArrayPoolEventSource` constructor 😄 

Resolves https://github.com/dotnet/coreclr/issues/15954