### PR TITLE
Cancel CTS immediately if delay is zero.

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/CancellationTokenSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/CancellationTokenSource.cs
@@ -202,16 +202,26 @@ namespace System.Threading
             InitializeWithTimer(millisecondsDelay);
         }
 
-        /// <summary>Common initialization logic when constructing a CTS with a delay parameter</summary>
+        /// <summary>
+        /// Common initialization logic when constructing a CTS with a delay parameter.
+        /// A zero delay will result in immediate cancellation.
+        /// </summary>
         private void InitializeWithTimer(int millisecondsDelay)
         {
-            _state = NotCanceledState;
-            _timer = new TimerQueueTimer(s_timerCallback, this, (uint)millisecondsDelay, Timeout.UnsignedInfinite, flowExecutionContext: false);
+            if (millisecondsDelay == 0)
+            {
+                _state = NotifyingCompleteState;
+            }
+            else
+            {
+                _state = NotCanceledState;
+                _timer = new TimerQueueTimer(s_timerCallback, this, (uint)millisecondsDelay, Timeout.UnsignedInfinite, flowExecutionContext: false);
 
-            // The timer roots this CTS instance while it's scheduled.  That is by design, so
-            // that code like:
-            //     CancellationToken ct = new CancellationTokenSource(timeout).Token;
-            // will successfully cancel the token after the timeout.
+                // The timer roots this CTS instance while it's scheduled.  That is by design, so
+                // that code like:
+                //     CancellationToken ct = new CancellationTokenSource(timeout).Token;
+                // will successfully cancel the token after the timeout.
+            }
         }
 
         /// <summary>Communicates a request for cancellation.</summary>


### PR DESCRIPTION
The intended behaviour on specifying a delay of zero is that the CancellationTokenSource is cancelled immediately - before this change, it would depend on the scheduling of the timer callback which could lead to seeing a non-cancelled token. Now, it marks itself as cancelled immediately, without invoking any callbacks (as this method is called only from within the constructor of the object, before any callbacks could have been registered.

I can't find any tests for this code, so I'm not in a position to update those, apologies if I've missed them.