### PR TITLE
Fix GC stress modes 4 and 8 on Linux ARM

### DIFF
--- a/src/vm/arm/cgencpu.h
+++ b/src/vm/arm/cgencpu.h
@@ -30,7 +30,9 @@ struct ArgLocDesc;
 
 extern PCODE GetPreStubEntryPoint();
 
+#ifndef FEATURE_PAL
 #define USE_REDIRECT_FOR_GCSTRESS
+#endif // FEATURE_PAL
 
 // CPU-dependent functions
 Stub * GenerateInitPInvokeFrameHelper();

--- a/src/vm/gccover.h
+++ b/src/vm/gccover.h
@@ -77,7 +77,7 @@ public:
 // 16-bit illegal instructions which will cause exception and cause 
 // control to go to GcStress codepath
 #define INTERRUPT_INSTR                 0xde00             
-#define INTERRUPT_INSTR_CALL            0xde01             
+#define INTERRUPT_INSTR_CALL            0xde03  // 0xde01 generates SIGTRAP (breakpoint) instead of SIGILL on Unix             
 #define INTERRUPT_INSTR_PROTECT_RET     0xde02      
 
 // 32-bit illegal instructions. It is necessary to replace a 16-bit instruction


### PR DESCRIPTION
There were two problems:
* The illegal instruction 0xde01 used for INTERRUPT_INSTR_CALL doesn't
  generate SIGILL, but SIGTRAP, since this is the code used for
  breakpoints.
* The USE_REDIRECT_FOR_GCSTRESS was defined even for FEATURE_PAL for
  ARM, which is incorrect and resulted in explicit redirect frame not
  being created in DoGcStress and thus the GC stack walk was skipping
  managed frames that it should walk.