### PR TITLE
Fix stacktrace formatting to make it work on CoreRT as well

### DIFF
--- a/src/mscorlib/shared/System/Diagnostics/Debug.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Debug.cs
@@ -95,7 +95,7 @@ namespace System.Diagnostics
                 string stackTrace;
                 try
                 {
-                    stackTrace = new StackTrace(0, true).ToString(System.Diagnostics.StackTrace.TraceFormat.Normal);
+                    stackTrace = new StackTrace(0, true).ToString();
                 }
                 catch
                 {
@@ -113,7 +113,7 @@ namespace System.Diagnostics
                 string stackTrace;
                 try
                 {
-                    stackTrace = new StackTrace(0, true).ToString(System.Diagnostics.StackTrace.TraceFormat.Normal);
+                    stackTrace = new StackTrace(0, true).ToString();
                 }
                 catch
                 {


### PR DESCRIPTION
``` StackTrace.ToString()```  with TraceFormat is not available on CoreRT. Changing it to the default ```StackTrace.ToString()``` to make it work across CoreRT/ProjectN as well.