### PR TITLE
Enable tailcall_v4\smallFrame\smallFrame

### DIFF
--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -87249,7 +87249,7 @@ RelativePath=JIT\Methodical\tailcall_v4\smallFrame\smallFrame.cmd
 WorkingDir=JIT\Methodical\tailcall_v4\smallFrame
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=JIT;9462;EXPECTED_FAIL;6881;EXCLUDED;ILLEGAL_IL_TAILCALL_POP_RET
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b99222.cmd_10958]

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -58785,7 +58785,7 @@ RelativePath=JIT\Methodical\tailcall_v4\smallFrame\smallFrame.cmd
 WorkingDir=JIT\Methodical\tailcall_v4\smallFrame
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=JIT;9462;EXPECTED_FAIL;6881;EXCLUDED;ILLEGAL_IL_TAILCALL_POP_RET
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [tailcall_AV.cmd_7668]

--- a/tests/testsUnsupported.arm.txt
+++ b/tests/testsUnsupported.arm.txt
@@ -1,7 +1,6 @@
 CoreMangLib/cti/system/reflection/emit/DynMethodJumpStubTests/DynMethodJumpStubTests/DynMethodJumpStubTests.sh
 JIT/Directed/tailcall/tailcall/tailcall.sh
 JIT/Methodical/tailcall_v4/hijacking/hijacking.sh
-JIT/Methodical/tailcall_v4/smallFrame/smallFrame.sh
 JIT/Methodical/xxobj/sizeof/_il_dbgsizeof/_il_dbgsizeof.sh
 JIT/Methodical/xxobj/sizeof/_il_dbgsizeof32/_il_dbgsizeof32.sh
 JIT/Methodical/xxobj/sizeof/_il_dbgsizeof64/_il_dbgsizeof64.sh

--- a/tests/testsUnsupportedOutsideWindows.txt
+++ b/tests/testsUnsupportedOutsideWindows.txt
@@ -305,7 +305,6 @@ JIT/Methodical/tailcall/_il_dbgpointer/_il_dbgpointer.sh
 JIT/Methodical/tailcall/_il_dbgpointer_i/_il_dbgpointer_i.sh
 JIT/Methodical/tailcall/_il_relpointer/_il_relpointer.sh
 JIT/Methodical/tailcall/_il_relpointer_i/_il_relpointer_i.sh
-JIT/Methodical/tailcall_v4/smallFrame/smallFrame.sh
 JIT/opt/Inline/tests/security/security.sh
 JIT/opt/Inline/tests/xmodb/xmodb.sh
 JIT/opt/Tailcall/TailcallVerifyWithPrefix/TailcallVerifyWithPrefix.sh


### PR DESCRIPTION
PR #11316  removed the bad IL sequences from this test, but left these tests disabled for arm/arm64.