### PR TITLE
Improve SSE4.2 string processing intrinsic APIs

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Enums.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Enums.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+using System;
 
 namespace System.Runtime.Intrinsics.X86
 {
@@ -167,23 +168,56 @@ namespace System.Runtime.Intrinsics.X86
         TrueUnorderedSignaling = 31,
     }
 
+    [Flags]
     public enum StringComparisonMode : byte {
+        /// <summary>
+        /// _SIDD_CMP_EQUAL_ANY
+        /// </summary>
         EqualAny = 0x00,
+
+        /// <summary>
+        /// _SIDD_CMP_RANGES
+        /// </summary>
         Ranges = 0x04,
+
+        /// <summary>
+        /// _SIDD_CMP_EQUAL_EACH
+        /// </summary>
         EqualEach = 0x08,
+
+        /// <summary>
+        /// _SIDD_CMP_EQUAL_ORDERED
+        /// </summary>
         EqualOrdered = 0x0c,
-        NegativePolarity = 0x10,
-        MaskedNegativePolarity = 0x30,
+
+        /// <summary>
+        /// _SIDD_NEGATIVE_POLARITY
+        /// </summary>
+        NegativeResult = 0x10,
+
+        /// <summary>
+        /// _SIDD_MASKED_NEGATIVE_POLARITY
+        /// </summary>
+        NegativeUsefulResult = 0x30,
+
+        /// <summary>
+        /// _SIDD_LEAST_SIGNIFICANT
+        /// </summary>
         LeastSignificant = 0x00,
+
+        /// <summary>
+        /// _SIDD_MOST_SIGNIFICANT
+        /// </summary>
         MostSignificant = 0x40,
-    }
 
+        /// <summary>
+        /// _SIDD_BIT_MASK
+        /// </summary>
+        BitMask = 0x00,
 
-    public enum ResultsFlag : byte {
-        CFlag = 0,
-        NotCFlagAndNotZFlag = 1,
-        OFlag = 2,
-        SFlag = 3,
-        ZFlag = 4,
+        /// <summary>
+        /// _SIDD_UNIT_MASK
+        /// </summary>
+        UnitMask = 0x40,
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse42.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse42.PlatformNotSupported.cs
@@ -18,259 +18,338 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// int _mm_cmpistra (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistrc (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistro (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistrs (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistrz (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static bool CompareImplicitLength(Vector128<sbyte> left, Vector128<sbyte> right, ResultsFlag flag, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        public static bool CompareNoMatchAndRightNotTerminated(Vector128<sbyte> left, Vector128<sbyte> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_cmpistra (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistrc (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistro (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistrs (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistrz (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static bool CompareImplicitLength(Vector128<byte> left, Vector128<byte> right, ResultsFlag flag, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        public static bool CompareNoMatchAndRightNotTerminated(Vector128<byte> left, Vector128<byte> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_cmpistra (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistrc (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistro (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistrs (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistrz (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static bool CompareImplicitLength(Vector128<short> left, Vector128<short> right, ResultsFlag flag, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
-
+        public static bool CompareNoMatchAndRightNotTerminated(Vector128<short> left, Vector128<short> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_cmpistra (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareNoMatchAndRightNotTerminated(Vector128<ushort> left, Vector128<ushort> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
         /// int _mm_cmpistrc (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareHasMatch(Vector128<sbyte> left, Vector128<sbyte> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// int _mm_cmpistrc (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareHasMatch(Vector128<byte> left, Vector128<byte> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// int _mm_cmpistrc (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareHasMatch(Vector128<short> left, Vector128<short> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// int _mm_cmpistrc (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareHasMatch(Vector128<ushort> left, Vector128<ushort> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
         /// int _mm_cmpistro (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareReturnFirstResultBit(Vector128<sbyte> left, Vector128<sbyte> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// int _mm_cmpistro (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareReturnFirstResultBit(Vector128<byte> left, Vector128<byte> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// int _mm_cmpistro (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareReturnFirstResultBit(Vector128<short> left, Vector128<short> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// int _mm_cmpistro (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareReturnFirstResultBit(Vector128<ushort> left, Vector128<ushort> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
         /// int _mm_cmpistrs (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareLeftTerminated(Vector128<sbyte> left, Vector128<sbyte> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// int _mm_cmpistrs (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareLeftTerminated(Vector128<byte> left, Vector128<byte> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// int _mm_cmpistrs (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareLeftTerminated(Vector128<short> left, Vector128<short> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// int _mm_cmpistrs (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareLeftTerminated(Vector128<ushort> left, Vector128<ushort> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
         /// int _mm_cmpistrz (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static bool CompareImplicitLength(Vector128<ushort> left, Vector128<ushort> right, ResultsFlag flag, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        public static bool CompareRightTerminated(Vector128<sbyte> left, Vector128<sbyte> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// int _mm_cmpistrz (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareRightTerminated(Vector128<byte> left, Vector128<byte> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// int _mm_cmpistrz (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareRightTerminated(Vector128<short> left, Vector128<short> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// int _mm_cmpistrz (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareRightTerminated(Vector128<ushort> left, Vector128<ushort> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_cmpestra (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestrc (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestro (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestrs (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestrz (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static bool CompareExplicitLength(Vector128<sbyte> left, byte leftLength, Vector128<sbyte> right, byte rightLength, ResultsFlag flag, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
-
+        public static bool CompareNoMatchAndRightNotTerminated(Vector128<sbyte> left, int leftLength, Vector128<sbyte> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        
         /// <summary>
         /// int _mm_cmpestra (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestrc (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestro (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestrs (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestrz (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static bool CompareExplicitLength(Vector128<byte> left, byte leftLength, Vector128<byte> right, byte rightLength, ResultsFlag flag, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
-
+        public static bool CompareNoMatchAndRightNotTerminated(Vector128<byte> left, int leftLength, Vector128<byte> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        
         /// <summary>
         /// int _mm_cmpestra (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestrc (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestro (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestrs (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestrz (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static bool CompareExplicitLength(Vector128<short> left, byte leftLength, Vector128<short> right, byte rightLength, ResultsFlag flag, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
-
+        public static bool CompareNoMatchAndRightNotTerminated(Vector128<short> left, int leftLength, Vector128<short> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        
         /// <summary>
         /// int _mm_cmpestra (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareNoMatchAndRightNotTerminated(Vector128<ushort> left, int leftLength, Vector128<ushort> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
         /// int _mm_cmpestrc (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareHasMatch(Vector128<sbyte> left, int leftLength, Vector128<sbyte> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        
+        /// <summary>
+        /// int _mm_cmpestrc (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareHasMatch(Vector128<byte> left, int leftLength, Vector128<byte> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        
+        /// <summary>
+        /// int _mm_cmpestrc (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareHasMatch(Vector128<short> left, int leftLength, Vector128<short> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        
+        /// <summary>
+        /// int _mm_cmpestrc (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareHasMatch(Vector128<ushort> left, int leftLength, Vector128<ushort> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
         /// int _mm_cmpestro (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareReturnFirstResultBit(Vector128<sbyte> left, int leftLength, Vector128<sbyte> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        
+        /// <summary>
+        /// int _mm_cmpestro (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareReturnFirstResultBit(Vector128<byte> left, int leftLength, Vector128<byte> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        
+        /// <summary>
+        /// int _mm_cmpestro (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareReturnFirstResultBit(Vector128<short> left, int leftLength, Vector128<short> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        
+        /// <summary>
+        /// int _mm_cmpestro (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareReturnFirstResultBit(Vector128<ushort> left, int leftLength, Vector128<ushort> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
         /// int _mm_cmpestrs (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareLeftTerminated(Vector128<sbyte> left, int leftLength, Vector128<sbyte> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        
+        /// <summary>
+        /// int _mm_cmpestrs (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareLeftTerminated(Vector128<byte> left, int leftLength, Vector128<byte> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        
+        /// <summary>
+        /// int _mm_cmpestrs (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareLeftTerminated(Vector128<short> left, int leftLength, Vector128<short> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        
+        /// <summary>
+        /// int _mm_cmpestrs (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareLeftTerminated(Vector128<ushort> left, int leftLength, Vector128<ushort> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
         /// int _mm_cmpestrz (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static bool CompareExplicitLength(Vector128<ushort> left, byte leftLength, Vector128<ushort> right, byte rightLength, ResultsFlag flag, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        public static bool CompareRightTerminated(Vector128<sbyte> left, int leftLength, Vector128<sbyte> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        
+        /// <summary>
+        /// int _mm_cmpestrz (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareRightTerminated(Vector128<byte> left, int leftLength, Vector128<byte> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        
+        /// <summary>
+        /// int _mm_cmpestrz (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareRightTerminated(Vector128<short> left, int leftLength, Vector128<short> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        
+        /// <summary>
+        /// int _mm_cmpestrz (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareRightTerminated(Vector128<ushort> left, int leftLength, Vector128<ushort> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_cmpistri (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static int CompareImplicitLengthIndex(Vector128<sbyte> left, Vector128<sbyte> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        public static int CompareIndex(Vector128<sbyte> left, Vector128<sbyte> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_cmpistri (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static int CompareImplicitLengthIndex(Vector128<byte> left, Vector128<byte> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        public static int CompareIndex(Vector128<byte> left, Vector128<byte> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_cmpistri (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static int CompareImplicitLengthIndex(Vector128<short> left, Vector128<short> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        public static int CompareIndex(Vector128<short> left, Vector128<short> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_cmpistri (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static int CompareImplicitLengthIndex(Vector128<ushort> left, Vector128<ushort> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        public static int CompareIndex(Vector128<ushort> left, Vector128<ushort> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_cmpestri (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static int CompareExplicitLengthIndex(Vector128<sbyte> left, byte leftLength, Vector128<sbyte> right, byte rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        public static int CompareIndex(Vector128<sbyte> left, int leftLength, Vector128<sbyte> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_cmpestri (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static int CompareExplicitLengthIndex(Vector128<byte> left, byte leftLength, Vector128<byte> right, byte rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        public static int CompareIndex(Vector128<byte> left, int leftLength, Vector128<byte> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_cmpestri (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static int CompareExplicitLengthIndex(Vector128<short> left, byte leftLength, Vector128<short> right, byte rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        public static int CompareIndex(Vector128<short> left, int leftLength, Vector128<short> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_cmpestri (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static int CompareExplicitLengthIndex(Vector128<ushort> left, byte leftLength, Vector128<ushort> right, byte rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        public static int CompareIndex(Vector128<ushort> left, int leftLength, Vector128<ushort> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm_cmpistrm (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRM xmm, xmm/m128, imm8
         /// </summary>
-        public static Vector128<ushort> CompareImplicitLengthBitMask(Vector128<sbyte> left, Vector128<sbyte> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        public static Vector128<sbyte> CompareMask(Vector128<sbyte> left, Vector128<sbyte> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm_cmpistrm (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRM xmm, xmm/m128, imm8
         /// </summary>
-        public static Vector128<ushort> CompareImplicitLengthBitMask(Vector128<byte> left, Vector128<byte> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        public static Vector128<byte> CompareMask(Vector128<byte> left, Vector128<byte> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm_cmpistrm (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRM xmm, xmm/m128, imm8
         /// </summary>
-        public static Vector128<byte> CompareImplicitLengthBitMask(Vector128<short> left, Vector128<short> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        public static Vector128<short> CompareMask(Vector128<short> left, Vector128<short> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm_cmpistrm (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRM xmm, xmm/m128, imm8
         /// </summary>
-        public static Vector128<byte> CompareImplicitLengthBitMask(Vector128<ushort> left, Vector128<ushort> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
-
-        /// <summary>
-        /// __m128i _mm_cmpistrm (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRM xmm, xmm/m128, imm8
-        /// </summary>
-        public static Vector128<byte> CompareImplicitLengthUnitMask(Vector128<sbyte> left, Vector128<sbyte> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
-
-        /// <summary>
-        /// __m128i _mm_cmpistrm (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRM xmm, xmm/m128, imm8
-        /// </summary>
-        public static Vector128<byte> CompareImplicitLengthUnitMask(Vector128<byte> left, Vector128<byte> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
-
-        /// <summary>
-        /// __m128i _mm_cmpistrm (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRM xmm, xmm/m128, imm8
-        /// </summary>
-        public static Vector128<ushort> CompareImplicitLengthUnitMask(Vector128<short> left, Vector128<short> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
-
-        /// <summary>
-        /// __m128i _mm_cmpistrm (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRM xmm, xmm/m128, imm8
-        /// </summary>
-        public static Vector128<ushort> CompareImplicitLengthUnitMask(Vector128<ushort> left, Vector128<ushort> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        public static Vector128<ushort> CompareMask(Vector128<ushort> left, Vector128<ushort> right, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm_cmpestrm (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRM xmm, xmm/m128, imm8
         /// </summary>
-        public static Vector128<ushort> CompareExplicitLengthBitMask(Vector128<sbyte> left, byte leftLength, Vector128<sbyte> right, byte rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        public static Vector128<sbyte> CompareMask(Vector128<sbyte> left, int leftLength, Vector128<sbyte> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm_cmpestrm (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRM xmm, xmm/m128, imm8
         /// </summary>
-        public static Vector128<ushort> CompareExplicitLengthBitMask(Vector128<byte> left, byte leftLength, Vector128<byte> right, byte rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        public static Vector128<byte> CompareMask(Vector128<byte> left, int leftLength, Vector128<byte> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm_cmpestrm (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRM xmm, xmm/m128, imm8
         /// </summary>
-        public static Vector128<byte> CompareExplicitLengthBitMask(Vector128<short> left, byte leftLength, Vector128<short> right, byte rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        public static Vector128<short> CompareMask(Vector128<short> left, int leftLength, Vector128<short> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm_cmpestrm (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRM xmm, xmm/m128, imm8
         /// </summary>
-        public static Vector128<byte> CompareExplicitLengthBitMask(Vector128<ushort> left, byte leftLength, Vector128<ushort> right, byte rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
-
-        /// <summary>
-        /// __m128i _mm_cmpestrm (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRM xmm, xmm/m128, imm8
-        /// </summary>
-        public static Vector128<byte> CompareExplicitLengthUnitMask(Vector128<sbyte> left, byte leftLength, Vector128<sbyte> right, byte rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
-
-        /// <summary>
-        /// __m128i _mm_cmpestrm (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRM xmm, xmm/m128, imm8
-        /// </summary>
-        public static Vector128<byte> CompareExplicitLengthUnitMask(Vector128<byte> left, byte leftLength, Vector128<byte> right, byte rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
-
-        /// <summary>
-        /// __m128i _mm_cmpestrm (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRM xmm, xmm/m128, imm8
-        /// </summary>
-        public static Vector128<ushort> CompareExplicitLengthUnitMask(Vector128<short> left, byte leftLength, Vector128<short> right, byte rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
-
-        /// <summary>
-        /// __m128i _mm_cmpestrm (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRM xmm, xmm/m128, imm8
-        /// </summary>
-        public static Vector128<ushort> CompareExplicitLengthUnitMask(Vector128<ushort> left, byte leftLength, Vector128<ushort> right, byte rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
+        public static Vector128<ushort> CompareMask(Vector128<ushort> left, int leftLength, Vector128<ushort> right, int rightLength, StringComparisonMode mode) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm_cmpgt_epi64 (__m128i a, __m128i b)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse42.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse42.cs
@@ -18,259 +18,338 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// int _mm_cmpistra (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistrc (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistro (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistrs (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistrz (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static bool CompareImplicitLength(Vector128<sbyte> left, Vector128<sbyte> right, ResultsFlag flag, StringComparisonMode mode) => CompareImplicitLength(left, right, flag, mode);
+        public static bool CompareNoMatchAndRightNotTerminated(Vector128<sbyte> left, Vector128<sbyte> right, StringComparisonMode mode) => CompareNoMatchAndRightNotTerminated(left, right, mode);
 
         /// <summary>
         /// int _mm_cmpistra (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistrc (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistro (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistrs (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistrz (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static bool CompareImplicitLength(Vector128<byte> left, Vector128<byte> right, ResultsFlag flag, StringComparisonMode mode) => CompareImplicitLength(left, right, flag, mode);
+        public static bool CompareNoMatchAndRightNotTerminated(Vector128<byte> left, Vector128<byte> right, StringComparisonMode mode) => CompareNoMatchAndRightNotTerminated(left, right, mode);
 
         /// <summary>
         /// int _mm_cmpistra (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistrc (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistro (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistrs (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpistrz (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static bool CompareImplicitLength(Vector128<short> left, Vector128<short> right, ResultsFlag flag, StringComparisonMode mode) => CompareImplicitLength(left, right, flag, mode);
-
+        public static bool CompareNoMatchAndRightNotTerminated(Vector128<short> left, Vector128<short> right, StringComparisonMode mode) => CompareNoMatchAndRightNotTerminated(left, right, mode);
 
         /// <summary>
         /// int _mm_cmpistra (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareNoMatchAndRightNotTerminated(Vector128<ushort> left, Vector128<ushort> right, StringComparisonMode mode) => CompareNoMatchAndRightNotTerminated(left, right, mode);
+
+        /// <summary>
         /// int _mm_cmpistrc (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareHasMatch(Vector128<sbyte> left, Vector128<sbyte> right, StringComparisonMode mode) => CompareHasMatch(left, right, mode);
+
+        /// <summary>
+        /// int _mm_cmpistra (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareHasMatch(Vector128<byte> left, Vector128<byte> right, StringComparisonMode mode) => CompareHasMatch(left, right, mode);
+
+        /// <summary>
+        /// int _mm_cmpistra (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareHasMatch(Vector128<short> left, Vector128<short> right, StringComparisonMode mode) => CompareHasMatch(left, right, mode);
+
+        /// <summary>
+        /// int _mm_cmpistra (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareHasMatch(Vector128<ushort> left, Vector128<ushort> right, StringComparisonMode mode) => CompareHasMatch(left, right, mode);
+
+        /// <summary>
         /// int _mm_cmpistro (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareReturnFirstResultBit(Vector128<sbyte> left, Vector128<sbyte> right, StringComparisonMode mode) => CompareReturnFirstResultBit(left, right, mode);
+
+        /// <summary>
+        /// int _mm_cmpistro (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareReturnFirstResultBit(Vector128<byte> left, Vector128<byte> right, StringComparisonMode mode) => CompareReturnFirstResultBit(left, right, mode);
+
+        /// <summary>
+        /// int _mm_cmpistro (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareReturnFirstResultBit(Vector128<short> left, Vector128<short> right, StringComparisonMode mode) => CompareReturnFirstResultBit(left, right, mode);
+
+        /// <summary>
+        /// int _mm_cmpistro (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareReturnFirstResultBit(Vector128<ushort> left, Vector128<ushort> right, StringComparisonMode mode) => CompareReturnFirstResultBit(left, right, mode);
+
+        /// <summary>
         /// int _mm_cmpistrs (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareLeftTerminated(Vector128<sbyte> left, Vector128<sbyte> right, StringComparisonMode mode) => CompareLeftTerminated(left, right, mode);
+
+        /// <summary>
+        /// int _mm_cmpistrs (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareLeftTerminated(Vector128<byte> left, Vector128<byte> right, StringComparisonMode mode) => CompareLeftTerminated(left, right, mode);
+
+        /// <summary>
+        /// int _mm_cmpistrs (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareLeftTerminated(Vector128<short> left, Vector128<short> right, StringComparisonMode mode) => CompareLeftTerminated(left, right, mode);
+
+        /// <summary>
+        /// int _mm_cmpistrs (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareLeftTerminated(Vector128<ushort> left, Vector128<ushort> right, StringComparisonMode mode) => CompareLeftTerminated(left, right, mode);
+
+        /// <summary>
         /// int _mm_cmpistrz (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static bool CompareImplicitLength(Vector128<ushort> left, Vector128<ushort> right, ResultsFlag flag, StringComparisonMode mode) => CompareImplicitLength(left, right, flag, mode);
+        public static bool CompareRightTerminated(Vector128<sbyte> left, Vector128<sbyte> right, StringComparisonMode mode) => CompareRightTerminated(left, right, mode);
+
+        /// <summary>
+        /// int _mm_cmpistrz (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareRightTerminated(Vector128<byte> left, Vector128<byte> right, StringComparisonMode mode) => CompareRightTerminated(left, right, mode);
+
+        /// <summary>
+        /// int _mm_cmpistrz (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareRightTerminated(Vector128<short> left, Vector128<short> right, StringComparisonMode mode) => CompareRightTerminated(left, right, mode);
+
+        /// <summary>
+        /// int _mm_cmpistrz (__m128i a, __m128i b, const int imm8)
+        ///   PCMPISTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareRightTerminated(Vector128<ushort> left, Vector128<ushort> right, StringComparisonMode mode) => CompareRightTerminated(left, right, mode);
 
         /// <summary>
         /// int _mm_cmpestra (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestrc (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestro (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestrs (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestrz (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static bool CompareExplicitLength(Vector128<sbyte> left, byte leftLength, Vector128<sbyte> right, byte rightLength, ResultsFlag flag, StringComparisonMode mode) => CompareExplicitLength(left, leftLength, right, rightLength, flag, mode);
-
+        public static bool CompareNoMatchAndRightNotTerminated(Vector128<sbyte> left, int leftLength, Vector128<sbyte> right, int rightLength, StringComparisonMode mode) => CompareNoMatchAndRightNotTerminated(left, leftLength, right, rightLength, mode);
+        
         /// <summary>
         /// int _mm_cmpestra (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestrc (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestro (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestrs (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestrz (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static bool CompareExplicitLength(Vector128<byte> left, byte leftLength, Vector128<byte> right, byte rightLength, ResultsFlag flag, StringComparisonMode mode) => CompareExplicitLength(left, leftLength, right, rightLength, flag, mode);
-
+        public static bool CompareNoMatchAndRightNotTerminated(Vector128<byte> left, int leftLength, Vector128<byte> right, int rightLength, StringComparisonMode mode) => CompareNoMatchAndRightNotTerminated(left, leftLength, right, rightLength, mode);
+        
         /// <summary>
         /// int _mm_cmpestra (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestrc (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestro (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestrs (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
-        /// int _mm_cmpestrz (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static bool CompareExplicitLength(Vector128<short> left, byte leftLength, Vector128<short> right, byte rightLength, ResultsFlag flag, StringComparisonMode mode) => CompareExplicitLength(left, leftLength, right, rightLength, flag, mode);
-
+        public static bool CompareNoMatchAndRightNotTerminated(Vector128<short> left, int leftLength, Vector128<short> right, int rightLength, StringComparisonMode mode) => CompareNoMatchAndRightNotTerminated(left, leftLength, right, rightLength, mode);
+        
         /// <summary>
         /// int _mm_cmpestra (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareNoMatchAndRightNotTerminated(Vector128<ushort> left, int leftLength, Vector128<ushort> right, int rightLength, StringComparisonMode mode) => CompareNoMatchAndRightNotTerminated(left, leftLength, right, rightLength, mode);
+
+        /// <summary>
         /// int _mm_cmpestrc (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareHasMatch(Vector128<sbyte> left, int leftLength, Vector128<sbyte> right, int rightLength, StringComparisonMode mode) => CompareHasMatch(left, leftLength, right, rightLength, mode);
+        
+        /// <summary>
+        /// int _mm_cmpestrc (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareHasMatch(Vector128<byte> left, int leftLength, Vector128<byte> right, int rightLength, StringComparisonMode mode) => CompareHasMatch(left, leftLength, right, rightLength, mode);
+        
+        /// <summary>
+        /// int _mm_cmpestrc (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareHasMatch(Vector128<short> left, int leftLength, Vector128<short> right, int rightLength, StringComparisonMode mode) => CompareHasMatch(left, leftLength, right, rightLength, mode);
+        
+        /// <summary>
+        /// int _mm_cmpestrc (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareHasMatch(Vector128<ushort> left, int leftLength, Vector128<ushort> right, int rightLength, StringComparisonMode mode) => CompareHasMatch(left, leftLength, right, rightLength, mode);
+
+        /// <summary>
         /// int _mm_cmpestro (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareReturnFirstResultBit(Vector128<sbyte> left, int leftLength, Vector128<sbyte> right, int rightLength, StringComparisonMode mode) => CompareReturnFirstResultBit(left, leftLength, right, rightLength, mode);
+        
+        /// <summary>
+        /// int _mm_cmpestro (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareReturnFirstResultBit(Vector128<byte> left, int leftLength, Vector128<byte> right, int rightLength, StringComparisonMode mode) => CompareReturnFirstResultBit(left, leftLength, right, rightLength, mode);
+        
+        /// <summary>
+        /// int _mm_cmpestro (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareReturnFirstResultBit(Vector128<short> left, int leftLength, Vector128<short> right, int rightLength, StringComparisonMode mode) => CompareReturnFirstResultBit(left, leftLength, right, rightLength, mode);
+        
+        /// <summary>
+        /// int _mm_cmpestro (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareReturnFirstResultBit(Vector128<ushort> left, int leftLength, Vector128<ushort> right, int rightLength, StringComparisonMode mode) => CompareReturnFirstResultBit(left, leftLength, right, rightLength, mode);
+
+        /// <summary>
         /// int _mm_cmpestrs (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareLeftTerminated(Vector128<sbyte> left, int leftLength, Vector128<sbyte> right, int rightLength, StringComparisonMode mode) => CompareLeftTerminated(left, leftLength, right, rightLength, mode);
+        
+        /// <summary>
+        /// int _mm_cmpestrs (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareLeftTerminated(Vector128<byte> left, int leftLength, Vector128<byte> right, int rightLength, StringComparisonMode mode) => CompareLeftTerminated(left, leftLength, right, rightLength, mode);
+        
+        /// <summary>
+        /// int _mm_cmpestrs (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareLeftTerminated(Vector128<short> left, int leftLength, Vector128<short> right, int rightLength, StringComparisonMode mode) => CompareLeftTerminated(left, leftLength, right, rightLength, mode);
+        
+        /// <summary>
+        /// int _mm_cmpestrs (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareLeftTerminated(Vector128<ushort> left, int leftLength, Vector128<ushort> right, int rightLength, StringComparisonMode mode) => CompareLeftTerminated(left, leftLength, right, rightLength, mode);
+
+        /// <summary>
         /// int _mm_cmpestrz (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static bool CompareExplicitLength(Vector128<ushort> left, byte leftLength, Vector128<ushort> right, byte rightLength, ResultsFlag flag, StringComparisonMode mode) => CompareExplicitLength(left, leftLength, right, rightLength, flag, mode);
+        public static bool CompareRightTerminated(Vector128<sbyte> left, int leftLength, Vector128<sbyte> right, int rightLength, StringComparisonMode mode) => CompareRightTerminated(left, leftLength, right, rightLength, mode);
+        
+        /// <summary>
+        /// int _mm_cmpestrz (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareRightTerminated(Vector128<byte> left, int leftLength, Vector128<byte> right, int rightLength, StringComparisonMode mode) => CompareRightTerminated(left, leftLength, right, rightLength, mode);
+        
+        /// <summary>
+        /// int _mm_cmpestrz (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareRightTerminated(Vector128<short> left, int leftLength, Vector128<short> right, int rightLength, StringComparisonMode mode) => CompareRightTerminated(left, leftLength, right, rightLength, mode);
+        
+        /// <summary>
+        /// int _mm_cmpestrz (__m128i a, int la, __m128i b, int lb, const int imm8)
+        ///   PCMPESTRI xmm, xmm/m128, imm8
+        /// </summary>
+        public static bool CompareRightTerminated(Vector128<ushort> left, int leftLength, Vector128<ushort> right, int rightLength, StringComparisonMode mode) => CompareRightTerminated(left, leftLength, right, rightLength, mode);
 
         /// <summary>
         /// int _mm_cmpistri (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static int CompareImplicitLengthIndex(Vector128<sbyte> left, Vector128<sbyte> right, StringComparisonMode mode) => CompareImplicitLengthIndex(left, right, mode);
+        public static int CompareIndex(Vector128<sbyte> left, Vector128<sbyte> right, StringComparisonMode mode) => CompareIndex(left, right, mode);
 
         /// <summary>
         /// int _mm_cmpistri (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static int CompareImplicitLengthIndex(Vector128<byte> left, Vector128<byte> right, StringComparisonMode mode) => CompareImplicitLengthIndex(left, right, mode);
+        public static int CompareIndex(Vector128<byte> left, Vector128<byte> right, StringComparisonMode mode) => CompareIndex(left, right, mode);
 
         /// <summary>
         /// int _mm_cmpistri (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static int CompareImplicitLengthIndex(Vector128<short> left, Vector128<short> right, StringComparisonMode mode) => CompareImplicitLengthIndex(left, right, mode);
+        public static int CompareIndex(Vector128<short> left, Vector128<short> right, StringComparisonMode mode) => CompareIndex(left, right, mode);
 
         /// <summary>
         /// int _mm_cmpistri (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static int CompareImplicitLengthIndex(Vector128<ushort> left, Vector128<ushort> right, StringComparisonMode mode) => CompareImplicitLengthIndex(left, right, mode);
+        public static int CompareIndex(Vector128<ushort> left, Vector128<ushort> right, StringComparisonMode mode) => CompareIndex(left, right, mode);
 
         /// <summary>
         /// int _mm_cmpestri (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static int CompareExplicitLengthIndex(Vector128<sbyte> left, byte leftLength, Vector128<sbyte> right, byte rightLength, StringComparisonMode mode) => CompareExplicitLengthIndex(left, leftLength, right, rightLength, mode);
+        public static int CompareIndex(Vector128<sbyte> left, int leftLength, Vector128<sbyte> right, int rightLength, StringComparisonMode mode) => CompareIndex(left, leftLength, right, rightLength, mode);
 
         /// <summary>
         /// int _mm_cmpestri (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static int CompareExplicitLengthIndex(Vector128<byte> left, byte leftLength, Vector128<byte> right, byte rightLength, StringComparisonMode mode) => CompareExplicitLengthIndex(left, leftLength, right, rightLength, mode);
+        public static int CompareIndex(Vector128<byte> left, int leftLength, Vector128<byte> right, int rightLength, StringComparisonMode mode) => CompareIndex(left, leftLength, right, rightLength, mode);
 
         /// <summary>
         /// int _mm_cmpestri (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static int CompareExplicitLengthIndex(Vector128<short> left, byte leftLength, Vector128<short> right, byte rightLength, StringComparisonMode mode) => CompareExplicitLengthIndex(left, leftLength, right, rightLength, mode);
+        public static int CompareIndex(Vector128<short> left, int leftLength, Vector128<short> right, int rightLength, StringComparisonMode mode) => CompareIndex(left, leftLength, right, rightLength, mode);
 
         /// <summary>
         /// int _mm_cmpestri (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRI xmm, xmm/m128, imm8
         /// </summary>
-        public static int CompareExplicitLengthIndex(Vector128<ushort> left, byte leftLength, Vector128<ushort> right, byte rightLength, StringComparisonMode mode) => CompareExplicitLengthIndex(left, leftLength, right, rightLength, mode);
+        public static int CompareIndex(Vector128<ushort> left, int leftLength, Vector128<ushort> right, int rightLength, StringComparisonMode mode) => CompareIndex(left, leftLength, right, rightLength, mode);
 
         /// <summary>
         /// __m128i _mm_cmpistrm (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRM xmm, xmm/m128, imm8
         /// </summary>
-        public static Vector128<ushort> CompareImplicitLengthBitMask(Vector128<sbyte> left, Vector128<sbyte> right, StringComparisonMode mode) => CompareImplicitLengthBitMask(left, right, mode);
+        public static Vector128<sbyte> CompareMask(Vector128<sbyte> left, Vector128<sbyte> right, StringComparisonMode mode) => CompareMask(left, right, mode);
 
         /// <summary>
         /// __m128i _mm_cmpistrm (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRM xmm, xmm/m128, imm8
         /// </summary>
-        public static Vector128<ushort> CompareImplicitLengthBitMask(Vector128<byte> left, Vector128<byte> right, StringComparisonMode mode) => CompareImplicitLengthBitMask(left, right, mode);
+        public static Vector128<byte> CompareMask(Vector128<byte> left, Vector128<byte> right, StringComparisonMode mode) => CompareMask(left, right, mode);
 
         /// <summary>
         /// __m128i _mm_cmpistrm (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRM xmm, xmm/m128, imm8
         /// </summary>
-        public static Vector128<byte> CompareImplicitLengthBitMask(Vector128<short> left, Vector128<short> right, StringComparisonMode mode) => CompareImplicitLengthBitMask(left, right, mode);
+        public static Vector128<short> CompareMask(Vector128<short> left, Vector128<short> right, StringComparisonMode mode) => CompareMask(left, right, mode);
 
         /// <summary>
         /// __m128i _mm_cmpistrm (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRM xmm, xmm/m128, imm8
         /// </summary>
-        public static Vector128<byte> CompareImplicitLengthBitMask(Vector128<ushort> left, Vector128<ushort> right, StringComparisonMode mode) => CompareImplicitLengthBitMask(left, right, mode);
-
-        /// <summary>
-        /// __m128i _mm_cmpistrm (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRM xmm, xmm/m128, imm8
-        /// </summary>
-        public static Vector128<byte> CompareImplicitLengthUnitMask(Vector128<sbyte> left, Vector128<sbyte> right, StringComparisonMode mode) => CompareImplicitLengthUnitMask(left, right, mode);
-
-        /// <summary>
-        /// __m128i _mm_cmpistrm (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRM xmm, xmm/m128, imm8
-        /// </summary>
-        public static Vector128<byte> CompareImplicitLengthUnitMask(Vector128<byte> left, Vector128<byte> right, StringComparisonMode mode) => CompareImplicitLengthUnitMask(left, right, mode);
-
-        /// <summary>
-        /// __m128i _mm_cmpistrm (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRM xmm, xmm/m128, imm8
-        /// </summary>
-        public static Vector128<ushort> CompareImplicitLengthUnitMask(Vector128<short> left, Vector128<short> right, StringComparisonMode mode) => CompareImplicitLengthUnitMask(left, right, mode);
-
-        /// <summary>
-        /// __m128i _mm_cmpistrm (__m128i a, __m128i b, const int imm8)
-        ///   PCMPISTRM xmm, xmm/m128, imm8
-        /// </summary>
-        public static Vector128<ushort> CompareImplicitLengthUnitMask(Vector128<ushort> left, Vector128<ushort> right, StringComparisonMode mode) => CompareImplicitLengthUnitMask(left, right, mode);
+        public static Vector128<ushort> CompareMask(Vector128<ushort> left, Vector128<ushort> right, StringComparisonMode mode) => CompareMask(left, right, mode);
 
         /// <summary>
         /// __m128i _mm_cmpestrm (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRM xmm, xmm/m128, imm8
         /// </summary>
-        public static Vector128<ushort> CompareExplicitLengthBitMask(Vector128<sbyte> left, byte leftLength, Vector128<sbyte> right, byte rightLength, StringComparisonMode mode) => CompareExplicitLengthBitMask(left, leftLength, right, rightLength, mode);
+        public static Vector128<sbyte> CompareMask(Vector128<sbyte> left, int leftLength, Vector128<sbyte> right, int rightLength, StringComparisonMode mode) => CompareMask(left, leftLength, right, rightLength, mode);
 
         /// <summary>
         /// __m128i _mm_cmpestrm (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRM xmm, xmm/m128, imm8
         /// </summary>
-        public static Vector128<ushort> CompareExplicitLengthBitMask(Vector128<byte> left, byte leftLength, Vector128<byte> right, byte rightLength, StringComparisonMode mode) => CompareExplicitLengthBitMask(left, leftLength, right, rightLength, mode);
+        public static Vector128<byte> CompareMask(Vector128<byte> left, int leftLength, Vector128<byte> right, int rightLength, StringComparisonMode mode) => CompareMask(left, leftLength, right, rightLength, mode);
 
         /// <summary>
         /// __m128i _mm_cmpestrm (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRM xmm, xmm/m128, imm8
         /// </summary>
-        public static Vector128<byte> CompareExplicitLengthBitMask(Vector128<short> left, byte leftLength, Vector128<short> right, byte rightLength, StringComparisonMode mode) => CompareExplicitLengthBitMask(left, leftLength, right, rightLength, mode);
+        public static Vector128<short> CompareMask(Vector128<short> left, int leftLength, Vector128<short> right, int rightLength, StringComparisonMode mode) => CompareMask(left, leftLength, right, rightLength, mode);
 
         /// <summary>
         /// __m128i _mm_cmpestrm (__m128i a, int la, __m128i b, int lb, const int imm8)
         ///   PCMPESTRM xmm, xmm/m128, imm8
         /// </summary>
-        public static Vector128<byte> CompareExplicitLengthBitMask(Vector128<ushort> left, byte leftLength, Vector128<ushort> right, byte rightLength, StringComparisonMode mode) => CompareExplicitLengthBitMask(left, leftLength, right, rightLength, mode);
-
-        /// <summary>
-        /// __m128i _mm_cmpestrm (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRM xmm, xmm/m128, imm8
-        /// </summary>
-        public static Vector128<byte> CompareExplicitLengthUnitMask(Vector128<sbyte> left, byte leftLength, Vector128<sbyte> right, byte rightLength, StringComparisonMode mode) => CompareExplicitLengthUnitMask(left, leftLength, right, rightLength, mode);
-
-        /// <summary>
-        /// __m128i _mm_cmpestrm (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRM xmm, xmm/m128, imm8
-        /// </summary>
-        public static Vector128<byte> CompareExplicitLengthUnitMask(Vector128<byte> left, byte leftLength, Vector128<byte> right, byte rightLength, StringComparisonMode mode) => CompareExplicitLengthUnitMask(left, leftLength, right, rightLength, mode);
-
-        /// <summary>
-        /// __m128i _mm_cmpestrm (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRM xmm, xmm/m128, imm8
-        /// </summary>
-        public static Vector128<ushort> CompareExplicitLengthUnitMask(Vector128<short> left, byte leftLength, Vector128<short> right, byte rightLength, StringComparisonMode mode) => CompareExplicitLengthUnitMask(left, leftLength, right, rightLength, mode);
-
-        /// <summary>
-        /// __m128i _mm_cmpestrm (__m128i a, int la, __m128i b, int lb, const int imm8)
-        ///   PCMPESTRM xmm, xmm/m128, imm8
-        /// </summary>
-        public static Vector128<ushort> CompareExplicitLengthUnitMask(Vector128<ushort> left, byte leftLength, Vector128<ushort> right, byte rightLength, StringComparisonMode mode) => CompareExplicitLengthUnitMask(left, leftLength, right, rightLength, mode);
+        public static Vector128<ushort> CompareMask(Vector128<ushort> left, int leftLength, Vector128<ushort> right, int rightLength, StringComparisonMode mode) => CompareMask(left, leftLength, right, rightLength, mode);
 
         /// <summary>
         /// __m128i _mm_cmpgt_epi64 (__m128i a, __m128i b)


### PR DESCRIPTION
This PR improves SSE4.2 string processing APIs
1. eliminate suffix `ImplicitLength`/`ExplicitLength` and handle it by overloads
2. redesign `StringComparisonMode` (still in discussing)
3. encode result flags into more understandable function names

| Result Flags| new intrinsic names |
| -----------------|--------------|
| CFlag  | CompareHasMatch |
| ZFlag | CompareRightTerminated |
| SFlag | CompareLeftTerminated |
| OFlag | CompareReturnFirstResultBit |
| NotCFlagAndNotZFlag | CompareNoMatchAndRightNotTerminated|

Related to https://github.com/dotnet/corefx/issues/30373