### PR TITLE
Fix issue in Compiler::impImportStaticFieldAccess

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -6564,8 +6564,16 @@ GenTree* Compiler::impImportStaticFieldAccess(CORINFO_RESOLVED_TOKEN* pResolvedT
 
     if (!(access & CORINFO_ACCESS_ADDRESS))
     {
-        op1 = gtNewOperNode(GT_IND, lclTyp, op1);
-        op1->gtFlags |= GTF_GLOB_REF;
+        if (varTypeIsStruct(lclTyp))
+        {
+            // Constructor adds GTF_GLOB_REF.  Note that this is *not* GTF_EXCEPT.
+            op1 = gtNewObjNode(pFieldInfo->structType, op1);
+        }
+        else
+        {
+            op1 = gtNewOperNode(GT_IND, lclTyp, op1);
+            op1->gtFlags |= GTF_GLOB_REF;
+        }
     }
 
     return op1;


### PR DESCRIPTION
When CORINFO_FIELD_STATIC_SHARED_STATIC_HELPER accessor is being processed for
structs, the method creates a GT_IND node instead of GT_OBJ node. For structs
that can be normalized to a specific type (like TYP_SIMD8), it causes an assert
in Compiler::impNormStructVal in the switch case for GT_IND.

This change modifies the node creation to work the same way as in the default
case for accessors, creating GT_OBJ for structs and GT_IND otherwise.