### PR TITLE
sigsegv_handler: handle case when it is called on original stack

### DIFF
--- a/src/pal/src/exception/seh.cpp
+++ b/src/pal/src/exception/seh.cpp
@@ -344,8 +344,8 @@ CatchHardwareExceptionHolder::~CatchHardwareExceptionHolder()
 
 bool CatchHardwareExceptionHolder::IsEnabled()
 {
-    CPalThread *pThread = InternalGetCurrentThread();
-    return pThread->IsHardwareExceptionsEnabled();
+    CPalThread *pThread = GetCurrentPalThread();
+    return pThread ? pThread->IsHardwareExceptionsEnabled() : false;
 }
 
 /*++

--- a/src/vm/threads.inl
+++ b/src/vm/threads.inl
@@ -26,7 +26,7 @@
 #ifndef __llvm__
 EXTERN_C __declspec(thread) ThreadLocalInfo gCurrentThreadInfo;
 #else // !__llvm__
-EXTERN_C __thread ThreadLocalInfo gCurrentThreadInfo;
+EXTERN_C __thread ThreadLocalInfo gCurrentThreadInfo __attribute__ ((tls_model("initial-exec")));
 #endif // !__llvm__
 
 EXTERN_C inline Thread* STDCALL GetThread()


### PR DESCRIPTION
If sigsegv_handler is called on original stack (for example, if segmentation fault occurs in native application's thread that hasn't alternate signal stack) we should call common_signal_handler directly othersize sigsegv_handler's stackframe will be corrupted.
```
+--------------------+
|                    |      <- ExecuteHandlerOnOriginalStack's frame
|                    | 
+--------------------+
|                    |
+--------------------+
|    returnPoint     |      <- sigsegv_handler's frame
+--------------------+
|                    |
+--------------------+
|                    |
|   saved registers  |  
|                    |
+--------------------+      <- SIGSEGV (original stack sp)
|                    |
```

Such kind of crash can be reproduced using following example:
```cs
using System;
using System.Threading;
using System.Runtime.InteropServices;


public class Test
{
    [DllImport("libtest.so")]
    internal static extern void SleepAndSegFault(int ms);

    static void Main()
    {
        SleepAndSegFault(200);

        while (true) {}
    }
}
```
`libtest.c`:
```c
#include <stdlib.h>
#include <unistd.h>

void *TestTask(void *arg)
{
    int ms = *(int *)arg;
    usleep(ms*1024);
    int *p = NULL;
    *p = 1;
    return NULL;
}

extern void SleepAndSegFault(int ms)
{
    pthread_t TestThread;
    pthread_create(&TestThread, NULL, TestTask, (void *)&ms);
}
```

In some cases it can lead to stack smashing errors that are described in https://github.com/dotnet/coreclr/issues/16208