### PR TITLE
Edits to fix conflicts in generated Vector.cs file

### DIFF
--- a/src/mscorlib/shared/System/Numerics/Vector.tt
+++ b/src/mscorlib/shared/System/Numerics/Vector.tt
@@ -68,12 +68,12 @@ namespace System.Numerics
         /// Returns a vector containing all zeroes.
         /// </summary>
         public static Vector<T> Zero
-        { 
+        {
             [Intrinsic]
             get
             {
                 return s_zero;
-            } 
+            }
         }
         private static readonly Vector<T> s_zero = new Vector<T>();
 
@@ -84,7 +84,7 @@ namespace System.Numerics
         {
             [Intrinsic]
             get
-            { 
+            {
                 return s_one;
             }
         }
@@ -999,7 +999,7 @@ namespace System.Numerics
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
         public static Vector<T> operator ~(Vector<T> value)
         {
-            return allOnes ^ value;
+            return s_allOnes ^ value;
         }
         #endregion Bitwise Operators
 


### PR DESCRIPTION
Fixed minor space changes and one syntax error that causes conflict between checked in Vector.cs file and the freshly auto-generated Vector.cs file.

This is as per the discussion at this [link](https://github.com/dotnet/corefx/pull/26499#issuecomment-369376926).

@eerhardt Please review the changes.

Thanks,
Mandar