### PR TITLE
port #17618 to the 2.1 branch (Disable timeout test)

### DIFF
--- a/tests/src/JIT/Regression/JitBlue/DevDiv_255294/DevDiv_255294.csproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_255294/DevDiv_255294.csproj
@@ -23,6 +23,8 @@
   <PropertyGroup>
     <DebugType></DebugType>
     <Optimize>True</Optimize>
+    <!-- It hits timeout with R2R and JitStress=1, issue 16573 -->
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="DevDiv_255294.cs" />


### PR DESCRIPTION
disable DevDiv_255294 in stress modes. (PR to master #17618, issue #17605) 

It is a test only change.