### PR TITLE
[x86/Linux] Fix unwinding of funclets with no epilog

### DIFF
--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -36,7 +36,8 @@
 #define X86_INSTR_PUSH_EBP              0x55    // push ebp
 #define X86_INSTR_W_MOV_EBP_ESP         0xEC8B  // mov ebp, esp
 #define X86_INSTR_POP_ECX               0x59    // pop ecx
-#define X86_INSTR_RET                   0xC2    // ret
+#define X86_INSTR_RET                   0xC2    // ret imm16
+#define X86_INSTR_RETN                  0xC3    // ret
 #define X86_INSTR_w_LEA_ESP_EBP_BYTE_OFFSET     0x658d      // lea esp, [ebp-bOffset]
 #define X86_INSTR_w_LEA_ESP_EBP_DWORD_OFFSET    0xa58d      // lea esp, [ebp-dwOffset]
 #define X86_INSTR_JMP_NEAR_REL32     0xE9        // near jmp rel32
@@ -3858,19 +3859,9 @@ bool UnwindEbpDoubleAlignFrame(
             //   epilog: add esp, 12
             //           ret
             // SP alignment padding should be added for all instructions except the first one and the last one.
-            TADDR funcletStart = pCodeInfo->GetJitManager()->GetFuncletStartAddress(pCodeInfo);
-
-            const ULONG32 funcletLastInstSize = 1; // 0xc3, ret
-            BOOL atFuncletLastInst = (pCodeInfo->GetRelOffset() + funcletLastInstSize) >= info->methodSize;
-            if (!atFuncletLastInst)
-            {
-                EECodeInfo nextCodeInfo;
-                nextCodeInfo.Init(pCodeInfo->GetCodeAddress() + funcletLastInstSize);
-                atFuncletLastInst = !nextCodeInfo.IsValid() || !nextCodeInfo.IsFunclet() ||
-                    nextCodeInfo.GetJitManager()->GetFuncletStartAddress(&nextCodeInfo) != funcletStart;
-            }
-
-            if (!atFuncletLastInst && funcletStart != pCodeInfo->GetCodeAddress())
+            // Epilog may not exist (unreachable), so we need to check the instruction code.
+            const TADDR funcletStart = pCodeInfo->GetJitManager()->GetFuncletStartAddress(pCodeInfo);
+            if (funcletStart != pCodeInfo->GetCodeAddress() && methodStart[pCodeInfo->GetRelOffset()] != X86_INSTR_RETN)
                 baseSP += 12;
 
             pContext->PCTAddr = baseSP;


### PR DESCRIPTION
This PR provides additional fix to funclet unwinding (https://github.com/dotnet/coreclr/pull/17144) for the case when a funclet has no epilog:
```
    0xb615654b: 5e                 popl   %esi
    0xb615654c: 5f                 popl   %edi
    0xb615654d: 5d                 popl   %ebp
    0xb615654e: c3                 retl   
;
; Main functions ends here.
; Funclet 1:
;
    0xb615654f: 83 ec 0c           subl   $0xc, %esp
    0xb6156552: 89 45 d0           movl   %eax, -0x30(%ebp)
    0xb6156555: 90                 nop    
    0xb6156556: b9 77 00 00 00     movl   $0x77, %ecx
    0xb615655b: ba e8 88 bb b6     movl   $0xb6bb88e8, %edx         ; imm = 0xB6BB88E8 
    0xb6156560: e8 3b cb 49 01     calll  0xb75f30a0                ; JIT_StrCns at jithelpers.cpp:2976
    0xb6156565: 8b c8              movl   %eax, %ecx
    0xb6156567: ff 15 bc a4 bb b6  calll  *-0x49445b44
    0xb615656d: 90                 nop    
    0xb615656e: e8 ed 56 4a 01     calll  0xb75fbc60                ; IL_Rethrow at jithelpers.cpp:5302
    0xb6156573: cc                 int3   
;
; Funclet 1 ends here but there is no epilog with stack alignment fix.
; `int3` is the last instruction in the funclet code and
; there is no `addl   $0xc, %esp` instruction.
;
; Next, Funclet 2:
;
    0xb6156574: 83 ec 0c           subl   $0xc, %esp
    0xb6156577: 90                 nop    
    ...
    0xb61565ab: 90                 nop    
    0xb61565ac: 83 c4 0c           addl   $0xc, %esp
    0xb61565af: c3                 retl   
;
; Funclet 2 ends with proper epilog
;
```

This PR simplifies the check for SP alignment fix during unwinding by just checking for instruction code (`ret`).

@janvorli PTAL

CC @Dmitri-Botcharnikov