### PR TITLE
FailFast after an inline attempt in Compiler::impIntrinsic.

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -3670,6 +3670,11 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                     impPopStack();
                     GenTree* typeHandleOp =
                         impTokenToHandle(pConstrainedResolvedToken, nullptr, TRUE /* mustRestoreHandle */);
+                    if (typeHandleOp == nullptr)
+                    {
+                        assert(compDonotInline());
+                        return nullptr;
+                    }
                     GenTreeArgList* helperArgs = gtNewArgList(typeHandleOp);
                     GenTree*        runtimeType =
                         gtNewHelperCallNode(CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPE, TYP_REF, helperArgs);


### PR DESCRIPTION
`impTokenToHandle` can return `nullptr` if it aborts an inline attempt. Check it and fail fast.
Fix DevDiv_543045.

It is another hit of #13272 (Revisit the strategy for fail fasts from compInlineResult->NoteFatal.).