### PR TITLE
Fix Valuenum:EvalFuncForConstantArgs

### DIFF
--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -1098,6 +1098,11 @@ ValueNum ValueNumStore::VNForFunc(var_types typ, VNFunc func, ValueNum arg0VN, V
         {
             canFold = false;
         }
+        if (typ == TYP_BYREF)
+        {
+            // We don't want to fold expressions that produce TYP_BYREF
+            canFold = false;
+        }
 
         if (canFold)
         {
@@ -1750,12 +1755,6 @@ ValueNum ValueNumStore::EvalFuncForConstantArgs(var_types typ, VNFunc func, Valu
     if (func == VNF_Cast)
     {
         return EvalCastForConstantArgs(typ, func, arg0VN, arg1VN);
-    }
-
-    if (typ == TYP_BYREF)
-    {
-        // We don't want to fold expressions that produce TYP_BYREF
-        return false;
     }
 
     var_types arg0VNtyp = TypeOfVN(arg0VN);


### PR DESCRIPTION
For such tree:
```
N009 (  1,  1) [008525] ------------              |        /--*  CNS_INT   long   12 field offset Fseq[_firstChar]
N010 (  5,  4) [008526] ------------              |     /--*  ADD       byref
N008 (  3,  2) [008524] ------------              |     |  \--*  LCL_VAR   ref    V43 tmp35        u:4 (last use)
```
where `LCL_VAR   ref    V43` is known to be a constant RyuJit calculated Vn as Null:
`N010 [008526]   ADD       => $VN.Null`
 and merged it with other expressions with Null VN. Because constants were different in each case it caused bugs:

```
N003 (  1,  1) [008534] ------------              |  |  /--*  CNS_INT   long   8 field offset Fseq[_stringLength]
N004 (  4, 11) [008535] -------N----              |  \--*  ADD       byref
N002 (  3, 10) [008537] ------------              |     \--*  NOP       ref
N001 (  3, 10) [008536] ------------              |        \--*  CNS_INT(h) ref    0x421150 [ICON_STR_HDL]
N004 [008535]   ADD       => $VN.Null
```
`VN  [008535] == VN  [008526] == Null`, so all these constants were replaced with the first tree that had `VN == Null`:
```
VN based copy assertion for [004523] V16 @00000000 by [008560] V24 @00000000.
VN based copy assertion for [008648] V41 @00000000 by [008560] V24 @00000000
etc.
```

The original code was added in CS 946058 with other assert fixes and looks like we were lucky not to hit this issue for several years because CoreCLR doesn't produce constants with 'TYP_BYREF' (I think).

> // We don't want to fold expressions that produce TYP_BYREF 

I do not see any reasons why we should not fold them, but right now this code:
https://github.com/dotnet/coreclr/blob/master/src/jit/valuenum.cpp#L1813-L1817

doesn't not expect LONG add that produces BYREF and because our VN is very fragile we do not want to change it before the release, **do we want to have an issue to fix that later?**

The change will fix (some text to prevent closing this issue right after the merge) dotnet/corert#5661 after RyuJit version update.
