### PR TITLE
Handle TYP_SIMD8 correctly in genCodeForLclFld

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -4345,7 +4345,7 @@ void CodeGen::genCodeForLclFld(GenTreeLclFld* tree)
     unsigned varNum = tree->gtLclNum;
     assert(varNum < compiler->lvaCount);
 
-    getEmitter()->emitIns_R_S(ins_Move_Extend(targetType, false), size, targetReg, varNum, offs);
+    getEmitter()->emitIns_R_S(ins_Load(targetType), size, targetReg, varNum, offs);
 
     genProduceReg(tree);
 }

--- a/tests/src/JIT/Regression/JitBlue/GitHub_16443/GitHub_16443.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_16443/GitHub_16443.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Numerics;
+
+class Program
+{
+    struct vec2
+    {
+        public Vector2 value;
+        public vec2(float x, float y) => value = new Vector2(x, y);
+    }
+
+    static int Main()
+    {
+        var a = new vec2(0.42f, 0.24f);
+        var b = new vec2(0.42f, 0.24f);
+        return a.value.Equals(b.value) ? 100 : 1;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_16443/GitHub_16443.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_16443/GitHub_16443.csproj
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <DebugType></DebugType>
+    <Optimize>False</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_16443.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
When loading a `TYP_SIMD8` local field movsd should be used, not movups. Unlike `ins_Move_Extend`, `ins_Load` does the right thing and it's consistent with indirs.

No diffs.

Fixes #16443