### PR TITLE
Fix inlining of IAsyncStateMachineBox continuations

### DIFF
--- a/src/mscorlib/shared/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/mscorlib/shared/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -105,7 +105,7 @@ namespace System.Runtime.CompilerServices
                 return;
             }
 
-            box.Invoke(null);
+            box.MoveNext();
         };
 #endif
     }

--- a/src/mscorlib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -567,17 +567,6 @@ namespace System.Runtime.CompilerServices
                 }
             }
 
-            /// <summary>
-            /// Calls MoveNext on <see cref="StateMachine"/>. Implements ITaskCompletionAction.Invoke so
-            /// that the state machine object may be queued directly as a continuation into a Task's
-            /// continuation slot/list.
-            /// </summary>
-            /// <param name="ignored">The completing task that caused this method to be invoked, if there was one.</param>
-            void ITaskCompletionAction.Invoke(Task ignored) => MoveNext();
-
-            /// <summary>Signals to Task's continuation logic that <see cref="Invoke"/> runs arbitrary user code via MoveNext.</summary>
-            bool ITaskCompletionAction.InvokeMayRunArbitraryCode => true;
-
             /// <summary>Gets the state machine as a boxed object.  This should only be used for debugging purposes.</summary>
             IAsyncStateMachine IAsyncStateMachineBox.GetStateMachineObject() => StateMachine; // likely boxes, only use for debugging
         }
@@ -895,8 +884,11 @@ namespace System.Runtime.CompilerServices
     /// <summary>
     /// An interface implemented by all <see cref="AsyncStateMachineBox{TStateMachine, TResult}"/> instances, regardless of generics.
     /// </summary>
-    internal interface IAsyncStateMachineBox : ITaskCompletionAction
+    internal interface IAsyncStateMachineBox
     {
+        /// <summary>Move the state machine forward.</summary>
+        void MoveNext();
+
         /// <summary>
         /// Gets an action for moving forward the contained state machine.
         /// This will lazily-allocate the delegate as needed.

--- a/src/mscorlib/src/System/Threading/Tasks/TaskContinuation.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/TaskContinuation.cs
@@ -737,34 +737,65 @@ namespace System.Threading.Tasks
         /// <param name="allowInlining">
         /// true to allow inlining, or false to force the action to run asynchronously.
         /// </param>
-        /// <param name="currentTask">
-        /// A reference to the t_currentTask thread static value.
-        /// This is passed by-ref rather than accessed in the method in order to avoid
-        /// unnecessary thread-static writes.
-        /// </param>
         /// <remarks>
         /// No ExecutionContext work is performed used.  This method is only used in the
         /// case where a raw Action continuation delegate was stored into the Task, which
         /// only happens in Task.SetContinuationForAwait if execution context flow was disabled
         /// via using TaskAwaiter.UnsafeOnCompleted or a similar path.
         /// </remarks>
-        internal static void RunOrScheduleAction(Action action, bool allowInlining, ref Task currentTask)
+        internal static void RunOrScheduleAction(Action action, bool allowInlining)
         {
-            Debug.Assert(currentTask == Task.t_currentTask);
+            ref Task currentTask = ref Task.t_currentTask;
+            Task prevCurrentTask = currentTask;
 
             // If we're not allowed to run here, schedule the action
             if (!allowInlining || !IsValidLocationForInlining)
             {
-                UnsafeScheduleAction(action, currentTask);
+                UnsafeScheduleAction(action, prevCurrentTask);
                 return;
             }
 
             // Otherwise, run it, making sure that t_currentTask is null'd out appropriately during the execution
-            Task prevCurrentTask = currentTask;
             try
             {
                 if (prevCurrentTask != null) currentTask = null;
                 action();
+            }
+            catch (Exception exception)
+            {
+                ThrowAsyncIfNecessary(exception);
+            }
+            finally
+            {
+                if (prevCurrentTask != null) currentTask = prevCurrentTask;
+            }
+        }
+
+        /// <summary>Invokes or schedules the action to be executed.</summary>
+        /// <param name="box">The <see cref="IAsyncStateMachineBox"/> that needs to be invoked or queued.</param>
+        /// <param name="allowInlining">
+        /// true to allow inlining, or false to force the box's action to run asynchronously.
+        /// </param>
+        internal static void RunOrScheduleAction(IAsyncStateMachineBox box, bool allowInlining)
+        {
+            // Same logic as in the RunOrScheduleAction(Action, ...) overload, except invoking
+            // box.Invoke instead of action().
+
+            ref Task currentTask = ref Task.t_currentTask;
+            Task prevCurrentTask = currentTask;
+
+            // If we're not allowed to run here, schedule the action
+            if (!allowInlining || !IsValidLocationForInlining)
+            {
+                UnsafeScheduleAction(box.MoveNextAction, prevCurrentTask);
+                return;
+            }
+
+            // Otherwise, run it, making sure that t_currentTask is null'd out appropriately during the execution
+            try
+            {
+                if (prevCurrentTask != null) currentTask = null;
+                box.MoveNext();
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
Prior to .NET Core 2.1, if a task was awaited in a default context (or if ConfigureAwait(false) was used), and if the task was then completed on a non-default context (e.g. code running a non-default TaskScheduler calling SetResult on a TaskCompletionSource), its await continuations are not allowed to be inlined, due to concerns that we could be running an arbitrary amount of unknown code in a scheduling environment that's not amenable to it, like a UI thread. The optimizations added in 2.1 erroneously ended up bypassing that IsValidLocationForInlining check, leading to continuations getting inlined in places they weren't previously.

This commit fixes that.  Previously we'd made the IAsyncStateMachineBox interface inherit ITaskCompletionAction, with its Invoke interface method just delegating to MoveNext; then the box could be added to a task as a continuation.  But that ITaskCompletionAction logic isn't specific to async/await and doesn't invoke IsValidLocationForInlining.  We instead need to follow the Action logic that is meant to be used for async/await.  I've removed the ITaskCompletionAction from IAsyncStateMachineBox, replacing it just with a MoveNext interface method, and added a case for IAsyncStateMachineBox to Task's RunContinuations logic.  I then duplicated the AwaitTaskContinuation.RunOrScheduleAction logic that's there for Action and tweaked it for IAsyncStateMachineBox.  In the process I cleaned up a little code to use some newer C# features.

Contributes to https://github.com/dotnet/corefx/issues/27675
cc: @kouvel, @benaadams 