### PR TITLE
Fixes GitHub Issue 16065

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5712,7 +5712,7 @@ protected:
     void optCSEstop();
 
     CSEdsc* optCSEfindDsc(unsigned index);
-    void optUnmarkCSE(GenTree* tree);
+    bool optUnmarkCSE(GenTree* tree);
 
     // user defined callback data for the tree walk function optCSE_MaskHelper()
     struct optCSE_MaskData
@@ -5765,7 +5765,7 @@ protected:
     void     optValnumCSE_DataFlow();
     void     optValnumCSE_Availablity();
     void     optValnumCSE_Heuristic();
-    void optValnumCSE_UnmarkCSEs(GenTree* deadTree, GenTree* keepList);
+    void optValnumCSE_UnmarkCSEs(GenTree* deadTree, GenTree** wbKeepList);
 
 #endif // FEATURE_VALNUM_CSE
 

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -9956,18 +9956,13 @@ void Compiler::fgRemoveStmt(BasicBlock* block,
 DONE:
     fgStmtRemoved = true;
 
-    if (optValnumCSE_phase)
+    noway_assert(!optValnumCSE_phase);
+
+    if (updateRefCount)
     {
-        optValnumCSE_UnmarkCSEs(stmt->gtStmtExpr, nullptr);
-    }
-    else
-    {
-        if (updateRefCount)
+        if (fgStmtListThreaded)
         {
-            if (fgStmtListThreaded)
-            {
-                DecLclVarRefCountsVisitor::WalkTree(this, stmt->gtStmtExpr);
-            }
+            DecLclVarRefCountsVisitor::WalkTree(this, stmt->gtStmtExpr);
         }
     }
 

--- a/tests/src/JIT/opt/CSE/GitHub_16065a.cs
+++ b/tests/src/JIT/opt/CSE/GitHub_16065a.cs
@@ -1,0 +1,98 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace GitHub_16065a
+{
+    struct Array2D
+    {
+        public int Offset { get; }
+        public int LeadingDimension { get; }
+
+        public Array2D(int offset, int leadingDimension)
+        {
+            this.Offset = offset;
+            this.LeadingDimension = leadingDimension;
+        }
+
+        public int GetIndex(int row, int column) 
+            => this.Offset + row + this.LeadingDimension * column;
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        public ArraySlice Diagonal(int index)
+        {
+            int offset = (index > 0) ? GetIndex(0, index) : GetIndex(-index, 0);
+            // The problem is with this line:
+            int stride = this.LeadingDimension + 1;
+            return new ArraySlice(offset, stride);
+        }
+        public ArraySlice GetStride(int index)
+        {
+            int offset = (index > 0) ? GetIndex(0, index) : GetIndex(-index, 0);
+            // The problem is with this line, when inlined:
+            int stride = this.LeadingDimension + 1;
+            return new ArraySlice(offset, stride);
+        }
+    }
+    struct ArraySlice
+    {
+        public int Offset { get; }
+        public int Stride { get; }
+
+        public ArraySlice(int offset, int stride)
+        {
+            this.Offset = offset;
+            this.Stride = stride;
+        }
+    }
+
+    class Vector
+    {
+        public ArraySlice Storage { get; }
+        public Vector(ArraySlice storage)
+        {
+            this.Storage = storage;
+        }
+    }
+    class Matrix
+    {
+        public Array2D Storage { get; }
+
+        public Matrix(Array2D storage)
+        {
+            this.Storage = storage;
+        }
+        public Vector GetDiagonal(int index)
+        {
+            ArraySlice storage = this.Storage.Diagonal(index);
+            return new Vector(storage);
+        }
+    }
+
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            int result = 0;
+            var A = new Matrix(new Array2D(0, 4));
+            var d = A.GetDiagonal(0);
+            Console.WriteLine("Expected: 0:5");
+            Console.WriteLine("Actual: {0}:{1}", d.Storage.Offset, d.Storage.Stride);
+            if ((d.Storage.Offset == 0) && (d.Storage.Stride == 5))
+            {
+                Console.WriteLine("PASSED");
+                result = 100;
+            }
+            else
+            {
+                Console.WriteLine("FAILED");
+                result = 101;
+            }
+
+            return result;
+        }
+    }
+}
+

--- a/tests/src/JIT/opt/CSE/GitHub_16065a.csproj
+++ b/tests/src/JIT/opt/CSE/GitHub_16065a.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_16065a.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/opt/CSE/GitHub_16065b.cs
+++ b/tests/src/JIT/opt/CSE/GitHub_16065b.cs
@@ -1,0 +1,99 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace GitHub_16065b
+{
+    struct Array2D
+    {
+        public int Offset;
+        public int LeadingDimension;
+
+        public Array2D(int offset, int leadingDimension)
+        {
+            Offset = offset;
+            LeadingDimension = leadingDimension;
+        }
+
+        public int GetIndex(int row, int column)
+        { 
+            return this.Offset + row + this.LeadingDimension * column;
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        public ArraySlice Diagonal(int index)
+        {
+            int offset = (index > 0) ? GetIndex(0, index) : GetIndex(-index, 0);
+            // The problem is with this line:
+            int stride = this.LeadingDimension + 1;
+            return new ArraySlice(offset, stride);
+        }
+        public ArraySlice GetStride(int index)
+        {
+            int offset = (index > 0) ? GetIndex(0, index) : GetIndex(-index, 0);
+            // The problem is with this line, when inlined:
+            int stride = this.LeadingDimension + 1;
+            return new ArraySlice(offset, stride);
+        }
+    }
+    struct ArraySlice
+    {
+        public int Offset;
+        public int Stride;
+
+        public ArraySlice(int offset, int stride)
+        {
+            Offset = offset;
+            Stride = stride;
+        }
+    }
+
+    class Vector
+    {
+        public ArraySlice Storage;
+        public Vector(ArraySlice storage)
+        {
+            Storage = storage;
+        }
+    }
+    class Matrix
+    {
+        public Array2D Storage;
+
+        public Matrix(Array2D storage)
+        {
+            Storage = storage;
+        }
+        public Vector GetDiagonal(int index)
+        {
+            ArraySlice storage = this.Storage.Diagonal(index);
+            return new Vector(storage);
+        }
+    }
+
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            int result = 0;
+            var A = new Matrix(new Array2D(0, 4));
+            var d = A.GetDiagonal(0);
+            Console.WriteLine("Expected: 0:5");
+            Console.WriteLine("Actual: {0}:{1}", d.Storage.Offset, d.Storage.Stride);
+            if ((d.Storage.Offset == 0) && (d.Storage.Stride == 5))
+            {
+                Console.WriteLine("PASSED");
+                result = 100;
+            }
+            else
+            {
+                Console.WriteLine("FAILED");
+                result = 101;
+            }
+
+            return result;
+        }
+    }
+}

--- a/tests/src/JIT/opt/CSE/GitHub_16065b.csproj
+++ b/tests/src/JIT/opt/CSE/GitHub_16065b.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_16065b.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Bug in the CSE phase when a CSE use contains a CSE def

In the error cases we could unmark or discard a CSE def. This CSE def might be needed when
 performing a subsequent CSE replacement.  This could lead to an uninitialized value being
 used for the CSE use.

Changed optUnmarkCSE method to return a bool instead of a void.
Changed optValuenumCSE_UnmarkCSEs  to take a write-back mutable wbKeepList argument
Removed an unreachable code block in fgRemoveStmt and replaced it with a noway_assert
Added method headers for optUnmarkCSE and optUnmarkCSEs
Removed the code that allowed unmarking of a CSE def, instead we return false
Retyped the second arguments to optUnmarksCSEs and optValueNumCSE_UnmarkCSEs
 to support appending new nodes to keep using wbKeepList
Code modifications to PerformCSE() to support collecting both persistent side effects and
 any nested CSE defs found in CSE uses.  Move the location of the call to
optValueNumCSE_UnmarkCSEs so that it comes before the decision to create a GT_COMMA node
 for the cse use.