### PR TITLE
[1.1] Replace tool-runtime binaries with portable linux binaries

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -46,13 +46,11 @@ if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
                         if  [ "$__DISTRO_NAME" == 'ubuntu.16.04' ] ||
                             [ "$__DISTRO_NAME" == 'ubuntu.16.10' ] ||
                             [ "$__DISTRO_NAME" == 'ubuntu.18.04' ] ||
-                            [ "$__DISTRO_NAME" == 'debian.8' ] ||
                             [ "$__DISTRO_NAME" == 'fedora.23' ] ||
                             [ "$__DISTRO_NAME" == 'fedora.24' ] ||
                             [ "$__DISTRO_NAME" == 'fedora.27' ] ||
                             [ "$__DISTRO_NAME" == 'opensuse.13.2' ] ||
-                            [ "$__DISTRO_NAME" == 'opensuse.42.1' ] ||
-                            [ "$__DISTRO_NAME" == 'opensuse.42.3' ] ; then
+                            [ "$__DISTRO_NAME" == 'opensuse.42.1' ]; then
                             __PKG_RID=$__DISTRO_NAME
                         fi
                     fi
@@ -111,6 +109,11 @@ if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
     if [ $? -ne 0 ]; then
         echo [ERROR] Failed to copy Tools-Override.
         exit $?
+    fi
+
+    # Replace the binaries restored by the tool runtime script with the portable binaries
+    if [ "$__PKG_RID" == "linux" ]; then
+         cp -r $__DOTNET_PATH/shared/Microsoft.NETCore.App/*/* $__TOOLRUNTIME_DIR
     fi
 
     touch $__INIT_TOOLS_DONE_MARKER


### PR DESCRIPTION
When we restore the portable runtime on 1.1 we should also use those portable binaries for the tool-runtime. Otherwise we can run into conflicts between the native binaries expected by the portable-cli and the tool-runtime dependencies.

Also removes some platform specific CLI usages that I tested and verified with the portable CLI instead.

@janvorli this resolves the issues you were seeing with the x509certificates dll. Our tools were using an older version of the managed dll instead of the one in your portable CLi, resulting in failed attempted loads of native functions in the System.Security.Cryptography.Native .so.