### PR TITLE
JIT: Allow struct promotion in GS frames

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -18022,11 +18022,13 @@ void Compiler::fgPromoteStructs()
 
     if (!opts.OptEnabled(CLFLG_STRUCTPROMOTE))
     {
+        JITDUMP("  promotion opt flag not enabled\n");
         return;
     }
 
     if (fgNoStructPromotion)
     {
+        JITDUMP("  promotion disabled by JitNoStructPromotion\n");
         return;
     }
 
@@ -18063,11 +18065,7 @@ void Compiler::fgPromoteStructs()
 
     if (info.compIsVarArgs)
     {
-        return;
-    }
-
-    if (getNeedsGSSecurityCookie())
-    {
+        JITDUMP("  promotion disabled because of varargs\n");
         return;
     }
 


### PR DESCRIPTION
Enable struct promotion in methods where the jit is also emtting a stack guard.
Not allowing promotion seems like an unnecessary limitation and leads to poor
performance in methods with both Span and stackalloc.

Closes #16197.