### PR TITLE
Fix AV in crossgen when generating PDBs

### DIFF
--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -433,7 +433,7 @@ PCODE MethodDesc::GetPrecompiledR2RCode(PrepareCodeConfig* pConfig)
     Module * pModule = GetModule();
     if (pModule->IsReadyToRun())
     {
-        pCode = pModule->GetReadyToRunInfo()->GetEntryPoint(this, pConfig);
+        pCode = pModule->GetReadyToRunInfo()->GetEntryPoint(this, pConfig, TRUE /* fFixups */);
     }
 #endif
     return pCode;

--- a/src/vm/readytoruninfo.cpp
+++ b/src/vm/readytoruninfo.cpp
@@ -674,7 +674,7 @@ static bool SigMatchesMethodDesc(MethodDesc* pMD, SigPointer &sig, Module * pMod
     return true;
 }
 
-PCODE ReadyToRunInfo::GetEntryPoint(MethodDesc * pMD, PrepareCodeConfig* pConfig, BOOL fFixups /*=TRUE*/)
+PCODE ReadyToRunInfo::GetEntryPoint(MethodDesc * pMD, PrepareCodeConfig* pConfig, BOOL fFixups)
 {
     STANDARD_VM_CONTRACT;
 
@@ -864,7 +864,7 @@ PCODE ReadyToRunInfo::MethodIterator::GetMethodStartAddress()
 {
     STANDARD_VM_CONTRACT;
 
-    PCODE ret = m_pInfo->GetEntryPoint(GetMethodDesc(), FALSE);
+    PCODE ret = m_pInfo->GetEntryPoint(GetMethodDesc(), NULL, FALSE);
     _ASSERTE(ret != NULL);
     return ret;
 }

--- a/src/vm/readytoruninfo.h
+++ b/src/vm/readytoruninfo.h
@@ -52,7 +52,7 @@ public:
 
     static PTR_ReadyToRunInfo Initialize(Module * pModule, AllocMemTracker *pamTracker);
 
-    PCODE GetEntryPoint(MethodDesc * pMD, PrepareCodeConfig* pConfig, BOOL fFixups = TRUE);
+    PCODE GetEntryPoint(MethodDesc * pMD, PrepareCodeConfig* pConfig, BOOL fFixups);
 
     MethodDesc * GetMethodDescForEntryPoint(PCODE entryPoint);
 


### PR DESCRIPTION
I missed updating one of the callers of `ReadyToRunInfo::GetEntryPoint`
in #15801. Fix by making the last arg explicit so this kind of type
confusion error is less likely, and updating the missed call site.

Closes #16177.