### PR TITLE
Fix encoding methods for Span.Empty

### DIFF
--- a/src/mscorlib/shared/System/Runtime/InteropServices/MemoryMarshal.Fast.cs
+++ b/src/mscorlib/shared/System/Runtime/InteropServices/MemoryMarshal.Fast.cs
@@ -40,6 +40,20 @@ namespace System.Runtime.InteropServices
         public static ref T GetReference<T>(ReadOnlySpan<T> span) => ref span._pointer.Value;
 
         /// <summary>
+        /// Returns a reference to the 0th element of the Span. If the Span is empty, returns a reference to fake non-null pointer. Such a reference can be used
+        /// for pinning but must never be dereferenced. This is useful for interop with methods that do not accept null pointers for zero-sized buffers.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static unsafe ref T GetNonNullPinnableReference<T>(Span<T> span) => ref (span.Length != 0) ? ref span._pointer.Value : ref Unsafe.AsRef<T>((void*)1);
+
+        /// <summary>
+        /// Returns a reference to the 0th element of the Span. If the Span is empty, returns a reference to fake non-null pointer. Such a reference can be used
+        /// for pinning but must never be dereferenced. This is useful for interop with methods that do not accept null pointers for zero-sized buffers.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static unsafe ref T GetNonNullPinnableReference<T>(ReadOnlySpan<T> span) => ref (span.Length != 0) ? ref span._pointer.Value : ref Unsafe.AsRef<T>((void*)1);
+
+        /// <summary>
         /// Casts a Span of one primitive type <typeparamref name="TFrom"/> to another primitive type <typeparamref name="TTo"/>.
         /// These types may not contain pointers or references. This is checked at runtime in order to preserve type safety.
         /// </summary>

--- a/src/mscorlib/shared/System/Runtime/InteropServices/MemoryMarshal.Fast.cs
+++ b/src/mscorlib/shared/System/Runtime/InteropServices/MemoryMarshal.Fast.cs
@@ -29,13 +29,13 @@ namespace System.Runtime.InteropServices
 
         /// <summary>
         /// Returns a reference to the 0th element of the Span. If the Span is empty, returns a reference to the location where the 0th element
-        /// would have been stored. Such a reference can be used for pinning but must never be dereferenced.
+        /// would have been stored. Such a reference may or may not be null. It can be used for pinning but must never be dereferenced.
         /// </summary>
         public static ref T GetReference<T>(Span<T> span) => ref span._pointer.Value;
 
         /// <summary>
-        /// Returns a reference to the 0th element of the ReadOnlySpan. If the Span is empty, returns a reference to the location where the 0th element
-        /// would have been stored. Such a reference can be used for pinning but must never be dereferenced.
+        /// Returns a reference to the 0th element of the ReadOnlySpan. If the ReadOnlySpan is empty, returns a reference to the location where the 0th element
+        /// would have been stored. Such a reference may or may not be null. It can be used for pinning but must never be dereferenced.
         /// </summary>
         public static ref T GetReference<T>(ReadOnlySpan<T> span) => ref span._pointer.Value;
 
@@ -47,8 +47,8 @@ namespace System.Runtime.InteropServices
         internal static unsafe ref T GetNonNullPinnableReference<T>(Span<T> span) => ref (span.Length != 0) ? ref span._pointer.Value : ref Unsafe.AsRef<T>((void*)1);
 
         /// <summary>
-        /// Returns a reference to the 0th element of the Span. If the Span is empty, returns a reference to fake non-null pointer. Such a reference can be used
-        /// for pinning but must never be dereferenced. This is useful for interop with methods that do not accept null pointers for zero-sized buffers.
+        /// Returns a reference to the 0th element of the ReadOnlySpan. If the ReadOnlySpan is empty, returns a reference to fake non-null pointer. Such a reference
+        /// can be used for pinning but must never be dereferenced. This is useful for interop with methods that do not accept null pointers for zero-sized buffers.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe ref T GetNonNullPinnableReference<T>(ReadOnlySpan<T> span) => ref (span.Length != 0) ? ref span._pointer.Value : ref Unsafe.AsRef<T>((void*)1);

--- a/src/mscorlib/shared/System/Text/Decoder.cs
+++ b/src/mscorlib/shared/System/Text/Decoder.cs
@@ -134,7 +134,7 @@ namespace System.Text
 
         public virtual unsafe int GetCharCount(ReadOnlySpan<byte> bytes, bool flush)
         {
-            fixed (byte* bytesPtr = &MemoryMarshal.GetReference(bytes))
+            fixed (byte* bytesPtr = &MemoryMarshal.GetNonNullPinnableReference(bytes))
             {
                 return GetCharCount(bytesPtr, bytes.Length, flush);
             }
@@ -227,8 +227,8 @@ namespace System.Text
 
         public virtual unsafe int GetChars(ReadOnlySpan<byte> bytes, Span<char> chars, bool flush)
         {
-            fixed (byte* bytesPtr = &MemoryMarshal.GetReference(bytes))
-            fixed (char* charsPtr = &MemoryMarshal.GetReference(chars))
+            fixed (byte* bytesPtr = &MemoryMarshal.GetNonNullPinnableReference(bytes))
+            fixed (char* charsPtr = &MemoryMarshal.GetNonNullPinnableReference(chars))
             {
                 return GetChars(bytesPtr, bytes.Length, charsPtr, chars.Length, flush);
             }
@@ -341,8 +341,8 @@ namespace System.Text
 
         public virtual unsafe void Convert(ReadOnlySpan<byte> bytes, Span<char> chars, bool flush, out int bytesUsed, out int charsUsed, out bool completed)
         {
-            fixed (byte* bytesPtr = &MemoryMarshal.GetReference(bytes))
-            fixed (char* charsPtr = &MemoryMarshal.GetReference(chars))
+            fixed (byte* bytesPtr = &MemoryMarshal.GetNonNullPinnableReference(bytes))
+            fixed (char* charsPtr = &MemoryMarshal.GetNonNullPinnableReference(chars))
             {
                 Convert(bytesPtr, bytes.Length, charsPtr, chars.Length, flush, out bytesUsed, out charsUsed, out completed);
             }

--- a/src/mscorlib/shared/System/Text/Encoder.cs
+++ b/src/mscorlib/shared/System/Text/Encoder.cs
@@ -134,7 +134,7 @@ namespace System.Text
         {
             fixed (char* charsPtr = &MemoryMarshal.GetReference(chars))
             {
-                return GetByteCount(charsPtr, chars.Length, flush);
+                return GetByteCount((chars.Length != 0) ? charsPtr : (char*)2, chars.Length, flush);
             }
         }
 
@@ -224,7 +224,7 @@ namespace System.Text
             fixed (char* charsPtr = &MemoryMarshal.GetReference(chars))
             fixed (byte* bytesPtr = &MemoryMarshal.GetReference(bytes))
             {
-                return GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length, flush);
+                return GetBytes((chars.Length != 0) ? charsPtr : (char*)2, chars.Length, (bytes.Length != 0) ? bytesPtr : (byte*)1, bytes.Length, flush);
             }
         }
 
@@ -338,9 +338,8 @@ namespace System.Text
             fixed (char* charsPtr = &MemoryMarshal.GetReference(chars))
             fixed (byte* bytesPtr = &MemoryMarshal.GetReference(bytes))
             {
-                Convert(charsPtr, chars.Length, bytesPtr, bytes.Length, flush, out charsUsed, out bytesUsed, out completed);
+                Convert((chars.Length != 0) ? charsPtr : (char*)2, chars.Length, (bytes.Length != 0) ? bytesPtr : (byte*)1, bytes.Length, flush, out charsUsed, out bytesUsed, out completed);
             }
         }
     }
 }
-

--- a/src/mscorlib/shared/System/Text/Encoder.cs
+++ b/src/mscorlib/shared/System/Text/Encoder.cs
@@ -132,9 +132,9 @@ namespace System.Text
 
         public virtual unsafe int GetByteCount(ReadOnlySpan<char> chars, bool flush)
         {
-            fixed (char* charsPtr = &MemoryMarshal.GetReference(chars))
+            fixed (char* charsPtr = &MemoryMarshal.GetNonNullPinnableReference(chars))
             {
-                return GetByteCount((chars.Length != 0) ? charsPtr : (char*)2, chars.Length, flush);
+                return GetByteCount(charsPtr, chars.Length, flush);
             }
         }
 
@@ -221,10 +221,10 @@ namespace System.Text
 
         public virtual unsafe int GetBytes(ReadOnlySpan<char> chars, Span<byte> bytes, bool flush)
         {
-            fixed (char* charsPtr = &MemoryMarshal.GetReference(chars))
-            fixed (byte* bytesPtr = &MemoryMarshal.GetReference(bytes))
+            fixed (char* charsPtr = &MemoryMarshal.GetNonNullPinnableReference(chars))
+            fixed (byte* bytesPtr = &MemoryMarshal.GetNonNullPinnableReference(bytes))
             {
-                return GetBytes((chars.Length != 0) ? charsPtr : (char*)2, chars.Length, (bytes.Length != 0) ? bytesPtr : (byte*)1, bytes.Length, flush);
+                return GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length, flush);
             }
         }
 
@@ -335,11 +335,12 @@ namespace System.Text
 
         public virtual unsafe void Convert(ReadOnlySpan<char> chars, Span<byte> bytes, bool flush, out int charsUsed, out int bytesUsed, out bool completed)
         {
-            fixed (char* charsPtr = &MemoryMarshal.GetReference(chars))
-            fixed (byte* bytesPtr = &MemoryMarshal.GetReference(bytes))
+            fixed (char* charsPtr = &MemoryMarshal.GetNonNullPinnableReference(chars))
+            fixed (byte* bytesPtr = &MemoryMarshal.GetNonNullPinnableReference(bytes))
             {
-                Convert((chars.Length != 0) ? charsPtr : (char*)2, chars.Length, (bytes.Length != 0) ? bytesPtr : (byte*)1, bytes.Length, flush, out charsUsed, out bytesUsed, out completed);
+                Convert(charsPtr, chars.Length, bytesPtr, bytes.Length, flush, out charsUsed, out bytesUsed, out completed);
             }
         }
     }
 }
+

--- a/src/mscorlib/shared/System/Text/Encoding.cs
+++ b/src/mscorlib/shared/System/Text/Encoding.cs
@@ -713,9 +713,9 @@ namespace System.Text
 
         public virtual unsafe int GetByteCount(ReadOnlySpan<char> chars)
         {
-            fixed (char* charsPtr = &MemoryMarshal.GetReference(chars))
+            fixed (char* charsPtr = &MemoryMarshal.GetNonNullPinnableReference(chars))
             {
-                return GetByteCount((chars.Length != 0) ? charsPtr : (char*)2, chars.Length);
+                return GetByteCount(charsPtr, chars.Length);
             }
         }
 
@@ -895,10 +895,10 @@ namespace System.Text
 
         public virtual unsafe int GetBytes(ReadOnlySpan<char> chars, Span<byte> bytes)
         {
-            fixed (char* charsPtr = &MemoryMarshal.GetReference(chars))
-            fixed (byte* bytesPtr = &MemoryMarshal.GetReference(bytes))
+            fixed (char* charsPtr = &MemoryMarshal.GetNonNullPinnableReference(chars))
+            fixed (byte* bytesPtr = &MemoryMarshal.GetNonNullPinnableReference(bytes))
             {
-                return GetBytes((chars.Length != 0) ? charsPtr : (char*)2, chars.Length, (bytes.Length != 0) ? bytesPtr : (byte*)1, bytes.Length);
+                return GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length);
             }
         }
 
@@ -945,9 +945,9 @@ namespace System.Text
 
         public virtual unsafe int GetCharCount(ReadOnlySpan<byte> bytes)
         {
-            fixed (byte* bytesPtr = &MemoryMarshal.GetReference(bytes))
+            fixed (byte* bytesPtr = &MemoryMarshal.GetNonNullPinnableReference(bytes))
             {
-                return GetCharCount((bytes.Length != 0) ? bytesPtr : (byte*)1, bytes.Length);
+                return GetCharCount(bytesPtr, bytes.Length);
             }
         }
 
@@ -1057,10 +1057,10 @@ namespace System.Text
 
         public virtual unsafe int GetChars(ReadOnlySpan<byte> bytes, Span<char> chars)
         {
-            fixed (byte* bytesPtr = &MemoryMarshal.GetReference(bytes))
-            fixed (char* charsPtr = &MemoryMarshal.GetReference(chars))
+            fixed (byte* bytesPtr = &MemoryMarshal.GetNonNullPinnableReference(bytes))
+            fixed (char* charsPtr = &MemoryMarshal.GetNonNullPinnableReference(chars))
             {
-                return GetChars((bytes.Length != 0) ? bytesPtr : (byte*)1, bytes.Length, (chars.Length != 0) ? charsPtr : (char*)2, chars.Length);
+                return GetChars(bytesPtr, bytes.Length, charsPtr, chars.Length);
             }
         }
 
@@ -1087,9 +1087,9 @@ namespace System.Text
 
         public unsafe string GetString(ReadOnlySpan<byte> bytes)
         {
-            fixed (byte* bytesPtr = &MemoryMarshal.GetReference(bytes))
+            fixed (byte* bytesPtr = &MemoryMarshal.GetNonNullPinnableReference(bytes))
             {
-                return String.CreateStringFromEncoding((bytes.Length != 0) ? bytesPtr : (byte*)1, bytes.Length, this);
+                return GetString(bytesPtr, bytes.Length);
             }
         }
 

--- a/src/mscorlib/shared/System/Text/Encoding.cs
+++ b/src/mscorlib/shared/System/Text/Encoding.cs
@@ -715,7 +715,7 @@ namespace System.Text
         {
             fixed (char* charsPtr = &MemoryMarshal.GetReference(chars))
             {
-                return GetByteCount(charsPtr, chars.Length);
+                return GetByteCount((chars.Length != 0) ? charsPtr : (char*)2, chars.Length);
             }
         }
 
@@ -898,7 +898,7 @@ namespace System.Text
             fixed (char* charsPtr = &MemoryMarshal.GetReference(chars))
             fixed (byte* bytesPtr = &MemoryMarshal.GetReference(bytes))
             {
-                return GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length);
+                return GetBytes((chars.Length != 0) ? charsPtr : (char*)2, chars.Length, (bytes.Length != 0) ? bytesPtr : (byte*)1, bytes.Length);
             }
         }
 
@@ -947,7 +947,7 @@ namespace System.Text
         {
             fixed (byte* bytesPtr = &MemoryMarshal.GetReference(bytes))
             {
-                return GetCharCount(bytesPtr, bytes.Length);
+                return GetCharCount((bytes.Length != 0) ? bytesPtr : (byte*)1, bytes.Length);
             }
         }
 
@@ -1060,7 +1060,7 @@ namespace System.Text
             fixed (byte* bytesPtr = &MemoryMarshal.GetReference(bytes))
             fixed (char* charsPtr = &MemoryMarshal.GetReference(chars))
             {
-                return GetChars(bytesPtr, bytes.Length, charsPtr, chars.Length);
+                return GetChars((bytes.Length != 0) ? bytesPtr : (byte*)1, bytes.Length, (chars.Length != 0) ? charsPtr : (char*)2, chars.Length);
             }
         }
 
@@ -1089,7 +1089,7 @@ namespace System.Text
         {
             fixed (byte* bytesPtr = &MemoryMarshal.GetReference(bytes))
             {
-                return GetString(bytesPtr, bytes.Length);
+                return String.CreateStringFromEncoding((bytes.Length != 0) ? bytesPtr : (byte*)1, bytes.Length, this);
             }
         }
 


### PR DESCRIPTION
Encoding had a historic confusion about handling null pointers. Make sure that this confusion is not leaking into the new Span methods.