### PR TITLE
Allow TYP_SIMD normalization for GT_IND in importer (#16542)

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -13569,6 +13569,13 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
                 lclTyp = JITtype2varType(ciType);
 
+#ifdef FEATURE_SIMD
+                if (lclTyp == TYP_STRUCT)
+                {
+                    lclTyp = impNormStructType(clsHnd);
+                }
+#endif
+
 #ifdef _TARGET_AMD64
                 noway_assert(varTypeIsIntegralOrI(lclTyp) || varTypeIsFloating(lclTyp) || lclTyp == TYP_STRUCT);
 #endif // _TARGET_AMD64


### PR DESCRIPTION

Fix for #16542

Increasing the scope of the assertion to include TYP_SIMD allows the test to pass.

PTAL @sdmaclea @CarolEidt 