### PR TITLE
Enable building of Ubuntu/arm crossarch components in netci

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -2397,9 +2397,9 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                     // Ubuntu cross-compilation toolset (running on a Ubuntu x64 host).
 
                     def dockerImage = getDockerImageName(architecture, os, true)
-                    def dockerCmd = "docker run -i --rm -v \${WORKSPACE}:\${WORKSPACE} -w \${WORKSPACE} -e ROOTFS_DIR=/crossrootfs/arm ${dockerImage} "
+                    def dockerCmd = "docker run -i --rm -v \${WORKSPACE}:\${WORKSPACE} -w \${WORKSPACE} -e ROOTFS_DIR=/crossrootfs/arm -e CAC_ROOTFS_DIR=/crossrootfs/x86 ${dockerImage} "
 
-                    buildCommands += "${dockerCmd}\${WORKSPACE}/build.sh ${lowerConfiguration} ${architecture} cross"
+                    buildCommands += "${dockerCmd}\${WORKSPACE}/build.sh ${lowerConfiguration} ${architecture} cross crosscomponent"
 
                     // Then, using the same docker image, generate the CORE_ROOT layout using build-test.sh to
                     // download the appropriate CoreFX packages.


### PR DESCRIPTION
@BruceForstall Do you think it's safe now to enable building crosscomponents for Ubuntu arm (which automatically enables R2R crossgen-ing of S.P.C.dll before tests running)? FYI, I rebased dev/unit_test_workflow to include #17342 changes.

#17274 Innerloop is green and just one pri1 test failed during Normal (Loader/binding/assemblies/assemblybugs/177066w/repro177066/repro177066.sh).

/cc @RussKeldorph 