### PR TITLE
Adjust expected file size if ZapDisable is true

### DIFF
--- a/tests/src/tracing/eventpipesmoke/EventPipeSmoke.cs
+++ b/tests/src/tracing/eventpipesmoke/EventPipeSmoke.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Environment;
 using System.IO;
 using Tracing.Tests.Common;
 
@@ -8,7 +7,7 @@ namespace Tracing.Tests
     class EventPipeSmoke
     {
         private static int allocIterations = 10000;
-        private static bool zapDisabled = Int32.Parse(Environment.GetEnvironmentVariable("COMPlus_ZapDisable")) > 0;
+        private static bool zapDisabled = Int32.Parse(Environment.GetEnvironmentVariable("COMPlus_ZapDisable") ?? "0") > 0;
         private static int trivialSize = zapDisabled ? 64 * 1024 : 1 * 1024 * 1024;
 
         static int Main(string[] args)

--- a/tests/src/tracing/eventpipesmoke/EventPipeSmoke.cs
+++ b/tests/src/tracing/eventpipesmoke/EventPipeSmoke.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Environment;
 using System.IO;
 using Tracing.Tests.Common;
 
@@ -7,7 +8,8 @@ namespace Tracing.Tests
     class EventPipeSmoke
     {
         private static int allocIterations = 10000;
-        private static int trivialSize = 0x100000;
+        private static bool zapDisabled = Int32.Parse(Environment.GetEnvironmentVariable("COMPlus_ZapDisable")) > 0;
+        private static int trivialSize = zapDisabled ? 64 * 1024 : 1 * 1024 * 1024;
 
         static int Main(string[] args)
         {
@@ -39,6 +41,7 @@ namespace Tracing.Tests
             Console.WriteLine("\tEnd: Disable tracing.\n");
 
             FileInfo outputMeta = new FileInfo(outputFilename);
+            Console.WriteLine("\tExpecting at least {0} bytes of data", trivialSize);
             Console.WriteLine("\tCreated {0} bytes of data", outputMeta.Length);
 
             bool pass = false;


### PR DESCRIPTION
Adjust expected size of the events file to a lower value is COMPlus_ZapDisable is set to reflect the lack of rundown events

Closes: 16238
Related: 16220