### PR TITLE
Fix JIT.SIMD.VectorUtil.CheckValue<T>

### DIFF
--- a/tests/src/JIT/SIMD/VectorUtil.cs
+++ b/tests/src/JIT/SIMD/VectorUtil.cs
@@ -26,7 +26,14 @@ internal partial class VectorTest
         }
         if (returnVal == false)
         {
-            Console.WriteLine("CheckValue failed for type " + typeof(T).ToString() + ". Expected: {0} (0x{0:X}), Got: {1} (0x{1:X})", expectedValue, value);
+            if ((typeof(T) == typeof(double)) || (typeof(T) == typeof(float)))
+            {
+                Console.WriteLine("CheckValue failed for type " + typeof(T).ToString() + ". Expected: {0} , Got: {1}", expectedValue, value);
+            }
+            else
+            {
+                Console.WriteLine("CheckValue failed for type " + typeof(T).ToString() + ". Expected: {0} (0x{0:X}), Got: {1} (0x{1:X})", expectedValue, value);
+            }
         }
         return returnVal;
     }


### PR DESCRIPTION
CoreCLR is not supporting format `X` for floating point types.  This works around the issue by not trying to use that format.

Fixes #14400

@jkotas Please assign to appropriate reviewer.