### PR TITLE
Optionally support using the system-installed libunwind

### DIFF
--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -1,13 +1,18 @@
 cmake_minimum_required(VERSION 2.8.12.2)
 
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  # On OSX, we use the libunwind that's part of the OS
+  set(CLR_CMAKE_USE_SYSTEM_LIBUNWIND 1)
+endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+
 include_directories(SYSTEM /usr/local/include)
-include_directories(libunwind/include)
 
 add_compile_options(-fPIC)
 
-if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+if(NOT CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
+  include_directories(libunwind/include)
   add_subdirectory(libunwind)
-endif(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+endif(NOT CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
 
 include(configure.cmake)
 
@@ -240,10 +245,9 @@ set(SOURCES
   thread/tls.cpp
 )
 
-if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  # On OSX, we use the libunwind that's part of the OS
+if(NOT CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
   set(LIBUNWIND_OBJECTS $<TARGET_OBJECTS:libunwind>)
-endif(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+endif(NOT CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
 
 add_library(coreclrpal
   STATIC
@@ -267,10 +271,14 @@ if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 
 if(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+  if(CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
+    find_library(UNWIND unwind)
+  endif()
   find_library(INTL intl)
   target_link_libraries(coreclrpal
     pthread
     rt
+    ${UNWIND}
     ${INTL}
   )
 endif(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
@@ -303,7 +311,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
       ${LZMA})
   endif()
 
-
   if(CLR_MAKE_PLATFORM_ANDROID)
     find_library(ANDROID_SUPPORT NAMES android-support)
     find_library(ANDROID_GLOB NAMES android-glob)
@@ -326,20 +333,56 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     dl
   )
 
-
   if(NOT INTL STREQUAL INTL-NOTFOUND)
     target_link_libraries(coreclrpal ${INTL})
   endif(NOT INTL STREQUAL INTL-NOTFOUND)
 
+  if(CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
+    if(PAL_CMAKE_PLATFORM_ARCH_ARM)
+      find_library(UNWIND_ARCH NAMES unwind-arm)
+    endif()
+
+    if(PAL_CMAKE_PLATFORM_ARCH_ARM64)
+      find_library(UNWIND_ARCH NAMES unwind-aarch64)
+    endif()
+
+    if(PAL_CMAKE_PLATFORM_ARCH_AMD64)
+      find_library(UNWIND_ARCH NAMES unwind-x86_64)
+    endif()
+
+    if(NOT UNWIND_ARCH STREQUAL UNWIND_ARCH-NOTFOUND)
+      target_link_libraries(coreclrpal ${UNWIND_ARCH})
+    endif()
+
+    find_library(UNWIND_GENERIC NAMES unwind-generic)
+
+    if(NOT UNWIND_GENERIC STREQUAL UNWIND_GENERIC-NOTFOUND)
+      target_link_libraries(coreclrpal ${UNWIND_GENERIC})
+    endif()
+
+    find_library(UNWIND NAMES unwind)
+
+    if(UNWIND STREQUAL UNWIND-NOTFOUND)
+      message(FATAL_ERROR "Cannot find libunwind. Try installing libunwind8-dev or libunwind-devel.")
+    endif()
+
+    target_link_libraries(coreclrpal ${UNWIND})
+
+  endif(CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
+
 endif(CMAKE_SYSTEM_NAME STREQUAL Linux)
 
 if(CMAKE_SYSTEM_NAME STREQUAL NetBSD)
+  if (CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
+    find_library(UNWIND unwind)
+  endif()
   add_definitions(-D_KMEMUSER)
   find_library(INTL intl)
   find_library(KVM kvm)
   target_link_libraries(coreclrpal
     pthread
     rt
+    ${UNWIND}
     ${INTL}
     ${KVM}
   )

--- a/src/pal/src/configure.cmake
+++ b/src/pal/src/configure.cmake
@@ -978,7 +978,9 @@ int main()
 set(SYNCHMGR_SUSPENSION_SAFE_CONDITION_SIGNALING 1)
 set(ERROR_FUNC_FOR_GLOB_HAS_FIXED_PARAMS 1)
 
-list(INSERT CMAKE_REQUIRED_INCLUDES 0 ${CMAKE_CURRENT_SOURCE_DIR}/libunwind/include ${CMAKE_CURRENT_BINARY_DIR}/libunwind/include)
+if(NOT CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
+  list(INSERT CMAKE_REQUIRED_INCLUDES 0 ${CMAKE_CURRENT_SOURCE_DIR}/libunwind/include ${CMAKE_CURRENT_BINARY_DIR}/libunwind/include)
+endif()
 
 check_c_source_compiles("
 #include <libunwind.h>
@@ -991,7 +993,9 @@ int main(int argc, char **argv)
         return 0;
 }" UNWIND_CONTEXT_IS_UCONTEXT_T)
 
-list(REMOVE_AT CMAKE_REQUIRED_INCLUDES 0 1)
+if(NOT CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
+  list(REMOVE_AT CMAKE_REQUIRED_INCLUDES 0 1)
+endif()
 
 check_cxx_source_compiles("
 #include <sys/param.h>


### PR DESCRIPTION
This allows coreclr to link against a system-installed `libunwind` instead of using the copy included with the coreclr sources.

The default is still to use the bundled version, except on macOS, where we always use the system-installed version.

Many Linux distributions prefer to avoid bundled libraries as much as possible. For their reasons, please see:

- https://fedoraproject.org/wiki/Bundled_Libraries
- https://wiki.debian.org/UpstreamGuide#No_inclusion_of_third_party_code
- https://wiki.gentoo.org/wiki/Why_not_bundle_dependencies

One thing to note is that this removes the `include_directories(libunwind/include)` call on macOS. It doesn't make sense to me to try and use the bundled include headers but link against the system library. I can revert this change if that doesn't make sense.

This change also doesn't mark the new flag as an `OPTION`. I need to look into that. In the meantime, I have been using `./build.sh -cmakeargs -DCLR_USE_SYSTEM_LIBUNWIND=1`

Other things I found while implementing this:

- The configure tests are using `#include <libunwind.h>` (unconditionally). If `libunwind-devel` (or similar) is not installed, they simply don't find libunwind headers and the configure tests fail. If they do find the headers, they can't find a libunwind to link against and stiil fail. IMO, they should be fixed to find the bundled copy and test against that (after that bundled libunwind is build).
- If I remove `libunwind-devel` from my system, the build fails at compiling `seh-unwind.cpp`

```
In file included from /home/omajid/devel/dotnet/coreclr/src/pal/src/exception/seh.cpp:442:      
/home/omajid/devel/dotnet/coreclr/src/pal/src/exception/seh-unwind.cpp:31:10: fatal error: 'libunwind.h' file not
      found
#include <libunwind.h>
         ^~~~~~~~~~~~~                                                                                  
1 error generated.
```                                                    

Neither of these is affected by this change.

cc @janvorli @jkotas 