### PR TITLE
Add ability to use x64 host tools when building

### DIFF
--- a/build-test.cmd
+++ b/build-test.cmd
@@ -79,6 +79,7 @@ set __RuntimeId=
 set __ZipTests=
 set __TargetsWindows=1
 set __DoCrossgen=
+set __Use64BitHostTools=0
 
 :Arg_Loop
 if "%1" == "" goto ArgsDone
@@ -104,6 +105,7 @@ if /i "%1" == "crossgen"              (set __DoCrossgen=1&set processedArgs=!pro
 if /i "%1" == "runtimeid"             (set __RuntimeId=%2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)
 if /i "%1" == "targetsNonWindows"     (set __TargetsWindows=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "Exclude"               (set __Exclude=%2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)
+if /i "%1" == "use64BitHostTools"     (set __Use64BitHostTools=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 
 if [!processedArgs!]==[] (
   set __UnprocessedBuildArgs=%__args%
@@ -206,7 +208,7 @@ if not exist "%VSINSTALLDIR%DIA SDK" goto NoDIA
 :GenVSSolution
 
 pushd "%__NativeTestIntermediatesDir%"
-call "%__SourceDir%\pal\tools\gen-buildsys-win.bat" ""%__ProjectFilesDir%"" %__VSVersion% %__BuildArch%
+call "%__SourceDir%\pal\tools\gen-buildsys-win.bat" ""%__ProjectFilesDir%"" %__VSVersion% %__BuildArch% %__Use64BitHostTools%
 @if defined _echo @echo on
 popd
 

--- a/src/pal/tools/gen-buildsys-win.bat
+++ b/src/pal/tools/gen-buildsys-win.bat
@@ -5,7 +5,7 @@ rem This file invokes cmake and generates the build system for windows.
 set argC=0
 for %%x in (%*) do Set /A argC+=1
 
-if %argC% lss 3 GOTO :USAGE
+if %argC% lss 4 GOTO :USAGE
 if %1=="/?" GOTO :USAGE
 
 setlocal
@@ -18,6 +18,7 @@ if %basePath:~-1%==\ set "basePath=%basePath:~0,-1%"
 set __SourceDir=%1
 set __VSVersion=%2
 set __Arch=%3
+set __Use64BitHostTools=%4
 set __CmakeGenerator=Visual Studio
 if /i "%__VSVersion%" == "vs2017" (set __CmakeGenerator=%__CmakeGenerator% 15 2017)
 if /i "%__VSVersion%" == "vs2015" (set __CmakeGenerator=%__CmakeGenerator% 14 2015)
@@ -25,11 +26,18 @@ if /i "%__Arch%" == "x64" (set __CmakeGenerator=%__CmakeGenerator% Win64)
 if /i "%__Arch%" == "arm64" (set __CmakeGenerator=%__CmakeGenerator% Win64)
 if /i "%__Arch%" == "arm" (set __CmakeGenerator=%__CmakeGenerator% ARM)
 
+set __HOST=""
+
+if %__Use64BitHostTools% == 1 (
+  if /i "%__Arch%" == "x64" (set __HOST=-T host=x64)
+  if /i "%__Arch%" == "arm64" (set __HOST=-T host=x64)
+)
+
 if /i "%__NMakeMakefiles%" == "1" (set __CmakeGenerator=NMake Makefiles)
 
 :loop
-if [%4] == [] goto end_loop
-set __ExtraCmakeParams=%__ExtraCmakeParams% %4
+if [%5] == [] goto end_loop
+set __ExtraCmakeParams=%__ExtraCmakeParams% %5
 shift
 goto loop
 :end_loop
@@ -40,15 +48,18 @@ if defined CMakePath goto DoGen
 for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy ByPass "& "%basePath%\probe-win.ps1""') do %%a
 
 :DoGen
-"%CMakePath%" "-DCMAKE_USER_MAKE_RULES_OVERRIDE=%basePath%\windows-compiler-override.txt" "-DCMAKE_INSTALL_PREFIX:PATH=$ENV{__CMakeBinDir}" "-DCLR_CMAKE_HOST_ARCH=%__Arch%" %__ExtraCmakeParams% -G "%__CmakeGenerator%" %__SourceDir%
+"%CMakePath%" "-DCMAKE_USER_MAKE_RULES_OVERRIDE=%basePath%\windows-compiler-override.txt" "-DCMAKE_INSTALL_PREFIX:PATH=$ENV{__CMakeBinDir}" "-DCLR_CMAKE_HOST_ARCH=%__Arch%" %__ExtraCmakeParams% -G "%__CmakeGenerator%" %__HOST% %__SourceDir%
 endlocal
 GOTO :DONE
 
 :USAGE
   echo "Usage..."
-  echo "gen-buildsys-win.bat <path to top level CMakeLists.txt> <VSVersion>"
+  echo "gen-buildsys-win.bat <path to top level CMakeLists.txt> <VSVersion> <arch> <useX64BitHostTools> <Extra CMAKE Options>"
   echo "Specify the path to the top level CMake file - <ProjectK>/src/NDP"
   echo "Specify the VSVersion to be used - VS2015 or VS2017"
+  echo "Specify the arch"
+  echo "Use 64bit toolset 0 for x86 1 for x64"
+  echo "All additional cmake arguments"
   EXIT /B 1
 
 :DONE


### PR DESCRIPTION
Note this does not change the current build defaults. It will just allow building with the x64 host tools if amd64hosttools is passed.

Example build.cmd usage:
>build.cmd skiptests amd64hosttools