### PR TITLE
Add AllReady scenario to JitBench

### DIFF
--- a/tests/src/performance/Scenario/JitBench/Benchmarks/WebAppBenchmarks.cs
+++ b/tests/src/performance/Scenario/JitBench/Benchmarks/WebAppBenchmarks.cs
@@ -262,8 +262,8 @@ namespace JitBench
             return Environment.GetEnvironmentVariable("MUSICSTORE_PRIVATE_REPO");
         }
 
-        private const string JitBenchRepoUrl = "https://github.com/adamsitnik/JitBench";
-        private const string JitBenchCommitSha1Id = "7b74b0efdfcf083edefb51258733087fa4f27335";
+        private const string JitBenchRepoUrl = "https://github.com/aspnet/JitBench";
+        private const string JitBenchCommitSha1Id = "6bee730486f272d31f23f1033225090511f856f3";
         private const string EnvironmentFileName = "JitBenchEnvironment.txt";
         private const string StoreDirName = ".store";
         private readonly Metric StartupMetric = new Metric("Startup", "ms");

--- a/tests/src/performance/Scenario/JitBench/Benchmarks/WebAppBenchmarks.cs
+++ b/tests/src/performance/Scenario/JitBench/Benchmarks/WebAppBenchmarks.cs
@@ -110,7 +110,7 @@ namespace JitBench
                 .WithEnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0")
                 .WithEnvironmentVariable("JITBENCH_ASPNET_VERSION", "2.0")
                 .WithEnvironmentVariable("JITBENCH_TARGET_FRAMEWORK_MONIKER", tfm)
-                .WithEnvironmentVariable("JITBENCH_TARGET_FRAMEWORK_VERSION", dotNetInstall.FrameworkVersion)
+                .WithEnvironmentVariable("JITBENCH_FRAMEWORK_VERSION", dotNetInstall.FrameworkVersion)
                 .WithEnvironmentVariable("UseSharedCompilation", "false")
                 .WithLog(output)
                 .Run();

--- a/tests/src/performance/Scenario/JitBench/Benchmarks/WebAppBenchmarks.cs
+++ b/tests/src/performance/Scenario/JitBench/Benchmarks/WebAppBenchmarks.cs
@@ -264,8 +264,8 @@ namespace JitBench
             return Environment.GetEnvironmentVariable("MUSICSTORE_PRIVATE_REPO");
         }
 
-        private const string JitBenchRepoUrl = "https://github.com/aspnet/JitBench";
-        private const string JitBenchCommitSha1Id = "6e1327b633e2d7d45f4c13f498fc27698ea5735a";
+        private const string JitBenchRepoUrl = "https://github.com/adamsitnik/JitBench";
+        private const string JitBenchCommitSha1Id = "f145ba0435ebe7189cdfd721186d69db43823d41";
         private const string EnvironmentFileName = "JitBenchEnvironment.txt";
         private const string StoreDirName = ".store";
         private readonly Metric StartupMetric = new Metric("Startup", "ms");

--- a/tests/src/performance/Scenario/JitBench/Runner/Benchmark.cs
+++ b/tests/src/performance/Scenario/JitBench/Runner/Benchmark.cs
@@ -84,7 +84,7 @@ namespace JitBench
                     BenchmarkRunResult result = new BenchmarkRunResult(this, config);
                     StringBuilder stderr = new StringBuilder();
                     StringBuilder stdout = new StringBuilder();
-                    var scenarioConfiguration = new ScenarioTestConfiguration(TimeSpan.FromMilliseconds(60000), startInfo)
+                    var scenarioConfiguration = new ScenarioTestConfiguration(TimeSpan.FromMinutes(1), startInfo)
                     {
                         //XUnitPerformanceHarness writes files to disk starting with {runid}-{ScenarioBenchmarkName}-{TestName}
                         TestName = (Name + "-" + config.Name).Replace(' ', '_'),
@@ -142,6 +142,7 @@ namespace JitBench
                         "coreclr.dll",
                         "dotnet.exe",
                         "MusicStore.dll",
+                        "AllReady.dll",
                         "ntoskrnl.exe",
                         "System.Private.CoreLib.dll",
                         "Unknown",


### PR DESCRIPTION
This PR together with https://github.com/aspnet/JitBench/pull/86 adds a real-world ASP.NET Core app to our JitBench scenarios.

The implementation is simple, I just followed the pattern established previously by @noahfalk for MusicStore.

Why "NO MERGE" -> https://github.com/aspnet/JitBench/pull/85 needs to get merged first and then I need to change the repo url and commit hash.

/cc @jorive 