### PR TITLE
Fix BuildConfiguration casing so publishing works

### DIFF
--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -585,7 +585,7 @@
       "allowOverride": true
     },
     "BuildConfiguration": {
-      "value": "release"
+      "value": "Release"
     },
     "BuildPlatform": {
       "value": "any cpu"


### PR DESCRIPTION
Tough to be sure this is a real fix.  My private official build run got past the point of failure, though that could have been luck since it wasn't 100% repro.  Ultimately, the build failed due to dotnet/core-eng#2923, but I think it would have succeeded had it not been for that.

Fixes #16990 