### PR TITLE
skip empty regMask in verifyRegistersUsed

### DIFF
--- a/src/jit/regset.cpp
+++ b/src/jit/regset.cpp
@@ -95,6 +95,11 @@ void RegSet::verifyRegistersUsed(regMaskTP regMask)
         return;
     }
 
+    if (regMask == RBM_NONE)
+    {
+        return;
+    }
+
     // TODO-Cleanup: we need to identify the places where the registers
     //               are not marked as used when this is called.
     rsSetRegsModified(regMask);


### PR DESCRIPTION
Fixes #18367.

To repro this issue we need to call `verifyRegistersUsed` with `RBM_NONE`, it happens only when `genEmitHelperCall` returns empty `callKillSet` for the helper and this situation is possible only for `CORINFO_HELP_PROF_FCN_LEAVE` in `genProfilingLeaveCallback`. It means that we need an attached profiler to hit this issue.

Because the cost of the repro is higher that its expected value I have decided to push only the fix.