### PR TITLE
Add ItemRef and ValueRef to List/Dict (C# 7.2 constructs)

### DIFF
--- a/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
@@ -227,6 +228,11 @@ namespace System.Collections.Generic
         }
 
         // Returns reference to value with given key.
+        // Hidden due to the following considerations:
+        // - Updating the value via ref will not change the _version 
+        // - Across a size change (Trim, Add leading to Resize, etc)
+        //   a held ref will cease to be a live ref to the Dictionary's data
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public ref TValue ValueRef(TKey key)
         {
             int i = FindEntry(key);

--- a/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
@@ -44,6 +44,7 @@ namespace System.Collections.Generic
             public TValue value;         // Value of entry
         }
 
+        private static TValue s_emptyValue;
         private int[] _buckets;
         private Entry[] _entries;
         private int _count;
@@ -223,6 +224,21 @@ namespace System.Collections.Generic
                 bool modified = TryInsert(key, value, InsertionBehavior.OverwriteExisting);
                 Debug.Assert(modified);
             }
+        }
+
+        // Returns reference to value with given key.
+        public ref TValue ValueRef(TKey key)
+        {
+            int i = FindEntry(key);
+            if (i >= 0) return ref _entries[i].value;
+            ThrowHelper.ThrowKeyNotFoundException(key);
+            return ref EmptyValue;
+        }
+
+        private static ref TValue EmptyValue
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            get => ref s_emptyValue;
         }
 
         public void Add(TKey key, TValue value)

--- a/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/Dictionary.cs
@@ -45,7 +45,6 @@ namespace System.Collections.Generic
             public TValue value;         // Value of entry
         }
 
-        private static TValue s_emptyValue;
         private int[] _buckets;
         private Entry[] _entries;
         private int _count;
@@ -236,15 +235,12 @@ namespace System.Collections.Generic
         public ref TValue ValueRef(TKey key)
         {
             int i = FindEntry(key);
-            if (i >= 0) return ref _entries[i].value;
-            ThrowHelper.ThrowKeyNotFoundException(key);
-            return ref EmptyValue;
-        }
+            if (i < 0)
+            {
+                ThrowHelper.ThrowKeyNotFoundException(key);
+            }
 
-        private static ref TValue EmptyValue
-        {
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            get => ref s_emptyValue;
+            return ref _entries[i].value;
         }
 
         public void Add(TKey key, TValue value)

--- a/src/mscorlib/shared/System/Collections/Generic/List.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/List.cs
@@ -172,6 +172,16 @@ namespace System.Collections.Generic
             }
         }
 
+        // Returns reference to element at the given index.
+        public ref T ItemRef(int index)
+        {
+            if ((uint)index >= (uint)_size)
+            {
+                ThrowHelper.ThrowArgumentOutOfRange_IndexException();
+            }
+            return ref _items[index];
+        }
+
         private static bool IsCompatibleObject(object value)
         {
             // Non-null values are fine.  Only accept nulls if T is a class or Nullable<U>.

--- a/src/mscorlib/shared/System/Collections/Generic/List.cs
+++ b/src/mscorlib/shared/System/Collections/Generic/List.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -173,6 +174,12 @@ namespace System.Collections.Generic
         }
 
         // Returns reference to element at the given index.
+        // Hidden due to the following considerations:
+        // - Updating the value via ref will not change the _version 
+        // - Across a change=ing operation (Trim, Remove, Add leading to Resize, etc)
+        //   a held ref will cease to be a live ref to the List's data
+        //   or a reference to an different element (in same index)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public ref T ItemRef(int index)
         {
             if ((uint)index >= (uint)_size)


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/25189
Contributes to https://github.com/dotnet/corefx/issues/20684

* Adds ItemRef() to `List<T>`
* Adds ValueRef() to `Dictionary<TKey, TValue>`

As per https://github.com/dotnet/corefx/pull/25738

/cc @jkotas 