### PR TITLE
Adds original error info to NotSupportedException during FileStream initialization

### DIFF
--- a/src/System.Private.CoreLib/shared/System/IO/FileStream.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStream.Windows.cs
@@ -61,7 +61,7 @@ namespace System.IO
             int fileType = Interop.Kernel32.GetFileType(_fileHandle);
             if (fileType != Interop.Kernel32.FileTypes.FILE_TYPE_DISK)
             {
-                var errorCode = Marshal.GetLastWin32Error();
+                int errorCode = Marshal.GetLastWin32Error();
 
                 _fileHandle.Dispose();
 

--- a/src/System.Private.CoreLib/shared/System/IO/FileStream.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStream.Windows.cs
@@ -62,6 +62,12 @@ namespace System.IO
             if (fileType != Interop.Kernel32.FileTypes.FILE_TYPE_DISK)
             {
                 _fileHandle.Dispose();
+
+                var lastWin32Error = Marshal.GetLastWin32Error();
+                if (fileType == Interop.Kernel32.FileTypes.FILE_TYPE_UNKNOWN && lastWin32Error != Interop.Errors.ERROR_SUCCESS)
+                {
+                    throw new ExternalException(Interop.Kernel32.GetMessage(lastWin32Error), lastWin32Error);
+                }
                 throw new NotSupportedException(SR.NotSupported_FileStreamOnNonFiles);
             }
 

--- a/src/System.Private.CoreLib/shared/System/IO/FileStream.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStream.Windows.cs
@@ -61,15 +61,15 @@ namespace System.IO
             int fileType = Interop.Kernel32.GetFileType(_fileHandle);
             if (fileType != Interop.Kernel32.FileTypes.FILE_TYPE_DISK)
             {
+                var errorCode = Marshal.GetLastWin32Error();
+
                 _fileHandle.Dispose();
 
-                var lastWin32Error = Marshal.GetLastWin32Error();
-                ExternalException win32Exception = null;
-                if (fileType == Interop.Kernel32.FileTypes.FILE_TYPE_UNKNOWN && lastWin32Error != Interop.Errors.ERROR_SUCCESS)
+                if (fileType == Interop.Kernel32.FileTypes.FILE_TYPE_UNKNOWN && errorCode != Interop.Errors.ERROR_SUCCESS)
                 {
-                    win32Exception = new ExternalException(Interop.Kernel32.GetMessage(lastWin32Error), lastWin32Error);
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode);
                 }
-                throw new NotSupportedException(SR.NotSupported_FileStreamOnNonFiles, win32Exception);
+                throw new NotSupportedException(SR.NotSupported_FileStreamOnNonFiles);
             }
 
             // This is necessary for async IO using IO Completion ports via our 

--- a/src/System.Private.CoreLib/shared/System/IO/FileStream.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStream.Windows.cs
@@ -64,11 +64,12 @@ namespace System.IO
                 _fileHandle.Dispose();
 
                 var lastWin32Error = Marshal.GetLastWin32Error();
+                ExternalException win32Exception = null;
                 if (fileType == Interop.Kernel32.FileTypes.FILE_TYPE_UNKNOWN && lastWin32Error != Interop.Errors.ERROR_SUCCESS)
                 {
-                    throw new ExternalException(Interop.Kernel32.GetMessage(lastWin32Error), lastWin32Error);
+                    win32Exception = new ExternalException(Interop.Kernel32.GetMessage(lastWin32Error), lastWin32Error);
                 }
-                throw new NotSupportedException(SR.NotSupported_FileStreamOnNonFiles);
+                throw new NotSupportedException(SR.NotSupported_FileStreamOnNonFiles, win32Exception);
             }
 
             // This is necessary for async IO using IO Completion ports via our 

--- a/src/System.Private.CoreLib/shared/System/IO/FileStream.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStream.Windows.cs
@@ -61,11 +61,11 @@ namespace System.IO
             int fileType = Interop.Kernel32.GetFileType(_fileHandle);
             if (fileType != Interop.Kernel32.FileTypes.FILE_TYPE_DISK)
             {
-                int errorCode = Marshal.GetLastWin32Error();
+                int errorCode = fileType == Interop.Kernel32.FileTypes.FILE_TYPE_UNKNOWN ? Marshal.GetLastWin32Error() : Interop.Errors.ERROR_SUCCESS;
 
                 _fileHandle.Dispose();
 
-                if (fileType == Interop.Kernel32.FileTypes.FILE_TYPE_UNKNOWN && errorCode != Interop.Errors.ERROR_SUCCESS)
+                if (errorCode != Interop.Errors.ERROR_SUCCESS)
                 {
                     throw Win32Marshal.GetExceptionForWin32Error(errorCode);
                 }


### PR DESCRIPTION
Fixes #18454 

A couple of notes:
- I originally thought of throwing a Win32Exception but Win32Exception is not part of System.Private.Corelib;
- As I understand, throwing a new exception type is a breaking change, so instead I'm adding the error info to the current exception's InnerException
