### PR TITLE
Replace sizeof(TADDR) in Zap

### DIFF
--- a/src/zap/common.h
+++ b/src/zap/common.h
@@ -33,6 +33,7 @@
 #include "corcompile.h"
 #include "iceefilegen.h"
 #include "corpriv.h"
+#include "gcinfotypes.h"
 
 #include "holder.h"
 #include "strongname.h"

--- a/src/zap/zapcode.cpp
+++ b/src/zap/zapcode.cpp
@@ -1676,7 +1676,7 @@ void ZapColdCodeMap::Save(ZapWriter* pZapWriter)
 
 DWORD ZapHelperThunk::GetSize()
 {
-    return (m_dwHelper & CORCOMPILE_HELPER_PTR) ? sizeof(TADDR) : HELPER_TABLE_ENTRY_LEN;
+    return (m_dwHelper & CORCOMPILE_HELPER_PTR) ? TARGET_POINTER_SIZE : HELPER_TABLE_ENTRY_LEN;
 }
 
 void ZapHelperThunk::Save(ZapWriter * pZapWriter)

--- a/src/zap/zapcode.h
+++ b/src/zap/zapcode.h
@@ -792,7 +792,7 @@ public:
 
     virtual UINT GetAlignment()
     {
-        return sizeof(TADDR);
+        return TARGET_POINTER_SIZE;
     }
 
     virtual ZapNodeType GetType()
@@ -829,7 +829,7 @@ public:
     }
     virtual UINT GetAlignment()
     {
-        return sizeof(TADDR);
+        return TARGET_POINTER_SIZE;
     }
     virtual DWORD GetSize();
     virtual void Save(ZapWriter* pZapWriter);

--- a/src/zap/zapimage.cpp
+++ b/src/zap/zapimage.cpp
@@ -158,7 +158,7 @@ void ZapImage::InitializeSections()
     m_pUnwindDataTable = new (GetHeap()) ZapUnwindDataTable(this);
 #endif
 
-    m_pEEInfoTable = ZapBlob::NewAlignedBlob(this, NULL, sizeof(CORCOMPILE_EE_INFO_TABLE), sizeof(TADDR));
+    m_pEEInfoTable = ZapBlob::NewAlignedBlob(this, NULL, sizeof(CORCOMPILE_EE_INFO_TABLE), TARGET_POINTER_SIZE);
     m_pEETableSection->Place(m_pEEInfoTable);
 
     //
@@ -331,7 +331,7 @@ void ZapImage::AllocateVirtualSections()
 
         m_pPreloadSections[CORCOMPILE_SECTION_RVA_STATICS_HOT] = NewVirtualSection(pDataSection, IBCProfiledSection | HotRange | RVAStaticsSection);
 
-        m_pDelayLoadInfoTableSection[ZapImportSectionType_Eager] = NewVirtualSection(pDataSection, IBCUnProfiledSection | HotRange | DelayLoadInfoTableEagerSection, sizeof(TADDR));
+        m_pDelayLoadInfoTableSection[ZapImportSectionType_Eager] = NewVirtualSection(pDataSection, IBCUnProfiledSection | HotRange | DelayLoadInfoTableEagerSection, TARGET_POINTER_SIZE);
 
         //
         // Allocate dynamic info tables
@@ -340,12 +340,12 @@ void ZapImage::AllocateVirtualSections()
         // Place the HOT CorCompileTables now, the cold ones would be placed later in this routine (after other HOT sections)
         for (int i=0; i<ZapImportSectionType_Count; i++)
         {
-            m_pDelayLoadInfoTableSection[i] = NewVirtualSection(pDataSection, IBCProfiledSection | HotRange | DelayLoadInfoTableSection, sizeof(TADDR));
+            m_pDelayLoadInfoTableSection[i] = NewVirtualSection(pDataSection, IBCProfiledSection | HotRange | DelayLoadInfoTableSection, TARGET_POINTER_SIZE);
         }
 
-        m_pDynamicHelperCellSection = NewVirtualSection(pDataSection, IBCProfiledSection | HotColdSortedRange | ExternalMethodDataSection, sizeof(TADDR));
+        m_pDynamicHelperCellSection = NewVirtualSection(pDataSection, IBCProfiledSection | HotColdSortedRange | ExternalMethodDataSection, TARGET_POINTER_SIZE);
 
-        m_pExternalMethodCellSection = NewVirtualSection(pDataSection, IBCProfiledSection | HotColdSortedRange | ExternalMethodThunkSection, sizeof(TADDR));
+        m_pExternalMethodCellSection = NewVirtualSection(pDataSection, IBCProfiledSection | HotColdSortedRange | ExternalMethodThunkSection, TARGET_POINTER_SIZE);
 
         // m_pStubDispatchCellSection is  deliberately placed  directly after
         // the last m_pDelayLoadInfoTableSection (all .data sections go together in the order indicated).
@@ -359,12 +359,12 @@ void ZapImage::AllocateVirtualSections()
         // make sure the hot data is grouped with hot data in the
         // m_pDelayLoadInfoTableSection sections.
 
-        m_pStubDispatchCellSection = NewVirtualSection(pDataSection, IBCProfiledSection | HotColdSortedRange | StubDispatchDataSection, sizeof(TADDR));
+        m_pStubDispatchCellSection = NewVirtualSection(pDataSection, IBCProfiledSection | HotColdSortedRange | StubDispatchDataSection, TARGET_POINTER_SIZE);
 
         // Earlier we placed the HOT corCompile tables. Now place the cold ones after the stub dispatch cell section. 
         for (int i=0; i<ZapImportSectionType_Count; i++)
         {
-            m_pDelayLoadInfoTableSection[ZapImportSectionType_Cold + i] = NewVirtualSection(pDataSection, IBCProfiledSection | ColdRange | DelayLoadInfoTableSection, sizeof(TADDR));
+            m_pDelayLoadInfoTableSection[ZapImportSectionType_Cold + i] = NewVirtualSection(pDataSection, IBCProfiledSection | ColdRange | DelayLoadInfoTableSection, TARGET_POINTER_SIZE);
         }
 
         //
@@ -373,26 +373,26 @@ void ZapImage::AllocateVirtualSections()
 
         // This is everyhing that is assumed to be warm in the first strata
         // of non-profiled scenarios.  MethodTables related to objects etc.
-        m_pPreloadSections[CORCOMPILE_SECTION_WARM] = NewVirtualSection(pDataSection, IBCProfiledSection | WarmRange | EEDataSection, sizeof(TADDR));
+        m_pPreloadSections[CORCOMPILE_SECTION_WARM] = NewVirtualSection(pDataSection, IBCProfiledSection | WarmRange | EEDataSection, TARGET_POINTER_SIZE);
 
         m_pPreloadSections[CORCOMPILE_SECTION_RVA_STATICS_COLD] = NewVirtualSection(pDataSection, IBCProfiledSection | ColdRange | RVAStaticsSection);
 
         // In an ideal world these are cold in both profiled and the first strata
         // of non-profiled scenarios (i.e. no reflection, etc. )  The sections at the
         // bottom correspond to further strata of non-profiled scenarios.
-        m_pPreloadSections[CORCOMPILE_SECTION_CLASS_COLD] = NewVirtualSection(pDataSection, IBCProfiledSection | ColdRange | ClassSection, sizeof(TADDR));
-        m_pPreloadSections[CORCOMPILE_SECTION_CROSS_DOMAIN_INFO] = NewVirtualSection(pDataSection, IBCUnProfiledSection | ColdRange | CrossDomainInfoSection, sizeof(TADDR));
-        m_pPreloadSections[CORCOMPILE_SECTION_METHOD_DESC_COLD] = NewVirtualSection(pDataSection, IBCProfiledSection | ColdRange | MethodDescSection, sizeof(TADDR));
-        m_pPreloadSections[CORCOMPILE_SECTION_METHOD_DESC_COLD_WRITEABLE] = NewVirtualSection(pDataSection, IBCProfiledSection | ColdRange | MethodDescWriteableSection, sizeof(TADDR));
-        m_pPreloadSections[CORCOMPILE_SECTION_MODULE_COLD] = NewVirtualSection(pDataSection, IBCProfiledSection | ColdRange | ModuleSection, sizeof(TADDR));
-        m_pPreloadSections[CORCOMPILE_SECTION_DEBUG_COLD] = NewVirtualSection(pDataSection, IBCUnProfiledSection | ColdRange | DebugSection, sizeof(TADDR));
+        m_pPreloadSections[CORCOMPILE_SECTION_CLASS_COLD] = NewVirtualSection(pDataSection, IBCProfiledSection | ColdRange | ClassSection, TARGET_POINTER_SIZE);
+        m_pPreloadSections[CORCOMPILE_SECTION_CROSS_DOMAIN_INFO] = NewVirtualSection(pDataSection, IBCUnProfiledSection | ColdRange | CrossDomainInfoSection, TARGET_POINTER_SIZE);
+        m_pPreloadSections[CORCOMPILE_SECTION_METHOD_DESC_COLD] = NewVirtualSection(pDataSection, IBCProfiledSection | ColdRange | MethodDescSection, TARGET_POINTER_SIZE);
+        m_pPreloadSections[CORCOMPILE_SECTION_METHOD_DESC_COLD_WRITEABLE] = NewVirtualSection(pDataSection, IBCProfiledSection | ColdRange | MethodDescWriteableSection, TARGET_POINTER_SIZE);
+        m_pPreloadSections[CORCOMPILE_SECTION_MODULE_COLD] = NewVirtualSection(pDataSection, IBCProfiledSection | ColdRange | ModuleSection, TARGET_POINTER_SIZE);
+        m_pPreloadSections[CORCOMPILE_SECTION_DEBUG_COLD] = NewVirtualSection(pDataSection, IBCUnProfiledSection | ColdRange | DebugSection, TARGET_POINTER_SIZE);
 
         //
         // If we're instrumenting allocate a section for writing profile data
         //
         if (m_zapper->m_pOpt->m_compilerFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_BBINSTR))
         {
-            m_pInstrumentSection = NewVirtualSection(pDataSection, IBCUnProfiledSection | ColdRange | InstrumentSection, sizeof(TADDR));
+            m_pInstrumentSection = NewVirtualSection(pDataSection, IBCUnProfiledSection | ColdRange | InstrumentSection, TARGET_POINTER_SIZE);
         }
     }
 
@@ -419,14 +419,14 @@ void ZapImage::AllocateVirtualSections()
         m_pHelperTableSection               = NewVirtualSection(pXDataSection, IBCProfiledSection | HotColdSortedRange| HelperTableSection, HELPER_TABLE_ALIGN);
 
         // hot for writing, i.e. profiling has indicated a write to this item, so at least one write likely per item at some point
-        m_pPreloadSections[CORCOMPILE_SECTION_METHOD_PRECODE_WRITE] = NewVirtualSection(pXDataSection, IBCProfiledSection | HotRange | MethodPrecodeWriteSection, sizeof(TADDR));
-        m_pPreloadSections[CORCOMPILE_SECTION_METHOD_PRECODE_HOT] = NewVirtualSection(pXDataSection, IBCProfiledSection | HotRange | MethodPrecodeSection, sizeof(TADDR));
+        m_pPreloadSections[CORCOMPILE_SECTION_METHOD_PRECODE_WRITE] = NewVirtualSection(pXDataSection, IBCProfiledSection | HotRange | MethodPrecodeWriteSection, TARGET_POINTER_SIZE);
+        m_pPreloadSections[CORCOMPILE_SECTION_METHOD_PRECODE_HOT] = NewVirtualSection(pXDataSection, IBCProfiledSection | HotRange | MethodPrecodeSection, TARGET_POINTER_SIZE);
 
         //
         // cold sections
         //
-        m_pPreloadSections[CORCOMPILE_SECTION_METHOD_PRECODE_COLD] = NewVirtualSection(pXDataSection, IBCProfiledSection | ColdRange | MethodPrecodeSection, sizeof(TADDR));
-        m_pPreloadSections[CORCOMPILE_SECTION_METHOD_PRECODE_COLD_WRITEABLE] = NewVirtualSection(pXDataSection, IBCProfiledSection | ColdRange | MethodPrecodeWriteableSection, sizeof(TADDR));
+        m_pPreloadSections[CORCOMPILE_SECTION_METHOD_PRECODE_COLD] = NewVirtualSection(pXDataSection, IBCProfiledSection | ColdRange | MethodPrecodeSection, TARGET_POINTER_SIZE);
+        m_pPreloadSections[CORCOMPILE_SECTION_METHOD_PRECODE_COLD_WRITEABLE] = NewVirtualSection(pXDataSection, IBCProfiledSection | ColdRange | MethodPrecodeWriteableSection, TARGET_POINTER_SIZE);
     }
 
     {
@@ -520,8 +520,8 @@ void ZapImage::AllocateVirtualSections()
         // actually find any duplicates and put those in a small section.  For the rest, where there wasn't a duplicate in the entire image, we leave the
         // singleton in its normal place in the READONLY_HOT section, which was selected carefully by IBC.
         //
-        m_pPreloadSections[CORCOMPILE_SECTION_READONLY_SHARED_HOT] = NewVirtualSection(pTextSection, IBCProfiledSection | HotRange | ReadonlySharedSection, sizeof(TADDR));
-        m_pPreloadSections[CORCOMPILE_SECTION_READONLY_HOT] = NewVirtualSection(pTextSection, IBCProfiledSection | HotRange | ReadonlySection, sizeof(TADDR));
+        m_pPreloadSections[CORCOMPILE_SECTION_READONLY_SHARED_HOT] = NewVirtualSection(pTextSection, IBCProfiledSection | HotRange | ReadonlySharedSection, TARGET_POINTER_SIZE);
+        m_pPreloadSections[CORCOMPILE_SECTION_READONLY_HOT] = NewVirtualSection(pTextSection, IBCProfiledSection | HotRange | ReadonlySection, TARGET_POINTER_SIZE);
 
         //
         // GC Info for methods which were touched during profiling but didn't explicitly have
@@ -571,8 +571,8 @@ void ZapImage::AllocateVirtualSections()
         m_pUnwindDataSection = NewVirtualSection(pTextSection, IBCProfiledSection | WarmRange | ColdRange | UnwindDataSection, sizeof(DWORD));
 #endif // defined(WIN64EXCEPTIONS)
 
-        m_pPreloadSections[CORCOMPILE_SECTION_READONLY_WARM] = NewVirtualSection(pTextSection, IBCProfiledSection | WarmRange | ReadonlySection, sizeof(TADDR));
-        m_pPreloadSections[CORCOMPILE_SECTION_READONLY_VCHUNKS_AND_DICTIONARY] = NewVirtualSection(pTextSection, IBCProfiledSection | WarmRange | ReadonlySection, sizeof(TADDR));
+        m_pPreloadSections[CORCOMPILE_SECTION_READONLY_WARM] = NewVirtualSection(pTextSection, IBCProfiledSection | WarmRange | ReadonlySection, TARGET_POINTER_SIZE);
+        m_pPreloadSections[CORCOMPILE_SECTION_READONLY_VCHUNKS_AND_DICTIONARY] = NewVirtualSection(pTextSection, IBCProfiledSection | WarmRange | ReadonlySection, TARGET_POINTER_SIZE);
 
         //
         // GC Info for methods which were not touched in profiling
@@ -581,7 +581,7 @@ void ZapImage::AllocateVirtualSections()
 
         m_pDelayLoadInfoDelayListSectionCold = NewVirtualSection(pTextSection, IBCProfiledSection | ColdRange | DelayLoadInfoDelayListSection, sizeof(DWORD));
 
-        m_pPreloadSections[CORCOMPILE_SECTION_READONLY_COLD] = NewVirtualSection(pTextSection, IBCProfiledSection | ColdRange | ReadonlySection, sizeof(TADDR));
+        m_pPreloadSections[CORCOMPILE_SECTION_READONLY_COLD] = NewVirtualSection(pTextSection, IBCProfiledSection | ColdRange | ReadonlySection, TARGET_POINTER_SIZE);
 
         //
         // Allocate the cold code section near the end of the image

--- a/src/zap/zapimport.cpp
+++ b/src/zap/zapimport.cpp
@@ -128,16 +128,16 @@ static const struct ImportSectionProperties
     BYTE                    Type;
     BYTE                    EntrySize;
     WORD                    Flags;
-}   
+}
 c_ImportSectionProperties[ZapImportSectionType_Count] =
 {
-    { /* ZapImportSectionType_Handle,       */ CORCOMPILE_IMPORT_TYPE_UNKNOWN,         0,              0                               },
-    { /* ZapImportSectionType_TypeHandle,   */ CORCOMPILE_IMPORT_TYPE_TYPE_HANDLE,     sizeof(TADDR),  0                               },
-    { /* ZapImportSectionType_MethodHandle, */ CORCOMPILE_IMPORT_TYPE_METHOD_HANDLE,   sizeof(TADDR),  0                               },
+    { /* ZapImportSectionType_Handle,       */ CORCOMPILE_IMPORT_TYPE_UNKNOWN,         0,                    0                               },
+    { /* ZapImportSectionType_TypeHandle,   */ CORCOMPILE_IMPORT_TYPE_TYPE_HANDLE,     TARGET_POINTER_SIZE,  0                               },
+    { /* ZapImportSectionType_MethodHandle, */ CORCOMPILE_IMPORT_TYPE_METHOD_HANDLE,   TARGET_POINTER_SIZE,  0                               },
 #ifdef _TARGET_ARM_
-    { /* ZapImportSectionType_PCode,        */ CORCOMPILE_IMPORT_TYPE_UNKNOWN,         0,              CORCOMPILE_IMPORT_FLAGS_PCODE   },
+    { /* ZapImportSectionType_PCode,        */ CORCOMPILE_IMPORT_TYPE_UNKNOWN,         0,                    CORCOMPILE_IMPORT_FLAGS_PCODE   },
 #endif
-    { /* ZapImportSectionType_StringHandle, */ CORCOMPILE_IMPORT_TYPE_STRING_HANDLE,   sizeof(TADDR),  0                               },
+    { /* ZapImportSectionType_StringHandle, */ CORCOMPILE_IMPORT_TYPE_STRING_HANDLE,   TARGET_POINTER_SIZE,  0                               },
 };
 
 void ZapImportTable::PlaceImport(ZapImport * pImport)
@@ -229,8 +229,8 @@ void ZapImportTable::PlaceFixups(ZapImport ** pImports, NibbleWriter& writer)
         int tableIndex = pImport->GetSectionIndex();
         unsigned offset = pImport->GetOffset();
 
-        _ASSERTE(offset % sizeof(SIZE_T) == 0);
-        offset /= sizeof(SIZE_T);
+        _ASSERTE(offset % TARGET_POINTER_SIZE == 0);
+        offset /= TARGET_POINTER_SIZE;
 
         if (tableIndex != curTableIndex)
         {
@@ -607,12 +607,12 @@ public:
 
     virtual DWORD GetSize()
     {
-        return sizeof(TADDR);
+        return TARGET_POINTER_SIZE;
     }
 
     virtual UINT GetAlignment()
     {
-        return sizeof(TADDR);
+        return TARGET_POINTER_SIZE;
     }
 
     virtual ZapNodeType GetType()
@@ -661,7 +661,7 @@ void ZapImportSectionSignatures::PlaceStubDispatchCell(ZapImport * pImport)
     if (m_pImportSection->GetNodeCount() == 0)
     {
         m_dwIndex = m_pImage->GetImportSectionsTable()->Append(CORCOMPILE_IMPORT_TYPE_STUB_DISPATCH, CORCOMPILE_IMPORT_FLAGS_PCODE,
-            sizeof(TADDR), m_pImportSection, this, m_pGCRefMapTable);
+            TARGET_POINTER_SIZE, m_pImportSection, this, m_pGCRefMapTable);
     }
 
 #ifdef FEATURE_READYTORUN_COMPILER
@@ -706,12 +706,12 @@ public:
 
     virtual DWORD GetSize()
     {
-        return sizeof(TADDR);
+        return TARGET_POINTER_SIZE;
     }
 
     virtual UINT GetAlignment()
     {
-        return sizeof(TADDR);
+        return TARGET_POINTER_SIZE;
     }
 
     virtual ZapNodeType GetType()
@@ -763,7 +763,7 @@ void ZapImportSectionSignatures::PlaceExternalMethodCell(ZapImport * pImport)
     if (m_pImportSection->GetNodeCount() == 0)
     {
         m_dwIndex = m_pImage->GetImportSectionsTable()->Append(CORCOMPILE_IMPORT_TYPE_STUB_DISPATCH, CORCOMPILE_IMPORT_FLAGS_PCODE,
-            sizeof(TADDR), m_pImportSection, this, m_pGCRefMapTable);
+            TARGET_POINTER_SIZE, m_pImportSection, this, m_pGCRefMapTable);
     }
 
 #ifdef FEATURE_READYTORUN_COMPILER
@@ -1320,7 +1320,7 @@ public:
 
     virtual DWORD GetSize()
     {
-        return 2 * sizeof(TADDR);
+        return 2 * TARGET_POINTER_SIZE;
     }
 
     virtual void Save(ZapWriter * pZapWriter)
@@ -1440,7 +1440,7 @@ public:
     virtual DWORD GetSize()
     {
         // fixup cell, 3 pointers to interception method (Enter/Leave/Tailcall) and opaque handle
-        return kZapProfilingHandleImportValueIndexCount * sizeof(TADDR);
+        return kZapProfilingHandleImportValueIndexCount * TARGET_POINTER_SIZE;
     }
 
     virtual void Save(ZapWriter * pZapWriter)
@@ -1682,12 +1682,12 @@ public:
 
     virtual DWORD GetSize()
     {
-        return sizeof(TADDR);
+        return TARGET_POINTER_SIZE;
     }
 
     virtual UINT GetAlignment()
     {
-        return sizeof(TADDR);
+        return TARGET_POINTER_SIZE;
     }
 
     virtual ZapNodeType GetType()
@@ -1773,7 +1773,7 @@ void ZapImportSectionSignatures::PlaceDynamicHelperCell(ZapImport * pImport)
     if (m_pImportSection->GetNodeCount() == 0)
     {
         m_dwIndex = m_pImage->GetImportSectionsTable()->Append(CORCOMPILE_IMPORT_TYPE_UNKNOWN, CORCOMPILE_IMPORT_FLAGS_PCODE,
-            sizeof(TADDR), m_pImportSection, this, m_pGCRefMapTable);
+            TARGET_POINTER_SIZE, m_pImportSection, this, m_pGCRefMapTable);
     }
 
     // Create the delay load helper

--- a/src/zap/zapimport.h
+++ b/src/zap/zapimport.h
@@ -88,12 +88,12 @@ public:
 
     virtual DWORD GetSize()
     {
-        return sizeof(TADDR);
+        return TARGET_POINTER_SIZE;
     }
 
     virtual UINT GetAlignment()
     {
-        return sizeof(TADDR);
+        return TARGET_POINTER_SIZE;
     }
 
     virtual void Save(ZapWriter * pZapWriter);

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -1070,7 +1070,7 @@ void ZapInfo::allocMem(
         }
         else if (optForSize || (roDataSize < 8))
         {
-            align = sizeof(TADDR);
+            align = TARGET_POINTER_SIZE;
         }
         else
         {
@@ -1741,13 +1741,13 @@ void * ZapInfo::getHelperFtn (CorInfoHelpFunc ftnNum, void **ppIndirection)
     switch (ftnNum)
     {
     case CORINFO_HELP_PROF_FCN_ENTER:
-        *ppIndirection = m_pImage->GetInnerPtr(GetProfilingHandleImport(), kZapProfilingHandleImportValueIndexEnterAddr * sizeof(TADDR));
+        *ppIndirection = m_pImage->GetInnerPtr(GetProfilingHandleImport(), kZapProfilingHandleImportValueIndexEnterAddr * TARGET_POINTER_SIZE);
         return NULL;
     case CORINFO_HELP_PROF_FCN_LEAVE:
-        *ppIndirection = m_pImage->GetInnerPtr(GetProfilingHandleImport(), kZapProfilingHandleImportValueIndexLeaveAddr * sizeof(TADDR));
+        *ppIndirection = m_pImage->GetInnerPtr(GetProfilingHandleImport(), kZapProfilingHandleImportValueIndexLeaveAddr * TARGET_POINTER_SIZE);
         return NULL;
     case CORINFO_HELP_PROF_FCN_TAILCALL:
-        *ppIndirection = m_pImage->GetInnerPtr(GetProfilingHandleImport(), kZapProfilingHandleImportValueIndexTailcallAddr * sizeof(TADDR));
+        *ppIndirection = m_pImage->GetInnerPtr(GetProfilingHandleImport(), kZapProfilingHandleImportValueIndexTailcallAddr * TARGET_POINTER_SIZE);
         return NULL;
 #ifdef _TARGET_AMD64_
     case CORINFO_HELP_STOP_FOR_GC:
@@ -2036,7 +2036,7 @@ void ZapInfo::GetProfilingHandle(BOOL                      *pbHookFunction,
     //
     // Profiling handle is opaque token. It does not have to be aligned thus we can not store it in the same location as token.
     //
-    *pProfilerHandle = m_pImage->GetInnerPtr(GetProfilingHandleImport(), kZapProfilingHandleImportValueIndexClientData * sizeof(TADDR));
+    *pProfilerHandle = m_pImage->GetInnerPtr(GetProfilingHandleImport(), kZapProfilingHandleImportValueIndexClientData * TARGET_POINTER_SIZE);
 
     // All functions get hooked in ngen /Profile
     *pbHookFunction = TRUE;
@@ -2314,7 +2314,7 @@ void * ZapInfo::getFieldAddress(CORINFO_FIELD_HANDLE field, void **ppIndirection
     AppendConditionalImport(pImport);
 
     // Field address is not aligned thus we can not store it in the same location as token.
-    *ppIndirection = m_pImage->GetInnerPtr(pImport, sizeof(TADDR));
+    *ppIndirection = m_pImage->GetInnerPtr(pImport, TARGET_POINTER_SIZE);
 
     return NULL;
 }
@@ -2614,7 +2614,7 @@ void ZapInfo::recordRelocation(void *location, void *target,
         SIZE_T totalCodeSize = m_pCode->GetSize() + ((m_pColdCode != NULL) ? m_pColdCode->GetSize() : 0);
 
         // Prealocate relocations (assume that every other pointer may need relocation)
-        COUNT_T nEstimatedRelocations = (COUNT_T)(totalCodeSize / (2 * sizeof(TADDR)));
+        COUNT_T nEstimatedRelocations = (COUNT_T)(totalCodeSize / (2 * TARGET_POINTER_SIZE));
         if (nEstimatedRelocations > 1)
             m_CodeRelocations.Preallocate(nEstimatedRelocations);
     }

--- a/src/zap/zaprelocs.cpp
+++ b/src/zap/zaprelocs.cpp
@@ -46,7 +46,7 @@ void ZapBaseRelocs::WriteReloc(PVOID pSrc, int offset, ZapNode * pTarget, int ta
     case IMAGE_REL_BASED_PTR:
 #ifdef _TARGET_ARM_
         // Misaligned relocs disable ASLR on ARM. We should never ever emit them.
-        _ASSERTE(IS_ALIGNED(rva, sizeof(TADDR)));
+        _ASSERTE(IS_ALIGNED(rva, TARGET_POINTER_SIZE));
 #endif
         *(UNALIGNED TADDR *)pLocation = pActualTarget;
         break;
@@ -350,7 +350,7 @@ COUNT_T ZapBlobWithRelocs::GetCountOfStraddlerRelocations(DWORD dwPos)
     {
         if (pReloc->m_type == IMAGE_REL_BASED_PTR)
         {
-            if (AlignmentTrim(dwPos + pReloc->m_offset, RELOCATION_PAGE_SIZE) > RELOCATION_PAGE_SIZE - sizeof(TADDR))
+            if (AlignmentTrim(dwPos + pReloc->m_offset, RELOCATION_PAGE_SIZE) > RELOCATION_PAGE_SIZE - TARGET_POINTER_SIZE)
                 nStraddlers++;          
         }
     }


### PR DESCRIPTION
This PR is work towards Cross-Bitness Support for CrossGen (#16513):
* Add `#include "gcinfotypes.h"` to make macro `TARGET_POINTER_SIZE` available in src/zap
* Replace `sizeof(TADDR)` with macro `TARGET_POINTER_SIZE`

@jkotas PTAL