### PR TITLE
Updating runtime version for tests

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -44,7 +44,7 @@
     <!-- Scenario tests install this version of Microsoft.NetCore.App, then patch coreclr binaries via xcopy. At the moment it is
          updated manually whenever breaking changes require it to move forward, but it would be nice if we could update it automatically
          as we do with many of the package versions above -->
-    <BaselineMicrosoftNetCoreAppPackageVersion>2.1.0-preview2-26124-05</BaselineMicrosoftNetCoreAppPackageVersion>
+    <BaselineMicrosoftNetCoreAppPackageVersion>2.1.0-preview2-26131-06</BaselineMicrosoftNetCoreAppPackageVersion>
   </PropertyGroup>
 
   <!-- Package versions used as toolsets -->


### PR DESCRIPTION
Change 93ec62347a4e97b920513296eefb27bdacbecfe9 removed Span.NonPortableCast from System.Private.CoreLib.dll requiring tests to use an updated version of System.Memory.dll that no longer refers to it.

This should fix the recent break that occured in JitBench CI. I'm hoping we just got unlucky that CoreCLR took a breaking change last week just as JitBench work finished up, but we'll see how often it continues to occur. Thankfully after changing the perf CI run to record logs in the failure case diagnosing the version mismatch was fairly straightforward.

PTAL @jorive 