### PR TITLE
Log inner exceptions for Environment.Failfast 

### DIFF
--- a/src/classlibnative/bcltype/system.cpp
+++ b/src/classlibnative/bcltype/system.cpp
@@ -377,7 +377,7 @@ WCHAR g_szFailFastBuffer[256];
 
 // This is the common code for FailFast processing that is wrapped by the two
 // FailFast FCalls below.
-void SystemNative::GenericFailFast(STRINGREF refMesgString, EXCEPTIONREF refExceptionForWatsonBucketing, UINT_PTR retAddress, UINT exitCode, STRINGREF refErrorSourceString)
+void SystemNative::GenericFailFast(STRINGREF refMesgString, EXCEPTIONREF refExceptionForWatsonBucketing, UINT_PTR retAddress, UINT exitCode, STRINGREF refErrorSourceString, ExceptionObject * pInnerException)
 {
     CONTRACTL
     {
@@ -499,7 +499,7 @@ void SystemNative::GenericFailFast(STRINGREF refMesgString, EXCEPTIONREF refExce
     if (gc.refExceptionForWatsonBucketing != NULL)
         pThread->SetLastThrownObject(gc.refExceptionForWatsonBucketing);
 
-    EEPolicy::HandleFatalError(exitCode, retAddress, pszMessage, NULL, errorSourceString);
+    EEPolicy::HandleFatalError(exitCode, retAddress, pszMessage, NULL, errorSourceString, (VOID*)pInnerException);
 
     GCPROTECT_END();
 }
@@ -555,7 +555,7 @@ FCIMPL2(VOID, SystemNative::FailFastWithException, StringObject* refMessageUNSAF
     UINT_PTR retaddr = HELPER_METHOD_FRAME_GET_RETURN_ADDRESS();
     
     // Call the actual worker to perform failfast
-    GenericFailFast(refMessage, refException, retaddr, COR_E_FAILFAST, NULL);
+    GenericFailFast(refMessage, refException, retaddr, COR_E_FAILFAST, NULL, refExceptionUNSAFE);
 
     HELPER_METHOD_FRAME_END();
 }

--- a/src/classlibnative/bcltype/system.cpp
+++ b/src/classlibnative/bcltype/system.cpp
@@ -392,8 +392,6 @@ void SystemNative::GenericFailFast(STRINGREF refMesgString, EXCEPTIONREF refExce
         STRINGREF refMesgString;
         EXCEPTIONREF refExceptionForWatsonBucketing;
         STRINGREF refErrorSourceString;
-        StackSString msg;  // Used for generating inner exception message
-        StackScratchBuffer buf;  // Used for generating inner exception message
     } gc;
     ZeroMemory(&gc, sizeof(gc));
 
@@ -471,11 +469,12 @@ void SystemNative::GenericFailFast(STRINGREF refMesgString, EXCEPTIONREF refExce
         WszOutputDebugString(W("\"\r\n"));
     }
 
-    const CHAR * innerExceptionString = NULL;
+    const WCHAR * argExceptionString = NULL;
+    StackSString msg;
     if (gc.refExceptionForWatsonBucketing != NULL)
     {
-        GetExceptionMessage(gc.refExceptionForWatsonBucketing, gc.msg);
-        innerExceptionString = gc.msg.GetANSI(gc.buf);
+        GetExceptionMessage(gc.refExceptionForWatsonBucketing, msg);
+        argExceptionString = msg.GetUnicode();
     }
 
     Thread *pThread = GetThread();
@@ -508,7 +507,7 @@ void SystemNative::GenericFailFast(STRINGREF refMesgString, EXCEPTIONREF refExce
     if (gc.refExceptionForWatsonBucketing != NULL)
         pThread->SetLastThrownObject(gc.refExceptionForWatsonBucketing);
 
-    EEPolicy::HandleFatalError(exitCode, retAddress, pszMessage, NULL, errorSourceString, innerExceptionString);
+    EEPolicy::HandleFatalError(exitCode, retAddress, pszMessage, NULL, errorSourceString, argExceptionString);
 
     GCPROTECT_END();
 }

--- a/src/classlibnative/bcltype/system.h
+++ b/src/classlibnative/bcltype/system.h
@@ -76,7 +76,7 @@ public:
 
 private:
     // Common processing code for FailFast
-    static void GenericFailFast(STRINGREF refMesgString, EXCEPTIONREF refExceptionForWatsonBucketing, UINT_PTR retAddress, UINT exitCode, STRINGREF errorSource);
+    static void GenericFailFast(STRINGREF refMesgString, EXCEPTIONREF refExceptionForWatsonBucketing, UINT_PTR retAddress, UINT exitCode, STRINGREF errorSource, ExceptionObject * pInnerException=NULL);
 };
 
 /* static */

--- a/src/classlibnative/bcltype/system.h
+++ b/src/classlibnative/bcltype/system.h
@@ -76,7 +76,7 @@ public:
 
 private:
     // Common processing code for FailFast
-    static void GenericFailFast(STRINGREF refMesgString, EXCEPTIONREF refExceptionForWatsonBucketing, UINT_PTR retAddress, UINT exitCode, STRINGREF errorSource, ExceptionObject * pInnerException=NULL);
+    static void GenericFailFast(STRINGREF refMesgString, EXCEPTIONREF refExceptionForWatsonBucketing, UINT_PTR retAddress, UINT exitCode, STRINGREF errorSource);
 };
 
 /* static */

--- a/src/vm/crossgencompile.cpp
+++ b/src/vm/crossgencompile.cpp
@@ -384,7 +384,7 @@ extern "C" UINT_PTR STDCALL GetCurrentIP()
     return 0;
 }
 
-void EEPolicy::HandleFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pszMessage, PEXCEPTION_POINTERS pExceptionInfo, LPCWSTR errorSource)
+void EEPolicy::HandleFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pszMessage, PEXCEPTION_POINTERS pExceptionInfo, LPCWSTR errorSource, VOID * pInnerException)
 { 
     fprintf(stderr, "Fatal error: %08x\n", exitCode);
     ExitProcess(exitCode);

--- a/src/vm/crossgencompile.cpp
+++ b/src/vm/crossgencompile.cpp
@@ -384,7 +384,7 @@ extern "C" UINT_PTR STDCALL GetCurrentIP()
     return 0;
 }
 
-void EEPolicy::HandleFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pszMessage, PEXCEPTION_POINTERS pExceptionInfo, LPCWSTR errorSource, VOID * pInnerException)
+void EEPolicy::HandleFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pszMessage, PEXCEPTION_POINTERS pExceptionInfo, LPCWSTR errorSource, const CHAR * innerExceptionString)
 { 
     fprintf(stderr, "Fatal error: %08x\n", exitCode);
     ExitProcess(exitCode);

--- a/src/vm/crossgencompile.cpp
+++ b/src/vm/crossgencompile.cpp
@@ -384,7 +384,7 @@ extern "C" UINT_PTR STDCALL GetCurrentIP()
     return 0;
 }
 
-void EEPolicy::HandleFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pszMessage, PEXCEPTION_POINTERS pExceptionInfo, LPCWSTR errorSource, const CHAR * innerExceptionString)
+void EEPolicy::HandleFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pszMessage, PEXCEPTION_POINTERS pExceptionInfo, LPCWSTR errorSource, const WCHAR * argExceptionString)
 { 
     fprintf(stderr, "Fatal error: %08x\n", exitCode);
     ExitProcess(exitCode);

--- a/src/vm/eepolicy.cpp
+++ b/src/vm/eepolicy.cpp
@@ -1141,7 +1141,7 @@ StackWalkAction LogCallstackForLogCallback(
 // A worker to save managed stack trace.
 //
 // Arguments:
-//    reporter - EventReporter object for EventLog
+//    None
 //
 // Return Value:
 //    None
@@ -1200,6 +1200,22 @@ inline void DoLogForFailFastException(LPCWSTR pszMessage, PEXCEPTION_POINTERS pE
         {
             PrintToStdErrA("\n");
             LogCallstackForLogWorker();
+        }
+
+        if (errorSource == NULL) // Log inner exception details
+        {
+            EXCEPTIONREF refException = (EXCEPTIONREF)(pThread->LastThrownObject());
+            PrintToStdErrA("\n");
+            PrintToStdErrA("Inner exception details:");
+            PrintToStdErrA("\n");
+            if (refException != NULL) {
+                StackSString msg;
+                GetExceptionMessage(refException, msg);
+                StackScratchBuffer buf;
+                const CHAR * str = msg.GetANSI(buf);
+                PrintToStdErrA(str);
+                PrintToStdErrA("\n");
+            }
         }
     }
     EX_CATCH

--- a/src/vm/eepolicy.cpp
+++ b/src/vm/eepolicy.cpp
@@ -1200,20 +1200,18 @@ inline void DoLogForFailFastException(LPCWSTR pszMessage, PEXCEPTION_POINTERS pE
         {
             PrintToStdErrA("\n");
             LogCallstackForLogWorker();
-        }
-
-        if (errorSource == NULL) // Log inner exception details
-        {
             EXCEPTIONREF refException = (EXCEPTIONREF)(pThread->LastThrownObject());
-            PrintToStdErrA("\n");
-            PrintToStdErrA("Inner exception details:");
-            PrintToStdErrA("\n");
+
             if (refException != NULL) {
                 StackSString msg;
                 GetExceptionMessage(refException, msg);
                 StackScratchBuffer buf;
-                const CHAR * str = msg.GetANSI(buf);
-                PrintToStdErrA(str);
+                const CHAR * innerExceptionMsg = msg.GetANSI(buf);
+
+                PrintToStdErrA("\n");
+                PrintToStdErrA("Inner exception details:");
+                PrintToStdErrA("\n");
+                PrintToStdErrA(innerExceptionMsg);
                 PrintToStdErrA("\n");
             }
         }

--- a/src/vm/eepolicy.cpp
+++ b/src/vm/eepolicy.cpp
@@ -1176,7 +1176,7 @@ inline void LogCallstackForLogWorker()
 // Return Value:
 //    None
 //
-inline void DoLogForFailFastException(LPCWSTR pszMessage, PEXCEPTION_POINTERS pExceptionInfo, LPCWSTR errorSource, const CHAR * innerExceptionString)
+inline void DoLogForFailFastException(LPCWSTR pszMessage, PEXCEPTION_POINTERS pExceptionInfo, LPCWSTR errorSource, const WCHAR * argExceptionString)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1201,11 +1201,11 @@ inline void DoLogForFailFastException(LPCWSTR pszMessage, PEXCEPTION_POINTERS pE
             PrintToStdErrA("\n");
             LogCallstackForLogWorker();
 
-            if (innerExceptionString != NULL) {
+            if (argExceptionString != NULL) {
                 PrintToStdErrA("\n");
-                PrintToStdErrA("Inner exception details:");
+                PrintToStdErrA("Exception details:");
                 PrintToStdErrA("\n");
-                PrintToStdErrA(innerExceptionString);
+                PrintToStdErrW(argExceptionString);
                 PrintToStdErrA("\n");
             }
         }
@@ -1220,7 +1220,7 @@ inline void DoLogForFailFastException(LPCWSTR pszMessage, PEXCEPTION_POINTERS pE
 // Log an error to the event log if possible, then throw up a dialog box.
 //
 
-void EEPolicy::LogFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pszMessage, PEXCEPTION_POINTERS pExceptionInfo, LPCWSTR errorSource, const CHAR * innerExceptionString)
+void EEPolicy::LogFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pszMessage, PEXCEPTION_POINTERS pExceptionInfo, LPCWSTR errorSource, const WCHAR * argExceptionString)
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_TRIGGERS;
@@ -1231,7 +1231,7 @@ void EEPolicy::LogFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pszMessage
     // Log FailFast exception to StdErr
     if (exitCode == (UINT)COR_E_FAILFAST)
     {
-        DoLogForFailFastException(pszMessage, pExceptionInfo, errorSource, innerExceptionString);
+        DoLogForFailFastException(pszMessage, pExceptionInfo, errorSource, argExceptionString);
     }
 
     if(ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PRIVATE_PROVIDER_Context, FailFast))
@@ -1486,7 +1486,7 @@ void DECLSPEC_NORETURN EEPolicy::HandleFatalStackOverflow(EXCEPTION_POINTERS *pE
     UNREACHABLE();
 }
 
-void DECLSPEC_NORETURN EEPolicy::HandleFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pszMessage /* = NULL */, PEXCEPTION_POINTERS pExceptionInfo /* = NULL */, LPCWSTR errorSource /* = NULL */, const CHAR * innerExceptionString /* = NULL */)
+void DECLSPEC_NORETURN EEPolicy::HandleFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pszMessage /* = NULL */, PEXCEPTION_POINTERS pExceptionInfo /* = NULL */, LPCWSTR errorSource /* = NULL */, const WCHAR * argExceptionString /* = NULL */)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1536,11 +1536,11 @@ void DECLSPEC_NORETURN EEPolicy::HandleFatalError(UINT exitCode, UINT_PTR addres
         switch (GetEEPolicy()->GetActionOnFailure(FAIL_FatalRuntime))
         {
         case eRudeExitProcess:
-            LogFatalError(exitCode, address, pszMessage, pExceptionInfo, errorSource, innerExceptionString);
+            LogFatalError(exitCode, address, pszMessage, pExceptionInfo, errorSource, argExceptionString);
 	        SafeExitProcess(exitCode, TRUE);
             break;
         case eDisableRuntime:
-            LogFatalError(exitCode, address, pszMessage, pExceptionInfo, errorSource, innerExceptionString);
+            LogFatalError(exitCode, address, pszMessage, pExceptionInfo, errorSource, argExceptionString);
             DisableRuntime(SCA_ExitProcessWhenShutdownComplete);
             break;
         default:

--- a/src/vm/eepolicy.h
+++ b/src/vm/eepolicy.h
@@ -124,7 +124,7 @@ public:
 
     static void HandleExitProcess(ShutdownCompleteAction sca = SCA_ExitProcessWhenShutdownComplete);
 
-    static void DECLSPEC_NORETURN HandleFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pMessage=NULL, PEXCEPTION_POINTERS pExceptionInfo= NULL, LPCWSTR errorSource=NULL);
+    static void DECLSPEC_NORETURN HandleFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pMessage=NULL, PEXCEPTION_POINTERS pExceptionInfo= NULL, LPCWSTR errorSource=NULL, VOID * pInnerException=NULL);
 
     static void DECLSPEC_NORETURN HandleFatalStackOverflow(EXCEPTION_POINTERS *pException, BOOL fSkipDebugger = FALSE);
 
@@ -147,7 +147,7 @@ private:
     BOOL IsValidActionForFailure(EClrFailure failure, EPolicyAction action);
     EPolicyAction GetFinalAction(EPolicyAction action, Thread *pThread);
 
-    static void LogFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pMessage, PEXCEPTION_POINTERS pExceptionInfo, LPCWSTR errorSource);
+    static void LogFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pMessage, PEXCEPTION_POINTERS pExceptionInfo, LPCWSTR errorSource, VOID * pInnerException=NULL);
 
     // IMPORTANT NOTE: only the following two functions should be calling ExitProcessViaShim.
     // - CorHost2::ExitProcess

--- a/src/vm/eepolicy.h
+++ b/src/vm/eepolicy.h
@@ -124,7 +124,7 @@ public:
 
     static void HandleExitProcess(ShutdownCompleteAction sca = SCA_ExitProcessWhenShutdownComplete);
 
-    static void DECLSPEC_NORETURN HandleFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pMessage=NULL, PEXCEPTION_POINTERS pExceptionInfo= NULL, LPCWSTR errorSource=NULL, VOID * pInnerException=NULL);
+    static void DECLSPEC_NORETURN HandleFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pMessage=NULL, PEXCEPTION_POINTERS pExceptionInfo= NULL, LPCWSTR errorSource=NULL, const CHAR * innerExceptionString=NULL);
 
     static void DECLSPEC_NORETURN HandleFatalStackOverflow(EXCEPTION_POINTERS *pException, BOOL fSkipDebugger = FALSE);
 
@@ -147,7 +147,7 @@ private:
     BOOL IsValidActionForFailure(EClrFailure failure, EPolicyAction action);
     EPolicyAction GetFinalAction(EPolicyAction action, Thread *pThread);
 
-    static void LogFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pMessage, PEXCEPTION_POINTERS pExceptionInfo, LPCWSTR errorSource, VOID * pInnerException=NULL);
+    static void LogFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pMessage, PEXCEPTION_POINTERS pExceptionInfo, LPCWSTR errorSource, const CHAR * innerExceptionString=NULL);
 
     // IMPORTANT NOTE: only the following two functions should be calling ExitProcessViaShim.
     // - CorHost2::ExitProcess

--- a/src/vm/eepolicy.h
+++ b/src/vm/eepolicy.h
@@ -124,7 +124,7 @@ public:
 
     static void HandleExitProcess(ShutdownCompleteAction sca = SCA_ExitProcessWhenShutdownComplete);
 
-    static void DECLSPEC_NORETURN HandleFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pMessage=NULL, PEXCEPTION_POINTERS pExceptionInfo= NULL, LPCWSTR errorSource=NULL, const CHAR * innerExceptionString=NULL);
+    static void DECLSPEC_NORETURN HandleFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pMessage=NULL, PEXCEPTION_POINTERS pExceptionInfo= NULL, LPCWSTR errorSource=NULL, const WCHAR * argExceptionString=NULL);
 
     static void DECLSPEC_NORETURN HandleFatalStackOverflow(EXCEPTION_POINTERS *pException, BOOL fSkipDebugger = FALSE);
 
@@ -147,7 +147,7 @@ private:
     BOOL IsValidActionForFailure(EClrFailure failure, EPolicyAction action);
     EPolicyAction GetFinalAction(EPolicyAction action, Thread *pThread);
 
-    static void LogFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pMessage, PEXCEPTION_POINTERS pExceptionInfo, LPCWSTR errorSource, const CHAR * innerExceptionString=NULL);
+    static void LogFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pMessage, PEXCEPTION_POINTERS pExceptionInfo, LPCWSTR errorSource, const WCHAR * argExceptionString=NULL);
 
     // IMPORTANT NOTE: only the following two functions should be calling ExitProcessViaShim.
     // - CorHost2::ExitProcess


### PR DESCRIPTION
Fixes issue #15203

Enable logging inner exception on calls to ```Environment.FailFast(bool, ex)```

Pasted below is an example inner exception log produced with this fix for this program: 
```
FailFast:
Oops

   at System.Environment.FailFast(System.String, System.Exception)
   at Internal.Runtime.Augments.EnvironmentAugments.FailFast(System.String, System.Exception)
   at System.Environment.FailFast(System.String, System.Exception)
   at Program.Main()

Inner exception details:
System.ArgumentException: my ae ---> System.NullReferenceException: my nre
   at Program.D()
   at Program.C()
   at Program.B()
   --- End of inner exception stack trace ---
   at Program.B()
   at Program.A()
   at Program.Main()
```

Here is the program used to produce the log above.
```
class Program
{
    static void Main()
    {
        try
        {
            A();
        }
        catch(Exception ex)
        {
            Environment.FailFast("Oops", ex);
        }
    }

    static void A()
    {
        B();
    }

    static void B()
    {
        try
        {
            C();
        }
        catch (Exception ex)
        {
            throw new ArgumentException("my ae", ex);
        }
    }

    static void C()
    {
        D();
    }

    static void D()
    {
        throw new NullReferenceException("my nre");
    }
}

```

I will follow up with another PR to address the duplicate ```System.Environment.FailFast(System.String, System.Exception)``` appearing in the FailFast exception stack trace, but this PR addresses the more important problem of inner exception details getting dropped from the log.