### PR TITLE
Associating threadpool queues with CPU cores.

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
@@ -69,8 +69,16 @@ namespace System.Threading.Tasks
         protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
         {
             // If the task was previously scheduled, and we can't pop it, then return false.
-            if (taskWasPreviouslyQueued && !ThreadPool.TryPopCustomWorkItem(task))
-                return false;
+            if (taskWasPreviouslyQueued)
+            {
+                // do not inline in a nontrivial sync context - it could be stricter than what enqueuer had.
+                SynchronizationContext? syncCtx = SynchronizationContext.Current;
+                if (syncCtx != null && syncCtx.GetType() != typeof(SynchronizationContext))
+                    return false;
+
+                if (!ThreadPool.TryPopCustomWorkItem(task))
+                    return false;
+            }
 
             try
             {

--- a/src/System.Private.CoreLib/shared/System/Threading/ThreadPool.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ThreadPool.cs
@@ -73,8 +73,7 @@ namespace System.Threading
             internal const int MaxSegmentLength = 1024 * 1024;
 
             /// <summary>
-            /// Lock used to protect cross-segment operations"/>
-            /// and any operations that need to get a consistent view of them.
+            /// Lock used to make sure only one thread allocate the new segment.
             /// </summary>
             internal object _addSegmentLock = new object();
 
@@ -1370,7 +1369,8 @@ namespace System.Threading
                 return true;
             }
 
-            for (int i = 0; i < _localQueues.Length; ++i)
+            LocalQueue[] queues = _localQueues;
+            for (int i = 0; i < queues.Length; ++i)
             {
                 if (i == localQueueIndex)
                 {
@@ -1383,7 +1383,7 @@ namespace System.Threading
                     return false;
                 }
 
-                localQueue = _localQueues[i];
+                localQueue = queues[i];
                 if (localQueue != null && localQueue.TryRemove(callback))
                 {
                     return true;

--- a/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -519,6 +519,14 @@ namespace System.Threading
             return currentProcessorId;
         }
 
+        // Clear the cached processor Id
+        // This can be used before/after blocking the thread for nontrivial amount of time
+        // or around other operations which are likely to result in changing executing core.
+        internal static void FlushCurrentProcessorId()
+        {
+            t_currentProcessorIdCache = default;
+        }
+
         // Cached processor id used as a hint for which per-core stack to access. It is periodically
         // refreshed to trail the actual thread core affinity.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/vm/threadpoolrequest.h
+++ b/src/vm/threadpoolrequest.h
@@ -135,11 +135,9 @@ public:
 
 private:
     TPIndex m_index;
-    struct DECLSPEC_ALIGN(MAX_CACHE_LINE_SIZE) {
-        BYTE m_padding1[MAX_CACHE_LINE_SIZE - sizeof(LONG)];
+    struct ALIGNED(MAX_CACHE_LINE_SIZE) {
         // Only use with VolatileLoad+VolatileStore+FastInterlockCompareExchange
         LONG m_numRequestsPending;
-        BYTE m_padding2[MAX_CACHE_LINE_SIZE];
     };
 };
 
@@ -230,11 +228,9 @@ public:
 private:
     SpinLock m_lock;
     ULONG m_NumRequests;
-    struct DECLSPEC_ALIGN(MAX_CACHE_LINE_SIZE) {
-        BYTE m_padding1[MAX_CACHE_LINE_SIZE - sizeof(LONG)];
+    struct ALIGNED(MAX_CACHE_LINE_SIZE) {
         // Only use with VolatileLoad+VolatileStore+FastInterlockCompareExchange
         LONG m_outstandingThreadRequestCount;
-        BYTE m_padding2[MAX_CACHE_LINE_SIZE];
     };
 };
 

--- a/src/vm/util.hpp
+++ b/src/vm/util.hpp
@@ -48,6 +48,12 @@
 #define MAX_CACHE_LINE_SIZE 64
 #endif
 
+#ifdef _MSC_VER
+#define ALIGNED(x)   __declspec(align(x))
+#else
+#define ALIGNED(x)   __attribute__((aligned(x)))
+#endif
+
 //========================================================================
 // More convenient names for integer types of a guaranteed size.
 //========================================================================


### PR DESCRIPTION
New implementation of ThreadPool work queues as lock-free queues softly associated with CPU cores.

The implementation avoids 1:1 strict mapping between work queues and working threads which is often a far greater number than the number of cores.

This implementation improves handling of cases where the number of workers needs to exceeds the number of cores. It avoids precipitous performance drops because:
- the cost of snooping/stealing does not grow with the number of workers.
- the local queues tend to be deeper (since there are fewer of them) and thus stealing is less frequent and less contentious with enqueuing/popping.
- blocking or preempting a worker does not result in its entire work queue be only accessible through stealing.
- reduced likelihood that the workitem will have to execute on a core different from where it was scheduled.

Fixes:#19088

Also may alleviate issues as described in http://labs.criteo.com/2018/10/net-threadpool-starvation-and-how-queuing-makes-it-worse/