### PR TITLE
Fix identity package filtering

### DIFF
--- a/src/.nuget/dir.traversal.targets
+++ b/src/.nuget/dir.traversal.targets
@@ -3,21 +3,28 @@
 
   <Import Project="$(MSBuildThisFileDirectory)..\..\dir.traversal.targets" />
 
-  <PropertyGroup Condition="'$(OfficialBuildId)' != ''">
-    <!-- During an official build, only build identity packages in the AllConfigurations build -->
-    <BuildIdentityPackage Condition="'$(BuildIdentityPackage)' == '' AND '$(OS)' == 'Windows_NT' AND '$(BuildArch)' == 'x64'">true</BuildIdentityPackage>
+  <PropertyGroup Condition="'$(BuildIdentityPackage)' == ''">
+    <BuildIdentityPackage>true</BuildIdentityPackage>
+
+    <!-- Used to determine if we should build some packages only once across multiple official build legs. 
+         For offline builds we still set OfficialBuildId but we need to build all the packages for a single 
+         leg only, so we also take DotNetBuildOffline into account. -->
+    <BuildingAnOfficialBuildLeg Condition="'$(OfficialBuildId)' != '' AND '$(DotNetBuildOffline)' != 'true'">true</BuildingAnOfficialBuildLeg>
+
+    <!-- During an official build, only build identity packages on windows x64 legs -->
+    <BuildIdentityPackage Condition="'$(BuildingAnOfficialBuildLeg)' == 'true' AND ('$(OS)' != 'Windows_NT' OR '$(BuildArch)' != 'x64')">false</BuildIdentityPackage>
   </PropertyGroup>
 
   <Target Name="FilterProjects" BeforeTargets="Build">
     <Error Condition="'$(PackageRID)' == ''" Text="'PackageRID' property must be specified."/>
 
     <!-- Only build packages for current RID or non-RID-specific -->
-    <ItemGroup Condition="$(BuildIdentityPackage)!='true'">
+    <ItemGroup>
       <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '$(PackageRID)'" />
     </ItemGroup>
     
-    <ItemGroup Condition="$(BuildIdentityPackage)=='true'" >
-      <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '$(PackageRID)' OR '%(Project.PackageTargetRuntime)' == ''" />
+    <ItemGroup Condition="'$(BuildIdentityPackage)' == 'true'">
+      <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == ''" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
We only want to filter out identity package builds on
official builds that aren't windows x64, to avoid building
and publishing them more then once in an official build.

We also need to account for source-build which sets the
OfficialBuildId property to replicate the official builds,
so we also look at the DotNetBuildOffline property to
determine that we should still build the identity package.

cc @wtgodbe @dseefeld 