### PR TITLE
Write and WriteAsync overloads for StringBuilder.

### DIFF
--- a/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
@@ -853,7 +853,7 @@ namespace System.IO
             public override void WriteLine(string value) => _out.WriteLine(value);
 
             [MethodImpl(MethodImplOptions.Synchronized)]
-            public override void WriteLine(StringBuilder value) => _out.Write(value);
+            public override void WriteLine(StringBuilder value) => _out.WriteLine(value);
 
             [MethodImpl(MethodImplOptions.Synchronized)]
             public override void WriteLine(object value) => _out.WriteLine(value);

--- a/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
@@ -626,8 +626,8 @@ namespace System.IO
         /// <param name="value">The string (as a StringBuilder) to write to the stream</param>
         public async virtual Task WriteLineAsync(StringBuilder value, CancellationToken cancellationToken = default)
         {
-            await WriteAsync(value, cancellationToken);
-            await WriteAsync(CoreNewLine, cancellationToken);
+            await WriteAsync(value, cancellationToken).ConfigureAwait(false);
+            await WriteAsync(CoreNewLine, cancellationToken).ConfigureAwait(false);
         }
 
         public Task WriteLineAsync(char[] buffer)

--- a/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
@@ -891,7 +891,7 @@ namespace System.IO
             [MethodImpl(MethodImplOptions.Synchronized)]
             public override Task WriteAsync(StringBuilder value, CancellationToken cancellationToken = default)
             {
-                WriteAsync(value);
+                Write(value);
                 return Task.CompletedTask;
             }
 

--- a/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
@@ -283,6 +283,17 @@ namespace System.IO
             }
         }
 
+        /// <summary>
+        /// Equivalent to Write(stringBuilder.ToString()) however it uses the
+        /// StringBuilder.GetChunks() method to avoid creating the intermediate string 
+        /// </summary>
+        /// <param name="value">The string (as a StringBuilder) to write to the stream</param>
+        public virtual void Write(StringBuilder value)
+        {
+            foreach (ReadOnlyMemory<char> chunk in value.GetChunks())
+                Write(chunk);
+        }
+
         // Writes out a formatted string.  Uses the same semantics as
         // String.Format.
         // 
@@ -525,6 +536,17 @@ namespace System.IO
                 t.Item1.Write(t.Item2);
             },
             tuple, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+        }
+
+        /// <summary>
+        /// Equivalent to WriteAsync(stringBuilder.ToString()) however it uses the
+        /// StringBuilder.GetChunks() method to avoid creating the intermediate string 
+        /// </summary>
+        /// <param name="value">The string (as a StringBuilder) to write to the stream</param>
+        public async virtual Task WriteAsync(StringBuilder value)
+        {
+            foreach (ReadOnlyMemory<char> chunk in value.GetChunks())
+                await WriteAsync(chunk);
         }
 
         public Task WriteAsync(char[] buffer)

--- a/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
@@ -543,10 +543,10 @@ namespace System.IO
         /// StringBuilder.GetChunks() method to avoid creating the intermediate string 
         /// </summary>
         /// <param name="value">The string (as a StringBuilder) to write to the stream</param>
-        public async virtual Task WriteAsync(StringBuilder value)
+        public async virtual Task WriteAsync(StringBuilder value, CancellationToken cancellationToken = default)
         {
             foreach (ReadOnlyMemory<char> chunk in value.GetChunks())
-                await WriteAsync(chunk);
+                await WriteAsync(chunk, cancellationToken).ConfigureAwait(false);
         }
 
         public Task WriteAsync(char[] buffer)

--- a/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
@@ -557,14 +557,21 @@ namespace System.IO
         /// StringBuilder.GetChunks() method to avoid creating the intermediate string 
         /// </summary>
         /// <param name="value">The string (as a StringBuilder) to write to the stream</param>
-        public async virtual Task WriteAsync(StringBuilder value, CancellationToken cancellationToken = default)
+        public virtual Task WriteAsync(StringBuilder value, CancellationToken cancellationToken = default)
         {
+            // Do the agument checking before 'going async' so you get it early 
             if (value == null)
             {
                 throw new ArgumentNullException(nameof(value));
             }
-            foreach (ReadOnlyMemory<char> chunk in value.GetChunks())
-                await WriteAsync(chunk, cancellationToken).ConfigureAwait(false);
+            // Then do the rest which may be deferred (done in the returned Task)
+            return WriteAsyncCore(value, cancellationToken);
+
+            async Task WriteAsyncCore(StringBuilder sb, CancellationToken ct)
+            {
+                foreach (ReadOnlyMemory<char> chunk in sb.GetChunks())
+                    await WriteAsync(chunk, ct).ConfigureAwait(false);
+            }
         }
 
         public Task WriteAsync(char[] buffer)

--- a/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
@@ -626,8 +626,8 @@ namespace System.IO
         /// <param name="value">The string (as a StringBuilder) to write to the stream</param>
         public async virtual Task WriteLineAsync(StringBuilder value, CancellationToken cancellationToken = default)
         {
-            await WriteLineAsync(value, cancellationToken);
-            await WriteLineAsync(CoreNewLine, cancellationToken);
+            await WriteAsync(value, cancellationToken);
+            await WriteAsync(CoreNewLine, cancellationToken);
         }
 
         public Task WriteLineAsync(char[] buffer)
@@ -891,7 +891,7 @@ namespace System.IO
             [MethodImpl(MethodImplOptions.Synchronized)]
             public override Task WriteAsync(StringBuilder value, CancellationToken cancellationToken = default)
             {
-                WriteAsync(value, cancellationToken);
+                WriteAsync(value);
                 return Task.CompletedTask;
             }
 
@@ -919,7 +919,7 @@ namespace System.IO
             [MethodImpl(MethodImplOptions.Synchronized)]
             public override Task WriteLineAsync(StringBuilder value, CancellationToken cancellationToken = default)
             {
-                WriteLineAsync(value, cancellationToken);
+                WriteLine(value);
                 return Task.CompletedTask;
             }
 

--- a/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
@@ -290,6 +290,10 @@ namespace System.IO
         /// <param name="value">The string (as a StringBuilder) to write to the stream</param>
         public virtual void Write(StringBuilder value)
         {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
             foreach (ReadOnlyMemory<char> chunk in value.GetChunks())
                 Write(chunk);
         }
@@ -545,6 +549,10 @@ namespace System.IO
         /// <param name="value">The string (as a StringBuilder) to write to the stream</param>
         public async virtual Task WriteAsync(StringBuilder value, CancellationToken cancellationToken = default)
         {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
             foreach (ReadOnlyMemory<char> chunk in value.GetChunks())
                 await WriteAsync(chunk, cancellationToken).ConfigureAwait(false);
         }
@@ -767,6 +775,9 @@ namespace System.IO
             public override void Write(string value) => _out.Write(value);
 
             [MethodImpl(MethodImplOptions.Synchronized)]
+            public override void Write(StringBuilder value) => _out.Write(value);
+
+            [MethodImpl(MethodImplOptions.Synchronized)]
             public override void Write(object value) => _out.Write(value);
 
             [MethodImpl(MethodImplOptions.Synchronized)]
@@ -850,6 +861,13 @@ namespace System.IO
             public override Task WriteAsync(string value)
             {
                 Write(value);
+                return Task.CompletedTask;
+            }
+
+            [MethodImpl(MethodImplOptions.Synchronized)]
+            public override Task WriteAsync(StringBuilder value, CancellationToken cancellationToken = default)
+            {
+                WriteAsync(value, cancellationToken);
                 return Task.CompletedTask;
             }
 

--- a/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
@@ -462,6 +462,16 @@ namespace System.IO
             Write(CoreNewLineStr);
         }
 
+        /// <summary>
+        /// Equivalent to WriteLine(stringBuilder.ToString()) however it uses the
+        /// StringBuilder.GetChunks() method to avoid creating the intermediate string 
+        /// </summary>
+        public virtual void WriteLine(StringBuilder value)
+        {
+            Write(value);
+            WriteLine();
+        }
+
         // Writes the text representation of an object followed by a line
         // terminator to the text stream.
         //
@@ -607,6 +617,17 @@ namespace System.IO
                 t.Item1.WriteLine(t.Item2);
             },
             tuple, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+        }
+
+        /// <summary>
+        /// Equivalent to WriteLineAsync(stringBuilder.ToString()) however it uses the
+        /// StringBuilder.GetChunks() method to avoid creating the intermediate string 
+        /// </summary>
+        /// <param name="value">The string (as a StringBuilder) to write to the stream</param>
+        public async virtual Task WriteLineAsync(StringBuilder value, CancellationToken cancellationToken = default)
+        {
+            await WriteLineAsync(value, cancellationToken);
+            await WriteLineAsync(CoreNewLine, cancellationToken);
         }
 
         public Task WriteLineAsync(char[] buffer)
@@ -832,6 +853,9 @@ namespace System.IO
             public override void WriteLine(string value) => _out.WriteLine(value);
 
             [MethodImpl(MethodImplOptions.Synchronized)]
+            public override void WriteLine(StringBuilder value) => _out.Write(value);
+
+            [MethodImpl(MethodImplOptions.Synchronized)]
             public override void WriteLine(object value) => _out.WriteLine(value);
 
             [MethodImpl(MethodImplOptions.Synchronized)]
@@ -889,6 +913,13 @@ namespace System.IO
             public override Task WriteLineAsync(string value)
             {
                 WriteLine(value);
+                return Task.CompletedTask;
+            }
+
+            [MethodImpl(MethodImplOptions.Synchronized)]
+            public override Task WriteLineAsync(StringBuilder value, CancellationToken cancellationToken = default)
+            {
+                WriteLineAsync(value, cancellationToken);
                 return Task.CompletedTask;
             }
 


### PR DESCRIPTION
Addresses issue https://github.com/dotnet/corefx/issues/30048

Note that tests will come as a separate checking as part of the coreFX repo.

Uses the new StringBuilder.GetChunks() API to write out the StringBuilder in chunks and thus avoid making an intermediate String.  