### PR TITLE
Enable signing for cross targeting tools

### DIFF
--- a/src/sign.builds
+++ b/src/sign.builds
@@ -15,6 +15,11 @@
     <WindowsNativeLocation Include="$(BinDir)*.dll" />
     <WindowsNativeLocation Include="$(BinDir)*.exe" />
   </ItemGroup>
+  <!-- sign the cross targeted files as well -->
+  <ItemGroup Condition="'$(CrossTargetComponentFolder)' != ''">
+    <WindowsNativeLocation Include="$(BinDir)$(CrossTargetComponentFolder)/*.dll" />
+    <WindowsNativeLocation Include="$(BinDir)$(CrossTargetComponentFolder)/*.exe" />
+  </ItemGroup>
 
   <Target Name="GenerateSignForWindowsNative">
     <!--


### PR DESCRIPTION
cc @RussKeldorph @mmitche

After https://github.com/dotnet/core-setup/pull/3993 started pulling in the cross tools into Microsoft.NETCore.App the signing validation discovered these tools were not signed. See https://github.com/dotnet/core-setup/issues/4001. This should start signing those bits. 

fyi @sdmaclea @eerhardt  