### PR TITLE
restrict memory limit by taking VM into consideration

### DIFF
--- a/src/vm/corhost.cpp
+++ b/src/vm/corhost.cpp
@@ -2948,14 +2948,6 @@ void GetProcessMemoryLoad(LPMEMORYSTATUSEX pMSEX)
     pMSEX->dwLength = sizeof(MEMORYSTATUSEX);
     BOOL fRet = GlobalMemoryStatusEx(pMSEX);
     _ASSERTE (fRet);
-
-
-    // If the machine has more RAM than virtual address limit, let us cap it.
-    // Our GC can never use more than virtual address limit.
-    if (pMSEX->ullAvailPhys > pMSEX->ullTotalVirtual)
-    {
-        pMSEX->ullAvailPhys = pMSEX->ullAvailVirtual;
-    }
 }
 
 // This is the instance that exposes interfaces out to all the other DLLs of the CLR


### PR DESCRIPTION
for 32-bit processes when we look at the memory limit for the process we also should take VM into consideration. right now the VM limit is not implemented on PAL so this is only for non PAL.