### PR TITLE
Fix ephemeral limits checks in write barrier for ARM64

### DIFF
--- a/src/vm/arm64/asmhelpers.S
+++ b/src/vm/arm64/asmhelpers.S
@@ -429,8 +429,8 @@ LOCAL_LABEL(CheckCardTable):
     cmp  x15,  x12
 
     ldr  x12, LOCAL_LABEL(wbs_ephemeral_high)
-    ccmp x15, x12, 0x0, ge
-    bgt  LOCAL_LABEL(Exit)
+    ccmp x15, x12, 0x0, hs
+    bhi  LOCAL_LABEL(Exit)
 
 LOCAL_LABEL(SkipEphemeralCheck):
     // Check if we need to update the card table

--- a/src/vm/arm64/asmhelpers.asm
+++ b/src/vm/arm64/asmhelpers.asm
@@ -381,12 +381,12 @@ shadowupdateend
         adrp     x12,  g_ephemeral_low
         ldr      x12,  [x12, g_ephemeral_low]
         cmp      x15,  x12
-        blt      Exit
+        blo      Exit
 
         adrp     x12, g_ephemeral_high 
         ldr      x12, [x12, g_ephemeral_high]
         cmp      x15,  x12
-        bgt      Exit
+        bhi      Exit
 
         ; Check if we need to update the card table        
         adrp     x12, g_card_table


### PR DESCRIPTION
The code was incorrectly using signed conditions, which doesn't work for
server GC where the high ephemeral limit is 0xffffffffffffffff and so it
was checking if the address is less than -1, which is never the case. So
the card table was never updated.

Close #17640