### PR TITLE
Inlinable String.Equals for ref equality

### DIFF
--- a/src/mscorlib/shared/System/Globalization/CompareInfo.cs
+++ b/src/mscorlib/shared/System/Globalization/CompareInfo.cs
@@ -339,7 +339,7 @@ namespace System.Globalization
             if (_invariantMode)
             {
                 if ((options & CompareOptions.IgnoreCase) != 0)
-                    return CompareOrdinalIgnoreCase(string1, 0, string1.Length, string2, 0, string2.Length);
+                    return CompareOrdinalIgnoreCase(string1, string2);
 
                 return String.CompareOrdinal(string1, string2);
             }

--- a/src/mscorlib/shared/System/Span.NonGeneric.cs
+++ b/src/mscorlib/shared/System/Span.NonGeneric.cs
@@ -251,9 +251,10 @@ namespace System
         /// </summary>
         public static bool StartsWith(this ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
         {
+            StringSpanHelpers.CheckStringComparison(comparisonType);
+
             if (value.Length == 0)
             {
-                StringSpanHelpers.CheckStringComparison(comparisonType);
                 return true;
             }
 
@@ -276,10 +277,10 @@ namespace System
 
                 case StringComparison.OrdinalIgnoreCase:
                     return StartsWithOrdinalIgnoreCaseHelper(span, value);
-
-                default:
-                    throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
             }
+
+            Debug.Fail("StringComparison outside range");
+            return false;
         }
 
         internal static bool StartsWithCultureHelper(ReadOnlySpan<char> span, ReadOnlySpan<char> value, CompareInfo compareInfo)
@@ -401,9 +402,10 @@ namespace System
         /// </summary>
         public static bool EndsWith(this ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
         {
+            StringSpanHelpers.CheckStringComparison(comparisonType);
+
             if (value.Length == 0)
             {
-                StringSpanHelpers.CheckStringComparison(comparisonType);
                 return true;
             }
 
@@ -426,10 +428,10 @@ namespace System
 
                 case StringComparison.OrdinalIgnoreCase:
                     return EndsWithOrdinalIgnoreCaseHelper(span, value);
-
-                default:
-                    throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
             }
+
+            Debug.Fail("StringComparison outside range");
+            return false;
         }
 
         internal static bool EndsWithCultureHelper(ReadOnlySpan<char> span, ReadOnlySpan<char> value, CompareInfo compareInfo)

--- a/src/mscorlib/shared/System/String.Manipulation.cs
+++ b/src/mscorlib/shared/System/String.Manipulation.cs
@@ -916,29 +916,27 @@ namespace System
 
         public string Replace(string oldValue, string newValue, StringComparison comparisonType)
         {
+            StringSpanHelpers.CheckStringComparison(comparisonType);
+
             switch (comparisonType)
             {
                 case StringComparison.CurrentCulture:
-                    return ReplaceCore(oldValue, newValue, CultureInfo.CurrentCulture, CompareOptions.None);
-
                 case StringComparison.CurrentCultureIgnoreCase:
-                    return ReplaceCore(oldValue, newValue, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase);
+                    return ReplaceCore(oldValue, newValue, CultureInfo.CurrentCulture, StringSpanHelpers.GetCaseCompareOfComparisonCulture(comparisonType));
 
                 case StringComparison.InvariantCulture:
-                    return ReplaceCore(oldValue, newValue, CultureInfo.InvariantCulture, CompareOptions.None);
-
                 case StringComparison.InvariantCultureIgnoreCase:
-                    return ReplaceCore(oldValue, newValue, CultureInfo.InvariantCulture, CompareOptions.IgnoreCase);
+                    return ReplaceCore(oldValue, newValue, CultureInfo.InvariantCulture, StringSpanHelpers.GetCaseCompareOfComparisonCulture(comparisonType));
 
                 case StringComparison.Ordinal:
                     return Replace(oldValue, newValue);
 
                 case StringComparison.OrdinalIgnoreCase:
                     return ReplaceCore(oldValue, newValue, CultureInfo.InvariantCulture, CompareOptions.OrdinalIgnoreCase);
-
-                default:
-                    throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
             }
+
+            Debug.Fail("StringComparison outside range");
+            return null;
         }
 
         private unsafe string ReplaceCore(string oldValue, string newValue, CultureInfo culture, CompareOptions options)

--- a/src/mscorlib/shared/System/String.Searching.cs
+++ b/src/mscorlib/shared/System/String.Searching.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
 
@@ -44,31 +45,29 @@ namespace System
 
         public int IndexOf(char value, StringComparison comparisonType)
         {
+            StringSpanHelpers.CheckStringComparison(comparisonType);
+
             switch (comparisonType)
             {
                 case StringComparison.CurrentCulture:
-                    return CultureInfo.CurrentCulture.CompareInfo.IndexOf(this, value, CompareOptions.None);
-
                 case StringComparison.CurrentCultureIgnoreCase:
-                    return CultureInfo.CurrentCulture.CompareInfo.IndexOf(this, value, CompareOptions.IgnoreCase);
+                    return CultureInfo.CurrentCulture.CompareInfo.IndexOf(this, value, StringSpanHelpers.GetCaseCompareOfComparisonCulture(comparisonType));
 
                 case StringComparison.InvariantCulture:
-                    return CompareInfo.Invariant.IndexOf(this, value, CompareOptions.None);
-
                 case StringComparison.InvariantCultureIgnoreCase:
-                    return CompareInfo.Invariant.IndexOf(this, value, CompareOptions.IgnoreCase);
+                    return CompareInfo.Invariant.IndexOf(this, value, StringSpanHelpers.GetCaseCompareOfComparisonCulture(comparisonType));
 
                 case StringComparison.Ordinal:
                     return CompareInfo.Invariant.IndexOf(this, value, CompareOptions.Ordinal);
 
                 case StringComparison.OrdinalIgnoreCase:
                     return CompareInfo.Invariant.IndexOf(this, value, CompareOptions.OrdinalIgnoreCase);
-                    
-                default:
-                    throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
             }
+
+            Debug.Fail("StringComparison outside range");
+            return 0;
         }
-        
+
         public unsafe int IndexOf(char value, int startIndex, int count)
         {
             if (startIndex < 0 || startIndex > Length)
@@ -352,29 +351,27 @@ namespace System
             if (count < 0 || startIndex > this.Length - count)
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_Count);
 
+            StringSpanHelpers.CheckStringComparison(comparisonType);
+
             switch (comparisonType)
             {
                 case StringComparison.CurrentCulture:
-                    return CultureInfo.CurrentCulture.CompareInfo.IndexOf(this, value, startIndex, count, CompareOptions.None);
-
                 case StringComparison.CurrentCultureIgnoreCase:
-                    return CultureInfo.CurrentCulture.CompareInfo.IndexOf(this, value, startIndex, count, CompareOptions.IgnoreCase);
+                    return CultureInfo.CurrentCulture.CompareInfo.IndexOf(this, value, startIndex, count, StringSpanHelpers.GetCaseCompareOfComparisonCulture(comparisonType));
 
                 case StringComparison.InvariantCulture:
-                    return CompareInfo.Invariant.IndexOf(this, value, startIndex, count, CompareOptions.None);
-
                 case StringComparison.InvariantCultureIgnoreCase:
-                    return CompareInfo.Invariant.IndexOf(this, value, startIndex, count, CompareOptions.IgnoreCase);
+                    return CompareInfo.Invariant.IndexOf(this, value, startIndex, count, StringSpanHelpers.GetCaseCompareOfComparisonCulture(comparisonType));
 
                 case StringComparison.Ordinal:
                     return CompareInfo.Invariant.IndexOfOrdinal(this, value, startIndex, count, ignoreCase: false);
 
                 case StringComparison.OrdinalIgnoreCase:
                     return CompareInfo.Invariant.IndexOfOrdinal(this, value, startIndex, count, ignoreCase: true);
-
-                default:
-                    throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
             }
+
+            Debug.Fail("StringComparison outside range");
+            return 0;
         }
 
         // Returns the index of the last occurrence of a specified character in the current instance.
@@ -580,29 +577,25 @@ namespace System
             if (value.Length == 0)
                 return startIndex;
 
+            StringSpanHelpers.CheckStringComparison(comparisonType);
+
             switch (comparisonType)
             {
                 case StringComparison.CurrentCulture:
-                    return CultureInfo.CurrentCulture.CompareInfo.LastIndexOf(this, value, startIndex, count, CompareOptions.None);
-
                 case StringComparison.CurrentCultureIgnoreCase:
-                    return CultureInfo.CurrentCulture.CompareInfo.LastIndexOf(this, value, startIndex, count, CompareOptions.IgnoreCase);
+                    return CultureInfo.CurrentCulture.CompareInfo.LastIndexOf(this, value, startIndex, count, StringSpanHelpers.GetCaseCompareOfComparisonCulture(comparisonType));
 
                 case StringComparison.InvariantCulture:
-                    return CompareInfo.Invariant.LastIndexOf(this, value, startIndex, count, CompareOptions.None);
-
                 case StringComparison.InvariantCultureIgnoreCase:
-                    return CompareInfo.Invariant.LastIndexOf(this, value, startIndex, count, CompareOptions.IgnoreCase);
+                    return CompareInfo.Invariant.LastIndexOf(this, value, startIndex, count, StringSpanHelpers.GetCaseCompareOfComparisonCulture(comparisonType));
 
                 case StringComparison.Ordinal:
-                    return CompareInfo.Invariant.LastIndexOfOrdinal(this, value, startIndex, count, ignoreCase: false);
-
                 case StringComparison.OrdinalIgnoreCase:
-                    return CompareInfo.Invariant.LastIndexOfOrdinal(this, value, startIndex, count, ignoreCase: true);
-
-                default:
-                    throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
+                    return CompareInfo.Invariant.LastIndexOfOrdinal(this, value, startIndex, count, ignoreCase: comparisonType == StringComparison.OrdinalIgnoreCase);
             }
+
+            Debug.Fail("StringComparison outside range");
+            return 0;
         }
 
         [StructLayout(LayoutKind.Explicit, Size = PROBABILISTICMAP_SIZE * sizeof(uint))]

--- a/src/mscorlib/shared/System/StringComparer.cs
+++ b/src/mscorlib/shared/System/StringComparer.cs
@@ -4,6 +4,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.Serialization;
 
@@ -69,6 +70,8 @@ namespace System
         // Convert a StringComparison to a StringComparer
         public static StringComparer FromComparison(StringComparison comparisonType)
         {
+            StringSpanHelpers.CheckStringComparison(comparisonType);
+
             switch (comparisonType)
             {
                 case StringComparison.CurrentCulture:
@@ -83,9 +86,10 @@ namespace System
                     return Ordinal;
                 case StringComparison.OrdinalIgnoreCase:
                     return OrdinalIgnoreCase;
-                default:
-                    throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
             }
+
+            Debug.Fail("StringComparison outside range");
+            return null;
         }
 
         public static StringComparer Create(CultureInfo culture, bool ignoreCase)

--- a/src/mscorlib/shared/System/StringSpanHelpers.cs
+++ b/src/mscorlib/shared/System/StringSpanHelpers.cs
@@ -182,7 +182,7 @@ namespace System
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static ArgumentException GetStringComparisonException_NotSupported()
         {
-            throw new ArgumentException(SR.NotSupported_StringComparison, "comparisonType");
+            return new ArgumentException(SR.NotSupported_StringComparison, "comparisonType");
         }
     }
 }

--- a/src/mscorlib/shared/System/StringSpanHelpers.cs
+++ b/src/mscorlib/shared/System/StringSpanHelpers.cs
@@ -149,7 +149,7 @@ namespace System
             // Single comparison to check if comparisonType is within [CurrentCulture .. OrdinalIgnoreCase]
             if ((uint)(comparisonType - StringComparison.CurrentCulture) > (StringComparison.OrdinalIgnoreCase - StringComparison.CurrentCulture))
             {
-                throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
+                ThrowHelper.ThrowArgumentException(ExceptionResource.NotSupported_StringComparison, ExceptionArgument.comparisonType);
             }
         }
     }

--- a/src/mscorlib/src/System/String.Comparison.cs
+++ b/src/mscorlib/src/System/String.Comparison.cs
@@ -5,7 +5,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
-
+using System.Runtime.InteropServices;
 using Internal.Runtime.CompilerServices;
 
 #if BIT64

--- a/src/mscorlib/src/System/String.Comparison.cs
+++ b/src/mscorlib/src/System/String.Comparison.cs
@@ -923,16 +923,15 @@ namespace System
             }
         }
 
-
         // Determines whether two Strings match.
-        public static bool Equals(String a, String b)
+        public static bool Equals(string a, string b)
         {
-            if ((Object)a == (Object)b)
+            if (ReferenceEquals(a, b))
             {
                 return true;
             }
 
-            if ((Object)a == null || (Object)b == null || a.Length != b.Length)
+            if (a is null || a.Length != b.Length)
             {
                 return false;
             }
@@ -940,20 +939,20 @@ namespace System
             return EqualsHelper(a, b);
         }
 
-        public static bool Equals(String a, String b, StringComparison comparisonType)
+        public static bool Equals(string a, string b, StringComparison comparisonType)
         {
-            if ((Object)a == (Object)b)
+            bool isSameReference = ReferenceEquals(a, b);
+            if (isSameReference || a is null)
             {
                 StringSpanHelpers.CheckStringComparison(comparisonType);
-                return true;
+                return isSameReference;
             }
 
-            if ((Object)a == null || (Object)b == null)
-            {
-                StringSpanHelpers.CheckStringComparison(comparisonType);
-                return false;
-            }
+            return EqualsHelper(a, b, comparisonType);
+        }
 
+        private static bool EqualsHelper(string a, string b, StringComparison comparisonType)
+        {
             switch (comparisonType)
             {
                 case StringComparison.CurrentCulture:
@@ -970,13 +969,16 @@ namespace System
 
                 case StringComparison.Ordinal:
                     if (a.Length != b.Length)
+                    {
                         return false;
-
+                    }
                     return EqualsHelper(a, b);
 
                 case StringComparison.OrdinalIgnoreCase:
                     if (a.Length != b.Length)
+                    {
                         return false;
+                    }
                     else
                     {
                         // If both strings are ASCII strings, we can take the fast path.
@@ -994,14 +996,14 @@ namespace System
             }
         }
 
-        public static bool operator ==(String a, String b)
+        public static bool operator ==(string a, string b)
         {
-            return String.Equals(a, b);
+            return string.Equals(a, b);
         }
 
-        public static bool operator !=(String a, String b)
+        public static bool operator !=(string a, string b)
         {
-            return !String.Equals(a, b);
+            return !string.Equals(a, b);
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]

--- a/src/mscorlib/src/System/String.Comparison.cs
+++ b/src/mscorlib/src/System/String.Comparison.cs
@@ -22,42 +22,6 @@ namespace System
         //Native Static Methods
         //
 
-        private unsafe static int CompareOrdinalIgnoreCaseHelper(String strA, String strB)
-        {
-            Debug.Assert(strA != null);
-            Debug.Assert(strB != null);
-            int length = Math.Min(strA.Length, strB.Length);
-
-            fixed (char* ap = &strA._firstChar) fixed (char* bp = &strB._firstChar)
-            {
-                char* a = ap;
-                char* b = bp;
-                int charA = 0, charB = 0;
-
-                while (length != 0)
-                {
-                    charA = *a;
-                    charB = *b;
-
-                    Debug.Assert((charA | charB) <= 0x7F, "strings have to be ASCII");
-
-                    // uppercase both chars - notice that we need just one compare per char
-                    if ((uint)(charA - 'a') <= (uint)('z' - 'a')) charA -= 0x20;
-                    if ((uint)(charB - 'a') <= (uint)('z' - 'a')) charB -= 0x20;
-
-                    //Return the (case-insensitive) difference between them.
-                    if (charA != charB)
-                        return charA - charB;
-
-                    // Next char
-                    a++; b++;
-                    length--;
-                }
-
-                return strA.Length - strB.Length;
-            }
-        }
-
         // native call to COMString::CompareOrdinalEx
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern int CompareOrdinalHelper(String strA, int indexA, int countA, String strB, int indexB, int countB);

--- a/src/mscorlib/src/System/String.Comparison.cs
+++ b/src/mscorlib/src/System/String.Comparison.cs
@@ -803,7 +803,7 @@ namespace System
                 return true;
             }
 
-            if (value is null || value.Length != value.Length)
+            if (value is null || this.Length != value.Length)
             {
                 return false;
             }

--- a/src/mscorlib/src/System/String.Comparison.cs
+++ b/src/mscorlib/src/System/String.Comparison.cs
@@ -800,7 +800,7 @@ namespace System
                 return true;
             }
 
-            if (a is null || a.Length != b.Length)
+            if (a is null || b is null || a.Length != b.Length)
             {
                 return false;
             }
@@ -817,7 +817,7 @@ namespace System
                 return true;
             }
 
-            if (a is null)
+            if (a is null || b is null)
             {
                 return false;
             }

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -471,8 +471,7 @@ namespace System
         pointer,
         start,
         format,
-        culture,
-        comparisonType,
+        culture
     }
 
     //
@@ -582,7 +581,6 @@ namespace System
         InvalidOperation_HandleIsNotInitialized,
         AsyncMethodBuilder_InstanceNotInitialized,
         ArgumentNull_SafeHandle,
-        NotSupported_StringComparison,
     }
 }
 

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -471,7 +471,8 @@ namespace System
         pointer,
         start,
         format,
-        culture
+        culture,
+        comparisonType,
     }
 
     //
@@ -581,6 +582,7 @@ namespace System
         InvalidOperation_HandleIsNotInitialized,
         AsyncMethodBuilder_InstanceNotInitialized,
         ArgumentNull_SafeHandle,
+        NotSupported_StringComparison,
     }
 }
 


### PR DESCRIPTION
Allows String.Equals (of all forms) to inline for the null and ref equality parts.

Remove `case default` inline throw as `StringSpanHelpers.CheckStringComparison` already deals with out of range

Deduplicate calls to `StringSpanHelpers.CheckStringComparison` and always use it, rather than in some if branches (so the `case default` can be removed)

Add `GetCaseCompareOfComparisonCulture` that converts `StringComparison` to `CompareOptions` with a single `&` when comparison is a culture.

Dedupe the calls using it.

Remove the now other duplicated code (for equals)

Resolves #14320 
"Consider removing String.IsAscii() fast paths" as `CompareOrdinalIgnoreCase(ReadOnlySpan<char>,ReadOnlySpan<char>)` has an ascii fast-path in it

Resolves #10293 "Differences between String.CompareOrdinalIgnoreCaseHelper and CompareInfo.CompareOrdinalIgnoreCase" by removing the `string` version in consolidation