### PR TITLE
Early bail if String IsAscii not equal

### DIFF
--- a/src/mscorlib/shared/System/String.Comparison.cs
+++ b/src/mscorlib/shared/System/String.Comparison.cs
@@ -761,9 +761,16 @@ namespace System
                     if (this.Length != value.Length)
                         return false;
 #if CORECLR
-                    // If both strings are ASCII strings, we can take the fast path.
-                    if (this.IsAscii() && value.IsAscii())
+                    var thisIsAscii = this.IsAscii();
+                    var valueIsAscii = value.IsAscii();
+                    if (thisIsAscii != valueIsAscii)
                     {
+                        // If one string is ASCII and other is not; then they are not equal
+                        return false;
+                    }
+                    else if (thisIsAscii == true && thisIsAscii == valueIsAscii)
+                    {
+                        // If both strings are ASCII strings, we can take the fast path.
                         return EqualsIgnoreCaseAsciiHelper(this, value);
                     }
 #endif
@@ -828,9 +835,16 @@ namespace System
                     if (a.Length != b.Length)
                         return false;
 #if CORECLR
-                    // If both strings are ASCII strings, we can take the fast path.
-                    if (a.IsAscii() && b.IsAscii())
+                    var aIsAscii = a.IsAscii();
+                    var bIsAscii = b.IsAscii();
+                    if (aIsAscii != bIsAscii)
                     {
+                        // If one string is ASCII and other is not; then they are not equal
+                        return false;
+                    }
+                    else if (aIsAscii == true && aIsAscii == bIsAscii)
+                    {
+                        // If both strings are ASCII strings, we can take the fast path.
                         return EqualsIgnoreCaseAsciiHelper(a, b);
                     }
 #endif

--- a/src/mscorlib/shared/System/String.Comparison.cs
+++ b/src/mscorlib/shared/System/String.Comparison.cs
@@ -761,14 +761,13 @@ namespace System
                     if (this.Length != value.Length)
                         return false;
 #if CORECLR
-                    var thisIsAscii = this.IsAscii();
-                    var valueIsAscii = value.IsAscii();
-                    if (thisIsAscii != valueIsAscii)
+                    var isAscii = IsAscii();
+                    if (isAscii != value.IsAscii())
                     {
                         // If one string is ASCII and other is not; then they are not equal
                         return false;
                     }
-                    else if (thisIsAscii == true && thisIsAscii == valueIsAscii)
+                    else if (isAscii)
                     {
                         // If both strings are ASCII strings, we can take the fast path.
                         return EqualsIgnoreCaseAsciiHelper(this, value);
@@ -835,14 +834,13 @@ namespace System
                     if (a.Length != b.Length)
                         return false;
 #if CORECLR
-                    var aIsAscii = a.IsAscii();
-                    var bIsAscii = b.IsAscii();
-                    if (aIsAscii != bIsAscii)
+                    var isAscii = a.IsAscii();
+                    if (isAscii != b.IsAscii())
                     {
                         // If one string is ASCII and other is not; then they are not equal
                         return false;
                     }
-                    else if (aIsAscii == true && aIsAscii == bIsAscii)
+                    else if (isAscii)
                     {
                         // If both strings are ASCII strings, we can take the fast path.
                         return EqualsIgnoreCaseAsciiHelper(a, b);


### PR DESCRIPTION
`IsAscii` is probably only useful to interned strings (else it will scan strings twice; once to determine if ascii, second to do equality); but checking is interned is probably expensive?

Might be better to vectorize the comparison.