### PR TITLE
Revert TLS model change of the gCurrentThreadInfo

### DIFF
--- a/src/vm/threads.inl
+++ b/src/vm/threads.inl
@@ -26,7 +26,7 @@
 #ifndef __llvm__
 EXTERN_C __declspec(thread) ThreadLocalInfo gCurrentThreadInfo;
 #else // !__llvm__
-EXTERN_C __thread ThreadLocalInfo gCurrentThreadInfo __attribute__ ((tls_model("initial-exec")));
+EXTERN_C __thread ThreadLocalInfo gCurrentThreadInfo;
 #endif // !__llvm__
 
 EXTERN_C inline Thread* STDCALL GetThread()


### PR DESCRIPTION
This change causes crashes due to incorrect TLS variable initialization
on Alpine Linux. The initial-exec model that the variable was modified
to use recently cannot be safely used in shared libraries.