### PR TITLE
Fix Automatic Loading of Tracepoint Provider

### DIFF
--- a/src/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/dlls/mscoree/coreclr/CMakeLists.txt
@@ -139,11 +139,6 @@ if(FEATURE_EVENT_TRACE)
             eventprovider # On Windows this library contains only macros
         )
     endif(CLR_CMAKE_PLATFORM_UNIX)
-    if(CLR_CMAKE_PLATFORM_LINUX)
-        list(APPEND CORECLR_LIBRARIES
-            tracepointprovider
-        )
-    endif(CLR_CMAKE_PLATFORM_LINUX)
 endif(FEATURE_EVENT_TRACE)
 
 target_link_libraries(coreclr ${CORECLR_LIBRARIES})

--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -180,6 +180,7 @@ set(SOURCES
   misc/strutil.cpp
   misc/sysinfo.cpp
   misc/time.cpp
+  misc/tracepointprovider.cpp
   misc/utils.cpp
   numa/numa.cpp
   objmgr/palobjbase.cpp
@@ -238,15 +239,6 @@ add_library(coreclrpal
   ${ARCH_SOURCES}
   ${PLATFORM_SOURCES}
 )
-
-# This builds in functionality to load LTTng tracepoints at runtime
-# Needed when using LTTng to support event tracing on Linux
-if(CLR_CMAKE_PLATFORM_LINUX)
-    add_library(tracepointprovider
-      STATIC
-      misc/tracepointprovider.cpp
-    )
-endif(CLR_CMAKE_PLATFORM_LINUX)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   find_library(COREFOUNDATION CoreFoundation)


### PR DESCRIPTION
Fixes #16763.

It looks like #15611 broke automatic tracepoint provider loading which results in no events being sent to LTTng.  This change simplifies the CMake logic and simply depends on the ifdef __linux__ pre-processor directive in tracepointprovider.cpp.

