### PR TITLE
Workaround coreclr issue

### DIFF
--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -79,10 +79,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "setup_vs_tools.cmd",
+        "filename": "$(Pipeline.SourcesDirectory)\\setup_vs_tools.cmd",
         "arguments": "",
         "modifyEnvironment": "true",
-        "workingFolder": "$(Pipeline.SourcesDirectory)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },


### PR DESCRIPTION
VSTS does not seem to be correctly honoring the working directory for batch script steps.  Explicitly qualify the setup_vs_env.cmd path