### PR TITLE
Replacing Lock with Volatile.Read for SecureString Length

### DIFF
--- a/src/mscorlib/shared/System/Security/SecureString.cs
+++ b/src/mscorlib/shared/System/Security/SecureString.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace System.Security
 {
@@ -43,11 +43,8 @@ namespace System.Security
         {
             get
             {
-                lock (_methodLock)
-                {
-                    EnsureNotDisposed();
-                    return _decryptedLength;
-                }
+                EnsureNotDisposed();
+                return Volatile.Read(ref _decryptedLength);
             }
         }
 

--- a/src/mscorlib/shared/System/Security/SecureString.cs
+++ b/src/mscorlib/shared/System/Security/SecureString.cs
@@ -105,20 +105,14 @@ namespace System.Security
 
         public bool IsReadOnly()
         {
-            lock (_methodLock)
-            {
-                EnsureNotDisposed();
-                return _readOnly;
-            }
+            EnsureNotDisposed();
+            return Volatile.Read(ref _readOnly);
         }
 
         public void MakeReadOnly()
         {
-            lock (_methodLock)
-            {
-                EnsureNotDisposed();
-                _readOnly = true;
-            }
+            EnsureNotDisposed();
+            Volatile.Write(ref _readOnly, true);
         }
 
         public void RemoveAt(int index)


### PR DESCRIPTION
As requested and based on reasoning explained in dotnet/corefx#26685, this PR removes synchronization on SecureString Length

I'm also making the same change for IsReadOnly() and MakeReadOnly()

cc: @danmosemsft @stephentoub 