### PR TITLE
Update UsingYourBuild.md

### DIFF
--- a/Documentation/workflow/UsingYourBuild.md
+++ b/Documentation/workflow/UsingYourBuild.md
@@ -47,10 +47,13 @@ dotnet new console
 In order to update with your local changes, the application needs to be self-contained, as opposed to running on the
 shared framework.  In order to do that you will need to add a `RuntimeIdentifier` to your project.
 
+You also need to add a `PlatformTarget`, otherwise the default would be `x86`, and that would generate an incompatibility error.
+
 ```xml
 <PropertyGroup>
   ...
   <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+  <PlatformTarget>x64</PlatformTarget>
 </PropertyGroup>
 ```
 


### PR DESCRIPTION
Apparently it needs a PlatformTarget to be specified as well when targeting x64 architecture.

I was getting this error otherwise:

>C:\Dev\coreclr\Tools\dotnet-sdk-latest-win-x64\sdk\2.1.300-preview2-008171\Sdks\Microsoft.NET.Sdk\build\Microsoft.NET.RuntimeIdentifierInference.targets(125,5): error : The RuntimeIdentifier platform 'win-x64' and the PlatformTarget 'x86' must be compatible. [C:\Dev\coreclr\tests\helloworld\helloworld.csproj]
