### PR TITLE
Speed up Array.Reverse by using ref reassignment

### DIFF
--- a/src/mscorlib/shared/System/MemoryExtensions.cs
+++ b/src/mscorlib/shared/System/MemoryExtensions.cs
@@ -771,17 +771,21 @@ namespace System
         /// </summary>
         public static void Reverse<T>(this Span<T> span)
         {
-            ref T p = ref MemoryMarshal.GetReference(span);
-            int i = 0;
-            int j = span.Length - 1;
-            while (i < j)
+            if (span.Length <= 1)
             {
-                T temp = Unsafe.Add(ref p, i);
-                Unsafe.Add(ref p, i) = Unsafe.Add(ref p, j);
-                Unsafe.Add(ref p, j) = temp;
-                i++;
-                j--;
+                return;
             }
+
+            ref T first = ref MemoryMarshal.GetReference(span);
+            ref T last = ref Unsafe.Add(ref Unsafe.Add(ref first, span.Length), -1);
+            do
+            {
+                T temp = first;
+                first = last;
+                last = temp;
+                first = ref Unsafe.Add(ref first, 1);
+                last = ref Unsafe.Add(ref last, -1);
+            } while (Unsafe.IsAddressLessThan(ref first, ref last));
         }
 
         /// <summary>

--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -1569,9 +1569,11 @@ namespace System
         {
             if (array == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
-            if ((uint)index > (uint)array.Length)
-                ThrowHelper.ThrowArgumentOutOfRange_IndexException();
-            if ((uint)length > (uint)(array.Length - index))
+            if (index < 0)
+                ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
+            if (length < 0)
+                ThrowHelper.ThrowLengthArgumentOutOfRange_ArgumentOutOfRange_NeedNonNegNum();
+            if (array.Length - index < length)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
 
             if (length <= 1)

--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -1566,24 +1566,24 @@ namespace System
         {
             if (array == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
-            if (index < 0)
-                ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
-            if (length < 0)
-                ThrowHelper.ThrowLengthArgumentOutOfRange_ArgumentOutOfRange_NeedNonNegNum();
-            if (array.Length - index < length)
+            if ((uint)index > (uint)array.Length)
+                ThrowHelper.ThrowArgumentOutOfRange_IndexException();
+            if ((uint)length > (uint)(array.Length - index))
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
 
-            ref T p = ref Unsafe.As<byte, T>(ref array.GetRawSzArrayData());
-            int i = index;
-            int j = index + length - 1;
-            while (i < j)
+            if (length <= 1)
+                return;
+
+            ref T first = ref Unsafe.Add(ref Unsafe.As<byte, T>(ref array.GetRawSzArrayData()), index);
+            ref T last = ref Unsafe.Add(ref Unsafe.Add(ref first, length), -1);
+            do
             {
-                T temp = Unsafe.Add(ref p, i);
-                Unsafe.Add(ref p, i) = Unsafe.Add(ref p, j);
-                Unsafe.Add(ref p, j) = temp;
-                i++;
-                j--;
-            }
+                T temp = first;
+                first = last;
+                last = temp;
+                first = ref Unsafe.Add(ref first, 1);
+                last = ref Unsafe.Add(ref last, -1);
+            } while (Unsafe.IsAddressLessThan(ref first, ref last));
         }
 
         // Sorts the elements of an array. The sort compares the elements to each


### PR DESCRIPTION
This takes advantage of Roslyn's new ref reassignment feature to speed up the inner loop in `Array.Reverse`. Testing shows that for large arrays the reversal time is cut by approx. 20% from the baseline.

Old loop codegen:

```asm
00007ff8`8311fc2c 4c63c0          movsxd  r8,eax
00007ff8`8311fc2f 468b0c81        mov     r9d,dword ptr [rcx+r8*4]
00007ff8`8311fc33 4e8d0481        lea     r8,[rcx+r8*4]
00007ff8`8311fc37 4c63d2          movsxd  r10,edx
00007ff8`8311fc3a 468b1c91        mov     r11d,dword ptr [rcx+r10*4]
00007ff8`8311fc3e 458918          mov     dword ptr [r8],r11d
00007ff8`8311fc41 46890c91        mov     dword ptr [rcx+r10*4],r9d
00007ff8`8311fc45 ffc0            inc     eax
00007ff8`8311fc47 ffca            dec     edx
00007ff8`8311fc49 3bc2            cmp     eax,edx
00007ff8`8311fc4b 7cdf            jl      ... (00007ff8`8311fc2c)
```

New loop codegen:

```asm
00007ff8`831238e2 8b11            mov     edx,dword ptr [rcx]
00007ff8`831238e4 448b00          mov     r8d,dword ptr [rax]
00007ff8`831238e7 448901          mov     dword ptr [rcx],r8d
00007ff8`831238ea 8910            mov     dword ptr [rax],edx
00007ff8`831238ec 4883c104        add     rcx,4
00007ff8`831238f0 4883c0fc        add     rax,0FFFFFFFFFFFFFFFCh
00007ff8`831238f4 483bc8          cmp     rcx,rax
00007ff8`831238f7 72e9            jb      ... (00007ff8`831238e2)
```

The codegen samples above are for reversing an `int[]`. I saw similar performance gains for other types. Referential types like `object[]` don't get as large a benefit due to the card table checks, but there is still some speedup.

I also took the opportunity to collapse the precondition checks using the recommended patterns for (index, count) parameters.