### PR TITLE
Use sysconf(_SC_NPROCESSORS_CONF) in PAL_GetLogicalCpuCountFromOS

### DIFF
--- a/src/gc/unix/gcenv.unix.cpp
+++ b/src/gc/unix/gcenv.unix.cpp
@@ -67,7 +67,7 @@ bool GCToOSInterface::Initialize()
     g_pageSizeUnixInl = uint32_t((pageSize > 0) ? pageSize : 0x1000);
 
     // Calculate and cache the number of processors on this machine
-    int cpuCount = sysconf(_SC_NPROCESSORS_ONLN);
+    int cpuCount = sysconf(_SC_NPROCESSORS_CONF);
     if (cpuCount == -1)
     {
         return false;

--- a/src/pal/src/misc/sysinfo.cpp
+++ b/src/pal/src/misc/sysinfo.cpp
@@ -103,10 +103,10 @@ PAL_GetLogicalCpuCountFromOS()
     int nrcpus = 0;
 
 #if HAVE_SYSCONF
-    nrcpus = sysconf(_SC_NPROCESSORS_ONLN);
+    nrcpus = sysconf(_SC_NPROCESSORS_CONF);
     if (nrcpus < 1)
     {
-        ASSERT("sysconf failed for _SC_NPROCESSORS_ONLN (%d)\n", errno);
+        ASSERT("sysconf failed for _SC_NPROCESSORS_CONF (%d)\n", errno);
     }
 #elif HAVE_SYSCTL
     int rc;


### PR DESCRIPTION
As we found in #17851 `sysconf(_SC_NPROCESSORS_ONLN)` should not be used in `GetLogicalCpuCountFromOS` since it could return arbitrary number between 1 and actual number of logical CPU cores which causes VM to make wrong decision about which JIT_WriteBarrier to be used (SP vs MP).

When I tested `sysconf(_SC_NPROCESSORS_ONLN)` on NVIDIA Jetson TK1 I got all the values 1,2,3,4 depending on how busy the processor is.

As suggested in https://github.com/dotnet/coreclr/issues/17851#issuecomment-390333775 `sysconf(_SC_NPROCESSORS_CONF)` and https://github.com/seanmonstar/num_cpus/issues/34 should be used instead.