### PR TITLE
Mark JIT/Regression/JitBlue/GitHub_18056/Bool_And_Op_cs_do as JitOptimizationSensitive

### DIFF
--- a/tests/src/JIT/Regression/JitBlue/GitHub_18056/Bool_And_Op_cs_do.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_18056/Bool_And_Op_cs_do.csproj
@@ -23,6 +23,7 @@
   <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
+    <JitOptimizationSensitive>True</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Bool_And_Op.cs" />


### PR DESCRIPTION
This disables JIT/Regression/JitBlue/GitHub_18056/Bool_And_Op_cs_do under JitStress to avoid failures in PRs such as in #18117