### PR TITLE
Reject struct promotion of parameters when -GS checks are enabled

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1746,6 +1746,16 @@ void Compiler::lvaCanPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* S
     // profitably promoted.
     if (varDsc->lvIsUsedInSIMDIntrinsic())
     {
+        JITDUMP("  struct promotion of V%02u is disabled because lvIsUsedInSIMDIntrinsic()\n", lclNum);
+        StructPromotionInfo->canPromote = false;
+        return;
+    }
+
+    // Reject struct promotion of parameters when -GS stack reordering is enabled
+    // as we could introduce shadow copies of them.
+    if (varDsc->lvIsParam && compGSReorderStackLayout)
+    {
+        JITDUMP("  struct promotion of V%02u is disabled because lvIsParam and compGSReorderStackLayout\n", lclNum);
         StructPromotionInfo->canPromote = false;
         return;
     }
@@ -1757,6 +1767,7 @@ void Compiler::lvaCanPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* S
     // TODO-PERF - Allow struct promotion for HFA register arguments
     if (varDsc->lvIsHfaRegArg())
     {
+        JITDUMP("  struct promotion of V%02u is disabled because lvIsHfaRegArg()\n", lclNum);
         StructPromotionInfo->canPromote = false;
         return;
     }
@@ -1764,7 +1775,7 @@ void Compiler::lvaCanPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* S
 #if !FEATURE_MULTIREG_STRUCT_PROMOTE
     if (varDsc->lvIsMultiRegArg)
     {
-        JITDUMP("Skipping V%02u: marked lvIsMultiRegArg.\n", lclNum);
+        JITDUMP("  struct promotion of V%02u is disabled because lvIsMultiRegArg\n", lclNum);
         StructPromotionInfo->canPromote = false;
         return;
     }
@@ -1772,7 +1783,7 @@ void Compiler::lvaCanPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* S
 
     if (varDsc->lvIsMultiRegRet)
     {
-        JITDUMP("Skipping V%02u: marked lvIsMultiRegRet.\n", lclNum);
+        JITDUMP("  struct promotion of V%02u is disabled because lvIsMultiRegRet\n", lclNum);
         StructPromotionInfo->canPromote = false;
         return;
     }

--- a/tests/src/JIT/Regression/JitBlue/GitHub_17329/GitHub_17329.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_17329/GitHub_17329.cs
@@ -1,0 +1,108 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+// Having an UnsafeValueTypeAttribute on a struct causes incoming arguments to be
+//  spilled into shadow copies and the struct promotion optimization does not 
+//  currently handle this properly.
+// 
+
+[UnsafeValueTypeAttribute]
+struct DangerousBuffer
+{
+    public long a;
+    public long b;
+    public long c;
+}
+
+struct Point1
+{
+    long x;
+
+    public Point1(long _x)
+    {
+        x = _x;
+    }
+
+    public void Increase(ref Point1 s, long amount)
+    {
+        x = s.x + amount;
+    }
+
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    public long Value()
+    {
+        return x;
+    }
+}
+
+class TestCase
+{
+    static public long[] arr;
+
+    unsafe static long Test(int size, Point1 a, Point1 b, Point1 c)
+    {
+
+        // Mutate the values stored in a, b and c
+        // So if these have a shadow copy we will notice
+        // 
+        a.Increase(ref a, arr[0]);
+        b.Increase(ref b, arr[1]);
+        c.Increase(ref c, arr[2]);
+
+	DangerousBuffer db = new DangerousBuffer();
+        db.a = -1;
+        db.b = -2;
+        db.c = -3;
+
+        long* x1 = stackalloc long[size];
+	
+        long sum = 0;
+        if (size >= 3)
+        {
+            x1[0] = a.Value();
+            x1[1] = b.Value();
+            x1[2] = c.Value();
+            
+            for (int i = 0; i < size; i++)
+            {
+                sum += x1[i];
+            }
+        }        
+        return sum;
+    }
+
+    static int Main()
+    { 
+        long testResult = 0;
+        int mainResult = 0;
+
+        Point1 p1 = new Point1(1);
+        Point1 p2 = new Point1(3);
+        Point1 p3 = new Point1(5);
+
+	arr = new long[3];
+	arr[0] = 9;
+	arr[1] = 10;
+	arr[2] = 11;
+
+
+        testResult = Test(3, p1, p2, p3);
+
+        if (testResult != 39)
+        {
+            Console.WriteLine("FAILED!");
+            mainResult = -1;
+        }
+        else
+        {
+            Console.WriteLine("passed");
+            mainResult = 100;
+        }
+
+        return mainResult;
+    } 
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_17329/GitHub_17329.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_17329/GitHub_17329.csproj
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-B8089FFA8D79}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
This causes bad codegen when we introduce shadow copies for them.