### PR TITLE
JIT: handle GT_SUB in gtClone

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -7535,7 +7535,7 @@ GenTreePtr Compiler::gtClone(GenTree* tree, bool complexOK)
                 copy = gtNewFieldRef(tree->TypeGet(), tree->gtField.gtFldHnd, objp, tree->gtField.gtFldOffset);
                 copy->gtField.gtFldMayOverlap = tree->gtField.gtFldMayOverlap;
             }
-            else if (tree->gtOper == GT_ADD)
+            else if (tree->OperIs(GT_ADD, GT_SUB))
             {
                 GenTreePtr op1 = tree->gtOp.gtOp1;
                 GenTreePtr op2 = tree->gtOp.gtOp2;
@@ -7553,7 +7553,7 @@ GenTreePtr Compiler::gtClone(GenTree* tree, bool complexOK)
                         return nullptr;
                     }
 
-                    copy = gtNewOperNode(GT_ADD, tree->TypeGet(), op1, op2);
+                    copy = gtNewOperNode(tree->OperGet(), tree->TypeGet(), op1, op2);
                 }
                 else
                 {


### PR DESCRIPTION
For uniformity's sake, handle GT_SUB just like GT_ADD in gtClone.
Otherwise for a span s, the jit codegen for s[i+1] and s[i-1] can
end up substantially different.

See notes in #13097.