### PR TITLE
Fix CompareTo/Equals when dealing with Empty Span or Span wrapping a null string

### DIFF
--- a/src/mscorlib/shared/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/shared/System/Globalization/CompareInfo.Unix.cs
@@ -208,8 +208,6 @@ namespace System.Globalization
         {
             Debug.Assert(!_invariantMode);
             Debug.Assert((options & (CompareOptions.Ordinal | CompareOptions.OrdinalIgnoreCase)) == 0);
-            Debug.Assert(!string1.IsEmpty);
-            Debug.Assert(!string2.IsEmpty);
 
             fixed (char* pString1 = &MemoryMarshal.GetReference(string1))
             fixed (char* pString2 = &MemoryMarshal.GetReference(string2))

--- a/src/mscorlib/shared/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/shared/System/Globalization/CompareInfo.Unix.cs
@@ -193,7 +193,6 @@ namespace System.Globalization
         private unsafe int CompareString(ReadOnlySpan<char> string1, string string2, CompareOptions options)
         {
             Debug.Assert(!_invariantMode);
-            Debug.Assert(!string1.IsEmpty);
             Debug.Assert(string2 != null);
             Debug.Assert((options & (CompareOptions.Ordinal | CompareOptions.OrdinalIgnoreCase)) == 0);
 

--- a/src/mscorlib/shared/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/shared/System/Globalization/CompareInfo.Unix.cs
@@ -181,6 +181,8 @@ namespace System.Globalization
         private static unsafe int CompareStringOrdinalIgnoreCase(char* string1, int count1, char* string2, int count2)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
+            Debug.Assert(string1 != null);
+            Debug.Assert(string2 != null);
 
             return Interop.Globalization.CompareStringOrdinalIgnoreCase(string1, count1, string2, count2);
         }
@@ -191,6 +193,7 @@ namespace System.Globalization
         private unsafe int CompareString(ReadOnlySpan<char> string1, string string2, CompareOptions options)
         {
             Debug.Assert(!_invariantMode);
+            Debug.Assert(!string1.IsEmpty);
             Debug.Assert(string2 != null);
             Debug.Assert((options & (CompareOptions.Ordinal | CompareOptions.OrdinalIgnoreCase)) == 0);
 
@@ -205,6 +208,8 @@ namespace System.Globalization
         {
             Debug.Assert(!_invariantMode);
             Debug.Assert((options & (CompareOptions.Ordinal | CompareOptions.OrdinalIgnoreCase)) == 0);
+            Debug.Assert(!string1.IsEmpty);
+            Debug.Assert(!string2.IsEmpty);
 
             fixed (char* pString1 = &MemoryMarshal.GetReference(string1))
             fixed (char* pString2 = &MemoryMarshal.GetReference(string2))

--- a/src/mscorlib/shared/System/Globalization/CompareInfo.Windows.cs
+++ b/src/mscorlib/shared/System/Globalization/CompareInfo.Windows.cs
@@ -40,6 +40,8 @@ namespace System.Globalization
             bool bIgnoreCase)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
+            Debug.Assert(stringSource != null);
+            Debug.Assert(value != null);
 
             fixed (char* pSource = stringSource)
             fixed (char* pValue = value)
@@ -62,6 +64,8 @@ namespace System.Globalization
             bool bIgnoreCase)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
+            Debug.Assert(!source.IsEmpty);
+            Debug.Assert(!value.IsEmpty);
 
             fixed (char* pSource = &MemoryMarshal.GetReference(source))
             fixed (char* pValue = &MemoryMarshal.GetReference(value))
@@ -165,6 +169,8 @@ namespace System.Globalization
         private static unsafe int CompareStringOrdinalIgnoreCase(char* string1, int count1, char* string2, int count2)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
+            Debug.Assert(string1 != null);
+            Debug.Assert(string2 != null);
 
             // Use the OS to compare and then convert the result to expected value by subtracting 2 
             return Interop.Kernel32.CompareStringOrdinal(string1, count1, string2, count2, true) - 2;
@@ -175,6 +181,7 @@ namespace System.Globalization
         // that takes two spans.  But due to this issue, that's adding significant overhead.
         private unsafe int CompareString(ReadOnlySpan<char> string1, string string2, CompareOptions options)
         {
+            Debug.Assert(!string1.IsEmpty);
             Debug.Assert(string2 != null);
             Debug.Assert(!_invariantMode);
             Debug.Assert((options & (CompareOptions.Ordinal | CompareOptions.OrdinalIgnoreCase)) == 0);
@@ -210,6 +217,8 @@ namespace System.Globalization
         {
             Debug.Assert(!_invariantMode);
             Debug.Assert((options & (CompareOptions.Ordinal | CompareOptions.OrdinalIgnoreCase)) == 0);
+            Debug.Assert(!string1.IsEmpty);
+            Debug.Assert(!string2.IsEmpty);
 
             string localeName = _sortHandle != IntPtr.Zero ? null : _sortName;
 
@@ -245,6 +254,8 @@ namespace System.Globalization
                     int* pcchFound)
         {
             Debug.Assert(!_invariantMode);
+            Debug.Assert(!lpStringSource.IsEmpty);
+            Debug.Assert(!lpStringValue.IsEmpty);
 
             string localeName = _sortHandle != IntPtr.Zero ? null : _sortName;
 
@@ -277,6 +288,8 @@ namespace System.Globalization
             int* pcchFound)
         {
             Debug.Assert(!_invariantMode);
+            Debug.Assert(lpStringSource != null);
+            Debug.Assert(lpStringValue != null);
 
             string localeName = _sortHandle != IntPtr.Zero ? null : _sortName;
 
@@ -572,6 +585,7 @@ namespace System.Globalization
         private static unsafe bool IsSortable(char* text, int length)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
+            Debug.Assert(text != null);
 
             return Interop.Kernel32.IsNLSDefinedString(Interop.Kernel32.COMPARE_STRING, 0, IntPtr.Zero, text, length);
         }

--- a/src/mscorlib/shared/System/Globalization/CompareInfo.Windows.cs
+++ b/src/mscorlib/shared/System/Globalization/CompareInfo.Windows.cs
@@ -217,8 +217,6 @@ namespace System.Globalization
         {
             Debug.Assert(!_invariantMode);
             Debug.Assert((options & (CompareOptions.Ordinal | CompareOptions.OrdinalIgnoreCase)) == 0);
-            Debug.Assert(!string1.IsEmpty);
-            Debug.Assert(!string2.IsEmpty);
 
             string localeName = _sortHandle != IntPtr.Zero ? null : _sortName;
 
@@ -226,6 +224,8 @@ namespace System.Globalization
             fixed (char* pString1 = &MemoryMarshal.GetReference(string1))
             fixed (char* pString2 = &MemoryMarshal.GetReference(string2))
             {
+                Debug.Assert(pString1 != null);
+                Debug.Assert(pString2 != null);
                 int result = Interop.Kernel32.CompareStringEx(
                                     pLocaleName,
                                     (uint)GetNativeCompareFlags(options),

--- a/src/mscorlib/shared/System/Globalization/CompareInfo.Windows.cs
+++ b/src/mscorlib/shared/System/Globalization/CompareInfo.Windows.cs
@@ -181,7 +181,6 @@ namespace System.Globalization
         // that takes two spans.  But due to this issue, that's adding significant overhead.
         private unsafe int CompareString(ReadOnlySpan<char> string1, string string2, CompareOptions options)
         {
-            Debug.Assert(!string1.IsEmpty);
             Debug.Assert(string2 != null);
             Debug.Assert(!_invariantMode);
             Debug.Assert((options & (CompareOptions.Ordinal | CompareOptions.OrdinalIgnoreCase)) == 0);
@@ -192,6 +191,7 @@ namespace System.Globalization
             fixed (char* pString1 = &MemoryMarshal.GetReference(string1))
             fixed (char* pString2 = &string2.GetRawStringData())
             {
+                Debug.Assert(pString1 != null);
                 int result = Interop.Kernel32.CompareStringEx(
                                     pLocaleName,
                                     (uint)GetNativeCompareFlags(options),

--- a/src/mscorlib/shared/System/Globalization/CompareInfo.cs
+++ b/src/mscorlib/shared/System/Globalization/CompareInfo.cs
@@ -391,34 +391,22 @@ namespace System.Globalization
             return CompareString(string1, string2, options);
         }
 
-        internal virtual int CompareOptionNone(ReadOnlySpan<char> string1, ReadOnlySpan<char> string2)
+        internal int CompareOptionNone(ReadOnlySpan<char> string1, ReadOnlySpan<char> string2)
         {
             // Check for empty span or span from a null string
-            if (string1.IsEmpty)
-            {
-                if (string2.IsEmpty)
-                    return 0;
-                return -1;
-            }
-            if (string2.IsEmpty)
-                return 1;
+            if (string1.Length == 0 || string2.Length == 0)
+                return string1.Length - string2.Length;
 
             return _invariantMode ?
                 string.CompareOrdinal(string1, string2) :
                 CompareString(string1, string2, CompareOptions.None);
         }
 
-        internal virtual int CompareOptionIgnoreCase(ReadOnlySpan<char> string1, ReadOnlySpan<char> string2)
+        internal int CompareOptionIgnoreCase(ReadOnlySpan<char> string1, ReadOnlySpan<char> string2)
         {
             // Check for empty span or span from a null string
-            if (string1.IsEmpty)
-            {
-                if (string2.IsEmpty)
-                    return 0;
-                return -1;
-            }
-            if (string2.IsEmpty)
-                return 1;
+            if (string1.Length == 0 || string2.Length == 0)
+                return string1.Length - string2.Length;
 
             return _invariantMode ?
                 CompareOrdinalIgnoreCase(string1, string2) :
@@ -558,8 +546,6 @@ namespace System.Globalization
 
         internal static unsafe int CompareOrdinalIgnoreCase(ReadOnlySpan<char> strA, ReadOnlySpan<char> strB)
         {
-            Debug.Assert(!strA.IsEmpty);
-            Debug.Assert(!strB.IsEmpty);
             int length = Math.Min(strA.Length, strB.Length);
             int range = length;
 
@@ -914,7 +900,7 @@ namespace System.Globalization
             return IndexOfCore(source, value, startIndex, count, options, null);
         }
 
-        internal virtual int IndexOfOrdinal(ReadOnlySpan<char> source, ReadOnlySpan<char> value, bool ignoreCase)
+        internal int IndexOfOrdinal(ReadOnlySpan<char> source, ReadOnlySpan<char> value, bool ignoreCase)
         {
             Debug.Assert(!_invariantMode);
             Debug.Assert(!source.IsEmpty);
@@ -922,7 +908,7 @@ namespace System.Globalization
             return IndexOfOrdinalCore(source, value, ignoreCase);
         }
 
-        internal unsafe virtual int IndexOf(ReadOnlySpan<char> source, ReadOnlySpan<char> value, CompareOptions options)
+        internal unsafe int IndexOf(ReadOnlySpan<char> source, ReadOnlySpan<char> value, CompareOptions options)
         {
             Debug.Assert(!_invariantMode);
             Debug.Assert(!source.IsEmpty);

--- a/src/mscorlib/shared/System/Globalization/CompareInfo.cs
+++ b/src/mscorlib/shared/System/Globalization/CompareInfo.cs
@@ -393,6 +393,16 @@ namespace System.Globalization
 
         internal virtual int CompareOptionNone(ReadOnlySpan<char> string1, ReadOnlySpan<char> string2)
         {
+            // Check for empty span or span from a null string
+            if (string1.IsEmpty)
+            {
+                if (string2.IsEmpty)
+                    return 0;
+                return -1;
+            }
+            if (string2.IsEmpty)
+                return 1;
+
             return _invariantMode ?
                 string.CompareOrdinal(string1, string2) :
                 CompareString(string1, string2, CompareOptions.None);
@@ -400,6 +410,16 @@ namespace System.Globalization
 
         internal virtual int CompareOptionIgnoreCase(ReadOnlySpan<char> string1, ReadOnlySpan<char> string2)
         {
+            // Check for empty span or span from a null string
+            if (string1.IsEmpty)
+            {
+                if (string2.IsEmpty)
+                    return 0;
+                return -1;
+            }
+            if (string2.IsEmpty)
+                return 1;
+
             return _invariantMode ?
                 CompareOrdinalIgnoreCase(string1, string2) :
                 CompareString(string1, string2, CompareOptions.IgnoreCase);
@@ -538,6 +558,8 @@ namespace System.Globalization
 
         internal static unsafe int CompareOrdinalIgnoreCase(ReadOnlySpan<char> strA, ReadOnlySpan<char> strB)
         {
+            Debug.Assert(!strA.IsEmpty);
+            Debug.Assert(!strB.IsEmpty);
             int length = Math.Min(strA.Length, strB.Length);
             int range = length;
 
@@ -895,12 +917,16 @@ namespace System.Globalization
         internal virtual int IndexOfOrdinal(ReadOnlySpan<char> source, ReadOnlySpan<char> value, bool ignoreCase)
         {
             Debug.Assert(!_invariantMode);
+            Debug.Assert(!source.IsEmpty);
+            Debug.Assert(!value.IsEmpty);
             return IndexOfOrdinalCore(source, value, ignoreCase);
         }
 
         internal unsafe virtual int IndexOf(ReadOnlySpan<char> source, ReadOnlySpan<char> value, CompareOptions options)
         {
             Debug.Assert(!_invariantMode);
+            Debug.Assert(!source.IsEmpty);
+            Debug.Assert(!value.IsEmpty);
             return IndexOfCore(source, value, options, null);
         }
 

--- a/src/mscorlib/shared/System/MemoryExtensions.cs
+++ b/src/mscorlib/shared/System/MemoryExtensions.cs
@@ -113,6 +113,7 @@ namespace System
         /// </summary>
         /// <param name="span">The source span from which the characters are removed.</param>
         /// <param name="trimChars">The span which contains the set of characters to remove.</param>
+        /// <remarks>If <paramref name="trimChars"/> is empty, white-space characters are removed instead.</remarks>
         public static ReadOnlySpan<char> Trim(this ReadOnlySpan<char> span, ReadOnlySpan<char> trimChars)
         {
             return span.TrimStart(trimChars).TrimEnd(trimChars);
@@ -124,8 +125,14 @@ namespace System
         /// </summary>
         /// <param name="span">The source span from which the characters are removed.</param>
         /// <param name="trimChars">The span which contains the set of characters to remove.</param>
+        /// <remarks>If <paramref name="trimChars"/> is empty, white-space characters are removed instead.</remarks>
         public static ReadOnlySpan<char> TrimStart(this ReadOnlySpan<char> span, ReadOnlySpan<char> trimChars)
         {
+            if (trimChars.IsEmpty)
+            {
+                return span.TrimStart();
+            }
+
             int start = 0;
             for (; start < span.Length; start++)
             {
@@ -147,8 +154,14 @@ namespace System
         /// </summary>
         /// <param name="span">The source span from which the characters are removed.</param>
         /// <param name="trimChars">The span which contains the set of characters to remove.</param>
+        /// <remarks>If <paramref name="trimChars"/> is empty, white-space characters are removed instead.</remarks>
         public static ReadOnlySpan<char> TrimEnd(this ReadOnlySpan<char> span, ReadOnlySpan<char> trimChars)
         {
+            if (trimChars.IsEmpty)
+            {
+                return span.TrimEnd();
+            }
+
             int end = span.Length - 1;
             for (; end >= 0; end--)
             {


### PR DESCRIPTION
- Added missing Debug.Asserts to catch when an empty span is being passed to Interop code (which could result in NullReferenceException).
- Fixed Span.CompareTo and Span.Equals by adding checks for `length == 0` and addressing them ahead of time. Resolved based on the discussion in https://github.com/dotnet/corefx/issues/27350.
- Fixed the implementation of Trim, TrimStart, TrimEnd so that its behaviour is identical to the string APIs when trimChars is null/empty.

From https://msdn.microsoft.com/en-us/library/d4tt83f9(v=vs.110).aspx
> The string that remains after all occurrences of the characters in the trimChars parameter are removed from the start and end of the current string. If trimChars is null or an empty array, white-space characters are removed instead.

Added tests in corefx: https://github.com/dotnet/corefx/pull/28347

cc @KrzysztofCwalina, @jkotas, @tarekgh, @stephentoub, @joshfree, @VSadov 