### PR TITLE
ThrowExceptionFromContextInternal, RtlCaptureContext: fix for asan

### DIFF
--- a/src/pal/src/arch/amd64/exceptionhelper.S
+++ b/src/pal/src/arch/amd64/exceptionhelper.S
@@ -17,7 +17,11 @@ LEAF_ENTRY ThrowExceptionFromContextInternal, _TEXT
 #ifdef HAS_ASAN
         // Need to call __asan_handle_no_return explicitly here because we re-intialize RSP before
         // throwing exception in ThrowExceptionHelper
+        push_nonvol_reg rdi
+        push_nonvol_reg rsi
         call    EXTERNAL_C_FUNC(__asan_handle_no_return)
+        pop_nonvol_reg rsi
+        pop_nonvol_reg rdi
 #endif
 
         // Save the RBP to the stack so that the unwind can work at the instruction after

--- a/src/pal/src/arch/arm/exceptionhelper.S
+++ b/src/pal/src/arch/arm/exceptionhelper.S
@@ -14,7 +14,9 @@ LEAF_ENTRY ThrowExceptionFromContextInternal, _TEXT
 #ifdef HAS_ASAN
     // Need to call __asan_handle_no_return explicitly here because we re-intialize SP before
     // throwing exception in ThrowExceptionHelper
+    push_nonvol_reg "{r0, r1}"
     bl  EXTERNAL_C_FUNC(__asan_handle_no_return)
+    pop_nonvol_reg "{r0, r1}"
 #endif
 
     push_nonvol_reg {r7} /* FP. x64-RBP */

--- a/src/pal/src/arch/arm64/context2.S
+++ b/src/pal/src/arch/arm64/context2.S
@@ -138,9 +138,9 @@ LEAF_ENTRY RtlRestoreContext, _TEXT
     ldr w17, [x0, #(CONTEXT_ContextFlags)]
     tbz w17, #CONTEXT_CONTROL_BIT, LOCAL_LABEL(Restore_CONTEXT_FLOATING_POINT)
 
-    stp x0, x1, [sp]
+    stp x0, x1, [sp, -16]!
     bl EXTERNAL_C_FUNC(__asan_handle_no_return)
-    ldp x0, x1, [sp]
+    ldp x0, x1, [sp], 16
 
 LOCAL_LABEL(Restore_CONTEXT_FLOATING_POINT):
 #endif

--- a/src/pal/src/arch/arm64/exceptionhelper.S
+++ b/src/pal/src/arch/arm64/exceptionhelper.S
@@ -15,7 +15,9 @@ LEAF_ENTRY ThrowExceptionFromContextInternal, _TEXT
 #ifdef HAS_ASAN
         // Need to call __asan_handle_no_return explicitly here because we re-intialize SP before
         // throwing exception in ThrowExceptionHelper
+        stp x0, x1, [sp, -16]!
         bl  EXTERNAL_C_FUNC(__asan_handle_no_return)
+        ldp x0, x1, [sp], 16
 #endif
 
     // Save the FP & LR to the stack so that the unwind can work at the instruction after


### PR DESCRIPTION
- Save arguments on stack before calling __asan_handle_no_return in ThrowExceptionFromContextInternal
- Fix saving arguments on stack before calling __asan_handle_no_return in RtlCaptureContext for arm64
