### PR TITLE
Optimize the span property by using a local to store the _object field and using Unsafe.As

### DIFF
--- a/src/mscorlib/shared/System/Memory.cs
+++ b/src/mscorlib/shared/System/Memory.cs
@@ -270,13 +270,14 @@ namespace System
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
+                object obj = _object;
                 if (_index < 0)
                 {
                     Debug.Assert(_length >= 0);
-                    Debug.Assert(_object != null);
-                    return ((MemoryManager<T>)_object).GetSpan().Slice(_index & RemoveFlagsBitMask, _length);
+                    Debug.Assert(obj != null);
+                    return ((MemoryManager<T>)obj).GetSpan().Slice(_index & RemoveFlagsBitMask, _length);
                 }
-                else if (typeof(T) == typeof(char) && _object is string s)
+                else if (typeof(T) == typeof(char) && obj is string s)
                 {
                     Debug.Assert(_length >= 0);
                     // This is dangerous, returning a writable span for a string that should be immutable.
@@ -290,9 +291,10 @@ namespace System
                     return new Span<T>(ref Unsafe.As<char, T>(ref s.GetRawStringData()), s.Length).Slice(_index, _length);
 #endif // FEATURE_PORTABLE_SPAN
                 }
-                else if (_object != null)
+                else if (obj != null)
                 {
-                    return new Span<T>((T[])_object, _index, _length & RemoveFlagsBitMask);
+                    Debug.Assert(obj is T[]);
+                    return new Span<T>(Unsafe.As<T[]>(obj), _index, _length & RemoveFlagsBitMask);
                 }
                 else
                 {
@@ -331,12 +333,13 @@ namespace System
         /// </summary>
         public unsafe MemoryHandle Pin()
         {
+            object obj = _object;
             if (_index < 0)
             {
-                Debug.Assert(_object != null);
-                return ((MemoryManager<T>)_object).Pin((_index & RemoveFlagsBitMask));
+                Debug.Assert(obj != null);
+                return ((MemoryManager<T>)obj).Pin((_index & RemoveFlagsBitMask));
             }
-            else if (typeof(T) == typeof(char) && _object is string s)
+            else if (typeof(T) == typeof(char) && obj is string s)
             {
                 // This case can only happen if a ReadOnlyMemory<char> was created around a string
                 // and then that was cast to a Memory<char> using unsafe / marshaling code.  This needs
@@ -351,13 +354,14 @@ namespace System
 #endif // FEATURE_PORTABLE_SPAN
                 return new MemoryHandle(pointer, handle);
             }
-            else if (_object is T[] array)
+            else if (obj != null)
             {
-                GCHandle handle = _length < 0 ? default : GCHandle.Alloc(array, GCHandleType.Pinned);
+                Debug.Assert(obj is T[]);
+                GCHandle handle = _length < 0 ? default : GCHandle.Alloc(Unsafe.As<T[]>(obj), GCHandleType.Pinned);
 #if FEATURE_PORTABLE_SPAN
                 void* pointer = Unsafe.Add<T>((void*)handle.AddrOfPinnedObject(), _index);
 #else
-                void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref array.GetRawSzArrayData()), _index);
+                void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref Unsafe.As<T[]>(obj).GetRawSzArrayData()), _index);
 #endif // FEATURE_PORTABLE_SPAN
                 return new MemoryHandle(pointer, handle);
             }

--- a/src/mscorlib/shared/System/Memory.cs
+++ b/src/mscorlib/shared/System/Memory.cs
@@ -270,6 +270,7 @@ namespace System
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
+                // Only use the local 'obj' instead of the _object field directly to avoid issues with struct tearing
                 object obj = _object;
                 if (_index < 0)
                 {
@@ -293,6 +294,8 @@ namespace System
                 }
                 else if (obj != null)
                 {
+                    // obj is gauranteed to be a T[] here,
+                    // which is why we can use Unsafe.As as a performance optimization instead of an explicit cast
                     Debug.Assert(obj is T[]);
                     return new Span<T>(Unsafe.As<T[]>(obj), _index, _length & RemoveFlagsBitMask);
                 }
@@ -333,6 +336,7 @@ namespace System
         /// </summary>
         public unsafe MemoryHandle Pin()
         {
+            // Only use the local 'obj' instead of the _object field directly to avoid issues with struct tearing
             object obj = _object;
             if (_index < 0)
             {
@@ -356,6 +360,8 @@ namespace System
             }
             else if (obj != null)
             {
+                // obj is gauranteed to be a T[] here,
+                // which is why we can use Unsafe.As as a performance optimization instead of an explicit cast
                 Debug.Assert(obj is T[]);
                 GCHandle handle = _length < 0 ? default : GCHandle.Alloc(Unsafe.As<T[]>(obj), GCHandleType.Pinned);
 #if FEATURE_PORTABLE_SPAN

--- a/src/mscorlib/shared/System/ReadOnlyMemory.cs
+++ b/src/mscorlib/shared/System/ReadOnlyMemory.cs
@@ -184,6 +184,7 @@ namespace System
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
+                // Only use the local 'obj' instead of the _object field directly to avoid issues with struct tearing
                 object obj = _object;
                 if (_index < 0)
                 {
@@ -202,6 +203,8 @@ namespace System
                 }
                 else if (obj != null)
                 {
+                    // obj is gauranteed to be a T[] here,
+                    // which is why we can use Unsafe.As as a performance optimization instead of an explicit cast
                     Debug.Assert(obj is T[]);
                     return new ReadOnlySpan<T>(Unsafe.As<T[]>(obj), _index, _length & RemoveFlagsBitMask);
                 }
@@ -242,6 +245,7 @@ namespace System
         /// </summary>
         public unsafe MemoryHandle Pin()
         {
+            // Only use the local 'obj' instead of the _object field directly to avoid issues with struct tearing
             object obj = _object;
             if (_index < 0)
             {
@@ -260,6 +264,8 @@ namespace System
             }
             else if (obj != null)
             {
+                // obj is gauranteed to be a T[] here,
+                // which is why we can use Unsafe.As as a performance optimization instead of an explicit cast
                 Debug.Assert(obj is T[]);
                 GCHandle handle = _length < 0 ? default : GCHandle.Alloc(Unsafe.As<T[]>(obj), GCHandleType.Pinned);
 #if FEATURE_PORTABLE_SPAN

--- a/src/mscorlib/shared/System/ReadOnlyMemory.cs
+++ b/src/mscorlib/shared/System/ReadOnlyMemory.cs
@@ -184,13 +184,14 @@ namespace System
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
+                object obj = _object;
                 if (_index < 0)
                 {
                     Debug.Assert(_length >= 0);
-                    Debug.Assert(_object != null);
-                    return ((MemoryManager<T>)_object).GetSpan().Slice(_index & RemoveFlagsBitMask, _length);
+                    Debug.Assert(obj != null);
+                    return ((MemoryManager<T>)obj).GetSpan().Slice(_index & RemoveFlagsBitMask, _length);
                 }
-                else if (typeof(T) == typeof(char) && _object is string s)
+                else if (typeof(T) == typeof(char) && obj is string s)
                 {
                     Debug.Assert(_length >= 0);
 #if FEATURE_PORTABLE_SPAN
@@ -199,9 +200,10 @@ namespace System
                     return new ReadOnlySpan<T>(ref Unsafe.As<char, T>(ref s.GetRawStringData()), s.Length).Slice(_index, _length);
 #endif // FEATURE_PORTABLE_SPAN
                 }
-                else if (_object != null)
+                else if (obj != null)
                 {
-                    return new ReadOnlySpan<T>((T[])_object, _index, _length & RemoveFlagsBitMask);
+                    Debug.Assert(obj is T[]);
+                    return new ReadOnlySpan<T>(Unsafe.As<T[]>(obj), _index, _length & RemoveFlagsBitMask);
                 }
                 else
                 {
@@ -240,12 +242,13 @@ namespace System
         /// </summary>
         public unsafe MemoryHandle Pin()
         {
+            object obj = _object;
             if (_index < 0)
             {
-                Debug.Assert(_object != null);
-                return ((MemoryManager<T>)_object).Pin((_index & RemoveFlagsBitMask));
+                Debug.Assert(obj != null);
+                return ((MemoryManager<T>)obj).Pin((_index & RemoveFlagsBitMask));
             }
-            else if (typeof(T) == typeof(char) && _object is string s)
+            else if (typeof(T) == typeof(char) && obj is string s)
             {
                 GCHandle handle = GCHandle.Alloc(s, GCHandleType.Pinned);
 #if FEATURE_PORTABLE_SPAN
@@ -255,13 +258,14 @@ namespace System
 #endif // FEATURE_PORTABLE_SPAN
                 return new MemoryHandle(pointer, handle);
             }
-            else if (_object is T[] array)
+            else if (obj != null)
             {
-                GCHandle handle = _length < 0 ? default : GCHandle.Alloc(array, GCHandleType.Pinned);
+                Debug.Assert(obj is T[]);
+                GCHandle handle = _length < 0 ? default : GCHandle.Alloc(Unsafe.As<T[]>(obj), GCHandleType.Pinned);
 #if FEATURE_PORTABLE_SPAN
                 void* pointer = Unsafe.Add<T>((void*)handle.AddrOfPinnedObject(), _index);
 #else
-                void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref array.GetRawSzArrayData()), _index);
+                void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref Unsafe.As<T[]>(obj).GetRawSzArrayData()), _index);
 #endif // FEATURE_PORTABLE_SPAN
                 return new MemoryHandle(pointer, handle);
             }


### PR DESCRIPTION
Following the approach from https://github.com/dotnet/coreclr/pull/17471.

![image](https://user-images.githubusercontent.com/6527137/38535585-04002162-3c39-11e8-8f4f-067a0f7e5791.png)


cc @GrabYourPitchforks, @stephentoub, @davidfowl, @pakrym  