### PR TITLE
Check SuperPmi map for null

### DIFF
--- a/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -4327,6 +4327,7 @@ void MethodContext::dmpCanInlineTypeCheckWithObjectVTable(DWORDLONG key, DWORD v
 }
 BOOL MethodContext::repCanInlineTypeCheckWithObjectVTable(CORINFO_CLASS_HANDLE cls)
 {
+    AssertCodeMsg(CanInlineTypeCheckWithObjectVTable != nullptr, EXCEPTIONCODE_MC, "No map for CanInlineTypeCheckWithObjectVTable");
     return (BOOL)CanInlineTypeCheckWithObjectVTable->Get((DWORDLONG)cls);
 }
 


### PR DESCRIPTION
On Linux, calling an instance method with a null `this` pointer causes a seg fault.
This fixes the case of querying the `CanInlineTypeCheckWithObjectVTable` map in SuperPmi when no query has been recorded by `recCanInlineTypeCheckWithObjectVTable`. There appear to be other cases of this, but this is the one that I'm running into currently.