### PR TITLE
Reduce allocation in StringBuilder marshaling

### DIFF
--- a/src/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -204,22 +204,7 @@ namespace System.StubHelpers
                 return;
 
             int nbBytes = StubHelpers.strlen((sbyte*)pNative);
-            int numChar = Encoding.UTF8.GetCharCount((byte*)pNative, nbBytes);
-
-            // +1 GetCharCount return 0 if the pNative points to a 
-            // an empty buffer.We still need to allocate an empty 
-            // buffer with a '\0' to distingiush it from null.
-            // Note that pinning on (char *pinned = new char[0])
-            // return null and  Encoding.UTF8.GetChars do not like 
-            // null argument.
-            char[] cCharBuffer = new char[numChar + 1];
-            cCharBuffer[numChar] = '\0';
-            fixed (char* pBuffer = &cCharBuffer[0])
-            {
-                numChar = Encoding.UTF8.GetChars((byte*)pNative, nbBytes, pBuffer, numChar);
-                // replace string builder internal buffer
-                sb.ReplaceBufferInternal(pBuffer, numChar);
-            }
+            sb.ReplaceBufferUtf8Internal(new Span<byte>((byte*)pNative, nbBytes));
         }
     }
 


### PR DESCRIPTION
When marshaling back results for a StringBuilder argument in a P/Invoke:
- for UTF8 it's allocating a new char[], pinning it, and then handing that off to StringBuilder.ReplaceBufferInternal, which itself then allocates a new char[], and all of that happens even if the StringBuilder's char[] is already big enough to handle the results, which is commonly the case due to the StringBuilder having been sized appropriately from the get-go.
- for both Unicode and Ansi, it's similarly allocating a new char[] invariably, even if the existing buffer is already sufficient.

This commit cleans that up.

While ideally we wouldn't use StringBuilders at all in coreclr/corefx for marshaling, we still do in some places, e.g. Dns.GetHostName.  While we should separately fix that to avoid using a StringBuilder at all, it's useful to demonstrate the impact of the change here:
```C#
[Benchmark]
public static string GetHostName() => Dns.GetHostName();
```
on my machine results in:
```
      Method |  Gen 0 | Allocated |
------------ |-------:|----------:|
 Before      | 0.2668 |   1.09 KB |
 After       | 0.1392 |     584 B |
```

cc: @jkotas, @JeremyKuhne, @vancem