### PR TITLE
[local gc] fix for logalways eventing level

### DIFF
--- a/src/gc/gceventstatus.h
+++ b/src/gc/gceventstatus.h
@@ -85,7 +85,7 @@ public:
      */
     static void Set(GCEventProvider provider, GCEventKeyword keywords, GCEventLevel level)
     {
-        assert(level >= GCEventLevel_None && level < GCEventLevel_Max);
+        assert((level >= GCEventLevel_None && level < GCEventLevel_Max) || level == GCEventLevel_LogAlways);
 
         size_t index = static_cast<size_t>(provider);
 
@@ -133,6 +133,9 @@ private:
             break;
         case GCEventLevel_Verbose:
             fprintf(stderr, "  level: Verbose\n");
+            break;
+        case GCEventLevel_LogAlways:
+            fprintf(stderr, "  level: LogAlways");
             break;
         default:
             fprintf(stderr, "  level: %d?\n", level);

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -211,7 +211,8 @@ enum GCEventLevel
     GCEventLevel_Warning = 3,
     GCEventLevel_Information = 4,
     GCEventLevel_Verbose = 5,
-    GCEventLevel_Max = 6
+    GCEventLevel_Max = 6,
+    GCEventLevel_LogAlways = 255
 };
 
 // Event keywords corresponding to events that can be fired by the GC. These


### PR DESCRIPTION
Fix for #17118

When Always is set as the ETW keyword, it would fire an assert in GCEventStatus::Set. The logic still worked, since GCEventStatus::IsEnabled checks if the level you request is less than or equal to the level that was set. I just need to update the implementation of Set so it knew about LogAlways.