### PR TITLE
Change csharp_indent_labels from flush_left to one_less_than_current

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -29,7 +29,7 @@ csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
-csharp_indent_labels = flush_left
+csharp_indent_labels = one_less_than_current
 
 # avoid this. unless absolutely necessary
 dotnet_style_qualification_for_field = false:suggestion


### PR DESCRIPTION
Most of the places where we use goto and labels (that I have come across) use one_less_than_current formatting pattern.

Related corefx PR https://github.com/dotnet/corefx/pull/28121

cc @jkotas, @danmosemsft, @cod7alex, @karelz, @tannergooding, @stephentoub, @RussKeldorph 