### PR TITLE
Avoid marking the frame pointer is used in genFuncletProlog

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -5340,7 +5340,15 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
 #endif // !_TARGET_XARCH_
 
 #if CPU_LOAD_STORE_ARCH || !defined(_TARGET_UNIX_)
+        if (initReg == REG_FPBASE)
+        {
+            this->regSet.rsSetRegsModified(RBM_FPBASE);
+        }
         instGen_Set_Reg_To_Zero(EA_PTRSIZE, initReg);
+        if (initReg == REG_FPBASE)
+        {
+            this->regSet.rsRemoveRegsModified(RBM_FPBASE);
+        }
 #endif
 
         //
@@ -9615,8 +9623,6 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
 
     getEmitter()->emitIns_R_AR(INS_mov, EA_PTRSIZE, REG_FPBASE, REG_ARG_0, genFuncletInfo.fiPSP_slot_InitialSP_offset);
 
-    regSet.verifyRegUsed(REG_FPBASE);
-
     getEmitter()->emitIns_AR_R(INS_mov, EA_PTRSIZE, REG_FPBASE, REG_SPBASE, genFuncletInfo.fiPSP_slot_InitialSP_offset);
 
     if (genFuncletInfo.fiFunction_InitialSP_to_FP_delta != 0)
@@ -9624,9 +9630,6 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
         getEmitter()->emitIns_R_AR(INS_lea, EA_PTRSIZE, REG_FPBASE, REG_FPBASE,
                                    genFuncletInfo.fiFunction_InitialSP_to_FP_delta);
     }
-
-    // We've modified EBP, but not really. Say that we haven't...
-    regSet.rsRemoveRegsModified(RBM_FPBASE);
 }
 
 /*****************************************************************************


### PR DESCRIPTION
This pull request is a follow up of the pull request (#18230) I made earlier.

Initially, I followed the advice to mark the frame pointer as modified in `LinearScan::setFrameType()`, this results in an assert in the code below (ifdef eliminated for clarity)

`codegencommon.cpp`

    /* Count how many callee-saved registers will actually be saved (pushed) */

    // EBP cannot be (directly) modified for EBP frame and double-aligned frames
    noway_assert(!doubleAlignOrFramePointerUsed() || !regSet.rsRegsModified(RBM_FPBASE));

    // EBP cannot be (directly) modified
    noway_assert(!regSet.rsRegsModified(RBM_FPBASE));

    regMaskTP maskCalleeRegsPushed = regSet.rsGetModifiedRegsMask() & RBM_CALLEE_SAVED;

    if (isFramePointerUsed())
    {
        // For a FP based frame we have to push/pop the FP register
        //
        maskCalleeRegsPushed |= RBM_FPBASE;

        // This assert check that we are not using REG_FP
        // as both the frame pointer and as a codegen register
        //
        assert(!regSet.rsRegsModified(RBM_FPBASE));
    }

    // we always push LR.  See genPushCalleeSavedRegisters
    //
    maskCalleeRegsPushed |= RBM_LR;

Reading the code, it is apparent that if EBP is used as the frame pointer, it is expected that it is not marked as modified in the regSet, that is why I believe setting the frame pointer as modified in the `LinearScan::setFrameType()` is the wrong thing to do.

It remains to deal with the assert.

The code that I changed in this pull request is to bracket the particular instruction that modifies EBP in the prolog that asserts. The function `instGen_Set_Reg_To_Zero` is a generic function that zeros a register, as a side effect, it also asserts that the register is marked as modified. In general, this is the right thing to do, but only for this special case where we `modify` the frame pointer but not really ...

In some sense, the original code did pretty much that same, but it brackets a much larger region. This change narrowed down the region to just emitting one instruction in the large frame case.