### PR TITLE
Initialize Stack Allocated Data Structures in TraceLogging

### DIFF
--- a/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
@@ -434,6 +434,8 @@ namespace System.Diagnostics.Tracing
             var pinCount = eventTypes.pinCount;
             var scratch = stackalloc byte[eventTypes.scratchSize];
             var descriptors = stackalloc EventData[eventTypes.dataCount + 3];
+            for(int i = 0; i < eventTypes.dataCount + 3; i++)
+                descriptors[i] = default(EventData);
 
             var pins = stackalloc GCHandle[pinCount];
             for (int i = 0; i < pinCount; i++)
@@ -538,7 +540,10 @@ namespace System.Diagnostics.Tracing
 
                 // We make a descriptor for each EventData, and because we morph strings to counted strings
                 // we may have 2 for each arg, so we allocate enough for this.  
-                var descriptors = stackalloc EventData[eventTypes.dataCount + eventTypes.typeInfos.Length * 2 + 3];
+                var descriptorsLength = eventTypes.dataCount + eventTypes.typeInfos.Length * 2 + 3;
+                var descriptors = stackalloc EventData[descriptorsLength];
+                for(int i = 0; i < descriptorsLength; i++)
+                    descriptors[i] = default(EventData);
 
                 fixed (byte*
                     pMetadata0 = this.providerMetadata,
@@ -614,6 +619,8 @@ namespace System.Diagnostics.Tracing
                     var pinCount = eventTypes.pinCount;
                     var scratch = stackalloc byte[eventTypes.scratchSize];
                     var descriptors = stackalloc EventData[eventTypes.dataCount + 3];
+                    for(int i=0; i<eventTypes.dataCount + 3; i++)
+                        descriptors[i] = default(EventData);
 
                     var pins = stackalloc GCHandle[pinCount];
                     for (int i = 0; i < pinCount; i++)


### PR DESCRIPTION
TraceLogging was broken by #13728 because data structures allocated with stackalloc within code in System.Private.CoreLib are no longer zero-initialized.

TraceLogging ETW tests are not currently enabled and thus, there was no test coverage for this case.  I found this break while working to enable the TraceLogging ETW tests.