### PR TITLE
Port more Vector tests to Vector128/256<T>

### DIFF
--- a/tests/src/JIT/HardwareIntrinsics/X86/General/VectorArgs.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/VectorArgs.cs
@@ -1,0 +1,114 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+// This test case is ported from S.N.Vector counterpart 
+// https://github.com/dotnet/coreclr/blob/master/tests/src/JIT/SIMD/VectorArgs.cs
+
+using System;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+internal partial class IntelHardwareIntrinsicTest
+{
+    private const int Pass = 100;
+    private const int Fail = -1;
+
+    internal class VectorArg128
+    {
+        private Vector128<float> _rgb;
+
+        public VectorArg128(float r, float g, float b)
+        {
+            float[] temp = new float[4];
+            temp[0] = r; temp[1] = g; temp[2] = b;
+            unsafe
+            {
+                fixed (float* ptr = temp)
+                {
+                    _rgb = Sse.LoadVector128(ptr);
+                }
+            }
+        }
+
+        public VectorArg128(Vector128<float> _rgb)
+        { this._rgb = _rgb; }
+
+        public VectorArg128 Change(float f)
+        {
+            Vector128<float> t = Sse.SetAllVector128(f);
+            return new VectorArg128(Sse.Add(t, _rgb));
+        }
+
+        public Vector128<float> RGB { get { return _rgb; } }
+    }
+
+    internal class VectorArg256
+    {
+        private Vector256<float> _rgb;
+
+        public VectorArg256(float r, float g, float b)
+        {
+            float[] temp = new float[8];
+            temp[0] = r; temp[1] = g; temp[2] = b;
+            unsafe
+            {
+                fixed (float* ptr = temp)
+                {
+                    _rgb = Avx.LoadVector256(ptr);
+                }
+            }
+        }
+
+        public VectorArg256(Vector256<float> _rgb)
+        { this._rgb = _rgb; }
+
+        public VectorArg256 Change(float f)
+        {
+            Vector256<float> t = Avx.SetAllVector256(f);
+            return new VectorArg256(Avx.Add(t, _rgb));
+        }
+
+        public Vector256<float> RGB { get { return _rgb; } }
+    }
+
+    unsafe static int Main()
+    {
+        int returnVal = Pass;
+
+        if (Sse41.IsSupported)
+        {
+            Vector128<float> rgb = Sse.SetVector128(0, 1, 2, 3);
+            float x = 2f;
+            VectorArg128 c1 = new VectorArg128(rgb);
+            VectorArg128 c2 = c1.Change(x);
+            for (int i = 0; i < 4; i++)
+            {
+                if (((int)Sse41.Extract(c2.RGB, (byte)i)) != (3 - i) + x)
+                {
+                    returnVal = Fail;
+                }
+            }
+        }
+
+        if (Avx.IsSupported)
+        {
+            Vector256<float> rgb = Avx.SetVector256(0f, 1f, 2f, 3f, 4f, 5f, 6f, 7f);
+            float x = 2f;
+            VectorArg256 c1 = new VectorArg256(rgb);
+            VectorArg256 c2 = c1.Change(x);
+            float* buffer = stackalloc float[8];
+            Avx.Store(buffer, c2.RGB);
+            for (int i = 0; i < 8; i++)
+            {
+                if (((int)buffer[i]) != (7 - i) + x)
+                {
+                    returnVal = Fail;
+                }
+            }
+        }
+
+        return returnVal;
+    }
+}

--- a/tests/src/JIT/HardwareIntrinsics/X86/General/VectorArgs_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/VectorArgs_r.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize></Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="VectorArgs.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/HardwareIntrinsics/X86/General/VectorArgs_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/VectorArgs_ro.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="VectorArgs.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/HardwareIntrinsics/X86/General/VectorArray.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/VectorArray.cs
@@ -1,0 +1,148 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+// This test case is ported from S.N.Vector counterpart 
+// https://github.com/dotnet/coreclr/blob/master/tests/src/JIT/SIMD/VectorArray.cs
+
+using System;
+using System.Numerics;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using System.Runtime.CompilerServices;
+
+internal partial class IntelHardwareIntrinsicTest
+{
+    private const int Pass = 100;
+    private const int Fail = -1;
+
+    private class Vector128ArrayTest<T> where T : struct, IComparable<T>, IEquatable<T>
+    {
+        private static void Move(Vector128<T>[] pos, ref Vector128<T> delta)
+        {
+            for (int i = 0; i < pos.Length; ++i)
+            {
+                pos[i] = Vector128Add<T>(pos[i], delta);
+            }
+        }
+
+        static public unsafe int Vector128Array()
+        {
+            Vector128<T>[] v = new Vector128<T>[3];
+            int elementSize = Unsafe.SizeOf<T>();
+            const int vectorSize = 16;
+            int elementCount = vectorSize / elementSize;
+
+            for (int i = 0; i < v.Length; ++i)
+                v[i] = SetAllVector128<T>(GetValueFromInt<T>(i + 1));
+
+            Vector128<T> delta = SetAllVector128<T>(GetValueFromInt<T>(1));
+            Move(v, ref delta);
+
+            byte* buffer = stackalloc byte[vectorSize * v.Length];
+            for (int i = 0; i < v.Length; ++i)
+                Unsafe.Write<Vector128<T>>(buffer + i * vectorSize, v[i]);
+
+            for (int i = 0; i < v.Length; i++)
+            {
+                T checkValue = GetValueFromInt<T>(i + 2);
+                for (int j = 0; j < elementCount; j++)
+                {
+                    if (!CheckValue<T>(Unsafe.Read<T>(&buffer[i * vectorSize + j * elementSize]), checkValue)) return Fail;
+                }
+            }
+
+            return Pass;
+        }
+    }
+
+    private class Vector256ArrayTest<T> where T : struct, IComparable<T>, IEquatable<T>
+    {
+        private static void Move(Vector256<T>[] pos, ref Vector256<T> delta)
+        {
+            for (int i = 0; i < pos.Length; ++i)
+            {
+                pos[i] = Vector256Add<T>(pos[i], delta);
+            }
+        }
+
+        static public unsafe int Vector256Array()
+        {
+            Vector256<T>[] v = new Vector256<T>[3];
+            int elementSize = Unsafe.SizeOf<T>();
+            const int vectorSize = 32;
+            int elementCount = vectorSize / elementSize;
+
+            for (int i = 0; i < v.Length; ++i)
+                v[i] = Avx.SetAllVector256<T>((T)Convert.ChangeType(i + 1, typeof(T)));
+
+            Vector256<T> delta = Avx.SetAllVector256((T)Convert.ChangeType(1, typeof(T)));
+            Move(v, ref delta);
+
+            byte* buffer = stackalloc byte[vectorSize * v.Length];
+            for (int i = 0; i < v.Length; ++i)
+                Unsafe.Write<Vector256<T>>(buffer + i * vectorSize, v[i]);
+
+            for (int i = 0; i < v.Length; i++)
+            {
+                T checkValue = GetValueFromInt<T>(i + 2);
+                for (int j = 0; j < elementCount; j++)
+                {
+                    if (!CheckValue<T>(Unsafe.Read<T>(&buffer[i * vectorSize + j * elementSize]), checkValue)) return Fail;
+                }
+            }
+
+            return Pass;
+        }
+    }
+
+    unsafe static int Main()
+    {
+        int returnVal = Pass;
+        try
+        {
+            if (Sse2.IsSupported)
+            {
+                if (Vector128ArrayTest<float>.Vector128Array() != Pass) returnVal = Fail;
+                if (Vector128ArrayTest<double>.Vector128Array() != Pass) returnVal = Fail;
+                if (Vector128ArrayTest<byte>.Vector128Array() != Pass) returnVal = Fail;
+                if (Vector128ArrayTest<sbyte>.Vector128Array() != Pass) returnVal = Fail;
+                if (Vector128ArrayTest<short>.Vector128Array() != Pass) returnVal = Fail;
+                if (Vector128ArrayTest<ushort>.Vector128Array() != Pass) returnVal = Fail;
+                if (Vector128ArrayTest<int>.Vector128Array() != Pass) returnVal = Fail;
+                if (Vector128ArrayTest<uint>.Vector128Array() != Pass) returnVal = Fail;
+                if (Environment.Is64BitProcess)
+                {
+                    if (Vector128ArrayTest<long>.Vector128Array() != Pass) returnVal = Fail;
+                    if (Vector128ArrayTest<ulong>.Vector128Array() != Pass) returnVal = Fail;
+                }
+            }
+
+            if (Avx2.IsSupported)
+            {
+                if (Vector256ArrayTest<float>.Vector256Array() != Pass) returnVal = Fail;
+                if (Vector256ArrayTest<double>.Vector256Array() != Pass) returnVal = Fail;
+                if (Vector256ArrayTest<byte>.Vector256Array() != Pass) returnVal = Fail;
+                if (Vector256ArrayTest<sbyte>.Vector256Array() != Pass) returnVal = Fail;
+                if (Vector256ArrayTest<short>.Vector256Array() != Pass) returnVal = Fail;
+                if (Vector256ArrayTest<ushort>.Vector256Array() != Pass) returnVal = Fail;
+                if (Vector256ArrayTest<int>.Vector256Array() != Pass) returnVal = Fail;
+                if (Vector256ArrayTest<uint>.Vector256Array() != Pass) returnVal = Fail;
+                if (Environment.Is64BitProcess)
+                {
+                    if (Vector256ArrayTest<long>.Vector256Array() != Pass) returnVal = Fail;
+                    if (Vector256ArrayTest<ulong>.Vector256Array() != Pass) returnVal = Fail;
+                }
+            }
+        }
+        catch (NotSupportedException ex)
+        {
+            Console.WriteLine("NotSupportedException was raised");
+            Console.WriteLine(ex.StackTrace);
+            return Fail;
+        }
+
+        return returnVal;
+    }
+}

--- a/tests/src/JIT/HardwareIntrinsics/X86/General/VectorArray_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/VectorArray_r.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize></Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="VectorArray.cs" />
+    <Compile Include="VectorHelpers.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/HardwareIntrinsics/X86/General/VectorArray_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/VectorArray_ro.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="VectorArray.cs" />
+    <Compile Include="VectorHelpers.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/HardwareIntrinsics/X86/General/VectorHelpers.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/VectorHelpers.cs
@@ -1,0 +1,267 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+using System;
+using System.Numerics;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using System.Runtime.CompilerServices;
+
+internal partial class IntelHardwareIntrinsicTest
+{
+    public static Vector128<T> Vector128Add<T>(Vector128<T> left, Vector128<T> right) where T : struct
+    {
+        if (typeof(T) == typeof(byte))
+        {
+            return Sse.StaticCast<byte, T>(Sse2.Add(Sse.StaticCast<T, byte>(left), Sse.StaticCast<T, byte>(right)));
+        }
+        else if (typeof(T) == typeof(sbyte))
+        {
+            return Sse.StaticCast<sbyte, T>(Sse2.Add(Sse.StaticCast<T, sbyte>(left), Sse.StaticCast<T, sbyte>(right)));
+        }
+        else if (typeof(T) == typeof(short))
+        {
+            return Sse.StaticCast<short, T>(Sse2.Add(Sse.StaticCast<T, short>(left), Sse.StaticCast<T, short>(right)));
+        }
+        else if (typeof(T) == typeof(ushort))
+        {
+            return Sse.StaticCast<ushort, T>(Sse2.Add(Sse.StaticCast<T, ushort>(left), Sse.StaticCast<T, ushort>(right)));
+        }
+        else if (typeof(T) == typeof(int))
+        {
+            return Sse.StaticCast<int, T>(Sse2.Add(Sse.StaticCast<T, int>(left), Sse.StaticCast<T, int>(right)));
+        }
+        else if (typeof(T) == typeof(uint))
+        {
+            return Sse.StaticCast<uint, T>(Sse2.Add(Sse.StaticCast<T, uint>(left), Sse.StaticCast<T, uint>(right)));
+        }
+        else if (typeof(T) == typeof(long))
+        {
+            return Sse.StaticCast<long, T>(Sse2.Add(Sse.StaticCast<T, long>(left), Sse.StaticCast<T, long>(right)));
+        }
+        else if (typeof(T) == typeof(ulong))
+        {
+            return Sse.StaticCast<ulong, T>(Sse2.Add(Sse.StaticCast<T, ulong>(left), Sse.StaticCast<T, ulong>(right)));
+        }
+        else if (typeof(T) == typeof(float))
+        {
+            return Sse.StaticCast<float, T>(Sse.Add(Sse.StaticCast<T, float>(left), Sse.StaticCast<T, float>(right)));
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            return Sse.StaticCast<double, T>(Sse2.Add(Sse.StaticCast<T, double>(left), Sse.StaticCast<T, double>(right)));
+        }
+        else
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    public static Vector256<T> Vector256Add<T>(Vector256<T> left, Vector256<T> right) where T : struct
+    {
+        if (typeof(T) == typeof(byte))
+        {
+            return Avx.StaticCast<byte, T>(Avx2.Add(Avx.StaticCast<T, byte>(left), Avx.StaticCast<T, byte>(right)));
+        }
+        else if (typeof(T) == typeof(sbyte))
+        {
+            return Avx.StaticCast<sbyte, T>(Avx2.Add(Avx.StaticCast<T, sbyte>(left), Avx.StaticCast<T, sbyte>(right)));
+        }
+        else if (typeof(T) == typeof(short))
+        {
+            return Avx.StaticCast<short, T>(Avx2.Add(Avx.StaticCast<T, short>(left), Avx.StaticCast<T, short>(right)));
+        }
+        else if (typeof(T) == typeof(ushort))
+        {
+            return Avx.StaticCast<ushort, T>(Avx2.Add(Avx.StaticCast<T, ushort>(left), Avx.StaticCast<T, ushort>(right)));
+        }
+        else if (typeof(T) == typeof(int))
+        {
+            return Avx.StaticCast<int, T>(Avx2.Add(Avx.StaticCast<T, int>(left), Avx.StaticCast<T, int>(right)));
+        }
+        else if (typeof(T) == typeof(uint))
+        {
+            return Avx.StaticCast<uint, T>(Avx2.Add(Avx.StaticCast<T, uint>(left), Avx.StaticCast<T, uint>(right)));
+        }
+        else if (typeof(T) == typeof(long))
+        {
+            return Avx.StaticCast<long, T>(Avx2.Add(Avx.StaticCast<T, long>(left), Avx.StaticCast<T, long>(right)));
+        }
+        else if (typeof(T) == typeof(ulong))
+        {
+            return Avx.StaticCast<ulong, T>(Avx2.Add(Avx.StaticCast<T, ulong>(left), Avx.StaticCast<T, ulong>(right)));
+        }
+        else if (typeof(T) == typeof(float))
+        {
+            return Avx.StaticCast<float, T>(Avx.Add(Avx.StaticCast<T, float>(left), Avx.StaticCast<T, float>(right)));
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            return Avx.StaticCast<double, T>(Avx.Add(Avx.StaticCast<T, double>(left), Avx.StaticCast<T, double>(right)));
+        }
+        else
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    public static Vector128<T> SetAllVector128<T>(T value) where T : struct
+    {
+        if (typeof(T) == typeof(byte))
+        {
+            return Sse.StaticCast<byte, T>(Sse2.SetAllVector128(Convert.ToByte(value)));
+        }
+        else if (typeof(T) == typeof(sbyte))
+        {
+            return Sse.StaticCast<sbyte, T>(Sse2.SetAllVector128(Convert.ToSByte(value)));
+        }
+        else if (typeof(T) == typeof(short))
+        {
+            return Sse.StaticCast<short, T>(Sse2.SetAllVector128(Convert.ToInt16(value)));
+        }
+        else if (typeof(T) == typeof(ushort))
+        {
+            return Sse.StaticCast<ushort, T>(Sse2.SetAllVector128(Convert.ToUInt16(value)));
+        }
+        else if (typeof(T) == typeof(int))
+        {
+            return Sse.StaticCast<int, T>(Sse2.SetAllVector128(Convert.ToInt32(value)));
+        }
+        else if (typeof(T) == typeof(uint))
+        {
+            return Sse.StaticCast<uint, T>(Sse2.SetAllVector128(Convert.ToUInt32(value)));
+        }
+        else if (typeof(T) == typeof(long))
+        {
+            return Sse.StaticCast<long, T>(Sse2.SetAllVector128(Convert.ToInt64(value)));
+        }
+        else if (typeof(T) == typeof(ulong))
+        {
+            return Sse.StaticCast<ulong, T>(Sse2.SetAllVector128(Convert.ToUInt64(value)));
+        }
+        else if (typeof(T) == typeof(float))
+        {
+            return Sse.StaticCast<float, T>(Sse.SetAllVector128(Convert.ToSingle(value)));
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            return Sse.StaticCast<double, T>(Sse2.SetAllVector128(Convert.ToDouble(value)));
+        }
+        else
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    // These two helper functions are a workaround for the bug of Sse2.SetZeroVector128<float>
+    // https://github.com/dotnet/coreclr/pull/17691
+    public static Vector128<T> SetZeroVector128<T>() where T : struct
+    {
+        if (typeof(T) == typeof(float))
+        {
+            return Sse.StaticCast<float, T>(Sse.SetZeroVector128());
+        }
+        else
+        {
+            return Sse2SetZeroVector128<T>();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector128<T> Sse2SetZeroVector128<T>() where T : struct
+    {
+        if (typeof(T) == typeof(double) || typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte) || typeof(T) == typeof(short) ||
+            typeof(T) == typeof(ushort) || typeof(T) == typeof(int) || typeof(T) == typeof(uint) || typeof(T) == typeof(long) || typeof(T) == typeof(ulong))
+        {
+            return Sse2.SetZeroVector128<T>();
+        }
+        else
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    public static bool CheckValue<T>(T value, T expectedValue) where T : struct
+    {
+        bool returnVal;
+        if (typeof(T) == typeof(float))
+        {
+            returnVal = Math.Abs(((float)(object)value) - ((float)(object)expectedValue)) <= Single.Epsilon;
+        }
+        if (typeof(T) == typeof(double))
+        {
+            returnVal = Math.Abs(((double)(object)value) - ((double)(object)expectedValue)) <= Double.Epsilon;
+        }
+        else
+        {
+            returnVal = value.Equals(expectedValue);
+        }
+        if (returnVal == false)
+        {
+            if ((typeof(T) == typeof(double)) || (typeof(T) == typeof(float)))
+            {
+                Console.WriteLine("CheckValue failed for type " + typeof(T).ToString() + ". Expected: {0} , Got: {1}", expectedValue, value);
+            }
+            else
+            {
+                Console.WriteLine("CheckValue failed for type " + typeof(T).ToString() + ". Expected: {0} (0x{0:X}), Got: {1} (0x{1:X})", expectedValue, value);
+            }
+        }
+        return returnVal;
+    }
+
+    public static T GetValueFromInt<T>(int value) where T : struct
+    {
+        if (typeof(T) == typeof(float))
+        {
+            float floatValue = (float)value;
+            return (T)(object)floatValue;
+        }
+        if (typeof(T) == typeof(double))
+        {
+            double doubleValue = (double)value;
+            return (T)(object)doubleValue;
+        }
+        if (typeof(T) == typeof(int))
+        {
+            return (T)(object)value;
+        }
+        if (typeof(T) == typeof(uint))
+        {
+            uint uintValue = (uint)value;
+            return (T)(object)uintValue;
+        }
+        if (typeof(T) == typeof(long))
+        {
+            long longValue = (long)value;
+            return (T)(object)longValue;
+        }
+        if (typeof(T) == typeof(ulong))
+        {
+            ulong longValue = (ulong)value;
+            return (T)(object)longValue;
+        }
+        if (typeof(T) == typeof(ushort))
+        {
+            return (T)(object)(ushort)value;
+        }
+        if (typeof(T) == typeof(byte))
+        {
+            return (T)(object)(byte)value;
+        }
+        if (typeof(T) == typeof(short))
+        {
+            return (T)(object)(short)value;
+        }
+        if (typeof(T) == typeof(sbyte))
+        {
+            return (T)(object)(sbyte)value;
+        }
+        else
+        {
+            throw new ArgumentException();
+        }
+    }
+}

--- a/tests/src/JIT/HardwareIntrinsics/X86/General/VectorRet.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/VectorRet.cs
@@ -209,156 +209,27 @@ internal partial class IntelHardwareIntrinsicTest
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static Vector128<T> Vector128One<T>() where T : struct
     {
-        if (typeof(T) == typeof(float))
-        {
-            return Sse.StaticCast<float, T>(Sse.SetAllVector128(1.0f));
-        }
-        else if (typeof(T) == typeof(double))
-        {
-            return Sse.StaticCast<double, T>(Sse2.SetAllVector128((double)1));
-        }
-        else if (typeof(T) == typeof(byte))
-        {
-            return Sse.StaticCast<byte, T>(Sse2.SetAllVector128((byte)1));
-        }
-        else if (typeof(T) == typeof(sbyte))
-        {
-            return Sse.StaticCast<sbyte, T>(Sse2.SetAllVector128((sbyte)1));
-        }
-        else if (typeof(T) == typeof(short))
-        {
-            return Sse.StaticCast<short, T>(Sse2.SetAllVector128((short)1));
-        }
-        else if (typeof(T) == typeof(ushort))
-        {
-            return Sse.StaticCast<ushort, T>(Sse2.SetAllVector128((ushort)1));
-        }
-        else if (typeof(T) == typeof(int))
-        {
-            return Sse.StaticCast<int, T>(Sse2.SetAllVector128((int)1));
-        }
-        else if (typeof(T) == typeof(uint))
-        {
-            return Sse.StaticCast<uint, T>(Sse2.SetAllVector128((uint)1));
-        }
-        else if (typeof(T) == typeof(long))
-        {
-            return Sse.StaticCast<long, T>(Sse2.SetAllVector128((long)1));
-        }
-        else if (typeof(T) == typeof(ulong))
-        {
-            return Sse.StaticCast<ulong, T>(Sse2.SetAllVector128((ulong)1));
-        }
-        else
-        {
-            throw new NotSupportedException();
-        }
+        return SetAllVector128(GetValueFromInt<T>(1));
     }
 
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static Vector256<T> Vector256One<T>() where T : struct
     {
-        return Avx.SetAllVector256((T)Convert.ChangeType(1, typeof(T)));
+        return Avx.SetAllVector256(GetValueFromInt<T>(1));
     }
 
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static Vector128<T> Vector128PlusOne<T>(Vector128<T> v1) where T : struct
     {
         Vector128<T> v2 = Vector128One<T>();
-        if (typeof(T) == typeof(float))
-        {
-            return Sse.StaticCast<float, T>(Sse.Add(Sse.StaticCast<T, float>(v1), Sse.StaticCast<T, float>(v2)));
-        }
-        else if (typeof(T) == typeof(double))
-        {
-            return Sse.StaticCast<double, T>(Sse2.Add(Sse.StaticCast<T, double>(v1), Sse.StaticCast<T, double>(v2)));
-        }
-        else if (typeof(T) == typeof(byte))
-        {
-            return Sse.StaticCast<byte, T>(Sse2.Add(Sse.StaticCast<T, byte>(v1), Sse.StaticCast<T, byte>(v2)));
-        }
-        else if (typeof(T) == typeof(sbyte))
-        {
-            return Sse.StaticCast<sbyte, T>(Sse2.Add(Sse.StaticCast<T, sbyte>(v1), Sse.StaticCast<T, sbyte>(v2)));
-        }
-        else if (typeof(T) == typeof(short))
-        {
-            return Sse.StaticCast<short, T>(Sse2.Add(Sse.StaticCast<T, short>(v1), Sse.StaticCast<T, short>(v2)));
-        }
-        else if (typeof(T) == typeof(ushort))
-        {
-            return Sse.StaticCast<ushort, T>(Sse2.Add(Sse.StaticCast<T, ushort>(v1), Sse.StaticCast<T, ushort>(v2)));
-        }
-        else if (typeof(T) == typeof(int))
-        {
-            return Sse.StaticCast<int, T>(Sse2.Add(Sse.StaticCast<T, int>(v1), Sse.StaticCast<T, int>(v2)));
-        }
-        else if (typeof(T) == typeof(uint))
-        {
-            return Sse.StaticCast<uint, T>(Sse2.Add(Sse.StaticCast<T, uint>(v1), Sse.StaticCast<T, uint>(v2)));
-        }
-        else if (typeof(T) == typeof(long))
-        {
-            return Sse.StaticCast<long, T>(Sse2.Add(Sse.StaticCast<T, long>(v1), Sse.StaticCast<T, long>(v2)));
-        }
-        else if (typeof(T) == typeof(ulong))
-        {
-            return Sse.StaticCast<ulong, T>(Sse2.Add(Sse.StaticCast<T, ulong>(v1), Sse.StaticCast<T, ulong>(v2)));
-        }
-        else
-        {
-            throw new NotSupportedException();
-        }
+        return Vector128Add<T>(v1, v2);
     }
 
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static Vector256<T> Vector256PlusOne<T>(Vector256<T> v1) where T : struct
     {
         Vector256<T> v2 = Vector256One<T>();
-        if (typeof(T) == typeof(float))
-        {
-            return Avx.StaticCast<float, T>(Avx.Add(Avx.StaticCast<T, float>(v1), Avx.StaticCast<T, float>(v2)));
-        }
-        else if (typeof(T) == typeof(double))
-        {
-            return Avx.StaticCast<double, T>(Avx.Add(Avx.StaticCast<T, double>(v1), Avx.StaticCast<T, double>(v2)));
-        }
-        else if (typeof(T) == typeof(byte))
-        {
-            return Avx.StaticCast<byte, T>(Avx2.Add(Avx.StaticCast<T, byte>(v1), Avx.StaticCast<T, byte>(v2)));
-        }
-        else if (typeof(T) == typeof(sbyte))
-        {
-            return Avx.StaticCast<sbyte, T>(Avx2.Add(Avx.StaticCast<T, sbyte>(v1), Avx.StaticCast<T, sbyte>(v2)));
-        }
-        else if (typeof(T) == typeof(short))
-        {
-            return Avx.StaticCast<short, T>(Avx2.Add(Avx.StaticCast<T, short>(v1), Avx.StaticCast<T, short>(v2)));
-        }
-        else if (typeof(T) == typeof(ushort))
-        {
-            return Avx.StaticCast<ushort, T>(Avx2.Add(Avx.StaticCast<T, ushort>(v1), Avx.StaticCast<T, ushort>(v2)));
-        }
-        else if (typeof(T) == typeof(int))
-        {
-            return Avx.StaticCast<int, T>(Avx2.Add(Avx.StaticCast<T, int>(v1), Avx.StaticCast<T, int>(v2)));
-        }
-        else if (typeof(T) == typeof(uint))
-        {
-            return Avx.StaticCast<uint, T>(Avx2.Add(Avx.StaticCast<T, uint>(v1), Avx.StaticCast<T, uint>(v2)));
-        }
-        else if (typeof(T) == typeof(long))
-        {
-            return Avx.StaticCast<long, T>(Avx2.Add(Avx.StaticCast<T, long>(v1), Avx.StaticCast<T, long>(v2)));
-        }
-        else if (typeof(T) == typeof(ulong))
-        {
-            return Avx.StaticCast<ulong, T>(Avx2.Add(Avx.StaticCast<T, ulong>(v1), Avx.StaticCast<T, ulong>(v2)));
-        }
-        else
-        {
-            throw new NotSupportedException();
-        }
+        return Vector256Add<T>(v1, v2);
     }
 
     public static unsafe int Vector128ReturnTest()

--- a/tests/src/JIT/HardwareIntrinsics/X86/General/VectorRet.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/VectorRet.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 //
 
+// This test case is ported from S.N.Vector counterpart 
+// https://github.com/dotnet/coreclr/blob/master/tests/src/JIT/SIMD/VectorReturn.cs
+
 using System;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;

--- a/tests/src/JIT/HardwareIntrinsics/X86/General/VectorRet_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/VectorRet_r.csproj
@@ -28,6 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="VectorRet.cs" />
+    <Compile Include="VectorHelpers.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/General/VectorRet_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/VectorRet_ro.csproj
@@ -28,6 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="VectorRet.cs" />
+    <Compile Include="VectorHelpers.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/General/VectorUnused.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/VectorUnused.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+// This test case is ported from S.N.Vector counterpart 
+// https://github.com/dotnet/coreclr/blob/master/tests/src/JIT/SIMD/VectorUnused.cs
+
+using System;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+internal partial class IntelHardwareIntrinsicTest
+{
+    private const int Pass = 100;
+    private const int Fail = -1;
+
+    private class Vector128UnusedTest<T> where T : struct, IComparable<T>, IEquatable<T>
+    {
+        public static int VectorUnused(T t1, T t2)
+        {
+            if (Sse2.IsSupported)
+            {
+                Vector128<T> v1 = SetAllVector128<T>(t1);
+                v1 = Vector128Add<T>(v1, SetZeroVector128<T>());
+            }
+
+            return Pass;
+        }
+    }
+
+    private class Vector256UnusedTest<T> where T : struct, IComparable<T>, IEquatable<T>
+    {
+        public static int VectorUnused(T t1, T t2)
+        {
+            if (Avx.IsSupported)
+            {
+                Vector256<T> v1 = Avx.SetAllVector256<T>(t1);
+                v1 = Avx.Permute2x128(v1, Avx.SetAllVector256<T>(t2), 1);
+            }
+            return Pass;
+        }
+    }
+
+    private static int Main()
+    {
+        int returnVal = Pass;
+
+        if (Vector128UnusedTest<float>.VectorUnused(3f, 2f) != Pass) returnVal = Fail;
+        if (Vector128UnusedTest<double>.VectorUnused(3, 2) != Pass) returnVal = Fail;
+        if (Vector128UnusedTest<int>.VectorUnused(3, 2) != Pass) returnVal = Fail;
+        if (Vector128UnusedTest<uint>.VectorUnused(3, 2) != Pass) returnVal = Fail;
+        if (Vector128UnusedTest<ushort>.VectorUnused(3, 2) != Pass) returnVal = Fail;
+        if (Vector128UnusedTest<byte>.VectorUnused(3, 2) != Pass) returnVal = Fail;
+        if (Vector128UnusedTest<short>.VectorUnused(3, 2) != Pass) returnVal = Fail;
+        if (Vector128UnusedTest<sbyte>.VectorUnused(3, 2) != Pass) returnVal = Fail;
+        if (Environment.Is64BitProcess)
+        {
+            if (Vector128UnusedTest<long>.VectorUnused(3, 2) != Pass) returnVal = Fail;
+            if (Vector128UnusedTest<ulong>.VectorUnused(3, 2) != Pass) returnVal = Fail;
+        }
+
+        if (Vector256UnusedTest<float>.VectorUnused(3f, 2f) != Pass) returnVal = Fail;
+        if (Vector256UnusedTest<double>.VectorUnused(3, 2) != Pass) returnVal = Fail;
+        if (Vector256UnusedTest<int>.VectorUnused(3, 2) != Pass) returnVal = Fail;
+        if (Vector256UnusedTest<uint>.VectorUnused(3, 2) != Pass) returnVal = Fail;
+        if (Vector256UnusedTest<ushort>.VectorUnused(3, 2) != Pass) returnVal = Fail;
+        if (Vector256UnusedTest<byte>.VectorUnused(3, 2) != Pass) returnVal = Fail;
+        if (Vector256UnusedTest<short>.VectorUnused(3, 2) != Pass) returnVal = Fail;
+        if (Vector256UnusedTest<sbyte>.VectorUnused(3, 2) != Pass) returnVal = Fail;
+        if (Environment.Is64BitProcess)
+        {
+            if (Vector256UnusedTest<long>.VectorUnused(3, 2) != Pass) returnVal = Fail;
+            if (Vector256UnusedTest<ulong>.VectorUnused(3, 2) != Pass) returnVal = Fail;
+        }
+        return returnVal;
+    }
+}

--- a/tests/src/JIT/HardwareIntrinsics/X86/General/VectorUnused_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/VectorUnused_r.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize></Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="VectorUnused.cs" />
+    <Compile Include="VectorHelpers.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/HardwareIntrinsics/X86/General/VectorUnused_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/VectorUnused_ro.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="VectorUnused.cs" />
+    <Compile Include="VectorHelpers.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
This PR ports the test cases of [VectorArray](https://github.com/dotnet/coreclr/blob/master/tests/src/JIT/SIMD/VectorArray.cs), [VectorArgs](https://github.com/dotnet/coreclr/blob/master/tests/src/JIT/SIMD/VectorArgs.cs), and [VectorUnused](https://github.com/dotnet/coreclr/blob/master/tests/src/JIT/SIMD/VectorUnused.cs) to `Vector128/256<T>`.
Contribute to https://github.com/dotnet/coreclr/issues/15490

@CarolEidt @tannergooding PTAL