### PR TITLE
Port two changes from CoreFX to *memory.cs that were missed by mirror

### DIFF
--- a/src/mscorlib/shared/System/Memory.cs
+++ b/src/mscorlib/shared/System/Memory.cs
@@ -318,8 +318,11 @@ namespace System
 
         /// <summary>
         /// Creates a handle for the memory.
-        /// The GC will not move the array until the returned <see cref="MemoryHandle"/>
+        /// The GC will not move the memory until the returned <see cref="MemoryHandle"/>
         /// is disposed, enabling taking and using the memory's address.
+        /// <exception cref="System.ArgumentException">
+        /// An instance with nonprimitive (non-blittable) members cannot be pinned.
+        /// </exception>
         /// </summary>
         public unsafe MemoryHandle Pin()
         {
@@ -345,13 +348,26 @@ namespace System
             }
             else if (_object is T[] array)
             {
-                GCHandle handle = _length < 0 ? default : GCHandle.Alloc(array, GCHandleType.Pinned);
+                // Array is already pre-pinned
+                if (_length < 0)
+                {
 #if FEATURE_PORTABLE_SPAN
-                void* pointer = Unsafe.Add<T>((void*)handle.AddrOfPinnedObject(), _index);
+                    void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref MemoryMarshal.GetReference<T>(array)), _index);
 #else
-                void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref array.GetRawSzArrayData()), _index);
+                    void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref array.GetRawSzArrayData()), _index);
 #endif // FEATURE_PORTABLE_SPAN
-                return new MemoryHandle(pointer, handle);
+                    return new MemoryHandle(pointer);
+                }
+                else
+                {
+                    GCHandle handle = GCHandle.Alloc(array, GCHandleType.Pinned);
+#if FEATURE_PORTABLE_SPAN
+                    void* pointer = Unsafe.Add<T>((void*)handle.AddrOfPinnedObject(), _index);
+#else
+                    void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref array.GetRawSzArrayData()), _index);
+#endif // FEATURE_PORTABLE_SPAN
+                    return new MemoryHandle(pointer, handle);
+                }
             }
             return default;
         }

--- a/src/mscorlib/shared/System/ReadOnlyMemory.cs
+++ b/src/mscorlib/shared/System/ReadOnlyMemory.cs
@@ -235,8 +235,11 @@ namespace System
 
         /// <summary>
         /// Creates a handle for the memory.
-        /// The GC will not move the array until the returned <see cref="MemoryHandle"/>
+        /// The GC will not move the memory until the returned <see cref="MemoryHandle"/>
         /// is disposed, enabling taking and using the memory's address.
+        /// <exception cref="System.ArgumentException">
+        /// An instance with nonprimitive (non-blittable) members cannot be pinned.
+        /// </exception>
         /// </summary>
         public unsafe MemoryHandle Pin()
         {
@@ -257,13 +260,26 @@ namespace System
             }
             else if (_object is T[] array)
             {
-                GCHandle handle = _length < 0 ? default : GCHandle.Alloc(array, GCHandleType.Pinned);
+                // Array is already pre-pinned
+                if (_length < 0)
+                {
 #if FEATURE_PORTABLE_SPAN
-                void* pointer = Unsafe.Add<T>((void*)handle.AddrOfPinnedObject(), _index);
+                    void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref MemoryMarshal.GetReference<T>(array)), _index);
 #else
-                void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref array.GetRawSzArrayData()), _index);
+                    void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref array.GetRawSzArrayData()), _index);
 #endif // FEATURE_PORTABLE_SPAN
-                return new MemoryHandle(pointer, handle);
+                    return new MemoryHandle(pointer);
+                }
+                else
+                {
+                    GCHandle handle = GCHandle.Alloc(array, GCHandleType.Pinned);
+#if FEATURE_PORTABLE_SPAN
+                    void* pointer = Unsafe.Add<T>((void*)handle.AddrOfPinnedObject(), _index);
+#else
+                    void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref array.GetRawSzArrayData()), _index);
+#endif // FEATURE_PORTABLE_SPAN
+                    return new MemoryHandle(pointer, handle);
+                }
             }
             return default;
         }


### PR DESCRIPTION
https://github.com/dotnet/corefx/commit/b4d701a72c20b695715371a99b48473053b63250
Author: Ahson Khan <ahkha@microsoft.com>
Date:   Wed Apr 11 13:43:36 2018 -0700

Add CreateFromPinnedArray to System.Memory ref and add tests (#28992)
Fixing bug in Memory.Pin and adding API to uapaot baseline

Comments only, porting so we can start the mirror up without issues:

https://github.com/dotnet/corefx/commit/76e01040fcfdb1c652ef1bf4e8e123c7db4e1be8
Author: Ahson Khan <ahkha@microsoft.com>
Date:   Mon Apr 16 01:54:54 2018 -0700
    Update xml comment for {ReadOnly}Memory.Pin method (#29137)

Reconciliation on other side is https://github.com/dotnet/corefx/pull/29256