### PR TITLE
Distinguish genUpdateLife and compUpdateLife for sets and trees.

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -998,7 +998,7 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
         emit->emitIns_S_R(ins, attr, data->gtRegNum, varNum, offset);
     }
 
-    genUpdateLife(tree);
+    genUpdateLifeTree(tree);
     varDsc->lvRegNum = REG_STK;
 }
 
@@ -1059,7 +1059,7 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
 
             emit->emitIns_S_R(ins, attr, dataReg, varNum, /* offset */ 0);
 
-            genUpdateLife(tree);
+            genUpdateLifeTree(tree);
 
             varDsc->lvRegNum = REG_STK;
         }

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -1679,7 +1679,7 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
 
     emit->emitIns_S_R(ins, attr, dataReg, varNum, offset);
 
-    genUpdateLife(tree);
+    genUpdateLifeTree(tree);
 
     varDsc->lvRegNum = REG_STK;
 }
@@ -1758,7 +1758,7 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
 
             emit->emitIns_S_R(ins, attr, dataReg, varNum, /* offset */ 0);
 
-            genUpdateLife(tree);
+            genUpdateLifeTree(tree);
 
             varDsc->lvRegNum = REG_STK;
         }

--- a/src/jit/codegenclassic.h
+++ b/src/jit/codegenclassic.h
@@ -243,7 +243,7 @@ void genCodeForTree_DONE(GenTree* tree, regNumber reg)
 {
     /* Check whether this subtree has freed up any variables */
 
-    genUpdateLife(tree);
+    genUpdateLifeTree(tree);
 
     genCodeForTree_DONE_LIFE(tree, reg);
 }

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -468,7 +468,7 @@ void CodeGen::genPrepForEHCodegen()
 
 void CodeGenInterface::genUpdateLifeTree(GenTree* tree)
 {
-    compiler->compUpdateLife</*ForCodeGen*/ true>(tree);
+    compiler->compUpdateLifeTree</*ForCodeGen*/ true>(tree);
 }
 
 void CodeGenInterface::genUpdateLifeVars(VARSET_VALARG_TP newLife)

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -466,7 +466,7 @@ void CodeGen::genPrepForEHCodegen()
 #endif        // FEATURE_EH_CALLFINALLY_THUNKS
 }
 
-void CodeGenInterface::genUpdateLife(GenTree* tree)
+void CodeGenInterface::genUpdateLifeTree(GenTree* tree)
 {
     compiler->compUpdateLife</*ForCodeGen*/ true>(tree);
 }
@@ -2048,13 +2048,13 @@ AGAIN:
                 // In case genMarkLclVar(op1) bashed it above and it is
                 // the last use of the variable.
 
-                genUpdateLife(op1);
+                genUpdateLifeTree(op1);
 
                 /* 'reg1' is trashable, so add "icon" into it */
 
                 genIncRegBy(reg1, cns, addr, addr->TypeGet());
 
-                genUpdateLife(addr);
+                genUpdateLifeTree(addr);
                 return true;
             }
         }

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -473,7 +473,7 @@ void CodeGenInterface::genUpdateLife(GenTree* tree)
 
 void CodeGenInterface::genUpdateLife(VARSET_VALARG_TP newLife)
 {
-    compiler->compUpdateLife</*ForCodeGen*/ true>(newLife);
+    compiler->compUpdateLifeVars</*ForCodeGen*/ true>(newLife);
 }
 
 #ifdef LEGACY_BACKEND
@@ -1082,7 +1082,7 @@ void Compiler::compUpdateLifeVar(GenTree* tree, VARSET_TP* pLastUseVars)
 template void Compiler::compUpdateLifeVar<false>(GenTree* tree, VARSET_TP* pLastUseVars);
 
 template <bool ForCodeGen>
-void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
+void Compiler::compChangeLifeVars(VARSET_VALARG_TP newLife)
 {
     LclVarDsc* varDsc;
 
@@ -1218,7 +1218,7 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
 }
 
 // Need an explicit instantiation.
-template void Compiler::compChangeLife<true>(VARSET_VALARG_TP newLife);
+template void Compiler::compChangeLifeVars<true>(VARSET_VALARG_TP newLife);
 
 #ifdef LEGACY_BACKEND
 

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -471,7 +471,7 @@ void CodeGenInterface::genUpdateLife(GenTree* tree)
     compiler->compUpdateLife</*ForCodeGen*/ true>(tree);
 }
 
-void CodeGenInterface::genUpdateLife(VARSET_VALARG_TP newLife)
+void CodeGenInterface::genUpdateLifeVars(VARSET_VALARG_TP newLife)
 {
     compiler->compUpdateLifeVars</*ForCodeGen*/ true>(newLife);
 }

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -144,7 +144,7 @@ protected:
     regMaskTP genGetRegMask(GenTree* tree);
 
     void genUpdateLife(GenTree* tree);
-    void genUpdateLife(VARSET_VALARG_TP newLife);
+    void genUpdateLifeVars(VARSET_VALARG_TP newLife);
 
 #ifdef LEGACY_BACKEND
     regMaskTP genLiveMask(GenTree* tree);

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -143,7 +143,7 @@ protected:
     regMaskTP genGetRegMask(const LclVarDsc* varDsc);
     regMaskTP genGetRegMask(GenTree* tree);
 
-    void genUpdateLife(GenTree* tree);
+    void genUpdateLifeTree(GenTree* tree);
     void genUpdateLifeVars(VARSET_VALARG_TP newLife);
 
 #ifdef LEGACY_BACKEND

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -731,7 +731,7 @@ REG_OK:
     {
         /* In case we're computing a value into a register variable */
 
-        genUpdateLife(tree);
+        genUpdateLifeTree(tree);
 
         /* Mark the register as 'used' */
 
@@ -1162,7 +1162,7 @@ void CodeGen::genComputeRegPair(
     {
         /* In case we're computing a value into a register variable */
 
-        genUpdateLife(tree);
+        genUpdateLifeTree(tree);
 
         /* Mark the register as 'used' */
 
@@ -1369,7 +1369,7 @@ bool CodeGen::genMakeIndAddrMode(GenTree*        addr,
 
         if ((addr->InReg()) || (addr->gtOper == GT_LCL_VAR && genMarkLclVar(addr)))
         {
-            genUpdateLife(addr);
+            genUpdateLifeTree(addr);
 
             rv1 = addr;
             rv2 = scaledIndex = 0;
@@ -1429,7 +1429,7 @@ bool CodeGen::genMakeIndAddrMode(GenTree*        addr,
         rv1         = addr;
         rv2         = NULL;
         scaledIndex = NULL;
-        genUpdateLife(addr);
+        genUpdateLifeTree(addr);
         goto YES;
     }
 
@@ -1549,13 +1549,13 @@ bool CodeGen::genMakeIndAddrMode(GenTree*        addr,
 
             if (rev)
             {
-                genUpdateLife(rv2);
-                genUpdateLife(rv1);
+                genUpdateLifeTree(rv2);
+                genUpdateLifeTree(rv1);
             }
             else
             {
-                genUpdateLife(rv1);
-                genUpdateLife(rv2);
+                genUpdateLifeTree(rv1);
+                genUpdateLifeTree(rv2);
             }
 
             goto DONE_REGS;
@@ -1568,7 +1568,7 @@ bool CodeGen::genMakeIndAddrMode(GenTree*        addr,
             /* rv1 is already materialized in a register. Just update liveness
                to rv1 and generate code for rv2 */
 
-            genUpdateLife(rv1);
+            genUpdateLifeTree(rv1);
             regSet.rsMarkRegUsed(rv1, oper);
         }
 
@@ -1585,7 +1585,7 @@ bool CodeGen::genMakeIndAddrMode(GenTree*        addr,
             /* rv2 is already materialized in a register. Update liveness
                to after rv2 and then hang on to rv2 */
 
-            genUpdateLife(rv2);
+            genUpdateLifeTree(rv2);
             regSet.rsMarkRegUsed(rv2, oper);
         }
 
@@ -1607,7 +1607,7 @@ bool CodeGen::genMakeIndAddrMode(GenTree*        addr,
             /* We have evaluated rv1, and now we just need to update liveness
                to rv2 which was already in a register */
 
-            genUpdateLife(rv2);
+            genUpdateLifeTree(rv2);
         }
 
         goto DONE_REGS;
@@ -1700,7 +1700,7 @@ bool CodeGen::genMakeIndAddrMode(GenTree*        addr,
                evaluated rv2, and rv1 was already in a register. Just
                update liveness to rv1 and we are done. */
 
-            genUpdateLife(rv1);
+            genUpdateLifeTree(rv1);
         }
         else
         {
@@ -2294,7 +2294,7 @@ regMaskTP CodeGen::genMakeAddressable(
 
     if (tree->InReg())
     {
-        genUpdateLife(tree);
+        genUpdateLifeTree(tree);
 
         goto GOT_VAL;
     }
@@ -2320,14 +2320,14 @@ regMaskTP CodeGen::genMakeAddressable(
             // to worry about it being enregistered.
             noway_assert(compiler->lvaTable[tree->gtLclFld.gtLclNum].lvRegister == 0);
 
-            genUpdateLife(tree);
+            genUpdateLifeTree(tree);
             return 0;
 
         case GT_LCL_VAR:
 
             if (!genMarkLclVar(tree))
             {
-                genUpdateLife(tree);
+                genUpdateLifeTree(tree);
                 return 0;
             }
 
@@ -2335,7 +2335,7 @@ regMaskTP CodeGen::genMakeAddressable(
 
         case GT_REG_VAR:
 
-            genUpdateLife(tree);
+            genUpdateLifeTree(tree);
 
             goto GOT_VAL;
 
@@ -2375,7 +2375,7 @@ regMaskTP CodeGen::genMakeAddressable(
             if (genMakeIndAddrMode(tree->gtOp.gtOp1, tree, false, /* not for LEA */
                                    needReg, keepReg, &regMask, deferOK))
             {
-                genUpdateLife(tree);
+                genUpdateLifeTree(tree);
                 return regMask;
             }
 
@@ -2815,7 +2815,7 @@ GenTree* CodeGen::genMakeAddrOrFPstk(GenTree* tree, regMaskTP* regMaskPtr, bool 
             if (genMakeIndAddrMode(tree->gtOp.gtOp1, tree, false, /* not for LEA */
                                    0, RegSet::FREE_REG, regMaskPtr, false))
             {
-                genUpdateLife(tree);
+                genUpdateLifeTree(tree);
                 return tree;
             }
 
@@ -3062,7 +3062,7 @@ AGAIN:
             FlatFPX87_Unload(&compCurFPState, tree->gtRegNum);
         }
 #endif
-        genUpdateLife(tree);
+        genUpdateLifeTree(tree);
         gcInfo.gcMarkRegPtrVal(tree);
         return;
     }
@@ -4224,7 +4224,7 @@ emitJumpKind CodeGen::genCondSetFlags(GenTree* cond)
                     if (jumpKind != EJ_NONE)
                     {
                         addrReg1 = RBM_NONE;
-                        genUpdateLife(op1);
+                        genUpdateLifeTree(op1);
                         goto DONE_FLAGS;
                     }
                 }
@@ -4563,7 +4563,7 @@ emitJumpKind CodeGen::genCondSetFlags(GenTree* cond)
     noway_assert(op1->InReg());
     op1Reg = op1->gtRegNum;
 
-    genUpdateLife(op1);
+    genUpdateLifeTree(op1);
 
     /* Mark the register as 'used' */
     regSet.rsMarkRegUsed(op1);
@@ -4648,7 +4648,7 @@ DONE:
 
 DONE_FLAGS: // We have determined what jumpKind to use
 
-    genUpdateLife(cond);
+    genUpdateLifeTree(cond);
 
     /* The condition value is dead at the jump that follows */
 
@@ -5916,7 +5916,7 @@ void CodeGen::genCodeForQmark(GenTree* tree, regMaskTP destReg, regMaskTP bestRe
 
         /* We're just about done */
 
-        genUpdateLife(tree);
+        genUpdateLifeTree(tree);
     }
     else
     {
@@ -6023,7 +6023,7 @@ void CodeGen::genCodeForQmark(GenTree* tree, regMaskTP destReg, regMaskTP bestRe
 
         /* Check whether this subtree has freed up any variables */
 
-        genUpdateLife(tree);
+        genUpdateLifeTree(tree);
 
         genMarkTreeInReg(tree, reg);
     }
@@ -6200,8 +6200,8 @@ bool CodeGen::genCodeForQmarkWithCMOV(GenTree* tree, regMaskTP destReg, regMaskT
     gcInfo.gcMarkRegPtrVal(reg, predicateNode->TypeGet());
     regTracker.rsTrackRegTrash(reg);
 
-    genUpdateLife(alwaysNode);
-    genUpdateLife(predicateNode);
+    genUpdateLifeTree(alwaysNode);
+    genUpdateLifeTree(predicateNode);
     genCodeForTree_DONE_LIFE(tree, reg);
     return true;
 #else
@@ -6272,7 +6272,7 @@ void CodeGen::genCodeForMultEAX(GenTree* tree)
 
     /* Free up the operand, if it's a regvar */
 
-    genUpdateLife(op2);
+    genUpdateLifeTree(op2);
 
     /* The register is about to be trashed */
 
@@ -6369,7 +6369,7 @@ void CodeGen::genCodeForMult64(GenTree* tree, regMaskTP destReg, regMaskTP bestR
     noway_assert(op1->InReg());
 
     /* Free up the operands */
-    genUpdateLife(tree);
+    genUpdateLifeTree(tree);
 
     genReleaseReg(op1);
     genReleaseReg(op2);
@@ -6424,7 +6424,7 @@ void CodeGen::genCodeForMult64(GenTree* tree, regMaskTP destReg, regMaskTP bestR
             regSet.rsUnlockReg(genRegMask(regHi));
     }
 
-    genUpdateLife(tree);
+    genUpdateLifeTree(tree);
 
     if (tree->gtFlags & GTF_MUL_64RSLT)
         genMarkTreeInRegPair(tree, gen2regs2pair(regLo, regHi));
@@ -6662,7 +6662,7 @@ void CodeGen::genCodeForTreeSmpBinArithLogOp(GenTree* tree, regMaskTP destReg, r
 
                 if (treeType == TYP_BYREF)
                 {
-                    genUpdateLife(tree);
+                    genUpdateLifeTree(tree);
 
                     gcInfo.gcMarkRegSetNpt(genRegMask(reg)); // in case "reg" was a TYP_GCREF before
                     gcInfo.gcMarkRegPtrVal(reg, TYP_BYREF);
@@ -6792,7 +6792,7 @@ void CodeGen::genCodeForTreeSmpBinArithLogOp(GenTree* tree, regMaskTP destReg, r
                 op1->gtRegNum = newReg;
             }
             noway_assert(op1->InReg());
-            genUpdateLife(op1);
+            genUpdateLifeTree(op1);
 
             /* Mark the register as 'used' */
             regSet.rsMarkRegUsed(op1);
@@ -6808,7 +6808,7 @@ void CodeGen::genCodeForTreeSmpBinArithLogOp(GenTree* tree, regMaskTP destReg, r
 #ifdef DEBUG
             /* Update the live set of register variables */
             if (compiler->opts.varNames)
-                genUpdateLife(tree);
+                genUpdateLifeTree(tree);
 #endif
 
             /* Now we can update the register pointer information */
@@ -6951,7 +6951,7 @@ void CodeGen::genCodeForTreeSmpBinArithLogOp(GenTree* tree, regMaskTP destReg, r
     noway_assert(op1->InReg());
     op1Reg = op1->gtRegNum;
 
-    genUpdateLife(op1);
+    genUpdateLifeTree(op1);
 
     /* Mark the register as 'used' */
     regSet.rsMarkRegUsed(op1);
@@ -7080,7 +7080,7 @@ void CodeGen::genCodeForTreeSmpBinArithLogOp(GenTree* tree, regMaskTP destReg, r
 
     /* Free up the operand, if it's a regvar */
 
-    genUpdateLife(op2);
+    genUpdateLifeTree(op2);
 
     /* The register is about to be trashed */
 
@@ -9919,7 +9919,7 @@ void CodeGen::genCodeForTreeSmpOp(GenTree* tree, regMaskTP destReg, regMaskTP be
 #ifdef DEBUG
             /* Update the live set of register variables */
             if (compiler->opts.varNames)
-                genUpdateLife(tree);
+                genUpdateLifeTree(tree);
 #endif
 
             /* Now we can update the register pointer information */
@@ -9945,7 +9945,7 @@ void CodeGen::genCodeForTreeSmpOp(GenTree* tree, regMaskTP destReg, regMaskTP be
 
                 genCondJump(op1);
 
-                genUpdateLife(tree);
+                genUpdateLifeTree(tree);
                 return;
             }
 
@@ -10103,15 +10103,15 @@ void CodeGen::genCodeForTreeSmpOp(GenTree* tree, regMaskTP destReg, regMaskTP be
                 if (tree->gtType == TYP_VOID)
                 {
                     genEvalSideEffects(op2);
-                    genUpdateLife(op2);
+                    genUpdateLifeTree(op2);
                     genEvalSideEffects(op1);
-                    genUpdateLife(tree);
+                    genUpdateLifeTree(tree);
                     return;
                 }
 
                 // Generate op2
                 genCodeForTree(op2, needReg);
-                genUpdateLife(op2);
+                genUpdateLifeTree(op2);
 
                 noway_assert(op2->InReg());
 
@@ -10128,7 +10128,7 @@ void CodeGen::genCodeForTreeSmpOp(GenTree* tree, regMaskTP destReg, regMaskTP be
                 // set gc info if we need so
                 gcInfo.gcMarkRegPtrVal(op2->gtRegNum, treeType);
 
-                genUpdateLife(tree);
+                genUpdateLifeTree(tree);
                 genCodeForTree_DONE(tree, op2->gtRegNum);
 
                 return;
@@ -10140,7 +10140,7 @@ void CodeGen::genCodeForTreeSmpOp(GenTree* tree, regMaskTP destReg, regMaskTP be
                 /* Generate side effects of the first operand */
 
                 genEvalSideEffects(op1);
-                genUpdateLife(op1);
+                genUpdateLifeTree(op1);
 
                 /* Is the value of the second operand used? */
 
@@ -10151,7 +10151,7 @@ void CodeGen::genCodeForTreeSmpOp(GenTree* tree, regMaskTP destReg, regMaskTP be
                        to TYP_VOID if op2 isn't meant to yield a result. */
 
                     genEvalSideEffects(op2);
-                    genUpdateLife(tree);
+                    genUpdateLifeTree(tree);
                     return;
                 }
 
@@ -10307,8 +10307,8 @@ void CodeGen::genCodeForTreeSmpOp(GenTree* tree, regMaskTP destReg, regMaskTP be
                 goto LockBinOpCommon;
             }
 
-            genFlagsEqualToNone(); // We didn't compute a result into a register.
-            genUpdateLife(tree);   // We didn't compute an operand into anything.
+            genFlagsEqualToNone();   // We didn't compute a result into a register.
+            genUpdateLifeTree(tree); // We didn't compute an operand into anything.
             return;
 
         case GT_XADD:
@@ -10359,7 +10359,7 @@ void CodeGen::genCodeForTreeSmpOp(GenTree* tree, regMaskTP destReg, regMaskTP be
                 if (genMakeIndAddrMode(location, tree, false, /* not for LEA */
                                        needReg, RegSet::KEEP_REG, &addrReg))
                 {
-                    genUpdateLife(location);
+                    genUpdateLifeTree(location);
 
                     reg = regSet.rsPickFreeReg();
                     genComputeReg(value, genRegMask(reg), RegSet::EXACT_REG, RegSet::KEEP_REG);
@@ -10418,7 +10418,7 @@ void CodeGen::genCodeForTreeSmpOp(GenTree* tree, regMaskTP destReg, regMaskTP be
                 // If the operator was add, then we were called from the GT_LOCKADD
                 // case.  In that case we don't use the result, so we don't need to
                 // update anything.
-                genUpdateLife(tree);
+                genUpdateLifeTree(tree);
             }
             else
             {
@@ -10883,7 +10883,7 @@ void CodeGen::genCodeForNumericCast(GenTree* tree, regMaskTP destReg, regMaskTP 
 
                     inst_RV_TT(INS_movsdsse2, REG_XMM0, op1, 0, EA_8BYTE);
                     genDoneAddressableStackFP(op1, addrRegInt, addrRegFlt, RegSet::KEEP_REG);
-                    genUpdateLife(op1);
+                    genUpdateLifeTree(op1);
 
                     reg = regSet.rsPickReg(needReg);
                     getEmitter()->emitIns_R_R(INS_cvttsd2si, EA_8BYTE, reg, REG_XMM0);
@@ -10939,7 +10939,7 @@ void CodeGen::genCodeForNumericCast(GenTree* tree, regMaskTP destReg, regMaskTP 
                     // the reg is now trashed
                     regTracker.rsTrackRegTrash(reg);
                     genDoneAddressableStackFP(op1, addrRegInt, addrRegFlt, RegSet::KEEP_REG);
-                    genUpdateLife(op1);
+                    genUpdateLifeTree(op1);
                     genCodeForTree_DONE(tree, reg);
                 }
             }
@@ -11597,7 +11597,7 @@ void CodeGen::genCodeForTreeSmpOpAsg(GenTree* tree)
             }
 
             /* Free up the RHS */
-            genUpdateLife(op2);
+            genUpdateLifeTree(op2);
 
             /* Remember that we've also touched the op2 register */
 
@@ -11880,7 +11880,7 @@ void CodeGen::genCodeForTreeSmpOpAsg(GenTree* tree)
 #ifdef DEBUG
                 /* Update the current liveness info */
                 if (compiler->opts.varNames)
-                    genUpdateLife(tree);
+                    genUpdateLifeTree(tree);
 #endif
 
                 // If op2 register is still in use, free it.  (Might not be in use, if
@@ -11997,7 +11997,7 @@ void CodeGen::genCodeForTreeSmpOpAsg(GenTree* tree)
 #ifdef DEBUG
                 /* Update the current liveness info */
                 if (compiler->opts.varNames)
-                    genUpdateLife(tree);
+                    genUpdateLifeTree(tree);
 #endif
 
                 // This is done in WriteBarrier when (regGC != 0)
@@ -12039,8 +12039,8 @@ void CodeGen::genCodeForTreeSmpOpAsg_DONE_ASSG(GenTree* tree, regMaskTP addrReg,
     noway_assert(op2);
 
     if (op1->gtOper == GT_LCL_VAR || op1->gtOper == GT_REG_VAR)
-        genUpdateLife(op1);
-    genUpdateLife(tree);
+        genUpdateLifeTree(op1);
+    genUpdateLifeTree(tree);
 
 #if REDUNDANT_LOAD
 
@@ -12112,7 +12112,7 @@ void CodeGen::genCodeForTreeSpecialOp(GenTree* tree, regMaskTP destReg, regMaskT
                 genMarkTreeInReg(tree, genRegNumFromMask(regs));
             }
 
-            genUpdateLife(tree);
+            genUpdateLifeTree(tree);
             return;
 
         case GT_FIELD:
@@ -12860,7 +12860,7 @@ void CodeGen::genCodeForBBlist()
                     // reported as alive even though not used within the caller for managed debugger sake.  So
                     // consider the return value of the method as used if generating debuggable code.
                     genCodeForCall(tree->AsCall(), compiler->opts.MinOpts() || compiler->opts.compDbgCode);
-                    genUpdateLife(tree);
+                    genUpdateLifeTree(tree);
                     gcInfo.gcMarkRegSetNpt(RBM_INTRET);
                     break;
 
@@ -13564,7 +13564,7 @@ void CodeGen::genCodeForTreeLng(GenTree* tree, regMaskTP needReg, regMaskTP avoi
                 if (op2->gtOper == GT_LCL_VAR && op1->gtOper == GT_LCL_VAR &&
                     op2->gtLclVarCommon.gtLclNum == op1->gtLclVarCommon.gtLclNum)
                 {
-                    genUpdateLife(op2);
+                    genUpdateLifeTree(op2);
                     goto LAsgExit;
                 }
 
@@ -13707,8 +13707,8 @@ void CodeGen::genCodeForTreeLng(GenTree* tree, regMaskTP needReg, regMaskTP avoi
 
             LAsgExit:
 
-                genUpdateLife(op1);
-                genUpdateLife(tree);
+                genUpdateLifeTree(op1);
+                genUpdateLifeTree(tree);
 
                 /* For non-debuggable code, every definition of a lcl-var has
                  * to be checked to see if we need to open a new scope for it.
@@ -14663,7 +14663,7 @@ void CodeGen::genCodeForTreeLng(GenTree* tree, regMaskTP needReg, regMaskTP avoi
                 }
 #endif
 
-                genUpdateLife(tree);
+                genUpdateLifeTree(tree);
                 genDoneAddressable(tree, addrReg, RegSet::FREE_REG);
             }
                 goto DONE;
@@ -14962,7 +14962,7 @@ void CodeGen::genCodeForTreeLng(GenTree* tree, regMaskTP needReg, regMaskTP avoi
                 {
                     // Generate op2
                     genCodeForTreeLng(op2, needReg, avoidReg);
-                    genUpdateLife(op2);
+                    genUpdateLifeTree(op2);
 
                     noway_assert(op2->InReg());
 
@@ -14976,7 +14976,7 @@ void CodeGen::genCodeForTreeLng(GenTree* tree, regMaskTP needReg, regMaskTP avoi
 
                     genReleaseRegPair(op2);
 
-                    genUpdateLife(tree);
+                    genUpdateLifeTree(tree);
 
                     regPair = op2->gtRegPair;
                 }
@@ -14987,7 +14987,7 @@ void CodeGen::genCodeForTreeLng(GenTree* tree, regMaskTP needReg, regMaskTP avoi
                     /* Generate side effects of the first operand */
 
                     genEvalSideEffects(op1);
-                    genUpdateLife(op1);
+                    genUpdateLifeTree(op1);
 
                     /* Is the value of the second operand used? */
 
@@ -14996,7 +14996,7 @@ void CodeGen::genCodeForTreeLng(GenTree* tree, regMaskTP needReg, regMaskTP avoi
                         /* The right operand produces no result */
 
                         genEvalSideEffects(op2);
-                        genUpdateLife(tree);
+                        genUpdateLifeTree(tree);
                         return;
                     }
 
@@ -15064,7 +15064,7 @@ void CodeGen::genCodeForTreeLng(GenTree* tree, regMaskTP needReg, regMaskTP avoi
 
 DONE:
 
-    genUpdateLife(tree);
+    genUpdateLifeTree(tree);
 
     /* Here we've computed the value of 'tree' into 'regPair' */
 
@@ -15885,13 +15885,13 @@ size_t CodeGen::genPushArgList(GenTreeCall* call)
                         {
                             GenTree* op1 = arg->gtOp.gtOp1;
                             genEvalSideEffects(op1);
-                            genUpdateLife(op1);
+                            genUpdateLifeTree(op1);
                             arg = arg->gtOp.gtOp2;
                         }
                         if (!arg->IsNothingNode())
                         {
                             genEvalSideEffects(arg);
-                            genUpdateLife(arg);
+                            genUpdateLifeTree(arg);
                         }
                     }
 
@@ -15914,7 +15914,7 @@ size_t CodeGen::genPushArgList(GenTreeCall* call)
                 {
                     GenTree* op1 = arg->gtOp.gtOp1;
                     genEvalSideEffects(op1);
-                    genUpdateLife(op1);
+                    genUpdateLifeTree(op1);
                     arg = arg->gtOp.gtOp2;
                 }
 
@@ -16297,7 +16297,7 @@ size_t CodeGen::genPushArgList(GenTreeCall* call)
                                     }
                                 }
                             }
-                            genUpdateLife(structLocalTree);
+                            genUpdateLifeTree(structLocalTree);
 
                             break;
                         }
@@ -16408,7 +16408,7 @@ size_t CodeGen::genPushArgList(GenTreeCall* call)
 
         /* Update the current set of live variables */
 
-        genUpdateLife(curr);
+        genUpdateLifeTree(curr);
 
         /* Update the current set of register pointers */
 
@@ -16746,7 +16746,7 @@ size_t CodeGen::genPushArgList(GenTreeCall* call)
                         GenTree* op1 = arg->gtOp.gtOp1;
 
                         genEvalSideEffects(op1);
-                        genUpdateLife(op1);
+                        genUpdateLifeTree(op1);
                     }
                 }
                 break;
@@ -16760,7 +16760,7 @@ size_t CodeGen::genPushArgList(GenTreeCall* call)
                 {
                     GenTree* op1 = arg->gtOp.gtOp1;
                     genEvalSideEffects(op1);
-                    genUpdateLife(op1);
+                    genUpdateLifeTree(op1);
                     arg = arg->gtOp.gtOp2;
                 }
                 noway_assert((arg->OperGet() == GT_OBJ) || (arg->OperGet() == GT_MKREFANY));
@@ -16916,7 +16916,7 @@ size_t CodeGen::genPushArgList(GenTreeCall* call)
                         regSet.rsMarkRegFree(genRegMask(regSrc));
                     }
                     if (structLocalTree != NULL)
-                        genUpdateLife(structLocalTree);
+                        genUpdateLifeTree(structLocalTree);
                 }
                 else
                 {
@@ -16935,7 +16935,7 @@ size_t CodeGen::genPushArgList(GenTreeCall* call)
 
         /* Update the current set of live variables */
 
-        genUpdateLife(curr);
+        genUpdateLifeTree(curr);
 
         // Now, if some copied field locals were enregistered, and they're now dead, update the set of
         // register holding gc pointers.
@@ -17575,7 +17575,7 @@ void CodeGen::SetupLateArgs(GenTreeCall* call)
             {
                 GenTree* op1 = arg->gtOp.gtOp1;
                 genEvalSideEffects(op1);
-                genUpdateLife(op1);
+                genUpdateLifeTree(op1);
                 arg = arg->gtOp.gtOp2;
             }
             noway_assert((arg->OperGet() == GT_OBJ) || (arg->OperGet() == GT_LCL_VAR) ||
@@ -17946,7 +17946,7 @@ void CodeGen::SetupLateArgs(GenTreeCall* call)
 
             // If we're doing struct promotion, the liveness of the promoted field vars may change after this use,
             // so update liveness.
-            genUpdateLife(arg);
+            genUpdateLifeTree(arg);
 
             // Now, if some copied field locals were enregistered, and they're now dead, update the set of
             // register holding gc pointers.

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -11406,7 +11406,7 @@ void CodeGen::genCodeForTreeSmpOpAsg(GenTree* tree)
 
                 if (rpCanAsgOperWithoutReg(op2, true))
                 {
-                    genUpdateLife(VarSetOps::RemoveElem(compiler, compiler->compCurLife, varDsc->lvVarIndex));
+                    genUpdateLifeVars(VarSetOps::RemoveElem(compiler, compiler->compCurLife, varDsc->lvVarIndex));
                     needReg = regSet.rsNarrowHint(needReg, genRegMask(op1Reg));
 #ifdef DEBUG
                     needToUpdateRegSetCheckLevel = true;
@@ -12607,7 +12607,7 @@ void CodeGen::genCodeForBBlist()
 #endif
         gcInfo.gcResetForBB();
 
-        genUpdateLife(liveSet); // This updates regSet.rsMaskVars with bits from any enregistered LclVars
+        genUpdateLifeVars(liveSet); // This updates regSet.rsMaskVars with bits from any enregistered LclVars
 #if FEATURE_STACK_FP_X87
         VarSetOps::IntersectionD(compiler, liveSet, compiler->optAllNonFPvars);
 #endif
@@ -13163,7 +13163,7 @@ void CodeGen::genCodeForBBlist()
     } //------------------ END-FOR each block of the method -------------------
 
     /* Nothing is live at this point */
-    genUpdateLife(VarSetOps::MakeEmpty(compiler));
+    genUpdateLifeVars(VarSetOps::MakeEmpty(compiler));
 
     /* Finalize the spill  tracking logic */
 
@@ -16056,7 +16056,7 @@ size_t CodeGen::genPushArgList(GenTreeCall* call)
                                             genSinglePush();
 
                                             // Prepare the set of vars to be cleared from gcref/gcbyref set
-                                            // in case they become dead after genUpdateLife.
+                                            // in case they become dead after genUpdateLifeVars.
                                             // genDoneAddressable() will remove dead gc vars by calling
                                             // gcInfo.gcMarkRegSetNpt.
                                             // Although it is not addrReg, we just borrow the name here.
@@ -16097,7 +16097,7 @@ size_t CodeGen::genPushArgList(GenTreeCall* call)
                                             genSinglePush();
 
                                             // Prepare the set of vars to be cleared from gcref/gcbyref set
-                                            // in case they become dead after genUpdateLife.
+                                            // in case they become dead after genUpdateLifeVars.
                                             // genDoneAddressable() will remove dead gc vars by calling
                                             // gcInfo.gcMarkRegSetNpt.
                                             // Although it is not addrReg, we just borrow the name here.

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -1186,7 +1186,7 @@ regNumber CodeGen::genConsumeReg(GenTree* tree)
     // interferes with one of the other sources (or the target, if it's a "delayed use" register)).
     // TODO-Cleanup: This is a special copyReg case in LSRA - consider eliminating these and
     // always using GT_COPY to make the lclVar location explicit.
-    // Note that we have to do this before calling genUpdateLife because otherwise if we spill it
+    // Note that we have to do this before calling genUpdateLifeTree because otherwise if we spill it
     // the lvRegNum will be set to REG_STK and we will lose track of what register currently holds
     // the lclVar (normally when a lclVar is spilled it is then used from its former register
     // location, which matches the gtRegNum on the node).
@@ -1204,8 +1204,8 @@ regNumber CodeGen::genConsumeReg(GenTree* tree)
 
     genUnspillRegIfNeeded(tree);
 
-    // genUpdateLife() will also spill local var if marked as GTF_SPILL by calling CodeGen::genSpillVar
-    genUpdateLife(tree);
+    // genUpdateLifeTree() will also spill local var if marked as GTF_SPILL by calling CodeGen::genSpillVar
+    genUpdateLifeTree(tree);
 
     assert(tree->gtHasReg());
 
@@ -1291,7 +1291,7 @@ void CodeGen::genConsumeRegs(GenTree* tree)
             noway_assert(tree->IsRegOptional() || !varDsc->lvLRACandidate);
 
             // Update the life of the lcl var.
-            genUpdateLife(tree);
+            genUpdateLifeTree(tree);
         }
 #endif // _TARGET_XARCH_
         else if (tree->OperIsInitVal())
@@ -1714,7 +1714,7 @@ void CodeGen::genProduceReg(GenTree* tree)
         }
     }
 
-    genUpdateLife(tree);
+    genUpdateLifeTree(tree);
 
     // If we've produced a register, mark it as a pointer, as needed.
     if (tree->gtHasReg())

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -155,10 +155,11 @@ void CodeGen::genCodeForBBlist()
 
         compiler->m_pLinearScan->recordVarLocationsAtStartOfBB(block);
 
-        genUpdateLife(block->bbLiveIn);
+        genUpdateLifeVars(block->bbLiveIn);
 
         // Even if liveness didn't change, we need to update the registers containing GC references.
-        // genUpdateLife will update the registers live due to liveness changes. But what about registers that didn't
+        // genUpdateLifeVars will update the registers live due to liveness changes. But what about registers that
+        // didn't
         // change? We cleared them out above. Maybe we should just not clear them out, but update the ones that change
         // here. That would require handling the changes in recordVarLocationsAtStartOfBB().
 
@@ -649,7 +650,7 @@ void CodeGen::genCodeForBBlist()
     } //------------------ END-FOR each block of the method -------------------
 
     /* Nothing is live at this point */
-    genUpdateLife(VarSetOps::MakeEmpty(compiler));
+    genUpdateLifeVars(VarSetOps::MakeEmpty(compiler));
 
     /* Finalize the spill  tracking logic */
 

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -4275,7 +4275,7 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
     genConsumeRegs(op1);
     getEmitter()->emitInsBinary(ins_Store(targetType), emitTypeSize(tree), tree, op1);
 
-    genUpdateLife(tree);
+    genUpdateLifeTree(tree);
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7257,7 +7257,7 @@ public:
     }
 
     template <bool ForCodeGen>
-    void compUpdateLife(GenTree* tree);
+    void compUpdateLifeTree(GenTree* tree);
 
     // Updates "compCurLife" to its state after evaluate of "true".  If "pLastUseVars" is
     // non-null, sets "*pLastUseVars" to the set of tracked variables for which "tree" was a last

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7249,11 +7249,11 @@ public:
     GenTree*  compCurLifeTree; // node after which compCurLife has been computed
 
     template <bool ForCodeGen>
-    void compChangeLife(VARSET_VALARG_TP newLife);
+    void compChangeLifeVars(VARSET_VALARG_TP newLife);
 
     void genChangeLife(VARSET_VALARG_TP newLife)
     {
-        compChangeLife</*ForCodeGen*/ true>(newLife);
+        compChangeLifeVars</*ForCodeGen*/ true>(newLife);
     }
 
     template <bool ForCodeGen>
@@ -7266,7 +7266,7 @@ public:
     void compUpdateLifeVar(GenTree* tree, VARSET_TP* pLastUseVars = nullptr);
 
     template <bool ForCodeGen>
-    inline void compUpdateLife(VARSET_VALARG_TP newLife);
+    inline void compUpdateLifeVars(VARSET_VALARG_TP newLife);
 
     // Gets a register mask that represent the kill set for a helper call since
     // not all JIT Helper calls follow the standard ABI on the target architecture.

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -3585,11 +3585,11 @@ inline void Compiler::compUpdateLife(GenTree* tree)
 }
 
 template <bool ForCodeGen>
-inline void Compiler::compUpdateLife(VARSET_VALARG_TP newLife)
+inline void Compiler::compUpdateLifeVars(VARSET_VALARG_TP newLife)
 {
     if (!VarSetOps::Equal(this, compCurLife, newLife))
     {
-        compChangeLife<ForCodeGen>(newLife);
+        compChangeLifeVars<ForCodeGen>(newLife);
     }
 #ifdef DEBUG
     else

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -3568,7 +3568,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
  */
 
 template <bool ForCodeGen>
-inline void Compiler::compUpdateLife(GenTree* tree)
+inline void Compiler::compUpdateLifeTree(GenTree* tree)
 {
     // TODO-Cleanup: We shouldn't really be calling this more than once
     if (tree == compCurLifeTree)

--- a/src/jit/copyprop.cpp
+++ b/src/jit/copyprop.cpp
@@ -327,7 +327,7 @@ void Compiler::optBlockCopyProp(BasicBlock* block, LclNumToGenTreePtrStack* curS
         // Walk the tree to find if any local variable can be replaced with current live definitions.
         for (GenTree* tree = stmt->gtStmt.gtStmtList; tree; tree = tree->gtNext)
         {
-            compUpdateLife</*ForCodeGen*/ false>(tree);
+            compUpdateLifeTree</*ForCodeGen*/ false>(tree);
 
             optCopyProp(block, stmt, tree, curSsaName);
 

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -2899,7 +2899,7 @@ void emitter::emitInsLoadInd(instruction ins, emitAttr attr, regNumber dstReg, G
     {
         GenTreeLclVarCommon* varNode = addr->AsLclVarCommon();
         emitIns_R_S(ins, attr, dstReg, varNode->GetLclNum(), 0);
-        codeGen->genUpdateLife(varNode);
+        codeGen->genUpdateLifeTree(varNode);
         return;
     }
 
@@ -2957,7 +2957,7 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
             assert(!data->isContained());
             emitIns_S_R(ins, attr, data->gtRegNum, varNode->GetLclNum(), 0);
         }
-        codeGen->genUpdateLife(varNode);
+        codeGen->genUpdateLifeTree(varNode);
         return;
     }
 
@@ -3015,7 +3015,7 @@ void emitter::emitInsStoreLcl(instruction ins, emitAttr attr, GenTreeLclVarCommo
         assert(!data->isContained());
         emitIns_S_R(ins, attr, data->gtRegNum, varNode->GetLclNum(), 0);
     }
-    codeGen->genUpdateLife(varNode);
+    codeGen->genUpdateLifeTree(varNode);
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/instr.cpp
+++ b/src/jit/instr.cpp
@@ -2652,7 +2652,7 @@ void CodeGen::inst_RV_TT_IV(instruction ins, regNumber reg, GenTree* tree, int v
     assert(ins == INS_imul);
     ins = getEmitter()->inst3opImulForReg(reg);
 
-    genUpdateLife(tree);
+    genUpdateLifeVars(tree);
     inst_TT_IV(ins, tree, val);
 #else
     NYI("inst_RV_TT_IV - unknown target");

--- a/src/jit/registerfp.cpp
+++ b/src/jit/registerfp.cpp
@@ -415,7 +415,7 @@ void CodeGen::genFloatAssign(GenTree* tree)
 
                     inst_RV_RV(ins_FloatConv(type, op2->TypeGet()), op1Reg, op2->gtRegNum, type);
                 }
-                genUpdateLife(op1);
+                genUpdateLifeTree(op1);
                 goto DONE_ASG;
             }
             break;
@@ -468,7 +468,7 @@ void CodeGen::genFloatAssign(GenTree* tree)
             noway_assert(op2->IsRegVar());
 
             op2reg = op2->gtRegVar.gtRegNum;
-            genUpdateLife(op2);
+            genUpdateLifeTree(op2);
 
             goto CHK_VOLAT_UNALIGN;
         default:
@@ -601,7 +601,7 @@ CHK_VOLAT_UNALIGN:
 
 DONE_ASG:
 
-    genUpdateLife(tree);
+    genUpdateLifeTree(tree);
 
     /* For non-debuggable code, every definition of a lcl-var has
      * to be checked to see if we need to open a new scope for it.
@@ -1108,7 +1108,7 @@ GenTree* CodeGen::genMakeAddressableFloat(GenTree*   tree,
 
             if (genMakeIndAddrMode(tree->gtOp.gtOp1, tree, false, RBM_ALLFLOAT, RegSet::KEEP_REG, regMaskIntPtr, false))
             {
-                genUpdateLife(tree);
+                genUpdateLifeTree(tree);
                 return tree;
             }
             else
@@ -1225,7 +1225,7 @@ void CodeGen::genCodeForTreeCastFromFloat(GenTree* tree, RegSet::RegisterPrefere
         }
     }
 
-    genUpdateLife(op1);
+    genUpdateLifeTree(op1);
     genCodeForTree_DONE(tree, dstReg);
 }
 

--- a/src/jit/stackfp.cpp
+++ b/src/jit/stackfp.cpp
@@ -1358,7 +1358,7 @@ void CodeGen::genCodeForTreeStackFP_Leaf(GenTree* tree)
             assert(!"unexpected leaf");
     }
 
-    genUpdateLife(tree);
+    genUpdateLifeTree(tree);
 }
 
 void CodeGen::genCodeForTreeStackFP_Asg(GenTree* tree)
@@ -1529,7 +1529,7 @@ void CodeGen::genCodeForTreeStackFP_Asg(GenTree* tree)
             }
 
             genDoneAddressableStackFP(op1, addrRegInt, addrRegFlt, RegSet::KEEP_REG);
-            genUpdateLife(op1);
+            genUpdateLifeTree(op1);
             return;
 
         default:
@@ -1584,7 +1584,7 @@ void CodeGen::genSetupForOpStackFP(
                 // read only and not dying, so just make addressable
                 op1 = genMakeAddressableStackFP(op1, &addrRegInt, &addrRegFlt);
                 genKeepAddressableStackFP(op1, &addrRegInt, &addrRegFlt);
-                genUpdateLife(op2);
+                genUpdateLifeTree(op2);
             }
             else
             {
@@ -1624,7 +1624,7 @@ void CodeGen::genSetupForOpStackFP(
             !genRegVarDiesInSubTree(op2, op1->gtRegVar.gtRegNum)) // regvar can't die in op2 either
         {
             // First update liveness for op1, since we're "evaluating" it here
-            genUpdateLife(op1);
+            genUpdateLifeTree(op1);
 
             op2 = genCodeForCommaTree(op2);
 
@@ -1718,8 +1718,8 @@ void CodeGen::genCodeForTreeStackFP_Arithm(GenTree* tree)
         // Do operation
         result = genArithmStackFP(oper, op2, op2->gtRegVar.gtRegNum, op1, REG_FPNONE, !bReverse);
 
-        genUpdateLife(op1);
-        genUpdateLife(op2);
+        genUpdateLifeTree(op1);
+        genUpdateLifeTree(op2);
     }
     else if (!op1->IsRegVar() &&                         // We don't do this for regvars, as we'll need a scratch reg
              ((tree->gtFlags & GTF_SIDE_EFFECT) == 0) && // No side effects
@@ -2328,7 +2328,7 @@ void CodeGen::genCodeForTreeStackFP_SmpOp(GenTree* tree)
             // If exponent was all 1's, we need to throw ArithExcep
             genJumpToThrowHlpBlk(EJ_je, SCK_ARITH_EXCPN);
 
-            genUpdateLife(tree);
+            genUpdateLifeTree(tree);
 
             genCodeForTreeStackFP_DONE(tree, op1->gtRegNum);
             break;
@@ -3296,7 +3296,7 @@ GenTree* CodeGen::genMakeAddressableStackFP(GenTree*   tree,
             {
                 assert(false);
             }
-            genUpdateLife(tree);
+            genUpdateLifeTree(tree);
             return tree;
 
         case GT_IND:
@@ -3304,7 +3304,7 @@ GenTree* CodeGen::genMakeAddressableStackFP(GenTree*   tree,
 
             if (genMakeIndAddrMode(tree->gtOp.gtOp1, tree, false, 0, RegSet::KEEP_REG, regMaskIntPtr, false))
             {
-                genUpdateLife(tree);
+                genUpdateLifeTree(tree);
                 return tree;
             }
             else
@@ -3356,7 +3356,7 @@ void CodeGen::genKeepAddressableStackFP(GenTree* tree, regMaskTP* regMaskIntPtr,
             {
                 genRegVarDeathStackFP(tree);
             }
-            genUpdateLife(tree);
+            genUpdateLifeTree(tree);
 
             return;
         case GT_CNS_DBL:
@@ -3373,7 +3373,7 @@ void CodeGen::genKeepAddressableStackFP(GenTree* tree, regMaskTP* regMaskIntPtr,
         case GT_LCL_FLD:
         case GT_LCL_VAR:
         case GT_CLS_VAR:
-            genUpdateLife(tree);
+            genUpdateLifeTree(tree);
             return;
         case GT_IND:
         case GT_LEA:


### PR DESCRIPTION
These functions are used under different `#ifdefs` and now it is easier to find all matching calls to each of them.

PR 2/3, the first is #17041.
