### PR TITLE
Fix FakePromote assert

### DIFF
--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -924,8 +924,11 @@ void FakePromote(PTR_PTR_Object ppObj, ScanContext *pSC, uint32_t dwFlags)
         MODE_ANY;
     } CONTRACTL_END;
 
-    _ASSERTE(*ppObj == NULL);
-    *(CORCOMPILE_GCREFMAP_TOKENS *)ppObj = (dwFlags & GC_CALL_INTERIOR) ? GCREFMAP_INTERIOR : GCREFMAP_REF;
+    CORCOMPILE_GCREFMAP_TOKENS newToken = (dwFlags & GC_CALL_INTERIOR) ? GCREFMAP_INTERIOR : GCREFMAP_REF;
+
+    _ASSERTE((*ppObj == NULL) || (*(CORCOMPILE_GCREFMAP_TOKENS *)ppObj == newToken));
+
+    *(CORCOMPILE_GCREFMAP_TOKENS *)ppObj = newToken;
 }
 
 //=================================================================================


### PR DESCRIPTION
This assert was firing when there was a struct with explicit layout and
two byref fields overlapping each other. The assert was checking that
the respective location on the stack was not reported yet.
To fix that, I have changed the assert to fire only if the already
reported kind of reference was different from the current one. That
enables overlapping of two byref fields or two ref fields, but not a
byref and ref fields.

Close #17565