### PR TITLE
Fix instruction groups offset on the border between cold/hot code.

### DIFF
--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -4153,6 +4153,15 @@ AGAIN:
             goto AGAIN;
         }
     }
+#ifdef DEBUG
+    if (EMIT_INSTLIST_VERBOSE)
+    {
+        printf("\nLabels list after the jump dist binding:\n\n");
+        emitDispIGlist(false);
+    }
+
+    emitCheckIGoffsets();
+#endif // DEBUG
 }
 
 void emitter::emitCheckFuncletBranch(instrDesc* jmp, insGroup* jmpIG)
@@ -5008,7 +5017,15 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
     assert(emitInitGCrefRegs == 0xBAADFEED);
     assert(emitInitByrefRegs == 0xBAADFEED);
 
-#endif
+    if (EMIT_INSTLIST_VERBOSE)
+    {
+        printf("\nLabels list after the end of codegen:\n\n");
+        emitDispIGlist(false);
+    }
+
+    emitCheckIGoffsets();
+
+#endif // DEBUG
 
     // Assign the real prolog size
     *prologSize = emitCodeOffset(emitPrologIG, emitPrologEndPos);

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -4332,8 +4332,6 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
     }
 #endif
 
-    insGroup* ig;
-
     BYTE* consBlock;
     BYTE* codeBlock;
     BYTE* coldCodeBlock;
@@ -4706,7 +4704,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
 
 #define DEFAULT_CODE_BUFFER_INIT 0xcc
 
-    for (ig = emitIGlist; ig; ig = ig->igNext)
+    for (insGroup* ig = emitIGlist; ig != nullptr; ig = ig->igNext)
     {
         assert(!(ig->igFlags & IGF_PLACEHOLDER)); // There better not be any placeholder groups left
 
@@ -4726,7 +4724,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
         }
 
         /* Are we overflowing? */
-        if (ig->igNext && ig->igNum + 1 != ig->igNext->igNum)
+        if (ig->igNext && (ig->igNum + 1 != ig->igNext->igNum))
         {
             NO_WAY("Too many instruction groups");
         }
@@ -4874,14 +4872,14 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
 
     /* Output any initialized data we may have */
 
-    if (emitConsDsc.dsdOffs)
+    if (emitConsDsc.dsdOffs != 0)
     {
         emitOutputDataSec(&emitConsDsc, consBlock);
     }
 
     /* Make sure all GC ref variables are marked as dead */
 
-    if (emitGCrFrameOffsCnt)
+    if (emitGCrFrameOffsCnt != 0)
     {
         unsigned    vn;
         int         of;
@@ -4912,15 +4910,12 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
 
     if (emitFwdJumps)
     {
-        instrDescJmp* jmp;
-
-        for (jmp = emitJumpList; jmp; jmp = jmp->idjNext)
+        for (instrDescJmp* jmp = emitJumpList; jmp != nullptr; jmp = jmp->idjNext)
         {
-            insGroup* tgt;
 #ifdef _TARGET_XARCH_
             assert(jmp->idInsFmt() == IF_LABEL || jmp->idInsFmt() == IF_RWR_LABEL || jmp->idInsFmt() == IF_SWR_LABEL);
 #endif
-            tgt = jmp->idAddr()->iiaIGlabel;
+            insGroup* tgt = jmp->idAddr()->iiaIGlabel;
 
             if (jmp->idjTemp.idjAddr == nullptr)
             {
@@ -4937,7 +4932,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
 #endif
 
 #if DEBUG_EMIT
-                if (jmp->idDebugOnlyInfo()->idNum == (unsigned)INTERESTING_JUMP_NUM || INTERESTING_JUMP_NUM == 0)
+                if ((jmp->idDebugOnlyInfo()->idNum == (unsigned)INTERESTING_JUMP_NUM) || (INTERESTING_JUMP_NUM == 0))
                 {
 #ifdef _TARGET_ARM_
                     printf("[5] This output is broken for ARM, since it doesn't properly decode the jump offsets of "

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -4855,10 +4855,12 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
             if (actualHotCodeSize < allocatedHotCodeSize)
             {
                 // The allocated chunk is bigger than used, fill in unused space in it.
-                while (emitCurCodeOffs(cp) < allocatedHotCodeSize)
+                unsigned unusedSize = allocatedHotCodeSize - emitCurCodeOffs(cp);
+                for (unsigned i = 0; i < unusedSize; ++i)
                 {
                     *cp++ = DEFAULT_CODE_BUFFER_INIT;
                 }
+                assert(allocatedHotCodeSize == emitCurCodeOffs(cp));
             }
         }
 
@@ -5013,11 +5015,14 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
     // Fill in eventual unused space, but do not report this space as used.
     // If you add this padding during the emitIGlist loop, then it will
     // emit offsets after the loop with wrong value (for example for GC ref variables).
-    while (emitCurCodeOffs(cp) < emitTotalCodeSize)
+    unsigned unusedSize = emitTotalCodeSize - emitCurCodeOffs(cp);
+    for (unsigned i = 0; i < unusedSize; ++i)
     {
         *cp++ = DEFAULT_CODE_BUFFER_INIT;
     }
+    assert(emitTotalCodeSize == emitCurCodeOffs(cp));
 
+    // Total code size is sum of all IG->size and doesn't include padding in the last IG.
     emitTotalCodeSize = actualCodeSize;
 
 #ifdef DEBUG

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -5005,6 +5005,11 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
 
     unsigned actualCodeSize = emitCurCodeOffs(cp);
 
+#if EMITTER_STATS
+    totAllocdSize += emitTotalCodeSize;
+    totActualSize += actualCodeSize;
+#endif
+
     // Fill in eventual unused space, but do not report this space as used.
     // If you add this padding during the emitIGlist loop, then it will
     // emit offsets after the loop with wrong value (for example for GC ref variables).
@@ -5014,11 +5019,6 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
     }
 
     emitTotalCodeSize = actualCodeSize;
-
-#if EMITTER_STATS
-    totAllocdSize += emitTotalCodeSize;
-    totActualSize += actualCodeSize;
-#endif
 
 #ifdef DEBUG
 

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -3632,8 +3632,13 @@ AGAIN:
                 {
                     lstIG = lstIG->igNext;
                     assert(lstIG);
-                    // printf("Adjusted offset of block %02u from %04X to %04X\n", lstIG->igNum, lstIG->igOffs,
-                    // lstIG->igOffs - adjIG);
+#ifdef DEBUG
+                    if (EMITVERBOSE)
+                    {
+                        printf("Adjusted offset of block %02u from %04X to %04X\n", lstIG->igNum, lstIG->igOffs,
+                               lstIG->igOffs - adjIG);
+                    }
+#endif // DEBUG
                     lstIG->igOffs -= adjIG;
                     assert(IsCodeAligned(lstIG->igOffs));
                 } while (lstIG != jmpIG);
@@ -4100,8 +4105,13 @@ AGAIN:
             {
                 break;
             }
-            // printf("Adjusted offset of block %02u from %04X to %04X\n", lstIG->igNum, lstIG->igOffs,
-            // lstIG->igOffs - adjIG);
+#ifdef DEBUG
+            if (EMITVERBOSE)
+            {
+                printf("Adjusted offset of block %02u from %04X to %04X\n", lstIG->igNum, lstIG->igOffs,
+                       lstIG->igOffs - adjIG);
+            }
+#endif // DEBUG
             lstIG->igOffs -= adjIG;
             assert(IsCodeAligned(lstIG->igOffs));
         }


### PR DESCRIPTION
Fixes DevDiv_601045; assert while generating diffs:
https://github.com/dotnet/coreclr/blob/71f4199f7dd043c4901a187b9bd88ab40e2b87e2/src/jit/emit.cpp#L7185

I was not able to repro the original issue on Core and it did not allow me to go back and find when the desktop issue appeared. The new checks show that the problem exists in CoreCLR as well.

The fix doesn't change the generated code (it changes only unused allocated parts) and doesn't cause any diffs.

The important changes are in the fourth commit.