### PR TITLE
Rename internal Utf8String to MdUtf8String

### DIFF
--- a/src/mscorlib/src/System/Reflection/MdImport.cs
+++ b/src/mscorlib/src/System/Reflection/MdImport.cs
@@ -412,22 +412,22 @@ namespace System.Reflection
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern unsafe void _GetName(IntPtr scope, int mdToken, void** name);
-        public unsafe Utf8String GetName(int mdToken)
+        public unsafe InternalUtf8String GetName(int mdToken)
         {
             void* name;
             _GetName(m_metadataImport2, mdToken, &name);
 
-            return new Utf8String(name);
+            return new InternalUtf8String(name);
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern unsafe void _GetNamespace(IntPtr scope, int mdToken, void** namesp);
-        public unsafe Utf8String GetNamespace(int mdToken)
+        public unsafe InternalUtf8String GetNamespace(int mdToken)
         {
             void* namesp;
             _GetNamespace(m_metadataImport2, mdToken, &namesp);
 
-            return new Utf8String(namesp);
+            return new InternalUtf8String(namesp);
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
@@ -640,8 +640,8 @@ namespace System.Reflection
             int _attributes;
             void* _importName, _importDll;
             _GetPInvokeMap(m_metadataImport2, token, out _attributes, &_importName, &_importDll);
-            importName = new Utf8String(_importName).ToString();
-            importDll = new Utf8String(_importDll).ToString();
+            importName = new InternalUtf8String(_importName).ToString();
+            importDll = new InternalUtf8String(_importDll).ToString();
 
             attributes = (PInvokeAttributes)_attributes;
         }

--- a/src/mscorlib/src/System/Reflection/MdImport.cs
+++ b/src/mscorlib/src/System/Reflection/MdImport.cs
@@ -412,22 +412,22 @@ namespace System.Reflection
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern unsafe void _GetName(IntPtr scope, int mdToken, void** name);
-        public unsafe InternalUtf8String GetName(int mdToken)
+        public unsafe MdUtf8String GetName(int mdToken)
         {
             void* name;
             _GetName(m_metadataImport2, mdToken, &name);
 
-            return new InternalUtf8String(name);
+            return new MdUtf8String(name);
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern unsafe void _GetNamespace(IntPtr scope, int mdToken, void** namesp);
-        public unsafe InternalUtf8String GetNamespace(int mdToken)
+        public unsafe MdUtf8String GetNamespace(int mdToken)
         {
             void* namesp;
             _GetNamespace(m_metadataImport2, mdToken, &namesp);
 
-            return new InternalUtf8String(namesp);
+            return new MdUtf8String(namesp);
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
@@ -640,8 +640,8 @@ namespace System.Reflection
             int _attributes;
             void* _importName, _importDll;
             _GetPInvokeMap(m_metadataImport2, token, out _attributes, &_importName, &_importDll);
-            importName = new InternalUtf8String(_importName).ToString();
-            importDll = new InternalUtf8String(_importDll).ToString();
+            importName = new MdUtf8String(_importName).ToString();
+            importDll = new MdUtf8String(_importDll).ToString();
 
             attributes = (PInvokeAttributes)_attributes;
         }

--- a/src/mscorlib/src/System/Reflection/RuntimeEventInfo.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimeEventInfo.cs
@@ -124,7 +124,7 @@ namespace System.Reflection
             get
             {
                 if (m_name == null)
-                    m_name = new Utf8String(m_utf8name).ToString();
+                    m_name = new InternalUtf8String(m_utf8name).ToString();
 
                 return m_name;
             }

--- a/src/mscorlib/src/System/Reflection/RuntimeEventInfo.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimeEventInfo.cs
@@ -124,7 +124,7 @@ namespace System.Reflection
             get
             {
                 if (m_name == null)
-                    m_name = new InternalUtf8String(m_utf8name).ToString();
+                    m_name = new MdUtf8String(m_utf8name).ToString();
 
                 return m_name;
             }

--- a/src/mscorlib/src/System/Reflection/RuntimePropertyInfo.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimePropertyInfo.cs
@@ -189,7 +189,7 @@ namespace System.Reflection
             get
             {
                 if (m_name == null)
-                    m_name = new InternalUtf8String(m_utf8name).ToString();
+                    m_name = new MdUtf8String(m_utf8name).ToString();
 
                 return m_name;
             }

--- a/src/mscorlib/src/System/Reflection/RuntimePropertyInfo.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimePropertyInfo.cs
@@ -189,7 +189,7 @@ namespace System.Reflection
             get
             {
                 if (m_name == null)
-                    m_name = new Utf8String(m_utf8name).ToString();
+                    m_name = new InternalUtf8String(m_utf8name).ToString();
 
                 return m_name;
             }

--- a/src/mscorlib/src/System/RtType.cs
+++ b/src/mscorlib/src/System/RtType.cs
@@ -188,13 +188,13 @@ namespace System
 
             private struct Filter
             {
-                private Utf8String m_name;
+                private InternalUtf8String m_name;
                 private MemberListType m_listType;
                 private uint m_nameHash;
 
                 public unsafe Filter(byte* pUtf8Name, int cUtf8Name, MemberListType listType)
                 {
-                    m_name = new Utf8String((void*)pUtf8Name, cUtf8Name);
+                    m_name = new InternalUtf8String((void*)pUtf8Name, cUtf8Name);
                     m_listType = listType;
                     m_nameHash = 0;
 
@@ -204,7 +204,7 @@ namespace System
                     }
                 }
 
-                public bool Match(Utf8String name)
+                public bool Match(InternalUtf8String name)
                 {
                     bool retVal = true;
 
@@ -943,7 +943,7 @@ namespace System
 
                             if (filter.RequiresStringComparison())
                             {
-                                Utf8String name;
+                                InternalUtf8String name;
                                 name = scope.GetName(tkField);
 
                                 if (!filter.Match(name))
@@ -1179,7 +1179,7 @@ namespace System
 
                         if (filter.RequiresStringComparison())
                         {
-                            Utf8String name;
+                            InternalUtf8String name;
                             name = scope.GetName(tkEvent);
 
                             if (!filter.Match(name))
@@ -1296,7 +1296,7 @@ namespace System
                                 continue;
                             }
 
-                            Utf8String name;
+                            InternalUtf8String name;
                             name = declaringType.GetRuntimeModule().MetadataImport.GetName(tkProperty);
 
                             if (!filter.Match(name))
@@ -4917,7 +4917,7 @@ namespace System
     }
 
     #region Library
-    internal unsafe struct Utf8String
+    internal unsafe struct InternalUtf8String
     {
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern unsafe bool EqualsCaseSensitive(void* szLhs, void* szRhs, int cSz);
@@ -4949,7 +4949,7 @@ namespace System
         private void* m_pStringHeap;        // This is the raw UTF8 string.
         private int m_StringHeapByteLength;
 
-        internal Utf8String(void* pStringHeap)
+        internal InternalUtf8String(void* pStringHeap)
         {
             m_pStringHeap = pStringHeap;
             if (pStringHeap != null)
@@ -4962,13 +4962,13 @@ namespace System
             }
         }
 
-        internal unsafe Utf8String(void* pUtf8String, int cUtf8String)
+        internal unsafe InternalUtf8String(void* pUtf8String, int cUtf8String)
         {
             m_pStringHeap = pUtf8String;
             m_StringHeapByteLength = cUtf8String;
         }
 
-        internal unsafe bool Equals(Utf8String s)
+        internal unsafe bool Equals(InternalUtf8String s)
         {
             if (m_pStringHeap == null)
             {
@@ -4976,12 +4976,12 @@ namespace System
             }
             if ((s.m_StringHeapByteLength == m_StringHeapByteLength) && (m_StringHeapByteLength != 0))
             {
-                return Utf8String.EqualsCaseSensitive(s.m_pStringHeap, m_pStringHeap, m_StringHeapByteLength);
+                return InternalUtf8String.EqualsCaseSensitive(s.m_pStringHeap, m_pStringHeap, m_StringHeapByteLength);
             }
             return false;
         }
 
-        internal unsafe bool EqualsCaseInsensitive(Utf8String s)
+        internal unsafe bool EqualsCaseInsensitive(InternalUtf8String s)
         {
             if (m_pStringHeap == null)
             {
@@ -4989,14 +4989,14 @@ namespace System
             }
             if ((s.m_StringHeapByteLength == m_StringHeapByteLength) && (m_StringHeapByteLength != 0))
             {
-                return Utf8String.EqualsCaseInsensitive(s.m_pStringHeap, m_pStringHeap, m_StringHeapByteLength);
+                return InternalUtf8String.EqualsCaseInsensitive(s.m_pStringHeap, m_pStringHeap, m_StringHeapByteLength);
             }
             return false;
         }
 
         internal unsafe uint HashCaseInsensitive()
         {
-            return Utf8String.HashCaseInsensitive(m_pStringHeap, m_StringHeapByteLength);
+            return InternalUtf8String.HashCaseInsensitive(m_pStringHeap, m_StringHeapByteLength);
         }
 
         public override string ToString()

--- a/src/mscorlib/src/System/RtType.cs
+++ b/src/mscorlib/src/System/RtType.cs
@@ -188,13 +188,13 @@ namespace System
 
             private struct Filter
             {
-                private InternalUtf8String m_name;
+                private MdUtf8String m_name;
                 private MemberListType m_listType;
                 private uint m_nameHash;
 
                 public unsafe Filter(byte* pUtf8Name, int cUtf8Name, MemberListType listType)
                 {
-                    m_name = new InternalUtf8String((void*)pUtf8Name, cUtf8Name);
+                    m_name = new MdUtf8String((void*)pUtf8Name, cUtf8Name);
                     m_listType = listType;
                     m_nameHash = 0;
 
@@ -204,7 +204,7 @@ namespace System
                     }
                 }
 
-                public bool Match(InternalUtf8String name)
+                public bool Match(MdUtf8String name)
                 {
                     bool retVal = true;
 
@@ -943,7 +943,7 @@ namespace System
 
                             if (filter.RequiresStringComparison())
                             {
-                                InternalUtf8String name;
+                                MdUtf8String name;
                                 name = scope.GetName(tkField);
 
                                 if (!filter.Match(name))
@@ -1179,7 +1179,7 @@ namespace System
 
                         if (filter.RequiresStringComparison())
                         {
-                            InternalUtf8String name;
+                            MdUtf8String name;
                             name = scope.GetName(tkEvent);
 
                             if (!filter.Match(name))
@@ -1296,7 +1296,7 @@ namespace System
                                 continue;
                             }
 
-                            InternalUtf8String name;
+                            MdUtf8String name;
                             name = declaringType.GetRuntimeModule().MetadataImport.GetName(tkProperty);
 
                             if (!filter.Match(name))
@@ -4917,7 +4917,7 @@ namespace System
     }
 
     #region Library
-    internal unsafe struct InternalUtf8String
+    internal unsafe struct MdUtf8String
     {
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern unsafe bool EqualsCaseSensitive(void* szLhs, void* szRhs, int cSz);
@@ -4949,7 +4949,7 @@ namespace System
         private void* m_pStringHeap;        // This is the raw UTF8 string.
         private int m_StringHeapByteLength;
 
-        internal InternalUtf8String(void* pStringHeap)
+        internal MdUtf8String(void* pStringHeap)
         {
             m_pStringHeap = pStringHeap;
             if (pStringHeap != null)
@@ -4962,13 +4962,13 @@ namespace System
             }
         }
 
-        internal unsafe InternalUtf8String(void* pUtf8String, int cUtf8String)
+        internal unsafe MdUtf8String(void* pUtf8String, int cUtf8String)
         {
             m_pStringHeap = pUtf8String;
             m_StringHeapByteLength = cUtf8String;
         }
 
-        internal unsafe bool Equals(InternalUtf8String s)
+        internal unsafe bool Equals(MdUtf8String s)
         {
             if (m_pStringHeap == null)
             {
@@ -4976,12 +4976,12 @@ namespace System
             }
             if ((s.m_StringHeapByteLength == m_StringHeapByteLength) && (m_StringHeapByteLength != 0))
             {
-                return InternalUtf8String.EqualsCaseSensitive(s.m_pStringHeap, m_pStringHeap, m_StringHeapByteLength);
+                return MdUtf8String.EqualsCaseSensitive(s.m_pStringHeap, m_pStringHeap, m_StringHeapByteLength);
             }
             return false;
         }
 
-        internal unsafe bool EqualsCaseInsensitive(InternalUtf8String s)
+        internal unsafe bool EqualsCaseInsensitive(MdUtf8String s)
         {
             if (m_pStringHeap == null)
             {
@@ -4989,14 +4989,14 @@ namespace System
             }
             if ((s.m_StringHeapByteLength == m_StringHeapByteLength) && (m_StringHeapByteLength != 0))
             {
-                return InternalUtf8String.EqualsCaseInsensitive(s.m_pStringHeap, m_pStringHeap, m_StringHeapByteLength);
+                return MdUtf8String.EqualsCaseInsensitive(s.m_pStringHeap, m_pStringHeap, m_StringHeapByteLength);
             }
             return false;
         }
 
         internal unsafe uint HashCaseInsensitive()
         {
-            return InternalUtf8String.HashCaseInsensitive(m_pStringHeap, m_StringHeapByteLength);
+            return MdUtf8String.HashCaseInsensitive(m_pStringHeap, m_StringHeapByteLength);
         }
 
         public override string ToString()

--- a/src/mscorlib/src/System/RuntimeHandles.cs
+++ b/src/mscorlib/src/System/RuntimeHandles.cs
@@ -399,9 +399,9 @@ namespace System
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern void* _GetUtf8Name(RuntimeType type);
 
-        internal static Utf8String GetUtf8Name(RuntimeType type)
+        internal static InternalUtf8String GetUtf8Name(RuntimeType type)
         {
-            return new Utf8String(_GetUtf8Name(type));
+            return new InternalUtf8String(_GetUtf8Name(type));
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
@@ -876,9 +876,9 @@ namespace System
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern void* _GetUtf8Name(RuntimeMethodHandleInternal method);
 
-        internal static Utf8String GetUtf8Name(RuntimeMethodHandleInternal method)
+        internal static InternalUtf8String GetUtf8Name(RuntimeMethodHandleInternal method)
         {
-            return new Utf8String(_GetUtf8Name(method));
+            return new InternalUtf8String(_GetUtf8Name(method));
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
@@ -1126,7 +1126,7 @@ namespace System
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern unsafe void* _GetUtf8Name(RuntimeFieldHandleInternal field);
 
-        internal static unsafe Utf8String GetUtf8Name(RuntimeFieldHandleInternal field) { return new Utf8String(_GetUtf8Name(field)); }
+        internal static unsafe InternalUtf8String GetUtf8Name(RuntimeFieldHandleInternal field) { return new InternalUtf8String(_GetUtf8Name(field)); }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern bool MatchesNameHash(RuntimeFieldHandleInternal handle, uint hash);

--- a/src/mscorlib/src/System/RuntimeHandles.cs
+++ b/src/mscorlib/src/System/RuntimeHandles.cs
@@ -399,9 +399,9 @@ namespace System
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern void* _GetUtf8Name(RuntimeType type);
 
-        internal static InternalUtf8String GetUtf8Name(RuntimeType type)
+        internal static MdUtf8String GetUtf8Name(RuntimeType type)
         {
-            return new InternalUtf8String(_GetUtf8Name(type));
+            return new MdUtf8String(_GetUtf8Name(type));
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
@@ -876,9 +876,9 @@ namespace System
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern void* _GetUtf8Name(RuntimeMethodHandleInternal method);
 
-        internal static InternalUtf8String GetUtf8Name(RuntimeMethodHandleInternal method)
+        internal static MdUtf8String GetUtf8Name(RuntimeMethodHandleInternal method)
         {
-            return new InternalUtf8String(_GetUtf8Name(method));
+            return new MdUtf8String(_GetUtf8Name(method));
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
@@ -1126,7 +1126,7 @@ namespace System
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern unsafe void* _GetUtf8Name(RuntimeFieldHandleInternal field);
 
-        internal static unsafe InternalUtf8String GetUtf8Name(RuntimeFieldHandleInternal field) { return new InternalUtf8String(_GetUtf8Name(field)); }
+        internal static unsafe MdUtf8String GetUtf8Name(RuntimeFieldHandleInternal field) { return new MdUtf8String(_GetUtf8Name(field)); }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern bool MatchesNameHash(RuntimeFieldHandleInternal handle, uint hash);

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -474,10 +474,10 @@ FCFuncStart(gAppDomainFuncs)
 FCFuncEnd()
 
 
-FCFuncStart(gInternalUtf8String)
-    FCFuncElement("EqualsCaseSensitive", InternalUtf8String::EqualsCaseSensitive)
-    QCFuncElement("EqualsCaseInsensitive", InternalUtf8String::EqualsCaseInsensitive)
-    QCFuncElement("HashCaseInsensitive", InternalUtf8String::HashCaseInsensitive)
+FCFuncStart(gMdUtf8String)
+    FCFuncElement("EqualsCaseSensitive", MdUtf8String::EqualsCaseSensitive)
+    QCFuncElement("EqualsCaseInsensitive", MdUtf8String::EqualsCaseInsensitive)
+    QCFuncElement("HashCaseInsensitive", MdUtf8String::HashCaseInsensitive)
 FCFuncEnd()
 
 FCFuncStart(gTypeNameBuilder)
@@ -1307,7 +1307,6 @@ FCClassElement("IReflect", "System.Reflection", gStdMngIReflectFuncs)
 FCClassElement("InterfaceMarshaler", "System.StubHelpers", gInterfaceMarshalerFuncs)
 #endif
 FCClassElement("Interlocked", "System.Threading", gInterlockedFuncs)
-FCClassElement("InternalUtf8String", "System", gInternalUtf8String)
 FCClassElement("JitHelpers", "System.Runtime.CompilerServices", gJitHelpers)
 FCClassElement("LoaderAllocatorScout", "System.Reflection", gLoaderAllocatorFuncs)
 FCClassElement("ManifestBasedResourceGroveler", "System.Resources",  gManifestBasedResourceGrovelerFuncs)
@@ -1317,6 +1316,7 @@ FCClassElement("MathF", "System", gMathFFuncs)
 #ifdef MDA_SUPPORTED 
 FCClassElement("Mda", "System", gMda)
 #endif
+FCClassElement("MdUtf8String", "System", gMdUtf8String)
 FCClassElement("MemoryFailPoint", "System.Runtime", gMemoryFailPointFuncs)
 FCClassElement("MetadataImport", "System.Reflection", gMetaDataImport)
 FCClassElement("MissingMemberException", "System",  gMissingMemberExceptionFuncs)

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -474,10 +474,10 @@ FCFuncStart(gAppDomainFuncs)
 FCFuncEnd()
 
 
-FCFuncStart(gUtf8String)
-    FCFuncElement("EqualsCaseSensitive", Utf8String::EqualsCaseSensitive)
-    QCFuncElement("EqualsCaseInsensitive", Utf8String::EqualsCaseInsensitive)
-    QCFuncElement("HashCaseInsensitive", Utf8String::HashCaseInsensitive)
+FCFuncStart(gInternalUtf8String)
+    FCFuncElement("EqualsCaseSensitive", InternalUtf8String::EqualsCaseSensitive)
+    QCFuncElement("EqualsCaseInsensitive", InternalUtf8String::EqualsCaseInsensitive)
+    QCFuncElement("HashCaseInsensitive", InternalUtf8String::HashCaseInsensitive)
 FCFuncEnd()
 
 FCFuncStart(gTypeNameBuilder)
@@ -1307,6 +1307,7 @@ FCClassElement("IReflect", "System.Reflection", gStdMngIReflectFuncs)
 FCClassElement("InterfaceMarshaler", "System.StubHelpers", gInterfaceMarshalerFuncs)
 #endif
 FCClassElement("Interlocked", "System.Threading", gInterlockedFuncs)
+FCClassElement("InternalUtf8String", "System", gInternalUtf8String)
 FCClassElement("JitHelpers", "System.Runtime.CompilerServices", gJitHelpers)
 FCClassElement("LoaderAllocatorScout", "System.Reflection", gLoaderAllocatorFuncs)
 FCClassElement("ManifestBasedResourceGroveler", "System.Resources",  gManifestBasedResourceGrovelerFuncs)
@@ -1383,7 +1384,6 @@ FCClassElement("TypedReference", "System", gTypedReferenceFuncs)
 #ifdef FEATURE_COMINTEROP
 FCClassElement("UriMarshaler", "System.StubHelpers", gUriMarshalerFuncs)
 #endif
-FCClassElement("Utf8String", "System", gUtf8String)
 FCClassElement("ValueClassMarshaler", "System.StubHelpers", gValueClassMarshalerFuncs)
 FCClassElement("ValueType", "System", gValueTypeFuncs)
 #ifdef FEATURE_COMINTEROP

--- a/src/vm/runtimehandles.cpp
+++ b/src/vm/runtimehandles.cpp
@@ -32,7 +32,7 @@
 #include "invokeutil.h"
 
 
-FCIMPL3(FC_BOOL_RET, Utf8String::EqualsCaseSensitive, LPCUTF8 szLhs, LPCUTF8 szRhs, INT32 stringNumBytes)
+FCIMPL3(FC_BOOL_RET, InternalUtf8String::EqualsCaseSensitive, LPCUTF8 szLhs, LPCUTF8 szRhs, INT32 stringNumBytes)
 {
     CONTRACTL {
         FCALL_CHECK;
@@ -50,7 +50,7 @@ FCIMPL3(FC_BOOL_RET, Utf8String::EqualsCaseSensitive, LPCUTF8 szLhs, LPCUTF8 szR
 }
 FCIMPLEND
 
-BOOL QCALLTYPE Utf8String::EqualsCaseInsensitive(LPCUTF8 szLhs, LPCUTF8 szRhs, INT32 stringNumBytes)
+BOOL QCALLTYPE InternalUtf8String::EqualsCaseInsensitive(LPCUTF8 szLhs, LPCUTF8 szRhs, INT32 stringNumBytes)
 {
     QCALL_CONTRACT;
 
@@ -77,7 +77,7 @@ BOOL QCALLTYPE Utf8String::EqualsCaseInsensitive(LPCUTF8 szLhs, LPCUTF8 szRhs, I
     return fStringsEqual;
 }
 
-ULONG QCALLTYPE Utf8String::HashCaseInsensitive(LPCUTF8 sz, INT32 stringNumBytes)
+ULONG QCALLTYPE InternalUtf8String::HashCaseInsensitive(LPCUTF8 sz, INT32 stringNumBytes)
 {
     QCALL_CONTRACT;
 

--- a/src/vm/runtimehandles.cpp
+++ b/src/vm/runtimehandles.cpp
@@ -32,7 +32,7 @@
 #include "invokeutil.h"
 
 
-FCIMPL3(FC_BOOL_RET, InternalUtf8String::EqualsCaseSensitive, LPCUTF8 szLhs, LPCUTF8 szRhs, INT32 stringNumBytes)
+FCIMPL3(FC_BOOL_RET, MdUtf8String::EqualsCaseSensitive, LPCUTF8 szLhs, LPCUTF8 szRhs, INT32 stringNumBytes)
 {
     CONTRACTL {
         FCALL_CHECK;
@@ -50,7 +50,7 @@ FCIMPL3(FC_BOOL_RET, InternalUtf8String::EqualsCaseSensitive, LPCUTF8 szLhs, LPC
 }
 FCIMPLEND
 
-BOOL QCALLTYPE InternalUtf8String::EqualsCaseInsensitive(LPCUTF8 szLhs, LPCUTF8 szRhs, INT32 stringNumBytes)
+BOOL QCALLTYPE MdUtf8String::EqualsCaseInsensitive(LPCUTF8 szLhs, LPCUTF8 szRhs, INT32 stringNumBytes)
 {
     QCALL_CONTRACT;
 
@@ -77,7 +77,7 @@ BOOL QCALLTYPE InternalUtf8String::EqualsCaseInsensitive(LPCUTF8 szLhs, LPCUTF8 
     return fStringsEqual;
 }
 
-ULONG QCALLTYPE InternalUtf8String::HashCaseInsensitive(LPCUTF8 sz, INT32 stringNumBytes)
+ULONG QCALLTYPE MdUtf8String::HashCaseInsensitive(LPCUTF8 sz, INT32 stringNumBytes)
 {
     QCALL_CONTRACT;
 

--- a/src/vm/runtimehandles.h
+++ b/src/vm/runtimehandles.h
@@ -104,7 +104,7 @@ public:
     INT32 m_localIndex;
 };
 
-class InternalUtf8String {
+class MdUtf8String {
 public:
     static FCDECL3(FC_BOOL_RET, EqualsCaseSensitive, LPCUTF8 szLhs, LPCUTF8 szRhs, INT32 stringNumBytes);
 

--- a/src/vm/runtimehandles.h
+++ b/src/vm/runtimehandles.h
@@ -104,7 +104,7 @@ public:
     INT32 m_localIndex;
 };
 
-class Utf8String {
+class InternalUtf8String {
 public:
     static FCDECL3(FC_BOOL_RET, EqualsCaseSensitive, LPCUTF8 szLhs, LPCUTF8 szRhs, INT32 stringNumBytes);
 


### PR DESCRIPTION
We want to start prototyping Utf8String in CoreFxLab
and for that, we'll need a bare-bones System.Utf8String
class exposed from System.Private.CoreLib.

Unfortunately, CoreLib already has an internal
struct named System.Utf8String. Since it's only
an internal type, we'll exercise eminent domain
on its name now and get these noise changes out of
the way.