### PR TITLE
Add YieldAwaiter support to the async method builder delegate optimization

### DIFF
--- a/src/mscorlib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
+++ b/src/mscorlib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
@@ -33,7 +33,7 @@ namespace System.Runtime.CompilerServices
         [StructLayout(LayoutKind.Auto)]
         public readonly struct ConfiguredValueTaskAwaiter : ICriticalNotifyCompletion
 #if CORECLR
-            , IValueTaskAwaiter
+            , IStateMachineBoxAwareAwaiter
 #endif
         {
             /// <summary>The value being awaited.</summary>
@@ -94,7 +94,7 @@ namespace System.Runtime.CompilerServices
             }
 
 #if CORECLR
-            void IValueTaskAwaiter.AwaitUnsafeOnCompleted(IAsyncStateMachineBox box)
+            void IStateMachineBoxAwareAwaiter.AwaitUnsafeOnCompleted(IAsyncStateMachineBox box)
             {
                 if (_value.ObjectIsTask)
                 {
@@ -135,7 +135,7 @@ namespace System.Runtime.CompilerServices
         [StructLayout(LayoutKind.Auto)]
         public readonly struct ConfiguredValueTaskAwaiter : ICriticalNotifyCompletion
 #if CORECLR
-            , IValueTaskAwaiter
+            , IStateMachineBoxAwareAwaiter
 #endif
         {
             /// <summary>The value being awaited.</summary>
@@ -196,7 +196,7 @@ namespace System.Runtime.CompilerServices
             }
 
 #if CORECLR
-            void IValueTaskAwaiter.AwaitUnsafeOnCompleted(IAsyncStateMachineBox box)
+            void IStateMachineBoxAwareAwaiter.AwaitUnsafeOnCompleted(IAsyncStateMachineBox box)
             {
                 if (_value.ObjectIsTask)
                 {

--- a/src/mscorlib/shared/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/mscorlib/shared/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -11,7 +11,7 @@ namespace System.Runtime.CompilerServices
     /// <summary>Provides an awaiter for a <see cref="ValueTask"/>.</summary>
     public readonly struct ValueTaskAwaiter : ICriticalNotifyCompletion
 #if CORECLR
-            , IValueTaskAwaiter
+            , IStateMachineBoxAwareAwaiter
 #endif
     {
         /// <summary>Shim used to invoke an <see cref="Action"/> passed as the state argument to a <see cref="Action{Object}"/>.</summary>
@@ -80,7 +80,7 @@ namespace System.Runtime.CompilerServices
         }
 
 #if CORECLR
-        void IValueTaskAwaiter.AwaitUnsafeOnCompleted(IAsyncStateMachineBox box)
+        void IStateMachineBoxAwareAwaiter.AwaitUnsafeOnCompleted(IAsyncStateMachineBox box)
         {
             if (_value.ObjectIsTask)
             {
@@ -113,7 +113,7 @@ namespace System.Runtime.CompilerServices
     /// <summary>Provides an awaiter for a <see cref="ValueTask{TResult}"/>.</summary>
     public readonly struct ValueTaskAwaiter<TResult> : ICriticalNotifyCompletion
 #if CORECLR
-            , IValueTaskAwaiter
+            , IStateMachineBoxAwareAwaiter
 #endif
     {
         /// <summary>The value being awaited.</summary>
@@ -171,7 +171,7 @@ namespace System.Runtime.CompilerServices
         }
 
 #if CORECLR
-        void IValueTaskAwaiter.AwaitUnsafeOnCompleted(IAsyncStateMachineBox box)
+        void IStateMachineBoxAwareAwaiter.AwaitUnsafeOnCompleted(IAsyncStateMachineBox box)
         {
             if (_value.ObjectIsTask)
             {
@@ -190,8 +190,8 @@ namespace System.Runtime.CompilerServices
     }
 
 #if CORECLR
-    /// <summary>Internal interface used to enable optimizations from <see cref="AsyncTaskMethodBuilder"/> on <see cref="ValueTask"/>.</summary>>
-    internal interface IValueTaskAwaiter
+    /// <summary>Internal interface used to enable optimizations from <see cref="AsyncTaskMethodBuilder"/>.</summary>>
+    internal interface IStateMachineBoxAwareAwaiter
     {
         /// <summary>Invoked to set <see cref="ITaskCompletionAction.Invoke"/> of the <paramref name="box"/> as the awaiter's continuation.</summary>
         /// <param name="box">The box object.</param>

--- a/src/mscorlib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -389,11 +389,11 @@ namespace System.Runtime.CompilerServices
                 ref ConfiguredTaskAwaitable.ConfiguredTaskAwaiter ta = ref Unsafe.As<TAwaiter, ConfiguredTaskAwaitable.ConfiguredTaskAwaiter>(ref awaiter);
                 TaskAwaiter.UnsafeOnCompletedInternal(ta.m_task, box, ta.m_continueOnCapturedContext);
             }
-            else if ((null != (object)default(TAwaiter)) && (awaiter is IValueTaskAwaiter))
+            else if ((null != (object)default(TAwaiter)) && (awaiter is IStateMachineBoxAwareAwaiter))
             {
                 try
                 {
-                    ((IValueTaskAwaiter)awaiter).AwaitUnsafeOnCompleted(box);
+                    ((IStateMachineBoxAwareAwaiter)awaiter).AwaitUnsafeOnCompleted(box);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
We added an optimization to async methods that lets the builder avoid allocating the Action delegate when it recognizes the awaiter being used.  Previously this was enabled for all of the publicly exposed awaiters in corelib, with the exception of YieldAwaiter (what's used with Task.YIeld).  It was enabled by having the awaiter implement an internal interface.  This commit just generalizes that interface name and then implements it on YIeldAwaiter to complete the picture.

cc: @kouvel, @AndyAyersMS 