### PR TITLE
[1.1] Fix Debian packaging bug.

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -112,9 +112,8 @@ if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
     fi
 
     # Replace the binaries restored by the tool runtime script with the portable binaries
-    if [ "$__DISTRO_NAME" == 'fedora.28' ] ||
-        [ "$__DISTRO_NAME" == 'debian.9' ]; then
-         cp -r $__DOTNET_PATH/shared/Microsoft.NETCore.App/*/* $__TOOLRUNTIME_DIR
+    if [ "$__DISTRO_NAME" == 'debian.9' ]; then
+         cp -r $__DOTNET_PATH/shared/Microsoft.NETCore.App/*/System.Security.Cryptography.X509Certificates.dll $__TOOLRUNTIME_DIR
     fi
 
     touch $__INIT_TOOLS_DONE_MARKER

--- a/src/.nuget/Microsoft.NETCore.ILAsm/debian/8/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/debian/8/Microsoft.NETCore.ILAsm.pkgproj
@@ -19,7 +19,7 @@
     <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
     <File Include="@(ArchitectureSpecificNativeSymbol)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
       <IsSymbolFile>true</IsSymbolFile>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/debian/9/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/debian/9/Microsoft.NETCore.ILAsm.pkgproj
@@ -19,7 +19,7 @@
     <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
     <File Include="@(ArchitectureSpecificNativeSymbol)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
       <IsSymbolFile>true</IsSymbolFile>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/debian/8/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/debian/8/Microsoft.NETCore.ILDAsm.pkgproj
@@ -19,7 +19,7 @@
     <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
     <File Include="@(ArchitectureSpecificNativeSymbol)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
       <IsSymbolFile>true</IsSymbolFile>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/debian/9/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/debian/9/Microsoft.NETCore.ILDAsm.pkgproj
@@ -19,7 +19,7 @@
     <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
     <File Include="@(ArchitectureSpecificNativeSymbol)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
       <IsSymbolFile>true</IsSymbolFile>

--- a/src/.nuget/Microsoft.NETCore.Jit/debian/8/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/debian/8/Microsoft.NETCore.Jit.pkgproj
@@ -19,7 +19,7 @@
     <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
     <File Include="@(ArchitectureSpecificNativeSymbol)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
       <IsSymbolFile>true</IsSymbolFile>

--- a/src/.nuget/Microsoft.NETCore.Jit/debian/9/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/debian/9/Microsoft.NETCore.Jit.pkgproj
@@ -19,7 +19,7 @@
     <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
     <File Include="@(ArchitectureSpecificNativeSymbol)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
       <IsSymbolFile>true</IsSymbolFile>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/debian/8/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/debian/8/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -46,7 +46,7 @@
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\sosdocsunix.txt" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\crossgen" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
     <File Include="@(ArchitectureSpecificNativeSymbol)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
       <IsSymbolFile>true</IsSymbolFile>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/debian/9/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/debian/9/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -46,7 +46,7 @@
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\sosdocsunix.txt" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\crossgen" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
     <File Include="@(ArchitectureSpecificNativeSymbol)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
       <IsSymbolFile>true</IsSymbolFile>

--- a/src/.nuget/Microsoft.NETCore.TestHost/debian/8/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.TestHost/debian/8/Microsoft.NETCore.TestHost.pkgproj
@@ -19,7 +19,7 @@
     <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
     <File Include="@(ArchitectureSpecificNativeSymbol)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
       <IsSymbolFile>true</IsSymbolFile>

--- a/src/.nuget/Microsoft.NETCore.TestHost/debian/9/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.TestHost/debian/9/Microsoft.NETCore.TestHost.pkgproj
@@ -19,7 +19,7 @@
     <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
     <File Include="@(ArchitectureSpecificNativeSymbol)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
       <IsSymbolFile>true</IsSymbolFile>


### PR DESCRIPTION
- Fixes packaging for Debian8 and Debian9
- Further narrows down the scope of tool-runtime replacement with restored dotnetcli to only Debian9 and only the x509certififactes assembly.