### PR TITLE
Fix size-on-disk benchmark by disabling background build server

### DIFF
--- a/tests/src/sizeondisk/sodbench/SoDBench.cs
+++ b/tests/src/sizeondisk/sodbench/SoDBench.cs
@@ -371,7 +371,7 @@ namespace SoDBench
                     {
                         FileName = s_dotnetExe.FullName,
                         // The UserSharedCompiler flag is set to false to prevent handles from being held that will later cause deletion of the installed SDK to fail.
-                        Arguments = $"publish -c Release --runtime {os} --output {publishDir.FullName} /p:UseSharedCompilation=false",
+                        Arguments = $"publish -c Release --runtime {os} --output {publishDir.FullName} /p:UseSharedCompilation=false /p:UseRazorBuildServer=false",
                         UseShellExecute = false,
                         WorkingDirectory = deploymentSandbox.FullName
                     };


### PR DESCRIPTION
As described in https://github.com/dotnet/cli/issues/8849, publishing Razor applications creates a background build server. This build server prevents cleanup by holding handles to temporary files. This PR disables that build server to fix the benchmark