### PR TITLE
[Arm64] Implement managed Short Vector ABI for Vector64<T> Vector128<T>

### DIFF
--- a/Documentation/design-docs/arm64-intrinsics.md
+++ b/Documentation/design-docs/arm64-intrinsics.md
@@ -275,11 +275,30 @@ It is not clear if this is a new LSRA feature and if it is how much complexity t
 
 ## ARM ABI Vector64<T> and Vector128<T>
 
-For intrinsic method calls, these vector types will implicitly be treated as pass by vector register.
+These will conform to the AAPCS ARM64 procedure call standard treatment of `Short Vector` and `HVA` types.
 
-For other calls, ARM64 ABI conventions must be followed.  For purposes of the ABI calling conventions, these vector
-types will treated as composite struct type containing a contiguous array of `T`.  They will need to follow standard
-struct argument and return passing rules.
+`Vector64<T>` will be treated as a `HVA` containing a single 8 byte `Short Vector`
+`Vector128<T>` will be treated as a `HVA` containing a single 16 byte `Short Vector`
+
+Since a `Short Vector` and a single element `HVA` are treated the same by the ABI these should correctly
+interoperate with the native ABI.
+
+### Implementation
+
+Since `HVA` is a highly similar in concept to `HFA`, we will treat an `HVA` as a `HFA` with a `Short Vector` element type.
+
+VM will mark `Vector64<T>` and `Vector128<T>` as `HFA` with `Short Vector` element type.
+
+JIT to EE interface will be extended to pass additional HFA types.  A vector modifier will be aded for these limited use types.
+
+
+| VM HFA Type Name            | Jit HFA Type Name             |
+| --------------------------- | ----------------------------- |
+| `ELEMENT_TYPE_SHORT_VECTOR` | `CORINFO_TYPE_MOD_VECTOR`     |
+| `ELEMENT_TYPE_V8`           | `TYP_SIMD8`                   |
+| `ELEMENT_TYPE_V16`          | `TYP_SIMD16`                  |
+
+JIT will be modified to correctly handle `TYP_SIMD8` & `TYP_SIMD16` as primitive and aggregate argument & return types
 
 ## Half precision floating point
 

--- a/src/inc/corinfo.h
+++ b/src/inc/corinfo.h
@@ -213,11 +213,11 @@ TODO: Talk about initializing strutures before use
     #define SELECTANY extern __declspec(selectany)
 #endif
 
-SELECTANY const GUID JITEEVersionIdentifier = { /* 0ba106c8-81a0-407f-99a1-928448c1eb62 */
-    0x0ba106c8,
-    0x81a0,
-    0x407f,
-    {0x99, 0xa1, 0x92, 0x84, 0x48, 0xc1, 0xeb, 0x62}
+SELECTANY const GUID JITEEVersionIdentifier = { /* ee4d7d71-ae29-42d3-bcd6-43586dafb5d2 */
+    0xee4d7d71,
+    0xae29,
+    0x42d3,
+    {0xbc, 0xd6, 0x43, 0x58, 0x6d, 0xaf, 0xb5, 0xd2}
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -719,6 +719,7 @@ enum CorInfoTypeWithMod
 {
     CORINFO_TYPE_MASK            = 0x3F,        // lower 6 bits are type mask
     CORINFO_TYPE_MOD_PINNED      = 0x40,        // can be applied to CLASS, or BYREF to indiate pinned
+    CORINFO_TYPE_MOD_VECTOR      = 0x80,        // can be applied to FLOAT/DOUBLE to indicate HFA type SIMD8/SIMD16
 };
 
 inline CorInfoType strip(CorInfoTypeWithMod val) {

--- a/src/inc/corpriv.h
+++ b/src/inc/corpriv.h
@@ -262,6 +262,18 @@ typedef enum CorElementTypeZapSig
 
 } CorElementTypeZapSig;
 
+#if defined(_TARGET_ARM64_) || defined(_TARGET_AMD64_) // ARM64 or arm64altjit
+////////////////////////////////////////////////////////////////////////////////
+// Homogeneous Aggregate fundamental types which are not in the ECMA spec
+// Values are only used in GetHFAType() and its clients
+////////////////////////////////////////////////////////////////////////////////
+#define ELEMENT_TYPE_SHORT_VECTOR   0x80
+// 8 byte Short Vector
+#define ELEMENT_TYPE_V8             ((CorElementType) (0x0c | ELEMENT_TYPE_SHORT_VECTOR))
+// 16 byte Short Vector
+#define ELEMENT_TYPE_V16            ((CorElementType) (0x0d | ELEMENT_TYPE_SHORT_VECTOR))
+#endif // defined(_TARGET_ARM64_) || defined(_TARGET_AMD64_)
+
 typedef enum CorCallingConventionInternal
 {
     // IL stub signatures containing types that need to be restored have the highest

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2342,7 +2342,11 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
     }
     else
     {
+#if defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
+        assert(!varTypeIsStruct(call) || varTypeIsSIMD(call));
+#else  // defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
         assert(!varTypeIsStruct(call));
+#endif // defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
 
         if (call->gtType == TYP_REF)
         {
@@ -2497,7 +2501,11 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
             }
             else
 #endif // _TARGET_ARM_
-                if (varTypeIsFloating(returnType) && !compiler->opts.compUseSoftFP)
+#if defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
+                if ((varTypeIsFloating(returnType) && !compiler->opts.compUseSoftFP) || varTypeIsSIMD(returnType))
+#else  // defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
+            if ((varTypeIsFloating(returnType) && !compiler->opts.compUseSoftFP))
+#endif // defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
             {
                 returnReg = REG_FLOATRET;
             }
@@ -3651,7 +3659,11 @@ bool CodeGen::isStructReturn(GenTree* treeNode)
     // a bool or a void, for the end of a finally block.
     noway_assert(treeNode->OperGet() == GT_RETURN || treeNode->OperGet() == GT_RETFILT);
 
+#if defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
+    return (treeNode->TypeGet() == TYP_STRUCT);
+#else  // defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
     return varTypeIsStruct(treeNode);
+#endif // defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -2056,7 +2056,11 @@ inline void LclVarDsc::incRefCnts(BasicBlock::weight_t weight, Compiler* comp, b
 inline void LclVarDsc::setPrefReg(regNumber regNum, Compiler* comp)
 {
     regMaskTP regMask;
+#if defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
+    if (isFloatRegType(TypeGet()) || varTypeIsSIMD(TypeGet()))
+#else  // defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
     if (isFloatRegType(TypeGet()))
+#endif // defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
     {
         // Check for FP struct-promoted field being passed in integer register
         //
@@ -3352,7 +3356,11 @@ inline regNumber genMapFloatRegArgNumToRegNum(unsigned argNum)
 
 __forceinline regNumber genMapRegArgNumToRegNum(unsigned argNum, var_types type)
 {
+#if defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
+    if (varTypeIsFloating(type) || varTypeIsSIMD(type))
+#else  // defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
     if (varTypeIsFloating(type))
+#endif // defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
     {
         return genMapFloatRegArgNumToRegNum(argNum);
     }
@@ -3390,7 +3398,11 @@ inline regMaskTP genMapFloatRegArgNumToRegMask(unsigned argNum)
 __forceinline regMaskTP genMapArgNumToRegMask(unsigned argNum, var_types type)
 {
     regMaskTP result;
+#if defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
+    if (varTypeIsFloating(type) || varTypeIsSIMD(type))
+#else  // defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
     if (varTypeIsFloating(type))
+#endif // defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
     {
         result = genMapFloatRegArgNumToRegMask(argNum);
 #ifdef _TARGET_ARM_
@@ -3509,7 +3521,11 @@ inline unsigned genMapFloatRegNumToRegArgNum(regNumber regNum)
 
 inline unsigned genMapRegNumToRegArgNum(regNumber regNum, var_types type)
 {
+#if defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
+    if (varTypeIsFloating(type) || varTypeIsSIMD(type))
+#else  // defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
     if (varTypeIsFloating(type))
+#endif // defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
     {
         return genMapFloatRegNumToRegArgNum(regNum);
     }

--- a/src/jit/ee_il_dll.cpp
+++ b/src/jit/ee_il_dll.cpp
@@ -473,8 +473,9 @@ unsigned Compiler::eeGetArgSize(CORINFO_ARG_LIST_HANDLE list, CORINFO_SIG_INFO* 
             // Is the struct larger than 16 bytes
             if (structSize > (2 * TARGET_POINTER_SIZE))
             {
-                var_types hfaType = GetHfaType(argClass); // set to float or double if it is an HFA, otherwise TYP_UNDEF
-                bool      isHfa   = (hfaType != TYP_UNDEF);
+                var_types hfaType =
+                    GetHfaType(argClass); // set to float, double, or SIMD* if it is an HFA, otherwise TYP_UNDEF
+                bool isHfa = (hfaType != TYP_UNDEF);
                 if (!isHfa)
                 {
                     // This struct is passed by reference using a single 'slot'

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -8407,20 +8407,24 @@ private:
             unsigned returnLocalNum   = comp->lvaGrabTemp(true DEBUGARG("Single return block return value"));
             comp->genReturnLocal      = returnLocalNum;
             LclVarDsc& returnLocalDsc = comp->lvaTable[returnLocalNum];
+            var_types  returnType     = TYP_UNKNOWN;
 
             if (comp->compMethodReturnsNativeScalarType())
             {
                 returnLocalDsc.lvType = genActualType(comp->info.compRetNativeType);
+                returnType            = returnLocalDsc.lvType;
             }
             else if (comp->compMethodReturnsRetBufAddr())
             {
                 returnLocalDsc.lvType = TYP_BYREF;
+                returnType            = returnLocalDsc.lvType;
             }
             else if (comp->compMethodReturnsMultiRegRetType())
             {
                 returnLocalDsc.lvType = TYP_STRUCT;
                 comp->lvaSetStruct(returnLocalNum, comp->info.compMethodInfo->args.retTypeClass, true);
                 returnLocalDsc.lvIsMultiRegRet = true;
+                returnType                     = TYP_STRUCT;
             }
             else
             {
@@ -8453,7 +8457,7 @@ private:
 
             // make sure copy prop ignores this node (make sure it always does a reload from the temp).
             retTemp->gtFlags |= GTF_DONT_CSE;
-            returnExpr = comp->gtNewOperNode(GT_RETURN, retTemp->gtType, retTemp);
+            returnExpr = comp->gtNewOperNode(GT_RETURN, returnType, retTemp);
         }
         else
         {

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -3770,7 +3770,7 @@ struct GenTreeCall final : public GenTree
         // LEGACY_BACKEND does not use multi reg returns for calls with long return types
         return varTypeIsLong(gtType) || (varTypeIsStruct(gtType) && !HasRetBufArg());
 #elif FEATURE_MULTIREG_RET
-        return varTypeIsStruct(gtType) && !HasRetBufArg();
+        return (gtType == TYP_STRUCT) && !HasRetBufArg();
 #else
         return false;
 #endif

--- a/src/jit/hwintrinsicArm64.cpp
+++ b/src/jit/hwintrinsicArm64.cpp
@@ -183,7 +183,8 @@ GenTree* Compiler::impHWIntrinsic(NamedIntrinsic        intrinsic,
     {
         simdBaseType = getBaseTypeAndSizeOfSIMDType(simdClass, &simdSizeBytes);
 
-        if (simdBaseType == TYP_UNKNOWN)
+        assert(simdBaseType != TYP_UNKNOWN);
+        if (simdBaseType == TYP_UNDEF)
         {
             return impUnsupportedHWIntrinsic(CORINFO_HELP_THROW_TYPE_NOT_SUPPORTED, method, sig, mustExpand);
         }

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -252,7 +252,7 @@ void LinearScan::BuildCall(GenTreeCall* call)
         assert(retTypeDesc != nullptr);
         info->setDstCandidates(this, retTypeDesc->GetABIReturnRegs());
     }
-    else if (varTypeIsFloating(registerType))
+    else if (varTypeIsFloating(registerType) || varTypeIsSIMD(registerType))
     {
         info->setDstCandidates(this, RBM_FLOATRET);
     }

--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -2991,7 +2991,7 @@ void LinearScan::BuildReturn(GenTree* tree)
         info->srcCount = 1;
 
 #if FEATURE_MULTIREG_RET
-        if (varTypeIsStruct(tree))
+        if (tree->TypeGet() == TYP_STRUCT)
         {
             // op1 has to be either an lclvar or a multi-reg returning call
             if (op1->OperGet() != GT_LCL_VAR)
@@ -3012,6 +3012,12 @@ void LinearScan::BuildReturn(GenTree* tree)
                 case TYP_VOID:
                     useCandidates = RBM_NONE;
                     break;
+#if defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
+                case TYP_SIMD8:
+                case TYP_SIMD16:
+                    useCandidates = RBM_FLOATRET;
+                    break;
+#endif // defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
                 case TYP_FLOAT:
                     useCandidates = RBM_FLOATRET;
                     break;

--- a/src/jit/regalloc.cpp
+++ b/src/jit/regalloc.cpp
@@ -1231,6 +1231,10 @@ regMaskTP Compiler::rpPredictRegPick(var_types type, rpPredictReg predictReg, re
 
         case TYP_FLOAT:
         case TYP_DOUBLE:
+#if defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
+        case TYP_SIMD8:
+        case TYP_SIMD16:
+#endif // defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
 
 #if FEATURE_FP_REGALLOC
             regMaskTP restrictMask;

--- a/src/jit/register_arg_convention.h
+++ b/src/jit/register_arg_convention.h
@@ -56,7 +56,11 @@ public:
     // return ref to current register arg for this type
     unsigned& regArgNum(var_types type)
     {
+#if defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
+        return (varTypeIsFloating(type) || varTypeIsSIMD(type)) ? floatRegArgNum : intRegArgNum;
+#else  // defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
         return varTypeIsFloating(type) ? floatRegArgNum : intRegArgNum;
+#endif // defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
     }
 
     // Allocate a set of contiguous argument registers. "type" is either an integer
@@ -106,7 +110,11 @@ private:
     // return max register arg for this type
     unsigned maxRegArgNum(var_types type)
     {
+#if defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
+        return (varTypeIsFloating(type) || varTypeIsSIMD(type)) ? maxFloatRegArgNum : maxIntRegArgNum;
+#else  // defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
         return varTypeIsFloating(type) ? maxFloatRegArgNum : maxIntRegArgNum;
+#endif // defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
     }
 
     bool enoughAvailRegs(var_types type, unsigned numRegs = 1);

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -1011,6 +1011,13 @@ void CodeGen::psiBegProlog()
                 {
                     regType = lclVarDsc1->GetHfaType();
                 }
+#if defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
+                else if (varTypeIsStruct(regType))
+                {
+                    // Non HFA structs are passed in integer register
+                    regType = TYP_I_IMPL;
+                }
+#endif // defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
                 assert(genMapRegNumToRegArgNum(lclVarDsc1->lvArgReg, regType) != (unsigned)-1);
 #endif // DEBUG
 

--- a/src/jit/simd.cpp
+++ b/src/jit/simd.cpp
@@ -654,6 +654,10 @@ var_types Compiler::getBaseTypeAndSizeOfSIMDType(CORINFO_CLASS_HANDLE typeHnd, u
                             break;
 
                         default:
+#if defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
+                            // Vector128`1 is a HFA Short Vector Type even when base type is bogus
+                            simdBaseType = TYP_UNDEF;
+#endif // defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
                             JITDUMP("  Unknown Hardware Intrinsic SIMD Type Vector128<T>\n");
                     }
                 }
@@ -700,6 +704,10 @@ var_types Compiler::getBaseTypeAndSizeOfSIMDType(CORINFO_CLASS_HANDLE typeHnd, u
                             break;
 
                         default:
+#if defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
+                            // Vector64`1 is a HFA Short Vector Type even when base type is bogus
+                            simdBaseType = TYP_UNDEF;
+#endif // defined(FEATURE_HW_INTRINSICS) && defined(_TARGET_ARM64_)
                             JITDUMP("  Unknown Hardware Intrinsic SIMD Type Vector64<T>\n");
                     }
                 }

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -1552,8 +1552,13 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define FEATURE_MULTIREG_ARGS         1  // Support for passing a single argument in more than one register  
   #define FEATURE_MULTIREG_RET          1  // Support for returning a single value in more than one register  
   #define FEATURE_STRUCT_CLASSIFIER     0  // Uses a classifier function to determine is structs are passed/returned in more than one register
+#if defined(FEATURE_HW_INTRINSICS)
+  #define MAX_PASS_MULTIREG_BYTES      64  // Maximum size of a struct that could be passed in more than one register (max is 4 SIMD16 using an HFA)
+  #define MAX_RET_MULTIREG_BYTES       64  // Maximum size of a struct that could be returned in more than one register (Max is an HFA of 4 SIMD16)
+#else  // defined(FEATURE_HW_INTRINSICS)
   #define MAX_PASS_MULTIREG_BYTES      32  // Maximum size of a struct that could be passed in more than one register (max is 4 doubles using an HFA)
   #define MAX_RET_MULTIREG_BYTES       32  // Maximum size of a struct that could be returned in more than one register (Max is an HFA of 4 doubles)
+#endif // defined(FEATURE_HW_INTRINSICS)
   #define MAX_ARG_REG_COUNT             4  // Maximum registers used to pass a single argument in multiple registers. (max is 4 floats or doubles using an HFA)
   #define MAX_RET_REG_COUNT             4  // Maximum registers used to return a value.
 

--- a/src/pal/inc/unixasmmacrosarm64.inc
+++ b/src/pal/inc/unixasmmacrosarm64.inc
@@ -137,14 +137,14 @@ C_FUNC(\Name\()_End):
 // ArgumentRegisters::x2
 // ArgumentRegisters::x1
 // ArgumentRegisters::x0
-// FloatRegisters::d7
-// FloatRegisters::d6
-// FloatRegisters::d5
-// FloatRegisters::d4
-// FloatRegisters::d3
-// FloatRegisters::d2
-// FloatRegisters::d1
-// FloatRegisters::d0
+// FloatRegisters::q7
+// FloatRegisters::q6
+// FloatRegisters::q5
+// FloatRegisters::q4
+// FloatRegisters::q3
+// FloatRegisters::q2
+// FloatRegisters::q1
+// FloatRegisters::q0
 .macro PROLOG_WITH_TRANSITION_BLOCK extraLocals = 0, SaveFPArgs = 1
 
         __PWTB_FloatArgumentRegisters = \extraLocals
@@ -199,13 +199,13 @@ C_FUNC(\Name\()_End):
 
 .endm
 
-// Reserve 64 bytes of memory before calling  SAVE_FLOAT_ARGUMENT_REGISTERS
+// Reserve 128 bytes of memory before calling  SAVE_FLOAT_ARGUMENT_REGISTERS
 .macro SAVE_FLOAT_ARGUMENT_REGISTERS reg, ofs
 
-        stp                    d0, d1, [\reg, #(\ofs)]
-        stp                    d2, d3, [\reg, #(\ofs + 16)]
-        stp                    d4, d5, [\reg, #(\ofs + 32)]
-        stp                    d6, d7, [\reg, #(\ofs + 48)]
+        stp                    q0, q1, [\reg, #(\ofs)]
+        stp                    q2, q3, [\reg, #(\ofs + 32)]
+        stp                    q4, q5, [\reg, #(\ofs + 64)]
+        stp                    q6, q7, [\reg, #(\ofs + 96)]
 
 .endm
 
@@ -221,10 +221,10 @@ C_FUNC(\Name\()_End):
 
 .macro RESTORE_FLOAT_ARGUMENT_REGISTERS reg, ofs
 
-        ldp                    d0, d1, [\reg, #(\ofs)]
-        ldp                    d2, d3, [\reg, #(\ofs + 16)]
-        ldp                    d4, d5, [\reg, #(\ofs + 32)]
-        ldp                    d6, d7, [\reg, #(\ofs + 48)]
+        ldp                    q0, q1, [\reg, #(\ofs)]
+        ldp                    q2, q3, [\reg, #(\ofs + 32)]
+        ldp                    q4, q5, [\reg, #(\ofs + 64)]
+        ldp                    q6, q7, [\reg, #(\ofs + 96)]
 
 .endm
 

--- a/src/vm/argdestination.h
+++ b/src/vm/argdestination.h
@@ -64,24 +64,29 @@ public:
         // enregister each field.
 
         int floatRegCount = m_argLocDescForStructInRegs->m_cFloatReg;
-        bool typeFloat = m_argLocDescForStructInRegs->m_isSinglePrecision;
+        size_t elementSize = m_argLocDescForStructInRegs->m_hfaElementSizeBytes;
         void* dest = this->GetDestinationAddress();
 
-        if (typeFloat)
+        switch (elementSize)
         {
+        case 4:
             for (int i = 0; i < floatRegCount; ++i)
             {
                 // Copy 4 bytes on 16 bytes alignment
                 *((UINT64*)dest + 2*i) = *((UINT32*)src + i);
             }
-        }
-        else
-        {
+            break;
+        case 8:
             for (int i = 0; i < floatRegCount; ++i)
             {
                 // Copy 8 bytes on 16 bytes alignment
                 *((UINT64*)dest + 2*i) = *((UINT64*)src + i);
             }
+            break;
+        case 16:
+            // We can just do a memcpy.
+            memcpyNoGCRefs(dest, src, fieldBytes);
+            break;
         }
     }
 

--- a/src/vm/argdestination.h
+++ b/src/vm/argdestination.h
@@ -69,16 +69,19 @@ public:
 
         if (typeFloat)
         {
-            for (int i = 0; i < floatRegCount; ++i) 
+            for (int i = 0; i < floatRegCount; ++i)
             {
-                // Copy 4 bytes on 8 bytes alignment
-                *((UINT64*)dest + i) = *((UINT32*)src + i);
+                // Copy 4 bytes on 16 bytes alignment
+                *((UINT64*)dest + 2*i) = *((UINT32*)src + i);
             }
         }
         else
         {
-            // We can just do a memcpy.
-            memcpyNoGCRefs(dest, src, fieldBytes);
+            for (int i = 0; i < floatRegCount; ++i)
+            {
+                // Copy 8 bytes on 16 bytes alignment
+                *((UINT64*)dest + 2*i) = *((UINT64*)src + i);
+            }
         }
     }
 

--- a/src/vm/arm64/CallDescrWorkerARM64.asm
+++ b/src/vm/arm64/CallDescrWorkerARM64.asm
@@ -56,10 +56,10 @@ Ldonestack
         ;; given in x9. 
         ldr     x9, [x19,#CallDescrData__pFloatArgumentRegisters]
         cbz     x9, LNoFloatingPoint
-        ldp     d0, d1, [x9]
-        ldp     d2, d3, [x9, #16]
-        ldp     d4, d5, [x9, #32]
-        ldp     d6, d7, [x9, #48]
+        ldp     q0, q1, [x9]
+        ldp     q2, q3, [x9, #32]
+        ldp     q4, q5, [x9, #64]
+        ldp     q6, q7, [x9, #96]
 LNoFloatingPoint
 
         ;; Copy [pArgumentRegisters, ..., pArgumentRegisters + 64]

--- a/src/vm/arm64/asmconstants.h
+++ b/src/vm/arm64/asmconstants.h
@@ -58,7 +58,7 @@ ASMCONSTANTS_C_ASSERT(AppDomain__m_dwId == offsetof(AppDomain, m_dwId));
 #define SIZEOF__ArgumentRegisters 0x48
 ASMCONSTANTS_C_ASSERT(SIZEOF__ArgumentRegisters == sizeof(ArgumentRegisters))
 
-#define SIZEOF__FloatArgumentRegisters 0x40
+#define SIZEOF__FloatArgumentRegisters 0x80
 ASMCONSTANTS_C_ASSERT(SIZEOF__FloatArgumentRegisters == sizeof(FloatArgumentRegisters))
 
 #define CallDescrData__pSrc                0x00

--- a/src/vm/arm64/asmhelpers.S
+++ b/src/vm/arm64/asmhelpers.S
@@ -121,18 +121,18 @@ LEAF_END HelperMethodFrameRestoreState, _TEXT
 // The call in ndirect import precode points to this function.
 NESTED_ENTRY NDirectImportThunk, _TEXT, NoHandler
 
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -160
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -224
     SAVE_ARGUMENT_REGISTERS sp, 16
-    SAVE_FLOAT_ARGUMENT_REGISTERS sp, 88
+    SAVE_FLOAT_ARGUMENT_REGISTERS sp, 96
 
     mov x0, x12
     bl NDirectImportWorker
     mov x12, x0
 
     // pop the stack and restore original register state
-    RESTORE_FLOAT_ARGUMENT_REGISTERS sp, 88
+    RESTORE_FLOAT_ARGUMENT_REGISTERS sp, 96
     RESTORE_ARGUMENT_REGISTERS sp, 16
-    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 160
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 224
 
     // If we got back from NDirectImportWorker, the MD has been successfully
     // linked. Proceed to execute the original DLL call.
@@ -481,9 +481,9 @@ WRITE_BARRIER_END JIT_WriteBarrier
 NESTED_ENTRY VirtualMethodFixupStub, _TEXT, NoHandler
 
     // Save arguments and return address
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -160
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -224
     SAVE_ARGUMENT_REGISTERS sp, 16
-    SAVE_FLOAT_ARGUMENT_REGISTERS sp, 88
+    SAVE_FLOAT_ARGUMENT_REGISTERS sp, 96
 
     // Refer to ZapImportVirtualThunk::Save
     // for details on this.
@@ -500,8 +500,8 @@ NESTED_ENTRY VirtualMethodFixupStub, _TEXT, NoHandler
 
     // pop the stack and restore original register state
     RESTORE_ARGUMENT_REGISTERS sp, 16
-    RESTORE_FLOAT_ARGUMENT_REGISTERS sp, 88
-    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 160
+    RESTORE_FLOAT_ARGUMENT_REGISTERS sp, 96
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 224
 
     PATCH_LABEL VirtualMethodFixupPatchLabel
 
@@ -711,9 +711,9 @@ COMToCLRDispatchHelper_RegSetup
 NESTED_ENTRY TheUMEntryPrestub, _TEXT, UnhandledExceptionHandlerUnix
 
     // Save arguments and return address
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -160
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -224
     SAVE_ARGUMENT_REGISTERS sp, 16
-    SAVE_FLOAT_ARGUMENT_REGISTERS sp, 88
+    SAVE_FLOAT_ARGUMENT_REGISTERS sp, 96
 
     mov x0, x12
     bl C_FUNC(TheUMEntryPrestubWorker)
@@ -723,8 +723,8 @@ NESTED_ENTRY TheUMEntryPrestub, _TEXT, UnhandledExceptionHandlerUnix
 
     // pop the stack and restore original register state
     RESTORE_ARGUMENT_REGISTERS sp, 16
-    RESTORE_FLOAT_ARGUMENT_REGISTERS sp, 88
-    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 160
+    RESTORE_FLOAT_ARGUMENT_REGISTERS sp, 96
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 224
 
     // and tailcall to the actual method
     EPILOG_BRANCH_REG x12

--- a/src/vm/arm64/asmhelpers.asm
+++ b/src/vm/arm64/asmhelpers.asm
@@ -182,18 +182,18 @@ Done
 ; The call in ndirect import precode points to this function.
         NESTED_ENTRY NDirectImportThunk
 
-        PROLOG_SAVE_REG_PAIR           fp, lr, #-160!
+        PROLOG_SAVE_REG_PAIR           fp, lr, #-224!
         SAVE_ARGUMENT_REGISTERS        sp, 16
-        SAVE_FLOAT_ARGUMENT_REGISTERS  sp, 88 
+        SAVE_FLOAT_ARGUMENT_REGISTERS  sp, 96
 
         mov     x0, x12
         bl      NDirectImportWorker
         mov     x12, x0
 
         ; pop the stack and restore original register state
-        RESTORE_FLOAT_ARGUMENT_REGISTERS  sp, 88
+        RESTORE_FLOAT_ARGUMENT_REGISTERS  sp, 96
         RESTORE_ARGUMENT_REGISTERS        sp, 16
-        EPILOG_RESTORE_REG_PAIR           fp, lr, #160!
+        EPILOG_RESTORE_REG_PAIR           fp, lr, #224!
 
         ; If we got back from NDirectImportWorker, the MD has been successfully
         ; linked. Proceed to execute the original DLL call.
@@ -435,9 +435,9 @@ Exit
     NESTED_ENTRY VirtualMethodFixupStub
 
     ; Save arguments and return address
-    PROLOG_SAVE_REG_PAIR           fp, lr, #-160!
+    PROLOG_SAVE_REG_PAIR           fp, lr, #-224!
     SAVE_ARGUMENT_REGISTERS        sp, 16
-    SAVE_FLOAT_ARGUMENT_REGISTERS  sp, 88 
+    SAVE_FLOAT_ARGUMENT_REGISTERS  sp, 96
 
     ; Refer to ZapImportVirtualThunk::Save
     ; for details on this.
@@ -454,8 +454,8 @@ Exit
 
     ; pop the stack and restore original register state
     RESTORE_ARGUMENT_REGISTERS        sp, 16
-    RESTORE_FLOAT_ARGUMENT_REGISTERS  sp, 88
-    EPILOG_RESTORE_REG_PAIR           fp, lr, #160!
+    RESTORE_FLOAT_ARGUMENT_REGISTERS  sp, 96
+    EPILOG_RESTORE_REG_PAIR           fp, lr, #224!
 
     PATCH_LABEL VirtualMethodFixupPatchLabel
 
@@ -696,9 +696,9 @@ COMToCLRDispatchHelper_RegSetup
     NESTED_ENTRY TheUMEntryPrestub,,UMEntryPrestubUnwindFrameChainHandler
 
     ; Save arguments and return address
-    PROLOG_SAVE_REG_PAIR           fp, lr, #-160!
+    PROLOG_SAVE_REG_PAIR           fp, lr, #-224!
     SAVE_ARGUMENT_REGISTERS        sp, 16
-    SAVE_FLOAT_ARGUMENT_REGISTERS  sp, 88
+    SAVE_FLOAT_ARGUMENT_REGISTERS  sp, 96
 
     mov x0, x12
     bl  TheUMEntryPrestubWorker
@@ -708,8 +708,8 @@ COMToCLRDispatchHelper_RegSetup
 
     ; pop the stack and restore original register state
     RESTORE_ARGUMENT_REGISTERS        sp, 16
-    RESTORE_FLOAT_ARGUMENT_REGISTERS  sp, 88
-    EPILOG_RESTORE_REG_PAIR           fp, lr, #160!
+    RESTORE_FLOAT_ARGUMENT_REGISTERS  sp, 96
+    EPILOG_RESTORE_REG_PAIR           fp, lr, #224!
 
     ; and tailcall to the actual method
     EPILOG_BRANCH_REG x12

--- a/src/vm/arm64/asmmacros.h
+++ b/src/vm/arm64/asmmacros.h
@@ -179,7 +179,7 @@ __PWTB_SAVE_ARGUMENT_REGISTERS_OFFSET SETA 0
         str                    x8, [$reg, #(__PWTB_SAVE_ARGUMENT_REGISTERS_OFFSET + 64)]
     MEND
 
-; Reserve 64 bytes of memory before calling  SAVE_FLOAT_ARGUMENT_REGISTERS
+; Reserve 128 bytes of memory before calling  SAVE_FLOAT_ARGUMENT_REGISTERS
     MACRO
        SAVE_FLOAT_ARGUMENT_REGISTERS $reg, $offset 
 
@@ -191,10 +191,10 @@ __PWTB_SAVE_FLOAT_ARGUMENT_REGISTERS_OFFSET SETA $offset
 __PWTB_SAVE_FLOAT_ARGUMENT_REGISTERS_OFFSET SETA 0
        ENDIF
 
-        stp                    d0, d1, [$reg, #(__PWTB_SAVE_FLOAT_ARGUMENT_REGISTERS_OFFSET)]
-        stp                    d2, d3, [$reg, #(__PWTB_SAVE_FLOAT_ARGUMENT_REGISTERS_OFFSET + 16)]
-        stp                    d4, d5, [$reg, #(__PWTB_SAVE_FLOAT_ARGUMENT_REGISTERS_OFFSET + 32)]
-        stp                    d6, d7, [$reg, #(__PWTB_SAVE_FLOAT_ARGUMENT_REGISTERS_OFFSET + 48)]
+        stp                    q0, q1, [$reg, #(__PWTB_SAVE_FLOAT_ARGUMENT_REGISTERS_OFFSET)]
+        stp                    q2, q3, [$reg, #(__PWTB_SAVE_FLOAT_ARGUMENT_REGISTERS_OFFSET + 32)]
+        stp                    q4, q5, [$reg, #(__PWTB_SAVE_FLOAT_ARGUMENT_REGISTERS_OFFSET + 64)]
+        stp                    q6, q7, [$reg, #(__PWTB_SAVE_FLOAT_ARGUMENT_REGISTERS_OFFSET + 96)]
     MEND
 
     MACRO
@@ -226,10 +226,10 @@ __PWTB_RESTORE_FLOAT_ARGUMENT_REGISTERS_OFFSET SETA $offset
 __PWTB_RESTORE_FLOAT_ARGUMENT_REGISTERS_OFFSET SETA 0
        ENDIF
 
-        ldp                    d0, d1, [$reg, #(__PWTB_RESTORE_FLOAT_ARGUMENT_REGISTERS_OFFSET)]
-        ldp                    d2, d3, [$reg, #(__PWTB_RESTORE_FLOAT_ARGUMENT_REGISTERS_OFFSET + 16)]
-        ldp                    d4, d5, [$reg, #(__PWTB_RESTORE_FLOAT_ARGUMENT_REGISTERS_OFFSET + 32)]
-        ldp                    d6, d7, [$reg, #(__PWTB_RESTORE_FLOAT_ARGUMENT_REGISTERS_OFFSET + 48)]
+        ldp                    q0, q1, [$reg, #(__PWTB_RESTORE_FLOAT_ARGUMENT_REGISTERS_OFFSET)]
+        ldp                    q2, q3, [$reg, #(__PWTB_RESTORE_FLOAT_ARGUMENT_REGISTERS_OFFSET + 32)]
+        ldp                    q4, q5, [$reg, #(__PWTB_RESTORE_FLOAT_ARGUMENT_REGISTERS_OFFSET + 64)]
+        ldp                    q6, q7, [$reg, #(__PWTB_RESTORE_FLOAT_ARGUMENT_REGISTERS_OFFSET + 96)]
     MEND
 
 ; ------------------------------------------------------------------

--- a/src/vm/arm64/calldescrworkerarm64.S
+++ b/src/vm/arm64/calldescrworkerarm64.S
@@ -48,10 +48,10 @@ LOCAL_LABEL(donestack):
     // given in x8. 
     ldr     x9, [x19,#CallDescrData__pFloatArgumentRegisters]
     cbz     x9, LOCAL_LABEL(NoFloatingPoint)
-    ldp     d0, d1, [x9]
-    ldp     d2, d3, [x9, #16]
-    ldp     d4, d5, [x9, #32]
-    ldp     d6, d7, [x9, #48]
+    ldp     q0, q1, [x9]
+    ldp     q2, q3, [x9, #32]
+    ldp     q4, q5, [x9, #64]
+    ldp     q6, q7, [x9, #96]
 LOCAL_LABEL(NoFloatingPoint):
 
     // Copy [pArgumentRegisters, ..., pArgumentRegisters + 56]

--- a/src/vm/arm64/cgencpu.h
+++ b/src/vm/arm64/cgencpu.h
@@ -135,10 +135,11 @@ typedef DPTR(struct FloatArgumentRegisters) PTR_FloatArgumentRegisters;
 struct FloatArgumentRegisters {
     // armV8 supports 32 floating point registers. Each register is 128bits long.
     // It can be accessed as 128-bit value or 64-bit value(d0-d31) or as 32-bit value (s0-s31)
-    // or as 16-bit value or as 8-bit values. C# only has two builtin floating datatypes float(32-bit) and 
-    // double(64-bit). It does not have a quad-precision floating point.So therefore it does not make sense to
-    // store full 128-bit values in Frame when the upper 64 bit will not contain any values.
-    double  d[8];  // d0-d7
+    // or as 16-bit value or as 8-bit values.
+    // C# only has two builtin floating datatypes float(32-bit) and double(64-bit).
+    // It does not have a quad-precision floating point.
+    // However HW Intrinsics support using the full 128-bit value for passing Vectors.
+    double  qAsDouble[16];  // q0-q7
 };
 
 

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -9711,8 +9711,21 @@ CorInfoType CEEInfo::getHFAType(CORINFO_CLASS_HANDLE hClass)
 
     TypeHandle VMClsHnd(hClass);
 
-    result = asCorInfoType(VMClsHnd.GetHFAType());
-    
+    CorElementType hfaType = VMClsHnd.GetHFAType();
+
+#if defined(_TARGET_ARM64_) || defined(_TARGET_AMD64_) // ARM64 or arm64altjit
+    auto isVector =  hfaType & ELEMENT_TYPE_SHORT_VECTOR;
+    CorElementType hfaMaskedType = (CorElementType)(hfaType & ~ELEMENT_TYPE_SHORT_VECTOR);
+
+    result = asCorInfoType(hfaMaskedType);
+
+    if (isVector)
+    {
+        result = (CorInfoType)(result | CORINFO_TYPE_MOD_VECTOR);
+    }
+#else // defined(_TARGET_ARM64_) || defined(_TARGET_AMD64_)
+    result = asCorInfoType(hfaType);
+#endif // defined(_TARGET_ARM64_) || defined(_TARGET_AMD64_)
     EE_TO_JIT_TRANSITION();
 
     return result;

--- a/tests/src/JIT/HardwareIntrinsics/Arm64/Simd.cs
+++ b/tests/src/JIT/HardwareIntrinsics/Arm64/Simd.cs
@@ -3,9 +3,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
 using System.Runtime.Intrinsics.Arm.Arm64;
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
 
 namespace Arm64intrisicsTest
 {
@@ -448,7 +446,6 @@ namespace Arm64intrisicsTest
 
         static void TestAbs()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "Abs";
 
             if (Simd.IsSupported)
@@ -479,12 +476,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestAdd()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "Add";
 
             if (Simd.IsSupported)
@@ -538,12 +533,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestAnd()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "And";
 
             if (Simd.IsSupported)
@@ -597,12 +590,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestAndNot()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "AndNot";
 
             if (Simd.IsSupported)
@@ -656,12 +647,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestBitwiseSelect()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "BitwiseSelect";
 
             if (Simd.IsSupported)
@@ -715,12 +704,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestCompareEqual()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "CompareEqual";
 
             if (Simd.IsSupported)
@@ -774,12 +761,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestCompareEqualZero()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "CompareEqualZero";
 
             if (Simd.IsSupported)
@@ -833,12 +818,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestCompareGreaterThan()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "CompareGreaterThan";
 
             if (Simd.IsSupported)
@@ -892,12 +875,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestCompareGreaterThanZero()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "CompareGreaterThanZero";
 
             if (Simd.IsSupported)
@@ -951,12 +932,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestCompareGreaterThanOrEqual()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "CompareGreaterThanOrEqual";
 
             if (Simd.IsSupported)
@@ -1010,12 +989,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestCompareGreaterThanOrEqualZero()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "CompareGreaterThanOrEqualZero";
 
             if (Simd.IsSupported)
@@ -1069,12 +1046,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestCompareLessThanZero()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "CompareLessThanZero";
 
             if (Simd.IsSupported)
@@ -1128,12 +1103,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestCompareLessThanOrEqualZero()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "CompareLessThanOrEqualZero";
 
             if (Simd.IsSupported)
@@ -1187,12 +1160,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestCompareTest()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "CompareTest";
 
             if (Simd.IsSupported)
@@ -1246,12 +1217,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestDivide()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "Divide";
 
             if (Simd.IsSupported)
@@ -1268,10 +1237,8 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
         static T simdExtract<T>(Vector64<T> vector, byte index)
             where T : struct
@@ -1285,11 +1252,9 @@ namespace Arm64intrisicsTest
         {
             return Simd.Extract<T>(vector, index);
         }
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
 
         static void TestExtract()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "Extract";
 
             if (Simd.IsSupported)
@@ -1536,12 +1501,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestInsert()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "Insert";
 
             if (Simd.IsSupported)
@@ -1630,12 +1593,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestLeadingSignCount()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "LeadingSignCount";
 
             if (Simd.IsSupported)
@@ -1658,12 +1619,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestLeadingZeroCount()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "LeadingZeroCount";
 
             if (Simd.IsSupported)
@@ -1698,12 +1657,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestMax()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "Max";
 
             if (Simd.IsSupported)
@@ -1744,12 +1701,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestMin()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "Min";
 
             if (Simd.IsSupported)
@@ -1790,12 +1745,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestMultiply()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "Multiply";
 
             if (Simd.IsSupported)
@@ -1836,12 +1789,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestNegate()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "Negate";
 
             if (Simd.IsSupported)
@@ -1872,12 +1823,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestNot()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "Not";
 
             if (Simd.IsSupported)
@@ -1931,12 +1880,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestOr()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "Or";
 
             if (Simd.IsSupported)
@@ -1990,12 +1937,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestOrNot()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "OrNot";
 
             if (Simd.IsSupported)
@@ -2049,12 +1994,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestPopCount()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "PopCount";
 
             if (Simd.IsSupported)
@@ -2073,12 +2016,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestSetAllVector()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "SetAllVector";
 
             if (Simd.IsSupported)
@@ -2133,12 +2074,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestSqrt()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "Sqrt";
 
             if (Simd.IsSupported)
@@ -2155,12 +2094,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestSubtract()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "Subtract";
 
             if (Simd.IsSupported)
@@ -2215,12 +2152,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void TestXor()
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             String name = "Xor";
 
             if (Simd.IsSupported)
@@ -2274,7 +2209,6 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
         }
 
         static void initializeDataSetDefault()
@@ -2360,7 +2294,6 @@ namespace Arm64intrisicsTest
 
         static int Main(string[] args)
         {
-#if ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
             Console.WriteLine($"System.Runtime.Intrinsics.Arm.Arm64.Simd.IsSupported = {Simd.IsSupported}");
 
             // Reflection call
@@ -2368,7 +2301,6 @@ namespace Arm64intrisicsTest
             bool reflectedIsSupported = Convert.ToBoolean(typeof(Simd).GetMethod(issupported).Invoke(null, null));
 
             Debug.Assert(reflectedIsSupported == Simd.IsSupported, "Reflection result does not match");
-#endif // ARM64_SIMD_API_PENDING_APPROVAL_AND_OR_COREFX_MERGE
 
             initializeDataSetDefault();
 


### PR DESCRIPTION
This change implements changes necessary to support `Vector64<T>` `Vector128<T>` as Homogeneous Vector Aggregate (`HVA`) types each containing a single `Short Vector`.

It should also implement most of the change necessary to also handle multiple element `HVA`  in managed code.  I actually believe the functional implementation is complete.  Lacking test coverage it is difficult to confirm this also works.  I will write a test shortly.

This change is fairly extensive.  I would appreciate an early review.

Current status:
+ All Arm64 tests are passing with this change except one test is failing in `LinearScan::checkLastUses()` (debugging now) 
+ Need comments regarding use of `#ifdef`.  
    + I am tempted to add a `FEATURE_ARM64_HVA_ABI`
    + I added `#ifdef` in most places even when it felt like the code should be common
+ Need comments related to VM to JIT interface
   + I probably need to change the GUID
+ Need comments relative to whether this should be done.  
  + For Arm64 if we plan to do this, now would be good.  I have spent 6 days writing and debugging this so far.  I would hate to scrap it and then have to redo the work in 6 months.
+ Need comments about skipping treating types as a struct containing a Short Vector.  
  + It feels natural to me, but it was not the original plan

Fixes #14371
Fixes #16021
Prepares to fix #16022

@janvorli @jkotas @RussKeldorph @CarolEidt @tannergooding PTAL
@dotnet/jit-contrib @dotnet/arm64-contrib FYI