### PR TITLE
Patch LTTng ust-tracepoint.h on ARM/Trusty when building crossrootfs

### DIFF
--- a/cross/arm/trusty-lttng-2.4.patch
+++ b/cross/arm/trusty-lttng-2.4.patch
@@ -1,0 +1,71 @@
+From e72c9d7ead60e3317bd6d1fade995c07021c947b Mon Sep 17 00:00:00 2001
+From: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+Date: Thu, 7 May 2015 13:25:04 -0400
+Subject: [PATCH] Fix: building probe providers with C++ compiler
+
+Robert Daniels wrote:
+> > I'm attempting to use lttng userspace tracing with a C++ application
+> > on an ARM platform. I'm using GCC 4.8.4 on Linux 3.14 with the 2.6
+> > release of lttng. I've compiled lttng-modules, lttng-ust, and
+> > lttng-tools and have been able to get a simple test working with C
+> > code.  When I attempt to run the hello.cxx test on my target it will
+> > segfault.
+>
+>
+> I spent a little time digging into this issue and finally discovered the
+> cause of my segfault with ARM C++ tracepoints.
+>
+> There is a struct called 'lttng_event' in ust-events.h which contains an
+> empty union 'u'.  This was the cause of my issue.  Under C, this empty union
+> compiles to a zero byte member while under C++ it compiles to a one byte
+> member, and in my case was four-byte aligned which caused my C++ code to
+> have the 'cds_list_head node' offset incorrectly by four bytes.  This lead
+> to an incorrect linked list structure which caused my issue.
+>
+> Since this union is empty, I simply removed it from the struct and everything
+> worked correctly.
+>
+> I don't know the history or purpose behind this empty union so I'd like to
+> know if this is a safe fix.  If it is I can submit a patch with the union
+> removed.
+
+That's a very nice catch!
+
+We do not support building tracepoint probe provider with
+g++ yet, as stated in lttng-ust(3):
+
+"- Note for C++ support: although an application instrumented with
+   tracepoints can be compiled with g++, tracepoint probes should be
+   compiled with gcc (only tested with gcc so far)."
+
+However, if it works fine with this fix, then I'm tempted to take it,
+especially because removing the empty union does not appear to affect
+the layout of struct lttng_event as seen from liblttng-ust, which must
+be compiled with a C compiler,  and from probe providers compiled with
+a C compiler. So all we are changing is the layout of a probe provider
+compiled with a C++ compiler, which is anyway buggy at the moment,
+because it is not compatible with the layout expected by liblttng-ust
+compiled with a C compiler.
+
+Reported-by: Robert Daniels <robert.daniels@vantagecontrols.com>
+Signed-off-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+---
+ include/lttng/ust-events.h | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/usr/include/lttng/ust-events.h b/usr/include/lttng/ust-events.h
+index 328a875..3d7a274 100644
+--- a/usr/include/lttng/ust-events.h
++++ b/usr/include/lttng/ust-events.h
+@@ -407,8 +407,6 @@ struct lttng_event {
+ 	void *_deprecated1;
+ 	struct lttng_ctx *ctx;
+ 	enum lttng_ust_instrumentation instrumentation;
+-	union {
+-	} u;
+ 	struct cds_list_head node;		/* Event list in session */
+ 	struct cds_list_head _deprecated2;
+ 	void *_deprecated3;
+-- 
+2.7.4
+

--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -155,6 +155,7 @@ if [[ -n $__LinuxCodeName ]]; then
     if [[ "$__BuildArch" == "arm" && "$__LinuxCodeName" == "trusty" ]]; then
         pushd $__RootfsDir
         patch -p1 < $__CrossDir/$__BuildArch/trusty.patch
+        patch -p1 < $__CrossDir/$__BuildArch/trusty-lttng-2.4.patch
         popd
     fi
 elif [ "$__Tizen" == "tizen" ]; then


### PR DESCRIPTION
Fix a crash that occurs when LTTng is enabled on ARM32 devices.  This is fixed on LTTng 2.5+, but until we are able to move to a version that includes the fix, we can patch it directly in the crossrootfs.