### PR TITLE
Add NULL check in DispatchInfo::IsVariantByrefStaticArray

### DIFF
--- a/src/vm/dispatchinfo.cpp
+++ b/src/vm/dispatchinfo.cpp
@@ -3178,7 +3178,8 @@ BOOL DispatchInfo::IsVariantByrefStaticArray(VARIANT *pOle)
 
     if (V_VT(pOle) & VT_BYREF && V_VT(pOle) & VT_ARRAY)
     {
-        if ((*V_ARRAYREF(pOle))->fFeatures & FADF_STATIC)
+        SAFEARRAY *pSafeArray = *V_ARRAYREF(pOle);
+        if (pSafeArray && (pSafeArray->fFeatures & FADF_STATIC))
             return TRUE;
     }
 


### PR DESCRIPTION

The change is to add a NULL check during dereference passing variant pointer. Customer had met an crash when passing an uninitialized string array from VB to managed code.

Fix #14144 