### PR TITLE
[1.1] Clean up the portable-linux init-tools logic

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -31,6 +31,7 @@ if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
             OSName=$(uname -s)
             case $OSName in
                 Darwin)
+                    __PKG_RID=osx
                     OS=OSX
                     ulimit -n 2048
                     ;;

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -42,7 +42,6 @@ if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
                     if [ -e /etc/os-release ]; then
                         source /etc/os-release
                         __DISTRO_NAME=$ID.$VERSION_ID
-                        echo $__DISTRO_NAME
                         if  [ "$__DISTRO_NAME" == 'ubuntu.16.04' ] ||
                             [ "$__DISTRO_NAME" == 'ubuntu.16.10' ] ||
                             [ "$__DISTRO_NAME" == 'ubuntu.18.04' ] ||
@@ -54,7 +53,6 @@ if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
                             [ "$__DISTRO_NAME" == 'opensuse.42.1' ] ||
                             [ "$__DISTRO_NAME" == 'opensuse.42.3' ] ; then
                             __PKG_RID=$__DISTRO_NAME
-                            echo $__DISTRO_NAME
                         fi
                     fi
                     

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -15,51 +15,26 @@ __PROJECT_JSON_FILE=$__PROJECT_JSON_PATH/project.json
 __PROJECT_JSON_CONTENTS="{ \"dependencies\": { \"Microsoft.DotNet.BuildTools\": \"$__BUILD_TOOLS_PACKAGE_VERSION\" }, \"frameworks\": { \"netcoreapp1.0\": { } } }"
 __INIT_TOOLS_DONE_MARKER=$__PROJECT_JSON_PATH/done
 
-# Extended version of platform detection logic from dotnet/cli/scripts/obtain/dotnet-install.sh 16692fc
 get_current_linux_name() {
-    # Detect Distro
-    if [ "$(cat /etc/*-release | grep -cim1 ubuntu)" -eq 1 ]; then
-        if [ "$(cat /etc/*-release | grep -cim1 16.04)" -eq 1 ]; then
-            echo "ubuntu.16.04"
-            return 0
-        fi
-        if [ "$(cat /etc/*-release | grep -cim1 16.10)" -eq 1 ]; then
-            echo "ubuntu.16.10"
-            return 0
-        fi
-        if [ "$(cat /etc/*-release | grep -cim1 18.04)" -eq 1 ]; then
-            echo "ubuntu.18.04"
-            return 0
-        fi
-        echo "ubuntu"
-        return 0
-    elif [ "$(cat /etc/*-release | grep -cim1 centos)" -eq 1 ]; then
-        echo "centos"
-        return 0
-    elif [ "$(cat /etc/*-release | grep -cim1 rhel)" -eq 1 ]; then
-        echo "rhel"
-        return 0
-    elif [ "$(cat /etc/*-release | grep -cim1 debian)" -eq 1 ]; then
-        echo "debian"
-        return 0
-    elif [ "$(cat /etc/*-release | grep -cim1 fedora)" -eq 1 ]; then
-        echo -n "fedora."; cat /etc/*-release | grep  VERSION_ID= | cut -d "=" -f2
-        return 0;
-    elif [ "$(cat /etc/*-release | grep -cim1 opensuse)" -eq 1 ]; then
-        if [ "$(cat /etc/*-release | grep -cim1 13.2)" -eq 1 ]; then
-            echo "opensuse.13.2"
-            return 0
-        fi
-        if [ "$(cat /etc/*-release | grep -cim1 42.1)" -eq 1 ]; then
-            echo "opensuse.42.1"
-            return 0
-        fi 
-        echo "opensuse.42.3"
-        return 0
-    fi
+    # Detect Distro name and version
+    __DISTRO_TYPE="$(cat /etc/*-release | grep -w ID | cut -d "=" -f2 | tr -d '"')"
+    __DISTRO_VERSION="$(cat /etc/*-release | grep -w VERSION_ID | cut -d "=" -f2 | tr -d '"')"
+    __DISTRO_NAME=$__DISTRO_TYPE.$__DISTRO_VERSION
 
-    # Cannot determine Linux distribution, assuming Ubuntu 14.04.
-    echo "ubuntu"
+    if  [ "$__DISTRO_NAME" == 'ubuntu.16.04' ] ||
+        [ "$__DISTRO_NAME" == 'ubuntu.16.10' ] ||
+        [ "$__DISTRO_NAME" == 'ubuntu.18.04' ] ||
+        [ "$__DISTRO_NAME" == 'debian.8' ] ||
+        [ "$__DISTRO_NAME" == 'fedora.23' ] ||
+        [ "$__DISTRO_NAME" == 'fedora.24' ] ||
+        [ "$__DISTRO_NAME" == 'fedora.27' ] ||
+        [ "$__DISTRO_NAME" == 'opensuse.13.2' ] ||
+        [ "$__DISTRO_NAME" == 'opensuse.42.1' ] ||
+        [ "$__DISTRO_NAME" == 'opensuse.42.3' ] ; then
+        echo $__DISTRO_NAME
+    else
+        echo "linux"
+    fi
     return 0
 }
 
@@ -78,9 +53,9 @@ OSName=$(uname -s)
             ;;
 
         *)
-            echo "Unsupported OS '$OSName' detected. Downloading ubuntu-x64 tools."
+            echo "Unsupported OS '$OSName' detected. Downloading linux-x64 tools."
             OS=Linux
-            __DOTNET_PKG=dotnet-dev-ubuntu-x64
+            __DOTNET_PKG=dotnet-dev-linux-x64
             ;;
   esac
 fi


### PR DESCRIPTION
Changed around the logic to only use the platform specific CLIs when restoring for a specific distro type and version, falling back to the portable linux CLI when the RID doesn't match. Also cleaned up the nested if statements a bit.

Previously we would fall back to the previous distro version's CLI for a new version of a known distro.