### PR TITLE
Fix run-corefx-tests.py for Arm64 Linux cross build

### DIFF
--- a/tests/scripts/run-corefx-tests.py
+++ b/tests/scripts/run-corefx-tests.py
@@ -296,13 +296,35 @@ def main(args):
     # runtime with the runtime built in the coreclr build. The result will be that perhaps
     # some, hopefully few, corefx tests will fail, but the builds will never fail.
 
-    command = ' '.join(('build.cmd' if Is_windows else './build.sh',
-                        config_args))
+    if not Is_windows and arch == 'arm64' :
+        # Cross build corefx for arm64 on x64
+        command = ' '.join(('./build-native.sh', config_args))
+        log(command)
+        returncode = 0 if testing else os.system(command)
+        if returncode != 0:
+            sys.exit(1)
 
-    log(command)
-    returncode = 0 if testing else os.system(command)
-    if returncode != 0:
-        sys.exit(1)
+        command = ' '.join(('./build-managed.sh', '-release'))
+        log(command)
+        returncode = 0 if testing else os.system(command)
+        if returncode != 0:
+            sys.exit(1)
+
+        # Rename runtime to arm64
+        os.rename(os.path.join(fx_root,'bin','runtime', 'netcoreapp-%s-%s-%s' % (clr_os, 'Release', 'x64')),
+                  os.path.join(fx_root,'bin','runtime', 'netcoreapp-%s-%s-%s' % (clr_os, 'Release', 'arm64')))
+
+        os.rename(os.path.join(fx_root,'bin','testhost', 'netcoreapp-%s-%s-%s' % (clr_os, 'Release', 'x64')),
+                  os.path.join(fx_root,'bin','testhost', 'netcoreapp-%s-%s-%s' % (clr_os, 'Release', 'arm64')))
+
+    else:
+        command = ' '.join(('build.cmd' if Is_windows else './build.sh',
+                            config_args))
+        log(command)
+        returncode = 0 if testing else os.system(command)
+        if returncode != 0:
+            sys.exit(1)
+
 
     # Override the built corefx runtime (which it picked up by copying from packages determined
     # by its dependencies.props file). Note that we always build Release corefx.
@@ -321,6 +343,22 @@ def main(args):
 
     log('Updating CoreCLR: %s => %s' % (core_root, fx_runtime))
     copy_files(core_root, fx_runtime)
+
+    if not Is_windows and arch == 'arm64' :
+        fx_arm64_native = os.path.join(fx_root,
+                                       'bin',
+                                       '%s.%s.%s' % (clr_os, 'arm64', 'Release'),
+                                       'native')
+        log('Copying CoreFx Arm64 Native libraries: %s => %s' % (fx_arm64_native, fx_runtime))
+        copy_files(fx_arm64_native, fx_runtime)
+
+        # Replace dotnet binary with corerun softlink, to make run-test.sh work as is on ARM64 platform
+        # with the built runtime.
+        dotnet_base= os.path.join(fx_root,'bin','testhost', 'netcoreapp-%s-%s-%s' % (clr_os, 'Release', arch))
+        os.remove(os.path.join(dotnet_base,'dotnet'))
+        os.chdir(dotnet_base)
+        os.symlink(os.path.join('shared','Microsoft.NETCore.App','9.9.9','corerun'), 'dotnet')
+        os.chdir(fx_root)
 
     # Build the build-tests command line.
 


### PR DESCRIPTION
Modified the  **run-corefx-tests.py**  script to allow corefx cross build on x64  linux and generate arm64 corefx runtime  , along with the corefx tests.
This was needed as the arm64 `dotnet ` is not yet available.

CI integration yet to be done.

Command for above on X64 Linux:
  

> python tests/scripts/run-corefx-tests.py  -arch=arm64  -ci_arch=x64_arm64_cross  -build_type=release -no_run_tests

The generated runtime  **netcoreapp-Linux-Release-arm64** and **tests** can be copied on arm64 platform .
To run the tests on arm64 Linux, the existing corefx `run-test.sh` script can be invoked as below:

>  ./run-test.sh --runtime < path to netcoreapp-Linux-Release-arm64 >  --arch arm64  --corefx-tests < path >  --configurationGroup Release 

 The initial corefx **failed tests** on arm64 Ubuntu with the above scripts were as below:
 
  ```
   System.Composition.Tests  Total: 137, Errors: 0, Failed: 2, Skipped: 0, Time: 1.759s
   Invariant.Tests  Total: 289, Errors: 0, Failed: 79, Skipped: 0, Time: 3.292s
   System.Diagnostics.Process.Tests  Total: 236, Errors: 0, Failed: 3, Skipped: 1, Time: 21.367s
   System.Linq.Queryable.Tests  Total: 1324, Errors: 0, Failed: 2, Skipped: 0, Time: 2.768s
   System.IO.Pipes.Tests  Total: 505, Errors: 0, Failed: 1, Skipped: 0, Time: 6.255s
   System.Dynamic.Runtime.Tests  Total: 2900, Errors: 0, Failed: 1, Skipped: 0, Time: 13.187s
   System.Linq.Expressions.Tests  Total: 35203, Errors: 0, Failed: 4, Skipped: 5, Time: 48.791s
   System.Reflection.Emit.ILGeneration.Tests  Total: 221, Errors: 0, Failed: 2, Skipped: 0, Time: 1.417s
   System.Numerics.Vectors.Tests  Total: 1150, Errors: 0, Failed: 3, Skipped: 0, Time: 4.280s
   System.Runtime.Extensions.Tests  Total: 3855, Errors: 0, Failed: 2, Skipped: 15, Time: 8.340s
   System.Net.Requests.Tests  Total: 314, Errors: 0, Failed: 1, Skipped: 6, Time: 9.843s
   System.Xml.Xsl.XslCompiledTransformApi.Tests  Total: 1620, Errors: 0, Failed: 1, Skipped: 0, Time: 17.345s
```
Will add some more details on the failed cases in follow up.