### PR TITLE
Interop Copy tests now all return 101 during fail rather than crash

### DIFF
--- a/tests/src/Interop/MarshalAPI/Copy/CopyByteArray.cs
+++ b/tests/src/Interop/MarshalAPI/Copy/CopyByteArray.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using CoreFXTestLibrary;
 
-
 public class CopyByteArrayTest 
 {
     private byte[] TestArray = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
@@ -26,7 +25,6 @@ public class CopyByteArrayTest
         for (int i = 0; i < array1.Length; i++)
             if (!array1[i].Equals(array2[i]))
             {
-                
                 return false;
             }
 
@@ -64,33 +62,21 @@ public class CopyByteArrayTest
         try
         {
             Marshal.Copy(array, 0, IntPtr.Zero, 0);
-
-            Assert.ErrorWriteLine("Failed null values test.");
-            Assert.ErrorWriteLine("No exception from Copy when passed null as parameter.");
+            Assert.Fail("Failed null values test. No exception from Copy when passed null as parameter.");
         }
         catch (ArgumentNullException)
         {
             
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed null values test.");            
         }
 
         try
         {
             Marshal.Copy(IntPtr.Zero, array, 0, 0);
-
-            Assert.ErrorWriteLine("Failed null values test.");
-            Assert.ErrorWriteLine("No exception from Copy when passed null as parameter.");
+            Assert.Fail("Failed null values test. No exception from Copy when passed null as parameter.");
         }
         catch (ArgumentNullException)
         {
             
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed null values test.");            
         }
     }
 
@@ -103,49 +89,33 @@ public class CopyByteArrayTest
         try //try to copy more elements than the TestArray has
         {
             Marshal.Copy(TestArray, 0, ptr, TestArray.Length + 1);
-
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("No exception from Copy when trying to copy more elements than the TestArray has.");
+            Assert.Fail("Failed out of range values test. No exception from Copy when trying to copy more elements than the TestArray has.");
         }
         catch (ArgumentOutOfRangeException)
         {
-           
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed out of range values test.");            
+
         }
 
         try //try to copy from an out of bound startIndex
         {
             Marshal.Copy(TestArray, TestArray.Length + 1, ptr, 1);
 
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("No exception from Copy when trying to copy from an out of bound startIndex.");
+            Assert.Fail("Failed out of range values test. No exception from Copy when trying to copy from an out of bound startIndex.");
         }
         catch (ArgumentOutOfRangeException)
         {
             
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed out of range values test.");            
         }
 
         try //try to copy from a positive startIndex, with length taking it out of bounds
         {
             Marshal.Copy(TestArray, 2, ptr, TestArray.Length);
 
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("No exception from Copy when trying to copy from a positive startIndex, with length taking it out of bounds.");
+            Assert.Fail("Failed out of range values test. No exception from Copy when trying to copy from a positive startIndex, with length taking it out of bounds.");
         }
         catch (ArgumentOutOfRangeException)
         {
             
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed out of range values test.");            
         }
 
         Marshal.FreeCoTaskMem(ptr);
@@ -157,7 +127,7 @@ public class CopyByteArrayTest
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 
-        try //try to copy the entire array
+        //try to copy the entire array
         {
             Marshal.Copy(TestArray, 0, ptr, TestArray.Length);
 
@@ -167,16 +137,11 @@ public class CopyByteArrayTest
 
             if (!IsArrayEqual(TestArray, array))
             {
-                Assert.ErrorWriteLine("Failed copy round trip test");
-                Assert.ErrorWriteLine("Original array and round trip copied arrays do not match.");
+                Assert.Fail("Failed copy round trip test. Original array and round trip copied arrays do not match.");
             }
         }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed copy round trip test.");            
-        }
 
-        try //try to copy part of the array
+        //try to copy part of the array
         {
             Marshal.Copy(TestArray, 2, ptr, TestArray.Length - 4);
 
@@ -186,32 +151,33 @@ public class CopyByteArrayTest
 
             if (!IsSubArrayEqual(TestArray, array, 2, TestArray.Length - 4))
             {
-                Assert.ErrorWriteLine("Failed copy round trip test");
-                Assert.ErrorWriteLine("Original array and round trip partially copied arrays do not match.");
+                Assert.Fail("Failed copy round trip test. Original array and round trip partially copied arrays do not match.");
             }
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed copy round trip test.");            
         }
 
         Marshal.FreeCoTaskMem(ptr);
     }
 
-    public bool RunTests()
+    public void RunTests()
     {
         NullValueTests();
         OutOfRangeTests();
         CopyRoundTripTests();
-        return true;
     }
 
     public static int Main(String[] unusedArgs)
     {
-        if (new CopyByteArrayTest().RunTests())
-            return 100;
+        try
+        {
+            new CopyByteArrayTest().RunTests();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("Test failure: " + e.Message);
+            return 101;
+        }
 
-        return 99;
+        return 100;
     }
 
 }

--- a/tests/src/Interop/MarshalAPI/Copy/CopyCharArray.cs
+++ b/tests/src/Interop/MarshalAPI/Copy/CopyCharArray.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using CoreFXTestLibrary;
 
-
 public class CopyCharArrayTest 
 {
     private char[] TestArray = { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j' };
@@ -60,27 +59,21 @@ public class CopyCharArrayTest
         try
         {
             Marshal.Copy(array, 0, IntPtr.Zero, 0);            
-            throw new Exception("No exception from Copy when passed null as parameter.");
+            Assert.Fail("No exception from Copy when passed null as parameter.");
         }
         catch (ArgumentNullException)
-        {       
+        {
+
         }
        
-
         try
         {
             Marshal.Copy(IntPtr.Zero, array, 0, 0);
-
-            Assert.ErrorWriteLine("Failed null values test.");
-            Assert.ErrorWriteLine("No exception from Copy when passed null as parameter.");
+            Assert.Fail("Failed null values test. No exception from Copy when passed null as parameter.");
         }
         catch (ArgumentNullException)
         {
             
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed null values test.");            
         }
     }
 
@@ -94,46 +87,31 @@ public class CopyCharArrayTest
         {
             Marshal.Copy(TestArray, 0, ptr, TestArray.Length + 1);
 
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("No exception from Copy when trying to copy more elements than the TestArray has.");
+            Assert.Fail("Failed out of range values test. No exception from Copy when trying to copy more elements than the TestArray has.");
         }
         catch (ArgumentOutOfRangeException)
         {
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed out of range values test.");            
         }
 
         try //try to copy from an out of bound startIndex
         {
             Marshal.Copy(TestArray, TestArray.Length + 1, ptr, 1);
 
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("No exception from Copy when trying to copy from an out of bound startIndex.");
+            Assert.Fail("Failed out of range values test. No exception from Copy when trying to copy from an out of bound startIndex.");
         }
         catch (ArgumentOutOfRangeException)
         {
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed out of range values test.");            
         }
 
         try //try to copy from a positive startIndex, with length taking it out of bounds
         {
             Marshal.Copy(TestArray, 2, ptr, TestArray.Length);
 
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("No exception from Copy when trying to copy from a positive startIndex, with length taking it out of bounds.");
+            Assert.Fail("Failed out of range values test. No exception from Copy when trying to copy from a positive startIndex, with length taking it out of bounds.");
         }
         catch (ArgumentOutOfRangeException)
         {
             
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed out of range values test.");            
         }
 
         Marshal.FreeCoTaskMem(ptr);
@@ -145,7 +123,7 @@ public class CopyCharArrayTest
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 
-        try //try to copy the entire array
+        //try to copy the entire array
         {
             Marshal.Copy(TestArray, 0, ptr, TestArray.Length);
 
@@ -155,16 +133,11 @@ public class CopyCharArrayTest
 
             if (!IsArrayEqual(TestArray, array))
             {
-                Assert.ErrorWriteLine("Failed copy round trip test");
-                Assert.ErrorWriteLine("Original array and round trip copied arrays do not match.");
+                Assert.Fail("Failed copy round trip test. Original array and round trip copied arrays do not match.");
             }
         }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed copy round trip test.");            
-        }
 
-        try //try to copy part of the array
+        //try to copy part of the array
         {
             Marshal.Copy(TestArray, 2, ptr, TestArray.Length - 4);
 
@@ -174,31 +147,33 @@ public class CopyCharArrayTest
 
             if (!IsSubArrayEqual(TestArray, array, 2, TestArray.Length - 4))
             {
-                Assert.ErrorWriteLine("Failed copy round trip test");
-                Assert.ErrorWriteLine("Original array and round trip partially copied arrays do not match.");
+                Assert.Fail("Failed copy round trip test. Original array and round trip partially copied arrays do not match.");
             }
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed copy round trip test.");            
         }
 
         Marshal.FreeCoTaskMem(ptr);
     }
 
-    public bool RunTests()
+    public void RunTests()
     {
         NullValueTests();
         OutOfRangeTests();
         CopyRoundTripTests();
-        return true;
     }
 
     public static int Main(String[] unusedArgs)
     {
-        if (new CopyCharArrayTest().RunTests())
-            return 100;
-        return 99;
+        try
+        {
+            new CopyCharArrayTest().RunTests();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("Test failure: " + e.Message);
+            return 101;
+        }
+
+        return 100;
     }
 
 }

--- a/tests/src/Interop/MarshalAPI/Copy/CopyDoubleArray.cs
+++ b/tests/src/Interop/MarshalAPI/Copy/CopyDoubleArray.cs
@@ -58,30 +58,20 @@ public class CopyDoubleArrayTest
         try
         {
             Marshal.Copy(array, 0, IntPtr.Zero, 0);
-            Assert.ErrorWriteLine("Failed null values test.");
-            Assert.ErrorWriteLine("No exception from Copy when passed null as parameter.");
+            Assert.Fail("Failed null values test. No exception from Copy when passed null as parameter.");
         }
         catch (ArgumentNullException)
         {            
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed null values test.");            
         }
 
         try
         {
             Marshal.Copy(IntPtr.Zero, array, 0, 0);
 
-            Assert.ErrorWriteLine("Failed null values test.");
-            Assert.ErrorWriteLine("No exception from Copy when passed null as parameter.");
+            Assert.Fail("Failed null values test. No exception from Copy when passed null as parameter.");
         }
         catch (ArgumentNullException)
         {            
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed null values test.");            
         }
     }
 
@@ -95,46 +85,31 @@ public class CopyDoubleArrayTest
         {
             Marshal.Copy(TestArray, 0, ptr, TestArray.Length + 1);
 
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("No exception from Copy when trying to copy more elements than the TestArray has.");
+            Assert.Fail("Failed out of range values test. No exception from Copy when trying to copy more elements than the TestArray has.");
         }
         catch (ArgumentOutOfRangeException)
         {            
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed out of range values test.");            
         }
 
         try //try to copy from an out of bound startIndex
         {
             Marshal.Copy(TestArray, TestArray.Length + 1, ptr, 1);
 
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("No exception from Copy when trying to copy from an out of bound startIndex.");
+            Assert.Fail("Failed out of range values test. No exception from Copy when trying to copy from an out of bound startIndex.");
         }
         catch (ArgumentOutOfRangeException)
         {            
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed out of range values test.");            
         }
 
         try //try to copy from a positive startIndex, with length taking it out of bounds
         {
             Marshal.Copy(TestArray, 2, ptr, TestArray.Length);
 
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("No exception from Copy when trying to copy from a positive startIndex, with length taking it out of bounds.");
+            Assert.Fail("Failed out of range values test. No exception from Copy when trying to copy from a positive startIndex, with length taking it out of bounds.");
         }
         catch (ArgumentOutOfRangeException)
         {
             
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed out of range values test.");            
         }
 
         Marshal.FreeCoTaskMem(ptr);
@@ -146,7 +121,7 @@ public class CopyDoubleArrayTest
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 
-        try //try to copy the entire array
+        //try to copy the entire array
         {
             Marshal.Copy(TestArray, 0, ptr, TestArray.Length);
 
@@ -156,16 +131,11 @@ public class CopyDoubleArrayTest
 
             if (!IsArrayEqual(TestArray, array))
             {
-                Assert.ErrorWriteLine("Failed copy round trip test");
-                Assert.ErrorWriteLine("Original array and round trip copied arrays do not match.");
+                Assert.Fail("Failed copy round trip test. Original array and round trip copied arrays do not match.");
             }
         }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed copy round trip test.");            
-        }
 
-        try //try to copy part of the array
+        //try to copy part of the array
         {
             Marshal.Copy(TestArray, 2, ptr, TestArray.Length - 4);
 
@@ -175,31 +145,33 @@ public class CopyDoubleArrayTest
 
             if (!IsSubArrayEqual(TestArray, array, 2, TestArray.Length - 4))
             {
-                Assert.ErrorWriteLine("Failed copy round trip test");
-                Assert.ErrorWriteLine("Original array and round trip partially copied arrays do not match.");
+                Assert.Fail("Failed copy round trip test. Original array and round trip partially copied arrays do not match.");
             }
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed copy round trip test.");            
         }
 
         Marshal.FreeCoTaskMem(ptr);
     }
 
-    public bool RunTests()
+    public void RunTests()
     {        
         NullValueTests();
         OutOfRangeTests();        
-        CopyRoundTripTests();        
-        return true;
+        CopyRoundTripTests();
     }
 
     public static int Main(String[] unusedArgs)
     {
-        if (new CopyDoubleArrayTest().RunTests())
-            return 100;
-        return 99;
+        try
+        {
+            new CopyDoubleArrayTest().RunTests();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("Test failure: " + e.Message);
+            return 101;
+        }
+
+        return 100;
     }
 
 }

--- a/tests/src/Interop/MarshalAPI/Copy/CopyInt16Array.cs
+++ b/tests/src/Interop/MarshalAPI/Copy/CopyInt16Array.cs
@@ -58,31 +58,20 @@ public class CopyInt16ArrayTest
         {
             Marshal.Copy(array, 0, IntPtr.Zero, 0);
 
-            Assert.ErrorWriteLine("Failed null values test.");
-            Assert.ErrorWriteLine("No exception from Copy when passed null as parameter.");
+            Assert.Fail("Failed null values test. No exception from Copy when passed null as parameter.");
         }
         catch (ArgumentNullException)
         {            
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed null values test.");  
         }
 
         try
         {
             Marshal.Copy(IntPtr.Zero, array, 0, 0);
 
-            Assert.ErrorWriteLine("Failed null values test.");
-            Assert.ErrorWriteLine("No exception from Copy when passed null as parameter.");
+            Assert.Fail("Failed null values test. No exception from Copy when passed null as parameter.");
         }
         catch (ArgumentNullException)
         {            
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed null values test.");
-            Assert.ErrorWriteLine("Exception occurred: {0}", ex);
         }
     }
 
@@ -96,45 +85,30 @@ public class CopyInt16ArrayTest
         {
             Marshal.Copy(TestArray, 0, ptr, TestArray.Length + 1);
 
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("No exception from Copy when trying to copy more elements than the TestArray has.");
+            Assert.Fail("Failed out of range values test. No exception from Copy when trying to copy more elements than the TestArray has.");
         }
         catch (ArgumentOutOfRangeException)
         {            
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed out of range values test.");            
         }
 
         try //try to copy from an out of bound startIndex
         {
             Marshal.Copy(TestArray, TestArray.Length + 1, ptr, 1);
 
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("No exception from Copy when trying to copy from an out of bound startIndex.");
+            Assert.Fail("Failed out of range values test. No exception from Copy when trying to copy from an out of bound startIndex.");
         }
         catch (ArgumentOutOfRangeException)
         {            
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed out of range values test.");            
         }
 
         try //try to copy from a positive startIndex, with length taking it out of bounds
         {
             Marshal.Copy(TestArray, 2, ptr, TestArray.Length);
 
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("No exception from Copy when trying to copy from a positive startIndex, with length taking it out of bounds.");
+            Assert.Fail("Failed out of range values test. No exception from Copy when trying to copy from a positive startIndex, with length taking it out of bounds.");
         }
         catch (ArgumentOutOfRangeException)
         {            
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed out of range values test.");            
         }
 
         Marshal.FreeCoTaskMem(ptr);
@@ -146,7 +120,7 @@ public class CopyInt16ArrayTest
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 
-        try //try to copy the entire array
+        //try to copy the entire array
         {
             Marshal.Copy(TestArray, 0, ptr, TestArray.Length);
 
@@ -156,16 +130,11 @@ public class CopyInt16ArrayTest
 
             if (!IsArrayEqual(TestArray, array))
             {
-                Assert.ErrorWriteLine("Failed copy round trip test");
-                Assert.ErrorWriteLine("Original array and round trip copied arrays do not match.");
+                Assert.Fail("Failed copy round trip test. Original array and round trip copied arrays do not match.");
             }
         }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed copy round trip test.");            
-        }
 
-        try //try to copy part of the array
+        //try to copy part of the array
         {
             Marshal.Copy(TestArray, 2, ptr, TestArray.Length - 4);
 
@@ -175,31 +144,32 @@ public class CopyInt16ArrayTest
 
             if (!IsSubArrayEqual(TestArray, array, 2, TestArray.Length - 4))
             {
-                Assert.ErrorWriteLine("Failed copy round trip test");
-                Assert.ErrorWriteLine("Original array and round trip partially copied arrays do not match.");
+                Assert.Fail("Failed copy round trip test. Original array and round trip partially copied arrays do not match.");
             }
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed copy round trip test.");            
         }
 
         Marshal.FreeCoTaskMem(ptr);
     }
 
-    public bool RunTests()
+    public void RunTests()
     {
-        
-        NullValueTests();        
-        OutOfRangeTests();        
+        NullValueTests();
+        OutOfRangeTests();
         CopyRoundTripTests();
-        return true;
     }
 
     public static int Main(String[] unusedArgs)
     {
-        if (new CopyInt16ArrayTest().RunTests())
-            return 100;
-        return 99;
+        try
+        {
+            new CopyInt16ArrayTest().RunTests();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("Test failure: " + e.Message);
+            return 101;
+        }
+
+        return 100;
     }
 }

--- a/tests/src/Interop/MarshalAPI/Copy/CopyInt32Array.cs
+++ b/tests/src/Interop/MarshalAPI/Copy/CopyInt32Array.cs
@@ -9,6 +9,7 @@ using System.Security;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using CoreFXTestLibrary;
+
 public class CopyInt32ArrayTest 
 {
     private int[] TestArray = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
@@ -59,32 +60,20 @@ public class CopyInt32ArrayTest
         {
             Marshal.Copy(array, 0, IntPtr.Zero, 0);
 
-            Assert.ErrorWriteLine("Failed null values test.");
-            Assert.ErrorWriteLine("No exception from Copy when passed null as parameter.");
+            Assert.Fail("Failed null values test. No exception from Copy when passed null as parameter.");
         }
         catch (ArgumentNullException)
         {
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed null values test.");
-            Assert.ErrorWriteLine("Exception occurred: {0}", ex);
         }
 
         try
         {
             Marshal.Copy(IntPtr.Zero, array, 0, 0);
 
-            Assert.ErrorWriteLine("Failed null values test.");
-            Assert.ErrorWriteLine("No exception from Copy when passed null as parameter.");
+            Assert.Fail("Failed null values test. No exception from Copy when passed null as parameter.");
         }
         catch (ArgumentNullException)
         {
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed null values test.");
-            Assert.ErrorWriteLine("Exception occurred: {0}", ex);
         }
     }
 
@@ -98,46 +87,31 @@ public class CopyInt32ArrayTest
         {
             Marshal.Copy(TestArray, 0, ptr, TestArray.Length + 1);
 
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("No exception from Copy when trying to copy more elements than the TestArray has.");
+            Assert.Fail("Failed out of range values test. No exception from Copy when trying to copy more elements than the TestArray has.");
         }
         catch (ArgumentOutOfRangeException)
         {
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed out of range values test.");            
         }
 
         try //try to copy from an out of bound startIndex
         {
             Marshal.Copy(TestArray, TestArray.Length + 1, ptr, 1);
 
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("No exception from Copy when trying to copy from an out of bound startIndex.");
+            Assert.Fail("Failed out of range values test. No exception from Copy when trying to copy from an out of bound startIndex.");
         }
         catch (ArgumentOutOfRangeException)
         {
             
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed out of range values test.");            
         }
 
         try //try to copy from a positive startIndex, with length taking it out of bounds
         {
             Marshal.Copy(TestArray, 2, ptr, TestArray.Length);
 
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("No exception from Copy when trying to copy from a positive startIndex, with length taking it out of bounds.");
+            Assert.Fail("Failed out of range values test. No exception from Copy when trying to copy from a positive startIndex, with length taking it out of bounds.");
         }
         catch (ArgumentOutOfRangeException)
         {
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed out of range values test.");            
         }
 
         Marshal.FreeCoTaskMem(ptr);
@@ -149,7 +123,7 @@ public class CopyInt32ArrayTest
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 
-        try //try to copy the entire array
+        //try to copy the entire array
         {
             Marshal.Copy(TestArray, 0, ptr, TestArray.Length);
 
@@ -159,17 +133,11 @@ public class CopyInt32ArrayTest
 
             if (!IsArrayEqual(TestArray, array))
             {
-                Assert.ErrorWriteLine("Failed copy round trip test");
-                Assert.ErrorWriteLine("Original array and round trip copied arrays do not match.");
+                Assert.Fail("Failed copy round trip test. Original array and round trip copied arrays do not match.");
             }
         }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed copy round trip test.");
-            Assert.ErrorWriteLine("Exception occurred: {0}", ex);
-        }
 
-        try //try to copy part of the array
+        //try to copy part of the array
         {
             Marshal.Copy(TestArray, 2, ptr, TestArray.Length - 4);
 
@@ -179,32 +147,33 @@ public class CopyInt32ArrayTest
 
             if (!IsSubArrayEqual(TestArray, array, 2, TestArray.Length - 4))
             {
-                Assert.ErrorWriteLine("Failed copy round trip test");
-                Assert.ErrorWriteLine("Original array and round trip partially copied arrays do not match.");
+                Assert.Fail("Failed copy round trip test. Original array and round trip partially copied arrays do not match.");
             }
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed copy round trip test.");
-            Assert.ErrorWriteLine("Exception occurred: {0}", ex);
         }
 
         Marshal.FreeCoTaskMem(ptr);
     }
 
-    public bool RunTests()
+    public void RunTests()
     {        
         NullValueTests();
         OutOfRangeTests();
         CopyRoundTripTests();
-        return true;
     }
 
     public static int Main(String[] unusedArgs)
     {
-        if (new CopyInt32ArrayTest().RunTests()) 
-            return 100;
-        return 99;
+        try
+        {
+            new CopyInt32ArrayTest().RunTests();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("Test failure: " + e.Message);
+            return 101;
+        }
+
+        return 100;
     }
 
 }

--- a/tests/src/Interop/MarshalAPI/Copy/CopyInt64Array.cs
+++ b/tests/src/Interop/MarshalAPI/Copy/CopyInt64Array.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using CoreFXTestLibrary;
 
-
 public class CopyInt64ArrayTest
 {
     private long[] TestArray = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
@@ -60,31 +59,20 @@ public class CopyInt64ArrayTest
         {
             Marshal.Copy(array, 0, IntPtr.Zero, 0);
 
-            Assert.ErrorWriteLine("Failed null values test.");
-            Assert.ErrorWriteLine("No exception from Copy when passed null as parameter.");
+            Assert.Fail("Failed null values test. No exception from Copy when passed null as parameter.");
         }
         catch (ArgumentNullException)
         {            
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed null values test.");
-            Assert.ErrorWriteLine("Exception occurred: {0}", ex);
         }
 
         try
         {
             Marshal.Copy(IntPtr.Zero, array, 0, 0);
 
-            Assert.ErrorWriteLine("Failed null values test.");
-            Assert.ErrorWriteLine("No exception from Copy when passed null as parameter.");
+            Assert.Fail("Failed null values test. No exception from Copy when passed null as parameter.");
         }
         catch (ArgumentNullException)
         {            
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed null values test.");            
         }
     }
 
@@ -98,45 +86,30 @@ public class CopyInt64ArrayTest
         {
             Marshal.Copy(TestArray, 0, ptr, TestArray.Length + 1);
 
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("No exception from Copy when trying to copy more elements than the TestArray has.");
+            Assert.Fail("Failed out of range values test. No exception from Copy when trying to copy more elements than the TestArray has.");
         }
         catch (ArgumentOutOfRangeException)
         {            
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed out of range values test.");            
         }
 
         try //try to copy from an out of bound startIndex
         {
             Marshal.Copy(TestArray, TestArray.Length + 1, ptr, 1);
 
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("No exception from Copy when trying to copy from an out of bound startIndex.");
+            Assert.Fail("Failed out of range values test. No exception from Copy when trying to copy from an out of bound startIndex.");
         }
         catch (ArgumentOutOfRangeException)
         {            
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed out of range values test.");            
         }
 
         try //try to copy from a positive startIndex, with length taking it out of bounds
         {
             Marshal.Copy(TestArray, 2, ptr, TestArray.Length);
 
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("No exception from Copy when trying to copy from a positive startIndex, with length taking it out of bounds.");
+            Assert.Fail("Failed out of range values test. No exception from Copy when trying to copy from a positive startIndex, with length taking it out of bounds.");
         }
         catch (ArgumentOutOfRangeException)
         {            
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed out of range values test.");            
         }
 
         Marshal.FreeCoTaskMem(ptr);
@@ -148,7 +121,7 @@ public class CopyInt64ArrayTest
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 
-        try //try to copy the entire array
+        //try to copy the entire array
         {
             Marshal.Copy(TestArray, 0, ptr, TestArray.Length);
 
@@ -158,16 +131,11 @@ public class CopyInt64ArrayTest
 
             if (!IsArrayEqual(TestArray, array))
             {
-                Assert.ErrorWriteLine("Failed copy round trip test");
-                Assert.ErrorWriteLine("Original array and round trip copied arrays do not match.");
+                Assert.Fail("Failed copy round trip test. Original array and round trip copied arrays do not match.");
             }
         }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed copy round trip test.");            
-        }
 
-        try //try to copy part of the array
+        //try to copy part of the array
         {
             Marshal.Copy(TestArray, 2, ptr, TestArray.Length - 4);
 
@@ -177,31 +145,33 @@ public class CopyInt64ArrayTest
 
             if (!IsSubArrayEqual(TestArray, array, 2, TestArray.Length - 4))
             {
-                Assert.ErrorWriteLine("Failed copy round trip test");
-                Assert.ErrorWriteLine("Original array and round trip partially copied arrays do not match.");
+                Assert.Fail("Failed copy round trip test. Original array and round trip partially copied arrays do not match.");
             }
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed copy round trip test.");            
         }
 
         Marshal.FreeCoTaskMem(ptr);
     }
 
-    public bool RunTests()
+    public void RunTests()
     {
         NullValueTests();
         OutOfRangeTests();
         CopyRoundTripTests();
-        return true;
     }
 
     public static int Main(String[] unusedArgs)
     {
-        if (new CopyInt64ArrayTest().RunTests())
-            return 100;
-        return 99;
+        try
+        {
+            new CopyInt64ArrayTest().RunTests();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("Test failure: " + e.Message);
+            return 101;
+        }
+
+        return 100;
     }
 
 }

--- a/tests/src/Interop/MarshalAPI/Copy/CopyIntPtrArray.cs
+++ b/tests/src/Interop/MarshalAPI/Copy/CopyIntPtrArray.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
 using System;
 using System.IO;
 using System.Reflection;
@@ -58,32 +59,20 @@ public class CopyIntPtrArrayTest
         {
             Marshal.Copy(array, 0, IntPtr.Zero, 0);
 
-            Assert.ErrorWriteLine("Failed null values test.");
-            Assert.ErrorWriteLine("No exception from Copy when passed null as parameter.");
+            Assert.Fail("Failed null values test. No exception from Copy when passed null as parameter.");
         }
         catch (ArgumentNullException)
         {            
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed null values test.");
-            Assert.ErrorWriteLine("Exception occurred: {0}", ex);
         }
 
         try
         {
             Marshal.Copy(IntPtr.Zero, array, 0, 0);
 
-            Assert.ErrorWriteLine("Failed null values test.");
-            Assert.ErrorWriteLine("No exception from Copy when passed null as parameter.");
+            Assert.Fail("Failed null values test. No exception from Copy when passed null as parameter.");
         }
         catch (ArgumentNullException)
         {            
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed null values test.");
-            Assert.ErrorWriteLine("Exception occurred: {0}", ex);
         }
     }
 
@@ -97,49 +86,31 @@ public class CopyIntPtrArrayTest
         {
             Marshal.Copy(TestArray, 0, ptr, TestArray.Length + 1);
 
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("No exception from Copy when trying to copy more elements than the TestArray has.");
+            Assert.Fail("Failed out of range values test. No exception from Copy when trying to copy more elements than the TestArray has.");
         }
         catch (ArgumentOutOfRangeException)
         {            
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("Exception occurred: {0}", ex);
         }
 
         try //try to copy from an out of bound startIndex
         {
             Marshal.Copy(TestArray, TestArray.Length + 1, ptr, 1);
 
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("No exception from Copy when trying to copy from an out of bound startIndex.");
+            Assert.Fail("Failed out of range values test. No exception from Copy when trying to copy from an out of bound startIndex.");
         }
         catch (ArgumentOutOfRangeException)
         {            
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("Exception occurred: {0}", ex);
         }
 
         try //try to copy from a positive startIndex, with length taking it out of bounds
         {
             Marshal.Copy(TestArray, 2, ptr, TestArray.Length);
 
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("No exception from Copy when trying to copy from a positive startIndex, with length taking it out of bounds.");
+            Assert.Fail("Failed out of range values test. No exception from Copy when trying to copy from a positive startIndex, with length taking it out of bounds.");
         }
         catch (ArgumentOutOfRangeException)
         {
             
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("Exception occurred: {0}", ex);
         }
 
         Marshal.FreeCoTaskMem(ptr);
@@ -151,7 +122,7 @@ public class CopyIntPtrArrayTest
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 
-        try //try to copy the entire array
+        //try to copy the entire array
         {
             Marshal.Copy(TestArray, 0, ptr, TestArray.Length);
 
@@ -161,17 +132,11 @@ public class CopyIntPtrArrayTest
 
             if (!IsArrayEqual(TestArray, array))
             {
-                Assert.ErrorWriteLine("Failed copy round trip test");
-                Assert.ErrorWriteLine("Original array and round trip copied arrays do not match.");
+                Assert.Fail("Failed copy round trip test. Original array and round trip copied arrays do not match.");
             }
         }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed copy round trip test.");
-            Assert.ErrorWriteLine("Exception occurred: {0}", ex);
-        }
 
-        try //try to copy part of the array
+        //try to copy part of the array
         {
             Marshal.Copy(TestArray, 2, ptr, TestArray.Length - 4);
 
@@ -181,44 +146,39 @@ public class CopyIntPtrArrayTest
 
             if (!IsSubArrayEqual(TestArray, array, 2, TestArray.Length - 4))
             {
-                Assert.ErrorWriteLine("Failed copy round trip test");
-                Assert.ErrorWriteLine("Original array and round trip partially copied arrays do not match.");
+                Assert.Fail("Failed copy round trip test. Original array and round trip partially copied arrays do not match.");
             }
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed copy round trip test.");
-            Assert.ErrorWriteLine("Exception occurred: {0}", ex);
         }
 
         Marshal.FreeCoTaskMem(ptr);
     }
 
-    public bool RunTests()
+    public void RunTests()
     {        
         NullValueTests();        
         OutOfRangeTests();        
         CopyRoundTripTests();
-        return true;
     }
 
-    public bool Initialize()
+    public CopyIntPtrArrayTest()
     {        
         TestArray = new IntPtr[10];
         for (int i = 0; i < TestArray.Length; i++)
             TestArray[i] = new IntPtr(i);
-        return true;
     }
 
     public static int Main(String[] unusedArgs)
     {
-        CopyIntPtrArrayTest test = new CopyIntPtrArrayTest();
-        test.Initialize();
+        try
+        {
+            new CopyIntPtrArrayTest().RunTests();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("Test failure: " + e.Message);
+            return 101;
+        }
 
-        if (test.RunTests())
-            return 100;
-
-        return 99;
+        return 100;
     }
-
 }

--- a/tests/src/Interop/MarshalAPI/Copy/CopySingleArray.cs
+++ b/tests/src/Interop/MarshalAPI/Copy/CopySingleArray.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
 using System;
 using System.IO;
 using System.Reflection;
@@ -8,7 +9,6 @@ using System.Security;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using CoreFXTestLibrary;
-
 
 public class CopySingleArrayTest 
 {
@@ -24,7 +24,6 @@ public class CopySingleArrayTest
         for (int i = 0; i < array1.Length; i++)
             if (!array1[i].Equals(array2[i]))
             {
-               
                 return false;
             }
 
@@ -61,31 +60,21 @@ public class CopySingleArrayTest
         {
             Marshal.Copy(array, 0, IntPtr.Zero, 0);
 
-            Assert.ErrorWriteLine("Failed null values test.");
-            Assert.ErrorWriteLine("No exception from Copy when passed null as parameter.");
+            Assert.Fail("Failed null values test. No exception from Copy when passed null as parameter.");
         }
         catch (ArgumentNullException)
         {
             
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed null values test.");
-            Assert.ErrorWriteLine("Exception occurred: {0}", ex);
         }
 
         try
         {
             Marshal.Copy(IntPtr.Zero, array, 0, 0);
-            Assert.ErrorWriteLine("Failed null values test.");            
+            Assert.Fail("Failed null values test.");
         }
         catch (ArgumentNullException)
         {
             
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed null values test.");            
         }
     }
 
@@ -98,45 +87,33 @@ public class CopySingleArrayTest
         try //try to copy more elements than the TestArray has
         {
             Marshal.Copy(TestArray, 0, ptr, TestArray.Length + 1);
-            Assert.ErrorWriteLine("Failed out of range values test.");
+            Assert.Fail("Failed out of range values test.");
             
         }
         catch (ArgumentOutOfRangeException)
         {
             
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed out of range values test.");
-            Assert.ErrorWriteLine("Exception occurred: {0}", ex);
         }
 
         try //try to copy from an out of bound startIndex
         {
             Marshal.Copy(TestArray, TestArray.Length + 1, ptr, 1);
-            Assert.ErrorWriteLine("Failed out of range values test.");            
+            Assert.Fail("Failed out of range values test.");
         }
         catch (ArgumentOutOfRangeException)
         {
             
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed out of range values test.");            
         }
 
         try //try to copy from a positive startIndex, with length taking it out of bounds
         {
             Marshal.Copy(TestArray, 2, ptr, TestArray.Length);
-            Assert.ErrorWriteLine("Failed out of range values test.");
+            Assert.Fail("Failed out of range values test.");
             
         }
         catch (ArgumentOutOfRangeException)
-        {            
-        }
-        catch (Exception ex)
         {
-            Assert.ErrorWriteLine("Failed out of range values test.");            
+
         }
 
         Marshal.FreeCoTaskMem(ptr);
@@ -148,7 +125,7 @@ public class CopySingleArrayTest
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 
-        try //try to copy the entire array
+        //try to copy the entire array
         {
             Marshal.Copy(TestArray, 0, ptr, TestArray.Length);
 
@@ -158,17 +135,11 @@ public class CopySingleArrayTest
 
             if (!IsArrayEqual(TestArray, array))
             {
-                Assert.ErrorWriteLine("Failed copy round trip test");
-                Assert.ErrorWriteLine("Original array and round trip copied arrays do not match.");
+                Assert.Fail("Failed copy round trip test. Original array and round trip copied arrays do not match.");
             }
         }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed copy round trip test.");
-            Assert.ErrorWriteLine("Exception occurred: {0}", ex);
-        }
 
-        try //try to copy part of the array
+        //try to copy part of the array
         {
             Marshal.Copy(TestArray, 2, ptr, TestArray.Length - 4);
 
@@ -178,32 +149,33 @@ public class CopySingleArrayTest
 
             if (!IsSubArrayEqual(TestArray, array, 2, TestArray.Length - 4))
             {
-                Assert.ErrorWriteLine("Failed copy round trip test");
-                Assert.ErrorWriteLine("Original array and round trip partially copied arrays do not match.");
+                Assert.Fail("Failed copy round trip test. Original array and round trip partially copied arrays do not match.");
             }
-        }
-        catch (Exception ex)
-        {
-            Assert.ErrorWriteLine("Failed copy round trip test.");            
         }
 
         Marshal.FreeCoTaskMem(ptr);
     }
 
-    public bool RunTests()
+    public void RunTests()
     {        
         NullValueTests();        
         OutOfRangeTests();
         CopyRoundTripTests();
-        return true;
     }
 
     public static int Main(String[] unusedArgs)
     {
-        if (new CopySingleArrayTest().RunTests())
-            return 100;
+        try
+        {
+            new CopySingleArrayTest().RunTests();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("Test failure: " + e.Message);
+            return 101;
+        }
 
-        return 99;
+        return 100;
     }
 
 }


### PR DESCRIPTION
Currently taking stock of Interop tests and decided to make all the Copy tests consistent as a way to get familiar with building and running the tests.