### PR TITLE
Preserve VASigCookieReg across PInvokeStubWorker call

### DIFF
--- a/src/vm/arm64/PInvokeStubs.asm
+++ b/src/vm/arm64/PInvokeStubs.asm
@@ -80,15 +80,21 @@ __PInvokeGenStubFuncName SETS "$__PInvokeGenStubFuncName":CC:"_RetBuffArg"
         ENDIF
 
         ; x0 = pTransitionBlock
-        add                 x0, sp, #__PWTB_TransitionBlock      
+        add                 x0, sp, #__PWTB_TransitionBlock
 
         ; save hidden arg
         mov                 x19, $HiddenArg 
 
+        ; save VASigCookieReg
+        mov                 x20, $VASigCookieReg
+
         bl                  $__PInvokeStubWorkerName
 
+        ; restore VASigCookieReg
+        mov                 $VASigCookieReg, x20
+
         ; restore hidden arg (method desc or unmanaged target)
-        mov                 $HiddenArg , x19
+        mov                 $HiddenArg, x19
 
 
         EPILOG_WITH_TRANSITION_BLOCK_TAILCALL


### PR DESCRIPTION
I noticed something risky in this stub. We don't ensure that VASigCookieReg is preserved (if it's a temporary register, we don't know what may happen to it in the call to the PInvokeStubWorker). Let's save it in a callee-saved register so that when we come back after stub generation, we still have the correct value for the VASigCookie.

@janvorli PTAL