### PR TITLE
Add assert for failure to open a file in FastSerializer.

### DIFF
--- a/src/vm/fastserializer.cpp
+++ b/src/vm/fastserializer.cpp
@@ -24,6 +24,7 @@ FastSerializer::FastSerializer(SString &outputFilePath, FastSerializableObject &
     m_pFileStream = new CFileStream();
     if(FAILED(m_pFileStream->OpenForWrite(outputFilePath)))
     {
+        _ASSERTE(!"Unable to open file for write.");
         delete(m_pFileStream);
         m_pFileStream = NULL;
         return;


### PR DESCRIPTION
When FastSerializer is unable to open a file for write it fails silently, which is what we want on ret builds.  Tracing failures should not affect program correctness.  However on chk/debug builds it fails with an unrelated assert about the fact that the metadataLabel is 0, which happens because the stream position into the file is 0 because we couldn't open the file to write to it.  Rather than having to remember what the unrelated assert means, let's add an assert that states exactly what the problem is.

With this change, you get an assert like this:

```
Assert failure(PID 14100 [0x00003714], Thread: 4932 [0x1344]): !"Unable to open file for write."

CORECLR! FastSerializer::FastSerializer + 0x21D (0x00007ff8`951122dd)
CORECLR! EventPipeFile::EventPipeFile + 0x1C3 (0x00007ff8`94f80d83)
CORECLR! EventPipe::Enable + 0x2F3 (0x00007ff8`94b6dc33)
CORECLR! EventPipe::Enable + 0x179 (0x00007ff8`94b6df69)
CORECLR! EventPipeInternal::Enable + 0x1E8 (0x00007ff8`94b6e168)
SYSTEM.PRIVATE.CORELIB! <no symbol> + 0x0 (0x00007ff8`93eae2cf)
SYSTEM.PRIVATE.CORELIB! <no symbol> + 0x0 (0x00007ff8`93fdfc7e)
CORECLR! CallDescrWorkerInternal + 0x83 (0x00007ff8`94f8ba73)
CORECLR! CallDescrWorkerWithHandler + 0x1DE (0x00007ff8`94be617e)
CORECLR! `CallDescrWorkerReflectionWrapper'::`6'::__Body::Run + 0x52 (0x00007ff8`94fcc5e2)
    File: c:\src\coreclr\src\vm\fastserializer.cpp Line: 27
    Image: c:\src\coreclr\bin\tests\Windows_NT.x64.Debug\Tests\Core_Root\CoreRun.exe
```

Fixes #11632.