### PR TITLE
Unnecessary WinRT attribute Cleanup

### DIFF
--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/Attributes.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/Attributes.cs
@@ -32,7 +32,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
     // implement the CLR's support for WinRT, so this type is internal as marking tdWindowsRuntime should
     // generally be done via winmdexp for user code.
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Enum | AttributeTargets.Struct | AttributeTargets.Delegate, Inherited = false)]
-    // [System.Runtime.CompilerServices.FriendAccessAllowed]
     internal sealed class WindowsRuntimeImportAttribute : Attribute
     {
         internal WindowsRuntimeImportAttribute()

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/IRestrictedErrorInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/IRestrictedErrorInfo.cs
@@ -8,7 +8,6 @@ using System;
 
 namespace System.Runtime.InteropServices.WindowsRuntime
 {
-    // [System.Runtime.CompilerServices.FriendAccessAllowed]
     [ComImport]
     [Guid("82BA7092-4C88-427D-A7BC-16DD93FEB67E")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]

--- a/src/System.Private.CoreLib/src/mscorlib.Friends.cs
+++ b/src/System.Private.CoreLib/src/mscorlib.Friends.cs
@@ -6,4 +6,3 @@ using System.Runtime.CompilerServices;
 
 // Depends on things like WindowsRuntimeImportAttribute
 [assembly: InternalsVisibleTo("System.Runtime.WindowsRuntime, PublicKey=00000000000000000400000000000000", AllInternalsVisible = false)]
-[assembly: InternalsVisibleTo("System.Runtime.WindowsRuntime.UI.Xaml, PublicKey=00000000000000000400000000000000", AllInternalsVisible = false)]


### PR DESCRIPTION
- System.Runtime.WindowsRuntime:

 When compile S.R.WR.dll, it will include System/Runtime/InteropServices/WindowsRuntime/Attributes.cs and System/Runtime/InteropServices/WindowsRuntime/IRestrictedErrorInfo.cs to compile.

- System.Runtime.WindowsRuntime.UI.Xaml

 it is compiled against contract assembly and after scan its source code, I don't find any code using reflection to fetch internal members in S.P.Corelib.

The change is to remove these unnecessary [FriendAccessAllowed] and [InternalsVisibleTo] attribute