### PR TITLE
Enable MicroBuild Signing in CoreClr 1.0.0

### DIFF
--- a/src/publish.proj
+++ b/src/publish.proj
@@ -26,7 +26,6 @@
   <PropertyGroup>
     <PackageDownloadDirectory Condition="'$(DownloadDirectory)' == ''">$(PackagesDir)AzureTransfer\$(ConfigurationGroup)</PackageDownloadDirectory>
     <FinalPublishPattern>$(PackageDownloadDirectory)\**\*.nupkg</FinalPublishPattern>
-    <FinalPublishPrivatePattern>$(PackageDownloadDirectory)\**\*Private*.nupkg</FinalPublishPrivatePattern>
     <FinalSymbolsPackagesPattern>$(PackageDownloadDirectory)\**\*.symbols.nupkg</FinalSymbolsPackagesPattern>
     <!-- The SignFiles target needs OutDir to be defined -->
     <OutDir>$(PackageDownloadDirectory)</OutDir>
@@ -34,7 +33,7 @@
 
   <Target Name="GetPackagesToSign">
     <ItemGroup>
-      <FilesToSign Include="$(FinalPublishPattern)" Exclude="$(FinalPublishPrivatePattern);$(FinalSymbolsPackagesPattern)">
+      <FilesToSign Include="$(FinalPublishPattern)" Exclude="$(FinalSymbolsPackagesPattern)">
         <Authenticode>NuGet</Authenticode>
       </FilesToSign>
     </ItemGroup>


### PR DESCRIPTION
This will also require the following changes in the 1.0.0 pipebuild:

- Add a `MicroBuild Signing Plugin` step that mirrors `Install Signing Plugin` here: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=5123
- Add a `Command Line` step that mirrors `Sign Packages` in the same definition as above

@weshaggard @MattGal PTAL

For dotnet/core-eng#3393, and the same changeset in publish.proj as https://github.com/dotnet/coreclr/pull/17937