### PR TITLE
Fix EventPipe EventHandle Caching for TraceLogging

### DIFF
--- a/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -517,6 +517,7 @@
     <Compile Include="$(BclSourcesRoot)\System\Diagnostics\Eventing\EventPipeEventProvider.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Diagnostics\Eventing\EventPipeMetadataGenerator.cs" />
     <Compile Condition="Exists('$(IntermediateOutputPath)..\eventing\DotNETRuntimeEventSource.cs')" Include="$(IntermediateOutputPath)..\eventing\DotNETRuntimeEventSource.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Diagnostics\Eventing\TraceLogging\TraceLoggingEventHandleTable.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(BclSourcesRoot)\System\Diagnostics\Contracts\Contracts.cs" />

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/NameInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/NameInfo.cs
@@ -42,10 +42,6 @@ namespace System.Diagnostics.Tracing
         internal readonly int identity;
         internal readonly byte[] nameMetadata;
 
-#if FEATURE_PERFTRACING
-        private readonly object eventHandleCreationLock = new object();
-#endif
-
         public NameInfo(string name, EventTags tags, int typeMetadataSize)
         {
             this.name = name;
@@ -87,7 +83,7 @@ namespace System.Diagnostics.Tracing
             IntPtr eventHandle;
             if ((eventHandle = eventHandleTable[descriptor.EventId]) == IntPtr.Zero)
             {
-                lock (eventHandleCreationLock)
+                lock (eventHandleTable)
                 {
                     if ((eventHandle = eventHandleTable[descriptor.EventId]) == IntPtr.Zero)
                     {

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/NameInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/NameInfo.cs
@@ -84,8 +84,8 @@ namespace System.Diagnostics.Tracing
 #if FEATURE_PERFTRACING
         public IntPtr GetOrCreateEventHandle(EventProvider provider, TraceLoggingEventHandleTable eventHandleTable, EventDescriptor descriptor, TraceLoggingEventTypes eventTypes)
         {
-            IntPtr eventHandle = IntPtr.Zero;
-            if((eventHandle = eventHandleTable[descriptor.EventId]) == IntPtr.Zero)
+            IntPtr eventHandle;
+            if ((eventHandle = eventHandleTable[descriptor.EventId]) == IntPtr.Zero)
             {
                 lock (eventHandleCreationLock)
                 {

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
@@ -24,7 +24,6 @@ using System.Resources;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Collections.ObjectModel;
-using System.Collections.Concurrent;
 
 #if !ES_BUILD_AGAINST_DOTNET_V35
 using Contract = System.Diagnostics.Contracts.Contract;
@@ -49,7 +48,7 @@ namespace System.Diagnostics.Tracing
 #endif
 
 #if FEATURE_PERFTRACING
-        private ConcurrentDictionary<int, IntPtr> m_eventHandleMap = new ConcurrentDictionary<int, IntPtr>();
+        private TraceLoggingEventHandleTable m_eventHandleTable = new TraceLoggingEventHandleTable();
 #endif
 
         /// <summary>
@@ -437,7 +436,7 @@ namespace System.Diagnostics.Tracing
             EventDescriptor descriptor = new EventDescriptor(identity, level, opcode, (long)keywords);
 
 #if FEATURE_PERFTRACING
-            IntPtr eventHandle = nameInfo.GetOrCreateEventHandle(m_eventPipeProvider, m_eventHandleMap, descriptor, eventTypes);
+            IntPtr eventHandle = nameInfo.GetOrCreateEventHandle(m_eventPipeProvider, m_eventHandleTable, descriptor, eventTypes);
             Debug.Assert(eventHandle != IntPtr.Zero);
 #else
             IntPtr eventHandle = IntPtr.Zero;
@@ -552,7 +551,7 @@ namespace System.Diagnostics.Tracing
                 }
 
 #if FEATURE_PERFTRACING
-                    IntPtr eventHandle = nameInfo.GetOrCreateEventHandle(m_eventPipeProvider, m_eventHandleMap, descriptor, eventTypes);
+                    IntPtr eventHandle = nameInfo.GetOrCreateEventHandle(m_eventPipeProvider, m_eventHandleTable, descriptor, eventTypes);
                     Debug.Assert(eventHandle != IntPtr.Zero);
 #else
                     IntPtr eventHandle = IntPtr.Zero;
@@ -621,7 +620,7 @@ namespace System.Diagnostics.Tracing
                     }
 
 #if FEATURE_PERFTRACING
-                    IntPtr eventHandle = nameInfo.GetOrCreateEventHandle(m_eventPipeProvider, m_eventHandleMap, descriptor, eventTypes);
+                    IntPtr eventHandle = nameInfo.GetOrCreateEventHandle(m_eventPipeProvider, m_eventHandleTable, descriptor, eventTypes);
                     Debug.Assert(eventHandle != IntPtr.Zero);
 #else
                     IntPtr eventHandle = IntPtr.Zero;

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
@@ -48,7 +48,7 @@ namespace System.Diagnostics.Tracing
 #endif
 
 #if FEATURE_PERFTRACING
-        private TraceLoggingEventHandleTable m_eventHandleTable = new TraceLoggingEventHandleTable();
+        private readonly TraceLoggingEventHandleTable m_eventHandleTable = new TraceLoggingEventHandleTable();
 #endif
 
         /// <summary>

--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/TraceLogging/TraceLoggingEventHandleTable.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/TraceLogging/TraceLoggingEventHandleTable.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-using System.Runtime.CompilerServices;
+
 using System.Threading;
 
 namespace System.Diagnostics.Tracing
@@ -14,7 +14,6 @@ namespace System.Diagnostics.Tracing
     {
         private const int DefaultLength = 10;
         private IntPtr[] m_innerTable;
-        private object m_innerTableUpdateLock = new object();
 
         internal TraceLoggingEventHandleTable()
         {
@@ -50,7 +49,7 @@ namespace System.Diagnostics.Tracing
                 }
 
                 IntPtr[] newTable = new IntPtr[newSize];
-                Array.Copy(m_innerTable, newTable, m_innerTable.Length);
+                Array.Copy(m_innerTable, 0, newTable, 0, m_innerTable.Length);
                 Volatile.Write(ref m_innerTable, newTable);
             }
 

--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/TraceLogging/TraceLoggingEventHandleTable.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/TraceLogging/TraceLoggingEventHandleTable.cs
@@ -38,8 +38,9 @@ namespace System.Diagnostics.Tracing
 
         internal void SetEventHandle(int eventID, IntPtr eventHandle)
         {
-            // NOTE: We don't take a lock here when re-sizing the table because the caller (NameInfo.GetOrCreateEventHandle) locks on this table before calling us.
-            // If this gets called outside of this path, then a lock is likely required to ensure that the data is not lost during concurrent re-size operations.
+            // Set operations must be serialized to ensure that re-size operations don't lose concurrent writes.
+            Debug.Assert(Monitor.IsEntered(this));
+
             if (eventID >= m_innerTable.Length)
             {
                 int newSize = m_innerTable.Length * 2;

--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/TraceLogging/TraceLoggingEventHandleTable.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/TraceLogging/TraceLoggingEventHandleTable.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace System.Diagnostics.Tracing
+{
+#if FEATURE_PERFTRACING
+    /// <summary>
+    /// Per-EventSource data structure for caching EventPipe EventHandles associated with TraceLogging events.
+    /// </summary>
+    internal sealed class TraceLoggingEventHandleTable
+    {
+        private const int DefaultLength = 10;
+        private IntPtr[] m_innerTable;
+        private object m_innerTableUpdateLock = new object();
+
+        internal TraceLoggingEventHandleTable()
+        {
+            m_innerTable = new IntPtr[DefaultLength];
+        }
+
+        internal IntPtr this[int eventID]
+        {
+            get
+            {
+                IntPtr ret = IntPtr.Zero;
+                IntPtr[] innerTable = Volatile.Read(ref m_innerTable);
+
+                if (eventID >= 0 && eventID < innerTable.Length)
+                {
+                    ret = innerTable[eventID];
+                }
+
+                return ret;
+            }
+        }
+
+        internal void SetEventHandle(int eventID, IntPtr eventHandle)
+        {
+            // NOTE: We don't take a lock here when re-sizing the table because the caller (NameInfo.GetOrCreateEventHandle) takes a lock before calling us.
+            // If this gets called outside of this path, then a lock is likely required here to ensure that data is not lost during two concurrent re-size operations.
+            if (eventID >= m_innerTable.Length)
+            {
+                int newSize = m_innerTable.Length * 2;
+                if (newSize <= eventID)
+                {
+                    newSize = eventID + 1;
+                }
+
+                IntPtr[] newTable = new IntPtr[newSize];
+                Array.Copy(m_innerTable, newTable, m_innerTable.Length);
+                Volatile.Write(ref m_innerTable, newTable);
+            }
+
+            m_innerTable[eventID] = eventHandle;
+        }
+    }
+#endif
+}


### PR DESCRIPTION
EventSource can send both declared and TraceLogging events to EventPipe.  For the TraceLogging case, we must dynamically register and save the event handle on first use of each event.  Prior to this change, we used a ConcurrentDictionary, though there was a bug that resulted in the ConcurrentDictionary not actually being used.  Thus, all TraceLogging events were re-registered each time they were fired.

This PR replaces the usage of ConcurrentDictionary with a TraceLogging-specific data structure to accomplish the following:

1. Remove a non-O(1) data structure lookup during logging and replace it with a O(1) lookup.
2. Actually cache the handles.
3. Remove the usage of ConcurrentDictionary so that it can be removed from CoreLib via #18308.

Note: I have confirmed that the CoreFX tests pass on Windows when manually run in an elevated command prompt to ensure that both EventListener and ETW tests pass.