### PR TITLE
Revert to previous docker image for building to fix GLIBCXX errors

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -980,7 +980,7 @@ def static getDockerImageName(def architecture, def os, def isBuild) {
         }
         else if (architecture == 'arm') {
             if (os == 'Ubuntu') {
-                return "microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-cross-e435274-20180317125354"
+                return "microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-0cd4667-20170319080304"
             }
         }
     }


### PR DESCRIPTION
Errors seen:
```
/usr/lib/arm-linux-gnueabihf/libstdc++.so.6: version `GLIBCXX_3.4.20' not found
/usr/lib/arm-linux-gnueabihf/libstdc++.so.6: version `GLIBCXX_3.4.21' not found
```