### PR TITLE
Improve CMake detection on Windows when not in PATH

### DIFF
--- a/src/pal/tools/probe-win.ps1
+++ b/src/pal/tools/probe-win.ps1
@@ -6,7 +6,7 @@ function GetCMakeVersions
   $items = @()
   $items += @(Get-ChildItem hklm:\SOFTWARE\Wow6432Node\Kitware -ErrorAction SilentlyContinue)
   $items += @(Get-ChildItem hklm:\SOFTWARE\Kitware -ErrorAction SilentlyContinue)
-  return $items | where { $_.PSChildName.StartsWith("CMake ") }
+  return $items | where { $_.PSChildName.StartsWith("CMake") }
 }
 
 function GetCMakeInfo($regKey)
@@ -17,7 +17,13 @@ function GetCMakeInfo($regKey)
   catch {
     return $null
   }
-  $cmakeDir = (Get-ItemProperty $regKey.PSPath).'(default)'
+  $itemProperty = Get-ItemProperty $regKey.PSPath;
+  if (Get-Member -inputobject $itemProperty -name "InstallDir" -Membertype Properties) {
+    $cmakeDir = $itemProperty.InstallDir
+  }
+  else {
+    $cmakeDir = $itemProperty.'(default)'
+  }
   $cmakePath = [System.IO.Path]::Combine($cmakeDir, "bin\cmake.exe")
   if (![System.IO.File]::Exists($cmakePath)) {
     return $null


### PR DESCRIPTION
Port https://github.com/dotnet/corert/pull/5372

curl https://github.com/dotnet/corert/commit/b723f90c611a2c79a0921f95c7299ebb7325eb59.patch | git am -p 3 --directory='src/pal/tools/' --reject