### PR TITLE
Dict cache default comparer for object types

### DIFF
--- a/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
@@ -275,11 +275,12 @@ namespace System.Collections.Generic
 
         public bool ContainsValue(TValue value)
         {
+            Entry[] entries = _entries;
             if (value == null)
             {
                 for (int i = 0; i < _count; i++)
                 {
-                    if (_entries[i].hashCode >= 0 && _entries[i].value == null) return true;
+                    if (entries[i].hashCode >= 0 && entries[i].value == null) return true;
                 }
             }
             else
@@ -289,8 +290,7 @@ namespace System.Collections.Generic
                     // ValueType: Devirtualize with EqualityComparer<TValue>.Default intrinsic
                     for (int i = 0; i < _count; i++)
                     {
-                        ref var entry = ref _entries[i];
-                        if (entry.hashCode >= 0 && EqualityComparer<TValue>.Default.Equals(entry.value, value)) return true;
+                        if (entries[i].hashCode >= 0 && EqualityComparer<TValue>.Default.Equals(entries[i].value, value)) return true;
                     }
                 }
                 else
@@ -301,8 +301,7 @@ namespace System.Collections.Generic
                     EqualityComparer<TValue> defaultComparer = EqualityComparer<TValue>.Default;
                     for (int i = 0; i < _count; i++)
                     {
-                        ref var entry = ref _entries[i];
-                        if (entry.hashCode >= 0 && defaultComparer.Equals(entry.value, value)) return true;
+                        if (entries[i].hashCode >= 0 && defaultComparer.Equals(entries[i].value, value)) return true;
                     }
                 }
             }

--- a/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
@@ -284,9 +284,26 @@ namespace System.Collections.Generic
             }
             else
             {
-                for (int i = 0; i < _count; i++)
+                if (default(TValue) != null)
                 {
-                    if (_entries[i].hashCode >= 0 && EqualityComparer<TValue>.Default.Equals(_entries[i].value, value)) return true;
+                    // ValueType: Devirtualize with EqualityComparer<TValue>.Default intrinsic
+                    for (int i = 0; i < _count; i++)
+                    {
+                        ref var entry = ref _entries[i];
+                        if (entry.hashCode >= 0 && EqualityComparer<TValue>.Default.Equals(entry.value, value)) return true;
+                    }
+                }
+                else
+                {
+                    // Object type: Shared Generic, EqualityComparer<TValue>.Default won't devirtualize
+                    // https://github.com/dotnet/coreclr/issues/17273
+                    // So cache in a local rather than get EqualityComparer per loop iteration
+                    EqualityComparer<TValue> defaultComparer = EqualityComparer<TValue>.Default;
+                    for (int i = 0; i < _count; i++)
+                    {
+                        ref var entry = ref _entries[i];
+                        if (entry.hashCode >= 0 && defaultComparer.Equals(entry.value, value)) return true;
+                    }
                 }
             }
             return false;
@@ -364,24 +381,53 @@ namespace System.Collections.Generic
                     int hashCode = key.GetHashCode() & 0x7FFFFFFF;
                     // Value in _buckets is 1-based
                     i = buckets[hashCode % buckets.Length] - 1;
-                    do
+                    if (default(TKey) != null)
                     {
-                        // Should be a while loop https://github.com/dotnet/coreclr/issues/15476
-                        // Test in if to drop range check for following array access
-                        if ((uint)i >= (uint)entries.Length || (entries[i].hashCode == hashCode && EqualityComparer<TKey>.Default.Equals(entries[i].key, key)))
+                        // ValueType: Devirtualize with EqualityComparer<TValue>.Default intrinsic
+                        do
                         {
-                            break;
-                        }
+                            // Should be a while loop https://github.com/dotnet/coreclr/issues/15476
+                            // Test in if to drop range check for following array access
+                            if ((uint)i >= (uint)entries.Length || (entries[i].hashCode == hashCode && EqualityComparer<TKey>.Default.Equals(entries[i].key, key)))
+                            {
+                                break;
+                            }
 
-                        i = entries[i].next;
-                        if (collisionCount >= entries.Length)
+                            i = entries[i].next;
+                            if (collisionCount >= entries.Length)
+                            {
+                                // The chain of entries forms a loop; which means a concurrent update has happened.
+                                // Break out of the loop and throw, rather than looping forever.
+                                ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                            }
+                            collisionCount++;
+                        } while (true);
+                    }
+                    else
+                    {
+                        // Object type: Shared Generic, EqualityComparer<TValue>.Default won't devirtualize
+                        // https://github.com/dotnet/coreclr/issues/17273
+                        // So cache in a local rather than get EqualityComparer per loop iteration
+                        EqualityComparer<TKey> defaultComparer = EqualityComparer<TKey>.Default;
+                        do
                         {
-                            // The chain of entries forms a loop; which means a concurrent update has happened.
-                            // Break out of the loop and throw, rather than looping forever.
-                            ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
-                        }
-                        collisionCount++;
-                    } while (true);
+                            // Should be a while loop https://github.com/dotnet/coreclr/issues/15476
+                            // Test in if to drop range check for following array access
+                            if ((uint)i >= (uint)entries.Length || (entries[i].hashCode == hashCode && defaultComparer.Equals(entries[i].key, key)))
+                            {
+                                break;
+                            }
+
+                            i = entries[i].next;
+                            if (collisionCount >= entries.Length)
+                            {
+                                // The chain of entries forms a loop; which means a concurrent update has happened.
+                                // Break out of the loop and throw, rather than looping forever.
+                                ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                            }
+                            collisionCount++;
+                        } while (true);
+                    }
                 }
                 else
                 {
@@ -449,40 +495,85 @@ namespace System.Collections.Generic
 
             if (comparer == null)
             {
-                do
+                if (default(TKey) != null)
                 {
-                    // Should be a while loop https://github.com/dotnet/coreclr/issues/15476
-                    // Test uint in if rather than loop condition to drop range check for following array access
-                    if ((uint)i >= (uint)entries.Length)
+                    // ValueType: Devirtualize with EqualityComparer<TValue>.Default intrinsic
+                    do
                     {
-                        break;
-                    }
-
-                    if (entries[i].hashCode == hashCode && EqualityComparer<TKey>.Default.Equals(entries[i].key, key))
-                    {
-                        if (behavior == InsertionBehavior.OverwriteExisting)
+                        // Should be a while loop https://github.com/dotnet/coreclr/issues/15476
+                        // Test uint in if rather than loop condition to drop range check for following array access
+                        if ((uint)i >= (uint)entries.Length)
                         {
-                            entries[i].value = value;
-                            return true;
+                            break;
                         }
 
-                        if (behavior == InsertionBehavior.ThrowOnExisting)
+                        if (entries[i].hashCode == hashCode && EqualityComparer<TKey>.Default.Equals(entries[i].key, key))
                         {
-                            ThrowHelper.ThrowAddingDuplicateWithKeyArgumentException(key);
+                            if (behavior == InsertionBehavior.OverwriteExisting)
+                            {
+                                entries[i].value = value;
+                                return true;
+                            }
+
+                            if (behavior == InsertionBehavior.ThrowOnExisting)
+                            {
+                                ThrowHelper.ThrowAddingDuplicateWithKeyArgumentException(key);
+                            }
+
+                            return false;
                         }
 
-                        return false;
-                    }
-
-                    i = entries[i].next;
-                    if (collisionCount >= entries.Length)
+                        i = entries[i].next;
+                        if (collisionCount >= entries.Length)
+                        {
+                            // The chain of entries forms a loop; which means a concurrent update has happened.
+                            // Break out of the loop and throw, rather than looping forever.
+                            ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                        }
+                        collisionCount++;
+                    } while (true);
+                }
+                else
+                {
+                    // Object type: Shared Generic, EqualityComparer<TValue>.Default won't devirtualize
+                    // https://github.com/dotnet/coreclr/issues/17273
+                    // So cache in a local rather than get EqualityComparer per loop iteration
+                    EqualityComparer<TKey> defaultComparer = EqualityComparer<TKey>.Default;
+                    do
                     {
-                        // The chain of entries forms a loop; which means a concurrent update has happened.
-                        // Break out of the loop and throw, rather than looping forever.
-                        ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
-                    }
-                    collisionCount++;
-                } while (true);
+                        // Should be a while loop https://github.com/dotnet/coreclr/issues/15476
+                        // Test uint in if rather than loop condition to drop range check for following array access
+                        if ((uint)i >= (uint)entries.Length)
+                        {
+                            break;
+                        }
+
+                        if (entries[i].hashCode == hashCode && defaultComparer.Equals(entries[i].key, key))
+                        {
+                            if (behavior == InsertionBehavior.OverwriteExisting)
+                            {
+                                entries[i].value = value;
+                                return true;
+                            }
+
+                            if (behavior == InsertionBehavior.ThrowOnExisting)
+                            {
+                                ThrowHelper.ThrowAddingDuplicateWithKeyArgumentException(key);
+                            }
+
+                            return false;
+                        }
+
+                        i = entries[i].next;
+                        if (collisionCount >= entries.Length)
+                        {
+                            // The chain of entries forms a loop; which means a concurrent update has happened.
+                            // Break out of the loop and throw, rather than looping forever.
+                            ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                        }
+                        collisionCount++;
+                    } while (true);
+                }
             }
             else
             {

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/EventRegistrationToken.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/EventRegistrationToken.cs
@@ -52,7 +52,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
         bool IEquatable<EventRegistrationToken>.Equals(EventRegistrationToken other)
         {
-            return other.Equals(m_value);
+            return Equals(other);
         }
 
         private bool Equals(EventRegistrationToken other)

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/EventRegistrationToken.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/EventRegistrationToken.cs
@@ -11,7 +11,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
     // Event registration tokens are 64 bit opaque structures returned from WinRT style event adders, in order
     // to signify a registration of a particular delegate to an event.  The token's only real use is to
     // unregister the same delgate from the event at a later time.
-    public struct EventRegistrationToken
+    public struct EventRegistrationToken : IEquatable<EventRegistrationToken>
     {
         internal ulong m_value;
 
@@ -48,6 +48,16 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         public override int GetHashCode()
         {
             return m_value.GetHashCode();
+        }
+
+        bool IEquatable<EventRegistrationToken>.Equals(EventRegistrationToken other)
+        {
+            return other.Equals(m_value);
+        }
+
+        private bool Equals(EventRegistrationToken other)
+        {
+            return other.m_value == m_value;
         }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/dotnet/corefx/issues/28511 "Dictionary_ContainsValue_String* regressed 112%"

Its adds some repetition to the C# with a switch on `default(TValue) != null`

Changed `ContainsValue`, `FindEntry` and `TryInsert` but didn't change the two `Remove` methods as that would be a lot more code (though can if Removing is `object` keys perf sensitive?)

Also added an explicit implementation of `IEquatable<EventRegistrationToken>` to `EventRegistrationToken` as that was being used as a Dictionary key.

Dabbled with adding explicit implementation of  `IEquatable<KeyValuePair<TKey, TValue>>` and overriding `GetHashCode` for `KeyValuePair<TKey, TValue>` as that was also used as a key in `CommonlyUsedGenericInstantiations` for `Microsoft.Expression.DesignModel`, but that caused a code explosion so didn't think it was worthwhile?

/cc @AndyAyersMS @danmosemsft @ianhays @jkotas 