### PR TITLE
Use the actual type of LOCKADD's data operand

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -3528,7 +3528,7 @@ void CodeGen::genCodeForLockAdd(GenTreeOp* node)
 
     GenTree* addr = node->gtGetOp1();
     GenTree* data = node->gtGetOp2();
-    emitAttr size = emitTypeSize(data->TypeGet());
+    emitAttr size = emitActualTypeSize(data->TypeGet());
 
     assert(addr->isUsedFromReg());
     assert(data->isUsedFromReg() || data->isContainedIntOrIImmed());

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -320,7 +320,8 @@ GenTree* Lowering::LowerNode(GenTree* node)
                 node->ClearUnusedValue();
                 // Make sure the types are identical, since the node type is changed to VOID
                 // CodeGen relies on op2's type to determine the instruction size.
-                assert(node->gtGetOp2()->TypeGet() == node->TypeGet());
+                // Note that the node type cannot be a small int but the data operand can.
+                assert(genActualType(node->gtGetOp2()->TypeGet()) == node->TypeGet());
                 node->SetOper(GT_LOCKADD);
                 node->gtType = TYP_VOID;
                 CheckImmedAndMakeContained(node, node->gtGetOp2());


### PR DESCRIPTION
The data operand can theoretically be a small int so we need to use its actual type to determine instruction size.

In practice this issue does not seem to happen as the importer is pretty insistent in spilling interlocked arguments to lclvars that have the proper type. Even when the data argument is already a small int lclvar (e.g. short method argument) this still doesn't cause problems because there's a cast between the method argument and LOCKADD.