### PR TITLE
Add COMPlus Variable to Control Rundown

### DIFF
--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -734,6 +734,7 @@ RETAIL_CONFIG_DWORD_INFO(EXTERNAL_AllowDComReflection, W("AllowDComReflection"),
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_EnableEventPipe, W("EnableEventPipe"), 0, "Enable/disable event pipe.  Non-zero values enable tracing.")
 RETAIL_CONFIG_STRING_INFO(INTERNAL_EventPipeOutputFile, W("EventPipeOutputFile"), "The full path including file name for the trace file that will be written when COMPlus_EnableEventPipe&=1")
 RETAIL_CONFIG_STRING_INFO(INTERNAL_EventPipeConfig, W("EventPipeConfig"), "Configuration for EventPipe.")
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_EventPipeRundown, W("EventPipeRundown"), 1, "Enable/disable eventpipe rundown.")
 
 #ifdef FEATURE_GDBJIT
 ///


### PR DESCRIPTION
Rundown is on by default, but you can now disable it for testing purposes via:

```
export COMPlus_EventPipeRundown=0
```

This is useful for scenarios where rundown is not important.  Examples include developer testing as well as when you want to do a functional test run with EventPipe enabled (and not take a really really long time).

cc: @vancem, @adamsitnik 