### PR TITLE
Fix EventPipe Test Failures Under GCStress

### DIFF
--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -708,6 +708,10 @@ bool EventPipe::WalkManagedStackForThread(Thread *pThread, StackContents &stackC
     }
     CONTRACTL_END;
 
+    // Calling into StackWalkFrames in preemptive mode violates the host contract,
+    // but this contract is not used on CoreCLR.
+    CONTRACT_VIOLATION( HostViolation );
+
     stackContents.Reset();
 
     StackWalkAction swaRet = pThread->StackWalkFrames(

--- a/tests/src/tracing/tracevalidation/inducedgc/inducedgc.csproj
+++ b/tests/src/tracing/tracevalidation/inducedgc/inducedgc.csproj
@@ -12,6 +12,7 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
     <CLRTestPriority>0</CLRTestPriority>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'"></PropertyGroup>


### PR DESCRIPTION
 - Disable the EventPipe Induced GC test because under GCStress the induced GC count is much higher than the test expects.
 - Suppress the HOST_NOCALL violation in EventPipe::WalkManagedStackForThread as this contract does not apply on CoreCLR.

Fixes #16374.

cc: @BruceForstall 