### PR TITLE
Remove bogus NoInlining uses

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Convert.cs
+++ b/src/System.Private.CoreLib/shared/System/Convert.cs
@@ -376,31 +376,22 @@ namespace System
             return ic.ToType(conversionType, provider);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowCharOverflowException() { throw new OverflowException(SR.Overflow_Char); }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowByteOverflowException() { throw new OverflowException(SR.Overflow_Byte); }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowSByteOverflowException() { throw new OverflowException(SR.Overflow_SByte); }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowInt16OverflowException() { throw new OverflowException(SR.Overflow_Int16); }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUInt16OverflowException() { throw new OverflowException(SR.Overflow_UInt16); }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowInt32OverflowException() { throw new OverflowException(SR.Overflow_Int32); }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUInt32OverflowException() { throw new OverflowException(SR.Overflow_UInt32); }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowInt64OverflowException() { throw new OverflowException(SR.Overflow_Int64); }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowUInt64OverflowException() { throw new OverflowException(SR.Overflow_UInt64); }
 
         // Conversions to Boolean

--- a/src/System.Private.CoreLib/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Private.CoreLib/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -664,17 +664,15 @@ namespace System.Collections.Concurrent
             }
         }
 
-        // These exception throwing sites have been extracted into their own NoInlining methods
-        // as these are uncommonly needed and when inlined are observed to prevent the inlining
-        // of important methods like TryGetValue and ContainsKey.
+        // These exception throwing sites have been extracted into their own methods as these are
+        // uncommonly needed and when inlined are observed to prevent the inlining of important
+        // methods like TryGetValue and ContainsKey.
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowKeyNotFoundException(object key)
         {
             throw new KeyNotFoundException(SR.Format(SR.Arg_KeyNotFoundWithKey, key.ToString()));
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowKeyNullException()
         {
             throw new ArgumentNullException("key");


### PR DESCRIPTION
The JIT knows not to inline throw helper methods. Manually blocking inlining prevents the JIT from detecting that these methods do not return and that may negatively impact the quality of the caller method code.