### PR TITLE
Add reporting exception from ResolveEHClause

### DIFF
--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -3056,7 +3056,19 @@ CLRUnwindStatus ExceptionTracker::ProcessManagedCallFrame(
                             }
                             else
                             {
-                                TypeHandle typeHnd = pJitMan->ResolveEHClause(&EHClause, pcfThisFrame);
+                                TypeHandle typeHnd;
+                                EX_TRY
+                                {
+                                    typeHnd = pJitMan->ResolveEHClause(&EHClause, pcfThisFrame);
+                                }
+                                EX_CATCH_EX(Exception)
+                                {
+                                    StackSString msg;
+                                    GET_EXCEPTION()->GetMessage(msg);
+                                    msg.Insert(msg.Begin(), W("Cannot resolve EH clause:\n"));
+                                    EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_FAILFAST, msg.GetUnicode());
+                                }
+                                EX_END_CATCH(RethrowTransientExceptions);
 
                                 EH_LOG((LL_INFO100,
                                         "  clause type = %s\n",

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -3063,7 +3063,7 @@ CLRUnwindStatus ExceptionTracker::ProcessManagedCallFrame(
                                 }
                                 EX_CATCH_EX(Exception)
                                 {
-                                    StackSString msg;
+                                    SString msg;
                                     GET_EXCEPTION()->GetMessage(msg);
                                     msg.Insert(msg.Begin(), W("Cannot resolve EH clause:\n"));
                                     EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_FAILFAST, msg.GetUnicode());

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -1209,12 +1209,12 @@ void ZapInfo::setEHinfo(unsigned EHnumber,
 #endif // _DEBUG
                 ilClause->ClassToken = mdTypeRefNil;
             }
-            else if (getClassModule(resolvedToken.hClass) != m_currentMethodModule)
+            else
             {
-                // For clauses with types from external modules, add fixup to ensure the types are loaded
-                // before the code of the method containing the catch blocks is executed. This ensures
-                // that a failure to load the types would not happen when the exception handling is
-                // in progress and it is looking for a catch handler. At that point, we could only fail fast.
+                // For all clause types add fixup to ensure the types are loaded before the code of the method
+                // containing the catch blocks is executed. This ensures that a failure to load the types would
+                // not happen when the exception handling is in progress and it is looking for a catch handler.
+                // At that point, we could only fail fast.
                 classMustBeLoadedBeforeCodeIsRun(resolvedToken.hClass);
             }
         }

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -1181,20 +1181,8 @@ void ZapInfo::setEHinfo(unsigned EHnumber,
     {
         ilClause->ClassToken = clause->ClassToken;
 
-        if (m_zapper->m_pOpt->m_compilerFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_IL_STUB) && (clause->ClassToken != 0))
+        if (ilClause->ClassToken != 0)
         {
-            // IL stub tokens are 'private' and do not resolve correctly in their parent module's metadata.
-
-            // Currently, the only place we are using a token here is for a COM-to-CLR exception-to-HRESULT
-            // mapping catch clause.  We want this catch clause to catch all exceptions, so we override the
-            // token to be mdTypeRefNil, which used by the EH system to mean catch(...)
-
-#ifdef _DEBUG
-            // The proper way to do this, should we ever want to support arbitrary types here, is to "pre-
-            // resolve" the token and store the TypeHandle in the clause.  But this requires additional 
-            // infrastructure to ensure the TypeHandle is saved and fixed-up properly.  For now, we will
-            // simply assert that the original type was System.Object.
-
             CORINFO_RESOLVED_TOKEN resolvedToken = { 0 };
             resolvedToken.tokenContext = MAKE_METHODCONTEXT(m_currentMethodInfo.ftn);
             resolvedToken.tokenScope = m_currentMethodInfo.scope;
@@ -1203,11 +1191,32 @@ void ZapInfo::setEHinfo(unsigned EHnumber,
 
             resolveToken(&resolvedToken);
 
-            CORINFO_CLASS_HANDLE systemObjectHandle = getBuiltinClass(CLASSID_SYSTEM_OBJECT);
-            _ASSERTE(systemObjectHandle == resolvedToken.hClass);
-#endif // _DEBUG
+            if (m_zapper->m_pOpt->m_compilerFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_IL_STUB))
+            {
+                // IL stub tokens are 'private' and do not resolve correctly in their parent module's metadata.
 
-            ilClause->ClassToken = mdTypeRefNil; 
+                // Currently, the only place we are using a token here is for a COM-to-CLR exception-to-HRESULT
+                // mapping catch clause.  We want this catch clause to catch all exceptions, so we override the
+                // token to be mdTypeRefNil, which used by the EH system to mean catch(...)
+#ifdef _DEBUG
+                // The proper way to do this, should we ever want to support arbitrary types here, is to "pre-
+                // resolve" the token and store the TypeHandle in the clause.  But this requires additional
+                // infrastructure to ensure the TypeHandle is saved and fixed-up properly.  For now, we will
+                // simply assert that the original type was System.Object.
+
+                CORINFO_CLASS_HANDLE systemObjectHandle = getBuiltinClass(CLASSID_SYSTEM_OBJECT);
+                _ASSERTE(systemObjectHandle == resolvedToken.hClass);
+#endif // _DEBUG
+                ilClause->ClassToken = mdTypeRefNil;
+            }
+            else if (m_currentMethodModule != m_pImage->m_hModule)
+            {
+                // For clauses with types from external modules, add fixup to ensure the types are loaded
+                // before the code of the method containing the catch blocks is executed. This ensures
+                // that a failure to load the types would not happen when the exception handling is
+                // in progress and it is looking for a catch handler. At that point, we could only fail fast.
+                classMustBeLoadedBeforeCodeIsRun(resolvedToken.hClass);
+            }
         }
     }
 

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -1209,7 +1209,7 @@ void ZapInfo::setEHinfo(unsigned EHnumber,
 #endif // _DEBUG
                 ilClause->ClassToken = mdTypeRefNil;
             }
-            else if (m_currentMethodModule != m_pImage->m_hModule)
+            else if (getClassModule(resolvedToken.hClass) != m_currentMethodModule)
             {
                 // For clauses with types from external modules, add fixup to ensure the types are loaded
                 // before the code of the method containing the catch blocks is executed. This ensures


### PR DESCRIPTION
When an exception, like EEFileLoadException happens in the
ResolveEHClause, it was not caught by the runtime and so it caused exit
with `terminating with uncaught exception of type EEFileLoadException*`
message without any additional details.

This change adds catching the exception, reporting its details and call
stack and then failing fast.

Close #16438