### PR TITLE
Fix trigger for tier 1 call counting delay

### DIFF
--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -734,8 +734,12 @@ PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, J
     }
 
 #ifdef FEATURE_TIERED_COMPILATION
-    if (g_pConfig->TieredCompilation() && !flags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_TIER1))
+    if (flags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_TIER0))
     {
+        // The flag above is only set (in TieredCompilationManager::GetJitFlags()) when tiered compilation is enabled, this
+        // method was eligible for tiered compilation at the time when it was checked, and a tier 0 JIT was requested for this
+        // method
+        _ASSERTE(g_pConfig->TieredCompilation());
         GetAppDomain()->GetTieredCompilationManager()->OnTier0JitInvoked();
     }
 #endif // FEATURE_TIERED_COMPILATION

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -734,12 +734,10 @@ PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, J
     }
 
 #ifdef FEATURE_TIERED_COMPILATION
-    if (flags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_TIER0))
+    if (g_pConfig->TieredCompilation() && flags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_TIER0))
     {
-        // The flag above is only set (in TieredCompilationManager::GetJitFlags()) when tiered compilation is enabled, this
-        // method was eligible for tiered compilation at the time when it was checked, and a tier 0 JIT was requested for this
-        // method
-        _ASSERTE(g_pConfig->TieredCompilation());
+        // The flag above is only set (in TieredCompilationManager::GetJitFlags()) when this method was eligible for tiered
+        // compilation at the time when it was checked, and a tier 0 JIT was requested for this method
         GetAppDomain()->GetTieredCompilationManager()->OnTier0JitInvoked();
     }
 #endif // FEATURE_TIERED_COMPILATION


### PR DESCRIPTION
The trigger was taking into account all non-tier-1 JIT invocations to delay call counting, even for those methods that are not eligible for tiering. In the AllReady benchmark, some dynamic methods were being jitted frequently enough to not allow tier 1 call counting to begin. Fixed to count only eligible methods jitted at tier 0, such that methods not eligible for tiering don't interfere with the tiering heuristics.