### PR TITLE
Fix extra register-dependency on mem-form of vcvtsd/s2ss

### DIFF
--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -95,6 +95,8 @@ bool emitter::IsDstDstSrcAVXInstruction(instruction ins)
         case INS_cmpss:
         case INS_cvtsi2sd:
         case INS_cvtsi2ss:
+        case INS_cvtsd2ss:
+        case INS_cvtss2sd:
         case INS_divpd:
         case INS_divps:
         case INS_divsd:
@@ -251,8 +253,6 @@ bool emitter::IsDstSrcSrcAVXInstruction(instruction ins)
 {
     switch (ins)
     {
-        case INS_cvtsd2ss:
-        case INS_cvtss2sd:
         case INS_movhpd:
         case INS_movhps:
         case INS_movlpd:


### PR DESCRIPTION
Fix https://github.com/dotnet/coreclr/issues/17544

Originally, https://github.com/dotnet/coreclr/pull/14274 attempts to optimize `vcvtsd/s2ss/d` by keeping the second and third register same to avoid unnecessary register-dependency.
```asm
vcvtss2sd xmm0, xmm0, xmm1 ;;; depends on xmm0 and xmm1
vcvtss2sd xmm0, xmm1, xmm1 ;;; depends on xmm1 only
```

However, that does not work with the containment form. When the last op is a memory address, RyuJIT cannot determine the second register and just generate the default value of VEX.vvvv field (XMM0).
```asm
vcvtss2sd xmm6, xmm0, dword ptr [rip-0x11d1f3] ;;; depends on xmm0 that does not belong to vcvtss2sd
```

This PR reverts the change of https://github.com/dotnet/coreclr/pull/14274 to fix this performance regression, but we need to find a better solution for the containment form in the future.