### PR TITLE
Don't optimize away Task code needed for debugger

### DIFF
--- a/src/mscorlib/ILLinkTrim.xml
+++ b/src/mscorlib/ILLinkTrim.xml
@@ -9,6 +9,7 @@
     <type fullname="System.Threading.Tasks.Task">
       <property name="ParentForDebugger" />
       <property name="StateFlagsForDebugger" />
+      <method name="GetDelegateContinuationsForDebugger" />
     </type>
     <type fullname="System.Threading.ThreadPool">
       <method name="GetQueuedWorkItemsForDebugger" />
@@ -18,6 +19,15 @@
     <type fullname="System.Threading.Tasks.TaskScheduler">
       <method name="GetScheduledTasksForDebugger" />
       <method name="GetTaskSchedulersForDebugger" /> 
+    </type>
+    <type fullname="System.Runtime.CompilerServices.AsyncMethodBuilderCore">
+      <method name="TryGetStateMachineForDebugger" />
+    </type>
+    <type fullname="System.Runtime.CompilerServices.AsyncVoidMethodBuilder">
+      <property name="ObjectIdForDebugger" />
+    </type>
+    <type fullname="System.Runtime.CompilerServices.AsyncTaskMethodBuilder*">
+      <property name="ObjectIdForDebugger" />
     </type>
     <type fullname="System.Threading.Tasks.Task">
       <!-- Methods is used by VS Tasks Window. -->


### PR DESCRIPTION
This prevents the IL linker from optimizing away some properties/methods
related to tasks that are used by a debugger but are not referenced
anywhere else in coreclr.

This specifically fixes async callstack frames for the xplat C# debugger.

Fixes #17782