### PR TITLE
Fixes StringBuilder unbounded size growth in Clear() when we use a mix of Append and Insert

### DIFF
--- a/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
@@ -520,7 +520,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\Latin1Encoding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\NormalizationForm.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\StringBuilder.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Text\StringBuilder.Debug.cs" />
+    <Compile Condition="'$(Configuration)' == 'Debug'" Include="$(MSBuildThisFileDirectory)System\Text\StringBuilder.Debug.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\UnicodeEncoding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\UTF32Encoding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\UTF7Encoding.cs" />

--- a/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
@@ -520,7 +520,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\Latin1Encoding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\NormalizationForm.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\StringBuilder.cs" />
-    <Compile Condition="'$(Configuration)' == 'Debug'" Include="$(MSBuildThisFileDirectory)System\Text\StringBuilder.Debug.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Text\StringBuilder.Debug.cs" Condition="'$(Configuration)' == 'Debug'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\UnicodeEncoding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\UTF32Encoding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\UTF7Encoding.cs" />

--- a/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
@@ -520,6 +520,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\Latin1Encoding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\NormalizationForm.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\StringBuilder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Text\StringBuilder.Debug.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\UnicodeEncoding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\UTF32Encoding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\UTF7Encoding.cs" />

--- a/src/mscorlib/shared/System/Text/StringBuilder.Debug.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.Debug.cs
@@ -38,13 +38,11 @@ namespace System.Text
                 current = current.m_ChunkPrevious;
             }
             current = this;
-            int numChunksToShow = numChunks;
             for (int skipCount = numChunks - maxChunksToShow; skipCount > 0; skipCount--)
             {
                 current = current.m_ChunkPrevious;
-                numChunksToShow--;
             }
-            return (numChunksToShow, current);
+            return (maxChunksToShow < numChunks ? numChunks : maxChunksToShow, current);
         }
     }
 }

--- a/src/mscorlib/shared/System/Text/StringBuilder.Debug.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.Debug.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.Serialization;
+
+namespace System.Text
+{
+    public sealed partial class StringBuilder : ISerializable
+    {
+        private void ShowChunks(int maxChunksToShow = 10)
+        {
+            Debug.WriteLine('|' + string.Join('|', ShowChunksInOrder(maxChunksToShow)) + '|');
+        }
+
+        private IEnumerable<string> ShowChunksInOrder(int maxChunksToShow)
+        {
+            int numChunksToShow = 0;
+            StringBuilder lastChunk = null;
+            // Gets numChunksToShow. If numChunksToShow is larger than maxChunksToShow, then returns last chunk
+            GetNumChunksToShow(this, ref numChunksToShow, maxChunksToShow, ref lastChunk);
+            Span<string> chunkChars = new string[numChunksToShow];
+            var sb = lastChunk ?? this;
+
+            while (sb != null && maxChunksToShow > 0)
+            {
+                chunkChars[numChunksToShow - 1] = string.Create(sb.m_ChunkChars.Length, sb.m_ChunkChars, (Span<char> chars, char[] curChunksChars) =>
+                {
+                    for (int i = 0; i < curChunksChars.Length; i++)
+                    {
+                        chars[i] = curChunksChars[i];
+                    }
+                }).Replace('\0', '.');
+                sb = sb.m_ChunkPrevious;
+                numChunksToShow--;
+            }
+            return chunkChars.ToArray();
+        }
+        
+        private void GetNumChunksToShow(StringBuilder sb, ref int numToShow, int maxChunksToShow, ref StringBuilder lastChunk)
+        {
+            if (sb.m_ChunkPrevious != null)
+                GetNumChunksToShow(sb.m_ChunkPrevious, ref numToShow, maxChunksToShow, ref lastChunk);
+
+            if (numToShow < maxChunksToShow)
+            {
+                numToShow++;
+                if (numToShow == maxChunksToShow)
+                {
+                    lastChunk = sb;
+                }
+            }
+        }
+    }
+}

--- a/src/mscorlib/shared/System/Text/StringBuilder.Debug.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.Debug.cs
@@ -12,11 +12,6 @@ namespace System.Text
     {
         private void ShowChunks(int maxChunksToShow = 10)
         {
-            Debug.WriteLine('|' + string.Join('|', ShowChunksInOrder(maxChunksToShow)) + '|');
-        }
-
-        private IEnumerable<string> ShowChunksInOrder(int maxChunksToShow)
-        {
             int count = 0;
             StringBuilder head = this, current = this;
             while (current != null)
@@ -38,7 +33,7 @@ namespace System.Text
                 chunks[i - 1] = new string(current.m_ChunkChars).Replace('\0', '.');
                 current = current.m_ChunkPrevious;
             }
-            return chunks;
+            Debug.WriteLine('|' + string.Join('|', chunks) + '|');
         }
     }
 }

--- a/src/mscorlib/shared/System/Text/StringBuilder.Debug.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.Debug.cs
@@ -24,7 +24,7 @@ namespace System.Text
             Span<string> chunkChars = new string[numChunksToShow];
             var sb = lastChunk ?? this;
 
-            while (sb != null && maxChunksToShow > 0)
+            while (numChunksToShow > 0)
             {
                 chunkChars[numChunksToShow - 1] = string.Create(sb.m_ChunkChars.Length, sb.m_ChunkChars, (Span<char> chars, char[] curChunksChars) =>
                 {
@@ -32,6 +32,7 @@ namespace System.Text
                     {
                         chars[i] = curChunksChars[i];
                     }
+                    // Showing . for null chars
                 }).Replace('\0', '.');
                 sb = sb.m_ChunkPrevious;
                 numChunksToShow--;

--- a/src/mscorlib/shared/System/Text/StringBuilder.Debug.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.Debug.cs
@@ -17,32 +17,28 @@ namespace System.Text
 
         private IEnumerable<string> ShowChunksInOrder(int maxChunksToShow)
         {
-            (int count, StringBuilder head) chunksToShow = GetChunksToShow(maxChunksToShow);
-            string[] chunks = new string[chunksToShow.count];
-            StringBuilder current = chunksToShow.head;
-            for (int i = chunksToShow.count; i > 0; i--)
+            int count = 0;
+            StringBuilder head = this, current = this;
+            while (current != null)
+            {
+                if (count < maxChunksToShow)
+                {
+                    count++;
+                }
+                else
+                {
+                    head = head.m_ChunkPrevious;
+                }
+                current = current.m_ChunkPrevious;
+            }
+            current = head;
+            string[] chunks = new string[count];
+            for (int i = count; i > 0; i--)
             {
                 chunks[i - 1] = new string(current.m_ChunkChars).Replace('\0', '.');
                 current = current.m_ChunkPrevious;
             }
             return chunks;
-        }
-
-        private (int count, StringBuilder head) GetChunksToShow(int maxChunksToShow)
-        {
-            int numChunks = 0;
-            StringBuilder current = this;
-            while (current != null)
-            {
-                numChunks++;
-                current = current.m_ChunkPrevious;
-            }
-            current = this;
-            for (int skipCount = numChunks - maxChunksToShow; skipCount > 0; skipCount--)
-            {
-                current = current.m_ChunkPrevious;
-            }
-            return (maxChunksToShow < numChunks ? numChunks : maxChunksToShow, current);
         }
     }
 }

--- a/src/mscorlib/shared/System/Text/StringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.cs
@@ -270,6 +270,27 @@ namespace System.Text
             // Note: persist "m_currentThread" to be compatible with old versions
             info.AddValue(ThreadIDField, 0);
         }
+        
+        [System.Diagnostics.Conditional("DEBUG")]
+        private void DebugDump()
+        {
+            if (Length == 0)
+            {
+                return;
+            }
+            StringBuilder chunk = this;
+            // showing at most the last 10 chunks in this StringBuilder
+            const int maxChunksToPrint = 10;
+            var debugText = new StringBuilder();
+            for (int i = 0; chunk != null && i < maxChunksToPrint; i++)
+            {
+                debugText.Insert(0, "|" + new string(chunk.m_ChunkChars));
+                chunk = chunk.m_ChunkPrevious;
+            }
+            debugText.Append("|");
+
+            Debug.WriteLine(debugText.ToString().Replace("\0", "."));
+        }
 
         [System.Diagnostics.Conditional("DEBUG")]
         private void AssertInvariants()
@@ -436,6 +457,7 @@ namespace System.Text
 
         public StringBuilder Clear()
         {
+            Capacity = Math.Max(DefaultCapacity, Math.Min(Capacity, (int)(Length * 1.2)));
             this.Length = 0;
             return this;
         }

--- a/src/mscorlib/shared/System/Text/StringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.cs
@@ -270,27 +270,6 @@ namespace System.Text
             // Note: persist "m_currentThread" to be compatible with old versions
             info.AddValue(ThreadIDField, 0);
         }
-        
-        [System.Diagnostics.Conditional("DEBUG")]
-        private void DebugDump()
-        {
-            if (Length == 0)
-            {
-                return;
-            }
-            StringBuilder chunk = this;
-            // showing at most the last 10 chunks in this StringBuilder
-            const int maxChunksToPrint = 10;
-            var debugText = new StringBuilder();
-            for (int i = 0; chunk != null && i < maxChunksToPrint; i++)
-            {
-                debugText.Insert(0, "|" + new string(chunk.m_ChunkChars));
-                chunk = chunk.m_ChunkPrevious;
-            }
-            debugText.Append("|");
-
-            Debug.WriteLine(debugText.ToString().Replace("\0", "."));
-        }
 
         [System.Diagnostics.Conditional("DEBUG")]
         private void AssertInvariants()
@@ -457,6 +436,7 @@ namespace System.Text
 
         public StringBuilder Clear()
         {
+            // Retain enough storage to store the same size content, plus 20% buffer, to help avoid reallocating during repeated use
             Capacity = Math.Max(DefaultCapacity, Math.Min(Capacity, (int)(Length * 1.2)));
             this.Length = 0;
             return this;

--- a/src/mscorlib/shared/System/Text/StringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.cs
@@ -480,11 +480,11 @@ namespace System.Text
                     StringBuilder chunk = FindChunkForIndex(value);
                     if (chunk != this)
                     {
-                        // Avoid possible infinite capacity growth.  See https://github.com/dotnet/coreclr/pull/16926
-                        int capacityToPreserve = Math.Min(Capacity, Math.Max(Length * 6 / 5, m_ChunkChars.Length));
-                        
                         // We crossed a chunk boundary when reducing the Length. We must replace this middle-chunk with a new larger chunk,
                         // to ensure the original capacity is preserved.
+
+                        // Avoid possible infinite capacity growth.  See https://github.com/dotnet/coreclr/pull/16926
+                        int capacityToPreserve = Math.Min(Capacity, Math.Max(Length * 6 / 5, m_ChunkChars.Length));
                         int newLen = capacityToPreserve - chunk.m_ChunkOffset;
                         char[] newArray = new char[newLen];
 

--- a/src/mscorlib/shared/System/Text/StringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.cs
@@ -461,14 +461,11 @@ namespace System.Text
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), SR.ArgumentOutOfRange_SmallCapacity);
                 }
-#if DEBUG
-                int originalCapacity = Capacity;
-#endif
+
                 if (value == 0 && m_ChunkPrevious == null)
                 {
                     m_ChunkLength = 0;
                     m_ChunkOffset = 0;
-                    Debug.Assert(Capacity >= originalCapacity);
                     return;
                 }
 


### PR DESCRIPTION
Fixes dotnet/corefx#27625

Added tests in PR dotnet/corefx#28038

cc: @danmosemsft 
