### PR TITLE
Replace Agent.HomeDirectory with AgentToolsPath

### DIFF
--- a/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
+++ b/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
@@ -343,7 +343,7 @@
       "value": ""
     },
     "AgentToolsPath": {
-      "value": "$(Agent.HomeDirectory)\\AgentTools\\"
+      "value": "$(AgentToolsPath)"
     },
   },
   "retentionRules": [

--- a/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
+++ b/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
@@ -341,10 +341,7 @@
     },
     "CrossgenArg": {
       "value": ""
-    },
-    "AgentToolsPath": {
-      "value": "$(AgentToolsPath)"
-    },
+    }
   },
   "retentionRules": [
     {


### PR DESCRIPTION
Agent.HomeDirectory was pointed to E:\A which is nuked at times causing the files to go missing. Instead we've create a User Capability in the agents which points to c:\tools\AgentTools