### PR TITLE
Fix GetTempPath

### DIFF
--- a/src/mscorlib/shared/Interop/Windows/Kernel32/Interop.GetFullPathNameW.cs
+++ b/src/mscorlib/shared/Interop/Windows/Kernel32/Interop.GetFullPathNameW.cs
@@ -14,16 +14,17 @@ internal partial class Interop
         /// </summary>
         [DllImport(Libraries.Kernel32, SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false, ExactSpelling = true)]
 #if PROJECTN
-        internal static extern unsafe uint GetFullPathNameW(string path, uint numBufferChars, char* buffer, IntPtr mustBeZero);
+        internal static extern unsafe uint GetFullPathNameW(char* lpFileName, uint nBufferLength, char* lpBuffer, IntPtr lpFilePart);
 
         // Works around https://devdiv.visualstudio.com/web/wi.aspx?pcguid=011b8bdf-6d56-4f87-be0d-0092136884d9&id=575202
-        internal static unsafe uint GetFullPathNameW(string path, uint numBufferChars, ref char buffer, IntPtr mustBeZero)
+        internal static unsafe uint GetFullPathNameW(ref char lpFileName, uint nBufferLength, ref char lpBuffer, IntPtr lpFilePart)
         {
-            fixed (char* pBuffer = &buffer)
-                return GetFullPathNameW(path, numBufferChars, pBuffer, mustBeZero);
+            fixed (char* pBuffer = &lpBuffer)
+            fixed (char* pFileName = &lpFileName)
+                return GetFullPathNameW(pFileName, nBufferLength, pBuffer, mustBeZero);
         }
 #else
-        internal static extern uint GetFullPathNameW(ref char path, uint numBufferChars, ref char buffer, IntPtr mustBeZero);
+        internal static extern uint GetFullPathNameW(ref char lpFileName, uint nBufferLength, ref char lpBuffer, IntPtr lpFilePart);
 #endif
     }
 }

--- a/src/mscorlib/shared/Interop/Windows/Kernel32/Interop.GetFullPathNameW.cs
+++ b/src/mscorlib/shared/Interop/Windows/Kernel32/Interop.GetFullPathNameW.cs
@@ -23,7 +23,7 @@ internal partial class Interop
                 return GetFullPathNameW(path, numBufferChars, pBuffer, mustBeZero);
         }
 #else
-        internal static extern uint GetFullPathNameW(string path, uint numBufferChars, ref char buffer, IntPtr mustBeZero);
+        internal static extern uint GetFullPathNameW(ref char path, uint numBufferChars, ref char buffer, IntPtr mustBeZero);
 #endif
     }
 }

--- a/src/mscorlib/shared/Interop/Windows/Kernel32/Interop.GetTempFileNameW.cs
+++ b/src/mscorlib/shared/Interop/Windows/Kernel32/Interop.GetTempFileNameW.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Text;
 using System.Runtime.InteropServices;
 
 internal partial class Interop
@@ -11,6 +9,6 @@ internal partial class Interop
     internal partial class Kernel32
     {
         [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
-        internal static extern uint GetTempFileNameW(string tmpPath, string prefix, uint uniqueIdOrZero, [Out]StringBuilder tmpFileName);
+        internal static extern uint GetTempFileNameW(ref char lpPathName, string lpPrefixString, uint uUnique, ref char lpTempFileName);
     }
 }

--- a/src/mscorlib/shared/Interop/Windows/Kernel32/Interop.GetTempPathW.cs
+++ b/src/mscorlib/shared/Interop/Windows/Kernel32/Interop.GetTempPathW.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IO;
-using System.Text;
 using System.Runtime.InteropServices;
 
 internal partial class Interop
@@ -11,6 +9,6 @@ internal partial class Interop
     internal partial class Kernel32
     {
         [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, BestFitMapping = false)]
-        internal static extern uint GetTempPathW(int bufferLen, [Out]StringBuilder buffer);
+        internal static extern uint GetTempPathW(int bufferLen, ref char buffer);
     }
 }

--- a/src/mscorlib/shared/System/IO/Path.Windows.cs
+++ b/src/mscorlib/shared/System/IO/Path.Windows.cs
@@ -128,24 +128,60 @@ namespace System.IO
 
         public static string GetTempPath()
         {
-            StringBuilder sb = StringBuilderCache.Acquire(Interop.Kernel32.MAX_PATH);
-            uint r = Interop.Kernel32.GetTempPathW(Interop.Kernel32.MAX_PATH, sb);
-            if (r == 0)
+            Span<char> initialBuffer = stackalloc char[PathInternal.MaxShortPath];
+            ValueStringBuilder builder = new ValueStringBuilder(initialBuffer);
+
+            GetTempPath(ref builder);
+
+            string path = PathHelper.Normalize(builder.AsSpan());
+            builder.Dispose();
+            return path;
+        }
+
+        private static void GetTempPath(ref ValueStringBuilder builder)
+        {
+            uint result = 0;
+            while ((result = Interop.Kernel32.GetTempPathW(builder.Capacity, ref builder.GetPinnableReference())) > builder.Capacity)
+            {
+                // Reported size is greater than the buffer size. Increase the capacity.
+                builder.EnsureCapacity(checked((int)result));
+            }
+
+            if (result == 0)
                 throw Win32Marshal.GetExceptionForLastWin32Error();
-            return GetFullPath(StringBuilderCache.GetStringAndRelease(sb));
+
+            builder.Length = (int)result;
         }
 
         // Returns a unique temporary file name, and creates a 0-byte file by that
         // name on disk.
         public static string GetTempFileName()
         {
-            string path = GetTempPath();
+            Span<char> initialTempPathBuffer = stackalloc char[PathInternal.MaxShortPath];
+            ValueStringBuilder tempPathBuilder = new ValueStringBuilder(initialTempPathBuffer);
 
-            StringBuilder sb = StringBuilderCache.Acquire(Interop.Kernel32.MAX_PATH);
-            uint r = Interop.Kernel32.GetTempFileNameW(path, "tmp", 0, sb);
-            if (r == 0)
+            GetTempPath(ref tempPathBuilder);
+
+            Span<char> initialBuffer = stackalloc char[PathInternal.MaxShortPath];
+            ValueStringBuilder builder = new ValueStringBuilder(initialBuffer);
+
+            uint result = 0;
+            while ((result = Interop.Kernel32.GetTempFileNameW(
+                ref tempPathBuilder.GetPinnableReference(), "tmp", 0, ref builder.GetPinnableReference())) > builder.Capacity)
+            {
+                // Reported size is greater than the buffer size. Increase the capacity.
+                builder.EnsureCapacity(checked((int)result));
+            }
+
+            tempPathBuilder.Dispose();
+
+            if (result == 0)
                 throw Win32Marshal.GetExceptionForLastWin32Error();
-            return StringBuilderCache.GetStringAndRelease(sb);
+
+            builder.Length = (int)result;
+            string path = PathHelper.Normalize(builder.AsSpan());
+            builder.Dispose();
+            return path;
         }
 
         // Tests if the given path contains a root. A path is considered rooted

--- a/src/mscorlib/shared/System/IO/Path.Windows.cs
+++ b/src/mscorlib/shared/System/IO/Path.Windows.cs
@@ -133,7 +133,7 @@ namespace System.IO
 
             GetTempPath(ref builder);
 
-            string path = PathHelper.Normalize(builder.AsSpan());
+            string path = PathHelper.Normalize(ref builder);
             builder.Dispose();
             return path;
         }
@@ -150,8 +150,7 @@ namespace System.IO
             if (result == 0)
                 throw Win32Marshal.GetExceptionForLastWin32Error();
 
-            // We want the null terminator in the span
-            builder.Length = (int)result + 1;
+            builder.Length = (int)result;
         }
 
         // Returns a unique temporary file name, and creates a 0-byte file by that
@@ -179,10 +178,9 @@ namespace System.IO
             if (result == 0)
                 throw Win32Marshal.GetExceptionForLastWin32Error();
 
-            // We want the null terminator when we call normalize
-            builder.Length = (int)result + 1;
+            builder.Length = (int)result;
 
-            string path = PathHelper.Normalize(builder.AsSpan());
+            string path = PathHelper.Normalize(ref builder);
             builder.Dispose();
             return path;
         }

--- a/src/mscorlib/shared/System/IO/Path.Windows.cs
+++ b/src/mscorlib/shared/System/IO/Path.Windows.cs
@@ -129,7 +129,7 @@ namespace System.IO
         public static string GetTempPath()
         {
             Span<char> initialBuffer = stackalloc char[PathInternal.MaxShortPath];
-            ValueStringBuilder builder = new ValueStringBuilder(initialBuffer);
+            var builder = new ValueStringBuilder(initialBuffer);
 
             GetTempPath(ref builder);
 
@@ -163,7 +163,7 @@ namespace System.IO
             GetTempPath(ref tempPathBuilder);
 
             Span<char> initialBuffer = stackalloc char[PathInternal.MaxShortPath];
-            ValueStringBuilder builder = new ValueStringBuilder(initialBuffer);
+            var builder = new ValueStringBuilder(initialBuffer);
 
             uint result = 0;
             while ((result = Interop.Kernel32.GetTempFileNameW(

--- a/src/mscorlib/shared/System/IO/Path.Windows.cs
+++ b/src/mscorlib/shared/System/IO/Path.Windows.cs
@@ -150,7 +150,8 @@ namespace System.IO
             if (result == 0)
                 throw Win32Marshal.GetExceptionForLastWin32Error();
 
-            builder.Length = (int)result;
+            // We want the null terminator in the span
+            builder.Length = (int)result + 1;
         }
 
         // Returns a unique temporary file name, and creates a 0-byte file by that
@@ -178,7 +179,9 @@ namespace System.IO
             if (result == 0)
                 throw Win32Marshal.GetExceptionForLastWin32Error();
 
-            builder.Length = (int)result;
+            // We want the null terminator when we call normalize
+            builder.Length = (int)result + 1;
+
             string path = PathHelper.Normalize(builder.AsSpan());
             builder.Dispose();
             return path;

--- a/src/mscorlib/shared/System/IO/PathHelper.Windows.cs
+++ b/src/mscorlib/shared/System/IO/PathHelper.Windows.cs
@@ -146,7 +146,7 @@ namespace System.IO
             bool isDevice = PathInternal.IsDevice(outputBuilder.AsSpan());
 
             // As this is a corner case we're not going to add a stackalloc here to keep the stack pressure down.
-            ValueStringBuilder inputBuilder = new ValueStringBuilder();
+            var inputBuilder = new ValueStringBuilder();
 
             bool isDosUnc = false;
             int rootDifference = 0;

--- a/src/mscorlib/shared/System/IO/PathHelper.Windows.cs
+++ b/src/mscorlib/shared/System/IO/PathHelper.Windows.cs
@@ -29,7 +29,7 @@ namespace System.IO
             ValueStringBuilder builder = new ValueStringBuilder(initialBuffer);
 
             // Get the full path
-            GetFullPathName(path, ref builder);
+            GetFullPathName(path.AsSpanWithTerminator(), ref builder);
 
             // If we have the exact same string we were passed in, don't allocate another string.
             // TryExpandShortName does this input identity check.
@@ -61,6 +61,8 @@ namespace System.IO
 
         internal static void GetFullPathName(ReadOnlySpan<char> path, ref ValueStringBuilder builder)
         {
+            Debug.Assert(path.Length > 0 && path.Contains('\0'));
+
             // If the string starts with an extended prefix we would need to remove it from the path before we call GetFullPathName as
             // it doesn't root extended paths correctly. We don't currently resolve extended paths, so we'll just assert here.
             Debug.Assert(PathInternal.IsPartiallyQualified(path) || !PathInternal.IsExtended(path));
@@ -237,7 +239,7 @@ namespace System.IO
             // Strip out any added characters at the front of the string
             ReadOnlySpan<char> output = builderToUse.AsSpan(rootDifference);
 
-            string returnValue = !string.IsNullOrEmpty(originalPath) && output.EqualsOrdinal(originalPath.AsSpan())
+            string returnValue = ((originalPath != null) && output.EqualsOrdinal(originalPath.AsSpan()))
                 ? originalPath : new string(output);
 
             inputBuilder.Dispose();

--- a/src/mscorlib/shared/System/IO/PathHelper.Windows.cs
+++ b/src/mscorlib/shared/System/IO/PathHelper.Windows.cs
@@ -33,9 +33,9 @@ namespace System.IO
 
             // If we have the exact same string we were passed in, don't allocate another string.
             // TryExpandShortName does this input identity check.
-            string result = builder.AsSpan().Contains('~')
+            string result = builder.AsSpan().IndexOf('~') >= 0
                 ? TryExpandShortFileName(ref builder, originalPath: path)
-                : builder.AsSpan().EqualsOrdinal(path.AsSpan()) ? path : builder.ToString();
+                : builder.AsSpan().Equals(path.AsSpan(), StringComparison.Ordinal) ? path : builder.ToString();
 
             // Clear the buffer
             builder.Dispose();

--- a/src/mscorlib/shared/System/IO/PathHelper.Windows.cs
+++ b/src/mscorlib/shared/System/IO/PathHelper.Windows.cs
@@ -242,7 +242,7 @@ namespace System.IO
             // Strip out any added characters at the front of the string
             ReadOnlySpan<char> output = builderToUse.AsSpan(rootDifference);
 
-            string returnValue = ((originalPath != null) && output.EqualsOrdinal(originalPath.AsSpan()))
+            string returnValue = ((originalPath != null) && output.Equals(originalPath.AsSpan(), StringComparison.Ordinal))
                 ? originalPath : new string(output);
 
             inputBuilder.Dispose();

--- a/src/mscorlib/shared/System/MemoryExtensions.Fast.cs
+++ b/src/mscorlib/shared/System/MemoryExtensions.Fast.cs
@@ -434,14 +434,6 @@ namespace System
             return new ReadOnlySpan<char>(ref text.GetRawStringData(), text.Length);
         }
 
-        internal static ReadOnlySpan<char> AsSpanWithTerminator(this string text)
-        {
-            if (text == null)
-                return default;
-
-            return new ReadOnlySpan<char>(ref text.GetRawStringData(), text.Length + 1);
-        }
-
         /// <summary>
         /// Creates a new readonly span over the portion of the target string.
         /// </summary>

--- a/src/mscorlib/shared/System/MemoryExtensions.Fast.cs
+++ b/src/mscorlib/shared/System/MemoryExtensions.Fast.cs
@@ -434,6 +434,14 @@ namespace System
             return new ReadOnlySpan<char>(ref text.GetRawStringData(), text.Length);
         }
 
+        internal static ReadOnlySpan<char> AsSpanWithTerminator(this string text)
+        {
+            if (text == null)
+                return default;
+
+            return new ReadOnlySpan<char>(ref text.GetRawStringData(), text.Length + 1);
+        }
+
         /// <summary>
         /// Creates a new readonly span over the portion of the target string.
         /// </summary>

--- a/src/mscorlib/shared/System/Text/ValueStringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/ValueStringBuilder.cs
@@ -40,7 +40,19 @@ namespace System.Text
                 Grow(capacity - _chars.Length);
         }
 
-        public ref char GetPinnableReference() => ref MemoryMarshal.GetReference(_chars);
+        /// <summary>
+        /// Get a pinnable reference to the builder.
+        /// </summary>
+        /// <param name="terminate">Ensures that the builder has a null char after <see cref="Length"/></param>
+        public ref char GetPinnableReference(bool terminate = false)
+        {
+            if (terminate)
+            {
+                EnsureCapacity(Length + 1);
+                _chars[Length] = '\0';
+            }
+            return ref MemoryMarshal.GetReference(_chars);
+        }
 
         public ref char this[int index]
         {
@@ -58,7 +70,20 @@ namespace System.Text
             return s;
         }
 
-        public ReadOnlySpan<char> AsSpan() => _chars.Slice(0, _pos);
+        /// <summary>
+        /// Returns a span around the contents of the builder.
+        /// </summary>
+        /// <param name="terminate">Ensures that the builder has a null char after <see cref="Length"/></param>
+        public ReadOnlySpan<char> AsSpan(bool terminate = false)
+        {
+            if (terminate)
+            {
+                EnsureCapacity(Length + 1);
+                _chars[Length] = '\0';
+            }
+            return _chars.Slice(0, _pos);
+        }
+
         public ReadOnlySpan<char> AsSpan(int start) => _chars.Slice(start, _pos - start);
         public ReadOnlySpan<char> AsSpan(int start, int length) => _chars.Slice(start, length);
 

--- a/src/mscorlib/shared/System/Text/ValueStringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/ValueStringBuilder.cs
@@ -74,7 +74,7 @@ namespace System.Text
         /// Returns a span around the contents of the builder.
         /// </summary>
         /// <param name="terminate">Ensures that the builder has a null char after <see cref="Length"/></param>
-        public ReadOnlySpan<char> AsSpan(bool terminate = false)
+        public ReadOnlySpan<char> AsSpan(bool terminate)
         {
             if (terminate)
             {
@@ -84,6 +84,7 @@ namespace System.Text
             return _chars.Slice(0, _pos);
         }
 
+        public ReadOnlySpan<char> AsSpan() => _chars.Slice(0, _pos);
         public ReadOnlySpan<char> AsSpan(int start) => _chars.Slice(start, _pos - start);
         public ReadOnlySpan<char> AsSpan(int start, int length) => _chars.Slice(start, length);
 


### PR DESCRIPTION
GetTempPath and GetTempFileName weren't updated to handle long paths.
Update to use API properly and stop using StringBuilder. Also tweak
Normalize to allow utilizing an existing Span as input.

cc: @jkotas, @danmosemsft, @Anipik, @pjanotti 