### PR TITLE
Replace sizeof(void*)-like expressions with TARGET_POINTER_SIZE macro

### DIFF
--- a/src/inc/corinfo.h
+++ b/src/inc/corinfo.h
@@ -2375,7 +2375,7 @@ public:
     // This is only called for Value classes.  It returns a boolean array
     // in representing of 'cls' from a GC perspective.  The class is
     // assumed to be an array of machine words
-    // (of length // getClassSize(cls) / sizeof(void*)),
+    // (of length // getClassSize(cls) / TARGET_POINTER_SIZE),
     // 'gcPtrs' is a pointer to an array of BYTEs of this length.
     // getClassGClayout fills in this array so that gcPtrs[i] is set
     // to one of the CorInfoGCType values which is the GC type of

--- a/src/vm/array.cpp
+++ b/src/vm/array.cpp
@@ -704,9 +704,9 @@ MethodTable* Module::CreateArrayMethodTable(TypeHandle elemTypeHnd, CorElementTy
                          - ObjSizeOf(Object) - currentOffset;
                 }
 
-                _ASSERTE(!"Module::CreateArrayMethodTable() - unaligned GC info" || IS_ALIGNED(skip, sizeof(size_t)));
+                _ASSERTE(!"Module::CreateArrayMethodTable() - unaligned GC info" || IS_ALIGNED(skip, TARGET_POINTER_SIZE));
 
-                unsigned short NumPtrs = (unsigned short) (numPtrsInBytes / sizeof(void*));
+                unsigned short NumPtrs = (unsigned short) (numPtrsInBytes / TARGET_POINTER_SIZE);
                 if(skip > MAX_SIZE_FOR_VALUECLASS_IN_ARRAY || numPtrsInBytes > MAX_PTRS_FOR_VALUECLASSS_IN_ARRAY) {
                     StackSString ssElemName;
                     elemTypeHnd.GetName(ssElemName);

--- a/src/vm/callingconvention.h
+++ b/src/vm/callingconvention.h
@@ -183,7 +183,7 @@ struct TransitionBlock
 #if defined(UNIX_AMD64_ABI) && defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
         _ASSERTE(offset != TransitionBlock::StructInRegsOffset);
 #endif        
-        return (offset - GetOffsetOfArgumentRegisters()) / sizeof(TADDR);
+        return (offset - GetOffsetOfArgumentRegisters()) / TARGET_POINTER_SIZE;
     }
 
     static UINT GetStackArgumentIndexFromOffset(int offset)
@@ -242,7 +242,7 @@ struct TransitionBlock
         negSpaceSize += sizeof(FloatArgumentRegisters);
 #endif
 #ifdef _TARGET_ARM_
-        negSpaceSize += sizeof(TADDR); // padding to make FloatArgumentRegisters address 8-byte aligned
+        negSpaceSize += TARGET_POINTER_SIZE; // padding to make FloatArgumentRegisters address 8-byte aligned
 #endif
         return negSpaceSize;
     }
@@ -752,7 +752,7 @@ int ArgIteratorTemplate<ARGITERATOR_BASE>::GetRetBuffArgOffset()
     ret += (int) offsetof(ArgumentRegisters, x[8]);
 #else
     if (this->HasThis())
-        ret += sizeof(void *);
+        ret += TARGET_POINTER_SIZE;
 #endif
 
     return ret;
@@ -774,12 +774,12 @@ int ArgIteratorTemplate<ARGITERATOR_BASE>::GetVASigCookieOffset()
 
     if (this->HasThis())
     {
-        ret += sizeof(void*);
+        ret += TARGET_POINTER_SIZE;
     }
 
     if (this->HasRetBuffArg() && IsRetBuffPassedAsFirstArg())
     {
-        ret += sizeof(void*);
+        ret += TARGET_POINTER_SIZE;
     }
 
     return ret;
@@ -827,12 +827,12 @@ int ArgIteratorTemplate<ARGITERATOR_BASE>::GetParamTypeArgOffset()
 
     if (this->HasThis())
     {
-        ret += sizeof(void*);
+        ret += TARGET_POINTER_SIZE;
     }
 
     if (this->HasRetBuffArg() && IsRetBuffPassedAsFirstArg())
     {
-        ret += sizeof(void*);
+        ret += TARGET_POINTER_SIZE;
     }
 
     return ret;

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -1028,7 +1028,7 @@ void CEECompileInfo::GetCallRefMap(CORINFO_METHOD_HANDLE hMethod, GCRefMapBuilde
 
     nStackSlots = nStackBytes / sizeof(TADDR) + NUM_ARGUMENT_REGISTERS;
 #else
-    nStackSlots = (sizeof(TransitionBlock) + nStackBytes - TransitionBlock::GetOffsetOfArgumentRegisters()) / sizeof(TADDR);
+    nStackSlots = (sizeof(TransitionBlock) + nStackBytes - TransitionBlock::GetOffsetOfArgumentRegisters()) / TARGET_POINTER_SIZE;
 #endif
 
     for (UINT pos = 0; pos < nStackSlots; pos++)
@@ -1040,7 +1040,7 @@ void CEECompileInfo::GetCallRefMap(CORINFO_METHOD_HANDLE hMethod, GCRefMapBuilde
             (TransitionBlock::GetOffsetOfArgumentRegisters() + ARGUMENTREGISTERS_SIZE - (pos + 1) * sizeof(TADDR)) :
             (TransitionBlock::GetOffsetOfArgs() + (pos - NUM_ARGUMENT_REGISTERS) * sizeof(TADDR));
 #else
-        ofs = TransitionBlock::GetOffsetOfArgumentRegisters() + pos * sizeof(TADDR);
+        ofs = TransitionBlock::GetOffsetOfArgumentRegisters() + pos * TARGET_POINTER_SIZE;
 #endif
 
         CORCOMPILE_GCREFMAP_TOKENS token = *(CORCOMPILE_GCREFMAP_TOKENS *)(pFrame + ofs);
@@ -1083,7 +1083,7 @@ void CEECompileInfo::GetCallRefMap(CORINFO_METHOD_HANDLE hMethod, GCRefMapBuilde
             (TransitionBlock::GetOffsetOfArgumentRegisters() + ARGUMENTREGISTERS_SIZE - (pos + 1) * sizeof(TADDR)) :
             (TransitionBlock::GetOffsetOfArgs() + (pos - NUM_ARGUMENT_REGISTERS) * sizeof(TADDR));
 #else
-        ofs = TransitionBlock::GetOffsetOfArgumentRegisters() + pos * sizeof(TADDR);
+        ofs = TransitionBlock::GetOffsetOfArgumentRegisters() + pos * TARGET_POINTER_SIZE;
 #endif
 
         if (token != 0)
@@ -2113,7 +2113,7 @@ void CEECompileInfo::EncodeTypeLayout(CORINFO_CLASS_HANDLE classHandle, SigBuild
 
     // Check everything 
     dwFlags |= READYTORUN_LAYOUT_Alignment;
-    if (dwAlignment == sizeof(void *))
+    if (dwAlignment == TARGET_POINTER_SIZE)
         dwFlags |= READYTORUN_LAYOUT_Alignment_Native;
 
     dwFlags |= READYTORUN_LAYOUT_GCLayout;
@@ -2139,7 +2139,7 @@ void CEECompileInfo::EncodeTypeLayout(CORINFO_CLASS_HANDLE classHandle, SigBuild
 
     if ((dwFlags & READYTORUN_LAYOUT_GCLayout) && !(dwFlags & READYTORUN_LAYOUT_GCLayout_Empty))
     {
-        size_t cbGCRefMap = (dwSize / sizeof(TADDR) + 7) / 8;
+        size_t cbGCRefMap = (dwSize / TARGET_POINTER_SIZE + 7) / 8;
         _ASSERTE(cbGCRefMap > 0);
 
         BYTE * pGCRefMap = (BYTE *)_alloca(cbGCRefMap);

--- a/src/vm/fieldmarshaler.cpp
+++ b/src/vm/fieldmarshaler.cpp
@@ -289,8 +289,8 @@ do                                                      \
         }
         else if (corElemType == ELEMENT_TYPE_PTR)
         {
-            pfwalk->m_managedSize = sizeof(LPVOID);
-            pfwalk->m_managedAlignmentReq = sizeof(LPVOID);
+            pfwalk->m_managedSize = TARGET_POINTER_SIZE;
+            pfwalk->m_managedAlignmentReq = TARGET_POINTER_SIZE;
         }
         else if (corElemType == ELEMENT_TYPE_VALUETYPE)
         {

--- a/src/vm/siginfo.cpp
+++ b/src/vm/siginfo.cpp
@@ -4975,7 +4975,7 @@ void ReportPointersFromValueType(promote_func *fn, ScanContext *sc, PTR_MethodTa
     {
         // offset to embedded references in this series must be
         // adjusted by the VTable pointer, when in the unboxed state.
-        size_t offset = cur->GetSeriesOffset() - sizeof(void*);
+        size_t offset = cur->GetSeriesOffset() - TARGET_POINTER_SIZE;
         PTR_OBJECTREF srcPtr = dac_cast<PTR_OBJECTREF>(PTR_BYTE(pSrc) + offset);
         PTR_OBJECTREF srcPtrStop = dac_cast<PTR_OBJECTREF>(PTR_BYTE(srcPtr) + cur->GetSeriesSize() + size);         
         while (srcPtr < srcPtrStop)                                         


### PR DESCRIPTION
Use `TARGET_POINTER_SIZE` macro instead of `sizeof(void*)` `sizeof(size_t)` `sizeof(LPVOID)` in vm 

**Related issue:** #16513 