### PR TITLE
Stop building Linux with "verbose"

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -2329,7 +2329,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                         def bootstrapRid = Utilities.getBoostrapPublishRid(os)
                         def bootstrapRidEnv = bootstrapRid != null ? "__PUBLISH_RID=${bootstrapRid} " : ''
 
-                        buildCommands += "${bootstrapRidEnv}./build.sh verbose ${lowerConfiguration} ${architecture}"
+                        buildCommands += "${bootstrapRidEnv}./build.sh ${lowerConfiguration} ${architecture}"
                         buildCommands += "src/pal/tests/palsuite/runpaltests.sh \${WORKSPACE}/bin/obj/${osGroup}.${architecture}.${configuration} \${WORKSPACE}/bin/paltestout"
 
                         // Basic archiving of the build
@@ -2345,7 +2345,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                         assert isJitStressScenario(scenario)
 
                         // Build coreclr
-                        buildCommands += "./build.sh verbose ${lowerConfiguration} ${architecture}"
+                        buildCommands += "./build.sh ${lowerConfiguration} ${architecture}"
 
                         def scriptFileName = "\$WORKSPACE/set_stress_test_env.sh"
 
@@ -2367,7 +2367,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                     break
                 case 'arm64':
                     if (!doCoreFxTesting) {
-                        buildCommands += "ROOTFS_DIR=/opt/arm64-xenial-rootfs ./build.sh verbose ${lowerConfiguration} ${architecture} cross crosscomponent clang3.8"
+                        buildCommands += "ROOTFS_DIR=/opt/arm64-xenial-rootfs ./build.sh ${lowerConfiguration} ${architecture} cross crosscomponent clang3.8"
                         
                         // HACK -- Arm64 does not have corefx jobs yet.
                         buildCommands += "git clone https://github.com/dotnet/corefx fx"


### PR DESCRIPTION
Using "verbose" creates an extraordinary amount of output,
obscuring interesting output. I don't know of a compelling
reason to continue using "verbose", so stop doing so.