### PR TITLE
Expose SpinWait.SpinOnce(int sleep1Threshold) overload

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/ManualResetEventSlim.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ManualResetEventSlim.cs
@@ -551,7 +551,7 @@ namespace System.Threading
                 var spinner = new SpinWait();
                 while (spinner.Count < spinCount)
                 {
-                    spinner.SpinOnce(SpinWait.Sleep1ThresholdForSpinBeforeWait);
+                    spinner.SpinOnce(SpinWait.Sleep1ThresholdForLongSpinBeforeWait);
 
                     if (IsSet)
                     {

--- a/src/System.Private.CoreLib/shared/System/Threading/SemaphoreSlim.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/SemaphoreSlim.cs
@@ -345,12 +345,11 @@ namespace System.Threading
                     // spin, contention, etc. The usual number of spin iterations that would otherwise be used here is increased to
                     // lessen that extra expense of doing a proper wait.
                     int spinCount = SpinWait.SpinCountforSpinBeforeWait * 4;
-                    const int Sleep1Threshold = SpinWait.Sleep1ThresholdForSpinBeforeWait * 4;
 
                     var spinner = new SpinWait();
                     while (spinner.Count < spinCount)
                     {
-                        spinner.SpinOnce(Sleep1Threshold);
+                        spinner.SpinOnce(sleep1Threshold: 0);
 
                         if (m_currentCount != 0)
                         {

--- a/src/System.Private.CoreLib/shared/System/Threading/SemaphoreSlim.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/SemaphoreSlim.cs
@@ -349,7 +349,7 @@ namespace System.Threading
                     var spinner = new SpinWait();
                     while (spinner.Count < spinCount)
                     {
-                        spinner.SpinOnce(sleep1Threshold: 0);
+                        spinner.SpinOnce(sleep1Threshold: -1);
 
                         if (m_currentCount != 0)
                         {

--- a/src/System.Private.CoreLib/shared/System/Threading/SpinWait.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/SpinWait.cs
@@ -160,8 +160,7 @@ namespace System.Threading
                 throw new ArgumentOutOfRangeException(nameof(sleep1Threshold), sleep1Threshold, SR.ArgumentOutOfRange_NeedNonNegOrNegative1);
             }
 
-            // So that NextSpinWillYield behaves as expected:
-            if (sleep1Threshold >= 0 && sleep1Threshold < YieldThreshold && !PlatformHelper.IsSingleProcessor)
+            if (sleep1Threshold >= 0 && sleep1Threshold < YieldThreshold)
             {
                 sleep1Threshold = YieldThreshold;
             }
@@ -172,9 +171,7 @@ namespace System.Threading
         private void SpinOnceCore(int sleep1Threshold)
         {
             Debug.Assert(sleep1Threshold >= -1);
-
-            // So that NextSpinWillYield behaves as requested:
-            Debug.Assert(sleep1Threshold < 0 || sleep1Threshold >= YieldThreshold || PlatformHelper.IsSingleProcessor);
+            Debug.Assert(sleep1Threshold < 0 || sleep1Threshold >= YieldThreshold);
 
             // (_count - YieldThreshold) % 2 == 0: The purpose of this check is to interleave Thread.Yield/Sleep(0) with
             // Thread.SpinWait. Otherwise, the following issues occur:

--- a/src/System.Private.CoreLib/shared/System/Threading/SpinWait.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/SpinWait.cs
@@ -88,7 +88,16 @@ namespace System.Threading
         /// for here.
         /// </remarks>
         internal static readonly int SpinCountforSpinBeforeWait = PlatformHelper.IsSingleProcessor ? 1 : 35;
-        internal const int Sleep1ThresholdForSpinBeforeWait = 40; // should be greater than SpinCountforSpinBeforeWait
+
+        /// <summary>
+        /// Typically, Sleep(1) should not be issued for a spin-wait before a proper wait because it is usually more beneficial
+        /// to just issue the proper wait. For longer spin-waits (when the spin count is configurable), this value may be used as
+        /// a threshold for issuing Sleep(1).
+        /// </summary>
+        /// <remarks>
+        /// Should be greater than <see cref="SpinCountforSpinBeforeWait"/> so that Sleep(1) would not be used by default.
+        /// </remarks>
+        internal const int Sleep1ThresholdForLongSpinBeforeWait = 40;
 
         // The number of times we've spun already.
         private int _count;
@@ -127,12 +136,45 @@ namespace System.Threading
         /// </remarks>
         public void SpinOnce()
         {
-            SpinOnce(DefaultSleep1Threshold);
+            SpinOnceCore(DefaultSleep1Threshold);
         }
 
-        internal void SpinOnce(int sleep1Threshold)
+        /// <summary>
+        /// Performs a single spin.
+        /// </summary>
+        /// <param name="sleep1Threshold">
+        /// A minimum spin count after which <code>Thread.Sleep(1)</code> may be used. Zero may be used to disable the use of
+        /// <code>Thread.Sleep(1)</code>.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="sleep1Threshold"/> is less than zero.
+        /// </exception>
+        /// <remarks>
+        /// This is typically called in a loop, and may change in behavior based on the number of times a
+        /// <see cref="SpinOnce"/> has been called thus far on this instance.
+        /// </remarks>
+        public void SpinOnce(int sleep1Threshold)
         {
-            Debug.Assert(sleep1Threshold >= YieldThreshold || PlatformHelper.IsSingleProcessor); // so that NextSpinWillYield behaves as requested
+            if (sleep1Threshold < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(sleep1Threshold), sleep1Threshold, SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            // So that NextSpinWillYield behaves as expected:
+            if (sleep1Threshold != 0 && sleep1Threshold < YieldThreshold && !PlatformHelper.IsSingleProcessor)
+            {
+                sleep1Threshold = YieldThreshold;
+            }
+
+            SpinOnceCore(sleep1Threshold);
+        }
+
+        private void SpinOnceCore(int sleep1Threshold)
+        {
+            Debug.Assert(sleep1Threshold >= 0);
+
+            // So that NextSpinWillYield behaves as requested:
+            Debug.Assert(sleep1Threshold == 0 || sleep1Threshold >= YieldThreshold || PlatformHelper.IsSingleProcessor);
 
             // (_count - YieldThreshold) % 2 == 0: The purpose of this check is to interleave Thread.Yield/Sleep(0) with
             // Thread.SpinWait. Otherwise, the following issues occur:
@@ -145,7 +187,7 @@ namespace System.Threading
             //     contention), they may switch between one another, delaying work that can make progress.
             if ((
                     _count >= YieldThreshold &&
-                    (_count >= sleep1Threshold || (_count - YieldThreshold) % 2 == 0)
+                    ((_count >= sleep1Threshold && sleep1Threshold != 0) || (_count - YieldThreshold) % 2 == 0)
                 ) ||
                 PlatformHelper.IsSingleProcessor)
             {
@@ -164,7 +206,7 @@ namespace System.Threading
                 // configured to use the (default) coarse-grained system timer.
                 //
 
-                if (_count >= sleep1Threshold)
+                if (_count >= sleep1Threshold && sleep1Threshold != 0)
                 {
                     RuntimeThread.Sleep(1);
                 }

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -3013,7 +3013,7 @@ namespace System.Threading.Tasks
             var spinner = new SpinWait();
             while (spinner.Count < spinCount)
             {
-                spinner.SpinOnce(Threading.SpinWait.Sleep1ThresholdForSpinBeforeWait);
+                spinner.SpinOnce(sleep1Threshold: 0);
 
                 if (IsCompleted)
                 {

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -3013,7 +3013,7 @@ namespace System.Threading.Tasks
             var spinner = new SpinWait();
             while (spinner.Count < spinCount)
             {
-                spinner.SpinOnce(sleep1Threshold: 0);
+                spinner.SpinOnce(sleep1Threshold: -1);
 
                 if (IsCompleted)
                 {


### PR DESCRIPTION
To allow customizing the spin count threshold for Sleep(1) usage, and to allow disabling the use of Sleep(1).

API review: https://github.com/dotnet/corefx/issues/29623
Part of fix for https://github.com/dotnet/corefx/issues/29595