### PR TITLE
Add tests for struct-related issues

### DIFF
--- a/tests/src/JIT/Regression/JitBlue/GitHub_1133/GitHub_1133.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_1133/GitHub_1133.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class GitHub_1133
+{
+    static Guid s_dt;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Guid TestValueTypesInInlinedMethods()
+    {
+        var dt = new Guid();
+
+        // This method, once inlined, should directly copy the newly created 'Guid' to s_dt.
+        Method1(dt);
+
+        return dt;
+    }
+
+    private static void Method1(Guid dt)
+    {
+        Method2(dt);
+    }
+
+    private static void Method2(Guid dt)
+    {
+        Method3(dt);
+    }
+
+    private static void Method3(Guid dt)
+    {
+        s_dt = dt;
+    }
+    
+    public static int Main()
+    {
+        int result = 100;
+        try
+        {
+            Guid g = TestValueTypesInInlinedMethods();
+            if (g != s_dt)
+            {
+                result = -1;
+            }
+        }
+        catch (Exception)
+        {
+            result = -1;
+        }
+
+        return result;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_1133/GitHub_1133.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_1133/GitHub_1133.csproj
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-B8089FFA8D79}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_11407/GitHub_11407.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_11407/GitHub_11407.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// This test has two effectively identical initializations of an
+// array of byte vs. an array of structs containing a single byte field.
+// They should generate the same code.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class GitHub_11407
+{
+    struct foo { public byte b1, b2, b3, b4; }
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static foo getfoo() { return new foo(); }
+
+    static int Main()
+    {
+        int returnVal = 100;
+        foo myFoo = getfoo();
+        if (myFoo.b1 != 0 || myFoo.b2 != 0 || myFoo.b3 != 0 || myFoo.b4 != 0)
+        {
+            returnVal = -1;
+        }
+        return returnVal;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_11407/GitHub_11407.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_11407/GitHub_11407.csproj
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-B8089FFA8D79}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_1161/GitHub_1161.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_1161/GitHub_1161.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// This test illustrates a limitation in the JIT in that it will not promote
+// a struct that has a single double register. See GitHub issue #1161.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class GitHub_1161
+{
+    struct Number
+    {
+        private double value;
+        public static implicit operator Number(double value)
+        {
+            return new Number { value = value };
+        }
+        public static implicit operator double(Number number)
+        {
+            return number.value;
+        }
+        public static Number operator +(Number x, Number y)
+        {
+            return x.value + y.value;
+        }
+    }
+    class Program
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static int Test()
+        {
+            Number x = 4, y = 2;
+            return (int)(x + y);
+        }
+        static int Main()
+        {
+            return (Test() == 6) ? 100 : -1;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_1161/GitHub_1161.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_1161/GitHub_1161.csproj
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-B8089FFA8D79}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_11816/GitHub_11816.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_11816/GitHub_11816.cs
@@ -1,0 +1,134 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// This test captures the redundant struct zeroing from GitHub issue #11816.
+// Since the issue was filed, the 'TestStructManuallyInlined' case has apparently
+// gotten worse, as there is a MEMSET of the large struct to 0.
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+class GitHub_11816
+{
+    struct StructType
+    {
+        public Vector<float> A;
+        public Vector<float> B;
+        public Vector<float> C;
+        public Vector<float> D;
+        public Vector<float> E;
+        public Vector<float> F;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<float> GetVector()
+    {
+        return new Vector<float>(100);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void DoSomeWorkWithAStruct(ref Vector<float> source, out Vector<float> result)
+    {
+        StructType u;
+        u.A = new Vector<float>(2) * source;
+        u.B = new Vector<float>(3) * source;
+        u.C = new Vector<float>(4) * source;
+        u.D = new Vector<float>(5) * source;
+        u.E = new Vector<float>(6) * source;
+        u.F = new Vector<float>(7) * source;
+        result = u.A + u.B + u.C + u.D + u.E + u.F;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static float TestStruct()
+    {
+        Vector<float> f = GetVector();
+        for (int i = 0; i < 100; ++i)
+        {
+            DoSomeWorkWithAStruct(ref f, out f);
+        }
+        return f[0];
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static void DoSomeWorkWithAStructAggressiveInlining(ref Vector<float> source, out Vector<float> result)
+    {
+        StructType u;
+        u.A = new Vector<float>(2) * source;
+        u.B = new Vector<float>(3) * source;
+        u.C = new Vector<float>(4) * source;
+        u.D = new Vector<float>(5) * source;
+        u.E = new Vector<float>(6) * source;
+        u.F = new Vector<float>(7) * source;
+        result = u.A + u.B + u.C + u.D + u.E + u.F;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static float TestStructAggressiveInlining()
+    {
+        Vector<float> f = GetVector();
+        for (int i = 0; i < 100; ++i)
+        {
+            DoSomeWorkWithAStructAggressiveInlining(ref f, out f);
+        }
+        return f[0];
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static float TestStructManuallyInlined()
+    {
+        Vector<float> f = GetVector();
+        for (int i = 0; i < 100; ++i)
+        {
+            StructType u;
+            u.A = new Vector<float>(2) * f;
+            u.B = new Vector<float>(3) * f;
+            u.C = new Vector<float>(4) * f;
+            u.D = new Vector<float>(5) * f;
+            u.E = new Vector<float>(6) * f;
+            u.F = new Vector<float>(7) * f;
+            f = u.A + u.B + u.C + u.D + u.E + u.F;
+        }
+        return f[0];
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static void DoSomeWorkStructless(ref Vector<float> source, out Vector<float> result)
+    {
+        var a = new Vector<float>(2) * source;
+        var b = new Vector<float>(3) * source;
+        var c = new Vector<float>(4) * source;
+        var d = new Vector<float>(5) * source;
+        var e = new Vector<float>(6) * source;
+        var f = new Vector<float>(7) * source;
+        result = d + e + f + a + b + c;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static float TestStructless()
+    {
+        Vector<float> f = GetVector();
+        for (int i = 0; i < 100; ++i)
+        {
+            DoSomeWorkStructless(ref f, out f);
+        }
+        return f[0];
+    }
+
+    static int Main()
+    {
+        float value = 0.0F;
+        value += TestStruct();
+        value -= TestStructAggressiveInlining();
+        value += TestStructManuallyInlined();
+        value -= TestStructless();
+        if (!float.IsNaN(value))
+        {
+            Console.WriteLine(value.ToString());
+            return -1;
+        }
+        return 100;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_11816/GitHub_11816.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_11816/GitHub_11816.csproj
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-B8089FFA8D79}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_2003/GitHub_2003.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_2003/GitHub_2003.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// This test has two effectively identical initializations of an
+// array of byte vs. an array of structs containing a single byte field.
+// They should generate the same code.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class GitHub_2003
+{
+    static byte[] byteArray;
+    struct MyByte
+    {
+        private readonly byte _byte;
+        public MyByte(byte b)
+        {
+            _byte = b;
+        }
+
+        public byte Value
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return _byte; }
+        }
+    }
+    static MyByte[] myByteArray;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void initByteArray()
+    {
+        for (int j = 0; j < byteArray.Length; j++)
+        {
+            byteArray[j] = 123;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void initMyByteArray()
+    {
+        for (int j = 0; j < myByteArray.Length; j++)
+        {
+            myByteArray[j] = new MyByte(123);
+        }
+    }
+
+    static int Main()
+    {
+        byteArray = new byte[100];
+        myByteArray = new MyByte[100];
+        initByteArray();
+        initMyByteArray();
+        int returnVal = 100;
+        for (int j = 0; j < 100; j++)
+        {
+            if (byteArray[j] != myByteArray[j].Value)
+            {
+                returnVal = -1;
+            }
+        }
+        return returnVal;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_2003/GitHub_2003.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_2003/GitHub_2003.csproj
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-B8089FFA8D79}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_5556/GitHub_5556.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_5556/GitHub_5556.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// This test has two effectively identical methods, one of which copies
+// its input paramter to a local, allowing it to be promoted.
+// The JIT should be able to generate identical code for these.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class GitHub_5556
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static long SpanAsParam(Span<long> span)
+    {
+        long value = 0;
+        for (int i = 0; i < span.Length; i++)
+        {
+            value = span[i];
+        }
+        return value;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static long SpanWithLocalCopy(Span<long> span)
+    {
+        var spanLocal = span;
+        long value = 0;
+        for (int i = 0; i < spanLocal.Length; i++)
+        {
+            value = spanLocal[i];
+        }
+        return value;
+    }
+
+    static int Main()
+    {
+        long[] a = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        Span<long> mySpan = new Span<long>(a);
+        int returnVal = 100;
+        if (SpanAsParam(mySpan) != 9)
+        {
+            returnVal = -1;
+        }
+        if (SpanWithLocalCopy(mySpan) != 9)
+        {
+            returnVal = -1;
+        }
+        return returnVal;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_5556/GitHub_5556.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_5556/GitHub_5556.csproj
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-B8089FFA8D79}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Add tests for struct-related issues, where code was provided in the issue description, but did not yet exist in the benchmarks or tests. This will make it easier to check that future enhancements have the desired impact on these code sequences.