### PR TITLE
Reflection.Emit: Remove faulty Debug.Assert

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/SignatureHelper.cs
@@ -289,7 +289,6 @@ namespace System.Reflection.Emit
             // in the signature based on clsArgument. This helper is called for return type.
 
             Debug.Assert(clsArgument != null);
-            Debug.Assert((optionalCustomModifiers == null && requiredCustomModifiers == null) || !clsArgument.ContainsGenericParameters);
 
             if (optionalCustomModifiers != null)
             {


### PR DESCRIPTION
This is in response to, and resolves #17986.

The assertion being removed here fails when Reflection.Emit user code defines a method signature where custom modifiers are used in conjunction with a generic type parameter. Yet there is no obvious reason why that should be forbidden.

```csharp
public interface IType<T> where T : struct
{
    void Method(in T arg);
    //          ^^^^
    // If we tried to emit this type using Reflection.Emit, the assertion would try to prevent
    // this combination of `modreq(InAttribute)` and `T&` which contains a generic type parameter.
    // Yet it's a perfectly valid signature.
}
```

/cc @AtsushiKan