### PR TITLE
Add vcruntime to core_root for arm(64) jobs.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -3052,6 +3052,12 @@ def static CreateWindowsArmTestJob(def dslFactory, def project, def architecture
                 def archLocation = testListArch[architecture]
 
                 addCommand("copy %WORKSPACE%\\tests\\${archLocation}\\Tests.lst bin\\tests\\${osGroup}.${architecture}.${configuration}")
+
+                if (architecture == "arm64") {
+                    addCommand("copy C:\\Jenkins\\vcruntime140.dll bin\\tests\\${osGroup}.${architecture}.${configuration}\\Tests\\Core_Root")
+                    addCommand("copy C:\\Jenkins\\vcruntime140d.dll bin\\tests\\${osGroup}.${architecture}.${configuration}\\Tests\\Core_Root")
+                }
+
                 addCommand("pushd bin\\tests\\${osGroup}.${architecture}.${configuration}")
                 addCommand("${smartyCommand}")
 


### PR DESCRIPTION
This will solve the Arm64 Windows failures for missing vcruntime issues, without copying into C:\Windows\System32.