### PR TITLE
Include Linux/cross-arch components into NuGet packages

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -477,7 +477,7 @@ generate_NugetPackages()
     echo "DistroRid is "$__DistroRid
     echo "ROOTFS_DIR is "$ROOTFS_DIR
     # Build the packages
-    $__ProjectRoot/run.sh build -Project=$__SourceDir/.nuget/packages.builds -MsBuildEventLogging="/l:BinClashLogger,Tools/Microsoft.DotNet.Build.Tasks.dll;LogFile=binclash.log" -MsBuildLog="/flp:Verbosity=normal;LogFile=$__LogsDir/Nuget_$__BuildOS__$__BuildArch__$__BuildType.log" -BuildTarget -__IntermediatesDir=$__IntermediatesDir -__RootBinDir=$__RootBinDir -BuildNugetPackage=false -UseSharedCompilation=false $__RunArgs $__UnprocessedBuildArgs
+    $__ProjectRoot/run.sh build -Project=$__SourceDir/.nuget/packages.builds -MsBuildEventLogging="/l:BinClashLogger,Tools/Microsoft.DotNet.Build.Tasks.dll;LogFile=binclash.log" -MsBuildLog="/flp:Verbosity=normal;LogFile=$__LogsDir/Nuget_$__BuildOS__$__BuildArch__$__BuildType.log" -BuildTarget -__IntermediatesDir=$__IntermediatesDir -__RootBinDir=$__RootBinDir -BuildNugetPackage=false -UseSharedCompilation=false -__DoCrossArchBuild=$__DoCrossArchBuild $__RunArgs $__UnprocessedBuildArgs
 
     if [ $? -ne 0 ]; then
         echo "Failed to generate Nuget packages."

--- a/config.json
+++ b/config.json
@@ -186,6 +186,12 @@
       "values": [],
       "defaultValue": ""
     },
+    "__DoCrossArchBuild": {
+      "description": "Specifies if we build cross-architecture components on Linux.",
+      "valueType": "property",
+      "values": [],
+      "defaultValue": ""
+    },
     "GenerateVersionHeader": {
       "description": "Generates _version.h",
       "valueType": "passThrough",

--- a/dir.props
+++ b/dir.props
@@ -168,6 +168,7 @@
 
     <!-- Define packaging attributes for cross target components -->
     <HasCrossTargetComponents Condition="'$(TargetsWindows)' == 'true' and ('$(PackagePlatform)' =='arm64' or '$(PackagePlatform)' =='arm')">true</HasCrossTargetComponents>
+    <HasCrossTargetComponents Condition="'$(TargetsLinux)' == 'true' and '$(PackagePlatform)' =='arm' and '$(__DoCrossArchBuild)' == '1'">true</HasCrossTargetComponents>
     <CrossTargetComponentFolder Condition="'$(PackagePlatform)' == 'arm64'">x64</CrossTargetComponentFolder>
     <CrossTargetComponentFolder Condition="'$(PackagePlatform)' == 'arm'">x86</CrossTargetComponentFolder>
 

--- a/src/.nuget/Microsoft.NETCore.Jit/runtime.Linux.Microsoft.NETCore.Jit.props
+++ b/src/.nuget/Microsoft.NETCore.Jit/runtime.Linux.Microsoft.NETCore.Jit.props
@@ -2,5 +2,6 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <NativeBinary Include="$(BinDir)libclrjit.so" />
+    <CrossArchitectureSpecificNativeFileAndSymbol Condition="'$(HasCrossTargetComponents)' == 'true'" Include="$(BinDir)$(CrossTargetComponentFolder)\libclrjit.so" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -25,5 +25,6 @@
     <NativeBinary Condition="'$(_PlatformDoesNotSupportCreatedump)' != 'true'" Include="$(BinDir)createdump" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
+    <CrossArchitectureSpecificToolFile Condition="'$(HasCrossTargetComponents)' == 'true'" Include="$(BinDir)$(CrossTargetComponentFolder)\crossgen" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR adds `__DoCrossArchBuild` parameter to `config.json` and uses the parameter value during NuGet packages building step to identify whether Linux/cross-architecture components (clrjit crossgen) can be included into `runtime.Linux.Microsoft.NETCore.Jit` and `runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR` NuGet packages

@RussKeldorph @jashook PTAL