### PR TITLE
Replace install with _install in all superpmi CMakeLists.txt files

### DIFF
--- a/crosscomponents.cmake
+++ b/crosscomponents.cmake
@@ -8,13 +8,8 @@ set (CLR_CROSS_COMPONENTS_LIST
 
 if(NOT CLR_CMAKE_PLATFORM_LINUX)
     list (APPEND CLR_CROSS_COMPONENTS_LIST
-        mcs
         mscordaccore
         mscordbi
         sos
-        superpmi
-        superpmi-shim-collector
-        superpmi-shim-counter
-        superpmi-shim-simple
     )
 endif()

--- a/src/ToolBox/superpmi/mcs/CMakeLists.txt
+++ b/src/ToolBox/superpmi/mcs/CMakeLists.txt
@@ -70,4 +70,4 @@ else()
     install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/mcs.pdb DESTINATION PDB)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
-install (TARGETS mcs DESTINATION .)
+_install (TARGETS mcs DESTINATION .)

--- a/src/ToolBox/superpmi/mcs/CMakeLists.txt
+++ b/src/ToolBox/superpmi/mcs/CMakeLists.txt
@@ -67,7 +67,7 @@ else()
         ${STATIC_MT_CPP_LIB}
     )
 
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/mcs.pdb DESTINATION PDB)
+    _install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/mcs.pdb DESTINATION PDB)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
 _install (TARGETS mcs DESTINATION .)

--- a/src/ToolBox/superpmi/superpmi-shim-collector/CMakeLists.txt
+++ b/src/ToolBox/superpmi/superpmi-shim-collector/CMakeLists.txt
@@ -70,4 +70,4 @@ else()
     install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/superpmi-shim-collector.pdb DESTINATION PDB)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
-install (TARGETS superpmi-shim-collector DESTINATION .)
+_install (TARGETS superpmi-shim-collector DESTINATION .)

--- a/src/ToolBox/superpmi/superpmi-shim-collector/CMakeLists.txt
+++ b/src/ToolBox/superpmi/superpmi-shim-collector/CMakeLists.txt
@@ -67,7 +67,7 @@ else()
         ${STATIC_MT_CPP_LIB}
     )
 
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/superpmi-shim-collector.pdb DESTINATION PDB)
+    _install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/superpmi-shim-collector.pdb DESTINATION PDB)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
 _install (TARGETS superpmi-shim-collector DESTINATION .)

--- a/src/ToolBox/superpmi/superpmi-shim-counter/CMakeLists.txt
+++ b/src/ToolBox/superpmi/superpmi-shim-counter/CMakeLists.txt
@@ -71,4 +71,4 @@ else()
     install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/superpmi-shim-counter.pdb DESTINATION PDB)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
-install (TARGETS superpmi-shim-counter DESTINATION .)
+_install (TARGETS superpmi-shim-counter DESTINATION .)

--- a/src/ToolBox/superpmi/superpmi-shim-counter/CMakeLists.txt
+++ b/src/ToolBox/superpmi/superpmi-shim-counter/CMakeLists.txt
@@ -68,7 +68,7 @@ else()
         ${STATIC_MT_CPP_LIB}
     )
 
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/superpmi-shim-counter.pdb DESTINATION PDB)
+    _install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/superpmi-shim-counter.pdb DESTINATION PDB)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
 _install (TARGETS superpmi-shim-counter DESTINATION .)

--- a/src/ToolBox/superpmi/superpmi-shim-simple/CMakeLists.txt
+++ b/src/ToolBox/superpmi/superpmi-shim-simple/CMakeLists.txt
@@ -70,4 +70,4 @@ else()
     install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/superpmi-shim-simple.pdb DESTINATION PDB)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
-install (TARGETS superpmi-shim-simple DESTINATION .)
+_install (TARGETS superpmi-shim-simple DESTINATION .)

--- a/src/ToolBox/superpmi/superpmi-shim-simple/CMakeLists.txt
+++ b/src/ToolBox/superpmi/superpmi-shim-simple/CMakeLists.txt
@@ -67,7 +67,7 @@ else()
         ${STATIC_MT_CPP_LIB}
     )
 
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/superpmi-shim-simple.pdb DESTINATION PDB)
+    _install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/superpmi-shim-simple.pdb DESTINATION PDB)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
 _install (TARGETS superpmi-shim-simple DESTINATION .)

--- a/src/ToolBox/superpmi/superpmi/CMakeLists.txt
+++ b/src/ToolBox/superpmi/superpmi/CMakeLists.txt
@@ -71,4 +71,4 @@ else()
     install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/superpmi.pdb DESTINATION PDB)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
-install (TARGETS superpmi DESTINATION .)
+_install (TARGETS superpmi DESTINATION .)

--- a/src/ToolBox/superpmi/superpmi/CMakeLists.txt
+++ b/src/ToolBox/superpmi/superpmi/CMakeLists.txt
@@ -68,7 +68,7 @@ else()
         ${STATIC_MT_CPP_LIB}
     )
 
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/superpmi.pdb DESTINATION PDB)
+    _install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/superpmi.pdb DESTINATION PDB)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
 _install (TARGETS superpmi DESTINATION .)


### PR DESCRIPTION
Currently, we don't build cross-architecture superpmi when running on Linux (as defined in crosscomponents.cmake), but we continue installing them in superpmi CMakeLists.txt files which causes CMake errors during build. For example, when running the following command: `build.sh arm checked cross crosscomponent`

This PR will replace `install` with `_install` in superpmi CMakeLists.txt files which install only if we are NOT building cross-architecture components (i.e., if we do native build)
 
@BruceForstall @dotnet/jit-contrib @janvorli PTAL