### PR TITLE
Fix table-driven framework for one-type-arg generic HW intrinsics

### DIFF
--- a/src/jit/hwintrinsicxarch.cpp
+++ b/src/jit/hwintrinsicxarch.cpp
@@ -501,7 +501,7 @@ GenTree* Compiler::impX86HWIntrinsic(NamedIntrinsic        intrinsic,
         }
     }
 
-    if ((flags & HW_Flag_Generic) != 0)
+    if ((flags & (HW_Flag_OneTypeGeneric | HW_Flag_TwoTypeGeneric)) != 0)
     {
         assert(baseType != TYP_UNKNOWN);
         // When the type argument is not a numeric type (and we are not being forced to expand), we need to

--- a/src/jit/namedintrinsiclist.h
+++ b/src/jit/namedintrinsiclist.h
@@ -46,10 +46,10 @@ enum HWIntrinsicFlag : unsigned int
 
     // Generic
     // - must throw NotSupportException if the type argument is not numeric type
-    HW_Flag_Generic = 0x4,
+    HW_Flag_OneTypeGeneric = 0x4,
     // Two-type Generic
     // - the intrinsic has two type parameters
-    HW_Flag_TwoTypeGeneric = 0xC,
+    HW_Flag_TwoTypeGeneric = 0x8,
 
     // NoCodeGen
     // - should be transformed in the compiler front-end, cannot reach CodeGen


### PR DESCRIPTION
Avoid one-type-generic intrinsics (e.g., `Avx.SetZeroVector256<T>()`) falling into the two-type-generic process (i.e. `StaticCast<T, U>`).