### PR TITLE
Disable tiered compilation for collectible assemblies

### DIFF
--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -1252,7 +1252,7 @@ public:
             !IsUnboxingStub() &&
             !IsInstantiatingStub() &&
             !IsDynamicMethod() &&
-            !GetModule()->IsCollectible() &&
+            !GetLoaderAllocator()->IsCollectible() &&
             !CORDisableJITOptimizations(GetModule()->GetDebuggerInfoBits()) &&
             !CORProfilerDisableTieredCompilation();
     }

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -1252,6 +1252,7 @@ public:
             !IsUnboxingStub() &&
             !IsInstantiatingStub() &&
             !IsDynamicMethod() &&
+            !GetModule()->IsCollectible() &&
             !CORDisableJITOptimizations(GetModule()->GetDebuggerInfoBits()) &&
             !CORProfilerDisableTieredCompilation();
     }

--- a/tests/src/reflection/Tier1Collectible/Tier1Collectible.cs
+++ b/tests/src/reflection/Tier1Collectible/Tier1Collectible.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+public static class Program
+{
+    private static int Main()
+    {
+        const int Pass = 100, Fail = 1;
+
+        PromoteToTier1AndRun(() =>
+        {
+            CollectibleTestIteration();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.WaitForPendingFinalizers();
+        });
+
+        return Pass;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void CollectibleTestIteration()
+    {
+        GetCollectible().Hello();
+    }
+
+    private static int s_collectibleIndex = 0;
+
+    public interface IHelloWorld
+    {
+        void Hello();
+    }
+
+    private static IHelloWorld GetCollectible()
+    {
+        int collectibleIndex = s_collectibleIndex++;
+
+        AssemblyBuilder ab = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName("CollectibleAssembly" + collectibleIndex),
+            AssemblyBuilderAccess.RunAndCollect);
+
+        ModuleBuilder mb = ab.DefineDynamicModule("CollectibleModule" + collectibleIndex);
+
+        TypeBuilder tb = mb.DefineType("CollectibleHelloType" + collectibleIndex, TypeAttributes.Public);
+        tb.AddInterfaceImplementation(typeof(IHelloWorld));
+        tb.DefineDefaultConstructor(MethodAttributes.Public);
+
+        MethodBuilder methb = tb.DefineMethod("Hello", MethodAttributes.Public | MethodAttributes.Virtual);
+        methb.GetILGenerator().Emit(OpCodes.Ret);
+
+        Type helloType = tb.CreateTypeInfo().UnderlyingSystemType;
+        return (IHelloWorld)Activator.CreateInstance(helloType);
+    }
+
+    private static void PromoteToTier1AndRun(Action action)
+    {
+        // Call the method once to register a call for call counting
+        action();
+
+        // Allow time for call counting to begin
+        Thread.Sleep(500);
+
+        // Call the method enough times to trigger tier 1 promotion
+        for (int i = 0; i < 100; i++)
+        {
+            action();
+        }
+
+        // Allow time for the method to be jitted at tier 1
+        Thread.Sleep(500);
+
+        // Run the tier 1 code
+        action();
+    }
+}

--- a/tests/src/reflection/Tier1Collectible/Tier1Collectible.csproj
+++ b/tests/src/reflection/Tier1Collectible/Tier1Collectible.csproj
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{58DB4A46-51BE-46A1-AEA1-0C32FBAF5562}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <LangVersion>latest</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Tier1Collectible.cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_EXPERIMENTAL_TieredCompilation=1
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_EXPERIMENTAL_TieredCompilation=1
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
- An assembly can be marked collectible with methods not marked as dynamic
- The method desc and code can be deleted and a new method desc reallocated in the same location, code versioning doesn't handle this at the moment