### PR TITLE
Clean up FlushInstructionCache for precodes and interlocked target change operations

### DIFF
--- a/src/vm/i386/stublinkerx86.cpp
+++ b/src/vm/i386/stublinkerx86.cpp
@@ -6828,8 +6828,10 @@ BOOL ThisPtrRetBufPrecode::SetTargetInterlocked(TADDR target, TADDR expected)
     _ASSERTE(m_rel32 == REL32_JMP_SELF);
 
     // Use pMD == NULL to allocate the jump stub in non-dynamic heap that has the same lifetime as the precode itself
-    m_rel32 = rel32UsingJumpStub(&m_rel32, target, NULL /* pMD */, ((MethodDesc *)GetMethodDesc())->GetLoaderAllocatorForCode());
+    INT32 newRel32 = rel32UsingJumpStub(&m_rel32, target, NULL /* pMD */, ((MethodDesc *)GetMethodDesc())->GetLoaderAllocatorForCode());
 
+    _ASSERTE(IS_ALIGNED(&m_rel32, sizeof(INT32)));
+    FastInterlockExchange((LONG *)&m_rel32, (LONG)newRel32);
     return TRUE;
 }
 #endif // !DACCESS_COMPILE

--- a/src/vm/i386/stublinkerx86.h
+++ b/src/vm/i386/stublinkerx86.h
@@ -546,7 +546,7 @@ struct StubPrecode {
         CONTRACTL_END;
 
         EnsureWritableExecutablePages(&m_rel32);
-        return rel32SetInterlocked(&m_rel32, GetPreStubEntryPoint(), (MethodDesc*)GetMethodDesc());
+        rel32SetInterlocked(&m_rel32, GetPreStubEntryPoint(), (MethodDesc*)GetMethodDesc());
     }
 
     BOOL SetTargetInterlocked(TADDR target, TADDR expected)

--- a/src/vm/precode.cpp
+++ b/src/vm/precode.cpp
@@ -448,6 +448,9 @@ void Precode::ResetTargetInterlocked()
             UnexpectedPrecodeType("Precode::ResetTargetInterlocked", precodeType);
             break;
     }
+
+    // Although executable code is modified on x86/x64, a FlushInstructionCache() is not necessary on those platforms due to the
+    // interlocked operation above (see ClrFlushInstructionCache())
 }
 
 BOOL Precode::SetTargetInterlocked(PCODE target, BOOL fOnlyRedirectFromPrestub)
@@ -492,15 +495,8 @@ BOOL Precode::SetTargetInterlocked(PCODE target, BOOL fOnlyRedirectFromPrestub)
         break;
     }
 
-    //
-    // SetTargetInterlocked does not modify code on ARM so the flush instruction cache is
-    // not necessary.
-    //
-#if !defined(_TARGET_ARM_) && !defined(_TARGET_ARM64_)
-    if (ret) {
-        FlushInstructionCache(GetCurrentProcess(),this,SizeOf());
-    }
-#endif
+    // Although executable code is modified on x86/x64, a FlushInstructionCache() is not necessary on those platforms due to the
+    // interlocked operation above (see ClrFlushInstructionCache())
 
     _ASSERTE(!IsPointingToPrestub());
     return ret;
@@ -512,7 +508,7 @@ void Precode::Reset()
 
     MethodDesc* pMD = GetMethodDesc();
     Init(GetType(), pMD, pMD->GetLoaderAllocatorForCode());
-    FlushInstructionCache(GetCurrentProcess(),this,SizeOf());
+    ClrFlushInstructionCache(this, SizeOf());
 }
 
 /* static */ 


### PR DESCRIPTION
Updated based on discussion below

~~Add missing FlushInstructionCache to ResetTargetInterlocked~~

~~Not sure if it's necessary considering the interlocked operation, but it's there in Precode::SetTargetInterlocked so I assume it's necessary. Probably no issue anyway, it's unlikely that call counting won't be done as a result of the instruction cache. No change to perf on JitBench with tiering enabled. On arm32 and arm64 executable code is not changed, so no need for the flush there.~~