### PR TITLE
Update the eol linuxes in release/2.0.0

### DIFF
--- a/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
+++ b/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
@@ -294,7 +294,7 @@
       "value": "linux-x64"
     },
     "TargetQueues": {
-      "value": "debian.82.amd64,fedora.23.amd64,redhat.72.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1610.amd64"
+      "value": "debian.82.amd64,fedora.26.amd64,fedora.27.amd64,redhat.73.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1804.amd64,opensuse.423.amd64,sles.12.amd64"
     },
     "TestProduct": {
       "value": "coreclr"

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -376,7 +376,7 @@
             "HelixJobType": "test/functional/cli/",
             "TargetsWindows": "false",
             "Rid": "osx-x64",
-            "TargetQueues": "osx.1012.amd64",
+            "TargetQueues": "osx.1012.amd64,osx.1013.amd64",
             "TestContainerSuffix": "osx",
             "TargetsNonWindowsArg": "TargetsNonWindows "
           },
@@ -393,7 +393,7 @@
             "HelixJobType": "test/functional/r2r/cli/",
             "TargetsWindows": "false",
             "Rid": "osx-x64",
-            "TargetQueues": "osx.1012.amd64",
+            "TargetQueues": "osx.1012.amd64,osx.1013.amd64",
             "TestContainerSuffix": "osx-r2r",
             "CrossgenArg": "Crossgen ",
             "TargetsNonWindowsArg": "TargetsNonWindows "
@@ -411,7 +411,7 @@
             "HelixJobType": "test/functional/cli/",
             "TargetsWindows": "false",
             "Rid": "linux-x64",
-            "TargetQueues": "debian.82.amd64,fedora.25.amd64,redhat.72.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64",
+            "TargetQueues": "debian.82.amd64,fedora.26.amd64,fedora.27.amd64,redhat.73.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1804.amd64,opensuse.423.amd64,sles.12.amd64",
             "TestContainerSuffix": "linux",
             "TargetsNonWindowsArg": "TargetsNonWindows "
           },
@@ -428,7 +428,7 @@
             "HelixJobType": "test/functional/r2r/cli/",
             "TargetsWindows": "false",
             "Rid": "linux-x64",
-            "TargetQueues": "debian.82.amd64,fedora.25.amd64,redhat.72.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64",
+            "TargetQueues": "debian.82.amd64,fedora.26.amd64,fedora.27.amd64,redhat.73.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1804.amd64,opensuse.423.amd64,sles.12.amd64",
             "TestContainerSuffix": "linux-r2r",
             "CrossgenArg": "Crossgen ",
             "TargetsNonWindowsArg": "TargetsNonWindows "


### PR DESCRIPTION
Note this pr is based on: https://github.com/dotnet/coreclr/pull/16309

/cc @RussKeldorph 