### PR TITLE
Re-enable arg assert in scanArgRegTable

### DIFF
--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -2658,9 +2658,8 @@ unsigned scanArgRegTableI(PTR_CBYTE     table,
                 }
                 while (argOfs);
 
-                _ASSERTE(!hasPartialArgInfo    ||
-                         isZero(argHigh)       ||
-                        (argHigh == CONSTRUCT_ptrArgTP(1, (argCnt-1))));
+                // At this point, either we have no more args, or the next arg is in the position corresponding to argCnt.
+                _ASSERTE(isZero(argHigh) || (argHigh == CONSTRUCT_ptrArgTP(1, (argCnt-1))));
 
                 if (hasPartialArgInfo)
                 {


### PR DESCRIPTION
This assert was formerly enabled only for the "full arg info case", i.e. when there was not a frame on x86. WIth PR #10782 the sense of the first condition was inadvertently changed. With PR #17363 the tracking of `argCnt` vs. `argHigh` was fixed so that the assert is correct for the "partial arg info" case.
The first condition should be removed to make it cover the "full argo info case" as well (as before #10782).