### PR TITLE
[1.1] Remove libsosplugin from OpenSuse423

### DIFF
--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/opensuse/42.3/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/opensuse/42.3/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -14,7 +14,6 @@
     <NativeSplittableBinary Include="$(BinDir)libmscordaccore.so" />
     <NativeSplittableBinary Include="$(BinDir)libmscordbi.so" />
     <NativeSplittableBinary Include="$(BinDir)libsos.so" />
-    <NativeSplittableBinary Include="$(BinDir)libsosplugin.so" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
     <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt" />
     <ArchitectureSpecificNativeFile Include="$(BinDir)mscorlib.ni.dll" />


### PR DESCRIPTION
Required libraries are missing to make the libsosplugin on opensuse423 unless we get them from sources that aren't officially supported.

@janvorli 