### PR TITLE
Dictionary exposes internal type comparer

### DIFF
--- a/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
@@ -143,7 +143,7 @@ namespace System.Collections.Generic
         {
             get
             {
-                return _comparer;
+                return (_comparer is NonRandomizedStringEqualityComparer) ? (IEqualityComparer<TKey>)EqualityComparer<string>.Default : _comparer;
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/26033

This is my first pull on this repo(maybe i'm in the wrong place). I don't know if there is a "guide" to do "cross repo" test for core*.
If i want to add a test on corefx with this "merge", do i have to wait and clean/rebuild?

cc: @jkotas 