### PR TITLE
System.Reflection: Replicate custom modifiers of method parameters in MemberRef signatures

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
@@ -442,10 +442,6 @@ namespace System.Reflection.Emit
 
         private int GetMemberRefToken(MethodBase methodInfo, Type[] optionalParameterTypes)
         {
-            Type[] parameterTypes;
-            Type[][] parameterTypeRequiredCustomModifiers;
-            Type[][] parameterTypeOptionalCustomModifiers;
-
             if (optionalParameterTypes != null && (methodInfo.CallingConvention & CallingConventions.VarArgs) == 0)
                 throw new InvalidOperationException(SR.InvalidOperation_NotAVarArgCallingConvention);
 
@@ -455,25 +451,11 @@ namespace System.Reflection.Emit
             if (rtMeth == null && dm == null)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeMethodInfo, nameof(methodInfo));
 
-            ParameterInfo[] paramInfo = methodInfo.GetParametersNoCopy();
-            if (paramInfo != null && paramInfo.Length != 0)
-            {
-                parameterTypes = new Type[paramInfo.Length];
-                parameterTypeRequiredCustomModifiers = new Type[paramInfo.Length][];
-                parameterTypeOptionalCustomModifiers = new Type[paramInfo.Length][];
-                for (int i = 0; i < paramInfo.Length; i++)
-                {
-                    parameterTypes[i] = paramInfo[i].ParameterType;
-                    parameterTypeRequiredCustomModifiers[i] = paramInfo[i].GetRequiredCustomModifiers();
-                    parameterTypeOptionalCustomModifiers[i] = paramInfo[i].GetOptionalCustomModifiers();
-                }
-            }
-            else
-            {
-                parameterTypes = null;
-                parameterTypeRequiredCustomModifiers = null;
-                parameterTypeOptionalCustomModifiers = null;
-            }
+            SignatureHelper.ExtractParametersTypeArrays(
+                methodInfo.GetParametersNoCopy(),
+                out Type[] parameterTypes,
+                out Type[][] parameterTypeRequiredCustomModifiers,
+                out Type[][] parameterTypeOptionalCustomModifiers);
 
             SignatureHelper sig = GetMemberRefSignature(methodInfo.CallingConvention,
                                                      MethodBuilder.GetMethodBaseReturnType(methodInfo),

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/ILGenerator.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/ILGenerator.cs
@@ -215,7 +215,7 @@ namespace System.Reflection.Emit
         private SignatureHelper GetMemberRefSignature(CallingConventions call, Type returnType,
             Type[] parameterTypes, Type[] optionalParameterTypes, int cGenericParameters)
         {
-            return ((ModuleBuilder)m_methodBuilder.Module).GetMemberRefSignature(call, returnType, parameterTypes, optionalParameterTypes, cGenericParameters);
+            return ((ModuleBuilder)m_methodBuilder.Module).GetMemberRefSignature(call, returnType, parameterTypes, null, null, optionalParameterTypes, cGenericParameters);
         }
 
         internal byte[] BakeByteArray()

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/ILGenerator.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/ILGenerator.cs
@@ -207,15 +207,17 @@ namespace System.Reflection.Emit
         }
 
         internal virtual SignatureHelper GetMemberRefSignature(CallingConventions call, Type returnType,
-            Type[] parameterTypes, Type[] optionalParameterTypes)
+            Type[] parameterTypes, Type[][] parameterTypeRequiredCustomModifiers, Type[][] parameterTypeOptionalCustomModifiers,
+            Type[] optionalParameterTypes)
         {
-            return GetMemberRefSignature(call, returnType, parameterTypes, optionalParameterTypes, 0);
+            return GetMemberRefSignature(call, returnType, parameterTypes, parameterTypeRequiredCustomModifiers, parameterTypeOptionalCustomModifiers, optionalParameterTypes, 0);
         }
 
         private SignatureHelper GetMemberRefSignature(CallingConventions call, Type returnType,
-            Type[] parameterTypes, Type[] optionalParameterTypes, int cGenericParameters)
+            Type[] parameterTypes, Type[][] parameterTypeRequiredCustomModifiers, Type[][] parameterTypeOptionalCustomModifiers,
+            Type[] optionalParameterTypes, int cGenericParameters)
         {
-            return ((ModuleBuilder)m_methodBuilder.Module).GetMemberRefSignature(call, returnType, parameterTypes, null, null, optionalParameterTypes, cGenericParameters);
+            return ((ModuleBuilder)m_methodBuilder.Module).GetMemberRefSignature(call, returnType, parameterTypes, parameterTypeRequiredCustomModifiers, parameterTypeOptionalCustomModifiers, optionalParameterTypes, cGenericParameters);
         }
 
         internal byte[] BakeByteArray()
@@ -506,6 +508,8 @@ namespace System.Reflection.Emit
             sig = GetMemberRefSignature(callingConvention,
                                         returnType,
                                         parameterTypes,
+                                        null,
+                                        null,
                                         optionalParameterTypes);
 
             EnsureCapacity(7);

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.cs
@@ -298,20 +298,17 @@ namespace System.Reflection.Emit
                 ParameterInfo[] parameters = con.GetParameters();
                 if (parameters == null)
                     throw new ArgumentException(SR.Argument_InvalidConstructorInfo);
-
-                Type[] parameterTypes = new Type[parameters.Length];
-                Type[][] requiredCustomModifiers = new Type[parameters.Length][];
-                Type[][] optionalCustomModifiers = new Type[parameters.Length][];
-
                 for (int i = 0; i < parameters.Length; i++)
                 {
                     if (parameters[i] == null)
                         throw new ArgumentException(SR.Argument_InvalidConstructorInfo);
-
-                    parameterTypes[i] = parameters[i].ParameterType;
-                    requiredCustomModifiers[i] = parameters[i].GetRequiredCustomModifiers();
-                    optionalCustomModifiers[i] = parameters[i].GetOptionalCustomModifiers();
                 }
+
+                SignatureHelper.ExtractParametersTypeArrays(
+                    parameters,
+                    out Type[] parameterTypes,
+                    out Type[][] requiredCustomModifiers,
+                    out Type[][] optionalCustomModifiers);
 
                 tr = GetTypeTokenInternal(con.ReflectedType).Token;
 
@@ -456,16 +453,11 @@ namespace System.Reflection.Emit
                 returnType = MethodBuilder.GetMethodBaseReturnType(method);
             }
 
-            Type[] parameterTypes = new Type[parameters.Length];
-            Type[][] parameterTypeRequiredCustomModifiers = new Type[parameterTypes.Length][];
-            Type[][] parameterTypeOptionalCustomModifiers = new Type[parameterTypes.Length][];
-
-            for (int i = 0; i < parameterTypes.Length; i++)
-            {
-                parameterTypes[i] = parameters[i].ParameterType;
-                parameterTypeRequiredCustomModifiers[i] = parameters[i].GetRequiredCustomModifiers();
-                parameterTypeOptionalCustomModifiers[i] = parameters[i].GetOptionalCustomModifiers();
-            }
+            SignatureHelper.ExtractParametersTypeArrays(
+                parameters,
+                out Type[] parameterTypes,
+                out Type[][] parameterTypeRequiredCustomModifiers,
+                out Type[][] parameterTypeOptionalCustomModifiers);
 
             int sigLength;
             byte[] sigBytes = GetMemberRefSignature(method.CallingConvention, returnType, parameterTypes,
@@ -1287,16 +1279,11 @@ namespace System.Reflection.Emit
                     // go through the slower code path, i.e. retrieve parameters and form signature helper.
                     ParameterInfo[] parameters = method.GetParameters();
 
-                    Type[] parameterTypes = new Type[parameters.Length];
-                    Type[][] requiredCustomModifiers = new Type[parameterTypes.Length][];
-                    Type[][] optionalCustomModifiers = new Type[parameterTypes.Length][];
-
-                    for (int i = 0; i < parameters.Length; i++)
-                    {
-                        parameterTypes[i] = parameters[i].ParameterType;
-                        requiredCustomModifiers[i] = parameters[i].GetRequiredCustomModifiers();
-                        optionalCustomModifiers[i] = parameters[i].GetOptionalCustomModifiers();
-                    }
+                    SignatureHelper.ExtractParametersTypeArrays(
+                        parameters,
+                        out Type[] parameterTypes,
+                        out Type[][] requiredCustomModifiers,
+                        out Type[][] optionalCustomModifiers);
 
                     tr = getGenericTypeDefinition ? GetTypeToken(method.DeclaringType).Token : GetTypeTokenInternal(method.DeclaringType).Token;
 

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/SignatureHelper.cs
@@ -191,6 +191,58 @@ namespace System.Reflection.Emit
 
             return new SignatureHelper(module, type);
         }
+
+        internal static void ExtractParametersTypeArrays(ParameterInfo[] parameters,
+                                                         out Type[] parameterTypes,
+                                                         out Type[][] parameterTypeRequiredCustomModifiers,
+                                                         out Type[][] parameterTypeOptionalCustomModifiers)
+        {
+            // This method tries to allocate as few arrays as possible. In the absence of parameters or
+            // custom modifiers, arrays or single items will default to null. The returned arrays will
+            // generally be fed back to a `SignatureHelper` which must perform null checks where necessary.
+
+            Type[] types = null;
+            Type[][] requiredCustomModifiers = null;
+            Type[][] optionalCustomModifiers = null;
+
+            Debug.Assert(parameters != null);
+
+            if (parameters.Length > 0)
+            {
+                types = new Type[parameters.Length];
+                for (int i = 0; i < parameters.Length; i++)
+                {
+                    Debug.Assert(parameters[i] != null);
+
+                    types[i] = parameters[i].ParameterType;
+
+                    Type[] rcms = parameters[i].GetRequiredCustomModifiers();
+                    if (rcms.Length > 0)
+                    {
+                        if (requiredCustomModifiers == null)
+                        {
+                            requiredCustomModifiers = new Type[parameters.Length][];
+                        }
+                        requiredCustomModifiers[i] = rcms;
+                    }
+
+                    Type[] ocms = parameters[i].GetOptionalCustomModifiers();
+                    if (ocms.Length > 0)
+                    {
+                        if (optionalCustomModifiers == null)
+                        {
+                            optionalCustomModifiers = new Type[parameters.Length][];
+                        }
+                        optionalCustomModifiers[i] = ocms;
+                    }
+                }
+            }
+
+            parameterTypes = types;
+            parameterTypeRequiredCustomModifiers = requiredCustomModifiers;
+            parameterTypeOptionalCustomModifiers = optionalCustomModifiers;
+        }
+
         #endregion
 
         #region Private Data Members


### PR DESCRIPTION
This is in response to https://github.com/dotnet/corefx/issues/29254.

`ModuleBuilder.GetMemberRefToken` reproduces a method's signature for use in a *MethodRef* metadata entry, but currently ignores custom modifiers placed on the method's parameters... which leads to non-matching signatures and `MissingMethodException`s when using e.g. reflection.

This commit adds a new method overload (in order to avoid a larger refactoring for now) that allows the inclusion of custom modifiers on parameters.

~~This is currently work in progress:~~

* [X] ~~Needs further testing.~~  
   I ran successful end-to-end tests using tests from Castle DynamicProxy, which has tests targeting this. I'm going to submit another PR with tests for dotnet/corefx.

* [X] ~~Are there any code paths into `ModuleBuilder.GetMemberRefToken` that are negatively affected by the change made?~~  
   It appears unlikely and did not find any (but it's pretty hard to keep track here, given all the branching and similarly named methods strewn across at least two classes).

* [X] ~~Are there any other code paths into the method that could profit from the change made?~~  
   Additional code paths have been included in the second commit of this PR.

* [X] ~~Shouldn't the same be done for the methods' return type (not just its parameters)?~~  
   Yes, but as it turns out, doing this for return parameters poses some unique problems that are perhaps better dealt with in a separate, dedicated PR.