### PR TITLE
[WIP] Add perf tests for Span IndexOf<T> and StartsWith<T>

### DIFF
--- a/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
@@ -1174,9 +1174,11 @@ namespace Span
             
             for (var i = 0; i < iterationCount; i++)
             {
-                var length = random.Next(2, array.Length - i);
+                var index = random.Next(0, array.Length - 1);
 
-                var lookup = new ReadOnlySpan<T>(array, i, length);
+                var length = random.Next(1, array.Length - index);
+
+                var lookup = new ReadOnlySpan<T>(array, index, length);
 
                 span.StartsWith(lookup);
             }


### PR DESCRIPTION
Addresses issue dotnet/coreclr#10954

This pull request is my initial attempt at addressing the micro benchmarks requested in issue:

#10954

I wanted to check my early implementation because it seems like I am not following the intended design for these type of benchmarks.