### PR TITLE
Add explicit null check for VSD via tail call stub.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8206,7 +8206,9 @@ void Compiler::fgMorphTailCall(GenTreeCall* call, void* pfnCopyArgs)
     call->gtCallMoreFlags |= GTF_CALL_M_VARARGS | GTF_CALL_M_TAILCALL | GTF_CALL_M_TAILCALL_VIA_HELPER;
     call->gtFlags &= ~GTF_CALL_POP_ARGS;
 
-#endif // _TARGET_*
+#elif defined(_TARGET_ARM64_)
+    NYI("Tail calls via stub are unsupported on this platform.");
+#endif // _TARGET_ARM64_
 
     // The function is responsible for doing explicit null check when it is neseccary.
     assert(!call->NeedsNullCheck());
@@ -8737,6 +8739,11 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
                     // NYI - TAILCALL_RECURSIVE/TAILCALL_HELPER.
                     // So, bail out if we can't make fast tail call.
                     szFailReason = "Non-qualified fast tail call";
+
+                    if (call->IsTailPrefixedCall())
+                    {
+                        NYI("Arm64 does not support tail calls via helpers.");
+                    }
                 }
 #endif
 #endif // LEGACY_BACKEND

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8208,7 +8208,7 @@ void Compiler::fgMorphTailCall(GenTreeCall* call, void* pfnCopyArgs)
     call->gtFlags &= ~GTF_CALL_POP_ARGS;
 
 #elif defined(_TARGET_ARM64_)
-    NYI("Tail calls via stub are unsupported on this platform.");
+    NYI_ARM64("Tail calls via stub are unsupported on this platform.");
 #endif // _TARGET_ARM64_
 
     // The function is responsible for doing explicit null check when it is necessary.
@@ -8743,7 +8743,7 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
 
                     if (call->IsTailPrefixedCall())
                     {
-                        NYI("Arm64 does not support tail calls via helpers.");
+                        NYI_ARM64("Arm64 does not support tail calls via helpers.");
                     }
                 }
 #endif

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7836,9 +7836,10 @@ void Compiler::fgMorphTailCall(GenTreeCall* call, void* pfnCopyArgs)
     JITDUMP("fgMorphTailCall (before):\n");
     DISPTREE(call);
 
-    // The runtime requires that we perforrm a null check on the `this` argument before tail
-    // calling to a virtual dispatch stub. This requirement is a consequence of limitations in the runtime's
-    // ability to map an AV to a NullReferenceException if the AV occurs in a dispatch stub.
+    // The runtime requires that we perform a null check on the `this` argument before
+    // tail calling  to a virtual dispatch stub. This requirement is a consequence of limitations
+    // in the runtime's ability to map an AV to a NullReferenceException if
+    // the AV occurs in a dispatch stub that has unmanaged caller.
     if (call->IsVirtualStub())
     {
         call->gtFlags |= GTF_CALL_NULLCHECK;
@@ -8210,7 +8211,7 @@ void Compiler::fgMorphTailCall(GenTreeCall* call, void* pfnCopyArgs)
     NYI("Tail calls via stub are unsupported on this platform.");
 #endif // _TARGET_ARM64_
 
-    // The function is responsible for doing explicit null check when it is neseccary.
+    // The function is responsible for doing explicit null check when it is necessary.
     assert(!call->NeedsNullCheck());
 
     JITDUMP("fgMorphTailCall (after):\n");

--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -94713,6 +94713,6 @@ RelativePath=JIT\Regression\JitBlue\GitHub_17585\GitHub_17585\GitHub_17585.cmd
 WorkingDir=JIT\Regression\JitBlue\GitHub_17585\GitHub_17585
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;17585;EXCLUDED
+Categories=EXPECTED_PASS
 HostStyle=0
 

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -94737,5 +94737,5 @@ RelativePath=JIT\Regression\JitBlue\GitHub_17585\GitHub_17585\GitHub_17585.cmd
 WorkingDir=JIT\Regression\JitBlue\GitHub_17585\GitHub_17585
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;17585;EXCLUDED
+Categories=EXPECTED_FAIL;6675;EXCLUDED
 HostStyle=0

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -39313,7 +39313,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i06\mcc_i06.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i06
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NATIVE_INTEROP
+Categories=EXPECTED_FAIL;6675;EXCLUDED;NATIVE_INTEROP
 HostStyle=0
 
 [mcc_i07.cmd_5191]
@@ -39345,7 +39345,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i16\mcc_i16.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i16
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS
+Categories=EXPECTED_FAIL;6675;EXCLUDED
 HostStyle=0
 
 [mcc_i17.cmd_5199]
@@ -39377,7 +39377,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i36\mcc_i36.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i36
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS
+Categories=EXPECTED_FAIL;6675;EXCLUDED
 HostStyle=0
 
 [mcc_i37.cmd_5207]
@@ -39409,7 +39409,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i56\mcc_i56.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i56
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS
+Categories=EXPECTED_FAIL;6675;EXCLUDED
 HostStyle=0
 
 [mcc_i57.cmd_5215]
@@ -39441,7 +39441,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i66\mcc_i66.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i66
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS
+Categories=EXPECTED_FAIL;6675;EXCLUDED
 HostStyle=0
 
 [mcc_i67.cmd_5223]
@@ -39473,7 +39473,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i76\mcc_i76.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i76
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS
+Categories=EXPECTED_FAIL;6675;EXCLUDED
 HostStyle=0
 
 [mcc_i77.cmd_5231]
@@ -39505,7 +39505,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i86\mcc_i86.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i86
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NATIVE_INTEROP
+Categories=EXPECTED_FAIL;6675;EXCLUDED;NATIVE_INTEROP
 HostStyle=0
 
 [mcc_i87.cmd_5239]
@@ -54825,7 +54825,7 @@ RelativePath=JIT\Methodical\Invoke\25params\25param2c_il_d\25param2c_il_d.cmd
 WorkingDir=JIT\Methodical\Invoke\25params\25param2c_il_d
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS
+Categories=EXPECTED_FAIL;6675;EXCLUDED
 HostStyle=0
 
 [25param2c_il_r.cmd_7167]
@@ -54833,7 +54833,7 @@ RelativePath=JIT\Methodical\Invoke\25params\25param2c_il_r\25param2c_il_r.cmd
 WorkingDir=JIT\Methodical\Invoke\25params\25param2c_il_r
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;Pri1
+Categories=EXPECTED_FAIL;6675;EXCLUDED;Pri1
 HostStyle=0
 
 [25param3a_cs_d.cmd_7168]
@@ -92737,7 +92737,7 @@ RelativePath=CoreMangLib\system\span\SlowTailCallArgs\SlowTailCallArgs.cmd
 WorkingDir=CoreMangLib\system\span\SlowTailCallArgs
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;Pri1;NEW
+Categories=EXPECTED_FAIL;6675;EXCLUDED;Pri1
 HostStyle=0
 
 [GitHub_13057.cmd_11966]

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -214,15 +214,6 @@
             <Issue>11469, The test causes OutOfMemory exception in crossgen mode.</Issue> 
         </ExcludeList>
     </ItemGroup>
-	
-	<!-- The following are x64 failures -->
-
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(BuildArch)' == 'x64'">
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\GitHub_17585\GitHub_17585\GitHub_17585.cmd">
-            <Issue>17585</Issue>
-        </ExcludeList>
-    </ItemGroup>
-
 
     <!-- The following are ARM32 failures -->
 


### PR DESCRIPTION
Always add explicit null check before calling tail call stub that calls VSD.

Fixes #17585.

For arm64 it hits #6675.