### PR TITLE
List: improved performance of InsertRange for lazy enumerable

### DIFF
--- a/src/mscorlib/shared/System/Collections/Generic/List.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/List.cs
@@ -799,12 +799,24 @@ namespace System.Collections.Generic
             }
             else if (index < _size)
             {
-                // We're inserting a lazy enumerable. Call Insert on each of the constituent items.
-                using (IEnumerator<T> en = collection.GetEnumerator())
+                int initialSize = _size;
+
+                try
                 {
-                    while (en.MoveNext())
+                    // We're inserting a lazy enumerable. First, add items to the end of this list.
+                    AddEnumerable(collection);
+                }
+                finally
+                {
+                    if (_size != initialSize)
                     {
-                        Insert(index++, en.Current);
+                        // If items were added, move new items to the required position.
+                        // It needs to be done even if enumeration fails to maintain the clean state.
+
+                        // Swap [index, initialSize] and [initialSize, _size] segments.
+                        Array.Reverse(_items, index, initialSize - index);
+                        Array.Reverse(_items, initialSize, _size - initialSize);
+                        Array.Reverse(_items, index, _size - index);
                     }
                 }
             }


### PR DESCRIPTION
# Summary
Fixes #14876. Improved performance of `InsertRange()` when inserting lazy `IEnumerable` in the middle of a list **by up to 99%**.

# Description
Detailed explanation can also be found in #14876. Short description:

If `IEnumerable` is being inserted in the list (not added to the end), it simply inserts items one-ny-one, shifting right part of the list on each iteration. It results in O(M*N) complexity. Improved logic is to enumerate collection to the end of the list and then move enumerated items to desired position. This is O(max(M,N)) complexity.

# Benchmarks

I have tested by inserting `IEnumerable` to the beginning of the list (worst possible scenario). For example, Insert1000In100000List means inserting enumerable with 1000 items to list with 100000 items.

``` ini

BenchmarkDotNet=v0.10.13, OS=Windows 10 Redstone 1 [1607, Anniversary Update] (10.0.14393.2125)
Intel Core i7-7800X CPU 3.50GHz (Kaby Lake), 1 CPU, 6 logical cores and 6 physical cores
.NET Core SDK=2.1.300-preview3-008391
  [Host]     : .NET Core 2.0.5 (CoreCLR 4.6.26020.03, CoreFX 4.6.26018.01), 64bit RyuJIT
  Job-HXIMAP : .NET Core ? (CoreCLR 4.6.0.0, CoreFX 4.6.26420.0), 64bit RyuJIT
  Job-MVNXHZ : .NET Core ? (CoreCLR 4.6.26310.01, CoreFX 4.6.26420.0), 64bit RyuJIT


```
|                  Method | Toolchain |         Mean |        Error |       StdDev |
|------------------------ |---------- |-------------:|-------------:|-------------:|
|  Insert1000In100000List |    before |  17,031.6 us |   199.233 us |   186.362 us |
| Insert1000In1000000List |    before | 277,366.5 us | 3,890.782 us | 3,449.077 us |
|  Insert10000In10000List |    before |  16,673.8 us |   177.103 us |   165.662 us |
|  Insert1000In100000List |     after |     788.1 us |     8.808 us |     8.239 us |
| Insert1000In1000000List |     after |   6,302.9 us |    83.200 us |    73.755 us |
|  Insert10000In10000List |     after |     149.2 us |     2.440 us |     2.282 us |

# Remarks
There is a special case: what if `IEnumerable` throws an exception? By default list will end up in incorrect state: inserted items will be at the end of the list, not in desired position. I was choosing between two possible solutions:

1. Return the list to original state
2. Restore the list to a valid state

I have chosen second approach for consistency, because `AddRange` (=`InsertRange` at the end) works the same way: in case of exception it ends up in a partially inserted enumerable too.