### PR TITLE
Protect SuperPMI from crashes calling jitStartup

### DIFF
--- a/src/ToolBox/superpmi/superpmi/jitinstance.h
+++ b/src/ToolBox/superpmi/superpmi/jitinstance.h
@@ -54,6 +54,8 @@ public:
     HRESULT StartUp(char* PathToJit, bool copyJit, bool breakOnDebugBreakorAV, MethodContext* firstContext);
     bool reLoad(MethodContext* firstContext);
 
+    bool callJitStartup(ICorJitHost* newHost);
+
     bool resetConfig(MethodContext* firstContext);
 
     Result CompileMethod(MethodContext* MethodToCompile, int mcIndex, bool collectThroughput);


### PR DESCRIPTION
When we call jitStartup, we pass a JitHost interface that the JIT
calls to query for data. These queries look up in the recorded
MCH data, and could fail (and throw an exception) if data is
missing, which it can be for running non-matching altjit against
a collection. Protect these calls with exception handling.