### PR TITLE
Mark delete_next_card_table

### DIFF
--- a/tests/src/Regressions/coreclr/0080/delete_next_card_table.csproj
+++ b/tests/src/Regressions/coreclr/0080/delete_next_card_table.csproj
@@ -11,6 +11,8 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>BuildAndRun</CLRTestKind>
+    <GCStressIncompatible>true</GCStressIncompatible>
+    <IsLongRunningGCTest>true</IsLongRunningGCTest>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->


### PR DESCRIPTION
mark Regressions/coreclr/0080/delete_next_card_table
GCStressIncompatible=true
IsLongRunningGCTest=true

This is almost an exact duplicate of GC/Coverage/delete_next_card_table.cs which is marked the same way.  This should be marked IsLongRunningGCTest because it deliberately forces OutOfMemory condition which doesn't play nicely with running tests in parallel.

@Maoni0 @swgillespie @jkotas PTAL