### PR TITLE
[ARM] Disable fragile NGen when compiling S.P.C.dll for _TARGET_ARM_

### DIFF
--- a/src/tools/crossgen/crossgen.cpp
+++ b/src/tools/crossgen/crossgen.cpp
@@ -833,8 +833,11 @@ int _cdecl wmain(int argc, __in_ecount(argc) WCHAR **argv)
     // Are we compiling mscorlib.dll? 
     bool fCompilingMscorlib = StringEndsWith((LPWSTR)pwzFilename, CoreLibName_IL_W);
 
+// Disable fragile NGen when compiling Mscorlib for ARM.
+#ifndef _TARGET_ARM_
     if (fCompilingMscorlib)
         dwFlags &= ~NGENWORKER_FLAGS_READYTORUN;
+#endif // _TARGET_ARM_
 
     if(pwzPlatformAssembliesPaths != nullptr)
     {


### PR DESCRIPTION
#16864 was resolved and #16882 unblocked us (see #16862) from switching to R2R crossgen for `System.Private.CoreLib.dll` when `_TARGET_ARM_` 

**Related issue:** #16826 

@jkotas @RussKeldorph PTAL again
