### PR TITLE
JIT: add a bit more importer folding

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -12062,6 +12062,9 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     op1->gtFlags |= GTF_RELOP_NAN_UN | GTF_UNSIGNED;
                 }
 
+                // Fold result, if possible.
+                op1 = gtFoldExpr(op1);
+
                 impPushOnStack(op1, tiRetVal);
                 break;
 


### PR DESCRIPTION
Eagerly fold expression trees for non-branch conditional operations.

Leads to elimination of boxes in some idiomatic uses. See notes and
examples in #14472.