### PR TITLE
[WIP] Fix failing System.Reflection.Emit tests

### DIFF
--- a/src/mscorlib/src/System/Reflection/Emit/FieldBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/FieldBuilder.cs
@@ -178,6 +178,13 @@ namespace System.Reflection.Emit
         {
             m_typeBuilder.ThrowIfCreated();
 
+            if (defaultValue == null && m_fieldType.IsValueType)
+            {
+                // nullable types can hold null value.
+                if (!(m_fieldType.IsGenericType && m_fieldType.GetGenericTypeDefinition() == typeof(Nullable<>)))
+                    throw new ArgumentException(SR.Argument_ConstantNull);
+            }
+
             TypeBuilder.SetConstantValue(m_typeBuilder.GetModuleBuilder(), GetToken().Token, m_fieldType, defaultValue);
         }
 


### PR DESCRIPTION
Commit fceac03e82 removed a test from `TypeBuilder.SetConstantValue` that was too strict when called from `ParameterBuilder`, but that both `FieldBuilder` and `EnumBuilder` require. Add the same test back, but in `FieldBuilder.SetConstant`.