### PR TITLE
Ensure thumb bit is set when searching for debugger jit info on ARM

### DIFF
--- a/src/debug/ee/functioninfo.cpp
+++ b/src/debug/ee/functioninfo.cpp
@@ -1580,6 +1580,13 @@ DebuggerJitInfo *DebuggerMethodInfo::FindOrCreateInitAndAddJitInfo(MethodDesc* f
         _ASSERTE(g_pEEInterface->GetNativeCodeMethodDesc(startAddr) == fd);
     }
 
+#ifdef _TARGET_ARM_
+    if (startAddr != NULL)
+    {
+        startAddr |= THUMB_CODE;
+    }
+#endif
+
     // Check the lsit to see if we've already populated an entry for this JitInfo.
     // If we didn't have a JitInfo before, lazily create it now.
     // We don't care if we were prejitted or not.


### PR DESCRIPTION
This ensures that the ARM thumb bit is set on ARM platforms when searching for _DebuggerJitInfo_ in DebuggerMethodInfo::FindOrCreateInitAndAddJitInfo.

When adding breakpoints the thumb bit **is** set, where here wasn't, leading to two instances of _DebuggerJitInfo_ being created for the same underlying code in certain circumstances. This can then lead to multiple patches being applied to the same code when creating breakpoints, ending in the created breakpoint being hit twice. 