### PR TITLE
Add GetPinnableReference back to Span and ReadOnlySpan

### DIFF
--- a/src/mscorlib/shared/System/ReadOnlySpan.Fast.cs
+++ b/src/mscorlib/shared/System/ReadOnlySpan.Fast.cs
@@ -154,13 +154,7 @@ namespace System
         /// It can be used for pinning and is required to support the use of span within a fixed statement.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public ref readonly T GetPinnableReference()
-        {
-            if (_length == 0)
-                return ref s_nullPtr;
-            else
-                return ref _pointer.Value;
-        }
+        public unsafe ref readonly T GetPinnableReference() => ref (_length != 0) ? ref _pointer.Value : ref Unsafe.AsRef<T>(null);
 
         /// <summary>
         /// Copies the contents of this read-only span into destination span. If the source
@@ -279,7 +273,5 @@ namespace System
             Buffer.Memmove(ref Unsafe.As<byte, T>(ref destination.GetRawSzArrayData()), ref _pointer.Value, (nuint)_length);
             return destination;
         }
-
-        private static T s_nullPtr = default;
     }
 }

--- a/src/mscorlib/shared/System/ReadOnlySpan.Fast.cs
+++ b/src/mscorlib/shared/System/ReadOnlySpan.Fast.cs
@@ -150,6 +150,19 @@ namespace System
         }
 
         /// <summary>
+        /// Returns a reference to the 0th element of the Span. If the Span is empty, returns null reference.
+        /// It can be used for pinning and is required to support the use of span within a fixed statement.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ref readonly T GetPinnableReference()
+        {
+            if (_length == 0)
+                return ref s_nullPtr;
+            else
+                return ref _pointer.Value;
+        }
+
+        /// <summary>
         /// Copies the contents of this read-only span into destination span. If the source
         /// and destinations overlap, this method behaves as if the original values in
         /// a temporary location before the destination is overwritten.
@@ -266,5 +279,7 @@ namespace System
             Buffer.Memmove(ref Unsafe.As<byte, T>(ref destination.GetRawSzArrayData()), ref _pointer.Value, (nuint)_length);
             return destination;
         }
+
+        private static T s_nullPtr = default;
     }
 }

--- a/src/mscorlib/shared/System/Span.Fast.cs
+++ b/src/mscorlib/shared/System/Span.Fast.cs
@@ -159,13 +159,7 @@ namespace System
         /// It can be used for pinning and is required to support the use of span within a fixed statement.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public ref T GetPinnableReference()
-        {
-            if (_length == 0)
-                return ref s_nullPtr;
-            else
-                return ref _pointer.Value;
-        }
+        public unsafe ref T GetPinnableReference() => ref (_length != 0) ? ref _pointer.Value : ref Unsafe.AsRef<T>(null);
 
         /// <summary>
         /// Clears the contents of this span.
@@ -359,7 +353,5 @@ namespace System
             Buffer.Memmove(ref Unsafe.As<byte, T>(ref destination.GetRawSzArrayData()), ref _pointer.Value, (nuint)_length);
             return destination;
         }
-
-        private static T s_nullPtr = default;
     }
 }

--- a/src/mscorlib/shared/System/Span.Fast.cs
+++ b/src/mscorlib/shared/System/Span.Fast.cs
@@ -155,6 +155,19 @@ namespace System
         }
 
         /// <summary>
+        /// Returns a reference to the 0th element of the Span. If the Span is empty, returns null reference.
+        /// It can be used for pinning and is required to support the use of span within a fixed statement.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ref T GetPinnableReference()
+        {
+            if (_length == 0)
+                return ref s_nullPtr;
+            else
+                return ref _pointer.Value;
+        }
+
+        /// <summary>
         /// Clears the contents of this span.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -346,5 +359,7 @@ namespace System
             Buffer.Memmove(ref Unsafe.As<byte, T>(ref destination.GetRawSzArrayData()), ref _pointer.Value, (nuint)_length);
             return destination;
         }
+
+        private static T s_nullPtr = default;
     }
 }


### PR DESCRIPTION
Part of https://github.com/dotnet/corefx/issues/28969

Related PR in corefx: https://github.com/dotnet/corefx/pull/29003

cc @davidfowl, @GrabYourPitchforks, @stephentoub, @KrzysztofCwalina, @pakrym, @ahsonkhan @jkotas, @VSadov, @benaadams 