### PR TITLE
Fix GC reporting for slow tail calls with by-ref-like args

### DIFF
--- a/src/vm/i386/stublinkerx86.cpp
+++ b/src/vm/i386/stublinkerx86.cpp
@@ -5930,11 +5930,28 @@ static void AppendGCLayout(ULONGARRAY &gcLayout, size_t baseOffset, BOOL fIsType
         {
             FindByRefPointerOffsetsInByRefLikeObject(
                 pMT,
-                baseOffset,
+                0 /* baseOffset */,
                 [&](size_t pointerOffset)
                 {
-                    _ASSERTE(gcLayout.Count() == 0 || pointerOffset > (gcLayout[gcLayout.Count() - 1] & ~(ULONG)1));
-                    *gcLayout.AppendThrowing() = (ULONG)(pointerOffset | 1); // "| 1" to mark it as an interior pointer
+                    // 'gcLayout' requires stack offsets relative to the top of the stack to be recorded, such that subtracting
+                    // the offset from the stack top yields the address of the field, given that subtracting 'baseOffset' from
+                    // the stack top yields the address of the first field in this struct. See TailCallFrame::GcScanRoots() for
+                    // how these offsets are used to calculate stack addresses for fields.
+                    _ASSERTE(pointerOffset < baseOffset);
+                    size_t stackOffsetFromTop = baseOffset - pointerOffset;
+                    _ASSERTE(FitsInU4(stackOffsetFromTop));
+
+                    // Offsets in 'gcLayout' are expected to be in increasing order
+                    int gcLayoutInsertIndex = gcLayout.Count();
+                    _ASSERTE(gcLayoutInsertIndex >= 0);
+                    while (gcLayoutInsertIndex != 0 && stackOffsetFromTop < gcLayout[gcLayoutInsertIndex - 1])
+                    {
+                        --gcLayoutInsertIndex;
+                        _ASSERTE(stackOffsetFromTop != (gcLayout[gcLayoutInsertIndex] & ~(ULONG)1));
+                    }
+
+                    _ASSERTE(gcLayout.Count() == 0 || stackOffsetFromTop > (gcLayout[gcLayout.Count() - 1] & ~(ULONG)1));
+                    *gcLayout.InsertThrowing(gcLayoutInsertIndex) = (ULONG)(stackOffsetFromTop | 1); // "| 1" to mark it as an interior pointer
                 });
         }
 

--- a/src/vm/i386/stublinkerx86.cpp
+++ b/src/vm/i386/stublinkerx86.cpp
@@ -5944,10 +5944,17 @@ static void AppendGCLayout(ULONGARRAY &gcLayout, size_t baseOffset, BOOL fIsType
                     // Offsets in 'gcLayout' are expected to be in increasing order
                     int gcLayoutInsertIndex = gcLayout.Count();
                     _ASSERTE(gcLayoutInsertIndex >= 0);
-                    while (gcLayoutInsertIndex != 0 && stackOffsetFromTop < gcLayout[gcLayoutInsertIndex - 1])
+                    for (; gcLayoutInsertIndex != 0; --gcLayoutInsertIndex)
                     {
-                        --gcLayoutInsertIndex;
-                        _ASSERTE(stackOffsetFromTop != (gcLayout[gcLayoutInsertIndex] & ~(ULONG)1));
+                        ULONG prevStackOffsetFromTop = gcLayout[gcLayoutInsertIndex - 1] & ~(ULONG)1;
+                        if (stackOffsetFromTop > prevStackOffsetFromTop)
+                        {
+                            break;
+                        }
+                        if (stackOffsetFromTop == prevStackOffsetFromTop)
+                        {
+                            return;
+                        }
                     }
 
                     _ASSERTE(gcLayout.Count() == 0 || stackOffsetFromTop > (gcLayout[gcLayout.Count() - 1] & ~(ULONG)1));

--- a/tests/src/CoreMangLib/system/span/SlowTailCallArgs.cs
+++ b/tests/src/CoreMangLib/system/span/SlowTailCallArgs.cs
@@ -111,8 +111,11 @@ internal static class ByRefLikeTest
         GC.Collect();
         for (int i = 0; i < 10000; i++)
             GC.KeepAlive(new object());
-        if (a.span[0] != 42 || b.span[0] != 42 || c.span[0] != 42 || d.span[0] != 42 || e.span[0] != 42)
+        if (a.span[0] != 42 || b.span[0] != 42 || c.span[0] != 42 || d.span[0] != 42 || e.span[0] != 42 ||
+            a.span2[0] != 42 || b.span2[0] != 42 || c.span2[0] != 42 || d.span2[0] != 42 || e.span2[0] != 42)
+        {
             throw new ArgumentException();
+        }
     }
 
     private delegate void ActionOfTestByRefLike(TestByRefLike x);

--- a/tests/src/CoreMangLib/system/span/SlowTailCallArgs.cs
+++ b/tests/src/CoreMangLib/system/span/SlowTailCallArgs.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Runtime.InteropServices;
 
 internal static class Program
 {
@@ -116,11 +117,19 @@ internal static class ByRefLikeTest
 
     private delegate void ActionOfTestByRefLike(TestByRefLike x);
 
+    [StructLayout(LayoutKind.Explicit)]
     private ref struct TestByRefLike
     {
+        [FieldOffset(8 * 0)]
         private object obj;
+        [FieldOffset(8 * 0)]
         private object obj2;
+        [FieldOffset(8 * 1)]
         public Span<int> span;
+        [FieldOffset(8 * 1)]
+        public Span<int> span2;
+        [FieldOffset(8 * 3)]
+        private object obj3;
 
         public TestByRefLike(int[] values)
         {
@@ -130,7 +139,11 @@ internal static class ByRefLikeTest
             obj2 = null;
             if (obj2 != null)
                 obj2 = null;
+            obj3 = null;
+            if (obj3 != null)
+                obj3 = null;
             span = new Span<int>(values);
+            span2 = span;
         }
     }
 }

--- a/tests/src/CoreMangLib/system/span/SlowTailCallArgs.csproj
+++ b/tests/src/CoreMangLib/system/span/SlowTailCallArgs.csproj
@@ -9,6 +9,7 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/16229:
- Offsets recorded in the GC layout are intended to be offsets from the top of the stack, fixed by calculating the proper offset