### PR TITLE
Fix UpdatePublishedVersions.ps1

### DIFF
--- a/UpdatePublishedVersions.ps1
+++ b/UpdatePublishedVersions.ps1
@@ -16,7 +16,7 @@ param(
     # A pattern matching all packages in the set that the versions repository should be set to.
     [Parameter(Mandatory=$true)][string]$nupkgPath)
 
-& "$PSScriptRoot\Tools\run.cmd" build -- tests\build.proj /t:UpdatePublishedVersions `
+& "$PSScriptRoot\run.cmd" build -- tests\build.proj /t:UpdatePublishedVersions `
     /p:GitHubUser="$gitHubUser" `
     /p:GitHubEmail="$gitHubEmail" `
     /p:GitHubAuthToken="$gitHubAuthToken" `


### PR DESCRIPTION
Remove the "Tools" string accidentally left in the run.cmd invocation