### PR TITLE
CoreFX #24343 Vector Ctor using Span

### DIFF
--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -3715,4 +3715,7 @@
   <data name="Argument_OverlapAlignmentMismatch" xml:space="preserve">
     <value>Overlapping spans have mismatching alignment.</value>
   </data>
+  <data name="Arg_InsufficientNumberOfElements" xml:space="preserve">
+    <value>At least {0} element(s) are expected in the parameter "{1}".</value>
+  </data>
 </root>

--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -33,8 +33,7 @@
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <SignAssembly>true</SignAssembly>
     <DelaySign>true</DelaySign>
-    <DefineConstants>$(DefineConstants);CORECLR;_USE_NLS_PLUS_TABLE;RESOURCE_SATELLITE_CONFIG;CODE_ANALYSIS_BASELINE</DefineConstants>
-    <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp' OR '$(TargetGroup)'=='uap' OR '$(TargetGroup)'=='uapaot'">$(DefineConstants);netcoreapp</DefineConstants>
+    <DefineConstants>$(DefineConstants);CORECLR;_USE_NLS_PLUS_TABLE;RESOURCE_SATELLITE_CONFIG;CODE_ANALYSIS_BASELINE;netcoreapp</DefineConstants>
     <!-- We don't use any of MSBuild's resolution logic for resolving the framework, so just set these two properties to any folder that exists to skip
          the GenerateReferenceAssemblyPaths task (not target) and to prevent it from outputting a warning (MSB3644). -->
     <_TargetFrameworkDirectories>$(MSBuildThisFileDirectory)/Documentation</_TargetFrameworkDirectories>

--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -34,6 +34,7 @@
     <SignAssembly>true</SignAssembly>
     <DelaySign>true</DelaySign>
     <DefineConstants>$(DefineConstants);CORECLR;_USE_NLS_PLUS_TABLE;RESOURCE_SATELLITE_CONFIG;CODE_ANALYSIS_BASELINE</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp' OR '$(TargetGroup)'=='uap' OR '$(TargetGroup)'=='uapaot'">$(DefineConstants);netcoreapp</DefineConstants>
     <!-- We don't use any of MSBuild's resolution logic for resolving the framework, so just set these two properties to any folder that exists to skip
          the GenerateReferenceAssemblyPaths task (not target) and to prevent it from outputting a warning (MSB3644). -->
     <_TargetFrameworkDirectories>$(MSBuildThisFileDirectory)/Documentation</_TargetFrameworkDirectories>

--- a/src/mscorlib/shared/System/Numerics/GenerationConfig.ttinclude
+++ b/src/mscorlib/shared/System/Numerics/GenerationConfig.ttinclude
@@ -1,5 +1,6 @@
 ﻿<#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Collections.Generic" #>
+<#@ import namespace="System.Text" #>
 <#+ 
     /*    This file includes static data used as compilation configuration for the rest of the code generation. 
         It is shared here to ensure that all generated code compiles with the same constants and configurations.    */
@@ -143,5 +144,30 @@
     {
         string keyword = (type == allTypes.ToArray()[0]) ? "if" : "else if";
         return string.Format("{0} (typeof(T) == typeof({1}))", keyword, type.Name);
+    }
+
+    public string MakeTypeComparisonCondition(Type type)
+    {
+        return string.Format("(typeof(T) == typeof({0}))", type.Name);
+    }
+
+    public string GenerateIfConditionAllTypes(IEnumerable<Type> allTypes)
+    {
+        StringBuilder sbuilder = new StringBuilder();
+        bool firstTime = true;
+        foreach (var type in allTypes)
+        {
+            if (firstTime)
+            {
+                sbuilder.Append("if (").Append(MakeTypeComparisonCondition(type));
+                firstTime = false;
+            }
+            else
+            {
+                sbuilder.AppendLine().Append("                || ").Append(MakeTypeComparisonCondition(type));
+            }
+        }
+        sbuilder.Append(")");
+        return sbuilder.ToString();
     }
 #>

--- a/src/mscorlib/shared/System/Numerics/Vector.cs
+++ b/src/mscorlib/shared/System/Numerics/Vector.cs
@@ -2,9 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if (!netfx && !netstandard)
+using Internal.Runtime.CompilerServices;
+#endif
 using System.Globalization;
 using System.Numerics.Hashing;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace System.Numerics
@@ -386,7 +390,7 @@ namespace System.Numerics
             }
             if (index < 0 || (values.Length - index) < Count)
             {
-                throw new IndexOutOfRangeException();
+                throw new IndexOutOfRangeException(SR.Format(SR.Arg_InsufficientNumberOfElements, Vector<T>.Count, nameof(values)));
             }
 
             if (Vector.IsHardwareAccelerated)
@@ -762,6 +766,35 @@ namespace System.Numerics
         private Vector(ref Register existingRegister)
         {
             this.register = existingRegister;
+        }
+
+        /// <summary>
+        /// Constructs a vector from the given span. The span must contain at least Vector'T.Count elements.
+        /// </summary>
+        public Vector(Span<T> values)
+            : this()
+        {
+            if ((typeof(T) == typeof(Byte))
+                || (typeof(T) == typeof(SByte))
+                || (typeof(T) == typeof(UInt16))
+                || (typeof(T) == typeof(Int16))
+                || (typeof(T) == typeof(UInt32))
+                || (typeof(T) == typeof(Int32))
+                || (typeof(T) == typeof(UInt64))
+                || (typeof(T) == typeof(Int64))
+                || (typeof(T) == typeof(Single))
+                || (typeof(T) == typeof(Double)))
+            {
+                if (values.Length < Count)
+                {
+                    throw new IndexOutOfRangeException(SR.Format(SR.Arg_InsufficientNumberOfElements, Vector<T>.Count, nameof(values)));
+                }
+                this = Unsafe.ReadUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values)));
+            }
+            else
+            {
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
+            }
         }
         #endregion Constructors
 

--- a/src/mscorlib/shared/System/Numerics/Vector.cs
+++ b/src/mscorlib/shared/System/Numerics/Vector.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if (!netfx && !netstandard)
+#if netcoreapp
 using Internal.Runtime.CompilerServices;
 #endif
 using System.Globalization;
@@ -768,6 +768,7 @@ namespace System.Numerics
             this.register = existingRegister;
         }
 
+#if netcoreapp
         /// <summary>
         /// Constructs a vector from the given span. The span must contain at least Vector'T.Count elements.
         /// </summary>
@@ -796,6 +797,7 @@ namespace System.Numerics
                 throw new NotSupportedException(SR.Arg_TypeNotSupported);
             }
         }
+#endif
         #endregion Constructors
 
         #region Public Instance Methods

--- a/src/mscorlib/shared/System/Numerics/Vector.tt
+++ b/src/mscorlib/shared/System/Numerics/Vector.tt
@@ -7,9 +7,13 @@
 <#@ import namespace="System.Runtime.InteropServices" #>
 <#@ include file="GenerationConfig.ttinclude" #><# GenerateCopyrightHeader(); #>
 
+#if (!netfx && !netstandard)
+using Internal.Runtime.CompilerServices;
+#endif
 using System.Globalization;
 using System.Numerics.Hashing;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace System.Numerics
@@ -198,7 +202,7 @@ namespace System.Numerics
             }
             if (index < 0 || (values.Length - index) < Count)
             {
-                throw new IndexOutOfRangeException();
+                throw new IndexOutOfRangeException(SR.Format(SR.Arg_InsufficientNumberOfElements, Vector<T>.Count, nameof(values)));
             }
 
             if (Vector.IsHardwareAccelerated)
@@ -282,6 +286,26 @@ namespace System.Numerics
         private Vector(ref Register existingRegister)
         {
             this.register = existingRegister;
+        }
+
+        /// <summary>
+        /// Constructs a vector from the given span. The span must contain at least Vector'T.Count elements.
+        /// </summary>
+        public Vector(Span<T> values)
+            : this()
+        {
+            <#=GenerateIfConditionAllTypes(supportedTypes)#>
+            {
+                if (values.Length < Count)
+                {
+                    throw new IndexOutOfRangeException(SR.Format(SR.Arg_InsufficientNumberOfElements, Vector<T>.Count, nameof(values)));
+                }
+                this = Unsafe.ReadUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values)));
+            }
+            else
+            {
+                throw new NotSupportedException(SR.Arg_TypeNotSupported);
+            }
         }
         #endregion Constructors
 

--- a/src/mscorlib/shared/System/Numerics/Vector.tt
+++ b/src/mscorlib/shared/System/Numerics/Vector.tt
@@ -7,7 +7,7 @@
 <#@ import namespace="System.Runtime.InteropServices" #>
 <#@ include file="GenerationConfig.ttinclude" #><# GenerateCopyrightHeader(); #>
 
-#if (!netfx && !netstandard)
+#if netcoreapp
 using Internal.Runtime.CompilerServices;
 #endif
 using System.Globalization;
@@ -288,6 +288,7 @@ namespace System.Numerics
             this.register = existingRegister;
         }
 
+#if netcoreapp
         /// <summary>
         /// Constructs a vector from the given span. The span must contain at least Vector'T.Count elements.
         /// </summary>
@@ -307,6 +308,7 @@ namespace System.Numerics
                 throw new NotSupportedException(SR.Arg_TypeNotSupported);
             }
         }
+#endif
         #endregion Constructors
 
         #region Public Instance Methods


### PR DESCRIPTION
This PR is for new constructor for `System.Numercis.Vector` in library `System.Private.CoreLib` that accepts a `Span` for the issue dotnet/corefx#24343.

dotnet/corefx#26499 is dependent on merging of this PR for successful compilation.

@eerhardt Kindly review.