### PR TITLE
Reflection: Allow ParameterBuilder.SetConstant(nonNullValue) for nullable enum parameters

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
@@ -301,6 +301,10 @@ namespace System.Reflection.Emit
                 if (destType.IsByRef)
                     destType = destType.GetElementType();
 
+                // Convert nullable types to their underlying type.
+                // This is necessary for nullable enum types to pass the IsEnum check that's coming next.
+                destType = Nullable.GetUnderlyingType(destType) ?? destType;
+
                 if (destType.IsEnum)
                 {
                     //                                   |  UnderlyingSystemType     |  Enum.GetUnderlyingType() |  IsEnum

--- a/src/System.Private.CoreLib/src/System/Reflection/MdConstant.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/MdConstant.cs
@@ -23,6 +23,12 @@ namespace System.Reflection
 
             if (fieldType.IsEnum && raw == false)
             {
+                // NOTE: Unlike in `TypeBuilder.SetConstantValue`, if `fieldType` describes
+                // a nullable enum type `Nullable<TEnum>`, we do not unpack it to `TEnum` to
+                // successfully enter this `if` clause. Default values of `TEnum?`-typed
+                // parameters have been reported as values of the underlying type, changing
+                // this now might be a breaking change.
+
                 long defaultValue = 0;
 
                 switch (corElementType)


### PR DESCRIPTION
This is a fix for #17893.

* Makes it possible to call `ParameterBuilder.SetConstant(nonNullValue)` for a parameter of type `TEnum?`.

* But does not change the behavior of `ParameterInfo.DefaultValue`, which will report a default value of the enum's underlying type for `TEnum?` parameters (unlike with `TEnum` parameters, where the reported default value has type `TEnum`). While it would be nice to change this, it might also break existing user code:

   ```csharp
   class Class
   {
       public void Method(AttributeTargets? arg = AttributeTargets.Constructor) { }
   }

   // This assertion currently succeeds, perhaps safest to keep it that way for now:
   Debug.Assert(typeof(Class).GetMethod("Method").GetParameters()[0].DefaultValue is int);
   ```

/cc @AtsushiKan