### PR TITLE
Dial back aggressive checks in Path

### DIFF
--- a/src/mscorlib/shared/System/IO/Path.Unix.cs
+++ b/src/mscorlib/shared/System/IO/Path.Unix.cs
@@ -116,8 +116,9 @@ namespace System.IO
             return path.Length > 0 && path[0] == PathInternal.DirectorySeparatorChar;
         }
 
-        // The resulting string is null if path is null. If the path is empty or
-        // only contains whitespace characters an ArgumentException gets thrown.
+        /// <summary>
+        /// Returns the path root or null if path is empty or null.
+        /// </summary>
         public static string GetPathRoot(string path)
         {
             if (PathInternal.IsEffectivelyEmpty(path)) return null;

--- a/src/mscorlib/shared/System/IO/Path.Unix.cs
+++ b/src/mscorlib/shared/System/IO/Path.Unix.cs
@@ -120,11 +120,9 @@ namespace System.IO
         // only contains whitespace characters an ArgumentException gets thrown.
         public static string GetPathRoot(string path)
         {
-            if (path == null) return null;
-            if (PathInternal.IsEffectivelyEmpty(path))
-                throw new ArgumentException(SR.Arg_PathEmpty, nameof(path));
+            if (PathInternal.IsEffectivelyEmpty(path)) return null;
 
-            return IsPathRooted(path) ? PathInternal.DirectorySeparatorCharAsString : String.Empty;
+            return IsPathRooted(path) ? PathInternal.DirectorySeparatorCharAsString : string.Empty;
         }
 
         public static ReadOnlySpan<char> GetPathRoot(ReadOnlySpan<char> path)

--- a/src/mscorlib/shared/System/IO/Path.Windows.cs
+++ b/src/mscorlib/shared/System/IO/Path.Windows.cs
@@ -182,7 +182,8 @@ namespace System.IO
         public static bool IsPathRooted(ReadOnlySpan<char> path)
         {
             int length = path.Length;
-            return (length >= 1 && PathInternal.IsDirectorySeparator(path[0])) || (length >= 2 && PathInternal.IsValidDriveChar(path[0]) && path[1] == PathInternal.VolumeSeparatorChar);
+            return (length >= 1 && PathInternal.IsDirectorySeparator(path[0]))
+                || (length >= 2 && PathInternal.IsValidDriveChar(path[0]) && path[1] == PathInternal.VolumeSeparatorChar);
         }
 
         // Returns the root portion of the given path. The resulting string
@@ -196,11 +197,8 @@ namespace System.IO
         // only contains whitespace characters an ArgumentException gets thrown.
         public static string GetPathRoot(string path)
         {
-            if (path == null)
-                return null;
-
             if (PathInternal.IsEffectivelyEmpty(path))
-                throw new ArgumentException(SR.Arg_PathEmpty, nameof(path));
+                return null;
 
             ReadOnlySpan<char> result = GetPathRoot(path.AsReadOnlySpan());
             if (path.Length == result.Length)
@@ -223,7 +221,6 @@ namespace System.IO
 
         /// <summary>Gets whether the system is case-sensitive.</summary>
         internal static bool IsCaseSensitive { get { return false; } }
-
 
         /// <summary>
         /// Returns the volume name for dos, UNC and device paths.

--- a/src/mscorlib/shared/System/IO/Path.cs
+++ b/src/mscorlib/shared/System/IO/Path.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -52,7 +51,7 @@ namespace System.IO
                         s = path.Substring(0, i);
                         break;
                     }
-                    if (PathInternal.IsDirectoryOrVolumeSeparator(ch)) break;
+                    if (PathInternal.IsDirectorySeparator(ch)) break;
                 }
 
                 if (extension != null && path.Length != 0)
@@ -67,29 +66,30 @@ namespace System.IO
             return null;
         }
 
-        // Returns the directory path of a file path. This method effectively
-        // removes the last element of the given file path, i.e. it returns a
-        // string consisting of all characters up to but not including the last
-        // backslash ("\") in the file path. The returned value is null if the file
-        // path is null or if the file path denotes a root (such as "\", "C:", or
-        // "\\server\share").
+        /// <summary>
+        /// Returns the directory portion of a file path. This method effectively
+        /// removes the last segment of the given file path, i.e. it returns a
+        /// string consisting of all characters up to but not including the last
+        /// backslash ("\") in the file path. The returned value is null if the
+        /// specified path is null, empty, or a root (such as "\", "C:", or
+        /// "\\server\share").
+        /// </summary>
+        /// <remarks>
+        /// Directory separators are normalized in the returned string.
+        /// </remarks>
         public static string GetDirectoryName(string path)
         {
-            if (path == null)
+            if (PathInternal.IsEffectivelyEmpty(path))
                 return null;
 
-            if (PathInternal.IsEffectivelyEmpty(path))
-                throw new ArgumentException(SR.Arg_PathEmpty, nameof(path));
-
-            path = PathInternal.NormalizeDirectorySeparators(path);
-            int end = PathInternal.GetDirectoryNameOffset(path);
-            return end >= 0 ? path.Substring(0, end) : null;
+            int end = GetDirectoryNameOffset(path);
+            return end >= 0 ? PathInternal.NormalizeDirectorySeparators(path.Substring(0, end)) : null;
         }
 
         /// <summary>
-        /// Returns the directory path of a file path.
-        /// The returned value the an empty ReadOnlySpan if path is empty or 
-        /// if the file path denotes as root  (such as "\", "C:", or "\\server\share"). 
+        /// Returns the directory portion of a file path. The returned value is empty
+        /// if the specified path is null, empty, or a root (such as "\", "C:", or
+        /// "\\server\share").
         /// </summary>
         /// <remarks>
         /// Unlike the string overload, this method will not normalize directory separators.
@@ -99,8 +99,24 @@ namespace System.IO
             if (PathInternal.IsEffectivelyEmpty(path))
                 return ReadOnlySpan<char>.Empty;
 
-            int end = PathInternal.GetDirectoryNameOffset(path);
+            int end = GetDirectoryNameOffset(path);
             return end >= 0 ? path.Slice(0, end) : ReadOnlySpan<char>.Empty;
+        }
+
+        private static int GetDirectoryNameOffset(ReadOnlySpan<char> path)
+        {
+            int rootLength = PathInternal.GetRootLength(path);
+            int end = path.Length;
+            if (end <= rootLength)
+                return -1;
+
+            while (end > rootLength && !PathInternal.IsDirectorySeparator(path[--end]));
+
+            // Trim off any remaining separators (to deal with C:\foo\\bar)
+            while (end > rootLength && PathInternal.IsDirectorySeparator(path[end - 1]))
+                end--;
+
+            return end;
         }
 
         // Returns the extension of the given path. The returned value includes the
@@ -119,7 +135,7 @@ namespace System.IO
         /// Returns the extension of the given path.
         /// </summary>
         /// <remarks> 
-        /// The returned value is an empty ReadOnlySpan if the given path doesnot include an extension.
+        /// The returned value is an empty ReadOnlySpan if the given path does not include an extension.
         /// </remarks>
         public static ReadOnlySpan<char> GetExtension(ReadOnlySpan<char> path)
         {
@@ -135,7 +151,7 @@ namespace System.IO
                     else
                         return ReadOnlySpan<char>.Empty;
                 }
-                if (PathInternal.IsDirectoryOrVolumeSeparator(ch))
+                if (PathInternal.IsDirectorySeparator(ch))
                     break;
             }
             return ReadOnlySpan<char>.Empty;
@@ -156,14 +172,23 @@ namespace System.IO
             return new string(result);
         }
 
-        /// <summary> 
+        /// <summary>
         /// The returned ReadOnlySpan contains the characters of the path that follows the last separator in path.
         /// </summary>
         public static ReadOnlySpan<char> GetFileName(ReadOnlySpan<char> path)
         {
-            int offset = PathInternal.FindFileNameIndex(path);
-            int count = path.Length - offset;
-            return path.Slice(offset, count);
+            int root = GetPathRoot(path).Length;
+
+            // We don't want to cut off "C:\file.txt:stream" (i.e. should be "file.txt:stream")
+            // but we *do* want "C:Foo" => "Foo". This necessitates checking for the root.
+
+            for (int i = path.Length; --i >= 0;)
+            {
+                if (i < root || PathInternal.IsDirectorySeparator(path[i]))
+                    return path.Slice(i + 1, path.Length - i - 1);
+            }
+
+            return path;
         }
 
         public static string GetFileNameWithoutExtension(string path)
@@ -183,13 +208,11 @@ namespace System.IO
         /// </summary>
         public static ReadOnlySpan<char> GetFileNameWithoutExtension(ReadOnlySpan<char> path)
         {
-            int length = path.Length;
-            int offset = PathInternal.FindFileNameIndex(path);
-
-            int end = path.Slice(offset, length - offset).LastIndexOf('.');
-            return end == -1 ?
-                path.Slice(offset) : // No extension was found
-                path.Slice(offset, end);
+            ReadOnlySpan<char> fileName = GetFileName(path);
+            int lastPeriod = fileName.LastIndexOf('.');
+            return lastPeriod == -1 ?
+                fileName : // No extension was found
+                fileName.Slice(0, lastPeriod);
         }
 
         // Returns a cryptographically strong random 8.3 string that can be 
@@ -223,9 +246,8 @@ namespace System.IO
         public static bool IsPathFullyQualified(string path)
         {
             if (path == null)
-            {
                 throw new ArgumentNullException(nameof(path));
-            }
+
             return IsPathFullyQualified(path.AsReadOnlySpan());
         }
 
@@ -256,7 +278,7 @@ namespace System.IO
                 {
                     return i != path.Length - 1;
                 }
-                if (PathInternal.IsDirectoryOrVolumeSeparator(ch))
+                if (PathInternal.IsDirectorySeparator(ch))
                     break;
             }
             return false;
@@ -322,7 +344,7 @@ namespace System.IO
                 }
 
                 char ch = paths[i][paths[i].Length - 1];
-                if (!PathInternal.IsDirectoryOrVolumeSeparator(ch))
+                if (!PathInternal.IsDirectorySeparator(ch))
                     finalSize++;
             }
 
@@ -342,7 +364,7 @@ namespace System.IO
                 else
                 {
                     char ch = finalPath[finalPath.Length - 1];
-                    if (!PathInternal.IsDirectoryOrVolumeSeparator(ch))
+                    if (!PathInternal.IsDirectorySeparator(ch))
                     {
                         finalPath.Append(PathInternal.DirectorySeparatorChar);
                     }
@@ -376,8 +398,8 @@ namespace System.IO
 
         private static string CombineNoChecks(string first, string second)
         {
-			if (string.IsNullOrEmpty(first))
-				return second;
+            if (string.IsNullOrEmpty(first))
+                return second;
 
             if (string.IsNullOrEmpty(second))
                 return first;
@@ -617,7 +639,7 @@ namespace System.IO
             // Remove "//", "/./", and "/../" from the path by copying each character to the output, 
             // except the ones we're removing, such that the builder contains the normalized path 
             // at the end.
-            var sb = StringBuilderCache.Acquire(path.Length);
+            StringBuilder sb = StringBuilderCache.Acquire(path.Length);
             if (skip > 0)
             {
                 sb.Append(path, 0, skip);

--- a/src/mscorlib/shared/System/IO/Path.cs
+++ b/src/mscorlib/shared/System/IO/Path.cs
@@ -424,7 +424,7 @@ namespace System.IO
             if (IsPathRooted(second))
                 return CombineNoChecks(second, third);
 
-            return CombineNoChecksInternal(first, second, third);            
+            return CombineNoChecksInternal(first, second, third);
         }
 
         private static string CombineNoChecks(string first, string second, string third)
@@ -471,9 +471,9 @@ namespace System.IO
                 return CombineNoChecks(second, third, fourth);
             if (string.IsNullOrEmpty(second))
                 return CombineNoChecks(first, third, fourth);
-			if (string.IsNullOrEmpty(third))
+            if (string.IsNullOrEmpty(third))
                 return CombineNoChecks(first, second, fourth);
-			if (string.IsNullOrEmpty(fourth))
+            if (string.IsNullOrEmpty(fourth))
                 return CombineNoChecks(first, second, third);
 
             if (IsPathRooted(fourth.AsReadOnlySpan()))

--- a/src/mscorlib/shared/System/IO/PathHelper.Windows.cs
+++ b/src/mscorlib/shared/System/IO/PathHelper.Windows.cs
@@ -178,13 +178,10 @@ namespace System.IO
             // it doesn't root extended paths correctly. We don't currently resolve extended paths, so we'll just assert here.
             Debug.Assert(PathInternal.IsPartiallyQualified(path) || !PathInternal.IsExtended(path));
 
-            // Historically we would skip leading spaces *only* if the path started with a drive " C:" or a UNC " \\"
-            int startIndex = PathInternal.PathStartSkip(path);
-
             fixed (char* pathStart = path)
             {
                 uint result = 0;
-                while ((result = Interop.Kernel32.GetFullPathNameW(pathStart + startIndex, (uint)fullPath.Capacity, fullPath.UnderlyingArray, IntPtr.Zero)) > fullPath.Capacity)
+                while ((result = Interop.Kernel32.GetFullPathNameW(pathStart, (uint)fullPath.Capacity, fullPath.UnderlyingArray, IntPtr.Zero)) > fullPath.Capacity)
                 {
                     // Reported size is greater than the buffer size. Increase the capacity.
                     fullPath.EnsureCapacity(checked((int)result));

--- a/src/mscorlib/shared/System/IO/PathInternal.Unix.cs
+++ b/src/mscorlib/shared/System/IO/PathInternal.Unix.cs
@@ -77,19 +77,6 @@ namespace System.IO
             return builder.ToString();
         }
 
-        /// <summary>
-        /// Returns true if the character is a directory or volume separator.
-        /// </summary>
-        /// <param name="ch">The character to test.</param>
-        internal static bool IsDirectoryOrVolumeSeparator(char ch)
-        {
-            // The directory separator, volume separator, and the alternate directory
-            // separator should be the same on Unix, so we only need to check one.
-            Debug.Assert(DirectorySeparatorChar == AltDirectorySeparatorChar);
-            Debug.Assert(DirectorySeparatorChar == VolumeSeparatorChar);
-            return ch == DirectorySeparatorChar;
-        }
-
         internal static bool IsPartiallyQualified(ReadOnlySpan<char> path)
         {
             // This is much simpler than Windows where paths can be rooted, but not fully qualified (such as Drive Relative)

--- a/src/mscorlib/shared/System/IO/PathInternal.Windows.cs
+++ b/src/mscorlib/shared/System/IO/PathInternal.Windows.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Text;
 
 namespace System.IO
@@ -397,15 +395,6 @@ namespace System.IO
             }
 
             return builder.ToString();
-        }
-
-        /// <summary>
-        /// Returns true if the character is a directory or volume separator.
-        /// </summary>
-        /// <param name="ch">The character to test.</param>
-        internal static bool IsDirectoryOrVolumeSeparator(char ch)
-        {
-            return IsDirectorySeparator(ch) || VolumeSeparatorChar == ch;
         }
 
         /// <summary>

--- a/src/mscorlib/shared/System/IO/PathInternal.cs
+++ b/src/mscorlib/shared/System/IO/PathInternal.cs
@@ -2,38 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
-using System.Text;
-
 namespace System.IO
 {
     /// <summary>Contains internal path helpers that are shared between many projects.</summary>
     internal static partial class PathInternal
     {
-        /// <summary>
-        /// Returns the start index of the filename
-        /// in the given path, or 0 if no directory
-        /// or volume separator is found.
-        /// </summary>
-        /// <param name="path">The path in which to find the index of the filename.</param>
-        /// <remarks>
-        /// This method returns path.Length for
-        /// inputs like "/usr/foo/" on Unix. As such,
-        /// it is not safe for being used to index
-        /// the string without additional verification.
-        /// </remarks>
-        internal static int FindFileNameIndex(ReadOnlySpan<char> path)
-        {
-            for (int i = path.Length - 1; i >= 0; i--)
-            {
-                char ch = path[i];
-                if (IsDirectoryOrVolumeSeparator(ch))
-                    return i + 1;
-            }
-
-            return 0; // the whole path is the filename
-        }
-
         /// <summary>
         /// Returns true if the path ends in a directory separator.
         /// </summary>
@@ -111,38 +84,6 @@ namespace System.IO
                     indexB: 0,
                     length: firstRootLength,
                     comparisonType: comparisonType) == 0;
-        }
-
-        /// <summary>
-        /// Returns false for ".." unless it is specified as a part of a valid File/Directory name.
-        /// (Used to avoid moving up directories.)
-        ///
-        ///       Valid: a..b   abc..d
-        ///     Invalid: ..ab   ab..   ..   abc..d\abc..
-        /// </summary>
-        internal static void CheckSearchPattern(string searchPattern)
-        {
-            int index;
-            while ((index = searchPattern.IndexOf("..", StringComparison.Ordinal)) != -1)
-            {
-                // Terminal ".." . Files names cannot end in ".."
-                if (index + 2 == searchPattern.Length
-                    || IsDirectorySeparator(searchPattern[index + 2]))
-                    throw new ArgumentException(SR.Format(SR.Arg_InvalidSearchPattern, searchPattern));
-
-                searchPattern = searchPattern.Substring(index + 2);
-            }
-        }
-
-        internal static int GetDirectoryNameOffset(ReadOnlySpan<char> path)
-        {
-            int root = GetRootLength(path);
-            int i = path.Length;
-            if (i <= root)
-                return -1;
-
-            while (i > root && !IsDirectorySeparator(path[--i]));
-            return i;
         }
     }
 }


### PR DESCRIPTION
Aggressive checks are preventing crossplat and extended Windows solutions. This change:

- Doesn't throw on empty paths fro GetDirectoryName, GetPathRoot
- Doesn't consider colon when looking at path segments on Windows
- Moves non-shared code out of PathInternal
- Fix span GetDirectoryName to handle multiple separators

I've marked this as no merge- I'll be linking in the necessary test fixes (not many).