### PR TITLE
Use sysconf(_SC_NPROCESSORS_CONF) in PAL and GC ONLY on ARM and ARM64

### DIFF
--- a/src/gc/unix/gcenv.unix.cpp
+++ b/src/gc/unix/gcenv.unix.cpp
@@ -40,6 +40,12 @@
 #include <unistd.h> // sysconf
 #include "globals.h"
 
+#if defined(_ARM_) || defined(_ARM64_)
+#define SYSCONF_GET_NUMPROCS _SC_NPROCESSORS_CONF
+#else
+#define SYSCONF_GET_NUMPROCS _SC_NPROCESSORS_ONLN
+#endif
+
 // The cachced number of logical CPUs observed.
 static uint32_t g_logicalCpuCount = 0;
 
@@ -67,7 +73,7 @@ bool GCToOSInterface::Initialize()
     g_pageSizeUnixInl = uint32_t((pageSize > 0) ? pageSize : 0x1000);
 
     // Calculate and cache the number of processors on this machine
-    int cpuCount = sysconf(_SC_NPROCESSORS_CONF);
+    int cpuCount = sysconf(SYSCONF_GET_NUMPROCS);
     if (cpuCount == -1)
     {
         return false;

--- a/src/pal/src/misc/sysinfo.cpp
+++ b/src/pal/src/misc/sysinfo.cpp
@@ -103,10 +103,18 @@ PAL_GetLogicalCpuCountFromOS()
     int nrcpus = 0;
 
 #if HAVE_SYSCONF
-    nrcpus = sysconf(_SC_NPROCESSORS_CONF);
+
+#if defined(_ARM_) || defined(_ARM64_)
+#define SYSCONF_GET_NUMPROCS       _SC_NPROCESSORS_CONF
+#define SYSCONF_GET_NUMPROCS_NAME "_SC_NPROCESSORS_CONF"
+#else
+#define SYSCONF_GET_NUMPROCS       _SC_NPROCESSORS_ONLN
+#define SYSCONF_GET_NUMPROCS_NAME "_SC_NPROCESSORS_ONLN"
+#endif
+    nrcpus = sysconf(SYSCONF_GET_NUMPROCS);
     if (nrcpus < 1)
     {
-        ASSERT("sysconf failed for _SC_NPROCESSORS_CONF (%d)\n", errno);
+        ASSERT("sysconf failed for %s (%d)\n", SYSCONF_GET_NUMPROCS_NAME, errno);
     }
 #elif HAVE_SYSCTL
     int rc;


### PR DESCRIPTION
This PR limits usage of `sysconf(_SC_NPROCESSORS_CONF)` only to ARM and ARM64 (see https://github.com/dotnet/coreclr/pull/18053#issuecomment-391902688) in the same way it is done in Release/2.1 #18055 

@janvorli PTAL
/cc @RussKeldorph 