### PR TITLE
Add GetLoaderAllocatorObjectForGC to IGCToCLR

### DIFF
--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -55,6 +55,9 @@ public:
     static gc_alloc_context * GetAllocContext();
 
     static void GcEnumAllocContexts(enum_alloc_context_func* fn, void* param);
+
+    static uint8_t* GetLoaderAllocatorObjectForGC(Object* pObject);
+
     // Diagnostics methods.
     static void DiagGCStart(int gen, bool isInduced);
     static void DiagUpdateGenerationBounds();

--- a/src/gc/env/gcenv.object.h
+++ b/src/gc/env/gcenv.object.h
@@ -121,12 +121,6 @@ public:
     {
         return true;
     }
-
-    uint8_t* GetLoaderAllocatorObjectForGC()
-    {
-        // [LOCALGC TODO] this is not correct
-        return nullptr;
-    }
 };
 
 class Object

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -125,6 +125,12 @@ inline void GCToEEInterface::GcEnumAllocContexts(enum_alloc_context_func* fn, vo
     g_theGCToCLR->GcEnumAllocContexts(fn, param);
 }
 
+inline uint8_t *GCToEEInterface::GetLoaderAllocatorObjectForGC(Object* pObject)
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->GetLoaderAllocatorObjectForGC(pObject);
+}
+
 inline void GCToEEInterface::DiagGCStart(int gen, bool isInduced)
 {
     assert(g_theGCToCLR != nullptr);

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -251,6 +251,10 @@ public:
     virtual
     void GcEnumAllocContexts(enum_alloc_context_func* fn, void* param) = 0;
 
+    // Get the Allocator for objects from collectible assemblies
+    virtual
+    uint8_t* GetLoaderAllocatorObjectForGC(Object* pObject) = 0;
+
     // Creates and returns a new thread.
     // Parameters:
     //  threadStart - The function that will serve as the thread stub for the

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -218,6 +218,11 @@ void GCToEEInterface::GcEnumAllocContexts (enum_alloc_context_func* fn, void* pa
     }
 }
 
+uint8_t* GCToEEInterface::GetLoaderAllocatorObjectForGC(Object* pObject)
+{
+    return NULL;
+}
+
 void GCToEEInterface::SyncBlockCacheWeakPtrScan(HANDLESCANPROC /*scanProc*/, uintptr_t /*lp1*/, uintptr_t /*lp2*/)
 {
 }

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -347,6 +347,19 @@ void GCToEEInterface::GcEnumAllocContexts(enum_alloc_context_func* fn, void* par
     }
 }
 
+
+uint8_t* GCToEEInterface::GetLoaderAllocatorObjectForGC(Object* pObject)
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+    }
+    CONTRACTL_END;
+
+    return pObject->GetMethodTable()->GetLoaderAllocatorObjectForGC();
+}
+
 bool GCToEEInterface::IsPreemptiveGCDisabled()
 {
     WRAPPER_NO_CONTRACT;

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -35,6 +35,7 @@ public:
     Thread* GetThread();
     gc_alloc_context * GetAllocContext();
     void GcEnumAllocContexts(enum_alloc_context_func* fn, void* param);
+    uint8_t* GetLoaderAllocatorObjectForGC(Object* pObject);
 
     // Diagnostics methods.
     void DiagGCStart(int gen, bool isInduced);


### PR DESCRIPTION
Adds the method to the IGCToClr interface. I don't think now is the right time to tackle #14701, since it is so close to release. With this method we can do the work in the future without having to add a new interface version