### PR TITLE
Fix Incorrect Array Dereference When Clearing EventData.Reserved

### DIFF
--- a/src/mscorlib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -901,7 +901,7 @@ namespace System.Diagnostics.Tracing
                     EventSource.EventData* descrs = stackalloc EventSource.EventData[2];
                     descrs[0].DataPointer = (IntPtr)string1Bytes;
                     descrs[0].Size = ((arg1.Length + 1) * 2);
-                    descrs[1].Reserved = 0;
+                    descrs[0].Reserved = 0;
                     descrs[1].DataPointer = (IntPtr)(&arg2);
                     descrs[1].Size = 8;
                     descrs[1].Reserved = 0;


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/28099.

With the change to no longer initialize locals in System.Private.CoreLib, EventData.Reserved must be manually initialized to zero for manifest-based ETW.  This was done in https://github.com/dotnet/coreclr/pull/16283.  This change fixes an instance of missing initialization due to an incorrect array index.

cc: @danmosemsft, @JeremyKuhne