### PR TITLE
Fix allocation methods at few places in PAL

### DIFF
--- a/src/pal/src/include/pal/malloc.hpp
+++ b/src/pal/src/include/pal/malloc.hpp
@@ -85,12 +85,28 @@ namespace CorUnix{
         return new (pMem) T();
     }
 
+    // 1 arg case.
+    template<class T, class A1>
+    T* InternalNew(A1 arg1)
+    {
+        INTERNAL_NEW_COMMON();
+        return new (pMem) T(arg1);
+    }
+
     // 2 args case.
     template<class T, class A1, class A2>
     T* InternalNew(A1 arg1, A2 arg2)
     {
         INTERNAL_NEW_COMMON();
         return new (pMem) T(arg1, arg2);
+    }
+
+    // 3 args case.
+    template<class T, class A1, class A2, class A3>
+    T* InternalNew(A1 arg1, A2 arg2, A3 arg3)
+    {
+        INTERNAL_NEW_COMMON();
+        return new (pMem) T(arg1, arg2, arg3);
     }
 
     // 4 args case.

--- a/src/pal/src/locale/utf8.cpp
+++ b/src/pal/src/locale/utf8.cpp
@@ -20,6 +20,9 @@ Revision History:
 --*/
 
 #include "pal/utf8.h"
+#include "pal/malloc.hpp"
+
+using namespace CorUnix;
 
 #define FASTLOOP
 
@@ -253,6 +256,8 @@ class DecoderFallbackBuffer
     // These wrap the internal methods so that we can check for people doing stuff that's incorrect
 
 public:
+    virtual ~DecoderFallbackBuffer() = default;
+
     virtual bool Fallback(BYTE bytesUnknown[], int index, int size) = 0;
 
     // Get next character
@@ -552,7 +557,7 @@ public:
 
     virtual DecoderFallbackBuffer* CreateFallbackBuffer()
     {
-        return new DecoderExceptionFallbackBuffer();
+        return InternalNew<DecoderExceptionFallbackBuffer>();
     }
 
     // Maximum number of characters that this instance of this fallback could return
@@ -564,7 +569,7 @@ public:
 
 DecoderFallbackBuffer* DecoderReplacementFallback::CreateFallbackBuffer()
 {
-    return new DecoderReplacementFallbackBuffer(this);
+    return InternalNew<DecoderReplacementFallbackBuffer>(this);
 }
 
 class EncoderFallbackException : public ArgumentException
@@ -728,6 +733,8 @@ class EncoderFallbackBuffer
     // These wrap the internal methods so that we can check for people doing stuff that is incorrect
 
 public:
+    virtual ~EncoderFallbackBuffer() = default;
+
     virtual bool Fallback(WCHAR charUnknown, int index) = 0;
 
     virtual bool Fallback(WCHAR charUnknownHigh, WCHAR charUnknownLow, int index) = 0;
@@ -1044,7 +1051,7 @@ public:
 
     virtual EncoderFallbackBuffer* CreateFallbackBuffer()
     {
-        return new EncoderExceptionFallbackBuffer();
+        return InternalNew<EncoderExceptionFallbackBuffer>();
     }
 
     // Maximum number of characters that this instance of this fallback could return
@@ -1056,7 +1063,7 @@ public:
 
 EncoderFallbackBuffer* EncoderReplacementFallback::CreateFallbackBuffer()
 {
-    return new EncoderReplacementFallbackBuffer(this);
+    return InternalNew<EncoderReplacementFallbackBuffer>(this);
 }
 
 class UTF8Encoding
@@ -1620,6 +1627,8 @@ public:
         Contract::Assert(fallback == nullptr || fallback->GetRemaining() == 0,
             "[UTF8Encoding.GetCharCount]Expected empty fallback buffer at end");
 
+        InternalDelete(fallback);
+
         return charCount;
 
     }
@@ -2123,6 +2132,8 @@ public:
         Contract::Assert(fallback == nullptr || fallback->GetRemaining() == 0,
             "[UTF8Encoding.GetChars]Expected empty fallback buffer at end");
 
+        InternalDelete(fallback);
+
         return PtrDiff(pTarget, chars);
     }
 
@@ -2511,6 +2522,8 @@ public:
             ch = 0;
         }
 
+        InternalDelete(fallbackBuffer); 
+
         return (int)(pTarget - bytes);
     }
 
@@ -2837,6 +2850,8 @@ public:
 
         Contract::Assert(fallbackBuffer == nullptr || fallbackBuffer->GetRemaining() == 0,
             "[UTF8Encoding.GetByteCount]Expected Empty fallback buffer");
+
+        InternalDelete(fallbackBuffer);
 
         return byteCount;
     }

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -1544,7 +1544,7 @@ public:
         LONG ref = InterlockedDecrement(&m_ref);
         if (ref == 0)
         {
-            delete this;
+            InternalDelete(this);
         }
         return ref;
     }
@@ -1836,7 +1836,7 @@ PAL_RegisterForRuntimeStartup(
     _ASSERTE(pfnCallback != NULL);
     _ASSERTE(ppUnregisterToken != NULL);
 
-    PAL_RuntimeStartupHelper *helper = new PAL_RuntimeStartupHelper(dwProcessId, pfnCallback, parameter);
+    PAL_RuntimeStartupHelper *helper = InternalNew<PAL_RuntimeStartupHelper>(dwProcessId, pfnCallback, parameter);
 
     // Create the debuggee startup semaphore so the runtime (debuggee) knows to wait for 
     // a debugger connection.


### PR DESCRIPTION
In the utf8.cpp and process.cpp, PAL was incorectly using the
global new operator. This results in calling this operator's
definition in coreclr runtime, which is wrong. In the case
of the utf8 stuff, a customer has reported a crash happening
due to that when the path from which the PAL was initialized
contained chinese characters.

The fix is to use InternalNew / InternalDelete functions instead.

I have also found that we were missing deletions of the DecoderFallbackBuffer
and EncoderFallbackBuffer, so I have added them.