### PR TITLE
Fix Race Condition During EventPipe Rundown

### DIFF
--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -594,6 +594,15 @@ void EventPipe::WriteEventInternal(EventPipeEvent &event, EventPipeEventPayload 
     }
     else if(s_pConfig->RundownEnabled())
     {
+        // It is possible that some events that are enabled on rundown can be emitted from other threads.
+        // We're not interested in these events and they can cause corrupted trace files because rundown
+        // events are written synchronously and not under lock.
+        // If we encounter an event that did not originate on the thread that is doing rundown, ignore it.
+        if(!s_pConfig->IsRundownThread(pThread))
+        {
+            return;
+        }
+
         BYTE *pData = payload.GetFlatData();
         if (pData != NULL)
         {

--- a/src/vm/eventpipeconfiguration.cpp
+++ b/src/vm/eventpipeconfiguration.cpp
@@ -19,6 +19,7 @@ EventPipeConfiguration::EventPipeConfiguration()
 
     m_enabled = false;
     m_rundownEnabled = false;
+    m_pRundownThread = NULL;
     m_pConfigProvider = NULL;
     m_pSession = NULL;
     m_pProviderList = new SList<SListElem<EventPipeProvider*>>();
@@ -409,6 +410,7 @@ void EventPipeConfiguration::Disable(EventPipeSession *pSession)
 
     m_enabled = false;
     m_rundownEnabled = false;
+    m_pRundownThread = NULL;
     m_pSession = NULL;
 }
 
@@ -440,8 +442,10 @@ void EventPipeConfiguration::EnableRundown(EventPipeSession *pSession)
     // Build the rundown configuration.
     _ASSERTE(m_pSession == NULL);
 
-    // Enable rundown.
+    // Enable rundown and keep track of the rundown thread.
     // TODO: Move this into EventPipeSession once Enable takes an EventPipeSession object.
+    m_pRundownThread = GetThread();
+    _ASSERTE(m_pRundownThread != NULL);
     m_rundownEnabled = true;
 
     // Enable tracing.

--- a/src/vm/eventpipeconfiguration.h
+++ b/src/vm/eventpipeconfiguration.h
@@ -82,6 +82,15 @@ public:
     // Delete deferred providers.
     void DeleteDeferredProviders();
 
+    // Determine if the specified thread is the rundown thread.
+    // Used during rundown to ignore events from all other threads so that we don't corrupt the trace file.
+    inline bool IsRundownThread(Thread *pThread)
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        return (pThread == m_pRundownThread);
+    }
+
 private:
 
     // Get the provider without taking the lock.
@@ -111,6 +120,9 @@ private:
 
     // True if rundown is enabled.
     Volatile<bool> m_rundownEnabled;
+
+    // The rundown thread.  If rundown is not enabled, this is NULL.
+    Thread *m_pRundownThread;
 };
 
 #endif // FEATURE_PERFTRACING


### PR DESCRIPTION
We've seen a handful of corrupted traces and now also have an app can create corrupted traces on the fly.  This is due to a race condition during EventPipe rundown which is explained here along with a proposed fix.

EventPipe rundown is responsible for logging all of the information required to do symbolic lookup when analyzing a trace file.  It occurs in 3 steps:

1. Enable rundown - this is done by enabling the DotNETRuntime and DotNETRuntimeRundown providers.
2. Calling ```ETW::EnumerationLog::EndRundown()```
3. Disabling rundown.

During rundown, all events are written synchronously to the file instead of to the circular buffer to ensure that there is no chance of losing these events due to a small circular buffer size.  This means that if multiple threads happen to write to the file at the same time, it will result in corrupted events at a minimum, possibly a corrupted file.

Because we only want rundown events to come from code doing the actual rundown, we can safely ignore all events that are not written from thread that is performing rundown.  This PR changes the behavior of rundown to do just that.