### PR TITLE
Fix arm corefx test exclusions

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -3315,10 +3315,8 @@ def static CreateOtherTestJob(def dslFactory, def project, def branch, def archi
             }
 
             if (doCoreFxTesting) {
-                // This isn't in corefx yet:
-                //    --test-exclude-file \${WORKSPACE}/tests/${architecture}/corefx_linux_test_exclusions.txt
                 shell("""\
-\${WORKSPACE}/${workspaceRelativeFxRootLinux}/run-test.sh --sequential --runtime \${WORKSPACE}/${workspaceRelativeFxRootLinux}/bin/testhost/netcoreapp-Linux-Release-${architecture} --arch ${architecture} --corefx-tests \${WORKSPACE}/${workspaceRelativeFxRootLinux}/bin --configurationGroup Release""")
+\${WORKSPACE}/${workspaceRelativeFxRootLinux}/run-test.sh --sequential --test-exclude-file \${WORKSPACE}/tests/${architecture}/corefx_linux_test_exclusions.txt --runtime \${WORKSPACE}/${workspaceRelativeFxRootLinux}/bin/testhost/netcoreapp-Linux-Release-${architecture} --arch ${architecture} --corefx-tests \${WORKSPACE}/${workspaceRelativeFxRootLinux}/bin --configurationGroup Release""")
             }
             else {
                 def runScript = "${dockerCmd}./tests/runtest.sh"

--- a/tests/arm/corefx_linux_test_exclusions.txt
+++ b/tests/arm/corefx_linux_test_exclusions.txt
@@ -5,4 +5,7 @@ System.Diagnostics.Process.Tests
 System.Drawing.Common.Tests
 System.IO.FileSystem.Tests
 System.IO.Ports.Tests
+System.Linq.Expressions.Tests        # https://github.com/dotnet/coreclr/issues/17738
 System.Management.Tests
+System.Net.Http.Functional.Tests     # https://github.com/dotnet/coreclr/issues/17739
+System.Net.NameResolution.Pal.Tests  # https://github.com/dotnet/coreclr/issues/17740

--- a/tests/arm/corefx_test_exclusions.txt
+++ b/tests/arm/corefx_test_exclusions.txt
@@ -4,6 +4,8 @@ System.Console.Tests
 System.Data.SqlClient.Tests
 System.Diagnostics.Process.Tests
 System.Drawing.Common.Tests
+System.Net.HttpListener.Tests      # https://github.com/dotnet/coreclr/issues/17584
 System.IO.FileSystem.Tests
 System.IO.Ports.Tests
 System.Management.Tests
+System.Runtime.Tests               # https://github.com/dotnet/coreclr/issues/17585


### PR DESCRIPTION
1. Enable using the test exclusion file for Ubuntu arm32.
2. Update the Ubuntu and Windows arm32 exclusion files based on
current GitHub issues.