### PR TITLE
JIT: refine x86 gc reg kill set for CORINFO_HELP_INIT_PINVOKE_FRAME

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -752,6 +752,11 @@ regMaskTP Compiler::compNoGCHelperCallKillSet(CorInfoHelpFunc helper)
             return RBM_CALLEE_TRASH_NOGC;
 #endif // defined(_TARGET_AMD64_)
 
+#if defined(_TARGET_X86_)
+        case CORINFO_HELP_INIT_PINVOKE_FRAME:
+            return RBM_INIT_PINVOKE_FRAME_TRASH;
+#endif // defined(_TARGET_X86_)
+
         default:
             return RBM_CALLEE_TRASH_NOGC;
     }


### PR DESCRIPTION
This helper only kills EAX/ESI on x86, so make sure that is reflected in
the gc kill set.

Resolves #17404.