### PR TITLE
Fix ARM32 on ARM64 Tracing

### DIFF
--- a/src/inc/eventtracebase.h
+++ b/src/inc/eventtracebase.h
@@ -100,7 +100,7 @@ enum EtwThreadFlags
 #define ETWFireEvent(EventName)
 
 #define ETW_TRACING_INITIALIZED(RegHandle) (TRUE)
-#define ETW_EVENT_ENABLED(Context, EventDescriptor) (EventPipeHelper::Enabled() || EventEnabled##EventDescriptor())
+#define ETW_EVENT_ENABLED(Context, EventDescriptor) (EventPipeHelper::Enabled() || XplatEventLogger::IsEventLoggingEnabled())
 #define ETW_CATEGORY_ENABLED(Context, Level, Keyword) (EventPipeHelper::Enabled() || XplatEventLogger::IsEventLoggingEnabled())
 #define ETW_TRACING_ENABLED(Context, EventDescriptor) (EventEnabled##EventDescriptor())
 #define ETW_TRACING_CATEGORY_ENABLED(Context, Level, Keyword) (EventPipeHelper::Enabled() || XplatEventLogger::IsEventLoggingEnabled())
@@ -111,7 +111,7 @@ enum EtwThreadFlags
 #define ETWFireEvent(EventName)
 
 #define ETW_TRACING_INITIALIZED(RegHandle) (TRUE)
-#define ETW_EVENT_ENABLED(Context, EventDescriptor) (EventEnabled##EventDescriptor())
+#define ETW_EVENT_ENABLED(Context, EventDescriptor) (XplatEventLogger::IsEventLoggingEnabled())
 #define ETW_CATEGORY_ENABLED(Context, Level, Keyword) (XplatEventLogger::IsEventLoggingEnabled())
 #define ETW_TRACING_ENABLED(Context, EventDescriptor) (EventEnabled##EventDescriptor())
 #define ETW_TRACING_CATEGORY_ENABLED(Context, Level, Keyword) (XplatEventLogger::IsEventLoggingEnabled())

--- a/src/scripts/genEventPipe.py
+++ b/src/scripts/genEventPipe.py
@@ -437,7 +437,7 @@ bool WriteToBuffer(const T &value, char *&buffer, size_t& offset, size_t& size, 
             return false;
     }}
 
-    *(T *)(buffer + offset) = value;
+    memcpy(buffer + offset, (char *)&value, sizeof(T));
     offset += sizeof(T);
     return true;
 }}

--- a/src/scripts/genEventing.py
+++ b/src/scripts/genEventing.py
@@ -285,7 +285,7 @@ def generateClrallEvents(eventNodes,allTemplates):
         clrallEvents.append(eventName)
         clrallEvents.append("() {return ")
         clrallEvents.append("EventPipeEventEnabled" + eventName + "() || ")
-        clrallEvents.append("EventXplatEnabled" + eventName + "();}\n\n")
+        clrallEvents.append("(XplatEventLogger::IsEventLoggingEnabled() && EventXplatEnabled" + eventName + "());}\n\n")
         #generate FireEtw functions
         fnptype     = []
         fnbody      = []

--- a/src/scripts/genLttngProvider.py
+++ b/src/scripts/genLttngProvider.py
@@ -732,7 +732,7 @@ bool WriteToBuffer(const T &value, char *&buffer, size_t& offset, size_t& size, 
             return false;
     }
 
-    *(T *)(buffer + offset) = value;
+    memcpy(buffer + offset, (char *)&value, sizeof(T));
     offset += sizeof(T);
     return true;
 }


### PR DESCRIPTION
Fixes #17321.

There are two issues that broke tracing on ARM32 on ARM64:

1. The tracing environment variable check was removed for some paths but not others.  Because ARM32 builds on Ubuntu 14.04 with lttng-ust-dev 2.6 which doesn't have support for tracing_enabled checks, this resulted in the checks being hardcoded to TRUE.  Thus, we always run through tracing paths even when tracing is off.
2. When tracing is on (purposefully or inadvertently) there is a possibly unaligned double store in WriteToBuffer.  WriteToBuffer is used to format the data that is written into LTTng and EventPipe.  If the store is unaligned, the process is terminated with a bus error because the store double instruction does not handle alignment automatically.

Issue 1 is fixed by re-introducing the environment variable checks so that we don't go down the path of doing all the work that tracing requires when it is disabled.
Issue 2 is fixed by converting the unaligned store to a memcpy.