### PR TITLE
Revert "Temporarily disable package signing in 2.0.0"

### DIFF
--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -155,7 +155,7 @@
     },
     {
       "environment": {},
-      "enabled": false,
+      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Sign Packages",


### PR DESCRIPTION
Reverts dotnet/coreclr#18421

Don't merge until the 2.0.0 Publish job has signing permissions

CC @weshaggard 