### PR TITLE
Fix encoding of RCPPS and RSQRTPS

### DIFF
--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -216,11 +216,9 @@ bool emitter::IsDstSrcSrcAVXInstruction(instruction ins)
         case INS_movlpd:
         case INS_movlps:
         case INS_movss:
-        case INS_rcpps:
         case INS_rcpss:
         case INS_roundsd:
         case INS_roundss:
-        case INS_rsqrtps:
         case INS_rsqrtss:
         case INS_sqrtsd:
         case INS_sqrtss:


### PR DESCRIPTION
These instructions do not permit a 3rd register, and the vvvv field must be all ones (same as xmm0 encoding, which is why this can go undetected)

Fix #16135