### PR TITLE
Don't close the JIT func info file on shutdown

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -1438,14 +1438,6 @@ void Compiler::compShutdown()
     }
 #endif // FEATURE_JIT_METHOD_PERF
 
-#if FUNC_INFO_LOGGING
-    if (compJitFuncInfoFile != nullptr)
-    {
-        fclose(compJitFuncInfoFile);
-        compJitFuncInfoFile = nullptr;
-    }
-#endif // FUNC_INFO_LOGGING
-
 #if COUNT_RANGECHECKS
     if (optRangeChkAll > 0)
     {


### PR DESCRIPTION
During shutdown there can be a race between closing/nulling `compJitFuncInfoFile` in `compShutdown` and a background thread trying to write to it after checking that it was not null. This was found with tiering enabled but it looks like it can happen normally with unlucky timing because background threads aren't torn down on the shutdown path after main exits.