### PR TITLE
delete unused variables from jit

### DIFF
--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -5487,7 +5487,6 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
     insFormat     fmt           = id->idInsFmt();
     emitAttr      size          = id->idOpSize();
     unsigned char callInstrSize = 0;
-    ssize_t       condcode;
 
 #ifdef DEBUG
     bool dspOffs = emitComp->opts.dspGCtbls || !emitComp->opts.disDiffable;
@@ -5502,9 +5501,6 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
     switch (fmt)
     {
         int       imm;
-        int       imm0;
-        int       mask;
-        int       bit;
         BYTE*     addr;
         regMaskTP gcrefRegs;
         regMaskTP byrefRegs;
@@ -5517,11 +5513,13 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 
 #ifdef FEATURE_ITINSTRUCTION
         case IF_T1_B: // T1_B    ........cccc....                                           cond
+        {
             assert(id->idGCref() == GCT_NONE);
-            condcode = emitGetInsSC(id);
-            dst      = emitOutputIT(dst, ins, fmt, condcode);
-            sz       = SMALL_IDSC_SIZE;
-            break;
+            ssize_t condcode = emitGetInsSC(id);
+            dst              = emitOutputIT(dst, ins, fmt, condcode);
+            sz               = SMALL_IDSC_SIZE;
+        }
+        break;
 #endif // FEATURE_ITINSTRUCTION
 
         case IF_T1_C: // T1_C    .....iiiiinnnddd                       R1  R2              imm5

--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -8500,7 +8500,6 @@ BYTE* emitter::emitOutputLJ(insGroup* ig, BYTE* dst, instrDesc* i)
     BYTE*    srcAddr;
     BYTE*    dstAddr;
     ssize_t  distVal;
-    ssize_t  loBits;
 
     // Set default ins/fmt from id.
     instruction ins = id->idIns();
@@ -9116,7 +9115,6 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
     insFormat     fmt  = id->idInsFmt();
     emitAttr      size = id->idOpSize();
     unsigned char callInstrSize = 0;
-    unsigned      condcode;
 
 #ifdef DEBUG
 #if DUMP_GC_TABLES
@@ -9137,11 +9135,8 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         ssize_t  imm;
         ssize_t  index;
         ssize_t  index2;
-        unsigned scale;
         unsigned cmode;
         unsigned immShift;
-        bool     hasShift;
-        emitAttr extSize;
         emitAttr elemsize;
         emitAttr datasize;
 
@@ -10844,7 +10839,6 @@ void emitter::emitDispIns(
         ssize_t      imm;
         int          doffs;
         bool         isExtendAlias;
-        bool         canEncode;
         bitMaskImm   bmi;
         halfwordImm  hwi;
         condFlagsImm cfi;

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -3119,8 +3119,6 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
     {
         switch (oper)
         {
-            GenTreeIntConCommon* con;
-
 #ifdef _TARGET_ARM_
             case GT_CNS_LNG:
                 costSz = 9;
@@ -3134,12 +3132,12 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                 goto COMMON_CNS;
 
             case GT_CNS_INT:
-
+            {
                 // If the constant is a handle then it will need to have a relocation
                 //  applied to it.
                 // Any constant that requires a reloc must use the movw/movt sequence
                 //
-                con = tree->AsIntConCommon();
+                GenTreeIntConCommon* con = tree->AsIntConCommon();
 
                 if (con->ImmedValNeedsReloc(this) || !codeGen->validImmForInstr(INS_mov, tree->gtIntCon.gtIconVal))
                 {
@@ -3160,6 +3158,7 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                     costEx = 1;
                 }
                 goto COMMON_CNS;
+            }
 
 #elif defined _TARGET_XARCH_
 
@@ -3178,7 +3177,7 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                 // If the constant is a handle then it will need to have a relocation
                 //  applied to it.
                 //
-                con = tree->AsIntConCommon();
+                GenTreeIntConCommon* con = tree->AsIntConCommon();
 
                 bool iconNeedsReloc = con->ImmedValNeedsReloc(this);
 

--- a/src/jit/hwintrinsicxarch.cpp
+++ b/src/jit/hwintrinsicxarch.cpp
@@ -978,7 +978,6 @@ GenTree* Compiler::impSSE2Intrinsic(NamedIntrinsic        intrinsic,
     assert((simdSize == 16) || (simdSize == 0));
 
     CORINFO_ARG_LIST_HANDLE argList = sig->args;
-    CORINFO_CLASS_HANDLE    argClass;
     var_types               argType = TYP_UNKNOWN;
 
     switch (intrinsic)

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2293,11 +2293,10 @@ GenTree* Lowering::LowerTailCallViaHelper(GenTreeCall* call, GenTree* callTarget
     // The callTarget tree needs to be sequenced.
     LIR::Range callTargetRange = LIR::SeqTree(comp, callTarget);
 
-    fgArgTabEntry* argEntry;
-
 #if defined(_TARGET_AMD64_) || defined(_TARGET_ARM_)
 
-// For ARM32 and AMD64, first argument is CopyRoutine and second argument is a place holder node.
+    // For ARM32 and AMD64, first argument is CopyRoutine and second argument is a place holder node.
+    fgArgTabEntry* argEntry;
 
 #ifdef DEBUG
     argEntry = comp->gtArgEntryByArgNum(call, 0);
@@ -2335,6 +2334,8 @@ GenTree* Lowering::LowerTailCallViaHelper(GenTreeCall* call, GenTree* callTarget
     nNewStkArgsWords -= 4;
 
     unsigned numArgs = call->fgArgInfo->ArgCount();
+
+    fgArgTabEntry* argEntry;
 
     // arg 0 == callTarget.
     argEntry = comp->gtArgEntryByArgNum(call, numArgs - 1);

--- a/src/jit/lowerarmarch.cpp
+++ b/src/jit/lowerarmarch.cpp
@@ -785,7 +785,6 @@ void Lowering::ContainCheckCompare(GenTreeOp* cmp)
 void Lowering::ContainCheckBoundsChk(GenTreeBoundsChk* node)
 {
     assert(node->OperIsBoundsCheck());
-    GenTree* other;
     if (!CheckImmedAndMakeContained(node, node->gtIndex))
     {
         CheckImmedAndMakeContained(node, node->gtArrLen);

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -216,9 +216,6 @@ int LinearScan::BuildNode(GenTree* tree)
 
     switch (tree->OperGet())
     {
-        GenTree* op1;
-        GenTree* op2;
-
         case GT_LCL_VAR:
         case GT_LCL_FLD:
         {
@@ -269,7 +266,7 @@ int LinearScan::BuildNode(GenTree* tree)
         {
             // TODO-ARM: Implement other type of intrinsics (round, sqrt and etc.)
             // Both operand and its result must be of the same floating point type.
-            op1 = tree->gtGetOp1();
+            GenTree* op1 = tree->gtGetOp1();
             assert(varTypeIsFloating(op1));
             assert(op1->TypeGet() == tree->TypeGet());
             BuildUse(op1);

--- a/src/jit/lsraarm64.cpp
+++ b/src/jit/lsraarm64.cpp
@@ -74,9 +74,6 @@ int LinearScan::BuildNode(GenTree* tree)
 
     switch (tree->OperGet())
     {
-        GenTree* op1;
-        GenTree* op2;
-
         default:
             srcCount = BuildSimple(tree);
             break;
@@ -314,7 +311,7 @@ int LinearScan::BuildNode(GenTree* tree)
                          (tree->gtIntrinsic.gtIntrinsicId == CORINFO_INTRINSIC_Sqrt));
 
             // Both operand and its result must be of the same floating point type.
-            op1 = tree->gtGetOp1();
+            GenTree* op1 = tree->gtGetOp1();
             assert(varTypeIsFloating(op1));
             assert(op1->TypeGet() == tree->TypeGet());
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2123,9 +2123,8 @@ GenTree* Compiler::fgMakeTmpArgNode(unsigned tmpVarNum UNIX_AMD64_ABI_ONLY_ARG(c
         // Otherwise, it will return TYP_UNKNOWN and we will pass by reference.
 
         bool                 passedInRegisters = false;
-        structPassingKind    kind;
-        CORINFO_CLASS_HANDLE clsHnd         = varDsc->lvVerTypeInfo.GetClassHandle();
-        var_types            structBaseType = getPrimitiveTypeForStruct(lvaLclExactSize(tmpVarNum), clsHnd);
+        CORINFO_CLASS_HANDLE clsHnd            = varDsc->lvVerTypeInfo.GetClassHandle();
+        var_types            structBaseType    = getPrimitiveTypeForStruct(lvaLclExactSize(tmpVarNum), clsHnd);
 
         if (structBaseType != TYP_UNKNOWN)
         {
@@ -4531,14 +4530,12 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
 void Compiler::fgMorphSystemVStructArgs(GenTreeCall* call, bool hasStructArgument)
 {
     unsigned flagsSummary = 0;
-    GenTree* args;
-    GenTree* argx;
 
     if (hasStructArgument)
     {
         fgArgInfo* allArgInfo = call->fgArgInfo;
 
-        for (args = call->gtCallArgs; args != nullptr; args = args->gtOp.gtOp2)
+        for (GenTree* args = call->gtCallArgs; args != nullptr; args = args->gtOp.gtOp2)
         {
             // For late arguments the arg tree that is overridden is in the gtCallLateArgs list.
             // For such late args the gtCallArgList contains the setup arg node (evaluating the arg.)

--- a/src/jit/unwindamd64.cpp
+++ b/src/jit/unwindamd64.cpp
@@ -528,7 +528,6 @@ void DumpUnwindInfo(bool                     isHotCode,
 
     for (unsigned i = 0; i < pHeader->CountOfUnwindCodes; i++)
     {
-        unsigned                 offset;
         const UNWIND_CODE* const pCode = &(pHeader->UnwindCode[i]);
         switch (pCode->UnwindOp)
         {
@@ -572,17 +571,19 @@ void DumpUnwindInfo(bool                     isHotCode,
 #ifdef UNIX_AMD64_ABI
 
             case UWOP_SET_FPREG_LARGE:
+            {
                 printf("    CodeOffset: 0x%02X UnwindOp: UWOP_SET_FPREG_LARGE (%u) OpInfo: Unused (%u)\n",
                        pCode->CodeOffset, pCode->UnwindOp, pCode->OpInfo); // This should be zero
                 i++;
-                offset = *(ULONG*)&(pHeader->UnwindCode[i]);
+                unsigned offset = *(ULONG*)&(pHeader->UnwindCode[i]);
                 i++;
                 printf("      Scaled Offset: %u * 16 = %u = 0x%08X\n", offset, offset * 16, offset * 16);
                 if ((offset & 0xF0000000) != 0)
                 {
                     printf("      Illegal unscaled offset: too large\n");
                 }
-                break;
+            }
+            break;
 
 #endif // UNIX_AMD64_ABI
 


### PR DESCRIPTION
Delete unused variables after the `legacy_backend` death.