### PR TITLE
Use .netCore for UpdatePublishDependencies

### DIFF
--- a/UpdatePublishedVersions.ps1
+++ b/UpdatePublishedVersions.ps1
@@ -16,7 +16,7 @@ param(
     # A pattern matching all packages in the set that the versions repository should be set to.
     [Parameter(Mandatory=$true)][string]$nupkgPath)
 
-& "$PSScriptRoot\run.cmd" build -- tests\build.proj /t:UpdatePublishedVersions `
+& "$PSScriptRoot\Tools\dotnetcli\dotnet.exe" Tools\msbuild.exe tests\build.proj /t:UpdatePublishedVersions `
     /p:GitHubUser="$gitHubUser" `
     /p:GitHubEmail="$gitHubEmail" `
     /p:GitHubAuthToken="$gitHubAuthToken" `


### PR DESCRIPTION
@dagood PTAL

Use .Net Core instead of full framework to invoke UpdatePublishedVersions task. Should hopefully unblock 1.1.0 pipebuild.