### PR TITLE
Rename ConvertScalarToVector128UInt32Scalar to ConvertScalarToVector128UInt32

### DIFF
--- a/src/mscorlib/src/System/Runtime/Intrinsics/X86/Sse2.PlatformNotSupported.cs
+++ b/src/mscorlib/src/System/Runtime/Intrinsics/X86/Sse2.PlatformNotSupported.cs
@@ -568,7 +568,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128i _mm_cvtsi32_si128 (int a)
         ///   MOVD xmm, reg/m32
         /// </summary>
-        public static Vector128<uint> ConvertScalarToVector128UInt32Scalar(uint value) { throw new PlatformNotSupportedException(); }
+        public static Vector128<uint> ConvertScalarToVector128UInt32(uint value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtsi64_si128 (__int64 a)
         ///   MOVQ xmm, reg/m64

--- a/src/mscorlib/src/System/Runtime/Intrinsics/X86/Sse2.cs
+++ b/src/mscorlib/src/System/Runtime/Intrinsics/X86/Sse2.cs
@@ -568,7 +568,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128i _mm_cvtsi32_si128 (int a)
         ///   MOVD xmm, reg/m32
         /// </summary>
-        public static Vector128<uint> ConvertScalarToVector128UInt32Scalar(uint value) => ConvertScalarToVector128UInt32Scalar(value);
+        public static Vector128<uint> ConvertScalarToVector128UInt32(uint value) => ConvertScalarToVector128UInt32(value);
         /// <summary>
         /// __m128i _mm_cvtsi64_si128 (__int64 a)
         ///   MOVQ xmm, reg/m64


### PR DESCRIPTION
FYI. @CarolEidt, @fiigii, @eerhardt 

One of them missed removing the suffix. Caught this in the CoreFX build.