### PR TITLE
Remove replaced Span/ReadOnlySpan methods.

### DIFF
--- a/src/mscorlib/shared/System/ReadOnlySpan.cs
+++ b/src/mscorlib/shared/System/ReadOnlySpan.cs
@@ -102,19 +102,6 @@ namespace System
             _length = length;
         }
 
-        /// <summary>
-        /// Create a new read-only span over a portion of a regular managed object. This can be useful
-        /// if part of a managed object represents a "fixed array." This is dangerous because neither the
-        /// <paramref name="length"/> is checked, nor <paramref name="obj"/> being null, nor the fact that
-        /// "rawPointer" actually lies within <paramref name="obj"/>.
-        /// </summary>
-        /// <param name="obj">The managed object that contains the data to span over.</param>
-        /// <param name="objectData">A reference to data within that object.</param>
-        /// <param name="length">The number of <typeparamref name="T"/> elements the memory contains.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static ReadOnlySpan<T> DangerousCreate(object obj, ref T objectData, int length) => new ReadOnlySpan<T>(ref objectData, length);
-
         // Constructor for internal use only.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal ReadOnlySpan(ref T ptr, int length)

--- a/src/mscorlib/shared/System/ReadOnlySpan.cs
+++ b/src/mscorlib/shared/System/ReadOnlySpan.cs
@@ -116,17 +116,6 @@ namespace System
         private string DebuggerDisplay => string.Format("{{{0}[{1}]}}", typeof(T).Name, _length);
 
         /// <summary>
-        /// Returns a reference to the 0th element of the Span. If the Span is empty, returns a reference to the location where the 0th element
-        /// would have been stored. Such a reference can be used for pinning but must never be dereferenced.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        internal ref readonly T DangerousGetPinnableReference()
-        {
-            return ref _pointer.Value;
-        }
-
-        /// <summary>
         /// The number of items in the read-only span.
         /// </summary>
         public int Length
@@ -197,7 +186,7 @@ namespace System
 
             if ((uint)_length <= (uint)destination.Length)
             {
-                Buffer.Memmove(ref destination.DangerousGetPinnableReference(), ref _pointer.Value, (nuint)_length);
+                Buffer.Memmove(ref destination._pointer.Value, ref _pointer.Value, (nuint)_length);
             }
             else
             {
@@ -217,7 +206,7 @@ namespace System
             bool retVal = false;
             if ((uint)_length <= (uint)destination.Length)
             {
-                Buffer.Memmove(ref destination.DangerousGetPinnableReference(), ref _pointer.Value, (nuint)_length);
+                Buffer.Memmove(ref destination._pointer.Value, ref _pointer.Value, (nuint)_length);
                 retVal = true;
             }
             return retVal;

--- a/src/mscorlib/shared/System/Runtime/InteropServices/MemoryMarshal.Fast.cs
+++ b/src/mscorlib/shared/System/Runtime/InteropServices/MemoryMarshal.Fast.cs
@@ -60,7 +60,7 @@ namespace System.Runtime.InteropServices
                 ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(TTo));
 
             return new Span<TTo>(
-                ref Unsafe.As<TFrom, TTo>(ref source.DangerousGetPinnableReference()),
+                ref Unsafe.As<TFrom, TTo>(ref source._pointer.Value),
                 checked((int)((long)source.Length * Unsafe.SizeOf<TFrom>() / Unsafe.SizeOf<TTo>())));
         }
 

--- a/src/mscorlib/shared/System/Runtime/InteropServices/MemoryMarshal.Fast.cs
+++ b/src/mscorlib/shared/System/Runtime/InteropServices/MemoryMarshal.Fast.cs
@@ -50,7 +50,6 @@ namespace System.Runtime.InteropServices
         /// <exception cref="System.ArgumentException">
         /// Thrown when <typeparamref name="TFrom"/> or <typeparamref name="TTo"/> contains pointers.
         /// </exception>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Span<TTo> Cast<TFrom, TTo>(Span<TFrom> source)
             where TFrom : struct
             where TTo : struct
@@ -76,7 +75,6 @@ namespace System.Runtime.InteropServices
         /// <exception cref="System.ArgumentException">
         /// Thrown when <typeparamref name="TFrom"/> or <typeparamref name="TTo"/> contains pointers.
         /// </exception>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ReadOnlySpan<TTo> Cast<TFrom, TTo>(ReadOnlySpan<TFrom> source)
             where TFrom : struct
             where TTo : struct

--- a/src/mscorlib/shared/System/Span.NonGeneric.cs
+++ b/src/mscorlib/shared/System/Span.NonGeneric.cs
@@ -132,58 +132,6 @@ namespace System
         }
 
         /// <summary>
-        /// Casts a Span of one primitive type <typeparamref name="TFrom"/> to another primitive type <typeparamref name="TTo"/>.
-        /// These types may not contain pointers or references. This is checked at runtime in order to preserve type safety.
-        /// </summary>
-        /// <remarks>
-        /// Supported only for platforms that support misaligned memory access.
-        /// </remarks>
-        /// <param name="source">The source slice, of type <typeparamref name="TFrom"/>.</param>
-        /// <exception cref="System.ArgumentException">
-        /// Thrown when <typeparamref name="TFrom"/> or <typeparamref name="TTo"/> contains pointers.
-        /// </exception>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Span<TTo> NonPortableCast<TFrom, TTo>(this Span<TFrom> source)
-            where TFrom : struct
-            where TTo : struct
-        {
-            if (RuntimeHelpers.IsReferenceOrContainsReferences<TFrom>())
-                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(TFrom));
-            if (RuntimeHelpers.IsReferenceOrContainsReferences<TTo>())
-                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(TTo));
-
-            return new Span<TTo>(
-                ref Unsafe.As<TFrom, TTo>(ref source.DangerousGetPinnableReference()),
-                checked((int)((long)source.Length * Unsafe.SizeOf<TFrom>() / Unsafe.SizeOf<TTo>())));
-        }
-
-        /// <summary>
-        /// Casts a ReadOnlySpan of one primitive type <typeparamref name="TFrom"/> to another primitive type <typeparamref name="TTo"/>.
-        /// These types may not contain pointers or references. This is checked at runtime in order to preserve type safety.
-        /// </summary>
-        /// <remarks>
-        /// Supported only for platforms that support misaligned memory access.
-        /// </remarks>
-        /// <param name="source">The source slice, of type <typeparamref name="TFrom"/>.</param>
-        /// <exception cref="System.ArgumentException">
-        /// Thrown when <typeparamref name="TFrom"/> or <typeparamref name="TTo"/> contains pointers.
-        /// </exception>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ReadOnlySpan<TTo> NonPortableCast<TFrom, TTo>(this ReadOnlySpan<TFrom> source)
-            where TFrom : struct
-            where TTo : struct
-        {
-            if (RuntimeHelpers.IsReferenceOrContainsReferences<TFrom>())
-                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(TFrom));
-            if (RuntimeHelpers.IsReferenceOrContainsReferences<TTo>())
-                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(TTo));
-
-            return new ReadOnlySpan<TTo>(
-                ref Unsafe.As<TFrom, TTo>(ref MemoryMarshal.GetReference(source)),
-                checked((int)((long)source.Length * Unsafe.SizeOf<TFrom>() / Unsafe.SizeOf<TTo>())));
-        }
-
-        /// <summary>
         /// Creates a new readonly span over the portion of the target string.
         /// </summary>
         /// <param name="text">The target string.</param>

--- a/src/mscorlib/shared/System/Span.cs
+++ b/src/mscorlib/shared/System/Span.cs
@@ -108,19 +108,6 @@ namespace System
             _length = length;
         }
 
-        /// <summary>
-        /// Create a new span over a portion of a regular managed object. This can be useful
-        /// if part of a managed object represents a "fixed array." This is dangerous because neither the
-        /// <paramref name="length"/> is checked, nor <paramref name="obj"/> being null, nor the fact that
-        /// "rawPointer" actually lies within <paramref name="obj"/>.
-        /// </summary>
-        /// <param name="obj">The managed object that contains the data to span over.</param>
-        /// <param name="objectData">A reference to data within that object.</param>
-        /// <param name="length">The number of <typeparamref name="T"/> elements the memory contains.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static Span<T> DangerousCreate(object obj, ref T objectData, int length) => new Span<T>(ref objectData, length);
-
         // Constructor for internal use only.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal Span(ref T ptr, int length)

--- a/src/mscorlib/shared/System/Span.cs
+++ b/src/mscorlib/shared/System/Span.cs
@@ -122,17 +122,6 @@ namespace System
         private string DebuggerDisplay => string.Format("{{{0}[{1}]}}", typeof(T).Name, _length);
 
         /// <summary>
-        /// Returns a reference to the 0th element of the Span. If the Span is empty, returns a reference to the location where the 0th element
-        /// would have been stored. Such a reference can be used for pinning but must never be dereferenced.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        internal ref T DangerousGetPinnableReference()
-        {
-            return ref _pointer.Value;
-        }
-
-        /// <summary>
         /// The number of items in the span.
         /// </summary>
         public int Length
@@ -222,7 +211,7 @@ namespace System
                 if (length == 0)
                     return;
 
-                ref T r = ref DangerousGetPinnableReference();
+                ref T r = ref _pointer.Value;
 
                 // TODO: Create block fill for value types of power of two sizes e.g. 2,4,8,16
 
@@ -271,7 +260,7 @@ namespace System
 
             if ((uint)_length <= (uint)destination.Length)
             {
-                Buffer.Memmove(ref destination.DangerousGetPinnableReference(), ref _pointer.Value, (nuint)_length);
+                Buffer.Memmove(ref destination._pointer.Value, ref _pointer.Value, (nuint)_length);
             }
             else
             {
@@ -292,7 +281,7 @@ namespace System
             bool retVal = false;
             if ((uint)_length <= (uint)destination.Length)
             {
-                Buffer.Memmove(ref destination.DangerousGetPinnableReference(), ref _pointer.Value, (nuint)_length);
+                Buffer.Memmove(ref destination._pointer.Value, ref _pointer.Value, (nuint)_length);
                 retVal = true;
             }
             return retVal;

--- a/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
@@ -475,41 +475,41 @@ namespace Span
         }
         #endregion
 
-        #region TestSpanDangerousCreate<T>
+        #region TestSpanCreate<T>
         [Benchmark(InnerIterationCount = BaseIterations)]
         [InlineData(100)]
-        public static void TestSpanDangerousCreateByte(int length)
+        public static void TestSpanCreateByte(int length)
         {
-            InvokeTestSpanDangerousCreate<byte>(length);
+            InvokeTestSpanCreate<byte>(length);
         }
 
         [Benchmark(InnerIterationCount = BaseIterations)]
         [InlineData(100)]
-        public static void TestSpanDangerousCreateString(int length)
+        public static void TestSpanCreateString(int length)
         {
-            InvokeTestSpanDangerousCreate<string>(length);
+            InvokeTestSpanCreate<string>(length);
         }
 
-        static void InvokeTestSpanDangerousCreate<T>(int length)
+        static void InvokeTestSpanCreate<T>(int length)
         {
             TestClass<T> testClass = new TestClass<T>();
             testClass.C0 = new T[length];
 
-            Invoke((int innerIterationCount) => TestSpanDangerousCreate<T>(testClass, innerIterationCount, false),
-                "TestSpanDangerousCreate<{0}>({1})", typeof(T).Name, length);
+            Invoke((int innerIterationCount) => TestSpanCreate<T>(testClass, innerIterationCount, false),
+                "TestSpanCreate<{0}>({1})", typeof(T).Name, length);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static void TestSpanDangerousCreate<T>(TestClass<T> testClass, int iterationCount, bool untrue)
+        static void TestSpanCreate<T>(TestClass<T> testClass, int iterationCount, bool untrue)
         {
             var sink = Sink<T>.Instance;
 
             for (int i = 0; i < iterationCount; i++)
             {
-                var span = Span<T>.DangerousCreate(testClass, ref testClass.C0[0], testClass.C0.Length);
+                var span = MemoryMarshal.CreateSpan<T>(ref testClass.C0[0], testClass.C0.Length);
                 // Under a condition that we know is false but the jit doesn't,
                 // add a read from 'span' to make sure it's not dead, and an assignment
-                // to 'testClass' so the DangerousCreate call won't get hoisted.
+                // to 'testClass' so the Create call won't get hoisted.
                 if (untrue) { sink.Data = span[0]; testClass = new TestClass<T>(); }
             }
         }
@@ -967,33 +967,33 @@ namespace Span
         }
         #endregion
 
-        #region TestSpanNonPortableCast<T>
+        #region TestSpanCast<T>
         [Benchmark(InnerIterationCount = BaseIterations)]
         [InlineData(100)]
-        public static void TestSpanNonPortableCastFromByteToInt(int length)
+        public static void TestSpanCastFromByteToInt(int length)
         {
-            InvokeTestSpanNonPortableCast<byte, int>(length);
+            InvokeTestSpanCast<byte, int>(length);
         }
 
         [Benchmark(InnerIterationCount = BaseIterations)]
         [InlineData(100)]
-        public static void TestSpanNonPortableCastFromIntToByte(int length)
+        public static void TestSpanCastFromIntToByte(int length)
         {
-            InvokeTestSpanNonPortableCast<int, byte>(length);
+            InvokeTestSpanCast<int, byte>(length);
         }
 
-        static void InvokeTestSpanNonPortableCast<From, To>(int length)
+        static void InvokeTestSpanCast<From, To>(int length)
             where From : struct
             where To : struct
         {
             var array = new From[length];
 
-            Invoke((int innerIterationCount) => TestSpanNonPortableCast<From, To>(array, innerIterationCount, false),
-                "TestSpanNonPortableCast<{0}, {1}>({2})", typeof(From).Name, typeof(To).Name, length);
+            Invoke((int innerIterationCount) => TestSpanCast<From, To>(array, innerIterationCount, false),
+                "TestSpanCast<{0}, {1}>({2})", typeof(From).Name, typeof(To).Name, length);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static void TestSpanNonPortableCast<From, To>(From[] array, int iterationCount, bool untrue)
+        static void TestSpanCast<From, To>(From[] array, int iterationCount, bool untrue)
             where From : struct
             where To : struct
         {
@@ -1002,7 +1002,7 @@ namespace Span
 
             for (int i = 0; i < iterationCount; i++)
             {
-                var toSpan = span.NonPortableCast<From, To>();
+                var toSpan = MemoryMarshal.Cast<From, To>(span);
                 // Under a condition that we know is false but the jit doesn't,
                 // add a read from 'toSpan' to make sure it's not dead, and an assignment
                 // to 'span' so the AsBytes call won't get hoisted.


### PR DESCRIPTION
Continuation of https://github.com/dotnet/coreclr/pull/15941

This PR removes the old functions that are no longer being exposed in corefx as of the merging of https://github.com/dotnet/corefx/pull/26467.

cc: @ahsonkhan @stephentoub 