### PR TITLE
Making IProducerConsumerCollectionDebugView APIs public

### DIFF
--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -60,9 +60,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\CLSCompliantAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Comparer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Concurrent\ConcurrentQueue.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Concurrent\ConcurrentQueue_Segment.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Concurrent\ConcurrentQueueSegment.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Concurrent\IProducerConsumerCollection.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Concurrent\ProducerConsumerCollectionDebugView.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Concurrent\IProducerConsumerCollectionDebugView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\DictionaryEntry.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Generic\Dictionary.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Generic\ICollection.cs" />

--- a/src/System.Private.CoreLib/shared/System/Collections/Concurrent/ConcurrentQueueSegment.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Concurrent/ConcurrentQueueSegment.cs
@@ -14,7 +14,7 @@ namespace System.Collections.Concurrent
     /// These segments are linked together to form the unbounded <see cref="ConcurrentQueue{T}"/>. 
     /// </summary>
     [DebuggerDisplay("Capacity = {Capacity}")]
-    internal sealed class Segment<T>
+    internal sealed class ConcurrentQueueSegment<T>
     {
         // Segment design is inspired by the algorithm outlined at:
         // http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue
@@ -33,14 +33,14 @@ namespace System.Collections.Concurrent
         internal bool _frozenForEnqueues;
 #pragma warning disable 0649 // some builds don't assign to this field
         /// <summary>The segment following this one in the queue, or null if this segment is the last in the queue.</summary>
-        internal Segment<T> _nextSegment;
+        internal ConcurrentQueueSegment<T> _nextSegment;
 #pragma warning restore 0649
 
         /// <summary>Creates the segment.</summary>
         /// <param name="boundedLength">
         /// The maximum number of elements the segment can contain.  Must be a power of 2.
         /// </param>
-        internal Segment(int boundedLength)
+        internal ConcurrentQueueSegment(int boundedLength)
         {
             // Validate the length
             Debug.Assert(boundedLength >= 2, $"Must be >= 2, got {boundedLength}");

--- a/src/System.Private.CoreLib/shared/System/Collections/Concurrent/IProducerConsumerCollectionDebugView.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Concurrent/IProducerConsumerCollectionDebugView.cs
@@ -11,7 +11,7 @@ namespace System.Collections.Concurrent
     /// collection's contents at a point in time.
     /// </summary>
     /// <typeparam name="T">The type of elements stored within.</typeparam>
-    internal sealed class ProducerConsumerCollectionDebugView<T>
+    internal sealed class IProducerConsumerCollectionDebugView<T>
     {
         private readonly IProducerConsumerCollection<T> _collection; // The collection being viewed.
 
@@ -19,7 +19,7 @@ namespace System.Collections.Concurrent
         /// Constructs a new debugger view object for the provided collection object.
         /// </summary>
         /// <param name="collection">A collection to browse in the debugger.</param>
-        internal ProducerConsumerCollectionDebugView(IProducerConsumerCollection<T> collection)
+        public IProducerConsumerCollectionDebugView(IProducerConsumerCollection<T> collection)
         {
             if (collection == null)
             {
@@ -33,7 +33,7 @@ namespace System.Collections.Concurrent
         /// Returns a snapshot of the underlying collection's elements.
         /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        internal T[] Items
+        public T[] Items
         {
             get { return _collection.ToArray(); }
         }

--- a/src/System.Private.CoreLib/src/System/Collections/Concurrent/ConcurrentStack.cs
+++ b/src/System.Private.CoreLib/src/System/Collections/Concurrent/ConcurrentStack.cs
@@ -35,7 +35,7 @@ namespace System.Collections.Concurrent
     /// concurrently from multiple threads.
     /// </remarks>
     [DebuggerDisplay("Count = {Count}")]
-    [DebuggerTypeProxy(typeof(ProducerConsumerCollectionDebugView<>))]
+    [DebuggerTypeProxy(typeof(IProducerConsumerCollectionDebugView<>))]
     internal class ConcurrentStack<T> : IProducerConsumerCollection<T>, IReadOnlyCollection<T>
     {
         /// <summary>


### PR DESCRIPTION
Moving ConcurrentQueue to shared

Applying code review feedbacks: 

1- Making IProducerConsumerCollectionDebugView apis public

2- Renaming 
- Segment to ConcurrentQueueSegment. 
- ProducerConsumerCollectionDebugView  to IProducerConsumerCollectionDebugView 

Fixes: #17751

cc: @jkotas @stephentoub @danmosemsft @safern 