### PR TITLE
Fixing lambda capture unused errors.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7384,6 +7384,9 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
         {
             JITDUMP("[Fast tailcall decision]: %s\n", msg);
         }
+#else
+        (void)this;
+        (void)callee;
 #endif // DEBUG
     };
 


### PR DESCRIPTION
These errors were happening when compiling with clang 5.0.1.

Since the whole method is defined inside a #if DEBUG, it was
erroring when compiling in release mode because the lambda
variables were not being used.

I ran into this while [attempting to package .NET Core](https://dev.solus-project.com/T2325) for [Solus](https://solus-project.com/).