### PR TITLE
Disable rundown tracevalidation test

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -187,6 +187,9 @@
         <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeGeneratorTests\TypeGeneratorTest683\Generated683\*">
             <Issue>6707</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\tracing\tracevalidation\rundown\rundown\rundown.cmd">
+            <Issue>16784</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- The following are x86 failures -->


### PR DESCRIPTION
I am OOF until Monday and do not want to leave R2R tests broken, so I am disabling the rundown test

https://github.com/dotnet/coreclr/pull/16784