### PR TITLE
fix the desktop build break

### DIFF
--- a/src/jit/lsraarm64.cpp
+++ b/src/jit/lsraarm64.cpp
@@ -484,6 +484,7 @@ int LinearScan::BuildNode(GenTree* tree)
 #if FEATURE_ARG_SPLIT
         case GT_PUTARG_SPLIT:
             srcCount = BuildPutArgSplit(tree->AsPutArgSplit());
+            dstCount = tree->AsPutArgSplit()->gtNumRegs;
             break;
 #endif // FEATURE _SPLIT_ARG
 

--- a/src/jit/lsraarm64.cpp
+++ b/src/jit/lsraarm64.cpp
@@ -483,7 +483,7 @@ int LinearScan::BuildNode(GenTree* tree)
 
 #if FEATURE_ARG_SPLIT
         case GT_PUTARG_SPLIT:
-            BuildPutArgSplit(tree->AsPutArgSplit());
+            srcCount = BuildPutArgSplit(tree->AsPutArgSplit());
             break;
 #endif // FEATURE _SPLIT_ARG
 


### PR DESCRIPTION
Introduced by #18346.

`BuildPutArgSplit` returns `The number of sources consumed by this node.`, so looks like it should go into `srcCount`.

The warning was: `lsraarm64.cpp(811): warning C4701: potentially uninitialized local variable 'srcCount' used`.
After I merge PR #18318 I will try to sync the list of warnings enabled on desktop with CoreCLR to prevent such breaks.

PTAL @dotnet/jit-contrib 