### PR TITLE
Fix Managed Thread Name Setting

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -2211,7 +2211,12 @@ namespace System.Diagnostics.Tracing
                         break;
                     default:
                         if (innerEx != null)
+                        {
+                            // The innermost exception is the interesting one.  
+                            while (innerEx.InnerException != null)
+                                innerEx = innerEx.InnerException;
                             ReportOutOfBandMessage(errorPrefix + ": " + innerEx.GetType() + ":" + innerEx.Message, true);
+                        }
                         else
                             ReportOutOfBandMessage(errorPrefix, true);
                         if (ThrowOnEventWriteErrors) throw new EventSourceException(innerEx);

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -2212,9 +2212,7 @@ namespace System.Diagnostics.Tracing
                     default:
                         if (innerEx != null)
                         {
-                            // The innermost exception is the interesting one.  
-                            while (innerEx.InnerException != null)
-                                innerEx = innerEx.InnerException;
+                            innerEx = innerEx.GetBaseException();
                             ReportOutOfBandMessage(errorPrefix + ": " + innerEx.GetType() + ":" + innerEx.Message, true);
                         }
                         else

--- a/src/vm/comsynchronizable.cpp
+++ b/src/vm/comsynchronizable.cpp
@@ -473,7 +473,7 @@ void ThreadNative::StartInner(ThreadBaseObject* pThisUNSAFE)
         STRINGREF managedThreadName = gc.pThis->GetName();
         if (managedThreadName != NULL)
         {
-            managedThreadName.GetString(threadNameBuffer).
+            managedThreadName->GetString(threadNameBuffer).
             nativeThreadName = threadNameBuffer.GetUnicode();
         }
 

--- a/src/vm/comsynchronizable.cpp
+++ b/src/vm/comsynchronizable.cpp
@@ -470,10 +470,10 @@ void ThreadNative::StartInner(ThreadBaseObject* pThisUNSAFE)
         // copy out the managed name into a buffer that will not move if a GC happens
         const WCHAR* nativeThreadName = NULL;
         InlineSString<64> threadNameBuffer;
-        STRINGREF managedThreaddName = gc.pThis->GetName();
-        if (managedThreaddName != NULL)
+        STRINGREF managedThreadName = gc.pThis->GetName();
+        if (managedThreadName != NULL)
         {
-            threadNameBuffer.Set(managedThreaddName->GetBuffer());
+            threadNameBuffer.Set(managedThreadName->GetBuffer());
             nativeThreadName = threadNameBuffer.GetUnicode();
         }
 

--- a/src/vm/comsynchronizable.cpp
+++ b/src/vm/comsynchronizable.cpp
@@ -473,7 +473,7 @@ void ThreadNative::StartInner(ThreadBaseObject* pThisUNSAFE)
         STRINGREF managedThreadName = gc.pThis->GetName();
         if (managedThreadName != NULL)
         {
-            managedThreadName->GetString(threadNameBuffer).
+            managedThreadName->GetSString(threadNameBuffer);
             nativeThreadName = threadNameBuffer.GetUnicode();
         }
 

--- a/src/vm/comsynchronizable.cpp
+++ b/src/vm/comsynchronizable.cpp
@@ -473,7 +473,7 @@ void ThreadNative::StartInner(ThreadBaseObject* pThisUNSAFE)
         STRINGREF managedThreadName = gc.pThis->GetName();
         if (managedThreadName != NULL)
         {
-            threadNameBuffer.Set(managedThreadName->GetBuffer());
+            managedThreadName.GetString(threadNameBuffer).
             nativeThreadName = threadNameBuffer.GetUnicode();
         }
 

--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -1443,7 +1443,7 @@ private:
     //  at run time, not compile time.
     OBJECTREF     m_ExecutionContext;
     OBJECTREF     m_SynchronizationContext;
-    OBJECTREF     m_Name;
+    STRINGREF     m_Name;
     OBJECTREF     m_Delegate;
     OBJECTREF     m_ThreadStartArg;
 
@@ -1497,6 +1497,10 @@ public:
     
     }
 
+    STRINGREF GetName() {
+        LIMITED_METHOD_CONTRACT;
+        return m_Name;
+    }
     OBJECTREF GetDelegate()                   { LIMITED_METHOD_CONTRACT; return m_Delegate; }
     void      SetDelegate(OBJECTREF delegate);
 

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -2226,7 +2226,8 @@ BOOL Thread::CreateNewThread(SIZE_T stackSize, LPTHREAD_START_ROUTINE start, voi
     bRet = CreateNewOSThread(stackSize, start, args);
 #ifndef FEATURE_PAL
     UndoRevert(bReverted, token);
-    SetThreadName(m_ThreadHandle, pName);
+    if (pName != NULL)
+        SetThreadName(m_ThreadHandle, pName);
 #endif // !FEATURE_PAL
 
     return bRet;


### PR DESCRIPTION
System.Thread has a  'Name' Property that will call the Windows OS SetThreadDescription that will give the thread that friendly name for debuggers and profilers.   However this code was broken in a couple ways.

First, it actually calls the  SetThreadDescription  with a null name when a thread is created (even if later the name is set).   Secondly, if the Thread.Name is set before the thread is actually started, then SetThreadDescription is called on an invalid Thread handle and the thread never gets a name.  

This change fixes both of these issues.   First, when a thread is created it uses the Name property if it is set.   Second if the name property is set, it does not call SetThreadDescription if the Thread has not been created.   Third, it skips calls to SetThreadDescription if the name is null.