### PR TITLE
[RyuJit] add new compiler phase: PHASE_COMPUTE_REACHABILITY

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4718,6 +4718,7 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
 
         // Compute reachability sets and dominators.
         fgComputeReachability();
+        EndPhase(PHASE_COMPUTE_REACHABILITY);
     }
 
     // Transform each GT_ALLOCOBJ node into either an allocation helper call or

--- a/src/jit/compphases.h
+++ b/src/jit/compphases.h
@@ -45,6 +45,7 @@ CompPhaseNameMacro(PHASE_COMPUTE_EDGE_WEIGHTS,   "Compute edge weights (1, false
 CompPhaseNameMacro(PHASE_CREATE_FUNCLETS,        "Create EH funclets",             "EH-FUNC",  false, -1, false)
 #endif // FEATURE_EH_FUNCLETS
 CompPhaseNameMacro(PHASE_OPTIMIZE_LAYOUT,        "Optimize layout",                "LAYOUT",   false, -1, false)
+CompPhaseNameMacro(PHASE_COMPUTE_REACHABILITY,   "Compute blocks reachability",    "BL_REACH", false, -1, false)
 CompPhaseNameMacro(PHASE_ALLOCATE_OBJECTS,       "Allocate Objects",               "ALLOC-OBJ",false, -1, false)
 CompPhaseNameMacro(PHASE_OPTIMIZE_LOOPS,         "Optimize loops",                 "LOOP-OPT", false, -1, false)
 CompPhaseNameMacro(PHASE_CLONE_LOOPS,            "Clone loops",                    "LP-CLONE", false, -1, false)


### PR DESCRIPTION
This phase has an algorithm with quadratic time and we need a separate phase to see its timings,
now it goes to `Allocate objects`:
```
     PHASE                          inv/meth   Mcycles    time (ms)  % of total    max (ms)
     Create EH funclets               1.00      104.04      30.538       0.00%      30.536
     Optimize layout                  1.00   180038.02   52846.290       0.25%    52846.282
     Allocate Objects                 1.00  71379259.81   20951847.058      99.64%    20951847.048
```

It is a part of #16573.