### PR TITLE
Fix OpenVirtualProcess on Linux issue.

### DIFF
--- a/src/md/datasource/datatargetreader.cpp
+++ b/src/md/datasource/datatargetreader.cpp
@@ -171,12 +171,14 @@ HRESULT DataTargetReader::GetRemotePointerSize(ULONG32* pPointerSize)
     HRESULT hr = S_OK;
     CorDebugPlatform platform;
     IfFailRet(m_pDataTarget->GetPlatform(&platform));
-    if (platform == CORDB_PLATFORM_WINDOWS_X86)
+    if ((platform == CORDB_PLATFORM_WINDOWS_X86) || (platform == CORDB_PLATFORM_POSIX_X86) || (platform == CORDB_PLATFORM_MAC_X86))
         *pPointerSize = 4;
-    else if (platform == CORDB_PLATFORM_WINDOWS_AMD64)
+    else if ((platform == CORDB_PLATFORM_WINDOWS_AMD64) || (platform == CORDB_PLATFORM_POSIX_AMD64) || (platform == CORDB_PLATFORM_MAC_AMD64))
         *pPointerSize = 8;
-    else if (platform == CORDB_PLATFORM_WINDOWS_ARM)
+    else if ((platform == CORDB_PLATFORM_WINDOWS_ARM) || (platform == CORDB_PLATFORM_POSIX_ARM))
         *pPointerSize = 4;
+    else if ((platform == CORDB_PLATFORM_WINDOWS_ARM64) || (platform == CORDB_PLATFORM_POSIX_ARM64))
+        *pPointerSize = 8;
     else
         return CORDBG_E_UNSUPPORTED;
     return S_OK;


### PR DESCRIPTION
Fix DataTargetReader::GetRemotePointerSize to work on Linux/MacOS platforms so VS's new Linux core dump support works.