### PR TITLE
Treat EDI as killed by MaskMove

### DIFF
--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -1112,8 +1112,11 @@ private:
 
     static Compiler::fgWalkResult markAddrModeOperandsHelperMD(GenTree* tree, void* p);
 
-    // Helper for getKillSetForNode().
+    // Helpers for getKillSetForNode().
     regMaskTP getKillSetForStoreInd(GenTreeStoreInd* tree);
+#ifdef FEATURE_HW_INTRINSICS
+    regMaskTP getKillSetForHWIntrinsic(GenTreeHWIntrinsic* node);
+#endif // FEATURE_HW_INTRINSICS
 
     // Return the registers killed by the given tree node.
     regMaskTP getKillSetForNode(GenTree* tree);


### PR DESCRIPTION
It should really only be a fixed reference, not a kill, but if the reference is changed by `LinearScan::resolveConflictingDefAndUse()` it can fail to cause the value in EDI to be killed.