### PR TITLE
JIT: don't trust field offsets in R2R for nullcheck bypass

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -6703,7 +6703,12 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
                 else
                 {
 #if CONSERVATIVE_NULL_CHECK_BYREF_CREATION
-                    addExplicitNullCheck = (mac->m_kind == MACK_Addr && (mac->m_totalOffset + fldOffset > 0));
+                    // In R2R mode the field offset may be changed when the code is loaded.
+                    // So we can't rely on a zero offset here to suppress the null check.
+                    //
+                    // See GitHub issue #16454.
+                    addExplicitNullCheck =
+                        (mac->m_kind == MACK_Addr) && ((mac->m_totalOffset + fldOffset > 0) || opts.IsReadyToRun());
 #else
                     addExplicitNullCheck = (objRef->gtType == TYP_BYREF && mac->m_kind == MACK_Addr &&
                                             (mac->m_totalOffset + fldOffset > 0));


### PR DESCRIPTION
When the jit is forming an field address to pass off to points unknown
it will nullcheck at the point of creation, unless it can prove that the
field is at offset zero. Unfortunately in R2R mode field offsets are not
known at jit time and so a zero value seen when prejitting may end up
being nonzero when the code is loaded and fixed up and fool the jit into
omitting a null check that is potentially needed.

So in R2R mode, always emit null checks.

Fixes #16454.