### PR TITLE
Switch source build property to DotNetBuildFromSource

### DIFF
--- a/src/.nuget/dir.traversal.targets
+++ b/src/.nuget/dir.traversal.targets
@@ -6,10 +6,10 @@
   <PropertyGroup Condition="'$(BuildIdentityPackage)' == ''">
     <BuildIdentityPackage>true</BuildIdentityPackage>
 
-    <!-- Used to determine if we should build some packages only once across multiple official build legs. 
-         For offline builds we still set OfficialBuildId but we need to build all the packages for a single 
-         leg only, so we also take DotNetBuildOffline into account. -->
-    <BuildingAnOfficialBuildLeg Condition="'$(OfficialBuildId)' != '' AND '$(DotNetBuildOffline)' != 'true'">true</BuildingAnOfficialBuildLeg>
+    <!-- Used to determine if we should build some packages only once across multiple official build legs.
+         For offline builds we still set OfficialBuildId but we need to build all the packages for a single
+         leg only, so we also take DotNetBuildFromSource into account. -->
+    <BuildingAnOfficialBuildLeg Condition="'$(OfficialBuildId)' != '' AND '$(DotNetBuildFromSource)' != 'true'">true</BuildingAnOfficialBuildLeg>
 
     <!-- During an official build, only build identity packages on windows x64 legs -->
     <BuildIdentityPackage Condition="'$(BuildingAnOfficialBuildLeg)' == 'true' AND ('$(OS)' != 'Windows_NT' OR '$(BuildArch)' != 'x64')">false</BuildIdentityPackage>
@@ -22,7 +22,7 @@
     <ItemGroup>
       <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '$(PackageRID)'" />
     </ItemGroup>
-    
+
     <ItemGroup Condition="'$(BuildIdentityPackage)' == 'true'">
       <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == ''" />
     </ItemGroup>


### PR DESCRIPTION
Detect source-build via DotNetBuildFromSource instead of
DotNetBuildOffline which is set for the tarball build.

cc @dseefeld 