### PR TITLE
Fix strings from being concatenated

### DIFF
--- a/src/coreclr/hosts/corerun/corerun.cpp
+++ b/src/coreclr/hosts/corerun/corerun.cpp
@@ -264,7 +264,7 @@ public:
                         W("*.dll"),
                         W("*.ni.exe"),
                         W("*.exe"),
-                        W("*.ni.winmd")
+                        W("*.ni.winmd"),
                         W("*.winmd")
                         };
 


### PR DESCRIPTION
Added a comma to prevent the compiler from concatenating the strings.