### PR TITLE
[Arm64/Arm32] Add MemoryBarrier to ErectWriteBarrierForMT

### DIFF
--- a/src/vm/gchelpers.cpp
+++ b/src/vm/gchelpers.cpp
@@ -1514,7 +1514,7 @@ void ErectWriteBarrierForMT(MethodTable **dst, MethodTable *ref)
     STATIC_CONTRACT_GC_NOTRIGGER;
     STATIC_CONTRACT_SO_TOLERANT;
 
-    *dst = ref;
+    VolatileStore(dst, ref);
 
 #ifdef WRITE_BARRIER_CHECK
     updateGCShadow((Object **)dst, (Object *)ref);     // support debugging write barrier, updateGCShadow only cares that these are pointers


### PR DESCRIPTION
I believe a memory barrier is required here for Arm64 & Arm32.  x64/x86 should not be affected because of total store ordering. 

While I believe the barrier is required, I cannot prove it.

@jkotas @janvorli @Maoni0 @swgillespie Please tell me why I am wrong :smile: 


