### PR TITLE
Vectorize and use ROSpan.LastIndexOf as the workhorse for string.LastIndexOf

### DIFF
--- a/src/mscorlib/shared/System/MemoryExtensions.cs
+++ b/src/mscorlib/shared/System/MemoryExtensions.cs
@@ -247,9 +247,8 @@ namespace System
                     Unsafe.As<T, byte>(ref value),
                     span.Length);
             if (typeof(T) == typeof(char))
-                return span.Length == 0 ? -1 : SpanHelpers.LastIndexOf(
+                return SpanHelpers.LastIndexOf(
                     ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
-                    span.Length - 1,
                     Unsafe.As<T, char>(ref value),
                     span.Length);
 
@@ -374,9 +373,8 @@ namespace System
                     Unsafe.As<T, byte>(ref value),
                     span.Length);
             if (typeof(T) == typeof(char))
-                return span.Length == 0 ? -1 : SpanHelpers.LastIndexOf(
+                return SpanHelpers.LastIndexOf(
                     ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
-                    span.Length - 1,
                     Unsafe.As<T, char>(ref value),
                     span.Length);
 

--- a/src/mscorlib/shared/System/MemoryExtensions.cs
+++ b/src/mscorlib/shared/System/MemoryExtensions.cs
@@ -246,6 +246,12 @@ namespace System
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                     Unsafe.As<T, byte>(ref value),
                     span.Length);
+            if (typeof(T) == typeof(char))
+                return span.Length == 0 ? -1 : SpanHelpers.LastIndexOf(
+                    ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
+                    span.Length - 1,
+                    Unsafe.As<T, char>(ref value),
+                    span.Length);
 
             return SpanHelpers.LastIndexOf<T>(ref MemoryMarshal.GetReference(span), value, span.Length);
         }
@@ -366,6 +372,12 @@ namespace System
                 return SpanHelpers.LastIndexOf(
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                     Unsafe.As<T, byte>(ref value),
+                    span.Length);
+            if (typeof(T) == typeof(char))
+                return span.Length == 0 ? -1 : SpanHelpers.LastIndexOf(
+                    ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
+                    span.Length - 1,
+                    Unsafe.As<T, char>(ref value),
                     span.Length);
 
             return SpanHelpers.LastIndexOf<T>(ref MemoryMarshal.GetReference(span), value, span.Length);

--- a/src/mscorlib/shared/System/SpanHelpers.Char.cs
+++ b/src/mscorlib/shared/System/SpanHelpers.Char.cs
@@ -72,7 +72,8 @@ namespace System
             while ((byte*)i < (byte*)minLength)
             {
                 int result = Unsafe.Add(ref first, i).CompareTo(Unsafe.Add(ref second, i));
-                if (result != 0) return result;
+                if (result != 0)
+                    return result;
                 i += 1;
             }
 
@@ -167,6 +168,91 @@ namespace System
             }
         }
 
+        public static unsafe int LastIndexOf(ref char firstChar, int startIndex, char value, int length)
+        {
+            Debug.Assert(length >= 0);
+            
+            fixed (char* pChars = &firstChar)
+            {
+                char* pCh = pChars + startIndex;
+                char* pEndCh = pCh - length;
+
+#if !netstandard11
+                if (Vector.IsHardwareAccelerated && length >= Vector<ushort>.Count * 2)
+                {
+                    const int elementsPerByte = sizeof(ushort) / sizeof(byte);
+                    length = (((int)pCh & (Unsafe.SizeOf<Vector<ushort>>() - 1)) / elementsPerByte) + 1;
+                }
+            SequentialScan:
+#endif
+                while (length >= 4)
+                {
+                    length -= 4;
+
+                    if (*pCh == value)
+                        goto Found;
+                    if (*(pCh - 1) == value)
+                        goto Found1;
+                    if (*(pCh - 2) == value)
+                        goto Found2;
+                    if (*(pCh - 3) == value)
+                        goto Found3;
+
+                    pCh -= 4;
+                }
+
+                while (length > 0)
+                {
+                    length -= 1;
+
+                    if (*pCh == value)
+                        goto Found;
+
+                    pCh -= 1;
+                }
+#if !netstandard11
+                // We get past SequentialScan only if IsHardwareAccelerated is true. However, we still have the redundant check to allow
+                // the JIT to see that the code is unreachable and eliminate it when the platform does not have hardware accelerated.
+                if (Vector.IsHardwareAccelerated && pCh > pEndCh)
+                {
+                    length = (int)((pCh - pEndCh) & ~(Vector<ushort>.Count - 1));
+
+                    // Get comparison Vector
+                    Vector<ushort> vComparison = new Vector<ushort>(value);
+
+                    while (length > 0)
+                    {
+                        char* pStart = pCh - Vector<ushort>.Count + 1;
+                        Vector<ushort> vMatches = Vector.Equals(vComparison, Unsafe.ReadUnaligned<Vector<ushort>>(pStart));
+                        if (Vector<ushort>.Zero.Equals(vMatches))
+                        {
+                            pCh -= Vector<ushort>.Count;
+                            length -= Vector<ushort>.Count;
+                            continue;
+                        }
+                        // Find offset of last match
+                        return (int)(pStart - pChars) + LocateLastFoundChar(vMatches);
+                    }
+
+                    if (pCh > pEndCh)
+                    {
+                        length = (int)(pCh - pEndCh);
+                        goto SequentialScan;
+                    }
+                }
+#endif
+                return -1;
+            Found3:
+                pCh--;
+            Found2:
+                pCh--;
+            Found1:
+                pCh--;
+            Found:
+                return (int)(pCh - pChars);
+            }
+        }
+
 #if !netstandard11
         // Vector sub-search adapted from https://github.com/aspnet/KestrelHttpServer/pull/1138
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -204,6 +290,40 @@ namespace System
         private const ulong XorPowerOfTwoToHighChar = (0x03ul |
                                                        0x02ul << 16 |
                                                        0x01ul << 32) + 1;
+
+        // Vector sub-search adapted from https://github.com/aspnet/KestrelHttpServer/pull/1138
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int LocateLastFoundChar(Vector<ushort> match)
+        {
+            var vector64 = Vector.AsVectorUInt64(match);
+            ulong candidate = 0;
+            int i = Vector<ulong>.Count - 1;
+            // Pattern unrolled by jit https://github.com/dotnet/coreclr/pull/8001
+            for (; i >= 0; i--)
+            {
+                candidate = vector64[i];
+                if (candidate != 0)
+                {
+                    break;
+                }
+            }
+
+            // Single LEA instruction with jitted const (using function result)
+            return i * 4 + LocateLastFoundChar(candidate);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int LocateLastFoundChar(ulong match)
+        {
+            // Find the most significant char that has its highest bit set
+            int index = 3;
+            while ((long)match > 0)
+            {
+                match = match << 16;
+                index--;
+            }
+            return index;
+        }
 #endif
     }
 }

--- a/src/mscorlib/shared/System/SpanHelpers.Char.cs
+++ b/src/mscorlib/shared/System/SpanHelpers.Char.cs
@@ -181,7 +181,7 @@ namespace System
                 if (Vector.IsHardwareAccelerated && length >= Vector<ushort>.Count * 2)
                 {
                     const int elementsPerByte = sizeof(ushort) / sizeof(byte);
-                    length = (((int)pCh & (Unsafe.SizeOf<Vector<ushort>>() - 1)) / elementsPerByte) + 1;
+                    length = (((int)pCh & (Unsafe.SizeOf<Vector<ushort>>() - 1)) / elementsPerByte);
                 }
             SequentialScan:
 #endif
@@ -218,11 +218,12 @@ namespace System
                     // Get comparison Vector
                     Vector<ushort> vComparison = new Vector<ushort>(value);
 
-                    while (length > Vector<ushort>.Count - 1)
+                    while (length > 0)
                     {
                         char* pStart = pCh - Vector<ushort>.Count;
-                        // Using Unsafe.ReadUnaligned instead of Read since it isn't gauranteed that pStart is vector aligned
-                        Vector<ushort> vMatches = Vector.Equals(vComparison, Unsafe.ReadUnaligned<Vector<ushort>>(pStart));
+                        // Using Unsafe.Read instead of ReadUnaligned since the search space is pinned and pCh (and hence pSart) is always vector aligned
+                        Debug.Assert(((int)pStart & (Unsafe.SizeOf<Vector<ushort>>() - 1)) == 0);
+                        Vector<ushort> vMatches = Vector.Equals(vComparison, Unsafe.Read<Vector<ushort>>(pStart));
                         if (Vector<ushort>.Zero.Equals(vMatches))
                         {
                             pCh -= Vector<ushort>.Count;

--- a/src/mscorlib/shared/System/String.Searching.cs
+++ b/src/mscorlib/shared/System/String.Searching.cs
@@ -353,13 +353,7 @@ namespace System
         // The character at position startIndex is included in the search.  startIndex is the larger
         // index within the string.
         //
-        public int LastIndexOf(char value)
-        {
-            if (Length == 0)
-                return -1;
-
-            return SpanHelpers.LastIndexOf(ref _firstChar, Length - 1, value, Length);
-        }
+        public int LastIndexOf(char value) => SpanHelpers.LastIndexOf(ref _firstChar, value, Length);
 
         public int LastIndexOf(char value, int startIndex)
         {
@@ -377,7 +371,10 @@ namespace System
             if ((uint)count > (uint)startIndex + 1)
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_Count);
 
-            return SpanHelpers.LastIndexOf(ref _firstChar, startIndex, value, count);
+            int startSearchAt = startIndex + 1 - count;
+            int result = SpanHelpers.LastIndexOf(ref Unsafe.Add(ref _firstChar, startSearchAt), value, count);
+
+            return result == -1 ? result : result + startSearchAt;
         }
 
         // Returns the index of the last occurrence of any specified character in the current instance.

--- a/src/mscorlib/shared/System/String.Searching.cs
+++ b/src/mscorlib/shared/System/String.Searching.cs
@@ -71,8 +71,6 @@ namespace System
 
         public unsafe int IndexOf(char value, int startIndex, int count)
         {
-            // These bounds checks are redundant since AsSpan does them already, but are required
-            // so that the correct parameter name is thrown as part of the exception.
             if ((uint)startIndex > (uint)Length)
                 throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
 
@@ -357,7 +355,10 @@ namespace System
         //
         public int LastIndexOf(char value)
         {
-            return LastIndexOf(value, this.Length - 1, this.Length);
+            if (Length == 0)
+                return -1;
+
+            return SpanHelpers.LastIndexOf(ref _firstChar, Length - 1, value, Length);
         }
 
         public int LastIndexOf(char value, int startIndex)
@@ -376,112 +377,7 @@ namespace System
             if ((uint)count > (uint)startIndex + 1)
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_Count);
 
-            fixed (char* pChars = &_firstChar)
-            {
-                char* pCh = pChars + startIndex;
-                char* pEndCh = pCh - count;
-
-                //We search [startIndex..EndIndex]
-                if (Vector.IsHardwareAccelerated && count >= Vector<ushort>.Count * 2)
-                {
-                    unchecked
-                    {
-                        const int elementsPerByte = sizeof(ushort) / sizeof(byte);
-                        count = (((int)pCh & (Vector<byte>.Count - 1)) / elementsPerByte) + 1;
-                    }
-                }
-            SequentialScan:
-                while (count >= 4)
-                {
-                    if (*pCh == value) goto ReturnIndex;
-                    if (*(pCh - 1) == value) goto ReturnIndex1;
-                    if (*(pCh - 2) == value) goto ReturnIndex2;
-                    if (*(pCh - 3) == value) goto ReturnIndex3;
-
-                    count -= 4;
-                    pCh -= 4;
-                }
-
-                while (count > 0)
-                {
-                    if (*pCh == value)
-                        goto ReturnIndex;
-
-                    count--;
-                    pCh--;
-                }
-
-                if (pCh > pEndCh)
-                {
-                    count = (int)((pCh - pEndCh) & ~(Vector<ushort>.Count - 1));
-
-                    // Get comparison Vector
-                    Vector<ushort> vComparison = new Vector<ushort>(value);
-                    while (count > 0)
-                    {
-                        char* pStart = pCh - Vector<ushort>.Count + 1;
-                        var vMatches = Vector.Equals(vComparison, Unsafe.ReadUnaligned<Vector<ushort>>(pStart));
-                        if (Vector<ushort>.Zero.Equals(vMatches))
-                        {
-                            pCh -= Vector<ushort>.Count;
-                            count -= Vector<ushort>.Count;
-                            continue;
-                        }
-                        // Find offset of last match
-                        return (int)(pStart - pChars) + LocateLastFoundChar(vMatches);
-                    }
-
-                    if (pCh > pEndCh)
-                    {
-                        unchecked
-                        {
-                            count = (int)(pCh - pEndCh);
-                        }
-                        goto SequentialScan;
-                    }
-                }
-                return -1;
-
-            ReturnIndex3: pCh--;
-            ReturnIndex2: pCh--;
-            ReturnIndex1: pCh--;
-            ReturnIndex:
-                return (int)(pCh - pChars);
-            }
-        }
-
-        // Vector sub-search adapted from https://github.com/aspnet/KestrelHttpServer/pull/1138
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int LocateLastFoundChar(Vector<ushort> match)
-        {
-            var vector64 = Vector.AsVectorUInt64(match);
-            ulong candidate = 0;
-            int i = Vector<ulong>.Count - 1;
-            // Pattern unrolled by jit https://github.com/dotnet/coreclr/pull/8001
-            for (; i >= 0; i--)
-            {
-                candidate = vector64[i];
-                if (candidate != 0)
-                {
-                    break;
-                }
-            }
-
-            // Single LEA instruction with jitted const (using function result)
-            return i * 4 + LocateLastFoundChar(candidate);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int LocateLastFoundChar(ulong match)
-        {
-            // Find the most significant char that has its highest bit set
-            int index = 3;
-            while ((long)match > 0)
-            {
-                match = match << 16;
-                index--;
-            }
-            return index;
+            return SpanHelpers.LastIndexOf(ref _firstChar, startIndex, value, count);
         }
 
         // Returns the index of the last occurrence of any specified character in the current instance.


### PR DESCRIPTION
~The extra span.Length checks (required by the way string.LastIndexOf was implemented) ends up adding overhead for small spans.~

~**TODO:** Investigate a way to avoid that overhead without having two separate implementations.~

![image](https://user-images.githubusercontent.com/6527137/38287730-1367f3d0-3781-11e8-8b04-4f1b7d7339bf.png)

<summary>Version 1 of the PR (out-dated)
<details>

![image](https://user-images.githubusercontent.com/6527137/38160200-8edc4298-346e-11e8-9948-5be2f337354f.png)
</details>
</summary>

Related PR: https://github.com/dotnet/coreclr/pull/17284

cc @jkotas, @tarekgh, @eerhardt 