### PR TITLE
Remove IsAscii fast paths from Equals and Compare OrdinalIgnoreCase

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Boolean.cs
+++ b/src/System.Private.CoreLib/shared/System/Boolean.cs
@@ -175,6 +175,27 @@ namespace System
         // Static Methods
         // 
 
+        // Custom string compares for early application use by config switches, etc
+        // 
+        internal static bool IsTrueStringIgnoreCase(ReadOnlySpan<char> value)
+        {
+            return (value.Length == 4 &&
+                    (value[0] == 't' || value[0] == 'T') &&
+                    (value[1] == 'r' || value[1] == 'R') &&
+                    (value[2] == 'u' || value[2] == 'U') &&
+                    (value[3] == 'e' || value[3] == 'E'));
+        }
+
+        internal static bool IsFalseStringIgnoreCase(ReadOnlySpan<char> value)
+        {
+            return (value.Length == 5 &&
+                    (value[0] == 'f' || value[0] == 'F') &&
+                    (value[1] == 'a' || value[1] == 'A') &&
+                    (value[2] == 'l' || value[2] == 'L') &&
+                    (value[3] == 's' || value[3] == 'S') &&
+                    (value[4] == 'e' || value[4] == 'E'));
+        }
+
         // Determines whether a String represents true or false.
         // 
         public static Boolean Parse(String value)
@@ -201,15 +222,13 @@ namespace System
 
         public static bool TryParse(ReadOnlySpan<char> value, out bool result)
         {
-            ReadOnlySpan<char> trueSpan = TrueLiteral.AsSpan();
-            if (trueSpan.EqualsOrdinalIgnoreCase(value))
+            if (IsTrueStringIgnoreCase(value))
             {
                 result = true;
                 return true;
             }
 
-            ReadOnlySpan<char> falseSpan = FalseLiteral.AsSpan();
-            if (falseSpan.EqualsOrdinalIgnoreCase(value))
+            if (IsFalseStringIgnoreCase(value))
             {
                 result = false;
                 return true;
@@ -218,13 +237,13 @@ namespace System
             // Special case: Trim whitespace as well as null characters.
             value = TrimWhiteSpaceAndNull(value);
 
-            if (trueSpan.EqualsOrdinalIgnoreCase(value))
+            if (IsTrueStringIgnoreCase(value))
             {
                 result = true;
                 return true;
             }
 
-            if (falseSpan.EqualsOrdinalIgnoreCase(value))
+            if (IsFalseStringIgnoreCase(value))
             {
                 result = false;
                 return true;

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
@@ -178,13 +178,15 @@ namespace System.Globalization
             return -1;
         }
 
-        private static unsafe int CompareStringOrdinalIgnoreCase(char* string1, int count1, char* string2, int count2)
+        private static unsafe int CompareStringOrdinalIgnoreCase(ref char string1, int count1, ref char string2, int count2)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
-            Debug.Assert(string1 != null);
-            Debug.Assert(string2 != null);
 
-            return Interop.Globalization.CompareStringOrdinalIgnoreCase(string1, count1, string2, count2);
+            fixed (char* char1 = &string1)
+            fixed (char* char2 = &string2)
+            {
+                return Interop.Globalization.CompareStringOrdinalIgnoreCase(char1, count1, char2, count2);
+            }
         }
 
         // TODO https://github.com/dotnet/coreclr/issues/13827:

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Windows.cs
@@ -166,14 +166,16 @@ namespace System.Globalization
             }
         }
 
-        private static unsafe int CompareStringOrdinalIgnoreCase(char* string1, int count1, char* string2, int count2)
+        private static unsafe int CompareStringOrdinalIgnoreCase(ref char string1, int count1, ref char string2, int count2)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
-            Debug.Assert(string1 != null);
-            Debug.Assert(string2 != null);
 
-            // Use the OS to compare and then convert the result to expected value by subtracting 2 
-            return Interop.Kernel32.CompareStringOrdinal(string1, count1, string2, count2, true) - 2;
+            fixed (char* char1 = &string1)
+            fixed (char* char2 = &string2)
+            {
+                // Use the OS to compare and then convert the result to expected value by subtracting 2 
+                return Interop.Kernel32.CompareStringOrdinal(char1, count1, char2, count2, true) - 2;
+            }
         }
 
         // TODO https://github.com/dotnet/coreclr/issues/13827:

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
@@ -17,7 +17,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Buffers;
-using System.Text;
+using Internal.Runtime.CompilerServices;
 
 namespace System.Globalization
 {
@@ -529,57 +529,103 @@ namespace System.Globalization
         {
             Debug.Assert(indexA + lengthA <= strA.Length);
             Debug.Assert(indexB + lengthB <= strB.Length);
-            return CompareOrdinalIgnoreCase(strA.AsSpan(indexA, lengthA), strB.AsSpan(indexB, lengthB));
+            return CompareOrdinalIgnoreCase(
+                ref Unsafe.Add(ref strA.GetRawStringData(), indexA),
+                lengthA,
+                ref Unsafe.Add(ref strB.GetRawStringData(), indexB),
+                lengthB);
         }
 
-        internal static unsafe int CompareOrdinalIgnoreCase(ReadOnlySpan<char> strA, ReadOnlySpan<char> strB)
+        internal static int CompareOrdinalIgnoreCase(ReadOnlySpan<char> strA, ReadOnlySpan<char> strB)
         {
-            int length = Math.Min(strA.Length, strB.Length);
+            return CompareOrdinalIgnoreCase(ref MemoryMarshal.GetReference(strA), strA.Length, ref MemoryMarshal.GetReference(strB), strB.Length);
+        }
+
+        internal static int CompareOrdinalIgnoreCase(string strA, string strB)
+        {
+            return CompareOrdinalIgnoreCase(ref strA.GetRawStringData(), strA.Length, ref strB.GetRawStringData(), strB.Length);
+        }
+
+        internal static int CompareOrdinalIgnoreCase(ref char strA, int lengthA, ref char strB, int lengthB)
+        {
+            int length = Math.Min(lengthA, lengthB);
             int range = length;
 
-            fixed (char* ap = &MemoryMarshal.GetReference(strA))
-            fixed (char* bp = &MemoryMarshal.GetReference(strB))
+            ref char charA = ref strA;
+            ref char charB = ref strB;
+
+            // in InvariantMode we support all range and not only the ascii characters.
+            char maxChar = (GlobalizationMode.Invariant ? (char)0xFFFF : (char)0x7F);
+
+            while (length != 0 && charA <= maxChar && charB <= maxChar)
             {
-                char* a = ap;
-                char* b = bp;
-
-                // in InvariantMode we support all range and not only the ascii characters.
-                char maxChar = (char) (GlobalizationMode.Invariant ? 0xFFFF : 0x7F);
-
-                while (length != 0 && (*a <= maxChar) && (*b <= maxChar))
+                // Ordinal equals or lowercase equals if the result ends up in the a-z range 
+                if (charA == charB ||
+                    ((charA | 0x20) == (charB | 0x20) &&
+                        (uint)((charA | 0x20) - 'a') <= (uint)('z' - 'a')))
                 {
-                    int charA = *a;
-                    int charB = *b;
+                    length--;
+                    charA = ref Unsafe.Add(ref charA, 1);
+                    charB = ref Unsafe.Add(ref charB, 1);
+                }
+                else
+                {
+                    int currentA = charA;
+                    int currentB = charB;
 
-                    if (charA == charB)
-                    {
-                        a++; b++;
-                        length--;
-                        continue;
-                    }
-
-                    // uppercase both chars - notice that we need just one compare per char
-                    if ((uint)(charA - 'a') <= 'z' - 'a') charA -= 0x20;
-                    if ((uint)(charB - 'a') <= 'z' - 'a') charB -= 0x20;
+                    // Uppercase both chars if needed
+                    if ((uint)(charA - 'a') <= 'z' - 'a')
+                        currentA -= 0x20;
+                    if ((uint)(charB - 'a') <= 'z' - 'a')
+                        currentB -= 0x20;
 
                     // Return the (case-insensitive) difference between them.
-                    if (charA != charB)
-                        return charA - charB;
-
-                    // Next char
-                    a++; b++;
-                    length--;
+                    return currentA - currentB;
                 }
-
-                if (length == 0)
-                    return strA.Length - strB.Length;
-
-                Debug.Assert(!GlobalizationMode.Invariant);
-
-                range -= length;
-
-                return CompareStringOrdinalIgnoreCase(a, strA.Length - range, b, strB.Length - range);
             }
+
+            if (length == 0)
+                return lengthA - lengthB;
+
+            Debug.Assert(!GlobalizationMode.Invariant);
+
+            range -= length;
+
+            return CompareStringOrdinalIgnoreCase(ref charA, lengthA - range, ref charB, lengthB - range);
+        }
+
+
+        internal static bool EqualsOrdinalIgnoreCase(ref char strA, ref char strB, int length)
+        {
+            ref char charA = ref strA;
+            ref char charB = ref strB;
+
+            // in InvariantMode we support all range and not only the ascii characters.
+            char maxChar = (GlobalizationMode.Invariant ? (char)0xFFFF : (char)0x7F);
+
+            while (length != 0 && charA <= maxChar && charB <= maxChar)
+            {
+                // Ordinal equals or lowercase equals if the result ends up in the a-z range 
+                if (charA == charB ||
+                    ((charA | 0x20) == (charB | 0x20) &&
+                        (uint)((charA | 0x20) - 'a') <= (uint)('z' - 'a')))
+                {
+                    length--;
+                    charA = ref Unsafe.Add(ref charA, 1);
+                    charB = ref Unsafe.Add(ref charB, 1);
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            if (length == 0)
+                return true;
+
+            Debug.Assert(!GlobalizationMode.Invariant);
+
+            return CompareStringOrdinalIgnoreCase(ref charA, length, ref charB, length) == 0;
         }
 
         ////////////////////////////////////////////////////////////////////////

--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
@@ -80,7 +80,7 @@ namespace System
                 return false;
             if (value.Length == 0)  // span.Length == value.Length == 0
                 return true;
-            return (CompareInfo.CompareOrdinalIgnoreCase(span, value) == 0);
+            return CompareInfo.EqualsOrdinalIgnoreCase(ref MemoryMarshal.GetReference(span), ref MemoryMarshal.GetReference(value), span.Length);
         }
 
         // TODO https://github.com/dotnet/corefx/issues/27526

--- a/src/System.Private.CoreLib/shared/System/String.Comparison.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Comparison.cs
@@ -19,42 +19,6 @@ namespace System
 {
     public partial class String
     {
-        private static unsafe int CompareOrdinalIgnoreCaseHelper(string strA, string strB)
-        {
-            Debug.Assert(strA != null);
-            Debug.Assert(strB != null);
-            int length = Math.Min(strA.Length, strB.Length);
-
-            fixed (char* ap = &strA._firstChar) fixed (char* bp = &strB._firstChar)
-            {
-                char* a = ap;
-                char* b = bp;
-                int charA = 0, charB = 0;
-
-                while (length != 0)
-                {
-                    charA = *a;
-                    charB = *b;
-
-                    Debug.Assert((charA | charB) <= 0x7F, "strings have to be ASCII");
-
-                    // uppercase both chars - notice that we need just one compare per char
-                    if ((uint)(charA - 'a') <= (uint)('z' - 'a')) charA -= 0x20;
-                    if ((uint)(charB - 'a') <= (uint)('z' - 'a')) charB -= 0x20;
-
-                    //Return the (case-insensitive) difference between them.
-                    if (charA != charB)
-                        return charA - charB;
-
-                    // Next char
-                    a++; b++;
-                    length--;
-                }
-
-                return strA.Length - strB.Length;
-            }
-        }
-
         //
         // Search/Query methods
         //
@@ -84,44 +48,12 @@ namespace System
             return SpanHelpers.SequenceCompareTo(ref Unsafe.Add(ref strA.GetRawStringData(), indexA), countA, ref Unsafe.Add(ref strB.GetRawStringData(), indexB), countB);
         }
 
-        private static unsafe bool EqualsIgnoreCaseAsciiHelper(string strA, string strB)
+        private static bool EqualsOrdinalIgnoreCase(string strA, string strB)
         {
-            Debug.Assert(strA != null);
-            Debug.Assert(strB != null);
             Debug.Assert(strA.Length == strB.Length);
-            int length = strA.Length;
 
-            fixed (char* ap = &strA._firstChar) fixed (char* bp = &strB._firstChar)
-            {
-                char* a = ap;
-                char* b = bp;
-
-                while (length != 0)
-                {
-                    int charA = *a;
-                    int charB = *b;
-
-                    Debug.Assert((charA | charB) <= 0x7F, "strings have to be ASCII");
-
-                    // Ordinal equals or lowercase equals if the result ends up in the a-z range 
-                    if (charA == charB ||
-                       ((charA | 0x20) == (charB | 0x20) &&
-                          (uint)((charA | 0x20) - 'a') <= (uint)('z' - 'a')))
-                    {
-                        a++;
-                        b++;
-                        length--;
-                    }
-                    else
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
+            return CompareInfo.EqualsOrdinalIgnoreCase(ref strA.GetRawStringData(), ref strB.GetRawStringData(), strB.Length);
         }
-
         private static unsafe int CompareOrdinalHelper(string strA, string strB)
         {
             Debug.Assert(strA != null);
@@ -306,14 +238,7 @@ namespace System
                     return CompareOrdinalHelper(strA, strB);
 
                 case StringComparison.OrdinalIgnoreCase:
-#if CORECLR
-                    // If both strings are ASCII strings, we can take the fast path.
-                    if (strA.IsAscii() && strB.IsAscii())
-                    {
-                        return CompareOrdinalIgnoreCaseHelper(strA, strB);
-                    }
-#endif
-                    return CompareInfo.CompareOrdinalIgnoreCase(strA, 0, strA.Length, strB, 0, strB.Length);
+                    return CompareInfo.CompareOrdinalIgnoreCase(strA, strB);
 
                 default:
                     throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
@@ -744,14 +669,8 @@ namespace System
                 case StringComparison.OrdinalIgnoreCase:
                     if (this.Length != value.Length)
                         return false;
-#if CORECLR
-                    // If both strings are ASCII strings, we can take the fast path.
-                    if (this.IsAscii() && value.IsAscii())
-                    {
-                        return EqualsIgnoreCaseAsciiHelper(this, value);
-                    }
-#endif
-                    return (CompareInfo.CompareOrdinalIgnoreCase(this, 0, this.Length, value, 0, value.Length) == 0);
+
+                    return EqualsOrdinalIgnoreCase(this, value);
 
                 default:
                     throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
@@ -807,14 +726,8 @@ namespace System
                 case StringComparison.OrdinalIgnoreCase:
                     if (a.Length != b.Length)
                         return false;
-#if CORECLR
-                    // If both strings are ASCII strings, we can take the fast path.
-                    if (a.IsAscii() && b.IsAscii())
-                    {
-                        return EqualsIgnoreCaseAsciiHelper(a, b);
-                    }
-#endif
-                    return (CompareInfo.CompareOrdinalIgnoreCase(a, 0, a.Length, b, 0, b.Length) == 0);
+
+                    return EqualsOrdinalIgnoreCase(a, b);
 
                 default:
                     throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
@@ -950,7 +863,7 @@ namespace System
                     {
                         return false;
                     }
-                    return (CompareInfo.CompareOrdinalIgnoreCase(this, 0, value.Length, value, 0, value.Length) == 0);
+                    return CompareInfo.EqualsOrdinalIgnoreCase(ref this.GetRawStringData(), ref value.GetRawStringData(), value.Length);
 
                 default:
                     throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));

--- a/src/System.Private.CoreLib/src/System/CLRConfig.cs
+++ b/src/System.Private.CoreLib/src/System/CLRConfig.cs
@@ -41,11 +41,11 @@ namespace System
                         return true;
                     break;
                 case 4:
-                    if ("true".AsSpan().EqualsOrdinalIgnoreCase(buffer.Slice(0, 4)))
+                    if (bool.IsTrueStringIgnoreCase(buffer.Slice(0, 4)))
                         return true;
                     break;
                 case 5:
-                    if ("false".AsSpan().EqualsOrdinalIgnoreCase(buffer.Slice(0, 5)))
+                    if (bool.IsFalseStringIgnoreCase(buffer.Slice(0, 5)))
                         return false;
                     break;
             }

--- a/src/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.cs
@@ -21,7 +21,7 @@ namespace System.Globalization
                 string switchValue = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT");
                 if (switchValue != null)
                 {
-                    ret = switchValue.Equals("true", StringComparison.OrdinalIgnoreCase) || switchValue.Equals("1");
+                    ret = bool.IsTrueStringIgnoreCase(switchValue) || switchValue.Equals("1");
                 }
             }
 


### PR DESCRIPTION
For consideration.

Contributes to https://github.com/dotnet/coreclr/issues/14320

IsAscii is optimized for one specific scenario so the removal of that code does see a 10% regression in equalling old strings. However it takes 11 EqualsLateExitBothCached compares to earn back the initial expense of the EqualsLateExitNoCached compare. So both strings need to be fairly long lived.

Equals OrdinalIgnoreCase

Method | Before | After | Improvement |
----------------------------------|----------:|----------:|----------:|
EqualsEarlyExitBothCached | 26.50 ns | 14.43 ns | 0.8x |
EqualsEarlyExitRightCached | 98.35 ns | 13.76 ns | 6.0x |
EqualsEarlyExitLeftCached | 101.01 ns | 13.92 ns | 6.2x |
EqualsEarlyExitNoCached | 170.91 ns | 13.83 ns | 11.3x |
EqualsLateExitBothCached | 101.63 ns | 113.29 ns | **-0.1x** |
EqualsLateExitRightCached | 174.00 ns | 116.34 ns | 0.5x |
EqualsLateExitLeftCached | 176.17 ns | 113.41 ns | 0.5x |
EqualsLateExitNoCached | 243.51 ns | 114.05 ns | 1.1x |
EqualsUnicodeEarlyExitBothCached |  29.70 ns | 13.88 ns | 1.1x |
EqualsUnicodeEarlyExitRightCached |  33.98 ns | 14.06 ns | 1.4x |
EqualsUnicodeEarlyExitLeftCached |  29.39 ns | 13.91 ns | 1.1x |
EqualsUnicodeEarlyExitNoCached |  35.25 ns | 14.84 ns | 1.3x |
EqualsUnicodeLateExitBothCached | 148.29 ns | 127.02 ns | 0.1x |
EqualsUnicodeLateExitRightCached | 224.69 ns | 127.14 ns | 0.7x |
EqualsUnicodeLateExitLeftCached | 148.28 ns | 126.70 ns | 0.2x |
EqualsUnicodeLateExitNoCached | 223.75 ns | 127.45 ns | 0.7x |

Compare OrdinalIgnoreCase

Method | Before | After | Improvement |
----------------------------------- |----------:|----------:|----------:|
CompareEarlyExitBothCached |  27.46 ns | 15.72 ns | 0.7x |
CompareEarlyExitRightCached |  99.46 ns | 15.84 ns | 5.2x |
CompareEarlyExitLeftCached |  99.28 ns | 15.16 ns | 5.5x |
CompareEarlyExitNoCached | 174.50 ns | 15.22 ns | 10.4x |
CompareLateExitBothCached | 134.67 ns | 109.96 ns | 0.2x |
CompareLateExitRightCached | 210.49 ns | 110.25 ns | 0.9x |
CompareLateExitLeftCached | 207.10 ns | 110.03 ns | 0.8x |
CompareLateExitNoCached | 280.76 ns | 110.62 ns | 1.5x |
CompareUnicodeEarlyExitBothCached |  28.87 ns | 15.39 ns | 0.8x |
CompareUnicodeEarlyExitRightCached |  32.94 ns | 15.40 ns | 1.1x |
CompareUnicodeEarlyExitLeftCached |  28.93 ns | 15.97 ns | 0.8x |
CompareUnicodeEarlyExitNoCached |  33.21 ns | 15.30 ns | 1.1x |
CompareUnicodeLateExitBothCached | 147.15 ns | 131.04 ns | 0.1x |
CompareUnicodeLateExitRightCached | 227.18 ns | 131.10 ns | 0.7x |
CompareUnicodeLateExitLeftCached | 147.45 ns | 130.74 ns | 0.1x |
CompareUnicodeLateExitNoCached | 229.50 ns | 130.99 ns | 0.7x |

Equals OrdinalIgnoreCase now has a dependency on environment variables that it didn't have before on ASCII values. Broke the circular path with a custom bool string compare. 10ns quicker but its only there for that reason. Any other risk factors here with startup code calling into OrdinalIgnoreCase?
