### PR TITLE
Publish x86_arm/crossgen during Linux/arm build

### DIFF
--- a/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
@@ -155,7 +155,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm -e ROOTFS_DIR $(DockerCommonRunArgs) ./build.sh $(PB_BuildType) $(Architecture) skipnuget cross -skiprestore stripSymbols -OfficialBuildId=$(OfficialBuildId) -- /flp:\"v=diag\"",
+        "arguments": "run --rm -e ROOTFS_DIR=$(ROOTFS_DIR) -e CAC_ROOTFS_DIR=$(CAC_ROOTFS_DIR) $(DockerCommonRunArgs) ./build.sh $(PB_BuildType) $(Architecture) skipnuget cross $(CrossArchBuildArgs) -skiprestore stripSymbols -OfficialBuildId=$(OfficialBuildId) -- /flp:\"v=diag\"",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -175,7 +175,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs) ./build-packages.sh -BuildType=$(PB_BuildType) -BuildArch=$(Architecture) -- /p:OfficialBuildId=$(OfficialBuildId)",
+        "arguments": "run --rm $(DockerCommonRunArgs) ./build-packages.sh -BuildType=$(PB_BuildType) -BuildArch=$(Architecture) $(CrossArchBuildPackagesArgs) -- /p:OfficialBuildId=$(OfficialBuildId)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -479,6 +479,14 @@
     "Architecture": {
       "value": "arm"
     },
+    "CrossArchBuildArgs": {
+      "value": "",
+      "allowOverride": true
+    },
+    "CrossArchBuildPackagesArgs": {
+       "value": "",
+       "allowOverride": true
+    },
     "CommitToCheckout": {
       "value": "HEAD",
       "allowOverride": true
@@ -488,6 +496,10 @@
     },
     "ROOTFS_DIR": {
       "value": "/crossrootfs/$(Architecture)"
+    },
+    "CAC_ROOTFS_DIR": {
+      "value": "",
+      "allowOverride": true
     },
     "DockerVolumeName": {
       "value": "coreclr-cross-$(Build.BuildId)"

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -130,9 +130,13 @@
         {
           "Name": "DotNet-CoreClr-Trusted-Linux-Crossbuild",
           "Parameters": {
-            "DockerTag": "ubuntu-14.04-cross-0cd4667-20170319080304",
+            "DockerTag": "ubuntu-16.04-cross-e435274-20180317125354",
             "Architecture": "arm",
-            "Rid": "linux"
+            "Rid": "linux",
+            "CrossArchitecture": "x86",
+            "CrossArchBuildArgs": "crosscomponent",
+            "CrossArchBuildPackagesArgs": "-__DoCrossArchBuild=1",
+            "CAC_ROOTFS_DIR": "/crossrootfs/$(CrossArchitecture)"
           },
           "ReportingParameters": {
             "OperatingSystem": "Linux",

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -130,7 +130,7 @@
         {
           "Name": "DotNet-CoreClr-Trusted-Linux-Crossbuild",
           "Parameters": {
-            "DockerTag": "ubuntu-16.04-cross-e435274-20180317125354",
+            "DockerTag": "ubuntu-14.04-cross-e435274-20180317125300",
             "Architecture": "arm",
             "Rid": "linux",
             "CrossArchitecture": "x86",


### PR DESCRIPTION
This PR adds compiling and publishing of x86_arm/crossgen (so called, cross-crossgen) to Linux/arm official build

Merge **ONLY AFTER** dotnet/dotnet-buildtools-prereqs-docker#22 is resolved and official build images are updated
