### PR TITLE
Explictly initialize EventData.Reserved for System.Private.CoreLib

### DIFF
--- a/src/mscorlib/shared/System/Buffers/ArrayPoolEventSource.cs
+++ b/src/mscorlib/shared/System/Buffers/ArrayPoolEventSource.cs
@@ -39,12 +39,16 @@ namespace System.Buffers
             EventData* payload = stackalloc EventData[4];
             payload[0].Size = sizeof(int);
             payload[0].DataPointer = ((IntPtr)(&bufferId));
+            payload[0].Reserved = 0;
             payload[1].Size = sizeof(int);
             payload[1].DataPointer = ((IntPtr)(&bufferSize));
+            payload[1].Reserved = 0;
             payload[2].Size = sizeof(int);
             payload[2].DataPointer = ((IntPtr)(&poolId));
+            payload[2].Reserved = 0;
             payload[3].Size = sizeof(int);
             payload[3].DataPointer = ((IntPtr)(&bucketId));
+            payload[3].Reserved = 0;
             WriteEventCore(1, 4, payload);
         }
 
@@ -59,14 +63,19 @@ namespace System.Buffers
             EventData* payload = stackalloc EventData[5];
             payload[0].Size = sizeof(int);
             payload[0].DataPointer = ((IntPtr)(&bufferId));
+            payload[0].Reserved = 0;
             payload[1].Size = sizeof(int);
             payload[1].DataPointer = ((IntPtr)(&bufferSize));
+            payload[1].Reserved = 0;
             payload[2].Size = sizeof(int);
             payload[2].DataPointer = ((IntPtr)(&poolId));
+            payload[2].Reserved = 0;
             payload[3].Size = sizeof(int);
             payload[3].DataPointer = ((IntPtr)(&bucketId));
+            payload[3].Reserved = 0;
             payload[4].Size = sizeof(BufferAllocatedReason);
             payload[4].DataPointer = ((IntPtr)(&reason));
+            payload[4].Reserved = 0;
             WriteEventCore(2, 5, payload);
         }
 

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/EventProvider.cs
@@ -958,6 +958,8 @@ namespace System.Diagnostics.Tracing
                     List<int> refObjPosition = new List<int>(s_etwAPIMaxRefObjCount);
                     List<object> dataRefObj = new List<object>(s_etwAPIMaxRefObjCount);
                     EventData* userData = stackalloc EventData[2 * argCount];
+                    for (int i = 0; i < 2 * argCount; i++)
+                        userData[i] = default(EventData);
                     EventData* userDataPtr = (EventData*)userData;
                     byte* dataBuffer = stackalloc byte[s_basicTypeAllocationBufferSize * 2 * argCount]; // Assume 16 chars for non-string argument
                     byte* currentBuffer = dataBuffer;

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -742,6 +742,7 @@ namespace System.Diagnostics.Tracing
                 EventSource.EventData* descrs = stackalloc EventSource.EventData[1];
                 descrs[0].DataPointer = (IntPtr)(&arg1);
                 descrs[0].Size = 4;
+                descrs[0].Reserved = 0;
                 WriteEventCore(eventId, 1, descrs);
             }
         }
@@ -754,8 +755,10 @@ namespace System.Diagnostics.Tracing
                 EventSource.EventData* descrs = stackalloc EventSource.EventData[2];
                 descrs[0].DataPointer = (IntPtr)(&arg1);
                 descrs[0].Size = 4;
+                descrs[0].Reserved = 0;
                 descrs[1].DataPointer = (IntPtr)(&arg2);
                 descrs[1].Size = 4;
+                descrs[1].Reserved = 0;
                 WriteEventCore(eventId, 2, descrs);
             }
         }
@@ -768,10 +771,13 @@ namespace System.Diagnostics.Tracing
                 EventSource.EventData* descrs = stackalloc EventSource.EventData[3];
                 descrs[0].DataPointer = (IntPtr)(&arg1);
                 descrs[0].Size = 4;
+                descrs[0].Reserved = 0;
                 descrs[1].DataPointer = (IntPtr)(&arg2);
                 descrs[1].Size = 4;
+                descrs[1].Reserved = 0;
                 descrs[2].DataPointer = (IntPtr)(&arg3);
                 descrs[2].Size = 4;
+                descrs[2].Reserved = 0;
                 WriteEventCore(eventId, 3, descrs);
             }
         }
@@ -785,6 +791,7 @@ namespace System.Diagnostics.Tracing
                 EventSource.EventData* descrs = stackalloc EventSource.EventData[1];
                 descrs[0].DataPointer = (IntPtr)(&arg1);
                 descrs[0].Size = 8;
+                descrs[0].Reserved = 0;
                 WriteEventCore(eventId, 1, descrs);
             }
         }
@@ -797,8 +804,10 @@ namespace System.Diagnostics.Tracing
                 EventSource.EventData* descrs = stackalloc EventSource.EventData[2];
                 descrs[0].DataPointer = (IntPtr)(&arg1);
                 descrs[0].Size = 8;
+                descrs[0].Reserved = 0;
                 descrs[1].DataPointer = (IntPtr)(&arg2);
                 descrs[1].Size = 8;
+                descrs[1].Reserved = 0;
                 WriteEventCore(eventId, 2, descrs);
             }
         }
@@ -811,10 +820,13 @@ namespace System.Diagnostics.Tracing
                 EventSource.EventData* descrs = stackalloc EventSource.EventData[3];
                 descrs[0].DataPointer = (IntPtr)(&arg1);
                 descrs[0].Size = 8;
+                descrs[0].Reserved = 0;
                 descrs[1].DataPointer = (IntPtr)(&arg2);
                 descrs[1].Size = 8;
+                descrs[1].Reserved = 0;
                 descrs[2].DataPointer = (IntPtr)(&arg3);
                 descrs[2].Size = 8;
+                descrs[2].Reserved = 0;
                 WriteEventCore(eventId, 3, descrs);
             }
         }
@@ -831,6 +843,7 @@ namespace System.Diagnostics.Tracing
                     EventSource.EventData* descrs = stackalloc EventSource.EventData[1];
                     descrs[0].DataPointer = (IntPtr)string1Bytes;
                     descrs[0].Size = ((arg1.Length + 1) * 2);
+                    descrs[0].Reserved = 0;
                     WriteEventCore(eventId, 1, descrs);
                 }
             }
@@ -849,8 +862,10 @@ namespace System.Diagnostics.Tracing
                     EventSource.EventData* descrs = stackalloc EventSource.EventData[2];
                     descrs[0].DataPointer = (IntPtr)string1Bytes;
                     descrs[0].Size = ((arg1.Length + 1) * 2);
+                    descrs[0].Reserved = 0;
                     descrs[1].DataPointer = (IntPtr)string2Bytes;
                     descrs[1].Size = ((arg2.Length + 1) * 2);
+                    descrs[1].Reserved = 0;
                     WriteEventCore(eventId, 2, descrs);
                 }
             }
@@ -871,10 +886,13 @@ namespace System.Diagnostics.Tracing
                     EventSource.EventData* descrs = stackalloc EventSource.EventData[3];
                     descrs[0].DataPointer = (IntPtr)string1Bytes;
                     descrs[0].Size = ((arg1.Length + 1) * 2);
+                    descrs[0].Reserved = 0;
                     descrs[1].DataPointer = (IntPtr)string2Bytes;
                     descrs[1].Size = ((arg2.Length + 1) * 2);
+                    descrs[1].Reserved = 0;
                     descrs[2].DataPointer = (IntPtr)string3Bytes;
                     descrs[2].Size = ((arg3.Length + 1) * 2);
+                    descrs[2].Reserved = 0;
                     WriteEventCore(eventId, 3, descrs);
                 }
             }
@@ -892,8 +910,10 @@ namespace System.Diagnostics.Tracing
                     EventSource.EventData* descrs = stackalloc EventSource.EventData[2];
                     descrs[0].DataPointer = (IntPtr)string1Bytes;
                     descrs[0].Size = ((arg1.Length + 1) * 2);
+                    descrs[0].Reserved = 0;
                     descrs[1].DataPointer = (IntPtr)(&arg2);
                     descrs[1].Size = 4;
+                    descrs[1].Reserved = 0;
                     WriteEventCore(eventId, 2, descrs);
                 }
             }
@@ -910,10 +930,13 @@ namespace System.Diagnostics.Tracing
                     EventSource.EventData* descrs = stackalloc EventSource.EventData[3];
                     descrs[0].DataPointer = (IntPtr)string1Bytes;
                     descrs[0].Size = ((arg1.Length + 1) * 2);
+                    descrs[0].Reserved = 0;
                     descrs[1].DataPointer = (IntPtr)(&arg2);
                     descrs[1].Size = 4;
+                    descrs[1].Reserved = 0;
                     descrs[2].DataPointer = (IntPtr)(&arg3);
                     descrs[2].Size = 4;
+                    descrs[2].Reserved = 0;
                     WriteEventCore(eventId, 3, descrs);
                 }
             }
@@ -931,8 +954,10 @@ namespace System.Diagnostics.Tracing
                     EventSource.EventData* descrs = stackalloc EventSource.EventData[2];
                     descrs[0].DataPointer = (IntPtr)string1Bytes;
                     descrs[0].Size = ((arg1.Length + 1) * 2);
+                    descrs[1].Reserved = 0;
                     descrs[1].DataPointer = (IntPtr)(&arg2);
                     descrs[1].Size = 8;
+                    descrs[1].Reserved = 0;
                     WriteEventCore(eventId, 2, descrs);
                 }
             }
@@ -950,8 +975,10 @@ namespace System.Diagnostics.Tracing
                     EventSource.EventData* descrs = stackalloc EventSource.EventData[2];
                     descrs[0].DataPointer = (IntPtr)(&arg1);
                     descrs[0].Size = 8;
+                    descrs[0].Reserved = 0;
                     descrs[1].DataPointer = (IntPtr)string2Bytes;
                     descrs[1].Size = ((arg2.Length + 1) * 2);
+                    descrs[1].Reserved = 0;
                     WriteEventCore(eventId, 2, descrs);
                 }
             }
@@ -969,8 +996,10 @@ namespace System.Diagnostics.Tracing
                     EventSource.EventData* descrs = stackalloc EventSource.EventData[2];
                     descrs[0].DataPointer = (IntPtr)(&arg1);
                     descrs[0].Size = 4;
+                    descrs[0].Reserved = 0;
                     descrs[1].DataPointer = (IntPtr)string2Bytes;
                     descrs[1].Size = ((arg2.Length + 1) * 2);
+                    descrs[1].Reserved = 0;
                     WriteEventCore(eventId, 2, descrs);
                 }
             }
@@ -987,8 +1016,10 @@ namespace System.Diagnostics.Tracing
                     int blobSize = 0;
                     descrs[0].DataPointer = (IntPtr)(&blobSize);
                     descrs[0].Size = 4;
+                    descrs[0].Reserved = 0;
                     descrs[1].DataPointer = (IntPtr)(&blobSize); // valid address instead of empty content 
                     descrs[1].Size = 0;
+                    descrs[1].Reserved = 0;
                     WriteEventCore(eventId, 2, descrs);
                 }
                 else
@@ -998,8 +1029,10 @@ namespace System.Diagnostics.Tracing
                     {
                         descrs[0].DataPointer = (IntPtr)(&blobSize);
                         descrs[0].Size = 4;
+                        descrs[0].Reserved = 0;
                         descrs[1].DataPointer = (IntPtr)blob;
                         descrs[1].Size = blobSize;
+                        descrs[1].Reserved = 0;
                         WriteEventCore(eventId, 2, descrs);
                     }
                 }
@@ -1014,13 +1047,16 @@ namespace System.Diagnostics.Tracing
                 EventSource.EventData* descrs = stackalloc EventSource.EventData[3];
                 descrs[0].DataPointer = (IntPtr)(&arg1);
                 descrs[0].Size = 8;
+                descrs[0].Reserved = 0;
                 if (arg2 == null || arg2.Length == 0)
                 {
                     int blobSize = 0;
                     descrs[1].DataPointer = (IntPtr)(&blobSize);
                     descrs[1].Size = 4;
+                    descrs[1].Reserved = 0;
                     descrs[2].DataPointer = (IntPtr)(&blobSize); // valid address instead of empty contents 
                     descrs[2].Size = 0;
+                    descrs[2].Reserved = 0;
                     WriteEventCore(eventId, 3, descrs);
                 }
                 else
@@ -1030,8 +1066,10 @@ namespace System.Diagnostics.Tracing
                     {
                         descrs[1].DataPointer = (IntPtr)(&blobSize);
                         descrs[1].Size = 4;
+                        descrs[1].Reserved = 0;
                         descrs[2].DataPointer = (IntPtr)blob;
                         descrs[2].Size = blobSize;
+                        descrs[2].Reserved = 0;
                         WriteEventCore(eventId, 3, descrs);
                     }
                 }
@@ -1055,6 +1093,12 @@ namespace System.Diagnostics.Tracing
             /// Size of the argument referenced by DataPointer
             /// </summary>
             public int Size { get { return m_Size; } set { m_Size = value; } }
+
+            /// <summary>
+            /// Reserved by ETW.  This property is present to ensure that we can zero it
+            /// since System.Private.CoreLib uses are not zero'd.
+            /// </summary>
+            internal int Reserved { get { return m_Reserved; } set { m_Reserved = value; } }
 
             #region private
             /// <summary>
@@ -1097,8 +1141,10 @@ namespace System.Diagnostics.Tracing
         ///                EventSource.EventData* descrs = stackalloc EventSource.EventData[2];
         ///                descrs[0].DataPointer = (IntPtr)(&amp;arg1);
         ///                descrs[0].Size = 8;
+        ///                descrs[0].Reserved = 0;
         ///                descrs[1].DataPointer = (IntPtr)string2Bytes;
         ///                descrs[1].Size = ((arg2.Length + 1) * 2);
+        ///                descrs[1].Reserved = 0;
         ///                WriteEventCore(eventId, 2, descrs);
         ///            }
         ///        }

--- a/src/mscorlib/src/System/Diagnostics/Eventing/FrameworkEventSource.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/FrameworkEventSource.cs
@@ -102,12 +102,16 @@ namespace System.Diagnostics.Tracing
                     EventSource.EventData* descrs = stackalloc EventSource.EventData[4];
                     descrs[0].DataPointer = (IntPtr)(&arg1);
                     descrs[0].Size = 8;
+                    descrs[0].Reserved = 0;
                     descrs[1].DataPointer = (IntPtr)(&arg2);
                     descrs[1].Size = 4;
+                    descrs[1].Reserved = 0;
                     descrs[2].DataPointer = (IntPtr)string3Bytes;
                     descrs[2].Size = ((arg3.Length + 1) * 2);
+                    descrs[2].Reserved = 0;
                     descrs[3].DataPointer = (IntPtr)(&arg4);
                     descrs[3].Size = 4;
+                    descrs[3].Reserved = 0;
                     WriteEventCore(eventId, 4, descrs);
                 }
             }
@@ -129,10 +133,13 @@ namespace System.Diagnostics.Tracing
                     EventSource.EventData* descrs = stackalloc EventSource.EventData[3];
                     descrs[0].DataPointer = (IntPtr)(&arg1);
                     descrs[0].Size = 8;
+                    descrs[0].Reserved = 0;
                     descrs[1].DataPointer = (IntPtr)(&arg2);
                     descrs[1].Size = 4;
+                    descrs[1].Reserved = 0;
                     descrs[2].DataPointer = (IntPtr)string3Bytes;
                     descrs[2].Size = ((arg3.Length + 1) * 2);
+                    descrs[2].Reserved = 0;
                     WriteEventCore(eventId, 3, descrs);
                 }
             }
@@ -154,12 +161,16 @@ namespace System.Diagnostics.Tracing
                     EventSource.EventData* descrs = stackalloc EventSource.EventData[4];
                     descrs[0].DataPointer = (IntPtr)(&arg1);
                     descrs[0].Size = 8;
+                    descrs[0].Reserved = 0;
                     descrs[1].DataPointer = (IntPtr)string2Bytes;
                     descrs[1].Size = ((arg2.Length + 1) * 2);
+                    descrs[1].Reserved = 0;
                     descrs[2].DataPointer = (IntPtr)(&arg3);
                     descrs[2].Size = 4;
+                    descrs[2].Reserved = 0;
                     descrs[3].DataPointer = (IntPtr)(&arg4);
                     descrs[3].Size = 4;
+                    descrs[3].Reserved = 0;
                     WriteEventCore(eventId, 4, descrs);
                 }
             }
@@ -178,10 +189,13 @@ namespace System.Diagnostics.Tracing
                 EventSource.EventData* descrs = stackalloc EventSource.EventData[3];
                 descrs[0].DataPointer = (IntPtr)(&arg1);
                 descrs[0].Size = 8;
+                descrs[0].Reserved = 0;
                 descrs[1].DataPointer = (IntPtr)(&arg2);
                 descrs[1].Size = 4;
+                descrs[1].Reserved = 0;
                 descrs[2].DataPointer = (IntPtr)(&arg3);
                 descrs[2].Size = 4;
+                descrs[2].Reserved = 0;
                 WriteEventCore(eventId, 3, descrs);
             }
         }
@@ -199,12 +213,16 @@ namespace System.Diagnostics.Tracing
                 EventSource.EventData* descrs = stackalloc EventSource.EventData[4];
                 descrs[0].DataPointer = (IntPtr)(&arg1);
                 descrs[0].Size = 8;
+                descrs[0].Reserved = 0;
                 descrs[1].DataPointer = (IntPtr)(&arg2);
                 descrs[1].Size = 4;
+                descrs[1].Reserved = 0;
                 descrs[2].DataPointer = (IntPtr)(&arg3);
                 descrs[2].Size = 4;
+                descrs[2].Reserved = 0;
                 descrs[3].DataPointer = (IntPtr)(&arg4);
                 descrs[3].Size = 4;
+                descrs[3].Reserved = 0;
                 WriteEventCore(eventId, 4, descrs);
             }
         }

--- a/src/mscorlib/src/System/Threading/Tasks/TPLETWProvider.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/TPLETWProvider.cs
@@ -228,16 +228,22 @@ namespace System.Threading.Tasks
                     EventData* eventPayload = stackalloc EventData[6];
                     eventPayload[0].Size = sizeof(int);
                     eventPayload[0].DataPointer = ((IntPtr)(&OriginatingTaskSchedulerID));
+                    eventPayload[0].Reserved = 0;
                     eventPayload[1].Size = sizeof(int);
                     eventPayload[1].DataPointer = ((IntPtr)(&OriginatingTaskID));
+                    eventPayload[1].Reserved = 0;
                     eventPayload[2].Size = sizeof(int);
                     eventPayload[2].DataPointer = ((IntPtr)(&TaskID));
+                    eventPayload[2].Reserved = 0;
                     eventPayload[3].Size = sizeof(int);
                     eventPayload[3].DataPointer = ((IntPtr)(&CreatingTaskID));
+                    eventPayload[3].Reserved = 0;
                     eventPayload[4].Size = sizeof(int);
                     eventPayload[4].DataPointer = ((IntPtr)(&TaskCreationOptions));
+                    eventPayload[4].Reserved = 0;
                     eventPayload[5].Size = sizeof(int);
                     eventPayload[5].DataPointer = ((IntPtr)(&appDomain));
+                    eventPayload[5].Reserved = 0;
                     if (TasksSetActivityIds)
                     {
                         Guid childActivityId = CreateGuidForTaskID(TaskID);
@@ -290,12 +296,16 @@ namespace System.Threading.Tasks
                     Int32 isExceptionalInt = IsExceptional ? 1 : 0;
                     eventPayload[0].Size = sizeof(int);
                     eventPayload[0].DataPointer = ((IntPtr)(&OriginatingTaskSchedulerID));
+                    eventPayload[0].Reserved = 0;
                     eventPayload[1].Size = sizeof(int);
                     eventPayload[1].DataPointer = ((IntPtr)(&OriginatingTaskID));
+                    eventPayload[1].Reserved = 0;
                     eventPayload[2].Size = sizeof(int);
                     eventPayload[2].DataPointer = ((IntPtr)(&TaskID));
+                    eventPayload[2].Reserved = 0;
                     eventPayload[3].Size = sizeof(int);
                     eventPayload[3].DataPointer = ((IntPtr)(&isExceptionalInt));
+                    eventPayload[3].Reserved = 0;
                     WriteEventCore(TASKCOMPLETED_ID, 4, eventPayload);
                 }
             }
@@ -326,14 +336,19 @@ namespace System.Threading.Tasks
                     EventData* eventPayload = stackalloc EventData[5];
                     eventPayload[0].Size = sizeof(int);
                     eventPayload[0].DataPointer = ((IntPtr)(&OriginatingTaskSchedulerID));
+                    eventPayload[0].Reserved = 0;
                     eventPayload[1].Size = sizeof(int);
                     eventPayload[1].DataPointer = ((IntPtr)(&OriginatingTaskID));
+                    eventPayload[1].Reserved = 0;
                     eventPayload[2].Size = sizeof(int);
                     eventPayload[2].DataPointer = ((IntPtr)(&TaskID));
+                    eventPayload[2].Reserved = 0;
                     eventPayload[3].Size = sizeof(int);
                     eventPayload[3].DataPointer = ((IntPtr)(&Behavior));
+                    eventPayload[3].Reserved = 0;
                     eventPayload[4].Size = sizeof(int);
                     eventPayload[4].DataPointer = ((IntPtr)(&ContinueWithTaskID));
+                    eventPayload[4].Reserved = 0;
                     if (TasksSetActivityIds)
                     {
                         Guid childActivityId = CreateGuidForTaskID(TaskID);
@@ -414,10 +429,13 @@ namespace System.Threading.Tasks
                     EventData* eventPayload = stackalloc EventData[3];
                     eventPayload[0].Size = sizeof(int);
                     eventPayload[0].DataPointer = ((IntPtr)(&OriginatingTaskSchedulerID));
+                    eventPayload[0].Reserved = 0;
                     eventPayload[1].Size = sizeof(int);
                     eventPayload[1].DataPointer = ((IntPtr)(&OriginatingTaskID));
+                    eventPayload[1].Reserved = 0;
                     eventPayload[2].Size = sizeof(int);
                     eventPayload[2].DataPointer = ((IntPtr)(&ContinuwWithTaskId));
+                    eventPayload[2].Reserved = 0;
                     if (TasksSetActivityIds)
                     {
                         Guid continuationActivityId = CreateGuidForTaskID(ContinuwWithTaskId);
@@ -442,12 +460,15 @@ namespace System.Threading.Tasks
                         EventData* eventPayload = stackalloc EventData[3];
                         eventPayload[0].Size = sizeof(int);
                         eventPayload[0].DataPointer = ((IntPtr)(&TaskID));
+                        eventPayload[0].Reserved = 0;
 
                         eventPayload[1].Size = ((OperationName.Length + 1) * 2);
                         eventPayload[1].DataPointer = ((IntPtr)operationNamePtr);
+                        eventPayload[1].Reserved = 0;
 
                         eventPayload[2].Size = sizeof(long);
                         eventPayload[2].DataPointer = ((IntPtr)(&RelatedContext));
+                        eventPayload[2].Reserved = 0;
                         WriteEventCore(TRACEOPERATIONSTART_ID, 3, eventPayload);
                     }
                 }
@@ -489,6 +510,7 @@ namespace System.Threading.Tasks
                     EventData* eventPayload = stackalloc EventData[1];
                     eventPayload[0].Size = sizeof(int);
                     eventPayload[0].DataPointer = ((IntPtr)(&Work));
+                    eventPayload[0].Reserved = 0;
 
                     WriteEventCore(TRACESYNCHRONOUSWORKSTOP_ID, 1, eventPayload);
                 }


### PR DESCRIPTION
In System.Private.CoreLib stackalloc allocations are no longer zeroed.  This change ensures that EventData.Reserved is always initialized to zero before it is passed to ETW.

This initialization is done early enough that EventSource can change the value of Reserved if required by TraceLogging.

In addition to CI validation, I am also doing some validation with these EventSources enabled.