### PR TITLE
Mark GCCollect test as GC stress excluded

### DIFF
--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -40073,7 +40073,7 @@ RelativePath=CoreMangLib\cti\system\gc\GCCollect\GCCollect.cmd
 WorkingDir=CoreMangLib\cti\system\gc\GCCollect
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;Pri1
+Categories=EXPECTED_PASS;GCSTRESS_EXCLUDE;Pri1
 HostStyle=0
 
 [DictionaryValueCollectionCopyTo.cmd_5028]

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -10945,7 +10945,7 @@ RelativePath=CoreMangLib\cti\system\gc\GCCollect\GCCollect.cmd
 WorkingDir=CoreMangLib\cti\system\gc\GCCollect
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri1;RT;EXPECTED_PASS;GCSTRESS_FAIL;10070
+Categories=Pri1;RT;EXPECTED_PASS;GCSTRESS_EXCLUDE
 HostStyle=0
 
 [GCGetTotalMemory.cmd_1420]


### PR DESCRIPTION
This test is incompatible with GC stress. The tests compares results of
GC.GetTotalMemory before and after GC.Collect and fails if the size
before the collection is smaller than after the collection. But GC
stress breaks this assumption.