### PR TITLE
Fix SpanHelpers.ClearWithoutReferences alignment detection

### DIFF
--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.cs
@@ -233,13 +233,13 @@ namespace System
 
             nuint i = 0; // byte offset at which we're copying
 
-            if ((Unsafe.As<byte, int>(ref b) & 3) != 0)
+            if (((nuint)Unsafe.AsPointer(ref b) & 3) != 0)
             {
-                if ((Unsafe.As<byte, int>(ref b) & 1) != 0)
+                if (((nuint)Unsafe.AsPointer(ref b) & 1) != 0)
                 {
-                    Unsafe.AddByteOffset<byte>(ref b, i) = 0;
+                    b = 0;
                     i += 1;
-                    if ((Unsafe.As<byte, int>(ref b) & 2) != 0)
+                    if (((nuint)Unsafe.AsPointer(ref b) & 2) != 0)
                         goto IntAligned;
                 }
                 Unsafe.As<byte, short>(ref Unsafe.AddByteOffset<byte>(ref b, i)) = 0;
@@ -256,7 +256,7 @@ namespace System
             // The thing 1, 2, 3, and 4 have in common that the others don't is that if you
             // subtract one from them, their 3rd lsb will not be set. Hence, the below check.
 
-            if (((Unsafe.As<byte, int>(ref b) - 1) & 4) == 0)
+            if ((((nuint)Unsafe.AsPointer(ref b) - 1) & 4) == 0)
             {
                 Unsafe.As<byte, int>(ref Unsafe.AddByteOffset<byte>(ref b, i)) = 0;
                 i += 4;


### PR DESCRIPTION
The current code reads the span elements instead of using the element addresses.
With this fix `Span.Clear` is 1.4x faster on a 100 byte array on x86 if the span is aligned and contains non-zero data.

#16614 might be related to this.