### PR TITLE
JIT: fix issue with zero-length stackalloc

### DIFF
--- a/tests/src/JIT/Regression/JitBlue/GitHub_18176/GitHub_18176.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_18176/GitHub_18176.il
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib { auto }
+.assembly GitHub_18176 { }
+
+// Ensure the jit is not tripped up by a foldable zero-length localloc
+
+.class private auto ansi beforefieldinit X
+       extends [mscorlib]System.Object
+{
+  .method private hidebysig static void  Foo(int32* x) cil managed noinlining
+  {
+    ret
+  }
+
+  .method public hidebysig static int32  Main() cil managed
+  {
+    .entrypoint
+    .maxstack  2
+    .locals init (int32* V_0)
+    ldc.i4.0
+    conv.u
+    ldc.i4.4
+    mul.ovf.un
+    localloc
+    stloc.0
+    ldloc.0
+    call       void X::Foo(int32*)
+    ldc.i4.s   100
+    ret
+  }
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    ldarg.0
+    call       instance void [mscorlib]System.Object::.ctor()
+    ret
+  }
+
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_18176/GitHub_18176.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_18176/GitHub_18176.ilproj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Defer calling `setNeedsGSSecurityCookie` until we know for sure that
the jit won't do the zero-length stackalloc optimization.

Closes #18176.