### PR TITLE
[RyuJit] fix clang switch warning

### DIFF
--- a/src/jit/stacklevelsetter.cpp
+++ b/src/jit/stacklevelsetter.cpp
@@ -91,8 +91,7 @@ void StackLevelSetter::ProcessBlock(BasicBlock* block)
         // Set throw blocks incoming stack depth for x86.
         if (throwHelperBlocksUsed && !framePointerRequired)
         {
-            bool operMightThrow = ((node->gtFlags & GTF_EXCEPT) != 0);
-            if (operMightThrow)
+            if (node->OperMayThrow(comp))
             {
                 SetThrowHelperBlocks(node, block);
             }
@@ -119,13 +118,16 @@ void StackLevelSetter::ProcessBlock(BasicBlock* block)
 //                       from the node.
 //
 // Notes:
-//   one node can target several helper blocks.
+//   one node can target several helper blocks, but not all operands that throw do this.
+//   So the function can set 0-2 throw blocks depends on oper and overflow flag.
 //
 // Arguments:
 //   node - the node to process;
 //   block - the source block for the node.
 void StackLevelSetter::SetThrowHelperBlocks(GenTree* node, BasicBlock* block)
 {
+    assert(node->OperMayThrow(comp));
+
     // Check that it uses throw block, find its kind, find the block, set level.
     switch (node->OperGet())
     {
@@ -151,7 +153,7 @@ void StackLevelSetter::SetThrowHelperBlocks(GenTree* node, BasicBlock* block)
             SetThrowHelperBlock(SCK_ARITH_EXCPN, block);
         }
         break;
-        default: // Other opers do not target throw blocks.
+        default: // Other opers can target throw only due to overflow.
             break;
     }
     if (node->gtOverflowEx())

--- a/src/jit/stacklevelsetter.cpp
+++ b/src/jit/stacklevelsetter.cpp
@@ -151,6 +151,8 @@ void StackLevelSetter::SetThrowHelperBlocks(GenTree* node, BasicBlock* block)
             SetThrowHelperBlock(SCK_ARITH_EXCPN, block);
         }
         break;
+        default: // Other opers do not target throw blocks.
+            break;
     }
     if (node->gtOverflowEx())
     {


### PR DESCRIPTION
There was warning:
```
/opt/code/src/jit/stacklevelsetter.cpp:130:13: error: 121 enumeration values not handled in switch: 'GT_NONE', 'GT_LCL_VAR', 'GT_LCL_FLD'... [-Werror,-Wswitch]
    switch (node->OperGet())
            ^
```
add `default` to be explicit.

It is safe because we have the checker, that checks that all throw blocks are initialized (If there is a throw kind that is not covered by this switch its throw block won't be initialized and we hit assert in codegencommon about `acdStkLvlInit` when we generate jump to the throw helper block).