### PR TITLE
Change the Span ToString semantics to return the contents for T=char

### DIFF
--- a/src/mscorlib/shared/System/ReadOnlySpan.cs
+++ b/src/mscorlib/shared/System/ReadOnlySpan.cs
@@ -258,7 +258,11 @@ namespace System
         {
             if (typeof(T) == typeof(char))
             {
-                return new string(this);
+                unsafe
+                {
+                    fixed (char* src = &Unsafe.As<T, char>(ref _pointer.Value))
+                        return new string(src, 0, _length);
+                }
             }
             return string.Format("System.ReadOnlySpan<{0}>[{1}]", typeof(T).Name, _length);
         }

--- a/src/mscorlib/shared/System/ReadOnlySpan.cs
+++ b/src/mscorlib/shared/System/ReadOnlySpan.cs
@@ -251,9 +251,17 @@ namespace System
         }
 
         /// <summary>
-        /// Returns a <see cref="String"/> with the name of the type and the number of elements
+        /// For <see cref="ReadOnlySpan{Char}"/>, returns a new instance of string that represents the characters pointed to by the span.
+        /// Otherwise, returns a <see cref="String"/> with the name of the type and the number of elements.
         /// </summary>
-        public override string ToString() => string.Format("System.ReadOnlySpan<{0}>[{1}]", typeof(T).Name, _length);
+        public override string ToString()
+        {
+            if (typeof(T) == typeof(char))
+            {
+                return new string(this);
+            }
+            return string.Format("System.ReadOnlySpan<{0}>[{1}]", typeof(T).Name, _length);
+        }
 
         /// <summary>
         /// Defines an implicit conversion of an array to a <see cref="ReadOnlySpan{T}"/>

--- a/src/mscorlib/shared/System/Span.cs
+++ b/src/mscorlib/shared/System/Span.cs
@@ -326,9 +326,17 @@ namespace System
         }
 
         /// <summary>
-        /// Returns a <see cref="String"/> with the name of the type and the number of elements
+        /// For <see cref="ReadOnlySpan{Char}"/>, returns a new instance of string that represents the characters pointed to by the span.
+        /// Otherwise, returns a <see cref="String"/> with the name of the type and the number of elements.
         /// </summary>
-        public override string ToString() => string.Format("System.Span<{0}>[{1}]", typeof(T).Name, _length);
+        public override string ToString()
+        {
+            if (typeof(T) == typeof(char))
+            {
+                return new string(this);
+            }
+            return string.Format("System.Span<{0}>[{1}]", typeof(T).Name, _length);
+        }
 
         /// <summary>
         /// Defines an implicit conversion of an array to a <see cref="Span{T}"/>

--- a/src/mscorlib/shared/System/Span.cs
+++ b/src/mscorlib/shared/System/Span.cs
@@ -326,14 +326,18 @@ namespace System
         }
 
         /// <summary>
-        /// For <see cref="ReadOnlySpan{Char}"/>, returns a new instance of string that represents the characters pointed to by the span.
+        /// For <see cref="Span{Char}"/>, returns a new instance of string that represents the characters pointed to by the span.
         /// Otherwise, returns a <see cref="String"/> with the name of the type and the number of elements.
         /// </summary>
         public override string ToString()
         {
             if (typeof(T) == typeof(char))
             {
-                return new string(this);
+                unsafe
+                {
+                    fixed (char* src = &Unsafe.As<T, char>(ref DangerousGetPinnableReference()))
+                        return new string(src, 0, _length);
+                }
             }
             return string.Format("System.Span<{0}>[{1}]", typeof(T).Name, _length);
         }

--- a/src/mscorlib/shared/System/Span.cs
+++ b/src/mscorlib/shared/System/Span.cs
@@ -335,7 +335,7 @@ namespace System
             {
                 unsafe
                 {
-                    fixed (char* src = &Unsafe.As<T, char>(ref DangerousGetPinnableReference()))
+                    fixed (char* src = &Unsafe.As<T, char>(ref _pointer.Value))
                         return new string(src, 0, _length);
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/26584

Related PR: https://github.com/dotnet/corefx/pull/26726

**Question:** Does it make sense to special case for T = string as well (concatenate the strings)?

cc @pakrym, @jkotas, @stephentoub, @dotnet/corefxlab-contrib 