### PR TITLE
import dir.targets in CoreClr 1.0.0

### DIFF
--- a/src/publish.proj
+++ b/src/publish.proj
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <Import Project="$(ToolsDir)PublishContent.targets" />
   <Import Project="$(ToolsDir)versioning.targets" />
+  <Import Project="..\dir.targets" />
 
   <!-- gathers the items to be published -->
   <Target Name="GatherItemsForPattern">


### PR DESCRIPTION
This will ensure we import Build.Common.Targets from BuildTools, which is necessary for getting the SignFiles target (Same as my CoreFx PRs from the other day).

CC @weshaggard