### PR TITLE
 Updating the HWIntrinsic APIs to use the unmanaged constraint

### DIFF
--- a/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Arm64/Simd.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Arm64/Simd.PlatformNotSupported.cs
@@ -38,102 +38,102 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         /// Vector add
         /// Corresponds to vector forms of ARM64 ADD & FADD
         /// </summary>
-        public static Vector64<T>  Add<T>(Vector64<T>  left, Vector64<T>  right) where T : struct { throw new PlatformNotSupportedException(); }
-        public static Vector128<T> Add<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector64<T>  Add<T>(Vector64<T>  left, Vector64<T>  right) where T : unmanaged { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> Add<T>(Vector128<T> left, Vector128<T> right) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// Vector and
         /// Corresponds to vector forms of ARM64 AND
         /// </summary>
-        public static Vector64<T>  And<T>(Vector64<T>  left, Vector64<T>  right) where T : struct { throw new PlatformNotSupportedException(); }
-        public static Vector128<T> And<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector64<T>  And<T>(Vector64<T>  left, Vector64<T>  right) where T : unmanaged { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> And<T>(Vector128<T> left, Vector128<T> right) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// Vector and not
         /// Corresponds to vector forms of ARM64 BIC
         /// </summary>
-        public static Vector64<T>  AndNot<T>(Vector64<T>  left, Vector64<T>  right) where T : struct { throw new PlatformNotSupportedException(); }
-        public static Vector128<T> AndNot<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector64<T>  AndNot<T>(Vector64<T>  left, Vector64<T>  right) where T : unmanaged { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> AndNot<T>(Vector128<T> left, Vector128<T> right) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// Vector BitwiseSelect
         /// For each bit in the vector result[bit] = sel[bit] ? left[bit] : right[bit]
         /// Corresponds to vector forms of ARM64 BSL (Also BIF & BIT)
         /// </summary>
-        public static Vector64<T>  BitwiseSelect<T>(Vector64<T>  sel, Vector64<T>  left, Vector64<T>  right) where T : struct { throw new PlatformNotSupportedException(); }
-        public static Vector128<T> BitwiseSelect<T>(Vector128<T> sel, Vector128<T> left, Vector128<T> right) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector64<T>  BitwiseSelect<T>(Vector64<T>  sel, Vector64<T>  left, Vector64<T>  right) where T : unmanaged { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> BitwiseSelect<T>(Vector128<T> sel, Vector128<T> left, Vector128<T> right) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// Vector CompareEqual
         /// For each element result[elem] = (left[elem] == right[elem]) ? ~0 : 0
         /// Corresponds to vector forms of ARM64 CMEQ & FCMEQ
         /// </summary>
-        public static Vector64<T>  CompareEqual<T>(Vector64<T>  left, Vector64<T>  right) where T : struct { throw new PlatformNotSupportedException(); }
-        public static Vector128<T> CompareEqual<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector64<T>  CompareEqual<T>(Vector64<T>  left, Vector64<T>  right) where T : unmanaged { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> CompareEqual<T>(Vector128<T> left, Vector128<T> right) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// Vector CompareEqualZero
         /// For each element result[elem] = (left[elem] == 0) ? ~0 : 0
         /// Corresponds to vector forms of ARM64 CMEQ & FCMEQ
         /// </summary>
-        public static Vector64<T>  CompareEqualZero<T>(Vector64<T>  value) where T : struct { throw new PlatformNotSupportedException(); }
-        public static Vector128<T> CompareEqualZero<T>(Vector128<T> value) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector64<T>  CompareEqualZero<T>(Vector64<T>  value) where T : unmanaged { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> CompareEqualZero<T>(Vector128<T> value) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// Vector CompareGreaterThan
         /// For each element result[elem] = (left[elem] > right[elem]) ? ~0 : 0
         /// Corresponds to vector forms of ARM64 CMGT/CMHI & FCMGT
         /// </summary>
-        public static Vector64<T>  CompareGreaterThan<T>(Vector64<T>  left, Vector64<T>  right) where T : struct { throw new PlatformNotSupportedException(); }
-        public static Vector128<T> CompareGreaterThan<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector64<T>  CompareGreaterThan<T>(Vector64<T>  left, Vector64<T>  right) where T : unmanaged { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> CompareGreaterThan<T>(Vector128<T> left, Vector128<T> right) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// Vector CompareGreaterThanZero
         /// For each element result[elem] = (left[elem] > 0) ? ~0 : 0
         /// Corresponds to vector forms of ARM64 CMGT & FCMGT
         /// </summary>
-        public static Vector64<T>  CompareGreaterThanZero<T>(Vector64<T>  value) where T : struct { throw new PlatformNotSupportedException(); }
-        public static Vector128<T> CompareGreaterThanZero<T>(Vector128<T> value) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector64<T>  CompareGreaterThanZero<T>(Vector64<T>  value) where T : unmanaged { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> CompareGreaterThanZero<T>(Vector128<T> value) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// Vector CompareGreaterThanOrEqual
         /// For each element result[elem] = (left[elem] >= right[elem]) ? ~0 : 0
         /// Corresponds to vector forms of ARM64 CMGE/CMHS & FCMGE
         /// </summary>
-        public static Vector64<T>  CompareGreaterThanOrEqual<T>(Vector64<T>  left, Vector64<T>    right) where T : struct { throw new PlatformNotSupportedException(); }
-        public static Vector128<T> CompareGreaterThanOrEqual<T>(Vector128<T> left, Vector128<T>   right) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector64<T>  CompareGreaterThanOrEqual<T>(Vector64<T>  left, Vector64<T>    right) where T : unmanaged { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> CompareGreaterThanOrEqual<T>(Vector128<T> left, Vector128<T>   right) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// Vector CompareGreaterThanOrEqualZero
         /// For each element result[elem] = (left[elem] >= 0) ? ~0 : 0
         /// Corresponds to vector forms of ARM64 CMGE & FCMGE
         /// </summary>
-        public static Vector64<T>  CompareGreaterThanOrEqualZero<T>(Vector64<T>  value) where T : struct { throw new PlatformNotSupportedException(); }
-        public static Vector128<T> CompareGreaterThanOrEqualZero<T>(Vector128<T> value) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector64<T>  CompareGreaterThanOrEqualZero<T>(Vector64<T>  value) where T : unmanaged { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> CompareGreaterThanOrEqualZero<T>(Vector128<T> value) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// Vector CompareLessThanZero
         /// For each element result[elem] = (left[elem] < 0) ? ~0 : 0
         /// Corresponds to vector forms of ARM64 CMGT & FCMGT
         /// </summary>
-        public static Vector64<T>  CompareLessThanZero<T>(Vector64<T>  value) where T : struct { throw new PlatformNotSupportedException(); }
-        public static Vector128<T> CompareLessThanZero<T>(Vector128<T> value) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector64<T>  CompareLessThanZero<T>(Vector64<T>  value) where T : unmanaged { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> CompareLessThanZero<T>(Vector128<T> value) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// Vector CompareLessThanOrEqualZero
         /// For each element result[elem] = (left[elem] < 0) ? ~0 : 0
         /// Corresponds to vector forms of ARM64 CMGT & FCMGT
         /// </summary>
-        public static Vector64<T>  CompareLessThanOrEqualZero<T>(Vector64<T>  value) where T : struct { throw new PlatformNotSupportedException(); }
-        public static Vector128<T> CompareLessThanOrEqualZero<T>(Vector128<T> value) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector64<T>  CompareLessThanOrEqualZero<T>(Vector64<T>  value) where T : unmanaged { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> CompareLessThanOrEqualZero<T>(Vector128<T> value) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// Vector CompareTest
         /// For each element result[elem] = (left[elem] & right[elem]) ? ~0 : 0
         /// Corresponds to vector forms of ARM64 CMTST
         /// </summary>
-        public static Vector64<T>  CompareTest<T>(Vector64<T>  left, Vector64<T>  right) where T : struct { throw new PlatformNotSupportedException(); }
-        public static Vector128<T> CompareTest<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector64<T>  CompareTest<T>(Vector64<T>  left, Vector64<T>  right) where T : unmanaged { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> CompareTest<T>(Vector128<T> left, Vector128<T> right) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// TBD Convert...
 
@@ -155,8 +155,8 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         ///
         /// Corresponds to vector forms of ARM64 MOV
         /// </summary>
-        public static T Extract<T>(Vector64<T>  vector, byte index) where T : struct { throw new PlatformNotSupportedException(); }
-        public static T Extract<T>(Vector128<T> vector, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static T Extract<T>(Vector64<T>  vector, byte index) where T : unmanaged { throw new PlatformNotSupportedException(); }
+        public static T Extract<T>(Vector128<T> vector, byte index) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// Vector insert item
@@ -169,8 +169,8 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         ///
         /// Corresponds to vector forms of ARM64 INS
         /// </summary>
-        public static Vector64<T>  Insert<T>(Vector64<T>  vector, byte index, T data) where T : struct { throw new PlatformNotSupportedException(); }
-        public static Vector128<T> Insert<T>(Vector128<T> vector, byte index, T data) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector64<T>  Insert<T>(Vector64<T>  vector, byte index, T data) where T : unmanaged { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> Insert<T>(Vector128<T> vector, byte index, T data) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// Vector LeadingSignCount
@@ -284,22 +284,22 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         /// Vector not
         /// Corresponds to vector forms of ARM64 NOT
         /// </summary>
-        public static Vector64<T>  Not<T>(Vector64<T>  value) where T : struct { throw new PlatformNotSupportedException(); }
-        public static Vector128<T> Not<T>(Vector128<T> value) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector64<T>  Not<T>(Vector64<T>  value) where T : unmanaged { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> Not<T>(Vector128<T> value) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// Vector or
         /// Corresponds to vector forms of ARM64 ORR
         /// </summary>
-        public static Vector64<T>  Or<T>(Vector64<T>  left, Vector64<T>  right) where T : struct { throw new PlatformNotSupportedException(); }
-        public static Vector128<T> Or<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector64<T>  Or<T>(Vector64<T>  left, Vector64<T>  right) where T : unmanaged { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> Or<T>(Vector128<T> left, Vector128<T> right) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// Vector or not
         /// Corresponds to vector forms of ARM64 ORN
         /// </summary>
-        public static Vector64<T>  OrNot<T>(Vector64<T>  left, Vector64<T>  right) where T : struct { throw new PlatformNotSupportedException(); }
-        public static Vector128<T> OrNot<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector64<T>  OrNot<T>(Vector64<T>  left, Vector64<T>  right) where T : unmanaged { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> OrNot<T>(Vector128<T> left, Vector128<T> right) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// Vector PopCount
@@ -315,8 +315,8 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         ///
         /// Corresponds to vector forms of ARM64 DUP (general), DUP (element 0), FMOV (vector, immediate)
         /// </summary>
-        public static Vector64<T>    SetAllVector64<T>(T value) where T : struct { throw new PlatformNotSupportedException(); }
-        public static Vector128<T>   SetAllVector128<T>(T value) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector64<T>    SetAllVector64<T>(T value) where T : unmanaged { throw new PlatformNotSupportedException(); }
+        public static Vector128<T>   SetAllVector128<T>(T value) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// Vector square root
@@ -330,15 +330,15 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         /// Vector subtract
         /// Corresponds to vector forms of ARM64 SUB & FSUB
         /// </summary>
-        public static Vector64<T>  Subtract<T>(Vector64<T>  left, Vector64<T>  right) where T : struct { throw new PlatformNotSupportedException(); }
-        public static Vector128<T> Subtract<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector64<T>  Subtract<T>(Vector64<T>  left, Vector64<T>  right) where T : unmanaged { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> Subtract<T>(Vector128<T> left, Vector128<T> right) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
 
         /// <summary>
         /// Vector exclusive or
         /// Corresponds to vector forms of ARM64 EOR
         /// </summary>
-        public static Vector64<T>  Xor<T>(Vector64<T>  left, Vector64<T>  right) where T : struct { throw new PlatformNotSupportedException(); }
-        public static Vector128<T> Xor<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector64<T>  Xor<T>(Vector64<T>  left, Vector64<T>  right) where T : unmanaged { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> Xor<T>(Vector128<T> left, Vector128<T> right) where T : unmanaged { throw new PlatformNotSupportedException(); }
     }
 }

--- a/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Arm64/Simd.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Arm64/Simd.cs
@@ -38,102 +38,102 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         /// Vector add
         /// Corresponds to vector forms of ARM64 ADD & FADD
         /// </summary>
-        public static Vector64<T>  Add<T>(Vector64<T>  left, Vector64<T>  right) where T : struct => Add(left, right);
-        public static Vector128<T> Add<T>(Vector128<T> left, Vector128<T> right) where T : struct => Add(left, right);
+        public static Vector64<T>  Add<T>(Vector64<T>  left, Vector64<T>  right) where T : unmanaged => Add(left, right);
+        public static Vector128<T> Add<T>(Vector128<T> left, Vector128<T> right) where T : unmanaged => Add(left, right);
 
         /// <summary>
         /// Vector and
         /// Corresponds to vector forms of ARM64 AND
         /// </summary>
-        public static Vector64<T>  And<T>(Vector64<T>  left, Vector64<T>  right) where T : struct => And(left, right);
-        public static Vector128<T> And<T>(Vector128<T> left, Vector128<T> right) where T : struct => And(left, right);
+        public static Vector64<T>  And<T>(Vector64<T>  left, Vector64<T>  right) where T : unmanaged => And(left, right);
+        public static Vector128<T> And<T>(Vector128<T> left, Vector128<T> right) where T : unmanaged => And(left, right);
 
         /// <summary>
         /// Vector and not
         /// Corresponds to vector forms of ARM64 BIC
         /// </summary>
-        public static Vector64<T>  AndNot<T>(Vector64<T>  left, Vector64<T>  right) where T : struct => AndNot(left, right);
-        public static Vector128<T> AndNot<T>(Vector128<T> left, Vector128<T> right) where T : struct => AndNot(left, right);
+        public static Vector64<T>  AndNot<T>(Vector64<T>  left, Vector64<T>  right) where T : unmanaged => AndNot(left, right);
+        public static Vector128<T> AndNot<T>(Vector128<T> left, Vector128<T> right) where T : unmanaged => AndNot(left, right);
 
         /// <summary>
         /// Vector BitwiseSelect
         /// For each bit in the vector result[bit] = sel[bit] ? left[bit] : right[bit]
         /// Corresponds to vector forms of ARM64 BSL (Also BIF & BIT)
         /// </summary>
-        public static Vector64<T>  BitwiseSelect<T>(Vector64<T>  sel, Vector64<T>  left, Vector64<T>  right) where T : struct => BitwiseSelect(sel, left, right);
-        public static Vector128<T> BitwiseSelect<T>(Vector128<T> sel, Vector128<T> left, Vector128<T> right) where T : struct => BitwiseSelect(sel, left, right);
+        public static Vector64<T>  BitwiseSelect<T>(Vector64<T>  sel, Vector64<T>  left, Vector64<T>  right) where T : unmanaged => BitwiseSelect(sel, left, right);
+        public static Vector128<T> BitwiseSelect<T>(Vector128<T> sel, Vector128<T> left, Vector128<T> right) where T : unmanaged => BitwiseSelect(sel, left, right);
 
         /// <summary>
         /// Vector CompareEqual
         /// For each element result[elem] = (left[elem] == right[elem]) ? ~0 : 0
         /// Corresponds to vector forms of ARM64 CMEQ & FCMEQ
         /// </summary>
-        public static Vector64<T>  CompareEqual<T>(Vector64<T>  left, Vector64<T>  right) where T : struct => CompareEqual(left, right);
-        public static Vector128<T> CompareEqual<T>(Vector128<T> left, Vector128<T> right) where T : struct => CompareEqual(left, right);
+        public static Vector64<T>  CompareEqual<T>(Vector64<T>  left, Vector64<T>  right) where T : unmanaged => CompareEqual(left, right);
+        public static Vector128<T> CompareEqual<T>(Vector128<T> left, Vector128<T> right) where T : unmanaged => CompareEqual(left, right);
 
         /// <summary>
         /// Vector CompareEqualZero
         /// For each element result[elem] = (left[elem] == 0) ? ~0 : 0
         /// Corresponds to vector forms of ARM64 CMEQ & FCMEQ
         /// </summary>
-        public static Vector64<T>  CompareEqualZero<T>(Vector64<T>  value) where T : struct => CompareEqualZero(value);
-        public static Vector128<T> CompareEqualZero<T>(Vector128<T> value) where T : struct => CompareEqualZero(value);
+        public static Vector64<T>  CompareEqualZero<T>(Vector64<T>  value) where T : unmanaged => CompareEqualZero(value);
+        public static Vector128<T> CompareEqualZero<T>(Vector128<T> value) where T : unmanaged => CompareEqualZero(value);
 
         /// <summary>
         /// Vector CompareGreaterThan
         /// For each element result[elem] = (left[elem] > right[elem]) ? ~0 : 0
         /// Corresponds to vector forms of ARM64 CMGT/CMHI & FCMGT
         /// </summary>
-        public static Vector64<T>  CompareGreaterThan<T>(Vector64<T>  left, Vector64<T>  right) where T : struct => CompareGreaterThan(left, right);
-        public static Vector128<T> CompareGreaterThan<T>(Vector128<T> left, Vector128<T> right) where T : struct => CompareGreaterThan(left, right);
+        public static Vector64<T>  CompareGreaterThan<T>(Vector64<T>  left, Vector64<T>  right) where T : unmanaged => CompareGreaterThan(left, right);
+        public static Vector128<T> CompareGreaterThan<T>(Vector128<T> left, Vector128<T> right) where T : unmanaged => CompareGreaterThan(left, right);
 
         /// <summary>
         /// Vector CompareGreaterThanZero
         /// For each element result[elem] = (left[elem] > 0) ? ~0 : 0
         /// Corresponds to vector forms of ARM64 CMGT & FCMGT
         /// </summary>
-        public static Vector64<T>  CompareGreaterThanZero<T>(Vector64<T>  value) where T : struct => CompareGreaterThanZero(value);
-        public static Vector128<T> CompareGreaterThanZero<T>(Vector128<T> value) where T : struct => CompareGreaterThanZero(value);
+        public static Vector64<T>  CompareGreaterThanZero<T>(Vector64<T>  value) where T : unmanaged => CompareGreaterThanZero(value);
+        public static Vector128<T> CompareGreaterThanZero<T>(Vector128<T> value) where T : unmanaged => CompareGreaterThanZero(value);
 
         /// <summary>
         /// Vector CompareGreaterThanOrEqual
         /// For each element result[elem] = (left[elem] >= right[elem]) ? ~0 : 0
         /// Corresponds to vector forms of ARM64 CMGE/CMHS & FCMGE
         /// </summary>
-        public static Vector64<T>  CompareGreaterThanOrEqual<T>(Vector64<T>  left, Vector64<T>    right) where T : struct => CompareGreaterThanOrEqual(left, right);
-        public static Vector128<T> CompareGreaterThanOrEqual<T>(Vector128<T> left, Vector128<T>   right) where T : struct => CompareGreaterThanOrEqual(left, right);
+        public static Vector64<T>  CompareGreaterThanOrEqual<T>(Vector64<T>  left, Vector64<T>    right) where T : unmanaged => CompareGreaterThanOrEqual(left, right);
+        public static Vector128<T> CompareGreaterThanOrEqual<T>(Vector128<T> left, Vector128<T>   right) where T : unmanaged => CompareGreaterThanOrEqual(left, right);
 
         /// <summary>
         /// Vector CompareGreaterThanOrEqualZero
         /// For each element result[elem] = (left[elem] >= 0) ? ~0 : 0
         /// Corresponds to vector forms of ARM64 CMGE & FCMGE
         /// </summary>
-        public static Vector64<T>  CompareGreaterThanOrEqualZero<T>(Vector64<T>  value) where T : struct => CompareGreaterThanOrEqualZero(value);
-        public static Vector128<T> CompareGreaterThanOrEqualZero<T>(Vector128<T> value) where T : struct => CompareGreaterThanOrEqualZero(value);
+        public static Vector64<T>  CompareGreaterThanOrEqualZero<T>(Vector64<T>  value) where T : unmanaged => CompareGreaterThanOrEqualZero(value);
+        public static Vector128<T> CompareGreaterThanOrEqualZero<T>(Vector128<T> value) where T : unmanaged => CompareGreaterThanOrEqualZero(value);
 
         /// <summary>
         /// Vector CompareLessThanZero
         /// For each element result[elem] = (left[elem] < 0) ? ~0 : 0
         /// Corresponds to vector forms of ARM64 CMGT & FCMGT
         /// </summary>
-        public static Vector64<T>  CompareLessThanZero<T>(Vector64<T>  value) where T : struct => CompareLessThanZero(value);
-        public static Vector128<T> CompareLessThanZero<T>(Vector128<T> value) where T : struct => CompareLessThanZero(value);
+        public static Vector64<T>  CompareLessThanZero<T>(Vector64<T>  value) where T : unmanaged => CompareLessThanZero(value);
+        public static Vector128<T> CompareLessThanZero<T>(Vector128<T> value) where T : unmanaged => CompareLessThanZero(value);
 
         /// <summary>
         /// Vector CompareLessThanOrEqualZero
         /// For each element result[elem] = (left[elem] < 0) ? ~0 : 0
         /// Corresponds to vector forms of ARM64 CMGT & FCMGT
         /// </summary>
-        public static Vector64<T>  CompareLessThanOrEqualZero<T>(Vector64<T>  value) where T : struct => CompareLessThanOrEqualZero(value);
-        public static Vector128<T> CompareLessThanOrEqualZero<T>(Vector128<T> value) where T : struct => CompareLessThanOrEqualZero(value);
+        public static Vector64<T>  CompareLessThanOrEqualZero<T>(Vector64<T>  value) where T : unmanaged => CompareLessThanOrEqualZero(value);
+        public static Vector128<T> CompareLessThanOrEqualZero<T>(Vector128<T> value) where T : unmanaged => CompareLessThanOrEqualZero(value);
 
         /// <summary>
         /// Vector CompareTest
         /// For each element result[elem] = (left[elem] & right[elem]) ? ~0 : 0
         /// Corresponds to vector forms of ARM64 CMTST
         /// </summary>
-        public static Vector64<T>  CompareTest<T>(Vector64<T>  left, Vector64<T>  right) where T : struct => CompareTest(left, right);
-        public static Vector128<T> CompareTest<T>(Vector128<T> left, Vector128<T> right) where T : struct => CompareTest(left, right);
+        public static Vector64<T>  CompareTest<T>(Vector64<T>  left, Vector64<T>  right) where T : unmanaged => CompareTest(left, right);
+        public static Vector128<T> CompareTest<T>(Vector128<T> left, Vector128<T> right) where T : unmanaged => CompareTest(left, right);
 
         /// TBD Convert...
 
@@ -155,8 +155,8 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         ///
         /// Corresponds to vector forms of ARM64 MOV
         /// </summary>
-        public static T Extract<T>(Vector64<T>  vector, byte index) where T : struct => Extract(vector, index);
-        public static T Extract<T>(Vector128<T> vector, byte index) where T : struct => Extract(vector, index);
+        public static T Extract<T>(Vector64<T>  vector, byte index) where T : unmanaged => Extract(vector, index);
+        public static T Extract<T>(Vector128<T> vector, byte index) where T : unmanaged => Extract(vector, index);
 
         /// <summary>
         /// Vector insert item
@@ -169,8 +169,8 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         ///
         /// Corresponds to vector forms of ARM64 INS
         /// </summary>
-        public static Vector64<T>  Insert<T>(Vector64<T>  vector, byte index, T data) where T : struct => Insert(vector, index, data);
-        public static Vector128<T> Insert<T>(Vector128<T> vector, byte index, T data) where T : struct => Insert(vector, index, data);
+        public static Vector64<T>  Insert<T>(Vector64<T>  vector, byte index, T data) where T : unmanaged => Insert(vector, index, data);
+        public static Vector128<T> Insert<T>(Vector128<T> vector, byte index, T data) where T : unmanaged => Insert(vector, index, data);
 
         /// <summary>
         /// Vector LeadingSignCount
@@ -284,22 +284,22 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         /// Vector not
         /// Corresponds to vector forms of ARM64 NOT
         /// </summary>
-        public static Vector64<T>  Not<T>(Vector64<T>  value) where T : struct => Not(value);
-        public static Vector128<T> Not<T>(Vector128<T> value) where T : struct => Not(value);
+        public static Vector64<T>  Not<T>(Vector64<T>  value) where T : unmanaged => Not(value);
+        public static Vector128<T> Not<T>(Vector128<T> value) where T : unmanaged => Not(value);
 
         /// <summary>
         /// Vector or
         /// Corresponds to vector forms of ARM64 ORR
         /// </summary>
-        public static Vector64<T>  Or<T>(Vector64<T>  left, Vector64<T>  right) where T : struct => Or(left, right);
-        public static Vector128<T> Or<T>(Vector128<T> left, Vector128<T> right) where T : struct => Or(left, right);
+        public static Vector64<T>  Or<T>(Vector64<T>  left, Vector64<T>  right) where T : unmanaged => Or(left, right);
+        public static Vector128<T> Or<T>(Vector128<T> left, Vector128<T> right) where T : unmanaged => Or(left, right);
 
         /// <summary>
         /// Vector or not
         /// Corresponds to vector forms of ARM64 ORN
         /// </summary>
-        public static Vector64<T>  OrNot<T>(Vector64<T>  left, Vector64<T>  right) where T : struct => OrNot(left, right);
-        public static Vector128<T> OrNot<T>(Vector128<T> left, Vector128<T> right) where T : struct => OrNot(left, right);
+        public static Vector64<T>  OrNot<T>(Vector64<T>  left, Vector64<T>  right) where T : unmanaged => OrNot(left, right);
+        public static Vector128<T> OrNot<T>(Vector128<T> left, Vector128<T> right) where T : unmanaged => OrNot(left, right);
 
         /// <summary>
         /// Vector PopCount
@@ -315,8 +315,8 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         ///
         /// Corresponds to vector forms of ARM64 DUP (general), DUP (element 0), FMOV (vector, immediate)
         /// </summary>
-        public static Vector64<T>    SetAllVector64<T>(T value)  where T : struct => SetAllVector64(value);
-        public static Vector128<T>   SetAllVector128<T>(T value) where T : struct => SetAllVector128(value);
+        public static Vector64<T>    SetAllVector64<T>(T value)  where T : unmanaged => SetAllVector64(value);
+        public static Vector128<T>   SetAllVector128<T>(T value) where T : unmanaged => SetAllVector128(value);
 
         /// <summary>
         /// Vector square root
@@ -330,15 +330,15 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         /// Vector subtract
         /// Corresponds to vector forms of ARM64 SUB & FSUB
         /// </summary>
-        public static Vector64<T>  Subtract<T>(Vector64<T>  left, Vector64<T>  right) where T : struct => Subtract(left, right);
-        public static Vector128<T> Subtract<T>(Vector128<T> left, Vector128<T> right) where T : struct => Subtract(left, right);
+        public static Vector64<T>  Subtract<T>(Vector64<T>  left, Vector64<T>  right) where T : unmanaged => Subtract(left, right);
+        public static Vector128<T> Subtract<T>(Vector128<T> left, Vector128<T> right) where T : unmanaged => Subtract(left, right);
 
 
         /// <summary>
         /// Vector exclusive or
         /// Corresponds to vector forms of ARM64 EOR
         /// </summary>
-        public static Vector64<T>  Xor<T>(Vector64<T>  left, Vector64<T>  right) where T : struct => Xor(left, right);
-        public static Vector128<T> Xor<T>(Vector128<T> left, Vector128<T> right) where T : struct => Xor(left, right);
+        public static Vector64<T>  Xor<T>(Vector64<T>  left, Vector64<T>  right) where T : unmanaged => Xor(left, right);
+        public static Vector128<T> Xor<T>(Vector128<T> left, Vector128<T> right) where T : unmanaged => Xor(left, right);
     }
 }

--- a/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
@@ -13,7 +13,7 @@ namespace System.Runtime.Intrinsics
     [DebuggerDisplay("{DisplayString,nq}")]
     [DebuggerTypeProxy(typeof(Vector128DebugView<>))]
     [StructLayout(LayoutKind.Sequential, Size = 16)]
-    public struct Vector128<T> where T : struct
+    public struct Vector128<T> where T : unmanaged
     {
         // These fields exist to ensure the alignment is 8, rather than 1.
         // This also allows the debug view to work https://github.com/dotnet/coreclr/issues/15694)

--- a/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128DebugView.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128DebugView.cs
@@ -6,7 +6,7 @@ using Internal.Runtime.CompilerServices;
 
 namespace System.Runtime.Intrinsics
 {
-    internal struct Vector128DebugView<T> where T : struct
+    internal struct Vector128DebugView<T> where T : unmanaged
     {
         private Vector128<T> _value;
 

--- a/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
@@ -13,7 +13,7 @@ namespace System.Runtime.Intrinsics
     [DebuggerDisplay("{DisplayString,nq}")]
     [DebuggerTypeProxy(typeof(Vector256DebugView<>))]
     [StructLayout(LayoutKind.Sequential, Size = 32)]
-    public struct Vector256<T> where T : struct
+    public struct Vector256<T> where T : unmanaged
     {
         // These fields exist to ensure the alignment is 8, rather than 1.
         // This also allows the debug view to work https://github.com/dotnet/coreclr/issues/15694)

--- a/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256DebugView.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256DebugView.cs
@@ -6,7 +6,7 @@ using Internal.Runtime.CompilerServices;
 
 namespace System.Runtime.Intrinsics
 {
-    internal struct Vector256DebugView<T> where T : struct
+    internal struct Vector256DebugView<T> where T : unmanaged
     {
         private Vector256<T> _value;
 

--- a/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64.cs
@@ -13,7 +13,7 @@ namespace System.Runtime.Intrinsics
     [DebuggerDisplay("{DisplayString,nq}")]
     [DebuggerTypeProxy(typeof(Vector64DebugView<>))]
     [StructLayout(LayoutKind.Sequential, Size = 8)]
-    public struct Vector64<T> where T : struct
+    public struct Vector64<T> where T : unmanaged
     {
         // These fields exist to ensure the alignment is 8, rather than 1.
         // This also allows the debug view to work https://github.com/dotnet/coreclr/issues/15694)

--- a/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64DebugView.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64DebugView.cs
@@ -6,7 +6,7 @@ using Internal.Runtime.CompilerServices;
 
 namespace System.Runtime.Intrinsics
 {
-    internal struct Vector64DebugView<T> where T : struct
+    internal struct Vector64DebugView<T> where T : unmanaged
     {
         private Vector64<T> _value;
 

--- a/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx.PlatformNotSupported.cs
@@ -283,7 +283,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128i _mm256_extractf128_si256 (__m256i a, const int imm8)
         ///   VEXTRACTF128 xmm/m128, ymm, imm8
         /// </summary>
-        public static Vector128<T> ExtractVector128<T>(Vector256<T> value, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> ExtractVector128<T>(Vector256<T> value, byte index) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm256_extractf128_si256 (__m256i a, const int imm8)
@@ -344,7 +344,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_castsi128_si256 (__m128i a)
         ///   HELPER - No Codegen
         /// </summary>
-        public static Vector256<T> ExtendToVector256<T>(Vector128<T> value) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector256<T> ExtendToVector256<T>(Vector128<T> value) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m256 _mm256_floor_ps (__m256 a)
@@ -365,7 +365,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128i _mm256_castsi256_si128 (__m256i a)
         ///   HELPER - No Codegen
         /// </summary>
-        public static Vector128<T> GetLowerHalf<T>(Vector256<T> value) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> GetLowerHalf<T>(Vector256<T> value) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m256 _mm256_hadd_ps (__m256 a, __m256 b)
@@ -438,7 +438,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_insertf128_si256 (__m256i a, __m128i b, int imm8)
         ///   VINSERTF128 ymm, ymm, xmm/m128, imm8
         /// </summary>
-        public static Vector256<T> InsertVector128<T>(Vector256<T> value, Vector128<T> data, byte index) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector256<T> InsertVector128<T>(Vector256<T> value, Vector128<T> data, byte index) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m256i _mm256_insertf128_si256 (__m256i a, __m128i b, int imm8)
@@ -763,7 +763,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_permute2f128_si256 (__m256i a, __m256i b, int imm8)
         ///   VPERM2F128 ymm, ymm, ymm/m256, imm8
         /// </summary>
-        public static Vector256<T> Permute2x128<T>(Vector256<T> left, Vector256<T> right, byte control) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector256<T> Permute2x128<T>(Vector256<T> left, Vector256<T> right, byte control) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128 _mm_permutevar_ps (__m128 a, __m128i b)
@@ -915,7 +915,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256d _mm256_set1_pd (double a)
         ///   HELPER
         /// </summary>
-        public static Vector256<T> SetAllVector256<T>(T value) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector256<T> SetAllVector256<T>(T value) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m256 _mm256_set_m128 (__m128 hi, __m128 lo)
@@ -925,7 +925,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_set_m128i (__m128i hi, __m128i lo)
         ///   HELPER
         /// </summary>
-        public static Vector256<T> SetHighLow<T>(Vector128<T> hi, Vector128<T> lo) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector256<T> SetHighLow<T>(Vector128<T> hi, Vector128<T> lo) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m256i _mm256_setzero_si256 (void)
@@ -935,7 +935,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256d _mm256_setzero_pd (void)
         ///   HELPER
         /// </summary>
-        public static Vector256<T> SetZeroVector256<T>() where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector256<T> SetZeroVector256<T>() where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m256 _mm256_shuffle_ps (__m256 a, __m256 b, const int imm8)
@@ -973,7 +973,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256 _mm256_castsi256_ps (__m256i a)
         ///   HELPER - No Codegen
         /// </summary>
-        public static Vector256<U> StaticCast<T, U>(Vector256<T> value) where T : struct where U : struct { throw new PlatformNotSupportedException(); }
+        public static Vector256<U> StaticCast<T, U>(Vector256<T> value) where T : unmanaged where U : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void _mm256_store_si256 (__m256i * mem_addr, __m256i a)
@@ -1158,7 +1158,7 @@ namespace System.Runtime.Intrinsics.X86
         /// int _mm256_testc_pd (__m256d a, __m256d b)
         ///   VTESTPS ymm, ymm/m256
         /// </summary>
-        public static bool TestC<T>(Vector256<T> left, Vector256<T> right) where T : struct { throw new PlatformNotSupportedException(); }
+        public static bool TestC<T>(Vector256<T> left, Vector256<T> right) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_testnzc_ps (__m128 a, __m128 b)
@@ -1179,7 +1179,7 @@ namespace System.Runtime.Intrinsics.X86
         /// int _mm256_testnzc_pd (__m256d a, __m256d b)
         ///   VTESTPD ymm, ymm/m256
         /// </summary>
-        public static bool TestNotZAndNotC<T>(Vector256<T> left, Vector256<T> right) where T : struct { throw new PlatformNotSupportedException(); }
+        public static bool TestNotZAndNotC<T>(Vector256<T> left, Vector256<T> right) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_testz_ps (__m128 a, __m128 b)
@@ -1200,7 +1200,7 @@ namespace System.Runtime.Intrinsics.X86
         /// int _mm256_testz_pd (__m256d a, __m256d b)
         ///   VTESTPD ymm, ymm/m256
         /// </summary>
-        public static bool TestZ<T>(Vector256<T> left, Vector256<T> right) where T : struct { throw new PlatformNotSupportedException(); }
+        public static bool TestZ<T>(Vector256<T> left, Vector256<T> right) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m256 _mm256_unpackhi_ps (__m256 a, __m256 b)

--- a/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx.cs
@@ -371,7 +371,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128i _mm256_extractf128_si256 (__m256i a, const int imm8)
         ///   VEXTRACTF128 xmm/m128, ymm, imm8
         /// </summary>
-        public static Vector128<T> ExtractVector128<T>(Vector256<T> value, byte index) where T : struct
+        public static Vector128<T> ExtractVector128<T>(Vector256<T> value, byte index) where T : unmanaged
         {
             return ExtractVector128<T>(value, index);
         }
@@ -435,7 +435,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_castsi128_si256 (__m128i a)
         ///   HELPER - No Codegen
         /// </summary>
-        public static Vector256<T> ExtendToVector256<T>(Vector128<T> value) where T : struct
+        public static Vector256<T> ExtendToVector256<T>(Vector128<T> value) where T : unmanaged
         {
             return ExtendToVector256<T>(value);
         }
@@ -459,7 +459,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128i _mm256_castsi256_si128 (__m256i a)
         ///   HELPER - No Codegen
         /// </summary>
-        public static Vector128<T> GetLowerHalf<T>(Vector256<T> value) where T : struct
+        public static Vector128<T> GetLowerHalf<T>(Vector256<T> value) where T : unmanaged
         {
             return GetLowerHalf<T>(value);
         }
@@ -622,7 +622,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_insertf128_si256 (__m256i a, __m128i b, int imm8)
         ///   VINSERTF128 ymm, ymm, xmm/m128, imm8
         /// </summary>
-        public static Vector256<T> InsertVector128<T>(Vector256<T> value, Vector128<T> data, byte index) where T : struct
+        public static Vector256<T> InsertVector128<T>(Vector256<T> value, Vector128<T> data, byte index) where T : unmanaged
         {
             return InsertVector128<T>(value, data, index);
         }
@@ -950,7 +950,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_permute2f128_si256 (__m256i a, __m256i b, int imm8)
         ///   VPERM2F128 ymm, ymm, ymm/m256, imm8
         /// </summary>
-        public static Vector256<T> Permute2x128<T>(Vector256<T> left, Vector256<T> right, byte control) where T : struct
+        public static Vector256<T> Permute2x128<T>(Vector256<T> left, Vector256<T> right, byte control) where T : unmanaged
         {
             return Permute2x128<T>(left, right, control);
         }
@@ -1105,7 +1105,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256d _mm256_set1_pd (double a)
         ///   HELPER
         /// </summary>
-        public static Vector256<T> SetAllVector256<T>(T value) where T : struct
+        public static Vector256<T> SetAllVector256<T>(T value) where T : unmanaged
         {
             return SetAllVector256<T>(value);
         }
@@ -1118,7 +1118,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_set_m128i (__m128i hi, __m128i lo)
         ///   HELPER
         /// </summary>
-        public static Vector256<T> SetHighLow<T>(Vector128<T> hi, Vector128<T> lo) where T : struct
+        public static Vector256<T> SetHighLow<T>(Vector128<T> hi, Vector128<T> lo) where T : unmanaged
         {
             return SetHighLow<T>(hi, lo);
         }
@@ -1131,7 +1131,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256d _mm256_setzero_pd (void)
         ///   HELPER
         /// </summary>
-        public static Vector256<T> SetZeroVector256<T>() where T : struct
+        public static Vector256<T> SetZeroVector256<T>() where T : unmanaged
         {
             return SetZeroVector256<T>();
         }
@@ -1172,7 +1172,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256 _mm256_castsi256_ps (__m256i a)
         ///   HELPER - No Codegen
         /// </summary>
-        public static Vector256<U> StaticCast<T, U>(Vector256<T> value) where T : struct where U : struct
+        public static Vector256<U> StaticCast<T, U>(Vector256<T> value) where T : unmanaged where U : unmanaged
         {
             return StaticCast<T, U>(value);
         }
@@ -1360,7 +1360,7 @@ namespace System.Runtime.Intrinsics.X86
         /// int _mm256_testc_pd (__m256d a, __m256d b)
         ///   VTESTPS ymm, ymm/m256
         /// </summary>
-        public static bool TestC<T>(Vector256<T> left, Vector256<T> right) where T : struct
+        public static bool TestC<T>(Vector256<T> left, Vector256<T> right) where T : unmanaged
         {
             return TestC<T>(left, right);
         }
@@ -1384,7 +1384,7 @@ namespace System.Runtime.Intrinsics.X86
         /// int _mm256_testnzc_pd (__m256d a, __m256d b)
         ///   VTESTPD ymm, ymm/m256
         /// </summary>
-        public static bool TestNotZAndNotC<T>(Vector256<T> left, Vector256<T> right) where T : struct
+        public static bool TestNotZAndNotC<T>(Vector256<T> left, Vector256<T> right) where T : unmanaged
         {
             return TestNotZAndNotC<T>(left, right);
         }
@@ -1408,7 +1408,7 @@ namespace System.Runtime.Intrinsics.X86
         /// int _mm256_testz_pd (__m256d a, __m256d b)
         ///   VTESTPD ymm, ymm/m256
         /// </summary>
-        public static bool TestZ<T>(Vector256<T> left, Vector256<T> right) where T : struct
+        public static bool TestZ<T>(Vector256<T> left, Vector256<T> right) where T : unmanaged
         {
             return TestZ<T>(left, right);
         }

--- a/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx2.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx2.PlatformNotSupported.cs
@@ -248,7 +248,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128d _mm_broadcastsd_pd (__m128d a)
         ///   VMOVDDUP xmm, xmm
         /// </summary>
-        public static Vector128<T> BroadcastScalarToVector128<T>(Vector128<T> value) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> BroadcastScalarToVector128<T>(Vector128<T> value) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m256i _mm256_broadcastb_epi8 (__m128i a)
@@ -264,7 +264,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256d _mm256_broadcastsd_pd (__m128d a)
         ///   VBROADCASTSD ymm, xmm
         /// </summary>
-        public static Vector256<T> BroadcastScalarToVector256<T>(Vector128<T> value) where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector256<T> BroadcastScalarToVector256<T>(Vector128<T> value) where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m256i _mm256_broadcastsi128_si256 (__m128i a)

--- a/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx2.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx2.cs
@@ -248,7 +248,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128d _mm_broadcastsd_pd (__m128d a)
         ///   VMOVDDUP xmm, xmm
         /// </summary>
-        public static Vector128<T> BroadcastScalarToVector128<T>(Vector128<T> value) where T : struct
+        public static Vector128<T> BroadcastScalarToVector128<T>(Vector128<T> value) where T : unmanaged
         {
             return BroadcastScalarToVector128<T>(value);
         }
@@ -267,7 +267,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256d _mm256_broadcastsd_pd (__m128d a)
         ///   VBROADCASTSD ymm, xmm
         /// </summary>
-        public static Vector256<T> BroadcastScalarToVector256<T>(Vector128<T> value) where T : struct
+        public static Vector256<T> BroadcastScalarToVector256<T>(Vector128<T> value) where T : unmanaged
         {
             return BroadcastScalarToVector256<T>(value);
         }

--- a/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse.PlatformNotSupported.cs
@@ -501,7 +501,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128 _mm_castsi128_ps (__m128i a)
         ///   HELPER - No Codegen
         /// </summary>
-        public static Vector128<U> StaticCast<T, U>(Vector128<T> value) where T : struct where U : struct { throw new PlatformNotSupportedException(); }
+        public static Vector128<U> StaticCast<T, U>(Vector128<T> value) where T : unmanaged where U : unmanaged { throw new PlatformNotSupportedException(); }
 
 
         /// <summary>

--- a/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse.cs
@@ -524,7 +524,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128 _mm_castsi128_ps (__m128i a)
         ///   HELPER - No Codegen
         /// </summary>
-        public static Vector128<U> StaticCast<T, U>(Vector128<T> value) where T : struct where U : struct
+        public static Vector128<U> StaticCast<T, U>(Vector128<T> value) where T : unmanaged where U : unmanaged
         {
             return StaticCast<T, U>(value);
         }

--- a/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse2.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse2.PlatformNotSupported.cs
@@ -1071,7 +1071,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128d _mm_setzero_pd (void)
         ///   HELPER: XORPD
         /// </summary>
-        public static Vector128<T> SetZeroVector128<T>() where T : struct { throw new PlatformNotSupportedException(); }
+        public static Vector128<T> SetZeroVector128<T>() where T : unmanaged { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm_sad_epu8 (__m128i a,  __m128i b)

--- a/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse2.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse2.cs
@@ -1307,7 +1307,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128d _mm_setzero_pd (void)
         ///   HELPER: XORPD
         /// </summary>
-        public static Vector128<T> SetZeroVector128<T>() where T : struct
+        public static Vector128<T> SetZeroVector128<T>() where T : unmanaged
         {
             return SetZeroVector128<T>();
         }


### PR DESCRIPTION
FYI. @CarolEidt, @fiigii, @sdmaclea, @eerhardt, @jkotas 

This is mostly just for discussion right now, since the actual change can't be merged until after the branch opens again.

This is a new (and unshipped API) so back-compat should not be a concern here. However, there are some potential other issues with this change:
* The `unmanaged` constraint uses a `modreq` on the constraint, there are several known places where tools won't respect this
* The `modreq` also prevents compiler versions prior to C# 7.3 from consuming these APIs.

Some of the benefits are:
* The constraint is more accurate (but still not perfect)
* You can use unsafe operations with these types
  * This includes both unsafe operations that can and cannot be done with `System.Runtime.CompilerServices.Unsafe`
  * Examples of things not possible with a shim API include stackalloc and bypassing definite assignment rules