### PR TITLE
Remove UNW_LOCAL_ONLY define in unwinders on linux.

### DIFF
--- a/src/pal/src/exception/remote-unwind.cpp
+++ b/src/pal/src/exception/remote-unwind.cpp
@@ -48,7 +48,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "pal.h"
 #include <dlfcn.h>
 
+#ifndef __linux__
 #define UNW_LOCAL_ONLY
+#endif // !__linux__ 
 // Sub-headers included from the libunwind.h contain an empty struct
 // and clang issues a warning. Until the libunwind is fixed, disable
 // the warning.

--- a/src/pal/src/exception/seh-unwind.cpp
+++ b/src/pal/src/exception/seh-unwind.cpp
@@ -27,7 +27,9 @@ Abstract:
 #include "pal.h"
 #include <dlfcn.h>
  
+#ifndef __linux__
 #define UNW_LOCAL_ONLY
+#endif // !__linux__ 
 // Sub-headers included from the libunwind.h contain an empty struct
 // and clang issues a warning. Until the libunwind is fixed, disable
 // the warning.


### PR DESCRIPTION
This restores the previous behavior prior to #17094. Using local only was causing unwinding to fail in the debugger where we need full generic/remote unwinding.