### PR TITLE
Add CoreLib helpers for MemoryExtensions.AsSpan/AsMemory(T[], int)

### DIFF
--- a/src/mscorlib/shared/System/Memory.cs
+++ b/src/mscorlib/shared/System/Memory.cs
@@ -100,6 +100,11 @@ namespace System
             _length = length;
         }
 
+        // Gives Span.NonGeneric access to raw constructor. We don't want to expose the raw constructor itself as there are already multiple public constructors
+        // with the (X, int, int) signature. Exposing this overload would effectively shut down compile-time type-checking on those constructors.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static Memory<T> DangerousCreate(object obj, int index, int length) => new Memory<T>(obj, index, length);
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private Memory(object obj, int index, int length)
         {

--- a/src/mscorlib/shared/System/Memory.cs
+++ b/src/mscorlib/shared/System/Memory.cs
@@ -58,6 +58,26 @@ namespace System
             _length = array.Length;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal Memory(T[] array, int start)
+        {
+            if (array == null)
+            {
+                if (start != 0)
+                    ThrowHelper.ThrowArgumentOutOfRangeException();
+                this = default;
+                return; // returns default
+            }
+            if (default(T) == null && array.GetType() != typeof(T[]))
+                ThrowHelper.ThrowArrayTypeMismatchException();
+            if ((uint)start > (uint)array.Length)
+                ThrowHelper.ThrowArgumentOutOfRangeException();
+
+            _object = array;
+            _index = start;
+            _length = array.Length - start;
+        }
+
         /// <summary>
         /// Creates a new memory over the portion of the target array beginning
         /// at 'start' index and ending at 'end' index (exclusive).
@@ -99,11 +119,6 @@ namespace System
             _index = index | (1 << 31); // Before using _index, check if _index < 0, then 'and' it with RemoveOwnedFlagBitMask
             _length = length;
         }
-
-        // Gives Span.NonGeneric access to raw constructor. We don't want to expose the raw constructor itself as there are already multiple public constructors
-        // with the (X, int, int) signature. Exposing this overload would effectively shut down compile-time type-checking on those constructors.
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static Memory<T> DangerousCreate(object obj, int index, int length) => new Memory<T>(obj, index, length);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private Memory(object obj, int index, int length)

--- a/src/mscorlib/shared/System/Span.NonGeneric.cs
+++ b/src/mscorlib/shared/System/Span.NonGeneric.cs
@@ -341,6 +341,44 @@ namespace System
             return OrdinalHelper(span.Slice(span.Length - value.Length), value, value.Length);
         }
 
+        /// <summary>
+        /// Helper method for MemoryExtensions.AsSpan(T[] array, int start).
+        /// </summary>
+        public static Span<T> AsSpan<T>(T[] array, int start)
+        {
+            if (array == null)
+            {
+                if (start != 0)
+                    ThrowHelper.ThrowArgumentOutOfRangeException();
+                return default;
+            }
+            if (default(T) == null && array.GetType() != typeof(T[]))
+                ThrowHelper.ThrowArrayTypeMismatchException();
+            if ((uint)start > (uint)array.Length)
+                ThrowHelper.ThrowArgumentOutOfRangeException();
+
+            return new Span<T>(ref Unsafe.Add(ref Unsafe.As<byte, T>(ref array.GetRawSzArrayData()), start), array.Length - start);
+        }
+
+        /// <summary>
+        /// Helper method for MemoryExtensions.AsMemory(T[] array, int start).
+        /// </summary>
+        public static Memory<T> AsMemory<T>(T[] array, int start)
+        {
+            if (array == null)
+            {
+                if (start != 0)
+                    ThrowHelper.ThrowArgumentOutOfRangeException();
+                return default;
+            }
+            if (default(T) == null && array.GetType() != typeof(T[]))
+                ThrowHelper.ThrowArrayTypeMismatchException();
+            if ((uint)start > (uint)array.Length)
+                ThrowHelper.ThrowArgumentOutOfRangeException();
+
+            return Memory<T>.DangerousCreate(array, start, array.Length - start);
+        }
+
         /// <summary>Creates a new <see cref="ReadOnlyMemory{char}"/> over the portion of the target string.</summary>
         /// <param name="text">The target string.</param>
         /// <remarks>Returns default when <paramref name="text"/> is null.</remarks>

--- a/src/mscorlib/shared/System/Span.NonGeneric.cs
+++ b/src/mscorlib/shared/System/Span.NonGeneric.cs
@@ -363,21 +363,7 @@ namespace System
         /// <summary>
         /// Helper method for MemoryExtensions.AsMemory(T[] array, int start).
         /// </summary>
-        public static Memory<T> AsMemory<T>(T[] array, int start)
-        {
-            if (array == null)
-            {
-                if (start != 0)
-                    ThrowHelper.ThrowArgumentOutOfRangeException();
-                return default;
-            }
-            if (default(T) == null && array.GetType() != typeof(T[]))
-                ThrowHelper.ThrowArrayTypeMismatchException();
-            if ((uint)start > (uint)array.Length)
-                ThrowHelper.ThrowArgumentOutOfRangeException();
-
-            return Memory<T>.DangerousCreate(array, start, array.Length - start);
-        }
+        public static Memory<T> AsMemory<T>(T[] array, int start) => new Memory<T>(array, start);
 
         /// <summary>Creates a new <see cref="ReadOnlyMemory{char}"/> over the portion of the target string.</summary>
         /// <param name="text">The target string.</param>


### PR DESCRIPTION
(Part of https://github.com/dotnet/corefx/issues/26894)

We intentionally don't have (T[], int] constructor overloads
for Span and Memory. So as not to incur unnecessary argument checks,
we implement this directly in CoreLib and will invoke it from
CoreFx for the fast-Span version.