### PR TITLE
[R2R][RyuJit][ARM] Fix R2R relative indirection for arm.

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -3175,19 +3175,7 @@ GenTree* Lowering::LowerDirectCall(GenTreeCall* call)
             // a single indirection.
             GenTree* cellAddr = AddrGen(addr);
             GenTree* indir    = Ind(cellAddr);
-
-#ifdef FEATURE_READYTORUN_COMPILER
-#if defined(_TARGET_ARMARCH_)
-            // For arm64, we dispatch code same as VSD using X11 for indirection cell address,
-            // which ZapIndirectHelperThunk expects.
-            if (call->IsR2RRelativeIndir())
-            {
-                cellAddr->gtRegNum = REG_R2R_INDIRECT_PARAM;
-                indir->gtRegNum    = REG_JUMP_THUNK_PARAM;
-            }
-#endif
-#endif
-            result = indir;
+            result            = indir;
             break;
         }
 

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -160,13 +160,13 @@ void Rationalizer::RewriteNodeAsCall(GenTree**             use,
     assert(JITtype2varType(sig.retType) == tree->gtType);
 #endif // DEBUG
 
-    call = comp->fgMorphArgs(call);
-    // Determine if this call has changed any codegen requirements.
-    comp->fgCheckArgCnt();
-
 #ifdef FEATURE_READYTORUN_COMPILER
     call->gtCall.setEntryPoint(entryPoint);
 #endif
+
+    call = comp->fgMorphArgs(call);
+    // Determine if this call has changed any codegen requirements.
+    comp->fgCheckArgCnt();
 
     // Replace "tree" with "call"
     if (parents.Height() > 1)

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -7411,6 +7411,22 @@ void Compiler::fgValueNumberHelperCallFunc(GenTreeCall* call, VNFunc vnf, ValueN
         vnpUniq.SetBoth(vnStore->VNForExpr(compCurBB, call->TypeGet()));
     }
 
+#if defined(FEATURE_READYTORUN_COMPILER) && defined(_TARGET_ARMARCH_)
+    if (call->IsR2RRelativeIndir())
+    {
+#ifdef DEBUG
+        assert(args->Current()->OperGet() == GT_ARGPLACE);
+
+        // Find the corresponding late arg.
+        GenTree* indirectCellAddress = call->fgArgInfo->GetLateArg(0);
+        assert(indirectCellAddress->IsCnsIntOrI() && indirectCellAddress->gtRegNum == REG_R2R_INDIRECT_PARAM);
+#endif // DEBUG
+        // For ARM indirectCellAddress is consumed by the call itself, so it should have added as an implicit argument
+        // in morph. So we do not need to use EntryPointAddrAsArg0, because arg0 is already an entry point addr.
+        useEntryPointAddrAsArg0 = false;
+    }
+#endif // FEATURE_READYTORUN_COMPILER && _TARGET_ARMARCH_
+
     if (nArgs == 0)
     {
         if (generateUniqueVN)
@@ -7452,7 +7468,7 @@ void Compiler::fgValueNumberHelperCallFunc(GenTreeCall* call, VNFunc vnf, ValueN
             vnp0                = ValueNumPair(callAddrVN, callAddrVN);
         }
         else
-#endif
+#endif // FEATURE_READYTORUN_COMPILER
         {
             assert(!useEntryPointAddrAsArg0);
             ValueNumPair vnp0wx = getCurrentArg(0)->gtVNPair;


### PR DESCRIPTION
ARM R2R calls that are indirected through a relative address are dispatched as VSD using virtualStubParamInfo->GetReg() for indirection cell address, which ZapIndirectHelperThunk expects.

For VSD we add this argument in morph, do the same for this case.

So this PR:
1) adds an additional explicit argument for `call->IsR2RRelativeIndir()` on ARM
2) deletes requirement `cellAddr->gtRegNum = REG_R2R_INDIRECT_PARAM;` 
3) hacks `fgValueNumberHelperCallFunc` to accept the R2R arm helpers with non-standard number of arguments.

Fix #16589.