### PR TITLE
Increase build timeout for test build

### DIFF
--- a/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
+++ b/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
@@ -313,7 +313,7 @@
   ],
   "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)-$(Rid)",
   "jobAuthorizationScope": "projectCollection",
-  "jobTimeoutInMinutes": 180,
+  "jobTimeoutInMinutes": 240,
   "jobCancelTimeoutInMinutes": 5,
   "repository": {
     "properties": {


### PR DESCRIPTION
The test build on OSX is rather long.  Increase the timeout so it doesn't hit so often.  Currently we don't know what timed out while building the tests because the log for that step is inaccessible if the build is cancelled.