### PR TITLE
Re-enable parts of SpanBench

### DIFF
--- a/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
@@ -475,7 +475,6 @@ namespace Span
         }
         #endregion
 
-#if false // netcoreapp specific API https://github.com/dotnet/coreclr/issues/16126
         #region TestSpanCreate<T>
         [Benchmark(InnerIterationCount = BaseIterations)]
         [InlineData(100)]
@@ -515,7 +514,6 @@ namespace Span
             }
         }
         #endregion
-#endif
 
         #region TestMemoryMarshalGetReference<T>
         [Benchmark(InnerIterationCount = BaseIterations)]


### PR DESCRIPTION
A few parts of SpanBench were disabled in #16091 as we were compiling the
benchmarks with more restrictive netstandard versions and some APIs were
moved to be netcoreapp 2.1 only.

With the advent of #16378 we've removed those restrictions so the tests can
be re-enabled.