### PR TITLE
Fix test for GC.GetAllocatedBytesForCurrentThread to be more lenient with the accuracy

### DIFF
--- a/tests/src/GC/API/GC/GetAllocatedBytesForCurrentThread.cs
+++ b/tests/src/GC/API/GC/GetAllocatedBytesForCurrentThread.cs
@@ -89,7 +89,7 @@ public class Test
 
             nBytesAfter = (long)method.Invoke(null, null);
 
-            if (((nBytesBefore + 16) != nBytesAfter) && ((nBytesBefore + 24) != nBytesAfter))
+            if (nBytesAfter == nBytesBefore)  // Shouldn't be the same 
             {
                 int countAfter = GC.CollectionCount(0);
                 Console.WriteLine("b: {0}, a: {1}, iter {2}, {3}->{4}", nBytesBefore, nBytesAfter, i, countBefore, countAfter);


### PR DESCRIPTION
Fixes #16950