### PR TITLE
Fixed #16503 [x64 arm32] the test smalloom terminated with signal SIGKILL

### DIFF
--- a/tests/testsUnsupportedOutsideWindows.txt
+++ b/tests/testsUnsupportedOutsideWindows.txt
@@ -123,6 +123,7 @@ CoreMangLib/cti/system/decimal/DecimalToInt32/DecimalToInt32.sh
 CoreMangLib/cti/system/reflection/emit/DynMethodJumpStubTests/DynMethodJumpStubTests/DynMethodJumpStubTests.sh
 CoreMangLib/system/collections/generic/hashset/Regression_Dev10_609271/Regression_Dev10_609271.sh
 CoreMangLib/system/collections/generic/hashset/Regression_Dev10_624201/Regression_Dev10_624201.sh
+GC/Coverage/smalloom/smalloom.sh
 Interop/MarshalAPI/GetNativeVariantForObject/GetNativeVariantForObject/GetNativeVariantForObject.sh
 Interop/MarshalAPI/GetObjectForNativeVariant/GetObjectForNativeVariant/GetObjectForNativeVariant.sh
 Interop/MarshalAPI/GetObjectsForNativeVariants/GetObjectsForNativeVariants/GetObjectsForNativeVariants.sh


### PR DESCRIPTION
This test cannot be executed properly on Linux and Tizen because of the OOM Killer utility. See discussion in the issue. 