### PR TITLE
Enable Invoke and GetValue for ref-returning members

### DIFF
--- a/src/dlls/mscorrc/mscorrc.rc
+++ b/src/dlls/mscorrc/mscorrc.rc
@@ -1538,6 +1538,7 @@ BEGIN
 
     IDS_EE_TORNSTATE                        "Unexpected change made to file '%1'."
 
+    IDS_INVOKE_NULLREF_RETURNED             "The target method returned a null reference."
 END
 
 // These strings are generated from within the EE for streams

--- a/src/dlls/mscorrc/resource.h
+++ b/src/dlls/mscorrc/resource.h
@@ -898,3 +898,5 @@
 #define IDS_EE_NDIRECT_LOADLIB_MAC                 0x263f
 #define IDS_EE_NDIRECT_GETPROCADDRESS_UNIX         0x2640
 #define IDS_EE_ERROR_COM                           0x2641
+
+#define IDS_INVOKE_NULLREF_RETURNED             0x2642

--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -2935,8 +2935,8 @@
   <data name="NotSupported_ByRefLikeArray" xml:space="preserve">
     <value>Cannot create arrays of ByRef-like values.</value>
   </data>
-  <data name="NotSupported_ByRefReturn" xml:space="preserve">
-    <value>ByRef return value not supported in reflection invocation.</value>
+  <data name="NotSupported_ByRefToByRefLikeReturn" xml:space="preserve">
+    <value>ByRef to ByRefLike return values not supported in reflection invocation.</value>
   </data>
   <data name="NotSupported_CallToVarArg" xml:space="preserve">
     <value>Vararg calling convention not supported.</value>

--- a/src/mscorlib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -443,10 +443,10 @@ namespace System.Reflection
             {
                 throw new MemberAccessException();
             }
-            // ByRef return are not allowed in reflection
-            else if (ReturnType.IsByRef)
+            // ByRef to ByRefLike returns are not allowed in reflection
+            else if (ReturnType.IsByRef && ReturnType.GetElementType().IsByRefLike)
             {
-                throw new NotSupportedException(SR.NotSupported_ByRefReturn);
+                throw new NotSupportedException(SR.NotSupported_ByRefToByRefLikeReturn);
             }
 
             throw new TargetException();

--- a/src/mscorlib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -41,7 +41,7 @@ namespace System.Reflection
                     //
                     // first take care of all the NO_INVOKE cases. 
                     if (ContainsGenericParameters ||
-                         ReturnType.IsByRef ||
+                         (ReturnType.IsByRef && ReturnType.GetElementType().IsByRefLike) ||
                          (declaringType != null && declaringType.ContainsGenericParameters) ||
                          ((CallingConvention & CallingConventions.VarArgs) == CallingConventions.VarArgs))
                     {

--- a/src/vm/invokeutil.cpp
+++ b/src/vm/invokeutil.cpp
@@ -653,8 +653,8 @@ void InvokeUtil::ValidField(TypeHandle th, OBJECTREF* value)
 // CreateObjectAfterInvoke
 // This routine will create the specified object from the value returned by the Invoke target. 
 //
-// This does not handle the ELEMENT_TYPE_VALUETYPE case. There is no way for this function to handle that case in a GC-safe way.
-// The caller must preallocate the box object and copy the value type into it afterward.
+// This does not handle the ELEMENT_TYPE_VALUETYPE case. The caller must preallocate the box object and
+// copy the value type into it afterward.
 //
 OBJECTREF InvokeUtil::CreateObjectAfterInvoke(TypeHandle th, void * pValue) {
     CONTRACTL {
@@ -733,8 +733,6 @@ OBJECTREF InvokeUtil::CreateObjectAfterInvoke(TypeHandle th, void * pValue) {
         }
         break;
     
-    case ELEMENT_TYPE_BYREF:
-        COMPlusThrow(kNotSupportedException, W("NotSupported_ByRefReturn"));
     case ELEMENT_TYPE_END:
     default:
         _ASSERTE(!"Unknown Type");

--- a/src/vm/invokeutil.cpp
+++ b/src/vm/invokeutil.cpp
@@ -649,9 +649,14 @@ void InvokeUtil::ValidField(TypeHandle th, OBJECTREF* value)
         COMPlusThrow(kArgumentException,W("Arg_ObjObj"));
 }
 
-// InternalCreateObject
-// This routine will create the specified object from the value
-OBJECTREF InvokeUtil::CreateObject(TypeHandle th, void * pValue) {
+//
+// CreateObjectAfterInvoke
+// This routine will create the specified object from the value returned by the Invoke target. 
+//
+// This does not handle the ELEMENT_TYPE_VALUETYPE case. There is no way for this function to handle that case in a GC-safe way.
+// The caller must preallocate the box object and copy the value type into it afterward.
+//
+OBJECTREF InvokeUtil::CreateObjectAfterInvoke(TypeHandle th, void * pValue) {
     CONTRACTL {
         THROWS;
         GC_TRIGGERS;
@@ -665,6 +670,9 @@ OBJECTREF InvokeUtil::CreateObject(TypeHandle th, void * pValue) {
     CorElementType type = th.GetSignatureCorElementType();
     MethodTable *pMT = NULL;
     OBJECTREF obj = NULL;
+
+    // WARNING: pValue can be an inner reference into a managed object and it is not protected from GC. You must do nothing that
+    // triggers a GC until the all the data it points to has been captured in a GC-protected location.
 
     // Handle the non-table types
     switch (type) {
@@ -682,12 +690,8 @@ OBJECTREF InvokeUtil::CreateObject(TypeHandle th, void * pValue) {
         goto PrimitiveType;
 
     case ELEMENT_TYPE_VALUETYPE:
-    {
-        _ASSERTE(!th.IsTypeDesc());
-        pMT = th.AsMethodTable();
-        obj = pMT->Box(pValue);
+        _ASSERTE(!"You cannot use this function for arbitrary value types. You must preallocate a box object and copy the value in yourself.");
         break;
-    }
 
     case ELEMENT_TYPE_CLASS:        // Class
     case ELEMENT_TYPE_SZARRAY:      // Single Dim, Zero
@@ -718,9 +722,14 @@ OBJECTREF InvokeUtil::CreateObject(TypeHandle th, void * pValue) {
         {
             // Don't use MethodTable::Box here for perf reasons
             PREFIX_ASSUME(pMT != NULL);
-            obj = AllocateObject(pMT);
             DWORD size = pMT->GetNumInstanceFieldBytes();
-            memcpyNoGCRefs(obj->UnBox(), pValue, size);
+
+            UINT64 capturedValue;
+            memcpyNoGCRefs(&capturedValue, pValue, size); // Must capture the primitive value before we allocate the boxed object which can trigger a GC.
+
+            INDEBUG(pValue = (LPVOID)0xcccccccc); // We're about to allocate a GC object - can no longer trust pValue
+            obj = AllocateObject(pMT);
+            memcpyNoGCRefs(obj->UnBox(), &capturedValue, size);
         }
         break;
     

--- a/src/vm/invokeutil.h
+++ b/src/vm/invokeutil.h
@@ -105,7 +105,7 @@ public:
     // Given a type, this routine will convert an return value representing that
     //  type into an ObjectReference.  If the type is a primitive, the 
     //  value is wrapped in one of the Value classes.
-    static OBJECTREF CreateObject(TypeHandle th, void * pValue);
+    static OBJECTREF CreateObjectAfterInvoke(TypeHandle th, void * pValue);
 
     // This is a special purpose Exception creation function.  It
     //  creates the TargetInvocationExeption placing the passed


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/15960

Returned magic object is the object pointed to by
the ref. If the ref is null, NullReferenceException.