### PR TITLE
Address more stacktrace print issues

### DIFF
--- a/src/mscorlib/shared/System/Diagnostics/Debug.Unix.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Debug.Unix.cs
@@ -21,7 +21,19 @@ namespace System.Diagnostics
                 // In Core, we do not show a dialog.
                 // Fail in order to avoid anyone catching an exception and masking
                 // an assert failure.
-                var ex = new DebugAssertException(message, detailMessage, stackTrace);
+                DebugAssertException ex;
+                if (message == String.Empty) 
+                {
+                    ex = new DebugAssertException(stackTrace);
+                }
+                else if (detailMessage == String.Empty) 
+                {
+                    ex = new DebugAssertException(message, stackTrace);
+                }
+                else
+                {
+                    ex = new DebugAssertException(message, detailMessage, stackTrace);
+                }
                 Environment.FailFast(ex.Message, ex, errorSource);
             }
         }

--- a/src/mscorlib/shared/System/Diagnostics/Debug.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Debug.cs
@@ -327,17 +327,17 @@ namespace System.Diagnostics
         private sealed class DebugAssertException : Exception
         {
             internal DebugAssertException(string stackTrace) :
-                base(stackTrace)
+                base(Environment.NewLine + stackTrace)
             {
             }
 
             internal DebugAssertException(string message, string stackTrace) :
-                base(message + Environment.NewLine + stackTrace)
+                base(message + Environment.NewLine + Environment.NewLine + stackTrace)
             {
             }
 
             internal DebugAssertException(string message, string detailMessage, string stackTrace) :
-                base(message + Environment.NewLine + detailMessage + Environment.NewLine + stackTrace)
+                base(message + Environment.NewLine + detailMessage + Environment.NewLine + Environment.NewLine + stackTrace)
             {
             }
         }

--- a/src/mscorlib/shared/System/Diagnostics/Debug.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Debug.cs
@@ -113,7 +113,7 @@ namespace System.Diagnostics
                 string stackTrace;
                 try
                 {
-                    stackTrace = new StackTrace(0, true).ToString(System.Diagnostics.StackTrace.TraceFormat.Normal);
+                    stackTrace = new StackTrace(2, true).ToString(System.Diagnostics.StackTrace.TraceFormat.Normal);
                 }
                 catch
                 {
@@ -326,6 +326,16 @@ namespace System.Diagnostics
 
         private sealed class DebugAssertException : Exception
         {
+            internal DebugAssertException(string stackTrace) :
+                base(stackTrace)
+            {
+            }
+
+            internal DebugAssertException(string message, string stackTrace) :
+                base(message + Environment.NewLine + stackTrace)
+            {
+            }
+
             internal DebugAssertException(string message, string detailMessage, string stackTrace) :
                 base(message + Environment.NewLine + detailMessage + Environment.NewLine + stackTrace)
             {

--- a/src/mscorlib/src/System/Diagnostics/Contracts/ContractsBCL.cs
+++ b/src/mscorlib/src/System/Diagnostics/Contracts/ContractsBCL.cs
@@ -72,7 +72,7 @@ namespace System.Diagnostics.Contracts
 
             if (displayMessage == null) return;
 
-            System.Runtime.CompilerServices.ContractHelper.TriggerFailure(failureKind, String.Empty, userMessage, conditionText, innerException);
+            System.Runtime.CompilerServices.ContractHelper.TriggerFailure(failureKind, displayMessage, userMessage, conditionText, innerException);
         }
 
         /// <summary>
@@ -369,17 +369,6 @@ namespace System.Runtime.CompilerServices
             // error message.  Let's leverage Silverlight's default error message there.
             */
             String failureMessage = "";
-            /*
-            if (!String.IsNullOrEmpty(conditionText))
-            {
-                resourceName += "_Cnd";
-                failureMessage = SR.Format(SR.GetResourceString(resourceName), conditionText);
-            }
-            else
-            {
-                failureMessage = SR.GetResourceString(resourceName);
-            }
-            */
 
             // Now add in the user message, if present.
             if (!String.IsNullOrEmpty(userMessage))

--- a/src/mscorlib/src/System/Diagnostics/Contracts/ContractsBCL.cs
+++ b/src/mscorlib/src/System/Diagnostics/Contracts/ContractsBCL.cs
@@ -359,16 +359,23 @@ namespace System.Runtime.CompilerServices
 
         private static String GetDisplayMessage(ContractFailureKind failureKind, String userMessage, String conditionText)
         {
-            /*
-            String resourceName = GetResourceNameForFailure(failureKind);
+            String failureMessage;
             // Well-formatted English messages will take one of four forms.  A sentence ending in
             // either a period or a colon, the condition string, then the message tacked 
             // on to the end with two spaces in front.
             // Note that both the conditionText and userMessage may be null.  Also, 
             // on Silverlight we may not be able to look up a friendly string for the
-            // error message.  Let's leverage Silverlight's default error message there.
-            */
-            String failureMessage = "";
+            // error message.  Let's leverage Silverlight's default error message there. 
+            if (!String.IsNullOrEmpty(conditionText))
+            {
+                String resourceName = GetResourceNameForFailure(failureKind); 
+                resourceName += "_Cnd";
+                failureMessage = SR.Format(SR.GetResourceString(resourceName), conditionText);
+            }
+            else
+            {
+                failureMessage = "";
+            }
 
             // Now add in the user message, if present.
             if (!String.IsNullOrEmpty(userMessage))

--- a/src/mscorlib/src/System/Diagnostics/Contracts/ContractsBCL.cs
+++ b/src/mscorlib/src/System/Diagnostics/Contracts/ContractsBCL.cs
@@ -72,7 +72,7 @@ namespace System.Diagnostics.Contracts
 
             if (displayMessage == null) return;
 
-            System.Runtime.CompilerServices.ContractHelper.TriggerFailure(failureKind, displayMessage, userMessage, conditionText, innerException);
+            System.Runtime.CompilerServices.ContractHelper.TriggerFailure(failureKind, String.Empty, userMessage, conditionText, innerException);
         }
 
         /// <summary>
@@ -359,6 +359,7 @@ namespace System.Runtime.CompilerServices
 
         private static String GetDisplayMessage(ContractFailureKind failureKind, String userMessage, String conditionText)
         {
+            /*
             String resourceName = GetResourceNameForFailure(failureKind);
             // Well-formatted English messages will take one of four forms.  A sentence ending in
             // either a period or a colon, the condition string, then the message tacked 
@@ -366,7 +367,9 @@ namespace System.Runtime.CompilerServices
             // Note that both the conditionText and userMessage may be null.  Also, 
             // on Silverlight we may not be able to look up a friendly string for the
             // error message.  Let's leverage Silverlight's default error message there.
-            String failureMessage;
+            */
+            String failureMessage = "";
+            /*
             if (!String.IsNullOrEmpty(conditionText))
             {
                 resourceName += "_Cnd";
@@ -376,6 +379,7 @@ namespace System.Runtime.CompilerServices
             {
                 failureMessage = SR.GetResourceString(resourceName);
             }
+            */
 
             // Now add in the user message, if present.
             if (!String.IsNullOrEmpty(userMessage))

--- a/src/mscorlib/src/System/Diagnostics/Debug.Windows.cs
+++ b/src/mscorlib/src/System/Diagnostics/Debug.Windows.cs
@@ -17,7 +17,19 @@ namespace System.Diagnostics
                 // In Core, we do not show a dialog.
                 // Fail in order to avoid anyone catching an exception and masking
                 // an assert failure.
-                var ex = new DebugAssertException(message, detailMessage, stackTrace);
+                DebugAssertException ex;
+                if (message == String.Empty) 
+                {
+                    ex = new DebugAssertException(stackTrace);
+                }
+                else if (detailMessage == String.Empty) 
+                {
+                    ex = new DebugAssertException(message, stackTrace);
+                }
+                else
+                {
+                    ex = new DebugAssertException(message, detailMessage, stackTrace);
+                }
                 Environment.FailFast(ex.Message, ex, errorSource);
             }
         }


### PR DESCRIPTION
Follow-up PR to address more issues for #14867. Fixes newline issues for ```Debug.Assert``` and broken error message/stacktrace for Contract failures. 