### PR TITLE
Fix GitHub_16041 test.

### DIFF
--- a/tests/src/JIT/Regression/JitBlue/GitHub_16041/GitHub_16041.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_16041/GitHub_16041.il
@@ -76,6 +76,6 @@
        extends [mscorlib]System.ValueType
 {
   .pack 0
-  .size 28
+  .size 12
   .field private int32 Padding
 } // end of class StructY

--- a/tests/src/JIT/Regression/JitBlue/GitHub_16041/GitHub_16041.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_16041/GitHub_16041.il
@@ -45,7 +45,7 @@
     IL_0000:  ldloca.s   V_0
     IL_0002:  ldarg.0
     IL_0003:  conv.i
-    IL_0004:  ldc.i4.s   28
+    IL_0004:  ldc.i4.s   12
     IL_0006:  unaligned. 4 // This opcode created the bad tree, "Convert" needed to be inlined to have a LCL_VAR here.
     IL_0009:  cpblk
     IL_000b:  ldloc.0


### PR DESCRIPTION
This was doing a cpblk of 28 bytes (size of StructY) from StructX, but StructX was only 12 bytes big. Change StructY size to 12.

The discussion was in #16090.
cc @dotnet/jit-contrib.

I have checked that with the new size it still repro the original issue (but only on the old version, now It doesn't create necessary `GT_COMMA` for some reasons).