### PR TITLE
Consider specialPutArgs for jitStressRegs

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5834,6 +5834,7 @@ public:
     bool optIsSsaLocal(GenTree* tree);
     int optCopyProp_LclVarScore(LclVarDsc* lclVarDsc, LclVarDsc* copyVarDsc, bool preferOp2);
     void optVnCopyProp();
+    INDEBUG(void optDumpCopyPropStack(LclNumToGenTreePtrStack* curSsaName));
 
     /**************************************************************************
     *               Early value propagation

--- a/src/jit/copyprop.cpp
+++ b/src/jit/copyprop.cpp
@@ -61,6 +61,18 @@ void Compiler::optBlockCopyPropPopStacks(BasicBlock* block, LclNumToGenTreePtrSt
     }
 }
 
+#ifdef DEBUG
+void Compiler::optDumpCopyPropStack(LclNumToGenTreePtrStack* curSsaName)
+{
+    JITDUMP("{ ");
+    for (LclNumToGenTreePtrStack::KeyIterator iter = curSsaName->Begin(); !iter.Equal(curSsaName->End()); ++iter)
+    {
+        GenTree* node = iter.GetValue()->Index(0);
+        JITDUMP("%d-[%06d]:V%02u ", iter.Get(), dspTreeID(node), node->AsLclVarCommon()->gtLclNum);
+    }
+    JITDUMP("}\n\n");
+}
+#endif
 /*******************************************************************************************************
  *
  * Given the "lclVar" and "copyVar" compute if the copy prop will be beneficial.
@@ -296,7 +308,14 @@ bool Compiler::optIsSsaLocal(GenTree* tree)
 
 void Compiler::optBlockCopyProp(BasicBlock* block, LclNumToGenTreePtrStack* curSsaName)
 {
+#ifdef DEBUG
     JITDUMP("Copy Assertion for BB%02u\n", block->bbNum);
+    if (verbose)
+    {
+        printf("  curSsaName stack: ");
+        optDumpCopyPropStack(curSsaName);
+    }
+#endif
 
     // There are no definitions at the start of the block. So clear it.
     compCurLifeTree = nullptr;

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -667,8 +667,9 @@ LinearScan::LinearScan(Compiler* theCompiler)
     , listNodePool(theCompiler)
 {
 #ifdef DEBUG
-    maxNodeLocation   = 0;
-    activeRefPosition = nullptr;
+    maxNodeLocation    = 0;
+    activeRefPosition  = nullptr;
+    specialPutArgCount = 0;
 
     // Get the value of the environment variable that controls stress for register allocation
     lsraStressMask = JitConfig.JitStressRegs();

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -813,6 +813,11 @@ private:
     enum LsraStressLimitRegs{LSRA_LIMIT_NONE = 0, LSRA_LIMIT_CALLEE = 0x1, LSRA_LIMIT_CALLER = 0x2,
                              LSRA_LIMIT_SMALL_SET = 0x3, LSRA_LIMIT_MASK = 0x3};
 
+    // When we limit the number of candidate registers, we have to take into account any
+    // "specialPutArg" references that are in flight, as that increases the number of live
+    // registers between it and the next call.
+    int specialPutArgCount;
+
     // When LSRA_LIMIT_SMALL_SET is specified, it is desirable to select a "mixed" set of caller- and callee-save
     // registers, so as to get different coverage than limiting to callee or caller.
     // At least for x86 and AMD64, and potentially other architecture that will support SIMD,

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_543057/DevDiv_543057.cs
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_543057/DevDiv_543057.cs
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+// This tests passing variables in registers, which result in pass-through
+// "specialPutArg" Intervals, and then passing a struct with GT_FIELD_LIST
+// that also uses a number of registers.
+// This case exposed a bug in the stress-limiting of registers where it
+// wasn't taking these live "specialPutArg" Intervals into account.
+
+using System;
+using System.Runtime.CompilerServices;
+
+// Struct with 4 fields
+public struct MyStruct
+{
+    public int f1;
+    public int f2;
+    public int f3;
+    public int f4;
+}
+
+public class TestClass
+{
+    public const int Pass = 100;
+    public const int Fail = -1;
+
+    public TestClass()
+    {
+    }
+
+    // This is just here to set our lclVar to a non-constant.
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    public int Dummy1()
+    {
+        return 1;
+    }
+
+    // This is here to preference our lclVars to the appropriate parameter registers.
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    public void Dummy2(int p1, int p2, int p3, int p4)
+    {
+    }
+
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    public int Check1(int i1, int i2, MyStruct s1, int i3, int i4)
+    {
+        if ((s1.f1 != i1) || (s1.f2 != i2) || (s1.f3 != i3) || (s1.f4 != i4))
+        {
+            Console.WriteLine("Check1: FAIL");
+            return Fail;
+        }
+        Console.WriteLine("Check1: PASS");
+        return Pass;
+    }
+
+    // For this repro, we want two parameters that are "specialPutArg" - that is,
+    // they are passing lclVars that are live in the register they are wanted in,
+    // and we have to keep them live, because there's no way to mark it as spilled,
+    // in case it is used as another parameter prior to being killed by the call.
+    // To do this, we set up 'this' and 'a' such that they are preferenced to
+    // the first and second parameter registers, but we increase register pressure
+    // so that they have to be loaded just prior to the call, causing them to
+    // be put into the argument registers they are preferenced to. Then we
+    // pass a split struct (ARM) that uses 4 registers for its GT_FIELD_LIST.
+    // This exceeds the stress limit without any compensation for the "specialPutArg"s.
+    //
+    public int TestStruct()
+    {
+        MyStruct s1;
+        s1.f1 = 1; s1.f2 = 2; s1.f3 = 3; s1.f4 = 4;
+
+        int a = Dummy1();
+
+        // Call an instance method. This gets the value number for 'this' into the 'curSsaNames' in copyprop.
+        // Also, pass it a bunch of parameters to increase the register pressure here.
+        Dummy2(a, 2, 3, 4);
+
+        // Pass the struct as split ('this' is in the first arg register).
+        int retVal = Check1(a, 2, s1, 3, 4);
+
+        // Use 'this' again so our previous call isn't the last use.
+        retVal = Check1(a, 2, s1, 3, 4);
+
+        return retVal;
+    }
+}
+
+public class DevDiv_543057
+{
+    public static int Main()
+    {
+        int retVal = TestClass.Pass;
+        TestClass c = new TestClass();
+        if (c.TestStruct() != TestClass.Pass)
+        {
+            retVal = TestClass.Fail;
+        }
+        return retVal;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_543057/DevDiv_543057.csproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_543057/DevDiv_543057.csproj
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
When we have a lclVar that is being kept alive between its `PUTARG_REG` and the call, we need to take that into account in determining the minimum register requirement for a node.

Also, when attempting to create a repro, I found that I needed to duplicate some copyProp behavior, and it was rather difficult to track it down; to help, I added a dump of the `curSsaName` stack.