### PR TITLE
Update ILLink to version 0.1.4-preview-1421602

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -64,7 +64,7 @@
   <!-- ILLinik.Tasks package version -->
   <PropertyGroup>
     <ILLinkTasksPackage>ILLink.Tasks</ILLinkTasksPackage>
-    <ILLinkTasksPackageVersion>0.1.4-preview-1317495</ILLinkTasksPackageVersion>
+    <ILLinkTasksPackageVersion>0.1.4-preview-1421602</ILLinkTasksPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This build has a support for SHA256 source checksum algorithm. Previously Mono.Cecil didn't write correct algorithm GUID into the PDBs, which resulted in bad PDBs.
See jbevain/cecil#488