### PR TITLE
Inline String->ReadOnlySpan

### DIFF
--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -697,6 +697,7 @@ namespace System
             throw new ArgumentOutOfRangeException(nameof(length));
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static implicit operator ReadOnlySpan<char>(string value) =>
             value != null ? new ReadOnlySpan<char>(ref value.GetRawStringData(), value.Length) : default;
 


### PR DESCRIPTION
The conversion doesn't currently inline producing
```asm
       lea      rcx, bword ptr [rsp+58H]
       mov      rdx, rdi
       call     String:op_Implicit(ref):struct
       lea      rcx, bword ptr [rsp+48H]
       mov      rdx, rbx
       call     String:op_Implicit(ref):struct
       lea      rcx, bword ptr [rsp+38H]
       mov      rdx, bword ptr [rsp+58H]
       mov      bword ptr [rcx], rdx
       mov      edx, dword ptr [rsp+60H]
       mov      dword ptr [rcx+8], edx
       lea      rcx, bword ptr [rsp+28H]
       mov      rdx, bword ptr [rsp+48H]
       mov      bword ptr [rcx], rdx
       mov      edx, dword ptr [rsp+50H]
       mov      dword ptr [rcx+8], edx
       lea      rcx, bword ptr [rsp+38H]
       lea      rdx, bword ptr [rsp+28H]
       call     CompareInfo:CompareOrdinalIgnoreCase(struct,struct):int
```
When inlined this reduces to
```asm
       lea      rax, bword ptr [rdi+12]
       lea      r8, bword ptr [rbx+12]
       lea      r9, bword ptr [rsp+38H]
       mov      bword ptr [r9], rax
       mov      dword ptr [r9+8], ecx
       lea      rcx, bword ptr [rsp+28H]
       mov      bword ptr [rcx], r8
       mov      dword ptr [rcx+8], edx
       lea      rcx, bword ptr [rsp+38H]
       lea      rdx, bword ptr [rsp+28H]
       call     CompareInfo:CompareOrdinalIgnoreCase(struct,struct):int
```

/cc @jkotas @stephentoub 