### PR TITLE
[Arm64/Linux] Fix GenericPInvokeCalliHelper

### DIFF
--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -1746,8 +1746,8 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define RBM_PINVOKE_COOKIE_PARAM          RBM_R15
 
   // GenericPInvokeCalliHelper unmanaged target Parameter 
-  #define REG_PINVOKE_TARGET_PARAM          REG_R14
-  #define RBM_PINVOKE_TARGET_PARAM          RBM_R14
+  #define REG_PINVOKE_TARGET_PARAM          REG_R12
+  #define RBM_PINVOKE_TARGET_PARAM          RBM_R12
 
   // IL stub's secret MethodDesc parameter (JitFlags::JIT_FLAG_PUBLISH_SECRET_PARAM)
   #define REG_SECRET_STUB_PARAM     REG_R12

--- a/src/vm/amd64/PInvokeStubs.asm
+++ b/src/vm/amd64/PInvokeStubs.asm
@@ -32,14 +32,6 @@ LEAF_ENTRY GenericPInvokeCalliHelper, _TEXT
         jz              GenericPInvokeCalliGenILStub
 
         ;
-        ; We need to distinguish between a MethodDesc* and an unmanaged target in PInvokeStubForHost().  
-        ; The way we do this is to shift the managed target to the left by one bit and then set the 
-        ; least significant bit to 1.  This works because MethodDesc* are always 8-byte aligned.
-        ;
-        shl             PINVOKE_CALLI_TARGET_REGISTER, 1
-        or              PINVOKE_CALLI_TARGET_REGISTER, 1
-
-        ;
         ; jump to existing IL stub
         ;
         jmp             rax

--- a/src/vm/amd64/pinvokestubs.S
+++ b/src/vm/amd64/pinvokestubs.S
@@ -25,14 +25,6 @@ LEAF_ENTRY GenericPInvokeCalliHelper, _TEXT
         jz              C_FUNC(GenericPInvokeCalliGenILStub)
 
         //
-        // We need to distinguish between a MethodDesc* and an unmanaged target in PInvokeStubForHost().
-        // The way we do this is to shift the managed target to the left by one bit and then set the
-        // least significant bit to 1.  This works because MethodDesc* are always 8-byte aligned.
-        //
-        shl             PINVOKE_CALLI_TARGET_REGISTER, 1
-        or              PINVOKE_CALLI_TARGET_REGISTER, 1
-
-        //
         // jump to existing IL stub
         //
         jmp             rax

--- a/src/vm/arm64/PInvokeStubs.asm
+++ b/src/vm/arm64/PInvokeStubs.asm
@@ -124,9 +124,9 @@ __PInvokeGenStubFuncName SETS "$__PInvokeGenStubFuncName":CC:"_RetBuffArg"
 ;
 ; in:
 ; x15 = VASigCookie*
-; x14 = Unmanaged target
+; x12 = Unmanaged target
 ;
-        PINVOKE_STUB GenericPInvokeCalli, x15, x14, {true}
+        PINVOKE_STUB GenericPInvokeCalli, x15, x12, {true}
 
 ; ------------------------------------------------------------------
 ; VarargPInvokeStub_RetBuffArg & VarargPInvokeGenILStub_RetBuffArg

--- a/src/vm/arm64/pinvokestubs.S
+++ b/src/vm/arm64/pinvokestubs.S
@@ -32,7 +32,6 @@
         // if null goto stub generation
         cbz                 x9, LOCAL_LABEL(\__PInvokeStubFuncName\()_0)
 
-
         EPILOG_BRANCH_REG   x9 
 
 LOCAL_LABEL(\__PInvokeStubFuncName\()_0):
@@ -96,9 +95,9 @@ PINVOKE_STUB VarargPInvokeStub, VarargPInvokeGenILStub, VarargPInvokeStubWorker,
 //
 // in:
 // x15 = VASigCookie*
-// x14 = Unmanaged target
+// x12 = Unmanaged target
 //
-PINVOKE_STUB GenericPInvokeCalliHelper, GenericPInvokeCalliGenILStub, GenericPInvokeCalliStubWorker, x15, x14, 1
+PINVOKE_STUB GenericPInvokeCalliHelper, GenericPInvokeCalliGenILStub, GenericPInvokeCalliStubWorker, x15, x12, 1
 
 // ------------------------------------------------------------------
 // VarargPInvokeStub_RetBuffArg & VarargPInvokeGenILStub_RetBuffArg

--- a/src/vm/dllimport.cpp
+++ b/src/vm/dllimport.cpp
@@ -2253,31 +2253,9 @@ void NDirectStubLinker::DoNDirect(ILCodeStream *pcsEmit, DWORD dwStubFlags, Meth
                 // if we ever NGEN CALLI stubs, this would have to be done differently
                 _ASSERTE(!SF_IsNGENedStub(dwStubFlags));
 
-#ifndef CROSSGEN_COMPILE
-
-#ifdef _TARGET_X86_
-
-                {
-                    // for managed-to-unmanaged CALLI that requires marshaling, the target is passed
-                    // as the secret argument to the stub by GenericPInvokeCalliHelper (asmhelpers.asm)
-                    EmitLoadStubContext(pcsEmit, dwStubFlags);
-                }
-
-
-#else // _TARGET_X86_
-
-                {
-                    // the secret arg has been shifted to left and ORed with 1 (see code:GenericPInvokeCalliHelper)
-                    EmitLoadStubContext(pcsEmit, dwStubFlags);
-#ifndef _TARGET_ARM_
-                    pcsEmit->EmitLDC(1);
-                    pcsEmit->EmitSHR_UN();
-#endif
-                }
-
-#endif // _TARGET_X86_
-
-#endif // CROSSGEN_COMPILE
+                // for managed-to-unmanaged CALLI that requires marshaling, the target is passed
+                // as the secret argument to the stub by GenericPInvokeCalliHelper (asmhelpers.asm)
+                EmitLoadStubContext(pcsEmit, dwStubFlags);
             }
             else
 #ifdef FEATURE_COMINTEROP


### PR DESCRIPTION
@RussKeldorph @adityamandaleeka @jkotas This is an ask to port #17659 to release/2.1

This fixes one corefx test, the CALLI implementation for arm64 and removes some redundant amd64 operations.  I can make it ARM64 specific, if anyone has concerns about the amd64 changes.