### PR TITLE
Disable fragile NGen for System.Private.CoreLib.dll on ARM

### DIFF
--- a/src/tools/crossgen/crossgen.cpp
+++ b/src/tools/crossgen/crossgen.cpp
@@ -854,8 +854,10 @@ int _cdecl wmain(int argc, __in_ecount(argc) WCHAR **argv)
     // Are we compiling mscorlib.dll? 
     bool fCompilingMscorlib = StringEndsWith((LPWSTR)pwzFilename, CoreLibName_IL_W);
 
+#ifndef _TARGET_ARM_
     if (fCompilingMscorlib)
         dwFlags &= ~NGENWORKER_FLAGS_READYTORUN;
+#endif // _TARGET_ARM_
 
     if(pwzPlatformAssembliesPaths != nullptr)
     {


### PR DESCRIPTION
As discussed in #16826 switch to R2R crossgen for `System.Private.CoreLib.dll` when `_TARGET_ARM_`

@jkotas @RussKeldorph  PTAL