### PR TITLE
Change several ValueTask properties to methods

### DIFF
--- a/src/mscorlib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
+++ b/src/mscorlib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
@@ -61,11 +61,11 @@ namespace System.Runtime.CompilerServices
             {
                 if (_value.ObjectIsTask)
                 {
-                    _value.UnsafeTask.ConfigureAwait(_value.ContinueOnCapturedContext).GetAwaiter().OnCompleted(continuation);
+                    _value.UnsafeGetTask().ConfigureAwait(_value.ContinueOnCapturedContext).GetAwaiter().OnCompleted(continuation);
                 }
                 else if (_value._obj != null)
                 {
-                    _value.UnsafeValueTaskSource.OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token,
+                    _value.UnsafeGetValueTaskSource().OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token,
                         ValueTaskSourceOnCompletedFlags.FlowExecutionContext |
                             (_value.ContinueOnCapturedContext ? ValueTaskSourceOnCompletedFlags.UseSchedulingContext : ValueTaskSourceOnCompletedFlags.None));
                 }
@@ -80,11 +80,11 @@ namespace System.Runtime.CompilerServices
             {
                 if (_value.ObjectIsTask)
                 {
-                    _value.UnsafeTask.ConfigureAwait(_value.ContinueOnCapturedContext).GetAwaiter().UnsafeOnCompleted(continuation);
+                    _value.UnsafeGetTask().ConfigureAwait(_value.ContinueOnCapturedContext).GetAwaiter().UnsafeOnCompleted(continuation);
                 }
                 else if (_value._obj != null)
                 {
-                    _value.UnsafeValueTaskSource.OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token,
+                    _value.UnsafeGetValueTaskSource().OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token,
                         _value.ContinueOnCapturedContext ? ValueTaskSourceOnCompletedFlags.UseSchedulingContext : ValueTaskSourceOnCompletedFlags.None);
                 }
                 else
@@ -98,11 +98,11 @@ namespace System.Runtime.CompilerServices
             {
                 if (_value.ObjectIsTask)
                 {
-                    TaskAwaiter.UnsafeOnCompletedInternal(_value.UnsafeTask, box, _value.ContinueOnCapturedContext);
+                    TaskAwaiter.UnsafeOnCompletedInternal(_value.UnsafeGetTask(), box, _value.ContinueOnCapturedContext);
                 }
                 else if (_value._obj != null)
                 {
-                    _value.UnsafeValueTaskSource.OnCompleted(ValueTaskAwaiter.s_invokeAsyncStateMachineBox, box, _value._token,
+                    _value.UnsafeGetValueTaskSource().OnCompleted(ValueTaskAwaiter.s_invokeAsyncStateMachineBox, box, _value._token,
                         _value.ContinueOnCapturedContext ? ValueTaskSourceOnCompletedFlags.UseSchedulingContext : ValueTaskSourceOnCompletedFlags.None);
                 }
                 else
@@ -163,11 +163,11 @@ namespace System.Runtime.CompilerServices
             {
                 if (_value.ObjectIsTask)
                 {
-                    _value.UnsafeTask.ConfigureAwait(_value.ContinueOnCapturedContext).GetAwaiter().OnCompleted(continuation);
+                    _value.UnsafeGetTask().ConfigureAwait(_value.ContinueOnCapturedContext).GetAwaiter().OnCompleted(continuation);
                 }
                 else if (_value._obj != null)
                 {
-                    _value.UnsafeValueTaskSource.OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token,
+                    _value.UnsafeGetValueTaskSource().OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token,
                         ValueTaskSourceOnCompletedFlags.FlowExecutionContext |
                             (_value.ContinueOnCapturedContext ? ValueTaskSourceOnCompletedFlags.UseSchedulingContext : ValueTaskSourceOnCompletedFlags.None));
                 }
@@ -182,11 +182,11 @@ namespace System.Runtime.CompilerServices
             {
                 if (_value.ObjectIsTask)
                 {
-                    _value.UnsafeTask.ConfigureAwait(_value.ContinueOnCapturedContext).GetAwaiter().UnsafeOnCompleted(continuation);
+                    _value.UnsafeGetTask().ConfigureAwait(_value.ContinueOnCapturedContext).GetAwaiter().UnsafeOnCompleted(continuation);
                 }
                 else if (_value._obj != null)
                 {
-                    _value.UnsafeValueTaskSource.OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token,
+                    _value.UnsafeGetValueTaskSource().OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token,
                         _value.ContinueOnCapturedContext ? ValueTaskSourceOnCompletedFlags.UseSchedulingContext : ValueTaskSourceOnCompletedFlags.None);
                 }
                 else
@@ -200,11 +200,11 @@ namespace System.Runtime.CompilerServices
             {
                 if (_value.ObjectIsTask)
                 {
-                    TaskAwaiter.UnsafeOnCompletedInternal(_value.UnsafeTask, box, _value.ContinueOnCapturedContext);
+                    TaskAwaiter.UnsafeOnCompletedInternal(_value.UnsafeGetTask(), box, _value.ContinueOnCapturedContext);
                 }
                 else if (_value._obj != null)
                 {
-                    _value.UnsafeValueTaskSource.OnCompleted(ValueTaskAwaiter.s_invokeAsyncStateMachineBox, box, _value._token,
+                    _value.UnsafeGetValueTaskSource().OnCompleted(ValueTaskAwaiter.s_invokeAsyncStateMachineBox, box, _value._token,
                         _value.ContinueOnCapturedContext ? ValueTaskSourceOnCompletedFlags.UseSchedulingContext : ValueTaskSourceOnCompletedFlags.None);
                 }
                 else

--- a/src/mscorlib/shared/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/mscorlib/shared/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -50,11 +50,11 @@ namespace System.Runtime.CompilerServices
         {
             if (_value.ObjectIsTask)
             {
-                _value.UnsafeTask.GetAwaiter().OnCompleted(continuation);
+                _value.UnsafeGetTask().GetAwaiter().OnCompleted(continuation);
             }
             else if (_value._obj != null)
             {
-                _value.UnsafeValueTaskSource.OnCompleted(s_invokeActionDelegate, continuation, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext | ValueTaskSourceOnCompletedFlags.FlowExecutionContext);
+                _value.UnsafeGetValueTaskSource().OnCompleted(s_invokeActionDelegate, continuation, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext | ValueTaskSourceOnCompletedFlags.FlowExecutionContext);
             }
             else
             {
@@ -67,11 +67,11 @@ namespace System.Runtime.CompilerServices
         {
             if (_value.ObjectIsTask)
             {
-                _value.UnsafeTask.GetAwaiter().UnsafeOnCompleted(continuation);
+                _value.UnsafeGetTask().GetAwaiter().UnsafeOnCompleted(continuation);
             }
             else if (_value._obj != null)
             {
-                _value.UnsafeValueTaskSource.OnCompleted(s_invokeActionDelegate, continuation, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
+                _value.UnsafeGetValueTaskSource().OnCompleted(s_invokeActionDelegate, continuation, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
             }
             else
             {
@@ -84,11 +84,11 @@ namespace System.Runtime.CompilerServices
         {
             if (_value.ObjectIsTask)
             {
-                TaskAwaiter.UnsafeOnCompletedInternal(_value.UnsafeTask, box, continueOnCapturedContext: true);
+                TaskAwaiter.UnsafeOnCompletedInternal(_value.UnsafeGetTask(), box, continueOnCapturedContext: true);
             }
             else if (_value._obj != null)
             {
-                _value.UnsafeValueTaskSource.OnCompleted(s_invokeAsyncStateMachineBox, box, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
+                _value.UnsafeGetValueTaskSource().OnCompleted(s_invokeAsyncStateMachineBox, box, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
             }
             else
             {
@@ -141,11 +141,11 @@ namespace System.Runtime.CompilerServices
         {
             if (_value.ObjectIsTask)
             {
-                _value.UnsafeTask.GetAwaiter().OnCompleted(continuation);
+                _value.UnsafeGetTask().GetAwaiter().OnCompleted(continuation);
             }
             else if (_value._obj != null)
             {
-                _value.UnsafeValueTaskSource.OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext | ValueTaskSourceOnCompletedFlags.FlowExecutionContext);
+                _value.UnsafeGetValueTaskSource().OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext | ValueTaskSourceOnCompletedFlags.FlowExecutionContext);
             }
             else
             {
@@ -158,11 +158,11 @@ namespace System.Runtime.CompilerServices
         {
             if (_value.ObjectIsTask)
             {
-                _value.UnsafeTask.GetAwaiter().UnsafeOnCompleted(continuation);
+                _value.UnsafeGetTask().GetAwaiter().UnsafeOnCompleted(continuation);
             }
             else if (_value._obj != null)
             {
-                _value.UnsafeValueTaskSource.OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
+                _value.UnsafeGetValueTaskSource().OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
             }
             else
             {
@@ -175,11 +175,11 @@ namespace System.Runtime.CompilerServices
         {
             if (_value.ObjectIsTask)
             {
-                TaskAwaiter.UnsafeOnCompletedInternal(_value.UnsafeTask, box, continueOnCapturedContext: true);
+                TaskAwaiter.UnsafeOnCompletedInternal(_value.UnsafeGetTask(), box, continueOnCapturedContext: true);
             }
             else if (_value._obj != null)
             {
-                _value.UnsafeValueTaskSource.OnCompleted(ValueTaskAwaiter.s_invokeAsyncStateMachineBox, box, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
+                _value.UnsafeGetValueTaskSource().OnCompleted(ValueTaskAwaiter.s_invokeAsyncStateMachineBox, box, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
             }
             else
             {

--- a/src/mscorlib/shared/System/Threading/Tasks/ValueTask.cs
+++ b/src/mscorlib/shared/System/Threading/Tasks/ValueTask.cs
@@ -101,27 +101,21 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>Returns the <see cref="Task"/> stored in <see cref="_obj"/>.  This uses <see cref="Unsafe"/>.</summary>
-        internal Task UnsafeTask
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal Task UnsafeGetTask()
         {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                Debug.Assert(ObjectIsTask);
-                Debug.Assert(_obj is Task);
-                return Unsafe.As<Task>(_obj);
-            }
+            Debug.Assert(ObjectIsTask);
+            Debug.Assert(_obj is Task);
+            return Unsafe.As<Task>(_obj);
         }
 
         /// <summary>Returns the <see cref="IValueTaskSource"/> stored in <see cref="_obj"/>.  This uses <see cref="Unsafe"/>.</summary>
-        internal IValueTaskSource UnsafeValueTaskSource
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal IValueTaskSource UnsafeGetValueTaskSource()
         {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                Debug.Assert(!ObjectIsTask);
-                Debug.Assert(_obj is IValueTaskSource);
-                return Unsafe.As<IValueTaskSource>(_obj);
-            }
+            Debug.Assert(!ObjectIsTask);
+            Debug.Assert(_obj is IValueTaskSource);
+            return Unsafe.As<IValueTaskSource>(_obj);
         }
 
         /// <summary>Returns the hash code for this instance.</summary>
@@ -152,7 +146,7 @@ namespace System.Threading.Tasks
         /// </remarks>
         public Task AsTask() =>
             _obj == null ? ValueTask.CompletedTask :
-            ObjectIsTask ? UnsafeTask :
+            ObjectIsTask ? UnsafeGetTask() :
             GetTaskForValueTaskSource();
 
         /// <summary>Gets a <see cref="ValueTask"/> that may be used at any point in the future.</summary>
@@ -161,7 +155,7 @@ namespace System.Threading.Tasks
         /// <summary>Creates a <see cref="Task"/> to represent the <see cref="IValueTaskSource"/>.</summary>
         private Task GetTaskForValueTaskSource()
         {
-            IValueTaskSource t = UnsafeValueTaskSource;
+            IValueTaskSource t = UnsafeGetValueTaskSource();
             ValueTaskSourceStatus status = t.GetStatus(_token);
             if (status != ValueTaskSourceStatus.Pending)
             {
@@ -288,7 +282,7 @@ namespace System.Threading.Tasks
         public bool IsCompleted
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _obj == null || (ObjectIsTask ? UnsafeTask.IsCompleted : UnsafeValueTaskSource.GetStatus(_token) != ValueTaskSourceStatus.Pending);
+            get => _obj == null || (ObjectIsTask ? UnsafeGetTask().IsCompleted : UnsafeGetValueTaskSource().GetStatus(_token) != ValueTaskSourceStatus.Pending);
         }
 
         /// <summary>Gets whether the <see cref="ValueTask"/> represents a successfully completed operation.</summary>
@@ -301,9 +295,9 @@ namespace System.Threading.Tasks
 #if netstandard
                     UnsafeTask.Status == TaskStatus.RanToCompletion :
 #else
-                    UnsafeTask.IsCompletedSuccessfully :
+                    UnsafeGetTask().IsCompletedSuccessfully :
 #endif
-                    UnsafeValueTaskSource.GetStatus(_token) == ValueTaskSourceStatus.Succeeded);
+                    UnsafeGetValueTaskSource().GetStatus(_token) == ValueTaskSourceStatus.Succeeded);
         }
 
         /// <summary>Gets whether the <see cref="ValueTask"/> represents a failed operation.</summary>
@@ -311,7 +305,7 @@ namespace System.Threading.Tasks
         {
             get =>
                 _obj != null &&
-                (ObjectIsTask ? UnsafeTask.IsFaulted : UnsafeValueTaskSource.GetStatus(_token) == ValueTaskSourceStatus.Faulted);
+                (ObjectIsTask ? UnsafeGetTask().IsFaulted : UnsafeGetValueTaskSource().GetStatus(_token) == ValueTaskSourceStatus.Faulted);
         }
 
         /// <summary>Gets whether the <see cref="ValueTask"/> represents a canceled operation.</summary>
@@ -324,7 +318,7 @@ namespace System.Threading.Tasks
         {
             get =>
                 _obj != null &&
-                (ObjectIsTask ? UnsafeTask.IsCanceled : UnsafeValueTaskSource.GetStatus(_token) == ValueTaskSourceStatus.Canceled);
+                (ObjectIsTask ? UnsafeGetTask().IsCanceled : UnsafeGetValueTaskSource().GetStatus(_token) == ValueTaskSourceStatus.Canceled);
         }
 
         /// <summary>Throws the exception that caused the <see cref="ValueTask"/> to fail.  If it completed successfully, nothing is thrown.</summary>
@@ -339,12 +333,12 @@ namespace System.Threading.Tasks
 #if netstandard
                     UnsafeTask.GetAwaiter().GetResult();
 #else
-                    TaskAwaiter.ValidateEnd(UnsafeTask);
+                    TaskAwaiter.ValidateEnd(UnsafeGetTask());
 #endif
                 }
                 else
                 {
-                    UnsafeValueTaskSource.GetResult(_token);
+                    UnsafeGetValueTaskSource().GetResult(_token);
                 }
             }
         }
@@ -465,27 +459,21 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>Returns the <see cref="Task{TResult}"/> stored in <see cref="_obj"/>.  This uses <see cref="Unsafe"/>.</summary>
-        internal Task<TResult> UnsafeTask
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal Task<TResult> UnsafeGetTask()
         {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                Debug.Assert(ObjectIsTask);
-                Debug.Assert(_obj is Task<TResult>);
-                return Unsafe.As<Task<TResult>>(_obj);
-            }
+            Debug.Assert(ObjectIsTask);
+            Debug.Assert(_obj is Task<TResult>);
+            return Unsafe.As<Task<TResult>>(_obj);
         }
 
         /// <summary>Returns the <see cref="IValueTaskSource{TResult}"/> stored in <see cref="_obj"/>.  This uses <see cref="Unsafe"/>.</summary>
-        internal IValueTaskSource<TResult> UnsafeValueTaskSource
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal IValueTaskSource<TResult> UnsafeGetValueTaskSource()
         {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                Debug.Assert(!ObjectIsTask);
-                Debug.Assert(_obj is IValueTaskSource<TResult>);
-                return Unsafe.As<IValueTaskSource<TResult>>(_obj);
-            }
+            Debug.Assert(!ObjectIsTask);
+            Debug.Assert(_obj is IValueTaskSource<TResult>);
+            return Unsafe.As<IValueTaskSource<TResult>>(_obj);
         }
 
         /// <summary>Returns the hash code for this instance.</summary>
@@ -527,7 +515,7 @@ namespace System.Threading.Tasks
 #else
                 AsyncTaskMethodBuilder<TResult>.GetTaskForResult(_result) :
 #endif
-            ObjectIsTask ? UnsafeTask :
+            ObjectIsTask ? UnsafeGetTask() :
             GetTaskForValueTaskSource();
 
         /// <summary>Gets a <see cref="ValueTask{TResult}"/> that may be used at any point in the future.</summary>
@@ -536,7 +524,7 @@ namespace System.Threading.Tasks
         /// <summary>Creates a <see cref="Task{TResult}"/> to represent the <see cref="IValueTaskSource{TResult}"/>.</summary>
         private Task<TResult> GetTaskForValueTaskSource()
         {
-            IValueTaskSource<TResult> t = UnsafeValueTaskSource;
+            IValueTaskSource<TResult> t = UnsafeGetValueTaskSource();
             ValueTaskSourceStatus status = t.GetStatus(_token);
             if (status != ValueTaskSourceStatus.Pending)
             {
@@ -666,7 +654,7 @@ namespace System.Threading.Tasks
         public bool IsCompleted
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _obj == null || (ObjectIsTask ? UnsafeTask.IsCompleted : UnsafeValueTaskSource.GetStatus(_token) != ValueTaskSourceStatus.Pending);
+            get => _obj == null || (ObjectIsTask ? UnsafeGetTask().IsCompleted : UnsafeGetValueTaskSource().GetStatus(_token) != ValueTaskSourceStatus.Pending);
         }
 
         /// <summary>Gets whether the <see cref="ValueTask{TResult}"/> represents a successfully completed operation.</summary>
@@ -679,9 +667,9 @@ namespace System.Threading.Tasks
 #if netstandard
                     UnsafeTask.Status == TaskStatus.RanToCompletion :
 #else
-                    UnsafeTask.IsCompletedSuccessfully :
+                    UnsafeGetTask().IsCompletedSuccessfully :
 #endif
-                    UnsafeValueTaskSource.GetStatus(_token) == ValueTaskSourceStatus.Succeeded);
+                    UnsafeGetValueTaskSource().GetStatus(_token) == ValueTaskSourceStatus.Succeeded);
         }
 
         /// <summary>Gets whether the <see cref="ValueTask{TResult}"/> represents a failed operation.</summary>
@@ -689,7 +677,7 @@ namespace System.Threading.Tasks
         {
             get =>
                 _obj != null &&
-                (ObjectIsTask ? UnsafeTask.IsFaulted : UnsafeValueTaskSource.GetStatus(_token) == ValueTaskSourceStatus.Faulted);
+                (ObjectIsTask ? UnsafeGetTask().IsFaulted : UnsafeGetValueTaskSource().GetStatus(_token) == ValueTaskSourceStatus.Faulted);
         }
 
         /// <summary>Gets whether the <see cref="ValueTask{TResult}"/> represents a canceled operation.</summary>
@@ -702,7 +690,7 @@ namespace System.Threading.Tasks
         {
             get =>
                 _obj != null &&
-                (ObjectIsTask ? UnsafeTask.IsCanceled : UnsafeValueTaskSource.GetStatus(_token) == ValueTaskSourceStatus.Canceled);
+                (ObjectIsTask ? UnsafeGetTask().IsCanceled : UnsafeGetValueTaskSource().GetStatus(_token) == ValueTaskSourceStatus.Canceled);
         }
 
         /// <summary>Gets the result.</summary>
@@ -721,13 +709,13 @@ namespace System.Threading.Tasks
 #if netstandard
                     return UnsafeTask.GetAwaiter().GetResult();
 #else
-                    Task<TResult> t = UnsafeTask;
+                    Task<TResult> t = UnsafeGetTask();
                     TaskAwaiter.ValidateEnd(t);
                     return t.ResultOnSuccess;
 #endif
                 }
 
-                return UnsafeValueTaskSource.GetResult(_token);
+                return UnsafeGetValueTaskSource().GetResult(_token);
             }
         }
 


### PR DESCRIPTION
These do unsafe casts on an object, and we don't want a debugger's automatic evaluation accidentally invoking them.  That means either making them methods or adding [DebuggerBrowsable(DebuggerBrowsableState.Never)], and the former seems cleaner.

cc: @GrabYourPitchforks 