### PR TITLE
Arm64 debugger step into behavior

### DIFF
--- a/src/vm/arm64/asmhelpers.S
+++ b/src/vm/arm64/asmhelpers.S
@@ -1270,7 +1270,7 @@ DynamicHelper DynamicHelperFrameFlags_ObjectArg | DynamicHelperFrameFlags_Object
 
 #ifdef FEATURE_PREJIT
 // ------------------------------------------------------------------
-// void StubDispatchFixupStub(args in regs x0-x7 & stack and possibly retbuff arg in x8, x11:IndirectionCellAndFlags, x12:DispatchToken)
+// void StubDispatchFixupStub(args in regs x0-x7 & stack and possibly retbuff arg in x8, x11:IndirectionCellAndFlags)
 //
 // The stub dispatch thunk which transfers control to StubDispatchFixupWorker.
 NESTED_ENTRY StubDispatchFixupStub, _TEXT, NoHandler
@@ -1282,11 +1282,11 @@ NESTED_ENTRY StubDispatchFixupStub, _TEXT, NoHandler
     mov x2, #0 // sectionIndex
     mov x3, #0 // pModule
     bl C_FUNC(StubDispatchFixupWorker)
-    mov x9, x0
+    mov x12, x0
 
     EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
     PATCH_LABEL StubDispatchFixupPatchLabel
-    EPILOG_BRANCH_REG  x9
+    EPILOG_BRANCH_REG  x12
 
 NESTED_END StubDispatchFixupStub, _TEXT
 #endif

--- a/src/vm/arm64/asmhelpers.asm
+++ b/src/vm/arm64/asmhelpers.asm
@@ -1278,7 +1278,7 @@ Fail
         
 #ifdef FEATURE_PREJIT
 ;; ------------------------------------------------------------------
-;; void StubDispatchFixupStub(args in regs x0-x7 & stack and possibly retbuff arg in x8, x11:IndirectionCellAndFlags, x12:DispatchToken)
+;; void StubDispatchFixupStub(args in regs x0-x7 & stack and possibly retbuff arg in x8, x11:IndirectionCellAndFlags)
 ;;
 ;; The stub dispatch thunk which transfers control to StubDispatchFixupWorker.
         NESTED_ENTRY StubDispatchFixupStub
@@ -1290,11 +1290,11 @@ Fail
         mov x2, #0 ; sectionIndex
         mov x3, #0 ; pModule
         bl StubDispatchFixupWorker
-        mov x9, x0
+        mov x12, x0
 
         EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
         PATCH_LABEL StubDispatchFixupPatchLabel
-        EPILOG_BRANCH_REG  x9
+        EPILOG_BRANCH_REG  x12
 
         NESTED_END
 #endif

--- a/src/vm/stubmgr.h
+++ b/src/vm/stubmgr.h
@@ -934,6 +934,8 @@ public:
         return pContext->Rax;
 #elif defined(_TARGET_ARM_)
         return pContext->R12;
+#elif defined(_TARGET_ARM64_)
+        return pContext->X12;
 #else
         PORTABILITY_ASSERT("StubManagerHelpers::GetTailCallTarget");
         return NULL;
@@ -1000,7 +1002,7 @@ public:
 #endif
 #elif defined(_TARGET_ARM_)
         return pContext->R1;
-#elif defined(_TARGET_ARM_)
+#elif defined(_TARGET_ARM64_)
         return pContext->X1;
 #else
         PORTABILITY_ASSERT("StubManagerHelpers::GetSecondArg");


### PR DESCRIPTION
- Fix #ifdef in StubManagerHelpers::StubGetSecondArg that erroneously referred to TARGET_ARM instead of TARGET_ARM64
- Add condition in StubManagerHelpers::GetTailCallTarget to refer to X12 as is used by the various helpers that can pause in the midst of stepping
  - Fix StubDispatchFixupStub to use X12 as tail call register instead of X9 to match the other tail-calling stubs