### PR TITLE
Change assert in emit.cpp to consider unused space between hot/cold blocks.

### DIFF
--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -7254,7 +7254,9 @@ const char* emitter::emitOffsetToLabel(unsigned offs)
 
     for (ig = emitIGlist; ig != nullptr; ig = ig->igNext)
     {
-        assert(nextof == ig->igOffs);
+        // There is an eventual unused space after the last actual hot block
+        // before the first allocated cold block.
+        assert((nextof == ig->igOffs) || (ig == emitFirstColdIG));
 
         if (ig->igOffs == offs)
         {


### PR DESCRIPTION
I will publish the actual fix for the master branch later, but for 2.1 I prefer to go with such workaround.

cc @dotnet/jit-contrib 