### PR TITLE
[Arm64] Disable SIMD in crossgen (added as part of #14633)

### DIFF
--- a/src/zap/zapper.cpp
+++ b/src/zap/zapper.cpp
@@ -1308,14 +1308,6 @@ void Zapper::InitializeCompilerFlags(CORCOMPILE_VERSION_INFO * pVersionInfo)
 
 #endif // _TARGET_X86_
 
-#if defined(_TARGET_ARM64_)
-    static ConfigDWORD fFeatureSIMD;
-    if (fFeatureSIMD.val(CLRConfig::EXTERNAL_FeatureSIMD) != 0)
-    {
-        m_pOpt->m_compilerFlags.Set(CORJIT_FLAGS::CORJIT_FLAG_FEATURE_SIMD);
-    }
-#endif
-
     if (   m_pOpt->m_compilerFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_DEBUG_INFO)
         && m_pOpt->m_compilerFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_DEBUG_CODE)
         && m_pOpt->m_compilerFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_PROF_ENTERLEAVE))


### PR DESCRIPTION
Disable SIMD feature in crossgen for ARM64 for now as decided in #17543

This will let the following arm64 crossgen tests to pass. (#16541, #16542)