### PR TITLE
Fix ilasm COR header

### DIFF
--- a/src/pal/prebuilt/inc/buildnumber.h
+++ b/src/pal/prebuilt/inc/buildnumber.h
@@ -2,33 +2,28 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if 0
-/**** Generated Based on d:\ProjectK\src\InternalApis\Version\buildnumber.settings.targets
-Bizarely enough, you can't put comments in this file (without the #if) -
-because ndp\clr\src\Tools\applaunch preprocesses it into a perl script *****/
-#endif
 #define ProjectNMajorVersion   1
 #define ProjectNMinorVersion   0
 #define ProjectNMajorVersion_A "1"
 #define ProjectNMinorVersion_A "0"
-#define BuildNumberMajor       22220
+#define BuildNumberMajor       30319
 #define BuildNumberMinor       0
-#define BuildNumberMajor_A     "22220"
+#define BuildNumberMajor_A     "30319"
 #define BuildNumberMinor_A     "00"
-#define BuildNumbers_A         "22220.00"
-#define BuildNumbers_T         TEXT("22220.00")
+#define BuildNumbers_A         "30319.00"
+#define BuildNumbers_T         TEXT("30319.00")
 
-#define NDPBuildNumberMajor   22220
+#define NDPBuildNumberMajor   30319
 #define NDPBuildNumberMinor   0
-#define NDPBuildNumbers_A     "22220.00"
-#define NDPBuildNumbers_T     TEXT("22220.00")
+#define NDPBuildNumbers_A     "30319.00"
+#define NDPBuildNumbers_T     TEXT("30319.00")
 
 #define NDPFileVersionMinor   5
-#define NDPFileVersionBuild   22220
+#define NDPFileVersionBuild   30319
 #define NDPFileVersionRevision   0
 
 #define NDPFileVersionMinor_A     "5"
-#define NDPFileVersionBuild_A     "22220"
+#define NDPFileVersionBuild_A     "30319"
 #define NDPFileVersionRevision_A     "00"
 #define PROJECTN_VER_FILEVERSION_STR   ProjectNMajorVersion_A "." NDPFileVersionMinor_A "." NDPFileVersionBuild_A "." NDPFileVersionRevision_A 
 #define PROJECTN_VER_LEGALCOPYRIGHT_LOGO_STR "Copyright (c) Microsoft Corporation.  All rights reserved."


### PR DESCRIPTION
Ilasm was emitting the wrong metadata version in the COR header.

This created a difference when examining the metadata diff between desktop and core.

I've confirmed this fixes the issue, but not sure if you want to take this change since I see this used in many other places.

/cc @jkotas 