### PR TITLE
[x86/Linux] Fix COMNumber::DoubleToNumberFC arguments order

### DIFF
--- a/src/classlibnative/bcltype/number.cpp
+++ b/src/classlibnative/bcltype/number.cpp
@@ -1983,7 +1983,7 @@ ParseSection:
 #pragma warning(pop)
 #endif
 
-FCIMPL3(void, COMNumber::DoubleToNumberFC, double value, int precision, NUMBER* number)
+FCIMPL3_VII(void, COMNumber::DoubleToNumberFC, double value, int precision, NUMBER* number)
 {
     FCALL_CONTRACT;
 

--- a/src/classlibnative/bcltype/number.h
+++ b/src/classlibnative/bcltype/number.h
@@ -31,7 +31,7 @@ struct NUMBER {
 class COMNumber
 {
 public:
-    static FCDECL3(void, DoubleToNumberFC, double value, int precision, NUMBER* number);
+    static FCDECL3_VII(void, DoubleToNumberFC, double value, int precision, NUMBER* number);
     static FCDECL1(double, NumberToDoubleFC, NUMBER* number);
     static FCDECL2(FC_BOOL_RET, NumberBufferToDecimal, NUMBER* number, DECIMAL* value);
     


### PR DESCRIPTION
We should use FCDECL3_VII/FCIMPL3_VII instead of FCDECL3/FCIMPL3 otherwise we got incorrect order of arguments that leads to crashes.