### PR TITLE
EnsureCapacty(0) is expected to return zero when Dictionary is not initialized.

### DIFF
--- a/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
@@ -768,8 +768,9 @@ namespace System.Collections.Generic
         {
             if (capacity < 0)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.capacity);
-            if (_entries != null && _entries.Length >= capacity)
-                return _entries.Length;
+            int currentCapacity = _entries == null ? 0 : _entries.Length;
+            if (currentCapacity >= capacity)
+                return currentCapacity;
             if (_buckets == null)
                 return Initialize(capacity);
             int newSize = HashHelpers.GetPrime(capacity);


### PR DESCRIPTION
EnsureCapacty(0) should return zero as capacity for a non initialized Dictionary rather than doing initialization.

For more information please refer to [this comment thread](https://github.com/dotnet/corefx/pull/26239#pullrequestreview-92234076)

Issue is: dotnet/corefx#24445