### PR TITLE
Run ILLInk on System.Private.CoreLib.dll to remove dead code and clear initlocals.

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -64,7 +64,7 @@
   <!-- ILLinik.Tasks package version -->
   <PropertyGroup>
     <ILLinkTasksPackage>ILLink.Tasks</ILLinkTasksPackage>
-    <ILLinkTasksPackageVersion>0.1.4-preview-1317495</ILLinkTasksPackageVersion>
+    <ILLinkTasksPackageVersion>0.1.5-preview-1461378</ILLinkTasksPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/mscorlib/CreateRuntimeRootILLinkDescriptorFile.targets
+++ b/src/mscorlib/CreateRuntimeRootILLinkDescriptorFile.targets
@@ -11,6 +11,7 @@
     <_MscorlibFilePath Condition=" '$(_MscorlibFilePath)' == '' ">$(MSBuildThisFileDirectory)..\vm\mscorlib.h</_MscorlibFilePath>
     <_CortypeFilePath Condition=" '$(_CortypeFilePath)' == '' ">$(MSBuildThisFileDirectory)..\inc\cortypeinfo.h</_CortypeFilePath>
     <_RexcepFilePath Condition=" '$(_RexcepFilePath)' == '' ">$(MSBuildThisFileDirectory)..\vm\rexcep.h</_RexcepFilePath>
+    <_ILLinkTrimXmlFilePath Condition=" '$(_ILLinkTrimXmlFilePath)' == '' ">$(MSBuildThisFileDirectory)ILLinkTrim.xml</_ILLinkTrimXmlFilePath>
     <_ILLinkTasksToolsDir>$(PackagesDir)/illink.tasks/$(ILLinkTasksPackageVersion)/tools</_ILLinkTasksToolsDir>
     <_ILLinkTasksDir>$(_ILLinkTasksToolsDir)/net46/</_ILLinkTasksDir>
     <_ILLinkTasksDir Condition="'$(MSBuildRuntimeType)' == 'Core'">$(_ILLinkTasksToolsDir)/netcoreapp2.0/</_ILLinkTasksDir>
@@ -19,13 +20,14 @@
   <!-- Generates the xml root descriptor file for ILLink. The file contains roots required by the runtime. -->
   <UsingTask TaskName="CreateRuntimeRootILLinkDescriptorFile" AssemblyFile="$(_ILLinkTasksDir)ILLink.Tasks.dll" />
   <Target Name="_CreateILLinkRuntimeRootDescriptorFile"
-          Inputs="$(_NamespaceFilePath);$(_MscorlibFilePath);$(_CortypeFilePath);$(_RexcepFilePath)"
+          Inputs="$(_NamespaceFilePath);$(_MscorlibFilePath);$(_CortypeFilePath);$(_RexcepFilePath);$(_ILLinkTrimXmlFilePath)"
           Outputs="$(_ILLinkRuntimeRootDescriptorFilePath)">
     <Message Text="Generating ILLink roots file: $(_ILLinkRuntimeRootDescriptorFilePath)" />
     <CreateRuntimeRootILLinkDescriptorFile NamespaceFilePath="$(_NamespaceFilePath)"
                                            MscorlibFilePath="$(_MscorlibFilePath)"
                                            CortypeFilePath="$(_CortypeFilePath)"
                                            RexcepFilePath="$(_RexcepFilePath)"
+                                           ILLinkTrimXmlFilePath="$(_ILLinkTrimXmlFilePath)"
                                            RuntimeRootDescriptorFilePath="$(_ILLinkRuntimeRootDescriptorFilePath)" />
   </Target>
 </Project>

--- a/src/mscorlib/ILLink.targets
+++ b/src/mscorlib/ILLink.targets
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TargetsTriggeredByCompilation>
+      $(TargetsTriggeredByCompilation);
+      ILLinkTrimAssembly
+    </TargetsTriggeredByCompilation>
+  </PropertyGroup>
+
+  <!-- Inputs and outputs of ILLinkTrimAssembly -->
+  <PropertyGroup>
+    <ILLinkTasksToolsDir>$(PackagesDir)/illink.tasks/$(ILLinkTasksPackageVersion)/tools</ILLinkTasksToolsDir>
+    <ILLinkTasksDir>$(ILLinkTasksToolsDir)/net46/</ILLinkTasksDir>
+    <ILLinkTasksDir Condition="'$(MSBuildRuntimeType)' == 'Core'">$(ILLinkTasksToolsDir)/netcoreapp2.0/</ILLinkTasksDir>
+    <ILLinkTasksPath>$(ILLinkTasksDir)ILLink.Tasks.dll</ILLinkTasksPath>
+    <ILLinkTrimAssembly Condition="'$(ILLinkTrimAssembly)' == ''">true</ILLinkTrimAssembly>
+    <ILLinkTrimAssemblyPath>$(IntermediateOutputPath)$(TargetName)$(TargetExt)</ILLinkTrimAssemblyPath>
+    <ILLinkTrimAssemblySymbols>$(IntermediateOutputPath)$(TargetName).pdb</ILLinkTrimAssemblySymbols>
+    <ILLinkTrimInputPath>$(IntermediateOutputPath)PreTrim/</ILLinkTrimInputPath>
+    <ILLinkTrimInputAssembly>$(ILLinkTrimInputPath)$(TargetName)$(TargetExt)</ILLinkTrimInputAssembly>
+    <ILLinkTrimInputSymbols>$(ILLinkTrimInputPath)$(TargetName).pdb</ILLinkTrimInputSymbols>
+    <ILLinkTrimOutputPath>$(IntermediateOutputPath)</ILLinkTrimOutputPath>
+
+    <!-- if building a PDB, tell illink to rewrite the symbols file -->
+    <ILLinkRewritePDBs Condition="'$(ILLinkRewritePDBs)' == '' AND '$(DebugSymbols)' != 'false'">true</ILLinkRewritePDBs>
+  </PropertyGroup>
+
+  <!-- Custom binplacing for pre/post-trimming and reports that is useful for analysis 
+       Must be enabled by setting BinPlaceILLinkTrimAssembly=true
+  --> 
+  <ItemGroup Condition="'$(BinPlaceILLinkTrimAssembly)' == 'true'">
+    <BinPlaceConfiguration Include="$(BuildConfiguration)">
+      <RuntimePath>$(BinDir)ILLinkTrimAssembly/$(BuildConfiguration)/trimmed</RuntimePath>
+      <ItemName>TrimmedItem</ItemName>
+    </BinPlaceConfiguration>
+    <BinPlaceConfiguration Include="$(BuildConfiguration)">
+      <RuntimePath>$(BinDir)ILLinkTrimAssembly/$(BuildConfiguration)/reports</RuntimePath>
+      <ItemName>TrimmingReport</ItemName>
+    </BinPlaceConfiguration>
+    <BinPlaceConfiguration Include="$(BuildConfiguration)">
+      <RuntimePath>$(BinDir)ILLinkTrimAssembly/$(BuildConfiguration)/pretrimmed</RuntimePath>
+      <ItemName>PreTrimmedItem</ItemName>
+    </BinPlaceConfiguration>
+  </ItemGroup>
+
+  <!-- ILLinkTrimAssembly
+       Examines the "input assembly" for IL that is unreachable from public API and trims that,
+       rewriting the assembly to an "output assembly"
+  -->
+  <UsingTask TaskName="ILLink" AssemblyFile="$(ILLinkTasksPath)" />
+  <Target Name="ILLinkTrimAssembly" Condition="'$(ILLinkTrimAssembly)' == 'true'" DependsOnTargets="EnsureBuildToolsRuntime">
+    <PropertyGroup>
+      <ILLinkArgs>$(ILLinkArgs)-r $(TargetName)</ILLinkArgs>
+      <!-- default action for core assemblies -->
+      <ILLinkArgs>$(ILLinkArgs) -c skip</ILLinkArgs>
+      <!-- default action for non-core assemblies -->
+      <ILLinkArgs>$(ILLinkArgs) -u skip</ILLinkArgs>
+      <!-- trim the target assembly -->
+      <ILLinkArgs>$(ILLinkArgs) -p link $(TargetName)</ILLinkArgs>
+      <ILLinkArgs Condition="'$(ILLinkRewritePDBs)' == 'true' AND Exists('$(ILLinkTrimAssemblySymbols)')">$(ILLinkArgs) -b true</ILLinkArgs>
+      <!-- keep types and members required by Debugger-related attributes -->
+      <ILLinkArgs>$(ILLinkArgs) -v true</ILLinkArgs>
+      <!-- don't remove the embedded root xml resource since ILLink may run again on the assembly -->
+      <ILLinkArgs>$(ILLinkArgs) --strip-resources false</ILLinkArgs>
+      <!-- reflection heuristics to apply -->
+      <ILLinkArgs>$(ILLinkArgs) -h LdtokenTypeMethods,InstanceConstructors</ILLinkArgs>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(ILLinkTrimInputPath)" />
+
+    <!-- Move the assembly into a subdirectory for ILLink -->
+    <Move SourceFiles="$(ILLinkTrimAssemblyPath)"
+          DestinationFolder="$(ILLinkTrimInputPath)"
+    />
+
+    <!-- Move the PDB into a subdirectory for ILLink if we are rewriting PDBs -->
+    <Move SourceFiles="$(ILLinkTrimAssemblySymbols)"
+          DestinationFolder="$(ILLinkTrimInputPath)"
+          Condition="'$(ILLinkRewritePDBs)' == 'true' AND Exists('$(ILLinkTrimAssemblySymbols)')"
+    />
+
+    <ILLink AssemblyPaths="$(ILLinkTrimInputAssembly)"
+            RootAssemblyNames=""
+            OutputDirectory="$(ILLinkTrimOutputPath)"
+            ClearInitLocals="true"
+            ClearInitLocalsAssemblies="$(TargetName)"
+            ExtraArgs="$(ILLinkArgs)" />
+
+  </Target>
+
+  <!-- ILLink reporting.
+       Only enabled when developer specifies a path to the AsmDiff tool with property AsmDiffCmd.
+       EG: AsmDiffCmd=d:\tools\asmdiff\asmdiff.exe
+       This is necessary until the AsmDiff tool is ported to .NET Core. -->
+  <Target Name="_CreateILLinkTrimAssemblyReports"
+          AfterTargets="ILLinkTrimAssembly"
+          Condition="'$(AsmDiffCmd)' != ''">
+    <PropertyGroup>
+      <AsmDiffArgs>$(AsmDiffArgs) $(ILLinkTrimInputAssembly)</AsmDiffArgs>
+      <AsmDiffArgs>$(AsmDiffArgs) $(ILLinkTrimAssemblyPath)</AsmDiffArgs>
+      <AsmDiffArgs>$(AsmDiffArgs) -includePrivateApis -includeInternalApis -alwaysDiffMembers -diffAttributes</AsmDiffArgs>
+
+      <AsmDiffReport>$(IntermediateOutputPath)$(TargetName).diff.html</AsmDiffReport>
+      <AsmDiffReportArgs>$(AsmDiffArgs) -out:$(AsmDiffReport)</AsmDiffReportArgs>
+      <AsmDiffReportArgs>$(AsmDiffReportArgs) -unchanged -changed -added -removed</AsmDiffReportArgs>
+
+      <AsmDiffList>$(IntermediateOutputPath)$(TargetName).diff.csv</AsmDiffList>
+      <AsmDiffListArgs>$(AsmDiffArgs) -out:$(AsmDiffList)</AsmDiffListArgs>
+      <AsmDiffListArgs>$(AsmDiffListArgs) -unchanged -changed -added -removed </AsmDiffListArgs>
+      <AsmDiffListArgs>$(AsmDiffListArgs) -diffWriter:CSV</AsmDiffListArgs>
+    </PropertyGroup>
+
+    <Exec Command="$(AsmDiffCmd) $(AsmDiffReportArgs)" />
+    <Message Text="Assembly trimming diff: $(AsmDiffReport)" />
+    <Exec Command="$(AsmDiffCmd) $(AsmDiffListArgs)" />
+    <Message Text="Assembly trimming report: $(AsmDiffList)" />
+  </Target>
+  
+  <!-- Similar to _CheckForCompileOutputs and runs in the same places, 
+       always set these even if compile didn't run. -->
+  <Target Name="_CheckForILLinkTrimAssemblyOutputs" 
+          BeforeTargets="CopyFilesToOutputDirectory;_CleanGetCurrentAndPriorFileWrites"
+          Condition="'$(ILLinkTrimAssembly)' == 'true'">
+    <ItemGroup>
+      <PreTrimmedItem Condition="Exists('$(ILLinkTrimInputAssembly)')" Include="$(ILLinkTrimInputAssembly)" />
+      <PreTrimmedItem Condition="'$(ILLinkRewritePDBs)' == 'true' AND Exists('$(ILLinkTrimInputSymbols)')" Include="$(ILLinkTrimInputSymbols)" />
+      <FileWrites Include="@(PreTrimmedItem)" />
+
+      <TrimmedItem Condition="Exists('$(ILLinkTrimAssemblyPath)')" Include="$(ILLinkTrimAssemblyPath)" />
+      <TrimmedItem Condition="'$(ILLinkRewritePDBs)' == 'true' AND Exists('$(ILLinkTrimAssemblySymbols)')" Include="$(ILLinkTrimAssemblySymbols)" />
+
+      <TrimmingReport Condition="Exists('$(AsmDiffReport)')" Include="$(AsmDiffReport)" />
+      <TrimmingReport Condition="Exists('$(AsmDiffList)')" Include="$(AsmDiffList)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/mscorlib/ILLinkTrim.xml
+++ b/src/mscorlib/ILLinkTrim.xml
@@ -1,0 +1,23 @@
+<linker>
+  <assembly fullname="System.Private.CoreLib">
+    <type fullname="System.CommonlyUsedGenericInstantiations">
+      <!-- Method is purely an aid for NGen to statically deduce which
+           instantiations to save in the ngen image. -->
+      <method name="CommonlyUsedWinRTRedirectedInterfaceStubs" />
+    </type>
+    <type fullname="System.Threading.Tasks.Task">
+      <!-- Properties used by a debugger. -->
+      <property name="ParentForDebugger" />
+      <property name="StateFlagsForDebugger" />
+    </type>
+    <type fullname="System.Diagnostics.Tracing.EventListener">
+      <!-- Method gets used when the code is mirrored into CoreFX
+           and is packaged into Microsoft.Diagnostics.Tracing.EventSource.Redist. -->
+      <method name="DisposeOnShutdown" />
+    </type>
+    <type fullname="System.Threading.Tasks.Task">
+      <!-- Methods is used by VS Tasks Window. -->
+      <method name="GetActiveTaskFromId" />
+    </type>
+  </assembly>
+</linker>

--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -673,5 +673,7 @@
     <EmbeddedResource Include="$(_ILLinkRuntimeRootDescriptorFilePath)" />
   </ItemGroup>
 
+  <Import Project="ILLink.targets" />
+
   <Import Project="GenerateCompilerResponseFile.targets" />
 </Project>

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -7467,13 +7467,6 @@ getMethodInfoHelper(
         if (!fILIntrinsic)
         {
             getMethodInfoILMethodHeaderHelper(header, methInfo);
-
-            // Workaround for https://github.com/dotnet/coreclr/issues/1279
-            // Set init locals bit to zero for system module unless profiler may have overrided it. Remove once we have
-            // better solution for this issue.
-            if (pMT->GetModule()->IsSystem() && !(CORProfilerDisableAllNGenImages() || CORProfilerUseProfileImages()))
-                methInfo->options = (CorInfoOptions)0;
-
             pLocalSig = header->LocalVarSig;
             cbLocalSig = header->cbLocalVarSig;
         }


### PR DESCRIPTION
We already run ILLInk on corefx assemblies to remove dead code;
this change enables that for System.Private.CoreLib.dll.

The new ILLink.targets file is similar to the one in corefx.

All runtime dependencies were already computed and rooted in an xml file that
was embedded in System.Private.CoreLib.dll. This change adds ILLinkTrim.xml
with a few manual roots. They are also included in the embedded xml.

The dead code found by ILLink that could be removed from sources was already
removed in https://github.com/dotnet/coreclr/pull/16759 The remaining code removed by ILLink
falls into 4 categories:
1. Inlined constants.
2. Private default constructors when there are no other instance constructors.
3. System.Number+DoubleHelper.Sign that needs to stay in the sources for corert mirror.
4. EventListener._EventSourceCreated event methods (the event field is retained).

ILLink also clears initlocals on all methods so I removed the workaround
we had in jitinterface.cpp.