### PR TITLE
Improve the labeling of .NET Threads.

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -5345,7 +5345,7 @@ void set_thread_affinity_mask_for_heap(int heap_number, GCThreadAffinity* affini
 bool gc_heap::create_gc_thread ()
 {
     dprintf (3, ("Creating gc thread\n"));
-    return GCToEEInterface::CreateThread(gc_thread_stub, this, false, "Server GC");
+    return GCToEEInterface::CreateThread(gc_thread_stub, this, false, ".NET Server GC");
 }
 
 #ifdef _MSC_VER
@@ -26725,7 +26725,7 @@ BOOL gc_heap::create_bgc_thread(gc_heap* gh)
 
     //dprintf (2, ("Creating BGC thread"));
 
-    gh->bgc_thread_running = GCToEEInterface::CreateThread(gh->bgc_thread_stub, gh, true, "Background GC");
+    gh->bgc_thread_running = GCToEEInterface::CreateThread(gh->bgc_thread_stub, gh, true, ".NET Background GC");
     return gh->bgc_thread_running;
 }
 

--- a/src/vm/finalizerthread.cpp
+++ b/src/vm/finalizerthread.cpp
@@ -585,12 +585,6 @@ VOID FinalizerThread::FinalizerThreadWorker(void *args)
 
         GetFinalizerThread()->DisablePreemptiveGC();
 
-        // TODO: The following call causes 12 more classes loaded.
-        //if (!fNameSet) {
-        //    fNameSet = TRUE;
-        //    GetFinalizerThread()->SetName(L"FinalizerThread");
-        //}
-
 #ifdef _DEBUG
         // <TODO> workaround.  make finalization very lazy for gcstress 3 or 4.  
         // only do finalization if the system is quiescent</TODO>
@@ -904,7 +898,7 @@ void FinalizerThread::FinalizerThreadCreate()
     // actual thread terminates.
     GetFinalizerThread()->IncExternalCount();
 
-    if (GetFinalizerThread()->CreateNewThread(0, &FinalizerThreadStart, NULL, W("Finalizer")) )
+    if (GetFinalizerThread()->CreateNewThread(0, &FinalizerThreadStart, NULL, W(".NET Finalizer")) )
     {
         DWORD dwRet = GetFinalizerThread()->StartThread();
 

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -2254,7 +2254,7 @@ DWORD WINAPI Thread::intermediateThreadProc(PVOID arg)
     return ThreadFcnPtr(args);
 }
 
-HANDLE Thread::CreateUtilityThread(Thread::StackSizeBucket stackSizeBucket, LPTHREAD_START_ROUTINE start, void *args, DWORD flags, DWORD* pThreadId)
+HANDLE Thread::CreateUtilityThread(Thread::StackSizeBucket stackSizeBucket, LPTHREAD_START_ROUTINE start, void *args, LPCWSTR pName, DWORD flags, DWORD* pThreadId)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -2284,6 +2284,10 @@ HANDLE Thread::CreateUtilityThread(Thread::StackSizeBucket stackSizeBucket, LPTH
 
     DWORD threadId;
     HANDLE hThread = CreateThread(NULL, stackSize, start, args, flags, &threadId);
+#ifndef FEATURE_PAL
+    SetThreadName(hThread, pName);
+#endif // !FEATURE_PAL
+
 
     if (pThreadId)
         *pThreadId = threadId;

--- a/src/vm/threads.h
+++ b/src/vm/threads.h
@@ -1949,7 +1949,7 @@ public:
     // Creates a raw OS thread; use this only for CLR-internal threads that never execute user code.
     // StackSizeBucket determines how large the stack should be.
     //
-    static HANDLE CreateUtilityThread(StackSizeBucket stackSizeBucket, LPTHREAD_START_ROUTINE start, void *args, DWORD flags = 0, DWORD* pThreadId = NULL);
+    static HANDLE CreateUtilityThread(StackSizeBucket stackSizeBucket, LPTHREAD_START_ROUTINE start, void *args, LPCWSTR pName, DWORD flags = 0, DWORD* pThreadId = NULL);
 
     //--------------------------------------------------------------
     // Destructor

--- a/src/vm/win32threadpool.cpp
+++ b/src/vm/win32threadpool.cpp
@@ -1818,7 +1818,7 @@ Thread* ThreadpoolMgr::CreateUnimpersonatedThread(LPTHREAD_START_ROUTINE lpStart
         bOK = pThread->CreateNewThread(0,               // default stack size
                                        lpStartAddress,
                                        lpArgs,           //arguments
-                                       W(".NET Core ThreadPool"));
+                                       W(".NET ThreadPool Worker"));
     }
     else {
 #ifndef FEATURE_PAL
@@ -1839,6 +1839,9 @@ Thread* ThreadpoolMgr::CreateUnimpersonatedThread(LPTHREAD_START_ROUTINE lpStart
                                         lpThreadArgs,       // arguments
                                         CREATE_SUSPENDED,
                                         &threadId);
+#ifndef FEATURE_PAL
+            SetThreadName(threadHandle, W(".NET ThreadPool Worker"));
+#endif // !FEATURE_PAL
             if (threadHandle != NULL)
                 lpThreadArgs.SuppressRelease();
         }
@@ -2414,7 +2417,7 @@ BOOL ThreadpoolMgr::CreateWaitThread()
     }
 
     threadCB->startEvent.CreateAutoEvent(FALSE);
-    HANDLE threadHandle = Thread::CreateUtilityThread(Thread::StackSize_Small, WaitThreadStart, (LPVOID)threadCB, CREATE_SUSPENDED, &threadId);
+    HANDLE threadHandle = Thread::CreateUtilityThread(Thread::StackSize_Small, WaitThreadStart, (LPVOID)threadCB, W(".NET ThreadPool Wait"), CREATE_SUSPENDED, &threadId);
 
     if (threadHandle == NULL)
     {
@@ -3165,7 +3168,7 @@ BOOL ThreadpoolMgr::CreateGateThread()
 {
     LIMITED_METHOD_CONTRACT;
 
-    HANDLE threadHandle = Thread::CreateUtilityThread(Thread::StackSize_Small, GateThreadStart, NULL);
+    HANDLE threadHandle = Thread::CreateUtilityThread(Thread::StackSize_Small, GateThreadStart, NULL, W(".NET ThreadPool Gate"));
 
     if (threadHandle)
     {
@@ -4490,9 +4493,10 @@ BOOL ThreadpoolMgr::CreateTimerQueueTimer(PHANDLE phNewTimer,
         {
             CreateTimerThreadParams params;
             params.event.CreateAutoEvent(FALSE);
+
             params.setupSucceeded = FALSE;
 
-            HANDLE TimerThreadHandle = Thread::CreateUtilityThread(Thread::StackSize_Small, TimerThreadStart, &params);
+            HANDLE TimerThreadHandle = Thread::CreateUtilityThread(Thread::StackSize_Small, TimerThreadStart, &params, W(".NET Timer"));
 
             if (TimerThreadHandle == NULL)
             {


### PR DESCRIPTION
There was already some support for labeling threads using the Window SetThreadDescription API, however it was missing some important cases (like labeling the ThreadPool and GC server and Background threads).   Fix this.   Also make the naming consistant (they all start with .NET).

These names show up in PerfView traces and can be used by debuggers or other profilers as well.

@Maoni0  @brianrob 