### PR TITLE
Catch exception coming out of constraint resolution

### DIFF
--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -5219,10 +5219,22 @@ void CEEInfo::getCallInfo(
             }
         }
 
-        MethodDesc * directMethod = constrainedType.GetMethodTable()->TryResolveConstraintMethodApprox(
-            exactType, 
-            pMD, 
-            &fForceUseRuntimeLookup);
+        // In a try block because the interface method resolution might end up being
+        // ambiguous (diamond inheritance case of default interface methods).
+        MethodDesc * directMethod = nullptr;
+        EX_TRY
+        {
+            directMethod = constrainedType.GetMethodTable()->TryResolveConstraintMethodApprox(
+                exactType,
+                pMD,
+                &fForceUseRuntimeLookup);
+        }
+        EX_CATCH
+        {
+            // We will let this type get boxed and throw the same exception we just hit during dispatch.
+        }
+        EX_END_CATCH(RethrowTransientExceptions)
+
         if (directMethod)
         {
             // Either

--- a/tests/src/Regressions/coreclr/16123/ambiguousconstraint.il
+++ b/tests/src/Regressions/coreclr/16123/ambiguousconstraint.il
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern System.Runtime { }
+
+.assembly ambiguousconstraint { }
+
+.class interface private abstract auto ansi IFoo
+{
+  .method public hidebysig newslot abstract virtual instance void Frob() cil managed
+  {
+  }
+}
+
+.class interface private abstract auto ansi IBar
+       implements IFoo
+{
+  .method public hidebysig newslot virtual final instance void Frob() cil managed
+  {
+    .override IFoo::Frob
+    ret
+  }
+}
+
+.class interface private abstract auto ansi IBaz
+       implements IFoo
+{
+  .method public hidebysig newslot virtual final instance void Frob() cil managed
+  {
+    .override IFoo::Frob
+    ret
+  }
+}
+
+.class private auto ansi beforefieldinit Fooer
+       extends [System.Runtime]System.ValueType
+       implements IBar, IBaz
+{
+}
+
+.class private auto ansi beforefieldinit Gen`1<(IFoo) T>
+       extends [System.Runtime]System.Object
+{
+  .method public hidebysig static int32 Check(!T x) cil managed
+  {
+    .try
+    {
+      ldarga.s 0
+      constrained. !T
+      callvirt instance void IFoo::Frob()
+      leave.s Fail
+    }
+    catch [System.Runtime]System.NotSupportedException
+    {
+      pop
+      leave.s Success
+    }
+  Fail:
+    ldc.i4 -1
+    ret
+  Success:
+    ldc.i4 100
+    ret
+  }
+}
+
+.method public hidebysig static int32 Main() cil managed
+{
+  .entrypoint
+  .locals init (valuetype Fooer)
+  ldloc.0
+  call int32 class Gen`1<valuetype Fooer>::Check(!0)
+  ret
+}

--- a/tests/src/Regressions/coreclr/16123/ambiguousconstraint.ilproj
+++ b/tests/src/Regressions/coreclr/16123/ambiguousconstraint.ilproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{85DFC527-4DB1-595E-A7D7-E94EE1F8140D}</ProjectGuid>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="ambiguousconstraint.il" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
Ambiguous interface method resolution exception should throw at dispatch time, not at codegen time.

Fixes #16123.