### PR TITLE
Update SynchronizationContext due to decouple S.R.WindowsRuntime and S.P.Corelib

### DIFF
--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/FrameworkEventSource.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/FrameworkEventSource.cs
@@ -32,6 +32,7 @@ namespace System.Diagnostics.Tracing
     sealed internal class FrameworkEventSource : EventSource
     {
         // Defines the singleton instance for the Resources ETW provider
+        // This field wil be accessed through reflection by System.Runtime.WindowsRuntime
         public static readonly FrameworkEventSource Log = new FrameworkEventSource();
 
         // Keyword definitions.  These represent logical groups of events that can be turned on and off independently


### PR DESCRIPTION
Currently We are try to compile S.R.WindowsRuntime using contract assemblies to break the dependency between S.R.WindowsRuntime and S.P.Corelib, thus S.R.WindowsRuntime can't direct implement WinRTSynchronizationContextFactoryBase unless we expose WinRTSynchronizationContextFactoryBase into contract assemblies.

Since there is only 1 method inside WinRTSynchronizationContextFactoryBase and it might be OK to use reflection to create WinRT SynchronizationContext instance.

There is a related PR in corefx https://github.com/dotnet/corefx/pull/29731