### PR TITLE
Fix getting the Absolute path while looking up the TZ files

### DIFF
--- a/src/mscorlib/shared/System/TimeZoneInfo.Unix.cs
+++ b/src/mscorlib/shared/System/TimeZoneInfo.Unix.cs
@@ -385,7 +385,7 @@ namespace System
             if (symlinkPath != null)
             {
                 // Use Path.Combine to resolve links that contain a relative path (e.g. /etc/localtime).
-                symlinkPath = Path.Combine(tzFilePath, symlinkPath);
+                symlinkPath = Path.GetFullPath(symlinkPath, Path.GetDirectoryName(tzFilePath));
 
                 string timeZoneDirectory = GetTimeZoneDirectory();
                 if (symlinkPath.StartsWith(timeZoneDirectory, StringComparison.Ordinal))

--- a/src/mscorlib/shared/System/TimeZoneInfo.Unix.cs
+++ b/src/mscorlib/shared/System/TimeZoneInfo.Unix.cs
@@ -384,7 +384,7 @@ namespace System
             string symlinkPath = Interop.Sys.ReadLink(tzFilePath);
             if (symlinkPath != null)
             {
-                // Use Path.Combine to resolve links that contain a relative path (e.g. /etc/localtime).
+                // symlinkPath can be relative path, use Path to get the full absolute path.
                 symlinkPath = Path.GetFullPath(symlinkPath, Path.GetDirectoryName(tzFilePath));
 
                 string timeZoneDirectory = GetTimeZoneDirectory();


### PR DESCRIPTION
We used to call Path.Combine and passing 2 file paths (and not really a directory paths) which always produced a wrong full path. This causes us to always go and enumerate TZ files and compare the content of each file to the current TZ data we have. So, this should speed up the TZ creation on Linux as we'll not enumerate the TZ files. 

Also, this will fix getting the correct Id of the TZ. for example, when trying to get the Iran time zone, currently we'll get the Id= "Iran" as this is the TZ file name. while after the fix we'll get the correct Id= "Asia/Tehran" 