### PR TITLE
Removed length restrictions on named synchronization primitives lengths on Windows

### DIFF
--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -1577,7 +1577,7 @@
     <value>The unmanaged Version information is too large to persist.</value>
   </data>
   <data name="Argument_WaitHandleNameTooLong" xml:space="preserve">
-    <value>The name '{0}' can be no more than {1} characters in length.</value>
+    <value>The length of the name exceeds the maximum limit.</value>
   </data>
   <data name="Argument_WinRTSystemRuntimeType" xml:space="preserve">
     <value>Cannot marshal type '{0}' to Windows Runtime. Only 'System.RuntimeType' is supported.</value>

--- a/src/System.Private.CoreLib/shared/System/Threading/Mutex.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Mutex.Windows.cs
@@ -27,11 +27,11 @@ namespace System.Threading
             if (mutexHandle.IsInvalid)
             {
                 mutexHandle.SetHandleAsInvalid();
-
+#if PLATFORM_UNIX
                 if (errorCode == Interop.Errors.ERROR_FILENAME_EXCED_RANGE)
                     // On Unix, length validation is done by CoreCLR's PAL after converting to utf-8
                     throw new ArgumentException(SR.Argument_WaitHandleNameTooLong, nameof(name));
-
+#endif
                 if (errorCode == Interop.Errors.ERROR_INVALID_HANDLE)
                     throw new WaitHandleCannotBeOpenedException(SR.Format(SR.Threading_WaitHandleCannotBeOpenedException_InvalidHandle, name));
 
@@ -64,12 +64,13 @@ namespace System.Threading
             if (myHandle.IsInvalid)
             {
                 int errorCode = Marshal.GetLastWin32Error();
+#if PLATFORM_UNIX
                 if (errorCode == Interop.Errors.ERROR_FILENAME_EXCED_RANGE)
                 {
                     // On Unix, length validation is done by CoreCLR's PAL after converting to utf-8
                     throw new ArgumentException(SR.Argument_WaitHandleNameTooLong, nameof(name));
                 }
-
+#endif
                 if (Interop.Errors.ERROR_FILE_NOT_FOUND == errorCode || Interop.Errors.ERROR_INVALID_NAME == errorCode)
                     return OpenExistingResult.NameNotFound;
                 if (Interop.Errors.ERROR_PATH_NOT_FOUND == errorCode)

--- a/src/System.Private.CoreLib/shared/System/Threading/Mutex.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Mutex.Windows.cs
@@ -18,13 +18,6 @@ namespace System.Threading
         private const uint AccessRights =
             (uint)Interop.Kernel32.MAXIMUM_ALLOWED | Interop.Kernel32.SYNCHRONIZE | Interop.Kernel32.MUTEX_MODIFY_STATE;
 
-#if PLATFORM_UNIX
-        // Maximum file name length on tmpfs file system.
-        private const int WaitHandleNameMax = 255;
-#else
-        private const int WaitHandleNameMax = Interop.Kernel32.MAX_PATH;
-#endif
-
         private void CreateMutexCore(bool initiallyOwned, string name, out bool createdNew)
         {
             uint mutexFlags = initiallyOwned ? Interop.Kernel32.CREATE_MUTEX_INITIAL_OWNER : 0;
@@ -37,7 +30,7 @@ namespace System.Threading
 
                 if (errorCode == Interop.Errors.ERROR_FILENAME_EXCED_RANGE)
                     // On Unix, length validation is done by CoreCLR's PAL after converting to utf-8
-                    throw new ArgumentException(SR.Format(SR.Argument_WaitHandleNameTooLong, name, WaitHandleNameMax), nameof(name));
+                    throw new ArgumentException(SR.Argument_WaitHandleNameTooLong, nameof(name));
 
                 if (errorCode == Interop.Errors.ERROR_INVALID_HANDLE)
                     throw new WaitHandleCannotBeOpenedException(SR.Format(SR.Threading_WaitHandleCannotBeOpenedException_InvalidHandle, name));
@@ -74,7 +67,7 @@ namespace System.Threading
                 if (errorCode == Interop.Errors.ERROR_FILENAME_EXCED_RANGE)
                 {
                     // On Unix, length validation is done by CoreCLR's PAL after converting to utf-8
-                    throw new ArgumentException(SR.Format(SR.Argument_WaitHandleNameTooLong, name, WaitHandleNameMax), nameof(name));
+                    throw new ArgumentException(SR.Argument_WaitHandleNameTooLong, nameof(name));
                 }
 
                 if (Interop.Errors.ERROR_FILE_NOT_FOUND == errorCode || Interop.Errors.ERROR_INVALID_NAME == errorCode)

--- a/src/System.Private.CoreLib/shared/System/Threading/Mutex.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Mutex.cs
@@ -17,13 +17,11 @@ namespace System.Threading
     {
         public Mutex(bool initiallyOwned, string name, out bool createdNew)
         {
-            VerifyNameForCreate(name);
             CreateMutexCore(initiallyOwned, name, out createdNew);
         }
 
         public Mutex(bool initiallyOwned, string name)
         {
-            VerifyNameForCreate(name);
             CreateMutexCore(initiallyOwned, name, out _);
         }
 

--- a/src/System.Private.CoreLib/src/System/Threading/EventWaitHandle.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/EventWaitHandle.cs
@@ -49,11 +49,6 @@ namespace System.Threading
             {
 #if PLATFORM_UNIX
                 throw new PlatformNotSupportedException(SR.PlatformNotSupported_NamedSynchronizationPrimitives);
-#else
-                if (Interop.Kernel32.MAX_PATH < name.Length)
-                {
-                    throw new ArgumentException(SR.Format(SR.Argument_WaitHandleNameTooLong, name, Interop.Kernel32.MAX_PATH), nameof(name));
-                }
 #endif
             }
 
@@ -97,11 +92,6 @@ namespace System.Threading
             {
 #if PLATFORM_UNIX
                 throw new PlatformNotSupportedException(SR.PlatformNotSupported_NamedSynchronizationPrimitives);
-#else
-                if (Interop.Kernel32.MAX_PATH < name.Length)
-                {
-                    throw new ArgumentException(SR.Format(SR.Argument_WaitHandleNameTooLong, name, Interop.Kernel32.MAX_PATH), nameof(name));
-                }
 #endif
             }
             Win32Native.SECURITY_ATTRIBUTES secAttrs = null;
@@ -184,14 +174,7 @@ namespace System.Threading
                 throw new ArgumentException(SR.Argument_EmptyName, nameof(name));
             }
 
-            if (null != name && Interop.Kernel32.MAX_PATH < name.Length)
-            {
-                throw new ArgumentException(SR.Format(SR.Argument_WaitHandleNameTooLong, name, Interop.Kernel32.MAX_PATH), nameof(name));
-            }
-
-
             result = null;
-
             SafeWaitHandle myHandle = Win32Native.OpenEvent(AccessRights, false, name);
 
             if (myHandle.IsInvalid)

--- a/src/System.Private.CoreLib/src/System/Threading/Semaphore.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Semaphore.cs
@@ -92,9 +92,6 @@ namespace System.Threading
             {
 #if PLATFORM_UNIX
                 throw new PlatformNotSupportedException(SR.PlatformNotSupported_NamedSynchronizationPrimitives);
-#else
-                if (name.Length > Interop.Kernel32.MAX_PATH)
-                    throw new ArgumentException(SR.Format(SR.Argument_WaitHandleNameTooLong, name, Interop.Kernel32.MAX_PATH), nameof(name));
 #endif
             }
 
@@ -135,8 +132,6 @@ namespace System.Threading
                 throw new ArgumentNullException(nameof(name));
             if (name.Length == 0)
                 throw new ArgumentException(SR.Argument_EmptyName, nameof(name));
-            if (name.Length > Interop.Kernel32.MAX_PATH)
-                throw new ArgumentException(SR.Format(SR.Argument_WaitHandleNameTooLong, name, Interop.Kernel32.MAX_PATH), nameof(name));
 
             //Pass false to OpenSemaphore to prevent inheritedHandles
             SafeWaitHandle myHandle = Win32Native.OpenSemaphore(AccessRights, false, name);


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/18370
Tests PR :- https://github.com/dotnet/corefx/pull/30243

we're letting the API kick back names that are too long rather than pre-validating them.