### PR TITLE
Fix for assert(sideEffList) in clr\src\jit\optcse.cpp, Line: 2151

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5772,6 +5772,7 @@ protected:
     static fgWalkPreFn  optHasNonCSEChild;
 
     static fgWalkPreFn optUnmarkCSEs;
+    static fgWalkPreFn optHasCSEdefWithSideeffect;
 
     static int __cdecl optCSEcostCmpEx(const void* op1, const void* op2);
     static int __cdecl optCSEcostCmpSz(const void* op1, const void* op2);

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -328,7 +328,7 @@ Compiler::fgWalkResult Compiler::optUnmarkCSEs(GenTree** pTree, fgWalkData* data
         // This tree and all of its sub-trees will be kept
         //
         *wbKeepList = comp->gtBuildCommaList(*wbKeepList, tree);
-        
+
         return WALK_SKIP_SUBTREES;
     }
 
@@ -412,7 +412,7 @@ Compiler::fgWalkResult Compiler::optHasCSEdefWithSideeffect(GenTree** pTree, fgW
         //
         if (comp->gtTreeHasSideEffects(tree, GTF_PERSISTENT_SIDE_EFFECTS_IN_CSE))
         {
-            // This nested CSE def contains a persistent side effect 
+            // This nested CSE def contains a persistent side effect
             // We just abort now as this case is problematic.
             //
             return WALK_ABORT;
@@ -420,7 +420,6 @@ Compiler::fgWalkResult Compiler::optHasCSEdefWithSideeffect(GenTree** pTree, fgW
     }
     return WALK_CONTINUE;
 }
-
 
 Compiler::fgWalkResult Compiler::optCSE_MaskHelper(GenTree** pTree, fgWalkData* walkData)
 {
@@ -2536,7 +2535,7 @@ bool Compiler::optValnumCSE_UnmarkCSEs(GenTree* deadTree, GenTree** wbKeepList)
     // and is not deleted and does not have its ref counts decremented
     // We communicate this value using the walkData.pCallbackData field
     //
-    
+
     Compiler::fgWalkResult result = fgWalkTreePre(&deadTree, optUnmarkCSEs, (void*)wbKeepList);
     assert(result != WALK_ABORT);
 

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -406,7 +406,6 @@ Compiler::fgWalkResult Compiler::optHasCSEdefWithSideeffect(GenTree** pTree, fgW
     if (IS_CSE_DEF(tree->gtCSEnum))
     {
         // This node is a CSE def
-        assert(IS_CSE_DEF(tree->gtCSEnum));
 
         // If this node contains any persistent side effects then we will return WALK_ABORT.
         //

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -312,10 +312,17 @@ Compiler::fgWalkResult Compiler::optUnmarkCSEs(GenTree** pTree, fgWalkData* data
         // Instead we will add it to the 'keepList'.
         assert(IS_CSE_DEF(tree->gtCSEnum));
 
-        if (comp->gtTreeHasSideEffects(tree, GTF_PERSISTENT_SIDE_EFFECTS_IN_CSE))
+        // If we already have collected any persistent side effects then keepList is non-null
+        //  and we will return WALK_ABORT since we have a CSE def that we must keep.
+        //
+        // If we haven't kept any  side effects yet, we will create new GT_COMMA list with this one.
+        //
+        if ((keepList != nullptr) && comp->gtTreeHasSideEffects(tree, GTF_PERSISTENT_SIDE_EFFECTS_IN_CSE))
         {
-            // If the nested CSE def has persistent side effects then just abort
-            // as this case is problematic.
+            // If this nested CSE def has a persistent side effect and
+            //  we are already keeping other side effects then
+            //  just abort as this case is problematic.
+            // a
             return WALK_ABORT;
         }
         else


### PR DESCRIPTION
Added new tree walker helper optHasCSEdefWithSideeffect to determine up front if we have
a nested CSE def with side effects.  The refs counts will be wrong when we start unmarking
some CSE uses and then later abandon the replacement operation.
So now we decide up front if we have a CSE def with side effects before we call optUnmarkCSEs.
