### PR TITLE
Add public implementation FrameworkEventSourceSupport

### DIFF
--- a/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -301,10 +301,12 @@
     <Compile Include="$(BclSourcesRoot)\Internal\Runtime\Augments\EnvironmentAugments.cs" />
     <Compile Include="$(BclSourcesRoot)\Internal\Runtime\Augments\RuntimeThread.cs" />
     <Compile Include="$(BclSourcesRoot)\Internal\Console.cs" />
+<<<<<<< HEAD
     <Compile Condition="'$(FeatureCominterop)' == 'true'" Include="$(BclSourcesRoot)\Internal\Threading\Tasks\AsyncCausalitySupport.cs" />
     <Compile Condition="'$(FeatureCominterop)' == 'true'" Include="$(BclSourcesRoot)\Internal\Runtime\InteropServices\WindowsRuntime\ExceptionSupport.cs" />
     <Compile Condition="'$(FeatureAppX)' == 'true'" Include="$(BclSourcesRoot)\Internal\Resources\WindowsRuntimeResourceManagerBase.cs" />
     <Compile Condition="'$(FeatureAppX)' == 'true'" Include="$(BclSourcesRoot)\Internal\Resources\PRIExceptionInfo.cs" />
+    <Compile Condition="'$(FeatureAppX)' == 'true'"  Include="$(BclSourcesRoot)\Internal\Diagnostics\Tracing\FrameworkEventSourceSupport.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(BclSourcesRoot)\System\Reflection\Assembly.CoreCLR.cs" />

--- a/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -301,7 +301,6 @@
     <Compile Include="$(BclSourcesRoot)\Internal\Runtime\Augments\EnvironmentAugments.cs" />
     <Compile Include="$(BclSourcesRoot)\Internal\Runtime\Augments\RuntimeThread.cs" />
     <Compile Include="$(BclSourcesRoot)\Internal\Console.cs" />
-<<<<<<< HEAD
     <Compile Condition="'$(FeatureCominterop)' == 'true'" Include="$(BclSourcesRoot)\Internal\Threading\Tasks\AsyncCausalitySupport.cs" />
     <Compile Condition="'$(FeatureCominterop)' == 'true'" Include="$(BclSourcesRoot)\Internal\Runtime\InteropServices\WindowsRuntime\ExceptionSupport.cs" />
     <Compile Condition="'$(FeatureAppX)' == 'true'" Include="$(BclSourcesRoot)\Internal\Resources\WindowsRuntimeResourceManagerBase.cs" />

--- a/src/System.Private.CoreLib/src/Internal/Diagnostics/Tracing/FrameworkEventSourceSupport.cs
+++ b/src/System.Private.CoreLib/src/Internal/Diagnostics/Tracing/FrameworkEventSourceSupport.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics.Tracing;
+using System.Runtime.CompilerServices;
+
+namespace Internal.Diagnostics.Tracing
+{
+    //
+    // An internal contract that exposes just enough async debugger support needed by the AsTask() extension methods in the WindowsRuntimeSystemExtensions class.
+    //
+    public static class FrameworkEventSourceSupport
+    {
+        public static bool IsEnabled
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return FrameworkEventSource.Log.IsEnabled(EventLevel.Informational, FrameworkEventSource.Keywords.ThreadTransfer);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThreadTransferSendObj(object id, int kind, string info, bool multiDequeues)
+        {
+            FrameworkEventSource.Log.ThreadTransferSendObj(id, kind, info, multiDequeues);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThreadTransferReceiveObj(object id, int kind, string info)
+        {
+            FrameworkEventSource.Log.ThreadTransferReceiveObj(id, kind, info);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThreadTransferReceiveHandledObj(object id, int kind, string info)
+        {
+            FrameworkEventSource.Log.ThreadTransferReceiveHandledObj(id, kind, info);
+        }
+    }
+}
+

--- a/src/System.Private.CoreLib/src/Internal/Diagnostics/Tracing/FrameworkEventSourceSupport.cs
+++ b/src/System.Private.CoreLib/src/Internal/Diagnostics/Tracing/FrameworkEventSourceSupport.cs
@@ -9,7 +9,7 @@ using System.Runtime.CompilerServices;
 namespace Internal.Diagnostics.Tracing
 {
     //
-    // An internal contract that exposes just enough async debugger support needed by the AsTask() extension methods in the WindowsRuntimeSystemExtensions class.
+    // An internal contract that exposes FrameworkEventSourceSupport(ETW) support to System.Runtime.WindowsRuntime.dll
     //
     public static class FrameworkEventSourceSupport
     {

--- a/src/System.Private.CoreLib/src/Internal/Diagnostics/Tracing/FrameworkEventSourceSupport.cs
+++ b/src/System.Private.CoreLib/src/Internal/Diagnostics/Tracing/FrameworkEventSourceSupport.cs
@@ -13,13 +13,10 @@ namespace Internal.Diagnostics.Tracing
     //
     public static class FrameworkEventSourceSupport
     {
-        public static bool IsEnabled
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsEnabled(EventLevel level, EventKeywords keywords)
         {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                return FrameworkEventSource.Log.IsEnabled(EventLevel.Informational, FrameworkEventSource.Keywords.ThreadTransfer);
-            }
+            return FrameworkEventSource.Log.IsEnabled(level, keywords);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/FrameworkEventSource.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/FrameworkEventSource.cs
@@ -27,7 +27,6 @@ namespace System.Diagnostics.Tracing
     //
     // This will produce an XML file, where each event is pretty-printed with all its arguments nicely parsed.
     //
-    // [FriendAccessAllowed]
     [EventSource(Guid = "8E9F5090-2D75-4d03-8A81-E5AFBF85DAF1", Name = "System.Diagnostics.Eventing.FrameworkEventSource")]
     sealed internal class FrameworkEventSource : EventSource
     {


### PR DESCRIPTION
Add class FrameworkEventSourceSupport for S.P.WindowsRuntime to use.

corefx PR:https://github.com/dotnet/corefx/pull/30297