### PR TITLE
Prevent concurrent use corruption from causing infinite loops

### DIFF
--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -2539,6 +2539,9 @@
   <data name="InvalidOperation_CollectionCorrupted" xml:space="preserve">
     <value>A prior operation on this collection was interrupted by an exception. Collection's state is no longer trusted.</value>
   </data>
+  <data name="InvalidOperation_ConcurrentOperationsNotSupported" xml:space="preserve">
+    <value>Concurrent operations are not supported on non-concurrent collections. A concurrent operation was performed on this collection and corrupted its state. Collection's state is no longer correct.</value>
+  </data>
   <data name="InvalidOperation_ConstructorNotAllowedOnInterface" xml:space="preserve">
     <value>Interface cannot have constructors.</value>
   </data>

--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -2540,7 +2540,7 @@
     <value>A prior operation on this collection was interrupted by an exception. Collection's state is no longer trusted.</value>
   </data>
   <data name="InvalidOperation_ConcurrentOperationsNotSupported" xml:space="preserve">
-    <value>Concurrent operations are not supported on non-concurrent collections. A concurrent operation was performed on this collection and corrupted its state. Collection's state is no longer correct.</value>
+    <value>Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.</value>
   </data>
   <data name="InvalidOperation_ConstructorNotAllowedOnInterface" xml:space="preserve">
     <value>Interface cannot have constructors.</value>

--- a/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
@@ -364,7 +364,7 @@ namespace System.Collections.Generic
             int i = -1;
             int[] buckets = _buckets;
             Entry[] entries = _entries;
-            int loops = 0;
+            int collisionCount = 0;
             if (buckets != null)
             {
                 IEqualityComparer<TKey> comparer = _comparer;
@@ -383,13 +383,13 @@ namespace System.Collections.Generic
                         }
 
                         i = entries[i].next;
-                        if (loops >= entries.Length)
+                        if (collisionCount >= entries.Length)
                         {
-                            // The chain of entires forms a loop; which means a concurrent update has happened.
-                            // Break out of the loop and throw; rather than looping forever.
+                            // The chain of entries forms a loop; which means a concurrent update has happened.
+                            // Break out of the loop and throw, rather than looping forever.
                             ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
                         }
-                        loops++;
+                        collisionCount++;
                     } while (true);
                 }
                 else
@@ -408,13 +408,13 @@ namespace System.Collections.Generic
                         }
 
                         i = entries[i].next;
-                        if (loops >= entries.Length)
+                        if (collisionCount >= entries.Length)
                         {
-                            // The chain of entires forms a loop; which means a concurrent update has happened.
-                            // Break out of the loop and throw; rather than looping forever.
+                            // The chain of entries forms a loop; which means a concurrent update has happened.
+                            // Break out of the loop and throw, rather than looping forever.
                             ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
                         }
-                        loops++;
+                        collisionCount++;
                     } while (true);
                 }
             }
@@ -486,8 +486,8 @@ namespace System.Collections.Generic
                     i = entries[i].next;
                     if (collisionCount >= entries.Length)
                     {
-                        // The chain of entires forms a loop; which means a concurrent update has happened.
-                        // Break out of the loop and throw; rather than looping forever.
+                        // The chain of entries forms a loop; which means a concurrent update has happened.
+                        // Break out of the loop and throw, rather than looping forever.
                         ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
                     }
                     collisionCount++;
@@ -524,8 +524,8 @@ namespace System.Collections.Generic
                     i = entries[i].next;
                     if (collisionCount >= entries.Length)
                     {
-                        // The chain of entires forms a loop; which means a concurrent update has happened.
-                        // Break out of the loop and throw; rather than looping forever.
+                        // The chain of entries forms a loop; which means a concurrent update has happened.
+                        // Break out of the loop and throw, rather than looping forever.
                         ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
                     }
                     collisionCount++;

--- a/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
@@ -364,6 +364,7 @@ namespace System.Collections.Generic
             int i = -1;
             int[] buckets = _buckets;
             Entry[] entries = _entries;
+            int loops = 0;
             if (buckets != null)
             {
                 IEqualityComparer<TKey> comparer = _comparer;
@@ -382,6 +383,13 @@ namespace System.Collections.Generic
                         }
 
                         i = entries[i].next;
+                        if (loops >= entries.Length)
+                        {
+                            // The chain of entires forms a loop; which means a concurrent update has happened.
+                            // Break out of the loop and throw; rather than looping forever.
+                            ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                        }
+                        loops++;
                     } while (true);
                 }
                 else
@@ -400,6 +408,13 @@ namespace System.Collections.Generic
                         }
 
                         i = entries[i].next;
+                        if (loops >= entries.Length)
+                        {
+                            // The chain of entires forms a loop; which means a concurrent update has happened.
+                            // Break out of the loop and throw; rather than looping forever.
+                            ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                        }
+                        loops++;
                     } while (true);
                 }
             }
@@ -469,6 +484,12 @@ namespace System.Collections.Generic
                     }
 
                     i = entries[i].next;
+                    if (collisionCount >= entries.Length)
+                    {
+                        // The chain of entires forms a loop; which means a concurrent update has happened.
+                        // Break out of the loop and throw; rather than looping forever.
+                        ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                    }
                     collisionCount++;
                 } while (true);
             }
@@ -501,6 +522,12 @@ namespace System.Collections.Generic
                     }
 
                     i = entries[i].next;
+                    if (collisionCount >= entries.Length)
+                    {
+                        // The chain of entires forms a loop; which means a concurrent update has happened.
+                        // Break out of the loop and throw; rather than looping forever.
+                        ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                    }
                     collisionCount++;
                 } while (true);
 

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -284,6 +284,11 @@ namespace System
             throw GetInvalidOperationException(ExceptionResource.InvalidOperation_NoValue);
         }
 
+        internal static void ThrowInvalidOperationException_ConcurrentOperationsNotSupported()
+        {
+            throw GetInvalidOperationException(ExceptionResource.InvalidOperation_ConcurrentOperationsNotSupported);
+        }
+
         internal static void ThrowArraySegmentCtorValidationFailedExceptions(Array array, int offset, int count)
         {
             throw GetArraySegmentCtorValidationFailedException(array, offset, count);
@@ -591,6 +596,7 @@ namespace System
         AsyncMethodBuilder_InstanceNotInitialized,
         ArgumentNull_SafeHandle,
         NotSupported_StringComparison,
+        InvalidOperation_ConcurrentOperationsNotSupported,
     }
 }
 


### PR DESCRIPTION
For `Dictionary`

Resolves: https://github.com/dotnet/corefx/issues/28123

/cc @vancem @jkotas @danmosemsft @stephentoub 