### PR TITLE
Fix GC tests.

### DIFF
--- a/tests/src/GC/Scenarios/DoublinkList/dlbigleak.cs
+++ b/tests/src/GC/Scenarios/DoublinkList/dlbigleak.cs
@@ -12,6 +12,7 @@
 
 namespace DoubLink {
     using System;
+    using System.Runtime.CompilerServices;
 
     public class DLBigLeak
     {
@@ -65,13 +66,7 @@ namespace DoubLink {
 
         public bool runTest(int iRep, int iObj)
         {
-            Mv_Doub = new DoubLink[iRep];
-            for(int i=0; i<10; i++)
-            {
-                SetLink(iRep, iObj);
-                MakeLeak(iRep);
-                GC.Collect();
-            }
+            CreateDLinkListsWithLeak(iRep, iObj, 10);
 
             GC.Collect();
             GC.WaitForPendingFinalizers();
@@ -82,6 +77,21 @@ namespace DoubLink {
             Console.Write(DLinkNode.FinalCount);
             Console.WriteLine(" DLinkNodes finalized");
             return (DLinkNode.FinalCount==iRep*iObj*10);
+        }
+
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        // Do not inline the method that creates GC objects, because it could
+        // extend their live intervals until the end of the parent method.
+        public void CreateDLinkListsWithLeak(int iRep, int iObj, int iters)
+        {
+            Mv_Doub = new DoubLink[iRep];
+            for (int i = 0; i < iters; i++)
+            {
+                SetLink(iRep, iObj);
+                MakeLeak(iRep);
+                GC.Collect();
+            }
         }
 
 

--- a/tests/src/GC/Scenarios/DoublinkList/dlbigleakthd.cs
+++ b/tests/src/GC/Scenarios/DoublinkList/dlbigleakthd.cs
@@ -13,6 +13,7 @@ namespace DoubLink {
     using System.Threading;
     using System;
     using System.IO;
+    using System.Runtime.CompilerServices;
 
     public class DLBigLeakThd
     {
@@ -85,6 +86,23 @@ namespace DoubLink {
 
         public bool runTest(int iRep, int iObj, int iThd)
         {
+            CreateDLinkListsWithLeak(iRep, iObj, iThd, 20);
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            int goal = iRep*15*iThd*iObj+20*iRep*iObj;
+            Console.WriteLine("{0}/{1} DLinkNodes finalized", DLinkNode.FinalCount, goal);
+            return (DLinkNode.FinalCount==goal);
+        }
+
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        // Do not inline the method that creates GC objects, because it could
+        // extend their live intervals until the end of the parent method.
+        public void CreateDLinkListsWithLeak(int iRep, int iObj, int iThd, int iters)
+        {
             this.iRep = iRep;
             this.iObj = iObj;
             Mv_Doub = new DoubLink[iRep];
@@ -94,7 +112,7 @@ namespace DoubLink {
                 Mv_Thread[i] = new Thread(new ThreadStart(this.ThreadStart));
                 Mv_Thread[i].Start( );
             }
-            for(int i=0; i<20; i++)
+            for (int i = 0; i < iters; i++)
             {
                 SetLink(iRep, iObj);
                 MakeLeak(iRep);
@@ -103,15 +121,7 @@ namespace DoubLink {
             {
                 Mv_Thread[i].Join();
             }
-
             Mv_Doub = null;
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
-
-            int goal = iRep*15*iThd*iObj+20*iRep*iObj;
-            Console.WriteLine("{0}/{1} DLinkNodes finalized", DLinkNode.FinalCount, goal);
-            return (DLinkNode.FinalCount==goal);
         }
 
 

--- a/tests/src/GC/Scenarios/DoublinkList/dlcollect.cs
+++ b/tests/src/GC/Scenarios/DoublinkList/dlcollect.cs
@@ -93,15 +93,9 @@ namespace DoubLink {
 
         public bool runTest(int iRep, int iObj)
         {
+            CreateDLinkListsWithLeak(iRep, iObj, 10);
 
-            Mv_Collect = new List<DoubLink>(iRep);
             bool success = false;
-            for(int i=0; i <10; i++)
-            {
-                SetLink(iRep, iObj);
-                Mv_Collect.RemoveRange(0, Mv_Collect.Count);
-                GC.Collect();
-            }
 
             if (DrainFinalizerQueue(iRep, iObj))
             {
@@ -110,6 +104,21 @@ namespace DoubLink {
 
             Console.WriteLine("{0} DLinkNodes finalized", DLinkNode.FinalCount);
             return success;
+        }
+
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        // Do not inline the method that creates GC objects, because it could
+        // extend their live intervals until the end of the parent method.
+        public void CreateDLinkListsWithLeak(int iRep, int iObj, int iters)
+        {
+            Mv_Collect = new List<DoubLink>(iRep);
+            for(int i = 0; i < iters; i++)
+            {
+                SetLink(iRep, iObj);
+                Mv_Collect.RemoveRange(0, Mv_Collect.Count);
+                GC.Collect();
+            }
         }
 
 

--- a/tests/src/GC/Scenarios/DoublinkList/dlstack.cs
+++ b/tests/src/GC/Scenarios/DoublinkList/dlstack.cs
@@ -94,7 +94,7 @@ namespace DoubLink {
 
         public bool runTest(int iRep, int iObj)
         {
-            CreateDLinkListsWithLeak(iRep, iObj);
+            CreateDLinkListsWithLeak(iRep, iObj, 10);
 
             bool success = false;
             if (DrainFinalizerQueue(iRep, iObj))
@@ -111,9 +111,9 @@ namespace DoubLink {
         [MethodImpl(MethodImplOptions.NoInlining)]
         // Do not inline the method that creates GC objects, because it could 
         // extend their live intervals until the end of the parent method.
-        public void CreateDLinkListsWithLeak(int iRep, int iObj)
+        public void CreateDLinkListsWithLeak(int iRep, int iObj, int iters)
         {
-            for(int i=0; i <10; i++)
+            for(int i = 0; i < iters; i++)
             {
                 SetLink(iRep, iObj);
                 MakeLeak(iRep);

--- a/tests/src/GC/Scenarios/DoublinkList/doublinkgen.cs
+++ b/tests/src/GC/Scenarios/DoublinkList/doublinkgen.cs
@@ -91,8 +91,8 @@ namespace DoubLink {
 
         public bool runTest(int iRep, int iObj)
         {
-            SetLink(iRep, iObj);
-            Mv_Doub = null;
+            CreateDLinkListsWithLeak(iRep, iObj);
+
             bool success = false;
 
             if (DrainFinalizerQueue(iRep, iObj))
@@ -104,6 +104,18 @@ namespace DoubLink {
             Console.WriteLine(" DLinkNodes finalized");
             return success;
 
+        }
+
+
+        
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        // Do not inline the method that creates GC objects, because it could 
+        // extend their live intervals until the end of the parent method.
+        public void CreateDLinkListsWithLeak(int iRep, int iObj)
+        {
+            SetLink(iRep, iObj);
+            Mv_Doub = null;
         }
 
 

--- a/tests/src/GC/Scenarios/DoublinkList/doublinknoleak.cs
+++ b/tests/src/GC/Scenarios/DoublinkList/doublinknoleak.cs
@@ -11,6 +11,7 @@
 namespace DoubLink {
     using System;
     using System.Collections.Generic;
+    using System.Runtime.CompilerServices;
 
     public class DoubLinkNoLeak
     {
@@ -62,13 +63,7 @@ namespace DoubLink {
 
         public bool runTest(int iRep, int iObj)
         {
-            for(int i=0; i<10; i++)
-            {
-                SetLink(iRep, iObj);
-            }
-
-            Mv_Doub = null;
-            Mv_Save = null;
+            CreateDLinkListsWithLeak(iRep, iObj, 10);
 
             GC.Collect();
             GC.WaitForPendingFinalizers();
@@ -77,6 +72,21 @@ namespace DoubLink {
             Console.WriteLine("{0} DLinkNodes finalized", DLinkNode.FinalCount);
             return (DLinkNode.FinalCount==iRep*iObj*10);
 
+        }
+
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        // Do not inline the method that creates GC objects, because it could
+        // extend their live intervals until the end of the parent method.
+        public void CreateDLinkListsWithLeak(int iRep, int iObj, int iters)
+        {
+            for(int i = 0; i < iters; i++)
+            {
+                SetLink(iRep, iObj);
+            }
+
+            Mv_Doub = null;
+            Mv_Save = null;
         }
 
 

--- a/tests/src/GC/Scenarios/DoublinkList/doublinkstay.cs
+++ b/tests/src/GC/Scenarios/DoublinkList/doublinkstay.cs
@@ -13,6 +13,7 @@
 
 namespace DoubLink {
     using System;
+    using System.Runtime.CompilerServices;
 
     public class DoubLinkStay
     {
@@ -63,13 +64,7 @@ namespace DoubLink {
 
         public bool runTest(int iRep, int iObj)
         {
-            Mv_Doub = new DoubLink[iRep];
-            for(int i=0; i<20; i++)
-            {
-                SetLink(iRep, iObj);
-                MakeLeak(iRep);
-            }
-
+            CreateDLinkListsWithLeak(iRep, iObj, 20);
 
             GC.Collect();
             GC.WaitForPendingFinalizers();
@@ -81,6 +76,20 @@ namespace DoubLink {
             Console.WriteLine(" DLinkNodes finalized");
             return (DLinkNode.FinalCount==iRep*iObj*20);
 
+        }
+
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        // Do not inline the method that creates GC objects, because it could
+        // extend their live intervals until the end of the parent method.
+        public void CreateDLinkListsWithLeak(int iRep, int iObj, int iters)
+        {
+            Mv_Doub = new DoubLink[iRep];
+            for(int i = 0; i < iters; i++)
+            {
+                SetLink(iRep, iObj);
+                MakeLeak(iRep);
+            }
         }
 
         public void SetLink(int iRep, int iObj)


### PR DESCRIPTION
Jit can extend lifetime of temp objects after call to GC.Collect(), so we should not have any temp in the same scope with final `GC.Collect();`.

incorrect example 1:
```
var a = new Object(); // Jit can create a temp that will be alive after GC.Collect().
a = null;
GC.Collect();
GC.WaitForPendingFinalizers();
GC.Collect();
```

incorrect example 2:
```
SetLink();
GC.Collect();
GC.WaitForPendingFinalizers();
GC.Collect();

void SetLink() // this method could be inlined, we will get the first example.
{
       var a = new Object();
       a = null;
}
```

Incorrect example 3:
```
var a = SetLink(); // Jit can create a temp here with a long lifetime.
a = null;
GC.Collect();
GC.WaitForPendingFinalizers();
GC.Collect();

[MethodImpl(MethodImplOptions.NoInlining)]
Object SetLink()
{
       return new Object();
}
```

correct example 1:
```
SetLink();
GC.Collect();
GC.WaitForPendingFinalizers();
GC.Collect();

[MethodImpl(MethodImplOptions.NoInlining)]
void SetLink() // All temps are in this method and it is protected with NoInlining attribute.
{
       var a = new Object();
       a = null;
}
```





Fixes #17588.

The same problem as #15156.