### PR TITLE
Improve perf of DelegateConstruct

### DIFF
--- a/src/vm/comdelegate.cpp
+++ b/src/vm/comdelegate.cpp
@@ -1736,9 +1736,6 @@ FCIMPL3(void, COMDelegate::DelegateConstruct, Object* refThisUNSAFE, Object* tar
     if (method == NULL)
         COMPlusThrowArgumentNull(W("method"));
 
-    void* pRetAddr = _ReturnAddress();
-    MethodDesc * pCreatorMethod = ExecutionManager::GetCodeMethodDesc((PCODE)pRetAddr);
-
     _ASSERTE(gc.refThis);
     _ASSERTE(method);
 


### PR DESCRIPTION
Remove a range lookup that's no longer needed.

See related issue #12438.