### PR TITLE
[local gc] Fix for BitScanForward64, it was ignoring the high byte check

### DIFF
--- a/src/gc/env/gcenv.base.h
+++ b/src/gc/env/gcenv.base.h
@@ -255,19 +255,16 @@ inline uint8_t BitScanForward64(uint32_t *bitIndex, uint64_t mask)
     uint32_t fakeBitIndex = 0;
     
     uint8_t result = BitScanForward(bitIndex, lo);
-    if (result != 0)
+    if (result == 0)
     {
-        return result;
+        result = BitScanForward(&fakeBitIndex, hi);
+        if (result != 0)
+        {
+            *bitIndex = fakeBitIndex + 32;
+        }
     }
 
-    result = BitScanForward(&fakeBitIndex, hi);
-    if (result != 0)
-    {
-        *bitIndex = fakeBitIndex + 32;
-        return result;
-    }
-
-    return 0;
+    return result;
  #else
     return _BitScanForward64((unsigned long*)bitIndex, mask);
  #endif // _WIN32

--- a/src/gc/env/gcenv.base.h
+++ b/src/gc/env/gcenv.base.h
@@ -253,12 +253,21 @@ inline uint8_t BitScanForward64(uint32_t *bitIndex, uint64_t mask)
     uint32_t hi = (mask >> 32) & 0xFFFFFFFF;
     uint32_t lo = mask & 0xFFFFFFFF;
     uint32_t fakeBitIndex = 0;
-    if (BitScanForward(&fakeBitIndex, hi))
+    
+    uint8_t result = BitScanForward(bitIndex, lo);
+    if (result != 0)
     {
-        *bitIndex = fakeBitIndex + 32;
+        return result;
     }
 
-    return BitScanForward(bitIndex, lo);
+    result = BitScanForward(&fakeBitIndex, hi);
+    if (result != 0)
+    {
+        *bitIndex = fakeBitIndex + 32;
+        return result;
+    }
+
+    return 0;
  #else
     return _BitScanForward64((unsigned long*)bitIndex, mask);
  #endif // _WIN32


### PR DESCRIPTION
Fix for #17117. Our implementation of BitScanForward64 would check the high bits, then overwrite `bitIndex` on the call to BitScanForward for the low bits.

We never saw this in coreclr because the compiler intrinsic `_BitScanForward64` is used, and our implementation was only called in clrgc.dll. It's not obvious to me why that is, but this fixes the issue.

I ran the default set of tests with runtest.cmd with local gc enabled, and have a stress run going overnight.