### PR TITLE
Expose public implementation AsyncCausalitySupport to S.R.WindowsRuntime

### DIFF
--- a/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -364,6 +364,7 @@
     <Compile Include="$(BclSourcesRoot)\Internal\Runtime\Augments\EnvironmentAugments.cs" />
     <Compile Include="$(BclSourcesRoot)\Internal\Runtime\Augments\RuntimeThread.cs" />
     <Compile Include="$(BclSourcesRoot)\Internal\Console.cs" />
+    <Compile Condition="'$(FeatureCominterop)' == 'true'"  Include="$(BclSourcesRoot)\Internal\Threading\Tasks\AsyncCausalitySupport.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(BclSourcesRoot)\System\Reflection\Assembly.CoreCLR.cs" />

--- a/src/System.Private.CoreLib/src/Internal/Threading/Tasks/AsyncCausalitySupport.cs
+++ b/src/System.Private.CoreLib/src/Internal/Threading/Tasks/AsyncCausalitySupport.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using AsyncCausalityStatus = System.Threading.Tasks.AsyncCausalityStatus;
+using CausalityTraceLevel = System.Threading.Tasks.CausalityTraceLevel;
+
+namespace Internal.Threading.Tasks
+{
+    //
+    // An internal contract that exposes just enough async debugger support needed by the AsTask() extension methods in the WindowsRuntimeSystemExtensions class.
+    //
+    public static class AsyncCausalitySupport
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void AddToActiveTasks(Task task)
+        {
+            if (Task.s_asyncDebuggingEnabled)
+                Task.AddToActiveTasks(task);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void RemoveFromActiveTasks(Task task)
+        {
+            if (Task.s_asyncDebuggingEnabled)
+                Task.RemoveFromActiveTasks(task.Id);
+        }
+
+        public static bool LoggingOn
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return AsyncCausalityTracer.LoggingOn;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void TraceOperationCreation(Task task, String operationName)
+        {
+            AsyncCausalityTracer.TraceOperationCreation(CausalityTraceLevel.Required, task.Id, operationName, 0);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void TraceOperationCompletedSuccess(Task task)
+        {
+            AsyncCausalityTracer.TraceOperationCompletion(CausalityTraceLevel.Required, task.Id, AsyncCausalityStatus.Completed);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void TraceOperationCompletedError(Task task)
+        {
+            AsyncCausalityTracer.TraceOperationCompletion(CausalityTraceLevel.Required, task.Id, AsyncCausalityStatus.Error);
+        }
+    }
+}
+

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/AsyncCausalityTracer.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/AsyncCausalityTracer.cs
@@ -20,7 +20,6 @@ using WFD = Windows.Foundation.Diagnostics;
 
 namespace System.Threading.Tasks
 {
-    // [FriendAccessAllowed]
     internal enum CausalityTraceLevel
     {
 #if FEATURE_COMINTEROP
@@ -34,7 +33,6 @@ namespace System.Threading.Tasks
 #endif
     }
 
-    // [FriendAccessAllowed]
     internal enum AsyncCausalityStatus
     {
 #if FEATURE_COMINTEROP
@@ -80,7 +78,6 @@ namespace System.Threading.Tasks
 #endif
     }
 
-    // [FriendAccessAllowed]
     internal static class AsyncCausalityTracer
     {
         internal static void EnableToETW(bool enabled)
@@ -95,7 +92,6 @@ namespace System.Threading.Tasks
 
         internal static bool LoggingOn
         {
-            // [FriendAccessAllowed]
             get
             {
 #if FEATURE_COMINTEROP
@@ -173,8 +169,6 @@ namespace System.Threading.Tasks
         //
         // The TraceXXX methods should be called only if LoggingOn property returned true
         //
-
-        // [FriendAccessAllowed]
         [MethodImplAttribute(MethodImplOptions.NoInlining)] // Tracking is slow path. Disable inlining for it.
         internal static void TraceOperationCreation(CausalityTraceLevel traceLevel, int taskId, string operationName, ulong relatedContext)
         {
@@ -194,7 +188,6 @@ namespace System.Threading.Tasks
 #endif
         }
 
-        // [FriendAccessAllowed]
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
         internal static void TraceOperationCompletion(CausalityTraceLevel traceLevel, int taskId, AsyncCausalityStatus status)
         {

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -200,7 +200,6 @@ namespace System.Threading.Tasks
 
         // A private flag that would be set (only) by the debugger
         // When true the Async Causality logging trace is enabled as well as a dictionary to relate operation ids with Tasks
-        // [FriendAccessAllowed]
         internal static bool s_asyncDebuggingEnabled; //false by default
 
         // This dictonary relates the task id, from an operation id located in the Async Causality log to the actual
@@ -210,7 +209,6 @@ namespace System.Threading.Tasks
 
         // These methods are a way to access the dictionary both from this class and for other classes that also
         // activate dummy tasks. Specifically the AsyncTaskMethodBuilder and AsyncTaskMethodBuilder<>
-        // [FriendAccessAllowed]
         internal static bool AddToActiveTasks(Task task)
         {
             Debug.Assert(task != null, "Null Task objects can't be added to the ActiveTasks collection");
@@ -222,7 +220,6 @@ namespace System.Threading.Tasks
             return true;
         }
 
-        // [FriendAccessAllowed]
         internal static void RemoveFromActiveTasks(int taskId)
         {
             lock (s_activeTasksLock)


### PR DESCRIPTION
The change is to add a public implementation AsyncCausalitySupport and S.R.WindowsRuntime can use AsyncCausalitySupport  to enable async debugger support. 

Corefx PR: