### PR TITLE
Updating the JIT to take EnableSSE3_4 into account when setting the supported instruction sets

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -2666,44 +2666,41 @@ void Compiler::compSetProcessor()
                     opts.setSupportedISA(InstructionSet_POPCNT);
                 }
             }
-            if (jitFlags.IsSet(JitFlags::JIT_FLAG_USE_SSE3))
-            {
-                if (configEnableISA(InstructionSet_SSE3))
-                {
-                    opts.setSupportedISA(InstructionSet_SSE3);
-                }
-            }
-            if (jitFlags.IsSet(JitFlags::JIT_FLAG_USE_SSE41))
-            {
-                if (configEnableISA(InstructionSet_SSE41))
-                {
-                    opts.setSupportedISA(InstructionSet_SSE41);
-                }
-            }
-            if (jitFlags.IsSet(JitFlags::JIT_FLAG_USE_SSE42))
-            {
-                if (configEnableISA(InstructionSet_SSE42))
-                {
-                    opts.setSupportedISA(InstructionSet_SSE42);
-                }
-            }
-            if (jitFlags.IsSet(JitFlags::JIT_FLAG_USE_SSSE3))
-            {
-                if (configEnableISA(InstructionSet_SSSE3))
-                {
-                    opts.setSupportedISA(InstructionSet_SSSE3);
-                }
-            }
-        }
-    }
 
-    opts.compCanUseSSE4 = false;
-    if (!jitFlags.IsSet(JitFlags::JIT_FLAG_PREJIT) && jitFlags.IsSet(JitFlags::JIT_FLAG_USE_SSE41) &&
-        jitFlags.IsSet(JitFlags::JIT_FLAG_USE_SSE42))
-    {
-        if (JitConfig.EnableSSE3_4() != 0)
-        {
-            opts.compCanUseSSE4 = true;
+            // There are currently two sets of flags that control SSE3 through SSE4.2 support
+            // This is the general EnableSSE3_4 flag and the individual ISA flags. We need to
+            // check both for any given ISA.
+            if (JitConfig.EnableSSE3_4())
+            {
+                if (jitFlags.IsSet(JitFlags::JIT_FLAG_USE_SSE3))
+                {
+                    if (configEnableISA(InstructionSet_SSE3))
+                    {
+                        opts.setSupportedISA(InstructionSet_SSE3);
+                    }
+                }
+                if (jitFlags.IsSet(JitFlags::JIT_FLAG_USE_SSE41))
+                {
+                    if (configEnableISA(InstructionSet_SSE41))
+                    {
+                        opts.setSupportedISA(InstructionSet_SSE41);
+                    }
+                }
+                if (jitFlags.IsSet(JitFlags::JIT_FLAG_USE_SSE42))
+                {
+                    if (configEnableISA(InstructionSet_SSE42))
+                    {
+                        opts.setSupportedISA(InstructionSet_SSE42);
+                    }
+                }
+                if (jitFlags.IsSet(JitFlags::JIT_FLAG_USE_SSSE3))
+                {
+                    if (configEnableISA(InstructionSet_SSSE3))
+                    {
+                        opts.setSupportedISA(InstructionSet_SSSE3);
+                    }
+                }
+            }
         }
     }
 
@@ -2716,8 +2713,12 @@ void Compiler::compSetProcessor()
             codeGen->getEmitter()->SetContainsAVX(false);
             codeGen->getEmitter()->SetContains256bitAVX(false);
         }
-        else if (CanUseSSE4())
+        else if (compSupports(InstructionSet_SSSE3) || compSupports(InstructionSet_SSE41) ||
+                 compSupports(InstructionSet_SSE42))
         {
+            // Emitter::UseSSE4 controls whether we support the 4-byte encoding for certain
+            // instructions. We need to check if either is supported independently, since
+            // it is currently possible to enable/disable them separately.
             codeGen->getEmitter()->SetUseSSE4(true);
         }
     }

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7462,7 +7462,10 @@ private:
             return SIMD_AVX2_Supported;
         }
 
-        if (CanUseSSE4())
+        // SIMD_SSE4_Supported actually requires all of SSE3, SSSE3, SSE4.1, and SSE4.2
+        // to be supported. We can only enable it if all four are enabled in the compiler
+        if (compSupports(InstructionSet_SSE42) && compSupports(InstructionSet_SSE41) &&
+            compSupports(InstructionSet_SSSE3) && compSupports(InstructionSet_SSE3))
         {
             return SIMD_SSE4_Supported;
         }
@@ -7992,21 +7995,11 @@ private:
         return false;
     }
 
-    // Whether SSE2 is available
+    // Whether SSE and SSE2 is available
     bool canUseSSE2() const
     {
 #ifdef _TARGET_XARCH_
         return opts.compCanUseSSE2;
-#else
-        return false;
-#endif
-    }
-
-    // Whether SSE3, SSSE3, SSE4.1 and SSE4.2 is available
-    bool CanUseSSE4() const
-    {
-#ifdef _TARGET_XARCH_
-        return opts.compCanUseSSE4;
 #else
         return false;
 #endif
@@ -8137,7 +8130,6 @@ public:
         bool compUseCMOV;
 #ifdef _TARGET_XARCH_
         bool compCanUseSSE2; // Allow CodeGen to use "movq XMM" instructions
-        bool compCanUseSSE4; // Allow CodeGen to use SSE3, SSSE3, SSE4.1 and SSE4.2 instructions
 #endif                       // _TARGET_XARCH_
 
 #if defined(_TARGET_XARCH_) || defined(_TARGET_ARM64_)


### PR DESCRIPTION
Resolves the error brought up here: https://github.com/dotnet/coreclr/pull/16378#issuecomment-365701347

This updates the `setSupportedISA` calls to take `JitConfig.EnableSSE3_4` into account. This also removes the `compCanUseSSE4` field in favor of more explicit `compSupports` calls.

FYI. @fiigii, @CarolEidt, @AndyAyersMS 