### PR TITLE
Mark GcCollect test as incompatible with GcStress

### DIFF
--- a/tests/src/CoreMangLib/cti/system/gc/GCCollect.csproj
+++ b/tests/src/CoreMangLib/cti/system/gc/GCCollect.csproj
@@ -12,6 +12,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
Extends changes in #17319 to cover stress tests run via the normal
msbuild/xunit test harness.