### PR TITLE
null terminate the converted LPStr at the right index

### DIFF
--- a/src/vm/olevariant.cpp
+++ b/src/vm/olevariant.cpp
@@ -2310,8 +2310,11 @@ void OleVariant::MarshalLPSTRRArrayComToOle(BASEARRAYREF *pComArray, void *oleAr
                 ThrowOutOfMemory();
 
             // Convert the unicode string to an ansi string.
-            InternalWideToAnsi(stringRef->GetBuffer(), Length, lpstr, allocLength, fBestFitMapping, fThrowOnUnmappableChar);
-            lpstr[Length] = 0;
+            int bytesWritten = InternalWideToAnsi(stringRef->GetBuffer(), Length, lpstr, allocLength, fBestFitMapping, fThrowOnUnmappableChar);
+            if (bytesWritten < allocLength)
+                lpstr[bytesWritten] = 0;
+            else
+                lpstr[allocLength] = 0;
         }
 
         *pOle++ = lpstr;

--- a/src/vm/olevariant.cpp
+++ b/src/vm/olevariant.cpp
@@ -2311,10 +2311,8 @@ void OleVariant::MarshalLPSTRRArrayComToOle(BASEARRAYREF *pComArray, void *oleAr
 
             // Convert the unicode string to an ansi string.
             int bytesWritten = InternalWideToAnsi(stringRef->GetBuffer(), Length, lpstr, allocLength, fBestFitMapping, fThrowOnUnmappableChar);
-            if (bytesWritten < allocLength)
-                lpstr[bytesWritten] = 0;
-            else
-                lpstr[allocLength] = 0;
+            _ASSERTE(bytesWritten >= 0 && bytesWritten < allocLength);
+            lpstr[bytesWritten] = 0;
         }
 
         *pOle++ = lpstr;


### PR DESCRIPTION
Marshalling for arrays of multi-byte character set strings as LPStr are truncated due to how the null terminator is written.  

Here is an example:
[DllImport("NativeDependency", CharSet = CharSet.Ansi)]
private static extern void ArrayOfStrings(int argc, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr)] string[] argv);
string[] argv = new string[]  { "今日は", "彼女は20今日は"};
ArrayOfStrings(argv.Length, argv);

Native implementation:
extern "C"
void __stdcall ArrayOfStrings(int argc, char** argv)
{
}

The following is provided to the native entry point:
0 今・(0x8da193)
1 彼女は20 (0x94de8f9782cd3230)

What is expected is:
0 今日は (0x8da193fa82cd)
1 彼女は20今日は (0x94de8f9782cd32308da193fa82cd)

The issue is that the null terminator is being placed at the point of the MBCS Unicode string length, not the resulting ansi string length.

Must be repro'd on a machine with a MBCS enabled (for instance Japanese 932).