### PR TITLE
Fix ARM cast codegen

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -109,7 +109,7 @@ void CodeGen::instGen_Set_Reg_To_Imm(emitAttr size, regNumber reg, ssize_t imm, 
 
             if (getEmitter()->isLowRegister(reg) && (imm_hi16 == 0xffff) && ((imm_lo16 & 0x8000) == 0x8000))
             {
-                getEmitter()->emitIns_R_R(INS_sxth, EA_2BYTE, reg, reg);
+                getEmitter()->emitIns_R_R(INS_sxth, EA_4BYTE, reg, reg);
             }
             else
             {

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2878,10 +2878,8 @@ void CodeGen::genIntToIntCast(GenTree* treeNode)
     GenTree* castOp = treeNode->gtCast.CastOp();
     emitter* emit   = getEmitter();
 
-    var_types dstType     = treeNode->CastToType();
-    var_types srcType     = genActualType(castOp->TypeGet());
-    emitAttr  movSize     = emitActualTypeSize(dstType);
-    bool      movRequired = false;
+    var_types dstType = treeNode->CastToType();
+    var_types srcType = genActualType(castOp->TypeGet());
 
     assert(genTypeSize(srcType) <= genTypeSize(TYP_I_IMPL));
 
@@ -2894,8 +2892,6 @@ void CodeGen::genIntToIntCast(GenTree* treeNode)
     assert(genIsValidIntReg(targetReg));
     assert(genIsValidIntReg(sourceReg));
 
-    instruction ins = INS_invalid;
-
     genConsumeReg(castOp);
     Lowering::CastInfo castInfo;
 
@@ -2904,7 +2900,9 @@ void CodeGen::genIntToIntCast(GenTree* treeNode)
 
     if (castInfo.requiresOverflowCheck)
     {
-        emitAttr cmpSize = EA_ATTR(genTypeSize(srcType));
+        bool     movRequired = (sourceReg != targetReg);
+        emitAttr movSize     = emitActualTypeSize(dstType);
+        emitAttr cmpSize     = EA_ATTR(genTypeSize(srcType));
 
         if (castInfo.signCheckOnly)
         {
@@ -2994,72 +2992,63 @@ void CodeGen::genIntToIntCast(GenTree* treeNode)
             emitJumpKind jmpLT = genJumpKindForOper(GT_LT, CK_SIGNED);
             genJumpToThrowHlpBlk(jmpLT, SCK_OVERFLOW);
         }
-        ins = INS_mov;
+
+        if (movRequired)
+        {
+            emit->emitIns_R_R(INS_mov, movSize, targetReg, sourceReg);
+        }
     }
     else // Non-overflow checking cast.
     {
-        if (genTypeSize(srcType) == genTypeSize(dstType))
+        const unsigned srcSize = genTypeSize(srcType);
+        const unsigned dstSize = genTypeSize(dstType);
+        instruction    ins;
+        emitAttr       insSize;
+
+        if (dstSize < 4)
         {
-            ins = INS_mov;
+            // Casting to a small type really means widening from that small type to INT/LONG.
+            ins     = ins_Move_Extend(dstType, true);
+            insSize = emitActualTypeSize(treeNode->TypeGet());
         }
+#ifdef _TARGET_64BIT_
+        // dstType cannot be a long type on 32 bit targets, such casts should have been decomposed.
+        // srcType cannot be a small type since it's the "actual type" of the cast operand.
+        // This means that widening casts do not occur on 32 bit targets.
+        else if (dstSize > srcSize)
+        {
+            // (U)INT to (U)LONG widening cast
+            assert((srcSize == 4) && (dstSize == 8));
+            // Make sure the node type has the same size as the destination type.
+            assert(genTypeSize(treeNode->TypeGet()) == dstSize);
+
+            ins = treeNode->IsUnsigned() ? INS_mov : INS_sxtw;
+            // SXTW requires EA_8BYTE but MOV requires EA_4BYTE in order to zero out the upper 32 bits.
+            insSize = (ins == INS_sxtw) ? EA_8BYTE : EA_4BYTE;
+        }
+#endif
         else
         {
-            var_types extendType = TYP_UNKNOWN;
+            // Sign changing cast or narrowing cast
+            assert(dstSize <= srcSize);
+            // Note that narrowing casts are possible only on 64 bit targets.
+            assert(srcSize <= genTypeSize(TYP_I_IMPL));
+            // Make sure the node type has the same size as the destination type.
+            assert(genTypeSize(treeNode->TypeGet()) == dstSize);
 
-            if (genTypeSize(srcType) < genTypeSize(dstType))
-            {
-                // If we need to treat a signed type as unsigned
-                if ((treeNode->gtFlags & GTF_UNSIGNED) != 0)
-                {
-                    extendType = genUnsignedType(srcType);
-                }
-                else
-                    extendType = srcType;
-#ifdef _TARGET_ARM_
-                movSize = emitTypeSize(extendType);
-#endif // _TARGET_ARM_
-                if (extendType == TYP_UINT)
-                {
-#ifdef _TARGET_ARM64_
-                    // If we are casting from a smaller type to
-                    // a larger type, then we need to make sure the
-                    // higher 4 bytes are zero to gaurentee the correct value.
-                    // Therefore using a mov with EA_4BYTE in place of EA_8BYTE
-                    // will zero the upper bits
-                    movSize = EA_4BYTE;
-#endif // _TARGET_ARM64_
-                    movRequired = true;
-                }
-            }
-            else // (genTypeSize(srcType) > genTypeSize(dstType))
-            {
-                // If we need to treat a signed type as unsigned
-                if ((treeNode->gtFlags & GTF_UNSIGNED) != 0)
-                {
-                    extendType = genUnsignedType(dstType);
-                }
-                else
-                    extendType = dstType;
-#if defined(_TARGET_ARM_)
-                movSize = emitTypeSize(extendType);
-#elif defined(_TARGET_ARM64_)
-                if (extendType == TYP_INT)
-                {
-                    movSize = EA_8BYTE; // a sxtw instruction requires EA_8BYTE
-                }
-#endif // _TARGET_*
-            }
-
-            ins = ins_Move_Extend(extendType, true);
+            // This cast basically does nothing, even when narrowing it is the job of the
+            // consumer of this node to use the appropiate register size (32 or 64 bit)
+            // and not rely on the cast to set the upper 32 bits in a certain manner.
+            // Still, we will need to generate a MOV instruction if the source and target
+            // registers are different.
+            ins     = (sourceReg != targetReg) ? INS_mov : INS_none;
+            insSize = EA_SIZE(dstSize);
         }
-    }
 
-    // We should never be generating a load from memory instruction here!
-    assert(!emit->emitInsIsLoad(ins));
-
-    if ((ins != INS_mov) || movRequired || (targetReg != sourceReg))
-    {
-        emit->emitIns_R_R(ins, movSize, targetReg, sourceReg);
+        if (ins != INS_none)
+        {
+            emit->emitIns_R_R(ins, insSize, targetReg, sourceReg);
+        }
     }
 
     genProduceReg(treeNode);

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -2208,12 +2208,12 @@ void emitter::emitIns_R_R(
 
         case INS_sxtb:
         case INS_uxtb:
-            assert(size == EA_1BYTE);
+            assert(size == EA_4BYTE);
             goto EXTEND_COMMON;
 
         case INS_sxth:
         case INS_uxth:
-            assert(size == EA_2BYTE);
+            assert(size == EA_4BYTE);
         EXTEND_COMMON:
             assert(insDoesNotSetFlags(flags));
             if (isLowRegister(reg1) && isLowRegister(reg2))
@@ -2647,12 +2647,12 @@ void emitter::emitIns_R_R_I(instruction ins,
 
         case INS_sxtb:
         case INS_uxtb:
-            assert(size == EA_1BYTE);
+            assert(size == EA_4BYTE);
             goto EXTEND_COMMON;
 
         case INS_sxth:
         case INS_uxth:
-            assert(size == EA_2BYTE);
+            assert(size == EA_4BYTE);
         EXTEND_COMMON:
             assert(insOptsNone(opt));
             assert(insDoesNotSetFlags(flags));

--- a/tests/src/JIT/Directed/Convert/ldind_conv.il
+++ b/tests/src/JIT/Directed/Convert/ldind_conv.il
@@ -1,0 +1,11221 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern System.Private.CoreLib { auto }
+.assembly test { }
+
+.class auto Program extends [System.Private.CoreLib]System.Object
+{
+  .method private static void print(class [System.Private.CoreLib]System.String) cil managed
+  {
+    .maxstack 1
+    ldarg 0
+    call void [System.Private.CoreLib]Internal.Console::WriteLine(class [System.Private.CoreLib]System.String)
+    ret
+  }
+
+  .method private hidebysig static int32 Main() cil managed
+  {
+    .entrypoint
+    .maxstack 8
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i1_conv_i1(0x7F) == 0x0000007F"
+    call int32 Program::Check_ldind_i1_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i1_conv_i1(0x80) == 0xFFFFFF80"
+    call int32 Program::Check_ldind_i1_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i1_conv_i1(0xFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i1_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i1_conv_ovf_i1(0x7F) == 0x0000007F"
+    call int32 Program::Check_ldind_i1_conv_ovf_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i1_conv_ovf_i1(0x80) == 0xFFFFFF80"
+    call int32 Program::Check_ldind_i1_conv_ovf_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i1_conv_ovf_i1(0xFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i1_conv_ovf_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i1_conv_ovf_i1_un(0x7F) == 0x0000007F"
+    call int32 Program::Check_ldind_i1_conv_ovf_i1_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i1_conv_ovf_i1_un(0x80) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i1_conv_ovf_i1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i1_conv_ovf_i1_un(0xFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i1_conv_ovf_i1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i1_conv_u1(0x7F) == 0x0000007F"
+    call int32 Program::Check_ldind_i1_conv_u1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldc.i4 0x00000080
+    ldstr "Checking ldind_i1_conv_u1(0x80) == 0x00000080"
+    call int32 Program::Check_ldind_i1_conv_u1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i1_conv_u1(0xFF) == 0x000000FF"
+    call int32 Program::Check_ldind_i1_conv_u1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i1_conv_ovf_u1(0x7F) == 0x0000007F"
+    call int32 Program::Check_ldind_i1_conv_ovf_u1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i1_conv_ovf_u1(0x80) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i1_conv_ovf_u1(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i1_conv_ovf_u1(0xFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i1_conv_ovf_u1(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i1_conv_ovf_u1_un(0x7F) == 0x0000007F"
+    call int32 Program::Check_ldind_i1_conv_ovf_u1_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i1_conv_ovf_u1_un(0x80) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i1_conv_ovf_u1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i1_conv_ovf_u1_un(0xFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i1_conv_ovf_u1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i1_conv_i2(0x7F) == 0x0000007F"
+    call int32 Program::Check_ldind_i1_conv_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i1_conv_i2(0x80) == 0xFFFFFF80"
+    call int32 Program::Check_ldind_i1_conv_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i1_conv_i2(0xFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i1_conv_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i1_conv_ovf_i2(0x7F) == 0x0000007F"
+    call int32 Program::Check_ldind_i1_conv_ovf_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i1_conv_ovf_i2(0x80) == 0xFFFFFF80"
+    call int32 Program::Check_ldind_i1_conv_ovf_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i1_conv_ovf_i2(0xFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i1_conv_ovf_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i1_conv_ovf_i2_un(0x7F) == 0x0000007F"
+    call int32 Program::Check_ldind_i1_conv_ovf_i2_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i1_conv_ovf_i2_un(0x80) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i1_conv_ovf_i2_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i1_conv_ovf_i2_un(0xFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i1_conv_ovf_i2_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i1_conv_u2(0x7F) == 0x0000007F"
+    call int32 Program::Check_ldind_i1_conv_u2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldc.i4 0x0000FF80
+    ldstr "Checking ldind_i1_conv_u2(0x80) == 0x0000FF80"
+    call int32 Program::Check_ldind_i1_conv_u2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_i1_conv_u2(0xFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_i1_conv_u2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i1_conv_ovf_u2(0x7F) == 0x0000007F"
+    call int32 Program::Check_ldind_i1_conv_ovf_u2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i1_conv_ovf_u2(0x80) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i1_conv_ovf_u2(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i1_conv_ovf_u2(0xFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i1_conv_ovf_u2(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i1_conv_ovf_u2_un(0x7F) == 0x0000007F"
+    call int32 Program::Check_ldind_i1_conv_ovf_u2_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i1_conv_ovf_u2_un(0x80) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i1_conv_ovf_u2_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i1_conv_ovf_u2_un(0xFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i1_conv_ovf_u2_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i1_conv_i4(0x7F) == 0x0000007F"
+    call int32 Program::Check_ldind_i1_conv_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i1_conv_i4(0x80) == 0xFFFFFF80"
+    call int32 Program::Check_ldind_i1_conv_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i1_conv_i4(0xFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i1_conv_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i1_conv_ovf_i4(0x7F) == 0x0000007F"
+    call int32 Program::Check_ldind_i1_conv_ovf_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i1_conv_ovf_i4(0x80) == 0xFFFFFF80"
+    call int32 Program::Check_ldind_i1_conv_ovf_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i1_conv_ovf_i4(0xFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i1_conv_ovf_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i1_conv_ovf_i4_un(0x7F) == 0x0000007F"
+    call int32 Program::Check_ldind_i1_conv_ovf_i4_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i1_conv_ovf_i4_un(0x80) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i1_conv_ovf_i4_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i1_conv_ovf_i4_un(0xFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i1_conv_ovf_i4_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i1_conv_u4(0x7F) == 0x0000007F"
+    call int32 Program::Check_ldind_i1_conv_u4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i1_conv_u4(0x80) == 0xFFFFFF80"
+    call int32 Program::Check_ldind_i1_conv_u4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i1_conv_u4(0xFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i1_conv_u4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i1_conv_ovf_u4(0x7F) == 0x0000007F"
+    call int32 Program::Check_ldind_i1_conv_ovf_u4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i1_conv_ovf_u4(0x80) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i1_conv_ovf_u4(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i1_conv_ovf_u4(0xFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i1_conv_ovf_u4(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i1_conv_ovf_u4_un(0x7F) == 0x0000007F"
+    call int32 Program::Check_ldind_i1_conv_ovf_u4_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i1_conv_ovf_u4_un(0x80) == 0xFFFFFF80"
+    call int32 Program::Check_ldind_i1_conv_ovf_u4_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i1_conv_ovf_u4_un(0xFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i1_conv_ovf_u4_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i8 0x000000000000007F
+    ldstr "Checking ldind_i1_conv_i8(0x7F) == 0x000000000000007F"
+    call int32 Program::Check_ldind_i1_conv_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldc.i8 0xFFFFFFFFFFFFFF80
+    ldstr "Checking ldind_i1_conv_i8(0x80) == 0xFFFFFFFFFFFFFF80"
+    call int32 Program::Check_ldind_i1_conv_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i1_conv_i8(0xFF) == 0xFFFFFFFFFFFFFFFF"
+    call int32 Program::Check_ldind_i1_conv_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i8 0x000000000000007F
+    ldstr "Checking ldind_i1_conv_ovf_i8(0x7F) == 0x000000000000007F"
+    call int32 Program::Check_ldind_i1_conv_ovf_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldc.i8 0xFFFFFFFFFFFFFF80
+    ldstr "Checking ldind_i1_conv_ovf_i8(0x80) == 0xFFFFFFFFFFFFFF80"
+    call int32 Program::Check_ldind_i1_conv_ovf_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i1_conv_ovf_i8(0xFF) == 0xFFFFFFFFFFFFFFFF"
+    call int32 Program::Check_ldind_i1_conv_ovf_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i8 0x000000000000007F
+    ldstr "Checking ldind_i1_conv_ovf_i8_un(0x7F) == 0x000000000000007F"
+    call int32 Program::Check_ldind_i1_conv_ovf_i8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldc.i8 0x00000000FFFFFF80
+    ldstr "Checking ldind_i1_conv_ovf_i8_un(0x80) == 0x00000000FFFFFF80"
+    call int32 Program::Check_ldind_i1_conv_ovf_i8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i8 0x00000000FFFFFFFF
+    ldstr "Checking ldind_i1_conv_ovf_i8_un(0xFF) == 0x00000000FFFFFFFF"
+    call int32 Program::Check_ldind_i1_conv_ovf_i8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i8 0x000000000000007F
+    ldstr "Checking ldind_i1_conv_u8(0x7F) == 0x000000000000007F"
+    call int32 Program::Check_ldind_i1_conv_u8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldc.i8 0x00000000FFFFFF80
+    ldstr "Checking ldind_i1_conv_u8(0x80) == 0x00000000FFFFFF80"
+    call int32 Program::Check_ldind_i1_conv_u8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i8 0x00000000FFFFFFFF
+    ldstr "Checking ldind_i1_conv_u8(0xFF) == 0x00000000FFFFFFFF"
+    call int32 Program::Check_ldind_i1_conv_u8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i8 0x000000000000007F
+    ldstr "Checking ldind_i1_conv_ovf_u8(0x7F) == 0x000000000000007F"
+    call int32 Program::Check_ldind_i1_conv_ovf_u8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i1_conv_ovf_u8(0x80) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i1_conv_ovf_u8(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i1_conv_ovf_u8(0xFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i1_conv_ovf_u8(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i8 0x000000000000007F
+    ldstr "Checking ldind_i1_conv_ovf_u8_un(0x7F) == 0x000000000000007F"
+    call int32 Program::Check_ldind_i1_conv_ovf_u8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldc.i8 0x00000000FFFFFF80
+    ldstr "Checking ldind_i1_conv_ovf_u8_un(0x80) == 0x00000000FFFFFF80"
+    call int32 Program::Check_ldind_i1_conv_ovf_u8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i8 0x00000000FFFFFFFF
+    ldstr "Checking ldind_i1_conv_ovf_u8_un(0xFF) == 0x00000000FFFFFFFF"
+    call int32 Program::Check_ldind_i1_conv_ovf_u8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u1_conv_i1(0xFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u1_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u1_conv_ovf_i1(0xFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u1_conv_ovf_i1(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u1_conv_ovf_i1_un(0xFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u1_conv_ovf_i1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u1_conv_u1(0xFF) == 0x000000FF"
+    call int32 Program::Check_ldind_u1_conv_u1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u1_conv_ovf_u1(0xFF) == 0x000000FF"
+    call int32 Program::Check_ldind_u1_conv_ovf_u1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u1_conv_ovf_u1_un(0xFF) == 0x000000FF"
+    call int32 Program::Check_ldind_u1_conv_ovf_u1_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u1_conv_i2(0xFF) == 0x000000FF"
+    call int32 Program::Check_ldind_u1_conv_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u1_conv_ovf_i2(0xFF) == 0x000000FF"
+    call int32 Program::Check_ldind_u1_conv_ovf_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u1_conv_ovf_i2_un(0xFF) == 0x000000FF"
+    call int32 Program::Check_ldind_u1_conv_ovf_i2_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u1_conv_u2(0xFF) == 0x000000FF"
+    call int32 Program::Check_ldind_u1_conv_u2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u1_conv_ovf_u2(0xFF) == 0x000000FF"
+    call int32 Program::Check_ldind_u1_conv_ovf_u2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u1_conv_ovf_u2_un(0xFF) == 0x000000FF"
+    call int32 Program::Check_ldind_u1_conv_ovf_u2_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u1_conv_i4(0xFF) == 0x000000FF"
+    call int32 Program::Check_ldind_u1_conv_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u1_conv_ovf_i4(0xFF) == 0x000000FF"
+    call int32 Program::Check_ldind_u1_conv_ovf_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u1_conv_ovf_i4_un(0xFF) == 0x000000FF"
+    call int32 Program::Check_ldind_u1_conv_ovf_i4_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u1_conv_u4(0xFF) == 0x000000FF"
+    call int32 Program::Check_ldind_u1_conv_u4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u1_conv_ovf_u4(0xFF) == 0x000000FF"
+    call int32 Program::Check_ldind_u1_conv_ovf_u4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u1_conv_ovf_u4_un(0xFF) == 0x000000FF"
+    call int32 Program::Check_ldind_u1_conv_ovf_u4_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i8 0x00000000000000FF
+    ldstr "Checking ldind_u1_conv_i8(0xFF) == 0x00000000000000FF"
+    call int32 Program::Check_ldind_u1_conv_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i8 0x00000000000000FF
+    ldstr "Checking ldind_u1_conv_ovf_i8(0xFF) == 0x00000000000000FF"
+    call int32 Program::Check_ldind_u1_conv_ovf_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i8 0x00000000000000FF
+    ldstr "Checking ldind_u1_conv_ovf_i8_un(0xFF) == 0x00000000000000FF"
+    call int32 Program::Check_ldind_u1_conv_ovf_i8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i8 0x00000000000000FF
+    ldstr "Checking ldind_u1_conv_u8(0xFF) == 0x00000000000000FF"
+    call int32 Program::Check_ldind_u1_conv_u8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i8 0x00000000000000FF
+    ldstr "Checking ldind_u1_conv_ovf_u8(0xFF) == 0x00000000000000FF"
+    call int32 Program::Check_ldind_u1_conv_ovf_u8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i8 0x00000000000000FF
+    ldstr "Checking ldind_u1_conv_ovf_u8_un(0xFF) == 0x00000000000000FF"
+    call int32 Program::Check_ldind_u1_conv_ovf_u8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i2_conv_i1(0x7FFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i2_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldc.i4 0x00000000
+    ldstr "Checking ldind_i2_conv_i1(0x8000) == 0x00000000"
+    call int32 Program::Check_ldind_i2_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i2_conv_i1(0xFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i2_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i2_conv_i1(0x007F) == 0x0000007F"
+    call int32 Program::Check_ldind_i2_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i2_conv_i1(0xFF80) == 0xFFFFFF80"
+    call int32 Program::Check_ldind_i2_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i2_conv_i1(0x00FF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i2_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_i2_conv_ovf_i1(0x7FFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_i1(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_i2_conv_ovf_i1(0x8000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_i1(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i2_conv_ovf_i1(0xFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i2_conv_ovf_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i2_conv_ovf_i1(0x007F) == 0x0000007F"
+    call int32 Program::Check_ldind_i2_conv_ovf_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i2_conv_ovf_i1(0xFF80) == 0xFFFFFF80"
+    call int32 Program::Check_ldind_i2_conv_ovf_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i2_conv_ovf_i1(0x00FF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_i1(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_i2_conv_ovf_i1_un(0x7FFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_i1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_i2_conv_ovf_i1_un(0x8000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_i1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_i2_conv_ovf_i1_un(0xFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_i1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i2_conv_ovf_i1_un(0x007F) == 0x0000007F"
+    call int32 Program::Check_ldind_i2_conv_ovf_i1_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i2_conv_ovf_i1_un(0xFF80) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_i1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i2_conv_ovf_i1_un(0x00FF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_i1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i2_conv_u1(0x7FFF) == 0x000000FF"
+    call int32 Program::Check_ldind_i2_conv_u1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldc.i4 0x00000000
+    ldstr "Checking ldind_i2_conv_u1(0x8000) == 0x00000000"
+    call int32 Program::Check_ldind_i2_conv_u1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i2_conv_u1(0xFFFF) == 0x000000FF"
+    call int32 Program::Check_ldind_i2_conv_u1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i2_conv_u1(0x00FF) == 0x000000FF"
+    call int32 Program::Check_ldind_i2_conv_u1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_i2_conv_ovf_u1(0x7FFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_u1(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_i2_conv_ovf_u1(0x8000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_u1(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_i2_conv_ovf_u1(0xFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_u1(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i2_conv_ovf_u1(0x00FF) == 0x000000FF"
+    call int32 Program::Check_ldind_i2_conv_ovf_u1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_i2_conv_ovf_u1_un(0x7FFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_u1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_i2_conv_ovf_u1_un(0x8000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_u1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_i2_conv_ovf_u1_un(0xFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_u1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i2_conv_ovf_u1_un(0x00FF) == 0x000000FF"
+    call int32 Program::Check_ldind_i2_conv_ovf_u1_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_i2_conv_i2(0x7FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_i2_conv_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_i2_conv_i2(0x8000) == 0xFFFF8000"
+    call int32 Program::Check_ldind_i2_conv_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i2_conv_i2(0xFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i2_conv_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_i2_conv_ovf_i2(0x7FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_i2_conv_ovf_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_i2_conv_ovf_i2(0x8000) == 0xFFFF8000"
+    call int32 Program::Check_ldind_i2_conv_ovf_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i2_conv_ovf_i2(0xFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i2_conv_ovf_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_i2_conv_ovf_i2_un(0x7FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_i2_conv_ovf_i2_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_i2_conv_ovf_i2_un(0x8000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_i2_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_i2_conv_ovf_i2_un(0xFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_i2_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_i2_conv_u2(0x7FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_i2_conv_u2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldc.i4 0x00008000
+    ldstr "Checking ldind_i2_conv_u2(0x8000) == 0x00008000"
+    call int32 Program::Check_ldind_i2_conv_u2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_i2_conv_u2(0xFFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_i2_conv_u2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_i2_conv_ovf_u2(0x7FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_i2_conv_ovf_u2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_i2_conv_ovf_u2(0x8000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_u2(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_i2_conv_ovf_u2(0xFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_u2(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_i2_conv_ovf_u2_un(0x7FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_i2_conv_ovf_u2_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_i2_conv_ovf_u2_un(0x8000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_u2_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_i2_conv_ovf_u2_un(0xFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_u2_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_i2_conv_i4(0x7FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_i2_conv_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_i2_conv_i4(0x8000) == 0xFFFF8000"
+    call int32 Program::Check_ldind_i2_conv_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i2_conv_i4(0xFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i2_conv_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_i2_conv_ovf_i4(0x7FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_i2_conv_ovf_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_i2_conv_ovf_i4(0x8000) == 0xFFFF8000"
+    call int32 Program::Check_ldind_i2_conv_ovf_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i2_conv_ovf_i4(0xFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i2_conv_ovf_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_i2_conv_ovf_i4_un(0x7FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_i2_conv_ovf_i4_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_i2_conv_ovf_i4_un(0x8000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_i4_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_i2_conv_ovf_i4_un(0xFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_i4_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_i2_conv_u4(0x7FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_i2_conv_u4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_i2_conv_u4(0x8000) == 0xFFFF8000"
+    call int32 Program::Check_ldind_i2_conv_u4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i2_conv_u4(0xFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i2_conv_u4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_i2_conv_ovf_u4(0x7FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_i2_conv_ovf_u4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_i2_conv_ovf_u4(0x8000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_u4(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_i2_conv_ovf_u4(0xFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_u4(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_i2_conv_ovf_u4_un(0x7FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_i2_conv_ovf_u4_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_i2_conv_ovf_u4_un(0x8000) == 0xFFFF8000"
+    call int32 Program::Check_ldind_i2_conv_ovf_u4_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i2_conv_ovf_u4_un(0xFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i2_conv_ovf_u4_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i8 0x0000000000007FFF
+    ldstr "Checking ldind_i2_conv_i8(0x7FFF) == 0x0000000000007FFF"
+    call int32 Program::Check_ldind_i2_conv_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldc.i8 0xFFFFFFFFFFFF8000
+    ldstr "Checking ldind_i2_conv_i8(0x8000) == 0xFFFFFFFFFFFF8000"
+    call int32 Program::Check_ldind_i2_conv_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i2_conv_i8(0xFFFF) == 0xFFFFFFFFFFFFFFFF"
+    call int32 Program::Check_ldind_i2_conv_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i8 0x0000000000007FFF
+    ldstr "Checking ldind_i2_conv_ovf_i8(0x7FFF) == 0x0000000000007FFF"
+    call int32 Program::Check_ldind_i2_conv_ovf_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldc.i8 0xFFFFFFFFFFFF8000
+    ldstr "Checking ldind_i2_conv_ovf_i8(0x8000) == 0xFFFFFFFFFFFF8000"
+    call int32 Program::Check_ldind_i2_conv_ovf_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i2_conv_ovf_i8(0xFFFF) == 0xFFFFFFFFFFFFFFFF"
+    call int32 Program::Check_ldind_i2_conv_ovf_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i8 0x0000000000007FFF
+    ldstr "Checking ldind_i2_conv_ovf_i8_un(0x7FFF) == 0x0000000000007FFF"
+    call int32 Program::Check_ldind_i2_conv_ovf_i8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldc.i8 0x00000000FFFF8000
+    ldstr "Checking ldind_i2_conv_ovf_i8_un(0x8000) == 0x00000000FFFF8000"
+    call int32 Program::Check_ldind_i2_conv_ovf_i8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i8 0x00000000FFFFFFFF
+    ldstr "Checking ldind_i2_conv_ovf_i8_un(0xFFFF) == 0x00000000FFFFFFFF"
+    call int32 Program::Check_ldind_i2_conv_ovf_i8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i8 0x0000000000007FFF
+    ldstr "Checking ldind_i2_conv_u8(0x7FFF) == 0x0000000000007FFF"
+    call int32 Program::Check_ldind_i2_conv_u8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldc.i8 0x00000000FFFF8000
+    ldstr "Checking ldind_i2_conv_u8(0x8000) == 0x00000000FFFF8000"
+    call int32 Program::Check_ldind_i2_conv_u8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i8 0x00000000FFFFFFFF
+    ldstr "Checking ldind_i2_conv_u8(0xFFFF) == 0x00000000FFFFFFFF"
+    call int32 Program::Check_ldind_i2_conv_u8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i8 0x0000000000007FFF
+    ldstr "Checking ldind_i2_conv_ovf_u8(0x7FFF) == 0x0000000000007FFF"
+    call int32 Program::Check_ldind_i2_conv_ovf_u8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_i2_conv_ovf_u8(0x8000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_u8(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_i2_conv_ovf_u8(0xFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i2_conv_ovf_u8(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i8 0x0000000000007FFF
+    ldstr "Checking ldind_i2_conv_ovf_u8_un(0x7FFF) == 0x0000000000007FFF"
+    call int32 Program::Check_ldind_i2_conv_ovf_u8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldc.i8 0x00000000FFFF8000
+    ldstr "Checking ldind_i2_conv_ovf_u8_un(0x8000) == 0x00000000FFFF8000"
+    call int32 Program::Check_ldind_i2_conv_ovf_u8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i8 0x00000000FFFFFFFF
+    ldstr "Checking ldind_i2_conv_ovf_u8_un(0xFFFF) == 0x00000000FFFFFFFF"
+    call int32 Program::Check_ldind_i2_conv_ovf_u8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u2_conv_i1(0xFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u2_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_u2_conv_i1(0x007F) == 0x0000007F"
+    call int32 Program::Check_ldind_u2_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_u2_conv_i1(0xFF80) == 0xFFFFFF80"
+    call int32 Program::Check_ldind_u2_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u2_conv_i1(0x00FF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u2_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u2_conv_ovf_i1(0xFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u2_conv_ovf_i1(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_u2_conv_ovf_i1(0x007F) == 0x0000007F"
+    call int32 Program::Check_ldind_u2_conv_ovf_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_u2_conv_ovf_i1(0xFF80) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u2_conv_ovf_i1(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u2_conv_ovf_i1(0x00FF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u2_conv_ovf_i1(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u2_conv_ovf_i1_un(0xFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u2_conv_ovf_i1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_u2_conv_ovf_i1_un(0x007F) == 0x0000007F"
+    call int32 Program::Check_ldind_u2_conv_ovf_i1_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_u2_conv_ovf_i1_un(0xFF80) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u2_conv_ovf_i1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u2_conv_ovf_i1_un(0x00FF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u2_conv_ovf_i1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u2_conv_u1(0xFFFF) == 0x000000FF"
+    call int32 Program::Check_ldind_u2_conv_u1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u2_conv_u1(0x00FF) == 0x000000FF"
+    call int32 Program::Check_ldind_u2_conv_u1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u2_conv_ovf_u1(0xFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u2_conv_ovf_u1(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u2_conv_ovf_u1(0x00FF) == 0x000000FF"
+    call int32 Program::Check_ldind_u2_conv_ovf_u1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u2_conv_ovf_u1_un(0xFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u2_conv_ovf_u1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u2_conv_ovf_u1_un(0x00FF) == 0x000000FF"
+    call int32 Program::Check_ldind_u2_conv_ovf_u1_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u2_conv_i2(0xFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u2_conv_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u2_conv_ovf_i2(0xFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u2_conv_ovf_i2(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u2_conv_ovf_i2_un(0xFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u2_conv_ovf_i2_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u2_conv_u2(0xFFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_u2_conv_u2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u2_conv_ovf_u2(0xFFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_u2_conv_ovf_u2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u2_conv_ovf_u2_un(0xFFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_u2_conv_ovf_u2_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u2_conv_i4(0xFFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_u2_conv_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u2_conv_ovf_i4(0xFFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_u2_conv_ovf_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u2_conv_ovf_i4_un(0xFFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_u2_conv_ovf_i4_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u2_conv_u4(0xFFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_u2_conv_u4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u2_conv_ovf_u4(0xFFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_u2_conv_ovf_u4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u2_conv_ovf_u4_un(0xFFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_u2_conv_ovf_u4_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i8 0x000000000000FFFF
+    ldstr "Checking ldind_u2_conv_i8(0xFFFF) == 0x000000000000FFFF"
+    call int32 Program::Check_ldind_u2_conv_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i8 0x000000000000FFFF
+    ldstr "Checking ldind_u2_conv_ovf_i8(0xFFFF) == 0x000000000000FFFF"
+    call int32 Program::Check_ldind_u2_conv_ovf_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i8 0x000000000000FFFF
+    ldstr "Checking ldind_u2_conv_ovf_i8_un(0xFFFF) == 0x000000000000FFFF"
+    call int32 Program::Check_ldind_u2_conv_ovf_i8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i8 0x000000000000FFFF
+    ldstr "Checking ldind_u2_conv_u8(0xFFFF) == 0x000000000000FFFF"
+    call int32 Program::Check_ldind_u2_conv_u8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i8 0x000000000000FFFF
+    ldstr "Checking ldind_u2_conv_ovf_u8(0xFFFF) == 0x000000000000FFFF"
+    call int32 Program::Check_ldind_u2_conv_ovf_u8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i8 0x000000000000FFFF
+    ldstr "Checking ldind_u2_conv_ovf_u8_un(0xFFFF) == 0x000000000000FFFF"
+    call int32 Program::Check_ldind_u2_conv_ovf_u8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i4_conv_i1(0x7FFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldc.i4 0x00000000
+    ldstr "Checking ldind_i4_conv_i1(0x80000000) == 0x00000000"
+    call int32 Program::Check_ldind_i4_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i4_conv_i1(0xFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i4_conv_i1(0x0000007F) == 0x0000007F"
+    call int32 Program::Check_ldind_i4_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i4_conv_i1(0xFFFFFF80) == 0xFFFFFF80"
+    call int32 Program::Check_ldind_i4_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i4_conv_i1(0x000000FF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_i1(0x7FFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_i1(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldstr "Checking ldind_i4_conv_ovf_i1(0x80000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_i1(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_i1(0xFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_ovf_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i4_conv_ovf_i1(0x0000007F) == 0x0000007F"
+    call int32 Program::Check_ldind_i4_conv_ovf_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i4_conv_ovf_i1(0xFFFFFF80) == 0xFFFFFF80"
+    call int32 Program::Check_ldind_i4_conv_ovf_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i4_conv_ovf_i1(0x000000FF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_i1(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_i1_un(0x7FFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_i1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldstr "Checking ldind_i4_conv_ovf_i1_un(0x80000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_i1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_i1_un(0xFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_i1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i4_conv_ovf_i1_un(0x0000007F) == 0x0000007F"
+    call int32 Program::Check_ldind_i4_conv_ovf_i1_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i4_conv_ovf_i1_un(0xFFFFFF80) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_i1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i4_conv_ovf_i1_un(0x000000FF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_i1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i4_conv_u1(0x7FFFFFFF) == 0x000000FF"
+    call int32 Program::Check_ldind_i4_conv_u1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldc.i4 0x00000000
+    ldstr "Checking ldind_i4_conv_u1(0x80000000) == 0x00000000"
+    call int32 Program::Check_ldind_i4_conv_u1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i4_conv_u1(0xFFFFFFFF) == 0x000000FF"
+    call int32 Program::Check_ldind_i4_conv_u1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i4_conv_u1(0x000000FF) == 0x000000FF"
+    call int32 Program::Check_ldind_i4_conv_u1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_u1(0x7FFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_u1(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldstr "Checking ldind_i4_conv_ovf_u1(0x80000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_u1(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_u1(0xFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_u1(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i4_conv_ovf_u1(0x000000FF) == 0x000000FF"
+    call int32 Program::Check_ldind_i4_conv_ovf_u1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_u1_un(0x7FFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_u1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldstr "Checking ldind_i4_conv_ovf_u1_un(0x80000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_u1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_u1_un(0xFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_u1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i4_conv_ovf_u1_un(0x000000FF) == 0x000000FF"
+    call int32 Program::Check_ldind_i4_conv_ovf_u1_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i4_conv_i2(0x7FFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldc.i4 0x00000000
+    ldstr "Checking ldind_i4_conv_i2(0x80000000) == 0x00000000"
+    call int32 Program::Check_ldind_i4_conv_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i4_conv_i2(0xFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_i4_conv_i2(0x00007FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_i4_conv_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_i4_conv_i2(0xFFFF8000) == 0xFFFF8000"
+    call int32 Program::Check_ldind_i4_conv_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i4_conv_i2(0x0000FFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_i2(0x7FFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_i2(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldstr "Checking ldind_i4_conv_ovf_i2(0x80000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_i2(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_i2(0xFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_ovf_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_i4_conv_ovf_i2(0x00007FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_i4_conv_ovf_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_i4_conv_ovf_i2(0xFFFF8000) == 0xFFFF8000"
+    call int32 Program::Check_ldind_i4_conv_ovf_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_i4_conv_ovf_i2(0x0000FFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_i2(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_i2_un(0x7FFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_i2_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldstr "Checking ldind_i4_conv_ovf_i2_un(0x80000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_i2_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_i2_un(0xFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_i2_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_i4_conv_ovf_i2_un(0x00007FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_i4_conv_ovf_i2_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_i4_conv_ovf_i2_un(0xFFFF8000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_i2_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_i4_conv_ovf_i2_un(0x0000FFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_i2_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_i4_conv_u2(0x7FFFFFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_i4_conv_u2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldc.i4 0x00000000
+    ldstr "Checking ldind_i4_conv_u2(0x80000000) == 0x00000000"
+    call int32 Program::Check_ldind_i4_conv_u2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_i4_conv_u2(0xFFFFFFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_i4_conv_u2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_i4_conv_u2(0x0000FFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_i4_conv_u2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_u2(0x7FFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_u2(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldstr "Checking ldind_i4_conv_ovf_u2(0x80000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_u2(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_u2(0xFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_u2(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_i4_conv_ovf_u2(0x0000FFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_i4_conv_ovf_u2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_u2_un(0x7FFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_u2_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldstr "Checking ldind_i4_conv_ovf_u2_un(0x80000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_u2_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_u2_un(0xFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_u2_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_i4_conv_ovf_u2_un(0x0000FFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_i4_conv_ovf_u2_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldc.i4 0x7FFFFFFF
+    ldstr "Checking ldind_i4_conv_i4(0x7FFFFFFF) == 0x7FFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldc.i4 0x80000000
+    ldstr "Checking ldind_i4_conv_i4(0x80000000) == 0x80000000"
+    call int32 Program::Check_ldind_i4_conv_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i4_conv_i4(0xFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldc.i4 0x7FFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_i4(0x7FFFFFFF) == 0x7FFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_ovf_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldc.i4 0x80000000
+    ldstr "Checking ldind_i4_conv_ovf_i4(0x80000000) == 0x80000000"
+    call int32 Program::Check_ldind_i4_conv_ovf_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_i4(0xFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_ovf_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldc.i4 0x7FFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_i4_un(0x7FFFFFFF) == 0x7FFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_ovf_i4_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldstr "Checking ldind_i4_conv_ovf_i4_un(0x80000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_i4_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_i4_un(0xFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_i4_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldc.i4 0x7FFFFFFF
+    ldstr "Checking ldind_i4_conv_u4(0x7FFFFFFF) == 0x7FFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_u4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldc.i4 0x80000000
+    ldstr "Checking ldind_i4_conv_u4(0x80000000) == 0x80000000"
+    call int32 Program::Check_ldind_i4_conv_u4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i4_conv_u4(0xFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_u4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldc.i4 0x7FFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_u4(0x7FFFFFFF) == 0x7FFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_ovf_u4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldstr "Checking ldind_i4_conv_ovf_u4(0x80000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_u4(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_u4(0xFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_u4(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldc.i4 0x7FFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_u4_un(0x7FFFFFFF) == 0x7FFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_ovf_u4_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldc.i4 0x80000000
+    ldstr "Checking ldind_i4_conv_ovf_u4_un(0x80000000) == 0x80000000"
+    call int32 Program::Check_ldind_i4_conv_ovf_u4_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_u4_un(0xFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_ovf_u4_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldc.i8 0x000000007FFFFFFF
+    ldstr "Checking ldind_i4_conv_i8(0x7FFFFFFF) == 0x000000007FFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldc.i8 0xFFFFFFFF80000000
+    ldstr "Checking ldind_i4_conv_i8(0x80000000) == 0xFFFFFFFF80000000"
+    call int32 Program::Check_ldind_i4_conv_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i4_conv_i8(0xFFFFFFFF) == 0xFFFFFFFFFFFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldc.i8 0x000000007FFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_i8(0x7FFFFFFF) == 0x000000007FFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_ovf_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldc.i8 0xFFFFFFFF80000000
+    ldstr "Checking ldind_i4_conv_ovf_i8(0x80000000) == 0xFFFFFFFF80000000"
+    call int32 Program::Check_ldind_i4_conv_ovf_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_i8(0xFFFFFFFF) == 0xFFFFFFFFFFFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_ovf_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldc.i8 0x000000007FFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_i8_un(0x7FFFFFFF) == 0x000000007FFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_ovf_i8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldc.i8 0x0000000080000000
+    ldstr "Checking ldind_i4_conv_ovf_i8_un(0x80000000) == 0x0000000080000000"
+    call int32 Program::Check_ldind_i4_conv_ovf_i8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i8 0x00000000FFFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_i8_un(0xFFFFFFFF) == 0x00000000FFFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_ovf_i8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldc.i8 0x000000007FFFFFFF
+    ldstr "Checking ldind_i4_conv_u8(0x7FFFFFFF) == 0x000000007FFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_u8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldc.i8 0x0000000080000000
+    ldstr "Checking ldind_i4_conv_u8(0x80000000) == 0x0000000080000000"
+    call int32 Program::Check_ldind_i4_conv_u8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i8 0x00000000FFFFFFFF
+    ldstr "Checking ldind_i4_conv_u8(0xFFFFFFFF) == 0x00000000FFFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_u8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldc.i8 0x000000007FFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_u8(0x7FFFFFFF) == 0x000000007FFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_ovf_u8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldstr "Checking ldind_i4_conv_ovf_u8(0x80000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_u8(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_u8(0xFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i4_conv_ovf_u8(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x7FFFFFFF
+    ldc.i8 0x000000007FFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_u8_un(0x7FFFFFFF) == 0x000000007FFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_ovf_u8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x80000000
+    ldc.i8 0x0000000080000000
+    ldstr "Checking ldind_i4_conv_ovf_u8_un(0x80000000) == 0x0000000080000000"
+    call int32 Program::Check_ldind_i4_conv_ovf_u8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i8 0x00000000FFFFFFFF
+    ldstr "Checking ldind_i4_conv_ovf_u8_un(0xFFFFFFFF) == 0x00000000FFFFFFFF"
+    call int32 Program::Check_ldind_i4_conv_ovf_u8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u4_conv_i1(0xFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u4_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_u4_conv_i1(0x0000007F) == 0x0000007F"
+    call int32 Program::Check_ldind_u4_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_u4_conv_i1(0xFFFFFF80) == 0xFFFFFF80"
+    call int32 Program::Check_ldind_u4_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u4_conv_i1(0x000000FF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u4_conv_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u4_conv_ovf_i1(0xFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u4_conv_ovf_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_u4_conv_ovf_i1(0x0000007F) == 0x0000007F"
+    call int32 Program::Check_ldind_u4_conv_ovf_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_u4_conv_ovf_i1(0xFFFFFF80) == 0xFFFFFF80"
+    call int32 Program::Check_ldind_u4_conv_ovf_i1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u4_conv_ovf_i1(0x000000FF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u4_conv_ovf_i1(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u4_conv_ovf_i1_un(0xFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u4_conv_ovf_i1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_u4_conv_ovf_i1_un(0x0000007F) == 0x0000007F"
+    call int32 Program::Check_ldind_u4_conv_ovf_i1_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_u4_conv_ovf_i1_un(0xFFFFFF80) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u4_conv_ovf_i1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u4_conv_ovf_i1_un(0x000000FF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u4_conv_ovf_i1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u4_conv_u1(0xFFFFFFFF) == 0x000000FF"
+    call int32 Program::Check_ldind_u4_conv_u1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u4_conv_u1(0x000000FF) == 0x000000FF"
+    call int32 Program::Check_ldind_u4_conv_u1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u4_conv_ovf_u1(0xFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u4_conv_ovf_u1(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u4_conv_ovf_u1(0x000000FF) == 0x000000FF"
+    call int32 Program::Check_ldind_u4_conv_ovf_u1(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u4_conv_ovf_u1_un(0xFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u4_conv_ovf_u1_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u4_conv_ovf_u1_un(0x000000FF) == 0x000000FF"
+    call int32 Program::Check_ldind_u4_conv_ovf_u1_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u4_conv_i2(0xFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u4_conv_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_u4_conv_i2(0x00007FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_u4_conv_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_u4_conv_i2(0xFFFF8000) == 0xFFFF8000"
+    call int32 Program::Check_ldind_u4_conv_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u4_conv_i2(0x0000FFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u4_conv_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u4_conv_ovf_i2(0xFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u4_conv_ovf_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_u4_conv_ovf_i2(0x00007FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_u4_conv_ovf_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_u4_conv_ovf_i2(0xFFFF8000) == 0xFFFF8000"
+    call int32 Program::Check_ldind_u4_conv_ovf_i2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u4_conv_ovf_i2(0x0000FFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u4_conv_ovf_i2(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u4_conv_ovf_i2_un(0xFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u4_conv_ovf_i2_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x00007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_u4_conv_ovf_i2_un(0x00007FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_u4_conv_ovf_i2_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_u4_conv_ovf_i2_un(0xFFFF8000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u4_conv_ovf_i2_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u4_conv_ovf_i2_un(0x0000FFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u4_conv_ovf_i2_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u4_conv_u2(0xFFFFFFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_u4_conv_u2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u4_conv_u2(0x0000FFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_u4_conv_u2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u4_conv_ovf_u2(0xFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u4_conv_ovf_u2(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u4_conv_ovf_u2(0x0000FFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_u4_conv_ovf_u2(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u4_conv_ovf_u2_un(0xFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u4_conv_ovf_u2_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0x0000FFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u4_conv_ovf_u2_un(0x0000FFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_u4_conv_ovf_u2_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u4_conv_i4(0xFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u4_conv_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u4_conv_ovf_i4(0xFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u4_conv_ovf_i4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u4_conv_ovf_i4_un(0xFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u4_conv_ovf_i4_un(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u4_conv_u4(0xFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u4_conv_u4(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u4_conv_ovf_u4(0xFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u4_conv_ovf_u4(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u4_conv_ovf_u4_un(0xFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u4_conv_ovf_u4_un(int32, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_u4_conv_i8(0xFFFFFFFF) == 0xFFFFFFFFFFFFFFFF"
+    call int32 Program::Check_ldind_u4_conv_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_u4_conv_ovf_i8(0xFFFFFFFF) == 0xFFFFFFFFFFFFFFFF"
+    call int32 Program::Check_ldind_u4_conv_ovf_i8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i8 0x00000000FFFFFFFF
+    ldstr "Checking ldind_u4_conv_ovf_i8_un(0xFFFFFFFF) == 0x00000000FFFFFFFF"
+    call int32 Program::Check_ldind_u4_conv_ovf_i8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i8 0x00000000FFFFFFFF
+    ldstr "Checking ldind_u4_conv_u8(0xFFFFFFFF) == 0x00000000FFFFFFFF"
+    call int32 Program::Check_ldind_u4_conv_u8(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u4_conv_ovf_u8(0xFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u4_conv_ovf_u8(int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 0xFFFFFFFF
+    ldc.i8 0x00000000FFFFFFFF
+    ldstr "Checking ldind_u4_conv_ovf_u8_un(0xFFFFFFFF) == 0x00000000FFFFFFFF"
+    call int32 Program::Check_ldind_u4_conv_ovf_u8_un(int32, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i8_conv_i1(0x7FFFFFFFFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_i1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldc.i4 0x00000000
+    ldstr "Checking ldind_i8_conv_i1(0x8000000000000000) == 0x00000000"
+    call int32 Program::Check_ldind_i8_conv_i1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i8_conv_i1(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_i1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000000000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i8_conv_i1(0x000000000000007F) == 0x0000007F"
+    call int32 Program::Check_ldind_i8_conv_i1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFF80
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i8_conv_i1(0xFFFFFFFFFFFFFF80) == 0xFFFFFF80"
+    call int32 Program::Check_ldind_i8_conv_i1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000000000FF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i8_conv_i1(0x00000000000000FF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_i1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_i1(0x7FFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i1(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldstr "Checking ldind_i8_conv_ovf_i1(0x8000000000000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i1(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_i1(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_ovf_i1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000000000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i8_conv_ovf_i1(0x000000000000007F) == 0x0000007F"
+    call int32 Program::Check_ldind_i8_conv_ovf_i1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFF80
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_i8_conv_ovf_i1(0xFFFFFFFFFFFFFF80) == 0xFFFFFF80"
+    call int32 Program::Check_ldind_i8_conv_ovf_i1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000000000FF
+    ldstr "Checking ldind_i8_conv_ovf_i1(0x00000000000000FF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i1(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_i1_un(0x7FFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i1_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldstr "Checking ldind_i8_conv_ovf_i1_un(0x8000000000000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i1_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_i1_un(0xFFFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i1_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000000000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_i8_conv_ovf_i1_un(0x000000000000007F) == 0x0000007F"
+    call int32 Program::Check_ldind_i8_conv_ovf_i1_un(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFF80
+    ldstr "Checking ldind_i8_conv_ovf_i1_un(0xFFFFFFFFFFFFFF80) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i1_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000000000FF
+    ldstr "Checking ldind_i8_conv_ovf_i1_un(0x00000000000000FF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i1_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i8_conv_u1(0x7FFFFFFFFFFFFFFF) == 0x000000FF"
+    call int32 Program::Check_ldind_i8_conv_u1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldc.i4 0x00000000
+    ldstr "Checking ldind_i8_conv_u1(0x8000000000000000) == 0x00000000"
+    call int32 Program::Check_ldind_i8_conv_u1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i8_conv_u1(0xFFFFFFFFFFFFFFFF) == 0x000000FF"
+    call int32 Program::Check_ldind_i8_conv_u1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i8_conv_u1(0x00000000000000FF) == 0x000000FF"
+    call int32 Program::Check_ldind_i8_conv_u1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_u1(0x7FFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_u1(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldstr "Checking ldind_i8_conv_ovf_u1(0x8000000000000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_u1(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_u1(0xFFFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_u1(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i8_conv_ovf_u1(0x00000000000000FF) == 0x000000FF"
+    call int32 Program::Check_ldind_i8_conv_ovf_u1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_u1_un(0x7FFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_u1_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldstr "Checking ldind_i8_conv_ovf_u1_un(0x8000000000000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_u1_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_u1_un(0xFFFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_u1_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_i8_conv_ovf_u1_un(0x00000000000000FF) == 0x000000FF"
+    call int32 Program::Check_ldind_i8_conv_ovf_u1_un(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i8_conv_i2(0x7FFFFFFFFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_i2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldc.i4 0x00000000
+    ldstr "Checking ldind_i8_conv_i2(0x8000000000000000) == 0x00000000"
+    call int32 Program::Check_ldind_i8_conv_i2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i8_conv_i2(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_i2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x0000000000007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_i8_conv_i2(0x0000000000007FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_i8_conv_i2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFF8000
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_i8_conv_i2(0xFFFFFFFFFFFF8000) == 0xFFFF8000"
+    call int32 Program::Check_ldind_i8_conv_i2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000000000FFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i8_conv_i2(0x000000000000FFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_i2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_i2(0x7FFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i2(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldstr "Checking ldind_i8_conv_ovf_i2(0x8000000000000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i2(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_i2(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_ovf_i2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x0000000000007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_i8_conv_ovf_i2(0x0000000000007FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_i8_conv_ovf_i2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFF8000
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_i8_conv_ovf_i2(0xFFFFFFFFFFFF8000) == 0xFFFF8000"
+    call int32 Program::Check_ldind_i8_conv_ovf_i2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000000000FFFF
+    ldstr "Checking ldind_i8_conv_ovf_i2(0x000000000000FFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i2(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_i2_un(0x7FFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i2_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldstr "Checking ldind_i8_conv_ovf_i2_un(0x8000000000000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i2_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_i2_un(0xFFFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i2_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x0000000000007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_i8_conv_ovf_i2_un(0x0000000000007FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_i8_conv_ovf_i2_un(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFF8000
+    ldstr "Checking ldind_i8_conv_ovf_i2_un(0xFFFFFFFFFFFF8000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i2_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000000000FFFF
+    ldstr "Checking ldind_i8_conv_ovf_i2_un(0x000000000000FFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i2_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_i8_conv_u2(0x7FFFFFFFFFFFFFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_i8_conv_u2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldc.i4 0x00000000
+    ldstr "Checking ldind_i8_conv_u2(0x8000000000000000) == 0x00000000"
+    call int32 Program::Check_ldind_i8_conv_u2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_i8_conv_u2(0xFFFFFFFFFFFFFFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_i8_conv_u2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000000000FFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_i8_conv_u2(0x000000000000FFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_i8_conv_u2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_u2(0x7FFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_u2(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldstr "Checking ldind_i8_conv_ovf_u2(0x8000000000000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_u2(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_u2(0xFFFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_u2(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000000000FFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_i8_conv_ovf_u2(0x000000000000FFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_i8_conv_ovf_u2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_u2_un(0x7FFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_u2_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldstr "Checking ldind_i8_conv_ovf_u2_un(0x8000000000000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_u2_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_u2_un(0xFFFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_u2_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000000000FFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_i8_conv_ovf_u2_un(0x000000000000FFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_i8_conv_ovf_u2_un(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i8_conv_i4(0x7FFFFFFFFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_i4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldc.i4 0x00000000
+    ldstr "Checking ldind_i8_conv_i4(0x8000000000000000) == 0x00000000"
+    call int32 Program::Check_ldind_i8_conv_i4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i8_conv_i4(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_i4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000007FFFFFFF
+    ldc.i4 0x7FFFFFFF
+    ldstr "Checking ldind_i8_conv_i4(0x000000007FFFFFFF) == 0x7FFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_i4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFF80000000
+    ldc.i4 0x80000000
+    ldstr "Checking ldind_i8_conv_i4(0xFFFFFFFF80000000) == 0x80000000"
+    call int32 Program::Check_ldind_i8_conv_i4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000FFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i8_conv_i4(0x00000000FFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_i4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_i4(0x7FFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i4(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldstr "Checking ldind_i8_conv_ovf_i4(0x8000000000000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i4(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_i4(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_ovf_i4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000007FFFFFFF
+    ldc.i4 0x7FFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_i4(0x000000007FFFFFFF) == 0x7FFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_ovf_i4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFF80000000
+    ldc.i4 0x80000000
+    ldstr "Checking ldind_i8_conv_ovf_i4(0xFFFFFFFF80000000) == 0x80000000"
+    call int32 Program::Check_ldind_i8_conv_ovf_i4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000FFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_i4(0x00000000FFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i4(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_i4_un(0x7FFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i4_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldstr "Checking ldind_i8_conv_ovf_i4_un(0x8000000000000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i4_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_i4_un(0xFFFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i4_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000007FFFFFFF
+    ldc.i4 0x7FFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_i4_un(0x000000007FFFFFFF) == 0x7FFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_ovf_i4_un(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFF80000000
+    ldstr "Checking ldind_i8_conv_ovf_i4_un(0xFFFFFFFF80000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i4_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000FFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_i4_un(0x00000000FFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i4_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i8_conv_u4(0x7FFFFFFFFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_u4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldc.i4 0x00000000
+    ldstr "Checking ldind_i8_conv_u4(0x8000000000000000) == 0x00000000"
+    call int32 Program::Check_ldind_i8_conv_u4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i8_conv_u4(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_u4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000FFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i8_conv_u4(0x00000000FFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_u4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_u4(0x7FFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_u4(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldstr "Checking ldind_i8_conv_ovf_u4(0x8000000000000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_u4(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_u4(0xFFFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_u4(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000FFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_u4(0x00000000FFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_ovf_u4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_u4_un(0x7FFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_u4_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldstr "Checking ldind_i8_conv_ovf_u4_un(0x8000000000000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_u4_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_u4_un(0xFFFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_u4_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000FFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_u4_un(0x00000000FFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_ovf_u4_un(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_i8(0x7FFFFFFFFFFFFFFF) == 0x7FFFFFFFFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_i8(int64, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldc.i8 0x8000000000000000
+    ldstr "Checking ldind_i8_conv_i8(0x8000000000000000) == 0x8000000000000000"
+    call int32 Program::Check_ldind_i8_conv_i8(int64, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_i8(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFFFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_i8(int64, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_i8(0x7FFFFFFFFFFFFFFF) == 0x7FFFFFFFFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_ovf_i8(int64, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldc.i8 0x8000000000000000
+    ldstr "Checking ldind_i8_conv_ovf_i8(0x8000000000000000) == 0x8000000000000000"
+    call int32 Program::Check_ldind_i8_conv_ovf_i8(int64, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_i8(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFFFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_ovf_i8(int64, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_i8_un(0x7FFFFFFFFFFFFFFF) == 0x7FFFFFFFFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_ovf_i8_un(int64, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldstr "Checking ldind_i8_conv_ovf_i8_un(0x8000000000000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i8_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_i8_un(0xFFFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_i8_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_u8(0x7FFFFFFFFFFFFFFF) == 0x7FFFFFFFFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_u8(int64, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldc.i8 0x8000000000000000
+    ldstr "Checking ldind_i8_conv_u8(0x8000000000000000) == 0x8000000000000000"
+    call int32 Program::Check_ldind_i8_conv_u8(int64, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_u8(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFFFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_u8(int64, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_u8(0x7FFFFFFFFFFFFFFF) == 0x7FFFFFFFFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_ovf_u8(int64, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldstr "Checking ldind_i8_conv_ovf_u8(0x8000000000000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_u8(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_u8(0xFFFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_i8_conv_ovf_u8(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldc.i8 0x7FFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_u8_un(0x7FFFFFFFFFFFFFFF) == 0x7FFFFFFFFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_ovf_u8_un(int64, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x8000000000000000
+    ldc.i8 0x8000000000000000
+    ldstr "Checking ldind_i8_conv_ovf_u8_un(0x8000000000000000) == 0x8000000000000000"
+    call int32 Program::Check_ldind_i8_conv_ovf_u8_un(int64, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_i8_conv_ovf_u8_un(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFFFFFFFFFF"
+    call int32 Program::Check_ldind_i8_conv_ovf_u8_un(int64, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u8_conv_i1(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u8_conv_i1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000000000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_u8_conv_i1(0x000000000000007F) == 0x0000007F"
+    call int32 Program::Check_ldind_u8_conv_i1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFF80
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_u8_conv_i1(0xFFFFFFFFFFFFFF80) == 0xFFFFFF80"
+    call int32 Program::Check_ldind_u8_conv_i1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000000000FF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u8_conv_i1(0x00000000000000FF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u8_conv_i1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u8_conv_ovf_i1(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u8_conv_ovf_i1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000000000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_u8_conv_ovf_i1(0x000000000000007F) == 0x0000007F"
+    call int32 Program::Check_ldind_u8_conv_ovf_i1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFF80
+    ldc.i4 0xFFFFFF80
+    ldstr "Checking ldind_u8_conv_ovf_i1(0xFFFFFFFFFFFFFF80) == 0xFFFFFF80"
+    call int32 Program::Check_ldind_u8_conv_ovf_i1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000000000FF
+    ldstr "Checking ldind_u8_conv_ovf_i1(0x00000000000000FF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u8_conv_ovf_i1(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_u8_conv_ovf_i1_un(0xFFFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u8_conv_ovf_i1_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000000000007F
+    ldc.i4 0x0000007F
+    ldstr "Checking ldind_u8_conv_ovf_i1_un(0x000000000000007F) == 0x0000007F"
+    call int32 Program::Check_ldind_u8_conv_ovf_i1_un(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFF80
+    ldstr "Checking ldind_u8_conv_ovf_i1_un(0xFFFFFFFFFFFFFF80) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u8_conv_ovf_i1_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000000000FF
+    ldstr "Checking ldind_u8_conv_ovf_i1_un(0x00000000000000FF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u8_conv_ovf_i1_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u8_conv_u1(0xFFFFFFFFFFFFFFFF) == 0x000000FF"
+    call int32 Program::Check_ldind_u8_conv_u1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u8_conv_u1(0x00000000000000FF) == 0x000000FF"
+    call int32 Program::Check_ldind_u8_conv_u1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_u8_conv_ovf_u1(0xFFFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u8_conv_ovf_u1(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u8_conv_ovf_u1(0x00000000000000FF) == 0x000000FF"
+    call int32 Program::Check_ldind_u8_conv_ovf_u1(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_u8_conv_ovf_u1_un(0xFFFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u8_conv_ovf_u1_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000000000FF
+    ldc.i4 0x000000FF
+    ldstr "Checking ldind_u8_conv_ovf_u1_un(0x00000000000000FF) == 0x000000FF"
+    call int32 Program::Check_ldind_u8_conv_ovf_u1_un(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u8_conv_i2(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u8_conv_i2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x0000000000007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_u8_conv_i2(0x0000000000007FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_u8_conv_i2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFF8000
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_u8_conv_i2(0xFFFFFFFFFFFF8000) == 0xFFFF8000"
+    call int32 Program::Check_ldind_u8_conv_i2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000000000FFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u8_conv_i2(0x000000000000FFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u8_conv_i2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u8_conv_ovf_i2(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u8_conv_ovf_i2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x0000000000007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_u8_conv_ovf_i2(0x0000000000007FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_u8_conv_ovf_i2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFF8000
+    ldc.i4 0xFFFF8000
+    ldstr "Checking ldind_u8_conv_ovf_i2(0xFFFFFFFFFFFF8000) == 0xFFFF8000"
+    call int32 Program::Check_ldind_u8_conv_ovf_i2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000000000FFFF
+    ldstr "Checking ldind_u8_conv_ovf_i2(0x000000000000FFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u8_conv_ovf_i2(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_u8_conv_ovf_i2_un(0xFFFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u8_conv_ovf_i2_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x0000000000007FFF
+    ldc.i4 0x00007FFF
+    ldstr "Checking ldind_u8_conv_ovf_i2_un(0x0000000000007FFF) == 0x00007FFF"
+    call int32 Program::Check_ldind_u8_conv_ovf_i2_un(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFF8000
+    ldstr "Checking ldind_u8_conv_ovf_i2_un(0xFFFFFFFFFFFF8000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u8_conv_ovf_i2_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000000000FFFF
+    ldstr "Checking ldind_u8_conv_ovf_i2_un(0x000000000000FFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u8_conv_ovf_i2_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u8_conv_u2(0xFFFFFFFFFFFFFFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_u8_conv_u2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000000000FFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u8_conv_u2(0x000000000000FFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_u8_conv_u2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_u8_conv_ovf_u2(0xFFFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u8_conv_ovf_u2(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000000000FFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u8_conv_ovf_u2(0x000000000000FFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_u8_conv_ovf_u2(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_u8_conv_ovf_u2_un(0xFFFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u8_conv_ovf_u2_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000000000FFFF
+    ldc.i4 0x0000FFFF
+    ldstr "Checking ldind_u8_conv_ovf_u2_un(0x000000000000FFFF) == 0x0000FFFF"
+    call int32 Program::Check_ldind_u8_conv_ovf_u2_un(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u8_conv_i4(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u8_conv_i4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000007FFFFFFF
+    ldc.i4 0x7FFFFFFF
+    ldstr "Checking ldind_u8_conv_i4(0x000000007FFFFFFF) == 0x7FFFFFFF"
+    call int32 Program::Check_ldind_u8_conv_i4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFF80000000
+    ldc.i4 0x80000000
+    ldstr "Checking ldind_u8_conv_i4(0xFFFFFFFF80000000) == 0x80000000"
+    call int32 Program::Check_ldind_u8_conv_i4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000FFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u8_conv_i4(0x00000000FFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u8_conv_i4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u8_conv_ovf_i4(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u8_conv_ovf_i4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000007FFFFFFF
+    ldc.i4 0x7FFFFFFF
+    ldstr "Checking ldind_u8_conv_ovf_i4(0x000000007FFFFFFF) == 0x7FFFFFFF"
+    call int32 Program::Check_ldind_u8_conv_ovf_i4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFF80000000
+    ldc.i4 0x80000000
+    ldstr "Checking ldind_u8_conv_ovf_i4(0xFFFFFFFF80000000) == 0x80000000"
+    call int32 Program::Check_ldind_u8_conv_ovf_i4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000FFFFFFFF
+    ldstr "Checking ldind_u8_conv_ovf_i4(0x00000000FFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u8_conv_ovf_i4(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_u8_conv_ovf_i4_un(0xFFFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u8_conv_ovf_i4_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x000000007FFFFFFF
+    ldc.i4 0x7FFFFFFF
+    ldstr "Checking ldind_u8_conv_ovf_i4_un(0x000000007FFFFFFF) == 0x7FFFFFFF"
+    call int32 Program::Check_ldind_u8_conv_ovf_i4_un(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFF80000000
+    ldstr "Checking ldind_u8_conv_ovf_i4_un(0xFFFFFFFF80000000) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u8_conv_ovf_i4_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000FFFFFFFF
+    ldstr "Checking ldind_u8_conv_ovf_i4_un(0x00000000FFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u8_conv_ovf_i4_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u8_conv_u4(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u8_conv_u4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000FFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u8_conv_u4(0x00000000FFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u8_conv_u4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_u8_conv_ovf_u4(0xFFFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u8_conv_ovf_u4(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000FFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u8_conv_ovf_u4(0x00000000FFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u8_conv_ovf_u4(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_u8_conv_ovf_u4_un(0xFFFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u8_conv_ovf_u4_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0x00000000FFFFFFFF
+    ldc.i4 0xFFFFFFFF
+    ldstr "Checking ldind_u8_conv_ovf_u4_un(0x00000000FFFFFFFF) == 0xFFFFFFFF"
+    call int32 Program::Check_ldind_u8_conv_ovf_u4_un(int64, int32, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_u8_conv_i8(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFFFFFFFFFF"
+    call int32 Program::Check_ldind_u8_conv_i8(int64, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_u8_conv_ovf_i8(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFFFFFFFFFF"
+    call int32 Program::Check_ldind_u8_conv_ovf_i8(int64, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_u8_conv_ovf_i8_un(0xFFFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u8_conv_ovf_i8_un(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_u8_conv_u8(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFFFFFFFFFF"
+    call int32 Program::Check_ldind_u8_conv_u8(int64, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_u8_conv_ovf_u8(0xFFFFFFFFFFFFFFFF) == OverflowException"
+    call int32 Program::CheckOvf_ldind_u8_conv_ovf_u8(int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldc.i8 0xFFFFFFFFFFFFFFFF
+    ldstr "Checking ldind_u8_conv_ovf_u8_un(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFFFFFFFFFF"
+    call int32 Program::Check_ldind_u8_conv_ovf_u8_un(int64, int64, class [System.Private.CoreLib]System.String)
+    brfalse FAIL
+
+    ldc.i4 100
+    ret
+
+FAIL:
+    ldstr "FAILED"
+    call void Program::print(class [System.Private.CoreLib]System.String)    
+    ldc.i4 1
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_i1(int8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.i1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_i1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_i1(int8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_ovf_i1(int8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.ovf.i1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_ovf_i1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_i1(int8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i1_conv_ovf_i1(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_i1(int8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_ovf_i1_un(int8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.ovf.i1.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_ovf_i1_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_i1_un(int8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i1_conv_ovf_i1_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_i1_un(int8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_u1(int8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.u1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_u1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_u1(int8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_ovf_u1(int8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.ovf.u1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_ovf_u1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_u1(int8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i1_conv_ovf_u1(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_u1(int8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_ovf_u1_un(int8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.ovf.u1.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_ovf_u1_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_u1_un(int8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i1_conv_ovf_u1_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_u1_un(int8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_i2(int8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.i2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_i2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_i2(int8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_ovf_i2(int8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.ovf.i2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_ovf_i2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_i2(int8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i1_conv_ovf_i2(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_i2(int8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_ovf_i2_un(int8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.ovf.i2.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_ovf_i2_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_i2_un(int8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i1_conv_ovf_i2_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_i2_un(int8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_u2(int8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.u2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_u2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_u2(int8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_ovf_u2(int8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.ovf.u2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_ovf_u2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_u2(int8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i1_conv_ovf_u2(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_u2(int8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_ovf_u2_un(int8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.ovf.u2.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_ovf_u2_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_u2_un(int8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i1_conv_ovf_u2_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_u2_un(int8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_i4(int8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.i4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_i4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_i4(int8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_ovf_i4(int8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.ovf.i4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_ovf_i4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_i4(int8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i1_conv_ovf_i4(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_i4(int8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_ovf_i4_un(int8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.ovf.i4.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_ovf_i4_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_i4_un(int8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i1_conv_ovf_i4_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_i4_un(int8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_u4(int8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.u4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_u4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_u4(int8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_ovf_u4(int8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.ovf.u4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_ovf_u4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_u4(int8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i1_conv_ovf_u4(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_u4(int8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_ovf_u4_un(int8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.ovf.u4.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_ovf_u4_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_u4_un(int8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i1_conv_ovf_u4_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_u4_un(int8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_i8(int8& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.i8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_i8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_i8(int8&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_ovf_i8(int8& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.ovf.i8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_ovf_i8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_i8(int8&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i1_conv_ovf_i8(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_i8(int8&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_ovf_i8_un(int8& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.ovf.i8.un
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_ovf_i8_un(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_i8_un(int8&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i1_conv_ovf_i8_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_i8_un(int8&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_u8(int8& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.u8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_u8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_u8(int8&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_ovf_u8(int8& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.ovf.u8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_ovf_u8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_u8(int8&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i1_conv_ovf_u8(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_u8(int8&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i1_conv_ovf_u8_un(int8& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i1
+    conv.ovf.u8.un
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i1_conv_ovf_u8_un(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_u8_un(int8&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i1_conv_ovf_u8_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int8 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i1_conv_ovf_u8_un(int8&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_i1(uint8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.i1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_i1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_i1(uint8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_ovf_i1(uint8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.ovf.i1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_ovf_i1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_i1(uint8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u1_conv_ovf_i1(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_i1(uint8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_ovf_i1_un(uint8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.ovf.i1.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_ovf_i1_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_i1_un(uint8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u1_conv_ovf_i1_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_i1_un(uint8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_u1(uint8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.u1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_u1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_u1(uint8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_ovf_u1(uint8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.ovf.u1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_ovf_u1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_u1(uint8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u1_conv_ovf_u1(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_u1(uint8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_ovf_u1_un(uint8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.ovf.u1.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_ovf_u1_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_u1_un(uint8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u1_conv_ovf_u1_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_u1_un(uint8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_i2(uint8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.i2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_i2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_i2(uint8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_ovf_i2(uint8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.ovf.i2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_ovf_i2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_i2(uint8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u1_conv_ovf_i2(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_i2(uint8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_ovf_i2_un(uint8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.ovf.i2.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_ovf_i2_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_i2_un(uint8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u1_conv_ovf_i2_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_i2_un(uint8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_u2(uint8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.u2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_u2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_u2(uint8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_ovf_u2(uint8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.ovf.u2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_ovf_u2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_u2(uint8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u1_conv_ovf_u2(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_u2(uint8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_ovf_u2_un(uint8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.ovf.u2.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_ovf_u2_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_u2_un(uint8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u1_conv_ovf_u2_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_u2_un(uint8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_i4(uint8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.i4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_i4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_i4(uint8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_ovf_i4(uint8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.ovf.i4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_ovf_i4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_i4(uint8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u1_conv_ovf_i4(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_i4(uint8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_ovf_i4_un(uint8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.ovf.i4.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_ovf_i4_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_i4_un(uint8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u1_conv_ovf_i4_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_i4_un(uint8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_u4(uint8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.u4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_u4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_u4(uint8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_ovf_u4(uint8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.ovf.u4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_ovf_u4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_u4(uint8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u1_conv_ovf_u4(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_u4(uint8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_ovf_u4_un(uint8& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.ovf.u4.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_ovf_u4_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_u4_un(uint8&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u1_conv_ovf_u4_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_u4_un(uint8&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_i8(uint8& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.i8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_i8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_i8(uint8&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_ovf_i8(uint8& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.ovf.i8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_ovf_i8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_i8(uint8&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u1_conv_ovf_i8(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_i8(uint8&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_ovf_i8_un(uint8& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.ovf.i8.un
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_ovf_i8_un(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_i8_un(uint8&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u1_conv_ovf_i8_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_i8_un(uint8&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_u8(uint8& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.u8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_u8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_u8(uint8&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_ovf_u8(uint8& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.ovf.u8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_ovf_u8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_u8(uint8&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u1_conv_ovf_u8(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_u8(uint8&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u1_conv_ovf_u8_un(uint8& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u1
+    conv.ovf.u8.un
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u1_conv_ovf_u8_un(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_u8_un(uint8&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u1_conv_ovf_u8_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint8 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u1_conv_ovf_u8_un(uint8&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_i1(int16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.i1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_i1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_i1(int16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_ovf_i1(int16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.ovf.i1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_ovf_i1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_i1(int16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i2_conv_ovf_i1(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_i1(int16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_ovf_i1_un(int16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.ovf.i1.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_ovf_i1_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_i1_un(int16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i2_conv_ovf_i1_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_i1_un(int16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_u1(int16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.u1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_u1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_u1(int16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_ovf_u1(int16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.ovf.u1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_ovf_u1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_u1(int16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i2_conv_ovf_u1(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_u1(int16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_ovf_u1_un(int16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.ovf.u1.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_ovf_u1_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_u1_un(int16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i2_conv_ovf_u1_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_u1_un(int16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_i2(int16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.i2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_i2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_i2(int16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_ovf_i2(int16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.ovf.i2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_ovf_i2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_i2(int16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i2_conv_ovf_i2(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_i2(int16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_ovf_i2_un(int16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.ovf.i2.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_ovf_i2_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_i2_un(int16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i2_conv_ovf_i2_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_i2_un(int16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_u2(int16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.u2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_u2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_u2(int16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_ovf_u2(int16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.ovf.u2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_ovf_u2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_u2(int16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i2_conv_ovf_u2(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_u2(int16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_ovf_u2_un(int16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.ovf.u2.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_ovf_u2_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_u2_un(int16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i2_conv_ovf_u2_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_u2_un(int16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_i4(int16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.i4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_i4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_i4(int16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_ovf_i4(int16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.ovf.i4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_ovf_i4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_i4(int16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i2_conv_ovf_i4(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_i4(int16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_ovf_i4_un(int16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.ovf.i4.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_ovf_i4_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_i4_un(int16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i2_conv_ovf_i4_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_i4_un(int16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_u4(int16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.u4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_u4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_u4(int16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_ovf_u4(int16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.ovf.u4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_ovf_u4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_u4(int16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i2_conv_ovf_u4(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_u4(int16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_ovf_u4_un(int16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.ovf.u4.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_ovf_u4_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_u4_un(int16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i2_conv_ovf_u4_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_u4_un(int16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_i8(int16& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.i8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_i8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_i8(int16&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_ovf_i8(int16& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.ovf.i8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_ovf_i8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_i8(int16&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i2_conv_ovf_i8(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_i8(int16&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_ovf_i8_un(int16& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.ovf.i8.un
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_ovf_i8_un(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_i8_un(int16&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i2_conv_ovf_i8_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_i8_un(int16&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_u8(int16& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.u8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_u8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_u8(int16&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_ovf_u8(int16& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.ovf.u8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_ovf_u8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_u8(int16&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i2_conv_ovf_u8(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_u8(int16&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i2_conv_ovf_u8_un(int16& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i2
+    conv.ovf.u8.un
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i2_conv_ovf_u8_un(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_u8_un(int16&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i2_conv_ovf_u8_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int16 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i2_conv_ovf_u8_un(int16&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_i1(uint16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.i1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_i1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_i1(uint16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_ovf_i1(uint16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.ovf.i1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_ovf_i1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_i1(uint16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u2_conv_ovf_i1(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_i1(uint16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_ovf_i1_un(uint16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.ovf.i1.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_ovf_i1_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_i1_un(uint16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u2_conv_ovf_i1_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_i1_un(uint16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_u1(uint16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.u1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_u1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_u1(uint16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_ovf_u1(uint16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.ovf.u1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_ovf_u1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_u1(uint16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u2_conv_ovf_u1(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_u1(uint16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_ovf_u1_un(uint16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.ovf.u1.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_ovf_u1_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_u1_un(uint16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u2_conv_ovf_u1_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_u1_un(uint16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_i2(uint16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.i2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_i2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_i2(uint16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_ovf_i2(uint16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.ovf.i2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_ovf_i2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_i2(uint16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u2_conv_ovf_i2(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_i2(uint16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_ovf_i2_un(uint16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.ovf.i2.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_ovf_i2_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_i2_un(uint16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u2_conv_ovf_i2_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_i2_un(uint16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_u2(uint16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.u2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_u2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_u2(uint16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_ovf_u2(uint16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.ovf.u2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_ovf_u2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_u2(uint16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u2_conv_ovf_u2(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_u2(uint16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_ovf_u2_un(uint16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.ovf.u2.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_ovf_u2_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_u2_un(uint16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u2_conv_ovf_u2_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_u2_un(uint16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_i4(uint16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.i4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_i4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_i4(uint16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_ovf_i4(uint16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.ovf.i4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_ovf_i4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_i4(uint16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u2_conv_ovf_i4(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_i4(uint16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_ovf_i4_un(uint16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.ovf.i4.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_ovf_i4_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_i4_un(uint16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u2_conv_ovf_i4_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_i4_un(uint16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_u4(uint16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.u4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_u4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_u4(uint16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_ovf_u4(uint16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.ovf.u4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_ovf_u4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_u4(uint16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u2_conv_ovf_u4(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_u4(uint16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_ovf_u4_un(uint16& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.ovf.u4.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_ovf_u4_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_u4_un(uint16&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u2_conv_ovf_u4_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_u4_un(uint16&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_i8(uint16& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.i8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_i8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_i8(uint16&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_ovf_i8(uint16& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.ovf.i8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_ovf_i8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_i8(uint16&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u2_conv_ovf_i8(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_i8(uint16&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_ovf_i8_un(uint16& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.ovf.i8.un
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_ovf_i8_un(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_i8_un(uint16&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u2_conv_ovf_i8_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_i8_un(uint16&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_u8(uint16& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.u8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_u8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_u8(uint16&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_ovf_u8(uint16& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.ovf.u8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_ovf_u8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_u8(uint16&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u2_conv_ovf_u8(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_u8(uint16&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u2_conv_ovf_u8_un(uint16& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u2
+    conv.ovf.u8.un
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u2_conv_ovf_u8_un(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_u8_un(uint16&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u2_conv_ovf_u8_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint16 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u2_conv_ovf_u8_un(uint16&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_i1(int32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.i1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_i1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_i1(int32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_ovf_i1(int32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.ovf.i1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_ovf_i1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_i1(int32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i4_conv_ovf_i1(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_i1(int32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_ovf_i1_un(int32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.ovf.i1.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_ovf_i1_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_i1_un(int32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i4_conv_ovf_i1_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_i1_un(int32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_u1(int32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.u1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_u1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_u1(int32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_ovf_u1(int32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.ovf.u1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_ovf_u1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_u1(int32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i4_conv_ovf_u1(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_u1(int32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_ovf_u1_un(int32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.ovf.u1.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_ovf_u1_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_u1_un(int32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i4_conv_ovf_u1_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_u1_un(int32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_i2(int32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.i2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_i2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_i2(int32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_ovf_i2(int32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.ovf.i2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_ovf_i2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_i2(int32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i4_conv_ovf_i2(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_i2(int32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_ovf_i2_un(int32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.ovf.i2.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_ovf_i2_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_i2_un(int32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i4_conv_ovf_i2_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_i2_un(int32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_u2(int32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.u2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_u2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_u2(int32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_ovf_u2(int32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.ovf.u2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_ovf_u2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_u2(int32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i4_conv_ovf_u2(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_u2(int32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_ovf_u2_un(int32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.ovf.u2.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_ovf_u2_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_u2_un(int32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i4_conv_ovf_u2_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_u2_un(int32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_i4(int32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.i4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_i4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_i4(int32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_ovf_i4(int32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.ovf.i4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_ovf_i4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_i4(int32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i4_conv_ovf_i4(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_i4(int32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_ovf_i4_un(int32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.ovf.i4.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_ovf_i4_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_i4_un(int32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i4_conv_ovf_i4_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_i4_un(int32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_u4(int32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.u4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_u4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_u4(int32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_ovf_u4(int32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.ovf.u4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_ovf_u4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_u4(int32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i4_conv_ovf_u4(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_u4(int32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_ovf_u4_un(int32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.ovf.u4.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_ovf_u4_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_u4_un(int32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i4_conv_ovf_u4_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_u4_un(int32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_i8(int32& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.i8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_i8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_i8(int32&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_ovf_i8(int32& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.ovf.i8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_ovf_i8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_i8(int32&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i4_conv_ovf_i8(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_i8(int32&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_ovf_i8_un(int32& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.ovf.i8.un
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_ovf_i8_un(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_i8_un(int32&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i4_conv_ovf_i8_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_i8_un(int32&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_u8(int32& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.u8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_u8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_u8(int32&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_ovf_u8(int32& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.ovf.u8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_ovf_u8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_u8(int32&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i4_conv_ovf_u8(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_u8(int32&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i4_conv_ovf_u8_un(int32& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i4
+    conv.ovf.u8.un
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i4_conv_ovf_u8_un(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_u8_un(int32&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i4_conv_ovf_u8_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int32 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i4_conv_ovf_u8_un(int32&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_i1(uint32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.i1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_i1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_i1(uint32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_ovf_i1(uint32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.ovf.i1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_ovf_i1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_i1(uint32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u4_conv_ovf_i1(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_i1(uint32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_ovf_i1_un(uint32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.ovf.i1.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_ovf_i1_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_i1_un(uint32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u4_conv_ovf_i1_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_i1_un(uint32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_u1(uint32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.u1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_u1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_u1(uint32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_ovf_u1(uint32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.ovf.u1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_ovf_u1(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_u1(uint32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u4_conv_ovf_u1(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_u1(uint32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_ovf_u1_un(uint32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.ovf.u1.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_ovf_u1_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_u1_un(uint32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u4_conv_ovf_u1_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_u1_un(uint32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_i2(uint32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.i2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_i2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_i2(uint32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_ovf_i2(uint32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.ovf.i2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_ovf_i2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_i2(uint32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u4_conv_ovf_i2(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_i2(uint32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_ovf_i2_un(uint32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.ovf.i2.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_ovf_i2_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_i2_un(uint32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u4_conv_ovf_i2_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_i2_un(uint32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_u2(uint32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.u2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_u2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_u2(uint32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_ovf_u2(uint32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.ovf.u2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_ovf_u2(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_u2(uint32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u4_conv_ovf_u2(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_u2(uint32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_ovf_u2_un(uint32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.ovf.u2.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_ovf_u2_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_u2_un(uint32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u4_conv_ovf_u2_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_u2_un(uint32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_i4(uint32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.i4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_i4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_i4(uint32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_ovf_i4(uint32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.ovf.i4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_ovf_i4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_i4(uint32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u4_conv_ovf_i4(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_i4(uint32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_ovf_i4_un(uint32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.ovf.i4.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_ovf_i4_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_i4_un(uint32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u4_conv_ovf_i4_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_i4_un(uint32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_u4(uint32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.u4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_u4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_u4(uint32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_ovf_u4(uint32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.ovf.u4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_ovf_u4(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_u4(uint32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u4_conv_ovf_u4(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_u4(uint32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_ovf_u4_un(uint32& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.ovf.u4.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_ovf_u4_un(int32 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_u4_un(uint32&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u4_conv_ovf_u4_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_u4_un(uint32&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_i8(uint32& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.i8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_i8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_i8(uint32&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_ovf_i8(uint32& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.ovf.i8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_ovf_i8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_i8(uint32&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u4_conv_ovf_i8(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_i8(uint32&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_ovf_i8_un(uint32& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.ovf.i8.un
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_ovf_i8_un(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_i8_un(uint32&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u4_conv_ovf_i8_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_i8_un(uint32&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_u8(uint32& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.u8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_u8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_u8(uint32&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_ovf_u8(uint32& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.ovf.u8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_ovf_u8(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_u8(uint32&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u4_conv_ovf_u8(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_u8(uint32&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u4_conv_ovf_u8_un(uint32& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u4
+    conv.ovf.u8.un
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u4_conv_ovf_u8_un(int32 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_u8_un(uint32&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u4_conv_ovf_u8_un(int32 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint32 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u4_conv_ovf_u8_un(uint32&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_i1(int64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.i1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_i1(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_i1(int64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_ovf_i1(int64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.ovf.i1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_ovf_i1(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_i1(int64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i8_conv_ovf_i1(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_i1(int64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_ovf_i1_un(int64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.ovf.i1.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_ovf_i1_un(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_i1_un(int64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i8_conv_ovf_i1_un(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_i1_un(int64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_u1(int64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.u1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_u1(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_u1(int64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_ovf_u1(int64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.ovf.u1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_ovf_u1(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_u1(int64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i8_conv_ovf_u1(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_u1(int64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_ovf_u1_un(int64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.ovf.u1.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_ovf_u1_un(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_u1_un(int64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i8_conv_ovf_u1_un(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_u1_un(int64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_i2(int64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.i2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_i2(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_i2(int64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_ovf_i2(int64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.ovf.i2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_ovf_i2(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_i2(int64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i8_conv_ovf_i2(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_i2(int64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_ovf_i2_un(int64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.ovf.i2.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_ovf_i2_un(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_i2_un(int64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i8_conv_ovf_i2_un(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_i2_un(int64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_u2(int64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.u2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_u2(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_u2(int64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_ovf_u2(int64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.ovf.u2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_ovf_u2(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_u2(int64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i8_conv_ovf_u2(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_u2(int64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_ovf_u2_un(int64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.ovf.u2.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_ovf_u2_un(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_u2_un(int64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i8_conv_ovf_u2_un(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_u2_un(int64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_i4(int64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.i4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_i4(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_i4(int64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_ovf_i4(int64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.ovf.i4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_ovf_i4(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_i4(int64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i8_conv_ovf_i4(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_i4(int64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_ovf_i4_un(int64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.ovf.i4.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_ovf_i4_un(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_i4_un(int64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i8_conv_ovf_i4_un(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_i4_un(int64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_u4(int64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.u4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_u4(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_u4(int64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_ovf_u4(int64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.ovf.u4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_ovf_u4(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_u4(int64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i8_conv_ovf_u4(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_u4(int64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_ovf_u4_un(int64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.ovf.u4.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_ovf_u4_un(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_u4_un(int64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i8_conv_ovf_u4_un(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_u4_un(int64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_i8(int64& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.i8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_i8(int64 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_i8(int64&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_ovf_i8(int64& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.ovf.i8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_ovf_i8(int64 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_i8(int64&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i8_conv_ovf_i8(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_i8(int64&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_ovf_i8_un(int64& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.ovf.i8.un
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_ovf_i8_un(int64 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_i8_un(int64&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i8_conv_ovf_i8_un(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_i8_un(int64&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_u8(int64& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.u8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_u8(int64 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_u8(int64&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_ovf_u8(int64& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.ovf.u8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_ovf_u8(int64 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_u8(int64&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i8_conv_ovf_u8(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_u8(int64&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_i8_conv_ovf_u8_un(int64& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.i8
+    conv.ovf.u8.un
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_i8_conv_ovf_u8_un(int64 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_u8_un(int64&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_i8_conv_ovf_u8_un(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(int64 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_i8_conv_ovf_u8_un(int64&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_i1(uint64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.i1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_i1(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_i1(uint64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_ovf_i1(uint64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.ovf.i1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_ovf_i1(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_i1(uint64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u8_conv_ovf_i1(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_i1(uint64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_ovf_i1_un(uint64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.ovf.i1.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_ovf_i1_un(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_i1_un(uint64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u8_conv_ovf_i1_un(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_i1_un(uint64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_u1(uint64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.u1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_u1(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_u1(uint64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_ovf_u1(uint64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.ovf.u1
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_ovf_u1(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_u1(uint64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u8_conv_ovf_u1(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_u1(uint64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_ovf_u1_un(uint64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.ovf.u1.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_ovf_u1_un(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_u1_un(uint64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u8_conv_ovf_u1_un(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_u1_un(uint64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_i2(uint64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.i2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_i2(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_i2(uint64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_ovf_i2(uint64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.ovf.i2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_ovf_i2(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_i2(uint64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u8_conv_ovf_i2(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_i2(uint64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_ovf_i2_un(uint64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.ovf.i2.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_ovf_i2_un(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_i2_un(uint64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u8_conv_ovf_i2_un(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_i2_un(uint64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_u2(uint64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.u2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_u2(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_u2(uint64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_ovf_u2(uint64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.ovf.u2
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_ovf_u2(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_u2(uint64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u8_conv_ovf_u2(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_u2(uint64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_ovf_u2_un(uint64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.ovf.u2.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_ovf_u2_un(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_u2_un(uint64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u8_conv_ovf_u2_un(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_u2_un(uint64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_i4(uint64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.i4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_i4(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_i4(uint64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_ovf_i4(uint64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.ovf.i4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_ovf_i4(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_i4(uint64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u8_conv_ovf_i4(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_i4(uint64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_ovf_i4_un(uint64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.ovf.i4.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_ovf_i4_un(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_i4_un(uint64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u8_conv_ovf_i4_un(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_i4_un(uint64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_u4(uint64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.u4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_u4(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_u4(uint64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_ovf_u4(uint64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.ovf.u4
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_ovf_u4(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_u4(uint64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u8_conv_ovf_u4(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_u4(uint64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_ovf_u4_un(uint64& src, int32& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.ovf.u4.un
+    stind.i4
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_ovf_u4_un(int64 input, int32 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_u4_un(uint64&, int32&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u8_conv_ovf_u4_un(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int32 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_u4_un(uint64&, int32&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_i8(uint64& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.i8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_i8(int64 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_i8(uint64&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_ovf_i8(uint64& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.ovf.i8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_ovf_i8(int64 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_i8(uint64&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u8_conv_ovf_i8(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_i8(uint64&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_ovf_i8_un(uint64& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.ovf.i8.un
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_ovf_i8_un(int64 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_i8_un(uint64&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u8_conv_ovf_i8_un(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_i8_un(uint64&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_u8(uint64& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.u8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_u8(int64 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_u8(uint64&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_ovf_u8(uint64& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.ovf.u8
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_ovf_u8(int64 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_u8(uint64&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u8_conv_ovf_u8(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_u8(uint64&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+
+  .method private hidebysig static void Test_ldind_u8_conv_ovf_u8_un(uint64& src, int64& dst) cil managed noinlining
+  {
+    .maxstack 4
+    ldarg.1
+    ldarg.0
+    ldind.u8
+    conv.ovf.u8.un
+    stind.i8
+    ret
+  }
+
+  .method private hidebysig static int32 Check_ldind_u8_conv_ovf_u8_un(int64 input, int64 expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int64 dst)
+    ldarg.2
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_u8_un(uint64&, int64&)
+    ldloc.1
+    ldarg.1
+    ceq
+    ret
+  }
+
+  .method private hidebysig static int32 CheckOvf_ldind_u8_conv_ovf_u8_un(int64 input, class [System.Private.CoreLib]System.String desc) cil managed noinlining
+  {
+    .maxstack 4
+    .locals init(uint64 src, int64 dst, int32 ovf)
+    ldarg.1
+    call void Program::print(class [System.Private.CoreLib]System.String)
+    ldarg.0
+    stloc 0
+    .try {
+    ldloca 0
+    ldloca 1
+    call void Program::Test_ldind_u8_conv_ovf_u8_un(uint64&, int64&)
+    leave END
+    } catch [System.Private.CoreLib]System.OverflowException {
+    ldc.i4 1
+    stloc 2
+    leave END
+    }
+    END: ldloc.2
+    ret
+  }
+}

--- a/tests/src/JIT/Directed/Convert/ldind_conv.ilproj
+++ b/tests/src/JIT/Directed/Convert/ldind_conv.ilproj
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/Directed/Convert/ldind_conv_gen.csx
+++ b/tests/src/JIT/Directed/Convert/ldind_conv_gen.csx
@@ -1,0 +1,471 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// This C# script can be executed using the csi
+// tool found in Tools\net46\roslyn\tools.
+//
+// It produces an IL file (on stdout) containing tests
+// for all possible integral ldind/conv combinations.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+class ILType
+{
+    public static readonly ILType I1 = new ILType(byteSize: 1, unsigned: false, min: 0xFFFF_FFFF_FFFF_FF80, max: 0x7F);
+    public static readonly ILType U1 = new ILType(byteSize: 1, unsigned: true, min: 0, max: 0xFF);
+    public static readonly ILType I2 = new ILType(byteSize: 2, unsigned: false, min: 0xFFFF_FFFF_FFFF_8000, max: 0x7FFF);
+    public static readonly ILType U2 = new ILType(byteSize: 2, unsigned: true, min: 0, max: 0xFFFF);
+    public static readonly ILType I4 = new ILType(byteSize: 4, unsigned: false, min: 0xFFFF_FFFF_8000_0000, max: 0x7FFF_FFFF);
+    public static readonly ILType U4 = new ILType(byteSize: 4, unsigned: true, min: 0, max: 0xFFFF_FFFF);
+    public static readonly ILType I8 = new ILType(byteSize: 8, unsigned: false, min: 0x8000_0000_0000_0000, max: 0x7FFF_FFFF_FFFF_FFFF);
+    public static readonly ILType U8 = new ILType(byteSize: 8, unsigned: true, min: 0, max: 0xFFFF_FFFF_FFFF_FFFF);
+
+    public static readonly IEnumerable<ILType> Types = new[] { I1, U1, I2, U2, I4, U4, I8, U8 };
+
+    public readonly int ByteSize;
+    public readonly bool IsUnsigned;
+    public readonly ulong Min;
+    public readonly ulong Max;
+
+    ILType(int byteSize, bool unsigned, ulong min, ulong max)
+    {
+        ByteSize = byteSize;
+        IsUnsigned = unsigned;
+        Min = min;
+        Max = max;
+    }
+
+    public int BitSize => ByteSize * 8;
+    public bool IsSigned => !IsUnsigned;
+    public bool IsSmall => ByteSize < 4;
+    public bool IsSmallUnsigned => IsSmall && IsUnsigned;
+    public bool IsSmallSigned => IsSmall && IsSigned;
+
+    public string Name => $"{(IsUnsigned ? "u" : "")}int{BitSize}";
+    public string ShortName => $"{(IsUnsigned ? "u" : "i")}{ByteSize}";
+
+    public ILType ActualType => ByteSize <= 4 ? I4 : I8;
+
+    public ILType UnsignedType
+    {
+        get
+        {
+            switch (ByteSize)
+            {
+            case 1:
+                return U1;
+            case 2:
+                return U2;
+            case 4:
+                return U4;
+            case 8:
+                return U8;
+            default:
+                throw new Exception();
+            }
+        }
+    }
+
+    public ILType SignedType
+    {
+        get
+        {
+            switch (ByteSize)
+            {
+            case 1:
+                return I1;
+            case 2:
+                return I2;
+            case 4:
+                return I4;
+            case 8:
+                return I8;
+            default:
+                throw new Exception();
+            }
+        }
+    }
+
+    public ulong AllOnes => UnsignedType.Max;
+
+    public string ILConst(ulong value) => $"ldc.i{ActualType.ByteSize} {Hex(value)}";
+
+    public string Hex(ulong value)
+    {
+        string hex = value.ToString("X16");
+
+        if (hex.Length > ByteSize * 2)
+        {
+            hex = hex.Substring(hex.Length - ByteSize * 2);
+        }
+
+        return "0x" + hex;
+    }
+}
+
+class ILConv
+{
+    public static IEnumerable<ILConv> Conversions
+    {
+        get
+        {
+            foreach (ILType type in ILType.Types)
+            {
+                yield return new ILConv(type, false, false);
+                yield return new ILConv(type, true, false);
+                yield return new ILConv(type, true, true);
+            }
+        }
+    }
+
+    public readonly ILType Type;
+    public readonly bool Ovf;
+    public readonly bool Un;
+
+    ILConv(ILType type, bool overflow, bool unsigned)
+    {
+        Type = type;
+        Ovf = overflow;
+        Un = unsigned;
+    }
+
+    public string IL => $"conv.{(Ovf ? "ovf." : "")}{Type.ShortName}{(Ovf & Un ? ".un" : "")}";
+
+    static ulong SignExtend(ulong value, ILType valueType)
+    {
+        if ((value & valueType.Min) != 0)
+            value |= ~valueType.AllOnes;
+        return value;
+    }
+
+    static ulong ZeroExtend(ulong value, ILType valueType)
+    {
+        return value & valueType.AllOnes;
+    }
+
+    static ulong Widen(ulong value, ILType valueType)
+    {
+        return valueType.IsSigned ? SignExtend(value, valueType) : ZeroExtend(value, valueType);
+    }
+
+    public ulong? Eval(ulong value, ILType valueType)
+    {
+        valueType = valueType.ActualType;
+
+        if (Ovf)
+        {
+            if (Un)
+            {
+                valueType = valueType.UnsignedType;
+            }
+
+            value = Widen(value, valueType);
+
+            if (valueType.IsSigned)
+            {
+                if ((long)value < (long)Type.Min)
+                    return null;
+            }
+
+            if (Type.IsUnsigned)
+            {
+                if (value > Type.Max)
+                    return null;
+            }
+            else
+            {
+                if (valueType.IsSigned)
+                {
+                    if ((long)value > (long)Type.Max)
+                        return null;
+                }
+                else
+                {
+                    if (value > Type.Max)
+                        return null;
+                }
+            }
+        }
+
+        if (Type.ByteSize <= 4)
+        {
+            value &= Type.AllOnes;
+
+            if (Type.IsSmallSigned)
+            {
+                value = SignExtend(value, Type);
+            }
+        }
+        else
+        {
+            value &= valueType.AllOnes;
+
+            if (valueType == ILType.I4 && Type == ILType.I8)
+            {
+                if ((value & valueType.Min) != 0)
+                {
+                    value |= ~valueType.AllOnes;
+                }
+            }
+        }
+
+        return value;
+    }
+}
+
+class ILLdInd
+{
+    public readonly ILType Type;
+
+    public ILLdInd(ILType type)
+    {
+        Type = type;
+    }
+
+    public ulong Eval(ulong bits)
+    {
+        bits &= Type.AllOnes;
+
+        if (Type.IsSmallSigned && ((bits & Type.Min) != 0))
+        {
+            bits |= ~Type.AllOnes;
+        }
+
+        return bits;
+    }
+
+    public string IL => $"ldind.{Type.ShortName}";
+}
+
+class ILStInd
+{
+    public readonly ILType Type;
+
+    public ILStInd(ILType type)
+    {
+        Type = type;
+    }
+
+    public string IL => $"stind.{Type.ShortName}";
+}
+
+class Test
+{
+    public readonly ILLdInd Load;
+    public readonly ILConv Conv;
+    public readonly ILStInd Store;
+
+    public string Name => $"{Load.IL}_{Conv.IL}".Replace('.', '_');
+
+    public Test(ILLdInd load, ILConv conv)
+    {
+        Load = load;
+        Conv = conv;
+        Store = new ILStInd(conv.Type.ActualType);
+    }
+
+    public void WriteConvMethod(TextWriter writer)
+    {
+        writer.WriteLine();
+        writer.WriteLine($"  .method private hidebysig static void Test_{Name}({Load.Type.Name}& src, {Store.Type.Name}& dst) cil managed noinlining");
+        writer.WriteLine($"  {{");
+        writer.WriteLine($"    .maxstack 4");
+        writer.WriteLine($"    ldarg.1");
+        writer.WriteLine($"    ldarg.0");
+        writer.WriteLine($"    {Load.IL}");
+        writer.WriteLine($"    {Conv.IL}");
+        writer.WriteLine($"    {Store.IL}");
+        writer.WriteLine($"    ret");
+        writer.WriteLine($"  }}");
+    }
+
+    public void WriteCheckMethod(TextWriter writer)
+    {
+        writer.WriteLine();
+        writer.WriteLine($"  .method private hidebysig static int32 Check_{Name}({Load.Type.ActualType.Name} input, {Store.Type.Name} expected, class [System.Private.CoreLib]System.String desc) cil managed noinlining");
+        writer.WriteLine($"  {{");
+        writer.WriteLine($"    .maxstack 4");
+        writer.WriteLine($"    .locals init({Load.Type.Name} src, {Store.Type.Name} dst)");
+        writer.WriteLine($"    ldarg.2");
+        writer.WriteLine($"    call void Program::print(class [System.Private.CoreLib]System.String)");
+        writer.WriteLine($"    ldarg.0");
+        writer.WriteLine($"    stloc 0");
+        writer.WriteLine($"    ldloca 0");
+        writer.WriteLine($"    ldloca 1");
+        writer.WriteLine($"    call void Program::Test_{Name}({Load.Type.Name}&, {Store.Type.Name}&)");
+        writer.WriteLine($"    ldloc.1");
+        writer.WriteLine($"    ldarg.1");
+        writer.WriteLine($"    ceq");
+        writer.WriteLine($"    ret");
+        writer.WriteLine($"  }}");
+    }
+
+    public void WriteCheckOverflowMethod(TextWriter writer)
+    {
+        writer.WriteLine();
+        writer.WriteLine($"  .method private hidebysig static int32 CheckOvf_{Name}({Load.Type.ActualType.Name} input, class [System.Private.CoreLib]System.String desc) cil managed noinlining");
+        writer.WriteLine($"  {{");
+        writer.WriteLine($"    .maxstack 4");
+        writer.WriteLine($"    .locals init({Load.Type.Name} src, {Store.Type.Name} dst, int32 ovf)");
+        writer.WriteLine($"    ldarg.1");
+        writer.WriteLine($"    call void Program::print(class [System.Private.CoreLib]System.String)");
+        writer.WriteLine($"    ldarg.0");
+        writer.WriteLine($"    stloc 0");
+        writer.WriteLine($"    .try {{");
+        writer.WriteLine($"    ldloca 0");
+        writer.WriteLine($"    ldloca 1");
+        writer.WriteLine($"    call void Program::Test_{Name}({Load.Type.Name}&, {Store.Type.Name}&)");
+        writer.WriteLine($"    leave END");
+        writer.WriteLine($"    }} catch [System.Private.CoreLib]System.OverflowException {{");
+        writer.WriteLine($"    ldc.i4 1");
+        writer.WriteLine($"    stloc 2");
+        writer.WriteLine($"    leave END");
+        writer.WriteLine($"    }}");
+        writer.WriteLine($"    END: ldloc.2");
+        writer.WriteLine($"    ret");
+        writer.WriteLine($"  }}");
+    }
+
+    public ulong? Eval(ulong value) => Conv.Eval(Load.Eval(value), Load.Type);
+}
+
+class TestInput
+{
+    public readonly ulong Input;
+    public readonly ulong? Expected;
+
+    public TestInput(Test test, ulong input)
+    {
+        Input = input;
+        Expected = test.Eval(input);
+    }
+}
+
+const string FileBeginIL = @"// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern System.Private.CoreLib { auto }
+.assembly test { }
+
+.class auto Program extends [System.Private.CoreLib]System.Object
+{
+  .method private static void print(class [System.Private.CoreLib]System.String) cil managed
+  {
+    .maxstack 1
+    ldarg 0
+    call void [System.Private.CoreLib]Internal.Console::WriteLine(class [System.Private.CoreLib]System.String)
+    ret
+  }";
+
+const string MainMethodBeginIL = @"
+  .method private hidebysig static int32 Main() cil managed
+  {
+    .entrypoint
+    .maxstack 8";
+
+const string MainMethodEndIL = @"
+    ldc.i4 100
+    ret
+
+FAIL:
+    ldstr ""FAILED""
+    call void Program::print(class [System.Private.CoreLib]System.String)    
+    ldc.i4 1
+    ret
+  }";
+
+IEnumerable<Test> GenerateTests()
+{
+    var tests = new List<Test>();
+
+    foreach (ILType loadType in ILType.Types)
+    {
+        foreach (ILConv conv in ILConv.Conversions)
+        {
+            tests.Add(new Test(new ILLdInd(loadType), conv));
+        }
+    }
+
+    return tests;
+}
+
+IEnumerable<TestInput> GenerateTestInputs(Test test)
+{
+    var inputs = new List<TestInput>();
+
+    inputs.Add(new TestInput(test, test.Load.Type.Max));
+
+    if (test.Load.Type.IsSigned)
+    {
+        inputs.Add(new TestInput(test, test.Load.Type.Min));
+        inputs.Add(new TestInput(test, test.Load.Type.AllOnes));
+    }
+
+    if (test.Conv.Type.ByteSize < test.Load.Type.ByteSize)
+    {
+        inputs.Add(new TestInput(test, test.Conv.Type.Max));
+
+        if (test.Conv.Type.IsSigned)
+        {
+            inputs.Add(new TestInput(test, test.Conv.Type.Min));
+            inputs.Add(new TestInput(test, test.Conv.Type.AllOnes));
+        }
+    }
+
+    return inputs;
+}
+
+void WriteMainMethod(TextWriter write, IEnumerable<Test> tests)
+{
+    writer.WriteLine(MainMethodBeginIL);
+
+    foreach (Test t in tests)
+    {
+        foreach (TestInput i in GenerateTestInputs(t))
+        {
+            writer.WriteLine();
+            writer.WriteLine($"    {t.Load.Type.ActualType.ILConst(i.Input)}");
+
+            if (i.Expected == null)
+            {
+                writer.WriteLine($"    ldstr \"Checking {t.Name}({t.Load.Type.Hex(i.Input)}) == OverflowException\"");
+                writer.WriteLine($"    call int32 Program::CheckOvf_{t.Name}({t.Load.Type.ActualType.Name}, class [System.Private.CoreLib]System.String)");
+            }
+            else
+            {
+                writer.WriteLine($"    {t.Store.Type.ILConst(i.Expected.Value)}");
+                writer.WriteLine($"    ldstr \"Checking {t.Name}({t.Load.Type.Hex(i.Input)}) == {t.Store.Type.Hex(i.Expected.Value)}\"");
+                writer.WriteLine($"    call int32 Program::Check_{t.Name}({t.Load.Type.ActualType.Name}, {t.Store.Type.Name}, class [System.Private.CoreLib]System.String)");
+            }
+
+            writer.WriteLine($"    brfalse FAIL");
+        }
+    }
+
+    writer.WriteLine(MainMethodEndIL);
+}
+
+void WriteTestMethods(TextWriter writer, IEnumerable<Test> tests)
+{
+    foreach (Test t in tests)
+    {
+        t.WriteConvMethod(writer);
+        t.WriteCheckMethod(writer);
+
+        if (t.Conv.Ovf)
+        {
+            t.WriteCheckOverflowMethod(writer);
+        }
+    }
+}
+
+var tests = GenerateTests();
+var writer = Console.Out;
+writer.WriteLine(FileBeginIL);
+WriteMainMethod(writer, tests);
+WriteTestMethods(writer, tests);
+writer.WriteLine("}");


### PR DESCRIPTION
ARM cast codegen is rather convoluted and sometimes does the wrong thing by applying `GTF_UNSIGNED` to the destination type even though this flag is only about the source type.

Fixes #18040