### PR TITLE
[WIP] Speed-up FP Math.Min/Max

### DIFF
--- a/src/mscorlib/shared/System/Double.cs
+++ b/src/mscorlib/shared/System/Double.cs
@@ -69,6 +69,16 @@ namespace System
             return (bits & 0x7FFFFFFFFFFFFFFF) > 0x7FF0000000000000;
         }
 
+        // A faster version of IsNaN. This can throw for signaling NaNs if floating point exceptions are unmasked
+        // so it's not a direct replacement. It can be safely used when the value to check has already been used
+        // in other floating point operations that can also throw (or when throwing an exception is acceptable).
+        internal static bool IsNaNFast(double d)
+        {
+#pragma warning disable 1718 
+            return d != d;
+#pragma warning restore
+        }
+
         /// <summary>Determines whether the specified value is negative.</summary>
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -135,8 +145,8 @@ namespace System
                 if (m_value == d) return 0;
 
                 // At least one of the values is NaN.
-                if (IsNaN(m_value))
-                    return (IsNaN(d) ? 0 : -1);
+                if (IsNaNFast(m_value))
+                    return (IsNaNFast(d) ? 0 : -1);
                 else
                     return 1;
             }
@@ -150,8 +160,8 @@ namespace System
             if (m_value == value) return 0;
 
             // At least one of the values is NaN.
-            if (IsNaN(m_value))
-                return (IsNaN(value) ? 0 : -1);
+            if (IsNaNFast(m_value))
+                return (IsNaNFast(value) ? 0 : -1);
             else
                 return 1;
         }
@@ -170,7 +180,7 @@ namespace System
             {
                 return true;
             }
-            return IsNaN(temp) && IsNaN(m_value);
+            return IsNaNFast(temp) && IsNaNFast(m_value);
         }
 
         [NonVersionable]
@@ -215,7 +225,7 @@ namespace System
             {
                 return true;
             }
-            return IsNaN(obj) && IsNaN(m_value);
+            return IsNaNFast(obj) && IsNaNFast(m_value);
         }
 
         //The hashcode for a double is the absolute value of the integer representation

--- a/src/mscorlib/shared/System/Math.cs
+++ b/src/mscorlib/shared/System/Math.cs
@@ -463,7 +463,7 @@ namespace System
                 return val1;
             }
 
-            if (double.IsNaN(val1))
+            if (double.IsNaNFast(val1))
             {
                 return val1;
             }
@@ -503,7 +503,7 @@ namespace System
                 return val1;
             }
 
-            if (float.IsNaN(val1))
+            if (float.IsNaNFast(val1))
             {
                 return val1;
             }
@@ -551,7 +551,7 @@ namespace System
                 return val1;
             }
 
-            if (double.IsNaN(val1))
+            if (double.IsNaNFast(val1))
             {
                 return val1;
             }
@@ -591,7 +591,7 @@ namespace System
                 return val1;
             }
 
-            if (float.IsNaN(val1))
+            if (float.IsNaNFast(val1))
             {
                 return val1;
             }

--- a/src/mscorlib/shared/System/Single.cs
+++ b/src/mscorlib/shared/System/Single.cs
@@ -65,6 +65,16 @@ namespace System
             return (bits & 0x7FFFFFFF) > 0x7F800000;
         }
 
+        // A faster version of IsNaN. This can throw for signaling NaNs if floating point exceptions are unmasked
+        // so it's not a direct replacement. It can be safely used when the value to check has already been used
+        // in other floating point operations that can also throw (or when throwing an exception is acceptable).
+        internal static bool IsNaNFast(double f)
+        {
+#pragma warning disable 1718 
+            return f != f;
+#pragma warning restore
+        }
+
         /// <summary>Determines whether the specified value is negative.</summary>
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -130,8 +140,8 @@ namespace System
                 if (m_value == f) return 0;
 
                 // At least one of the values is NaN.
-                if (IsNaN(m_value))
-                    return (IsNaN(f) ? 0 : -1);
+                if (IsNaNFast(m_value))
+                    return (IsNaNFast(f) ? 0 : -1);
                 else // f is NaN.
                     return 1;
             }
@@ -146,8 +156,8 @@ namespace System
             if (m_value == value) return 0;
 
             // At least one of the values is NaN.
-            if (IsNaN(m_value))
-                return (IsNaN(value) ? 0 : -1);
+            if (IsNaNFast(m_value))
+                return (IsNaNFast(value) ? 0 : -1);
             else // f is NaN.
                 return 1;
         }
@@ -200,7 +210,7 @@ namespace System
                 return true;
             }
 
-            return IsNaN(temp) && IsNaN(m_value);
+            return IsNaNFast(temp) && IsNaNFast(m_value);
         }
 
         public bool Equals(Single obj)
@@ -210,7 +220,7 @@ namespace System
                 return true;
             }
 
-            return IsNaN(obj) && IsNaN(m_value);
+            return IsNaNFast(obj) && IsNaNFast(m_value);
         }
 
         public unsafe override int GetHashCode()


### PR DESCRIPTION
The current IsNaN implementation is rather inefficient, the same (almost) result can be obtained by simply comparing the number to itself.

Unfortunately, comparing a signaling NaN will raise an exception if floaing point exceptions are unmasked. To avoid breaking existing code this method of testing for NaN can only be used if the tested value was already involved in another floating point operation (as it happens in Min/Max/Equals/CompareTo).