### PR TITLE
Make Windows builds always portable

### DIFF
--- a/src/.nuget/dir.props
+++ b/src/.nuget/dir.props
@@ -67,13 +67,8 @@
     <When Condition="'$(PackageRID)' != ''" />
     <When Condition="'$(_runtimeOSFamily)' == 'win'">
       <PropertyGroup>
-        <RIDPlatform>win7</RIDPlatform>
-        <RIDPlatform Condition="'$(ArchGroup)' == 'arm'">win8</RIDPlatform>
-        <RIDPlatform Condition="'$(ArchGroup)' == 'arm64'">win10</RIDPlatform>
-        
-        <!-- Set the platform part of the RID if we are doing a portable build -->
-        <RIDPlatform Condition="'$(PortableBuild)' == 'true'">win</RIDPlatform>
-        <PackageRID>$(RIDPlatform)-$(ArchGroup)</PackageRID>
+        <!-- Note: Windows builds are always portable (-PortableBuild=false is ignored) -->
+        <PackageRID>win-$(ArchGroup)</PackageRID>
       </PropertyGroup>
     </When>
     <When Condition="'$(_runtimeOSFamily)' == 'osx'">


### PR DESCRIPTION
Apparently there is little or no need for a non-portable Windows build, so
rather than trying to figure out which version of Windows we are building
on, just ignore -PortableBuild=false.  We can add a warning or refuse to
accept the switch later if necessary, but for now we need to continue
accepting it to avoid build breaks.

Fixes #14291