### PR TITLE
GC env vars

### DIFF
--- a/src/coreclr/hosts/corerun/corerun.cpp
+++ b/src/coreclr/hosts/corerun/corerun.cpp
@@ -19,7 +19,7 @@
 
 // Environment variable for setting whether or not to use Server GC.
 // Off by default.
-static const wchar_t *serverGcVar = W("CORECLR_SERVER_GC");
+static const wchar_t *serverGcVar = W("COMPlus_gcServer");
 
 // Environment variable for setting whether or not to use Concurrent GC.
 // On by default.

--- a/src/coreclr/hosts/corerun/corerun.cpp
+++ b/src/coreclr/hosts/corerun/corerun.cpp
@@ -23,7 +23,7 @@ static const wchar_t *serverGcVar = W("COMPlus_gcServer");
 
 // Environment variable for setting whether or not to use Concurrent GC.
 // On by default.
-static const wchar_t *concurrentGcVar = W("CORECLR_CONCURRENT_GC");
+static const wchar_t *concurrentGcVar = W("COMPlus_gcConcurrent");
 
 // The name of the CoreCLR native runtime DLL.
 static const wchar_t *coreCLRDll = W("CoreCLR.dll");

--- a/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
+++ b/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
@@ -33,7 +33,7 @@
 // Name of the environment variable controlling server GC.
 // If set to 1, server GC is enabled on startup. If 0, server GC is
 // disabled. Server GC is off by default.
-static const char* serverGcVar = "CORECLR_SERVER_GC";
+static const char* serverGcVar = "COMPlus_gcServer";
 
 // Name of environment variable to control "System.Globalization.Invariant"
 // Set to 1 for Globalization Invariant mode to be true. Default is false.

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -1236,7 +1236,7 @@ if ((disableEventLogging == 0)); then
     export COMPlus_EnableEventLog=1
 fi
 
-export CORECLR_SERVER_GC="$serverGC"
+export COMPlus_gcServer="$serverGC"
 
 if [ -z "$testRootDir" ]; then
     echo "--testRootDir is required."


### PR DESCRIPTION
Remove CORECLR_SERVER_GC and CORECLR_CONCURRENT_GC, and make COMPlus_gcServer and COMPlus_gcConcurrent available on Windows.