### PR TITLE
Add public implementation WindowsRuntimeResourceManagerBase

### DIFF
--- a/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -364,6 +364,8 @@
     <Compile Include="$(BclSourcesRoot)\Internal\Runtime\Augments\RuntimeThread.cs" />
     <Compile Include="$(BclSourcesRoot)\Internal\Console.cs" />
     <Compile Condition="'$(FeatureCominterop)' == 'true'"  Include="$(BclSourcesRoot)\Internal\Threading\Tasks\AsyncCausalitySupport.cs" />
+    <Compile Condition="'$(FeatureAppX)' == 'true'" Include="$(BclSourcesRoot)\Internal\Resources\WindowsRuntimeResourceManagerBase.cs" />
+    <Compile Condition="'$(FeatureAppX)' == 'true'" Include="$(BclSourcesRoot)\Internal\Resources\PRIExceptionInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(BclSourcesRoot)\System\Reflection\Assembly.CoreCLR.cs" />

--- a/src/System.Private.CoreLib/src/Internal/Resources/PRIExceptionInfo.cs
+++ b/src/System.Private.CoreLib/src/Internal/Resources/PRIExceptionInfo.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Internal.Resources
+{
+    public class PRIExceptionInfo
+    {
+        public string PackageSimpleName;
+        public string ResWFile;
+    }
+}

--- a/src/System.Private.CoreLib/src/Internal/Resources/WindowsRuntimeResourceManagerBase.cs
+++ b/src/System.Private.CoreLib/src/Internal/Resources/WindowsRuntimeResourceManagerBase.cs
@@ -7,13 +7,8 @@ using System.Globalization;
 
 namespace Internal.Resources
 {
-    //
     // This is implemented in System.Runtime.WindowsRuntime as function System.Resources.WindowsRuntimeResourceManager,
     // allowing us to ask for a WinRT-specific ResourceManager.
-    // It is important to have WindowsRuntimeResourceManagerBase as regular class with virtual methods and default implementations. 
-    // Defining WindowsRuntimeResourceManagerBase as abstract class or interface will cause issues when adding more methods to it 
-    // because it'll create dependency between mscorlib and System.Runtime.WindowsRuntime which will require always shipping both DLLs together. 
-    //
     public abstract class WindowsRuntimeResourceManagerBase
     {
         public abstract bool Initialize(string libpath, string reswFilename, out PRIExceptionInfo exceptionInfo);

--- a/src/System.Private.CoreLib/src/Internal/Resources/WindowsRuntimeResourceManagerBase.cs
+++ b/src/System.Private.CoreLib/src/Internal/Resources/WindowsRuntimeResourceManagerBase.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+
+namespace Internal.Resources
+{
+    //
+    // This is implemented in System.Runtime.WindowsRuntime as function System.Resources.WindowsRuntimeResourceManager,
+    // allowing us to ask for a WinRT-specific ResourceManager.
+    // It is important to have WindowsRuntimeResourceManagerBase as regular class with virtual methods and default implementations. 
+    // Defining WindowsRuntimeResourceManagerBase as abstract class or interface will cause issues when adding more methods to it 
+    // because it'll create dependency between mscorlib and System.Runtime.WindowsRuntime which will require always shipping both DLLs together. 
+    //
+    public abstract class WindowsRuntimeResourceManagerBase
+    {
+        public abstract bool Initialize(string libpath, string reswFilename, out PRIExceptionInfo exceptionInfo);
+
+        public abstract string GetString(string stringName, string startingCulture, string neutralResourcesCulture);
+
+        public abstract CultureInfo GlobalResourceContextBestFitCultureInfo
+        {
+            get;
+        }
+
+        public abstract bool SetGlobalResourceContextDefaultCulture(CultureInfo ci);
+    }
+}

--- a/src/System.Private.CoreLib/src/Internal/Resources/WindowsRuntimeResourceManagerBase.cs
+++ b/src/System.Private.CoreLib/src/Internal/Resources/WindowsRuntimeResourceManagerBase.cs
@@ -7,7 +7,7 @@ using System.Globalization;
 
 namespace Internal.Resources
 {
-    // This is implemented in System.Runtime.WindowsRuntime as function System.Resources.WindowsRuntimeResourceManager,
+    // This is implemented in System.Runtime.WindowsRuntime as System.Resources.WindowsRuntimeResourceManager,
     // allowing us to ask for a WinRT-specific ResourceManager.
     public abstract class WindowsRuntimeResourceManagerBase
     {

--- a/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.Windows.cs
@@ -11,6 +11,7 @@ using Internal.Runtime.Augments;
 using System.Threading;
 #if FEATURE_APPX
 using System.Resources;
+using Internal.Resources;
 #endif
 
 namespace System.Globalization

--- a/src/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
+++ b/src/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
@@ -30,38 +30,9 @@ namespace System.Resources
     using System.Collections.Generic;
     using System.Runtime.Versioning;
     using System.Diagnostics;
-
 #if FEATURE_APPX
-    //
-    // This is implemented in System.Runtime.WindowsRuntime as function System.Resources.WindowsRuntimeResourceManager,
-    // allowing us to ask for a WinRT-specific ResourceManager.
-    // It is important to have WindowsRuntimeResourceManagerBase as regular class with virtual methods and default implementations. 
-    // Defining WindowsRuntimeResourceManagerBase as abstract class or interface will cause issues when adding more methods to it 
-    // because it'll create dependency between mscorlib and System.Runtime.WindowsRuntime which will require always shipping both DLLs together. 
-    //
-    // [FriendAccessAllowed]
-    internal abstract class WindowsRuntimeResourceManagerBase
-    {
-        public abstract bool Initialize(string libpath, string reswFilename, out PRIExceptionInfo exceptionInfo);
-
-        public abstract string GetString(string stringName, string startingCulture, string neutralResourcesCulture);
-
-        public abstract CultureInfo GlobalResourceContextBestFitCultureInfo
-        {
-            get;
-        }
-
-        public abstract bool SetGlobalResourceContextDefaultCulture(CultureInfo ci);
-    }
-
-    // [FriendAccessAllowed]
-    internal class PRIExceptionInfo
-    {
-        public string _PackageSimpleName;
-        public string _ResWFile;
-    }
-#endif // FEATURE_APPX
-
+    using Internal.Resources;
+#endif
     // Resource Manager exposes an assembly's resources to an application for
     // the correct CultureInfo.  An example would be localizing text for a 
     // user-visible message.  Create a set of resource files listing a name 
@@ -919,7 +890,6 @@ namespace System.Resources
                                     try
                                     {
                                         _PRIonAppXInitialized = _WinRTResourceManager.Initialize(resourcesAssembly.Location, reswFilename, out _PRIExceptionInfo);
-
                                         // Note that _PRIExceptionInfo might be null - this is OK.
                                         // In that case we will just throw the generic
                                         // MissingManifestResource_NoPRIresources exception.
@@ -1016,8 +986,8 @@ namespace System.Resources
                 {
                     // Always throw if we did not fully succeed in initializing the WinRT Resource Manager.
 
-                    if (_PRIExceptionInfo != null && _PRIExceptionInfo._PackageSimpleName != null && _PRIExceptionInfo._ResWFile != null)
-                        throw new MissingManifestResourceException(SR.Format(SR.MissingManifestResource_ResWFileNotLoaded, _PRIExceptionInfo._ResWFile, _PRIExceptionInfo._PackageSimpleName));
+                    if (_PRIExceptionInfo != null && _PRIExceptionInfo.PackageSimpleName != null && _PRIExceptionInfo.ResWFile != null)
+                        throw new MissingManifestResourceException(SR.Format(SR.MissingManifestResource_ResWFileNotLoaded, _PRIExceptionInfo.ResWFile, _PRIExceptionInfo.PackageSimpleName));
 
                     throw new MissingManifestResourceException(SR.MissingManifestResource_NoPRIresources);
                 }


### PR DESCRIPTION
The change is to add public implementation WindowsRuntimeResourceManagerBase and PRIExceptionInfo in S.P.Corelib for S.P.WindowsRuntime to use.  It will help to  remove [assembly: InternalsVisibleTo(S.R.WindowsRuntime) ] in S.P.Corelib later.