### PR TITLE
Fix publishing errors

### DIFF
--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -131,27 +131,6 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Inject signed symbol catalogs",
-      "timeoutInMinutes": 0,
-      "condition": "and(succeeded(), ne(variables['PB_SignType'], 'oss'))",
-      "refName": "Task7",
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "msbuild",
-        "arguments": "/t:InjectSignedSymbolCatalogIntoSymbolPackages /p:SymbolPackagesToPublishGlob=$(Pipeline.SourcesDirectory)\\packages\\AzureTransfer\\$(ConfigurationGroup)\\$(AzureContainerSymbolPackageGlob) /p:SymbolCatalogCertificateId=$(PB_SymbolCatalogCertificateId)",
-        "workingFolder": "$(Pipeline.SourcesDirectory)",
-        "failOnStandardError": "true"
-      }
-    },
-    {
-      "environment": {},
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
       "displayName": "Index symbol packages",
       "timeoutInMinutes": 0,
       "refName": "Task8",
@@ -469,7 +448,7 @@
       "displayName": "Publish Artifact: DebugLogs",
       "timeoutInMinutes": 0,
       "condition": "succeededOrFailed()",
-      "refName": "PublishBuildArtifacts1",
+      "refName": "PublishBuildArtifacts3",
       "task": {
         "id": "2ff763a7-ce83-4e1f-bc89-0ae63477cebe",
         "versionSpec": "1.*",


### PR DESCRIPTION
Fix two errors:
    * Remove unneeded signed symbol catalog injection
    * Build definition is not importing becuase of duplicated task name.