### PR TITLE
Draft for fixing fgComputeReachabilitySets.

### DIFF
--- a/src/jit/arraystack.h
+++ b/src/jit/arraystack.h
@@ -117,6 +117,11 @@ public:
         return tosIndex;
     }
 
+    bool Empty()
+    {
+        return Height() == 0;
+    }
+
     // return the bottom of the stack
     T Bottom()
     {

--- a/src/jit/block.cpp
+++ b/src/jit/block.cpp
@@ -1380,6 +1380,7 @@ BasicBlock* Compiler::bbNewBasicBlock(BBjumpKinds jumpKind)
     block->bbNatLoopNum = BasicBlock::NOT_IN_LOOP;
 
     block->bbSuccs = nullptr;
+    block->visited = false;
 
     return block;
 }

--- a/src/jit/block.cpp
+++ b/src/jit/block.cpp
@@ -1379,5 +1379,7 @@ BasicBlock* Compiler::bbNewBasicBlock(BBjumpKinds jumpKind)
 
     block->bbNatLoopNum = BasicBlock::NOT_IN_LOOP;
 
+    block->bbSuccs = nullptr;
+
     return block;
 }

--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -895,6 +895,8 @@ struct BasicBlock : private LIR::Range
         flowList*       bbPreds;      // ptr to list of predecessors
     };
 
+    flowList* bbSuccs; // ptr to list of successors
+
     BlockSet    bbReach; // Set of all blocks that can reach this one
     BasicBlock* bbIDom;  // Represent the closest dominator to this block (called the Immediate
                          // Dominator) used to compute the dominance tree.

--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -895,6 +895,7 @@ struct BasicBlock : private LIR::Range
         flowList*       bbPreds;      // ptr to list of predecessors
     };
 
+    bool      visited;
     flowList* bbSuccs; // ptr to list of successors
 
     BlockSet    bbReach; // Set of all blocks that can reach this one

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3723,6 +3723,7 @@ public:
 
     bool fgModified;         // True if the flow graph has been modified recently
     bool fgComputePredsDone; // Have we computed the bbPreds list
+    bool fgComputeSuccsDone; // Have we computed the bbSuccs list
     bool fgCheapPredsValid;  // Is the bbCheapPreds list valid?
     bool fgDomsComputed;     // Have we computed the dominator sets?
     bool fgOptimizedFinally; // Did we optimize any try-finallys?
@@ -4346,6 +4347,12 @@ protected:
     void fgUpdateChangedFlowGraph();
 
 public:
+    // Compute the successors of the blocks in the control flow graph.
+    void fgComputeSuccs();
+
+    // Remove all successors information.
+    void fgRemoveSuccs();
+
     // Compute the predecessors of the blocks in the control flow graph.
     void fgComputePreds();
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4307,6 +4307,8 @@ protected:
 
     void fgComputeReachabilitySets(); // Compute bbReach sets. (Also sets BBF_GC_SAFE_POINT flag on blocks.)
 
+    void fgSetBlockHasGCSafepoint(); // Sets BBF_GC_SAFE_POINT flag on blocks.
+
     void fgComputeEnterBlocksSet(); // Compute the set of entry blocks, 'fgEnterBlks'.
 
     bool fgRemoveUnreachableBlocks(); // Remove blocks determined to be unreachable by the bbReach sets.


### PR DESCRIPTION
This is a  draft PR to show the general ideas of PRs that I will start publishing soon and get feedback on early stage.

1 commit: Separate `fgSetBlockHasGCSafepoint` and `fgComputeReachabilitySets`, they are  different things that should not be together and need different algorithms.

2 commit: Creates successors lists for blocks that will be used later; in the PR for merge I think I will replace linked list with vectors for both preds and succs (Yes, we already have several functions that return successors, for example `getSucc([compiler], number)`, however, neither of them match `fgComputePreds` behavior because we have mess with exception blocks).

3 commit: optimize `fgSetBlockHasGCSafepoint` to use a linear algorithm (`O(N * [JitHashTable access time]`). The previous algorithm was slow and did not run new iteration if ` BBF_GC_SAFE_POINT` changed, but `bbReach` did not; however, because we did many extra iteration for `bbReach` we did not hit this case (and because missing `BBF_GC_SAFE_POINT` does not affect correctness).

4 commit: optimize fgComputeReachabilitySets, use classic iterative algorithm, its complexity is `Sum for all node of F(node), where F(node) is number of loops that include this node`. Before we have `Number of nodes * depth of the biggest nested loop`

These changes fix #16573.

These changes doesn't show any measurable throughput diff on System.Private.CoreLib with pintool.

What is not included in this PR, but will be made as part of work on #16573:
1. `fgRemoveUnreachableBlocks` and `BBF_LOOP_HEAD` will be separated;
2. `fgRemoveUnreachableBlocks` will be rewritten to use primitive block liveness linear scan, not it is using reachability sets (why???);
3. `fgComputeReachabilitySets` will be called only once when all unreachable blocks are deleted (now we recalculate it for each iteration, that we can have more on arm because of the special hack for exception unwinding).
4. optimize variables liveness in the same way.

All these changes will be extracted in a separate class with headers and other comments.