### PR TITLE
Use flat layout for GetAssemblyName

### DIFF
--- a/src/vm/assemblyname.cpp
+++ b/src/vm/assemblyname.cpp
@@ -56,6 +56,8 @@ FCIMPL1(Object*, AssemblyNameNative::GetFileInformation, StringObject* filenameU
     SString sFileName(gc.filename->GetBuffer());
     PEImageHolder pImage = PEImage::OpenImage(sFileName, MDInternalImport_NoCache);
 
+    PEImageLayoutHolder pLayout(pImage->GetLayout(PEImageLayout::LAYOUT_FLAT, PEImage::LAYOUT_CREATEIFNEEDED));
+
     // Allow AssemblyLoadContext.GetAssemblyName for native images on CoreCLR
     if (pImage->HasNTHeaders() && pImage->HasCorHeader() && pImage->HasNativeHeader())
         pImage->VerifyIsNIAssembly();


### PR DESCRIPTION
This change will result in the use of flat layouts for the temporary
layouts created by GetAssemblyName. This allows crossgen'd PE images
created for a different OS to be loaded in the code path that
retrieves the assembly name.

Fixes https://github.com/dotnet/coreclr/issues/13230.

@jkotas PTAL