### PR TITLE
Use ROSpan.IndexOf as the workhorse for string.IndexOf

### DIFF
--- a/src/mscorlib/shared/System/SpanHelpers.Char.cs
+++ b/src/mscorlib/shared/System/SpanHelpers.Char.cs
@@ -93,7 +93,7 @@ namespace System
                 if (Vector.IsHardwareAccelerated && length >= Vector<ushort>.Count * 2)
                 {
                     const int elementsPerByte = sizeof(ushort) / sizeof(byte);
-                    int unaligned = ((int)pCh & (Vector<byte>.Count - 1)) / elementsPerByte;
+                    int unaligned = ((int)pCh & (Unsafe.SizeOf<Vector<ushort>>() - 1)) / elementsPerByte;
                     length = ((Vector<ushort>.Count - unaligned) & (Vector<ushort>.Count - 1));
                 }
             SequentialScan:
@@ -136,7 +136,7 @@ namespace System
                     while (length > 0)
                     {
                         // Using Unsafe.Read instead of ReadUnaligned since the search space is pinned and pCh is always vector aligned
-                        Debug.Assert(((int)pCh & (Vector<byte>.Count - 1)) == 0);
+                        Debug.Assert(((int)pCh & (Unsafe.SizeOf<Vector<ushort>>() - 1)) == 0);
                         Vector<ushort> vMatches = Vector.Equals(vComparison, Unsafe.Read<Vector<ushort>>(pCh));
                         if (Vector<ushort>.Zero.Equals(vMatches))
                         {

--- a/src/mscorlib/shared/System/SpanHelpers.Char.cs
+++ b/src/mscorlib/shared/System/SpanHelpers.Char.cs
@@ -135,8 +135,8 @@ namespace System
 
                     while (length > 0)
                     {
-                        // Using Unsafe.Read instead of ReadUnaligned since the search space is pinned and pCh is always word aligned
-                        Debug.Assert(((int)pCh % IntPtr.Size) == 0);
+                        // Using Unsafe.Read instead of ReadUnaligned since the search space is pinned and pCh is always vector aligned
+                        Debug.Assert(((int)pCh & (Vector<byte>.Count - 1)) == 0);
                         Vector<ushort> vMatches = Vector.Equals(vComparison, Unsafe.Read<Vector<ushort>>(pCh));
                         if (Vector<ushort>.Zero.Equals(vMatches))
                         {

--- a/src/mscorlib/shared/System/SpanHelpers.Char.cs
+++ b/src/mscorlib/shared/System/SpanHelpers.Char.cs
@@ -84,79 +84,86 @@ namespace System
         {
             Debug.Assert(length >= 0);
 
-            uint uValue = value; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr nLength = (IntPtr)length;
+            fixed (char* pChars = &searchSpace)
+            {
+                char* pCh = pChars;
+                char* pEndCh = pCh + length;
+
 #if !netstandard11
-            if (Vector.IsHardwareAccelerated && length >= Vector<ushort>.Count * 2)
-            {
-                const int elementsPerByte = sizeof(ushort) / sizeof(byte);
-                int unaligned = ((int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1)) / elementsPerByte;
-                nLength = (IntPtr)((Vector<ushort>.Count - unaligned) & (Vector<ushort>.Count - 1));
-            }
-        SequentialScan:
-#endif
-            while ((byte*)nLength >= (byte*)4)
-            {
-                nLength -= 4;
-
-                if (uValue == Unsafe.Add(ref searchSpace, index))
-                    goto Found;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 1))
-                    goto Found1;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 2))
-                    goto Found2;
-                if (uValue == Unsafe.Add(ref searchSpace, index + 3))
-                    goto Found3;
-
-                index += 4;
-            }
-
-            while ((byte*)nLength > (byte*)0)
-            {
-                nLength -= 1;
-
-                if (uValue == Unsafe.Add(ref searchSpace, index))
-                    goto Found;
-
-                index += 1;
-            }
-#if !netstandard11
-            if (Vector.IsHardwareAccelerated && ((int)(byte*)index < length))
-            {
-                nLength = (IntPtr)((length - (int)(byte*)index) & ~(Vector<ushort>.Count - 1));
-
-                // Get comparison Vector
-                Vector<ushort> vComparison = new Vector<ushort>(value);
-
-                while ((byte*)nLength > (byte*)index)
+                if (Vector.IsHardwareAccelerated && length >= Vector<ushort>.Count * 2)
                 {
-                    var vMatches = Vector.Equals(vComparison, Unsafe.ReadUnaligned<Vector<ushort>>(ref Unsafe.As<char, byte>(ref Unsafe.Add(ref searchSpace, index))));
-                    if (Vector<ushort>.Zero.Equals(vMatches))
+                    const int elementsPerByte = sizeof(ushort) / sizeof(byte);
+                    int unaligned = ((int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1)) / elementsPerByte;
+                    length = ((Vector<ushort>.Count - unaligned) & (Vector<ushort>.Count - 1));
+                }
+            SequentialScan:
+#endif
+                while (length >= 4)
+                {
+                    length -= 4;
+
+                    if (*pCh == value)
+                        goto Found;
+                    if (*(pCh + 1) == value)
+                        goto Found1;
+                    if (*(pCh + 2) == value)
+                        goto Found2;
+                    if (*(pCh + 3) == value)
+                        goto Found3;
+
+                    pCh += 4;
+                }
+
+                while (length > 0)
+                {
+                    length -= 1;
+
+                    if (*pCh == value)
+                        goto Found;
+
+                    pCh += 1;
+                }
+#if !netstandard11
+                if (Vector.IsHardwareAccelerated && pCh < pEndCh)
+                {
+                    length = (int)((pEndCh - pCh) & ~(Vector<ushort>.Count - 1));
+
+                    // Get comparison Vector
+                    Vector<ushort> vComparison = new Vector<ushort>(value);
+
+                    while (length > 0)
                     {
-                        index += Vector<ushort>.Count;
-                        continue;
+                        Vector<ushort> vMatches = Vector.Equals(vComparison, Unsafe.ReadUnaligned<Vector<ushort>>(pCh));
+                        if (Vector<ushort>.Zero.Equals(vMatches))
+                        {
+                            pCh += Vector<ushort>.Count;
+                            length -= Vector<ushort>.Count;
+                            continue;
+                        }
+                        // Find offset of first match
+                        return (int)(pCh - pChars) + LocateFirstFoundChar(vMatches);
                     }
-                    // Find offset of first match
-                    return (int)(byte*)index + LocateFirstFoundChar(vMatches);
-                }
 
-                if ((int)(byte*)index < length)
-                {
-                    nLength = (IntPtr)(length - (int)(byte*)index);
-                    goto SequentialScan;
+                    if (pCh < pEndCh)
+                    {
+                        unchecked
+                        {
+                            length = (int)(pEndCh - pCh);
+                        }
+                        goto SequentialScan;
+                    }
                 }
-            }
 #endif
-            return -1;
-        Found: // Workaround for https://github.com/dotnet/coreclr/issues/13549
-            return (int)(byte*)index;
-        Found1:
-            return (int)(byte*)(index + 1);
-        Found2:
-            return (int)(byte*)(index + 2);
-        Found3:
-            return (int)(byte*)(index + 3);
+                return -1;
+            Found3:
+                pCh++;
+            Found2:
+                pCh++;
+            Found1:
+                pCh++;
+            Found:
+                return (int)(pCh - pChars);
+            }
         }
 
 #if !netstandard11

--- a/src/mscorlib/shared/System/SpanHelpers.Char.cs
+++ b/src/mscorlib/shared/System/SpanHelpers.Char.cs
@@ -93,7 +93,7 @@ namespace System
                 if (Vector.IsHardwareAccelerated && length >= Vector<ushort>.Count * 2)
                 {
                     const int elementsPerByte = sizeof(ushort) / sizeof(byte);
-                    int unaligned = ((int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1)) / elementsPerByte;
+                    int unaligned = ((int)pCh & (Vector<byte>.Count - 1)) / elementsPerByte;
                     length = ((Vector<ushort>.Count - unaligned) & (Vector<ushort>.Count - 1));
                 }
             SequentialScan:
@@ -146,10 +146,7 @@ namespace System
 
                     if (pCh < pEndCh)
                     {
-                        unchecked
-                        {
-                            length = (int)(pEndCh - pCh);
-                        }
+                        length = (int)(pEndCh - pCh);
                         goto SequentialScan;
                     }
                 }

--- a/src/mscorlib/shared/System/String.Searching.cs
+++ b/src/mscorlib/shared/System/String.Searching.cs
@@ -79,9 +79,6 @@ namespace System
             if ((uint)count > (uint)(Length - startIndex))
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_Count);
 
-            if (count == 0)
-                return -1;
-            
             int result = SpanHelpers.IndexOf(ref Unsafe.Add(ref _firstChar, startIndex), value, count);
 
             return result == -1 ? result : result + startIndex;

--- a/src/mscorlib/shared/System/String.Searching.cs
+++ b/src/mscorlib/shared/System/String.Searching.cs
@@ -35,7 +35,7 @@ namespace System
         // Returns the index of the first occurrence of a specified character in the current instance.
         // The search starts at startIndex and runs thorough the next count characters.
         //
-        public int IndexOf(char value) => this.AsSpan().IndexOf(value);
+        public int IndexOf(char value) => SpanHelpers.IndexOf(ref _firstChar, value, Length);
 
         public int IndexOf(char value, int startIndex)
         {
@@ -82,7 +82,7 @@ namespace System
             if (count == 0)
                 return -1;
             
-            int result = this.AsSpan(startIndex, count).IndexOf(value);
+            int result = SpanHelpers.IndexOf(ref Unsafe.Add(ref _firstChar, startIndex), value, count);
 
             return result == -1 ? result : result + startIndex;
         }

--- a/src/mscorlib/shared/System/String.Searching.cs
+++ b/src/mscorlib/shared/System/String.Searching.cs
@@ -35,10 +35,7 @@ namespace System
         // Returns the index of the first occurrence of a specified character in the current instance.
         // The search starts at startIndex and runs thorough the next count characters.
         //
-        public int IndexOf(char value)
-        {
-            return IndexOf(value, 0, this.Length);
-        }
+        public int IndexOf(char value) => this.AsSpan().IndexOf(value);
 
         public int IndexOf(char value, int startIndex)
         {
@@ -74,121 +71,21 @@ namespace System
 
         public unsafe int IndexOf(char value, int startIndex, int count)
         {
+            // These bounds checks are redundant since AsSpan does them already, but are required
+            // so that the correct parameter name is thrown as part of the exception.
             if ((uint)startIndex > (uint)Length)
                 throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
 
             if ((uint)count > (uint)(Length - startIndex))
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_Count);
 
-            fixed (char* pChars = &_firstChar)
-            {
-                char* pCh = pChars + startIndex;
-                char* pEndCh = pCh + count;
-
-                if (Vector.IsHardwareAccelerated && count >= Vector<ushort>.Count * 2)
-                {
-                    unchecked
-                    {
-                        const int elementsPerByte = sizeof(ushort) / sizeof(byte);
-                        int unaligned = ((int)pCh & (Vector<byte>.Count - 1)) / elementsPerByte;
-                        count = ((Vector<ushort>.Count - unaligned) & (Vector<ushort>.Count - 1));
-                    }
-                }
-            SequentialScan:
-                while (count >= 4)
-                {
-                    if (*pCh == value) goto ReturnIndex;
-                    if (*(pCh + 1) == value) goto ReturnIndex1;
-                    if (*(pCh + 2) == value) goto ReturnIndex2;
-                    if (*(pCh + 3) == value) goto ReturnIndex3;
-
-                    count -= 4;
-                    pCh += 4;
-                }
-
-                while (count > 0)
-                {
-                    if (*pCh == value)
-                        goto ReturnIndex;
-
-                    count--;
-                    pCh++;
-                }
-
-                if (pCh < pEndCh)
-                {
-                    count = (int)((pEndCh - pCh) & ~(Vector<ushort>.Count - 1));
-                    // Get comparison Vector
-                    Vector<ushort> vComparison = new Vector<ushort>(value);
-                    while (count > 0)
-                    {
-                        var vMatches = Vector.Equals(vComparison, Unsafe.ReadUnaligned<Vector<ushort>>(pCh));
-                        if (Vector<ushort>.Zero.Equals(vMatches))
-                        {
-                            pCh += Vector<ushort>.Count;
-                            count -= Vector<ushort>.Count;
-                            continue;
-                        }
-                        // Find offset of first match
-                        return (int)(pCh - pChars) + LocateFirstFoundChar(vMatches);
-                    }
-
-                    if (pCh < pEndCh)
-                    {
-                        unchecked
-                        {
-                            count = (int)(pEndCh - pCh);
-                        }
-                        goto SequentialScan;
-                    }
-                }
-
+            if (count == 0)
                 return -1;
+            
+            int result = this.AsSpan(startIndex, count).IndexOf(value);
 
-            ReturnIndex3: pCh++;
-            ReturnIndex2: pCh++;
-            ReturnIndex1: pCh++;
-            ReturnIndex:
-                return (int)(pCh - pChars);
-            }
+            return result == -1 ? result : result + startIndex;
         }
-
-        // Vector sub-search adapted from https://github.com/aspnet/KestrelHttpServer/pull/1138
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int LocateFirstFoundChar(Vector<ushort> match)
-        {
-            var vector64 = Vector.AsVectorUInt64(match);
-            ulong candidate = 0;
-            int i = 0;
-            // Pattern unrolled by jit https://github.com/dotnet/coreclr/pull/8001
-            for (; i < Vector<ulong>.Count; i++)
-            {
-                candidate = vector64[i];
-                if (candidate != 0)
-                {
-                    break;
-                }
-            }
-
-            // Single LEA instruction with jitted const (using function result)
-            return i * 4 + LocateFirstFoundChar(candidate);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int LocateFirstFoundChar(ulong match)
-        {
-            unchecked
-            {
-                // Flag least significant power of two bit
-                var powerOfTwoFlag = match ^ (match - 1);
-                // Shift all powers of two into the high byte and extract
-                return (int)((powerOfTwoFlag * XorPowerOfTwoToHighChar) >> 49);
-            }
-        }
-
-        private const ulong XorPowerOfTwoToHighChar = (0x03ul |
-                                                       0x02ul << 16 |
-                                                       0x01ul << 32) + 1;
 
         // Returns the index of the first occurrence of any specified character in the current instance.
         // The search starts at startIndex and runs to startIndex + count - 1.


### PR DESCRIPTION
~**Do we want to make such changes for this and other string APIs to avoid code duplication?**

The concern is, for small strings, the overhead of casting to a span causes performance regression.~

The performance should be identical now.

<summary>Version 1 of the PR
<details>
**Before modifying Span.IndexOf:**
![image](https://user-images.githubusercontent.com/6527137/38005276-f06ea496-31f4-11e8-9cba-2e9bbe32d159.png)

**After modifying Span.IndexOf (to follow the implementation of string.IndexOf, using fixed):**
![image](https://user-images.githubusercontent.com/6527137/38007084-8aa75006-31fc-11e8-9bed-5cdf7fb209cf.png)
</details>
</summary>

cc @jkotas, @tarekgh, @eerhardt 