### PR TITLE
Specify ordering between CrstUniqueStack and CrstReadyToRunEntryPointToMethodDescMap

### DIFF
--- a/src/inc/CrstTypes.def
+++ b/src/inc/CrstTypes.def
@@ -789,5 +789,5 @@ Crst NotifyGdb
 End
 
 Crst ReadyToRunEntryPointToMethodDescMap
-    AcquiredBefore ExecuteManRangeLock
+    AcquiredBefore ExecuteManRangeLock UniqueStack
 End

--- a/src/inc/crsttypes.h
+++ b/src/inc/crsttypes.h
@@ -322,7 +322,7 @@ int g_rgCrstLevelMap[] =
     3,			// CrstRCWCache
     0,			// CrstRCWCleanupList
     3,			// CrstRCWRefCache
-    3,			// CrstReadyToRunEntryPointToMethodDescMap
+    4,			// CrstReadyToRunEntryPointToMethodDescMap
     0,			// CrstReDacl
     9,			// CrstReflection
     7,			// CrstReJITDomainTable


### PR DESCRIPTION
I saw a failure in one of our profiler regression tests that had this particular call stack when run under Debug build & GCStress:

```
Consistency check failed: Crst Level violation: Can't take level 3 lock CrstUniqueStack because you already holding level 3 lock CrstReadyToRunEntryPointToMethodDescMap

            00:06.612: CORECLR! CHECK::Trigger + 0x275 (0x00007ffc`499fd345)
            00:06.613: CORECLR! CrstBase::IsSafeToTake + 0x5F4 (0x00007ffc`49b09284)
            00:06.614: CORECLR! CrstBase::Enter + 0x233 (0x00007ffc`49b087d3)
            00:06.615: CORECLR! CrstBase::AcquireLock + 0x15 (0x00007ffc`49a84a15)
            00:06.616: CORECLR! CrstBase::CrstHolder::CrstHolder + 0x25 (0x00007ffc`49a83785)
            00:06.617: CORECLR! Thread::UniqueStack + 0x27C (0x00007ffc`49bce67c)
            00:06.617: CORECLR! WKS::GCHeap::StressHeap + 0xC0 (0x00007ffc`4a470000)
            00:06.618: CORECLR! Thread::PerformPreemptiveGC + 0x3B4 (0x00007ffc`49b95dc4)
            00:06.619: CORECLR! Thread::RareEnablePreemptiveGC + 0x23B (0x00007ffc`49b96beb)
            00:06.620: CORECLR! Thread::EnablePreemptiveGC + 0x11F (0x00007ffc`49a86c2f)
```
This lock was added in https://github.com/dotnet/coreclr/pull/17376, and there wasn't any order specified between CrstUniqueStack and CrstReadyToRunEntryPointToMethodDescMap, so I added it to the def. 
