### PR TITLE
Check mismatched types for SIMD copy

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -10760,7 +10760,7 @@ GenTree* Compiler::fgMorphCopyBlock(GenTree* tree)
 
         if (!srcDoFldAsg && (srcLclVar != nullptr) && !srcSingleLclVarAsg)
         {
-            if (!srcLclVar->lvRegStruct)
+            if (!srcLclVar->lvRegStruct || (srcLclVar->lvType != dest->TypeGet()))
             {
                 lvaSetVarDoNotEnregister(srcLclNum DEBUGARG(DNER_BlockOp));
             }

--- a/tests/src/JIT/Regression/JitBlue/GitHub_16254/GitHub_16254.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_16254/GitHub_16254.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Globalization;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace UnsafeTesting
+{
+    public class Program
+    {
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static Quaternion Add(Quaternion value1, Quaternion value2)
+        {
+            Vector4 q1 = Unsafe.As<Quaternion, Vector4>(ref value1);
+            Vector4 q2 = Unsafe.As<Quaternion, Vector4>(ref value2);
+
+            Vector4 result = q1 + q2;
+
+            return Unsafe.As<Vector4, Quaternion>(ref result);
+        }
+        public static bool QuaternionAddTest()
+        {
+            Quaternion a = new Quaternion(1.0f, 2.0f, 3.0f, 4.0f);
+            Quaternion b = new Quaternion(5.0f, 6.0f, 7.0f, 8.0f);
+
+            Quaternion expected = new Quaternion(6.0f, 8.0f, 10.0f, 12.0f);
+            Quaternion actual;
+
+            actual = Add(a, b);
+
+            if (actual != expected)
+            {
+                return false;
+            }
+            return true;
+        }
+        static int Main()
+        {
+            if (QuaternionAddTest())
+            {
+                Console.WriteLine("PASS");
+                return 100;
+            }
+            else
+            {
+                Console.WriteLine("FAIL");
+                return -1;
+            }
+        }
+
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_16254/GitHub_16254.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_16254/GitHub_16254.csproj
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{76E69AA0-8C5A-4F76-8561-B8089FFA8D79}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+  <PropertyGroup>
+    <ProjectAssetsFile>$(JitPackagesConfigFileDirectory)benchmark\obj\project.assets.json</ProjectAssetsFile>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
If we have a block copy from an enregisterable struct (today, that's just SIMD) to a different type target, it needs to be marked as address-taken, because the destination type is what's used for the copy, and all non-enregisterable destination types expect their source in memory.

Fix #16254