### PR TITLE
delete unused mirror files

### DIFF
--- a/src/.nuget/.gitmirrorall
+++ b/src/.nuget/.gitmirrorall
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/ToolBox/SOS/.gitmirror
+++ b/src/ToolBox/SOS/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/ToolBox/SOS/DacTableGen/.gitmirror
+++ b/src/ToolBox/SOS/DacTableGen/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/ToolBox/SOS/NETCore/.gitmirror
+++ b/src/ToolBox/SOS/NETCore/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/ToolBox/SOS/Strike/.gitmirror
+++ b/src/ToolBox/SOS/Strike/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/ToolBox/SOS/Strike/inc/.gitmirror
+++ b/src/ToolBox/SOS/Strike/inc/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/ToolBox/SOS/Strike/xplat/.gitmirror
+++ b/src/ToolBox/SOS/Strike/xplat/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/ToolBox/SOS/diasdk/.gitmirror
+++ b/src/ToolBox/SOS/diasdk/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/ToolBox/SOS/lldbplugin/.gitmirrorall
+++ b/src/ToolBox/SOS/lldbplugin/.gitmirrorall
@@ -1,1 +1,0 @@
-This folder will be mirrored by the Git-TFS Mirror recursively.

--- a/src/ToolBox/SOS/tests/.gitmirrorall
+++ b/src/ToolBox/SOS/tests/.gitmirrorall
@@ -1,1 +1,0 @@
-This folder will be mirrored by the Git-TFS Mirror recursively.

--- a/src/binder/.gitmirror
+++ b/src/binder/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/binder/inc/.gitmirror
+++ b/src/binder/inc/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/binder/v3binder/.gitmirror
+++ b/src/binder/v3binder/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/binder/v3binder_crossgen/.gitmirror
+++ b/src/binder/v3binder_crossgen/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/classlibnative/.gitmirror
+++ b/src/classlibnative/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/classlibnative/bcltype/.gitmirror
+++ b/src/classlibnative/bcltype/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/classlibnative/float/.gitmirror
+++ b/src/classlibnative/float/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/classlibnative/inc/.gitmirror
+++ b/src/classlibnative/inc/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/classlibnative/nls/.gitmirror
+++ b/src/classlibnative/nls/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/coreclr/.gitmirror
+++ b/src/coreclr/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/coreclr/hosts/.gitmirror
+++ b/src/coreclr/hosts/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/coreclr/hosts/coreconsole/.gitmirror
+++ b/src/coreclr/hosts/coreconsole/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/coreclr/hosts/corerun/.gitmirror
+++ b/src/coreclr/hosts/corerun/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/coreclr/hosts/inc/.gitmirrorall
+++ b/src/coreclr/hosts/inc/.gitmirrorall
@@ -1,1 +1,0 @@
-This folder will be mirrored by the Git-TFS Mirror recursively.

--- a/src/coreclr/hosts/osxbundlerun/.gitmirrorall
+++ b/src/coreclr/hosts/osxbundlerun/.gitmirrorall
@@ -1,1 +1,0 @@
-This folder will be mirrored by the Git-TFS Mirror recursively.

--- a/src/coreclr/hosts/unixcoreconsole/.gitmirrorall
+++ b/src/coreclr/hosts/unixcoreconsole/.gitmirrorall
@@ -1,1 +1,0 @@
-This folder will be mirrored by the Git-TFS Mirror recursively.

--- a/src/coreclr/hosts/unixcorerun/.gitmirrorall
+++ b/src/coreclr/hosts/unixcorerun/.gitmirrorall
@@ -1,1 +1,0 @@
-This folder will be mirrored by the Git-TFS Mirror recursively.

--- a/src/coreclr/hosts/unixcoreruncommon/.gitmirror
+++ b/src/coreclr/hosts/unixcoreruncommon/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/corefx/.gitmirrorall
+++ b/src/corefx/.gitmirrorall
@@ -1,1 +1,0 @@
-This folder will be mirrored by the Git-TFS Mirror recursively.

--- a/src/debug/.gitmirror
+++ b/src/debug/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/createdump/.gitmirrorall
+++ b/src/debug/createdump/.gitmirrorall
@@ -1,1 +1,0 @@
-This folder will be mirrored by the Git-TFS Mirror recursively.

--- a/src/debug/daccess/.gitmirror
+++ b/src/debug/daccess/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/daccess/amd64/.gitmirror
+++ b/src/debug/daccess/amd64/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/daccess/arm/.gitmirror
+++ b/src/debug/daccess/arm/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/daccess/arm64/.gitmirror
+++ b/src/debug/daccess/arm64/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/daccess/i386/.gitmirror
+++ b/src/debug/daccess/i386/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/dbgutil/.gitmirror
+++ b/src/debug/dbgutil/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/debug-pal/.gitmirror
+++ b/src/debug/debug-pal/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/debug-pal/unix/.gitmirror
+++ b/src/debug/debug-pal/unix/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/debug-pal/win/.gitmirror
+++ b/src/debug/debug-pal/win/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/di/.gitmirror
+++ b/src/debug/di/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/di/amd64/.gitmirror
+++ b/src/debug/di/amd64/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/di/arm/.gitmirror
+++ b/src/debug/di/arm/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/di/arm64/.gitmirror
+++ b/src/debug/di/arm64/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/di/i386/.gitmirror
+++ b/src/debug/di/i386/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/ee/.gitmirror
+++ b/src/debug/ee/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/ee/amd64/.gitmirror
+++ b/src/debug/ee/amd64/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/ee/arm/.gitmirror
+++ b/src/debug/ee/arm/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/ee/arm64/.gitmirror
+++ b/src/debug/ee/arm64/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/ee/dac/.gitmirror
+++ b/src/debug/ee/dac/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/ee/i386/.gitmirror
+++ b/src/debug/ee/i386/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/ee/wks/.gitmirror
+++ b/src/debug/ee/wks/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/ildbsymlib/.gitmirror
+++ b/src/debug/ildbsymlib/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/inc/.gitmirror
+++ b/src/debug/inc/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/inc/amd64/.gitmirror
+++ b/src/debug/inc/amd64/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/inc/arm/.gitmirror
+++ b/src/debug/inc/arm/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/inc/arm64/.gitmirror
+++ b/src/debug/inc/arm64/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/inc/dump/.gitmirror
+++ b/src/debug/inc/dump/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/inc/i386/.gitmirror
+++ b/src/debug/inc/i386/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/shared/.gitmirror
+++ b/src/debug/shared/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/shared/amd64/.gitmirror
+++ b/src/debug/shared/amd64/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/shared/arm/.gitmirror
+++ b/src/debug/shared/arm/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/shared/arm64/.gitmirror
+++ b/src/debug/shared/arm64/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/shared/i386/.gitmirror
+++ b/src/debug/shared/i386/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/debug/shim/.gitmirror
+++ b/src/debug/shim/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/dlls/.gitmirror
+++ b/src/dlls/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/dlls/clretwrc/.gitmirror
+++ b/src/dlls/clretwrc/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/dlls/dbgshim/.gitmirror
+++ b/src/dlls/dbgshim/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/dlls/mscordac/.gitmirror
+++ b/src/dlls/mscordac/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/dlls/mscordbi/.gitmirror
+++ b/src/dlls/mscordbi/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/dlls/mscoree/.gitmirror
+++ b/src/dlls/mscoree/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/dlls/mscoree/coreclr/.gitmirror
+++ b/src/dlls/mscoree/coreclr/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/dlls/mscorpe/.gitmirrorall
+++ b/src/dlls/mscorpe/.gitmirrorall
@@ -1,1 +1,0 @@
-This folder will be mirrored by the Git-TFS Mirror recursively.

--- a/src/dlls/mscorrc/.gitmirror
+++ b/src/dlls/mscorrc/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/dlls/mscorrc/full/.gitmirror
+++ b/src/dlls/mscorrc/full/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/dlls/mscorrc/small/.gitmirror
+++ b/src/dlls/mscorrc/small/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/gc/.gitmirrorall
+++ b/src/gc/.gitmirrorall
@@ -1,1 +1,0 @@
-This folder will be mirrored by the Git-TFS Mirror recursively.

--- a/src/gcdump/.gitmirror
+++ b/src/gcdump/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/gcdump/i386/.gitmirror
+++ b/src/gcdump/i386/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/gcinfo/.gitmirror
+++ b/src/gcinfo/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/gcinfo/crossgen/.gitmirror
+++ b/src/gcinfo/crossgen/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/gcinfo/lib/.gitmirror
+++ b/src/gcinfo/lib/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/ilasm/.gitmirrorall
+++ b/src/ilasm/.gitmirrorall
@@ -1,1 +1,0 @@
-This folder will be mirrored by the Git-TFS Mirror recursively.

--- a/src/ildasm/.gitmirrorall
+++ b/src/ildasm/.gitmirrorall
@@ -1,1 +1,0 @@
-This folder will be mirrored by the Git-TFS Mirror recursively.

--- a/src/inc/.gitmirrorall
+++ b/src/inc/.gitmirrorall
@@ -1,1 +1,0 @@
-This folder will be mirrored by the Git-TFS Mirror recursively.

--- a/src/ipcman/.gitmirror
+++ b/src/ipcman/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/ipcman/ipcman-staticcrt/.gitmirror
+++ b/src/ipcman/ipcman-staticcrt/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/.gitmirror
+++ b/src/md/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/ceefilegen/.gitmirror
+++ b/src/md/ceefilegen/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/compiler/.gitmirror
+++ b/src/md/compiler/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/compiler/crossgen/.gitmirror
+++ b/src/md/compiler/crossgen/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/compiler/dac/.gitmirror
+++ b/src/md/compiler/dac/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/compiler/dbi/.gitmirror
+++ b/src/md/compiler/dbi/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/compiler/wks/.gitmirror
+++ b/src/md/compiler/wks/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/datasource/.gitmirror
+++ b/src/md/datasource/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/datasource/dbi/.gitmirror
+++ b/src/md/datasource/dbi/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/enc/.gitmirror
+++ b/src/md/enc/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/enc/crossgen/.gitmirror
+++ b/src/md/enc/crossgen/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/enc/dac/.gitmirror
+++ b/src/md/enc/dac/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/enc/dbi/.gitmirror
+++ b/src/md/enc/dbi/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/enc/wks/.gitmirror
+++ b/src/md/enc/wks/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/heaps/.gitmirror
+++ b/src/md/heaps/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/hotdata/.gitmirror
+++ b/src/md/hotdata/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/hotdata/crossgen/.gitmirror
+++ b/src/md/hotdata/crossgen/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/hotdata/dac/.gitmirror
+++ b/src/md/hotdata/dac/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/hotdata/full-staticcrt/.gitmirror
+++ b/src/md/hotdata/full-staticcrt/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/hotdata/full/.gitmirror
+++ b/src/md/hotdata/full/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/inc/.gitmirror
+++ b/src/md/inc/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/runtime/.gitmirror
+++ b/src/md/runtime/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/runtime/crossgen/.gitmirror
+++ b/src/md/runtime/crossgen/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/runtime/dac/.gitmirror
+++ b/src/md/runtime/dac/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/runtime/dbi/.gitmirror
+++ b/src/md/runtime/dbi/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/runtime/wks/.gitmirror
+++ b/src/md/runtime/wks/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/tables/.gitmirror
+++ b/src/md/tables/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/winmd/.gitmirror
+++ b/src/md/winmd/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/winmd/crossgen/.gitmirror
+++ b/src/md/winmd/crossgen/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/winmd/dac/.gitmirror
+++ b/src/md/winmd/dac/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/winmd/dbi/.gitmirror
+++ b/src/md/winmd/dbi/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/winmd/inc/.gitmirror
+++ b/src/md/winmd/inc/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/md/winmd/wks/.gitmirror
+++ b/src/md/winmd/wks/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/mscorlib/.gitmirrorall
+++ b/src/mscorlib/.gitmirrorall
@@ -1,1 +1,0 @@
-This folder will be mirrored by the Git-TFS Mirror recursively.

--- a/src/nativeresources/.gitmirror
+++ b/src/nativeresources/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/pal/.gitmirrorall
+++ b/src/pal/.gitmirrorall
@@ -1,1 +1,0 @@
-This folder will be mirrored by the Git-TFS Mirror recursively.

--- a/src/palrt/.gitmirror
+++ b/src/palrt/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/scripts/.gitmirrorall
+++ b/src/scripts/.gitmirrorall
@@ -1,1 +1,0 @@
-This folder will be mirrored by the Git-TFS Mirror recursively.

--- a/src/strongname/.gitmirror
+++ b/src/strongname/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/strongname/api/.gitmirror
+++ b/src/strongname/api/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/strongname/api/crossgen/.gitmirror
+++ b/src/strongname/api/crossgen/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/strongname/api/dac/.gitmirror
+++ b/src/strongname/api/dac/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/strongname/api/wks/.gitmirror
+++ b/src/strongname/api/wks/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/strongname/inc/.gitmirror
+++ b/src/strongname/inc/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/tools/.gitmirror
+++ b/src/tools/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/tools/GenClrDebugResource/.gitmirror
+++ b/src/tools/GenClrDebugResource/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/tools/InjectResource/.gitmirror
+++ b/src/tools/InjectResource/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/tools/crossgen/.gitmirror
+++ b/src/tools/crossgen/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/tools/metainfo/.gitmirrorall
+++ b/src/tools/metainfo/.gitmirrorall
@@ -1,1 +1,0 @@
-This folder will be mirrored by the Git-TFS Mirror recursively.

--- a/src/tools/util/.gitmirror
+++ b/src/tools/util/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/unwinder/.gitmirror
+++ b/src/unwinder/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/unwinder/amd64/.gitmirror
+++ b/src/unwinder/amd64/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/unwinder/arm/.gitmirror
+++ b/src/unwinder/arm/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/unwinder/arm64/.gitmirror
+++ b/src/unwinder/arm64/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/unwinder/dac/.gitmirror
+++ b/src/unwinder/dac/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/unwinder/dac/hostlocal/.gitmirror
+++ b/src/unwinder/dac/hostlocal/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/unwinder/dac/hostwinamd64/.gitmirror
+++ b/src/unwinder/dac/hostwinamd64/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/unwinder/dac/hostwinx86/.gitmirror
+++ b/src/unwinder/dac/hostwinx86/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/unwinder/wks/.gitmirror
+++ b/src/unwinder/wks/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/utilcode/.gitmirror
+++ b/src/utilcode/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/utilcode/crossgen/.gitmirror
+++ b/src/utilcode/crossgen/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/utilcode/dac/.gitmirror
+++ b/src/utilcode/dac/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/utilcode/dyncrt/.gitmirror
+++ b/src/utilcode/dyncrt/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/utilcode/staticnohost/.gitmirror
+++ b/src/utilcode/staticnohost/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/vm/.gitmirror
+++ b/src/vm/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/vm/amd64/.gitmirror
+++ b/src/vm/amd64/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/vm/arm/.gitmirror
+++ b/src/vm/arm/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/vm/arm64/.gitmirror
+++ b/src/vm/arm64/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/vm/coreclr/.gitmirror
+++ b/src/vm/coreclr/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/vm/crossgen/.gitmirror
+++ b/src/vm/crossgen/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/vm/crossgen_mscorlib/.gitmirror
+++ b/src/vm/crossgen_mscorlib/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/vm/dac/.gitmirror
+++ b/src/vm/dac/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/vm/i386/.gitmirror
+++ b/src/vm/i386/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/vm/wks/.gitmirror
+++ b/src/vm/wks/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/zap/.gitmirror
+++ b/src/zap/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/zap/crossgen/.gitmirror
+++ b/src/zap/crossgen/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 

--- a/src/zap/wks/.gitmirror
+++ b/src/zap/wks/.gitmirror
@@ -1,1 +1,0 @@
-Only contents of this folder, excluding subfolders, will be mirrored by the Git-TFS Mirror. 


### PR DESCRIPTION
PR #8087 stopped sync most folders between TF and Git, and [the comment](https://github.com/dotnet/coreclr/pull/8087#issuecomment-260029230) there says:

>  After this is merged, I will get TFS and Git back in sync (there have been changes in superpmi that were made after the stopped syncing that directory) and then resume the mirror. After that's complete, I'll clean up the lingering .gitmirror files that are no longer needed.

But the second part was not done and the lingering .gitmirror files are still there.

Delete them. 
After this change we have .gitmirror only in Toolbox and jit folders and one .gitmirrorselective in the root dir.