### PR TITLE
Plumb the Activity ID Through to EventListener

### DIFF
--- a/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
@@ -671,7 +671,7 @@ namespace System.Diagnostics.Tracing
                             if (m_Dispatchers != null)
                             {
                                 var eventData = (EventPayload)(eventTypes.typeInfos[0].GetData(data));
-                                WriteToAllListeners(eventName, ref descriptor, nameInfo.tags, pActivityId, eventData);
+                                WriteToAllListeners(eventName, ref descriptor, nameInfo.tags, pActivityId, pRelatedActivityId, eventData);
                             }
 
                         }
@@ -700,7 +700,7 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        private unsafe void WriteToAllListeners(string eventName, ref EventDescriptor eventDescriptor, EventTags tags, Guid* pActivityId, EventPayload payload)
+        private unsafe void WriteToAllListeners(string eventName, ref EventDescriptor eventDescriptor, EventTags tags, Guid* pActivityId, Guid* pChildActivityId, EventPayload payload)
         {
             EventWrittenEventArgs eventCallbackArgs = new EventWrittenEventArgs(this);
             eventCallbackArgs.EventName = eventName;
@@ -712,7 +712,9 @@ namespace System.Diagnostics.Tracing
             // Self described events do not have an id attached. We mark it internally with -1.
             eventCallbackArgs.EventId = -1;
             if (pActivityId != null)
-                eventCallbackArgs.RelatedActivityId = *pActivityId;
+                eventCallbackArgs.ActivityId = *pActivityId;
+            if (pChildActivityId != null)
+                eventCallbackArgs.RelatedActivityId = *pChildActivityId;
 
             if (payload != null)
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/23108.

EventWrittenEventArgs currently pulls the activity from a thread-local variable.  This results in EventListeners getting the wrong activity ID when the ID has changed as a result of the event currently being logged (a start or stop event).  ETW is unaffected because the activity ID and the related activity ID are both plumbed all the way down to ETW as part of writing the event.

This change plumbs the activity ID all the way into EventWrittenEventArgs to match the behavior.

NOTE: We explicitly do not plumb the activity ID when writing an EventSource error to an EventListener - this is consistent with the previous behavior where related activity ID is not plumbed in this case either.

I validated this change with this test case (I also tested without recursive activities, and got what I believe to be correct results where the previous activity was stopped and thus there was no related activity or nesting behavior): 

```
using System;
using System.Collections.ObjectModel;
using System.Linq;
using System.Diagnostics.Tracing;

namespace activitypaths
{
class MySource : EventSource
    {
        [Event(1, Message = "{0}")]
        public void Message(string arg) { WriteEvent(1, arg); }

        [Event(2, Message = "{0}", ActivityOptions = EventActivityOptions.Recursive)]
        public void MyActivityStart(string arg) { WriteEvent(2, arg); }

        [Event(3, Message = "{0}", ActivityOptions = EventActivityOptions.Recursive)]
        public void MyActivityStop(string arg) { WriteEvent(3, arg); }

        public static MySource Logger = new MySource();
    }

    class MyListener : EventListener
    {
        public const EventKeywords TasksFlowActivityIds = (EventKeywords)0x80;
        protected override void OnEventSourceCreated(EventSource eventSource)
        {
            if (eventSource.Name == "MySource")
            {
                EnableEvents(eventSource, EventLevel.Verbose);
                Console.WriteLine("*** In MyListener: turning on MySource");
            }
            else if (eventSource.Name == "System.Threading.Tasks.TplEventSource")
            {
                EnableEvents(eventSource, EventLevel.Verbose, TasksFlowActivityIds);
                Console.WriteLine("*** In MyListener: turning on Task library Activity Flow");
            }
        }
        protected override void OnEventWritten(EventWrittenEventArgs eventData)
        {
            // We expect the activity and relatedActities to be set properly, currently they are zero.  
            Console.WriteLine("MyListener: level {0}, message: {1} activity {2}  related {3}",
                eventData.Level, 
                eventData.Message != null ? string.Format(eventData.Message, eventData.Payload.ToArray()) : "", 
                eventData.ActivityId, eventData.RelatedActivityId);
        }
    }

    public class Program
    {
        public static void Main(string[] args)
        {
            MyListener listener = new MyListener();

            // Currently the activityIDs generated in the OnEventWritten EventListener callback are always 0.
            // They should be non-zero during the activity.   
            MySource.Logger.Message("Before Start");
            MySource.Logger.MyActivityStart("MYTask");
            MySource.Logger.MyActivityStart("MYTask1");
            MySource.Logger.Message("In task");
            MySource.Logger.MyActivityStop("MYTask1 stop");
            MySource.Logger.MyActivityStop("MYTask stop");
            MySource.Logger.Message("After task");
            Console.ReadKey();
        }
    }
}
```

Results when run are:

```
*** In MyListener: turning on MySource
MyListener: level Informational, message: Before Start activity 00000000-0000-0000-0000-000000000000  related 00000000-0000-0000-0000-000000000000
*** In MyListener: turning on Task library Activity Flow
MyListener: level Informational, message: MYTask activity 00000011-0000-0000-0000-0000caa49d59  related 00000000-0000-0000-0000-000000000000
MyListener: level Informational, message: MYTask1 activity 00001011-0000-0000-0000-0000ca949d59  related 00000011-0000-0000-0000-0000caa49d59
MyListener: level Informational, message: In task activity 00001011-0000-0000-0000-0000ca949d59  related 00000000-0000-0000-0000-000000000000
MyListener: level Informational, message: MYTask1 stop activity 00001011-0000-0000-0000-0000ca949d59  related 00000000-0000-0000-0000-000000000000
MyListener: level Informational, message: MYTask stop activity 00000011-0000-0000-0000-0000caa49d59  related 00000000-0000-0000-0000-000000000000
MyListener: level Informational, message: After task activity 00000000-0000-0000-0000-000000000000  related 00000000-0000-0000-0000-000000000000
```

cc: @karolz-ms