### PR TITLE
Improve performance of Convert.ToInt32(bool) and related functions

### DIFF
--- a/src/mscorlib/shared/System/Convert.cs
+++ b/src/mscorlib/shared/System/Convert.cs
@@ -649,7 +649,9 @@ namespace System
         [CLSCompliant(false)]
         public static sbyte ToSByte(bool value)
         {
-            return value ? (sbyte)Boolean.True : (sbyte)Boolean.False;
+            // Ideally we'd call BoolToByte(!!value) to normalize any true value to 1,
+            // but JIT optimizes !! away. The pattern below defeats this optimization.
+            return (sbyte)JitHelpers.BoolToByteNonNormalized(JitHelpers.BoolToByteNonNormalized(value) != 0);
         }
 
         [CLSCompliant(false)]
@@ -769,7 +771,9 @@ namespace System
 
         public static byte ToByte(bool value)
         {
-            return value ? (byte)Boolean.True : (byte)Boolean.False;
+            // Ideally we'd call BoolToByte(!!value) to normalize any true value to 1,
+            // but JIT optimizes !! away. The pattern below defeats this optimization.
+            return JitHelpers.BoolToByteNonNormalized(JitHelpers.BoolToByteNonNormalized(value) != 0);
         }
 
         public static byte ToByte(byte value)
@@ -881,7 +885,9 @@ namespace System
 
         public static short ToInt16(bool value)
         {
-            return value ? (short)Boolean.True : (short)Boolean.False;
+            // Ideally we'd call BoolToByte(!!value) to normalize any true value to 1,
+            // but JIT optimizes !! away. The pattern below defeats this optimization.
+            return JitHelpers.BoolToByteNonNormalized(JitHelpers.BoolToByteNonNormalized(value) != 0);
         }
 
         public static short ToInt16(char value)
@@ -995,7 +1001,9 @@ namespace System
         [CLSCompliant(false)]
         public static ushort ToUInt16(bool value)
         {
-            return value ? (ushort)Boolean.True : (ushort)Boolean.False;
+            // Ideally we'd call BoolToByte(!!value) to normalize any true value to 1,
+            // but JIT optimizes !! away. The pattern below defeats this optimization.
+            return JitHelpers.BoolToByteNonNormalized(JitHelpers.BoolToByteNonNormalized(value) != 0);
         }
 
         [CLSCompliant(false)]
@@ -1117,7 +1125,9 @@ namespace System
 
         public static int ToInt32(bool value)
         {
-            return value ? Boolean.True : Boolean.False;
+            // Ideally we'd call BoolToByte(!!value) to normalize any true value to 1,
+            // but JIT optimizes !! away. The pattern below defeats this optimization.
+            return JitHelpers.BoolToByteNonNormalized(JitHelpers.BoolToByteNonNormalized(value) != 0);
         }
 
         public static int ToInt32(char value)
@@ -1248,7 +1258,9 @@ namespace System
         [CLSCompliant(false)]
         public static uint ToUInt32(bool value)
         {
-            return value ? (uint)Boolean.True : (uint)Boolean.False;
+            // Ideally we'd call BoolToByte(!!value) to normalize any true value to 1,
+            // but JIT optimizes !! away. The pattern below defeats this optimization.
+            return JitHelpers.BoolToByteNonNormalized(JitHelpers.BoolToByteNonNormalized(value) != 0);
         }
 
         [CLSCompliant(false)]
@@ -1375,7 +1387,9 @@ namespace System
 
         public static long ToInt64(bool value)
         {
-            return value ? Boolean.True : Boolean.False;
+            // Ideally we'd call BoolToByte(!!value) to normalize any true value to 1,
+            // but JIT optimizes !! away. The pattern below defeats this optimization.
+            return JitHelpers.BoolToByteNonNormalized(JitHelpers.BoolToByteNonNormalized(value) != 0);
         }
 
         public static long ToInt64(char value)
@@ -1483,7 +1497,9 @@ namespace System
         [CLSCompliant(false)]
         public static ulong ToUInt64(bool value)
         {
-            return value ? (ulong)Boolean.True : (ulong)Boolean.False;
+            // Ideally we'd call BoolToByte(!!value) to normalize any true value to 1,
+            // but JIT optimizes !! away. The pattern below defeats this optimization.
+            return JitHelpers.BoolToByteNonNormalized(JitHelpers.BoolToByteNonNormalized(value) != 0);
         }
 
         [CLSCompliant(false)]

--- a/src/mscorlib/src/System/Runtime/CompilerServices/jithelpers.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/jithelpers.cs
@@ -191,5 +191,27 @@ namespace System.Runtime.CompilerServices
             typeof(ArrayPinningHelper).ToString(); // Type used by the actual method body
             throw new InvalidOperationException();
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static internal byte BoolToByteNonNormalized(bool value)
+        {
+            // The body of this function will be replaced by the EE.
+
+            // Per ECMA 335, Sec III.1.1.2, the Boolean data type occupies 1 byte
+            // of memory. Per Sec. I.8.2.2 and I.8.7, the Boolean data type is internally
+            // treated as a one-byte integer interchangeable with Byte / SByte. This
+            // means that "casting" a Boolean to a Byte is both verifiable and free.
+
+            // n.b. The return value of this method isn't limited to 0 or 1. It'll contain
+            // the raw value behind the input Boolean, and technically 'true' could correspond
+            // to any non-zero value. If the caller doesn't know where the Boolean value
+            // came from and needs to normalize 'true' to 1, the caller should instead use
+            // Convert.ToInt32(Boolean), which performs normalization.
+
+            // ldarg.0
+            // ret
+
+            throw new InvalidOperationException();
+        }
     }
 }

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -6973,6 +6973,17 @@ bool getILIntrinsicImplementation(MethodDesc * ftn,
         methInfo->options = (CorInfoOptions)0;
         return true;
     }
+    else if (tk == MscorlibBinder::GetMethod(METHOD__JIT_HELPERS__BOOL_TO_BYTE_NON_NORMALIZED)->GetMemberDef())
+    {
+        static BYTE ilcode[] = { CEE_LDARG_0, CEE_RET };
+
+        methInfo->ILCode = const_cast<BYTE*>(ilcode);
+        methInfo->ILCodeSize = sizeof(ilcode);
+        methInfo->maxStack = 1;
+        methInfo->EHcount = 0;
+        methInfo->options = (CorInfoOptions)0;
+        return true;
+    }
 
     return false;
 }

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -767,6 +767,7 @@ DEFINE_METHOD(JIT_HELPERS,          UNSAFE_ENUM_CAST_LONG,  UnsafeEnumCastLong, 
 DEFINE_METHOD(JIT_HELPERS,          UNSAFE_CAST_TO_STACKPTR,UnsafeCastToStackPointer, NoSig)
 #endif // _DEBUG
 DEFINE_METHOD(JIT_HELPERS,          GET_RAW_SZ_ARRAY_DATA,  GetRawSzArrayData, NoSig)
+DEFINE_METHOD(JIT_HELPERS,          BOOL_TO_BYTE_NON_NORMALIZED, BoolToByteNonNormalized, NoSig)
 
 DEFINE_CLASS(UNSAFE,                InternalCompilerServices,       Unsafe)
 DEFINE_METHOD(UNSAFE,               AS_POINTER,             AsPointer, NoSig)


### PR DESCRIPTION
The current implementation of `Convert.ToInt32(bool)` uses branching to return `1` or `0` to its caller, making it prone to branch mispredictions. This PR makes the implementation branchless. In my Win10 x64 testbed application, this results in a **370% increase in tps** for calls to this routine when the input values are random. (Before: 1,780 ms for 500MM calls. After: 480 ms for 500MM calls.)

This might seem esoteric, but it matters because it can be used as a springboard to help developers write their own high-performance branchless routines. For example, the statement `int skipLastChunk = isFinalBlock ? 4 : 0;` in [the Base64 decoder routine](https://github.com/dotnet/corefx/blob/40cbd5636851093309b841db4d53af369b7ef1c6/src/System.Memory/src/System/Buffers/Text/Base64Decoder.cs#L51) can utilize this to become branchless by being rewritten as `int skipLastChunk = Convert.ToInt32(isFinalBlock) << 2;`.

Disassembly of `Convert.ToInt32(bool)` before the change (amd64):

```asm
; assume r8b contains 'value' and edi will receive the result
  test r8d, r8d
  jne IF_TRUE
IF_FALSE:
  xor r8d, r8d
  jmp FINISHED
IF_TRUE:
  mov r8d, 1
FINISHED:
  mov edi, r8d
```

Disassembly after the change:

```asm
  test r8d, r8d
  setne dil
  movzx edi, dil
```

For non-random values (e.g., all test inputs are already _true_ or _false_), the modified code performs +/- 5% of the original code. I don't see a real difference above the normal noise.