### PR TITLE
[WIP] Send fatal error log to Windows Event Log

### DIFF
--- a/src/vm/eventreporter.cpp
+++ b/src/vm/eventreporter.cpp
@@ -448,7 +448,6 @@ BOOL ShouldLogInEventLog()
     }
     CONTRACTL_END;
 
-#ifndef FEATURE_CORESYSTEM
     // If the process is being debugged, don't log
     if ((CORDebuggerAttached() || IsDebuggerPresent())
 #ifdef _DEBUG
@@ -471,10 +470,6 @@ BOOL ShouldLogInEventLog()
         return FALSE;
     else
         return TRUE;
-#else
-    // no event log on Apollo
-    return FALSE;
-#endif //!FEATURE_CORESYSTEM
 }
 
 //---------------------------------------------------------------------------------------


### PR DESCRIPTION
Address issue #16735. I've tested the fix on both regular Windows 10 on Desktop and Windows Server 2012 for now, and confirmed that it works on both (screenshots attached). 

Desktop:
<img width="1920" alt="screenshot" src="https://user-images.githubusercontent.com/30421794/37232361-8aaf7e6e-23a3-11e8-9856-244d4e8131e0.png">

Server:
<img width="1920" alt="server_screenshot" src="https://user-images.githubusercontent.com/30421794/37232438-de864f04-23a3-11e8-92d5-be9e705fbb79.png">


