### PR TITLE
Update osx-instructions.md

### DIFF
--- a/Documentation/building/osx-instructions.md
+++ b/Documentation/building/osx-instructions.md
@@ -101,6 +101,7 @@ Build the Framework
 ===================
 
 ```sh
+dotnet-mbp:coreclr richlander$ cd ../corefx/
 dotnet-mbp:corefx richlander$ ./build.sh
 ```
 


### PR DESCRIPTION
When following this instruction CoreFX build won't happen until we change the folder to the CoreFX's one. In essence ./build.sh will trigger CoreCLR build once again. It may be a minor thing for an experienced user but can become a significant blocker for someone who's not that experienced with the command line and needs to compile CoreCLR. And it will diminish the awesomeness of .NET Core which we can't allow!

The proposed change is just a directory change when inside the CoreCLR folder.