### PR TITLE
Fix handling of FCalls in ExternalMethodFixupWorker

### DIFF
--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -4409,7 +4409,10 @@ BOOL MethodDescChunk::IsCompactEntryPointAtAddress(PCODE addr)
     if (fSpeculative INDEBUG(|| TRUE))
     {
 #ifdef _TARGET_ARM_
-        if (!IsCompactEntryPointAtAddress(addr))
+        TADDR instrCodeAddr = PCODEToPINSTR(addr);
+        if (!IsCompactEntryPointAtAddress(addr) ||
+            *PTR_BYTE(instrCodeAddr) != TEP_ENTRY_INSTR1_BYTE1 ||
+            *PTR_BYTE(instrCodeAddr+1) != TEP_ENTRY_INSTR1_BYTE2)
 #else // _TARGET_ARM_
         if ((addr & 3) != 1 ||
             *PTR_BYTE(addr) != X86_INSTR_MOV_AL ||


### PR DESCRIPTION
When running ready to run code on ARM, the ExternalMethodFixupWorker
doesn't handle the entrypoints of FCalls correctly. It tries to handle
them as compact entrypoints, but those use a different machine code
instructions and it results in an assert in debug / checked build as follows:
```
Assert failure(PID 3028 [0x00000bd4], Thread: 3028 [0x0bd4]): offset >= - MAX_OFFSET_UNCONDITIONAL_BRANCH_THUMB && offset < MAX_OFFSET_UNCONDITIONAL_BRANCH_THUMB
    File: /mnt/j/workspace/dotnet_coreclr/dev_unix_test_workflow/arm_cross_checked_ubuntu_prtest/src/vm/arm/cgencpu.h Line: 285
    Image: /ssd/j/workspace/dotnet_coreclr/dev_unix_test_workflow/arm_cross_checked_ubuntu_r2r_tst_prtest/bin/tests/Linux.arm.Checked/Tests/Core_Root/corerun
```

This was reported in #16965

This change detects the runtime supplied calls before trying to check
for the compact entrypoint.

