### PR TITLE
Delete printing of security transparency in SOS

### DIFF
--- a/src/ToolBox/SOS/Strike/apollososdocs.txt
+++ b/src/ToolBox/SOS/Strike/apollososdocs.txt
@@ -931,7 +931,6 @@ associated with it. For example, this output from K:
 	Module:       001caa38
 	IsJitted:     yes
 	CodeAddr:     03ef00b8
-	Transparency: Critical
 	Source file:  c:\Code\prj.mini\exc.cs @ 39
 
 We have taken a return address into Mainy.Main, and discovered information 
@@ -1041,7 +1040,6 @@ Sample output:
 	Module: 001e2fd8
 	IsJitted: yes
 	CodeAddr: 033bbca0
-	Transparency: Critical
 
 	EHHandler 0: TYPED catch(System.IO.FileNotFoundException) 
 	Clause: [033bbd2b, 033bbd3c] [8b, 9c]

--- a/src/ToolBox/SOS/Strike/sosdocs.txt
+++ b/src/ToolBox/SOS/Strike/sosdocs.txt
@@ -917,7 +917,6 @@ associated with it. For example, this output from K:
 	Module:       001caa38
 	IsJitted:     yes
 	CodeAddr:     03ef00b8
-	Transparency: Critical
 	Source file:  c:\Code\prj.mini\exc.cs @ 39
 
 We have taken a return address into Mainy.Main, and discovered information 
@@ -1031,7 +1030,6 @@ Sample output:
 	Module: 001e2fd8
 	IsJitted: yes
 	CodeAddr: 033bbca0
-	Transparency: Critical
 
 	EHHandler 0: TYPED catch(System.IO.FileNotFoundException) 
 	Clause: [033bbd2b, 033bbd3c] [8b, 9c]

--- a/src/ToolBox/SOS/Strike/sosdocsunix.txt
+++ b/src/ToolBox/SOS/Strike/sosdocsunix.txt
@@ -658,7 +658,6 @@ associated with it. For example, this output from K:
         Module:       00007ffff7f6b938
         IsJitted:     yes
         CodeAddr:     00007ffff04976c0
-        Transparency: Critical
 
 We have taken a return address into Mainy.Main, and discovered information 
 about that method. You could run U, DumpMT, DumpClass, DumpMD, or 
@@ -770,7 +769,6 @@ Sample output:
 	Module: 001e2fd8
 	IsJitted: yes
 	CodeAddr: 033bbca0
-	Transparency: Critical
 
 	EHHandler 0: TYPED catch(System.IO.FileNotFoundException) 
 	Clause: [033bbd2b, 033bbd3c] [8b, 9c]

--- a/src/ToolBox/SOS/Strike/strike.cpp
+++ b/src/ToolBox/SOS/Strike/strike.cpp
@@ -1245,12 +1245,6 @@ DECLARE_API(DumpClass)
     
     ExtOut("\n");        
 
-    DacpMethodTableTransparencyData transparency;
-    if (SUCCEEDED(transparency.Request(g_sos, methodTable)))
-    {
-        ExtOut("Transparency:        %s\n", GetTransparency(transparency));
-    }
-
     DacpMethodTableFieldData vMethodTableFields;
     if (SUCCEEDED(vMethodTableFields.Request(g_sos, methodTable)))
     {

--- a/src/ToolBox/SOS/Strike/util.cpp
+++ b/src/ToolBox/SOS/Strike/util.cpp
@@ -3417,12 +3417,6 @@ void DumpMDInfoFromMethodDescData(DacpMethodDescData * pMethodDescData, DacpReJi
             DumpTieredNativeCodeAddressInfo(codeAddrs, cCodeAddrs);
         }
         
-        DacpMethodDescTransparencyData transparency;
-        if (SUCCEEDED(transparency.Request(g_sos, pMethodDescData->MethodDescPtr)))
-        {
-            ExtOut("Transparency: %s\n", GetTransparency(transparency));
-        }
-
         DumpAllRejitDataIfNecessary(pMethodDescData, pRevertedRejitData, cRevertedRejitData);
     }
     else

--- a/src/ToolBox/SOS/Strike/util.h
+++ b/src/ToolBox/SOS/Strike/util.h
@@ -1943,27 +1943,6 @@ void PrintNotReachableInRange(TADDR rngStart, TADDR rngEnd, BOOL bExcludeReadyFo
 
 const char *EHTypeName(EHClauseType et);
 
-template<typename T>
-inline const LPCSTR GetTransparency(const T &t)
-{
-    if (!t.bHasCriticalTransparentInfo)
-    {
-        return "Not calculated";
-    }
-    else if (t.bIsCritical && !t.bIsTreatAsSafe)
-    {
-        return "Critical";
-    }
-    else if (t.bIsCritical)
-    {
-        return "Safe critical";
-    }
-    else
-    {
-        return "Transparent";
-    }
-}
-
 struct StringHolder
 {
     LPSTR data;


### PR DESCRIPTION
Security transparency is not relevant in .NET Core.