### PR TITLE
Fix faulty assert in Utilities.SelectBucketIndex

### DIFF
--- a/src/mscorlib/shared/System/Buffers/Utilities.cs
+++ b/src/mscorlib/shared/System/Buffers/Utilities.cs
@@ -12,7 +12,7 @@ namespace System.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int SelectBucketIndex(int bufferSize)
         {
-            Debug.Assert(bufferSize > 0);
+            Debug.Assert(bufferSize >= 0);
 
             uint bitsRemaining = ((uint)bufferSize - 1) >> 4;
 


### PR DESCRIPTION
0 is a valid length.

Fixes #17862
cc: @BruceForstall, @jkotas, @MarcoRossignoli 