### PR TITLE
Remove xunit.console.netcore StaticDependency

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -157,10 +157,6 @@
       <Version>$(XunitPerformanceApiPackageVersion)</Version>
     </StaticDependency>
 
-    <StaticDependency Include="xunit.console.netcore">
-      <Version>$(XunitConsoleNetcorePackageVersion)</Version>
-    </StaticDependency>
-
     <DependencyBuildInfo Include="@(StaticDependency)">
       <PackageId>%(Identity)</PackageId>
       <UpdateStableVersions>true</UpdateStableVersions>


### PR DESCRIPTION
It depends on `XunitConsoleNetcorePackageVersion` which was removed in https://github.com/dotnet/coreclr/pull/16378. This is currently breaking CoreCLR auto-update builds: https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=1423564

FYI @AndyAyersMS 