### PR TITLE
Implemented low-memory notification simulation on Unix

### DIFF
--- a/src/inc/readme.md
+++ b/src/inc/readme.md
@@ -1,0 +1,12 @@
+# Updating idl files
+
+This directory has a variety of .idl files (such as corprof.idl) that need a little special handling when you make changes. Originally when we built on Windows only
+the build rules would automatically convert the idls into corresponding .h/.c files and include them in compilations. On non-windows platforms we don't have an equivalent
+for midl.exe which did that conversion so we work around the issue by doing:
+
+- Build on Windows as normal, which will generate files in bin\obj\Windows_NT.x64.Debug\src\inc\idls_out\
+- Copy any updated headers into src\pal\prebuilt\inc\
+- If needed, adjust any of the .cpp files in src\pal\prebuilt\idl\ by hand, using the corresponding bin\obj\Windows_NT.x64.Debug\src\inc\idls_out\*_i.c as a guide. Typically
+this is just adding MIDL_DEFINE_GUID(...) for any new classes/interfaces that have been added to the idl file.
+
+Include these src changes with the remainder of your work when you submit a PR.

--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -489,14 +489,10 @@ if(CLR_CMAKE_PLATFORM_UNIX)
         ${ARCH_SOURCES_DIR}/unixstubs.cpp
         unixlowmem.cpp
     )
-endif(CLR_CMAKE_PLATFORM_UNIX)
-
-if(CLR_CMAKE_PLATFORM_UNIX)
     list(APPEND VM_SOURCES_WKS
         unixlowmem.cpp
     )
 endif(CLR_CMAKE_PLATFORM_UNIX)
-
 
 set(VM_SOURCES_DAC_ARCH
     gcinfodecoder.cpp

--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -487,6 +487,7 @@ endif()
 if(CLR_CMAKE_PLATFORM_UNIX)
     list(APPEND VM_SOURCES_WKS_ARCH
         ${ARCH_SOURCES_DIR}/unixstubs.cpp
+        unixlowmem.cpp
     )
 endif(CLR_CMAKE_PLATFORM_UNIX)
 

--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -487,7 +487,6 @@ endif()
 if(CLR_CMAKE_PLATFORM_UNIX)
     list(APPEND VM_SOURCES_WKS_ARCH
         ${ARCH_SOURCES_DIR}/unixstubs.cpp
-        unixlowmem.cpp
     )
     list(APPEND VM_SOURCES_WKS
         unixlowmem.cpp

--- a/src/vm/finalizerthread.cpp
+++ b/src/vm/finalizerthread.cpp
@@ -20,7 +20,7 @@
 BOOL FinalizerThread::fRunFinalizersOnUnload = FALSE;
 BOOL FinalizerThread::fQuitFinalizer = FALSE;
 
-#if defined(PLATFORM_UNIX) && defined(FEATURE_PAL)
+#if defined(FEATURE_PAL)
 #include "unixlowmem.h"
 
 #define LOWMEMORY_CHECK_TIMEOUT 100
@@ -474,7 +474,7 @@ void FinalizerThread::WaitForFinalizerEvent (CLREvent *event)
             cEventsForWait,                           // # objects to wait on
             &(MHandles[uiEventIndexOffsetForWait]),   // array of objects to wait on
             FALSE,          // bWaitAll == FALSE, so wait for first signal
-#if defined (LOWMEMORY_CHECK_TIMEOUT)
+#ifdef LOWMEMORY_CHECK_TIMEOUT
             LOWMEMORY_CHECK_TIMEOUT,
 #else
             INFINITE,       // timeout
@@ -520,7 +520,7 @@ void FinalizerThread::WaitForFinalizerEvent (CLREvent *event)
                 GetFinalizerThread()->EnablePreemptiveGC();
             }
 #ifdef LINUX_HEAP_DUMP_TIME_OUT
-            if ((++uiTimeoutCounter > (LINUX_HEAP_DUMP_TIME_OUT / LOWMEMORY_CHECK_TIMEOUT))
+            if ((++uiTimeoutCounter >= (LINUX_HEAP_DUMP_TIME_OUT / LOWMEMORY_CHECK_TIMEOUT))
                 && g_TriggerHeapDump)
             {
                 return;

--- a/src/vm/finalizerthread.cpp
+++ b/src/vm/finalizerthread.cpp
@@ -913,8 +913,10 @@ void FinalizerThread::FinalizerThreadCreate()
     hEventShutDownToFinalizer = new CLREvent();
     hEventShutDownToFinalizer->CreateAutoEvent(FALSE);
 
+#ifdef FEATURE_UNIX_LOW_MEMORY_NOTIFICATION
     _ASSERTE(s_pLowMemoryDetector == 0);
     s_pLowMemoryDetector = new UnixLowMemoryDetector();
+#endif // FEATURE_UNIX_LOW_MEMORY_NOTIFICATION
 
     _ASSERTE(g_pFinalizerThread == 0);
     g_pFinalizerThread = SetupUnstartedThread();

--- a/src/vm/finalizerthread.h
+++ b/src/vm/finalizerthread.h
@@ -6,6 +6,12 @@
 #ifndef _FINALIZER_THREAD_H_
 #define _FINALIZER_THREAD_H_
 
+#include "unixlowmem.h"
+
+#if defined(__linux__) && defined(FEATURE_PAL)
+#define FEATURE_UNIX_LOW_MEMORY_NOTIFICATION
+#endif
+
 class FinalizerThread
 {
     static BOOL fRunFinalizersOnUnload;
@@ -14,6 +20,10 @@ class FinalizerThread
     
 #if defined(__linux__) && defined(FEATURE_EVENT_TRACE)
     static ULONGLONG LastHeapDumpTime;
+#endif
+
+#if defined(FEATURE_UNIX_LOW_MEMORY_NOTIFICATION)
+    static UnixLowMemoryDetector *s_pLowMemoryDetector;
 #endif
 
     static CLREvent *hEventFinalizer;

--- a/src/vm/unixlowmem.cpp
+++ b/src/vm/unixlowmem.cpp
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ===========================================================================
+
+#include "common.h"
+#include "unixlowmem.h"
+#include <stdlib.h>
+#include "debugmacros.h"
+
+#ifdef FEATURE_PAL
+
+UnixLowMemoryDetector::UnixLowMemoryDetector()
+{
+    LIMITED_METHOD_CONTRACT;
+
+    auto percent = max(min(ReadLowMemoryLimitPercent(), 100), 1);
+    this->m_szLowMemoryLimitBytes = ReadPhysicalMemoryLimitBytes() * percent / 100;
+}
+
+size_t UnixLowMemoryDetector::ReadLowMemoryLimitPercent()
+{
+    LIMITED_METHOD_CONTRACT;
+
+    char* defaultStackSizeStr = getenv("COMPlus_UnixLowMemoryLimitPercent");
+    if (defaultStackSizeStr != NULL)
+    {
+        errno = 0;
+        auto size = atoi(defaultStackSizeStr);
+
+        if (errno == 0)
+            return (size_t)size;
+    }
+    return 75; // default value
+}
+
+size_t UnixLowMemoryDetector::ReadPhysicalMemoryLimitBytes()
+{
+    LIMITED_METHOD_CONTRACT;
+
+    return PAL_GetRestrictedPhysicalMemoryLimit();
+}
+
+bool UnixLowMemoryDetector::IsLowMemory()
+{
+    LIMITED_METHOD_CONTRACT;
+
+    size_t szWorkingSet;
+    if (FALSE == PAL_GetWorkingSetSize(&szWorkingSet))
+        return false;
+
+    return szWorkingSet > this->m_szLowMemoryLimitBytes;
+}
+
+#endif

--- a/src/vm/unixlowmem.h
+++ b/src/vm/unixlowmem.h
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ===========================================================================
+
+#ifndef _UNIXLOWMEM_H_
+#define _UNIXLOWMEM_H_
+
+#ifdef FEATURE_PAL
+class UnixLowMemoryDetector
+{
+    size_t m_szLowMemoryLimitBytes;
+
+public:
+    UnixLowMemoryDetector();
+
+    size_t ReadLowMemoryLimitPercent();
+    size_t ReadPhysicalMemoryLimitBytes();
+    bool IsLowMemory();
+};
+
+#endif
+#endif


### PR DESCRIPTION
Added UnixLowMemoryDetector which reads memory limit on construction and
compares with working set when IsLowMemory() is called
COMPlus_UnixLowMemoryLimitPercent variable defines low-memory threshold in
percent and defaults to 75.

Fix #5551