### PR TITLE
Add ReadOnlySpan string-like Equals/CompareTo/IndexOf/Contains API with globalization support

### DIFF
--- a/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.Collation.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Globalization.Native/Interop.Collation.cs
@@ -22,12 +22,16 @@ internal static partial class Interop
 
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IndexOf")]
         internal unsafe static extern int IndexOf(SafeSortHandle sortHandle, string target, int cwTargetLength, char* pSource, int cwSourceLength, CompareOptions options, int* matchLengthPtr);
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IndexOf")]
+        internal unsafe static extern int IndexOf(SafeSortHandle sortHandle, char* target, int cwTargetLength, char* pSource, int cwSourceLength, CompareOptions options, int* matchLengthPtr);
 
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_LastIndexOf")]
         internal unsafe static extern int LastIndexOf(SafeSortHandle sortHandle, string target, int cwTargetLength, char* pSource, int cwSourceLength, CompareOptions options);
 
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IndexOfOrdinalIgnoreCase")]
         internal unsafe static extern int IndexOfOrdinalIgnoreCase(string target, int cwTargetLength, char* pSource, int cwSourceLength, bool findLast);
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IndexOfOrdinalIgnoreCase")]
+        internal unsafe static extern int IndexOfOrdinalIgnoreCase(char* target, int cwTargetLength, char* pSource, int cwSourceLength, bool findLast);
 
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_StartsWith")]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/mscorlib/shared/System/Globalization/CompareInfo.Invariant.cs
+++ b/src/mscorlib/shared/System/Globalization/CompareInfo.Invariant.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace System.Globalization
 {
@@ -23,6 +24,18 @@ namespace System.Globalization
                     return index + startIndex;
                 }
                 return -1;
+            }
+        }
+
+        internal static unsafe int InvariantIndexOf(ReadOnlySpan<char> source, ReadOnlySpan<char> value, bool ignoreCase)
+        {
+            Debug.Assert(source.Length != 0);
+            Debug.Assert(value.Length != 0);
+
+            fixed (char* pSource = &MemoryMarshal.GetReference(source))
+            fixed (char* pValue = &MemoryMarshal.GetReference(value))
+            {
+                return InvariantFindString(pSource, source.Length, pValue, value.Length, ignoreCase, start: true);
             }
         }
 

--- a/src/mscorlib/shared/System/Globalization/CompareInfo.cs
+++ b/src/mscorlib/shared/System/Globalization/CompareInfo.cs
@@ -910,6 +910,18 @@ namespace System.Globalization
             return IndexOfCore(source, value, startIndex, count, options, null);
         }
 
+        internal unsafe virtual int IndexOfOrdinal(ReadOnlySpan<char> source, ReadOnlySpan<char> value, bool ignoreCase)
+        {
+            Debug.Assert(!_invariantMode);
+            return IndexOfOrdinalCore(source, value, ignoreCase);
+        }
+
+        internal unsafe virtual int IndexOf(ReadOnlySpan<char> source, ReadOnlySpan<char> value, CompareOptions options, int* matchLengthPtr)
+        {
+            Debug.Assert(!_invariantMode);
+            return IndexOfCore(source, value, options, matchLengthPtr);
+        }
+
         // The following IndexOf overload is mainly used by String.Replace. This overload assumes the parameters are already validated
         // and the caller is passing a valid matchLengthPtr pointer.
         internal unsafe int IndexOf(string source, string value, int startIndex, int count, CompareOptions options, int* matchLengthPtr)

--- a/src/mscorlib/shared/System/Globalization/CompareInfo.cs
+++ b/src/mscorlib/shared/System/Globalization/CompareInfo.cs
@@ -298,7 +298,7 @@ namespace System.Globalization
             return (Compare(string1, string2, CompareOptions.None));
         }
 
-        public unsafe virtual int Compare(string string1, string string2, CompareOptions options)
+        public virtual int Compare(string string1, string string2, CompareOptions options)
         {
             if (options == CompareOptions.OrdinalIgnoreCase)
             {
@@ -350,7 +350,7 @@ namespace System.Globalization
         // TODO https://github.com/dotnet/coreclr/issues/13827:
         // This method shouldn't be necessary, as we should be able to just use the overload
         // that takes two spans.  But due to this issue, that's adding significant overhead.
-        internal unsafe int Compare(ReadOnlySpan<char> string1, string string2, CompareOptions options)
+        internal int Compare(ReadOnlySpan<char> string1, string string2, CompareOptions options)
         {
             if (options == CompareOptions.OrdinalIgnoreCase)
             {
@@ -390,7 +390,7 @@ namespace System.Globalization
         }
 
         // TODO https://github.com/dotnet/corefx/issues/21395: Expose this publicly?
-        internal unsafe virtual int Compare(ReadOnlySpan<char> string1, ReadOnlySpan<char> string2, CompareOptions options)
+        internal virtual int Compare(ReadOnlySpan<char> string1, ReadOnlySpan<char> string2, CompareOptions options)
         {
             if (options == CompareOptions.OrdinalIgnoreCase)
             {
@@ -436,7 +436,7 @@ namespace System.Globalization
         ////////////////////////////////////////////////////////////////////////
 
 
-        public unsafe virtual int Compare(string string1, int offset1, int length1, string string2, int offset2, int length2)
+        public virtual int Compare(string string1, int offset1, int length1, string string2, int offset2, int length2)
         {
             return Compare(string1, offset1, length1, string2, offset2, length2, 0);
         }
@@ -547,7 +547,7 @@ namespace System.Globalization
         // it assumes the strings are Ascii string till we hit non Ascii character in strA or strB and then we continue the comparison by
         // calling the OS.
         //
-        internal static unsafe int CompareOrdinalIgnoreCase(string strA, int indexA, int lengthA, string strB, int indexB, int lengthB)
+        internal static int CompareOrdinalIgnoreCase(string strA, int indexA, int lengthA, string strB, int indexB, int lengthB)
         {
             Debug.Assert(indexA + lengthA <= strA.Length);
             Debug.Assert(indexB + lengthB <= strB.Length);
@@ -910,16 +910,16 @@ namespace System.Globalization
             return IndexOfCore(source, value, startIndex, count, options, null);
         }
 
-        internal unsafe virtual int IndexOfOrdinal(ReadOnlySpan<char> source, ReadOnlySpan<char> value, bool ignoreCase)
+        internal virtual int IndexOfOrdinal(ReadOnlySpan<char> source, ReadOnlySpan<char> value, bool ignoreCase)
         {
             Debug.Assert(!_invariantMode);
             return IndexOfOrdinalCore(source, value, ignoreCase);
         }
 
-        internal unsafe virtual int IndexOf(ReadOnlySpan<char> source, ReadOnlySpan<char> value, CompareOptions options, int* matchLengthPtr)
+        internal unsafe virtual int IndexOf(ReadOnlySpan<char> source, ReadOnlySpan<char> value, CompareOptions options)
         {
             Debug.Assert(!_invariantMode);
-            return IndexOfCore(source, value, options, matchLengthPtr);
+            return IndexOfCore(source, value, options, null);
         }
 
         // The following IndexOf overload is mainly used by String.Replace. This overload assumes the parameters are already validated

--- a/src/mscorlib/shared/System/Span.NonGeneric.cs
+++ b/src/mscorlib/shared/System/Span.NonGeneric.cs
@@ -23,10 +23,9 @@ namespace System
     /// </summary>
     public static class Span
     {
-
         public static bool Contains(this ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
         {
-            return (IndexOf(span, value, comparisonType, out _) >= 0);
+            return (IndexOf(span, value, comparisonType) >= 0);
         }
 
         public static bool Equals(this ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
@@ -50,20 +49,20 @@ namespace System
                 case StringComparison.Ordinal:
                     if (span.Length != value.Length)
                         return false;
-                    if (value.Length == 0)
+                    if (value.Length == 0)  // span.Length == value.Length == 0
                         return true;
                     return OrdinalHelper(span, value, value.Length);
 
                 case StringComparison.OrdinalIgnoreCase:
                     if (span.Length != value.Length)
                         return false;
-                    if (value.Length == 0)
+                    if (value.Length == 0)  // span.Length == value.Length == 0
                         return true;
                     return (CompareInfo.CompareOrdinalIgnoreCase(span, value) == 0);
-
-                default:
-                    throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
             }
+
+            Debug.Fail("StringComparison outside range");
+            return false;
         }
 
         public static int CompareTo(this ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
@@ -87,101 +86,79 @@ namespace System
                 case StringComparison.Ordinal:
                     if (span.Length == 0 || value.Length == 0)
                         return span.Length - value.Length;
-                    return CompareOrdinalHelper(span, value);
+                    return string.CompareOrdinal(span, value);
 
                 case StringComparison.OrdinalIgnoreCase:
                     return CompareInfo.CompareOrdinalIgnoreCase(span, value);
-
-                default:
-                    throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
             }
+
+            Debug.Fail("StringComparison outside range");
+            return 0;
         }
 
-        public static unsafe int IndexOf(this ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType, out int matchedLength)
+        public static int IndexOf(this ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
         {
+            StringSpanHelpers.CheckStringComparison(comparisonType);
+
             if (value.Length == 0)
             {
-                StringSpanHelpers.CheckStringComparison(comparisonType);
-                matchedLength = 0;
                 return 0;
             }
 
             if (span.Length == 0)
             {
-                StringSpanHelpers.CheckStringComparison(comparisonType);
-                matchedLength = 0;
                 return -1;
             }
-
-            int defaultMatchLength = value.Length;
 
             switch (comparisonType)
             {
                 case StringComparison.CurrentCulture:
-                    int index = IndexOfCultureHelper(span, value, &defaultMatchLength);
-                    matchedLength = defaultMatchLength;
-                    return index;
+                    return IndexOfCultureHelper(span, value, CultureInfo.CurrentCulture.CompareInfo);
 
                 case StringComparison.CurrentCultureIgnoreCase:
-                    index = IndexOfCultureIgnoreCaseHelper(span, value, &defaultMatchLength);
-                    matchedLength = defaultMatchLength;
-                    return index;
+                    return IndexOfCultureIgnoreCaseHelper(span, value, CultureInfo.CurrentCulture.CompareInfo);
 
                 case StringComparison.InvariantCulture:
-                    index = IndexOfCultureHelper(span, value, &defaultMatchLength, invariantCulture: true);
-                    matchedLength = defaultMatchLength;
-                    return index;
+                    return IndexOfCultureHelper(span, value, CompareInfo.Invariant);
 
                 case StringComparison.InvariantCultureIgnoreCase:
-                    index = IndexOfCultureIgnoreCaseHelper(span, value, &defaultMatchLength, invariantCulture: true);
-                    matchedLength = defaultMatchLength;
-                    return index;
+                    return IndexOfCultureIgnoreCaseHelper(span, value, CompareInfo.Invariant);
 
                 case StringComparison.Ordinal:
-                    matchedLength = defaultMatchLength;
-                    return IndexOfOrdinalHelper(span, value, false);
+                    return IndexOfOrdinalHelper(span, value, ignoreCase: false);
 
                 case StringComparison.OrdinalIgnoreCase:
-                    matchedLength = defaultMatchLength;
-                    return IndexOfOrdinalHelper(span, value, true);
-
-                default:
-                    throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
+                    return IndexOfOrdinalHelper(span, value, ignoreCase: true);
             }
+
+            Debug.Fail("StringComparison outside range");
+            return -1;
         }
 
-        internal static unsafe int IndexOfCultureHelper(ReadOnlySpan<char> span, ReadOnlySpan<char> value, int* matchLengthPtr, bool invariantCulture = false)
+        internal static int IndexOfCultureHelper(ReadOnlySpan<char> span, ReadOnlySpan<char> value, CompareInfo compareInfo)
         {
             Debug.Assert(span.Length != 0);
             Debug.Assert(value.Length != 0);
-            Debug.Assert(matchLengthPtr != null);
 
             if (GlobalizationMode.Invariant)
             {
-                *matchLengthPtr = value.Length;
-                return CompareInfo.InvariantIndexOf(span, value, false);
+                return CompareInfo.InvariantIndexOf(span, value, ignoreCase: false);
             }
 
-            return invariantCulture ?
-                CompareInfo.Invariant.IndexOf(span, value, CompareOptions.None, matchLengthPtr) :
-                CultureInfo.CurrentCulture.CompareInfo.IndexOf(span, value, CompareOptions.None, matchLengthPtr);
+            return compareInfo.IndexOf(span, value, CompareOptions.None);
         }
 
-        internal static unsafe int IndexOfCultureIgnoreCaseHelper(ReadOnlySpan<char> span, ReadOnlySpan<char> value, int* matchLengthPtr, bool invariantCulture = false)
+        internal static int IndexOfCultureIgnoreCaseHelper(ReadOnlySpan<char> span, ReadOnlySpan<char> value, CompareInfo compareInfo)
         {
             Debug.Assert(span.Length != 0);
             Debug.Assert(value.Length != 0);
-            Debug.Assert(matchLengthPtr != null);
 
             if (GlobalizationMode.Invariant)
             {
-                *matchLengthPtr = value.Length;
-                return CompareInfo.InvariantIndexOf(span, value, true);
+                return CompareInfo.InvariantIndexOf(span, value, ignoreCase: true);
             }
 
-            return invariantCulture ?
-                CompareInfo.Invariant.IndexOf(span, value, CompareOptions.IgnoreCase, matchLengthPtr) :
-                CultureInfo.CurrentCulture.CompareInfo.IndexOf(span, value, CompareOptions.IgnoreCase, matchLengthPtr);
+            return compareInfo.IndexOf(span, value, CompareOptions.IgnoreCase);
         }
 
         internal static int IndexOfOrdinalHelper(ReadOnlySpan<char> span, ReadOnlySpan<char> value, bool ignoreCase)
@@ -283,16 +260,16 @@ namespace System
             switch (comparisonType)
             {
                 case StringComparison.CurrentCulture:
-                    return StartsWithCultureHelper(span, value);
+                    return StartsWithCultureHelper(span, value, CultureInfo.CurrentCulture.CompareInfo);
 
                 case StringComparison.CurrentCultureIgnoreCase:
-                    return StartsWithCultureIgnoreCaseHelper(span, value);
+                    return StartsWithCultureIgnoreCaseHelper(span, value, CultureInfo.CurrentCulture.CompareInfo);
 
                 case StringComparison.InvariantCulture:
-                    return StartsWithCultureHelper(span, value, invariantCulture: true);
+                    return StartsWithCultureHelper(span, value, CompareInfo.Invariant);
 
                 case StringComparison.InvariantCultureIgnoreCase:
-                    return StartsWithCultureIgnoreCaseHelper(span, value, invariantCulture: true);
+                    return StartsWithCultureIgnoreCaseHelper(span, value, CompareInfo.Invariant);
 
                 case StringComparison.Ordinal:
                     return StartsWithOrdinalHelper(span, value);
@@ -305,7 +282,7 @@ namespace System
             }
         }
 
-        internal static bool StartsWithCultureHelper(ReadOnlySpan<char> span, ReadOnlySpan<char> value, bool invariantCulture = false)
+        internal static bool StartsWithCultureHelper(ReadOnlySpan<char> span, ReadOnlySpan<char> value, CompareInfo compareInfo)
         {
             Debug.Assert(value.Length != 0);
 
@@ -317,12 +294,10 @@ namespace System
             {
                 return false;
             }
-            return invariantCulture ?
-                CompareInfo.Invariant.IsPrefix(span, value, CompareOptions.None) :
-                CultureInfo.CurrentCulture.CompareInfo.IsPrefix(span, value, CompareOptions.None);
+            return compareInfo.IsPrefix(span, value, CompareOptions.None);
         }
 
-        internal static bool StartsWithCultureIgnoreCaseHelper(ReadOnlySpan<char> span, ReadOnlySpan<char> value, bool invariantCulture = false)
+        internal static bool StartsWithCultureIgnoreCaseHelper(ReadOnlySpan<char> span, ReadOnlySpan<char> value, CompareInfo compareInfo)
         {
             Debug.Assert(value.Length != 0);
 
@@ -334,9 +309,7 @@ namespace System
             {
                 return false;
             }
-            return invariantCulture ?
-                CompareInfo.Invariant.IsPrefix(span, value, CompareOptions.IgnoreCase) :
-                CultureInfo.CurrentCulture.CompareInfo.IsPrefix(span, value, CompareOptions.IgnoreCase);
+            return compareInfo.IsPrefix(span, value, CompareOptions.IgnoreCase);
         }
 
         internal static bool StartsWithOrdinalIgnoreCaseHelper(ReadOnlySpan<char> span, ReadOnlySpan<char> value)
@@ -350,7 +323,7 @@ namespace System
             return CompareInfo.CompareOrdinalIgnoreCase(span.Slice(0, value.Length), value) == 0;
         }
 
-        internal static unsafe bool StartsWithOrdinalHelper(ReadOnlySpan<char> span, ReadOnlySpan<char> value)
+        internal static bool StartsWithOrdinalHelper(ReadOnlySpan<char> span, ReadOnlySpan<char> value)
         {
             Debug.Assert(value.Length != 0);
 
@@ -423,128 +396,6 @@ namespace System
             }
         }
 
-        private static unsafe int CompareOrdinalHelper(ReadOnlySpan<char> span, ReadOnlySpan<char> value)
-        {
-            Debug.Assert(value.Length != 0);
-            Debug.Assert(span.Length != 0);
-            int length = Math.Min(span.Length, value.Length);
-
-            fixed (char* ap = &MemoryMarshal.GetReference(span))
-            fixed (char* bp = &MemoryMarshal.GetReference(value))
-            {
-                char* a = ap;
-                char* b = bp;
-
-                if (*a != *b)
-                    goto DiffOffsetStart;
-
-                if (length >= 2)
-                {
-                    if (*(a + 1) != *(b + 1))
-                        goto DiffOffset1;
-
-                    // Since we know that the first two chars are the same,
-                    // we can increment by 2 here and skip 4 bytes.
-                    // This leaves us 8-byte aligned, which results
-                    // on better perf for 64-bit platforms.
-                    length -= 2;
-                    a += 2;
-                    b += 2;
-                }
-
-                // unroll the loop
-#if BIT64
-                while (length >= 12)
-                {
-                    if (*(long*)a != *(long*)b)
-                        goto DiffOffset0;
-                    if (*(long*)(a + 4) != *(long*)(b + 4))
-                        goto DiffOffset4;
-                    if (*(long*)(a + 8) != *(long*)(b + 8))
-                        goto DiffOffset8;
-                    length -= 12;
-                    a += 12;
-                    b += 12;
-                }
-#else // BIT64
-                while (length >= 10)
-                {
-                    if (*(int*)a != *(int*)b) goto DiffOffset0;
-                    if (*(int*)(a + 2) != *(int*)(b + 2)) goto DiffOffset2;
-                    if (*(int*)(a + 4) != *(int*)(b + 4)) goto DiffOffset4;
-                    if (*(int*)(a + 6) != *(int*)(b + 6)) goto DiffOffset6;
-                    if (*(int*)(a + 8) != *(int*)(b + 8)) goto DiffOffset8;
-                    length -= 10; a += 10; b += 10; 
-                }
-#endif // BIT64
-
-                // Fallback loop:
-                // go back to slower code path and do comparison on 4 bytes at a time.
-                // This depends on the fact that the String objects are
-                // always zero terminated and that the terminating zero is not included
-                // in the length. For odd string sizes, the last compare will include
-                // the zero terminator.
-                while (length > 0)
-                {
-                    if (*(int*)a != *(int*)b)
-                        goto DiffNextInt;
-                    length -= 2;
-                    a += 2;
-                    b += 2;
-                }
-
-                // At this point, we have compared all the characters in at least one string.
-                // The longer string will be larger.
-                return span.Length - value.Length;
-
-#if BIT64
-DiffOffset8:
-                a += 4;
-                b += 4;
-DiffOffset4:
-                a += 4;
-                b += 4;
-#else // BIT64
-                // Use jumps instead of falling through, since
-                // otherwise going to DiffOffset8 will involve
-                // 8 add instructions before getting to DiffNextInt
-                DiffOffset8: a += 8; b += 8; goto DiffOffset0;
-                DiffOffset6: a += 6; b += 6; goto DiffOffset0;
-                DiffOffset4: a += 2; b += 2;
-                DiffOffset2: a += 2; b += 2;
-#endif // BIT64
-
-DiffOffset0:
-
-// If we reached here, we already see a difference in the unrolled loop above
-#if BIT64
-                if (*(int*)a == *(int*)b)
-                {
-                    a += 2;
-                    b += 2;
-                }
-#endif // BIT64
-
-DiffNextInt:
-                if (*a != *b)
-                    return *a - *b;
-
-                if (length == 1)
-                {
-                    if (span.Length == value.Length)
-                        return *a - *b;
-                    return span.Length - value.Length;
-                }
-DiffOffset1:
-                Debug.Assert(*(a + 1) != *(b + 1), "This char must be different if we reach here!");
-                return *(a + 1) - *(b + 1);
-
-DiffOffsetStart:
-                Debug.Assert(*a != *b, "This char must be different if we reach here!");
-                return *a - *b;
-            }
-        }
-
         /// <summary>
         /// Determines whether the end of the span matches the specified value when compared using the specified comparison option.
         /// </summary>
@@ -559,16 +410,16 @@ DiffOffsetStart:
             switch (comparisonType)
             {
                 case StringComparison.CurrentCulture:
-                    return EndsWithCultureHelper(span, value);
+                    return EndsWithCultureHelper(span, value, CultureInfo.CurrentCulture.CompareInfo);
 
                 case StringComparison.CurrentCultureIgnoreCase:
-                    return EndsWithCultureIgnoreCaseHelper(span, value);
+                    return EndsWithCultureIgnoreCaseHelper(span, value, CultureInfo.CurrentCulture.CompareInfo);
 
                 case StringComparison.InvariantCulture:
-                    return EndsWithCultureHelper(span, value, invariantCulture: true);
+                    return EndsWithCultureHelper(span, value, CompareInfo.Invariant);
 
                 case StringComparison.InvariantCultureIgnoreCase:
-                    return EndsWithCultureIgnoreCaseHelper(span, value, invariantCulture: true);
+                    return EndsWithCultureIgnoreCaseHelper(span, value, CompareInfo.Invariant);
 
                 case StringComparison.Ordinal:
                     return EndsWithOrdinalHelper(span, value);
@@ -581,7 +432,7 @@ DiffOffsetStart:
             }
         }
 
-        internal static bool EndsWithCultureHelper(ReadOnlySpan<char> span, ReadOnlySpan<char> value, bool invariantCulture = false)
+        internal static bool EndsWithCultureHelper(ReadOnlySpan<char> span, ReadOnlySpan<char> value, CompareInfo compareInfo)
         {
             Debug.Assert(value.Length != 0);
 
@@ -593,12 +444,10 @@ DiffOffsetStart:
             {
                 return false;
             }
-            return invariantCulture ?
-                CompareInfo.Invariant.IsSuffix(span, value, CompareOptions.None) :
-                CultureInfo.CurrentCulture.CompareInfo.IsSuffix(span, value, CompareOptions.None);
+            return compareInfo.IsSuffix(span, value, CompareOptions.None);
         }
 
-        internal static bool EndsWithCultureIgnoreCaseHelper(ReadOnlySpan<char> span, ReadOnlySpan<char> value, bool invariantCulture = false)
+        internal static bool EndsWithCultureIgnoreCaseHelper(ReadOnlySpan<char> span, ReadOnlySpan<char> value, CompareInfo compareInfo)
         {
             Debug.Assert(value.Length != 0);
 
@@ -610,9 +459,7 @@ DiffOffsetStart:
             {
                 return false;
             }
-            return invariantCulture ?
-                CompareInfo.Invariant.IsSuffix(span, value, CompareOptions.IgnoreCase) :
-                CultureInfo.CurrentCulture.CompareInfo.IsSuffix(span, value, CompareOptions.IgnoreCase);
+            return compareInfo.IsSuffix(span, value, CompareOptions.IgnoreCase);
         }
 
         internal static bool EndsWithOrdinalIgnoreCaseHelper(ReadOnlySpan<char> span, ReadOnlySpan<char> value)
@@ -626,7 +473,7 @@ DiffOffsetStart:
             return (CompareInfo.CompareOrdinalIgnoreCase(span.Slice(span.Length - value.Length), value) == 0);
         }
 
-        internal static unsafe bool EndsWithOrdinalHelper(ReadOnlySpan<char> span, ReadOnlySpan<char> value)
+        internal static bool EndsWithOrdinalHelper(ReadOnlySpan<char> span, ReadOnlySpan<char> value)
         {
             Debug.Assert(value.Length != 0);
 

--- a/src/mscorlib/src/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/src/System/Globalization/CompareInfo.Unix.cs
@@ -258,13 +258,12 @@ namespace System.Globalization
             }
         }
 
+        // For now, this method is only called from Span APIs with either options == CompareOptions.None or CompareOptions.IgnoreCase
         internal unsafe int IndexOfCore(ReadOnlySpan<char> source, ReadOnlySpan<char> target, CompareOptions options, int* matchLengthPtr)
         {
             Debug.Assert(!_invariantMode);
             Debug.Assert(source.Length != 0);
             Debug.Assert(target.Length != 0);
-            Debug.Assert((options == CompareOptions.None || options == CompareOptions.IgnoreCase));
-            Debug.Assert(matchLengthPtr != null);
 
             if (_isAsciiEqualityOrdinal && CanUseAsciiOrdinalForOptions(options))
             {
@@ -294,7 +293,6 @@ namespace System.Globalization
             Debug.Assert(!source.IsEmpty);
             Debug.Assert(!target.IsEmpty);
             Debug.Assert(_isAsciiEqualityOrdinal);
-            Debug.Assert(matchLengthPtr != null);
 
             fixed (char* ap = &MemoryMarshal.GetReference(source))
             fixed (char* bp = &MemoryMarshal.GetReference(target))
@@ -329,7 +327,8 @@ namespace System.Globalization
 
                     if (targetIndex == target.Length)
                     {
-                        *matchLengthPtr = target.Length;
+                        if (matchLengthPtr != null)
+                            *matchLengthPtr = target.Length;
                         return i;
                     }
                 }
@@ -345,7 +344,6 @@ namespace System.Globalization
             Debug.Assert(!source.IsEmpty);
             Debug.Assert(!target.IsEmpty);
             Debug.Assert(_isAsciiEqualityOrdinal);
-            Debug.Assert(matchLengthPtr != null);
 
             fixed (char* ap = &MemoryMarshal.GetReference(source))
             fixed (char* bp = &MemoryMarshal.GetReference(target))
@@ -369,7 +367,8 @@ namespace System.Globalization
 
                     if (targetIndex == target.Length)
                     {
-                        *matchLengthPtr = target.Length;
+                        if (matchLengthPtr != null)
+                            *matchLengthPtr = target.Length;
                         return i;
                     }
                 }

--- a/src/mscorlib/src/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/src/System/Globalization/CompareInfo.Unix.cs
@@ -116,7 +116,8 @@ namespace System.Globalization
 
                 for (valueIndex = 0, sourceIndex = i;
                      valueIndex < value.Length && source[sourceIndex] == value[valueIndex];
-                     valueIndex++, sourceIndex++) ;
+                     valueIndex++, sourceIndex++)
+                    ;
 
                 if (valueIndex == value.Length)
                 {
@@ -300,6 +301,17 @@ namespace System.Globalization
                 char* a = ap;
                 char* b = bp;
                 int endIndex = source.Length - target.Length;
+
+                if (endIndex < 0)
+                    goto InteropCall;
+
+                for (int j = 0; j < target.Length; j++)
+                {
+                    char targetChar = *(b + j);
+                    if (targetChar >= 0x80 || s_highCharTable[targetChar])
+                        goto InteropCall;
+                }
+
                 int i = 0;
                 for (; i <= endIndex; i++)
                 {
@@ -318,10 +330,15 @@ namespace System.Globalization
                         }
 
                         // uppercase both chars - notice that we need just one compare per char
-                        if ((uint)(valueChar - 'a') <= (uint)('z' - 'a')) valueChar -= 0x20;
-                        if ((uint)(targetChar - 'a') <= (uint)('z' - 'a')) targetChar -= 0x20;
+                        if ((uint)(valueChar - 'a') <= ('z' - 'a'))
+                            valueChar = (char)(valueChar - 0x20);
+                        if ((uint)(targetChar - 'a') <= ('z' - 'a'))
+                            targetChar = (char)(targetChar - 0x20);
 
-                        if (valueChar != targetChar || valueChar >= 0x80 || s_highCharTable[valueChar]) break;
+                        if (valueChar >= 0x80 || s_highCharTable[valueChar])
+                            goto InteropCall;
+                        else if (valueChar != targetChar)
+                            break;
                         sourceIndex++;
                     }
 
@@ -332,8 +349,10 @@ namespace System.Globalization
                         return i;
                     }
                 }
-                if (i > endIndex) return -1;
-                return Interop.Globalization.IndexOf(_sortHandle, b, length, a, length, options, matchLengthPtr);
+                if (i > endIndex)
+                    return -1;
+            InteropCall:
+                return Interop.Globalization.IndexOf(_sortHandle, b, target.Length, a, source.Length, options, matchLengthPtr);
             }
         }
 
@@ -351,6 +370,17 @@ namespace System.Globalization
                 char* a = ap;
                 char* b = bp;
                 int endIndex = source.Length - target.Length;
+
+                if (endIndex < 0)
+                    goto InteropCall;
+
+                for (int j = 0; j < target.Length; j++)
+                {
+                    char targetChar = *(b + j);
+                    if (targetChar >= 0x80 || s_highCharTable[targetChar])
+                        goto InteropCall;
+                }
+
                 int i = 0;
                 for (; i <= endIndex; i++)
                 {
@@ -361,7 +391,10 @@ namespace System.Globalization
                     {
                         char valueChar = *(a + sourceIndex);
                         char targetChar = *(b + targetIndex);
-                        if (valueChar != targetChar || valueChar >= 0x80 || s_highCharTable[valueChar]) break;
+                        if (valueChar >= 0x80 || s_highCharTable[valueChar])
+                            goto InteropCall;
+                        else if (valueChar != targetChar)
+                            break;
                         sourceIndex++;
                     }
 
@@ -372,8 +405,10 @@ namespace System.Globalization
                         return i;
                     }
                 }
-                if (i > endIndex) return -1;
-                return Interop.Globalization.IndexOf(_sortHandle, b, length, a, length, options, matchLengthPtr);
+                if (i > endIndex)
+                    return -1;
+            InteropCall:
+                return Interop.Globalization.IndexOf(_sortHandle, b, target.Length, a, source.Length, options, matchLengthPtr);
             }
         }
 

--- a/src/mscorlib/src/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/src/System/Globalization/CompareInfo.Unix.cs
@@ -87,6 +87,46 @@ namespace System.Globalization
             return -1;
         }
 
+        internal static unsafe int IndexOfOrdinalCore(ReadOnlySpan<char> source, ReadOnlySpan<char> value, bool ignoreCase)
+        {
+            Debug.Assert(!GlobalizationMode.Invariant);
+
+            Debug.Assert(source.Length != 0);
+            Debug.Assert(value.Length != 0);
+
+            if (source.Length < value.Length)
+            {
+                return -1;
+            }
+
+            if (ignoreCase)
+            {
+                fixed (char* pSource = &MemoryMarshal.GetReference(source))
+                fixed (char* pValue = &MemoryMarshal.GetReference(value))
+                {
+                    int index = Interop.Globalization.IndexOfOrdinalIgnoreCase(pValue, value.Length, pSource, source.Length, findLast: false);
+                    return index;
+                }
+            }
+
+            int endIndex = source.Length - value.Length;
+            for (int i = 0; i <= endIndex; i++)
+            {
+                int valueIndex, sourceIndex;
+
+                for (valueIndex = 0, sourceIndex = i;
+                     valueIndex < value.Length && source[sourceIndex] == value[valueIndex];
+                     valueIndex++, sourceIndex++) ;
+
+                if (valueIndex == value.Length)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
         internal static unsafe int LastIndexOfOrdinalCore(string source, string value, int startIndex, int count, bool ignoreCase)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
@@ -215,6 +255,126 @@ namespace System.Globalization
                 index = Interop.Globalization.IndexOf(_sortHandle, target, target.Length, pSource + startIndex, count, options, matchLengthPtr);
 
                 return index != -1 ? index + startIndex : -1;
+            }
+        }
+
+        internal unsafe int IndexOfCore(ReadOnlySpan<char> source, ReadOnlySpan<char> target, CompareOptions options, int* matchLengthPtr)
+        {
+            Debug.Assert(!_invariantMode);
+            Debug.Assert(source.Length != 0);
+            Debug.Assert(target.Length != 0);
+            Debug.Assert((options == CompareOptions.None || options == CompareOptions.IgnoreCase));
+            Debug.Assert(matchLengthPtr != null);
+
+            if (_isAsciiEqualityOrdinal && CanUseAsciiOrdinalForOptions(options))
+            {
+                if ((options & CompareOptions.IgnoreCase) == CompareOptions.IgnoreCase)
+                {
+                    return IndexOfOrdinalIgnoreCaseHelper(source, target, options, matchLengthPtr);
+                }
+                else
+                {
+                    return IndexOfOrdinalHelper(source, target, options, matchLengthPtr);
+                }
+            }
+            else
+            {
+                fixed (char* pSource = &MemoryMarshal.GetReference(source))
+                fixed (char* pTarget = &MemoryMarshal.GetReference(target))
+                {
+                    return Interop.Globalization.IndexOf(_sortHandle, pTarget, target.Length, pSource, source.Length, options, matchLengthPtr);
+                }
+            }
+        }
+
+        private unsafe int IndexOfOrdinalIgnoreCaseHelper(ReadOnlySpan<char> source, ReadOnlySpan<char> target, CompareOptions options, int* matchLengthPtr)
+        {
+            Debug.Assert(!_invariantMode);
+
+            Debug.Assert(!source.IsEmpty);
+            Debug.Assert(!target.IsEmpty);
+            Debug.Assert(_isAsciiEqualityOrdinal);
+            Debug.Assert(matchLengthPtr != null);
+
+            fixed (char* ap = &MemoryMarshal.GetReference(source))
+            fixed (char* bp = &MemoryMarshal.GetReference(target))
+            {
+                char* a = ap;
+                char* b = bp;
+                int endIndex = source.Length - target.Length;
+                int i = 0;
+                for (; i <= endIndex; i++)
+                {
+                    int targetIndex = 0;
+                    int sourceIndex = i;
+
+                    for (; targetIndex < target.Length; targetIndex++)
+                    {
+                        char valueChar = *(a + sourceIndex);
+                        char targetChar = *(b + targetIndex);
+
+                        if (valueChar == targetChar && valueChar < 0x80 && !s_highCharTable[valueChar])
+                        {
+                            sourceIndex++;
+                            continue;
+                        }
+
+                        // uppercase both chars - notice that we need just one compare per char
+                        if ((uint)(valueChar - 'a') <= (uint)('z' - 'a')) valueChar -= 0x20;
+                        if ((uint)(targetChar - 'a') <= (uint)('z' - 'a')) targetChar -= 0x20;
+
+                        if (valueChar != targetChar || valueChar >= 0x80 || s_highCharTable[valueChar]) break;
+                        sourceIndex++;
+                    }
+
+                    if (targetIndex == target.Length)
+                    {
+                        *matchLengthPtr = target.Length;
+                        return i;
+                    }
+                }
+                if (i > endIndex) return -1;
+                return Interop.Globalization.IndexOf(_sortHandle, b, length, a, length, options, matchLengthPtr);
+            }
+        }
+
+        private unsafe int IndexOfOrdinalHelper(ReadOnlySpan<char> source, ReadOnlySpan<char> target, CompareOptions options, int* matchLengthPtr)
+        {
+            Debug.Assert(!_invariantMode);
+
+            Debug.Assert(!source.IsEmpty);
+            Debug.Assert(!target.IsEmpty);
+            Debug.Assert(_isAsciiEqualityOrdinal);
+            Debug.Assert(matchLengthPtr != null);
+
+            fixed (char* ap = &MemoryMarshal.GetReference(source))
+            fixed (char* bp = &MemoryMarshal.GetReference(target))
+            {
+                char* a = ap;
+                char* b = bp;
+                int endIndex = source.Length - target.Length;
+                int i = 0;
+                for (; i <= endIndex; i++)
+                {
+                    int targetIndex = 0;
+                    int sourceIndex = i;
+
+                    for (; targetIndex < target.Length; targetIndex++)
+                    {
+                        char valueChar = *(a + sourceIndex);
+                        char targetChar = *(b + targetIndex);
+                        if (valueChar != targetChar || valueChar >= 0x80 || s_highCharTable[valueChar]) break;
+                        sourceIndex++;
+                    }
+
+                    if (targetIndex == target.Length)
+                    {
+                        *matchLengthPtr = target.Length;
+                        return i;
+                    }
+                }
+                if (i > endIndex) return -1;
+                return Interop.Globalization.IndexOf(_sortHandle, b, length, a, length, options, matchLengthPtr);
             }
         }
 

--- a/src/mscorlib/src/System/Globalization/CompareInfo.Windows.cs
+++ b/src/mscorlib/src/System/Globalization/CompareInfo.Windows.cs
@@ -329,7 +329,6 @@ namespace System.Globalization
             Debug.Assert(source.Length != 0);
             Debug.Assert(target.Length != 0);
             Debug.Assert((options == CompareOptions.None || options == CompareOptions.IgnoreCase));
-            Debug.Assert(matchLengthPtr != null);
 
             int retValue = FindString(FIND_FROMSTART | (uint)GetNativeCompareFlags(options), source, target, matchLengthPtr);
             return retValue;

--- a/src/mscorlib/src/System/Globalization/CompareInfo.Windows.cs
+++ b/src/mscorlib/src/System/Globalization/CompareInfo.Windows.cs
@@ -56,6 +56,28 @@ namespace System.Globalization
             }
         }
 
+        private static unsafe int FindStringOrdinal(
+            uint dwFindStringOrdinalFlags,
+            ReadOnlySpan<char> source,
+            ReadOnlySpan<char> value,
+            bool bIgnoreCase)
+        {
+            Debug.Assert(!GlobalizationMode.Invariant);
+
+            fixed (char* pSource = &MemoryMarshal.GetReference(source))
+            fixed (char* pValue = &MemoryMarshal.GetReference(value))
+            {
+                int ret = Interop.Kernel32.FindStringOrdinal(
+                            dwFindStringOrdinalFlags,
+                            pSource,
+                            source.Length,
+                            pValue,
+                            value.Length,
+                            bIgnoreCase ? 1 : 0);
+                return ret;
+            }
+        }
+
         internal static int IndexOfOrdinalCore(string source, string value, int startIndex, int count, bool ignoreCase)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
@@ -64,6 +86,16 @@ namespace System.Globalization
             Debug.Assert(value != null);
 
             return FindStringOrdinal(FIND_FROMSTART, source, startIndex, count, value, value.Length, ignoreCase);
+        }
+
+        internal static int IndexOfOrdinalCore(ReadOnlySpan<char> source, ReadOnlySpan<char> value, bool ignoreCase)
+        {
+            Debug.Assert(!GlobalizationMode.Invariant);
+
+            Debug.Assert(source.Length != 0);
+            Debug.Assert(value.Length != 0);
+
+            return FindStringOrdinal(FIND_FROMSTART, source, value, ignoreCase);
         }
 
         internal static int LastIndexOfOrdinalCore(string source, string value, int startIndex, int count, bool ignoreCase)
@@ -288,6 +320,19 @@ namespace System.Globalization
             }
 
             return -1;
+        }
+
+        internal unsafe int IndexOfCore(ReadOnlySpan<char> source, ReadOnlySpan<char> target, CompareOptions options, int* matchLengthPtr)
+        {
+            Debug.Assert(!_invariantMode);
+
+            Debug.Assert(source.Length != 0);
+            Debug.Assert(target.Length != 0);
+            Debug.Assert((options == CompareOptions.None || options == CompareOptions.IgnoreCase));
+            Debug.Assert(matchLengthPtr != null);
+
+            int retValue = FindString(FIND_FROMSTART | (uint)GetNativeCompareFlags(options), source, target, matchLengthPtr);
+            return retValue;
         }
 
         private unsafe int LastIndexOfCore(string source, string target, int startIndex, int count, CompareOptions options)


### PR DESCRIPTION
Part of https://github.com/dotnet/corefx/issues/21395#issuecomment-359906138

- Equals
- CompareTo
- IndexOf ~(fast span only)~
- Contains ~(fast span only)~

**TODO:**
- Add more tests in corefx
- ~Verify correctness on Unix~
- ~Can we expose string.IndexOf with `out int matchedLength` parameter? Can we expose string.Contains with `StringComparison comparisonType` parameter? If not, these APIs cannot be implemented for portable span.~

Related corefx PR: https://github.com/dotnet/corefx/pull/27319

cc @jkotas, @stephentoub, @KrzysztofCwalina, @tarekgh, @JeremyKuhne, @joshfree 