### PR TITLE
Fix unloading of images mapped by PAL

### DIFF
--- a/src/vm/peimagelayout.cpp
+++ b/src/vm/peimagelayout.cpp
@@ -469,9 +469,9 @@ MappedImageLayout::MappedImageLayout(HANDLE hFile, PEImage* pOwner)
 #else //!FEATURE_PAL
 
 #ifndef CROSSGEN_COMPILE
-    m_FileView = PAL_LOADLoadPEFile(hFile);
+    m_LoadedFile = PAL_LOADLoadPEFile(hFile);
 
-    if (m_FileView == NULL)
+    if (m_LoadedFile == NULL)
     {
         // For CoreCLR, try to load all files via LoadLibrary first. If LoadLibrary did not work, retry using 
         // regular mapping - but not for native images.
@@ -481,10 +481,10 @@ MappedImageLayout::MappedImageLayout(HANDLE hFile, PEImage* pOwner)
     }
 
     LOG((LF_LOADER, LL_INFO1000, "PEImage: image %S (hFile %p) mapped @ %p\n",
-        (LPCWSTR) GetPath(), hFile, (void*)m_FileView));
+        (LPCWSTR) GetPath(), hFile, (void*)m_LoadedFile));
 
-    TESTHOOKCALL(ImageMapped(GetPath(),m_FileView,IM_IMAGEMAP));            
-    IfFailThrow(Init((void *) m_FileView));
+    TESTHOOKCALL(ImageMapped(GetPath(),m_LoadedFile,IM_IMAGEMAP));
+    IfFailThrow(Init((void *) m_LoadedFile));
 
     if (!HasCorHeader())
         ThrowHR(COR_E_BADIMAGEFORMAT);
@@ -500,7 +500,7 @@ MappedImageLayout::MappedImageLayout(HANDLE hFile, PEImage* pOwner)
     }
 
 #else // !CROSSGEN_COMPILE
-    m_FileView = NULL;
+    m_LoadedFile = NULL;
 #endif // !CROSSGEN_COMPILE
 
 #endif // !FEATURE_PAL

--- a/src/vm/peimagelayout.h
+++ b/src/vm/peimagelayout.h
@@ -120,8 +120,12 @@ class MappedImageLayout: public PEImageLayout
     VPTR_VTABLE_CLASS(MappedImageLayout,PEImageLayout)
     VPTR_UNIQUE(0x15)
 protected:
+#ifndef FEATURE_PAL
     HandleHolder m_FileMap;
     CLRMapViewHolder m_FileView;
+#else
+    PALPEFileHolder m_LoadedFile;
+#endif
 public:
 #ifndef DACCESS_COMPILE    
     MappedImageLayout(HANDLE hFile, PEImage* pOwner);    

--- a/src/vm/util.hpp
+++ b/src/vm/util.hpp
@@ -728,6 +728,13 @@ typedef Wrapper<void *, DoNothing, VoidCLRUnmapViewOfFile> CLRMapViewHolder;
 typedef Wrapper<void *, DoNothing, DoNothing> CLRMapViewHolder;
 #endif
 
+#ifndef DACCESS_COMPILE
+FORCEINLINE void VoidPALUnloadPEFile(void *ptr) { PAL_LOADUnloadPEFile(ptr); }
+typedef Wrapper<void *, DoNothing, VoidPALUnloadPEFile> PALPEFileHolder;
+#else
+typedef Wrapper<void *, DoNothing, DoNothing> PALPEFileHolder;
+#endif
+
 void GetProcessMemoryLoad(LPMEMORYSTATUSEX pMSEX);
 
 void ProcessEventForHost(EClrEvent event, void *data);

--- a/src/vm/util.hpp
+++ b/src/vm/util.hpp
@@ -728,12 +728,14 @@ typedef Wrapper<void *, DoNothing, VoidCLRUnmapViewOfFile> CLRMapViewHolder;
 typedef Wrapper<void *, DoNothing, DoNothing> CLRMapViewHolder;
 #endif
 
+#ifdef FEATURE_PAL
 #ifndef DACCESS_COMPILE
 FORCEINLINE void VoidPALUnloadPEFile(void *ptr) { PAL_LOADUnloadPEFile(ptr); }
 typedef Wrapper<void *, DoNothing, VoidPALUnloadPEFile> PALPEFileHolder;
 #else
 typedef Wrapper<void *, DoNothing, DoNothing> PALPEFileHolder;
 #endif
+#endif // FEATURE_PAL
 
 void GetProcessMemoryLoad(LPMEMORYSTATUSEX pMSEX);
 


### PR DESCRIPTION
The m_FileView member of MappedImageLayout is a CLRMapViewHolder,
which runs CLRUnmapViewOfFile on release. This is fine on
Windows, where the MappedImageLayout constructor calls
CLRMapViewOfFile. However, with FEATURE_PAL, the constructor calls
PAL_LOADLoadPEFile, which simulates LoadLibrary and records multiple
mapping entries. Each entry increases the refcount of the underlying
file handle PAL object. PAL_LOADUnloadPEFile should be called in this
case (instead of CLRUnmapViewOfFile), to decrease the refcount for
each mapping entry.

Fixes https://github.com/dotnet/coreclr/issues/15189.

@jkotas, @janvorli PTAL