### PR TITLE
Disable corefx Microsoft.Win32.Registry.Tests on ARM

### DIFF
--- a/tests/arm/corefx_test_exclusions.txt
+++ b/tests/arm/corefx_test_exclusions.txt
@@ -1,3 +1,4 @@
+Microsoft.Win32.Registry.Tests
 System.Console.Tests
 System.Data.SqlClient.Tests
 System.Diagnostics.Process.Tests


### PR DESCRIPTION
Failures tracked by #17423.