### PR TITLE
Fix GC KeepAlive test

### DIFF
--- a/tests/src/GC/API/GC/KeepAlive.cs
+++ b/tests/src/GC/API/GC/KeepAlive.cs
@@ -56,8 +56,10 @@ public class Test
     }
 
 
-    public static void RunTest()
+    public static bool RunTest()
     {
+        bool success = false;
+
         Dummy obj = new Dummy();
 
         RunTest2();
@@ -71,14 +73,18 @@ public class Test
         GC.Collect();
         //}
 
+        success = (visited1 == false) && (visited2 == true);
+
         GC.KeepAlive(obj);  // will keep obj alive until this point
+
+        return success;
     }
 
     public static int Main()
     {
-        RunTest();
+        bool success = RunTest();
 
-        if ((visited1 == false) && (visited2 == true))
+        if (success)
         {
             Console.WriteLine("Test for KeepAlive() passed!");
             return 100;
@@ -86,8 +92,6 @@ public class Test
         else
         {
             Console.WriteLine("Test for KeepAlive() failed!");
-
-
             return 1;
         }
     }


### PR DESCRIPTION
We need to determine that an object finalizer has not been run
*before* the KeepAlive call. After the call, it is perfectly
valid for the finalizer to be called, which can happen under
GCStress.

Fixes #18437