### PR TITLE
Improve checking of GTF_CALL flag.

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -21164,6 +21164,11 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
         chkFlags |= GTF_EXCEPT;
     }
 
+    if (tree->OperRequiresCallFlag(this))
+    {
+        chkFlags |= GTF_CALL;
+    }
+
     /* Is this a leaf node? */
 
     if (kind & GTK_LEAF)
@@ -21348,8 +21353,6 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
 
                 call = tree->AsCall();
 
-                chkFlags |= GTF_CALL;
-
                 if (call->gtCallObjp)
                 {
                     fgDebugCheckFlags(call->gtCallObjp);
@@ -21531,8 +21534,8 @@ void Compiler::fgDebugCheckFlagsHelper(GenTree* tree, unsigned treeFlags, unsign
     }
     else if (treeFlags & ~chkFlags)
     {
-        // TODO: We are currently only checking extra GTF_EXCEPT and GTF_ASG flags.
-        if ((treeFlags & ~chkFlags & ~GTF_GLOB_REF & ~GTF_ORDER_SIDEEFF & ~GTF_CALL) != 0)
+        // TODO: We are currently only checking extra GTF_EXCEPT, GTF_ASG, and GTF_CALL flags.
+        if ((treeFlags & ~chkFlags & ~GTF_GLOB_REF & ~GTF_ORDER_SIDEEFF) != 0)
         {
             // Print the tree so we can see it in the log.
             printf("Extra flags on parent tree [%X]: ", tree);

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -1826,6 +1826,8 @@ public:
 
     bool OperRequiresAsgFlag();
 
+    bool OperRequiresCallFlag(Compiler* comp);
+
     bool OperMayThrow(Compiler* comp);
 
     unsigned GetScaleIndexMul();

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -1584,6 +1584,7 @@ void fgArgInfo::ArgsComplete()
             }
         }
 
+        bool treatLikeCall = ((argx->gtFlags & GTF_CALL) != 0);
 #if FEATURE_FIXED_OUT_ARGS
         // Like calls, if this argument has a tree that will do an inline throw,
         // a call to a jit helper, then we need to treat it like a call (but only
@@ -1592,8 +1593,7 @@ void fgArgInfo::ArgsComplete()
         // conservative, but I want to avoid as much special-case debug-only code
         // as possible, so leveraging the GTF_CALL flag is the easiest.
         //
-        if (!(argx->gtFlags & GTF_CALL) && (argx->gtFlags & GTF_EXCEPT) && (argCount > 1) &&
-            compiler->opts.compDbgCode &&
+        if (!treatLikeCall && (argx->gtFlags & GTF_EXCEPT) && (argCount > 1) && compiler->opts.compDbgCode &&
             (compiler->fgWalkTreePre(&argx, Compiler::fgChkThrowCB) == Compiler::WALK_ABORT))
         {
             for (unsigned otherInx = 0; otherInx < argCount; otherInx++)
@@ -1605,7 +1605,7 @@ void fgArgInfo::ArgsComplete()
 
                 if (argTable[otherInx]->regNum == REG_STK)
                 {
-                    argx->gtFlags |= GTF_CALL;
+                    treatLikeCall = true;
                     break;
                 }
             }
@@ -1620,7 +1620,7 @@ void fgArgInfo::ArgsComplete()
            since the call won't be modifying any non-address taken LclVars.
          */
 
-        if (argx->gtFlags & GTF_CALL)
+        if (treatLikeCall)
         {
             if (argCount > 1) // If this is not the only argument
             {
@@ -12385,7 +12385,7 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac)
 
         assert(tree->gtOper != GT_CALL);
 
-        if ((tree->gtOper != GT_INTRINSIC) || !IsIntrinsicImplementedByUserCall(tree->gtIntrinsic.gtIntrinsicId))
+        if (!tree->OperRequiresCallFlag(this))
         {
             tree->gtFlags &= ~GTF_CALL;
         }
@@ -12572,24 +12572,22 @@ DONE_MORPHING_CHILDREN:
             tree->gtFlags &= ~GTF_ASG;
         }
     }
-/*-------------------------------------------------------------------------
- * Now do POST-ORDER processing
- */
 
-#if FEATURE_FIXED_OUT_ARGS && !defined(_TARGET_64BIT_)
-    // Variable shifts of a long end up being helper calls, so mark the tree as such. This
-    // is potentially too conservative, since they'll get treated as having side effects.
-    // It is important to mark them as calls so if they are part of an argument list,
-    // they will get sorted and processed properly (for example, it is important to handle
-    // all nested calls before putting struct arguments in the argument registers). We
-    // could mark the trees just before argument processing, but it would require a full
-    // tree walk of the argument tree, so we just do it here, instead, even though we'll
-    // mark non-argument trees (that will still get converted to calls, anyway).
-    if (GenTree::OperIsShift(oper) && (tree->TypeGet() == TYP_LONG) && (op2->OperGet() != GT_CNS_INT))
+    if (tree->OperRequiresCallFlag(this))
     {
         tree->gtFlags |= GTF_CALL;
     }
-#endif // FEATURE_FIXED_OUT_ARGS && !_TARGET_64BIT_
+    else
+    {
+        if (((op1 == nullptr) || ((op1->gtFlags & GTF_CALL) == 0)) &&
+            ((op2 == nullptr) || ((op2->gtFlags & GTF_CALL) == 0)))
+        {
+            tree->gtFlags &= ~GTF_CALL;
+        }
+    }
+    /*-------------------------------------------------------------------------
+     * Now do POST-ORDER processing
+     */
 
     if (varTypeIsGC(tree->TypeGet()) && (op1 && !varTypeIsGC(op1->TypeGet())) && (op2 && !varTypeIsGC(op2->TypeGet())))
     {
@@ -14077,11 +14075,11 @@ DONE_MORPHING_CHILDREN:
                     commaNode         = commaNode->gtOp.gtOp2;
                     commaNode->gtType = typ;
                     commaNode->gtFlags =
-                        (treeFlags & ~GTF_REVERSE_OPS & ~GTF_ASG); // Bashing the GT_COMMA flags here is
-                                                                   // dangerous, clear the GTF_REVERSE_OPS at
-                                                                   // least.
+                        (treeFlags & ~GTF_REVERSE_OPS & ~GTF_ASG & ~GTF_CALL); // Bashing the GT_COMMA flags here is
+                    // dangerous, clear the GTF_REVERSE_OPS, GT_ASG, and GT_CALL at
+                    // least.
                     commaNode->gtFlags |=
-                        ((commaNode->gtOp.gtOp1->gtFlags & GTF_ASG) | (commaNode->gtOp.gtOp2->gtFlags & GTF_ASG));
+                        ((commaNode->gtOp.gtOp1->gtFlags | commaNode->gtOp.gtOp2->gtFlags) & (GTF_ASG | GTF_CALL));
 #ifdef DEBUG
                     commaNode->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
 #endif
@@ -14175,11 +14173,14 @@ DONE_MORPHING_CHILDREN:
             {
                 // Perform the transform ADDR(COMMA(x, ..., z)) == COMMA(x, ..., ADDR(z)).
                 // (Be sure to mark "z" as an l-value...)
-                GenTree* commaNode = op1;
-                while (commaNode->gtOp.gtOp2->gtOper == GT_COMMA)
+
+                GenTreePtrStack commas(this);
+                for (GenTree* comma = op1; comma != nullptr && comma->gtOper == GT_COMMA; comma = comma->gtGetOp2())
                 {
-                    commaNode = commaNode->gtOp.gtOp2;
+                    commas.Push(comma);
                 }
+                GenTree* commaNode = commas.Top();
+
                 // The top-level addr might be annotated with a zeroOffset field.
                 FieldSeqNode* zeroFieldSeq = nullptr;
                 bool          isZeroOffset = GetZeroOffsetFieldMap()->Lookup(tree, &zeroFieldSeq);
@@ -14216,22 +14217,17 @@ DONE_MORPHING_CHILDREN:
                 // TODO: the comma flag update below is conservative and can be improved.
                 // For example, if we made the ADDR(IND(x)) == x transformation, we may be able to
                 // get rid of some of the the IND flags on the COMMA nodes (e.g., GTF_GLOB_REF).
-                commaNode = tree;
-                while (commaNode->gtOper == GT_COMMA)
+
+                while (commas.Height() > 0)
                 {
-                    commaNode->gtType = op1->gtType;
-                    commaNode->gtFlags |= op1->gtFlags;
+                    GenTree* comma = commas.Pop();
+                    comma->gtType  = op1->gtType;
+                    comma->gtFlags |= op1->gtFlags;
 #ifdef DEBUG
-                    commaNode->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
+                    comma->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
 #endif
-                    commaNode = commaNode->gtOp.gtOp2;
+                    gtUpdateNodeSideEffects(comma);
                 }
-
-                tree->gtFlags &= ~GTF_EXCEPT;
-
-                // Propagate the new flags
-                tree->gtFlags |= (tree->gtOp.gtOp1->gtFlags & GTF_EXCEPT);
-                tree->gtFlags |= (tree->gtOp.gtOp2->gtFlags & GTF_EXCEPT);
 
                 return tree;
             }
@@ -14274,7 +14270,7 @@ DONE_MORPHING_CHILDREN:
                 {
                     // Replace the left hand side with the side effect list.
                     tree->gtOp.gtOp1 = op1SideEffects;
-                    tree->gtFlags |= (op1SideEffects->gtFlags & GTF_ALL_EFFECT);
+                    gtUpdateNodeSideEffects(tree);
                 }
                 else
                 {
@@ -15828,6 +15824,8 @@ GenTree* Compiler::fgMorphTree(GenTree* tree, MorphAddrContext* mac)
                 tree = bndsChk->gtIndex;
             }
 
+            bndsChk->gtFlags &= ~GTF_CALL;
+
             // Propagate effects flags upwards
             bndsChk->gtFlags |= (bndsChk->gtIndex->gtFlags & GTF_ALL_EFFECT);
             bndsChk->gtFlags |= (bndsChk->gtArrLen->gtFlags & GTF_ALL_EFFECT);
@@ -15844,6 +15842,8 @@ GenTree* Compiler::fgMorphTree(GenTree* tree, MorphAddrContext* mac)
             {
                 tree->gtArrElem.gtArrInds[dim] = fgMorphTree(tree->gtArrElem.gtArrInds[dim]);
             }
+
+            tree->gtFlags &= ~GTF_CALL;
 
             tree->gtFlags |= tree->gtArrElem.gtArrObj->gtFlags & GTF_ALL_EFFECT;
 
@@ -15863,6 +15863,7 @@ GenTree* Compiler::fgMorphTree(GenTree* tree, MorphAddrContext* mac)
             tree->gtArrOffs.gtIndex  = fgMorphTree(tree->gtArrOffs.gtIndex);
             tree->gtArrOffs.gtArrObj = fgMorphTree(tree->gtArrOffs.gtArrObj);
 
+            tree->gtFlags &= ~GTF_CALL;
             tree->gtFlags |= tree->gtArrOffs.gtOffset->gtFlags & GTF_ALL_EFFECT;
             tree->gtFlags |= tree->gtArrOffs.gtIndex->gtFlags & GTF_ALL_EFFECT;
             tree->gtFlags |= tree->gtArrOffs.gtArrObj->gtFlags & GTF_ALL_EFFECT;
@@ -15877,7 +15878,7 @@ GenTree* Compiler::fgMorphTree(GenTree* tree, MorphAddrContext* mac)
             tree->gtCmpXchg.gtOpValue     = fgMorphTree(tree->gtCmpXchg.gtOpValue);
             tree->gtCmpXchg.gtOpComparand = fgMorphTree(tree->gtCmpXchg.gtOpComparand);
 
-            tree->gtFlags &= ~GTF_EXCEPT;
+            tree->gtFlags &= (~GTF_EXCEPT & ~GTF_CALL);
 
             tree->gtFlags |= tree->gtCmpXchg.gtOpLocation->gtFlags & GTF_ALL_EFFECT;
             tree->gtFlags |= tree->gtCmpXchg.gtOpValue->gtFlags & GTF_ALL_EFFECT;
@@ -15893,7 +15894,7 @@ GenTree* Compiler::fgMorphTree(GenTree* tree, MorphAddrContext* mac)
             tree->gtDynBlk.Addr()        = fgMorphTree(tree->gtDynBlk.Addr());
             tree->gtDynBlk.gtDynamicSize = fgMorphTree(tree->gtDynBlk.gtDynamicSize);
 
-            tree->gtFlags &= ~GTF_EXCEPT;
+            tree->gtFlags &= (~GTF_EXCEPT & ~GTF_CALL);
             tree->SetIndirExceptionFlags(this);
 
             if (tree->OperGet() == GT_STORE_DYN_BLK)
@@ -15905,8 +15906,15 @@ GenTree* Compiler::fgMorphTree(GenTree* tree, MorphAddrContext* mac)
             break;
 
         case GT_INDEX_ADDR:
-            tree->AsIndexAddr()->Index() = fgMorphTree(tree->AsIndexAddr()->Index());
-            tree->AsIndexAddr()->Arr()   = fgMorphTree(tree->AsIndexAddr()->Arr());
+            GenTreeIndexAddr* indexAddr;
+            indexAddr          = tree->AsIndexAddr();
+            indexAddr->Index() = fgMorphTree(indexAddr->Index());
+            indexAddr->Arr()   = fgMorphTree(indexAddr->Arr());
+
+            tree->gtFlags &= ~GTF_CALL;
+
+            tree->gtFlags |= indexAddr->Index()->gtFlags & GTF_ALL_EFFECT;
+            tree->gtFlags |= indexAddr->Arr()->gtFlags & GTF_ALL_EFFECT;
             break;
 
         default:


### PR DESCRIPTION
The checker ensures that GTF_CALL is set only where
it's needed: on GT_CALL nodes, on GT_INTRINSIC nodes where
intrinsics are implemented by user calls, and on nodes that
have a child with GT_CALL flag set.

Fixes #17794.