### PR TITLE
Fix registry path for ETW argument lookup

### DIFF
--- a/src/mscorlib/shared/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/EventProvider.cs
@@ -561,7 +561,7 @@ namespace System.Diagnostics.Tracing
             if (filterData == null)
             {
 #if (!ES_BUILD_PCL && !ES_BUILD_PN && PLATFORM_WINDOWS)
-                string regKey = @"\Microsoft\Windows\CurrentVersion\Winevt\Publishers\{" + m_providerName + "}";
+                string regKey = @"\Microsoft\Windows\CurrentVersion\Winevt\Publishers\{" + m_providerId + "}";
                 if (System.Runtime.InteropServices.Marshal.SizeOf(typeof(IntPtr)) == 8)
                     regKey = @"HKEY_LOCAL_MACHINE\Software" + @"\Wow6432Node" + regKey;
                 else


### PR DESCRIPTION
Arguments can be passed from TraceEvent to EventSource via the registry.  This is used to pass custom parameters such as EventCounterIntervalSec.  The registry path contains the provider GUID but as part of the conversion from GUID to string name in EventPipe the registry path was inadvertently changed to include name instead of GUID.  This change reverts the path back to GUID.