### PR TITLE
[1.1] Add missing fed28 and deb9 requirements

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -240,6 +240,9 @@ isMSBuildOnNETCoreSupported()
                 "debian.8-x64")
                     __isMSBuildOnNETCoreSupported=1
                     ;;
+                "debian.9-x64")
+                    __isMSBuildOnNETCoreSupported=1
+                    ;;
                 "fedora.23-x64")
                     __isMSBuildOnNETCoreSupported=1
                     ;;
@@ -247,6 +250,9 @@ isMSBuildOnNETCoreSupported()
                     __isMSBuildOnNETCoreSupported=1
                     ;;
                 "fedora.27-x64")
+                    __isMSBuildOnNETCoreSupported=1
+                    ;;
+                "fedora.28-x64")
                     __isMSBuildOnNETCoreSupported=1
                     ;;
                 "opensuse.13.2-x64")

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -112,7 +112,8 @@ if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
     fi
 
     # Replace the binaries restored by the tool runtime script with the portable binaries
-    if [ "$__PKG_RID" == "linux" ]; then
+    if [ "$__DISTRO_NAME" == 'fedora.28' ] ||
+        [ "$__DISTRO_NAME" == 'debian.9' ]; then
          cp -r $__DOTNET_PATH/shared/Microsoft.NETCore.App/*/* $__TOOLRUNTIME_DIR
     fi
 


### PR DESCRIPTION
- Adds some tags necessary to produce managed components of the build for fed28 and deb9
- Makes the tool-runtime CLI override only happen on platforms where it's required.