### PR TITLE
Fix impl of ReadOnlySpan ToLower/ToUpper for Unix.

### DIFF
--- a/src/mscorlib/shared/System/Globalization/TextInfo.Unix.cs
+++ b/src/mscorlib/shared/System/Globalization/TextInfo.Unix.cs
@@ -81,24 +81,26 @@ namespace System.Globalization
                 {
                     if (IsAsciiCasingSameAsInvariant)
                     {
-                        int length = source.Length;
+                        int length = 0;
                         char* a = pSource, b = pResult;
                         if (toUpper)
                         {
-                            while (length-- != 0 && *a < 0x80)
+                            while (length < source.Length && *a < 0x80)
                             {
                                 *b++ = ToUpperAsciiInvariant(*a++);
+                                length++;
                             }
                         }
                         else
                         {
-                            while (length-- != 0 && *a < 0x80)
+                            while (length < source.Length && *a < 0x80)
                             {
                                 *b++ = ToLowerAsciiInvariant(*a++);
+                                length++;
                             }
                         }
 
-                        if (length != 0)
+                        if (length != source.Length)
                         {
                             ChangeCase(a, source.Length - length, b, destination.Length - length, toUpper);
                         }


### PR DESCRIPTION
Update to https://github.com/dotnet/coreclr/pull/16379

Ran the new tests locally on OSX and they all pass now.

Fixes the test failures - https://mc.dot.net/#/user/ahsonkhan/pr~2Fjenkins~2Fdotnet~2Fcorefx~2Fmaster~2F/test~2Ffunctional~2Fcli~2F/e0a26daab80419c10a37646444d5155d5495d241/workItem/System.Memory.Tests/wilogs

```text
System.SpanTests.ReadOnlySpanTests.LengthMismatchToLower [FAIL]
2018-02-22 03:47:55,702: INFO: proc(54): run_and_log_output: Output:       Assert.Equal() Failure
2018-02-22 03:47:55,703: INFO: proc(54): run_and_log_output: Output:       Expected: Char[] ['a', 'b', 'c', 'D']
2018-02-22 03:47:55,703: INFO: proc(54): run_and_log_output: Output:       Actual:   Char[] ['a', 'b', 'c', '\0']
```

Related PR: https://github.com/dotnet/corefx/pull/27193

cc @jkotas, @stephentoub, @KrzysztofCwalina, @tarekgh, @JeremyKuhne 