### PR TITLE
 Add runtesttilstable.sh script

### DIFF
--- a/tests/runtesttilstable.sh
+++ b/tests/runtesttilstable.sh
@@ -141,8 +141,6 @@ if [ $exitCode -eq $EXIT_CODE_TEST_FAILURE ]; then
         fi
         mv "$testRootDir/coreclrtests.fail.txt" "$retryFile"
 
-read -p "Press [Enter] to continue"
-
         ${scriptPath}/runtest.sh --sequential --playlist=${retryFile} ${__UnprocessedBuildArgs}
         exitCode=$?
         if [ $exitCode -ne $EXIT_CODE_TEST_FAILURE ]; then


### PR DESCRIPTION
runtesttilstable.sh runs runtest.sh, then as long as there are
failures, reruns the failures in sequential mode, up to a maximum
number of tries (by default, 3 reruns).

This is useful for handling flaky platforms or flaky tests, at
least temporarily.