### PR TITLE
Add implicit cast for assignments in ValueNumbering when necessary

### DIFF
--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -5990,6 +5990,21 @@ void Compiler::fgValueNumberTree(GenTree* tree, bool evalAsgLhsInd)
                 }
 #endif // !LEGACY_BACKEND
             }
+
+            // Is the type being stored different from the type computed by the rhs?
+            if (rhs->TypeGet() != lhs->TypeGet())
+            {
+                // This menas that there is an implicit cast on the rhs value
+                //
+                // We will add a cast function to reflect the possible narrowing of the rhs value
+                //
+                var_types castToType   = lhs->TypeGet();
+                var_types castFromType = rhs->TypeGet();
+                bool      isUnsigned   = varTypeIsUnsigned(castFromType);
+
+                rhsVNPair = vnStore->VNPairForCast(rhsVNPair, castToType, castFromType, isUnsigned);
+            }
+
             if (tree->TypeGet() != TYP_VOID)
             {
                 // Assignment operators, as expressions, return the value of the RHS.

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -5994,7 +5994,7 @@ void Compiler::fgValueNumberTree(GenTree* tree, bool evalAsgLhsInd)
             // Is the type being stored different from the type computed by the rhs?
             if (rhs->TypeGet() != lhs->TypeGet())
             {
-                // This menas that there is an implicit cast on the rhs value
+                // This means that there is an implicit cast on the rhs value
                 //
                 // We will add a cast function to reflect the possible narrowing of the rhs value
                 //

--- a/tests/src/JIT/opt/CSE/NarrowStore.cs
+++ b/tests/src/JIT/opt/CSE/NarrowStore.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace NarrowStore
+{
+    class Program 
+    { 
+        byte x01;
+        byte t01;
+    
+        int Test()
+        {
+            x01 = 3;
+            t01 = (byte)~x01;
+            if (t01 == 252)
+            {
+                Console.WriteLine("Pass");
+                return 100;
+            }
+            else
+            {
+                Console.WriteLine("FAIL");
+                return -1;
+            }
+        }
+
+        static int Main(string[] args) 
+        { 
+            Program prog = new Program();
+            
+            int result = prog.Test();
+            return result;
+        }
+    }
+}
+

--- a/tests/src/JIT/opt/CSE/NarrowStore.csproj
+++ b/tests/src/JIT/opt/CSE/NarrowStore.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="NarrowStore.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
When value numbering an assignment we may need to insert an implicit cast operation

Test case opt/CSE/NarrowStore.cs added