### PR TITLE
Fix dlStack test

### DIFF
--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -881,7 +881,7 @@ RelativePath=GC\Scenarios\DoublinkList\dlstack\dlstack.cmd
 WorkingDir=GC\Scenarios\DoublinkList\dlstack
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;JITSTRESS_FAIL;15156
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1222.cmd_112]

--- a/tests/src/GC/Scenarios/DoublinkList/dlstack.cs
+++ b/tests/src/GC/Scenarios/DoublinkList/dlstack.cs
@@ -94,13 +94,9 @@ namespace DoubLink {
 
         public bool runTest(int iRep, int iObj)
         {
-            bool success = false;
-            for(int i=0; i <10; i++)
-            {
-                SetLink(iRep, iObj);
-                MakeLeak(iRep);
-            }
+            CreateDLinkListsWithLeak(iRep, iObj);
 
+            bool success = false;
             if (DrainFinalizerQueue(iRep, iObj))
             {
                 success = true;
@@ -109,6 +105,19 @@ namespace DoubLink {
             Console.WriteLine("{0} DLinkNodes finalized", DLinkNode.FinalCount);
             return success;
 
+        }
+
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        // Do not inline the method that creates GC objects, because it could 
+        // extend their live intervals until the end of the parent method.
+        public void CreateDLinkListsWithLeak(int iRep, int iObj)
+        {
+            for(int i=0; i <10; i++)
+            {
+                SetLink(iRep, iObj);
+                MakeLeak(iRep);
+            }
         }
 
 


### PR DESCRIPTION
If `SetLink(iRep, iObj)`  was inlined into `public bool runTest(int iRep, int iObj)` then objects that were created in `SetLink` could be alive until the end of the parent (`runTest`) method. It means that at the moment of the `DrainFinalizerQueue` call they could be alive and can't be collected.

Create the heap objects in a separate method that is marked as `NoInlining`.

Fix #15156.
