### PR TITLE
Remove most ARM NYI

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -160,7 +160,9 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
 #else  // !_TARGET_ARM64_
                 if (varTypeIsFloating(treeNode))
                 {
-                    NYI_ARM("genRegCopy from 'int' to 'float'");
+                    // GT_BITCAST on ARM is only used to cast floating-point arguments to integer
+                    // registers. Nobody generates GT_BITCAST from int to float currently.
+                    NYI_ARM("GT_BITCAST from 'int' to 'float'");
                 }
                 else
                 {
@@ -172,7 +174,8 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
                     }
                     else
                     {
-                        regNumber otherReg = (regNumber)treeNode->AsMultiRegOp()->gtOtherReg;
+                        assert(op1->TypeGet() == TYP_DOUBLE);
+                        regNumber otherReg = treeNode->AsMultiRegOp()->gtOtherReg;
                         assert(otherReg != REG_NA);
                         inst_RV_RV_RV(INS_vmov_d2i, targetReg, otherReg, genConsumeReg(op1), EA_8BYTE);
                     }
@@ -334,22 +337,21 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
             genCallInstruction(treeNode->AsCall());
             break;
 
+        case GT_MEMORYBARRIER:
+            instGen_MemoryBarrier();
+            break;
+
+#ifdef _TARGET_ARM64_
         case GT_LOCKADD:
         case GT_XCHG:
         case GT_XADD:
             genLockedInstructions(treeNode->AsOp());
             break;
 
-        case GT_MEMORYBARRIER:
-            instGen_MemoryBarrier();
-            break;
-
         case GT_CMPXCHG:
-            NYI_ARM("GT_CMPXCHG");
-#ifdef _TARGET_ARM64_
             genCodeForCmpXchg(treeNode->AsCmpXchg());
-#endif
             break;
+#endif
 
         case GT_RELOAD:
             // do nothing - reload is just a marker.
@@ -511,12 +513,12 @@ void CodeGen::genIntrinsic(GenTree* treeNode)
             genConsumeOperands(treeNode->AsOp());
             getEmitter()->emitInsBinary(INS_frintm, emitActualTypeSize(treeNode), treeNode, srcNode);
             break;
-#endif
+
         case CORINFO_INTRINSIC_Round:
-            NYI_ARM("genIntrinsic for round - not implemented yet");
             genConsumeOperands(treeNode->AsOp());
-            getEmitter()->emitInsBinary(INS_ROUND, emitActualTypeSize(treeNode), treeNode, srcNode);
+            getEmitter()->emitInsBinary(INS_frintn, emitActualTypeSize(treeNode), treeNode, srcNode);
             break;
+#endif
 
         case CORINFO_INTRINSIC_Sqrt:
             genConsumeOperands(treeNode->AsOp());
@@ -2116,6 +2118,8 @@ void CodeGen::genRegCopy(GenTree* treeNode)
 #else  // !_TARGET_ARM64_
         if (varTypeIsFloating(treeNode))
         {
+            // GT_COPY from 'int' to 'float' currently can't happen. Maybe if ARM SIMD is implemented
+            // it will happen, according to the comment above?
             NYI_ARM("genRegCopy from 'int' to 'float'");
         }
         else

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -331,7 +331,7 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
         case GT_PUTARG_SPLIT:
             genPutArgSplit(treeNode->AsPutArgSplit());
             break;
-#endif
+#endif // _TARGET_ARM_
 
         case GT_CALL:
             genCallInstruction(treeNode->AsCall());
@@ -351,7 +351,7 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
         case GT_CMPXCHG:
             genCodeForCmpXchg(treeNode->AsCmpXchg());
             break;
-#endif
+#endif // _TARGET_ARM64_
 
         case GT_RELOAD:
             // do nothing - reload is just a marker.
@@ -518,7 +518,7 @@ void CodeGen::genIntrinsic(GenTree* treeNode)
             genConsumeOperands(treeNode->AsOp());
             getEmitter()->emitInsBinary(INS_frintn, emitActualTypeSize(treeNode), treeNode, srcNode);
             break;
-#endif
+#endif // _TARGET_ARM64_
 
         case CORINFO_INTRINSIC_Sqrt:
             genConsumeOperands(treeNode->AsOp());

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -3576,7 +3576,7 @@ void CodeGen::genLockedInstructions(GenTreeOp* treeNode)
 }
 
 //------------------------------------------------------------------------
-// genCodeForSwap: Produce code for a GT_CMPXCHG node.
+// genCodeForCmpXchg: Produce code for a GT_CMPXCHG node.
 //
 // Arguments:
 //    tree - the GT_CMPXCHG node
@@ -8640,9 +8640,7 @@ void CodeGen::genStoreLongLclVar(GenTree* treeNode)
         GenTree* loVal = op1->gtGetOp1();
         GenTree* hiVal = op1->gtGetOp2();
 
-        // NYI: Contained immediates.
-        NYI_IF((loVal->gtRegNum == REG_NA) || (hiVal->gtRegNum == REG_NA),
-               "Store of long lclVar with contained immediate");
+        noway_assert((loVal->gtRegNum != REG_NA) && (hiVal->gtRegNum != REG_NA));
 
         emit->emitIns_S_R(ins_Store(TYP_INT), EA_4BYTE, loVal->gtRegNum, lclNum, 0);
         emit->emitIns_S_R(ins_Store(TYP_INT), EA_4BYTE, hiVal->gtRegNum, lclNum, genTypeSize(TYP_INT));

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -10548,9 +10548,8 @@ const instruction INS_ADDC            = INS_adc;
 const instruction INS_SUBC            = INS_sbc;
 const instruction INS_NOT             = INS_mvn;
 
-const instruction INS_ABS   = INS_vabs;
-const instruction INS_ROUND = INS_invalid;
-const instruction INS_SQRT  = INS_vsqrt;
+const instruction INS_ABS  = INS_vabs;
+const instruction INS_SQRT = INS_vsqrt;
 
 #endif
 
@@ -10559,9 +10558,8 @@ const instruction INS_SQRT  = INS_vsqrt;
 const instruction INS_MULADD     = INS_madd;
 const instruction INS_BREAKPOINT = INS_bkpt;
 
-const instruction INS_ABS   = INS_fabs;
-const instruction INS_ROUND = INS_frintn;
-const instruction INS_SQRT  = INS_fsqrt;
+const instruction INS_ABS  = INS_fabs;
+const instruction INS_SQRT = INS_fsqrt;
 
 #endif
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -10526,7 +10526,7 @@ const instruction INS_ADDC            = INS_adc;
 const instruction INS_SUBC            = INS_sbb;
 const instruction INS_NOT             = INS_not;
 
-#endif
+#endif // _TARGET_XARCH_
 
 #ifdef _TARGET_ARM_
 
@@ -10551,7 +10551,7 @@ const instruction INS_NOT             = INS_mvn;
 const instruction INS_ABS  = INS_vabs;
 const instruction INS_SQRT = INS_vsqrt;
 
-#endif
+#endif // _TARGET_ARM_
 
 #ifdef _TARGET_ARM64_
 
@@ -10561,7 +10561,7 @@ const instruction INS_BREAKPOINT = INS_bkpt;
 const instruction INS_ABS  = INS_fabs;
 const instruction INS_SQRT = INS_fsqrt;
 
-#endif
+#endif // _TARGET_ARM64_
 
 /*****************************************************************************/
 

--- a/src/jit/lowerarmarch.cpp
+++ b/src/jit/lowerarmarch.cpp
@@ -409,16 +409,11 @@ void Lowering::LowerCast(GenTree* tree)
     if (varTypeIsFloating(srcType))
     {
         noway_assert(!tree->gtOverflow());
+        assert(!varTypeIsSmall(dstType)); // fgMorphCast creates intermediate casts when converting from float to small
+                                          // int.
     }
 
     assert(!varTypeIsSmall(srcType));
-
-    // case of src is a floating point type and dst is a small type.
-    if (varTypeIsFloating(srcType) && varTypeIsSmall(dstType))
-    {
-        NYI_ARM("Lowering for cast from float to small type"); // Not tested yet.
-        tmpType = TYP_INT;
-    }
 
     if (tmpType != TYP_UNDEF)
     {

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -756,14 +756,6 @@ void LinearScan::BuildNode(GenTree* tree)
         }
         break;
 
-        default:
-#ifdef DEBUG
-            char message[256];
-            _snprintf_s(message, _countof(message), _TRUNCATE, "NYI: Unimplemented node type %s",
-                        GenTree::OpName(tree->OperGet()));
-            NYIRAW(message);
-#endif
-
         case GT_LCL_FLD:
         case GT_LCL_FLD_ADDR:
         case GT_LCL_VAR:
@@ -787,6 +779,15 @@ void LinearScan::BuildNode(GenTree* tree)
             info->srcCount         = appendBinaryLocationInfoToList(tree->AsOp());
             assert(info->srcCount == 2);
             break;
+
+        default:
+#ifdef DEBUG
+            char message[256];
+            _snprintf_s(message, _countof(message), _TRUNCATE, "NYI: Unimplemented node type %s",
+                        GenTree::OpName(tree->OperGet()));
+            NYIRAW(message);
+#endif
+            unreached();
     } // end switch (tree->OperGet())
 
     if (tree->IsUnusedValue() && (info->dstCount != 0))

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -237,7 +237,7 @@ void LinearScan::BuildNode(GenTree* tree)
                     assert(info->dstCount == 1);
                     break;
                 default:
-                    NYI_ARM("LinearScan::Build for GT_INTRINSIC");
+                    unreached();
                     break;
             }
         }
@@ -762,9 +762,8 @@ void LinearScan::BuildNode(GenTree* tree)
             _snprintf_s(message, _countof(message), _TRUNCATE, "NYI: Unimplemented node type %s",
                         GenTree::OpName(tree->OperGet()));
             NYIRAW(message);
-#else
-            NYI_ARM("BuildNode default case");
 #endif
+
         case GT_LCL_FLD:
         case GT_LCL_FLD_ADDR:
         case GT_LCL_VAR:


### PR DESCRIPTION
Convert most existing ARM NYI either to asserts or remove
the code entirely.

A few NYI are left, including:
1. GT_BITCAST from 'int' to 'float'
2. initblk unrolling is unimplemented: https://github.com/dotnet/coreclr/issues/16349
3. SIMD-related NYI (SIMD is currently unimplemented)