### PR TITLE
Expose Exception.set_HResult as Public

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Guid.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Guid.Windows.cs
@@ -19,7 +19,7 @@ namespace System
             if (hr != 0)
             {
                 Exception ex = new Exception();
-                ex.SetErrorCode(hr);
+                ex.HResult = hr;
                 throw ex;
             }
             return g;

--- a/src/System.Private.CoreLib/src/System/Exception.cs
+++ b/src/System.Private.CoreLib/src/System/Exception.cs
@@ -681,7 +681,7 @@ namespace System
             {
                 return _HResult;
             }
-            protected set
+            set
             {
                 _HResult = value;
             }

--- a/src/System.Private.CoreLib/src/System/Exception.cs
+++ b/src/System.Private.CoreLib/src/System/Exception.cs
@@ -335,12 +335,6 @@ namespace System
             return remoteStackTraceString + tempStackTraceString;
         }
 
-        // [FriendAccessAllowed]
-        internal void SetErrorCode(int hr)
-        {
-            HResult = hr;
-        }
-
         // Sets the help link for this exception.
         // This should be in a URL/URN form, such as:
         // "file:///C:/Applications/Bazzal/help.html#ErrorNum42"

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/CLRIPropertyValueImpl.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/CLRIPropertyValueImpl.cs
@@ -330,7 +330,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
                 catch (InvalidCastException elementCastException)
                 {
                     Exception e = new InvalidCastException(SR.Format(SR.InvalidCast_WinRTIPropertyValueArrayCoersion, this.Type, typeof (T).MakeArrayType().Name, i, elementCastException.Message), elementCastException);
-                    e.SetErrorCode(elementCastException._HResult);
+                    e.HResult = elementCastException._HResult;
                     throw e;
                 }
             }

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/ConstantSplittableMap.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/ConstantSplittableMap.cs
@@ -101,7 +101,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (!found)
             {
                 Exception e = new KeyNotFoundException(SR.Format(SR.Arg_KeyNotFoundWithKey, key.ToString()));
-                e.SetErrorCode(HResults.E_BOUNDS);
+                e.HResult = HResults.E_BOUNDS;
                 throw e;
             }
 

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/DictionaryToMapAdapter.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/DictionaryToMapAdapter.cs
@@ -42,7 +42,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (!keyFound)
             {
                 Exception e = new KeyNotFoundException(SR.Format(SR.Arg_KeyNotFoundWithKey, key.ToString()));
-                e.SetErrorCode(HResults.E_BOUNDS);
+                e.HResult = HResults.E_BOUNDS;
                 throw e;
             }
 
@@ -97,7 +97,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (!removed)
             {
                 Exception e = new KeyNotFoundException(SR.Format(SR.Arg_KeyNotFoundWithKey, key.ToString()));
-                e.SetErrorCode(HResults.E_BOUNDS);
+                e.HResult = HResults.E_BOUNDS;
                 throw e;
             }
         }

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/IReadOnlyDictionaryToIMapViewAdapter.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/IReadOnlyDictionaryToIMapViewAdapter.cs
@@ -41,7 +41,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (!keyFound)
             {
                 Exception e = new KeyNotFoundException(SR.Format(SR.Arg_KeyNotFoundWithKey, key.ToString()));
-                e.SetErrorCode(HResults.E_BOUNDS);
+                e.HResult = HResults.E_BOUNDS;
                 throw e;
             }
 

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/IReadOnlyListToIVectorViewAdapter.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/IReadOnlyListToIVectorViewAdapter.cs
@@ -43,7 +43,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             }
             catch (ArgumentOutOfRangeException ex)
             {
-                ex.SetErrorCode(HResults.E_BOUNDS);
+                ex.HResult = HResults.E_BOUNDS;
                 throw;
             }
         }
@@ -127,7 +127,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (((uint)Int32.MaxValue) <= index || index >= (uint)listCapacity)
             {
                 Exception e = new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_IndexLargerThanMaxValue);
-                e.SetErrorCode(HResults.E_BOUNDS);
+                e.HResult = HResults.E_BOUNDS;
                 throw e;
             }
         }

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/ListToBindableVectorAdapter.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/ListToBindableVectorAdapter.cs
@@ -110,7 +110,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             catch (ArgumentOutOfRangeException ex)
             {
                 // Change error code to match what WinRT expects
-                ex.SetErrorCode(HResults.E_BOUNDS);
+                ex.HResult = HResults.E_BOUNDS;
                 throw;
             }
         }
@@ -128,7 +128,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             catch (ArgumentOutOfRangeException ex)
             {
                 // Change error code to match what WinRT expects
-                ex.SetErrorCode(HResults.E_BOUNDS);
+                ex.HResult = HResults.E_BOUNDS;
                 throw;
             }
         }
@@ -147,7 +147,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (_this.Count == 0)
             {
                 Exception e = new InvalidOperationException(SR.InvalidOperation_CannotRemoveLastFromEmptyCollection);
-                e.SetErrorCode(HResults.E_BOUNDS);
+                e.HResult = HResults.E_BOUNDS;
                 throw e;
             }
 
@@ -171,7 +171,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (((uint)Int32.MaxValue) <= index || index >= (uint)listCapacity)
             {
                 Exception e = new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_IndexLargerThanMaxValue);
-                e.SetErrorCode(HResults.E_BOUNDS);
+                e.HResult = HResults.E_BOUNDS;
                 throw e;
             }
         }

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/ListToBindableVectorViewAdapter.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/ListToBindableVectorViewAdapter.cs
@@ -37,7 +37,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (((uint)Int32.MaxValue) <= index || index >= (uint)listCapacity)
             {
                 Exception e = new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_IndexLargerThanMaxValue);
-                e.SetErrorCode(HResults.E_BOUNDS);
+                e.HResult = HResults.E_BOUNDS;
                 throw e;
             }
         }

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/ListToVectorAdapter.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/ListToVectorAdapter.cs
@@ -119,7 +119,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             catch (ArgumentOutOfRangeException ex)
             {
                 // Change error code to match what WinRT expects
-                ex.SetErrorCode(HResults.E_BOUNDS);
+                ex.HResult = HResults.E_BOUNDS;
                 throw;
             }
         }
@@ -137,7 +137,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             catch (ArgumentOutOfRangeException ex)
             {
                 // Change error code to match what WinRT expects
-                ex.SetErrorCode(HResults.E_BOUNDS);
+                ex.HResult = HResults.E_BOUNDS;
                 throw;
             }
         }
@@ -156,7 +156,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (_this.Count == 0)
             {
                 Exception e = new InvalidOperationException(SR.InvalidOperation_CannotRemoveLastFromEmptyCollection);
-                e.SetErrorCode(HResults.E_BOUNDS);
+                e.HResult = HResults.E_BOUNDS;
                 throw e;
             }
 
@@ -202,7 +202,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (((uint)Int32.MaxValue) <= index || index >= (uint)listCapacity)
             {
                 Exception e = new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_IndexLargerThanMaxValue);
-                e.SetErrorCode(HResults.E_BOUNDS);
+                e.HResult = HResults.E_BOUNDS;
                 throw e;
             }
         }

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeMarshal.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeMarshal.cs
@@ -1072,7 +1072,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
                 e = new Exception(message);
             }
 
-            e.SetErrorCode(hresult);
+            e.HResult = hresult;
             return e;
         }
 


### PR DESCRIPTION
This is to change Excetion.set_HResult from protected to public, so that others can set HResult value for a given exception.

Approved API: https://github.com/dotnet/corefx/issues/29696
Related Corefx Change(ref assembly): https://github.com/dotnet/corefx/pull/29986