### PR TITLE
Make non-portable Windows build use Host RID

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -113,6 +113,11 @@
   <!-- Import Build tools common props file where repo-independent properties are found -->
   <Import Condition="Exists('$(ToolsDir)Build.Common.props')" Project="$(ToolsDir)Build.Common.props" />
 
+  <!-- Where to store the build host's info if needed -->
+  <PropertyGroup>
+    <HostMachineInfoPropsFile>$(BaseIntermediateOutputPath)HostMachineInfo.props</HostMachineInfoPropsFile>
+  </PropertyGroup>
+
   <!-- Setup common target properties that we use to conditionally include sources -->
   <PropertyGroup>
     <TargetsFreeBSD Condition="'$(BuildOS)' == 'FreeBSD'">true</TargetsFreeBSD>

--- a/src/.nuget/dir.props
+++ b/src/.nuget/dir.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildThisFileDirectory)..\..\dir.props" />
+  <Import Project="$(HostMachineInfoPropsFile)" />
 
   <PropertyGroup>
     <!-- defined in buildtools packaging.targets, but we need this before targets are imported -->
@@ -67,9 +68,19 @@
     <When Condition="'$(PackageRID)' != ''" />
     <When Condition="'$(_runtimeOSFamily)' == 'win'">
       <PropertyGroup>
-        <RIDPlatform>win7</RIDPlatform>
-        <RIDPlatform Condition="'$(ArchGroup)' == 'arm'">win8</RIDPlatform>
-        <RIDPlatform Condition="'$(ArchGroup)' == 'arm64'">win10</RIDPlatform>
+        <!-- Set the non-portable RID platform.  This logic is fragile and questionable since
+             it confuses the concepts of "portable build" and "cross build."
+        -->
+        <RIDPlatform>$(HostMachineRid.Substring(0, $(HostMachineRid.IndexOf('-'))))</RIDPlatform>
+        <RIDPlatform Condition="'$(ArchGroup)' == 'arm' and '$(RIDPlatform)' == 'win7'">
+          win8
+        </RIDPlatform>
+        <RIDPlatform Condition="'$(ArchGroup)' == 'arm64' and
+            ('$(RIDPlatform)' == 'win7' or
+             '$(RIDPlatform)' == 'win8' or
+             '$(RIDPlatform)' == 'win81')">
+          win10
+        </RIDPlatform>
         
         <!-- Set the platform part of the RID if we are doing a portable build -->
         <RIDPlatform Condition="'$(PortableBuild)' == 'true'">win</RIDPlatform>

--- a/src/.nuget/packages.builds
+++ b/src/.nuget/packages.builds
@@ -1,5 +1,6 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildThisFileDirectory)..\..\dir.props" />
+  <UsingTask TaskName="GetTargetMachineInfo" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
   <PropertyGroup>
     <!-- This property must be set to the same value as $(PackageOutputPath) for the nuspecs and nupkgs to be binplaced to the intended location. -->
@@ -28,6 +29,26 @@
   <Import Project="$(ToolsDir)versioning.targets" />
   <!-- Make sure we create version.txt file since it will be packaged -->
   <Target Name="EnsureVersionInfoFileExists" BeforeTargets="Build" DependsOnTargets="CreateVersionInfoFile" />
+
+  <Target Name="CreateHostMachineInfoFile" BeforeTargets="Build">
+    <GetTargetMachineInfo>
+      <Output PropertyName="HostMachineRid" TaskParameter="RuntimeIdentifier" />
+    </GetTargetMachineInfo>
+
+    <PropertyGroup>
+      <HostMachineInfoPropsContent>
+&lt;Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"&gt;
+  &lt;PropertyGroup&gt;
+    &lt;HostMachineRid&gt;$(HostMachineRid)&lt;/HostMachineRid&gt;
+  &lt;/PropertyGroup&gt;
+&lt;/Project&gt;
+      </HostMachineInfoPropsContent>
+    </PropertyGroup>
+
+    <WriteLinesToFile File="$(HostMachineInfoPropsFile)"
+                      Lines="$(HostMachineInfoPropsContent)"
+                      Overwrite="True" />
+  </Target>
 
   <Import Project="$(MSBuildThisFileDirectory)..\..\dir.traversal.targets" />
 </Project>


### PR DESCRIPTION
Much of this logic was ported from dotnet/core-setup#3266

I have spent little time analyzing it, but the coreclr RID handling
logic appears to be unnecessarily complex.  We need to spend time cleaning
it up among other things.  For now, however, this seems to be a low risk
way to fix #14291.