### PR TITLE
JIT: look for escaping byrefs

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -19158,11 +19158,9 @@ Compiler::fgWalkResult Compiler::fgMarkAddrTakenLocalsPreCB(GenTree** pTree, fgW
                 // We may need to Quirk the storage size for this LCL_VAR
                 // some PInvoke signatures incorrectly specify a ByRef to an INT32
                 // when they actually write a SIZE_T or INT64
-                if (axc == AXC_Addr)
-                {
-                    comp->gtCheckQuirkAddrExposedLclVar(tree, fgWalkPre->parentStack);
-                }
+                comp->gtCheckQuirkAddrExposedLclVar(tree, fgWalkPre->parentStack);
             }
+
             // Push something to keep the PostCB, which will pop it, happy.
             axcStack->Push(AXC_None);
             // The tree is a leaf.
@@ -19221,16 +19219,6 @@ Compiler::fgWalkResult Compiler::fgMarkAddrTakenLocalsPreCB(GenTree** pTree, fgW
         {
             // Scan for byref args
             GenTreeCall* const call = tree->AsCall();
-
-            if (call->gtCallObjp)
-            {
-                if (call->gtCallObjp->gtType == TYP_BYREF)
-                {
-                    axcStack->Push(AXC_IndWide);
-                    return WALK_CONTINUE;
-                }
-            }
-
             for (GenTree* args = call->gtCallArgs; (args != nullptr); args = args->gtOp.gtOp2)
             {
                 if (args->gtOp.gtOp1->gtType == TYP_BYREF)

--- a/tests/src/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_1.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_1.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public struct float4
+{
+    public float4(float x, float y, float z, float w)
+    {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.w = w;
+    }
+
+    public float x;
+    public float y;
+    public float z;
+    public float w;
+    
+    public unsafe float this[int index]
+    {
+        get
+        {
+            fixed (float* array = &x) { return array[index]; }
+        }
+        set
+        {
+            fixed (float* array = &x) { array[index] = value; }
+        }
+    }
+}
+
+class X
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static float P(int i)
+    {
+        var test = new float4(5, 4, 3, 2);
+        return test[i];
+    }
+
+    static int Main(string[] args)
+    {
+        float v0 = P(0);
+        float v1 = P(1);
+        float v2 = P(2);
+        float v3 = P(3);
+
+        Console.WriteLine($"v0={v0} v1={v1} v2={v2} v3={v3}");
+        bool ok = (v0 == 5 && v1 == 4 && v2 == 3 && v3 == 2);
+        return (ok ? 100 : 0);
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_1.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_1.csproj
@@ -10,7 +10,6 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_1.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_1.csproj
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_16210_1.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_2.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_2.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+ public struct float4
+{
+    public float4(float x, float y, float z, float w)
+    {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.w = w;
+    }
+    
+    public float x;
+    public float y;
+    public float z;
+    public float w;
+}
+
+class X
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static float E(ref float p, int i)
+    {
+        return Unsafe.Add(ref p, i);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static float P(int i)
+    {
+        var test = new float4(5, 4, 3, 2);
+        return E(ref test.x, i);
+    }
+
+    static int Main(string[] args)
+    {
+        float v0 = P(0);
+        float v1 = P(1);
+        float v2 = P(2);
+        float v3 = P(3);
+
+        Console.WriteLine($"v0={v0} v1={v1} v2={v2} v3={v3}");
+        bool ok = (v0 == 5 && v1 == 4 && v2 == 3 && v3 == 2);
+        return (ok ? 100 : 0);
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_2.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_2.csproj
@@ -10,7 +10,6 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_2.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_2.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_16210_2.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_3.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_3.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+ public struct float4
+{
+    public float4(float x, float y, float z, float w)
+    {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.w = w;
+    }
+    
+    public float x;
+    public float y;
+    public float z;
+    public float w;
+}
+
+class X
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static float P(int i)
+    {
+        var test = new float4(5, 4, 3, 2);
+        ref float p = ref test.x;
+        Console.WriteLine(p);
+        return Unsafe.Add(ref p, i);
+    }
+
+    public static int Main()
+    {
+        float v0 = P(0);
+        float v1 = P(1);
+        float v2 = P(2);
+        float v3 = P(3);
+
+        Console.WriteLine($"v0={v0} v1={v1} v2={v2} v3={v3}");
+        bool ok = (v0 == 5 && v1 == 4 && v2 == 3 && v3 == 2);
+        return (ok ? 100 : 0);
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_3.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_3.csproj
@@ -10,7 +10,6 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_3.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_3.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_16210_3.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
If a byref is passed to a call or used in an assign, assume it escapes and
that subsequent dereferences may be made at arbitrary offsets.

This handles cases where a user takes the address of one field of a struct,
then uses that byref that to access other fields or non-field content within
the struct, and the byref formation and use are split across statements or
across caller-callee contexts.

Closes #16210.