### PR TITLE
[Linux/x86] Fix tests in case of 4-byte alignment for 64-bit types

### DIFF
--- a/tests/src/JIT/Directed/RVAInit/nested.il
+++ b/tests/src/JIT/Directed/RVAInit/nested.il
@@ -35,6 +35,7 @@
   .field public int64 _long
   .field public unsigned int64 _ulong
   .field public float32 _float
+  .field public unsigned int32 _pad
   .field public float64 _double
 } // end of class Internal
 
@@ -42,6 +43,7 @@
        extends [mscorlib]System.ValueType
 {
   .field public unsigned int8 _byte
+  .field public unsigned int32 _pad
   .field public valuetype Internal intern
   .field public int8 _sbyte
   .field public int16 _short

--- a/tests/src/JIT/Directed/RVAInit/simple.il
+++ b/tests/src/JIT/Directed/RVAInit/simple.il
@@ -24,6 +24,7 @@
   .field public int64 _long
   .field public unsigned int64 _ulong
   .field public float32 _float
+  .field public unsigned int32 _pad
   .field public float64 _double
   .field public static valuetype Test static_test at D_1
   .method private hidebysig static char  hex(unsigned int8 v) cil managed

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b103058/b103058.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b103058/b103058.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.InteropServices;
 
 internal struct VT
 {
@@ -20,13 +21,21 @@ internal unsafe class test
     private static unsafe bool CheckDoubleAlignment1(VT* p)
     {
         Console.WriteLine("Address {0}", (IntPtr)p);
-        if ((int)(long)p % sizeof(double) != 0)
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || (RuntimeInformation.ProcessArchitecture != Architecture.X86))
         {
-            Console.WriteLine("not double aligned");
-            return false;
+            if ((int)(long)p % sizeof(double) != 0)
+            {
+                Console.WriteLine("not double aligned");
+                return false;
+            }
+            else
+            {
+                return true;
+            }
         }
         else
         {
+            // Current JIT implementation doesn't use double alignment stack optimization for Linux/x86
             return true;
         }
     }


### PR DESCRIPTION
This patch fixes following tests on Linux/x86:

JIT/Directed/RVAInit/nested
JIT/Directed/RVAInit/simple
JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b103058/b103058