### PR TITLE
Fix the fired asset in CompareInfo.IndexOf

### DIFF
--- a/src/mscorlib/shared/System/Globalization/CompareInfo.cs
+++ b/src/mscorlib/shared/System/Globalization/CompareInfo.cs
@@ -819,6 +819,11 @@ namespace System.Globalization
             if (count < 0 || startIndex > source.Length - count)
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_Count);
 
+            if (source.Length == 0)
+            {
+                return -1;
+            }
+
             if (options == CompareOptions.OrdinalIgnoreCase)
             {
                 return source.IndexOf(value.ToString(), startIndex, count, StringComparison.OrdinalIgnoreCase);
@@ -828,7 +833,7 @@ namespace System.Globalization
             // Ordinal can't be selected with other flags
             if ((options & ValidIndexMaskOffFlags) != 0 && (options != CompareOptions.Ordinal))
                 throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
-            
+
             if (_invariantMode)
                 return IndexOfOrdinal(source, new string(value, 1), startIndex, count, ignoreCase: (options & (CompareOptions.IgnoreCase | CompareOptions.OrdinalIgnoreCase)) != 0);
 
@@ -1259,7 +1264,7 @@ namespace System.Globalization
             }
 
             //
-            // GetHashCodeOfString does more parameters validation. basically will throw when  
+            // GetHashCodeOfString does more parameters validation. basically will throw when
             // having Ordinal, OrdinalIgnoreCase and StringSort
             //
 


### PR DESCRIPTION
Fixes #16331

This fix the assert fired in the CI runs:

```
13:40:53   Assertion Failed
13:40:53   
13:40:53   
13:40:53      at System.Globalization.CompareInfo.IndexOfCore(String source, String target, Int32 startIndex, Int32 count, CompareOptions options, Int32* matchLengthPtr)
13:40:54      at System.Globalization.CompareInfo.IndexOf(String source, Char value, Int32 startIndex, Int32 count, CompareOptions options)
13:40:54      at System.String.Contains(Char value, StringComparison comparisonType)
13:40:54      at System.Tests.StringTests.Contains(String s, Char value, StringComparison comparisionType, Boolean expected) in /mnt/j/workspace/dotnet_coreclr/master/jitstress/x64_checked_ubuntu_corefx_baseline_prtest/_/fx/src/System.Runtime/tests/System/StringTests.netcoreapp.cs:line 144
13:40:54      at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
13:40:54      at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, BindingFlags invokeAttr, Object[] parameters, Object[] arguments)
13:40:54      at Xunit.Sdk.TestInvoker`1.<>c__DisplayClass46_1.<<InvokeTestMethodAsync>b__1>d.MoveNext()
13:40:54      at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
... 
```