### PR TITLE
Refactor the signature of genGetSimdInsOpt to use emitAttr

### DIFF
--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -67,7 +67,7 @@ enum SIMDScalarMoveType
 };
 
 #ifdef _TARGET_ARM64_
-insOpts genGetSimdInsOpt(bool is16B, var_types elementType);
+insOpts genGetSimdInsOpt(emitAttr size, var_types elementType);
 #endif
 instruction getOpForSIMDIntrinsic(SIMDIntrinsicID intrinsicId, var_types baseType, unsigned* ival = nullptr);
 void genSIMDScalarMove(

--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -11449,8 +11449,9 @@ void emitter::emitDispIns(
                 emitDispReg(id->idReg2(), size, true);
                 emitDispVectorReg(id->idReg3(), id->idInsOpt(), false);
             }
-            else
+            else // INS_sha1su0, INS_sha256su1
             {
+                // Vd, Vn, Vm   (vector)
                 emitDispVectorReg(id->idReg1(), id->idInsOpt(), true);
                 emitDispVectorReg(id->idReg2(), id->idInsOpt(), true);
                 emitDispVectorReg(id->idReg3(), id->idInsOpt(), false);


### PR DESCRIPTION
Eliminates the use of bool is16Byte from the code base
Added my comments from the code review of PR #16565 to emitarm64.cpp