### PR TITLE
Adding EnumerateChunks which allow efficient scanning of a StringBuilder

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
@@ -588,11 +588,10 @@ namespace System.Text
         /// </summary>
         public struct ChunkEnumerator
         {
-            [ComponentModel.EditorBrowsable(ComponentModel.EditorBrowsableState.Never)] // Only here to make foreach work
-
             /// <summary>
             /// Implement IEnumerable.GetEnumerator() to return  'this' as the IEnumerator  
             /// </summary>
+            [ComponentModel.EditorBrowsable(ComponentModel.EditorBrowsableState.Never)] // Only here to make foreach work
             public ChunkEnumerator GetEnumerator() { return this;  }
 
             /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
@@ -563,8 +563,19 @@ namespace System.Text
         /// as chunks (ReadOnlyMemory) of characters.  An example use is:
         /// 
         ///      foreach (ReadOnlyMemory<char> chunk in sb.EnumerateChunks())
-        ///      {  /* operate on chars using 'chunk' */   }
+        ///         foreach(char c in chunk.Span)
+        ///             { /* operation on c }
         ///      
+        /// Note that creating a ReadOnlySpan from a ReadOnlyMemory is expensive compared to the
+        /// fetching of the character, so create a local variable for the SPAN if you need to use
+        /// a for statement for example 
+        /// 
+        ///    foreach (ReadOnlyMemory<char> chunk in sb.EnumerateChunks())
+        ///    {
+        ///         var span = chunk.Span;
+        ///         for(int i = 0; i < span.Length; i++)
+        ///             { /* operation on span[i] */ }
+        ///    }
         /// </summary>
         public ChunkEnumerable EnumerateChunks() => new ChunkEnumerable(this);
 
@@ -583,7 +594,7 @@ namespace System.Text
             #region private
             internal ChunkEnumerable(StringBuilder stringBuilder)
             {
-                Debug.Assert(stringBuilder != null);    // Because it is only called with at 'this' pointer.    
+                Debug.Assert(stringBuilder != null);    // Because it is only called with a 'this' pointer.    
                 _stringBuilder = stringBuilder;
             }
             private StringBuilder _stringBuilder;   // We insure this is never null. 
@@ -593,7 +604,7 @@ namespace System.Text
         /// <summary>
         /// ChunkEnumerator supports the IEnumerator pattern so foreach works (see EnumerateChunks)  
         /// It needs to be public (so the compiler can use it when building a foreach statement) 
-        /// but users typically don't use it explicitly (which is why it is a nested type).  
+        /// but users typically don't use it explicitly (which is why it is a nested type). 
         /// </summary>
         public struct ChunkEnumerator
         {
@@ -614,6 +625,7 @@ namespace System.Text
                 _currentChunk = next;
                 return true;
             }
+
             /// <summary>
             /// Implements the IEnumerator pattern.
             /// </summary>
@@ -668,6 +680,7 @@ namespace System.Text
                     _chunks = new StringBuilder[chunkCount];
                     while (0 <= --chunkCount)
                     {
+                        Debug.Assert(stringBuilder != null);
                         _chunks[chunkCount] = stringBuilder;
                         stringBuilder = stringBuilder.m_ChunkPrevious;
                     }

--- a/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
@@ -573,9 +573,12 @@ namespace System.Text
         /// </summary>
         public struct ChunkEnumerable
         {
-            internal ChunkEnumerable(StringBuilder stringBuilder) { _stringBuilder = stringBuilder; }
+            internal ChunkEnumerable(StringBuilder stringBuilder) {
+                Debug.Assert(stringBuilder != null);    // Because it is only called with at 'this' pointer.    
+                _stringBuilder = stringBuilder;
+            }
             public ChunkEnumerator GetEnumerator() => new ChunkEnumerator(this._stringBuilder);
-            private StringBuilder _stringBuilder;
+            private StringBuilder _stringBuilder;   // We insure this is never null. 
         }
 
         /// <summary>
@@ -604,8 +607,9 @@ namespace System.Text
             #region private
             internal ChunkEnumerator(StringBuilder stringBuilder)
             {
+                Debug.Assert(stringBuilder != null);
                 _firstChunk = stringBuilder;
-                _currentChunk = null;
+                _currentChunk = null;   // MoveNext will find the last chunk if we do this.  
                 _manyChunks = null;
 
                 // There is a performance-vs-allocation tradeoff.   Because the chunks
@@ -647,7 +651,7 @@ namespace System.Text
                 public ManyChunkInfo(StringBuilder stringBuilder, int chunkCount)
                 {
                     _chunks = new StringBuilder[chunkCount];
-                    while (0 < --chunkCount)
+                    while (0 <= --chunkCount)
                     {
                         _chunks[chunkCount] = stringBuilder;
                         stringBuilder = stringBuilder.m_ChunkPrevious;
@@ -661,7 +665,7 @@ namespace System.Text
             StringBuilder _firstChunk;        // The first Stringbuilder chunk (which is the end of the logical string)
             StringBuilder _currentChunk;      // The chunk that this enumerator is currently returning (Current).  
             ManyChunkInfo _manyChunks;        // Only used for long string builders with many chunks (see constructor)
-            #endregion
+#endregion
         }
 
         /// <summary>
@@ -1186,7 +1190,7 @@ namespace System.Text
             return this;
         }
 
-        #region AppendJoin
+#region AppendJoin
 
         public unsafe StringBuilder AppendJoin(string separator, params object[] values)
         {
@@ -1294,7 +1298,7 @@ namespace System.Text
             return this;
         }
 
-        #endregion
+#endregion
 
         public StringBuilder Insert(int index, String value)
         {

--- a/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
@@ -560,8 +560,8 @@ namespace System.Text
         /// <summary>
         /// EnumerateChunks returns ChunkEnumerable that follows the IEnumerable pattern and
         /// thus can be used in a C# 'foreach' statement.   Thus 
-        ///      foreach (ReadOnlyMemory<char> span in sb.EnumerateChunks())
-        ///      {  /* opererate on bytes using 'span' */   }
+        ///      foreach (ReadOnlyMemory<char> chunk in sb.EnumerateChunks())
+        ///      {  /* opererate on bytes using 'chunk' */   }
         ///      
         /// </summary>
         public ChunkEnumerable EnumerateChunks() => new ChunkEnumerable(this);
@@ -599,7 +599,7 @@ namespace System.Text
                 _currentChunk = next;
                 return true;
             }
-            public ReadOnlySpan<char> Current => new ReadOnlySpan<char>(_currentChunk.m_ChunkChars, 0, _currentChunk.m_ChunkLength);
+            public ReadOnlyMemory<char> Current => new ReadOnlyMemory<char>(_currentChunk.m_ChunkChars, 0, _currentChunk.m_ChunkLength);
 
             #region private
             internal ChunkEnumerator(StringBuilder stringBuilder)

--- a/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
@@ -558,8 +558,8 @@ namespace System.Text
         }
 
         /// <summary>
-        /// EnumerateChunks returns ChunkEnumerable that follows the IEnumerable pattern and
-        /// thus can be used in a C# 'foreach' statemens to retreive the data in the StringBuilder
+        /// EnumerateChunks returns ChunkEnumerator that follows the IEnumerable pattern and
+        /// thus can be used in a C# 'foreach' statements to retreive the data in the StringBuilder
         /// as chunks (ReadOnlyMemory) of characters.  An example use is:
         /// 
         ///      foreach (ReadOnlyMemory<char> chunk in sb.EnumerateChunks())
@@ -577,37 +577,24 @@ namespace System.Text
         ///             { /* operation on span[i] */ }
         ///    }
         /// </summary>
-        public ChunkEnumerable EnumerateChunks() => new ChunkEnumerable(this);
+        public ChunkEnumerator EnumerateChunks() => new ChunkEnumerator(this);
+
 
         /// <summary>
-        /// ChunkEnumerable supports the IEnumerable pattern so foreach works (see EnumerateChunks)  
-        /// It needs to be public (so the compiler can use it when building a foreach statement) 
-        /// but users typically don't use it explicitly (which is why it is a nested type).  
-        /// </summary>
-        readonly public struct ChunkEnumerable
-        {
-            /// <summary>
-            /// Implements the IEnumerable pattern.  
-            /// </summary>
-            public ChunkEnumerator GetEnumerator() => new ChunkEnumerator(this._stringBuilder);
-
-            #region private
-            internal ChunkEnumerable(StringBuilder stringBuilder)
-            {
-                Debug.Assert(stringBuilder != null);    // Because it is only called with a 'this' pointer.    
-                _stringBuilder = stringBuilder;
-            }
-            readonly private StringBuilder _stringBuilder;   // We ensure this is never null. 
-            #endregion
-        }
-
-        /// <summary>
-        /// ChunkEnumerator supports the IEnumerator pattern so foreach works (see EnumerateChunks)  
-        /// It needs to be public (so the compiler can use it when building a foreach statement) 
-        /// but users typically don't use it explicitly (which is why it is a nested type). 
+        /// ChunkEnumerator supports both the IEnumerable and IEnumerator pattern so foreach 
+        /// works (see EnumerateChunks).  It needs to be public (so the compiler can use it 
+        /// when building a foreach statement) but users typically don't use it explicitly.
+        /// (which is why it is a nested type). 
         /// </summary>
         public struct ChunkEnumerator
         {
+            [ComponentModel.EditorBrowsable(ComponentModel.EditorBrowsableState.Never)] // Only here to make foreach work
+
+            /// <summary>
+            /// Implement IEnumerable.GetEnumerator() to return  'this' as the IEnumerator  
+            /// </summary>
+            public ChunkEnumerator GetEnumerator() { return this;  }
+
             /// <summary>
             /// Implements the IEnumerator pattern.
             /// </summary>

--- a/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
@@ -579,7 +579,6 @@ namespace System.Text
         /// </summary>
         public ChunkEnumerator EnumerateChunks() => new ChunkEnumerator(this);
 
-
         /// <summary>
         /// ChunkEnumerator supports both the IEnumerable and IEnumerator pattern so foreach 
         /// works (see EnumerateChunks).  It needs to be public (so the compiler can use it 
@@ -588,7 +587,6 @@ namespace System.Text
         /// </summary>
         public struct ChunkEnumerator
         {
-
             /// <summary>
             /// Implement IEnumerable.GetEnumerator() to return  'this' as the IEnumerator  
             /// </summary>

--- a/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
@@ -561,7 +561,7 @@ namespace System.Text
         /// EnumerateChunks returns ChunkEnumerable that follows the IEnumerable pattern and
         /// thus can be used in a C# 'foreach' statement.   Thus 
         ///      foreach (ReadOnlyMemory<char> chunk in sb.EnumerateChunks())
-        ///      {  /* opererate on bytes using 'chunk' */   }
+        ///      {  /* operate on bytes using 'chunk' */   }
         ///      
         /// </summary>
         public ChunkEnumerable EnumerateChunks() => new ChunkEnumerable(this);

--- a/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
@@ -584,7 +584,7 @@ namespace System.Text
         /// It needs to be public (so the compiler can use it when building a foreach statement) 
         /// but users typically don't use it explicitly (which is why it is a nested type).  
         /// </summary>
-        public struct ChunkEnumerable
+        readonly public struct ChunkEnumerable
         {
             /// <summary>
             /// Implements the IEnumerable pattern.  

--- a/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
@@ -588,6 +588,7 @@ namespace System.Text
         /// </summary>
         public struct ChunkEnumerator
         {
+
             /// <summary>
             /// Implement IEnumerable.GetEnumerator() to return  'this' as the IEnumerator  
             /// </summary>
@@ -1205,7 +1206,7 @@ namespace System.Text
             return this;
         }
 
-#region AppendJoin
+        #region AppendJoin
 
         public unsafe StringBuilder AppendJoin(string separator, params object[] values)
         {
@@ -1313,7 +1314,7 @@ namespace System.Text
             return this;
         }
 
-#endregion
+        #endregion
 
         public StringBuilder Insert(int index, String value)
         {

--- a/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
@@ -597,7 +597,7 @@ namespace System.Text
                 Debug.Assert(stringBuilder != null);    // Because it is only called with a 'this' pointer.    
                 _stringBuilder = stringBuilder;
             }
-            private StringBuilder _stringBuilder;   // We insure this is never null. 
+            readonly private StringBuilder _stringBuilder;   // We ensure this is never null. 
             #endregion
         }
 
@@ -686,13 +686,14 @@ namespace System.Text
                     }
                     _chunkPos = -1;
                 }
-                StringBuilder[] _chunks;    // These are in normal order (first chunk first) 
+
+                readonly StringBuilder[] _chunks;    // These are in normal order (first chunk first) 
                 int _chunkPos;
             }
 
-            StringBuilder _firstChunk;        // The first Stringbuilder chunk (which is the end of the logical string)
-            StringBuilder _currentChunk;      // The chunk that this enumerator is currently returning (Current).  
-            ManyChunkInfo _manyChunks;        // Only used for long string builders with many chunks (see constructor)
+            readonly StringBuilder _firstChunk; // The first Stringbuilder chunk (which is the end of the logical string)
+            StringBuilder _currentChunk;        // The chunk that this enumerator is currently returning (Current).  
+            readonly ManyChunkInfo _manyChunks; // Only used for long string builders with many chunks (see constructor)
 #endregion
         }
 

--- a/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
@@ -559,9 +559,11 @@ namespace System.Text
 
         /// <summary>
         /// EnumerateChunks returns ChunkEnumerable that follows the IEnumerable pattern and
-        /// thus can be used in a C# 'foreach' statement.   Thus 
+        /// thus can be used in a C# 'foreach' statemens to retreive the data in the StringBuilder
+        /// as chunks (ReadOnlyMemory) of characters.  An example use is:
+        /// 
         ///      foreach (ReadOnlyMemory<char> chunk in sb.EnumerateChunks())
-        ///      {  /* operate on bytes using 'chunk' */   }
+        ///      {  /* operate on chars using 'chunk' */   }
         ///      
         /// </summary>
         public ChunkEnumerable EnumerateChunks() => new ChunkEnumerable(this);
@@ -569,25 +571,35 @@ namespace System.Text
         /// <summary>
         /// ChunkEnumerable supports the IEnumerable pattern so foreach works (see EnumerateChunks)  
         /// It needs to be public (so the compiler can use it when building a foreach statement) 
-        /// but users typically don't use it explicitly (which is why it is nested).  
+        /// but users typically don't use it explicitly (which is why it is a nested type).  
         /// </summary>
         public struct ChunkEnumerable
         {
-            internal ChunkEnumerable(StringBuilder stringBuilder) {
+            /// <summary>
+            /// Implements the IEnumerable pattern.  
+            /// </summary>
+            public ChunkEnumerator GetEnumerator() => new ChunkEnumerator(this._stringBuilder);
+
+            #region private
+            internal ChunkEnumerable(StringBuilder stringBuilder)
+            {
                 Debug.Assert(stringBuilder != null);    // Because it is only called with at 'this' pointer.    
                 _stringBuilder = stringBuilder;
             }
-            public ChunkEnumerator GetEnumerator() => new ChunkEnumerator(this._stringBuilder);
             private StringBuilder _stringBuilder;   // We insure this is never null. 
+            #endregion
         }
 
         /// <summary>
-        /// ChunkEnumerator supports the IEnumerable pattern so foreach works (see EnumerateChunks)  
+        /// ChunkEnumerator supports the IEnumerator pattern so foreach works (see EnumerateChunks)  
         /// It needs to be public (so the compiler can use it when building a foreach statement) 
-        /// but users typically don't use it explicitly (which is why it is nested).  
+        /// but users typically don't use it explicitly (which is why it is a nested type).  
         /// </summary>
         public struct ChunkEnumerator
         {
+            /// <summary>
+            /// Implements the IEnumerator pattern.
+            /// </summary>
             public bool MoveNext()
             {
                 if (_currentChunk == _firstChunk)
@@ -602,6 +614,9 @@ namespace System.Text
                 _currentChunk = next;
                 return true;
             }
+            /// <summary>
+            /// Implements the IEnumerator pattern.
+            /// </summary>
             public ReadOnlyMemory<char> Current => new ReadOnlyMemory<char>(_currentChunk.m_ChunkChars, 0, _currentChunk.m_ChunkLength);
 
             #region private


### PR DESCRIPTION
This change is the start of addressing the issue  CoreFX issue 

https://github.com/dotnet/corefx/issues/21248

which wants to have an efficient way of reading the characters of a StringBuilder.      However it has morphed alot since then (from a callback to an iterator model).   The API review part of this is the following issue. 

https://github.com/dotnet/corefx/issues/29770

This PR is an implementation of that spec.  In particular we implement the following new method on StringBuilder. 
```
class StringBuilder { 
      ChunkEnumerator EnumerateChunks();
}
```
ChunkEnumerator is a struct that follows the IEnumerable<ReadOnlyMemory<char>> pattern and thus works with the C# foreach statement.   Here is an example for efficiently implementing 'IndexOf' using EnumerateChunks
```
        static int IndexOf(StringBuilder sb, char c)
        {
            int pos = 0;
            foreach (ReadOnlyMemory<char> chunk in sb.EnumerateChunks())
            {
                var span = chunk.Span;  // We create a local variable because it is more efficient
                for (int i = 0; i < span .Length; i++)
                    if (span [i] == c)
                        return pos + i;
                pos += span.Length;
            }
            return -1;
        }
```
The PR contains the actual implementation.    Note that ChunkEnumerable does not actually implement IEnumerable<ReadOnlyMemory<char>>.  

We considered having it return ReadOnlySpan, but decided that it was too fragile in that Span can't be used across 'await' calls and can't be passed to methods that MAY be async.   ReadOnlyMemory does not have this problem (but is a bit less efficient), but does require you to convert it to a Span before accessing the characters (and notice you need to cache the span in a local variable to keep span creation out of the inner loop).    

This is not ideal, but is this issue will resurface other places (whenever we want to return chunks), and so it is likely we will invest in JIT optimization to optimize away any inefficiency of using ReadOnlyMemory and converting immediately to Span (which is what would happen in the synchronous case).  
 
At this point it is ready for API review.    This amounts to signing off on using ReadOnlyMemory instead of ReadOnlySpan, and the names (is 'Chunks' the right suffix?) and the fact that ChunkEnumerable does not actually implement IEnumerable<ReadOnlyMemory<char>> (It could, it is just more code (which we can add later)).  

I have tests, however there seems to be a chicken and egg problem in that you need to have an implementation, before CoreFX can expose it (and have tests for it).    I have tested the code (all code paths are covered), but I will need to check in tests as a separate PR.  