### PR TITLE
an additional assert for fgValueNumberHelperCallFunc

### DIFF
--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -7519,6 +7519,8 @@ void Compiler::fgValueNumberHelperCallFunc(GenTreeCall* call, VNFunc vnf, ValueN
         // Add the accumulated exceptions.
         call->gtVNPair = vnStore->VNPWithExc(call->gtVNPair, vnpExc);
     }
+    assert(args == nullptr ||
+           generateUniqueVN); // All arguments should be processed or we generate unique VN and do not care.
 }
 
 void Compiler::fgValueNumberCall(GenTreeCall* call)


### PR DESCRIPTION
Add the assert that helper call function VN includes all arguments.

Question: why do we use `unsigned nArgs = ValueNumStore::VNFuncArity(vnf);` instead of iterating over the list?

spmi was clean.