### PR TITLE
JIT: treat SIMD types as structs in box optimizations

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -13730,7 +13730,15 @@ GenTree* Compiler::gtTryRemoveBoxUpstreamEffects(GenTree* op, BoxRemovalOptions 
     {
         hasSrcSideEffect = true;
 
-        if (copySrc->gtType == TYP_STRUCT)
+        bool isStructType = (copySrc->gtType == TYP_STRUCT);
+
+#ifdef FEATURE_SIMD
+
+        isStructType |= varTypeIsSIMD(copySrc->gtType);
+
+#endif // FEATURE_SIMD
+
+        if (isStructType)
         {
             isStructCopy = true;
 

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -13730,15 +13730,7 @@ GenTree* Compiler::gtTryRemoveBoxUpstreamEffects(GenTree* op, BoxRemovalOptions 
     {
         hasSrcSideEffect = true;
 
-        bool isStructType = (copySrc->gtType == TYP_STRUCT);
-
-#ifdef FEATURE_SIMD
-
-        isStructType |= varTypeIsSIMD(copySrc->gtType);
-
-#endif // FEATURE_SIMD
-
-        if (isStructType)
+        if (varTypeIsStruct(copySrc->gtType))
         {
             isStructCopy = true;
 


### PR DESCRIPTION
Otherwise we may leave unconsumed GT_OBJs around, which is problematic for the
jit later on.

Fixes #18043.