### PR TITLE
Up the jit stress timeout to 5 hours

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -641,7 +641,7 @@ def static setJobTimeout(newJob, isPR, architecture, configuration, scenario, is
             timeout = 360
         }
         else if (isJitStressScenario(scenario)) {
-            timeout = 240
+            timeout = 300
         }
         else if (isR2RBaselineScenario(scenario)) {
             timeout = 240


### PR DESCRIPTION
Current jitx86hwintrinsicnoavx job runs around 4 hours. Which will cause timeouts if over.

This is linked with conversation on https://github.com/dotnet/coreclr/pull/16817#issuecomment-372078465.

/cc @4creators @jkotas 