### PR TITLE
Fix GC tests that contain GC.Collect() used in wrong scope

### DIFF
--- a/tests/src/GC/API/GC/Finalize.cs
+++ b/tests/src/GC/API/GC/Finalize.cs
@@ -5,6 +5,7 @@
 // Tests Finalize() and WaitForPendingFinalizers()
 
 using System;
+using System.Runtime.CompilerServices;
 
 public class Test
 {
@@ -28,12 +29,10 @@ public class Test
             obj = new Dummy();
         }
 
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public void RunTest()
         {
             obj = null;
-            GC.Collect();
-
-            GC.WaitForPendingFinalizers();  // makes sure Finalize() is called.
         }
     }
 
@@ -42,6 +41,9 @@ public class Test
         CreateObj temp = new CreateObj();
         temp.RunTest();
 
+        GC.Collect();
+        GC.WaitForPendingFinalizers();  // makes sure Finalize() is called.
+        GC.Collect();
 
         if (visited)
         {

--- a/tests/src/GC/API/GC/KeepAlive.cs
+++ b/tests/src/GC/API/GC/KeepAlive.cs
@@ -16,6 +16,7 @@
  */
 
 using System;
+using System.Runtime.CompilerServices;
 
 public class Test
 {
@@ -47,6 +48,7 @@ public class Test
     }
 
 
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static void RunTest2()
     {
         Dummy2 obj2 = new Dummy2();
@@ -66,6 +68,7 @@ public class Test
         //for (int i=0; i<5; i++) {
         GC.Collect();
         GC.WaitForPendingFinalizers();
+        GC.Collect();
         //}
 
         GC.KeepAlive(obj);  // will keep obj alive until this point

--- a/tests/src/GC/API/GC/KeepAliveNull.cs
+++ b/tests/src/GC/API/GC/KeepAliveNull.cs
@@ -5,6 +5,7 @@
 // Tests KeepAlive()
 
 using System;
+using System.Runtime.CompilerServices;
 
 public class Test
 {
@@ -27,11 +28,19 @@ public class Test
             obj = new Dummy();
         }
 
-        public void RunTest()
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public void DestroyObj()
         {
             obj = null;     // this will collect the obj even if we have KeepAlive()		
+        }
+
+        public void RunTest()
+        {
+            DestroyObj();
+
             GC.Collect();
             GC.WaitForPendingFinalizers();
+            GC.Collect();
 
             GC.KeepAlive(obj);  // will keep alive 'obj' till this point
         }

--- a/tests/src/GC/API/GC/KeepAliveRecur.cs
+++ b/tests/src/GC/API/GC/KeepAliveRecur.cs
@@ -28,6 +28,7 @@ public class Test
 
         GC.Collect();
         GC.WaitForPendingFinalizers();
+        GC.Collect();
 
         foo(o);     //Recursive call
 

--- a/tests/src/GC/API/GC/SuppressFinalize.cs
+++ b/tests/src/GC/API/GC/SuppressFinalize.cs
@@ -5,6 +5,7 @@
 // Tests SuppressFinalize()
 
 using System;
+using System.Runtime.CompilerServices;
 
 public class Test {
 
@@ -17,16 +18,21 @@ public class Test {
 		}
 	}
 
-	public static int Main() {
-
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    public static void RunTest()
+    {
 		Dummy obj1 = new Dummy();
-	
 		GC.SuppressFinalize(obj1);	// should not call the Finalizer() for obj1
 		obj1=null;
-			
+    }
+
+	public static int Main()
+    {
+        RunTest();
+
 		GC.Collect();
-		
 		GC.WaitForPendingFinalizers();   // call all Finalizers.
+		GC.Collect();
 
 		if(Dummy.visited == false) {
 			Console.WriteLine("Test for SuppressFinalize() passed!");

--- a/tests/src/GC/API/GCHandle/HandleCopy.cs
+++ b/tests/src/GC/API/GCHandle/HandleCopy.cs
@@ -39,7 +39,7 @@ public class Test
         }
 
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
-        public bool DestroyObj()
+        public void DestroyObj()
         {
             obj = null;
         }    

--- a/tests/src/GC/API/GCHandle/HandleCopy.cs
+++ b/tests/src/GC/API/GCHandle/HandleCopy.cs
@@ -7,6 +7,7 @@
 // Also tests the target of the handle.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 public class Test
@@ -37,13 +38,17 @@ public class Test
             copy = handle;
         }
 
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public bool DestroyObj()
+        {
+            obj = null;
+        }    
+
         public bool RunTest()
         {
-            // ensuring that GC happens even with /debug mode
-            obj = null;
             GC.Collect();
-
             GC.WaitForPendingFinalizers();
+            GC.Collect();
 
             bool ans1 = handle.IsAllocated;
             bool ans2 = copy.IsAllocated;

--- a/tests/src/GC/API/GCHandle/Normal.cs
+++ b/tests/src/GC/API/GCHandle/Normal.cs
@@ -21,7 +21,7 @@ public class Test {
 	}
 
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
-    public bool RunTest()
+    public static void RunTest()
     {
         Dummy obj = new Dummy();
 		
@@ -41,7 +41,6 @@ public class Test {
 		GC.Collect();
 		
 		if(Dummy.flag == 0) {
-			
 			Console.WriteLine("Test for GCHandleType.Normal passed!");
             return 100;
 		}

--- a/tests/src/GC/API/GCHandle/Normal.cs
+++ b/tests/src/GC/API/GCHandle/Normal.cs
@@ -6,6 +6,7 @@
 // should not be collected.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 public class Test {
@@ -19,18 +20,25 @@ public class Test {
 		}
 	}
 
-	public static int Main() {
-
-		Dummy obj = new Dummy();
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    public bool RunTest()
+    {
+        Dummy obj = new Dummy();
 		
 		Console.WriteLine("Allocating a normal handle to object..");
 		GCHandle handle = GCHandle.Alloc(obj,GCHandleType.Normal); // Normal handle
 		
 		// ensuring that GC happens even with /debug mode
 		obj=null;
+    }    
+
+
+	public static int Main() {
+        RunTest();
 
 		GC.Collect();
 		GC.WaitForPendingFinalizers();
+		GC.Collect();
 		
 		if(Dummy.flag == 0) {
 			

--- a/tests/src/GC/API/GCHandle/Weak.cs
+++ b/tests/src/GC/API/GCHandle/Weak.cs
@@ -31,30 +31,24 @@ public class Test
             GCHandle handle = GCHandle.Alloc(obj, GCHandleType.Weak);
         }
 
-        public bool RunTest()
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public void RunTest()
         {
             // ensuring that GC happens even with /debug mode
             obj = null;
-            GC.Collect();
-
-            GC.WaitForPendingFinalizers();
-
-            if (Dummy.flag == 99)
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
         }
     }
 
     public static int Main()
     {
         CreateObj temp = new CreateObj();
+        temp.RunTest();
 
-        if (temp.RunTest())
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        if (Dummy.flag == 99)
         {
             Console.WriteLine("Test for GCHandleType.Weak passed!");
             return 100;

--- a/tests/src/GC/API/GCHandle/Weak.cs
+++ b/tests/src/GC/API/GCHandle/Weak.cs
@@ -6,6 +6,7 @@
 // will be collected.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 public class Test

--- a/tests/src/GC/API/GCHandleCollector/Usage.cs
+++ b/tests/src/GC/API/GCHandleCollector/Usage.cs
@@ -47,17 +47,6 @@ public class Usage
     private int _numInstances = 100;
     private const int deltaPercent = 10;
 
-    [MethodImplAttribute(MethodImplOptions.NoInlining)]
-    private void CreateObjCase1()
-    {
-        HandleCollectorTest h;
-
-        // create objects and let them go out of scope
-        for (int i = 0; i < _numInstances; i++)
-            h = new HandleCollectorTest();
-
-        h = null;
-    }
 
     // ensures GC Collections occur when handle count exceeds maximum
     private bool Case1()
@@ -71,11 +60,15 @@ public class Usage
 
         int original = GC.CollectionCount(0);
 
-        CreateObjCase1();
+        HandleCollectorTest h;
 
-        GC.Collect();
+        // create objects and let them go out of scope
+        for (int i = 0; i < _numInstances; i++)
+            h = new HandleCollectorTest();
+
+        h = null;
+
         GC.WaitForPendingFinalizers();
-        GC.Collect();
 
         // Collection should not have occurred
         if (GC.CollectionCount(0) != original)
@@ -108,9 +101,7 @@ public class Usage
         {
             new HandleCollectorTest();
 
-            GC.Collect();
             GC.WaitForPendingFinalizers();
-            GC.Collect();
 
             handleCount = HandleCollectorTest.Count;
             //Note that the GC should occur when handle count is 101 but it will happen at anytime after a creation and we stick to the previous

--- a/tests/src/GC/API/GCHandleCollector/Usage.cs
+++ b/tests/src/GC/API/GCHandleCollector/Usage.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // the class that holds the HandleCollectors
@@ -46,6 +47,18 @@ public class Usage
     private int _numInstances = 100;
     private const int deltaPercent = 10;
 
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    private void CreateObjCase1()
+    {
+        HandleCollectorTest h;
+
+        // create objects and let them go out of scope
+        for (int i = 0; i < _numInstances; i++)
+            h = new HandleCollectorTest();
+
+        h = null;
+    }
+
     // ensures GC Collections occur when handle count exceeds maximum
     private bool Case1()
     {
@@ -56,15 +69,13 @@ public class Usage
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        HandleCollectorTest h;
         int original = GC.CollectionCount(0);
 
-        // create objects and let them go out of scope
-        for (int i = 0; i < _numInstances; i++)
-            h = new HandleCollectorTest();
+        CreateObjCase1();
 
-        h = null;
+        GC.Collect();
         GC.WaitForPendingFinalizers();
+        GC.Collect();
 
         // Collection should not have occurred
         if (GC.CollectionCount(0) != original)
@@ -96,7 +107,11 @@ public class Usage
         for (int i = 0; i < _numInstances; i++)
         {
             new HandleCollectorTest();
+
+            GC.Collect();
             GC.WaitForPendingFinalizers();
+            GC.Collect();
+
             handleCount = HandleCollectorTest.Count;
             //Note that the GC should occur when handle count is 101 but it will happen at anytime after a creation and we stick to the previous
             //count to avoid error

--- a/tests/src/GC/API/WeakReference/Finalize.cs
+++ b/tests/src/GC/API/WeakReference/Finalize.cs
@@ -6,12 +6,13 @@
 
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 public class Test {
 
-    public class Dummy {
-
+    public class Dummy 
+    {
         public static bool visited=false;
         ~Dummy() {
             Console.WriteLine("In Finalize() of Dummy");    
@@ -20,17 +21,20 @@ public class Test {
         }
     }
 
-    public class CreateObj {
+    public class CreateObj 
+    {
         Dummy dummy1;
         Dummy dummy2;
 
-        public CreateObj() {
+        public CreateObj() 
+        {
             dummy1 = new Dummy();
             dummy2 = new Dummy();
         }
 
-        public bool RunTest() {
-            
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public bool RunTest() 
+        {
             WeakReference weak1 = new WeakReference(dummy1);
             GCHandle handle = GCHandle.Alloc(dummy1,GCHandleType.Normal); // Strong Reference
 
@@ -39,27 +43,25 @@ public class Test {
             // ensuring that GC happens even with /debug mode
             dummy1=null;
             dummy2=null;
-
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-
-            if(Dummy.visited == true) 
-                return true;
-            else 
-                return false;
         }    
     }
 
-    public static int Main() {
-        
+    public static int Main() 
+    {
         CreateObj temp = new CreateObj();
-        bool passed = temp.RunTest();
+        temp.RunTest();
 
-        if(passed) {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        if (Dummy.visited) 
+        {
             Console.WriteLine("Test for WeakReference.Finalize() passed!");
             return 100;
         }
-        else {
+        else 
+        {
             Console.WriteLine("Test for WeakReference.Finalize() failed!");
             return 1;
         }

--- a/tests/src/GC/API/WeakReference/Finalize.cs
+++ b/tests/src/GC/API/WeakReference/Finalize.cs
@@ -33,7 +33,7 @@ public class Test {
         }
 
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
-        public bool RunTest() 
+        public void RunTest() 
         {
             WeakReference weak1 = new WeakReference(dummy1);
             GCHandle handle = GCHandle.Alloc(dummy1,GCHandleType.Normal); // Strong Reference

--- a/tests/src/GC/Features/Finalizer/finalizeio/finalizeio.cs
+++ b/tests/src/GC/Features/Finalizer/finalizeio/finalizeio.cs
@@ -85,7 +85,7 @@ Line 23
 ******************* END *****************************");
         }
 
-        RunTest();
+        temp.RunTest();
 
         GC.Collect();
         GC.WaitForPendingFinalizers();  // makes sure Finalize() is called.

--- a/tests/src/GC/Features/Finalizer/finalizeio/finalizeio.cs
+++ b/tests/src/GC/Features/Finalizer/finalizeio/finalizeio.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 
 public class Test {
 
@@ -45,15 +46,9 @@ public class Test {
             obj = new Dummy();
         }
 
-        public bool RunTest() {
-
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public void RunTest() {
             obj=null;
-            GC.Collect();
-
-            GC.WaitForPendingFinalizers();  // makes sure Finalize() is called.
-
-            return Dummy.visited;
-
         }
     }
 
@@ -90,8 +85,15 @@ Line 23
 ******************* END *****************************");
         }
 
+        RunTest();
 
-        if (temp.RunTest()) {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();  // makes sure Finalize() is called.
+        GC.Collect();
+
+
+        if (Dummy.visited) 
+        {
             Console.WriteLine("Test for Finalize() & WaitForPendingFinalizers() passed!");
             return 100;
         }

--- a/tests/src/GC/Features/Finalizer/finalizeother/finalizearray.cs
+++ b/tests/src/GC/Features/Finalizer/finalizeother/finalizearray.cs
@@ -5,46 +5,46 @@
 // Tests Finalize() on array of objects
 
 using System;
+using System.Runtime.CompilerServices;
 
-public class Test {
+public class Test 
+{
+    public class Dummy 
+    {
+        public static int count=0;
+        ~Dummy() 
+        {
+            count++;
+        }
+    }
 
-	public class Dummy {
-		public static int count=0;
-		~Dummy() {
-			count++;
-		}
-	}
+    public class CreateObj 
+    {
+        public Dummy[] obj;
 
-	public class CreateObj {
-		public Dummy[] obj;
+        public CreateObj() {
+            obj = new Dummy[10000];
+            for(int i=0;i<10000;i++) {
+                obj[i] = new Dummy();
+            }
+        }
 
-		public CreateObj() {
-			
-			obj = new Dummy[10000];
-			for(int i=0;i<10000;i++) {
-				obj[i] = new Dummy();
-			}
-		}
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public void RunTest() 
+        {
+            obj=null;     // making sure collect is called even with /debug
+        }
+    }
 
-		public bool RunTest() {
-			obj=null;     // making sure collect is called even with /debug
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-		
-			if(Dummy.count == 10000) {     // all objects in array finalized!
-                return true;
-			}
-			else {
-                return false;
-			}
-		}
-	}
+    public static int Main() {
+        CreateObj temp = new CreateObj();
+        temp.RunTest();
 
-	public static int Main() {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
 
-		CreateObj temp = new CreateObj();
-
-        if (temp.RunTest())
+        if (Dummy.count == 10000)  // all objects in array finalized!
         {
             Console.WriteLine("Test for Finalize() for array of objects passed!");
             return 100;
@@ -55,5 +55,5 @@ public class Test {
             return 1;
         }
 
-	}
+    }
 }

--- a/tests/src/GC/Features/Finalizer/finalizeother/finalizearraysleep.cs
+++ b/tests/src/GC/Features/Finalizer/finalizeother/finalizearraysleep.cs
@@ -6,54 +6,50 @@
 
 using System;
 using System.Threading;
+using System.Runtime.CompilerServices;
 
 public class Test {
 
-	public class Dummy {
-		public static int count=0;
-		~Dummy() {
-			count++;
-			Thread.Sleep(1000);
-		}
-	}
+    public class Dummy {
+        public static int count=0;
+        ~Dummy() {
+            count++;
+            Thread.Sleep(1000);
+        }
+    }
 
-	public class CreateObj {
-		public Dummy[] obj;
-                public int ExitCode = 0;		
+    public class CreateObj {
+        public Dummy[] obj;
+        public int ExitCode = 0;		
 
-		public CreateObj() {
-		obj = new Dummy[10];
+        public CreateObj() {
+            obj = new Dummy[10];
 
-		for(int i=0;i<10;i++) {
-			obj[i] = new Dummy();
-		}
-		}
-	
-		public void RunTest() {		
+            for(int i=0;i<10;i++) {
+                obj[i] = new Dummy();
+            }
+        }
 
-		obj=null;     // making sure collect is called even with /debug
-		GC.Collect();
-		GC.WaitForPendingFinalizers();
-		
-		if(Dummy.count == 10) {     // all objects in array finalized!
-			ExitCode = 100;
-			//Console.WriteLine("Test for Finalize() for array of objects passed!");
-		}
-		else {
-			ExitCode = 1;
-			//Console.WriteLine("Test for Finalize() for array of objects failed!");
-		}
-		}
-	}
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public void RunTest() {		
+            obj=null;     // making sure collect is called even with /debug
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+    }
 
-	public static int Main() {
-		CreateObj temp = new CreateObj();
-		temp.RunTest();
+    public static int Main() {
+        CreateObj temp = new CreateObj();
+        temp.RunTest();
 
-		if(temp.ExitCode==100)
-			Console.WriteLine("Test for Finalize() for array of objects passed!");
-		else 
-			Console.WriteLine("Test for Finalize() for array of objects failed!");
-                return temp.ExitCode;				
-	}
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        if (Dummy.count == 10)
+            Console.WriteLine("Test for Finalize() for array of objects passed!");
+        else 
+            Console.WriteLine("Test for Finalize() for array of objects failed!");
+        return temp.ExitCode;				
+    }
 }

--- a/tests/src/GC/Features/Finalizer/finalizeother/finalizedest.cs
+++ b/tests/src/GC/Features/Finalizer/finalizeother/finalizedest.cs
@@ -48,6 +48,7 @@ public class Test
 
         GC.Collect(); 
         GC.WaitForPendingFinalizers();  // makes sure Finalize() is called.
+        GC.Collect(); 
 
         if (Dummy.visited)
         {

--- a/tests/src/GC/Features/Finalizer/finalizeother/finalizedest.cs
+++ b/tests/src/GC/Features/Finalizer/finalizeother/finalizedest.cs
@@ -5,6 +5,7 @@
 // Tests Finalize() and WaitForPendingFinalizers()
 
 using System;
+using System.Runtime.CompilerServices;
 
 public class Test
 {
@@ -12,7 +13,7 @@ public class Test
     public class Dummy
     {
 
-        public static bool visited;
+        public static bool visited=false;
 
         ~Dummy()
         {
@@ -33,22 +34,22 @@ public class Test
             obj = new Dummy();
         }
 
-        public bool RunTest()
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void RunTest()
         {
             obj=null;
-            GC.Collect();
-
-            GC.WaitForPendingFinalizers();  // makes sure Finalize() is called.
-
-            return Dummy.visited;
         }
     }
 
     public static int Main()
     {
         CreateObj temp = new CreateObj();
+        temp.RunTest();
 
-        if (temp.RunTest())
+        GC.Collect(); 
+        GC.WaitForPendingFinalizers();  // makes sure Finalize() is called.
+
+        if (Dummy.visited)
         {
             Console.WriteLine("Test Passed");
             return 100;

--- a/tests/src/GC/Features/Finalizer/finalizeother/finalizeexcep.cs
+++ b/tests/src/GC/Features/Finalizer/finalizeother/finalizeexcep.cs
@@ -5,58 +5,53 @@
 // Tests Exception handling in Finalize() 
 
 using System;
+using System.Runtime.CompilerServices;
 
 public class Test {
 
-	public class List {
-		public int val;
-		public List next;
-	}
-	public class Dummy {
+    public class List {
+        public int val;
+        public List next;
+    }
 
-		public static bool visited;
-	
-		~Dummy() {
-			List lst = new List();
-			Console.WriteLine("In Finalize() of Dummy");
-			try {
-				Console.WriteLine(lst.next.val);    // should throw nullreference exception
-			} catch(NullReferenceException) {
+    public class Dummy {
+        public static bool visited;
+
+        ~Dummy() {
+            List lst = new List();
+            Console.WriteLine("In Finalize() of Dummy");
+            try {
+                Console.WriteLine(lst.next.val);    // should throw nullreference exception
+            } catch(NullReferenceException) {
                 Console.WriteLine("Caught NullReferenceException in Finalize()");				
                 visited=true;
-			}
-			
-			
-		}
-	}
+            }
+        }
+    }
 
-	public class CreateObj {
-		public Dummy obj;
+    public class CreateObj {
+        public Dummy obj;
 
-		public CreateObj() {
-			obj = new Dummy();
-		}
+        public CreateObj() {
+            obj = new Dummy();
+        }
 
-		public bool RunTest() {
-			obj=null;
-			GC.Collect();
-		
-			GC.WaitForPendingFinalizers();  // makes sure Finalize() is called.
+        [MethodImplAttribute(MethodImplOptions.NoInlining)] 
+        public void RunTest() {
+            obj=null;
+        }
+    }
 
-			if(Dummy.visited == true) {
-                return true;
-			}
-			else {
-                return false;
-			}
-		}
-	}
+    public static int Main() {
 
-	public static int Main() {
+        CreateObj temp= new CreateObj();
+        temp.RunTest();
 
-		CreateObj temp= new CreateObj();
+        GC.Collect();
+        GC.WaitForPendingFinalizers();  // makes sure Finalize() is called.
+        GC.Collect();
 
-        if (temp.RunTest())
+        if (Dummy.visited)
         {
             Console.WriteLine("Test for Exception handling in Finalize() passed!");
             return 100;
@@ -66,7 +61,7 @@ public class Test {
             Console.WriteLine("Test for Exception handling in Finalize() failed!");
             return 1;
         }
-		
-		
-	}
+
+
+    }
 }

--- a/tests/src/GC/Features/Finalizer/finalizeother/finalizeinherit.cs
+++ b/tests/src/GC/Features/Finalizer/finalizeother/finalizeinherit.cs
@@ -18,7 +18,8 @@ namespace One
     {
         ~B()
         {
-            Console.WriteLine("In Finalize of B"); }
+            Console.WriteLine("In Finalize of B");
+        }
     }
 
     class C: B

--- a/tests/src/GC/Features/Finalizer/finalizeother/finalizeinherit.cs
+++ b/tests/src/GC/Features/Finalizer/finalizeother/finalizeinherit.cs
@@ -5,6 +5,7 @@
 // Tests Finalize() with Inheritance
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace One
 {
@@ -17,8 +18,7 @@ namespace One
     {
         ~B()
         {
-            Console.WriteLine("In Finalize of B");
-        }
+            Console.WriteLine("In Finalize of B"); }
     }
 
     class C: B
@@ -61,6 +61,7 @@ namespace Three {
             d = new D();
         }
 
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public bool RunTest()
         {
             A a = c;
@@ -83,7 +84,12 @@ namespace Three {
         {
             CreateObj temp = new CreateObj();
 
-            if (temp.RunTest())
+            temp.RunTest();
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            if (C.count == 2)
             {
                 Console.WriteLine("Test Passed");
                 return 100;

--- a/tests/src/GC/Features/Finalizer/finalizeother/finalizenested.cs
+++ b/tests/src/GC/Features/Finalizer/finalizeother/finalizenested.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Threading;
+using System.Runtime.CompilerServices;
 
 public class Test {
 
@@ -99,22 +100,28 @@ public class Test {
             obj=new Dummy();
         }
 
-        public bool RunTest()
+        public void RunTest()
         {
             obj=null;
-            GC.Collect();
-
-            GC.WaitForPendingFinalizers();  // makes sure Finalize() is called.
-
-            return Dummy.visited;
         }
     }
 
-    public static int Main() {
-
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void AllocAndDealloc() 
+    {
         CreateObj temp = new CreateObj();
+        temp.RunTest();
+    }
 
-        if (temp.RunTest())
+    public static int Main() 
+    {
+        AllocAndDealloc();
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();  // makes sure Finalize() is called.
+        GC.Collect();
+
+        if (Dummy.visited)
         {
             Console.WriteLine("Test Passed");
             return 100;

--- a/tests/src/GC/Features/Pinning/PinningOther/PinnedInt.cs
+++ b/tests/src/GC/Features/Pinning/PinningOther/PinnedInt.cs
@@ -19,8 +19,10 @@ public class Test
 
         temp1 = GCUtil.GetTarget(handle);
         Console.WriteLine(temp1);
+
         GC.Collect();
         GC.WaitForPendingFinalizers();
+        GC.Collect();
 
         temp2 = GCUtil.GetTarget(handle);
         Console.WriteLine(temp2);

--- a/tests/src/GC/Performance/Tests/GCLarge.cs
+++ b/tests/src/GC/Performance/Tests/GCLarge.cs
@@ -46,7 +46,6 @@ internal class List
         SmallGC [] sgc;
         sgc = new SmallGC [LOOP];
 
-        AllocateSmallObjects();
         for (int j = 0; j < LOOP; j++)
             sgc[j] = new SmallGC(0);
 
@@ -57,6 +56,7 @@ internal class List
 
         GC.Collect();
         GC.WaitForPendingFinalizers();
+        GC.Collect();
                     
         for(long i = 0; i < iterations; i++)
         {

--- a/tests/src/GC/Performance/Tests/GCLarge.cs
+++ b/tests/src/GC/Performance/Tests/GCLarge.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 
 internal class List
 {
@@ -24,23 +25,28 @@ internal class List
             CreateLargeObjects();
             GC.Collect();
             GC.WaitForPendingFinalizers();
+            GC.Collect();
         }
 
         //Large Object Collection (half array)
         CreateLargeObjectsHalf();
         GC.Collect();
         GC.WaitForPendingFinalizers();
+        GC.Collect();
 
         for(long i = 0; i < iterations; i++)
         {
             CreateLargeObjectsHalf();
             GC.Collect();
             GC.WaitForPendingFinalizers();
+            GC.Collect();
         }
 
         //Promote from Gen1 to Gen2
         SmallGC [] sgc;
         sgc = new SmallGC [LOOP];
+
+        AllocateSmallObjects();
         for (int j = 0; j < LOOP; j++)
             sgc[j] = new SmallGC(0);
 
@@ -110,6 +116,7 @@ internal class List
         }
     }
 
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static List PopulateList(int len)
     {
         if (len == 0) return null;
@@ -127,6 +134,7 @@ internal class List
         }
         return Node;
     }
+
     public static int ValidateList(List First, int len)
     {
         List tmp1 = First;
@@ -151,6 +159,7 @@ internal class List
     }
 
 
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static void CreateLargeObjects()
     {
         LargeGC [] lgc;
@@ -159,6 +168,7 @@ internal class List
             lgc[i] = new LargeGC();
     }
 
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static void CreateLargeObjectsHalf()
     {
         LargeGC [] lgc;

--- a/tests/src/GC/Performance/Tests/GCMicroBench.cs
+++ b/tests/src/GC/Performance/Tests/GCMicroBench.cs
@@ -261,6 +261,7 @@ namespace GC_Microbenchmarks
                 m_list = null;
                 return ( (m_list.Count > 0) && (m_list[0] is FNode));
             }
+            return false;
         }
 
 

--- a/tests/src/GC/Performance/Tests/GCMicroBench.cs
+++ b/tests/src/GC/Performance/Tests/GCMicroBench.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
 
@@ -252,25 +253,30 @@ namespace GC_Microbenchmarks
         }
 
 
+        public bool ClearList()
+        {
+            if (m_list != null)
+            {
+                m_list.Clear();
+                m_list = null;
+                return ( (m_list.Count > 0) && (m_list[0] is FNode));
+            }
+        }
+
+
         // releases references to allocated objects
         // times GC.Collect()
         // if objects are finalizable, also times GC.WaitForPendingFinalizers()
         public void Deallocate()
         {
-            bool finalizable = false;
-
-            if (m_list != null)
-            {
-                finalizable  = ( (m_list.Count > 0) && (m_list[0] is FNode));
-                m_list.Clear();
-                m_list = null;
-            }
+            bool finalizable = ClearList();
 
             GC.Collect();
 
             if (finalizable)
             {
                 GC.WaitForPendingFinalizers();
+                GC.Collect();
             }
 
         }

--- a/tests/src/GC/Scenarios/BaseFinal/basefinal.cs
+++ b/tests/src/GC/Scenarios/BaseFinal/basefinal.cs
@@ -10,6 +10,7 @@
 
 namespace DefaultNamespace {
     using System;
+    using System.Runtime.CompilerServices;
     using System.Collections.Generic;
 
     internal class BaseFinal
@@ -104,18 +105,15 @@ namespace DefaultNamespace {
             //Console.WriteLine("after all objects were created, the heapsize is " + GC.GetTotalMemory(false));
         }
 
-        public bool RunTest()
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public void DestroyNode()
         {
             obj = null;
+        }
 
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
-
-            Console.Write(BNode.icFinalNode);
-            Console.WriteLine(" Nodes were finalized and resurrected.");
-            //Console.WriteLine("after all objects were deleted and resurrected in Finalize() , the heapsize is " + GC.GetTotalMemory(false));
-
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public void ResurrectNodes()
+        {
             for(int i=0; i< BNode.rlNode.Count; i++)
             {
                 BNode oldNode = (BNode)BNode.rlNode[ i ];
@@ -126,6 +124,21 @@ namespace DefaultNamespace {
                 oldNode = null;
                 BNode.rlNode[ i ] = null;
             }
+        }
+
+        public bool RunTest()
+        {
+            DestroyNode();
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            Console.Write(BNode.icFinalNode);
+            Console.WriteLine(" Nodes were finalized and resurrected.");
+            //Console.WriteLine("after all objects were deleted and resurrected in Finalize() , the heapsize is " + GC.GetTotalMemory(false));
+
+            ResurrectNodes(); 
 
             GC.Collect();
             GC.WaitForPendingFinalizers();

--- a/tests/src/GC/Scenarios/DoublinkList/dlbigleak.cs
+++ b/tests/src/GC/Scenarios/DoublinkList/dlbigleak.cs
@@ -107,6 +107,7 @@ namespace DoubLink {
         }
 
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public void MakeLeak(int iRep)
         {
 

--- a/tests/src/GC/Scenarios/DoublinkList/doublinknoleak2.cs
+++ b/tests/src/GC/Scenarios/DoublinkList/doublinknoleak2.cs
@@ -93,6 +93,7 @@ namespace DoubLink {
 
             GC.Collect();
             GC.WaitForPendingFinalizers();
+            GC.Collect();
 
             //do a second GC collect since some nodes may have been still alive at the time of first collect
             GC.Collect();

--- a/tests/src/GC/Scenarios/FinalNStruct/finalnstruct.cs
+++ b/tests/src/GC/Scenarios/FinalNStruct/finalnstruct.cs
@@ -17,7 +17,7 @@ namespace NStruct {
     {
 
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
-        public static STRMAP[] CreateObj(int iObj)
+        public static void CreateObj(int iObj)
         {
             STRMAP []strmap = new STRMAP[iObj];
             for (int i=0; i< iObj; i++ ) //allocate 3100KB

--- a/tests/src/GC/Scenarios/FinalNStruct/finalnstruct.cs
+++ b/tests/src/GC/Scenarios/FinalNStruct/finalnstruct.cs
@@ -16,28 +16,21 @@ namespace NStruct {
     internal class FinalNStruct
     {
 
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public static STRMAP[] CreateObj(int iObj)
         {
-
             STRMAP []strmap = new STRMAP[iObj];
             for (int i=0; i< iObj; i++ ) //allocate 3100KB
             {
                 strmap[i] = new STRMAP();
             }
-            return strmap;
-
-        }
-
-        [MethodImplAttribute(MethodImplOptions.NoInlining)]
-        public static void DeleteStrmap()
-        {
             for( int i=0; i< iObj; i++ )
             {
                 strmap[i] = null;
             }
         }
 
-        public static bool RunTest(int iObj,STRMAP []strmap)
+        public static bool RunTest()
         {
             GC.Collect();
             GC.WaitForPendingFinalizers();
@@ -47,14 +40,13 @@ namespace NStruct {
         }
 
         public static int Main(String [] args){
-
             int iObj = 100;
-            STRMAP []strmaptemp;
 
             Console.WriteLine("Test should return with ExitCode 100 ...");
 
-            strmaptemp = CreateObj(iObj);
-            if (RunTest(iObj,strmaptemp))
+            CreateObj(iObj);
+
+            if (RunTest())
             {
                 Console.WriteLine( "Created objects number is same with finalized objects." );
                 Console.WriteLine( "Test Passed !" );

--- a/tests/src/GC/Scenarios/FinalNStruct/finalnstruct.cs
+++ b/tests/src/GC/Scenarios/FinalNStruct/finalnstruct.cs
@@ -11,6 +11,7 @@
 
 namespace NStruct {
     using System;
+    using System.Runtime.CompilerServices;
 
     internal class FinalNStruct
     {
@@ -27,20 +28,22 @@ namespace NStruct {
 
         }
 
-        public static bool RunTest(int iObj,STRMAP []strmap)
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static void DeleteStrmap()
         {
-
             for( int i=0; i< iObj; i++ )
             {
                 strmap[i] = null;
             }
+        }
 
+        public static bool RunTest(int iObj,STRMAP []strmap)
+        {
             GC.Collect();
             GC.WaitForPendingFinalizers();
             GC.Collect();
 
             return ( FinalizeCount.icFinal == FinalizeCount.icCreat );
-
         }
 
         public static int Main(String [] args){

--- a/tests/src/GC/Scenarios/FinalNStruct/nstructtun.cs
+++ b/tests/src/GC/Scenarios/FinalNStruct/nstructtun.cs
@@ -4,6 +4,7 @@
 
 namespace NStruct {
     using System;
+    using System.Runtime.CompilerServices;
 
     internal class NStructTun
     {
@@ -14,18 +15,23 @@ namespace NStruct {
 #pragma warning disable 0414
             private STRMAP Strmap;
 #pragma warning restore 0414
+
             public CreateObj(int Rep)
             {
                  for( int i=0; i< Rep; i++ )
                  {
                     Strmap = new STRMAP();
                  }
-             }
+            }
+         
+            [MethodImplAttribute(MethodImplOptions.NoInlining)]
+            public void DeleteStrmap()
+            {
+                Strmap=null;
+            }
 
             public bool RunTest()
             {
-                Strmap=null;
-
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
                 GC.Collect();

--- a/tests/src/GC/Scenarios/FragMan/fragman.cs
+++ b/tests/src/GC/Scenarios/FragMan/fragman.cs
@@ -11,6 +11,7 @@
 
 namespace DefaultNamespace {
     using System;
+    using System.Runtime.CompilerServices;
 
     public class FragMan
     {
@@ -26,6 +27,7 @@ namespace DefaultNamespace {
 
             GC.Collect();
             GC.WaitForPendingFinalizers();
+            GC.Collect();
 
             if (FragNode.Finalized == 0)
             {
@@ -45,7 +47,7 @@ namespace DefaultNamespace {
 
         public FragMan( )
         {
-            buildTree( );
+            buildTree();
             fnM = CvA_FNodes[12];
             CvA_FNodes = null;
             enumNode( fnM );
@@ -83,6 +85,7 @@ namespace DefaultNamespace {
         }
 
 
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public void buildTree( )
         {
             CvA_FNodes = new FragNode[26];

--- a/tests/src/GC/Scenarios/LeakGen/leakgen.cs
+++ b/tests/src/GC/Scenarios/LeakGen/leakgen.cs
@@ -5,6 +5,7 @@
 
 namespace LGen {
     using System;
+    using System.Runtime.CompilerServices;
 
     public class LeakGen
     {
@@ -52,7 +53,6 @@ namespace LGen {
             }
         }
 
-
         public bool runTest(int iRep, int iObj)
         {
 
@@ -71,6 +71,7 @@ namespace LGen {
         }
 
 
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public void MakeLeak(int iObj)
         {
             int [] mem;

--- a/tests/src/GC/Scenarios/NDPin/ndpinfinal.cs
+++ b/tests/src/GC/Scenarios/NDPin/ndpinfinal.cs
@@ -66,9 +66,9 @@ namespace DefaultNamespace {
 
 
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
-        public static void RemovePinList()
+        public static void RemovePinList(int iObj)
         {
-            for( int i=0; i< iObj; i++ )
+            for ( int i=0; i< iObj; i++ )
             {
                 pinList[i] = null;
             }
@@ -90,7 +90,7 @@ namespace DefaultNamespace {
             GC.WaitForPendingFinalizers();
             GC.Collect();
             
-            RemovePinList();
+            RemovePinList(iObj);
 
             GC.Collect();
             GC.WaitForPendingFinalizers();

--- a/tests/src/GC/Scenarios/NDPin/ndpinfinal.cs
+++ b/tests/src/GC/Scenarios/NDPin/ndpinfinal.cs
@@ -13,7 +13,9 @@ namespace DefaultNamespace {
 
     using System;
     using System.Collections.Generic;
+    using System.Runtime.CompilerServices;
     using System.Runtime.InteropServices;
+
 
     internal class NDPinFinal
     {
@@ -55,6 +57,24 @@ namespace DefaultNamespace {
             }
         }
 
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static void RemoveN()
+        {
+            m_n = null;
+        }
+
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static void RemovePinList()
+        {
+            for( int i=0; i< iObj; i++ )
+            {
+                pinList[i] = null;
+            }
+        }
+
+
         public static bool RunTest(int iObj)
         {
 
@@ -64,18 +84,17 @@ namespace DefaultNamespace {
                 return false;
             }
 
-            m_n = null;
+            RemoveN();
+
             GC.Collect();
             GC.WaitForPendingFinalizers();
             GC.Collect();
             
-            for( int i=0; i< iObj; i++ )
-            {
-                pinList[i] = null;
-            }
+            RemovePinList();
 
             GC.Collect();
             GC.WaitForPendingFinalizers();
+            GC.Collect();
            
             if( cFinalObj == cCreatObj )
             {

--- a/tests/src/GC/Scenarios/ReflectObj/reflectobj.cs
+++ b/tests/src/GC/Scenarios/ReflectObj/reflectobj.cs
@@ -16,8 +16,9 @@
 
 namespace App {
     using System;
-    using System.Reflection;
     using System.Collections.Generic;
+    using System.Reflection;
+    using System.Runtime.CompilerServices;
 
     class ReflectObj
     {
@@ -112,6 +113,7 @@ namespace App {
 
             }
 
+            [MethodImplAttribute(MethodImplOptions.NoInlining)]
             public void CreateMoreObj()
             {
                 rtype = new Type[0];

--- a/tests/src/GC/Scenarios/Resurrection/continue.cs
+++ b/tests/src/GC/Scenarios/Resurrection/continue.cs
@@ -4,6 +4,7 @@
 
 namespace DefaultNamespace {
     using System;
+    using System.Runtime.CompilerServices;
    
 
     internal class Continue
@@ -15,7 +16,9 @@ namespace DefaultNamespace {
         public class CreateObj
         {
             BNode obj;
+
 #pragma warning restore 0414
+            [MethodImplAttribute(MethodImplOptions.NoInlining)]
             public CreateObj()
             {
                 Continue mv_Obj = new Continue();
@@ -30,17 +33,16 @@ namespace DefaultNamespace {
                 Console.WriteLine(" Nodes were created.");
             }
 
-
-            public bool RunTest()
+            [MethodImplAttribute(MethodImplOptions.NoInlining)]
+            public void DestroyObj()
             {
                 obj = null;
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                GC.Collect();
+            }
 
-                Console.Write(BNode.icFinalNode); 
-                Console.WriteLine(" Nodes were finalized and resurrected.");
 
+            [MethodImplAttribute(MethodImplOptions.NoInlining)]
+            public void ResurrectNodes()
+            {
                 for (int i = 0; i < BNode.rlNodeCount; i++)
                 {
                     BNode oldNode = (BNode)BNode.rlNode[i];
@@ -51,16 +53,29 @@ namespace DefaultNamespace {
                     oldNode = null;
                     BNode.rlNode[ i ] = null;
                 }
+            }
+
+            public bool RunTest()
+            {
+                DestroyObj();
+
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+
+                Console.Write(BNode.icFinalNode); 
+                Console.WriteLine(" Nodes were finalized and resurrected.");
+
+                ResurrectNodes();
 
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
                 GC.Collect();
 
                 return ( BNode.icCreateNode == BNode.icFinalNode );
-
             }
-
         }
+
 
         public static int Main()
         {

--- a/tests/src/GC/Scenarios/Rootmem/rootmem.cs
+++ b/tests/src/GC/Scenarios/Rootmem/rootmem.cs
@@ -18,6 +18,12 @@ namespace DefaultNamespace {
         internal static GCHandle [] root;
         internal static int n;
 
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static void AllocRoot()
+        {
+        }
+
         public static int Main( String [] args )
         {
             int iSize = 1000;
@@ -32,30 +38,28 @@ namespace DefaultNamespace {
                  rm_obj = new RootMem( n );
                  root[n] = GCHandle.Alloc(rm_obj );
             }
-            //Console.WriteLine("After save objects to Root and before GCed: "+GC.GetTotalMemory(false) );
+
             GC.Collect();
             GC.WaitForPendingFinalizers();
             GC.Collect();
-            //Console.WriteLine("After save objects to Root and after GCed: "+GC.GetTotalMemory(false) );
 
             Object v;
             for( int i=0; i< iSize; i++)
             {
                 v = ( root[i]) ;
             }
-            //Console.WriteLine("After Get objects from root and before GCed: "+GC.GetTotalMemory(false) );
+
             GC.Collect();
-            //Console.WriteLine("After Get objects from root and after GCed: "+GC.GetTotalMemory(false) );
 
             for( int i=0; i<iSize; i++ )
             {
                 root[i].Free();
             }
-            //Console.WriteLine("After free root and before GCed: "+GC.GetTotalMemory(false) );
+
             GC.Collect();
             GC.WaitForPendingFinalizers();
             GC.Collect();
-            //Console.WriteLine("After free root and after GCed: "+GC.GetTotalMemory(false) );
+
             try
             {
                 for( int i=0; i<iSize; i++ )

--- a/tests/src/GC/Scenarios/Rootmem/rootmem.cs
+++ b/tests/src/GC/Scenarios/Rootmem/rootmem.cs
@@ -10,6 +10,7 @@
 
 namespace DefaultNamespace {
     using System;
+    using System.Runtime.CompilerServices;
     using System.Runtime.InteropServices;
 
     internal class RootMem

--- a/tests/src/GC/Scenarios/SingLinkList/singlinkgen.cs
+++ b/tests/src/GC/Scenarios/SingLinkList/singlinkgen.cs
@@ -93,7 +93,10 @@ namespace SingLink {
                 //Console.WriteLine("after number {0} singlink is set: {1}", i, GC.GetTotalMemory(false) );
 
                 Delete();
+
+                GC.Collect();
                 GC.WaitForPendingFinalizers();
+                GC.Collect();
 
             }
             //Console.WriteLine("total allocated memory: {0}", GC.GetTotalMemory(false));

--- a/tests/src/GC/Scenarios/WeakReference/weakreffinal.cs
+++ b/tests/src/GC/Scenarios/WeakReference/weakreffinal.cs
@@ -5,6 +5,7 @@
 namespace DefaultNamespace {
     using System;
     using System.Collections.Generic;
+    using System.Runtime.CompilerServices;
 
     internal class CreateObj
     {
@@ -31,6 +32,7 @@ namespace DefaultNamespace {
             return result;
         }
 
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public void DeleteObj(int iObj,int iSwitch)
         {
             for( int i= 0; i< iObj; i++ )

--- a/tests/src/GC/Stress/Tests/LargeObjectAlloc2.cs
+++ b/tests/src/GC/Stress/Tests/LargeObjectAlloc2.cs
@@ -56,8 +56,9 @@ namespace LargeObjectTest
         public static int ExitCode = -1;
 
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
-        public static bool AllocAndCollect()
+        public static bool AllocAndCollect(int loop)
         {
+            LargeObject largeobj;
             try
             {
                 largeobj = new LargeObject();
@@ -77,22 +78,24 @@ namespace LargeObjectTest
         public static int Main()
         {
             int loop = 0;
-            LargeObject largeobj;
 
             TestLibrary.Logging.WriteLine("Test should pass with ExitCode 100\n");
 
 
             while (loop <= 200)
             {
+                loop++;
                 TestLibrary.Logging.Write(String.Format("LOOP: {0}\n", loop));
 
-                if (!AllocAndCollect())
+                if (!AllocAndCollect(loop))
                 {
                     return 1;
                 }
 
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
+                GC.Collect();
+
                 TestLibrary.Logging.WriteLine("LargeObject Collected\n");
             }
 

--- a/tests/src/GC/Stress/Tests/PlugGaps.cs
+++ b/tests/src/GC/Stress/Tests/PlugGaps.cs
@@ -6,6 +6,7 @@
 //
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
 
@@ -34,6 +35,7 @@ public class GCUtil
     }
 
 
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static void FreePins()
     {
         foreach (GCHandle gch in list)
@@ -45,6 +47,7 @@ public class GCUtil
     }
 
 
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static void FreeNonPins()
     {
         blist.Clear();
@@ -70,6 +73,7 @@ public class GCUtil
 
 
 
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static void FreePins2()
     {
         foreach (GCHandle gch in list2)
@@ -82,6 +86,7 @@ public class GCUtil
 
 
 
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static void FreeNonPins2()
     {
         blist2.Clear();

--- a/tests/src/GC/Stress/Tests/doubLinkStay.cs
+++ b/tests/src/GC/Stress/Tests/doubLinkStay.cs
@@ -4,6 +4,7 @@
 
 
 using System;
+using System.Runtime.CompilerServices;
 
 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
@@ -75,7 +76,6 @@ namespace DoubLink
                 MakeLeak(iRep);
             }
 
-
             GC.Collect();
             GC.WaitForPendingFinalizers();
 
@@ -87,6 +87,7 @@ namespace DoubLink
             return (DLinkNode.FinalCount == iRep * iObj * 20);
         }
 
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public void SetLink(int iRep, int iObj)
         {
             for (int i = 0; i < iRep; i++)
@@ -96,6 +97,7 @@ namespace DoubLink
         }
 
 
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public void MakeLeak(int iRep)
         {
             for (int i = 0; i < iRep; i++)


### PR DESCRIPTION
This same fix has been made in #17656 and #17594. I went through all the GC tests and fixed places where we observe a similar issue. Note that most of these tests don't necessarily depend on this fix, since the JIT won't inline methods / extend lifetime of temps for most of these tests, but wanted to fix these before we see more test failures coming from the various scenarios these tests will be running against. 