### PR TITLE
Increase timeout and log the result for some WaitAny tests that expect AbandonedMutexException

### DIFF
--- a/tests/src/baseservices/threading/waithandle/waitany/waitanyex2a.cs
+++ b/tests/src/baseservices/threading/waithandle/waitany/waitanyex2a.cs
@@ -36,7 +36,7 @@ class WaitAnyEx
         {
             Console.WriteLine("Waiting...");
             int i = WaitHandle.WaitAny(
-                new WaitHandle[]{myMutex, myMRE});
+                new WaitHandle[]{myMutex, myMRE}, 30000);
             Console.WriteLine("WaitAny did not throw AbandonedMutexException. Result: {0}", i);
         }
         catch(AbandonedMutexException)

--- a/tests/src/baseservices/threading/waithandle/waitany/waitanyex4.cs
+++ b/tests/src/baseservices/threading/waithandle/waitany/waitanyex4.cs
@@ -29,8 +29,8 @@ class WaitAnyEx
         try
         {
             Console.WriteLine("Waiting...");
-            int i = WaitHandle.WaitAny(wh, 5000);
-            Console.WriteLine("WaitAny did not throw an exception");
+            int i = WaitHandle.WaitAny(wh, 30000);
+            Console.WriteLine("WaitAny did not throw AbandonedMutexException. Result: {0}", i);
         }
         catch(AbandonedMutexException)
         {
@@ -43,10 +43,9 @@ class WaitAnyEx
 
     private void AbandonOne()
     {
-        Mutex m = new Mutex();
         foreach(WaitHandle w in wh)
         {
-            if(w.GetType() == m.GetType())
+            if(w is Mutex)
             {
                 w.WaitOne();
                 break;

--- a/tests/src/baseservices/threading/waithandle/waitany/waitanyex4a.cs
+++ b/tests/src/baseservices/threading/waithandle/waitany/waitanyex4a.cs
@@ -29,8 +29,8 @@ class WaitAnyEx
         try
         {
             Console.WriteLine("Waiting...");
-            int i = WaitHandle.WaitAny(wh);
-            Console.WriteLine("WaitAny did not throw an exception");
+            int i = WaitHandle.WaitAny(wh, 30000);
+            Console.WriteLine("WaitAny did not throw AbandonedMutexException. Result: {0}", i);
         }
         catch(AbandonedMutexException)
         {
@@ -43,10 +43,9 @@ class WaitAnyEx
 
     private void AbandonOne()
     {
-        Mutex m = new Mutex();
         foreach(WaitHandle w in wh)
         {
-            if(w.GetType() == m.GetType())
+            if(w is Mutex)
             {
                 w.WaitOne();
                 break;


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/coreclr/pull/13298, missed a few cases.