### PR TITLE
Use string.IsNullOrEmpty to eliminate bounds check to first char

### DIFF
--- a/src/mscorlib/shared/System/String.cs
+++ b/src/mscorlib/shared/System/String.cs
@@ -442,6 +442,8 @@ namespace System
             // value.Length == 0 as it will elide the bounds check to
             // the first char: value[0] if that is performed following the test
             // for the same test cost.
+            // Ternary operator returning true/false prevents redundant asm generation:
+            // https://github.com/dotnet/coreclr/issues/914
             return (value == null || 0u >= (uint)value.Length) ? true : false;
         }
 

--- a/src/mscorlib/shared/System/String.cs
+++ b/src/mscorlib/shared/System/String.cs
@@ -442,7 +442,7 @@ namespace System
             // value.Length == 0 as it will elide the bounds check to
             // the first char: value[0] if that is performed following the test
             // for the same test cost.
-            return (value == null || 0u >= (uint)value.Length);
+            return (value == null || 0u >= (uint)value.Length) ? true : false;
         }
 
         public static bool IsNullOrWhiteSpace(string value)

--- a/src/mscorlib/shared/System/String.cs
+++ b/src/mscorlib/shared/System/String.cs
@@ -438,7 +438,11 @@ namespace System
         [NonVersionable]
         public static bool IsNullOrEmpty(string value)
         {
-            return (value == null || value.Length == 0);
+            // Using 0u >= (uint)value.Length rather than
+            // value.Length == 0 as it will elide the bounds check to
+            // the first char: value[0] if that is performed following the test
+            // for the same test cost.
+            return (value == null || 0u >= (uint)value.Length);
         }
 
         public static bool IsNullOrWhiteSpace(string value)


### PR DESCRIPTION
```
Total bytes of diff: -649 (-0.02% of base)
    diff is an improvement.

Total byte diff includes 0 bytes from reconciling methods
        Base had    0 unique methods,        0 unique bytes
        Diff had    0 unique methods,        0 unique bytes

Top file improvements by size (bytes):
        -649 : System.Private.CoreLib.dasm (-0.02% of base)

1 total files with size differences (1 improved, 0 regressed), 0 unchanged.

Top method improvements by size (bytes):
         -64 : System.Private.CoreLib.dasm - Win32Marshal:GetExceptionForWin32Error(int,ref):ref
         -57 : System.Private.CoreLib.dasm - TimeZoneInfo:GetLocalizedNamesByRegistryKey(ref,byref,byref,byref)
         -32 : System.Private.CoreLib.dasm - String:Concat(ref,ref,ref,ref):ref
         -32 : System.Private.CoreLib.dasm - Path:CombineInternal(ref,ref,ref,ref):ref
         -24 : System.Private.CoreLib.dasm - String:Concat(ref,ref):ref (2 methods)
         -24 : System.Private.CoreLib.dasm - String:Concat(ref,ref,ref):ref (2 methods)
         -24 : System.Private.CoreLib.dasm - Path:CombineInternal(ref,ref,ref):ref
         -24 : System.Private.CoreLib.dasm - CalendarData:.ctor(ref,ushort,bool):this
         -23 : System.Private.CoreLib.dasm - Environment:SetEnvironmentVariableCore(ref,ref)
         -22 : System.Private.CoreLib.dasm - String:MakeSeparatorList(ref,byref,byref):this
         -17 : System.Private.CoreLib.dasm - PathInternal:NormalizeDirectorySeparators(ref):ref
         -16 : System.Private.CoreLib.dasm - Path:CombineInternal(ref,ref):ref
         -16 : System.Private.CoreLib.dasm - PathInternal:EqualStartingCharacterCount(ref,ref,bool):int
         -16 : System.Private.CoreLib.dasm - CalendarData:InitializeEraNames(ref,ushort):this
         -16 : System.Private.CoreLib.dasm - CalendarData:InitializeAbbreviatedEraNames(ref,ushort):this
         -16 : System.Private.CoreLib.dasm - ContractHelper:GetDisplayMessage(int,ref,ref):ref
         -11 : System.Private.CoreLib.dasm - CoreLib:FixupCoreLibName(ref):ref
         -11 : System.Private.CoreLib.dasm - String:Concat(ref):ref (5 methods)
         -11 : System.Private.CoreLib.dasm - CultureData:get_SENGDISPLAYNAME():ref:this
         -11 : System.Private.CoreLib.dasm - CultureData:get_SNATIVEDISPLAYNAME():ref:this
          -8 : System.Private.CoreLib.dasm - AppContextDefaultValues:TryParseFrameworkName(ref,byref,byref,byref):bool
          -8 : System.Private.CoreLib.dasm - Environment:ValidateVariableAndValue(ref,byref)
          -8 : System.Private.CoreLib.dasm - ArgumentException:get_Message():ref:this
          -8 : System.Private.CoreLib.dasm - Contract:AssertMustUseRewriter(int,ref)
          -8 : System.Private.CoreLib.dasm - Contract:ReportFailure(int,ref,ref,ref)
          -8 : System.Private.CoreLib.dasm - EventPipeProviderConfiguration:.ctor(ref,long,int):this
          -8 : System.Private.CoreLib.dasm - EventPipeConfiguration:.ctor(ref,int):this
          -8 : System.Private.CoreLib.dasm - Path:GetRelativePath(ref,ref,int):ref
          -8 : System.Private.CoreLib.dasm - PathInternal:EndsWithPeriodOrSpace(ref):bool
          -8 : System.Private.CoreLib.dasm - CultureInfo:get_Parent():ref:this
          -8 : System.Private.CoreLib.dasm - CultureData:GetCultureData(int,bool):ref
          -8 : System.Private.CoreLib.dasm - CultureData:get_TimeSeparator():ref:this
          -8 : System.Private.CoreLib.dasm - CultureData:GetNFIValues(ref):this
          -8 : System.Private.CoreLib.dasm - NumberFormatInfo:.ctor(ref):this
          -8 : System.Private.CoreLib.dasm - SystemTypeMarshaler:ConvertToManaged(long,byref)
          -8 : System.Private.CoreLib.dasm - StringBuilder:Insert(int,ref,int):ref:this
          -8 : System.Private.CoreLib.dasm - AssemblyLoadContext:ValidateAssemblyNameWithSimpleName(ref,ref):ref:this
          -8 : System.Private.CoreLib.dasm - ExternalException:ToString():ref:this
          -8 : System.Private.CoreLib.dasm - ContractHelper:TriggerFailure(int,ref,ref,ref,ref)
          -8 : System.Private.CoreLib.dasm - TypeForwardedFromAttribute:.ctor(ref):this
          -4 : System.Private.CoreLib.dasm - ResourceManager:GetStringFromPRI(ref,ref,ref):ref:this
          -2 : System.Private.CoreLib.dasm - String:IsNullOrEmpty(ref):bool
          -2 : System.Private.CoreLib.dasm - Environment:SetEnvironmentVariableCore(ref,ref,int)
          -2 : System.Private.CoreLib.dasm - TimeZoneInfo:TryGetLocalizedNameByMuiNativeResource(ref):ref
          -2 : System.Private.CoreLib.dasm - CultureData:GetCultureDataForRegion(ref,bool):ref
          -2 : System.Private.CoreLib.dasm - CultureData:GetCultureData(ref,bool):ref
          -2 : System.Private.CoreLib.dasm - CultureData:get_SLOCALIZEDDISPLAYNAME():ref:this
          -2 : System.Private.CoreLib.dasm - CultureData:get_IsInvariantCulture():bool:this
          -2 : System.Private.CoreLib.dasm - Assembly:LoadFromResolveHandler(ref,ref):ref
          -2 : System.Private.CoreLib.dasm - WindowsRuntimeMetadata:OnDesignerNamespaceResolveEvent(ref,ref):ref

50 total methods with size differences (50 improved, 0 regressed), 17247 unchanged.
```

From https://github.com/aspnet/KestrelHttpServer/pull/2347#discussion_r180545535

```
public static bool StartsWithBracket(string hostText)
{
    if (hostText == null || 0u >= (uint)hostText.Length)
    {
        return false;
    }

    var firstChar = hostText[0];
    if (firstChar == '[')
    {
        return true;
    }
    
    return false;
}

; Desktop CLR v4.7.2563.00 (clr.dll) on amd64.

Program.StartsWithBracket(System.String)
    L0000: test rcx, rcx
    L0003: jz L000c
    L0005: mov eax, [rcx+0x8]
    L0008: test eax, eax
    L000a: jnz L000f
    L000c: xor eax, eax
    L000e: ret
    L000f: cmp word [rcx+0xc], 0x5b
    L0014: jnz L001c
    L0016: mov eax, 0x1
    L001b: ret
    L001c: xor eax, eax
    L001e: ret
```
vs
```
public static bool StartsWithBracket(string hostText)
{
    if (hostText == null || hostText.Length == 0)
    {
        return false;
    }

    var firstChar = hostText[0];
    if (firstChar == '[')
    {
        return true;
    }
    
    return false;
}

; Desktop CLR v4.7.2563.00 (clr.dll) on amd64.

Program.StartsWithBracket(System.String)
    L0000: sub rsp, 0x28
    L0004: test rcx, rcx
    L0007: jz L0010
    L0009: mov edx, [rcx+0x8]
    L000c: test edx, edx
    L000e: jnz L0017
    L0010: xor eax, eax
    L0012: add rsp, 0x28
    L0016: ret
    L0017: cmp edx, 0x0
    L001a: jbe L0034
    L001c: cmp word [rcx+0xc], 0x5b
    L0021: jnz L002d
    L0023: mov eax, 0x1
    L0028: add rsp, 0x28
    L002c: ret
    L002d: xor eax, eax
    L002f: add rsp, 0x28
    L0033: ret
    L0034: call 0x7ffaff4223c0
    L0039: int3
```