### PR TITLE
Check apparent dead code

### DIFF
--- a/src/jit/lowerarmarch.cpp
+++ b/src/jit/lowerarmarch.cpp
@@ -79,13 +79,7 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode)
             case GT_LE:
             case GT_GE:
             case GT_GT:
-                if (childNode->IsIntegralConst(0))
-                {
-                    // TODO-ARM-Cleanup: not tested yet.
-                    NYI_ARM("ARM IsContainableImmed for floating point type");
-
-                    return true;
-                }
+                assert(!childNode->IsIntegralConst(0));
                 break;
         }
     }


### PR DESCRIPTION
This doesn't appear to do what it says it does.

GT_EQ/etc have TYP_INT, with op2 as float/double 0.0. The
existing code doesn't check for that.