### PR TITLE
Fix regression in StreamWriter.Write perf for small inputs

### DIFF
--- a/src/mscorlib/shared/System/IO/StreamReader.cs
+++ b/src/mscorlib/shared/System/IO/StreamReader.cs
@@ -70,20 +70,20 @@ namespace System.IO
         // We don't guarantee thread safety on StreamReader, but we should at 
         // least prevent users from trying to read anything while an Async
         // read from the same thread is in progress.
-        private volatile Task _asyncReadTask;
+        private Task _asyncReadTask = Task.CompletedTask;
 
         private void CheckAsyncTaskInProgress()
         {
             // We are not locking the access to _asyncReadTask because this is not meant to guarantee thread safety. 
             // We are simply trying to deter calling any Read APIs while an async Read from the same thread is in progress.
-
-            Task t = _asyncReadTask;
-
-            if (t != null && !t.IsCompleted)
+            if (!_asyncReadTask.IsCompleted)
             {
-                throw new InvalidOperationException(SR.InvalidOperation_AsyncIOInProgress);
+                ThrowAsyncIOInProgress();
             }
         }
+
+        private static void ThrowAsyncIOInProgress() =>
+            throw new InvalidOperationException(SR.InvalidOperation_AsyncIOInProgress);
 
         // StreamReader by default will ignore illegal UTF8 characters. We don't want to 
         // throw here because we want to be able to read ill-formed data without choking. 

--- a/src/mscorlib/shared/System/IO/StreamWriter.cs
+++ b/src/mscorlib/shared/System/IO/StreamWriter.cs
@@ -326,11 +326,13 @@ namespace System.IO
             }
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)] // prevent WriteSpan from bloating call sites
         public override void Write(char[] buffer)
         {
             WriteSpan(buffer, appendNewLine: false);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)] // prevent WriteSpan from bloating call sites
         public override void Write(char[] buffer, int index, int count)
         {
             if (buffer == null)
@@ -353,6 +355,7 @@ namespace System.IO
             WriteSpan(buffer.AsSpan(index, count), appendNewLine: false);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)] // prevent WriteSpan from bloating call sites
         public override void Write(ReadOnlySpan<char> buffer)
         {
             if (GetType() == typeof(StreamWriter))
@@ -444,17 +447,20 @@ namespace System.IO
             }
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)] // prevent WriteSpan from bloating call sites
         public override void Write(string value)
         {
             WriteSpan(value, appendNewLine: false);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)] // prevent WriteSpan from bloating call sites
         public override void WriteLine(string value)
         {
             CheckAsyncTaskInProgress();
             WriteSpan(value, appendNewLine: true);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)] // prevent WriteSpan from bloating call sites
         public override void WriteLine(ReadOnlySpan<char> value)
         {
             if (GetType() == typeof(StreamWriter))


### PR DESCRIPTION
My previous changes to add span support to StreamWriter regressed performance for small inputs.  This was primarily due to refactoring out a bunch of duplicated code into a shared span-based helper.

This change keeps the helper but uses AggressiveInlining to avoid the extra function call, essentially restoring the previous "every method has its own copy" approach but without the C# code duplication.  I also cleaned up the CheckAsyncTaskInProgress helper to make it streamlined and inlineable.

| Test                                                                      | Before      | After    | Improvement | 
|---------------------------------------------------------------------------|-------------|----------|-------------| 
| System.IO.Tests.Perf_StreamWriter.WriteCharArray(writeLength: 100)        | 1041.38 | 971.10  | 6.75%       | 
| System.IO.Tests.Perf_StreamWriter.WriteCharArray(writeLength: 2)          | 168.70 | 109.17  | 35.29%      | 
| System.IO.Tests.Perf_StreamWriter.WritePartialCharArray(writeLength: 100) | 1096.65 | 1001.64 | 8.66%       | 
| System.IO.Tests.Perf_StreamWriter.WritePartialCharArray(writeLength: 2)   | 225.62 | 153.26  | 32.07%      | 
| System.IO.Tests.Perf_StreamWriter.WriteString(writeLength: 100)           | 1095.40 | 987.03  | 9.89%       | 
| System.IO.Tests.Perf_StreamWriter.WriteString(writeLength: 2)             | 192.74 | 114.06  | 40.82%      | 

Fixes https://github.com/dotnet/corefx/issues/27496
cc: @danmosemsft, @jkotas 