### PR TITLE
Native lib relative path

### DIFF
--- a/src/vm/ceeload.h
+++ b/src/vm/ceeload.h
@@ -1903,7 +1903,7 @@ protected:
 
     BOOL IsIntrospectionOnly();
 
-#ifndef DACCESS_COMMPILE
+#ifndef DACCESS_COMPILE
     VOID EnsureActive();
     VOID EnsureAllocated();    
     VOID EnsureLibraryLoaded();


### PR DESCRIPTION
Don't add the a prefix when searching for a library with a relative path containing a path delimiter. #17604