### PR TITLE
Fix register being shifted in PInvoke stub

### DIFF
--- a/src/vm/arm64/PInvokeStubs.asm
+++ b/src/vm/arm64/PInvokeStubs.asm
@@ -64,8 +64,8 @@ __PInvokeGenStubFuncName SETS "$__PInvokeGenStubFuncName":CC:"_RetBuffArg"
             ; The way we do this is to shift the managed target to the left by one bit and then set the
             ; least significant bit to 1.  This works because MethodDesc* are always 8-byte aligned.
             ;
-            lsl             x12, x12, #1
-            orr             x12, x12, #1
+            lsl             $HiddenArg, $HiddenArg, #1
+            orr             $HiddenArg, $HiddenArg, #1
         ENDIF
 
         EPILOG_BRANCH_REG   x9 

--- a/src/vm/arm64/PInvokeStubs.asm
+++ b/src/vm/arm64/PInvokeStubs.asm
@@ -64,8 +64,8 @@ __PInvokeGenStubFuncName SETS "$__PInvokeGenStubFuncName":CC:"_RetBuffArg"
             ; The way we do this is to shift the managed target to the left by one bit and then set the
             ; least significant bit to 1.  This works because MethodDesc* are always 8-byte aligned.
             ;
-            lsl             x9, x9, #1
-            orr             x9, x9, #1
+            lsl             x12, x12, #1
+            orr             x12, x12, #1
         ENDIF
 
         EPILOG_BRANCH_REG   x9 

--- a/src/vm/arm64/pinvokestubs.S
+++ b/src/vm/arm64/pinvokestubs.S
@@ -38,8 +38,8 @@
             // The way we do this is to shift the managed target to the left by one bit and then set the
             // least significant bit to 1.  This works because MethodDesc* are always 8-byte aligned.
             //
-            lsl             x9, x9, #1
-            orr             x9, x9, #1
+            lsl             x12, x12, #1
+            orr             x12, x12, #1
         .endif
 
         EPILOG_BRANCH_REG   x9 

--- a/src/vm/arm64/pinvokestubs.S
+++ b/src/vm/arm64/pinvokestubs.S
@@ -38,8 +38,8 @@
             // The way we do this is to shift the managed target to the left by one bit and then set the
             // least significant bit to 1.  This works because MethodDesc* are always 8-byte aligned.
             //
-            lsl             x12, x12, #1
-            orr             x12, x12, #1
+            lsl             \HiddenArg, \HiddenArg, #1
+            orr             \HiddenArg, \HiddenArg, #1
         .endif
 
         EPILOG_BRANCH_REG   x9 


### PR DESCRIPTION
Found a little mistake in https://github.com/dotnet/coreclr/pull/17734: it intended to shift/OR the register containing the unmanaged target, but instead on ARM64 it shifts the address of the stub that it jumps to.

@sdmaclea @jkotas 