### PR TITLE
Remove EOL OSes and add new / missing ones

### DIFF
--- a/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
+++ b/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
@@ -255,7 +255,7 @@
       "value": "linux-x64"
     },
     "TargetQueues": {
-      "value": "debian.82.amd64,fedora.23.amd64,redhat.72.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1610.amd64"
+      "value": "debian.82.amd64,fedora.26.amd64,fedora.27.amd64,redhat.73.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1710.amd64,ubuntu.1804.amd64,opensuse.423.amd64,sles.12.amd64"
     },
     "TestProduct": {
       "value": "coreclr"

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -438,7 +438,7 @@
             "HelixJobType": "test/functional/cli/",
             "TargetsWindows": "false",
             "Rid": "osx-x64",
-            "TargetQueues": "osx.1012.amd64",
+            "TargetQueues": "osx.1012.amd64,osx.1013.amd64",
             "TestContainerSuffix": "osx",
             "TargetsNonWindowsArg": "TargetsNonWindows "
           },
@@ -455,7 +455,7 @@
             "HelixJobType": "test/functional/r2r/cli/",
             "TargetsWindows": "false",
             "Rid": "osx-x64",
-            "TargetQueues": "osx.1012.amd64",
+            "TargetQueues": "osx.1012.amd64,osx.1013.amd64",
             "TestContainerSuffix": "osx-r2r",
             "CrossgenArg": "Crossgen ",
             "TargetsNonWindowsArg": "TargetsNonWindows "
@@ -473,7 +473,7 @@
             "HelixJobType": "test/functional/cli/",
             "TargetsWindows": "false",
             "Rid": "linux-x64",
-            "TargetQueues": "debian.82.amd64,fedora.25.amd64,redhat.72.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1710.amd64",
+            "TargetQueues": "debian.82.amd64,fedora.26.amd64,fedora.27.amd64,redhat.73.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1710.amd64,ubuntu.1804.amd64,opensuse.423.amd64,sles.12.amd64",
             "TestContainerSuffix": "linux",
             "TargetsNonWindowsArg": "TargetsNonWindows "
           },
@@ -490,7 +490,7 @@
             "HelixJobType": "test/functional/r2r/cli/",
             "TargetsWindows": "false",
             "Rid": "linux-x64",
-            "TargetQueues": "debian.82.amd64,fedora.25.amd64,redhat.72.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1710.amd64",
+            "TargetQueues": "debian.82.amd64,fedora.26.amd64,fedora.27.amd64,redhat.73.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1710.amd64,ubuntu.1804.amd64,opensuse.423.amd64,sles.12.amd64",
             "TestContainerSuffix": "linux-r2r",
             "CrossgenArg": "Crossgen ",
             "TargetsNonWindowsArg": "TargetsNonWindows "


### PR DESCRIPTION
@jashook I understand you're on point for this for your team.  SHouldn't be too bad, but ideally you could port these changes to any release branches you guys still run tests from;  starting the 15th, sending work to the EOL linuxes will cause work sent there to instantly fail.

@leecow FYI.

Removals:

Fedora 23
RedHat 7.2
Ubuntu 16.10

Additions:
OSX 10.13
Ubuntu.17.10
Ubuntu 18.04
OpenSuse 42.3
SLES 12