### PR TITLE
[release/1.1.0] Add UpdateDependencies.ps1 to fix auto-PR submission

### DIFF
--- a/UpdateDependencies.ps1
+++ b/UpdateDependencies.ps1
@@ -16,5 +16,6 @@ $initTools = Join-Path $PSScriptRoot "init-tools.cmd"
 # Execute MSBuild using the dotnet.exe host
 $dotNetExe = Join-Path $toolsLocalPath "dotnetcli\dotnet.exe"
 $msbuildExe = Join-Path $toolsLocalPath "msbuild.exe"
-& $dotNetExe $msbuildExe $args
+$testsBuildProj = Join-Path $PSScriptRoot "tests\build.proj"
+& $dotNetExe $msbuildExe $testsBuildProj /t:UpdateDependenciesAndSubmitPullRequest $args
 exit $LastExitCode

--- a/UpdateDependencies.ps1
+++ b/UpdateDependencies.ps1
@@ -1,0 +1,20 @@
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+# This script initializes tools if necessary, then calls MSBuild using the
+# dotnet CLI. This allows Maestro to run auto-update targets without
+# encountering errors when contacting GitHub: .NET Core CLI supports TLS 1.2
+# by default, but full framework doesn't.
+
+$toolsLocalPath = Join-Path $PSScriptRoot "Tools"
+
+$initTools = Join-Path $PSScriptRoot "init-tools.cmd"
+& $initTools
+
+# Execute MSBuild using the dotnet.exe host
+$dotNetExe = Join-Path $toolsLocalPath "dotnetcli\dotnet.exe"
+$msbuildExe = Join-Path $toolsLocalPath "msbuild.exe"
+& $dotNetExe $msbuildExe $args
+exit $LastExitCode


### PR DESCRIPTION
This allows Maestro to run auto-update targets in .NET Core, where TLS 1.2 is supported by default.

The script is derived from Core-Setup's [run.ps1](https://github.com/dotnet/core-setup/blob/6ce618d3382719d123b07c85bdc757102f07bd61/run.ps1). Example PR: https://github.com/dagood/coreclr/pull/5

@wtgodbe is also looking at possibly porting the fix to BuildTools 1.1.0, so that we can avoid using this workaround. (The challenging part is figuring out if we can safely upgrade CoreCLR's BuildTools.)

To use this, [subscriptions.json](https://github.com/dotnet/versions/blob/430e314c2958b89c559b0b1cba80c9e75db84dd6/Maestro/subscriptions.json#L201-L206) will need a few changes: use this script instead of `run.cmd`, and only pass the msbuild properties. That's because this script calls msbuild directly with the correct project and target instead of using `config.json`.