### PR TITLE
Throwing IO Related exception only on FileStream.Dispose(disposing:true)

### DIFF
--- a/src/mscorlib/shared/System/IO/FileStream.Unix.cs
+++ b/src/mscorlib/shared/System/IO/FileStream.Unix.cs
@@ -240,7 +240,7 @@ namespace System.IO
                     {
                         FlushWriteBuffer();
                     }
-                    catch (IOException) when (!disposing)
+                    catch (Exception e) when (IsIoRelatedException(e) && !disposing)
                     {
                         // On finalization, ignore failures from trying to flush the write buffer,
                         // e.g. if this stream is wrapping a pipe and the pipe is now broken.

--- a/src/mscorlib/shared/System/IO/FileStream.Windows.cs
+++ b/src/mscorlib/shared/System/IO/FileStream.Windows.cs
@@ -268,7 +268,15 @@ namespace System.IO
                     // want us to do this.
                     if (_writePos > 0)
                     {
-                        FlushWriteBuffer(!disposing);
+                        try
+                        {
+                            FlushWriteBuffer(!disposing);
+                        }
+                        catch (Exception e) when (IsIoRelatedException(e) && !disposing)
+                        {
+                            // On finalization, ignore failures from trying to flush the write buffer,
+                            // e.g. if this stream is wrapping a pipe and the pipe is now broken.
+                        }
                     }
                 }
             }

--- a/src/mscorlib/shared/System/IO/FileStream.cs
+++ b/src/mscorlib/shared/System/IO/FileStream.cs
@@ -673,7 +673,7 @@ namespace System.IO
         }
 
         internal virtual bool IsClosed => _fileHandle.IsClosed;
-        
+
         private static bool IsIoRelatedException(Exception e) =>
             // These all derive from IOException
             //     DirectoryNotFoundException
@@ -684,10 +684,11 @@ namespace System.IO
             //     PathTooLongException
             //     PipeException 
             e is IOException ||
+            // Note that SecurityException is only thrown on runtimes that support CAS
+            // e is SecurityException || 
             e is UnauthorizedAccessException ||
             e is NotSupportedException ||
-            (e is ArgumentException && !(e is ArgumentNullException)) ||
-            e is SecurityException;
+            (e is ArgumentException && !(e is ArgumentNullException));
 
         /// <summary>
         /// Gets the array used for buffering reading and writing.  

--- a/src/mscorlib/shared/System/IO/FileStream.cs
+++ b/src/mscorlib/shared/System/IO/FileStream.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
 using System.Diagnostics;
+using System.Security;
 
 namespace System.IO
 {
@@ -672,6 +673,21 @@ namespace System.IO
         }
 
         internal virtual bool IsClosed => _fileHandle.IsClosed;
+        
+        private static bool IsIoRelatedException(Exception e) =>
+            // These all derive from IOException
+            //     DirectoryNotFoundException
+            //     DriveNotFoundException
+            //     EndOfStreamException
+            //     FileLoadException
+            //     FileNotFoundException
+            //     PathTooLongException
+            //     PipeException 
+            e is IOException ||
+            e is UnauthorizedAccessException ||
+            e is NotSupportedException ||
+            (e is ArgumentException && !(e is ArgumentNullException)) ||
+            e is SecurityException;
 
         /// <summary>
         /// Gets the array used for buffering reading and writing.  


### PR DESCRIPTION
Dispose may throw if FileStream fails to flush write buffer. 

In this bugfix we intend to make Windows behavior become more consistent with Unix behavior and to ignore exception on finalization. The same exception is expected to throw on FileStream.Dispose(true).

I added two corefx tests for this fix in PR: dotnet/corefx#26921

Fixes: #26734

cc: @danmosemsft 