### PR TITLE
Improve Windows test build performance by building projects in groups - 4x less memory 326% faster build.

### DIFF
--- a/tests/build.proj
+++ b/tests/build.proj
@@ -9,9 +9,9 @@
   </ItemGroup>
 
   <Import Project="dir.targets" />
-  
+
   <Import Project="dir.traversal.targets" />
-  
+
   <PropertyGroup>
     <TraversalBuildDependsOn>
       BatchRestorePackages;
@@ -34,15 +34,15 @@
     <RestoreProjects Include="$(MSBuildThisFileDirectory)src\TestWrappersConfig\TestWrappersConfig.csproj" />
   </ItemGroup>
 
-  <Target Name="BuildTargetingPack" AfterTargets="BatchRestorePackages">
+  <Target Name="BuildTargetingPack" AfterTargets="BatchRestorePackages" Condition="$(__SkipTargetingPackBuild) != 'true'">
     <Message Text="Building Targeting Pack" Importance="High" />
     <Error  Text="BuildOS has not been specified. Please do that then run build again."  Condition="'$(BuildOS)' == 'AnyOS'" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)\src\Common\external\external.depproj" />
   </Target>
 
-  <Target Name="BatchRestorePackages">
+  <Target Name="BatchRestorePackages" Condition="$(__SkipPackageRestore) != 'true'">
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Restoring all packages..." />
-    
+
     <!-- restore all csproj's with PackageReferences in one pass -->
     <MSBuild Projects="build.proj"
              Properties="RestoreProj=%(RestoreProjects.Identity)"

--- a/tests/src/dirs.proj
+++ b/tests/src/dirs.proj
@@ -32,8 +32,9 @@
       <DisabledProjects Include="Loader\classloader\generics\regressions\DD117522\Test.csproj" />
       <DisabledProjects Include="Loader\classloader\generics\GenericMethods\VSW491668.csproj" /> <!-- issue 5501 -->
     </ItemGroup>
-    
-    <ItemGroup>
+
+    <!-- Unix builds do not support subgroups -->
+    <ItemGroup Condition="$(__BuildOS) != 'Windows_NT' And $(__TestGroupToBuild) == '1' And $(TestBuildSlice) == '1'">
       <Project Include="*\**\*.csproj" Exclude="@(DisabledProjects)">
         <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
       </Project>
@@ -41,6 +42,215 @@
         <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
       </Project>
     </ItemGroup>
+
+    <!-- Test build is divided in slices which can be created within Test Group
+         Priority 0 tests are build using Test Group 1 with 2 subgroups or slices -->
+    <ItemGroup Condition="$(__BuildOS) == 'Windows_NT' And $(__TestGroupToBuild) == '1' And $(TestBuildSlice) == '1'">
+      <Project Include="*\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+    </ItemGroup>
+
+    <ItemGroup Condition="$(__BuildOS) == 'Windows_NT' And $(__TestGroupToBuild) == '1' And $(TestBuildSlice) == '2'">
+      <Project Include="*\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+    </ItemGroup>
+
+    <!-- Test build is divided in slices which can be created within Test Group
+         Priority 1 or higher tests are build using Test Group 2 with 16 subgroups or slices -->    
+    <ItemGroup Condition="($(__BuildOS) == 'Windows_NT' And $(__TestGroupToBuild) == '2' And $(TestBuildSlice) == '1')">
+      <Project Include="baseservices\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="Common\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>      
+      <Project Include="baseservices\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="Common\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>      
+    </ItemGroup>
+
+    <ItemGroup Condition="($(__BuildOS) == 'Windows_NT' And $(__TestGroupToBuild) == '2' And $(TestBuildSlice) == '2')">
+      <Project Include="CoreMangLib\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="CoreMangLib\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+    </ItemGroup>
+
+    <ItemGroup Condition="($(__BuildOS) == 'Windows_NT' And $(__TestGroupToBuild) == '2' And $(TestBuildSlice) == '3')">
+      <Project Include="E*\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="GC\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="Interop\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="E*\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="GC\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="Interop\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+    </ItemGroup>
+
+    <ItemGroup Condition="($(__BuildOS) == 'Windows_NT' And $(__TestGroupToBuild) == '2' And $(TestBuildSlice) == '4')">
+      <Project Include="JIT\B*\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="JIT\C*\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="JIT\Directed\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>      
+    </ItemGroup>
+
+    <ItemGroup Condition="($(__BuildOS) == 'Windows_NT' And $(__TestGroupToBuild) == '2' And $(TestBuildSlice) == '5')">    
+      <Project Include="JIT\B*\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="JIT\C*\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="JIT\Directed\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+    </ItemGroup>    
+
+    <ItemGroup Condition="($(__BuildOS) == 'Windows_NT' And $(__TestGroupToBuild) == '2' And $(TestBuildSlice) == '6')">
+      <Project Include="JIT\Generics\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="JIT\*Intrinsics\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>      
+      <Project Include="JIT\Generics\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="JIT\*Intrinsics\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+    </ItemGroup>
+
+    <ItemGroup Condition="($(__BuildOS) == 'Windows_NT' And $(__TestGroupToBuild) == '2' And $(TestBuildSlice) == '7')">
+      <Project Include="JIT\IL_Conformance\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="JIT\IL_Conformance\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+    </ItemGroup>
+
+    <ItemGroup Condition="($(__BuildOS) == 'Windows_NT' And $(__TestGroupToBuild) == '2' And $(TestBuildSlice) == '8')">
+      <Project Include="JIT\jit64\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="JIT\jit64\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+    </ItemGroup>
+
+    <ItemGroup Condition="($(__BuildOS) == 'Windows_NT' And $(__TestGroupToBuild) == '2' And $(TestBuildSlice) == '9')">
+      <Project Include="JIT\Methodical\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+    </ItemGroup>
+
+    <ItemGroup Condition="($(__BuildOS) == 'Windows_NT' And $(__TestGroupToBuild) == '2' And $(TestBuildSlice) == '10')">
+      <Project Include="JIT\Methodical\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+    </ItemGroup>    
+
+    <ItemGroup Condition="($(__BuildOS) == 'Windows_NT' And $(__TestGroupToBuild) == '2' And $(TestBuildSlice) == '11')">
+      <Project Include="JIT\opt\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="JIT\Performance\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="JIT\S*\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>            
+      <Project Include="JIT\opt\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="JIT\Performance\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="JIT\S*\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+    </ItemGroup>
+
+    <ItemGroup Condition="($(__BuildOS) == 'Windows_NT' And $(__TestGroupToBuild) == '2' And $(TestBuildSlice) == '12')">
+      <Project Include="JIT\R*\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+    </ItemGroup>
+
+    <ItemGroup Condition="($(__BuildOS) == 'Windows_NT' And $(__TestGroupToBuild) == '2' And $(TestBuildSlice) == '13')">
+      <Project Include="JIT\R*\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+    </ItemGroup>    
+
+    <ItemGroup Condition="($(__BuildOS) == 'Windows_NT' And $(__TestGroupToBuild) == '2' And $(TestBuildSlice) == '14')">
+      <Project Include="Loader\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+    </ItemGroup>
+
+    <ItemGroup Condition="($(__BuildOS) == 'Windows_NT' And $(__TestGroupToBuild) == '2' And $(TestBuildSlice) == '15')">
+      <Project Include="Loader\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+    </ItemGroup>    
+
+    <ItemGroup Condition="($(__BuildOS) == 'Windows_NT' And $(__TestGroupToBuild) == '2' And $(TestBuildSlice) == '16')">
+      <Project Include="m*\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="p*\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="r*\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="s*\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="t*\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>            
+      <Project Include="m*\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="p*\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="r*\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="s*\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="t*\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+    </ItemGroup>
+
   </Target>
 
   <Import Project="..\dir.traversal.targets" />


### PR DESCRIPTION
Fixes #14594 and is a part of #17149 

The build time improvement for priority 1 tests: 02:09:09.700 (2 hours 9 minutes 9 seconds .700) on 03:46:42.325 original time and now takes 01:37:32.619 what means that build and test is **~132% faster**.

Test build time improved from 02:45:09:518 to 00:38:47.199 what is **~326% faster.**