### PR TITLE
Fix #16402

### DIFF
--- a/src/vm/assemblyspec.cpp
+++ b/src/vm/assemblyspec.cpp
@@ -792,9 +792,9 @@ BOOL AreSameBinderInstance(ICLRPrivBinder *pBinderA, ICLRPrivBinder *pBinderB)
 {
     LIMITED_METHOD_CONTRACT;
     
-    BOOL fIsSameInstance = FALSE;
+    BOOL fIsSameInstance = (pBinderA == pBinderB);
     
-    if ((pBinderA != NULL) && (pBinderB != NULL))
+    if (!fIsSameInstance && (pBinderA != NULL) && (pBinderB != NULL))
     {
         // Get the ID for the first binder
         UINT_PTR binderIDA = 0, binderIDB = 0;

--- a/src/vm/hash.cpp
+++ b/src/vm/hash.cpp
@@ -878,9 +878,18 @@ void HashMap::Rehash()
     _ASSERTE (OwnLock());
 #endif
 
-    DWORD cbNewSize = g_rgPrimes[m_iPrimeIndex = NewSize()];
+    UPTR newPrimeIndex = NewSize();
 
-    ASSERT(m_iPrimeIndex < 70);
+    ASSERT(newPrimeIndex < g_rgNumPrimes);
+
+    if ((m_iPrimeIndex == newPrimeIndex) && (m_cbDeletes == 0))
+    {
+        return;
+    }
+
+    m_iPrimeIndex = newPrimeIndex;
+
+    DWORD cbNewSize = g_rgPrimes[m_iPrimeIndex];
 
     Bucket* rgBuckets = Buckets();
     UPTR cbCurrSize =   GetSize(rgBuckets);


### PR DESCRIPTION
AssemblySpec comparisons were failing when binders were null.
Also add early out to `HashMap::Rehash()`

Fixes #16402

@jkotas Please assign as appropriate