### PR TITLE
Use cached strings for ToString on integer values 0 to 9

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
@@ -251,6 +251,8 @@ namespace System
         private const int CharStackBufferSize = 32;
         private const string PosNumberFormat = "#";
 
+        private static readonly string[] s_singleDigitStringCache = { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9" };
+
         private static readonly string[] s_posCurrencyFormats =
         {
             "$#", "#$", "$ #", "# $"
@@ -1095,6 +1097,13 @@ namespace System
         private static unsafe string UInt32ToDecStr(uint value, int digits)
         {
             int bufferLength = Math.Max(digits, FormattingHelpers.CountDigits(value));
+
+            // For single-digit values that are very common, especially 0 and 1, just return cached strings.
+            if (bufferLength == 1)
+            {
+                return s_singleDigitStringCache[value];
+            }
+
             string result = string.FastAllocateString(bufferLength);
             fixed (char* buffer = result)
             {
@@ -1339,6 +1348,13 @@ namespace System
                 digits = 1;
 
             int bufferLength = Math.Max(digits, FormattingHelpers.CountDigits(value));
+
+            // For single-digit values that are very common, especially 0 and 1, just return cached strings.
+            if (bufferLength == 1)
+            {
+                return s_singleDigitStringCache[value];
+            }
+
             string result = string.FastAllocateString(bufferLength);
             fixed (char* buffer = result)
             {


### PR DESCRIPTION
When doing ToString on single-digit integers, just return a cached string.  This helps avoid string allocation/formatting costs for this very common case, while only costing one comparison for other cases.

Microbenchmark:
```C#
using System;
using System.Diagnostics;
using System.Runtime.CompilerServices;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using BenchmarkDotNet.Attributes.Jobs;

[MemoryDiagnoser]
[InProcess]
public class Benchmarks
{
    private static void Main() => BenchmarkRunner.Run<Benchmarks>();

    [Benchmark]
    public static string ToString1() => 1.ToString();

    [Benchmark]
    public static string ToString11() => 11.ToString();
}
```

Before:

|     Method |     Mean |     Error |    StdDev |  Gen 0 | Allocated |
|----------- |---------:|----------:|----------:|-------:|----------:|
|  ToString1 | 20.13 ns | 0.4800 ns | 0.5527 ns | 0.0057 |      24 B |
| ToString11 | 23.45 ns | 0.5625 ns | 1.0970 ns | 0.0076 |      32 B |

After:

|     Method |     Mean |     Error |    StdDev |  Gen 0 | Allocated |
|----------- |---------:|----------:|----------:|-------:|----------:|
|  ToString1 | 14.79 ns | 0.3820 ns | 0.3752 ns |      - |       0 B |
| ToString11 | 23.11 ns | 0.5537 ns | 0.6154 ns | 0.0076 |      32 B |

cc: @jkotas, @mjsabby, @ahsonkhan 