### PR TITLE
Mark MemoryMarshal.Cast methods for aggressive inlining

### DIFF
--- a/src/mscorlib/shared/System/Runtime/InteropServices/MemoryMarshal.Fast.cs
+++ b/src/mscorlib/shared/System/Runtime/InteropServices/MemoryMarshal.Fast.cs
@@ -50,6 +50,7 @@ namespace System.Runtime.InteropServices
         /// <exception cref="System.ArgumentException">
         /// Thrown when <typeparamref name="TFrom"/> or <typeparamref name="TTo"/> contains pointers.
         /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Span<TTo> Cast<TFrom, TTo>(Span<TFrom> source)
             where TFrom : struct
             where TTo : struct
@@ -75,6 +76,7 @@ namespace System.Runtime.InteropServices
         /// <exception cref="System.ArgumentException">
         /// Thrown when <typeparamref name="TFrom"/> or <typeparamref name="TTo"/> contains pointers.
         /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ReadOnlySpan<TTo> Cast<TFrom, TTo>(ReadOnlySpan<TFrom> source)
             where TFrom : struct
             where TTo : struct


### PR DESCRIPTION
Inlining doesn't streamline the cast logic any, but it facilitates
caller struct promotion which can substantially boost perf.

See discussion in dotnet/corefx#27485.