### PR TITLE
Dictionary/List code clean up/formatting (C#7)

### DIFF
--- a/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
@@ -672,7 +672,6 @@ namespace System.Collections.Generic
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
             }
 
-            _version++;
             if (_buckets != null)
             {
                 int hashCode = (_comparer?.GetHashCode(key) ?? key.GetHashCode()) & 0x7FFFFFFF;
@@ -708,6 +707,7 @@ namespace System.Collections.Generic
                         }
                         _freeList = i;
                         _freeCount++;
+                        _version++;
                         return true;
                     }
 
@@ -728,7 +728,6 @@ namespace System.Collections.Generic
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
             }
 
-            _version++;
             if (_buckets != null)
             {
                 int hashCode = (_comparer?.GetHashCode(key) ?? key.GetHashCode()) & 0x7FFFFFFF;
@@ -767,6 +766,7 @@ namespace System.Collections.Generic
                         }
                         _freeList = i;
                         _freeCount++;
+                        _version++;
                         return true;
                     }
 

--- a/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
@@ -315,7 +315,7 @@ namespace System.Collections.Generic
             {
                 if (entries[i].hashCode >= 0)
                 {
-                    array[index++] = new KeyValuePair<TKey, TValue>(entries[i].key, entries[i].value);
+                    array[index + i] = new KeyValuePair<TKey, TValue>(entries[i].key, entries[i].value);
                 }
             }
         }
@@ -822,7 +822,7 @@ namespace System.Collections.Generic
                 {
                     if (entries[i].hashCode >= 0)
                     {
-                        dictEntryArray[index++] = new DictionaryEntry(entries[i].key, entries[i].value);
+                        dictEntryArray[index + i] = new DictionaryEntry(entries[i].key, entries[i].value);
                     }
                 }
             }
@@ -842,7 +842,7 @@ namespace System.Collections.Generic
                     {
                         if (entries[i].hashCode >= 0)
                         {
-                            objects[index++] = new KeyValuePair<TKey, TValue>(entries[i].key, entries[i].value);
+                            objects[index + i] = new KeyValuePair<TKey, TValue>(entries[i].key, entries[i].value);
                         }
                     }
                 }
@@ -1210,7 +1210,7 @@ namespace System.Collections.Generic
                 Entry[] entries = _dictionary._entries;
                 for (int i = 0; i < count; i++)
                 {
-                    if (entries[i].hashCode >= 0) array[index++] = entries[i].key;
+                    if (entries[i].hashCode >= 0) array[index + i] = entries[i].key;
                 }
             }
 
@@ -1270,7 +1270,7 @@ namespace System.Collections.Generic
                     {
                         for (int i = 0; i < count; i++)
                         {
-                            if (entries[i].hashCode >= 0) objects[index++] = entries[i].key;
+                            if (entries[i].hashCode >= 0) objects[index + i] = entries[i].key;
                         }
                     }
                     catch (ArrayTypeMismatchException)
@@ -1393,7 +1393,7 @@ namespace System.Collections.Generic
                 Entry[] entries = _dictionary._entries;
                 for (int i = 0; i < count; i++)
                 {
-                    if (entries[i].hashCode >= 0) array[index++] = entries[i].value;
+                    if (entries[i].hashCode >= 0) array[index + i] = entries[i].value;
                 }
             }
 
@@ -1453,7 +1453,7 @@ namespace System.Collections.Generic
                     {
                         for (int i = 0; i < count; i++)
                         {
-                            if (entries[i].hashCode >= 0) objects[index++] = entries[i].value;
+                            if (entries[i].hashCode >= 0) objects[index + i] = entries[i].value;
                         }
                     }
                     catch (ArrayTypeMismatchException)

--- a/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
@@ -2,11 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
+using System.Threading;
 
 namespace System.Collections.Generic
 {
@@ -34,7 +33,7 @@ namespace System.Collections.Generic
     [DebuggerTypeProxy(typeof(IDictionaryDebugView<,>))]
     [DebuggerDisplay("Count = {Count}")]
     [Serializable]
-    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Dictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue>, ISerializable, IDeserializationCallback
     {
         private struct Entry
@@ -217,7 +216,7 @@ namespace System.Collections.Generic
                 int i = FindEntry(key);
                 if (i >= 0) return _entries[i].value;
                 ThrowHelper.ThrowKeyNotFoundException(key);
-                return default(TValue);
+                return default;
             }
             set
             {
@@ -233,9 +232,7 @@ namespace System.Collections.Generic
         }
 
         void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> keyValuePair)
-        {
-            Add(keyValuePair.Key, keyValuePair.Value);
-        }
+            => Add(keyValuePair.Key, keyValuePair.Value);
 
         bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> keyValuePair)
         {
@@ -274,9 +271,7 @@ namespace System.Collections.Generic
         }
 
         public bool ContainsKey(TKey key)
-        {
-            return FindEntry(key) >= 0;
-        }
+            => FindEntry(key) >= 0;
 
         public bool ContainsValue(TValue value)
         {
@@ -304,7 +299,7 @@ namespace System.Collections.Generic
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
             }
 
-            if (index < 0 || index > array.Length)
+            if ((uint)index > (uint)array.Length)
             {
                 ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
             }
@@ -326,14 +321,10 @@ namespace System.Collections.Generic
         }
 
         public Enumerator GetEnumerator()
-        {
-            return new Enumerator(this, Enumerator.KeyValuePair);
-        }
+            => new Enumerator(this, Enumerator.KeyValuePair);
 
         IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
-        {
-            return new Enumerator(this, Enumerator.KeyValuePair);
-        }
+            => new Enumerator(this, Enumerator.KeyValuePair);
 
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
         {
@@ -585,8 +576,7 @@ namespace System.Collections.Generic
 
         public virtual void OnDeserialization(object sender)
         {
-            SerializationInfo siInfo;
-            HashHelpers.SerializationInfoTable.TryGetValue(this, out siInfo);
+            HashHelpers.SerializationInfoTable.TryGetValue(this, out SerializationInfo siInfo);
 
             if (siInfo == null)
             {
@@ -630,9 +620,7 @@ namespace System.Collections.Generic
         }
 
         private void Resize()
-        {
-            Resize(HashHelpers.ExpandPrime(_count), false);
-        }
+            => Resize(HashHelpers.ExpandPrime(_count), false);
 
         private void Resize(int newSize, bool forceNewHashCodes)
         {
@@ -684,6 +672,7 @@ namespace System.Collections.Generic
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
             }
 
+            _version++;
             if (_buckets != null)
             {
                 int hashCode = (_comparer?.GetHashCode(key) ?? key.GetHashCode()) & 0x7FFFFFFF;
@@ -711,15 +700,14 @@ namespace System.Collections.Generic
 
                         if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
                         {
-                            entry.key = default(TKey);
+                            entry.key = default;
                         }
                         if (RuntimeHelpers.IsReferenceOrContainsReferences<TValue>())
                         {
-                            entry.value = default(TValue);
+                            entry.value = default;
                         }
                         _freeList = i;
                         _freeCount++;
-                        _version++;
                         return true;
                     }
 
@@ -740,6 +728,7 @@ namespace System.Collections.Generic
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
             }
 
+            _version++;
             if (_buckets != null)
             {
                 int hashCode = (_comparer?.GetHashCode(key) ?? key.GetHashCode()) & 0x7FFFFFFF;
@@ -770,15 +759,14 @@ namespace System.Collections.Generic
 
                         if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
                         {
-                            entry.key = default(TKey);
+                            entry.key = default;
                         }
                         if (RuntimeHelpers.IsReferenceOrContainsReferences<TValue>())
                         {
-                            entry.value = default(TValue);
+                            entry.value = default;
                         }
                         _freeList = i;
                         _freeCount++;
-                        _version++;
                         return true;
                     }
 
@@ -786,7 +774,7 @@ namespace System.Collections.Generic
                     i = entry.next;
                 }
             }
-            value = default(TValue);
+            value = default;
             return false;
         }
 
@@ -798,57 +786,37 @@ namespace System.Collections.Generic
                 value = _entries[i].value;
                 return true;
             }
-            value = default(TValue);
+            value = default;
             return false;
         }
 
-        public bool TryAdd(TKey key, TValue value) => TryInsert(key, value, InsertionBehavior.None);
+        public bool TryAdd(TKey key, TValue value)
+            => TryInsert(key, value, InsertionBehavior.None);
 
-        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly
-        {
-            get { return false; }
-        }
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly => false;
 
         void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int index)
-        {
-            CopyTo(array, index);
-        }
+            => CopyTo(array, index);
 
         void ICollection.CopyTo(Array array, int index)
         {
             if (array == null)
-            {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
-            }
-
             if (array.Rank != 1)
-            {
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_RankMultiDimNotSupported);
-            }
-
             if (array.GetLowerBound(0) != 0)
-            {
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_NonZeroLowerBound);
-            }
-
-            if (index < 0 || index > array.Length)
-            {
+            if ((uint)index > (uint)array.Length)
                 ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
-            }
-
             if (array.Length - index < Count)
-            {
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_ArrayPlusOffTooSmall);
-            }
 
-            KeyValuePair<TKey, TValue>[] pairs = array as KeyValuePair<TKey, TValue>[];
-            if (pairs != null)
+            if (array is KeyValuePair<TKey, TValue>[] pairs)
             {
                 CopyTo(pairs, index);
             }
-            else if (array is DictionaryEntry[])
+            else if (array is DictionaryEntry[] dictEntryArray)
             {
-                DictionaryEntry[] dictEntryArray = array as DictionaryEntry[];
                 Entry[] entries = _entries;
                 for (int i = 0; i < _count; i++)
                 {
@@ -886,9 +854,7 @@ namespace System.Collections.Generic
         }
 
         IEnumerator IEnumerable.GetEnumerator()
-        {
-            return new Enumerator(this, Enumerator.KeyValuePair);
-        }
+            => new Enumerator(this, Enumerator.KeyValuePair);
 
         /// <summary>
         /// Ensures that the dictionary can hold up to 'capacity' entries without any further expansion of its backing storage
@@ -919,9 +885,7 @@ namespace System.Collections.Generic
         /// dictionary.TrimExcess();
         /// </summary>
         public void TrimExcess()
-        {
-            TrimExcess(Count);
-        }
+            => TrimExcess(Count);
 
         /// <summary>
         /// Sets the capacity of this dictionary to hold up 'capacity' entries without any further expansion of its backing storage
@@ -964,10 +928,7 @@ namespace System.Collections.Generic
             _freeCount = 0;
         }
 
-        bool ICollection.IsSynchronized
-        {
-            get { return false; }
-        }
+        bool ICollection.IsSynchronized => false;
 
         object ICollection.SyncRoot
         {
@@ -975,31 +936,19 @@ namespace System.Collections.Generic
             {
                 if (_syncRoot == null)
                 {
-                    System.Threading.Interlocked.CompareExchange<Object>(ref _syncRoot, new Object(), null);
+                    Interlocked.CompareExchange<object>(ref _syncRoot, new object(), null);
                 }
                 return _syncRoot;
             }
         }
 
-        bool IDictionary.IsFixedSize
-        {
-            get { return false; }
-        }
+        bool IDictionary.IsFixedSize => false;
 
-        bool IDictionary.IsReadOnly
-        {
-            get { return false; }
-        }
+        bool IDictionary.IsReadOnly => false;
 
-        ICollection IDictionary.Keys
-        {
-            get { return (ICollection)Keys; }
-        }
+        ICollection IDictionary.Keys => (ICollection)Keys;
 
-        ICollection IDictionary.Values
-        {
-            get { return (ICollection)Values; }
-        }
+        ICollection IDictionary.Values => (ICollection)Values;
 
         object IDictionary.this[object key]
         {
@@ -1089,9 +1038,7 @@ namespace System.Collections.Generic
         }
 
         IDictionaryEnumerator IDictionary.GetEnumerator()
-        {
-            return new Enumerator(this, Enumerator.DictEntry);
-        }
+            => new Enumerator(this, Enumerator.DictEntry);
 
         void IDictionary.Remove(object key)
         {
@@ -1147,10 +1094,7 @@ namespace System.Collections.Generic
                 return false;
             }
 
-            public KeyValuePair<TKey, TValue> Current
-            {
-                get { return _current; }
-            }
+            public KeyValuePair<TKey, TValue> Current => _current;
 
             public void Dispose()
             {
@@ -1167,7 +1111,7 @@ namespace System.Collections.Generic
 
                     if (_getEnumeratorRetType == DictEntry)
                     {
-                        return new System.Collections.DictionaryEntry(_current.Key, _current.Value);
+                        return new DictionaryEntry(_current.Key, _current.Value);
                     }
                     else
                     {
@@ -1243,9 +1187,7 @@ namespace System.Collections.Generic
             }
 
             public Enumerator GetEnumerator()
-            {
-                return new Enumerator(_dictionary);
-            }
+                => new Enumerator(_dictionary);
 
             public void CopyTo(TKey[] array, int index)
             {
@@ -1272,30 +1214,18 @@ namespace System.Collections.Generic
                 }
             }
 
-            public int Count
-            {
-                get { return _dictionary.Count; }
-            }
+            public int Count => _dictionary.Count;
 
-            bool ICollection<TKey>.IsReadOnly
-            {
-                get { return true; }
-            }
+            bool ICollection<TKey>.IsReadOnly => true;
 
             void ICollection<TKey>.Add(TKey item)
-            {
-                ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_KeyCollectionSet);
-            }
+                => ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_KeyCollectionSet);
 
             void ICollection<TKey>.Clear()
-            {
-                ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_KeyCollectionSet);
-            }
+                => ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_KeyCollectionSet);
 
             bool ICollection<TKey>.Contains(TKey item)
-            {
-                return _dictionary.ContainsKey(item);
-            }
+                => _dictionary.ContainsKey(item);
 
             bool ICollection<TKey>.Remove(TKey item)
             {
@@ -1304,44 +1234,25 @@ namespace System.Collections.Generic
             }
 
             IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator()
-            {
-                return new Enumerator(_dictionary);
-            }
+                => new Enumerator(_dictionary);
 
             IEnumerator IEnumerable.GetEnumerator()
-            {
-                return new Enumerator(_dictionary);
-            }
+                => new Enumerator(_dictionary);
 
             void ICollection.CopyTo(Array array, int index)
             {
                 if (array == null)
-                {
                     ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
-                }
-
                 if (array.Rank != 1)
-                {
                     ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_RankMultiDimNotSupported);
-                }
-
                 if (array.GetLowerBound(0) != 0)
-                {
                     ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_NonZeroLowerBound);
-                }
-
-                if (index < 0 || index > array.Length)
-                {
+                if ((uint)index > (uint)array.Length)
                     ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
-                }
-
                 if (array.Length - index < _dictionary.Count)
-                {
                     ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_ArrayPlusOffTooSmall);
-                }
 
-                TKey[] keys = array as TKey[];
-                if (keys != null)
+                if (array is TKey[] keys)
                 {
                     CopyTo(keys, index);
                 }
@@ -1369,17 +1280,11 @@ namespace System.Collections.Generic
                 }
             }
 
-            bool ICollection.IsSynchronized
-            {
-                get { return false; }
-            }
+            bool ICollection.IsSynchronized => false;
 
-            object ICollection.SyncRoot
-            {
-                get { return ((ICollection)_dictionary).SyncRoot; }
-            }
+            object ICollection.SyncRoot => ((ICollection)_dictionary).SyncRoot;
 
-            public struct Enumerator : IEnumerator<TKey>, System.Collections.IEnumerator
+            public struct Enumerator : IEnumerator<TKey>, IEnumerator
             {
                 private Dictionary<TKey, TValue> _dictionary;
                 private int _index;
@@ -1391,7 +1296,7 @@ namespace System.Collections.Generic
                     _dictionary = dictionary;
                     _version = dictionary._version;
                     _index = 0;
-                    _currentKey = default(TKey);
+                    _currentKey = default;
                 }
 
                 public void Dispose()
@@ -1417,19 +1322,13 @@ namespace System.Collections.Generic
                     }
 
                     _index = _dictionary._count + 1;
-                    _currentKey = default(TKey);
+                    _currentKey = default;
                     return false;
                 }
 
-                public TKey Current
-                {
-                    get
-                    {
-                        return _currentKey;
-                    }
-                }
+                public TKey Current => _currentKey;
 
-                object System.Collections.IEnumerator.Current
+                object IEnumerator.Current
                 {
                     get
                     {
@@ -1442,7 +1341,7 @@ namespace System.Collections.Generic
                     }
                 }
 
-                void System.Collections.IEnumerator.Reset()
+                void IEnumerator.Reset()
                 {
                     if (_version != _dictionary._version)
                     {
@@ -1450,7 +1349,7 @@ namespace System.Collections.Generic
                     }
 
                     _index = 0;
-                    _currentKey = default(TKey);
+                    _currentKey = default;
                 }
             }
         }
@@ -1471,9 +1370,7 @@ namespace System.Collections.Generic
             }
 
             public Enumerator GetEnumerator()
-            {
-                return new Enumerator(_dictionary);
-            }
+                => new Enumerator(_dictionary);
 
             public void CopyTo(TValue[] array, int index)
             {
@@ -1500,20 +1397,12 @@ namespace System.Collections.Generic
                 }
             }
 
-            public int Count
-            {
-                get { return _dictionary.Count; }
-            }
+            public int Count => _dictionary.Count;
 
-            bool ICollection<TValue>.IsReadOnly
-            {
-                get { return true; }
-            }
+            bool ICollection<TValue>.IsReadOnly => true;
 
             void ICollection<TValue>.Add(TValue item)
-            {
-                ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_ValueCollectionSet);
-            }
+                => ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_ValueCollectionSet);
 
             bool ICollection<TValue>.Remove(TValue item)
             {
@@ -1522,52 +1411,31 @@ namespace System.Collections.Generic
             }
 
             void ICollection<TValue>.Clear()
-            {
-                ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_ValueCollectionSet);
-            }
+                => ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_ValueCollectionSet);
 
             bool ICollection<TValue>.Contains(TValue item)
-            {
-                return _dictionary.ContainsValue(item);
-            }
+                => _dictionary.ContainsValue(item);
 
             IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator()
-            {
-                return new Enumerator(_dictionary);
-            }
+                => new Enumerator(_dictionary);
 
             IEnumerator IEnumerable.GetEnumerator()
-            {
-                return new Enumerator(_dictionary);
-            }
+                => new Enumerator(_dictionary);
 
             void ICollection.CopyTo(Array array, int index)
             {
                 if (array == null)
-                {
                     ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
-                }
-
                 if (array.Rank != 1)
-                {
                     ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_RankMultiDimNotSupported);
-                }
-
                 if (array.GetLowerBound(0) != 0)
-                {
                     ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_NonZeroLowerBound);
-                }
-
-                if (index < 0 || index > array.Length)
-                {
+                if ((uint)index > (uint)array.Length)
                     ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
-                }
-
                 if (array.Length - index < _dictionary.Count)
                     ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_ArrayPlusOffTooSmall);
 
-                TValue[] values = array as TValue[];
-                if (values != null)
+                if (array is TValue[] values)
                 {
                     CopyTo(values, index);
                 }
@@ -1595,17 +1463,11 @@ namespace System.Collections.Generic
                 }
             }
 
-            bool ICollection.IsSynchronized
-            {
-                get { return false; }
-            }
+            bool ICollection.IsSynchronized => false;
 
-            object ICollection.SyncRoot
-            {
-                get { return ((ICollection)_dictionary).SyncRoot; }
-            }
+            object ICollection.SyncRoot => ((ICollection)_dictionary).SyncRoot;
 
-            public struct Enumerator : IEnumerator<TValue>, System.Collections.IEnumerator
+            public struct Enumerator : IEnumerator<TValue>, IEnumerator
             {
                 private Dictionary<TKey, TValue> _dictionary;
                 private int _index;
@@ -1617,7 +1479,7 @@ namespace System.Collections.Generic
                     _dictionary = dictionary;
                     _version = dictionary._version;
                     _index = 0;
-                    _currentValue = default(TValue);
+                    _currentValue = default;
                 }
 
                 public void Dispose()
@@ -1642,19 +1504,13 @@ namespace System.Collections.Generic
                         }
                     }
                     _index = _dictionary._count + 1;
-                    _currentValue = default(TValue);
+                    _currentValue = default;
                     return false;
                 }
 
-                public TValue Current
-                {
-                    get
-                    {
-                        return _currentValue;
-                    }
-                }
+                public TValue Current => _currentValue;
 
-                object System.Collections.IEnumerator.Current
+                object IEnumerator.Current
                 {
                     get
                     {
@@ -1667,14 +1523,14 @@ namespace System.Collections.Generic
                     }
                 }
 
-                void System.Collections.IEnumerator.Reset()
+                void IEnumerator.Reset()
                 {
                     if (_version != _dictionary._version)
                     {
                         ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
                     }
                     _index = 0;
-                    _currentValue = default(TValue);
+                    _currentValue = default;
                 }
             }
         }

--- a/src/mscorlib/shared/System/Collections/Generic/List.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/List.cs
@@ -676,7 +676,6 @@ namespace System.Collections.Generic
         // 
         public void Insert(int index, T item)
         {
-            _version++;
             // Note that insertions at the end are legal.
             if ((uint)index > (uint)_size)
             {
@@ -689,6 +688,7 @@ namespace System.Collections.Generic
             }
             _items[index] = item;
             _size++;
+            _version++;
         }
 
         void IList.Insert(int index, object item)
@@ -868,7 +868,6 @@ namespace System.Collections.Generic
         // The complexity is O(n).
         public int RemoveAll(Predicate<T> match)
         {
-            _version++;
             if (match == null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.match);
@@ -900,6 +899,7 @@ namespace System.Collections.Generic
 
             int result = _size - freeIndex;
             _size = freeIndex;
+            _version++;
             return result;
         }
 
@@ -947,12 +947,13 @@ namespace System.Collections.Generic
                 {
                     Array.Copy(_items, index + count, _items, index, _size - index);
                 }
+
+                _version++;
                 if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
                 {
                     Array.Clear(_items, _size, count);
                 }
             }
-            _version++;
         }
 
         // Reverses the elements in this list.
@@ -1091,10 +1092,10 @@ namespace System.Collections.Generic
 
         private void AddEnumerable(IEnumerable<T> enumerable)
         {
-            _version++; // Even if the enumerable has no items, we can update _version.
             Debug.Assert(enumerable != null);
             Debug.Assert(!(enumerable is ICollection<T>), "We should have optimized for this beforehand.");
 
+            _version++; // Even if the enumerable has no items, we can update _version.
             using (IEnumerator<T> en = enumerable.GetEnumerator())
             {
 

--- a/src/mscorlib/shared/System/Collections/Generic/List.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/List.cs
@@ -5,6 +5,7 @@
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace System.Collections.Generic
 {
@@ -17,8 +18,8 @@ namespace System.Collections.Generic
     [DebuggerTypeProxy(typeof(ICollectionDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
     [Serializable]
-    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public class List<T> : IList<T>, System.Collections.IList, IReadOnlyList<T>
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+    public class List<T> : IList<T>, IList, IReadOnlyList<T>
     {
         private const int DefaultCapacity = 4;
 
@@ -63,8 +64,7 @@ namespace System.Collections.Generic
             if (collection == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.collection);
 
-            ICollection<T> c = collection as ICollection<T>;
-            if (c != null)
+            if (collection is ICollection<T> c)
             {
                 int count = c.Count;
                 if (count == 0)
@@ -123,44 +123,26 @@ namespace System.Collections.Generic
         }
 
         // Read-only property describing how many elements are in the List.
-        public int Count
-        {
-            get
-            {
-                return _size;
-            }
-        }
+        public int Count => _size;
 
-        bool System.Collections.IList.IsFixedSize
-        {
-            get { return false; }
-        }
+        bool IList.IsFixedSize => false;
 
         // Is this List read-only?
-        bool ICollection<T>.IsReadOnly
-        {
-            get { return false; }
-        }
+        bool ICollection<T>.IsReadOnly => false;
 
-        bool System.Collections.IList.IsReadOnly
-        {
-            get { return false; }
-        }
+        bool IList.IsReadOnly => false;
 
         // Is this List synchronized (thread-safe)?
-        bool System.Collections.ICollection.IsSynchronized
-        {
-            get { return false; }
-        }
+        bool ICollection.IsSynchronized => false;
 
         // Synchronization root for this object.
-        object System.Collections.ICollection.SyncRoot
+        object ICollection.SyncRoot
         {
             get
             {
                 if (_syncRoot == null)
                 {
-                    System.Threading.Interlocked.CompareExchange<object>(ref _syncRoot, new object(), null);
+                    Interlocked.CompareExchange<object>(ref _syncRoot, new object(), null);
                 }
                 return _syncRoot;
             }
@@ -181,12 +163,12 @@ namespace System.Collections.Generic
 
             set
             {
+                _version++;
                 if ((uint)index >= (uint)_size)
                 {
                     ThrowHelper.ThrowArgumentOutOfRange_IndexException();
                 }
                 _items[index] = value;
-                _version++;
             }
         }
 
@@ -197,7 +179,7 @@ namespace System.Collections.Generic
             return ((value is T) || (value == null && default(T) == null));
         }
 
-        object System.Collections.IList.this[int index]
+        object IList.this[int index]
         {
             get
             {
@@ -225,9 +207,9 @@ namespace System.Collections.Generic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Add(T item)
         {
-            var array = _items;
-            var size = _size;
             _version++;
+            T[] array = _items;
+            int size = _size;
             if ((uint)size < (uint)array.Length)
             {
                 _size = size + 1;
@@ -243,13 +225,13 @@ namespace System.Collections.Generic
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void AddWithResize(T item)
         {
-            var size = _size;
+            int size = _size;
             EnsureCapacity(size + 1);
             _size = size + 1;
             _items[size] = item;
         }
 
-        int System.Collections.IList.Add(Object item)
+        int IList.Add(object item)
         {
             ThrowHelper.IfNullAndNullsAreIllegalThenThrow<T>(item, ExceptionArgument.item);
 
@@ -270,14 +252,10 @@ namespace System.Collections.Generic
         // capacity or the new size, whichever is larger.
         //
         public void AddRange(IEnumerable<T> collection)
-        {
-            InsertRange(_size, collection);
-        }
+            => InsertRange(_size, collection);
 
         public ReadOnlyCollection<T> AsReadOnly()
-        {
-            return new ReadOnlyCollection<T>(this);
-        }
+            => new ReadOnlyCollection<T>(this);
 
         // Searches a section of the list for a given element using a binary search
         // algorithm. Elements of the list are compared to the search value using
@@ -312,25 +290,20 @@ namespace System.Collections.Generic
         }
 
         public int BinarySearch(T item)
-        {
-            return BinarySearch(0, Count, item, null);
-        }
+            => BinarySearch(0, Count, item, null);
 
         public int BinarySearch(T item, IComparer<T> comparer)
-        {
-            return BinarySearch(0, Count, item, comparer);
-        }
-
+            => BinarySearch(0, Count, item, comparer);
 
         // Clears the contents of List.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Clear()
         {
+            _version++;
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
                 int size = _size;
                 _size = 0;
-                _version++;
                 if (size > 0)
                 {
                     Array.Clear(_items, 0, size); // Clear the elements so that the gc can reclaim the references.
@@ -339,7 +312,6 @@ namespace System.Collections.Generic
             else
             {
                 _size = 0;
-                _version++;
             }
         }
 
@@ -360,7 +332,7 @@ namespace System.Collections.Generic
             return _size != 0 && IndexOf(item) != -1;
         }
 
-        bool System.Collections.IList.Contains(object item)
+        bool IList.Contains(object item)
         {
             if (IsCompatibleObject(item))
             {
@@ -388,13 +360,11 @@ namespace System.Collections.Generic
         // Copies this List into array, which must be of a 
         // compatible array type.  
         public void CopyTo(T[] array)
-        {
-            CopyTo(array, 0);
-        }
+            => CopyTo(array, 0);
 
         // Copies this List into array, which must be of a 
         // compatible array type.  
-        void System.Collections.ICollection.CopyTo(Array array, int arrayIndex)
+        void ICollection.CopyTo(Array array, int arrayIndex)
         {
             if ((array != null) && (array.Rank != 1))
             {
@@ -452,9 +422,7 @@ namespace System.Collections.Generic
         }
 
         public bool Exists(Predicate<T> match)
-        {
-            return FindIndex(match) != -1;
-        }
+            => FindIndex(match) != -1;
 
         public T Find(Predicate<T> match)
         {
@@ -470,7 +438,7 @@ namespace System.Collections.Generic
                     return _items[i];
                 }
             }
-            return default(T);
+            return default;
         }
 
         public List<T> FindAll(Predicate<T> match)
@@ -492,14 +460,10 @@ namespace System.Collections.Generic
         }
 
         public int FindIndex(Predicate<T> match)
-        {
-            return FindIndex(0, _size, match);
-        }
+            => FindIndex(0, _size, match);
 
         public int FindIndex(int startIndex, Predicate<T> match)
-        {
-            return FindIndex(startIndex, _size - startIndex, match);
-        }
+            => FindIndex(startIndex, _size - startIndex, match);
 
         public int FindIndex(int startIndex, int count, Predicate<T> match)
         {
@@ -540,18 +504,14 @@ namespace System.Collections.Generic
                     return _items[i];
                 }
             }
-            return default(T);
+            return default;
         }
 
         public int FindLastIndex(Predicate<T> match)
-        {
-            return FindLastIndex(_size - 1, _size, match);
-        }
+            => FindLastIndex(_size - 1, _size, match);
 
         public int FindLastIndex(int startIndex, Predicate<T> match)
-        {
-            return FindLastIndex(startIndex, startIndex + 1, match);
-        }
+            => FindLastIndex(startIndex, startIndex + 1, match);
 
         public int FindLastIndex(int startIndex, int count, Predicate<T> match)
         {
@@ -622,19 +582,13 @@ namespace System.Collections.Generic
         // GetObject methods of the enumerator will throw an exception.
         //
         public Enumerator GetEnumerator()
-        {
-            return new Enumerator(this);
-        }
+            => new Enumerator(this);
 
         IEnumerator<T> IEnumerable<T>.GetEnumerator()
-        {
-            return new Enumerator(this);
-        }
+            => new Enumerator(this);
 
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-        {
-            return new Enumerator(this);
-        }
+        IEnumerator IEnumerable.GetEnumerator()
+            => new Enumerator(this);
 
         public List<T> GetRange(int index, int count)
         {
@@ -669,11 +623,9 @@ namespace System.Collections.Generic
         // search.
         // 
         public int IndexOf(T item)
-        {
-            return Array.IndexOf(_items, item, 0, _size);
-        }
+            => Array.IndexOf(_items, item, 0, _size);
 
-        int System.Collections.IList.IndexOf(object item)
+        int IList.IndexOf(object item)
         {
             if (IsCompatibleObject(item))
             {
@@ -724,6 +676,7 @@ namespace System.Collections.Generic
         // 
         public void Insert(int index, T item)
         {
+            _version++;
             // Note that insertions at the end are legal.
             if ((uint)index > (uint)_size)
             {
@@ -736,10 +689,9 @@ namespace System.Collections.Generic
             }
             _items[index] = item;
             _size++;
-            _version++;
         }
 
-        void System.Collections.IList.Insert(int index, Object item)
+        void IList.Insert(int index, object item)
         {
             ThrowHelper.IfNullAndNullsAreIllegalThenThrow<T>(item, ExceptionArgument.item);
 
@@ -770,9 +722,8 @@ namespace System.Collections.Generic
                 ThrowHelper.ThrowArgumentOutOfRange_IndexException();
             }
 
-            ICollection<T> c = collection as ICollection<T>;
-            if (c != null)
-            {    // if collection is ICollection<T>
+            if (collection is ICollection<T> c)
+            {
                 int count = c.Count;
                 if (count > 0)
                 {
@@ -905,7 +856,7 @@ namespace System.Collections.Generic
             return false;
         }
 
-        void System.Collections.IList.Remove(object item)
+        void IList.Remove(object item)
         {
             if (IsCompatibleObject(item))
             {
@@ -917,6 +868,7 @@ namespace System.Collections.Generic
         // The complexity is O(n).
         public int RemoveAll(Predicate<T> match)
         {
+            _version++;
             if (match == null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.match);
@@ -948,7 +900,6 @@ namespace System.Collections.Generic
 
             int result = _size - freeIndex;
             _size = freeIndex;
-            _version++;
             return result;
         }
 
@@ -967,7 +918,7 @@ namespace System.Collections.Generic
             }
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                _items[_size] = default(T);
+                _items[_size] = default;
             }
             _version++;
         }
@@ -996,20 +947,17 @@ namespace System.Collections.Generic
                 {
                     Array.Copy(_items, index + count, _items, index, _size - index);
                 }
-
-                _version++;
                 if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
                 {
                     Array.Clear(_items, _size, count);
                 }
             }
+            _version++;
         }
 
         // Reverses the elements in this list.
         public void Reverse()
-        {
-            Reverse(0, Count);
-        }
+            => Reverse(0, Count);
 
         // Reverses the elements in a range of this list. Following a call to this
         // method, an element in the range given by index and count
@@ -1041,16 +989,12 @@ namespace System.Collections.Generic
         // Sorts the elements in this list.  Uses the default comparer and 
         // Array.Sort.
         public void Sort()
-        {
-            Sort(0, Count, null);
-        }
+            => Sort(0, Count, null);
 
         // Sorts the elements in this list.  Uses Array.Sort with the
         // provided comparer.
         public void Sort(IComparer<T> comparer)
-        {
-            Sort(0, Count, comparer);
-        }
+            => Sort(0, Count, comparer);
 
         // Sorts the elements in a section of this list. The sort compares the
         // elements to each other using the given IComparer interface. If
@@ -1147,12 +1091,12 @@ namespace System.Collections.Generic
 
         private void AddEnumerable(IEnumerable<T> enumerable)
         {
+            _version++; // Even if the enumerable has no items, we can update _version.
             Debug.Assert(enumerable != null);
             Debug.Assert(!(enumerable is ICollection<T>), "We should have optimized for this beforehand.");
 
             using (IEnumerator<T> en = enumerable.GetEnumerator())
             {
-                _version++; // Even if the enumerable has no items, we can update _version.
 
                 while (en.MoveNext())
                 {
@@ -1170,7 +1114,7 @@ namespace System.Collections.Generic
             }
         }
 
-        public struct Enumerator : IEnumerator<T>, System.Collections.IEnumerator
+        public struct Enumerator : IEnumerator<T>, IEnumerator
         {
             private List<T> _list;
             private int _index;
@@ -1182,7 +1126,7 @@ namespace System.Collections.Generic
                 _list = list;
                 _index = 0;
                 _version = list._version;
-                _current = default(T);
+                _current = default;
             }
 
             public void Dispose()
@@ -1210,19 +1154,13 @@ namespace System.Collections.Generic
                 }
 
                 _index = _list._size + 1;
-                _current = default(T);
+                _current = default;
                 return false;
             }
 
-            public T Current
-            {
-                get
-                {
-                    return _current;
-                }
-            }
+            public T Current => _current;
 
-            object System.Collections.IEnumerator.Current
+            object IEnumerator.Current
             {
                 get
                 {
@@ -1234,7 +1172,7 @@ namespace System.Collections.Generic
                 }
             }
 
-            void System.Collections.IEnumerator.Reset()
+            void IEnumerator.Reset()
             {
                 if (_version != _list._version)
                 {
@@ -1242,7 +1180,7 @@ namespace System.Collections.Generic
                 }
 
                 _index = 0;
-                _current = default(T);
+                _current = default;
             }
         }
     }


### PR DESCRIPTION
and some mild asm improves
```
Total bytes of diff: -2037 (-0.06% of base)
    diff is an improvement.

Total byte diff includes 0 bytes from reconciling methods
        Base had    0 unique methods,        0 unique bytes
        Diff had    0 unique methods,        0 unique bytes

Top file improvements by size (bytes):
       -2037 : System.Private.CoreLib.dasm (-0.06% of base)

1 total files with size differences (1 improved, 0 regressed), 0 unchanged.

Top method improvements by size (bytes):
        -603 : System.Private.CoreLib.dasm - Dictionary`2:System.Collections.ICollection.CopyTo(ref,int):this (29 methods)
        -451 : System.Private.CoreLib.dasm - Dictionary`2:CopyTo(ref,int):this (29 methods)
        -376 : System.Private.CoreLib.dasm - ValueCollection:System.Collections.ICollection.CopyTo(ref,int):this (30 methods)
        -370 : System.Private.CoreLib.dasm - KeyCollection:System.Collections.ICollection.CopyTo(ref,int):this (30 methods)
         -71 : System.Private.CoreLib.dasm - KeyCollection:CopyTo(ref,int):this (31 methods)
         -71 : System.Private.CoreLib.dasm - ValueCollection:CopyTo(ref,int):this (31 methods)
         -33 : System.Private.CoreLib.dasm - List`1:RemoveRange(int,int):this (23 methods)
         -21 : System.Private.CoreLib.dasm - List`1:System.Collections.IList.Add(ref):int:this (27 methods)
         -18 : System.Private.CoreLib.dasm - List`1:set_Item(int,struct):this (12 methods)
          -9 : System.Private.CoreLib.dasm - List`1:Clear():this (27 methods)
          -3 : System.Private.CoreLib.dasm - List`1:set_Item(int,ref):this
          -2 : System.Private.CoreLib.dasm - PinnableBufferCache:TrimFreeListIfNeeded():bool:this
          -2 : System.Private.CoreLib.dasm - List`1:set_Item(int,ushort):this (2 methods)
          -2 : System.Private.CoreLib.dasm - List`1:set_Item(int,ubyte):this (2 methods)
          -1 : System.Private.CoreLib.dasm - EventSource:InitializeProviderMetadata():this
          -1 : System.Private.CoreLib.dasm - RuntimeAssembly:GetForwardedTypes():ref:this
          -1 : System.Private.CoreLib.dasm - List`1:set_Item(int,short):this
          -1 : System.Private.CoreLib.dasm - List`1:set_Item(int,byte):this
          -1 : System.Private.CoreLib.dasm - List`1:set_Item(int,bool):this

19 total methods with size differences (19 improved, 0 regressed), 17262 unchanged.
```