### PR TITLE
Disable CoreFx tests on Windows/arm and Linux/arm

### DIFF
--- a/tests/arm/corefx_linux_test_exclusions.txt
+++ b/tests/arm/corefx_linux_test_exclusions.txt
@@ -3,6 +3,7 @@ System.Data.SqlClient.Tests          # https://github.com/dotnet/coreclr/issues/
 System.Diagnostics.Process.Tests     # https://github.com/dotnet/coreclr/issues/16001
 System.Diagnostics.StackTrace.Tests  # https://github.com/dotnet/coreclr/issues/17557 -- JitStress=1; https://github.com/dotnet/coreclr/issues/17558 -- JitStress=2
 System.Drawing.Common.Tests          # https://github.com/dotnet/coreclr/issues/16001
+System.Dynamic.Runtime.Tests         # https://github.com/dotnet/coreclr/issues/18295
 System.IO.FileSystem.Tests           # https://github.com/dotnet/coreclr/issues/16001
 System.IO.Ports.Tests                # https://github.com/dotnet/coreclr/issues/16001
 System.Linq.Expressions.Tests        # https://github.com/dotnet/corefx/issues/29421 -- timeout

--- a/tests/arm/corefx_test_exclusions.txt
+++ b/tests/arm/corefx_test_exclusions.txt
@@ -6,6 +6,7 @@ System.Diagnostics.Process.Tests     # https://github.com/dotnet/coreclr/issues/
 System.Diagnostics.PerformanceCounter.Tests # https://github.com/dotnet/coreclr/issues/17799
 System.Diagnostics.StackTrace.Tests  # https://github.com/dotnet/coreclr/issues/17557 -- JitStress=1; https://github.com/dotnet/coreclr/issues/17558 -- JitStress=2
 System.Drawing.Common.Tests          # https://github.com/dotnet/coreclr/issues/16001
+System.Dynamic.Runtime.Tests         # https://github.com/dotnet/coreclr/issues/18295
 System.IO.FileSystem.Tests           # https://github.com/dotnet/coreclr/issues/16001
 System.IO.Ports.Tests                # https://github.com/dotnet/coreclr/issues/16001
 System.Management.Tests              # https://github.com/dotnet/coreclr/issues/16001

--- a/tests/arm/corefx_test_exclusions.txt
+++ b/tests/arm/corefx_test_exclusions.txt
@@ -9,6 +9,7 @@ System.Drawing.Common.Tests          # https://github.com/dotnet/coreclr/issues/
 System.Dynamic.Runtime.Tests         # https://github.com/dotnet/coreclr/issues/18295
 System.IO.FileSystem.Tests           # https://github.com/dotnet/coreclr/issues/16001
 System.IO.Ports.Tests                # https://github.com/dotnet/coreclr/issues/16001
+System.Linq.Expressions.Tests        # https://github.com/dotnet/coreclr/issues/18295 -- JitStress=2
 System.Management.Tests              # https://github.com/dotnet/coreclr/issues/16001
 System.Net.HttpListener.Tests        # https://github.com/dotnet/coreclr/issues/17584
 System.Runtime.Tests                 # https://github.com/dotnet/coreclr/issues/17585

--- a/tests/arm/corefx_test_exclusions.txt
+++ b/tests/arm/corefx_test_exclusions.txt
@@ -12,6 +12,7 @@ System.IO.Ports.Tests                # https://github.com/dotnet/coreclr/issues/
 System.Linq.Expressions.Tests        # https://github.com/dotnet/coreclr/issues/18295 -- JitStress=2
 System.Management.Tests              # https://github.com/dotnet/coreclr/issues/16001
 System.Net.HttpListener.Tests        # https://github.com/dotnet/coreclr/issues/17584
+System.Runtime.Numerics.Tests        # https://github.com/dotnet/coreclr/issues/18362 -- JitStress=1 JitStress=2
 System.Runtime.Tests                 # https://github.com/dotnet/coreclr/issues/17585
 System.Security.Cryptography.X509Certificates.Tests # https://github.com/dotnet/coreclr/issues/17801
 System.Text.RegularExpressions.Tests # https://github.com/dotnet/coreclr/issues/17754 -- timeout -- JitMinOpts only


### PR DESCRIPTION
Disable `System.Dynamic.Runtime.Tests` failing on Windows/arm and Linux/arm due to #18295 

**Update:** Disable `System.Linq.Expressions.Tests` failing on Windows/arm due to #18295; Disable `System.Runtime.Numerics.Tests` failing on Windows/arm due to #18362