### PR TITLE
Disable 3 tests incompatible with GCStress=3

### DIFF
--- a/tests/src/GC/Coverage/smalloom.csproj
+++ b/tests/src/GC/Coverage/smalloom.csproj
@@ -9,6 +9,7 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <GCStressIncompatible>true</GCStressIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/tracing/tracevalidation/jittingstarted/JittingStarted.csproj
+++ b/tests/src/tracing/tracevalidation/jittingstarted/JittingStarted.csproj
@@ -12,6 +12,7 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
     <CLRTestPriority>0</CLRTestPriority>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'"></PropertyGroup>

--- a/tests/src/tracing/tracevalidation/rundown/rundown.csproj
+++ b/tests/src/tracing/tracevalidation/rundown/rundown.csproj
@@ -12,6 +12,7 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
     <CLRTestPriority>0</CLRTestPriority>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'"></PropertyGroup>


### PR DESCRIPTION
The following fail in CI with arm Windows GCStress=3, and are now marked
`GCStressIncompatible`.

1. GC\Coverage\smalloom\smalloom.cmd
2. Issue #17480: tracing\tracevalidation\rundown\rundown\rundown.cmd, tracing\tracevalidation\jittingstarted\JittingStarted\JittingStarted.cmd