### PR TITLE
[x86/Linux] Change EventPipeProviderConfiguration layout

### DIFF
--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventPipe.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventPipe.cs
@@ -14,8 +14,8 @@ namespace System.Diagnostics.Tracing
     {
         [MarshalAs(UnmanagedType.LPWStr)]
         private string m_providerName;
-        private ulong m_keywords;
         private uint m_loggingLevel;
+        private ulong m_keywords;
 
         internal EventPipeProviderConfiguration(
             string providerName,

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -316,9 +316,12 @@ struct EventPipeProviderConfiguration
 
 private:
 
+    // We should use following field order to avoid align mismatches with corresponding managed
+    // structure on x86/Linux, where 4-byte alignment is used by default instead of 8-byte one
+    // that is used during marshalling in this case.
     LPCWSTR m_pProviderName;
-    UINT64 m_keywords;
     UINT32 m_loggingLevel;
+    UINT64 m_keywords;
 
 public:
 


### PR DESCRIPTION
Change EventPipeProviderConfiguration layout to avoid mismatches on x86/Linux.

This patch fixes sigfaults in tracing tests.