### PR TITLE
Reflection: Fix FormatException when querying ParameterInfo.DefaultValue of optional DateTime parameter

### DIFF
--- a/src/mscorlib/src/System/Reflection/MdConstant.cs
+++ b/src/mscorlib/src/System/Reflection/MdConstant.cs
@@ -94,6 +94,9 @@ namespace System.Reflection
                         defaultValue = buffer;
                         break;
 
+                    case CorElementType.Class:
+                        return null;
+
                     default:
                         throw new FormatException(SR.Arg_BadLiteralFormat);
                         #endregion


### PR DESCRIPTION
### Summary:

Fixes a reflection bug (as discussed in https://github.com/dotnet/corefx/issues/26164) which causes a `FormatException` when calling `ParameterInfo.DefaultValue` for an optional `DateTime` parameter having an encoded default value of `null` (which is how the Roslyn C# compiler encodes `default(DateTime)`).

### Example of the bug being fixed:

The following C# program currently throws an exception:

```csharp
class Program
{
    public void Method(System.DateTime arg = default(System.DateTime)) { }

    static void Main()
    {
        var argDefaultValue = typeof(Program).GetMethod("Method").GetParameters()[0].DefaultValue;
        System.Diagnostics.Debug.Assert(object.Equals(null, argDefaultValue));
    }
}
```

```
Unhandled Exception: System.FormatException: Encountered an invalid type for a default value.
   at System.Reflection.MdConstant.GetValue(MetadataImport scope, Int32 token, RuntimeTypeHandle fieldTypeHandle, Boolean raw)
   at System.Reflection.RuntimeParameterInfo.GetDefaultValueInternal(Boolean raw)
   at System.Reflection.RuntimeParameterInfo.GetDefaultValue(Boolean raw)
   at Program.Main()
```

This PR makes the above program succeed.

### Some additional notes:

* Reflection reporting a default value `null` when it's `default(DateTime)` in source code may seem surprising, but is in line with reflection's behavior for how C# encodes other `default(<any value type>)`.

* <sub>~~I'm including a test project `tests/src/reflection/OptionalParameters/DefaultValue.csproj`. `tests/src/reflection/OptionalParameters/DefaultValue.ilproj`, however it doesn't currently get built automatically (see #17331). I've run it manually to verify this bugfix.~~</sub>