### PR TITLE
Reflection: Fix FormatException when querying ParameterInfo.DefaultValue of optional (closed generic) enum parameter

### DIFF
--- a/src/mscorlib/src/System/Reflection/MdConstant.cs
+++ b/src/mscorlib/src/System/Reflection/MdConstant.cs
@@ -68,6 +68,9 @@ namespace System.Reflection
                         defaultValue = buffer;
                         break;
 
+                    case CorElementType.Class:
+                        return null;
+
                     default:
                         throw new FormatException(SR.Arg_BadLiteralFormat);
                         #endregion


### PR DESCRIPTION
This is similar to #17877, but about enums instead of `DateTime`. This should fix https://github.com/dotnet/corefx/issues/29570.

Given e.g. a generic method with a parameter `T arg = default(T)` where `T` is the generic type parameter, if that is instantiated with some enum as the generic type argument, then querying the default value of `arg` using `ParameterInfo.[Raw]DefaultValue` will throw a `FormatException`.

(The use of generics means that the C# compiler always records a `null` constant in metadata, which isn't usually the case for enums.)

/cc @AtsushiKan