### PR TITLE
ARM: call compRsvdRegCheck later

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -5989,7 +5989,20 @@ void Compiler::lvaAssignVirtualFrameOffsetsToLocals()
                 unsigned fieldVarNum            = varDsc->lvFieldLclStart;
                 lvaTable[fieldVarNum].lvStkOffs = varDsc->lvStkOffs;
             }
-#endif
+#endif // _TARGET_ARM64_
+#ifdef _TARGET_ARM_
+            // If we have an incoming register argument that has a promoted long
+            // then we need to copy the lvStkOff (the stack home) from the reg arg to the field lclvar
+            //
+            if (varDsc->lvIsRegArg && varDsc->lvPromoted)
+            {
+                assert(varTypeIsLong(varDsc) && (varDsc->lvFieldCnt == 2));
+
+                unsigned fieldVarNum                = varDsc->lvFieldLclStart;
+                lvaTable[fieldVarNum].lvStkOffs     = varDsc->lvStkOffs;
+                lvaTable[fieldVarNum + 1].lvStkOffs = varDsc->lvStkOffs + 4;
+            }
+#endif // _TARGET_ARM_
         }
     }
 

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -824,19 +824,24 @@ LinearScan::RegMaskIndex LinearScan::GetIndexForRegMask(regMaskTP mask)
     return result;
 }
 
-// We've decided that we can't use a register during register allocation (probably FPBASE),
+// We've decided that we can't use one or more registers during register allocation (probably FPBASE),
 // but we've already added it to the register masks. Go through the masks and remove it.
-void LinearScan::RemoveRegisterFromMasks(regNumber reg)
+void LinearScan::RemoveRegistersFromMasks(regMaskTP removeMask)
 {
-    JITDUMP("Removing register %s from LSRA register masks\n", getRegName(reg));
+    if (VERBOSE)
+    {
+        JITDUMP("Removing registers from LSRA register masks: ");
+        dumpRegMask(removeMask);
+        JITDUMP("\n");
+    }
 
-    regMaskTP mask = ~genRegMask(reg);
+    regMaskTP mask = ~removeMask;
     for (int i = 0; i < nextFreeMask; i++)
     {
         regMaskTable[i] &= mask;
     }
 
-    JITDUMP("After removing register:\n");
+    JITDUMP("After removing registers:\n");
     DBEXEC(VERBOSE, dspRegisterMaskTable());
 }
 
@@ -2493,19 +2498,10 @@ void LinearScan::setFrameType()
     // used during lowering. Luckily, the TreeNodeInfo only stores an index to
     // the masks stored in the LinearScan class, so we only need to walk the
     // unique masks and remove FPBASE.
+    regMaskTP removeMask = RBM_NONE;
     if (frameType == FT_EBP_FRAME)
     {
-        if ((availableIntRegs & RBM_FPBASE) != 0)
-        {
-            RemoveRegisterFromMasks(REG_FPBASE);
-
-            // We know that we're already in "read mode" for availableIntRegs. However,
-            // we need to remove the FPBASE register, so subsequent users (like callers
-            // to allRegs()) get the right thing. The RemoveRegisterFromMasks() code
-            // fixes up everything that already took a dependency on the value that was
-            // previously read, so this completes the picture.
-            availableIntRegs.OverrideAssign(availableIntRegs & ~RBM_FPBASE);
-        }
+        removeMask |= RBM_FPBASE;
     }
 
     compiler->rpFrameType = frameType;
@@ -2518,8 +2514,20 @@ void LinearScan::setFrameType()
         compiler->codeGen->regSet.rsMaskResvd |= RBM_OPT_RSVD;
         assert(REG_OPT_RSVD != REG_FP);
         JITDUMP("  Reserved REG_OPT_RSVD (%s) due to large frame\n", getRegName(REG_OPT_RSVD));
+        removeMask |= RBM_OPT_RSVD;
     }
 #endif // _TARGET_ARMARCH_
+
+    if ((removeMask != RBM_NONE) && ((availableIntRegs & removeMask) != 0))
+    {
+        RemoveRegistersFromMasks(removeMask);
+        // We know that we're already in "read mode" for availableIntRegs. However,
+        // we need to remove these registers, so subsequent users (like callers
+        // to allRegs()) get the right thing. The RemoveRegistersFromMasks() code
+        // fixes up everything that already took a dependency on the value that was
+        // previously read, so this completes the picture.
+        availableIntRegs.OverrideAssign(availableIntRegs & ~removeMask);
+    }
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -831,7 +831,7 @@ void LinearScan::RemoveRegistersFromMasks(regMaskTP removeMask)
     if (VERBOSE)
     {
         JITDUMP("Removing registers from LSRA register masks: ");
-        dumpRegMask(removeMask);
+        INDEBUG(dumpRegMask(removeMask));
         JITDUMP("\n");
     }
 

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -1958,7 +1958,7 @@ void LinearScan::identifyCandidates()
     {
         // Frame layout is only pre-computed for ARM
         printf("\nlvaTable after IdentifyCandidates\n");
-        compiler->lvaTableDump();
+        compiler->lvaTableDump(Compiler::FrameLayoutState::PRE_REGALLOC_FRAME_LAYOUT);
     }
 #endif // DEBUG
 #endif // _TARGET_ARM_
@@ -2509,6 +2509,17 @@ void LinearScan::setFrameType()
     }
 
     compiler->rpFrameType = frameType;
+
+#ifdef _TARGET_ARMARCH_
+    // Determine whether we need to reserve a register for large lclVar offsets.
+    if (compiler->compRsvdRegCheck(Compiler::REGALLOC_FRAME_LAYOUT))
+    {
+        // We reserve R10/IP1 in this case to hold the offsets in load/store instructions
+        compiler->codeGen->regSet.rsMaskResvd |= RBM_OPT_RSVD;
+        assert(REG_OPT_RSVD != REG_FP);
+        JITDUMP("  Reserved REG_OPT_RSVD (%s) due to large frame\n", getRegName(REG_OPT_RSVD));
+    }
+#endif // _TARGET_ARMARCH_
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -695,7 +695,7 @@ public:
 
     RegMaskIndex GetIndexForRegMask(regMaskTP mask);
     regMaskTP GetRegMaskForIndex(RegMaskIndex index);
-    void RemoveRegisterFromMasks(regNumber reg);
+    void RemoveRegistersFromMasks(regMaskTP removeMask);
 
     static bool isSingleRegister(regMaskTP regMask)
     {

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_545504/DevDiv_545504.cs
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_545504/DevDiv_545504.cs
@@ -1,0 +1,116 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+// The bug captured by this test was an ARM failure where:
+// - We have a fairly large frame going into the backend, but still not enough to trigger]
+//   the need to reserve REG_OPT_RSVD.
+// - The backend (decomposition in particular) generates many new locals, making the
+//   frame large enough to require REG_OPT_RSVD.
+// - The bug was that the analysis was being done prior to decomposition and lowering,
+//   thus missing this case.
+// - The fix was to move this analysis just prior to actual register allocation.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public class DevDiv_545504
+{
+    public const int Pass = 100;
+    public const int Fail = -1;
+
+    struct Struct_64bytes
+    {
+        long m_l0;
+        long m_l1;
+        long m_l2;
+        long m_l3;
+        long m_l4;
+        long m_l5;
+        long m_l6;
+        long m_l7;
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public Struct_64bytes(long l)
+        {
+            m_l0 = l;
+            m_l1 = l + 1;
+            m_l2 = l + 2;
+            m_l3 = l + 3;
+            m_l4 = l + 4;
+            m_l5 = l + 5;
+            m_l6= l + 6;
+            m_l7= l + 7;
+        }
+
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public long Compute()
+        {
+            long result = ((m_l0 << (int)m_l1) >> (int)(m_l2 / 2)) +
+                          ((m_l3 << (int)m_l4) >> (int)(m_l5 / 2)) +
+                          m_l6 + m_l7;
+            return result;
+        }
+    }
+
+    struct Struct_512bytes
+    {
+        Struct_64bytes m_s0;
+        Struct_64bytes m_s1;
+        Struct_64bytes m_s2;
+        Struct_64bytes m_s3;
+        Struct_64bytes m_s4;
+        Struct_64bytes m_s5;
+        Struct_64bytes m_s6;
+        Struct_64bytes m_s7;
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public Struct_512bytes(long l)
+        {
+            m_s0 = new Struct_64bytes(l);
+            m_s1 = new Struct_64bytes(l + 1);
+            m_s2 = new Struct_64bytes(l + 2);
+            m_s3 = new Struct_64bytes(l + 3);
+            m_s4 = new Struct_64bytes(l + 4);
+            m_s5 = new Struct_64bytes(l + 5);
+            m_s6 = new Struct_64bytes(l + 6);
+            m_s7 = new Struct_64bytes(l + 7);
+        }
+
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        public long Compute()
+        {
+            long result = ((m_s0.Compute() << (int)m_s1.Compute()) >> (int)(m_s2.Compute() / 2)) +
+                          ((m_s3.Compute() << (int)m_s4.Compute()) >> (int)(m_s5.Compute() / 2)) +
+                          m_s6.Compute() + m_s7.Compute();
+            return result;
+        }
+    }
+
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    public static long test(int count)
+    {
+        Struct_512bytes s0 = new Struct_512bytes(0);
+        Struct_512bytes s1 = new Struct_512bytes(1);
+        Struct_512bytes s2 = new Struct_512bytes(2);
+        Struct_512bytes s3 = new Struct_512bytes(3);
+        Struct_512bytes s4 = new Struct_512bytes(4);
+        Struct_512bytes s5 = new Struct_512bytes(5);
+
+        long result = ((s0.Compute() << (int)s1.Compute()) >> (int)(s2.Compute() / 2)) +
+                      ((s3.Compute() << (int)s4.Compute()) >> (int)(s5.Compute() / 2));
+
+        Console.WriteLine("Result: " + result);
+        return result;
+    }
+    public static int Main()
+    {
+        int result = (int)test(10);
+        if (result != 267386880)
+        {
+            return Fail;
+        }
+        return Pass;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_545504/DevDiv_545504.csproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_545504/DevDiv_545504.csproj
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
For RyuJIT backend, the number of locals can change due to decomposition and lowering.
So, determine whether to reserve a register for accessing large state displacements just prior to register allocation.
This is a bit more difficult on LEGACY_BACKEND because the register allocator can change its mind about whether or not it's going to have a frame.