### PR TITLE
[Arm64/Ubuntu] Enable official builds

### DIFF
--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -141,6 +141,21 @@
             "Architecture": "arm",
             "PB_BuildType": null
           }
+        },
+        {
+          "Name": "DotNet-CoreClr-Trusted-Linux-Crossbuild",
+          "Parameters": {
+            "DockerTag": "ubuntu-16.04-cross-arm64-a3ae44b-20180315221921",
+            "Architecture": "arm64",
+            "Rid": "linux"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Linux",
+            "SubType": "PortableCrossBuild",
+            "Type": "build/product/",
+            "Architecture": "arm64",
+            "PB_BuildType": null
+          }
         }
       ]
     }


### PR DESCRIPTION
The `ubuntu-16.04-cross-arm64-a3ae44b-20180315221921` image looks good
I have built coreclr inside the container 
```
ROOTFS_DIR=/crossrootfs/arm64/ ./build.sh checked clang3.9 cross arm64
```

I think we can try to reenable this now.

@mmitche @janvorli PTAL

Fixes #16900