### PR TITLE
Prevent compiler optimization that could cause local var values to change in multithreaded environments, in some places (#16089)

### DIFF
--- a/src/vm/syncblk.cpp
+++ b/src/vm/syncblk.cpp
@@ -2888,7 +2888,7 @@ void AwareLock::Enter()
     CONTRACTL_END;
 
     Thread *pCurThread = GetThread();
-    LockState state = m_lockState;
+    LockState state = m_lockState.VolatileLoadWithoutBarrier();
     if (!state.IsLocked() || m_HoldingThread != pCurThread)
     {
         if (m_lockState.InterlockedTryLock_Or_RegisterWaiter(this, state))
@@ -2950,7 +2950,7 @@ BOOL AwareLock::TryEnter(INT32 timeOut)
         pCurThread->HandleThreadAbort();
     }
 
-    LockState state = m_lockState;
+    LockState state = m_lockState.VolatileLoadWithoutBarrier();
     if (!state.IsLocked() || m_HoldingThread != pCurThread)
     {
         if (timeOut == 0

--- a/src/vm/synch.h
+++ b/src/vm/synch.h
@@ -219,6 +219,12 @@ private:
             return *this;
         }
 
+        Counts VolatileLoadWithoutBarrier() const
+        {
+            LIMITED_METHOD_CONTRACT;
+            return ::VolatileLoadWithoutBarrier(&data);
+        }
+
         Counts CompareExchange(Counts toCounts, Counts fromCounts)
         {
             LIMITED_METHOD_CONTRACT;
@@ -264,7 +270,11 @@ public:
 
 private:
     BYTE __padding1[MAX_CACHE_LINE_SIZE]; // padding to ensure that m_counts gets its own cache line
+
+    // Take care to use 'm_counts.VolatileLoadWithoutBarrier()` when loading this value into a local variable that will be
+    // reused. See AwareLock::m_lockState for details.
     Counts m_counts;
+
     BYTE __padding2[MAX_CACHE_LINE_SIZE]; // padding to ensure that m_counts gets its own cache line
 
 #if defined(DEBUG)


### PR DESCRIPTION
Port of https://github.com/dotnet/coreclr/pull/16089 (2f14b350960af0354608c041d7df501c44dc5640) to release/2.1

Fixes https://github.com/dotnet/coreclr/issues/15592