### PR TITLE
Handle getTailCallCopyArgsThunk returning NULL in the JIT

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4938,7 +4938,7 @@ private:
     GenTree* fgMorphField(GenTree* tree, MorphAddrContext* mac);
     bool fgCanFastTailCall(GenTreeCall* call);
     bool fgCheckStmtAfterTailCall();
-    void fgMorphTailCall(GenTreeCall* call);
+    void fgMorphTailCall(GenTreeCall* call, void* pfnCopyArgs);
     GenTree* fgGetStubAddrArg(GenTreeCall* call);
     void fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCall* recursiveTailCall);
     GenTree* fgAssignRecursiveCallArgToCallerParam(GenTree*       arg,

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -13700,7 +13700,7 @@ void* CEEInfo::getTailCallCopyArgsThunk(CORINFO_SIG_INFO       *pSig,
 
     void * ftn = NULL;
 
-#if defined(_TARGET_AMD64_) || defined(_TARGET_ARM_)
+#if (defined(_TARGET_AMD64_) || defined(_TARGET_ARM_)) && !defined(FEATURE_PAL)
 
     JIT_TO_EE_TRANSITION();
 
@@ -13710,7 +13710,7 @@ void* CEEInfo::getTailCallCopyArgsThunk(CORINFO_SIG_INFO       *pSig,
 
     EE_TO_JIT_TRANSITION();
 
-#endif // _TARGET_AMD64_ || _TARGET_ARM_
+#endif // (_TARGET_AMD64_ || _TARGET_ARM_) && !FEATURE_PAL
 
     return ftn;
 }


### PR DESCRIPTION
This saves the JIT from hardcoding the logic on where getTailCallCopyArgsThunk is implemented