### PR TITLE
fix jit format after better-wildcards PR

### DIFF
--- a/src/jit/jitconfig.cpp
+++ b/src/jit/jitconfig.cpp
@@ -89,10 +89,14 @@ void JitConfigValues::MethodSet::initialize(const wchar_t* list, ICorJitHost* ho
                         currChar = m_list[i];
                         // Advance until we see the second "
                         if (currChar == '"')
+                        {
                             break;
+                        }
                         // or until we see the end of string
                         if (currChar == '\0')
+                        {
                             break;
+                        }
                     }
 
                     // skip the initial "
@@ -167,10 +171,14 @@ void JitConfigValues::MethodSet::initialize(const wchar_t* list, ICorJitHost* ho
                         currChar = m_list[i];
                         // Advance until we see the second "
                         if (currChar == '"')
+                        {
                             break;
+                        }
                         // or until we see the end of string
                         if (currChar == '\0')
+                        {
                             break;
+                        }
                     }
 
                     // skip the initial "


### PR DESCRIPTION
[Ci format jobs](https://ci.dot.net/job/dotnet_coreclr/job/master/job/x64_windows_nt_formatting_prtest/) are failing after #17970.

Local run of `jit-format.bat --fix -c C:\git\coreclr` doesn't change anything and the format job in the PR was green, so it is a strange behavior.

However, it is easier to just apply the suggested patch right now.

cc @dotnet/jit-contrib 