### PR TITLE
Add support for BSWAP intrinsic

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Buffers/Binary/Reader.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Binary/Reader.cs
@@ -30,21 +30,21 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reverses a primitive value - performs an endianness swap
         /// </summary> 
+        [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static short ReverseEndianness(short value)
-        {
-            return (short)((value & 0x00FF) << 8 | (value & 0xFF00) >> 8);
-        }
+        public static short ReverseEndianness(short value) => (short)ReverseEndianness((ushort)value);
 
         /// <summary>
         /// Reverses a primitive value - performs an endianness swap
         /// </summary> 
+        [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int ReverseEndianness(int value) => (int)ReverseEndianness((uint)value);
 
         /// <summary>
         /// Reverses a primitive value - performs an endianness swap
         /// </summary> 
+        [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long ReverseEndianness(long value) => (long)ReverseEndianness((ulong)value);
 
@@ -54,7 +54,7 @@ namespace System.Buffers.Binary
         /// rather than having to skip byte fields.
         /// </summary> 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static byte ReverseEndianness(byte value)
+        public static byte ReverseEndianness(byte value) 
         {
             return value;
         }
@@ -63,6 +63,7 @@ namespace System.Buffers.Binary
         /// Reverses a primitive value - performs an endianness swap
         /// </summary> 
         [CLSCompliant(false)]
+        [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ushort ReverseEndianness(ushort value)
         {
@@ -80,6 +81,7 @@ namespace System.Buffers.Binary
         /// Reverses a primitive value - performs an endianness swap
         /// </summary> 
         [CLSCompliant(false)]
+        [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint ReverseEndianness(uint value)
         {
@@ -113,6 +115,7 @@ namespace System.Buffers.Binary
         /// Reverses a primitive value - performs an endianness swap
         /// </summary> 
         [CLSCompliant(false)]
+        [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong ReverseEndianness(ulong value)
         {

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -1035,6 +1035,7 @@ protected:
     void genCodeForIndexAddr(GenTreeIndexAddr* tree);
     void genCodeForIndir(GenTreeIndir* tree);
     void genCodeForNegNot(GenTree* tree);
+    void genCodeForBswap(GenTree* tree);
     void genCodeForLclVar(GenTreeLclVar* tree);
     void genCodeForLclFld(GenTreeLclFld* tree);
     void genCodeForStoreLclFld(GenTreeLclFld* tree);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -9741,6 +9741,8 @@ public:
             // Standard unary operators
             case GT_NOT:
             case GT_NEG:
+            case GT_BSWAP:
+            case GT_BSWAP16:
             case GT_COPY:
             case GT_RELOAD:
             case GT_ARR_LENGTH:

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -4311,6 +4311,8 @@ void GenTree::VisitOperands(TVisitor visitor)
         case GT_STORE_LCL_FLD:
         case GT_NOT:
         case GT_NEG:
+        case GT_BSWAP:
+        case GT_BSWAP16:
         case GT_COPY:
         case GT_RELOAD:
         case GT_ARR_LENGTH:

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -4748,6 +4748,8 @@ bool GenTree::TryGetUse(GenTree* def, GenTree*** use)
         case GT_NOP:
         case GT_RETURN:
         case GT_RETFILT:
+        case GT_BSWAP:
+        case GT_BSWAP16:
             if (def == this->AsUnOp()->gtOp1)
             {
                 *use = &this->AsUnOp()->gtOp1;
@@ -8348,6 +8350,8 @@ GenTreeUseEdgeIterator::GenTreeUseEdgeIterator(GenTree* node)
         case GT_NULLCHECK:
         case GT_PUTARG_REG:
         case GT_PUTARG_STK:
+        case GT_BSWAP:
+        case GT_BSWAP16:
 #if FEATURE_ARG_SPLIT
         case GT_PUTARG_SPLIT:
 #endif // FEATURE_ARG_SPLIT
@@ -12906,6 +12910,15 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                         i1 = -i1;
                         break;
 
+                    case GT_BSWAP:
+                        i1 = ((i1 >> 24) & 0xFF) | ((i1 >> 8) & 0xFF00) | ((i1 << 8) & 0xFF0000) |
+                             ((i1 << 24) & 0xFF000000);
+                        break;
+
+                    case GT_BSWAP16:
+                        i1 = ((i1 >> 8) & 0xFF) | ((i1 << 8) & 0xFF00);
+                        break;
+
                     case GT_CAST:
                         // assert (genActualType(tree->CastToType()) == tree->gtType);
                         switch (tree->CastToType())
@@ -13039,6 +13052,13 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
 
                     case GT_NEG:
                         lval1 = -lval1;
+                        break;
+
+                    case GT_BSWAP:
+                        lval1 = ((lval1 >> 56) & 0xFF) | ((lval1 >> 40) & 0xFF00) | ((lval1 >> 24) & 0xFF0000) |
+                                ((lval1 >> 8) & 0xFF000000) | ((lval1 << 8) & 0xFF00000000) |
+                                ((lval1 << 24) & 0xFF0000000000) | ((lval1 << 40) & 0xFF000000000000) |
+                                ((lval1 << 56) & 0xFF00000000000000);
                         break;
 
                     case GT_CAST:

--- a/src/jit/gtlist.h
+++ b/src/jit/gtlist.h
@@ -101,6 +101,9 @@ GTNODE(INIT_VAL         , GenTreeOp          ,0,GTK_UNOP)               // Initi
 
 GTNODE(RUNTIMELOOKUP    , GenTreeRuntimeLookup, 0,GTK_UNOP|GTK_EXOP)    // Runtime handle lookup
 
+GTNODE(BSWAP            , GenTreeOp          ,0,GTK_UNOP)               // Byte swap (32-bit or 64-bit)
+GTNODE(BSWAP16          , GenTreeOp          ,0,GTK_UNOP)               // Byte swap (16-bit)
+
 //-----------------------------------------------------------------------------
 //  Binary operators (2 operands):
 //-----------------------------------------------------------------------------

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -3927,6 +3927,44 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 break;
             }
 
+            case NI_System_Buffers_Binary_BinaryPrimitives_ReverseEndianness:
+            {
+                assert(sig->numArgs == 1);
+
+                // We expect the return type of the ReverseEndianness routine to match the type of the
+                // one and only argument to the method. We use a special instruction for 16-bit
+                // BSWAPs since on x86 processors this is implemented as ROR value, 8. Additionally,
+                // we only allow BSWAPs with 64-bit arguments on 64-bit architectures.
+
+                switch (sig->retType)
+                {
+                    case CorInfoType::CORINFO_TYPE_SHORT:
+                    case CorInfoType::CORINFO_TYPE_USHORT:
+                        retNode = gtNewOperNode(GT_BSWAP16, callType, impPopStack().val);
+                        break;
+
+                    case CorInfoType::CORINFO_TYPE_INT:
+                    case CorInfoType::CORINFO_TYPE_UINT:
+#ifdef _TARGET_64BIT_
+                    case CorInfoType::CORINFO_TYPE_LONG:
+                    case CorInfoType::CORINFO_TYPE_ULONG:
+#endif // _TARGET_64BIT_
+                        retNode = gtNewOperNode(GT_BSWAP, callType, impPopStack().val);
+                        break;
+
+                    default:
+                        // This default case gets hit on 32-bit archs when a call to a 64-bit overload
+                        // of ReverseEndianness is encountered. In that case we'll let JIT treat this as a standard
+                        // method call, where the implementation decomposes the operation into two 32-bit
+                        // bswap routines. If the input to the 64-bit function is a constant, then we rely
+                        // on inlining + constant folding of 32-bit bswaps to effectively constant fold
+                        // the 64-bit call site.
+                        break;
+                }
+
+                break;
+            }
+
             default:
                 break;
         }
@@ -4078,6 +4116,15 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
             result = NI_Math_Round;
         }
     }
+#if defined(_TARGET_XARCH_) // We currently only support BSWAP on x86
+    else if (strcmp(namespaceName, "System.Buffers.Binary") == 0)
+    {
+        if ((strcmp(className, "BinaryPrimitives") == 0) && (strcmp(methodName, "ReverseEndianness") == 0))
+        {
+            result = NI_System_Buffers_Binary_BinaryPrimitives_ReverseEndianness;
+        }
+    }
+#endif // !defined(_TARGET_XARCH_)
     else if (strcmp(namespaceName, "System.Collections.Generic") == 0)
     {
         if ((strcmp(className, "EqualityComparer`1") == 0) && (strcmp(methodName, "get_Default") == 0))

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -3933,8 +3933,9 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
 
                 // We expect the return type of the ReverseEndianness routine to match the type of the
                 // one and only argument to the method. We use a special instruction for 16-bit
-                // BSWAPs since on x86 processors this is implemented as ROR value, 8. Additionally,
-                // we only allow BSWAPs with 64-bit arguments on 64-bit architectures.
+                // BSWAPs since on x86 processors this is implemented as ROR <16-bit reg>, 8. Additionally,
+                // we only emit 64-bit BSWAP instructions on 64-bit archs; if we're asked to perform a
+                // 64-bit byte swap on a 32-bit arch, we'll fall to the default case in the switch block below.
 
                 switch (sig->retType)
                 {

--- a/src/jit/instrsxarch.h
+++ b/src/jit/instrsxarch.h
@@ -63,6 +63,10 @@ INST5(inc_l,            "inc",              IUM_RW, 0x0000FE,     BAD_CODE,     
 INST5(dec,              "dec",              IUM_RW, 0x0008FE,     BAD_CODE,     BAD_CODE,     BAD_CODE,     0x000048,    INS_FLAGS_WritesFlags)
 INST5(dec_l,            "dec",              IUM_RW, 0x0008FE,     BAD_CODE,     BAD_CODE,     BAD_CODE,     0x00C8FE,    INS_FLAGS_WritesFlags)
 
+// Multi-byte opcodes without modrm are represented in mixed endian fashion.
+// See comment around quarter way through this file for more information.
+INST5(bswap,            "bswap",            IUM_RW, 0x0F00C8,     BAD_CODE,     BAD_CODE,     BAD_CODE,     0x00C80F,    INS_FLAGS_None)
+
 //    id                nm                  um      mr            mi            rm            a4                         flags
 INST4(add,              "add",              IUM_RW, 0x000000,     0x000080,     0x000002,     0x000004,                  INS_FLAGS_WritesFlags)
 INST4(or,               "or",               IUM_RW, 0x000008,     0x000880,     0x00000A,     0x00000C,                  INS_FLAGS_WritesFlags)

--- a/src/jit/namedintrinsiclist.h
+++ b/src/jit/namedintrinsiclist.h
@@ -9,11 +9,12 @@
 
 enum NamedIntrinsic : unsigned short
 {
-    NI_Illegal                                                 = 0,
-    NI_System_Enum_HasFlag                                     = 1,
-    NI_MathF_Round                                             = 2,
-    NI_Math_Round                                              = 3,
-    NI_System_Collections_Generic_EqualityComparer_get_Default = 4,
+    NI_Illegal                                                  = 0,
+    NI_System_Enum_HasFlag                                      = 1,
+    NI_MathF_Round                                              = 2,
+    NI_Math_Round                                               = 3,
+    NI_System_Collections_Generic_EqualityComparer_get_Default  = 4,
+    NI_System_Buffers_Binary_BinaryPrimitives_ReverseEndianness = 5,
 #ifdef FEATURE_HW_INTRINSICS
     NI_HW_INTRINSIC_START,
 #if defined(_TARGET_XARCH_)

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -2603,6 +2603,8 @@ bool Compiler::optIsCSEcandidate(GenTree* tree)
 
         case GT_NEG:
         case GT_NOT:
+        case GT_BSWAP:
+        case GT_BSWAP16:
         case GT_CAST:
             return true; // CSE these Unary Operators
 

--- a/tests/src/JIT/Intrinsics/BinaryPrimitivesReverseEndianness.cs
+++ b/tests/src/JIT/Intrinsics/BinaryPrimitivesReverseEndianness.cs
@@ -1,0 +1,136 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+using System;
+using System.Buffers.Binary;
+using Internal;
+
+namespace BinaryPrimitivesReverseEndianness
+{
+    class Program
+    {
+        public const int Pass = 100;
+        public const int Fail = 0;
+
+        private const ushort ConstantUInt16Input = 0x9876;
+        private const ushort ConstantUInt16Expected = 0x7698;
+
+        private const uint ConstantUInt32Input = 0x98765432;
+        private const uint ConstantUInt32Expected = 0x32547698;
+
+        private const ulong ConstantUInt64Input = 0xfedcba9876543210;
+        private const ulong ConstantUInt64Expected = 0x1032547698badcfe;
+
+
+        static int Main(string[] args)
+        {
+            /*
+             * CONST VALUE TESTS
+             */
+
+            ushort swappedUInt16 = BinaryPrimitives.ReverseEndianness(ConstantUInt16Input);
+            if (swappedUInt16 != ConstantUInt16Expected)
+            {
+                Console.WriteLine($"BinaryPrimitives.ReverseEndianness(const UInt16) failed.");
+                Console.WriteLine($"Input:    0x{ConstantUInt16Input:X4}");
+                Console.WriteLine($"Output:   0x{swappedUInt16:X4}");
+                Console.WriteLine($"Expected: 0x{ConstantUInt16Expected:X4}");
+            }
+
+            uint swappedUInt32 = BinaryPrimitives.ReverseEndianness(ConstantUInt32Input);
+            if (swappedUInt32 != ConstantUInt32Expected)
+            {
+                Console.WriteLine($"BinaryPrimitives.ReverseEndianness(const UInt32) failed.");
+                Console.WriteLine($"Input:    0x{ConstantUInt32Input:X8}");
+                Console.WriteLine($"Output:   0x{swappedUInt32:X8}");
+                Console.WriteLine($"Expected: 0x{ConstantUInt32Expected:X8}");
+            }
+
+            ulong swappedUInt64 = BinaryPrimitives.ReverseEndianness(ConstantUInt64Input);
+            if (swappedUInt64 != ConstantUInt64Expected)
+            {
+                Console.WriteLine($"BinaryPrimitives.ReverseEndianness(const UInt32) failed.");
+                Console.WriteLine($"Input:    0x{ConstantUInt64Input:X16}");
+                Console.WriteLine($"Output:   0x{swappedUInt64:X16}");
+                Console.WriteLine($"Expected: 0x{ConstantUInt64Expected:X16}");
+            }
+
+            /*
+             * NON-CONST VALUE TESTS
+             */
+
+            ushort nonConstUInt16Input = (ushort)DateTime.UtcNow.Ticks;
+            ushort nonConstUInt16Output = BinaryPrimitives.ReverseEndianness(nonConstUInt16Input);
+            ushort nonConstUInt16Expected = ByteSwapUInt16_Control(nonConstUInt16Input);
+            if (nonConstUInt16Output != nonConstUInt16Expected)
+            {
+                Console.WriteLine($"BinaryPrimitives.ReverseEndianness(non-const UInt16) failed.");
+                Console.WriteLine($"Input:    0x{nonConstUInt16Input:X4}");
+                Console.WriteLine($"Output:   0x{nonConstUInt16Output:X4}");
+                Console.WriteLine($"Expected: 0x{nonConstUInt16Expected:X4}");
+            }
+
+            uint nonConstUInt32Input = (uint)DateTime.UtcNow.Ticks;
+            uint nonConstUInt32Output = BinaryPrimitives.ReverseEndianness(nonConstUInt32Input);
+            uint nonConstUInt32Expected = ByteSwapUInt32_Control(nonConstUInt32Input);
+            if (nonConstUInt32Output != nonConstUInt32Expected)
+            {
+                Console.WriteLine($"BinaryPrimitives.ReverseEndianness(non-const UInt32) failed.");
+                Console.WriteLine($"Input:    0x{nonConstUInt32Input:X8}");
+                Console.WriteLine($"Output:   0x{nonConstUInt32Output:X8}");
+                Console.WriteLine($"Expected: 0x{nonConstUInt32Expected:X8}");
+            }
+
+            ulong nonConstUInt64Input = (ulong)DateTime.UtcNow.Ticks;
+            ulong nonConstUInt64Output = BinaryPrimitives.ReverseEndianness(nonConstUInt64Input);
+            ulong nonConstUInt64Expected = ByteSwapUInt64_Control(nonConstUInt64Input);
+            if (nonConstUInt64Output != nonConstUInt64Expected)
+            {
+                Console.WriteLine($"BinaryPrimitives.ReverseEndianness(non-const UInt64) failed.");
+                Console.WriteLine($"Input:    0x{nonConstUInt64Input:X16}");
+                Console.WriteLine($"Output:   0x{nonConstUInt64Output:X16}");
+                Console.WriteLine($"Expected: 0x{nonConstUInt64Expected:X16}");
+            }
+
+            return Pass;
+        }
+
+        private static ushort ByteSwapUInt16_Control(ushort value)
+        {
+            return (ushort)ByteSwapUnsigned_General(value, sizeof(ushort));
+        }
+
+        private static uint ByteSwapUInt32_Control(uint value)
+        {
+            return (uint)ByteSwapUnsigned_General(value, sizeof(uint));
+        }
+
+        private static ulong ByteSwapUInt64_Control(ulong value)
+        {
+            return (ulong)ByteSwapUnsigned_General(value, sizeof(ulong));
+        }
+
+        private static ulong ByteSwapUnsigned_General(ulong value, int width)
+        {
+            // A naive byte swap routine that works on integers of any arbitrary width.
+            // Width is specified in bytes.
+
+            ulong retVal = 0;
+            do
+            {
+                retVal = retVal << 8 | (byte)value;
+                value >>= 8;
+            } while (--width > 0);
+
+            if (value != 0)
+            {
+                // All bits of value should've been shifted out at this point.
+                throw new Exception("Unexpected data width specified - error in test program?");
+            }
+
+            return retVal;
+        }
+    }
+}

--- a/tests/src/JIT/Intrinsics/BinaryPrimitivesReverseEndianness_r.csproj
+++ b/tests/src/JIT/Intrinsics/BinaryPrimitivesReverseEndianness_r.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <ReferenceSystemPrivateCoreLib>true</ReferenceSystemPrivateCoreLib>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>None</DebugType>
+    <Optimize></Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="BinaryPrimitivesReverseEndianness.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/Intrinsics/BinaryPrimitivesReverseEndianness_ro.csproj
+++ b/tests/src/JIT/Intrinsics/BinaryPrimitivesReverseEndianness_ro.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <ReferenceSystemPrivateCoreLib>true</ReferenceSystemPrivateCoreLib>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="BinaryPrimitivesReverseEndianness.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Addresses https://github.com/dotnet/coreclr/issues/14122

The general idea is that we expose APIs (for internal consumption) which are JIT intrinsics, replaced with `BSWAP` instructions instead of method calls at runtime. I've put them on `BitConverter` for now but haven't exposed them via the reference API. The System.Memory package already exposes `BinaryPrimitives.ReverseEndianness` APIs, and those can call through to these implementations due to the special relationship between corefx packages and System.Private.CoreLib.

Here's the x64 codegen of several `test_bswap` routines that I compiled and tested.

```asm
test_bswap(UInt32):
00007ffd`ac470080 8bc1            mov     eax,ecx
00007ffd`ac470082 0fc8            bswap   eax
00007ffd`ac470084 c3              ret

test_bswap(UInt64):
00007ffd`ab6a0080 488bc1          mov     rax,rcx
00007ffd`ab6a0083 480fc8          bswap   rax
00007ffd`ab6a0086 c3              ret

test_bswap(UInt16):
00007ffd`ab6d0080 0fb7c1          movzx   eax,cx
00007ffd`ab6d0083 66c1c808        ror     ax,8
00007ffd`ab6d0087 c3              ret
```

Open issues:

* How would I even begin to test this in a sane fashion? Right now I tested this by using a `DynamicMethod` to reference these intrinsic APIs, then compiling and observing the codegen in windbg. It works as far as seeing what's going on, but I can't use this for things like perf runs.

* An alternative implementation would be to recognize byte swap IL patterns directly, similar to how rotation IL patterns are recognized directly. I didn't pursue this because I thought it would be more error-prone than using special intrinsic methods, but perhaps somebody knows a more foolproof way of doing this.

* I didn't attempt to make this work on ARM because I don't have a test box. The ARM equivalents are `REV` / `REV16` / `REV64`. I may need to suppress the intrinsic entirely on ARM for now in order to avoid JIT breaks.

* Calling `ReverseEndianness(<some const uint64>)` works but isn't optimized properly. I think I need to update morph but I'll need assistance knowing where to look.

* Ideally if we detect a `GT_BSWAP` instruction immediately before or after a memory access, we can replace both operations with `movbe` on compatible architectures. I don't think this would have much impact on runtime, but it could save a scratch register and help avoid stack spillage in some scenarios.