### PR TITLE
temporarily disable pthread based named mutexes on FreeBSD

### DIFF
--- a/src/pal/src/include/pal/mutex.hpp
+++ b/src/pal/src/include/pal/mutex.hpp
@@ -71,7 +71,7 @@ DWORD SPINLOCKTryAcquire (LONG * lock);
 
 // Temporarily disabling usage of pthread process-shared mutexes on ARM/ARM64 due to functional issues that cannot easily be
 // detected with code due to hangs. See https://github.com/dotnet/coreclr/issues/5456.
-#if HAVE_FULLY_FEATURED_PTHREAD_MUTEXES && HAVE_FUNCTIONAL_PTHREAD_ROBUST_MUTEXES && !(defined(_ARM_) || defined(_ARM64_))
+#if HAVE_FULLY_FEATURED_PTHREAD_MUTEXES && HAVE_FUNCTIONAL_PTHREAD_ROBUST_MUTEXES && !(defined(_ARM_) || defined(_ARM64_) || defined(__FreeBSD__))
     #define NAMED_MUTEX_USE_PTHREAD_MUTEX 1
 #else
     #define NAMED_MUTEX_USE_PTHREAD_MUTEX 0


### PR DESCRIPTION
This should be further investigated.
With this change, all PAL tests do pass now on FreeBSD.

related to #18067


