### PR TITLE
Update SDK used to build jitutils to 2.1 RC

### DIFF
--- a/src/jit/inline.cpp
+++ b/src/jit/inline.cpp
@@ -96,7 +96,7 @@ const char* InlGetTargetString(InlineObservation obs)
     switch (t)
     {
         case InlineTarget::CALLER:
-            return "caller";
+                             return "caller";
         case InlineTarget::CALLEE:
             return "callee";
         case InlineTarget::CALLSITE:

--- a/src/jit/inline.cpp
+++ b/src/jit/inline.cpp
@@ -96,7 +96,7 @@ const char* InlGetTargetString(InlineObservation obs)
     switch (t)
     {
         case InlineTarget::CALLER:
-                             return "caller";
+            return "caller";
         case InlineTarget::CALLEE:
             return "callee";
         case InlineTarget::CALLSITE:

--- a/tests/scripts/format.py
+++ b/tests/scripts/format.py
@@ -88,7 +88,7 @@ def main(argv):
         dotnetcliUrl = "https://dotnetcli.azureedge.net/dotnet/Sdk/2.1.300/dotnet-sdk-2.1.300-linux-x64.tar.gz"
         dotnetcliFilename = os.path.join(dotnetcliPath, 'dotnetcli-jitutils.tar.gz')
     elif platform == 'OSX':
-        dotnetcliUrl = "https://dotnetcli.azureedge.net/dotnet/Sdk/2.1.300/dotnet-sdk-2.1.300-macos-x64.tar.gz"
+        dotnetcliUrl = "https://dotnetcli.azureedge.net/dotnet/Sdk/2.1.300/dotnet-sdk-2.1.300-osx-x64.tar.gz"
         dotnetcliFilename = os.path.join(dotnetcliPath, 'dotnetcli-jitutils.tar.gz')
     elif platform == 'Windows_NT':
         dotnetcliUrl = "https://dotnetcli.azureedge.net/dotnet/Sdk/2.1.300/dotnet-sdk-2.1.300-win-x64.zip"

--- a/tests/scripts/format.py
+++ b/tests/scripts/format.py
@@ -85,13 +85,13 @@ def main(argv):
 
     print("Downloading .Net CLI")
     if platform == 'Linux':
-        dotnetcliUrl = "https://dotnetcli.azureedge.net/dotnet/Sdk/2.0.0/dotnet-sdk-2.0.0-linux-x64.tar.gz"
+        dotnetcliUrl = "https://dotnetcli.azureedge.net/dotnet/Sdk/2.1.300/dotnet-sdk-2.1.300-linux-x64.tar.gz"
         dotnetcliFilename = os.path.join(dotnetcliPath, 'dotnetcli-jitutils.tar.gz')
     elif platform == 'OSX':
-        dotnetcliUrl = "https://dotnetcli.azureedge.net/dotnet/Sdk/2.0.0/dotnet-sdk-2.0.0-macos-x64.tar.gz"
+        dotnetcliUrl = "https://dotnetcli.azureedge.net/dotnet/Sdk/2.1.300/dotnet-sdk-2.1.300-macos-x64.tar.gz"
         dotnetcliFilename = os.path.join(dotnetcliPath, 'dotnetcli-jitutils.tar.gz')
     elif platform == 'Windows_NT':
-        dotnetcliUrl = "https://dotnetcli.azureedge.net/dotnet/Sdk/2.0.0/dotnet-sdk-2.0.0-win-x64.zip"
+        dotnetcliUrl = "https://dotnetcli.azureedge.net/dotnet/Sdk/2.1.300/dotnet-sdk-2.1.300-win-x64.zip"
         dotnetcliFilename = os.path.join(dotnetcliPath, 'dotnetcli-jitutils.zip')
     else:
         print('Unknown os ', os)

--- a/tests/scripts/format.py
+++ b/tests/scripts/format.py
@@ -223,6 +223,10 @@ def main(argv):
         proc = subprocess.Popen(["git", "diff", "--patch", "-U20"], env=my_env, stdout=patchFile)
         output,error = proc.communicate()
 
+    # shutdown the dotnet build servers before cleaning things up
+    proc = subprocess.Popen(["dotnet", "build-server", "shutdown"], env=my_env)
+    output,error = proc.communicate()
+
     if os.path.isdir(jitUtilsPath):
         print("Deleting " + jitUtilsPath)
         shutil.rmtree(jitUtilsPath, onerror=del_rw)


### PR DESCRIPTION
In anticipation of taking a dependence on netcoreapp2.1 for the
forthcoming PMI work from jitutils.

Also include a temporary deliberate formatting break to ensure the
formatter tool still works as expected.