### PR TITLE
delete unused debug arg from genChangeLife and compChangeLife.

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -1082,17 +1082,13 @@ void Compiler::compUpdateLifeVar(GenTree* tree, VARSET_TP* pLastUseVars)
 template void Compiler::compUpdateLifeVar<false>(GenTree* tree, VARSET_TP* pLastUseVars);
 
 template <bool ForCodeGen>
-void Compiler::compChangeLife(VARSET_VALARG_TP newLife DEBUGARG(GenTree* tree))
+void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
 {
     LclVarDsc* varDsc;
 
 #ifdef DEBUG
     if (verbose)
     {
-        if (tree != nullptr)
-        {
-            Compiler::printTreeID(tree);
-        }
         printf("Change life %s ", VarSetOps::ToString(this, compCurLife));
         dumpConvertedVarSet(this, compCurLife);
         printf(" -> %s ", VarSetOps::ToString(this, newLife));
@@ -1163,7 +1159,7 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife DEBUGARG(GenTree* tree))
             {
                 codeGen->gcInfo.gcRegByrefSetCur &= ~regMask;
             }
-            codeGen->genUpdateRegLife(varDsc, false /*isBorn*/, true /*isDying*/ DEBUGARG(tree));
+            codeGen->genUpdateRegLife(varDsc, false /*isBorn*/, true /*isDying*/ DEBUGARG(nullptr));
         }
 #ifndef LEGACY_BACKEND
         // This isn't in a register, so update the gcVarPtrSetCur.
@@ -1197,7 +1193,7 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife DEBUGARG(GenTree* tree))
 #endif // DEBUG
             VarSetOps::RemoveElemD(this, codeGen->gcInfo.gcVarPtrSetCur, bornVarIndex);
 #endif // !LEGACY_BACKEND
-            codeGen->genUpdateRegLife(varDsc, true /*isBorn*/, false /*isDying*/ DEBUGARG(tree));
+            codeGen->genUpdateRegLife(varDsc, true /*isBorn*/, false /*isDying*/ DEBUGARG(nullptr));
             regMaskTP regMask = varDsc->lvRegMask();
             if (isGCRef)
             {
@@ -1222,7 +1218,7 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife DEBUGARG(GenTree* tree))
 }
 
 // Need an explicit instantiation.
-template void Compiler::compChangeLife<true>(VARSET_VALARG_TP newLife DEBUGARG(GenTree* tree));
+template void Compiler::compChangeLife<true>(VARSET_VALARG_TP newLife);
 
 #ifdef LEGACY_BACKEND
 

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -12971,7 +12971,7 @@ void CodeGen::genCodeForBBlist()
         gcInfo.gcMarkRegSetNpt(gcrefRegs | byrefRegs);
 
         if (!VarSetOps::Equal(compiler, compiler->compCurLife, block->bbLiveOut))
-            compiler->genChangeLife(block->bbLiveOut DEBUGARG(NULL));
+            compiler->genChangeLife(block->bbLiveOut);
 
         /* Both stacks should always be empty on exit from a basic block */
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7251,9 +7251,9 @@ public:
     template <bool ForCodeGen>
     void compChangeLife(VARSET_VALARG_TP newLife DEBUGARG(GenTree* tree));
 
-    void genChangeLife(VARSET_VALARG_TP newLife DEBUGARG(GenTree* tree))
+    void genChangeLife(VARSET_VALARG_TP newLife)
     {
-        compChangeLife</*ForCodeGen*/ true>(newLife DEBUGARG(tree));
+        compChangeLife</*ForCodeGen*/ true>(newLife DEBUGARG(nullptr));
     }
 
     template <bool ForCodeGen>

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7249,11 +7249,11 @@ public:
     GenTree*  compCurLifeTree; // node after which compCurLife has been computed
 
     template <bool ForCodeGen>
-    void compChangeLife(VARSET_VALARG_TP newLife DEBUGARG(GenTree* tree));
+    void compChangeLife(VARSET_VALARG_TP newLife);
 
     void genChangeLife(VARSET_VALARG_TP newLife)
     {
-        compChangeLife</*ForCodeGen*/ true>(newLife DEBUGARG(nullptr));
+        compChangeLife</*ForCodeGen*/ true>(newLife);
     }
 
     template <bool ForCodeGen>

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -3589,7 +3589,7 @@ inline void Compiler::compUpdateLife(VARSET_VALARG_TP newLife)
 {
     if (!VarSetOps::Equal(this, compCurLife, newLife))
     {
-        compChangeLife<ForCodeGen>(newLife DEBUGARG(nullptr));
+        compChangeLife<ForCodeGen>(newLife);
     }
 #ifdef DEBUG
     else


### PR DESCRIPTION
This argument was always nullptr.
Found during work on #16587.
It is just a small ref.

PTAL @dotnet/jit-contrib.