### PR TITLE
[Release/2.1] Use sysconf(_SC_NPROCESSORS_ONLN) in PAL_GetLogicalCpuCountFromOS (#18053)

### DIFF
--- a/src/gc/unix/gcenv.unix.cpp
+++ b/src/gc/unix/gcenv.unix.cpp
@@ -40,6 +40,12 @@
 #include <unistd.h> // sysconf
 #include "globals.h"
 
+#if defined(_ARM_) || defined(_ARM64_)
+#define SYSCONF_GET_NUMPROCS _SC_NPROCESSORS_CONF
+#else
+#define SYSCONF_GET_NUMPROCS _SC_NPROCESSORS_ONLN
+#endif
+
 // The cachced number of logical CPUs observed.
 static uint32_t g_logicalCpuCount = 0;
 
@@ -67,7 +73,7 @@ bool GCToOSInterface::Initialize()
     g_pageSizeUnixInl = uint32_t((pageSize > 0) ? pageSize : 0x1000);
 
     // Calculate and cache the number of processors on this machine
-    int cpuCount = sysconf(_SC_NPROCESSORS_ONLN);
+    int cpuCount = sysconf(SYSCONF_GET_NUMPROCS);
     if (cpuCount == -1)
     {
         return false;

--- a/src/pal/src/misc/sysinfo.cpp
+++ b/src/pal/src/misc/sysinfo.cpp
@@ -103,11 +103,19 @@ PAL_GetLogicalCpuCountFromOS()
     int nrcpus = 0;
 
 #if HAVE_SYSCONF
-    nrcpus = sysconf(_SC_NPROCESSORS_ONLN);
+#if defined(_ARM_) || defined(_ARM64_)
+    nrcpus = sysconf(_SC_NPROCESSORS_CONF);
+    if (nrcpus < 1)
+    {
+        ASSERT("sysconf failed for _SC_NPROCESSORS_CONF (%d)\n", errno);
+    }
+#else
+    nrcpus = sysconf(_SC_NPROCESSORS_ONLN)
     if (nrcpus < 1)
     {
         ASSERT("sysconf failed for _SC_NPROCESSORS_ONLN (%d)\n", errno);
     }
+#endif // defined(_ARM_) || defined(_ARM64_)
 #elif HAVE_SYSCTL
     int rc;
     size_t sz;

--- a/src/pal/src/misc/sysinfo.cpp
+++ b/src/pal/src/misc/sysinfo.cpp
@@ -103,19 +103,19 @@ PAL_GetLogicalCpuCountFromOS()
     int nrcpus = 0;
 
 #if HAVE_SYSCONF
+
 #if defined(_ARM_) || defined(_ARM64_)
-    nrcpus = sysconf(_SC_NPROCESSORS_CONF);
-    if (nrcpus < 1)
-    {
-        ASSERT("sysconf failed for _SC_NPROCESSORS_CONF (%d)\n", errno);
-    }
+#define SYSCONF_GET_NUMPROCS       _SC_NPROCESSORS_CONF
+#define SYSCONF_GET_NUMPROCS_NAME "_SC_NPROCESSORS_CONF"
 #else
-    nrcpus = sysconf(_SC_NPROCESSORS_ONLN)
+#define SYSCONF_GET_NUMPROCS       _SC_NPROCESSORS_ONLN
+#define SYSCONF_GET_NUMPROCS_NAME "_SC_NPROCESSORS_ONLN"
+#endif
+    nrcpus = sysconf(SYSCONF_GET_NUMPROCS);
     if (nrcpus < 1)
     {
-        ASSERT("sysconf failed for _SC_NPROCESSORS_ONLN (%d)\n", errno);
+        ASSERT("sysconf failed for %s (%d)\n", SYSCONF_GET_NUMPROCS_NAME, errno);
     }
-#endif // defined(_ARM_) || defined(_ARM64_)
 #elif HAVE_SYSCTL
     int rc;
     size_t sz;


### PR DESCRIPTION
This is #18053 ifdef-d under `_ARM_` or `_ARM64_` only as suggested in https://github.com/dotnet/coreclr/pull/18053#issuecomment-390349093

/cc @RussKeldorph @dotnet/arm32-contrib @dotnet/arm64-contrib 