### PR TITLE
Fix parallel spmi return code.

### DIFF
--- a/src/ToolBox/superpmi/superpmi/superpmi.h
+++ b/src/ToolBox/superpmi/superpmi/superpmi.h
@@ -25,4 +25,14 @@ extern const char* const g_AllFormatStringFixedPrefix;
 extern const char* const g_SummaryFormatString;
 extern const char* const g_AsmDiffsSummaryFormatString;
 
+enum class SpmiResult
+{
+    JitFailedToInit = -2,
+    GeneralFailure  = -1,
+    Success         = 0,
+    Error           = 1,
+    Diffs           = 2,
+    Misses          = 3
+};
+
 #endif


### PR DESCRIPTION
Sort and merge child return codes for the parallel spmi runs.
Found after #17997; our internal system reports exit code 0x3 (missing values) even if there are actual errors (0x1).

cc @dotnet/jit-contrib 