### PR TITLE
fix build.cmd generateLayout

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -738,7 +738,7 @@ if %__BuildTests% EQU 1 (
     REM TODO, remove once the toolset is open.
     if not "%__ToolsetDir%" == "" call :PrivateToolSet
 
-    set NEXTCMD=call %__ProjectDir%\test\runtest.cmd %__BuildArch% %__BuildType% GenerateLayoutOnly %__UnprocessedBuildArgs%
+    set NEXTCMD=call %__ProjectDir%\tests\runtest.cmd %__BuildArch% %__BuildType% GenerateLayoutOnly %__UnprocessedBuildArgs%
     echo %__MsgPrefix%!NEXTCMD!
     !NEXTCMD!
 


### PR DESCRIPTION
output before:
```
build.cmd x64 debug skiptests generatelayout
C:\git\coreclr>call C:\git\coreclr\test\runtest.cmd x64 Debug GenerateLayoutOnly
The system cannot find the path specified.
```

PTAL @tannergooding, @jashook.
cc @dotnet/jit-contrib 

@tannergooding, Is it a typo? Did it work in #15673?