### PR TITLE
Fix hang on Ctrl+C when tiering is enabled

### DIFF
--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -8026,7 +8026,7 @@ void AppDomain::Exit(BOOL fRunFinalizers, BOOL fAsyncExit)
     // have exited the domain.
     //
 #ifdef FEATURE_TIERED_COMPILATION
-    m_tieredCompilationManager.Shutdown(FALSE);
+    m_tieredCompilationManager.Shutdown();
 #endif
 
     //

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -1641,13 +1641,6 @@ void STDMETHODCALLTYPE EEShutDownHelper(BOOL fIsDllUnloading)
         // Indicate the EE is the shut down phase.
         g_fEEShutDown |= ShutDown_Start;
 
-#ifdef FEATURE_TIERED_COMPILATION
-        {
-            GCX_PREEMP();
-            TieredCompilationManager::ShutdownAllDomains();
-        }
-#endif
-
         fFinalizeOK = TRUE;
 
         // Terminate the BBSweep thread

--- a/src/vm/tieredcompilation.cpp
+++ b/src/vm/tieredcompilation.cpp
@@ -317,23 +317,6 @@ void TieredCompilationManager::AsyncPromoteMethodToTier1(MethodDesc* pMethodDesc
     return;
 }
 
-// static
-// called from EEShutDownHelper
-void TieredCompilationManager::ShutdownAllDomains()
-{
-    STANDARD_VM_CONTRACT;
-
-    AppDomainIterator domain(TRUE);
-    while (domain.Next())
-    {
-        AppDomain * pDomain = domain.GetDomain();
-        if (pDomain != NULL)
-        {
-            pDomain->GetTieredCompilationManager()->Shutdown();
-        }
-    }
-}
-
 void TieredCompilationManager::Shutdown()
 {
     STANDARD_VM_CONTRACT;

--- a/src/vm/tieredcompilation.h
+++ b/src/vm/tieredcompilation.h
@@ -32,7 +32,6 @@ public:
     void OnMethodCalled(MethodDesc* pMethodDesc, DWORD currentCallCount, BOOL* shouldStopCountingCallsRef, BOOL* wasPromotedToTier1Ref);
     void OnMethodCallCountingStoppedWithoutTier1Promotion(MethodDesc* pMethodDesc);
     void AsyncPromoteMethodToTier1(MethodDesc* pMethodDesc);
-    static void ShutdownAllDomains();
     void Shutdown();
     static CORJIT_FLAGS GetJitFlags(NativeCodeVersion nativeCodeVersion);
 

--- a/src/vm/tieredcompilation.h
+++ b/src/vm/tieredcompilation.h
@@ -33,7 +33,7 @@ public:
     void OnMethodCallCountingStoppedWithoutTier1Promotion(MethodDesc* pMethodDesc);
     void AsyncPromoteMethodToTier1(MethodDesc* pMethodDesc);
     static void ShutdownAllDomains();
-    void Shutdown(BOOL fBlockUntilAsyncWorkIsComplete);
+    void Shutdown();
     static CORJIT_FLAGS GetJitFlags(NativeCodeVersion nativeCodeVersion);
 
 private:


### PR DESCRIPTION
- When the work thread count is nonzero at the time of Ctrl+C, by the time `TieredCompilationManager::Shutdown(BOOL)` runs (during `DllMain` for process detach), the background worker thread has already been torn down abruptly and it does not get a chance to exit gracefully and set the event, and Shutdown() hangs the process waiting for the event forever.
- It looks like there is no benefit to waiting for the work to complete, fixed by removing the wait and the event
- In the MusicStore benchmark it looks like the arch folder was missing in the 'publish' folder path. In case there is a difference in bin directory layout between the CI dotnet and current dotnet, changed to check for both paths.