### PR TITLE
Replace TryCopyTo with CopyTo

### DIFF
--- a/src/mscorlib/shared/System/Boolean.cs
+++ b/src/mscorlib/shared/System/Boolean.cs
@@ -100,10 +100,8 @@ namespace System
         {
             string s = m_value ? TrueLiteral : FalseLiteral;
 
-            if (s.Length <= destination.Length)
+            if (s.AsReadOnlySpan().TryCopyTo(destination))
             {
-                bool copied = s.AsReadOnlySpan().TryCopyTo(destination);
-                Debug.Assert(copied);
                 charsWritten = s.Length;
                 return true;
             }

--- a/src/mscorlib/shared/System/Number.Formatting.cs
+++ b/src/mscorlib/shared/System/Number.Formatting.cs
@@ -1128,10 +1128,8 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe bool TryCopyTo(char* src, int length, Span<char> destination, out int charsWritten)
         {
-            if (length <= destination.Length)
+            if (new ReadOnlySpan<char>(src, length).TryCopyTo(destination))
             {
-                bool copied = new ReadOnlySpan<char>(src, length).TryCopyTo(destination);
-                Debug.Assert(copied);
                 charsWritten = length;
                 return true;
             }
@@ -1708,8 +1706,7 @@ namespace System
                         if (thousandsSepCtr >= thousandsSepPos.Length)
                         {
                             var newThousandsSepPos = new int[thousandsSepPos.Length * 2];
-                            bool copied = thousandsSepPos.TryCopyTo(newThousandsSepPos);
-                            Debug.Assert(copied, "Expect copy to succeed, as the new array is larger than the original");
+                            thousandsSepPos.CopyTo(newThousandsSepPos);
                             thousandsSepPos = newThousandsSepPos;
                         }
 

--- a/src/mscorlib/shared/System/Text/ValueStringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/ValueStringBuilder.cs
@@ -112,8 +112,7 @@ namespace System.Text
                 Grow(s.Length);
             }
 
-            bool copied = s.AsReadOnlySpan().TryCopyTo(_chars.Slice(pos));
-            Debug.Assert(copied, "Grow should have made enough room to successfully copy");
+            s.AsReadOnlySpan().CopyTo(_chars.Slice(pos));
             _pos += s.Length;
         }
 
@@ -175,8 +174,7 @@ namespace System.Text
 
             char[] poolArray = ArrayPool<char>.Shared.Rent(Math.Max(_pos + requiredAdditionalCapacity, _chars.Length * 2));
 
-            bool success = _chars.TryCopyTo(poolArray);
-            Debug.Assert(success);
+            _chars.CopyTo(poolArray);
 
             char[] toReturn = _arrayToReturnToPool;
             _chars = _arrayToReturnToPool = poolArray;


### PR DESCRIPTION
While doing various Span-related work involving copying, in a few places I previously used a pattern of calling TryCopyTo and then asserting its result, in places where I knew the destination was long enough.  This was because CopyTo was implemented as a wrapper around TryCopyTo and thus involved an extra unnecessary branch.  Now that that's no longer the case, I'm simplifying the call sites.

cc: @GrabYourPitchforks 