### PR TITLE
increase timeout for debug jobs

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -802,8 +802,8 @@ def static setJobTimeout(newJob, isPR, architecture, configuration, scenario, is
     }
 
     if (configuration == 'Debug') {
-        // Debug runs can be very slow. Add an hour.
-        timeout += 60
+        // Debug runs can be very slow. Add 3 hours.
+        timeout += 180
     }
 
     if (architecture == 'x86_arm_altjit' || architecture == 'x64_arm64_altjit') {


### PR DESCRIPTION
Allow to get results from arm32 debug ubuntu build.

[arm_cross_debug_ubuntu_tst_prtest](https://ci.dot.net/job/dotnet_coreclr/job/master/job/arm_cross_debug_ubuntu_tst_prtest/) fails with timeout, it is not a single test that hangs because it can be aborted during different tests.

Our current timeout is 420 minutes and it allows to run ~10000 tests, so we need to be able to finish another 1000 test to make this green. 2 hours should be enough.