### PR TITLE
JIT: tolerate nonzero constant byrefs in impCheckForNullPointer

### DIFF
--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -4355,7 +4355,13 @@ inline GenTree* Compiler::impCheckForNullPointer(GenTree* obj)
     if (obj->gtOper == GT_CNS_INT)
     {
         assert(obj->gtType == TYP_REF || obj->gtType == TYP_BYREF);
-        assert(obj->gtIntCon.gtIconVal == 0);
+
+        // We can see non-zero byrefs for RVA statics.
+        if (obj->gtIntCon.gtIconVal != 0)
+        {
+            assert(obj->gtType == TYP_BYREF);
+            return obj;
+        }
 
         unsigned tmp = lvaGrabTemp(true DEBUGARG("CheckForNullPointer"));
 

--- a/tests/src/JIT/Directed/RVAInit/oddsize.ilproj
+++ b/tests/src/JIT/Directed/RVAInit/oddsize.ilproj
@@ -10,7 +10,6 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>


### PR DESCRIPTION
With the advent of #16966 we may now see constant nonzero byrefs from
things like RVA statics. Tolerate these in `impCheckForNullPointer`.

Note previously we'd type these as ints/longs and so bail out of
`impCheckForNullPointer` after the first check.

Closes #17008.