### PR TITLE
Add ReadOnlySpan string-like ToLower/ToUpper API with globalization support

### DIFF
--- a/src/mscorlib/shared/System/Globalization/TextInfo.Unix.cs
+++ b/src/mscorlib/shared/System/Globalization/TextInfo.Unix.cs
@@ -79,7 +79,6 @@ namespace System.Globalization
             {
                 fixed (char* pResult = &MemoryMarshal.GetReference(destination))
                 {
-#if CORECLR
                     if (IsAsciiCasingSameAsInvariant)
                     {
                         int length = source.Length;
@@ -105,7 +104,6 @@ namespace System.Globalization
                         }
                     }
                     else
-#endif
                     {
                         ChangeCase(pSource, source.Length, pResult, destination.Length, toUpper);
                     }

--- a/src/mscorlib/shared/System/Globalization/TextInfo.Unix.cs
+++ b/src/mscorlib/shared/System/Globalization/TextInfo.Unix.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
 
@@ -62,6 +63,54 @@ namespace System.Globalization
             }
 
             return result;
+        }
+
+        internal unsafe void ChangeCase(ReadOnlySpan<char> source, Span<char> destination, bool toUpper)
+        {
+            Debug.Assert(!_invariantMode);
+            Debug.Assert(destination.Length >= source.Length);
+
+            if (source.IsEmpty)
+            {
+                return;
+            }
+            
+            fixed (char* pSource = &MemoryMarshal.GetReference(source))
+            {
+                fixed (char* pResult = &MemoryMarshal.GetReference(destination))
+                {
+#if CORECLR
+                    if (IsAsciiCasingSameAsInvariant)
+                    {
+                        int length = source.Length;
+                        char* a = pSource, b = pResult;
+                        if (toUpper)
+                        {
+                            while (length-- != 0 && *a < 0x80)
+                            {
+                                *b++ = ToUpperAsciiInvariant(*a++);
+                            }
+                        }
+                        else
+                        {
+                            while (length-- != 0 && *a < 0x80)
+                            {
+                                *b++ = ToLowerAsciiInvariant(*a++);
+                            }
+                        }
+
+                        if (length != 0)
+                        {
+                            ChangeCase(a, source.Length - length, b, destination.Length - length, toUpper);
+                        }
+                    }
+                    else
+#endif
+                    {
+                        ChangeCase(pSource, source.Length, pResult, destination.Length, toUpper);
+                    }
+                }
+            }
         }
 
         private unsafe char ChangeCase(char c, bool toUpper)

--- a/src/mscorlib/shared/System/Globalization/TextInfo.cs
+++ b/src/mscorlib/shared/System/Globalization/TextInfo.cs
@@ -258,6 +258,43 @@ namespace System.Globalization
             }
         }
 
+        internal void ToLowerAsciiInvariant(ReadOnlySpan<char> source, Span<char> destination)
+        {
+            Debug.Assert(destination.Length >= source.Length);
+
+            if (source.Length == 0)
+            {
+                return;
+            }
+
+            int i = 0;
+            while (i < source.Length)
+            {
+                if ((uint)(source[i] - 'A') <= ('Z' - 'A'))
+                {
+                    break;
+                }
+                i++;
+            }
+            
+            if (i >= source.Length)
+            {
+                source.CopyTo(destination);
+                return;
+            }
+
+            source.Slice(0, i).CopyTo(destination);
+
+            destination[i] = (char)(source[i] | 0x20);
+            i++;
+
+            while (i < source.Length)
+            {
+                destination[i] = ToLowerAsciiInvariant(source[i]);
+                i++;
+            }
+        }
+
         private unsafe string ToUpperAsciiInvariant(string s)
         {
             if (s.Length == 0)
@@ -301,6 +338,43 @@ namespace System.Globalization
                 }
 
                 return result;
+            }
+        }
+
+        internal void ToUpperAsciiInvariant(ReadOnlySpan<char> source, Span<char> destination)
+        {
+            Debug.Assert(destination.Length >= source.Length);
+
+            if (source.Length == 0)
+            {
+                return;
+            }
+
+            int i = 0;
+            while (i < source.Length)
+            {
+                if ((uint)(source[i] - 'a') <= ('z' - 'a'))
+                {
+                    break;
+                }
+                i++;
+            }
+
+            if (i >= source.Length)
+            {
+                source.CopyTo(destination);
+                return;
+            }
+
+            source.Slice(0, i).CopyTo(destination);
+
+            destination[i] = (char)(source[i] & ~0x20);
+            i++;
+
+            while (i < source.Length)
+            {
+                destination[i] = ToUpperAsciiInvariant(source[i]);
+                i++;
             }
         }
 

--- a/src/mscorlib/shared/System/Globalization/TextInfo.cs
+++ b/src/mscorlib/shared/System/Globalization/TextInfo.cs
@@ -262,36 +262,9 @@ namespace System.Globalization
         {
             Debug.Assert(destination.Length >= source.Length);
 
-            if (source.Length == 0)
-            {
-                return;
-            }
-
-            int i = 0;
-            while (i < source.Length)
-            {
-                if ((uint)(source[i] - 'A') <= ('Z' - 'A'))
-                {
-                    break;
-                }
-                i++;
-            }
-            
-            if (i >= source.Length)
-            {
-                source.CopyTo(destination);
-                return;
-            }
-
-            source.Slice(0, i).CopyTo(destination);
-
-            destination[i] = (char)(source[i] | 0x20);
-            i++;
-
-            while (i < source.Length)
+            for (int i = 0; i < source.Length; i++)
             {
                 destination[i] = ToLowerAsciiInvariant(source[i]);
-                i++;
             }
         }
 
@@ -345,36 +318,9 @@ namespace System.Globalization
         {
             Debug.Assert(destination.Length >= source.Length);
 
-            if (source.Length == 0)
-            {
-                return;
-            }
-
-            int i = 0;
-            while (i < source.Length)
-            {
-                if ((uint)(source[i] - 'a') <= ('z' - 'a'))
-                {
-                    break;
-                }
-                i++;
-            }
-
-            if (i >= source.Length)
-            {
-                source.CopyTo(destination);
-                return;
-            }
-
-            source.Slice(0, i).CopyTo(destination);
-
-            destination[i] = (char)(source[i] & ~0x20);
-            i++;
-
-            while (i < source.Length)
+            for (int i = 0; i < source.Length; i++)
             {
                 destination[i] = ToUpperAsciiInvariant(source[i]);
-                i++;
             }
         }
 

--- a/src/mscorlib/shared/System/Span.NonGeneric.cs
+++ b/src/mscorlib/shared/System/Span.NonGeneric.cs
@@ -27,6 +27,76 @@ namespace System
         private static readonly bool s_invariantMode = GlobalizationMode.Invariant;
 
         /// <summary>
+        /// Copies the characters from the source span into the destination, converting each character to lowercase.
+        /// </summary>
+        public static void ToLower(this ReadOnlySpan<char> source, Span<char> destination, CultureInfo culture)
+        {
+            if (destination.Length < source.Length)
+                ThrowHelper.ThrowArgumentException_DestinationTooShort();
+            if (culture == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.culture);
+
+            if (s_invariantMode)
+            {
+                CultureInfo.CurrentCulture.TextInfo.ToLowerAsciiInvariant(source, destination);
+            }
+
+            CultureInfo.CurrentCulture.TextInfo.ChangeCase(source, destination, toUpper: false);
+        }
+
+        /// <summary>
+        /// Copies the characters from the source span into the destination, converting each character to lowercase
+        /// using the casing rules of the invariant culture.
+        /// </summary>
+        public static void ToLowerInvariant(this ReadOnlySpan<char> source, Span<char> destination)
+        {
+            if (destination.Length < source.Length)
+                ThrowHelper.ThrowArgumentException_DestinationTooShort();
+
+            if (s_invariantMode)
+            {
+                CultureInfo.InvariantCulture.TextInfo.ToLowerAsciiInvariant(source, destination);
+            }
+
+            CultureInfo.InvariantCulture.TextInfo.ChangeCase(source, destination, toUpper: false);
+        }
+
+        /// <summary>
+        /// Copies the characters from the source span into the destination, converting each character to uppercase.
+        /// </summary>
+        public static void ToUpper(this ReadOnlySpan<char> source, Span<char> destination, CultureInfo culture)
+        {
+            if (destination.Length < source.Length)
+                ThrowHelper.ThrowArgumentException_DestinationTooShort();
+            if (culture == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.culture);
+
+            if (s_invariantMode)
+            {
+                CultureInfo.CurrentCulture.TextInfo.ToUpperAsciiInvariant(source, destination);
+            }
+
+            CultureInfo.CurrentCulture.TextInfo.ChangeCase(source, destination, toUpper: true);
+        }
+
+        /// <summary>
+        /// Copies the characters from the source span into the destination, converting each character to uppercase
+        /// using the casing rules of the invariant culture.
+        /// </summary>
+        public static void ToUpperInvariant(this ReadOnlySpan<char> source, Span<char> destination)
+        {
+            if (destination.Length < source.Length)
+                ThrowHelper.ThrowArgumentException_DestinationTooShort();
+
+            if (s_invariantMode)
+            {
+                CultureInfo.InvariantCulture.TextInfo.ToUpperAsciiInvariant(source, destination);
+            }
+
+            CultureInfo.InvariantCulture.TextInfo.ChangeCase(source, destination, toUpper: true);
+        }
+
+        /// <summary>
         /// Determines whether the beginning of the span matches the specified value when compared using the specified comparison option.
         /// </summary>
         public static bool StartsWith(this ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)

--- a/src/mscorlib/shared/System/Span.NonGeneric.cs
+++ b/src/mscorlib/shared/System/Span.NonGeneric.cs
@@ -23,77 +23,76 @@ namespace System
     /// </summary>
     public static class Span
     {
-        // s_invariantMode is defined for the perf reason as accessing the instance field is faster than access the static property GlobalizationMode.Invariant
-        private static readonly bool s_invariantMode = GlobalizationMode.Invariant;
-
         /// <summary>
         /// Copies the characters from the source span into the destination, converting each character to lowercase.
         /// </summary>
-        public static void ToLower(this ReadOnlySpan<char> source, Span<char> destination, CultureInfo culture)
+        public static int ToLower(this ReadOnlySpan<char> source, Span<char> destination, CultureInfo culture)
         {
-            if (destination.Length < source.Length)
-                ThrowHelper.ThrowArgumentException_DestinationTooShort();
             if (culture == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.culture);
 
-            if (s_invariantMode)
-            {
-                CultureInfo.CurrentCulture.TextInfo.ToLowerAsciiInvariant(source, destination);
-            }
+            // Assuming that changing case does not affect length
+            if (destination.Length < source.Length)
+                return -1;
 
-            CultureInfo.CurrentCulture.TextInfo.ChangeCase(source, destination, toUpper: false);
+            if (GlobalizationMode.Invariant)
+                culture.TextInfo.ToLowerAsciiInvariant(source, destination);
+            else
+                culture.TextInfo.ChangeCase(source, destination, toUpper: false);
+            return source.Length;
         }
 
         /// <summary>
         /// Copies the characters from the source span into the destination, converting each character to lowercase
         /// using the casing rules of the invariant culture.
         /// </summary>
-        public static void ToLowerInvariant(this ReadOnlySpan<char> source, Span<char> destination)
+        public static int ToLowerInvariant(this ReadOnlySpan<char> source, Span<char> destination)
         {
+            // Assuming that changing case does not affect length
             if (destination.Length < source.Length)
-                ThrowHelper.ThrowArgumentException_DestinationTooShort();
+                return -1;
 
-            if (s_invariantMode)
-            {
+            if (GlobalizationMode.Invariant)
                 CultureInfo.InvariantCulture.TextInfo.ToLowerAsciiInvariant(source, destination);
-            }
-
-            CultureInfo.InvariantCulture.TextInfo.ChangeCase(source, destination, toUpper: false);
+            else
+                CultureInfo.InvariantCulture.TextInfo.ChangeCase(source, destination, toUpper: false);
+            return source.Length;
         }
 
         /// <summary>
         /// Copies the characters from the source span into the destination, converting each character to uppercase.
         /// </summary>
-        public static void ToUpper(this ReadOnlySpan<char> source, Span<char> destination, CultureInfo culture)
+        public static int ToUpper(this ReadOnlySpan<char> source, Span<char> destination, CultureInfo culture)
         {
-            if (destination.Length < source.Length)
-                ThrowHelper.ThrowArgumentException_DestinationTooShort();
             if (culture == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.culture);
 
-            if (s_invariantMode)
-            {
-                CultureInfo.CurrentCulture.TextInfo.ToUpperAsciiInvariant(source, destination);
-            }
+            // Assuming that changing case does not affect length
+            if (destination.Length < source.Length)
+                return -1;
 
-            CultureInfo.CurrentCulture.TextInfo.ChangeCase(source, destination, toUpper: true);
+            if (GlobalizationMode.Invariant)
+                culture.TextInfo.ToUpperAsciiInvariant(source, destination);
+            else
+                culture.TextInfo.ChangeCase(source, destination, toUpper: true);
+            return source.Length;
         }
 
         /// <summary>
         /// Copies the characters from the source span into the destination, converting each character to uppercase
         /// using the casing rules of the invariant culture.
         /// </summary>
-        public static void ToUpperInvariant(this ReadOnlySpan<char> source, Span<char> destination)
+        public static int ToUpperInvariant(this ReadOnlySpan<char> source, Span<char> destination)
         {
+            // Assuming that changing case does not affect length
             if (destination.Length < source.Length)
-                ThrowHelper.ThrowArgumentException_DestinationTooShort();
+                return -1;
 
-            if (s_invariantMode)
-            {
+            if (GlobalizationMode.Invariant)
                 CultureInfo.InvariantCulture.TextInfo.ToUpperAsciiInvariant(source, destination);
-            }
-
-            CultureInfo.InvariantCulture.TextInfo.ChangeCase(source, destination, toUpper: true);
+            else
+                CultureInfo.InvariantCulture.TextInfo.ChangeCase(source, destination, toUpper: true);
+            return source.Length;
         }
 
         /// <summary>
@@ -136,7 +135,7 @@ namespace System
         {
             Debug.Assert(value.Length != 0);
 
-            if (s_invariantMode)
+            if (GlobalizationMode.Invariant)
             {
                 return StartsWithOrdinalHelper(span, value);
             }
@@ -153,7 +152,7 @@ namespace System
         {
             Debug.Assert(value.Length != 0);
 
-            if (s_invariantMode)
+            if (GlobalizationMode.Invariant)
             {
                 return StartsWithOrdinalIgnoreCaseHelper(span, value);
             }
@@ -290,7 +289,7 @@ namespace System
         {
             Debug.Assert(value.Length != 0);
 
-            if (s_invariantMode)
+            if (GlobalizationMode.Invariant)
             {
                 return EndsWithOrdinalHelper(span, value);
             }
@@ -307,7 +306,7 @@ namespace System
         {
             Debug.Assert(value.Length != 0);
 
-            if (s_invariantMode)
+            if (GlobalizationMode.Invariant)
             {
                 return EndsWithOrdinalIgnoreCaseHelper(span, value);
             }

--- a/src/mscorlib/src/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/src/System/Globalization/CompareInfo.Unix.cs
@@ -380,7 +380,7 @@ namespace System.Globalization
                 char* a = ap;
                 char* b = bp;
 
-                while (length != 0 && (*a < 0x80) && (*b < 0x80) && (!HighCharTable[*a]) && (!HighCharTable[*b]))
+                while (length != 0 && (*a < 0x80) && (*b < 0x80) && (!s_highCharTable[*a]) && (!s_highCharTable[*b]))
                 {
                     int charA = *a;
                     int charB = *b;
@@ -427,7 +427,7 @@ namespace System.Globalization
                 char* a = ap;
                 char* b = bp;
 
-                while (length != 0 && (*a < 0x80) && (*b < 0x80) && (!HighCharTable[*a]) && (!HighCharTable[*b]))
+                while (length != 0 && (*a < 0x80) && (*b < 0x80) && (!s_highCharTable[*a]) && (!s_highCharTable[*b]))
                 {
                     int charA = *a;
                     int charB = *b;
@@ -605,7 +605,7 @@ namespace System.Globalization
         }
 
         // See https://github.com/dotnet/coreclr/blob/master/src/utilcode/util_nodependencies.cpp#L970
-        private static readonly bool[] HighCharTable = new bool[0x80]
+        private static readonly bool[] s_highCharTable = new bool[0x80]
         {
             true, /* 0x0, 0x0 */
             true, /* 0x1, .*/

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -470,7 +470,8 @@ namespace System
         ownedMemory,
         pointer,
         start,
-        format
+        format,
+        culture
     }
 
     //


### PR DESCRIPTION
Part of https://github.com/dotnet/corefx/issues/21395#issuecomment-359906138

- ToLower
- ToLowerInvariant
- ToUpper
- ToUpperInvariant

**TODO:**
- ~Add the allocating counterpart for slow span in corefx and add tests there.~

Related corefx PR: https://github.com/dotnet/corefx/pull/27193

cc @jkotas, @stephentoub, @KrzysztofCwalina, @tarekgh, @JeremyKuhne 