### PR TITLE
Update use of AsBytes in perf tests to use MemoryMarshal.AsBytes.

### DIFF
--- a/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
@@ -960,7 +960,7 @@ namespace Span
 
             for (int i = 0; i < iterationCount; i++)
             {
-                var byteSpan = span.AsBytes();
+                var byteSpan = MemoryMarshal.AsBytes(span);
                 // Under a condition that we know is false but the jit doesn't,
                 // add a read from 'byteSpan' to make sure it's not dead, and an assignment
                 // to 'span' so the AsBytes call won't get hoisted.


### PR DESCRIPTION
Part of https://github.com/dotnet/corefx/issues/27094