### PR TITLE
Be more aggressive with Partial NGen

### DIFF
--- a/src/zap/zapimage.cpp
+++ b/src/zap/zapimage.cpp
@@ -1939,7 +1939,7 @@ ZapImage::CompileStatus ZapImage::TryCompileMethodDef(mdMethodDef md, unsigned m
     CORINFO_METHOD_HANDLE handle = NULL;
     CompileStatus         result = NOT_COMPILED;
 
-    if (methodProfilingDataFlags != 0 || ShouldCompileMethodDef(md))
+    if (ShouldCompileMethodDef(md))
     {
         handle = m_pPreloader->LookupMethodDef(md);
         if (handle == nullptr)
@@ -1989,7 +1989,7 @@ ZapImage::CompileStatus ZapImage::TryCompileInstantiatedMethod(CORINFO_METHOD_HA
             return COMPILE_EXCLUDED;
     }
 
-    if (methodProfilingDataFlags == 0 && !ShouldCompileInstantiatedMethod(handle))
+    if (!ShouldCompileInstantiatedMethod(handle))
         return COMPILE_EXCLUDED;
 
     // If we compiling this method because it was specified by the IBC profile data

--- a/src/zap/zapimage.cpp
+++ b/src/zap/zapimage.cpp
@@ -2097,7 +2097,7 @@ ZapImage::CompileStatus ZapImage::TryCompileMethodWorker(CORINFO_METHOD_HANDLE h
         const ProfileDataHashEntry* pEntry = profileDataHashTable.LookupPtr(md);
         
         // When Partial Ngen is specified we will omit the AOT native code for every
-        // method that was not executed based on the profile data.
+        // method that does not have profile data
         //
         if (pEntry == nullptr && m_zapper->m_pOpt->m_fPartialNGen)
         {

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -422,6 +422,9 @@ void ZapInfo::CompileMethod()
     if (m_currentMethodInfo.ILCodeSize == 0)
         return;
 
+    if (!CurrentMethodHasProfileData() && m_zapper->m_pOpt->m_fPartialNGen)
+        return;
+
     // During ngen we look for a hint attribute on the method that indicates
     // the method should be preprocessed for early
     // preparation. This normally happens automatically, but for methods that

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -422,6 +422,7 @@ void ZapInfo::CompileMethod()
     if (m_currentMethodInfo.ILCodeSize == 0)
         return;
 
+    // If we are doing partial ngen, only compile methods with profile data
     if (!CurrentMethodHasProfileData() && m_zapper->m_pOpt->m_fPartialNGen)
         return;
 


### PR DESCRIPTION
In partial ngen, we only compile those methods that both have profile
data and have the ReadMethodCode flag set in the profile flags. That
means that we miss some functions that do have counts, which affects the
performance of assemblies crossgened with partial ngen. This change
makes partial ngen more aggressive by, in the cold path, first checking
to see if we already considered this method in the hot section, which
means that it has profile data, and only rejecting those methods that
were not already considered. Then, in CompileMethod, we check to confirm
that all the methods that we want to compile have counts, and only compile the
methods that have actual profile data attached to them.

On MusicStore, this change brings the performance of PartialNGen + IBC data to
parity with full IBC builds (without partial ngen), but with a 48% reduction in size across
the System assemblies.