### PR TITLE
Standardize CoreLib on PLATFORM_WINDOWS

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/Mutex.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Mutex.Windows.cs
@@ -27,7 +27,7 @@ namespace System.Threading
             if (mutexHandle.IsInvalid)
             {
                 mutexHandle.SetHandleAsInvalid();
-#if PLATFORM_UNIX
+#if !PLATFORM_WINDOWS
                 if (errorCode == Interop.Errors.ERROR_FILENAME_EXCED_RANGE)
                     // On Unix, length validation is done by CoreCLR's PAL after converting to utf-8
                     throw new ArgumentException(SR.Argument_WaitHandleNameTooLong, nameof(name));
@@ -64,7 +64,7 @@ namespace System.Threading
             if (myHandle.IsInvalid)
             {
                 int errorCode = Marshal.GetLastWin32Error();
-#if PLATFORM_UNIX
+#if !PLATFORM_WINDOWS
                 if (errorCode == Interop.Errors.ERROR_FILENAME_EXCED_RANGE)
                 {
                     // On Unix, length validation is done by CoreCLR's PAL after converting to utf-8

--- a/src/System.Private.CoreLib/src/System/Text/StringBuilder.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Text/StringBuilder.CoreCLR.cs
@@ -81,9 +81,7 @@ namespace System.Text
                 // Both MultiByteToWideChar and the UTF8Encoding instance used on Unix-like
                 // platforms default to replacing invalid characters with the Unicode replacement
                 // character U+FFFD.
-#if PLATFORM_UNIX
-                convertedChars = Encoding.UTF8.GetChars((byte*)newBuffer, newLength, pChunkChars, newLength);
-#else
+#if PLATFORM_WINDOWS
                 convertedChars = Interop.Kernel32.MultiByteToWideChar(
                     Interop.Kernel32.CP_ACP,
                     Interop.Kernel32.MB_PRECOMPOSED,
@@ -91,6 +89,8 @@ namespace System.Text
                     newLength,
                     pChunkChars,
                     newLength);
+#else
+                convertedChars = Encoding.UTF8.GetChars((byte*)newBuffer, newLength, pChunkChars, newLength);
 #endif
             }
 

--- a/src/System.Private.CoreLib/src/System/Threading/EventWaitHandle.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/EventWaitHandle.cs
@@ -45,12 +45,12 @@ namespace System.Threading
 
         public EventWaitHandle(bool initialState, EventResetMode mode, string name)
         {
+#if !PLATFORM_WINDOWS
             if (name != null)
             {
-#if PLATFORM_UNIX
                 throw new PlatformNotSupportedException(SR.PlatformNotSupported_NamedSynchronizationPrimitives);
-#endif
             }
+#endif
 
             uint eventFlags = initialState ? Win32Native.CREATE_EVENT_INITIAL_SET : 0;
             switch (mode)
@@ -88,12 +88,12 @@ namespace System.Threading
 
         internal unsafe EventWaitHandle(bool initialState, EventResetMode mode, string name, out bool createdNew, EventWaitHandleSecurity eventSecurity)
         {
+#if !PLATFORM_WINDOWS
             if (name != null)
             {
-#if PLATFORM_UNIX
                 throw new PlatformNotSupportedException(SR.PlatformNotSupported_NamedSynchronizationPrimitives);
-#endif
             }
+#endif
             Win32Native.SECURITY_ATTRIBUTES secAttrs = null;
 
             uint eventFlags = initialState ? Win32Native.CREATE_EVENT_INITIAL_SET : 0;
@@ -161,9 +161,7 @@ namespace System.Threading
 
         private static OpenExistingResult OpenExistingWorker(string name, EventWaitHandleRights rights, out EventWaitHandle result)
         {
-#if PLATFORM_UNIX
-            throw new PlatformNotSupportedException(SR.PlatformNotSupported_NamedSynchronizationPrimitives);
-#else
+#if PLATFORM_WINDOWS
             if (name == null)
             {
                 throw new ArgumentNullException(nameof(name));
@@ -192,6 +190,8 @@ namespace System.Threading
             }
             result = new EventWaitHandle(myHandle);
             return OpenExistingResult.Success;
+#else
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_NamedSynchronizationPrimitives);
 #endif
         }
         public bool Reset()

--- a/src/System.Private.CoreLib/src/System/Threading/Semaphore.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Semaphore.cs
@@ -88,12 +88,12 @@ namespace System.Threading
 
         private static SafeWaitHandle CreateSemaphore(int initialCount, int maximumCount, string name)
         {
+#if !PLATFORM_WINDOWS
             if (name != null)
             {
-#if PLATFORM_UNIX
                 throw new PlatformNotSupportedException(SR.PlatformNotSupported_NamedSynchronizationPrimitives);
-#endif
             }
+#endif
 
             Debug.Assert(initialCount >= 0);
             Debug.Assert(maximumCount >= 1);
@@ -125,9 +125,7 @@ namespace System.Threading
 
         private static OpenExistingResult OpenExistingWorker(string name, out Semaphore result)
         {
-#if PLATFORM_UNIX
-            throw new PlatformNotSupportedException(SR.PlatformNotSupported_NamedSynchronizationPrimitives);
-#else
+#if PLATFORM_WINDOWS
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
             if (name.Length == 0)
@@ -154,7 +152,9 @@ namespace System.Threading
 
             result = new Semaphore(myHandle);
             return OpenExistingResult.Success;
-#endif   
+#else
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_NamedSynchronizationPrimitives);
+#endif
         }
 
         public int Release()


### PR DESCRIPTION
There are a bunch of uses of PLATFORM_WINDOWS in System.Private.CoreLib, and just a few uses of PLATFORM_UNIX.  For consistency, standardize on the former, removing all occurrences of the latter.