### PR TITLE
Inlinable MulticastDelegate ==

### DIFF
--- a/src/mscorlib/src/System/MulticastDelegate.cs
+++ b/src/mscorlib/src/System/MulticastDelegate.cs
@@ -4,8 +4,6 @@
 
 using System;
 using System.Reflection;
-using System.Runtime;
-using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Diagnostics;
 using System.Reflection.Emit;
@@ -431,18 +429,22 @@ namespace System
 
         public static bool operator ==(MulticastDelegate d1, MulticastDelegate d2)
         {
-            if ((Object)d1 == null)
-                return (Object)d2 == null;
+            if (ReferenceEquals(d1, d2))
+            {
+                return true;
+            }
 
-            return d1.Equals(d2);
+            return d1 is null ? false : d1.Equals(d2);
         }
 
         public static bool operator !=(MulticastDelegate d1, MulticastDelegate d2)
         {
-            if ((Object)d1 == null)
-                return (Object)d2 != null;
+            if (ReferenceEquals(d1, d2))
+            {
+                return false;
+            }
 
-            return !d1.Equals(d2);
+            return d1 is null ? true : !d1.Equals(d2);
         }
 
         public override sealed int GetHashCode()


### PR DESCRIPTION
Comparing Actions with `==` is a common trope used in awaitables; [for example](https://github.com/aspnet/KestrelHttpServer/pull/2330/files)

```csharp
private readonly static Action _callbackCompleted = () => { };

private Action _callback;

public bool IsCompleted => _callback == _callbackCompleted; // MulticastDelegate delegate ==
```

While the `==` inlines it only tests nullablity, so if they both have a value it calls through to the chunky equals method [MulticastDelegate.cs#L57-L132](https://github.com/dotnet/coreclr/blob/df5a0272078d3102a9e1f84c1b46af3b128b7012/src/mscorlib/src/System/MulticastDelegate.cs#L57-L132) that will never inline (and nor should it) 

This moves ReferenceEquals into the `==` methods so if they are null or the same it doesn't need to call through to `MulticastDelegate.equals` as reference equality is generally what is being tested in these patterns.

/cc @stephentoub @jkotas 