### PR TITLE
Enable System.Collections.Tests and System.Runtime.Tests on Ubuntu/arm

### DIFF
--- a/tests/arm/corefx_linux_test_exclusions.txt
+++ b/tests/arm/corefx_linux_test_exclusions.txt
@@ -12,7 +12,5 @@ System.Net.NameResolution.Functional.Tests # https://github.com/dotnet/coreclr/i
 System.Net.NameResolution.Pal.Tests  # https://github.com/dotnet/coreclr/issues/17740
 System.Net.NetworkInformation.Functional.Tests # https://github.com/dotnet/coreclr/issues/17753 -- segmentation fault
 System.Net.Sockets.Tests             # https://github.com/dotnet/coreclr/issues/17753 -- segmentation fault
-System.Text.Encodings.Web.Tests      # https://github.com/dotnet/coreclr/issues/17754 -- timeout -- JitMinOpts only
 System.Text.RegularExpressions.Tests # https://github.com/dotnet/coreclr/issues/17754 -- timeout -- JitMinOpts only
 System.Transactions.Local.Tests      # https://github.com/dotnet/coreclr/issues/17754 -- timeout
-System.Xml.RW.XmlConvert.Tests       # https://github.com/dotnet/coreclr/issues/17754 -- timeout

--- a/tests/arm/corefx_linux_test_exclusions.txt
+++ b/tests/arm/corefx_linux_test_exclusions.txt
@@ -1,4 +1,3 @@
-System.Collections.Tests             # https://github.com/dotnet/coreclr/issues/17754 -- timeout
 System.Console.Tests
 System.Data.SqlClient.Tests          # https://github.com/dotnet/coreclr/issues/16001
 System.Diagnostics.Process.Tests     # https://github.com/dotnet/coreclr/issues/16001
@@ -13,7 +12,6 @@ System.Net.NameResolution.Functional.Tests # https://github.com/dotnet/coreclr/i
 System.Net.NameResolution.Pal.Tests  # https://github.com/dotnet/coreclr/issues/17740
 System.Net.NetworkInformation.Functional.Tests # https://github.com/dotnet/coreclr/issues/17753 -- segmentation fault
 System.Net.Sockets.Tests             # https://github.com/dotnet/coreclr/issues/17753 -- segmentation fault
-System.Runtime.Tests                 # https://github.com/dotnet/coreclr/issues/17755 -- JitStress only
 System.Text.Encodings.Web.Tests      # https://github.com/dotnet/coreclr/issues/17754 -- timeout -- JitMinOpts only
 System.Text.RegularExpressions.Tests # https://github.com/dotnet/coreclr/issues/17754 -- timeout -- JitMinOpts only
 System.Transactions.Local.Tests      # https://github.com/dotnet/coreclr/issues/17754 -- timeout


### PR DESCRIPTION
After increasing timeout to 15 minutes in dotnet/corefx#29388 enable `System.Collections.Tests` and `System.Runtime.Tests` on Ubuntu/arm

Fixes #17755 