### PR TITLE
Change gtExtractSideEffList to use GenTreeVisitor

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -4618,13 +4618,14 @@ GenTree* Compiler::optPrepareTreeForReplacement(GenTree* oldTree, GenTree* newTr
             //
             // Do a sanity check to ensure persistent side effects aren't discarded and
             // tell gtExtractSideEffList to ignore the root of the tree.
-            //
-            // Note that the check below is relaxed in order to allow discarding the
-            // root node even if it has exception side effects. It is assumed that
-            // the caller knows what it is doing (e.g. VN may be able to evaluate a
-            // DIV/MOD node to a constant and the node may still have GTF_EXCEPT set,
-            // even if it does not actually throw any exceptions).
             assert(!gtNodeHasSideEffects(oldTree, GTF_PERSISTENT_SIDE_EFFECTS));
+            //
+            // Exception side effects may be ignored if the root is known to be a constant
+            // (e.g. VN may evaluate a DIV/MOD node to a constant and the node may still
+            // have GTF_EXCEPT set, even if it does not actually throw any exceptions).
+            assert(!gtNodeHasSideEffects(oldTree, GTF_EXCEPT) ||
+                   vnStore->IsVNConstant(oldTree->gtVNPair.GetConservative()));
+
             ignoreRoot = true;
         }
 

--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -4605,18 +4605,39 @@ GenTree* Compiler::optPrepareTreeForReplacement(GenTree* oldTree, GenTree* newTr
 {
     // If we have side effects, extract them and append newTree to the list.
     GenTree* sideEffList = nullptr;
-    if (oldTree->gtFlags & GTF_PERSISTENT_SIDE_EFFECTS)
+    if ((oldTree->gtFlags & GTF_SIDE_EFFECT) != 0)
     {
-        gtExtractSideEffList(oldTree, &sideEffList, GTF_PERSISTENT_SIDE_EFFECTS_IN_CSE);
+        bool ignoreRoot = false;
+
+        if (oldTree == newTree)
+        {
+            // If the caller passed the same tree as both old and new then it means
+            // that it expects that the root of the tree has no side effects and it
+            // won't be extracted. Otherwise the resulting comma tree would be invalid,
+            // having both op1 and op2 point to the same tree.
+            //
+            // Do a sanity check to ensure persistent side effects aren't discarded and
+            // tell gtExtractSideEffList to ignore the root of the tree.
+            //
+            // Note that the check below is relaxed in order to allow discarding the
+            // root node even if it has exception side effects. It is assumed that
+            // the caller knows what it is doing (e.g. VN may be able to evaluate a
+            // DIV/MOD node to a constant and the node may still have GTF_EXCEPT set,
+            // even if it does not actually throw any exceptions).
+            assert(!gtNodeHasSideEffects(oldTree, GTF_PERSISTENT_SIDE_EFFECTS));
+            ignoreRoot = true;
+        }
+
+        gtExtractSideEffList(oldTree, &sideEffList, GTF_SIDE_EFFECT, ignoreRoot);
     }
-    if (sideEffList)
+    if (sideEffList != nullptr)
     {
-        noway_assert(sideEffList->gtFlags & GTF_SIDE_EFFECT);
+        noway_assert((sideEffList->gtFlags & GTF_SIDE_EFFECT) != 0);
 
         // Increment the ref counts as we want to keep the side effects.
         lvaRecursiveIncRefCounts(sideEffList);
 
-        if (newTree)
+        if (newTree != nullptr)
         {
             newTree = gtNewOperNode(GT_COMMA, newTree->TypeGet(), sideEffList, newTree);
         }

--- a/src/jit/compmemkind.h
+++ b/src/jit/compmemkind.h
@@ -53,6 +53,7 @@ CompMemKindMacro(LoopHoist)
 CompMemKindMacro(Unknown)
 CompMemKindMacro(RangeCheck)
 CompMemKindMacro(CopyProp)
+CompMemKindMacro(SideEffects)
 //clang-format on
 
 #undef CompMemKindMacro

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -15104,157 +15104,121 @@ GenTree* Compiler::gtBuildCommaList(GenTree* list, GenTree* expr)
     }
 }
 
-/*****************************************************************************
- *
- *  Extracts side effects from the given expression
- *  and appends them to a given list (actually a GT_COMMA list)
- *  If ignore root is specified, the method doesn't treat the top
- *  level tree node as having side-effect.
- */
-
+//------------------------------------------------------------------------
+// gtExtractSideEffList: Extracts side effects from the given expression.
+//
+// Arguments:
+//    expr       - the expression tree to extract side effects from
+//    pList      - pointer to a (possibly null) GT_COMMA list that
+//                 will contain the extracted side effects
+//    flags      - side effect flags to be considered
+//    ignoreRoot - ignore side effects on the expression root node
+//
+// Notes:
+//    Side effects are prepended to the GT_COMMA list such that op1 of
+//    each comma node holds the side effect tree and op2 points to the
+//    next comma node. The original side effect execution order is preserved.
+//
 void Compiler::gtExtractSideEffList(GenTree*  expr,
                                     GenTree** pList,
                                     unsigned  flags /* = GTF_SIDE_EFFECT*/,
                                     bool      ignoreRoot /* = false */)
 {
-    assert(expr);
-    assert(expr->gtOper != GT_STMT);
-
-    /* If no side effect in the expression return */
-
-    if (!gtTreeHasSideEffects(expr, flags))
+    class SideEffectExtractor final : public GenTreeVisitor<SideEffectExtractor>
     {
-        return;
-    }
+    public:
+        const unsigned       m_flags;
+        ArrayStack<GenTree*> m_sideEffects;
 
-    genTreeOps oper = expr->OperGet();
-    unsigned   kind = expr->OperKind();
-
-    // Look for any side effects that we care about
-    //
-    if (!ignoreRoot && gtNodeHasSideEffects(expr, flags))
-    {
-        // Add the side effect to the list and return
-        //
-        *pList = gtBuildCommaList(*pList, expr);
-        return;
-    }
-
-    if (kind & GTK_LEAF)
-    {
-        return;
-    }
-
-    if (oper == GT_LOCKADD || oper == GT_XADD || oper == GT_XCHG || oper == GT_CMPXCHG)
-    {
-        // These operations are kind of important to keep
-        *pList = gtBuildCommaList(*pList, expr);
-        return;
-    }
-
-    if (kind & GTK_SMPOP)
-    {
-        GenTree* op1 = expr->gtOp.gtOp1;
-        GenTree* op2 = expr->gtGetOp2IfPresent();
-
-        if (flags & GTF_EXCEPT)
+        enum
         {
-            // Special case - GT_ADDR of GT_IND nodes of TYP_STRUCT
-            // have to be kept together
+            DoPreOrder        = true,
+            UseExecutionOrder = true
+        };
 
-            if (oper == GT_ADDR && op1->OperIsIndir() && op1->gtType == TYP_STRUCT)
+        SideEffectExtractor(Compiler* compiler, unsigned flags)
+            : GenTreeVisitor(compiler), m_flags(flags), m_sideEffects(compiler->getAllocator(CMK_SideEffects))
+        {
+        }
+
+        fgWalkResult PreOrderVisit(GenTree** use, GenTree* user)
+        {
+            GenTree* node = *use;
+
+            if (!m_compiler->gtTreeHasSideEffects(node, m_flags))
             {
-                *pList = gtBuildCommaList(*pList, expr);
+                return Compiler::WALK_SKIP_SUBTREES;
+            }
 
-#ifdef DEBUG
-                if (verbose)
+            if (m_compiler->gtNodeHasSideEffects(node, m_flags))
+            {
+                m_sideEffects.Push(node);
+                return Compiler::WALK_SKIP_SUBTREES;
+            }
+
+            // These have GTF_ASG but for some reason gtNodeHasSideEffects ignores them.
+            // Anyway, they must be preserved, no matter what side effect flags are passed in.
+            if (node->OperIs(GT_LOCKADD, GT_XADD, GT_XCHG, GT_CMPXCHG))
+            {
+                m_sideEffects.Push(node);
+                return Compiler::WALK_SKIP_SUBTREES;
+            }
+
+            if ((m_flags & GTF_EXCEPT) != 0)
+            {
+                // Special case - GT_ADDR of GT_IND nodes of TYP_STRUCT have to be kept together.
+                if (node->OperIs(GT_ADDR) && node->gtGetOp1()->OperIsIndir() &&
+                    (node->gtGetOp1()->TypeGet() == TYP_STRUCT))
                 {
-                    printf("Keep the GT_ADDR and GT_IND together:\n");
-                }
+#ifdef DEBUG
+                    if (m_compiler->verbose)
+                    {
+                        printf("Keep the GT_ADDR and GT_IND together:\n");
+                    }
 #endif
-                return;
+                    m_sideEffects.Push(node);
+                    return Compiler::WALK_SKIP_SUBTREES;
+                }
             }
+
+            // Generally all GT_CALL nodes are considered to have side-effects.
+            // So if we get here it must be a helper call that we decided it does
+            // not have side effects that we needed to keep.
+            assert(!node->OperIs(GT_CALL) || (node->AsCall()->gtCallType == CT_HELPER));
+
+            return Compiler::WALK_CONTINUE;
         }
+    };
 
-        /* Continue searching for side effects in the subtrees of the expression
-         * NOTE: Be careful to preserve the right ordering - side effects are prepended
-         * to the list */
+    assert(!expr->OperIs(GT_STMT));
 
-        /* Continue searching for side effects in the subtrees of the expression
-         * NOTE: Be careful to preserve the right ordering
-         * as side effects are prepended to the list */
+    SideEffectExtractor extractor(this, flags);
 
-        if (expr->gtFlags & GTF_REVERSE_OPS)
-        {
-            assert(oper != GT_COMMA);
-            if (op1)
-            {
-                gtExtractSideEffList(op1, pList, flags);
-            }
-            if (op2)
-            {
-                gtExtractSideEffList(op2, pList, flags);
-            }
-        }
-        else
-        {
-            if (op2)
-            {
-                gtExtractSideEffList(op2, pList, flags);
-            }
-            if (op1)
-            {
-                gtExtractSideEffList(op1, pList, flags);
-            }
-        }
-    }
-
-    if (expr->OperGet() == GT_CALL)
+    if (ignoreRoot)
     {
-        // Generally all GT_CALL nodes are considered to have side-effects.
-        // So if we get here it must be a Helper call that we decided does
-        // not have side effects that we needed to keep
-        //
-        assert(expr->gtCall.gtCallType == CT_HELPER);
-
-        // We can remove this Helper call, but there still could be
-        // side-effects in the arguments that we may need to keep
-        //
-        GenTree* args;
-        for (args = expr->gtCall.gtCallArgs; args; args = args->gtOp.gtOp2)
+        for (GenTree* op : expr->Operands())
         {
-            assert(args->OperIsList());
-            gtExtractSideEffList(args->Current(), pList, flags);
-        }
-        for (args = expr->gtCall.gtCallLateArgs; args; args = args->gtOp.gtOp2)
-        {
-            assert(args->OperIsList());
-            gtExtractSideEffList(args->Current(), pList, flags);
+            extractor.WalkTree(&op, nullptr);
         }
     }
-
-    if (expr->OperGet() == GT_ARR_BOUNDS_CHECK
-#ifdef FEATURE_SIMD
-        || expr->OperGet() == GT_SIMD_CHK
-#endif // FEATURE_SIMD
-#ifdef FEATURE_HW_INTRINSICS
-        || expr->OperGet() == GT_HW_INTRINSIC_CHK
-#endif // FEATURE_HW_INTRINSICS
-        )
+    else
     {
-        gtExtractSideEffList(expr->AsBoundsChk()->gtIndex, pList, flags);
-        gtExtractSideEffList(expr->AsBoundsChk()->gtArrLen, pList, flags);
+        extractor.WalkTree(&expr, nullptr);
     }
 
-    if (expr->OperGet() == GT_DYN_BLK || expr->OperGet() == GT_STORE_DYN_BLK)
+    GenTree* list = *pList;
+
+    // The extractor returns side effects in execution order but gtBuildCommaList prepends
+    // to the comma-based side effect list so we have to build the list in reverse order.
+    // This is also why the list cannot be built while traversing the tree.
+    // The number of side effects is usually small (<= 4), less than the ArrayStack's
+    // built-in size, so memory allocation is avoided.
+    while (extractor.m_sideEffects.Height() > 0)
     {
-        if (expr->AsDynBlk()->Data() != nullptr)
-        {
-            gtExtractSideEffList(expr->AsDynBlk()->Data(), pList, flags);
-        }
-        gtExtractSideEffList(expr->AsDynBlk()->Addr(), pList, flags);
-        gtExtractSideEffList(expr->AsDynBlk()->gtDynamicSize, pList, flags);
+        list = gtBuildCommaList(list, extractor.m_sideEffects.Pop());
     }
+
+    *pList = list;
 }
 
 /*****************************************************************************

--- a/tests/src/JIT/Regression/JitBlue/GitHub_18232/GitHub_18232.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_18232/GitHub_18232.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+// Test cases for issues with optVNConstantPropOnTree/optPrepareTreeForReplacement/gtExtractSideEffList.
+
+class Program
+{
+    static int[,] s_1 = new int[1, 1] { { 42 } };
+    static ushort[,] s_2 = new ushort[,] { { 0 } };
+
+    static int Main()
+    {
+        if (!Test1() || (s_1[0, 0] != 0))
+        {
+            return -1;
+        }
+
+        if (!Test2())
+        {
+            return -1;
+        }
+
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool Test1()
+    {
+        try
+        {
+            M(s_1[0, 0] & 0);
+        }
+        catch (NullReferenceException)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    static void M(int arg0)
+    {
+        s_1[0, 0] = arg0;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool Test2()
+    {
+        try
+        {
+            bool vr5 = 0 == ((0 % ((0 & s_2[0, 0]) | 1)) * s_2[0, 0]);
+        }
+        catch (NullReferenceException)
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_18232/GitHub_18232.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_18232/GitHub_18232.csproj
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
This changes `gtExtractSideEffList` to use `GenTreeVisitor` instead of custom tree traversal logic. The existing code did not handle `GT_ARR_ELEM` and `GT_ARR_OFFSET` and did not always preserve side effect ordering.

Additionally, this changes `optPrepareTreeForReplacement` to use `GTF_SIDE_EFFECT` instead of ` GTF_PERSISTENT_SIDE_EFFECTS_IN_CSE` to avoid dropping exception side effects and class constructor calls.

More details in commit message and discussion below.

Unfortunately the change to use `GenTreeVisitor` slows down things a bit - around 0.05% instructions retired. But I don't think such a small regression can justify keeping the custom/duplicate tree traversal logic, especially if it can lead to bugs. Besides, there are plenty of places in the JIT where one can recover 0.05% without compromising code reliability and clarity.

Fixes #18232