### PR TITLE
fixes for  sos on FreeBSD

### DIFF
--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -16,8 +16,36 @@ if(NOT CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
   include_directories(${CMAKE_CURRENT_BINARY_DIR}/libunwind/include/tdep)
 
   add_subdirectory(libunwind)
-endif(NOT CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
+else()
+    if(PAL_CMAKE_PLATFORM_ARCH_ARM)
+      find_library(UNWIND_ARCH NAMES unwind-arm)
+    endif()
 
+    if(PAL_CMAKE_PLATFORM_ARCH_ARM64)
+      find_library(UNWIND_ARCH NAMES unwind-aarch64)
+    endif()
+
+    if(PAL_CMAKE_PLATFORM_ARCH_AMD64)
+      find_library(UNWIND_ARCH NAMES unwind-x86_64)
+    endif()
+
+    if(NOT UNWIND_ARCH STREQUAL UNWIND_ARCH-NOTFOUND)
+       set(UNWIND_LIBS ${UNWIND_ARCH})
+    endif()
+
+    find_library(UNWIND_GENERIC NAMES unwind-generic)
+
+    if(NOT UNWIND_GENERIC STREQUAL UNWIND_GENERIC-NOTFOUND)
+      set(UNWIND_LIBS ${UNWIND_LIBS} ${UNWIND_GENERIC})
+    endif()
+
+    find_library(UNWIND NAMES unwind)
+
+    if(UNWIND STREQUAL UNWIND-NOTFOUND)
+      message(FATAL_ERROR "Cannot find libunwind. Try installing libunwind8-dev or libunwind-devel.")
+    endif()
+
+    set(UNWIND_LIBS ${UNWIND_LIBS} ${UNWIND})endif(NOT CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
 include(configure.cmake)
 
 project(coreclrpal)
@@ -275,35 +303,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 
 if(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
-  if(CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
-    if(PAL_CMAKE_PLATFORM_ARCH_AMD64)
-      find_library(UNWIND_ARCH NAMES unwind-x86_64)
-    endif()
-
-    if(NOT UNWIND_ARCH STREQUAL UNWIND_ARCH-NOTFOUND)
-      target_link_libraries(coreclrpal ${UNWIND_ARCH})
-    endif()
-
-    find_library(UNWIND_GENERIC NAMES unwind-generic)
-
-    if(NOT UNWIND_GENERIC STREQUAL UNWIND_GENERIC-NOTFOUND)
-      target_link_libraries(coreclrpal ${UNWIND_GENERIC})
-    endif()
-
-    find_library(UNWIND NAMES unwind)
-
-    if(UNWIND STREQUAL UNWIND-NOTFOUND)
-      message(FATAL_ERROR "Cannot find libunwind. Try installing libunwind8-dev or libunwind-devel.")
-    endif()
-
-    target_link_libraries(coreclrpal ${UNWIND})
-  endif(CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
-
   find_library(INTL intl)
   target_link_libraries(coreclrpal
     pthread
     rt
-    ${UNWIND}
+    ${UNWIND_LIBS}
     ${INTL}
   )
 endif(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
@@ -363,36 +367,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   endif(NOT INTL STREQUAL INTL-NOTFOUND)
 
   if(CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
-    if(PAL_CMAKE_PLATFORM_ARCH_ARM)
-      find_library(UNWIND_ARCH NAMES unwind-arm)
-    endif()
-
-    if(PAL_CMAKE_PLATFORM_ARCH_ARM64)
-      find_library(UNWIND_ARCH NAMES unwind-aarch64)
-    endif()
-
-    if(PAL_CMAKE_PLATFORM_ARCH_AMD64)
-      find_library(UNWIND_ARCH NAMES unwind-x86_64)
-    endif()
-
-    if(NOT UNWIND_ARCH STREQUAL UNWIND_ARCH-NOTFOUND)
-      target_link_libraries(coreclrpal ${UNWIND_ARCH})
-    endif()
-
-    find_library(UNWIND_GENERIC NAMES unwind-generic)
-
-    if(NOT UNWIND_GENERIC STREQUAL UNWIND_GENERIC-NOTFOUND)
-      target_link_libraries(coreclrpal ${UNWIND_GENERIC})
-    endif()
-
-    find_library(UNWIND NAMES unwind)
-
-    if(UNWIND STREQUAL UNWIND-NOTFOUND)
-      message(FATAL_ERROR "Cannot find libunwind. Try installing libunwind8-dev or libunwind-devel.")
-    endif()
-
-    target_link_libraries(coreclrpal ${UNWIND})
-
+    target_link_libraries(coreclrpal ${UNWIND_LIBS})
   endif(CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
 
 endif(CMAKE_SYSTEM_NAME STREQUAL Linux)

--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -276,8 +276,29 @@ endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 
 if(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
   if(CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
-    find_library(UNWIND unwind)
-  endif()
+    if(PAL_CMAKE_PLATFORM_ARCH_AMD64)
+      find_library(UNWIND_ARCH NAMES unwind-x86_64)
+    endif()
+
+    if(NOT UNWIND_ARCH STREQUAL UNWIND_ARCH-NOTFOUND)
+      target_link_libraries(coreclrpal ${UNWIND_ARCH})
+    endif()
+
+    find_library(UNWIND_GENERIC NAMES unwind-generic)
+
+    if(NOT UNWIND_GENERIC STREQUAL UNWIND_GENERIC-NOTFOUND)
+      target_link_libraries(coreclrpal ${UNWIND_GENERIC})
+    endif()
+
+    find_library(UNWIND NAMES unwind)
+
+    if(UNWIND STREQUAL UNWIND-NOTFOUND)
+      message(FATAL_ERROR "Cannot find libunwind. Try installing libunwind8-dev or libunwind-devel.")
+    endif()
+
+    target_link_libraries(coreclrpal ${UNWIND})
+  endif(CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
+
   find_library(INTL intl)
   target_link_libraries(coreclrpal
     pthread

--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -45,7 +45,8 @@ else()
       message(FATAL_ERROR "Cannot find libunwind. Try installing libunwind8-dev or libunwind-devel.")
     endif()
 
-    set(UNWIND_LIBS ${UNWIND_LIBS} ${UNWIND})endif(NOT CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
+    set(UNWIND_LIBS ${UNWIND_LIBS} ${UNWIND})
+endif(NOT CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
 include(configure.cmake)
 
 project(coreclrpal)

--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -16,7 +16,7 @@ if(NOT CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
   include_directories(${CMAKE_CURRENT_BINARY_DIR}/libunwind/include/tdep)
 
   add_subdirectory(libunwind)
-else()
+elseif(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
     if(PAL_CMAKE_PLATFORM_ARCH_ARM)
       find_library(UNWIND_ARCH NAMES unwind-arm)
     endif()

--- a/src/pal/src/include/pal/thread.hpp
+++ b/src/pal/src/include/pal/thread.hpp
@@ -810,6 +810,13 @@ inline SIZE_T THREADSilentGetCurrentThreadId() {
     pthread_threadid_np(pthread_self(), &tid);
     return (SIZE_T)tid;
 }
+#elif defined(__FreeBSD__)
+#include <sys/thr.h>
+inline SIZE_T THREADSilentGetCurrentThreadId() {
+    long tid;
+    thr_self(&tid);
+    return (SIZE_T)tid;
+}
 #elif defined(__NetBSD__)
 #include <lwp.h>
 #define THREADSilentGetCurrentThreadId() (SIZE_T)_lwp_self()


### PR DESCRIPTION
add missing arch specific of libunwind so sos plugin can load.
Fix code for OS thread id so it does match with what lldb see. 

With this clrstack works on FreeBSD

```
(lldb) clrstack
GetTaskByOSThreadID:3452: 101422 th=000000080788E8C0
PrintThread:12070: hr=0 osID=101422  pStackWalk=0x83c27a000
OS Thread Id: 0x18c2e (16)
        Child SP               IP Call Site
00007FFFDF1AF8A8 00000008012a098a [Frame: 00007fffdf1af8a8] Interop+Sys.WaitForSocketEvents(IntPtr, SocketEvent*, Int32*)
00007FFFDF1AF8A8 0000000804d2ecc8 [InlinedCallFrame: 00007fffdf1af8a8] Interop+Sys.WaitForSocketEvents(IntPtr, SocketEvent*, Int32*)
00007FFFDF1AF8A0 0000000804D2ECC8 DomainBoundILStubClass.IL_STUB_PInvoke(IntPtr, SocketEvent*, Int32*)
00007FFFDF1AF920 0000000804D2EAE1 System.Net.Sockets.SocketAsyncEngine.EventLoop()
00007FFFDF1AF960 0000000804D2E469 System.Threading.Tasks.Task.ExecuteWithThreadLocal(System.Threading.Tasks.Task ByRef)
00007FFFDF1AFCE0 000000080248897f [GCFrame: 00007fffdf1afce0]
00007FFFDF1AFDB0 000000080248897f [DebuggerU2MCatchHandlerFrame: 00007fffdf1afdb0]
```
