### PR TITLE
Several updates to ValueTask

### DIFF
--- a/src/mscorlib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
+++ b/src/mscorlib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
@@ -74,7 +74,11 @@ namespace System.Runtime.CompilerServices
 
             /// <summary>Gets the task underlying the incomplete <see cref="_value"/>.</summary>
             /// <remarks>This method is used when awaiting and IsCompleted returned false; thus we expect the value task to be wrapping a non-null task.</remarks>
-            (Task task, bool continueOnCapturedContext) IConfiguredValueTaskAwaiter.GetTask() => (_value.AsTaskExpectNonNull(), _continueOnCapturedContext);
+            Task IConfiguredValueTaskAwaiter.GetTask(out bool continueOnCapturedContext)
+            {
+                continueOnCapturedContext = _continueOnCapturedContext;
+                return _value.AsTaskExpectNonNull();
+            }
         }
     }
 
@@ -83,6 +87,6 @@ namespace System.Runtime.CompilerServices
     /// </summary>
     internal interface IConfiguredValueTaskAwaiter
     {
-        (Task task, bool continueOnCapturedContext) GetTask();
+        Task GetTask(out bool continueOnCapturedContext);
     }
 }

--- a/src/mscorlib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
+++ b/src/mscorlib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
@@ -35,10 +35,10 @@ namespace System.Runtime.CompilerServices
 
         /// <summary>Provides an awaiter for a <see cref="ConfiguredValueTaskAwaitable{TResult}"/>.</summary>
         [StructLayout(LayoutKind.Auto)]
-        public struct ConfiguredValueTaskAwaiter : ICriticalNotifyCompletion, IConfiguredValueTaskAwaiter
+        public readonly struct ConfiguredValueTaskAwaiter : ICriticalNotifyCompletion, IConfiguredValueTaskAwaiter
         {
             /// <summary>The value being awaited.</summary>
-            private ValueTask<TResult> _value; // Methods are called on this; avoid making it readonly so as to avoid unnecessary copies
+            private readonly ValueTask<TResult> _value;
             /// <summary>The value to pass to ConfigureAwait.</summary>
             internal readonly bool _continueOnCapturedContext;
 

--- a/src/mscorlib/shared/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/mscorlib/shared/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -8,10 +8,10 @@ using System.Threading.Tasks;
 namespace System.Runtime.CompilerServices
 {
     /// <summary>Provides an awaiter for a <see cref="ValueTask{TResult}"/>.</summary>
-    public struct ValueTaskAwaiter<TResult> : ICriticalNotifyCompletion, IValueTaskAwaiter
+    public readonly struct ValueTaskAwaiter<TResult> : ICriticalNotifyCompletion, IValueTaskAwaiter
     {
         /// <summary>The value being awaited.</summary>
-        private ValueTask<TResult> _value; // Methods are called on this; avoid making it readonly so as to avoid unnecessary copies
+        private readonly ValueTask<TResult> _value;
 
         /// <summary>Initializes the awaiter.</summary>
         /// <param name="value">The value to be awaited.</param>

--- a/src/mscorlib/shared/System/Threading/Tasks/ValueTask.cs
+++ b/src/mscorlib/shared/System/Threading/Tasks/ValueTask.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -77,7 +76,7 @@ namespace System.Threading.Tasks
             }
 
             _task = task;
-            _result = default(TResult);
+            _result = default;
         }
 
         /// <summary>Returns the hash code for this instance.</summary>
@@ -166,13 +165,5 @@ namespace System.Threading.Tasks
                     string.Empty;
             }
         }
-
-        // TODO https://github.com/dotnet/corefx/issues/22171:
-        // Remove CreateAsyncMethodBuilder once the C# compiler relies on the AsyncBuilder attribute.
-
-        /// <summary>Creates a method builder for use with an async method.</summary>
-        /// <returns>The created builder.</returns>
-        [EditorBrowsable(EditorBrowsableState.Never)] // intended only for compiler consumption
-        public static AsyncValueTaskMethodBuilder<TResult> CreateAsyncMethodBuilder() => AsyncValueTaskMethodBuilder<TResult>.Create();
     }
 }

--- a/src/mscorlib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -413,8 +413,8 @@ namespace System.Runtime.CompilerServices
             }
             else if ((null != (object)default(TAwaiter)) && (awaiter is IConfiguredValueTaskAwaiter))
             {
-                (Task task, bool continueOnCapturedContext) t = ((IConfiguredValueTaskAwaiter)awaiter).GetTask();
-                TaskAwaiter.UnsafeOnCompletedInternal(t.task, box, t.continueOnCapturedContext);
+                Task t = ((IConfiguredValueTaskAwaiter)awaiter).GetTask(out bool continueOnCapturedContext);
+                TaskAwaiter.UnsafeOnCompletedInternal(t, box, continueOnCapturedContext);
             }
             // The awaiter isn't specially known. Fall back to doing a normal await.
             else


### PR DESCRIPTION
Make ValueTask code more easily shared with corefx
- Remove superfluous use of tuples that cause complications with corefx's netstandard1.0 build
- Move CoreCLR-specific API usage into a partial struct

With those changes, we'll be able to fully share the ValueTask code and associated CompilerServices code, other than the three methods in the .CoreCLR.cs file, and can delete corefx's duplicate implementation.

Make ValueTask awaiters readonly structs
- They previously weren't flagged because they had a non-readonly field.  That field is the wrapped ValueTask, and it wasn't readonly because doing so would have resulted in copies being made when invoking methods on ValueTask.  But now that ValueTask itself is readonly, we can make the field and then the struct readonly.

Remove defunct CreateAsyncMethodBuilder method
- This is a holdover from a beta release of a C# compiler.  It's not needed, and we agreed in API review that even though it did ship in the ref for the System.Threading.Tasks.Extensions.dll, the chances of it actually breaking anyone are close to zero, and the workaround if it does is to simply replace usage of it with `default`.

cc: @jkotas, @benaadams 