### PR TITLE
Remove HWIntrinsicFlag bitwise OR operator

### DIFF
--- a/src/jit/hwintrinsicxarch.cpp
+++ b/src/jit/hwintrinsicxarch.cpp
@@ -20,8 +20,10 @@ struct HWIntrinsicInfo
 };
 
 static const HWIntrinsicInfo hwIntrinsicInfoArray[] = {
+// clang-format off
 #define HARDWARE_INTRINSIC(id, name, isa, ival, size, numarg, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, category, flag) \
-    {NI_##id, name, InstructionSet_##isa, ival, size, numarg, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, category, flag},
+    {NI_##id, name, InstructionSet_##isa, ival, size, numarg, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, category, static_cast<HWIntrinsicFlag>(flag)},
+// clang-format on
 #include "hwintrinsiclistxarch.h"
 };
 

--- a/src/jit/namedintrinsiclist.h
+++ b/src/jit/namedintrinsiclist.h
@@ -112,11 +112,6 @@ enum HWIntrinsicFlag : unsigned int
     HW_Flag_SpecialImport = 0x80000,
 };
 
-inline HWIntrinsicFlag operator|(HWIntrinsicFlag c1, HWIntrinsicFlag c2)
-{
-    return static_cast<HWIntrinsicFlag>(static_cast<unsigned>(c1) | static_cast<unsigned>(c2));
-}
-
 enum HWIntrinsicCategory : unsigned int
 {
     // Simple SIMD intrinsics


### PR DESCRIPTION
This makes VC++ emit a dynamic initializer for hwIntrinsicInfoArray that bloats clrjit.dll with 70 kbytes of code