### PR TITLE
Removing the colon block that tosses out paths that are not device path.

### DIFF
--- a/src/mscorlib/shared/System/IO/Path.Windows.cs
+++ b/src/mscorlib/shared/System/IO/Path.Windows.cs
@@ -51,38 +51,11 @@ namespace System.IO
                 return path;
             }
 
-            bool isDevice = PathInternal.IsDevice(path);
-            if (!isDevice)
-            {
-                // Toss out paths with colons that aren't a valid drive specifier.
-                // Cannot start with a colon and can only be of the form "C:".
-                // (Note that we used to explicitly check "http:" and "file:"- these are caught by this check now.)
-                int startIndex = PathInternal.PathStartSkip(path);
-
-                // Move past the colon
-                startIndex += 2;
-
-                if ((path.Length > 0 && path[0] == PathInternal.VolumeSeparatorChar)
-                    || (path.Length >= startIndex && path[startIndex - 1] == PathInternal.VolumeSeparatorChar && !PathInternal.IsValidDriveChar(path[startIndex - 2]))
-                    || (path.Length > startIndex && path.IndexOf(PathInternal.VolumeSeparatorChar, startIndex) != -1))
-                {
-                    throw new NotSupportedException(SR.Format(SR.Argument_PathFormatNotSupported_Path, path));
-                }
-            }
-
             // Technically this doesn't matter but we used to throw for this case
             if (PathInternal.IsEffectivelyEmpty(path))
                 throw new ArgumentException(SR.Arg_PathEmpty, nameof(path));
 
-            // We don't want to check invalid characters for device format- see comments for extended above
-            string fullPath = PathHelper.Normalize(path, checkInvalidCharacters: !isDevice, expandShortPaths: true);
-
-            if (!isDevice)
-            {
-                // Emulate FileIOPermissions checks, retained for compatibility (normal invalid characters have already been checked)
-                if (PathInternal.HasWildCardCharacters(fullPath))
-                    throw new ArgumentException(SR.Argument_InvalidPathChars, nameof(path));
-            }
+            string fullPath = PathHelper.Normalize(path, checkInvalidCharacters: false, expandShortPaths: true);
 
             return fullPath;
         }

--- a/src/mscorlib/shared/System/IO/Path.Windows.cs
+++ b/src/mscorlib/shared/System/IO/Path.Windows.cs
@@ -54,10 +54,8 @@ namespace System.IO
             // Technically this doesn't matter but we used to throw for this case
             if (PathInternal.IsEffectivelyEmpty(path))
                 throw new ArgumentException(SR.Arg_PathEmpty, nameof(path));
-
-            string fullPath = PathHelper.Normalize(path, checkInvalidCharacters: false, expandShortPaths: true);
-
-            return fullPath;
+            
+            return PathHelper.Normalize(path);
         }
 
         public static string GetFullPath(string path, string basePath)

--- a/src/mscorlib/shared/System/IO/PathHelper.Windows.cs
+++ b/src/mscorlib/shared/System/IO/PathHelper.Windows.cs
@@ -29,8 +29,6 @@ namespace System.IO
         /// Note that invalid characters will be checked after the path is normalized, which could remove bad characters. (C:\|\..\a.txt -- C:\a.txt)
         /// </remarks>
         /// <param name="path">Path to normalize</param>
-        /// <param name="checkInvalidCharacters">True to check for invalid characters</param>
-        /// <param name="expandShortPaths">Attempt to expand short paths if true</param>
         /// <exception cref="ArgumentException">Thrown if the path is an illegal UNC (does not contain a full server/share) or contains illegal characters.</exception>
         /// <exception cref="PathTooLongException">Thrown if the path or a path segment exceeds the filesystem limits.</exception>
         /// <exception cref="FileNotFoundException">Thrown if Windows returns ERROR_FILE_NOT_FOUND. (See Win32Marshal.GetExceptionForWin32Error)</exception>
@@ -38,7 +36,7 @@ namespace System.IO
         /// <exception cref="UnauthorizedAccessException">Thrown if Windows returns ERROR_ACCESS_DENIED. (See Win32Marshal.GetExceptionForWin32Error)</exception>
         /// <exception cref="IOException">Thrown if Windows returns an error that doesn't map to the above. (See Win32Marshal.GetExceptionForWin32Error)</exception>
         /// <returns>Normalized path</returns>
-        internal static string Normalize(string path, bool checkInvalidCharacters, bool expandShortPaths)
+        internal static string Normalize(string path)
         {
             // Get the full path
             StringBuffer fullPath = new StringBuffer(PathInternal.MaxShortPath);
@@ -90,7 +88,6 @@ namespace System.IO
                             case '>':
                             case '<':
                             case '\"':
-                                if (checkInvalidCharacters) throw new ArgumentException(SR.Argument_InvalidPathChars);
                                 foundTilde = false;
                                 break;
                             case '~':
@@ -124,7 +121,6 @@ namespace System.IO
                                 break;
 
                             default:
-                                if (checkInvalidCharacters && current < ' ') throw new ArgumentException(SR.Argument_InvalidPathChars, nameof(path));
                                 break;
                         }
                     }
@@ -142,7 +138,7 @@ namespace System.IO
 
                 // Check for a short filename path and try and expand it. Technically you don't need to have a tilde for a short name, but
                 // this is how we've always done this. This expansion is costly so we'll continue to let other short paths slide.
-                if (expandShortPaths && possibleShortPath)
+                if (possibleShortPath)
                 {
                     return TryExpandShortFileName(ref fullPath, originalPath: path);
                 }


### PR DESCRIPTION
Fixes: dotnet/corefx#26359

Will create the corefx PR updating System.Runtime.Extensions shortly.
FYI, WIP: https://github.com/maryamariyan/corefx/pull/21/files