### PR TITLE
Fix unix test build by removing unnecessary 'managed_test_build' semafore file

### DIFF
--- a/build-test.sh
+++ b/build-test.sh
@@ -240,22 +240,13 @@ build_Tests()
 
     echo "Starting the Managed Tests Build..."
 
-    __ManagedTestBuiltMarker=${__TestBinDir}/managed_test_build
+    build_Tests_internal "Tests_Managed" "$__ProjectDir/tests/build.proj" "$__up" "Managed tests build (build tests)"
 
-    if [ ! -f $__ManagedTestBuiltMarker ]; then
-
-        build_Tests_internal "Tests_Managed" "$__ProjectDir/tests/build.proj" "$__up" "Managed tests build (build tests)"
-
-        if [ $? -ne 0 ]; then
-            echo "${__MsgPrefix}Error: build failed. Refer to the build log files for details (above)"
-            exit 1
-        else
-            echo "Tests have been built."
-            echo "Create marker \"${__ManagedTestBuiltMarker}\""
-            touch $__ManagedTestBuiltMarker
-        fi
+    if [ $? -ne 0 ]; then
+        echo "${__MsgPrefix}Error: build failed. Refer to the build log files for details (above)"
+        exit 1
     else
-        echo "Managed Tests had been built before."
+        echo "Managed tests build success!"
     fi
 
     if [ $__BuildTestWrappers -ne -0 ]; then

--- a/tests/src/dirs.proj
+++ b/tests/src/dirs.proj
@@ -34,7 +34,7 @@
     </ItemGroup>
 
     <!-- Unix builds do not support subgroups -->
-    <ItemGroup Condition="$(__BuildOS) != 'Windows_NT' And $(__TestGroupToBuild) == '1' And $(TestBuildSlice) == '1'">
+    <ItemGroup Condition="$(__BuildOS) != 'Windows_NT'" >
       <Project Include="*\**\*.csproj" Exclude="@(DisabledProjects)">
         <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
       </Project>


### PR DESCRIPTION

Fixes #17503

The error is caused by both:

1. Unnecessary usage of 'managed_test_build' semaphore file which is incorrectly
   set after /t:BatchRestorePackages build target and prevents managed test build
   which is invoked after semaphore alredy exists
2. Masked by the above error is a wrong condition in dirs.proj non-windows test build
   which was introduced by PR #17161 and which prevented unix build due to missing
   #17161 group build port to unix