### PR TITLE
Fix arm test list creator for Windows

### DIFF
--- a/tests/scripts/lst_creator.py
+++ b/tests/scripts/lst_creator.py
@@ -258,7 +258,7 @@ def parse_lst_file(lst_file):
             index = int(unique_name.split("_")[-1])
             metadata = defaultdict(lambda: None)
 
-            attributes = item.split(os.linesep)
+            attributes = item.split("\n")
             for attribute in attributes:
                 # Skip the removed new lines.
                 if len(attribute) == 0:

--- a/tests/scripts/lst_creator.py
+++ b/tests/scripts/lst_creator.py
@@ -48,8 +48,9 @@ def create_list_file(file_name, metadata):
     Args:
         file_name (str): Location to write the lstFile
         metadata ({ str: { str: str } }): Dictionary mapping test name to
-                                        : a dictionary of key/value
-                                        : attributes.
+                                        : a tuple, the first tuple's value is
+                                        : a dictionary of key/value attributes,
+                                        : the second is test index.
 
     """
 


### PR DESCRIPTION
When Python reads a file it converts all line separators to a single "\n".
But the value of `os.linesep` is [platform specific](https://docs.python.org/3/library/os.html#os.linesep) and used to parse binary files, so on Windows it is "\r\n" and `item.split(os.linesep)` can't split anything. On POSIX `os.linesep == \n` so it has worked fine.