### PR TITLE
Adds the CoreLib IL to packages

### DIFF
--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -21,8 +21,8 @@
     <NativeBinary Condition="'$(_PlatformDoesNotSupportSosPlugin)' != 'true'" Include="$(BinDir)libsosplugin.so" />
     <NativeBinary Include="$(BinDir)System.Globalization.Native.so" />
     <NativeBinary Include="$(BinDir)sosdocsunix.txt" />
-    <NativeBinary Include="$(BinDir)System.Private.CoreLib.dll" />
     <NativeBinary Condition="'$(_PlatformDoesNotSupportCreatedump)' != 'true'" Include="$(BinDir)createdump" />
+    <CrossGenBinary Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
     <CrossArchitectureSpecificToolFile Condition="'$(HasCrossTargetComponents)' == 'true'" Include="$(BinDir)$(CrossTargetComponentFolder)\crossgen" />

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.OSX.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.OSX.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -8,7 +8,7 @@
     <NativeBinary Include="$(BinDir)libsos.dylib" />
     <NativeBinary Include="$(BinDir)System.Globalization.Native.dylib" />
     <NativeBinary Include="$(BinDir)sosdocsunix.txt" />
-    <NativeBinary Include="$(BinDir)System.Private.CoreLib.dll" />
+    <CrossGenBinary Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
   </ItemGroup>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Windows_NT.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Windows_NT.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -20,7 +20,7 @@
     <NativeBinary Include="$(BinDir)mscorrc.dll" />
     <NativeBinary Include="$(BinDir)sos.dll" />
     <NativeBinary Include="$(UniversalCRTSDKDir)Redist\ucrt\DLLs\$(BuildArch)\*.dll" Condition="'$(BuildType)'=='Release' AND '$(BuildArch)' != 'arm64'" />
-    <NativeBinary Include="$(BinDir)System.Private.CoreLib.dll" />
+    <CrossGenBinary Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen.exe" />
     <CrossArchitectureSpecificToolFile Include="$(BinDir)$(CrossTargetComponentFolder)\crossgen.exe" />

--- a/src/.nuget/dir.targets
+++ b/src/.nuget/dir.targets
@@ -18,7 +18,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <NativeWithSymbolFile Include="@(NativeBinary)">
+      <NativeWithSymbolFile Include="@(NativeBinary);@(CrossGenBinary)">
         <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
       </NativeWithSymbolFile>
       <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
@@ -40,8 +40,15 @@
     </ItemGroup>
 
     <ItemGroup>
+      <!-- The symbols for these files are already in place together with respective *.ni.pdb -->
+      <IlForCrossGenedFie Include="@(CrossGenBinary -> '%(RootDir)%(Directory)IL\%(Filename).dll')">
+        <TargetPath>runtimes/$(PackageTargetRuntime)/il</TargetPath>
+      </IlForCrossGenedFie>
+    </ItemGroup>
+
+    <ItemGroup>
       <File Include="@(NativeWithSymbolFile)" />
-      <File Include="@(LongNameFile)">
+      <File Include="@(LongNameFile);@(IlForCrossGenedFie)">
         <IsSymbolFile>true</IsSymbolFile>
       </File>
     </ItemGroup>

--- a/src/.nuget/dir.targets
+++ b/src/.nuget/dir.targets
@@ -41,14 +41,14 @@
 
     <ItemGroup>
       <!-- The symbols for these files are already in place together with respective *.ni.pdb -->
-      <IlForCrossGenedFie Include="@(CrossGenBinary -> '%(RootDir)%(Directory)IL\%(Filename).dll')">
+      <IlForCrossGenedFile Include="@(CrossGenBinary -> '%(RootDir)%(Directory)IL\%(Filename).dll')">
         <TargetPath>runtimes/$(PackageTargetRuntime)/il</TargetPath>
-      </IlForCrossGenedFie>
+      </IlForCrossGenedFile>
     </ItemGroup>
 
     <ItemGroup>
       <File Include="@(NativeWithSymbolFile)" />
-      <File Include="@(LongNameFile);@(IlForCrossGenedFie)">
+      <File Include="@(LongNameFile);@(IlForCrossGenedFile)">
         <IsSymbolFile>true</IsSymbolFile>
       </File>
     </ItemGroup>


### PR DESCRIPTION
/cc @jkotas and @safern 

First step to fix #23588 (add the CoreLib IL to packages).

The purpose of this is to enable code coverage runs to include CoreLib in CI - for that it is necessary to make the IL version available.

Per discussion on the issue it won'be added to the runtime packaged generated by core-setup: https://github.com/dotnet/corefx/issues/23588#issuecomment-395610886