### PR TITLE
add test with tail call of VSD stub with AV.

### DIFF
--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -94708,3 +94708,11 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;NEW;EXCLUDED
 HostStyle=0
 
+[GitHub_17585.cmd_11895]
+RelativePath=JIT\Regression\JitBlue\GitHub_17585\GitHub_17585\GitHub_17585.cmd
+WorkingDir=JIT\Regression\JitBlue\GitHub_17585\GitHub_17585
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS;NEW
+HostStyle=0
+

--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -94713,6 +94713,6 @@ RelativePath=JIT\Regression\JitBlue\GitHub_17585\GitHub_17585\GitHub_17585.cmd
 WorkingDir=JIT\Regression\JitBlue\GitHub_17585\GitHub_17585
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_FAIL;17585;EXCLUDED
 HostStyle=0
 

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -94731,3 +94731,11 @@ Expected=0
 MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS
 HostStyle=0
+
+[GitHub_17585.cmd_12215]
+RelativePath=JIT\Regression\JitBlue\GitHub_17585\GitHub_17585\GitHub_17585.cmd
+WorkingDir=JIT\Regression\JitBlue\GitHub_17585\GitHub_17585
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS;NEW
+HostStyle=0

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -94737,5 +94737,5 @@ RelativePath=JIT\Regression\JitBlue\GitHub_17585\GitHub_17585\GitHub_17585.cmd
 WorkingDir=JIT\Regression\JitBlue\GitHub_17585\GitHub_17585
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_FAIL;17585;EXCLUDED
 HostStyle=0

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -214,6 +214,15 @@
             <Issue>11469, The test causes OutOfMemory exception in crossgen mode.</Issue> 
         </ExcludeList>
     </ItemGroup>
+	
+	<!-- The following are x64 failures -->
+
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(BuildArch)' == 'x64'">
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\GitHub_17585\GitHub_17585\GitHub_17585.cmd">
+            <Issue>17585</Issue>
+        </ExcludeList>
+    </ItemGroup>
+
 
     <!-- The following are ARM32 failures -->
 

--- a/tests/src/JIT/Regression/JitBlue/GitHub_17585/GitHub_17585.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_17585/GitHub_17585.il
@@ -9,7 +9,7 @@
 // transform into the NullReference exception. VM is not able to do that when the first frame on the stack is
 // unmanaged, in this case it is JIT_TailCallHelperStub_ReturnAddress from tail call optimization.
 // To repro this issue on amd64/arm64 it also requires to reject fast tail call, for this puprose
-// `IMyComparer::Compare` has several stack arguments.
+// `Interface::InterfaceMethodWithStackArgs` has several stack arguments.
 
 // The fix is to always generate explicit null check before calling VSD with tail call from tail call frame.
 
@@ -27,37 +27,37 @@
 
 // =============== CLASS MEMBERS DECLARATION ===================
 
-.class interface private abstract auto ansi Intreface
+.class interface private abstract auto ansi Interface
 {
   .method public hidebysig newslot abstract virtual 
-          instance int32  InterfaceMethodWithStackArgs(object a,
-                                                       object b,
-                                                       object c,
-                                                       object d,
-                                                       object e,
-                                                       object f,
-                                                       object g,
-                                                       object h,
-                                                       object i) cil managed
+          instance int32  InterfaceMethodWithStackArgs(int32 a,
+                                                       int32 b,
+                                                       int32 c,
+                                                       int32 d,
+                                                       int32 e,
+                                                       int32 f,
+                                                       int32 g,
+                                                       int32 h,
+                                                       int32 i) cil managed
   {
-  } // end of method Intreface::InterfaceMethodWithStackArgs
+  } // end of method Interface::InterfaceMethodWithStackArgs
 
-} // end of class Intreface
+} // end of class Interface
 
 .class private auto ansi beforefieldinit InterfaceImplementation
        extends [System.Runtime]System.Object
-       implements Intreface
+       implements Interface
 {
   .method public hidebysig newslot virtual final 
-          instance int32  InterfaceMethodWithStackArgs(object a,
-                                                       object b,
-                                                       object c,
-                                                       object d,
-                                                       object e,
-                                                       object f,
-                                                       object g,
-                                                       object h,
-                                                       object i) cil managed
+          instance int32  InterfaceMethodWithStackArgs(int32 a,
+                                                       int32 b,
+                                                       int32 c,
+                                                       int32 d,
+                                                       int32 e,
+                                                       int32 f,
+                                                       int32 g,
+                                                       int32 h,
+                                                       int32 i) cil managed
   {
     // Code size       2 (0x2)
     .maxstack  8
@@ -80,39 +80,30 @@
 .class private auto ansi beforefieldinit Test
        extends [System.Runtime]System.Object
 {
-  .method public hidebysig static int32  CallInterfaceMethod(class Intreface comparer) cil managed
+  .method public hidebysig static int32  CallInterfaceMethod(class Interface iface) cil managed
   {
-    // Code size       62 (0x3e)
+    // Code size       17 (0x11)
     .maxstack  10
     IL_0000:  ldarg.0
     IL_0001:  ldc.i4.1
-    IL_0002:  box        [System.Runtime]System.Int32
-    IL_0007:  ldc.i4.2
-    IL_0008:  box        [System.Runtime]System.Int32
-    IL_000d:  ldc.i4.3
-    IL_000e:  box        [System.Runtime]System.Int32
-    IL_0013:  ldc.i4.4
-    IL_0014:  box        [System.Runtime]System.Int32
-    IL_0019:  ldc.i4.5
-    IL_001a:  box        [System.Runtime]System.Int32
-    IL_001f:  ldc.i4.6
-    IL_0020:  box        [System.Runtime]System.Int32
-    IL_0025:  ldc.i4.7
-    IL_0026:  box        [System.Runtime]System.Int32
-    IL_002b:  ldc.i4.8
-    IL_002c:  box        [System.Runtime]System.Int32
-    IL_0031:  ldc.i4.s   9
-    IL_0033:  box        [System.Runtime]System.Int32
-    IL_0038:  tail. callvirt   instance int32 Intreface::InterfaceMethodWithStackArgs(object,
-                                                                                object,
-                                                                                object,
-                                                                                object,
-                                                                                object,
-                                                                                object,
-                                                                                object,
-                                                                                object,
-                                                                                object)
-    IL_003d:  ret
+    IL_0002:  ldc.i4.2
+    IL_0003:  ldc.i4.3
+    IL_0004:  ldc.i4.4
+    IL_0005:  ldc.i4.5
+    IL_0006:  ldc.i4.6
+    IL_0007:  ldc.i4.7
+    IL_0008:  ldc.i4.8
+    IL_0009:  ldc.i4.s   9
+    IL_000b:  tail. callvirt   instance int32 Interface::InterfaceMethodWithStackArgs(int32,
+                                                                                int32,
+                                                                                int32,
+                                                                                int32,
+                                                                                int32,
+                                                                                int32,
+                                                                                int32,
+                                                                                int32,
+                                                                                int32)
+    IL_0010:  ret
   } // end of method Test::CallInterfaceMethod
 
   .method public hidebysig static int32  Main() cil managed
@@ -120,19 +111,19 @@
     .entrypoint
     // Code size       35 (0x23)
     .maxstack  1
-    .locals init ([0] class InterfaceImplementation comparer)
+    .locals init ([0] class InterfaceImplementation iface)
     IL_0000:  newobj     instance void InterfaceImplementation::.ctor()
     IL_0005:  stloc.0
     IL_0006:  ldloc.0
-    IL_0007:  call       int32 Test::CallInterfaceMethod(class Intreface)
+    IL_0007:  call       int32 Test::CallInterfaceMethod(class Interface)
     IL_000c:  pop
     IL_000d:  ldloc.0
-    IL_000e:  call       int32 Test::CallInterfaceMethod(class Intreface)
+    IL_000e:  call       int32 Test::CallInterfaceMethod(class Interface)
     IL_0013:  pop
     .try
     {
       IL_0014:  ldnull
-      IL_0015:  call       int32 Test::CallInterfaceMethod(class Intreface)
+      IL_0015:  call       int32 Test::CallInterfaceMethod(class Interface)
       IL_001a:  pop
       IL_001b:  leave.s    IL_0020
 

--- a/tests/src/JIT/Regression/JitBlue/GitHub_17585/GitHub_17585.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_17585/GitHub_17585.il
@@ -57,7 +57,7 @@
                                                        int32 f,
                                                        int32 g,
                                                        int32 h,
-                                                       int32 i) cil managed
+                                                       int32 i) cil managed noinlining
   {
     // Code size       2 (0x2)
     .maxstack  8
@@ -80,7 +80,7 @@
 .class private auto ansi beforefieldinit Test
        extends [System.Runtime]System.Object
 {
-  .method public hidebysig static int32  CallInterfaceMethod(class Interface iface) cil managed
+  .method public hidebysig static int32  CallInterfaceMethod(class Interface iface) cil managed noinlining
   {
     // Code size       17 (0x11)
     .maxstack  10

--- a/tests/src/JIT/Regression/JitBlue/GitHub_17585/GitHub_17585.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_17585/GitHub_17585.il
@@ -1,0 +1,160 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+// This test shows an issue  with tail call optimization of an interface call through Virtual Dispatch Stub.
+// The optimized VSD checks that `this` method table is equal to the cached method table.
+// If `this` is `null` then the stub throws `Acess Violation` exception that VM should
+// transform into the NullReference exception. VM is not able to do that when the first frame on the stack is
+// unmanaged, in this case it is JIT_TailCallHelperStub_ReturnAddress from tail call optimization.
+// To repro this issue on amd64/arm64 it also requires to reject fast tail call, for this puprose
+// `IMyComparer::Compare` has several stack arguments.
+
+// The fix is to always generate explicit null check before calling VSD with tail call from tail call frame.
+
+
+.assembly extern System.Runtime
+{
+}
+.assembly extern System.Runtime.Extensions
+{
+}
+.assembly GitHub_17585
+{
+}
+
+
+// =============== CLASS MEMBERS DECLARATION ===================
+
+.class interface private abstract auto ansi Intreface
+{
+  .method public hidebysig newslot abstract virtual 
+          instance int32  InterfaceMethodWithStackArgs(object a,
+                                                       object b,
+                                                       object c,
+                                                       object d,
+                                                       object e,
+                                                       object f,
+                                                       object g,
+                                                       object h,
+                                                       object i) cil managed
+  {
+  } // end of method Intreface::InterfaceMethodWithStackArgs
+
+} // end of class Intreface
+
+.class private auto ansi beforefieldinit InterfaceImplementation
+       extends [System.Runtime]System.Object
+       implements Intreface
+{
+  .method public hidebysig newslot virtual final 
+          instance int32  InterfaceMethodWithStackArgs(object a,
+                                                       object b,
+                                                       object c,
+                                                       object d,
+                                                       object e,
+                                                       object f,
+                                                       object g,
+                                                       object h,
+                                                       object i) cil managed
+  {
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  ldc.i4.1
+    IL_0001:  ret
+  } // end of method InterfaceImplementation::InterfaceMethodWithStackArgs
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+    IL_0006:  ret
+  } // end of method InterfaceImplementation::.ctor
+
+} // end of class InterfaceImplementation
+
+.class private auto ansi beforefieldinit Test
+       extends [System.Runtime]System.Object
+{
+  .method public hidebysig static int32  CallInterfaceMethod(class Intreface comparer) cil managed
+  {
+    // Code size       62 (0x3e)
+    .maxstack  10
+    IL_0000:  ldarg.0
+    IL_0001:  ldc.i4.1
+    IL_0002:  box        [System.Runtime]System.Int32
+    IL_0007:  ldc.i4.2
+    IL_0008:  box        [System.Runtime]System.Int32
+    IL_000d:  ldc.i4.3
+    IL_000e:  box        [System.Runtime]System.Int32
+    IL_0013:  ldc.i4.4
+    IL_0014:  box        [System.Runtime]System.Int32
+    IL_0019:  ldc.i4.5
+    IL_001a:  box        [System.Runtime]System.Int32
+    IL_001f:  ldc.i4.6
+    IL_0020:  box        [System.Runtime]System.Int32
+    IL_0025:  ldc.i4.7
+    IL_0026:  box        [System.Runtime]System.Int32
+    IL_002b:  ldc.i4.8
+    IL_002c:  box        [System.Runtime]System.Int32
+    IL_0031:  ldc.i4.s   9
+    IL_0033:  box        [System.Runtime]System.Int32
+    IL_0038:  tail. callvirt   instance int32 Intreface::InterfaceMethodWithStackArgs(object,
+                                                                                object,
+                                                                                object,
+                                                                                object,
+                                                                                object,
+                                                                                object,
+                                                                                object,
+                                                                                object,
+                                                                                object)
+    IL_003d:  ret
+  } // end of method Test::CallInterfaceMethod
+
+  .method public hidebysig static int32  Main() cil managed
+  {
+    .entrypoint
+    // Code size       35 (0x23)
+    .maxstack  1
+    .locals init ([0] class InterfaceImplementation comparer)
+    IL_0000:  newobj     instance void InterfaceImplementation::.ctor()
+    IL_0005:  stloc.0
+    IL_0006:  ldloc.0
+    IL_0007:  call       int32 Test::CallInterfaceMethod(class Intreface)
+    IL_000c:  pop
+    IL_000d:  ldloc.0
+    IL_000e:  call       int32 Test::CallInterfaceMethod(class Intreface)
+    IL_0013:  pop
+    .try
+    {
+      IL_0014:  ldnull
+      IL_0015:  call       int32 Test::CallInterfaceMethod(class Intreface)
+      IL_001a:  pop
+      IL_001b:  leave.s    IL_0020
+
+    }  // end .try
+    catch [System.Runtime]System.NullReferenceException 
+    {
+      IL_001d:  pop
+      IL_001e:  leave.s    IL_0020
+
+    }  // end handler
+    IL_0020:  ldc.i4.s   100
+    IL_0022:  ret
+  } // end of method Test::Main
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+    IL_0006:  ret
+  } // end of method Test::.ctor
+
+} // end of class Test

--- a/tests/src/JIT/Regression/JitBlue/GitHub_17585/GitHub_17585.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_17585/GitHub_17585.ilproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_17585.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
This test reproduces the issue from #17585 without stress mode on arm32/arm64/**x64**.

[C# code](https://gist.github.com/sandreenko/965ded10af88dc9bfedef19158303063) for this test. 


