### PR TITLE
Fix number formatting exception with empty NumberGroupSizes array

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
@@ -1974,13 +1974,14 @@ namespace System
                 if (groupDigits != null)
                 {
                     int groupSizeIndex = 0;                             // Index into the groupDigits array.
-                    int groupSizeCount = groupDigits[groupSizeIndex];   // The current total of group size.
                     int bufferSize = digPos;                            // The length of the result buffer string.
                     int groupSize = 0;                                  // The current group size.
 
                     // Find out the size of the string buffer for the result.
                     if (groupDigits.Length != 0) // You can pass in 0 length arrays
                     {
+                        int groupSizeCount = groupDigits[groupSizeIndex];   // The current total of group size.
+
                         while (digPos > groupSizeCount)
                         {
                             groupSize = groupDigits[groupSizeIndex];


### PR DESCRIPTION
Contributes to https://github.com/dotnet/coreclr/issues/18218

If an empty NumberGroupSizes array is used as part of "Fixed" formatting (which is used by F, N, C, and P specifiers), we end up trying to access element 0 of the array, triggering an IndexOutOfRangeException.  The fix is simply to move the check down until after we've checked that the array isn't empty.

cc: @jkotas, @EgorBo 