### PR TITLE
[release/2.0] Port dictionary hang detection from 2.1

### DIFF
--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -2474,6 +2474,9 @@
   <data name="InvalidOperation_CollectionCorrupted" xml:space="preserve">
     <value>A prior operation on this collection was interrupted by an exception. Collection's state is no longer trusted.</value>
   </data>
+  <data name="InvalidOperation_ConcurrentOperationsNotSupported" xml:space="preserve">
+    <value>Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.</value>
+  </data>
   <data name="InvalidOperation_ConstructorNotAllowedOnInterface" xml:space="preserve">
     <value>Interface cannot have constructors.</value>
   </data>

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -251,6 +251,11 @@ namespace System
             throw GetInvalidOperationException(ExceptionResource.InvalidOperation_EnumOpCantHappen);
         }
 
+        internal static void ThrowInvalidOperationException_ConcurrentOperationsNotSupported()
+        {
+            throw GetInvalidOperationException(ExceptionResource.InvalidOperation_ConcurrentOperationsNotSupported);
+        }
+
         internal static void ThrowArraySegmentCtorValidationFailedExceptions(Array array, int offset, int count)
         {
             throw GetArraySegmentCtorValidationFailedException(array, offset, count);
@@ -525,6 +530,7 @@ namespace System
         InvalidOperation_HandleIsNotInitialized,
         AsyncMethodBuilder_InstanceNotInitialized,
         ArgumentNull_SafeHandle,
+        InvalidOperation_ConcurrentOperationsNotSupported,
     }
 }
 


### PR DESCRIPTION
This is a customer request: no merge, while I seek shiproom approval. Also @maryamariyan will run corefx tests locally.

2.1 change was https://github.com/dotnet/coreclr/pull/16991

This was a **hand merge** because the implementation has changed significantly. 

Note: are we missing the same protection in Remove() overloads? It contains code like
```c#
                while (i >= 0)
                {
                    ref Entry entry = ref entries[i];
...
                    i = entry.next;
                }
```

If so this is missing from master as well.