### PR TITLE
JIT: clear up some no-op casts in the importer

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -12490,14 +12490,14 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 {
                     // Nothing needs to change
                 }
-                else if  (!ovfl && (lclTyp == op1->TypeGet()) && (genTypeSize(type) == genTypeSize(lclTyp)))
+                else if (!ovfl && (lclTyp == op1->TypeGet()) && (genTypeSize(type) == genTypeSize(lclTyp)))
                 {
                     // Bash operand to right type
                     op1->gtType = lclTyp;
                 }
+                // Work is evidently required, add cast node
                 else
                 {
-                    // Work is evidently required, add cast node
 #if SMALL_TREE_NODES
                     if (callNode)
                     {

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -12490,11 +12490,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 {
                     // Nothing needs to change
                 }
-                else if (!ovfl && (lclTyp == op1->TypeGet()) && (genTypeSize(type) == genTypeSize(lclTyp)))
-                {
-                    // Bash operand to right type
-                    op1->gtType = lclTyp;
-                }
                 // Work is evidently required, add cast node
                 else
                 {

--- a/src/jit/jitconfig.cpp
+++ b/src/jit/jitconfig.cpp
@@ -89,10 +89,14 @@ void JitConfigValues::MethodSet::initialize(const wchar_t* list, ICorJitHost* ho
                         currChar = m_list[i];
                         // Advance until we see the second "
                         if (currChar == '"')
+                        {
                             break;
+                        }
                         // or until we see the end of string
                         if (currChar == '\0')
+                        {
                             break;
+                        }
                     }
 
                     // skip the initial "
@@ -167,10 +171,14 @@ void JitConfigValues::MethodSet::initialize(const wchar_t* list, ICorJitHost* ho
                         currChar = m_list[i];
                         // Advance until we see the second "
                         if (currChar == '"')
+                        {
                             break;
+                        }
                         // or until we see the end of string
                         if (currChar == '\0')
+                        {
                             break;
+                        }
                     }
 
                     // skip the initial "


### PR DESCRIPTION
If we see a no-op cast (say converting long to ulong) where the operand
to be cast already has the right stack type, don't generate a GT_CAST,
just use the operand.

This comes up in some cases with unsafe operations where the pointer type
is cast. Interposing a cast between an GT_IND and GT_ADDR results in poor
codegen as the jit thinks the addressed local is address taken.