### PR TITLE
Work around Jenkins problem with large env vars

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -22,6 +22,11 @@ if defined VS150COMNTOOLS (
   set __VSVersion=vs2015
 )
 
+:: Work around Jenkins CI + msbuild problem: Jenkins sometimes creates very large environment
+:: variables, and msbuild can't handle environment blocks with such large variables. So clear
+:: out the variables that might be too large.
+set ghprbCommentBody=
+
 :: Note that the msbuild project files (specifically, dir.proj) will use the following variables, if set:
 ::      __BuildArch         -- default: x64
 ::      __BuildType         -- default: Debug

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# Work around Jenkins CI + msbuild problem: Jenkins sometimes creates very large environment
+# variables, and msbuild can't handle environment blocks with such large variables. So clear
+# out the variables that might be too large.
+export ghprbCommentBody=
+
 # resolve python-version to use
 if [ "$PYTHON" == "" ] ; then
     if ! PYTHON=$(command -v python2.7 || command -v python2 || command -v python)


### PR DESCRIPTION
Clear out `ghprbCommentBody` before msbuild is invoked, which can't
deal with large environment variables.