### PR TITLE
Update for ClassicCOM UnitTest

### DIFF
--- a/tests/src/Interop/ClassicCOM/ClassicCOMUnitTest.cs
+++ b/tests/src/Interop/ClassicCOM/ClassicCOMUnitTest.cs
@@ -107,6 +107,16 @@ public class ClassicCOMUnitTest
             Console.WriteLine("Caught unexpected PlatformNotSupportedException: " + e);
             return false;
         }
+        catch(System.Runtime.InteropServices.COMException e)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return true;
+            }
+            
+            Console.WriteLine("Caught unexpected COMException: " + e);
+            return false;
+        }
         catch (Exception e)
         {
             Console.WriteLine("Caught unexpected exception: " + e);


### PR DESCRIPTION
The testcase will throw COMException during Activator.CreateInstance ContextMenu for nano OS.

In short time,  just return success if it throws COMException in Windows. 
in future, consider to use CoreFx.Private.TestUtilities.dll  from corefx to determine specific OS.

Fix #17289 