### PR TITLE
Fix for 17398.

### DIFF
--- a/tests/src/Regressions/coreclr/GitHub_17398/test17398.cs
+++ b/tests/src/Regressions/coreclr/GitHub_17398/test17398.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+// Repro case for CoreCLR 17398
+
+class X
+{
+    static int v;
+
+    string s;
+
+    public override string ToString() => s;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    X(int x)
+    {
+        s = "String" + x;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void F() { }
+
+    public static void T0(object o, int x)
+    {
+        GC.Collect(2);
+        throw new Exception(o.ToString());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Test()
+    {
+        object x1 = new X(1);
+        object x2 = new X(2);
+        
+        if (v == 1)
+        {
+            // Generate enough pressure here to 
+            // kill ESI so in linear flow it is dead
+            // at the call to T0
+            int w = v;
+            int x = v;
+            int y = v;
+            int z = v;
+
+            // Unbounded loop here forces fully interruptible GC
+            for (int i = 0; i < v; i++)
+            {
+                w++;
+            }
+
+            T0(x2, w + x + y + z);
+        }
+
+        // Encourage x1 to be in callee save (ESI)
+        F();
+
+        if (v == 2)
+        {
+            T0(x1, 0);
+        }
+    }
+
+    public static int Main()
+    {
+        v = 1;
+        int r = 0;
+
+        try
+        {
+            Test();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e.Message);
+            r = 100;
+        }
+
+        return r;
+    }
+}

--- a/tests/src/Regressions/coreclr/GitHub_17398/test17398.csproj
+++ b/tests/src/Regressions/coreclr/GitHub_17398/test17398.csproj
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{E55A6F8B-B9E3-45CE-88F4-22AE70F606CB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test17398.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
When enumerating live gc registers, if we are not on the active stack frame,
we need to report callee-save gc registers that are live before the call.
The reason is that the liveness of gc registers may change across a call
to a method that does not return. In this case the instruction after the call
may be a jump target and a register that didn't have a live gc pointer before
the call may have a live gc pointer after the jump. To make sure we report the
registers that have live gc pointers before the call we subtract 1 from curOffs.

Fixes #17398.

I included a repro provided by @AndyAyersMS that doesn't require GCStress or JitStress.