### PR TITLE
Disable tests that fail to build

### DIFF
--- a/tests/src/dirs.proj
+++ b/tests/src/dirs.proj
@@ -30,6 +30,10 @@
       <DisabledProjects Include="Performance\performance.csproj" />
       <DisabledProjects Include="Loader\classloader\generics\regressions\DD117522\Test.csproj" />
       <DisabledProjects Include="Loader\classloader\generics\GenericMethods\VSW491668.csproj" /> <!-- issue 5501 -->
+      <DisabledProjects Include="Interop\BestFitMapping\BestFitMapping.csproj" />
+      <DisabledProjects Include="JIT\Performance\CodeQuality\Span\Indexer.csproj" />
+      <DisabledProjects Include="JIT\Performance\CodeQuality\Span\SpanBench.csproj" />
+      <DisabledProjects Include="performance\linkbench\linkbench.csproj" />
       <DisabledProjects Include="JIT\Directed\nullabletypes\**\*.csproj" Condition="'$(RunningOnCore)' == 'true'" />
       <DisabledProjects Include="JIT\Performance\CodeQuality\Span\*.csproj" Condition="'$(RunningOnCore)' == 'true'" />
       <!-- The following project requires System.Reflection.Emit which is not supported on Linux, see issue corefx@4491 -->


### PR DESCRIPTION
These are failing with VS2017 Preview 1.0 [27502.1.d15.7].  Only the
JIT\Performance\CodeQuality\Span tests are failing in the official builds,
but the others fail for a reason I don't understand with VS Preview, so
I'm including them here.

Fixes #16734