### PR TITLE
(Re)Enable NativeVarargs for CoreCLR

### DIFF
--- a/src/System.Private.CoreLib/src/System/ArgIterator.cs
+++ b/src/System.Private.CoreLib/src/System/ArgIterator.cs
@@ -27,7 +27,7 @@ namespace System
         private IntPtr ArgPtr;                  // Pointer to remaining args.
         private int RemainingArgs;           // # of remaining args.
 
-#if VARARGS_ENABLED //The JIT doesn't support Varargs calling convention.
+#if PLATFORM_WINDOWS // Native Varargs are not supported on Unix
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private extern ArgIterator(IntPtr arglist);
 
@@ -132,7 +132,7 @@ namespace System
         {
             throw new NotSupportedException(SR.NotSupported_NYI);
         }
-#else
+#else 
         public ArgIterator(RuntimeArgumentHandle arglist)
         {
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_ArgIterator); // https://github.com/dotnet/coreclr/issues/9204
@@ -180,6 +180,6 @@ namespace System
         {
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_ArgIterator); // https://github.com/dotnet/coreclr/issues/9204
         }
-#endif //VARARGS_ENABLED
+#endif // PLATFORM_WINDOWS
     }
 }

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -598,6 +598,18 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo)
                 isHfaArg = varTypeIsFloating(hfaType);
             }
         }
+        else if (info.compIsVarArgs)
+        {
+#ifdef _TARGET_UNIX_
+            // Currently native varargs is not implemented on non windows targets.
+            //
+            // Note that some targets like Arm64 Unix should not need much work as
+            // the ABI is the same. While other targets may only need small changes
+            // such as amd64 Unix, which just expects RAX to pass numFPArguments.
+            NYI("InitUserArgs for Vararg callee is not yet implemented on non Windows targets.");
+#endif
+        }
+
         if (isHfaArg)
         {
             // We have an HFA argument, so from here on out treat the type as a float or double.

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2747,9 +2747,9 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
         // Note that some targets like Arm64 Unix should not need much work as
         // the ABI is the same. While other targets may only need small changes
         // such as amd64 Unix, which just expects RAX to pass numFPArguments.
-        NYI("Morhing Vararg call not yet implemented on non Windows targets.");
+        NYI("Morphing Vararg call not yet implemented on non Windows targets.");
     }
-#endif
+#endif // _TARGET_UNIX_
 
 #ifdef UNIX_AMD64_ABI
     // If fgMakeOutgoingStructArgCopy is called and copies are generated, hasStackArgCopy is set

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2737,9 +2737,18 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
     unsigned nonRegPassedStructSlots = 0;
     bool     reMorphing              = call->AreArgsComplete();
     bool     callHasRetBuffArg       = call->HasRetBufArg();
+    bool     callIsVararg            = call->IsVarargs();
 
-#ifndef _TARGET_X86_ // i.e. _TARGET_AMD64_ or _TARGET_ARM_
-    bool callIsVararg = call->IsVarargs();
+#ifdef _TARGET_UNIX_
+    if (callIsVararg)
+    {
+        // Currently native varargs is not implemented on non windows targets.
+        //
+        // Note that some targets like Arm64 Unix should not need much work as
+        // the ABI is the same. While other targets may only need small changes
+        // such as amd64 Unix, which just expects RAX to pass numFPArguments.
+        NYI("Morhing Vararg call not yet implemented on non Windows targets.");
+    }
 #endif
 
 #ifdef UNIX_AMD64_ABI

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -489,12 +489,14 @@ CEEInfo::ConvToJitSig(
         IfFailThrow(sig.GetCallingConvInfo(&data));
         sigRet->callConv = (CorInfoCallConv) data;
 
+#ifdef PLATFORM_UNIX
         if ((isCallConv(sigRet->callConv, IMAGE_CEE_CS_CALLCONV_VARARG)) ||
             (isCallConv(sigRet->callConv, IMAGE_CEE_CS_CALLCONV_NATIVEVARARG)))
         {
             // This signature corresponds to a method that uses varargs, which are not supported.
              COMPlusThrow(kInvalidProgramException, IDS_EE_VARARG_NOT_SUPPORTED);
         }
+#endif // PLATFORM_UNIX
 
         // Skip number of type arguments
         if (sigRet->callConv & IMAGE_CEE_CS_CALLCONV_GENERIC)

--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -48428,14 +48428,6 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;Pri1
 HostStyle=0
 
-[varargsupport_r.cmd_6076]
-RelativePath=baseservices\varargs\varargsupport_r\varargsupport_r.cmd
-WorkingDir=baseservices\varargs\varargsupport_r
-Expected=0
-MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS
-HostStyle=0
-
 [_il_relcatchfault_tail.cmd_6077]
 RelativePath=JIT\Methodical\Invoke\SEH\_il_relcatchfault_tail\_il_relcatchfault_tail.cmd
 WorkingDir=JIT\Methodical\Invoke\SEH\_il_relcatchfault_tail
@@ -74407,14 +74399,6 @@ HostStyle=0
 [NestedBaseClass03.cmd_9338]
 RelativePath=Loader\classloader\generics\Instantiation\Positive\NestedBaseClass03\NestedBaseClass03.cmd
 WorkingDir=Loader\classloader\generics\Instantiation\Positive\NestedBaseClass03
-Expected=0
-MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS
-HostStyle=0
-
-[varargsupport.cmd_9339]
-RelativePath=baseservices\varargs\varargsupport\varargsupport.cmd
-WorkingDir=baseservices\varargs\varargsupport
 Expected=0
 MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -4612,22 +4612,6 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;Pri1
 HostStyle=0
 
-[varargsupport.cmd_576]
-RelativePath=baseservices\varargs\varargsupport\varargsupport.cmd
-WorkingDir=baseservices\varargs\varargsupport
-Expected=0
-MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS
-HostStyle=0
-
-[varargsupport_r.cmd_577]
-RelativePath=baseservices\varargs\varargsupport_r\varargsupport_r.cmd
-WorkingDir=baseservices\varargs\varargsupport_r
-Expected=0
-MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS
-HostStyle=0
-
 [Co9600Ctor.cmd_578]
 RelativePath=CoreMangLib\components\stopwatch\Co9600Ctor\Co9600Ctor.cmd
 WorkingDir=CoreMangLib\components\stopwatch\Co9600Ctor

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -190,6 +190,12 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\GitHub_18056\Bool_And_Op_cs_do\Bool_And_Op_cs_do.cmd">
             <Issue>18056</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\baseservices\varargs\varargsupport\varargsupport.cmd">
+            <Issue>Varargs supported on this platform</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\baseservices\varargs\varargsupport_r\varargsupport_r.cmd">
+            <Issue>Varargs supported on this platform</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- The following are x86 failures -->


### PR DESCRIPTION
This will allow coreclr run programs which have native varargs.
It also re-enables the ArgIterator type for managed to managed native
vararg calls which will allow the use of the __arglist keyword.

This change also deletes a test which expects an invalid program exception
for native varargs usage.

**Limitations:**

NYI statements have been added for all Unix Targets.

With this change __arglist (native varargs) will be supported, **but not
yet tested** on:

```
Amd64 Windows
x86 Windows
Arm32 Windows
Arm64 Windows
```

This change does not address re-enablabling native vararg tests. This will be done
in a seperate change.

See #18377 for on initial thoughts on varargs bringup on 
unix platforms.