### PR TITLE
Compiler::lookupHWIntrinsic: fix oob read

### DIFF
--- a/src/jit/hwintrinsicxarch.cpp
+++ b/src/jit/hwintrinsicxarch.cpp
@@ -132,7 +132,7 @@ NamedIntrinsic Compiler::lookupHWIntrinsic(const char* methodName, InstructionSe
     NamedIntrinsic result = NI_Illegal;
     if (isa != InstructionSet_ILLEGAL)
     {
-        for (int i = 0; i < NI_HW_INTRINSIC_END - NI_HW_INTRINSIC_START; i++)
+        for (int i = 0; i < NI_HW_INTRINSIC_END - NI_HW_INTRINSIC_START - 1; i++)
         {
             if (isa == hwIntrinsicInfoArray[i].isa && strcmp(methodName, hwIntrinsicInfoArray[i].intrinsicName) == 0)
             {


### PR DESCRIPTION
Fix asan error:
```
FAILED   - JIT/HardwareIntrinsics/X86/Avx2/Add_r/Add_r.sh
               BEGIN EXECUTION
               /media/kbaladurin/data/dotnet/forked/coreclr/bin/tests/Linux.x64.Debug/Tests/Core_Root/corerun Add_r.exe
               =================================================================
               ==15684==ERROR: AddressSanitizer: global-buffer-overflow on address 0x7f6a089c0860 at pc 0x7f6a082370ba bp 0x7ffcc4adcbb0 sp 0x7ffcc4adcba8
               READ of size 4 at 0x7f6a089c0860 thread T0
                   #0 0x7f6a082370b9 in Compiler::lookupHWIntrinsic(char const*, InstructionSet) /media/kbaladurin/data/dotnet/forked/coreclr/src/jit/hwintrinsicxarch.cpp:137:48
                   #1 0x7f6a0801afde in Compiler::lookupNamedIntrinsic(CORINFO_METHOD_STRUCT_*) /media/kbaladurin/data/dotnet/forked/coreclr/src/jit/importer.cpp:4125:30
                   #2 0x7f6a08018cbf in Compiler::impIntrinsic(GenTree*, CORINFO_CLASS_STRUCT_*, CORINFO_METHOD_STRUCT_*, CORINFO_SIG_INFO*, unsigned int, int, bool, bool, CORINFO_RESOLVED_TOKEN*, CORINFO_THIS_TRANSFORM, CorInfoIntrinsics*, bool*) /media/kbaladurin/data/dotnet/forked/coreclr/src/jit/importer.cpp:3396:18
                   #3 0x7f6a08029e9e in Compiler::impImportCall(opcode_t, CORINFO_RESOLVED_TOKEN*, CORINFO_RESOLVED_TOKEN*, GenTree*, int, CORINFO_CALL_INFO*, unsigned int) /media/kbaladurin/data/dotnet/forked/coreclr/src/jit/importer.cpp:7148:20
                   #4 0x7f6a0804306c in Compiler::impImportBlockCode(BasicBlock*) /media/kbaladurin/data/dotnet/forked/coreclr/src/jit/importer.cpp:13476:27
                   #5 0x7f6a0805c7bf in Compiler::impImportBlock(BasicBlock*)::$_1::operator()(Compiler::impImportBlock(BasicBlock*)::FilterVerificationExceptionsParam*) const /media/kbaladurin/data/dotnet/forked/coreclr/src/jit/importer.cpp:16413:24
                   #6 0x7f6a0805a9cb in Compiler::impImportBlock(BasicBlock*) /media/kbaladurin/data/dotnet/forked/coreclr/src/jit/importer.cpp:16423:5
                   #7 0x7f6a0805f929 in Compiler::impImport(BasicBlock*) /media/kbaladurin/data/dotnet/forked/coreclr/src/jit/importer.cpp:17500:13
                   #8 0x7f6a07f81f95 in Compiler::fgImport() /media/kbaladurin/data/dotnet/forked/coreclr/src/jit/flowgraph.cpp:6825:5
                   #9 0x7f6a07f226ce in Compiler::compCompile(void**, unsigned int*, JitFlags*) /media/kbaladurin/data/dotnet/forked/coreclr/src/jit/compiler.cpp:4568:5
                   #10 0x7f6a07f29e13 in Compiler::compCompileHelper(CORINFO_MODULE_STRUCT_*, ICorJitInfo*, CORINFO_METHOD_INFO*, void**, unsigned int*, JitFlags*, CorInfoInstantiationVerification) /media/kbaladurin/data/dotnet/forked/coreclr/src/jit/compiler.cpp:6208:5
                   #11 0x7f6a07f27b02 in Compiler::compCompile(CORINFO_METHOD_STRUCT_*, CORINFO_MODULE_STRUCT_*, ICorJitInfo*, CORINFO_METHOD_INFO*, void**, unsigned int*, JitFlags*)::$_1::operator()(Compiler::compCompile(CORINFO_METHOD_STRUCT_*, CORINFO_MODULE_STRUCT_*, ICorJitInfo*, CORINFO_METHOD_INFO*, void**, unsigned int*, JitFlags*)::__JITParam*) const /media/kbaladurin/data/dotnet/forked/coreclr/src/jit/compiler.cpp:5550:41
                   #12 0x7f6a07f26c9f in Compiler::compCompile(CORINFO_METHOD_STRUCT_*, CORINFO_MODULE_STRUCT_*, ICorJitInfo*, CORINFO_METHOD_INFO*, void**, unsigned int*, JitFlags*) /media/kbaladurin/data/dotnet/forked/coreclr/src/jit/compiler.cpp:5570:5
                   #13 0x7f6a07f378ea in jitNativeCode(CORINFO_METHOD_STRUCT_*, CORINFO_MODULE_STRUCT_*, ICorJitInfo*, CORINFO_METHOD_INFO*, void**, unsigned int*, JitFlags*, void*)::$_3::operator()(jitNativeCode(CORINFO_METHOD_STRUCT_*, CORINFO_MODULE_STRUCT_*, ICorJitInfo*, CORINFO_METHOD_INFO*, void**, unsigned int*, JitFlags*, void*)::__JITParam*) const::{lambda(jitNativeCode(CORINFO_METHOD_STRUCT_*, CORINFO_MODULE_STRUCT_*, ICorJitInfo*, CORINFO_METHOD_INFO*, void**, unsigned int*, JitFlags*, void*)::$_3::operator()(jitNativeCode(CORINFO_METHOD_STRUCT_*, CORINFO_MODULE_STRUCT_*, ICorJitInfo*, CORINFO_METHOD_INFO*, void**, unsigned int*, JitFlags*, void*)::__JITParam*) const::__JITParam*)#1}::operator()(jitNativeCode(CORINFO_METHOD_STRUCT_*, CORINFO_MODULE_STRUCT_*, ICorJitInfo*, CORINFO_METHOD_INFO*, void**, unsigned int*, JitFlags*, void*)::$_3::operator()(jitNativeCode(CORINFO_METHOD_STRUCT_*, CORINFO_MODULE_STRUCT_*, ICorJitInfo*, CORINFO_METHOD_INFO*, void**, unsigned int*, JitFlags*, void*)::__JITParam*) const::__JITParam*) const /media/kbaladurin/data/dotnet/forked/coreclr/src/jit/compiler.cpp:6860:32
                   #14 0x7f6a07f2da32 in jitNativeCode(CORINFO_METHOD_STRUCT_*, CORINFO_MODULE_STRUCT_*, ICorJitInfo*, CORINFO_METHOD_INFO*, void**, unsigned int*, JitFlags*, void*)::$_3::operator()(jitNativeCode(CORINFO_METHOD_STRUCT_*, CORINFO_MODULE_STRUCT_*, ICorJitInfo*, CORINFO_METHOD_INFO*, void**, unsigned int*, JitFlags*, void*)::__JITParam*) const /media/kbaladurin/data/dotnet/forked/coreclr/src/jit/compiler.cpp:6884:9
                   #15 0x7f6a07f2d467 in jitNativeCode(CORINFO_METHOD_STRUCT_*, CORINFO_MODULE_STRUCT_*, ICorJitInfo*, CORINFO_METHOD_INFO*, void**, unsigned int*, JitFlags*, void*) /media/kbaladurin/data/dotnet/forked/coreclr/src/jit/compiler.cpp:6886:5
                   #16 0x7f6a07f424a1 in CILJit::compileMethod(ICorJitInfo*, CORINFO_METHOD_INFO*, unsigned int, unsigned char**, unsigned int*) /media/kbaladurin/data/dotnet/forked/coreclr/src/jit/ee_il_dll.cpp:300:14
                   #17 0x7f6a0c2639d6 in invokeCompileMethodHelper(EEJitManager*, CEEInfo*, CORINFO_METHOD_INFO*, CORJIT_FLAGS, unsigned char**, unsigned int*) /media/kbaladurin/data/dotnet/forked/coreclr/src/vm/jitinterface.cpp:12147:30
                   #18 0x7f6a0c263e07 in invokeCompileMethod(EEJitManager*, CEEInfo*, CORINFO_METHOD_INFO*, CORJIT_FLAGS, unsigned char**, unsigned int*) /media/kbaladurin/data/dotnet/forked/coreclr/src/vm/jitinterface.cpp:12214:24
                   #19 0x7f6a0c2644d3 in CallCompileMethodWithSEHWrapper(EEJitManager*, CEEInfo*, CORINFO_METHOD_INFO*, CORJIT_FLAGS, unsigned char**, unsigned int*, MethodDesc*)::$_4::operator()(CallCompileMethodWithSEHWrapper(EEJitManager*, CEEInfo*, CORINFO_METHOD_INFO*, CORJIT_FLAGS, unsigned char**, unsigned int*, MethodDesc*)::Param*) const /media/kbaladurin/data/dotnet/forked/coreclr/src/vm/jitinterface.cpp:12266:23
                   #20 0x7f6a0c26420a in CallCompileMethodWithSEHWrapper(EEJitManager*, CEEInfo*, CORINFO_METHOD_INFO*, CORJIT_FLAGS, unsigned char**, unsigned int*, MethodDesc*) /media/kbaladurin/data/dotnet/forked/coreclr/src/vm/jitinterface.cpp:12296:5
                   #21 0x7f6a0c26599c in UnsafeJitFunction(MethodDesc*, COR_ILMETHOD_DECODER*, CORJIT_FLAGS, unsigned int*) /media/kbaladurin/data/dotnet/forked/coreclr/src/vm/jitinterface.cpp:12768:19
                   #22 0x7f6a0c6cef62 in MethodDesc::JitCompileCodeLocked(PrepareCodeConfig*, ListLockEntryBase<NativeCodeVersion>*, unsigned int*, CORJIT_FLAGS*) /media/kbaladurin/data/dotnet/forked/coreclr/src/vm/prestub.cpp:836:17
                   #23 0x7f6a0c6ce96e in MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig*, ListLockEntryBase<NativeCodeVersion>*) /media/kbaladurin/data/dotnet/forked/coreclr/src/vm/prestub.cpp:715:17
                   #24 0x7f6a0c6cdda9 in MethodDesc::JitCompileCode(PrepareCodeConfig*) /media/kbaladurin/data/dotnet/forked/coreclr/src/vm/prestub.cpp:635:24
                   #25 0x7f6a0c6cd233 in MethodDesc::PrepareInitialCode() /media/kbaladurin/data/dotnet/forked/coreclr/src/vm/prestub.cpp:248:19
                   #26 0x7f6a0c6d1c5c in MethodDesc::DoPrestub(MethodTable*) /media/kbaladurin/data/dotnet/forked/coreclr/src/vm/prestub.cpp:1776:17
                   #27 0x7f6a0c6d1476 in PreStubWorker /media/kbaladurin/data/dotnet/forked/coreclr/src/vm/prestub.cpp:1517:21
                   #28 0x7f6a0c5bd0fb in ThePreStub /media/kbaladurin/data/dotnet/forked/coreclr/src/vm/amd64/theprestubamd64.S:17
                   #29 0x7f6a0c5bc2ea in CallDescrWorkerInternal /media/kbaladurin/data/dotnet/forked/coreclr/src/pal/inc/unixasmmacrosamd64.inc:862
                   #30 0x7f6a0c382b68 in CallDescrWorkerWithHandler(CallDescrData*, int) /media/kbaladurin/data/dotnet/forked/coreclr/src/vm/callhelpers.cpp:78:5
                   #31 0x7f6a0c383d67 in MethodDescCallSite::CallTargetWorker(unsigned long const*, unsigned long*, int) /media/kbaladurin/data/dotnet/forked/coreclr/src/vm/callhelpers.cpp:620:9
                   #32 0x7f6a0c3253f1 in MethodDescCallSite::Call_RetArgSlot(unsigned long const*) /media/kbaladurin/data/dotnet/forked/coreclr/src/vm/callhelpers.h:433:9
                   #33 0x7f6a0c5ff6ac in RunMain(MethodDesc*, short, int*, REF<PtrArray>*)::$_1::operator()(RunMain(MethodDesc*, short, int*, REF<PtrArray>*)::Param*) const::{lambda(RunMain(MethodDesc*, short, int*, REF<PtrArray>*)::Param*)#1}::operator()(RunMain(MethodDesc*, short, int*, REF<PtrArray>*)::Param*) const /media/kbaladurin/data/dotnet/forked/coreclr/src/vm/assembly.cpp:1709:52
                   #34 0x7f6a0c5fb743 in RunMain(MethodDesc*, short, int*, REF<PtrArray>*)::$_1::operator()(RunMain(MethodDesc*, short, int*, REF<PtrArray>*)::Param*) const /media/kbaladurin/data/dotnet/forked/coreclr/src/vm/assembly.cpp:1720:5
                   #35 0x7f6a0c5fb385 in RunMain(MethodDesc*, short, int*, REF<PtrArray>*) /media/kbaladurin/data/dotnet/forked/coreclr/src/vm/assembly.cpp:1720:5
                   #36 0x7f6a0c5fbad5 in Assembly::ExecuteMainMethod(REF<PtrArray>*, int) /media/kbaladurin/data/dotnet/forked/coreclr/src/vm/assembly.cpp:1817:18
                   #37 0x7f6a0c1d2b9e in CorHost2::ExecuteAssembly(unsigned int, char16_t const*, int, char16_t const**, unsigned int*) /media/kbaladurin/data/dotnet/forked/coreclr/src/vm/corhost.cpp:482:35
                   #38 0x7f6a0c18288a in coreclr_execute_assembly /media/kbaladurin/data/dotnet/forked/coreclr/src/dlls/mscoree/unixinterface.cpp:407:24
                   #39 0x50e2cb in ExecuteManagedAssembly(char const*, char const*, char const*, int, char const**) /media/kbaladurin/data/dotnet/forked/coreclr/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp:429:22
                   #40 0x50caff in corerun(int, char const**) /media/kbaladurin/data/dotnet/forked/coreclr/src/coreclr/hosts/unixcorerun/corerun.cpp:149:20
                   #41 0x7f6a0ffd482f in __libc_start_main /build/glibc-Cl5G7W/glibc-2.23/csu/../csu/libc-start.c:291
                   #42 0x41e088 in _start (/media/kbaladurin/data/dotnet/forked/coreclr/bin/tests/Linux.x64.Debug/Tests/Core_Root/corerun+0x41e088)
               
               0x7f6a089c0860 is located 16 bytes to the right of global variable 'hwIntrinsicInfoArray' defined in '/media/kbaladurin/data/dotnet/forked/coreclr/src/jit/hwintrinsicxarch.cpp:22:30' (0x7f6a089be640) of size 8720
               SUMMARY: AddressSanitizer: global-buffer-overflow /media/kbaladurin/data/dotnet/forked/coreclr/src/jit/hwintrinsicxarch.cpp:137:48 in Compiler::lookupHWIntrinsic(char const*, InstructionSet)
               Shadow bytes around the buggy address:
                 0x0fedc11300b0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
                 0x0fedc11300c0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
                 0x0fedc11300d0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
                 0x0fedc11300e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
                 0x0fedc11300f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
               =>0x0fedc1130100: 00 00 00 00 00 00 00 00 00 00 f9 f9[f9]f9 f9 f9
                 0x0fedc1130110: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
                 0x0fedc1130120: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
                 0x0fedc1130130: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
                 0x0fedc1130140: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
                 0x0fedc1130150: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
               Shadow byte legend (one shadow byte represents 8 application bytes):
                 Addressable:           00
                 Partially addressable: 01 02 03 04 05 06 07 
                 Heap left redzone:       fa
                 Heap right redzone:      fb
                 Freed heap region:       fd
                 Stack left redzone:      f1
                 Stack mid redzone:       f2
                 Stack right redzone:     f3
                 Stack partial redzone:   f4
                 Stack after return:      f5
                 Stack use after scope:   f8
                 Global redzone:          f9
                 Global init order:       f6
                 Poisoned by user:        f7
                 Container overflow:      fc
                 Array cookie:            ac
                 Intra object redzone:    bb
                 ASan internal:           fe
                 Left alloca redzone:     ca
                 Right alloca redzone:    cb
               ==15684==ABORTING
               Expected: 100
               Actual: 1
               END EXECUTION - FAILED
```