### PR TITLE
Fix build without libunwind installed

### DIFF
--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -11,6 +11,10 @@ add_compile_options(-fPIC)
 
 if(NOT CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
   include_directories(libunwind/include)
+  include_directories(libunwind/include/tdep)
+  include_directories(${CMAKE_CURRENT_BINARY_DIR}/libunwind/include)
+  include_directories(${CMAKE_CURRENT_BINARY_DIR}/libunwind/include/tdep)
+
   add_subdirectory(libunwind)
 endif(NOT CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
 

--- a/src/pal/src/configure.cmake
+++ b/src/pal/src/configure.cmake
@@ -960,7 +960,7 @@ if(NOT CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
   list(INSERT CMAKE_REQUIRED_INCLUDES 0 ${CMAKE_CURRENT_SOURCE_DIR}/libunwind/include ${CMAKE_CURRENT_BINARY_DIR}/libunwind/include)
 endif()
 
-set(CMAKE_REQUIRED_FLAGS "-c")
+set(CMAKE_REQUIRED_FLAGS "-c -Werror=implicit-function-declaration")
 
 check_c_source_compiles("
 #include <libunwind.h>

--- a/src/pal/src/configure.cmake
+++ b/src/pal/src/configure.cmake
@@ -100,28 +100,6 @@ check_function_exists(semget HAS_SYSV_SEMAPHORES)
 check_function_exists(pthread_mutex_init HAS_PTHREAD_MUTEXES)
 check_function_exists(ttrace HAVE_TTRACE)
 check_function_exists(pipe2 HAVE_PIPE2)
-set(CMAKE_REQUIRED_LIBRARIES unwind unwind-generic)
-check_cxx_source_compiles("
-#include <libunwind.h>
-
-int main(int argc, char **argv) {
-  unw_cursor_t cursor;
-  unw_save_loc_t saveLoc;
-  int reg = UNW_REG_IP;
-  unw_get_save_loc(&cursor, reg, &saveLoc);
-
-  return 0;
-}" HAVE_UNW_GET_SAVE_LOC)
-check_cxx_source_compiles("
-#include <libunwind.h>
-
-int main(int argc, char **argv) {
-  unw_addr_space_t as;
-  unw_get_accessors(as);
-
-  return 0;
-}" HAVE_UNW_GET_ACCESSORS)
-set(CMAKE_REQUIRED_LIBRARIES)
 
 check_cxx_source_compiles("
 #include <pthread_np.h>
@@ -982,6 +960,8 @@ if(NOT CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
   list(INSERT CMAKE_REQUIRED_INCLUDES 0 ${CMAKE_CURRENT_SOURCE_DIR}/libunwind/include ${CMAKE_CURRENT_BINARY_DIR}/libunwind/include)
 endif()
 
+set(CMAKE_REQUIRED_FLAGS "-c")
+
 check_c_source_compiles("
 #include <libunwind.h>
 #include <ucontext.h>
@@ -993,6 +973,29 @@ int main(int argc, char **argv)
         return 0;
 }" UNWIND_CONTEXT_IS_UCONTEXT_T)
 
+check_c_source_compiles("
+#include <libunwind.h>
+
+int main(int argc, char **argv) {
+  unw_cursor_t cursor;
+  unw_save_loc_t saveLoc;
+  int reg = UNW_REG_IP;
+  unw_get_save_loc(&cursor, reg, &saveLoc);
+
+  return 0;
+}" HAVE_UNW_GET_SAVE_LOC)
+
+check_c_source_compiles("
+#include <libunwind.h>
+
+int main(int argc, char **argv) {
+  unw_addr_space_t as;
+  unw_get_accessors(as);
+
+  return 0;
+}" HAVE_UNW_GET_ACCESSORS)
+
+set(CMAKE_REQUIRED_FLAGS)
 if(NOT CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
   list(REMOVE_AT CMAKE_REQUIRED_INCLUDES 0 1)
 endif()

--- a/src/pal/src/exception/remote-unwind.cpp
+++ b/src/pal/src/exception/remote-unwind.cpp
@@ -49,7 +49,13 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <dlfcn.h>
 
 #define UNW_LOCAL_ONLY
+// Sub-headers included from the libunwind.h contain an empty struct
+// and clang issues a warning. Until the libunwind is fixed, disable
+// the warning.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wextern-c-compat"
 #include <libunwind.h>
+#pragma clang diagnostic pop
 
 SET_DEFAULT_DEBUG_CHANNEL(EXCEPT);
 

--- a/src/pal/src/exception/seh-unwind.cpp
+++ b/src/pal/src/exception/seh-unwind.cpp
@@ -28,7 +28,13 @@ Abstract:
 #include <dlfcn.h>
  
 #define UNW_LOCAL_ONLY
+// Sub-headers included from the libunwind.h contain an empty struct
+// and clang issues a warning. Until the libunwind is fixed, disable
+// the warning.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wextern-c-compat"
 #include <libunwind.h>
+#pragma clang diagnostic pop
 
 //----------------------------------------------------------------------
 // Virtual Unwinding

--- a/src/pal/src/libunwind/CMakeLists.txt
+++ b/src/pal/src/libunwind/CMakeLists.txt
@@ -1,8 +1,3 @@
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/include/tdep)
-include_directories(include)
-include_directories(include/tdep)
-
 add_subdirectory(src)
 
 # define variables for the configure_file below


### PR DESCRIPTION
I have removed libunwind dependency in a recent commit, but
it turns out that the build was using incorrect include
paths and it was still depending on the libunwind installation
for the libunwind.h header.

This change fixes it.