### PR TITLE
Remove Tizen armel automatic PR triggered jobs

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -210,11 +210,6 @@ class Constants {
                 'Checked'
             ]
         ],
-        'Tizen': [
-            'armem': [
-                'Checked'
-            ]
-        ],
     ]
 
     // A set of scenarios that are valid for arm/arm64/armlb tests run on hardware. This is a map from valid scenario name
@@ -1687,21 +1682,15 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                 case 'Ubuntu16.04':
                     assert scenario != 'innerloop'
                     Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} Cross ${configuration} Build",
-                            "(?i).*test\\W+${os}\\W+${architecture}\\W+Cross\\W+${configuration}\\W+Build.*")
+                        "(?i).*test\\W+${os}\\W+${architecture}\\W+Cross\\W+${configuration}\\W+Build.*")
                     break
 
                 case 'Tizen':
                     architecture = 'armel'
 
-                    if (scenario == 'innerloop') {
-                        if (configuration == 'Checked') {
-                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} Cross ${configuration} Innerloop Build and Test")
-                        }
-                    }
-                    else {
-                        Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} Cross ${configuration} Build",
-                            "(?i).*test\\W+${os}\\W+${architecture}\\W+Cross\\W+${configuration}\\W+Build.*")
-                    }
+                    assert scenario != 'innerloop'
+                    Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} Cross ${configuration} Build",
+                        "(?i).*test\\W+${os}\\W+${architecture}\\W+Cross\\W+${configuration}\\W+Build.*")
                     break
             }
 


### PR DESCRIPTION
These are failing almost every job with "qeumu: Unsupported
syscall: 389". Issue: https://github.com/dotnet/coreclr/issues/12972.

Fixes #17028