### PR TITLE
Remove an incorrect assertion in containment analysis

### DIFF
--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -2353,10 +2353,6 @@ bool Lowering::IsContainableHWIntrinsicOp(GenTreeHWIntrinsic* containingNode, Ge
             return false;
     }
 
-    // For containable nodes, the base type of the original node and the base type of the contained node
-    // should be the same. This helps ensure we aren't reading too many or too few bits.
-    assert(!isContainable || (containingNode->gtSIMDBaseType == node->AsHWIntrinsic()->gtSIMDBaseType));
-
     return isContainable;
 }
 


### PR DESCRIPTION
This assertion is not correct because some SIMD intrinsics can have different types of parameters. For example, 
```csharp
// AVX2
public static Vector256<long> ShiftRightLogicalVariable(Vector256<long> value, Vector256<ulong> count)
```