### PR TITLE
Add tests for arm64 il issues.

### DIFF
--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -1,8 +1,8 @@
 ## This list file has been produced automatically. Any changes
 ## are subject to being overwritten when reproducing this file.
 ## 
-## Last Updated: 09-May-2018 14:46:07
-## Commit: 718347e434964969641031bd2dd46dd6607b1390
+## Last Updated: 09-May-2018 17:42:09
+## Commit: aa8dd0d8a9b1bb47e00fcd694342ed5defb46508
 ## 
 [int8_il_r.cmd_1]
 RelativePath=JIT\Directed\shift\int8_il_r\int8_il_r.cmd
@@ -94714,5 +94714,29 @@ WorkingDir=JIT\Regression\JitBlue\GitHub_17585\GitHub_17585
 Expected=0
 MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS
+HostStyle=0
+
+[DevDiv_590772.cmd_11896]
+RelativePath=JIT\Regression\JitBlue\DevDiv_590772\DevDiv_590772\DevDiv_590772.cmd
+WorkingDir=JIT\Regression\JitBlue\DevDiv_590772\DevDiv_590772
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS;Pri1;NEW
+HostStyle=0
+
+[DevDiv_605447.cmd_11897]
+RelativePath=JIT\Regression\JitBlue\DevDiv_605447\DevDiv_605447\DevDiv_605447.cmd
+WorkingDir=JIT\Regression\JitBlue\DevDiv_605447\DevDiv_605447
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS;Pri1;NEW
+HostStyle=0
+
+[DevDiv_590771.cmd_11898]
+RelativePath=JIT\Regression\JitBlue\DevDiv_590771\DevDiv_590771\DevDiv_590771.cmd
+WorkingDir=JIT\Regression\JitBlue\DevDiv_590771\DevDiv_590771
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS;Pri1;NEW
 HostStyle=0
 

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -1,8 +1,8 @@
 ## This list file has been produced automatically. Any changes
 ## are subject to being overwritten when reproducing this file.
 ## 
-## Last Updated: 09-May-2018 14:44:29
-## Commit: 718347e434964969641031bd2dd46dd6607b1390
+## Last Updated: 09-May-2018 17:46:52
+## Commit: aa8dd0d8a9b1bb47e00fcd694342ed5defb46508
 ## 
 [Dev10_535767.cmd_0]
 RelativePath=baseservices\compilerservices\dynamicobjectproperties\Dev10_535767\Dev10_535767.cmd
@@ -94739,3 +94739,28 @@ Expected=0
 MaxAllowedDurationSeconds=600
 Categories=EXPECTED_FAIL;6675;EXCLUDED
 HostStyle=0
+
+[DevDiv_590772.cmd_12216]
+RelativePath=JIT\Regression\JitBlue\DevDiv_590772\DevDiv_590772\DevDiv_590772.cmd
+WorkingDir=JIT\Regression\JitBlue\DevDiv_590772\DevDiv_590772
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS;NEW
+HostStyle=0
+
+[DevDiv_605447.cmd_12217]
+RelativePath=JIT\Regression\JitBlue\DevDiv_605447\DevDiv_605447\DevDiv_605447.cmd
+WorkingDir=JIT\Regression\JitBlue\DevDiv_605447\DevDiv_605447
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS;NEW
+HostStyle=0
+
+[DevDiv_590771.cmd_12218]
+RelativePath=JIT\Regression\JitBlue\DevDiv_590771\DevDiv_590771\DevDiv_590771.cmd
+WorkingDir=JIT\Regression\JitBlue\DevDiv_590771\DevDiv_590771
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS;NEW
+HostStyle=0
+

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -94745,7 +94745,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_590772\DevDiv_590772\DevDiv_590772.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_590772\DevDiv_590772
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_FAIL;17968;EXCLUDED
 HostStyle=0
 
 [DevDiv_605447.cmd_12217]
@@ -94753,7 +94753,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_605447\DevDiv_605447\DevDiv_605447.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_605447\DevDiv_605447
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_FAIL;17966;EXCLUDED
 HostStyle=0
 
 [DevDiv_590771.cmd_12218]
@@ -94761,6 +94761,6 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_590771\DevDiv_590771\DevDiv_590771.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_590771\DevDiv_590771
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_FAIL;17967;EXCLUDED
 HostStyle=0
 

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -226,6 +226,20 @@
         </ExcludeList>
     </ItemGroup>
 
+    <!-- The following are ARM64 failures -->
+
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(BuildArch)' == 'arm64'">
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_590772\DevDiv_590772\DevDiv_590772.cmd">
+            <Issue>17968</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_605447\DevDiv_605447\DevDiv_605447.cmd">
+            <Issue>17966</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_590771\DevDiv_590771\DevDiv_590771.cmd">
+            <Issue>17967</Issue>
+        </ExcludeList>
+    </ItemGroup>
+
     <!-- Tests that need to be triaged for vararg usage as that is not supported -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != ''">
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\1\arglist\arglist.cmd">

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -226,9 +226,9 @@
         </ExcludeList>
     </ItemGroup>
 
-    <!-- The following are ARM64 failures -->
+    <!-- The following are ARM64_altjit crossgen failures. For x64_arm64_altjit buildArm==x64. -->
 
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(BuildArch)' == 'arm64'">
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(BuildArch)' == 'x64'">
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_590772\DevDiv_590772\DevDiv_590772.cmd">
             <Issue>17968</Issue>
         </ExcludeList>

--- a/tests/scripts/lst_creator.py
+++ b/tests/scripts/lst_creator.py
@@ -301,7 +301,7 @@ def main(args):
         sys.exit(1)
 
     if pri0_test_dir is None or not os.path.isdir(pri0_test_dir):
-        print "Error the Pri1 test directory passed is not a valid directory."
+        print "Error the Pri0 test directory passed is not a valid directory."
         sys.exit(1)
 
     if pri1_test_dir is None or not os.path.isdir(pri1_test_dir):

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_590771/DevDiv_590771.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_590771/DevDiv_590771.il
@@ -1,0 +1,157 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib { auto }
+.assembly extern System.Runtime { auto }
+.assembly extern System.Console { auto }
+
+.assembly DevDiv_590771 { }
+
+.class public auto ansi beforefieldinit DevDiv_590771
+       extends [System.Runtime]System.Object
+{
+  .method static int8 ILGEN_METHOD(int64, char, native unsigned int, unsigned int32, char, native int)
+  {
+    .maxstack  174
+    .locals init (float64, int32, unsigned int32, native unsigned int, unsigned int32, int16, int64, native unsigned int, int32)
+    IL_0000: ldarg 0x0000
+    IL_0004: conv.i8
+    IL_0005: conv.ovf.u2.un
+    IL_0006: dup
+    IL_0007: ldarg.s 0x00
+    IL_0009: conv.ovf.u4.un
+    IL_000a: mul.ovf.un
+    IL_000b: not
+    IL_000c: neg
+    IL_000d: shr
+    IL_000e: neg
+    IL_000f: conv.ovf.u8
+    IL_0010: not
+    IL_0011: conv.r.un
+    IL_0012: ldloc.s 0x05
+    IL_0014: ldarg.s 0x02
+    IL_0016: sub.ovf
+    IL_0017: stloc.s 0x05
+    IL_0019: neg
+    IL_001a: ldc.i8 0xf5848c133a994bd5
+    IL_0023: ldc.i8 0x3744a843932f26f5
+    IL_002c: not
+    IL_002d: add
+    IL_002e: ldc.i8 0xf869128fbacc441f
+    IL_0037: conv.ovf.u1.un
+    IL_0038: conv.ovf.i8.un
+    IL_0039: rem.un
+    IL_003a: conv.ovf.i4
+    IL_003b: conv.r8
+    IL_003c: ckfinite
+    IL_003d: ceq
+    IL_003f: ldloc 0x0003
+    IL_0043: dup
+    IL_0044: clt.un
+    IL_0046: mul
+    IL_0047: nop
+    IL_0048: brtrue 
+    IL_00a2
+    IL_004d: ldc.i8 0xcfa1a742b8879a20
+    IL_0056: ldarg.s 0x00
+    IL_0058: ldarg.s 0x01
+    IL_005a: ldarg 0x0001
+    IL_005e: shl
+    IL_005f: conv.u8
+    IL_0060: conv.ovf.u8
+    IL_0061: conv.i8
+    IL_0062: xor
+    IL_0063: ldc.i8 0x971a2deac17412a0
+    IL_006c: clt.un
+    IL_006e: conv.ovf.i8.un
+    IL_006f: ldc.i4 0x4e48156f
+    IL_0074: not
+    IL_0075: neg
+    IL_0076: conv.ovf.i8
+    IL_0077: ldc.r8 float64(0x6d33412277487d96)
+    IL_0080: ldloc 0x0000
+    IL_0084: add
+    IL_0085: neg
+    IL_0086: conv.ovf.i8
+    IL_0087: rem.un
+    IL_0088: ldc.r8 float64(0x5945c246ce0853b1)
+    IL_0091: conv.u8
+    IL_0092: conv.ovf.i4
+    IL_0093: shr
+    IL_0094: pop
+    IL_0095: ldarg 0x0000
+    IL_0099: conv.u8
+    IL_009a: ldloc.s 0x06
+    IL_009c: pop
+    IL_009d: div
+    IL_009e: clt
+    IL_00a0: conv.r.un
+    IL_00a1: pop
+    IL_00a2: ldc.r8 float64(0x8ef6409240a112dc)
+    IL_00ab: ckfinite
+    IL_00ac: conv.ovf.u1.un
+    IL_00ad: ret
+  }
+
+
+  .method private hidebysig static int32 
+          Main() cil managed
+  {
+    .entrypoint
+    // Code size       36 (0x24)
+    .maxstack  6
+    .locals init (int32 V_0)
+    IL_0000:  nop
+    .try
+    {
+			IL_0001:  nop
+			IL_0002:  ldc.i4.s   100
+			IL_0004:  conv.i8
+			IL_0005:  ldc.i4.2
+			IL_0006:  ldc.i4.1
+			IL_0007:  conv.i
+			IL_0008:  ldc.i4.2
+			IL_0009:  ldc.i4.4
+			IL_000a:  ldc.i4.s   10
+			IL_000c:  conv.i
+			IL_000d:  call       int8 DevDiv_590771::ILGEN_METHOD(int64,
+																														 char,
+																														 native unsigned int,
+																														 unsigned int32,
+																														 char,
+																														 native int)
+
+      IL_0014:  pop
+      IL_0015:  nop
+      IL_0016:  leave.s    IL_001d
+
+    }  // end .try
+    catch [System.Runtime]System.Object 
+    {
+      IL_0018:  pop
+      IL_0019:  nop
+      IL_001a:  nop
+      IL_001b:  leave.s    IL_001d
+
+    }  // end handler
+    IL_001d:  ldc.i4.s   100
+    IL_001f:  stloc.0
+    IL_0020:  br.s       IL_0022
+
+    IL_0022:  ldloc.0
+    IL_0023:  ret
+  } // end of method DevDiv_590771::Main
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method DevDiv_590771::.ctor
+
+} // end of class DevDiv_590771

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_590771/DevDiv_590771.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_590771/DevDiv_590771.ilproj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_590772/DevDiv_590772.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_590772/DevDiv_590772.il
@@ -1,0 +1,174 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib { auto }
+.assembly extern System.Runtime { auto }
+.assembly extern System.Console { auto }
+
+.assembly DevDiv_590772 { }
+
+.class public auto ansi beforefieldinit DevDiv_590772
+       extends [System.Runtime]System.Object
+{
+	.method static unsigned int16 ILGEN_METHOD(unsigned int32, unsigned int32, int32, char, float32)
+	{
+		.maxstack  177
+		.locals init (unsigned int8, bool, int8, unsigned int32, int8, unsigned int64, int8)
+		IL_0000: ldloc 0x0001
+		IL_0004: stloc 0x0004
+		IL_0008: ldc.r8 float64(0xfa1caf5352b592b5)
+		IL_0011: conv.ovf.i4
+		IL_0012: ldarg 0x0003
+		IL_0016: conv.ovf.u8
+		IL_0017: ldarg 0x0001
+		IL_001b: conv.ovf.i8.un
+		IL_001c: conv.u8
+		IL_001d: neg
+		IL_001e: neg
+		IL_001f: not
+		IL_0020: ldloc 0x0000
+		IL_0024: conv.r4
+		IL_0025: conv.u8
+		IL_0026: neg
+		IL_0027: cgt.un
+		IL_0029: conv.r8
+		IL_002a: pop
+		IL_002b: conv.ovf.i8.un
+		IL_002c: ldloc 0x0002
+		IL_0030: conv.ovf.u1
+		IL_0031: conv.ovf.u8.un
+		IL_0032: conv.u8
+		IL_0033: ldloc.s 0x05
+		IL_0035: sub.ovf.un
+		IL_0036: conv.ovf.u8
+		IL_0037: ldloc.s 0x05
+		IL_0039: ldc.i8 0x3ef77ff626f9ded8
+		IL_0042: or
+		IL_0043: xor
+		IL_0044: or
+		IL_0045: not
+		IL_0046: ldarg 0x0004
+		IL_004a: ldarg 0x0004
+		IL_004e: neg
+		IL_004f: conv.r.un
+		IL_0050: mul
+		IL_0051: neg
+		IL_0052: ckfinite
+		IL_0053: pop
+		IL_0054: conv.r8
+		IL_0055: neg
+		IL_0056: ldarg 0x0004
+		IL_005a: ldloc.s 0x05
+		IL_005c: ldarg.s 0x04
+		IL_005e: conv.ovf.u8
+		IL_005f: and
+		IL_0060: pop
+		IL_0061: add
+		IL_0062: ldloc 0x0004
+		IL_0066: conv.ovf.i8
+		IL_0067: ldloc.s 0x00
+		IL_0069: conv.ovf.i8
+		IL_006a: dup
+		IL_006b: conv.u2
+		IL_006c: shr
+		IL_006d: div
+		IL_006e: conv.r4
+		IL_006f: ldloc.s 0x05
+		IL_0071: ldloc.s 0x05
+		IL_0073: div.un
+		IL_0074: conv.r4
+		IL_0075: neg
+		IL_0076: add
+		IL_0077: neg
+		IL_0078: ldarg.s 0x04
+		IL_007a: ldarg 0x0004
+		IL_007e: clt
+		IL_0080: ldloc 0x0000
+		IL_0084: sub.ovf
+		IL_0085: conv.r4
+		IL_0086: conv.r.un
+		IL_0087: ckfinite
+		IL_0088: conv.r4
+		IL_0089: add
+		IL_008a: dup
+		IL_008b: ckfinite
+		IL_008c: cgt
+		IL_008e: ldc.r8 float64(0x9c1be4140fda2146)
+		IL_0097: ckfinite
+		IL_0098: conv.ovf.u8.un
+		IL_0099: ldarg 0x0004
+		IL_009d: conv.i2
+		IL_009e: shr.un
+		IL_009f: conv.ovf.i8
+		IL_00a0: conv.ovf.i.un
+		IL_00a1: ldloc.s 0x04
+		IL_00a3: neg
+		IL_00a4: not
+		IL_00a5: ldloc.s 0x00
+		IL_00a7: xor
+		IL_00a8: shr
+		IL_00a9: neg
+		IL_00aa: rem
+		IL_00ab: nop
+		IL_00ac: conv.r8
+		IL_00ad: mul
+		IL_00ae: conv.ovf.i4.un
+		IL_00af: shr.un
+		IL_00b0: ret   
+	}
+
+ 	.method private hidebysig static int32 
+		  Main() cil managed
+	{
+		.entrypoint
+		// Code size       35 (0x23)
+		.maxstack  5
+		.locals init (int32 V_0)
+		IL_0000:  nop
+		.try
+		{
+		  IL_0001:  nop
+		  IL_0002:  ldc.i4.s   100
+		  IL_0004:  ldc.i4.s   100
+		  IL_0006:  ldc.i4.1
+		  IL_0007:  ldc.i4.s   97
+		  IL_0009:  ldc.r4     1.
+		  IL_000e:  call       uint16 DevDiv_590772::ILGEN_METHOD(uint32,
+																  uint32,
+																  int32,
+																  char,
+																  float32)
+		  IL_0013:  pop
+		  IL_0014:  nop
+		  IL_0015:  leave.s    IL_001c
+
+		}  // end .try
+		catch [System.Runtime]System.Object 
+		{
+		  IL_0017:  pop
+		  IL_0018:  nop
+		  IL_0019:  nop
+		  IL_001a:  leave.s    IL_001c
+
+		}  // end handler
+		IL_001c:  ldc.i4.s   100
+		IL_001e:  stloc.0
+		IL_001f:  br.s       IL_0021
+
+		IL_0021:  ldloc.0
+		IL_0022:  ret
+	} // end of method DevDiv_590772::Main
+
+	.method public hidebysig specialname rtspecialname 
+		  instance void  .ctor() cil managed
+	{
+		// Code size       8 (0x8)
+		.maxstack  8
+		IL_0000:  ldarg.0
+		IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+		IL_0006:  nop
+		IL_0007:  ret
+	} // end of method DevDiv_590772::.ctor
+
+} // end of class DevDiv_590772

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_590772/DevDiv_590772.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_590772/DevDiv_590772.ilproj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_605447/DevDiv_605447.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_605447/DevDiv_605447.il
@@ -1,0 +1,172 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib { auto }
+.assembly extern System.Runtime { auto }
+.assembly extern System.Console { auto }
+
+.assembly DevDiv_605447 { }
+
+.class private auto ansi beforefieldinit DevDiv_605447
+       extends [System.Runtime]System.Object
+{
+	.method static unsigned int16 ILGEN_METHOD(unsigned int32, unsigned int32, int32, char, float32)
+	{
+		.maxstack  177
+		.locals init (unsigned int8, bool, int8, unsigned int32, int8, unsigned int64, int8)
+
+		IL_0000: ldloc 0x0001
+		IL_0004: stloc 0x0004
+		IL_0008: ldc.r8 float64(0xfa1caf5352b592b5)
+		IL_0011: conv.ovf.i4
+		IL_0012: ldarg 0x0003
+		IL_0016: conv.ovf.u8
+		IL_0017: ldarg 0x0001
+		IL_001b: conv.ovf.i8.un
+		IL_001c: conv.u8
+		IL_001d: neg
+		IL_001e: neg
+		IL_001f: not
+		IL_0020: ldloc 0x0000
+		IL_0024: conv.r4
+		IL_0025: conv.u8
+		IL_0026: neg
+		IL_0027: cgt.un
+		IL_0029: conv.r8
+		IL_002a: pop
+		IL_002b: conv.ovf.i8.un
+		IL_002c: ldloc 0x0002
+		IL_0030: conv.ovf.u1
+		IL_0031: conv.ovf.u8.un
+		IL_0032: conv.u8
+		IL_0033: ldloc.s 0x05
+		IL_0035: sub.ovf.un
+		IL_0036: conv.ovf.u8
+		IL_0037: ldloc.s 0x05
+		IL_0039: ldc.i8 0x3ef77ff626f9ded8
+		IL_0042: or
+		IL_0043: xor
+		IL_0044: or
+		IL_0045: not
+		IL_0046: ldarg 0x0004
+		IL_004a: ldarg 0x0004
+		IL_004e: neg
+		IL_004f: conv.r.un
+		IL_0050: mul
+		IL_0051: neg
+		IL_0052: ckfinite
+		IL_0053: pop
+		IL_0054: conv.r8
+		IL_0055: neg
+		IL_0056: ldarg 0x0004
+		IL_005a: ldloc.s 0x05
+		IL_005c: ldarg.s 0x04
+		IL_005e: conv.ovf.u8
+		IL_005f: and
+		IL_0060: pop
+		IL_0061: add
+		IL_0062: ldloc 0x0004
+		IL_0066: conv.ovf.i8
+		IL_0067: ldloc.s 0x00
+		IL_0069: conv.ovf.i8
+		IL_006a: dup
+		IL_006b: conv.u2
+		IL_006c: shr
+		IL_006d: div
+		IL_006e: conv.r4
+		IL_006f: ldloc.s 0x05
+		IL_0071: ldloc.s 0x05
+		IL_0073: div.un
+		IL_0074: conv.r4
+		IL_0075: neg
+		IL_0076: add
+		IL_0077: neg
+		IL_0078: ldarg.s 0x04
+		IL_007a: ldarg 0x0004
+		IL_007e: clt
+		IL_0080: ldloc 0x0000
+		IL_0084: sub.ovf
+		IL_0085: conv.r4
+		IL_0086: conv.r.un
+		IL_0087: ckfinite
+		IL_0088: conv.r4
+		IL_0089: add
+		IL_008a: dup
+		IL_008b: ckfinite
+		IL_008c: cgt
+		IL_008e: ldc.r8 float64(0x9c1be4140fda2146)
+		IL_0097: ckfinite
+		IL_0098: conv.ovf.u8.un
+		IL_0099: ldarg 0x0004
+		IL_009d: conv.i2
+		IL_009e: shr.un
+		IL_009f: conv.ovf.i8
+		IL_00a0: conv.ovf.i.un
+		IL_00a1: ldloc.s 0x04
+		IL_00a3: neg
+		IL_00a4: not
+		IL_00a5: ldloc.s 0x00
+		IL_00a7: xor
+		IL_00a8: shr
+		IL_00a9: neg
+		IL_00aa: rem
+		IL_00ab: nop
+		IL_00ac: conv.r8
+		IL_00ad: mul
+		IL_00ae: conv.ovf.i4.un
+		IL_00af: shr.un
+		IL_00b0: ret   
+	}
+
+	.method private hidebysig static int32  Main() cil managed
+	{
+		.entrypoint
+		// Code size       33 (0x21)
+		.maxstack  5
+		.locals init (int32 V_0)
+		IL_0000:  nop
+		.try
+		{
+			IL_0001:  nop
+			IL_0002:  ldc.i4.1
+			IL_0003:  ldc.i4.2
+			IL_0004:  ldc.i4.3
+			IL_0005:  ldc.i4.s   52
+			IL_0007:  ldc.r4     6.
+			IL_000c:  call       uint16 DevDiv_605447::ILGEN_METHOD(uint32,
+																														uint32,
+																														int32,
+																														char,
+																														float32)
+			IL_0011:  pop
+			IL_0012:  nop
+			IL_0013:  leave.s    IL_001a
+		}  // end .try
+		catch [System.Runtime]System.Object 
+		{
+			IL_0015:  pop
+			IL_0016:  nop
+			IL_0017:  nop
+			IL_0018:  leave.s    IL_001a
+		}  // end handler
+		IL_001a:  ldc.i4.s   100
+		IL_001c:  stloc.0
+		IL_001d:  br.s       IL_001f
+		IL_001f:  ldloc.0
+		IL_0020:  ret
+	} // end of method DevDiv_605447::Main
+
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method DevDiv_605447::.ctor
+
+} // end of class DevDiv_605447

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_605447/DevDiv_605447.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_605447/DevDiv_605447.ilproj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/testsFailing.arm64.txt
+++ b/tests/testsFailing.arm64.txt
@@ -5,3 +5,6 @@ JIT/jit64/opt/cse/HugeField1/HugeField1.sh
 JIT/jit64/opt/cse/HugeField2/HugeField2.sh
 CoreMangLib/cti/system/string/StringFormat1/StringFormat1.sh
 CoreMangLib/cti/system/string/StringFormat2/StringFormat2.sh
+JIT/Regression/JitBlue/DevDiv_590772/DevDiv_590772/DevDiv_590772.sh
+JIT/Regression/JitBlue/DevDiv_605447/DevDiv_605447/DevDiv_605447.sh
+JIT/Regression/JitBlue/DevDiv_590771/DevDiv_590771/DevDiv_590771.sh


### PR DESCRIPTION
The PR adds tests that are failing in our internal test system with arm64 altjit.
Failures are:
```
codegencommon_cpp__6797____Assertion_failed__NYI__Initialize_floating_point_register_to_zero
liveness_cpp__39____Assertion_failed____We_should_never_encounter_a_reference_to_a_lclVar_that_has_a_zero_refCnt__
lsraarm64_cpp__241____Assertion_failed____Shouldn_t_see_an_integer_typed_GT_MOD_node_in_ARM64_
```
