### PR TITLE
Remove unnecessary SuppressFinalize() calls

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
@@ -375,7 +375,6 @@ namespace System.Threading
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         /// <summary>

--- a/src/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
@@ -644,7 +644,6 @@ namespace System.Threading
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         /// <summary>

--- a/src/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -901,7 +901,6 @@ namespace System.Threading
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         /// <summary>


### PR DESCRIPTION
Classes CancellationTokenSource, ManualResetEventSlim and SemaphoreSlim have SuppressFinalize() calls in their Dispose() methods, but actually this classes have no finalizers at all, so we don't need to suppress it.

So the points of this PR are:
- performance (SuppressFinalize() is not heavy, but also it isn't zero-cost)
- code health/cleanliness