### PR TITLE
Value number identities for compares and subs

### DIFF
--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -1154,10 +1154,18 @@ ValueNum ValueNumStore::VNForFunc(var_types typ, VNFunc func, ValueNum arg0VN, V
 
                     case GT_SUB:
                         // (x - 0) => x
-                        ZeroVN = VNZeroForType(typ);
-                        if (arg1VN == ZeroVN)
+                        // (x - x) => 0
+                        if (!varTypeIsFloating(typ))
                         {
-                            resultVN = arg0VN;
+                            ZeroVN = VNZeroForType(typ);
+                            if (arg1VN == ZeroVN)
+                            {
+                                resultVN = arg0VN;
+                            }
+                            else if ((arg0VN != NoVN) && (arg1VN == arg0VN))
+                            {
+                                resultVN = ZeroVN;
+                            }
                         }
                         break;
 
@@ -1249,7 +1257,11 @@ ValueNum ValueNumStore::VNForFunc(var_types typ, VNFunc func, ValueNum arg0VN, V
                         break;
 
                     case GT_EQ:
+                    case GT_GE:
+                    case GT_LE:
                         // (x == x) => true (unless x is NaN)
+                        // (x <= x) => true (unless x is NaN)
+                        // (x >= x) => true (unless x is NaN)
                         if (!varTypeIsFloating(TypeOfVN(arg0VN)) && (arg0VN != NoVN) && (arg0VN == arg1VN))
                         {
                             resultVN = VNOneForType(typ);
@@ -1260,8 +1272,13 @@ ValueNum ValueNumStore::VNForFunc(var_types typ, VNFunc func, ValueNum arg0VN, V
                             resultVN = VNZeroForType(typ);
                         }
                         break;
+
                     case GT_NE:
+                    case GT_GT:
+                    case GT_LT:
                         // (x != x) => false (unless x is NaN)
+                        // (x > x) => false (unless x is NaN)
+                        // (x < x) => false (unless x is NaN)
                         if (!varTypeIsFloating(TypeOfVN(arg0VN)) && (arg0VN != NoVN) && (arg0VN == arg1VN))
                         {
                             resultVN = VNZeroForType(typ);
@@ -1285,6 +1302,24 @@ ValueNum ValueNumStore::VNForFunc(var_types typ, VNFunc func, ValueNum arg0VN, V
         }
         else // must be a VNF_ function
         {
+            if ((arg0VN != NoVN) && (arg0VN == arg1VN))
+            {
+                assert(!varTypeIsFloating(TypeOfVN(arg0VN)));
+                // x <= x ==> true
+                // x >= x ==> true
+                if ((func == VNF_LE_UN) || (func == VNF_GE_UN))
+                {
+                    return VNOneForType(typ);
+                }
+                // x < x ==> false
+                // x > x ==> false
+                // x - x ==> 0
+                else if ((func == VNF_LT_UN) || (func == VNF_GT_UN) || (func == VNF_SUB_UN))
+                {
+                    return VNZeroForType(typ);
+                }
+            }
+
             if (func == VNF_CastClass)
             {
                 // In terms of values, a castclass always returns its second argument, the object being cast.

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -1137,35 +1137,30 @@ ValueNum ValueNumStore::VNForFunc(var_types typ, VNFunc func, ValueNum arg0VN, V
                 {
                     case GT_ADD:
                         // This identity does not apply for floating point (when x == -0.0)
-                        if (!varTypeIsFloating(typ))
+                        // (x + 0) == (0 + x) => x
+                        ZeroVN = VNZeroForType(typ);
+                        if (VNIsEqual(arg0VN, ZeroVN))
                         {
-                            // (x + 0) == (0 + x) => x
-                            ZeroVN = VNZeroForType(typ);
-                            if (arg0VN == ZeroVN)
-                            {
-                                resultVN = arg1VN;
-                            }
-                            else if (arg1VN == ZeroVN)
-                            {
-                                resultVN = arg0VN;
-                            }
+                            resultVN = arg1VN;
+                        }
+                        else if (VNIsEqual(arg1VN, ZeroVN))
+                        {
+                            resultVN = arg0VN;
                         }
                         break;
 
                     case GT_SUB:
+                        // This identity does not apply for floating point (when x == -0.0)
                         // (x - 0) => x
                         // (x - x) => 0
-                        if (!varTypeIsFloating(typ))
+                        ZeroVN = VNZeroForType(typ);
+                        if (VNIsEqual(arg1VN, ZeroVN))
                         {
-                            ZeroVN = VNZeroForType(typ);
-                            if (arg1VN == ZeroVN)
-                            {
-                                resultVN = arg0VN;
-                            }
-                            else if ((arg0VN != NoVN) && (arg1VN == arg0VN))
-                            {
-                                resultVN = ZeroVN;
-                            }
+                            resultVN = arg0VN;
+                        }
+                        else if (VNIsEqual(arg0VN, arg1VN))
+                        {
+                            resultVN = ZeroVN;
                         }
                         break;
 
@@ -1262,7 +1257,7 @@ ValueNum ValueNumStore::VNForFunc(var_types typ, VNFunc func, ValueNum arg0VN, V
                         // (x == x) => true (unless x is NaN)
                         // (x <= x) => true (unless x is NaN)
                         // (x >= x) => true (unless x is NaN)
-                        if (!varTypeIsFloating(TypeOfVN(arg0VN)) && (arg0VN != NoVN) && (arg0VN == arg1VN))
+                        if (VNIsEqual(arg0VN, arg1VN))
                         {
                             resultVN = VNOneForType(typ);
                         }
@@ -1279,7 +1274,7 @@ ValueNum ValueNumStore::VNForFunc(var_types typ, VNFunc func, ValueNum arg0VN, V
                         // (x != x) => false (unless x is NaN)
                         // (x > x) => false (unless x is NaN)
                         // (x < x) => false (unless x is NaN)
-                        if (!varTypeIsFloating(TypeOfVN(arg0VN)) && (arg0VN != NoVN) && (arg0VN == arg1VN))
+                        if (VNIsEqual(arg0VN, arg1VN))
                         {
                             resultVN = VNZeroForType(typ);
                         }
@@ -1302,9 +1297,8 @@ ValueNum ValueNumStore::VNForFunc(var_types typ, VNFunc func, ValueNum arg0VN, V
         }
         else // must be a VNF_ function
         {
-            if ((arg0VN != NoVN) && (arg0VN == arg1VN))
+            if (VNIsEqual(arg0VN, arg1VN))
             {
-                assert(!varTypeIsFloating(TypeOfVN(arg0VN)));
                 // x <= x ==> true
                 // x >= x ==> true
                 if ((func == VNF_LE_UN) || (func == VNF_GE_UN))

--- a/src/jit/valuenum.h
+++ b/src/jit/valuenum.h
@@ -670,6 +670,12 @@ public:
     {
     };
 
+    // Return true if two value numbers would compare equal.
+    bool VNIsEqual(ValueNum vn1, ValueNum vn2)
+    {
+        return (vn1 == vn2) && (vn1 != NoVN) && !varTypeIsFloating(TypeOfVN(vn1));
+    }
+
 private:
     struct Chunk;
 


### PR DESCRIPTION
Improve value number support for various subtracts and unsigned compares.
For instance for non-float values, x - x == 0.