### PR TITLE
Disable HugeArray test in GCStress modes

### DIFF
--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -49217,7 +49217,7 @@ RelativePath=JIT\jit64\opt\cse\HugeArray\HugeArray.cmd
 WorkingDir=JIT\jit64\opt\cse\HugeArray
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;Pri1
+Categories=EXPECTED_PASS;Pri1;GCSTRESS_EXCLUDE
 HostStyle=0
 
 [b11762.cmd_6176]

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -39945,7 +39945,7 @@ RelativePath=JIT\jit64\opt\cse\HugeArray\HugeArray.cmd
 WorkingDir=JIT\jit64\opt\cse\HugeArray
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=JIT;EXPECTED_PASS;Pri1
+Categories=JIT;EXPECTED_PASS;Pri1;GCSTRESS_EXCLUDE
 HostStyle=0
 
 [HugeArray1.cmd_5296]

--- a/tests/src/JIT/jit64/opt/cse/HugeArray.csproj
+++ b/tests/src/JIT/jit64/opt/cse/HugeArray.csproj
@@ -11,7 +11,7 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <!-- NOTE: this test simply takes too long to complete under GC stress; it is not fundamentally incompatible -->
-    <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
+    <GCStressIncompatible>true</GCStressIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->


### PR DESCRIPTION
This test takes too long under GCStress, and causes timeout failures.
It was already disabled for x86. Disable it for all platforms, to
avoid unexpected failures in the CI. E.g., especially for ARM, which
is slow.