### PR TITLE
Call ContainCheckIndir on the newly created indir

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -3265,6 +3265,7 @@ GenTree* Lowering::LowerDelegateInvoke(GenTreeCall* call)
     BlockRange().InsertAfter(thisExpr, newThisAddr, newThis);
 
     thisArgNode->gtOp.gtOp1 = newThis;
+    ContainCheckIndir(newThis->AsIndir());
 
     // the control target is
     // [originalThis + firstTgtOffs]


### PR DESCRIPTION
Contributes to #17932 (https://github.com/dotnet/coreclr/issues/17932#issuecomment-388008331)

It looks like containment might have been lost in #13198. Though it cause a significant diff so it's not clear how this slipped in.

```
; x64
Total bytes of diff: -23148 (-0.08% of base)
    diff is an improvement.
Total byte diff includes 0 bytes from reconciling methods
        Base had    0 unique methods,        0 unique bytes
        Diff had    0 unique methods,        0 unique bytes
Top file improvements by size (bytes):
      -12340 : System.Linq.Expressions.dasm (-0.45% of base)
       -3280 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.12% of base)
       -2009 : System.Private.CoreLib.dasm (-0.06% of base)
        -813 : CommandLine.dasm (-0.54% of base)
        -714 : System.Linq.dasm (-0.47% of base)
80 total files with size differences (80 improved, 0 regressed), 50 unchanged.
Top method improvements by size (bytes):
      -10599 : System.Linq.Expressions.dasm - FuncCallInstruction`3:Run(ref):int:this (3375 methods)
        -690 : System.Linq.Expressions.dasm - ActionCallInstruction`2:Run(ref):int:this (225 methods)
        -675 : System.Linq.Expressions.dasm - FuncCallInstruction`2:Run(ref):int:this (225 methods)
        -182 : System.Private.CoreLib.dasm - ArraySortHelper`1:PickPivotAndPartition(ref,int,int,ref):int (23 methods)
        -141 : System.Private.CoreLib.dasm - ArraySortHelper`1:DownHeap(ref,int,int,int,ref) (23 methods)
2491 total methods with size differences (2491 improved, 0 regressed), 143077 unchanged.

; x86
Total bytes of diff: -17119 (-0.08% of base)
    diff is an improvement.
Total byte diff includes 0 bytes from reconciling methods
        Base had    0 unique methods,        0 unique bytes
        Diff had    0 unique methods,        0 unique bytes
Top file improvements by size (bytes):
       -8973 : System.Linq.Expressions.dasm (-0.39% of base)
       -2307 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.11% of base)
       -1850 : System.Private.CoreLib.dasm (-0.06% of base)
        -550 : System.Linq.dasm (-0.46% of base)
        -542 : CommandLine.dasm (-0.43% of base)
80 total files with size differences (80 improved, 0 regressed), 50 unchanged.
Top method regessions by size (bytes):
           3 : System.Private.CoreLib.dasm - Module:FindTypes(ref,ref):ref:this
           1 : System.Private.CoreLib.dasm - Type:FindInterfaces(ref,ref):ref:this
Top method improvements by size (bytes):
       -7715 : System.Linq.Expressions.dasm - FuncCallInstruction`3:Run(ref):int:this (3375 methods)
        -454 : System.Linq.Expressions.dasm - ActionCallInstruction`2:Run(ref):int:this (225 methods)
        -450 : System.Linq.Expressions.dasm - FuncCallInstruction`2:Run(ref):int:this (225 methods)
        -310 : System.Private.CoreLib.dasm - ArraySortHelper`1:DownHeap(ref,int,int,int,ref) (23 methods)
        -299 : System.Private.CoreLib.dasm - ArraySortHelper`1:PickPivotAndPartition(ref,int,int,ref):int (23 methods)
2491 total methods with size differences (2489 improved, 2 regressed), 143063 unchanged.
```
