### PR TITLE
disable dialog box for forced unhandled exception

### DIFF
--- a/tests/src/baseservices/exceptions/WindowsEventLog/WindowsEventLog.cs
+++ b/tests/src/baseservices/exceptions/WindowsEventLog/WindowsEventLog.cs
@@ -3,16 +3,24 @@ using System.Linq;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
+using System.Runtime.InteropServices;
 
 class Program
 {
+
     private static void UnhandledException(string msg)
     {
+#if (WINDOWS)
+        DisableErrorDialog();
+#endif
         A(msg);
     }
 
     private static void FailFast(string msg)
     {
+#if (WINDOWS)
+        DisableErrorDialog();
+#endif
         try
         {
             A(msg);
@@ -97,6 +105,17 @@ class Program
         }
         return false;
     }
+
+#if (WINDOWS)
+    [DllImport("kernel32.dll")]
+    private static extern int SetErrorMode(uint uMode);
+
+    private static void DisableErrorDialog()
+    {
+        uint SEM_NOGPFAULTERRORBOX = 0x0002;
+        SetErrorMode(SEM_NOGPFAULTERRORBOX);
+    }
+#endif
 
     private static bool RunUnhandledExceptionTest()
     {

--- a/tests/src/baseservices/exceptions/WindowsEventLog/WindowsEventLog.csproj
+++ b/tests/src/baseservices/exceptions/WindowsEventLog/WindowsEventLog.csproj
@@ -12,6 +12,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
 
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
+    <DefineConstants Condition="$(OSGroup) == 'Windows_NT'">WINDOWS</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">


### PR DESCRIPTION
Fix for #17870 
Windows Event Log tests trigger an unhandled exception on purpose to test event logging. If we run this test from Desktop UI, it pops up a dialog box, and if the user doesn't click on "Close", it'll cause a timeout on the test and fail. This fix disables the dialog box from popping up so that tests will pass without having to click on the button.