### PR TITLE
JIT: implement assembly name dissassembly filtering

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -8003,6 +8003,11 @@ public:
 #endif // ALT_JIT
 
 #ifdef DEBUG
+    static bool                s_pJitDisasmIncludeAssembliesListInitialized;
+    static AssemblyNamesList2* s_pJitDisasmIncludeAssembliesList;
+#endif // DEBUG
+
+#ifdef DEBUG
 
     template <typename T>
     T dspPtr(T p)

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -141,10 +141,12 @@ CONFIG_INTEGER(TailcallStress, W("TailcallStress"), 0)
 CONFIG_INTEGER(TreesBeforeAfterMorph, W("JitDumpBeforeAfterMorph"), 0) // If 1, display each tree before/after morphing
 CONFIG_METHODSET(JitBreak, W("JitBreak")) // Stops in the importer when compiling a specified method
 CONFIG_METHODSET(JitDebugBreak, W("JitDebugBreak"))
-CONFIG_METHODSET(JitDisasm, W("JitDisasm")) // Dumps disassembly for specified method
-CONFIG_METHODSET(JitDump, W("JitDump"))     // Dumps trees for specified method
-CONFIG_METHODSET(JitDumpIR, W("JitDumpIR")) // Dumps trees (in linear IR form) for specified method
-CONFIG_METHODSET(JitEHDump, W("JitEHDump")) // Dump the EH table for the method, as reported to the VM
+CONFIG_METHODSET(JitDisasm, W("JitDisasm"))                  // Dumps disassembly for specified method
+CONFIG_STRING(JitDisasmAssemblies, W("JitDisasmAssemblies")) // Only disassemble methods from this list of
+                                                             // semicolon-delimited list of assemblies.
+CONFIG_METHODSET(JitDump, W("JitDump"))                      // Dumps trees for specified method
+CONFIG_METHODSET(JitDumpIR, W("JitDumpIR"))                  // Dumps trees (in linear IR form) for specified method
+CONFIG_METHODSET(JitEHDump, W("JitEHDump"))                  // Dump the EH table for the method, as reported to the VM
 CONFIG_METHODSET(JitExclude, W("JitExclude"))
 CONFIG_METHODSET(JitForceProcedureSplitting, W("JitForceProcedureSplitting"))
 CONFIG_METHODSET(JitGCDump, W("JitGCDump"))

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -142,8 +142,8 @@ CONFIG_INTEGER(TreesBeforeAfterMorph, W("JitDumpBeforeAfterMorph"), 0) // If 1, 
 CONFIG_METHODSET(JitBreak, W("JitBreak")) // Stops in the importer when compiling a specified method
 CONFIG_METHODSET(JitDebugBreak, W("JitDebugBreak"))
 CONFIG_METHODSET(JitDisasm, W("JitDisasm"))                  // Dumps disassembly for specified method
-CONFIG_STRING(JitDisasmAssemblies, W("JitDisasmAssemblies")) // Only disassemble methods from this list of
-                                                             // semicolon-delimited list of assemblies.
+CONFIG_STRING(JitDisasmAssemblies, W("JitDisasmAssemblies")) // Only show JitDisasm and related info for methods
+                                                             // from this semicolon-delimited list of assemblies.
 CONFIG_METHODSET(JitDump, W("JitDump"))                      // Dumps trees for specified method
 CONFIG_METHODSET(JitDumpIR, W("JitDumpIR"))                  // Dumps trees (in linear IR form) for specified method
 CONFIG_METHODSET(JitEHDump, W("JitEHDump"))                  // Dump the EH table for the method, as reported to the VM


### PR DESCRIPTION
Add `COMPlus_JitDisasmAssemblies` to specify a whitelist of assemblies
whose methods will be disassembled.

Intended use is for PMI asm diffing. Since PMI runs in process, current
disassembly will dissassemble various methods in PMI itself as well
as framework methods that did not get prejitted.

With this new config option we can restrict disassembly to just the assemblies
that we're processing via PMI.