### PR TITLE
[arm32] Disable corefx Microsoft.Win32.SystemEvents.Tests

### DIFF
--- a/tests/arm/corefx_test_exclusions.txt
+++ b/tests/arm/corefx_test_exclusions.txt
@@ -1,4 +1,5 @@
 Microsoft.Win32.Registry.Tests
+Microsoft.Win32.SystemEvents.Tests # https://github.com/dotnet/coreclr/issues/17582
 System.Console.Tests
 System.Data.SqlClient.Tests
 System.Diagnostics.Process.Tests


### PR DESCRIPTION
Tracking bug: https://github.com/dotnet/corefx/issues/29166