### PR TITLE
Fix multicast delegate step from delegate

### DIFF
--- a/src/debug/ee/controller.cpp
+++ b/src/debug/ee/controller.cpp
@@ -6319,8 +6319,8 @@ void DebuggerStepper::TrapStepOut(ControllerStackInfo *info, bool fForceTraditio
         _ASSERTE(IsCloserToLeaf(dbgLastFP, info->m_activeFrame.fp));
 #endif
 
-#ifdef FEATURE_STUBS_AS_IL
-        if (info->m_activeFrame.md->IsILStub() && info->m_activeFrame.md->AsDynamicMethodDesc()->IsMulticastStub())
+#ifdef FEATURE_MULTICASTSTUB_AS_IL
+        if (info->m_activeFrame.md != nullptr && info->m_activeFrame.md->IsILStub() && info->m_activeFrame.md->AsDynamicMethodDesc()->IsMulticastStub())
         {
             LOG((LF_CORDB, LL_INFO10000,
                  "DS::TSO: multicast frame.\n"));
@@ -6347,7 +6347,7 @@ void DebuggerStepper::TrapStepOut(ControllerStackInfo *info, bool fForceTraditio
                 break;          
         }
         else 
-#endif // FEATURE_STUBS_AS_IL
+#endif // FEATURE_MULTICASTSTUB_AS_IL
         if (info->m_activeFrame.managed)
         {
             LOG((LF_CORDB, LL_INFO10000,

--- a/src/debug/ee/frameinfo.cpp
+++ b/src/debug/ee/frameinfo.cpp
@@ -1563,7 +1563,7 @@ StackWalkAction DebuggerWalkStackProc(CrawlFrame *pCF, void *data)
     // The only exception is dynamic methods.  We want to report them when SIS is turned on.
     if ((md != NULL) && md->IsILStub() && pCF->IsFrameless())
     {
-#ifdef FEATURE_STUBS_AS_IL
+#ifdef FEATURE_MULTICASTSTUB_AS_IL
         if(md->AsDynamicMethodDesc()->IsMulticastStub())
         {
             use = true;

--- a/src/vm/stubmgr.h
+++ b/src/vm/stubmgr.h
@@ -978,7 +978,7 @@ public:
         Thread::VirtualUnwindCallFrame(&context);
         Thread::VirtualUnwindCallFrame(&context);
 
-        return pContext->Rip;
+        return context.Rip;
 #elif defined(_TARGET_ARM_)
         return *((PCODE *)pContext->R11 + 1);      
 #elif defined(_TARGET_ARM64_)


### PR DESCRIPTION
- Replace incorrect FEATURE_STUBS_AS_IL define check with FEATURE_MULTICASTSTUB_AS_IL
  - Allows step from one delegate to the next and step out from multicast delegate to function correctly.
- Add null check as the active frame's methoddesc isn't always non-null
  - In scenarios such as FuncEval, we also run through this code, and the md may be null.
- Fix unwind from StubHelpers::MulticastDebuggerTraceHelper function on amd64