### PR TITLE
Disable failing Ubuntu/arm tests

### DIFF
--- a/tests/testsFailing.arm.txt
+++ b/tests/testsFailing.arm.txt
@@ -1,2 +1,3 @@
 GC/API/GC/GetAllocatedBytesForCurrentThread/GetAllocatedBytesForCurrentThread.sh
 GC/Scenarios/LeakWheel/leakwheel/leakwheel.sh
+CoreMangLib/system/span/SlowTailCallArgs/SlowTailCallArgs.sh

--- a/tests/testsFailing.arm.txt
+++ b/tests/testsFailing.arm.txt
@@ -1,1 +1,2 @@
 GC/API/GC/GetAllocatedBytesForCurrentThread/GetAllocatedBytesForCurrentThread.sh
+GC/Scenarios/LeakWheel/leakwheel/leakwheel.sh


### PR DESCRIPTION
This PR disable the following tests on arm:
* GC/Scenarios/LeakWheel/leakwheel/leakwheel.sh (#16061)
* CoreMangLib/system/span/SlowTailCallArgs/SlowTailCallArgs.sh (#17565)