### PR TITLE
Update Span/ReadOnlySpan strings to match Portable Span

### DIFF
--- a/src/mscorlib/shared/System/ReadOnlySpan.cs
+++ b/src/mscorlib/shared/System/ReadOnlySpan.cs
@@ -125,9 +125,6 @@ namespace System
             _length = length;
         }
 
-        //Debugger Display = System.ReadOnlySpan<T>[length]
-        private string DebuggerDisplay => string.Format("System.ReadOnlySpan<{0}>[{1}]", typeof(T).Name, _length);
-
         /// <summary>
         /// Returns a reference to the 0th element of the Span. If the Span is empty, returns a reference to the location where the 0th element
         /// would have been stored. Such a reference can be used for pinning but must never be dereferenced.
@@ -280,7 +277,7 @@ namespace System
         /// <summary>
         /// Returns a <see cref="String"/> with the name of the type and the number of elements
         /// </summary>
-        public override string ToString() => string.Format("System.ReadOnlySpan<{0}>[{1}]", typeof(T).Name, Length);
+        public override string ToString() => string.Format("System.ReadOnlySpan<{0}>[{1}]", typeof(T).Name, _length);
 
         /// <summary>
         /// Defines an implicit conversion of an array to a <see cref="ReadOnlySpan{T}"/>

--- a/src/mscorlib/shared/System/ReadOnlySpan.cs
+++ b/src/mscorlib/shared/System/ReadOnlySpan.cs
@@ -125,8 +125,8 @@ namespace System
             _length = length;
         }
 
-        //Debugger Display = {T[length]}
-        private string DebuggerDisplay => string.Format("{{{0}[{1}]}}", typeof(T).Name, _length);
+        //Debugger Display = System.ReadOnlySpan<T>[length]
+        private string DebuggerDisplay => string.Format("System.ReadOnlySpan<{0}>[{1}]", typeof(T).Name, _length);
 
         /// <summary>
         /// Returns a reference to the 0th element of the Span. If the Span is empty, returns a reference to the location where the 0th element
@@ -280,7 +280,7 @@ namespace System
         /// <summary>
         /// Returns a <see cref="String"/> with the name of the type and the number of elements
         /// </summary>
-        public override string ToString() => "System.Span[" + Length.ToString() + "]";
+        public override string ToString() => string.Format("System.ReadOnlySpan<{0}>[{1}]", typeof(T).Name, Length);
 
         /// <summary>
         /// Defines an implicit conversion of an array to a <see cref="ReadOnlySpan{T}"/>

--- a/src/mscorlib/shared/System/Span.cs
+++ b/src/mscorlib/shared/System/Span.cs
@@ -131,9 +131,6 @@ namespace System
             _length = length;
         }
 
-        //Debugger Display = System.Span<T>[length]
-        private string DebuggerDisplay => string.Format("System.Span<{0}>[{1}]", typeof(T).Name, _length);
-
         /// <summary>
         /// Returns a reference to the 0th element of the Span. If the Span is empty, returns a reference to the location where the 0th element
         /// would have been stored. Such a reference can be used for pinning but must never be dereferenced.
@@ -355,7 +352,7 @@ namespace System
         /// <summary>
         /// Returns a <see cref="String"/> with the name of the type and the number of elements
         /// </summary>
-        public override string ToString() => string.Format("System.Span<{0}>[{1}]", typeof(T).Name, Length);
+        public override string ToString() => string.Format("System.Span<{0}>[{1}]", typeof(T).Name, _length);
 
         /// <summary>
         /// Defines an implicit conversion of an array to a <see cref="Span{T}"/>

--- a/src/mscorlib/shared/System/Span.cs
+++ b/src/mscorlib/shared/System/Span.cs
@@ -131,8 +131,8 @@ namespace System
             _length = length;
         }
 
-        //Debugger Display = {T[length]}
-        private string DebuggerDisplay => string.Format("{{{0}[{1}]}}", typeof(T).Name, _length);
+        //Debugger Display = System.Span<T>[length]
+        private string DebuggerDisplay => string.Format("System.Span<{0}>[{1}]", typeof(T).Name, _length);
 
         /// <summary>
         /// Returns a reference to the 0th element of the Span. If the Span is empty, returns a reference to the location where the 0th element
@@ -355,7 +355,7 @@ namespace System
         /// <summary>
         /// Returns a <see cref="String"/> with the name of the type and the number of elements
         /// </summary>
-        public override string ToString() => "System.Span[" + Length.ToString() + "]";
+        public override string ToString() => string.Format("System.Span<{0}>[{1}]", typeof(T).Name, Length);
 
         /// <summary>
         /// Defines an implicit conversion of an array to a <see cref="Span{T}"/>


### PR DESCRIPTION
The change made to Portable Span DebuggerDisplay string in https://github.com/dotnet/corefx/pull/26467 should be reflected in the fast span. 

Suggestion by @ahsonkhan [https://github.com/dotnet/corefx/pull/26467#discussion_r164534692](here).