### PR TITLE
JIT: fix case with slow generic delegate creation

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -12913,12 +12913,17 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
             DO_LDFTN:
                 op1 = impMethodPointer(&resolvedToken, &callInfo);
+
                 if (compDonotInline())
                 {
                     return;
                 }
 
+                // Call info may have more precise information about the function than
+                // the resolved token.
                 CORINFO_RESOLVED_TOKEN* heapToken = impAllocateToken(resolvedToken);
+                assert(callInfo.hMethod != nullptr);
+                heapToken->hMethod = callInfo.hMethod;
                 impPushOnStack(op1, typeInfo(heapToken));
 
                 break;
@@ -13025,8 +13030,12 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 }
 
                 CORINFO_RESOLVED_TOKEN* heapToken = impAllocateToken(resolvedToken);
+
                 assert(heapToken->tokenType == CORINFO_TOKENKIND_Method);
+                assert(callInfo.hMethod != nullptr);
+
                 heapToken->tokenType = CORINFO_TOKENKIND_Ldvirtftn;
+                heapToken->hMethod   = callInfo.hMethod;
                 impPushOnStack(fptr, typeInfo(heapToken));
 
                 break;


### PR DESCRIPTION
The jit has been using IR pattern matching to find the information needed for
optimizing delegate construction. This missed one case, causing the code to
use a very slow construction path.

Change #10663 introduced a token cache to convey this information to the
optimization for CoreRT and some R2R cases. With this change the jit now
now relies on the token cache for all the other cases too.

This initial commit preserves the pattern match code and verifies that when
it fires it reaches the same conclusion as the token cache does.

This cross-validation revealed one case where the token information was less
specific than the pattern match so we now also update the method handle in
the token from the call info.

A subsequent commit will remove the pattern matching when we are confident the
new token cache logic handles all the cases correctly.

Closes #12264.