### PR TITLE
Perf fix for month-day parsing ambiguity

### DIFF
--- a/src/mscorlib/shared/System/Globalization/GregorianCalendar.cs
+++ b/src/mscorlib/shared/System/Globalization/GregorianCalendar.cs
@@ -520,8 +520,13 @@ namespace System.Globalization
             throw new ArgumentOutOfRangeException(nameof(era), SR.ArgumentOutOfRange_InvalidEraValue);
         }
 
-        internal override Boolean TryToDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int era, out DateTime result)
+        internal override bool TryToDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int era, out DateTime result)
         {
+            if (!IsValidDay(year, month, day, era))
+            {
+                result = DateTime.Now;
+                return false;
+            }
             if (era == CurrentEra || era == ADEra)
             {
                 try

--- a/src/mscorlib/shared/System/Globalization/GregorianCalendar.cs
+++ b/src/mscorlib/shared/System/Globalization/GregorianCalendar.cs
@@ -522,28 +522,9 @@ namespace System.Globalization
 
         internal override bool TryToDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int era, out DateTime result)
         {
-            if (!IsValidDay(year, month, day, era))
-            {
-                result = DateTime.Now;
-                return false;
-            }
             if (era == CurrentEra || era == ADEra)
             {
-                try
-                {
-                    result = new DateTime(year, month, day, hour, minute, second, millisecond);
-                    return true;
-                }
-                catch (ArgumentOutOfRangeException)
-                {
-                    result = DateTime.Now;
-                    return false;
-                }
-                catch (ArgumentException)
-                {
-                    result = DateTime.Now;
-                    return false;
-                }
+                return DateTime.TryCreate(year, month, day, hour, minute, second, millisecond, out result);
             }
             result = DateTime.MinValue;
             return false;


### PR DESCRIPTION
The TryParse method naming pattern is designed to improve performance, as documented on [MSDN](https://msdn.microsoft.com/en-us/library/ms229009(v=vs.100).aspx):

> Consider the TryParse pattern for members that may throw exceptions in common scenarios to avoid performance problems related to exceptions.

DateTime's TryParseExact currently fails to catch a common scenario where the position of the month and day are reversed in the input string and input format. An example would be trying to parse "10/15/2017" as [Day]-[Month]-[Year]. Using a minimal parsing program, the following metrics were recorded. All experiments made 100,000 TryParseExact call on varying input dates, the times averaged over several runs.

Test # |  Test description | Time (ms) | 
|---|---|---|
| 1 | All parse successfully with format _yyyy-dd-MMTHH:mm:ss_  | 61  |
| 2 | All fail to parse due to format error (format is _yyyyZ-dd-MMTHH:mm:ss_) | 24  |
| 3 |  Switch month and day position (T1 format, input like 2014-01-15T01:02:30)  |  780  |
| 4 | Repeat T3, now with perf fix to GregorianCalendar | 58 |

Performance profiling showed that >90% of the slowdown was due to exception handling, and the throw can be traced to when the calendar verifies whether the parsed date is a valid one. Including a basic constraint check on the month and day and avoiding the exception in TryToDatetime prevents this perf issue.

While this change address the scenario above, there is future work to be done to avoid exception handling in the TryParse call path.