### PR TITLE
Update GC heap range in StompWriteBarrier on ARM

### DIFF
--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -879,10 +879,17 @@ void GCToEEInterface::StompWriteBarrier(WriteBarrierParameters* args)
         g_lowest_address = args->lowest_address;
         VolatileStore(&g_highest_address, args->highest_address);
 
-#if defined(_ARM64_)
+#if defined(_ARM64_) || defined(_ARM_)
         // Need to reupdate for changes to g_highest_address g_lowest_address
         is_runtime_suspended = (stompWBCompleteActions & SWB_EE_RESTART) || args->is_runtime_suspended;
         stompWBCompleteActions |= ::StompWriteBarrierResize(is_runtime_suspended, args->requires_upper_bounds_check);
+
+#ifdef _ARM_
+        if (stompWBCompleteActions & SWB_ICACHE_FLUSH)
+        {
+            ::FlushWriteBarrierInstructionCache();
+        }
+#endif
 
         is_runtime_suspended = (stompWBCompleteActions & SWB_EE_RESTART) || args->is_runtime_suspended;
         if(!is_runtime_suspended)


### PR DESCRIPTION
As discovered in #17851 JIT_CheckedWriteBarrier was not properly patched during `GCToEEInterface::StompWriteBarrier` when `operation=WriteBarrierOp::StompResize`

As consequence objects in higher generation sometime can miss cards on card table which causes objects in ephemeral ranges (assigned via JIT_CheckedWriteBarrier) be collected. Such situation is described in https://github.com/dotnet/coreclr/issues/17851#issuecomment-391206977

The problem manifest itself as intermittent segfaults in GC or WriteBarrier code and HeapVerify failures when `COMPlus_HeapVerify=1`. Affects both Windows and Linux.

This PR enables under ARM already implemented for ARM64 mechanism updating  `g_highest_address` `g_lowest_address` via `::StompWriteBarrierResize`. Also found that `::FlushWriteBarrierInstructionCache` call is needed right such call (at least for ARM).

Fixes #17851

*Tested manually on Ubuntu/arm for more than 10 hours and Windows/arm for couple hours*
@janvorli @jkotas PTAL