### PR TITLE
Update docker images for arm32

### DIFF
--- a/Documentation/building/linux-instructions.md
+++ b/Documentation/building/linux-instructions.md
@@ -37,6 +37,8 @@ In order to get clang-3.9, llvm-3.9 and lldb-3.9 on Ubuntu 14.04, we need to add
     ~$ echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.9 main" | sudo tee /etc/apt/sources.list.d/llvm.list
     ~$ wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
     ~$ sudo apt-get update
+
+Note: arm clang has a known issue with CompareExchange (#15074), so for arm you have to use clang-4.0 or higher, the official build uses clang-5.0.
     
 For other version of Debian/Ubuntu, please visit http://apt.llvm.org/.
 

--- a/build.sh
+++ b/build.sh
@@ -150,10 +150,10 @@ check_prereqs()
     hash cmake 2>/dev/null || { echo >&2 "Please install cmake before running this script"; exit 1; }
 
 
-    # Minimum required version of clang is version 3.9 for arm/armel cross build
+    # Minimum required version of clang is version 4.0 for arm/armel cross build
     if [[ $__CrossBuild == 1 && ("$__BuildArch" == "arm" || "$__BuildArch" == "armel") ]]; then
-        if ! [[ "$__ClangMajorVersion" -gt "3" || ( $__ClangMajorVersion == 3 && $__ClangMinorVersion == 9 ) ]]; then
-            echo "Please install clang3.9 or latest for arm/armel cross build"; exit 1;
+        if ! [[ "$__ClangMajorVersion" -ge "4"]]; then
+            echo "Please install clang4.0 or latest for arm/armel cross build"; exit 1;
         fi
     fi
 

--- a/build.sh
+++ b/build.sh
@@ -152,7 +152,7 @@ check_prereqs()
 
     # Minimum required version of clang is version 4.0 for arm/armel cross build
     if [[ $__CrossBuild == 1 && ("$__BuildArch" == "arm" || "$__BuildArch" == "armel") ]]; then
-        if ! [[ "$__ClangMajorVersion" -ge "4"]]; then
+        if ! [[ "$__ClangMajorVersion" -ge "4" ]]; then
             echo "Please install clang4.0 or latest for arm/armel cross build"; exit 1;
         fi
     fi

--- a/build.sh
+++ b/build.sh
@@ -894,8 +894,13 @@ fi
 
 # Set default clang version
 if [[ $__ClangMajorVersion == 0 && $__ClangMinorVersion == 0 ]]; then
-    __ClangMajorVersion=3
-    __ClangMinorVersion=9
+	if [[ "$__BuildArch" == "arm" || "$__BuildArch" == "armel" ]]; then
+		__ClangMajorVersion=5
+		__ClangMinorVersion=0
+	else
+		__ClangMajorVersion=3
+		__ClangMinorVersion=9
+	fi
 fi
 
 if [[ "$__BuildArch" == "armel" ]]; then

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -130,7 +130,7 @@
         {
           "Name": "DotNet-CoreClr-Trusted-Linux-Crossbuild",
           "Parameters": {
-            "DockerTag": "ubuntu-14.04-cross-e435274-Use_new_version_here)",
+            "DockerTag": "ubuntu-14.04-cross-e435274-20180405193556",
             "Architecture": "arm",
             "Rid": "linux",
             "CrossArchitecture": "x86",
@@ -149,7 +149,7 @@
         {
           "Name": "DotNet-CoreClr-Trusted-Linux-Crossbuild",
           "Parameters": {
-            "DockerTag": "ubuntu-16.04-cross-arm64-Use_new_version_here",
+            "DockerTag": "ubuntu-16.04-cross-arm64-a3ae44b-20180315221921",
             "Architecture": "arm64",
             "Rid": "linux",
             "CrossArchBuildArgs": "crosscomponent",

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -130,7 +130,7 @@
         {
           "Name": "DotNet-CoreClr-Trusted-Linux-Crossbuild",
           "Parameters": {
-            "DockerTag": "ubuntu-14.04-cross-e435274-20180323032140",
+            "DockerTag": "ubuntu-14.04-cross-e435274-Use_new_version_here)",
             "Architecture": "arm",
             "Rid": "linux",
             "CrossArchitecture": "x86",
@@ -149,7 +149,7 @@
         {
           "Name": "DotNet-CoreClr-Trusted-Linux-Crossbuild",
           "Parameters": {
-            "DockerTag": "ubuntu-16.04-cross-arm64-a3ae44b-20180315221921",
+            "DockerTag": "ubuntu-16.04-cross-arm64-Use_new_version_here",
             "Architecture": "arm64",
             "Rid": "linux",
             "CrossArchBuildArgs": "crosscomponent",

--- a/netci.groovy
+++ b/netci.groovy
@@ -968,10 +968,10 @@ def static getDockerImageName(def architecture, def os, def isBuild) {
         }
         else if (architecture == 'armem') {
             if (os == 'Ubuntu') {
-                return "microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-Use_new_version_here"
+                return "microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-e435274-20180405193556"
             }
             else if (os == 'Ubuntu16.04') {
-                return "microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-cross-Use_new_version_here"
+                return "microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-cross-e435274-20180404203310"
             }
             else if (os == 'Tizen') {
                 return "hqueue/dotnetcore:ubuntu1404_cross_prereqs_v4-tizen_rootfs"
@@ -979,7 +979,7 @@ def static getDockerImageName(def architecture, def os, def isBuild) {
         }
         else if (architecture == 'arm') {
             if (os == 'Ubuntu') {
-                return "microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-Use_new_version_here"
+                return "microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-e435274-20180405193556"
             }
         }
     }

--- a/netci.groovy
+++ b/netci.groovy
@@ -968,10 +968,10 @@ def static getDockerImageName(def architecture, def os, def isBuild) {
         }
         else if (architecture == 'armem') {
             if (os == 'Ubuntu') {
-                return "microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-0cd4667-20172211042239"
+                return "microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-Use_new_version_here"
             }
             else if (os == 'Ubuntu16.04') {
-                return "microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-cross-ef0ac75-20175511035548"
+                return "microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-cross-Use_new_version_here"
             }
             else if (os == 'Tizen') {
                 return "hqueue/dotnetcore:ubuntu1404_cross_prereqs_v4-tizen_rootfs"
@@ -979,7 +979,7 @@ def static getDockerImageName(def architecture, def os, def isBuild) {
         }
         else if (architecture == 'arm') {
             if (os == 'Ubuntu') {
-                return "microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-e435274-20180323032140"
+                return "microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-Use_new_version_here"
             }
         }
     }


### PR DESCRIPTION
Update docker containers that we use for arm builds. The new containers have clang-5.0 that fixes #16995.

Link dotnet/dotnet-buildtools-prereqs-docker#42

@jashook could you please check that I have marked all places that need to be changed?