### PR TITLE
Merge various restore tasks into one Sync target

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -320,7 +320,7 @@ REM ============================================================================
 
 if %__RestoreOptData% EQU 1 if %__BuildTypeRelease% EQU 1 (
     echo %__MsgPrefix%Restoring the OptimizationData Package
-    @call %__ProjectDir%\run.cmd sync -optdata %__UnprocessedBuildArgs%
+    @call %__ProjectDir%\run.cmd build -optdata %__RunArgs% %__UnprocessedBuildArgs%
     if not !errorlevel! == 0 (
         echo %__MsgPrefix%Error: Failed to restore the optimization data package.
         exit /b 1

--- a/build.proj
+++ b/build.proj
@@ -26,7 +26,15 @@
     <Delete Files="$(BinDir)System.Private.CoreLib.*" />
   </Target>
 
-  <Target Name="RestoreOptData">
+  <!--
+    BuildTools will conditionally restore additional packages, including IBC tools, using the "RestoreOptionalToolingPackages"
+    target, which runs automatically before "Sync". Since no "Sync" target actually exists, go ahead and define one now so that
+    the tools are fetched before "Build".
+  -->
+  <Target Name="Sync" BeforeTargets="Build"
+    DependsOnTargets="RestoreOptData;RestoreNETCorePlatforms" />
+
+  <Target Name="RestoreOptData" Condition="'$(RestoreDuringBuild)'=='true' and '$(BuildType)'=='Release'">
     <PropertyGroup>
       <_OptimizationDataFeed Condition="'$(DotNetBuildOffline)' != 'true'">--source https://dotnet.myget.org/F/dotnet-core-optimization-data/api/v3/index.json</_OptimizationDataFeed>
     </PropertyGroup>
@@ -35,14 +43,7 @@
           StandardOutputImportance="Low" />
   </Target>
 
-  <!--
-    BuildTools will conditionally restore additional packages, including IBC tools, using the "RestoreOptionalToolingPackages"
-    target, which runs automatically before "Sync". Since no "Sync" target actually exists, go ahead and define one now so that
-    the tools are fetched before "Build".
-  -->
-  <Target Name="Sync" BeforeTargets="Build" />
-
-  <Target Name="RestoreNETCorePlatforms" AfterTargets="Build" Condition="'$(RestoreDuringBuild)'=='true'">
+  <Target Name="RestoreNETCorePlatforms" Condition="'$(RestoreDuringBuild)'=='true'">
     <Exec Command="$(DotnetRestoreCommand) $(SourceDir).nuget/init/init.csproj"
           StandardOutputImportance="Low" />
   </Target>

--- a/build.sh
+++ b/build.sh
@@ -164,7 +164,7 @@ restore_optdata()
 
     if [[ ( $__SkipRestoreOptData == 0 ) && ( $__isMSBuildOnNETCoreSupported == 1 ) ]]; then
         echo "Restoring the OptimizationData package"
-        "$__ProjectRoot/run.sh" sync -optdata $__UnprocessedBuildArgs
+        "$__ProjectRoot/run.sh" build -optdata $__RunArgs $__UnprocessedBuildArgs
         if [ $? != 0 ]; then
             echo "Failed to restore the optimization data package."
             exit 1

--- a/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
@@ -115,7 +115,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs) ./sync.sh",
+        "arguments": "run --rm $(DockerCommonRunArgs) ./sync.sh -- /p:BuildType=$(PB_BuildType)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/DotNet-CoreClr-Trusted-Linux.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Linux.json
@@ -115,7 +115,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs) ./sync.sh",
+        "arguments": "run --rm $(DockerCommonRunArgs) ./sync.sh -- /p:BuildType=$(PB_BuildType)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/DotNet-CoreClr-Trusted-Mac.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Mac.json
@@ -35,7 +35,7 @@
       },
       "inputs": {
         "filename": "$(Agent.BuildDirectory)/s/sync.sh",
-        "arguments": "",
+        "arguments": " -- /p:BuildType=$(PB_BuildType)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/DotNet-CoreClr-Trusted-Windows-x86.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Windows-x86.json
@@ -77,7 +77,7 @@
       },
       "inputs": {
         "filename": "sync.cmd",
-        "arguments": "-p",
+        "arguments": "-p -- /p:BuildType=$(PB_BuildType)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/DotNet-CoreClr-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Windows.json
@@ -77,7 +77,7 @@
       },
       "inputs": {
         "filename": "sync.cmd",
-        "arguments": "-p",
+        "arguments": "-p -- /p:BuildType=$(PB_BuildType)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }

--- a/config.json
+++ b/config.json
@@ -84,8 +84,8 @@
       "values": [ "Windows_NT", "Linux", "Unix", "OSX", "Android" ],
       "defaultValue": "${OSName}"
     },
-    "RestoreNETCorePlatforms": {
-      "description": "MsBuild target that restores the NETCore packages.",
+    "Sync": {
+      "description": "MsBuild target that restores the packages.",
       "valueType": "target",
       "values": [],
       "defaultValue": ""
@@ -527,6 +527,13 @@
           "settings": {
             "Build": "default"
           }
+        },
+        "optdata": {
+          "description": "Restores optimization profile data for the repository.",
+          "settings": {
+            "Project": "./build.proj",
+            "RestoreOptData": "default"
+          }
         }
       },
       "defaultValues": {
@@ -578,21 +585,7 @@
           "settings": {
             "Project": "./build.proj",
             "RestoreDuringBuild": true,
-            "RestoreNETCorePlatforms": "default"
-          }
-        },
-        "optdata": {
-          "description": "Restores optimization profile data for the repository.",
-          "settings": {
-            "Project": "./build.proj",
-            "RestoreDuringBuild": true,
-            "RestoreOptData": "default"
-          }
-        },
-        "priority": {
-          "description": "Sets CLRTestPriorityToBuild property.",
-          "settings": {
-            "CLRTestPriorityToBuild": "default"
+            "Sync": "default"
           }
         },
         "ab": {
@@ -654,6 +647,12 @@
           "description": "To download a specific group of product packages, specify build number. The value for -BuildMajor required.",
           "settings": {
             "BuildNumberMinor": "default"
+          }
+        },
+        "buildType": {
+          "description": "Sets buildtype.",
+          "settings": {
+            "__BuildType": "default"
           }
         }
       },

--- a/config.json
+++ b/config.json
@@ -532,7 +532,8 @@
           "description": "Restores optimization profile data for the repository.",
           "settings": {
             "Project": "./build.proj",
-            "RestoreOptData": "default"
+            "RestoreOptData": "default",
+            "MsBuildEventLogging": " ",
           }
         }
       },


### PR DESCRIPTION
There were various restore targets happening independently
when they should all be combined so the sync step can be
independent from the build step. This change merges them
together under the Sync target.

In particular this moves RestoreOptData and RestoreNETCorePlatforms
to be part of the sync step instead of being individually ran.

Should fix https://github.com/dotnet/coreclr/issues/17176. 
Follow-up on https://github.com/dotnet/coreclr/pull/17136. 

cc @dpodder @wtgodbe 