### PR TITLE
Support of input/output streams redirection in dbgshim

### DIFF
--- a/src/dlls/dbgshim/dbgshim.h
+++ b/src/dlls/dbgshim/dbgshim.h
@@ -20,12 +20,36 @@ CreateProcessForLaunch(
     __out HANDLE *pResumeHandle);
 
 EXTERN_C HRESULT
+CreateProcessForLaunchEx(
+    __in LPWSTR lpCommandLine,
+    __in BOOL bSuspendProcess,
+    __in LPVOID lpEnvironment,
+    __in LPCWSTR lpCurrentDirectory,
+    __out PDWORD pProcessId,
+    __out HANDLE *pResumeHandle,
+    __out HANDLE *pStdInHandle,
+    __out HANDLE *pStdOutHandle,
+    __out HANDLE *pStdErrHandle);
+
+EXTERN_C HRESULT
 ResumeProcess(
     __in HANDLE hResumeHandle);
 
 EXTERN_C HRESULT
 CloseResumeHandle(
     __in HANDLE hResumeHandle);
+
+EXTERN_C HRESULT
+WriteStandardHandle(
+    __in HANDLE hStdInHandle,
+    __in LPCVOID lpBuffer,
+    __in DWORD dwNumberOfBytesToWrite,
+    __out DWORD *pdwNumberOfBytesWritten
+);
+
+EXTERN_C HRESULT
+CloseStandardHandle(
+    __in HANDLE hStandardHandle);
 
 EXTERN_C HRESULT
 RegisterForRuntimeStartup(

--- a/src/dlls/dbgshim/dbgshim_unixexports.src
+++ b/src/dlls/dbgshim/dbgshim_unixexports.src
@@ -3,8 +3,11 @@
 ; See the LICENSE file in the project root for more information.
 
 CreateProcessForLaunch
+CreateProcessForLaunchEx
 ResumeProcess
 CloseResumeHandle
+WriteStandardHandle
+CloseStandardHandle
 RegisterForRuntimeStartup
 UnregisterForRuntimeStartup
 GetStartupNotificationEvent


### PR DESCRIPTION
The following API is proposed for #17379:
* `CreateProcessForLaunchEx()` allows to redirect the input and output standard streams of the newly created process.
* `WriteStandardHandle()` allows to write to the input stream created by `CreateProcessForLaunchEx()`.
* `CloseStandardHandle()` closes standard handle created by `CreateProcessForLaunchEx()`.

**WIP**: API for polling/reading of handles is coming soon.