### PR TITLE
Re-Enable StructABI test for xplat

### DIFF
--- a/tests/src/JIT/Directed/StructABI/StructABI.c
+++ b/tests/src/JIT/Directed/StructABI/StructABI.c
@@ -85,6 +85,14 @@ struct PointerFloatAndByte
 	uint8_t Byte;
 };
 
+struct ShortIntFloatIntPtr
+{
+	__int16 Short;
+	__int32 Int;
+	float Float;
+	__int32* Pointer;
+};
+
 struct TwoLongs
 {
     uint64_t Long1;
@@ -259,6 +267,11 @@ DLLEXPORT struct ByteFloatAndPointer EchoByteFloatAndPointer(struct ByteFloatAnd
 }
 
 DLLEXPORT struct PointerFloatAndByte EchoPointerFloatAndByte(struct PointerFloatAndByte value)
+{
+	return value;
+}
+
+DLLEXPORT struct ShortIntFloatIntPtr EchoShortIntFloatIntPtr(struct ShortIntFloatIntPtr value)
 {
 	return value;
 }

--- a/tests/src/JIT/Directed/StructABI/StructABI.cs
+++ b/tests/src/JIT/Directed/StructABI/StructABI.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 
 struct SingleByte
 {
@@ -16,7 +17,7 @@ struct SingleByte
 
 	public bool Equals(SingleByte other)
 	{
-		return Byte == other.Byte;
+		return Byte == 42 && Byte == other.Byte;
 	}
 }
 
@@ -31,7 +32,7 @@ struct SingleLong
 
 	public bool Equals(SingleLong other)
 	{
-		return Long == other.Long;
+		return Long == other.Long && Long == 0xfeedfaceabadf00d;
 	}
 }
 
@@ -61,7 +62,7 @@ struct SingleDouble
 
 	public bool Equals(SingleDouble other)
 	{
-		return Double == other.Double;
+		return Double == other.Double && Double == 3.14159d;
 	}
 }
 
@@ -77,7 +78,8 @@ struct ByteAndFloat
 
 	public bool Equals(ByteAndFloat other)
 	{
-		return Byte == other.Byte && Float == other.Float;
+		return Byte == other.Byte && Float == other.Float &&
+				Byte == 42 && Float == 3.14159f;
 	}
 }
 
@@ -93,7 +95,8 @@ struct FloatAndByte
 
 	public bool Equals(FloatAndByte other)
 	{
-		return Byte == other.Byte && Float == other.Float;
+		return Byte == other.Byte && Float == other.Float &&
+				Byte == 42 && Float == 3.14159f;
 	}
 }
 
@@ -109,7 +112,8 @@ struct LongAndFloat
 
 	public bool Equals(LongAndFloat other)
 	{
-		return Long == other.Long && Float == other.Float;
+		return Long == other.Long && Float == other.Float &&
+				Long == 0xfeedfaceabadf00d && Float == 3.14159f;
 	}
 }
 
@@ -195,6 +199,7 @@ unsafe struct ByteFloatAndPointer
 	{
 		return Pointer == other.Pointer && Float == other.Float && Byte == other.Byte;
 	}
+
 }
 
 unsafe struct PointerFloatAndByte
@@ -212,6 +217,25 @@ unsafe struct PointerFloatAndByte
 	public bool Equals(PointerFloatAndByte other)
 	{
 		return Pointer == other.Pointer && Float == other.Float && Byte == other.Byte;
+	}
+}
+
+struct ShortIntFloatIntPtr
+{
+	public short Short;
+	public int Int;
+	public float Float;
+	public IntPtr Pointer;
+
+	public static ShortIntFloatIntPtr Get()
+	{
+		IntPtr unused = new IntPtr(42);
+		return new ShortIntFloatIntPtr { Short = 10, Int = 11, Float = 3.14f, Pointer = unused };
+	}
+
+	public bool Equals(ShortIntFloatIntPtr other)
+	{
+		return Short == other.Short && Int == other.Int && Float == other.Float && Pointer == other.Pointer;
 	}
 }
 
@@ -507,7 +531,7 @@ struct Nested1
 
 	public bool Equals(Nested1 other)
 	{
-		return Field1.Equals(other.Field1) && Field2.Equals(other.Field2);
+		return Field1.Equals(other.Field1) && Field2.Long == other.Field2.Long && Field2.Float == other.Field2.Float;
 	}
 }
 
@@ -527,7 +551,7 @@ struct Nested2
 
 	public bool Equals(Nested2 other)
 	{
-		return Field1.Equals(other.Field1) && Field2.Equals(other.Field2);
+		return Field1.Equals(other.Field1) && Field2.Byte == other.Field2.Byte && Field2.Float == other.Field2.Float;
 	}
 }
 
@@ -646,470 +670,1537 @@ struct Nested9
 
 public static partial class StructABI
 {
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern SingleByte EchoSingleByte(SingleByte value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern SingleLong EchoSingleLong(SingleLong value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern SingleFloat EchoSingleFloat(SingleFloat value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern SingleDouble EchoSingleDouble(SingleDouble value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern ByteAndFloat EchoByteAndFloat(ByteAndFloat value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern LongAndFloat EchoLongAndFloat(LongAndFloat value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern ByteAndDouble EchoByteAndDouble(ByteAndDouble value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern DoubleAndByte EchoDoubleAndByte(DoubleAndByte value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern PointerAndByte EchoPointerAndByte(PointerAndByte value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern ByteAndPointer EchoByteAndPointer(ByteAndPointer value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern ByteFloatAndPointer EchoByteFloatAndPointer(ByteFloatAndPointer value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern PointerFloatAndByte EchoPointerFloatAndByte(PointerFloatAndByte value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
+	static extern ShortIntFloatIntPtr EchoShortIntFloatIntPtr(ShortIntFloatIntPtr value);
+
+	[DllImport("StructABILib")]
 	static extern TwoLongs EchoTwoLongs(TwoLongs value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern TwoFloats EchoTwoFloats(TwoFloats value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern TwoDoubles EchoTwoDoubles(TwoDoubles value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern FourLongs EchoFourLongs(FourLongs value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern FourDoubles EchoFourDoubles(FourDoubles value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern InlineArray1 EchoInlineArray1(InlineArray1 value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern InlineArray2 EchoInlineArray2(InlineArray2 value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern InlineArray3 EchoInlineArray3(InlineArray3 value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern InlineArray4 EchoInlineArray4(InlineArray4 value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern InlineArray5 EchoInlineArray5(InlineArray5 value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern InlineArray6 EchoInlineArray6(InlineArray6 value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern Nested1 EchoNested1(Nested1 value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern Nested2 EchoNested2(Nested2 value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern Nested3 EchoNested3(Nested3 value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern Nested4 EchoNested4(Nested4 value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern Nested5 EchoNested5(Nested5 value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern Nested6 EchoNested6(Nested6 value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern Nested7 EchoNested7(Nested7 value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern Nested8 EchoNested8(Nested8 value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern Nested9 EchoNested9(Nested9 value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern TwoLongs NotEnoughRegistersSysV1(ulong a, ulong b, ulong c, ulong d, ulong e, ulong f, TwoLongs value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern TwoLongs NotEnoughRegistersSysV2(ulong a, ulong b, ulong c, ulong d, ulong e, TwoLongs value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern DoubleAndByte NotEnoughRegistersSysV3(ulong a, ulong b, ulong c, ulong d, ulong e, ulong f, DoubleAndByte value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern TwoDoubles NotEnoughRegistersSysV4(double a, double b, double c, double d, double e, double f, double g, double h, TwoDoubles value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern TwoDoubles NotEnoughRegistersSysV5(double a, double b, double c, double d, double e, double f, double g, TwoDoubles value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern DoubleAndByte NotEnoughRegistersSysV6(double a, double b, double c, double d, double e, double f, double g, double h, DoubleAndByte value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern TwoDoubles EnoughRegistersSysV1(ulong a, ulong b, ulong c, ulong d, ulong e, ulong f, TwoDoubles value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern DoubleAndByte EnoughRegistersSysV2(ulong a, ulong b, ulong c, ulong d, ulong e, DoubleAndByte value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern TwoLongs EnoughRegistersSysV3(double a, double b, double c, double d, double e, double f, double g, double h, TwoLongs value);
 
-	[DllImport(StructABILib)]
+	[DllImport("StructABILib")]
 	static extern DoubleAndByte EnoughRegistersSysV4(double a, double b, double c, double d, double e, double f, double g, DoubleAndByte value);
+
+	////////////////////////////////////////////////////////////////////////////
+	// Managed echo tests.
+	////////////////////////////////////////////////////////////////////////////
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static SingleByte EchoSingleByteManaged(SingleByte value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static SingleLong EchoSingleLongManaged(SingleLong value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static SingleFloat EchoSingleFloatManaged(SingleFloat value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static SingleDouble EchoSingleDoubleManaged(SingleDouble value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static ByteAndFloat EchoByteAndFloatManaged(ByteAndFloat value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static LongAndFloat EchoLongAndFloatManaged(LongAndFloat value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static ByteAndDouble EchoByteAndDoubleManaged(ByteAndDouble value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static DoubleAndByte EchoDoubleAndByteManaged(DoubleAndByte value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static PointerAndByte EchoPointerAndByteManaged(PointerAndByte value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static ByteAndPointer EchoByteAndPointerManaged(ByteAndPointer value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static ByteFloatAndPointer EchoByteFloatAndPointerManaged(ByteFloatAndPointer value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static PointerFloatAndByte EchoPointerFloatAndByteManaged(PointerFloatAndByte value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static ShortIntFloatIntPtr EchoShortIntFloatIntPtrManaged(ShortIntFloatIntPtr value)
+	{
+
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static TwoLongs EchoTwoLongsManaged(TwoLongs value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static TwoFloats EchoTwoFloatsManaged(TwoFloats value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static TwoDoubles EchoTwoDoublesManaged(TwoDoubles value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static FourLongs EchoFourLongsManaged(FourLongs value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static FourDoubles EchoFourDoublesManaged(FourDoubles value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static InlineArray1 EchoInlineArray1Managed(InlineArray1 value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static InlineArray2 EchoInlineArray2Managed(InlineArray2 value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static InlineArray3 EchoInlineArray3Managed(InlineArray3 value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static InlineArray4 EchoInlineArray4Managed(InlineArray4 value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static InlineArray5 EchoInlineArray5Managed(InlineArray5 value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static InlineArray6 EchoInlineArray6Managed(InlineArray6 value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static Nested1 EchoNested1Managed(Nested1 value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static Nested2 EchoNested2Managed(Nested2 value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static Nested3 EchoNested3Managed(Nested3 value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static Nested4 EchoNested4Managed(Nested4 value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static Nested5 EchoNested5Managed(Nested5 value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static Nested6 EchoNested6Managed(Nested6 value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static Nested7 EchoNested7Managed(Nested7 value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static Nested8 EchoNested8Managed(Nested8 value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static Nested9 EchoNested9Managed(Nested9 value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static TwoLongs NotEnoughRegistersSysV1Managed(ulong a, ulong b, ulong c, ulong d, ulong e, ulong f, TwoLongs value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static TwoLongs NotEnoughRegistersSysV2Managed(ulong a, ulong b, ulong c, ulong d, ulong e, TwoLongs value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static DoubleAndByte NotEnoughRegistersSysV3Managed(ulong a, ulong b, ulong c, ulong d, ulong e, ulong f, DoubleAndByte value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static TwoDoubles NotEnoughRegistersSysV4Managed(double a, double b, double c, double d, double e, double f, double g, double h, TwoDoubles value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static TwoDoubles NotEnoughRegistersSysV5Managed(double a, double b, double c, double d, double e, double f, double g, TwoDoubles value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static DoubleAndByte NotEnoughRegistersSysV6Managed(double a, double b, double c, double d, double e, double f, double g, double h, DoubleAndByte value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static TwoDoubles EnoughRegistersSysV1Managed(ulong a, ulong b, ulong c, ulong d, ulong e, ulong f, TwoDoubles value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static DoubleAndByte EnoughRegistersSysV2Managed(ulong a, ulong b, ulong c, ulong d, ulong e, DoubleAndByte value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static TwoLongs EnoughRegistersSysV3Managed(double a, double b, double c, double d, double e, double f, double g, double h, TwoLongs value)
+	{
+		return value;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static DoubleAndByte EnoughRegistersSysV4Managed(double a, double b, double c, double d, double e, double f, double g, DoubleAndByte value)
+	{
+		return value;
+	}
+
+	////////////////////////////////////////////////////////////////////////////
+	// Wrapper methods
+	//
+	// This will allow us to call both the PInvoke native function and
+	// managed method.
+	////////////////////////////////////////////////////////////////////////////
+
+	static bool EchoSingleByteWrapper()
+	{
+		bool ok = true;
+		SingleByte expectedSingleByte = SingleByte.Get();
+		SingleByte nativeSingleByte = EchoSingleByte(expectedSingleByte);
+		SingleByte managedSingleByte = EchoSingleByteManaged(expectedSingleByte);
+		
+		if (!expectedSingleByte.Equals(nativeSingleByte))
+		{
+			Console.WriteLine("Native call for EchoSingleByte failed");
+			ok = false;
+		}
+
+		if (!expectedSingleByte.Equals(managedSingleByte))
+		{
+			Console.WriteLine("Managed call for EchoSingleByte failed");
+			ok = false;
+		}
+
+		SingleByte expectedSingleByte2 = new SingleByte();
+		expectedSingleByte2.Byte = 42;
+
+		nativeSingleByte = EchoSingleByte(expectedSingleByte2);
+		managedSingleByte = EchoSingleByteManaged(expectedSingleByte2);
+		
+		if (!expectedSingleByte2.Equals(nativeSingleByte))
+		{
+			Console.WriteLine("Native call for EchoSingleByte failed");
+			ok = false;
+		}
+
+		if (!expectedSingleByte2.Equals(managedSingleByte))
+		{
+			Console.WriteLine("Managed call for EchoSingleByte failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoSingleLongWrapper()
+	{
+		bool ok = true;
+		SingleLong expectedSingleLong = SingleLong.Get();
+		SingleLong nativeSingleLong = EchoSingleLong(expectedSingleLong);
+		SingleLong managedSingleLong = EchoSingleLongManaged(expectedSingleLong);
+		
+		if (!expectedSingleLong.Equals(nativeSingleLong))
+		{
+			Console.WriteLine("Native call for EchoSingleLong failed");
+			ok = false;
+		}
+
+		if (!expectedSingleLong.Equals(managedSingleLong))
+		{
+			Console.WriteLine("Managed call for EchoSingleLong failed");
+			ok = false;
+		}
+
+		SingleLong expectedSingleLong2 = new SingleLong();
+		expectedSingleLong2.Long = 0xfeedfaceabadf00d;
+
+		nativeSingleLong = EchoSingleLong(expectedSingleLong2);
+		managedSingleLong = EchoSingleLongManaged(expectedSingleLong2);
+		
+		if (!expectedSingleLong2.Equals(nativeSingleLong))
+		{
+			Console.WriteLine("Native call for EchoSingleByte failed");
+			ok = false;
+		}
+
+		if (!expectedSingleLong2.Equals(managedSingleLong))
+		{
+			Console.WriteLine("Managed call for EchoSingleByte failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoSingleFloatWrapper()
+	{
+		bool ok = true;
+		SingleFloat expectedSingleFloat = SingleFloat.Get();
+		SingleFloat nativeSingleFloat = EchoSingleFloat(expectedSingleFloat);
+		SingleFloat managedSingleFloat = EchoSingleFloatManaged(expectedSingleFloat);
+		
+		if (!expectedSingleFloat.Equals(nativeSingleFloat))
+		{
+			Console.WriteLine("Native call for EchoSingleFloat failed");
+			ok = false;
+		}
+
+		if (!expectedSingleFloat.Equals(managedSingleFloat))
+		{
+			Console.WriteLine("Managed call for EchoSingleFloat failed");
+			ok = false;
+		}
+
+		SingleFloat expectedSingleFloat2 = new SingleFloat();
+		expectedSingleFloat2.Float = 3.14159f;
+
+		nativeSingleFloat = EchoSingleFloat(expectedSingleFloat2);
+		managedSingleFloat = EchoSingleFloatManaged(expectedSingleFloat2);
+		
+		if (!expectedSingleFloat2.Equals(nativeSingleFloat))
+		{
+			Console.WriteLine("Native call for EchoSingleFloat failed");
+			ok = false;
+		}
+
+		if (!expectedSingleFloat2.Equals(managedSingleFloat))
+		{
+			Console.WriteLine("Managed call for EchoSingleFloat failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoSingleDoubleWrapper()
+	{
+		bool ok = true;
+		SingleDouble expectedSingleDouble = SingleDouble.Get();
+		SingleDouble nativeSingleDouble = EchoSingleDouble(expectedSingleDouble);
+		SingleDouble managedSingleDouble = EchoSingleDoubleManaged(expectedSingleDouble);
+		
+		if (!expectedSingleDouble.Equals(nativeSingleDouble))
+		{
+			Console.WriteLine("Native call for EchoSingleDouble failed");
+			ok = false;
+		}
+
+		if (!expectedSingleDouble.Equals(managedSingleDouble))
+		{
+			Console.WriteLine("Managed call for EchoSingleDouble failed");
+			ok = false;
+		}
+
+		SingleDouble expectedSingleDouble2 = new SingleDouble();
+		expectedSingleDouble2.Double = 3.14159d;
+
+		nativeSingleDouble = EchoSingleDouble(expectedSingleDouble2);
+		managedSingleDouble = EchoSingleDoubleManaged(expectedSingleDouble2);
+		
+		if (!expectedSingleDouble2.Equals(nativeSingleDouble))
+		{
+			Console.WriteLine("Native call for EchoSingleDouble failed");
+			ok = false;
+		}
+
+		if (!expectedSingleDouble2.Equals(managedSingleDouble))
+		{
+			Console.WriteLine("Managed call for EchoSingleDouble failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoByteAndFloatWrapper()
+	{
+		bool ok = true;
+		ByteAndFloat expectedByteAndFloat = ByteAndFloat.Get();
+		ByteAndFloat nativeByteAndFloat = EchoByteAndFloat(expectedByteAndFloat);
+		ByteAndFloat managedByteAndFloat = EchoByteAndFloatManaged(expectedByteAndFloat);
+		
+		if (!expectedByteAndFloat.Equals(nativeByteAndFloat))
+		{
+			Console.WriteLine("Native call for EchoByteAndFloat failed");
+			ok = false;
+		}
+
+		if (!expectedByteAndFloat.Equals(managedByteAndFloat))
+		{
+			Console.WriteLine("Managed call for EchoByteAndFloat failed");
+			ok = false;
+		}
+
+		ByteAndFloat expectedByteAndFloat2 = new ByteAndFloat();
+		expectedByteAndFloat2.Byte = 42;
+		expectedByteAndFloat2.Float = 3.14159f;
+
+		nativeByteAndFloat = EchoByteAndFloat(expectedByteAndFloat2);
+		managedByteAndFloat = EchoByteAndFloatManaged(expectedByteAndFloat2);
+		
+		if (!expectedByteAndFloat2.Equals(nativeByteAndFloat))
+		{
+			Console.WriteLine("Native call for EchoByteAndFloat failed");
+			ok = false;
+		}
+
+		if (!expectedByteAndFloat2.Equals(managedByteAndFloat))
+		{
+			Console.WriteLine("Managed call for EchoByteAndFloat failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoLongAndFloatWrapper()
+	{
+		bool ok = true;
+		LongAndFloat expectedLongAndFloat = LongAndFloat.Get();
+		LongAndFloat nativeLongAndFloat = EchoLongAndFloat(expectedLongAndFloat);
+		LongAndFloat managedLongAndFloat = EchoLongAndFloatManaged(expectedLongAndFloat);
+		
+		if (!expectedLongAndFloat.Equals(nativeLongAndFloat))
+		{
+			Console.WriteLine("Native call for EchoLongAndFloat failed");
+			ok = false;
+		}
+
+		if (!expectedLongAndFloat.Equals(managedLongAndFloat))
+		{
+			Console.WriteLine("Managed call for EchoLongAndFloat failed");
+			ok = false;
+		}
+
+		LongAndFloat expectedLongAndFloat2 = new LongAndFloat();
+		expectedLongAndFloat2.Long = 0xfeedfaceabadf00d;
+		expectedLongAndFloat2.Float = 3.14159f;
+
+		nativeLongAndFloat = EchoLongAndFloat(expectedLongAndFloat2);
+		managedLongAndFloat = EchoLongAndFloatManaged(expectedLongAndFloat2);
+		
+		if (!expectedLongAndFloat2.Equals(nativeLongAndFloat))
+		{
+			Console.WriteLine("Native call for EchoLongAndFloat failed");
+			ok = false;
+		}
+
+		if (!expectedLongAndFloat2.Equals(managedLongAndFloat))
+		{
+			Console.WriteLine("Managed call for EchoLongAndFloat failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoByteAndDoubleWrapper()
+	{
+		bool ok = true;
+		ByteAndDouble expectedByteAndDouble = ByteAndDouble.Get();
+		ByteAndDouble nativeByteAndDouble = EchoByteAndDouble(expectedByteAndDouble);
+		ByteAndDouble managedByteAndDouble = EchoByteAndDoubleManaged(expectedByteAndDouble);
+		
+		if (!expectedByteAndDouble.Equals(nativeByteAndDouble))
+		{
+			Console.WriteLine("Native call for EchoByteAndDouble failed");
+			ok = false;
+		}
+
+		if (!expectedByteAndDouble.Equals(managedByteAndDouble))
+		{
+			Console.WriteLine("Managed call for EchoByteAndDouble failed");
+			ok = false;
+		}
+
+		ByteAndDouble expectedByteAndDouble2 = new ByteAndDouble();
+		expectedByteAndDouble2.Byte = 42;
+		expectedByteAndDouble2.Double = 3.14159d;
+
+		nativeByteAndDouble = EchoByteAndDouble(expectedByteAndDouble2);
+		managedByteAndDouble = EchoByteAndDoubleManaged(expectedByteAndDouble2);
+		
+		if (!expectedByteAndDouble2.Equals(nativeByteAndDouble))
+		{
+			Console.WriteLine("Native call for EchoByteAndDouble failed");
+			ok = false;
+		}
+
+		if (!expectedByteAndDouble2.Equals(managedByteAndDouble))
+		{
+			Console.WriteLine("Managed call for EchoByteAndDouble failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoDoubleAndByteWrapper()
+	{
+		bool ok = true;
+		DoubleAndByte expectedDoubleAndByte = DoubleAndByte.Get();
+		DoubleAndByte nativeDoubleAndByte = EchoDoubleAndByte(expectedDoubleAndByte);
+		DoubleAndByte managedDoubleAndByte = EchoDoubleAndByteManaged(expectedDoubleAndByte);
+		
+		if (!expectedDoubleAndByte.Equals(nativeDoubleAndByte))
+		{
+			Console.WriteLine("Native call for EchoDoubleAndByte failed");
+			ok = false;
+		}
+
+		if (!expectedDoubleAndByte.Equals(managedDoubleAndByte))
+		{
+			Console.WriteLine("Managed call for EchoDoubleAndByte failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoPointerAndByteWrapper()
+	{
+		bool ok = true;
+		PointerAndByte expectedPointerAndByte = PointerAndByte.Get();
+		PointerAndByte nativePointerAndByte = EchoPointerAndByte(expectedPointerAndByte);
+		PointerAndByte managedPointerAndByte = EchoPointerAndByteManaged(expectedPointerAndByte);
+		
+		if (!expectedPointerAndByte.Equals(nativePointerAndByte))
+		{
+			Console.WriteLine("Native call for EchoPointerAndByte failed");
+			ok = false;
+		}
+
+		if (!expectedPointerAndByte.Equals(managedPointerAndByte))
+		{
+			Console.WriteLine("Managed call for EchoPointerAndByte failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoByteAndPointerWrapper()
+	{
+		bool ok = true;
+		ByteAndPointer expectedByteAndPointer = ByteAndPointer.Get();
+		ByteAndPointer nativeByteAndPointer = EchoByteAndPointer(expectedByteAndPointer);
+		ByteAndPointer managedByteAndPointer = EchoByteAndPointerManaged(expectedByteAndPointer);
+		
+		if (!expectedByteAndPointer.Equals(nativeByteAndPointer))
+		{
+			Console.WriteLine("Native call for EchoByteAndPointer failed");
+			ok = false;
+		}
+
+		if (!expectedByteAndPointer.Equals(managedByteAndPointer))
+		{
+			Console.WriteLine("Managed call for EchoByteAndPointer failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoByteFloatAndPointerWrapper()
+	{
+		bool ok = true;
+		ByteFloatAndPointer expectedByteFloatAndPointer = ByteFloatAndPointer.Get();
+		ByteFloatAndPointer nativeByteFloatAndPointer = EchoByteFloatAndPointer(expectedByteFloatAndPointer);
+		ByteFloatAndPointer managedByteFloatAndPointer = EchoByteFloatAndPointerManaged(expectedByteFloatAndPointer);
+		
+		if (!expectedByteFloatAndPointer.Equals(nativeByteFloatAndPointer))
+		{
+			Console.WriteLine("Native call for EchoByteFloatAndPointer failed");
+			ok = false;
+		}
+
+		if (!expectedByteFloatAndPointer.Equals(managedByteFloatAndPointer))
+		{
+			Console.WriteLine("Managed call for EchoByteFloatAndPointer failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoPointerFloatAndByteWrapper()
+	{
+		bool ok = true;
+		PointerFloatAndByte expectedPointerFloatAndByte = PointerFloatAndByte.Get();
+		PointerFloatAndByte nativePointerFloatAndByte = EchoPointerFloatAndByte(expectedPointerFloatAndByte);
+		PointerFloatAndByte managedPointerFloatAndByte = EchoPointerFloatAndByteManaged(expectedPointerFloatAndByte);
+		
+		if (!expectedPointerFloatAndByte.Equals(nativePointerFloatAndByte))
+		{
+			Console.WriteLine("Native call for EchoPointerFloatAndByte failed");
+			ok = false;
+		}
+
+		if (!expectedPointerFloatAndByte.Equals(managedPointerFloatAndByte))
+		{
+			Console.WriteLine("Managed call for EchoPointerFloatAndByte failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoShortIntFloatIntPtrWrapper()
+	{
+		bool ok = true;
+		ShortIntFloatIntPtr expectedShortIntFloatIntPtr = ShortIntFloatIntPtr.Get();
+		ShortIntFloatIntPtr nativeShortIntFloatIntPtr = EchoShortIntFloatIntPtr(expectedShortIntFloatIntPtr);
+		ShortIntFloatIntPtr managedShortIntFloatIntPtr = EchoShortIntFloatIntPtrManaged(expectedShortIntFloatIntPtr);
+		
+		if (!expectedShortIntFloatIntPtr.Equals(nativeShortIntFloatIntPtr))
+		{
+			Console.WriteLine("Native call for EchoShortIntFloatIntPtr failed");
+			ok = false;
+		}
+
+		if (!expectedShortIntFloatIntPtr.Equals(managedShortIntFloatIntPtr))
+		{
+			Console.WriteLine("Managed call for EchoShortIntFloatIntPtr failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoTwoLongsWrapper()
+	{
+		bool ok = true;
+		TwoLongs expectedTwoLongs = TwoLongs.Get();
+		TwoLongs nativeTwoLongs = EchoTwoLongs(expectedTwoLongs);
+		TwoLongs managedTwoLongs = EchoTwoLongsManaged(expectedTwoLongs);
+		
+		if (!expectedTwoLongs.Equals(nativeTwoLongs))
+		{
+			Console.WriteLine("Native call for EchoTwoLongs failed");
+			ok = false;
+		}
+
+		if (!expectedTwoLongs.Equals(managedTwoLongs))
+		{
+			Console.WriteLine("Managed call for EchoTwoLongs failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoTwoFloatsWrapper()
+	{
+		bool ok = true;
+		TwoFloats expectedTwoFloats = TwoFloats.Get();
+		TwoFloats nativeTwoFloats = EchoTwoFloats(expectedTwoFloats);
+		TwoFloats managedTwoFloats = EchoTwoFloatsManaged(expectedTwoFloats);
+		
+		if (!expectedTwoFloats.Equals(nativeTwoFloats))
+		{
+			Console.WriteLine("Native call for EchoTwoFloats failed");
+			ok = false;
+		}
+
+		if (!expectedTwoFloats.Equals(managedTwoFloats))
+		{
+			Console.WriteLine("Managed call for EchoTwoFloats failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoTwoDoublesWrapper()
+	{
+		bool ok = true;
+		TwoDoubles expectedTwoDoubles = TwoDoubles.Get();
+		TwoDoubles nativeTwoDoubles = EchoTwoDoubles(expectedTwoDoubles);
+		TwoDoubles managedTwoDoubles = EchoTwoDoublesManaged(expectedTwoDoubles);
+		
+		if (!expectedTwoDoubles.Equals(nativeTwoDoubles))
+		{
+			Console.WriteLine("Native call for EchoTwoDoubles failed");
+			ok = false;
+		}
+
+		if (!expectedTwoDoubles.Equals(managedTwoDoubles))
+		{
+			Console.WriteLine("Managed call for EchoTwoDoubles failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoFourLongsWrapper()
+	{
+		bool ok = true;
+		FourLongs expectedFourLongs = FourLongs.Get();
+		FourLongs nativeFourLongs = EchoFourLongs(expectedFourLongs);
+		FourLongs managedFourLongs = EchoFourLongsManaged(expectedFourLongs);
+		
+		if (!expectedFourLongs.Equals(nativeFourLongs))
+		{
+			Console.WriteLine("Native call for EchoFourLongs failed");
+			ok = false;
+		}
+
+		if (!expectedFourLongs.Equals(managedFourLongs))
+		{
+			Console.WriteLine("Managed call for EchoFourLongs failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoFourDoublesWrapper()
+	{
+		bool ok = true;
+		FourDoubles expectedFourDoubles = FourDoubles.Get();
+		FourDoubles nativeFourDoubles = EchoFourDoubles(expectedFourDoubles);
+		FourDoubles managedFourDoubles = EchoFourDoublesManaged(expectedFourDoubles);
+		
+		if (!expectedFourDoubles.Equals(nativeFourDoubles))
+		{
+			Console.WriteLine("Native call for EchoFourDoubles failed");
+			ok = false;
+		}
+
+		if (!expectedFourDoubles.Equals(managedFourDoubles))
+		{
+			Console.WriteLine("Managed call for EchoFourDoubles failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoInlineArray1Wrapper()
+	{
+		bool ok = true;
+		InlineArray1 expectedInlineArray1 = InlineArray1.Get();
+		InlineArray1 nativeInlineArray1 = EchoInlineArray1(expectedInlineArray1);
+		InlineArray1 managedInlineArray1 = EchoInlineArray1Managed(expectedInlineArray1);
+		
+		if (!expectedInlineArray1.Equals(nativeInlineArray1))
+		{
+			Console.WriteLine("Native call for EchoInlineArray1 failed");
+			ok = false;
+		}
+
+		if (!expectedInlineArray1.Equals(managedInlineArray1))
+		{
+			Console.WriteLine("Managed call for EchoInlineArray1 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoInlineArray2Wrapper()
+	{
+		bool ok = true;
+		InlineArray2 expectedInlineArray2 = InlineArray2.Get();
+		InlineArray2 nativeInlineArray2 = EchoInlineArray2(expectedInlineArray2);
+		InlineArray2 managedInlineArray2 = EchoInlineArray2Managed(expectedInlineArray2);
+		
+		if (!expectedInlineArray2.Equals(nativeInlineArray2))
+		{
+			Console.WriteLine("Native call for EchoInlineArray2 failed");
+			ok = false;
+		}
+
+		if (!expectedInlineArray2.Equals(managedInlineArray2))
+		{
+			Console.WriteLine("Managed call for EchoInlineArray2 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoInlineArray3Wrapper()
+	{
+		bool ok = true;
+		InlineArray3 expectedInlineArray3 = InlineArray3.Get();
+		InlineArray3 nativeInlineArray3 = EchoInlineArray3(expectedInlineArray3);
+		InlineArray3 managedInlineArray3 = EchoInlineArray3Managed(expectedInlineArray3);
+		
+		if (!expectedInlineArray3.Equals(nativeInlineArray3))
+		{
+			Console.WriteLine("Native call for EchoInlineArray3 failed");
+			ok = false;
+		}
+
+		if (!expectedInlineArray3.Equals(managedInlineArray3))
+		{
+			Console.WriteLine("Managed call for EchoInlineArray3 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoInlineArray4Wrapper()
+	{
+		bool ok = true;
+		InlineArray4 expectedInlineArray4 = InlineArray4.Get();
+		InlineArray4 nativeInlineArray4 = EchoInlineArray4(expectedInlineArray4);
+		InlineArray4 managedInlineArray4 = EchoInlineArray4Managed(expectedInlineArray4);
+		
+		if (!expectedInlineArray4.Equals(nativeInlineArray4))
+		{
+			Console.WriteLine("Native call for EchoInlineArray4 failed");
+			ok = false;
+		}
+
+		if (!expectedInlineArray4.Equals(managedInlineArray4))
+		{
+			Console.WriteLine("Managed call for EchoInlineArray4 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoInlineArray5Wrapper()
+	{
+		bool ok = true;
+		InlineArray5 expectedInlineArray5 = InlineArray5.Get();
+		InlineArray5 nativeInlineArray5 = EchoInlineArray5(expectedInlineArray5);
+		InlineArray5 managedInlineArray5 = EchoInlineArray5Managed(expectedInlineArray5);
+		
+		if (!expectedInlineArray5.Equals(nativeInlineArray5))
+		{
+			Console.WriteLine("Native call for EchoInlineArray5 failed");
+			ok = false;
+		}
+
+		if (!expectedInlineArray5.Equals(managedInlineArray5))
+		{
+			Console.WriteLine("Managed call for EchoInlineArray5 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoInlineArray6Wrapper()
+	{
+		bool ok = true;
+		InlineArray6 expectedInlineArray6 = InlineArray6.Get();
+		InlineArray6 nativeInlineArray6 = EchoInlineArray6(expectedInlineArray6);
+		InlineArray6 managedInlineArray6 = EchoInlineArray6Managed(expectedInlineArray6);
+		
+		if (!expectedInlineArray6.Equals(nativeInlineArray6))
+		{
+			Console.WriteLine("Native call for EchoInlineArray6 failed");
+			ok = false;
+		}
+
+		if (!expectedInlineArray6.Equals(managedInlineArray6))
+		{
+			Console.WriteLine("Managed call for EchoInlineArray6 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoNested1Wrapper()
+	{
+		bool ok = true;
+		Nested1 expectedNested1 = Nested1.Get();
+		Nested1 nativeNested1 = EchoNested1(expectedNested1);
+		Nested1 managedNested1 = EchoNested1Managed(expectedNested1);
+		
+		if (!expectedNested1.Equals(nativeNested1))
+		{
+			Console.WriteLine("Native call for EchoNested1 failed");
+			ok = false;
+		}
+
+		if (!expectedNested1.Equals(managedNested1))
+		{
+			Console.WriteLine("Managed call for EchoNested1 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoNested2Wrapper()
+	{
+		bool ok = true;
+		Nested2 expectedNested2 = Nested2.Get();
+		Nested2 nativeNested2 = EchoNested2(expectedNested2);
+		Nested2 managedNested2 = EchoNested2Managed(expectedNested2);
+		
+		if (!expectedNested2.Equals(nativeNested2))
+		{
+			Console.WriteLine("Native call for EchoNested2 failed");
+			ok = false;
+		}
+
+		if (!expectedNested2.Equals(managedNested2))
+		{
+			Console.WriteLine("Managed call for EchoNested2 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoNested3Wrapper()
+	{
+		bool ok = true;
+		Nested3 expectedNested3 = Nested3.Get();
+		Nested3 nativeNested3 = EchoNested3(expectedNested3);
+		Nested3 managedNested3 = EchoNested3Managed(expectedNested3);
+		
+		if (!expectedNested3.Equals(nativeNested3))
+		{
+			Console.WriteLine("Native call for EchoNested3 failed");
+			ok = false;
+		}
+
+		if (!expectedNested3.Equals(managedNested3))
+		{
+			Console.WriteLine("Managed call for EchoNested3 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoNested4Wrapper()
+	{
+		bool ok = true;
+		Nested4 expectedNested4 = Nested4.Get();
+		Nested4 nativeNested4 = EchoNested4(expectedNested4);
+		Nested4 managedNested4 = EchoNested4Managed(expectedNested4);
+		
+		if (!expectedNested4.Equals(nativeNested4))
+		{
+			Console.WriteLine("Native call for EchoNested4 failed");
+			ok = false;
+		}
+
+		if (!expectedNested4.Equals(managedNested4))
+		{
+			Console.WriteLine("Managed call for EchoNested4 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoNested5Wrapper()
+	{
+		bool ok = true;
+		Nested5 expectedNested5 = Nested5.Get();
+		Nested5 nativeNested5 = EchoNested5(expectedNested5);
+		Nested5 managedNested5 = EchoNested5Managed(expectedNested5);
+		
+		if (!expectedNested5.Equals(nativeNested5))
+		{
+			Console.WriteLine("Native call for EchoNested5 failed");
+			ok = false;
+		}
+
+		if (!expectedNested5.Equals(managedNested5))
+		{
+			Console.WriteLine("Managed call for EchoNested5 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoNested6Wrapper()
+	{
+		bool ok = true;
+		Nested6 expectedNested6 = Nested6.Get();
+		Nested6 nativeNested6 = EchoNested6(expectedNested6);
+		Nested6 managedNested6 = EchoNested6Managed(expectedNested6);
+		
+		if (!expectedNested6.Equals(nativeNested6))
+		{
+			Console.WriteLine("Native call for EchoNested6 failed");
+			ok = false;
+		}
+
+		if (!expectedNested6.Equals(managedNested6))
+		{
+			Console.WriteLine("Managed call for EchoNested6 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoNested7Wrapper()
+	{
+		bool ok = true;
+		Nested7 expectedNested7 = Nested7.Get();
+		Nested7 nativeNested7 = EchoNested7(expectedNested7);
+		Nested7 managedNested7 = EchoNested7Managed(expectedNested7);
+		
+		if (!expectedNested7.Equals(nativeNested7))
+		{
+			Console.WriteLine("Native call for EchoNested7 failed");
+			ok = false;
+		}
+
+		if (!expectedNested7.Equals(managedNested7))
+		{
+			Console.WriteLine("Managed call for EchoNested7 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoNested8Wrapper()
+	{
+		bool ok = true;
+		Nested8 expectedNested8 = Nested8.Get();
+		Nested8 nativeNested8 = EchoNested8(expectedNested8);
+		Nested8 managedNested8 = EchoNested8Managed(expectedNested8);
+		
+		if (!expectedNested8.Equals(nativeNested8))
+		{
+			Console.WriteLine("Native call for EchoNested8 failed");
+			ok = false;
+		}
+
+		if (!expectedNested8.Equals(managedNested8))
+		{
+			Console.WriteLine("Managed call for EchoNested8 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EchoNested9Wrapper()
+	{
+		bool ok = true;
+		Nested9 expectedNested9 = Nested9.Get();
+		Nested9 nativeNested9 = EchoNested9(expectedNested9);
+		Nested9 managedNested9 = EchoNested9Managed(expectedNested9);
+		
+		if (!expectedNested9.Equals(nativeNested9))
+		{
+			Console.WriteLine("Native call for EchoNested9 failed");
+			ok = false;
+		}
+
+		if (!expectedNested9.Equals(managedNested9))
+		{
+			Console.WriteLine("Managed call for EchoNested9 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool NotEnoughRegistersSysV1Wrapper()
+	{
+		bool ok = true;
+
+		TwoLongs expectedNotEnoughRegistersSysV1 = TwoLongs.Get();
+		TwoLongs nativeNotEnoughRegistersSysV1 = NotEnoughRegistersSysV1(1, 2, 3, 4, 5, 6, expectedNotEnoughRegistersSysV1);
+		TwoLongs managedNotEnoughRegistersSysV1 = NotEnoughRegistersSysV1Managed(1, 2, 3, 4, 5, 6, expectedNotEnoughRegistersSysV1);
+
+		if (!expectedNotEnoughRegistersSysV1.Equals(nativeNotEnoughRegistersSysV1))
+		{
+			Console.WriteLine("Native NotEnoughRegistersSysV1 failed");
+			ok = false;
+		}
+
+		if (!expectedNotEnoughRegistersSysV1.Equals(managedNotEnoughRegistersSysV1))
+		{
+			Console.WriteLine("Managed NotEnoughRegistersSysV1 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool NotEnoughRegistersSysV2Wrapper()
+	{
+		bool ok = true;
+
+		TwoLongs expectedNotEnoughRegistersSysV2 = TwoLongs.Get();
+		TwoLongs nativeNotEnoughRegistersSysV2 = NotEnoughRegistersSysV2(1, 2, 3, 4, 5, expectedNotEnoughRegistersSysV2);
+		TwoLongs managedNotEnoughRegistersSysV2 = NotEnoughRegistersSysV2Managed(1, 2, 3, 4, 5, expectedNotEnoughRegistersSysV2);
+
+		if (!expectedNotEnoughRegistersSysV2.Equals(nativeNotEnoughRegistersSysV2))
+		{
+			Console.WriteLine("Native NotEnoughRegistersSysV2 failed");
+			ok = false;
+		}
+
+		if (!expectedNotEnoughRegistersSysV2.Equals(managedNotEnoughRegistersSysV2))
+		{
+			Console.WriteLine("Managed NotEnoughRegistersSysV2 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool NotEnoughRegistersSysV3Wrapper()
+	{
+		bool ok = true;
+		
+		DoubleAndByte expectedNotEnoughRegistersSysV3 = DoubleAndByte.Get();
+		DoubleAndByte nativeNotEnoughRegistersSysV3 = NotEnoughRegistersSysV3(1, 2, 3, 4, 5, 6, expectedNotEnoughRegistersSysV3);
+		DoubleAndByte managedNotEnoughRegistersSysV3 = NotEnoughRegistersSysV3Managed(1, 2, 3, 4, 5, 6, expectedNotEnoughRegistersSysV3);
+
+		if (!expectedNotEnoughRegistersSysV3.Equals(nativeNotEnoughRegistersSysV3))
+		{
+			Console.WriteLine("Native NotEnoughRegistersSysV3 failed");
+			ok = false;
+		}
+
+		if (!expectedNotEnoughRegistersSysV3.Equals(managedNotEnoughRegistersSysV3))
+		{
+			Console.WriteLine("Managed NotEnoughRegistersSysV3 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool NotEnoughRegistersSysV4Wrapper()
+	{
+		bool ok = true;
+
+		TwoDoubles expectedNotEnoughRegistersSysV4 = TwoDoubles.Get();
+		TwoDoubles nativeNotEnoughRegistersSysV4 = NotEnoughRegistersSysV4(1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d, 8.0d, expectedNotEnoughRegistersSysV4);
+		TwoDoubles managedNotEnoughRegistersSysV4 = NotEnoughRegistersSysV4Managed(1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d, 8.0d, expectedNotEnoughRegistersSysV4);
+
+		if (!expectedNotEnoughRegistersSysV4.Equals(nativeNotEnoughRegistersSysV4))
+		{
+			Console.WriteLine("Native NotEnoughRegistersSysV4 failed");
+			ok = false;
+		}
+
+		if (!expectedNotEnoughRegistersSysV4.Equals(managedNotEnoughRegistersSysV4))
+		{
+			Console.WriteLine("Managed NotEnoughRegistersSysV4 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool NotEnoughRegistersSysV5Wrapper()
+	{
+		bool ok = true;
+
+		TwoDoubles expectedNotEnoughRegistersSysV5 = TwoDoubles.Get();
+		TwoDoubles nativeNotEnoughRegistersSysV5 = NotEnoughRegistersSysV5(1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d, expectedNotEnoughRegistersSysV5);
+		TwoDoubles managedNotEnoughRegistersSysV5 = NotEnoughRegistersSysV5Managed(1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d, expectedNotEnoughRegistersSysV5);
+
+		if (!expectedNotEnoughRegistersSysV5.Equals(nativeNotEnoughRegistersSysV5))
+		{
+			Console.WriteLine("Native NotEnoughRegistersSysV5 failed");
+			ok = false;
+		}
+
+		if (!expectedNotEnoughRegistersSysV5.Equals(managedNotEnoughRegistersSysV5))
+		{
+			Console.WriteLine("Managed NotEnoughRegistersSysV5 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool NotEnoughRegistersSysV6Wrapper()
+	{
+		bool ok = true;
+		
+		DoubleAndByte expectedNotEnoughRegistersSysV6 = DoubleAndByte.Get();
+		DoubleAndByte nativeNotEnoughRegistersSysV6 = NotEnoughRegistersSysV6(1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d, 8.0d, expectedNotEnoughRegistersSysV6);
+		DoubleAndByte managedNotEnoughRegistersSysV6 = NotEnoughRegistersSysV6Managed(1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d, 8.0d, expectedNotEnoughRegistersSysV6);
+
+		if (!expectedNotEnoughRegistersSysV6.Equals(nativeNotEnoughRegistersSysV6))
+		{
+			Console.WriteLine("Native NotEnoughRegistersSysV6 failed");
+			ok = false;
+		}
+
+		if (!expectedNotEnoughRegistersSysV6.Equals(managedNotEnoughRegistersSysV6))
+		{
+			Console.WriteLine("Managed NotEnoughRegistersSysV6 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EnoughRegistersSysV1Wrapper()
+	{
+		bool ok = true;
+
+		TwoDoubles expectedEnoughRegistersSysV1 = TwoDoubles.Get();
+		TwoDoubles nativeEnoughRegistersSysV1 = EnoughRegistersSysV1(1, 2, 3, 4, 5, 6, expectedEnoughRegistersSysV1);
+		TwoDoubles managedEnoughRegistersSysV1 = EnoughRegistersSysV1Managed(1, 2, 3, 4, 5, 6, expectedEnoughRegistersSysV1);
+
+		if (!expectedEnoughRegistersSysV1.Equals(nativeEnoughRegistersSysV1))
+		{
+			Console.WriteLine("Native EnoughRegistersSysV1 failed");
+			ok = false;
+		}
+
+		if (!expectedEnoughRegistersSysV1.Equals(managedEnoughRegistersSysV1))
+		{
+			Console.WriteLine("Managed EnoughRegistersSysV1 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EnoughRegistersSysV2Wrapper()
+	{
+		bool ok = true;
+
+		DoubleAndByte expectedEnoughRegistersSysV2 = DoubleAndByte.Get();
+		DoubleAndByte nativeEnoughRegistersSysV2 = EnoughRegistersSysV2(1, 2, 3, 4, 5, expectedEnoughRegistersSysV2);
+		DoubleAndByte managedEnoughRegistersSysV2 = EnoughRegistersSysV2Managed(1, 2, 3, 4, 5, expectedEnoughRegistersSysV2);
+
+		if (!expectedEnoughRegistersSysV2.Equals(nativeEnoughRegistersSysV2))
+		{
+			Console.WriteLine("Native EnoughRegistersSysV2 failed");
+			ok = false;
+		}
+
+		if (!expectedEnoughRegistersSysV2.Equals(managedEnoughRegistersSysV2))
+		{
+			Console.WriteLine("Managed EnoughRegistersSysV2 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EnoughRegistersSysV3Wrapper()
+	{
+		bool ok = true;
+
+		TwoLongs expectedEnoughRegistersSysV3 = TwoLongs.Get();
+		TwoLongs nativeEnoughRegistersSysV3 = EnoughRegistersSysV3(1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d, 8.0d, expectedEnoughRegistersSysV3);
+		TwoLongs managedEnoughRegistersSysV3 = EnoughRegistersSysV3Managed(1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d, 8.0d, expectedEnoughRegistersSysV3);
+
+		if (!expectedEnoughRegistersSysV3.Equals(nativeEnoughRegistersSysV3))
+		{
+			Console.WriteLine("Native EnoughRegistersSysV3 failed");
+			ok = false;
+		}
+
+		if (!expectedEnoughRegistersSysV3.Equals(managedEnoughRegistersSysV3))
+		{
+			Console.WriteLine("Managed EnoughRegistersSysV3 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
+
+	static bool EnoughRegistersSysV4Wrapper()
+	{
+		bool ok = true;
+
+		DoubleAndByte expectedEnoughRegistersSysV4 = DoubleAndByte.Get();
+		DoubleAndByte nativeEnoughRegistersSysV4 = EnoughRegistersSysV4(1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d, expectedEnoughRegistersSysV4);
+		DoubleAndByte managedEnoughRegistersSysV4 = EnoughRegistersSysV4Managed(1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d, expectedEnoughRegistersSysV4);
+
+		if (!expectedEnoughRegistersSysV4.Equals(nativeEnoughRegistersSysV4))
+		{
+			Console.WriteLine("Native EnoughRegistersSysV4 failed");
+			ok = false;
+		}
+
+		if (!expectedEnoughRegistersSysV4.Equals(managedEnoughRegistersSysV4))
+		{
+			Console.WriteLine("Managed EnoughRegistersSysV4 failed");
+			ok = false;
+		}
+
+		return ok;
+	}
 
 	static int Main()
 	{
 		var ok = true;
-		SingleByte expectedSingleByte = SingleByte.Get();
-		SingleByte actualSingleByte = EchoSingleByte(expectedSingleByte);
-		if (!expectedSingleByte.Equals(actualSingleByte))
-		{
-			Console.WriteLine("EchoSingleByte failed");
-			ok = false;
-		}
-
-		SingleLong expectedSingleLong = SingleLong.Get();
-		SingleLong actualSingleLong = EchoSingleLong(expectedSingleLong);
-		if (!expectedSingleLong.Equals(actualSingleLong))
-		{
-			Console.WriteLine("EchoSingleLong failed");
-			ok = false;
-		}
-
-		SingleFloat expectedSingleFloat = SingleFloat.Get();
-		SingleFloat actualSingleFloat = EchoSingleFloat(expectedSingleFloat);
-		if (!expectedSingleFloat.Equals(actualSingleFloat))
-		{
-			Console.WriteLine("EchoSingleFloat failed");
-			ok = false;
-		}
-
-		SingleDouble expectedSingleDouble = SingleDouble.Get();
-		SingleDouble actualSingleDouble = EchoSingleDouble(expectedSingleDouble);
-		if (!expectedSingleDouble.Equals(actualSingleDouble))
-		{
-			Console.WriteLine("EchoSingleDouble failed");
-			ok = false;
-		}
-
-		ByteAndFloat expectedByteAndFloat = ByteAndFloat.Get();
-		ByteAndFloat actualByteAndFloat = EchoByteAndFloat(expectedByteAndFloat);
-		if (!expectedByteAndFloat.Equals(actualByteAndFloat))
-		{
-			Console.WriteLine("EchoByteAndFloat failed");
-			ok = false;
-		}
-
-		LongAndFloat expectedLongAndFloat = LongAndFloat.Get();
-		LongAndFloat actualLongAndFloat = EchoLongAndFloat(expectedLongAndFloat);
-		if (!expectedLongAndFloat.Equals(actualLongAndFloat))
-		{
-			Console.WriteLine("EchoLongAndFloat failed");
-			ok = false;
-		}
-
-		ByteAndDouble expectedByteAndDouble = ByteAndDouble.Get();
-		ByteAndDouble actualByteAndDouble = EchoByteAndDouble(expectedByteAndDouble);
-		if (!expectedByteAndDouble.Equals(actualByteAndDouble))
-		{
-			Console.WriteLine("EchoByteAndDouble failed");
-			ok = false;
-		}
-
-		DoubleAndByte expectedDoubleAndByte = DoubleAndByte.Get();
-		DoubleAndByte actualDoubleAndByte = EchoDoubleAndByte(expectedDoubleAndByte);
-		if (!expectedDoubleAndByte.Equals(actualDoubleAndByte))
-		{
-			Console.WriteLine("EchoDoubleAndByte failed");
-			ok = false;
-		}
-
-		PointerAndByte expectedPointerAndByte = PointerAndByte.Get();
-		PointerAndByte actualPointerAndByte = EchoPointerAndByte(expectedPointerAndByte);
-		if (!expectedPointerAndByte.Equals(actualPointerAndByte))
-		{
-			Console.WriteLine("EchoPointerAndByte failed");
-			ok = false;
-		}
-
-		ByteAndPointer expectedByteAndPointer = ByteAndPointer.Get();
-		ByteAndPointer actualByteAndPointer = EchoByteAndPointer(expectedByteAndPointer);
-		if (!expectedByteAndPointer.Equals(actualByteAndPointer))
-		{
-			Console.WriteLine("EchoByteAndPointer failed");
-			ok = false;
-		}
-
-		ByteFloatAndPointer expectedByteFloatAndPointer = ByteFloatAndPointer.Get();
-		ByteFloatAndPointer actualByteFloatAndPointer = EchoByteFloatAndPointer(expectedByteFloatAndPointer);
-		if (!expectedByteFloatAndPointer.Equals(actualByteFloatAndPointer))
-		{
-			Console.WriteLine("EchoByteFloatAndPointer failed");
-			ok = false;
-		}
-
-		PointerFloatAndByte expectedPointerFloatAndByte = PointerFloatAndByte.Get();
-		PointerFloatAndByte actualPointerFloatAndByte = EchoPointerFloatAndByte(expectedPointerFloatAndByte);
-		if (!expectedPointerFloatAndByte.Equals(actualPointerFloatAndByte))
-		{
-			Console.WriteLine("EchoPointerFloatAndByte failed");
-			ok = false;
-		}
-
-		TwoLongs expectedTwoLongs = TwoLongs.Get();
-		TwoLongs actualTwoLongs = EchoTwoLongs(expectedTwoLongs);
-		if (!expectedTwoLongs.Equals(actualTwoLongs))
-		{
-			Console.WriteLine("EchoTwoLongs failed");
-			ok = false;
-		}
-
-		TwoFloats expectedTwoFloats = TwoFloats.Get();
-		TwoFloats actualTwoFloats = EchoTwoFloats(expectedTwoFloats);
-		if (!expectedTwoFloats.Equals(actualTwoFloats))
-		{
-			Console.WriteLine("EchoTwoFloats failed");
-			ok = false;
-		}
-
-		TwoDoubles expectedTwoDoubles = TwoDoubles.Get();
-		TwoDoubles actualTwoDoubles = EchoTwoDoubles(expectedTwoDoubles);
-		if (!expectedTwoDoubles.Equals(actualTwoDoubles))
-		{
-			Console.WriteLine("EchoTwoDoubles failed");
-			ok = false;
-		}
-
-		FourLongs expectedFourLongs = FourLongs.Get();
-		FourLongs actualFourLongs = EchoFourLongs(expectedFourLongs);
-		if (!expectedFourLongs.Equals(actualFourLongs))
-		{
-			Console.WriteLine("EchoFourLongs failed");
-			ok = false;
-		}
-
-		FourDoubles expectedFourDoubles = FourDoubles.Get();
-		FourDoubles actualFourDoubles = EchoFourDoubles(expectedFourDoubles);
-		if (!expectedFourDoubles.Equals(actualFourDoubles))
-		{
-			Console.WriteLine("EchoFourDoubles failed");
-			ok = false;
-		}
-
-		InlineArray1 expectedInlineArray1 = InlineArray1.Get();
-		InlineArray1 actualInlineArray1 = EchoInlineArray1(expectedInlineArray1);
-		if (!expectedInlineArray1.Equals(actualInlineArray1))
-		{
-			Console.WriteLine("EchoInlineArray1 failed");
-			ok = false;
-		}
-
-		InlineArray2 expectedInlineArray2 = InlineArray2.Get();
-		InlineArray2 actualInlineArray2 = EchoInlineArray2(expectedInlineArray2);
-		if (!expectedInlineArray2.Equals(actualInlineArray2))
-		{
-			Console.WriteLine("EchoInlineArray2 failed");
-			ok = false;
-		}
-
-		InlineArray3 expectedInlineArray3 = InlineArray3.Get();
-		InlineArray3 actualInlineArray3 = EchoInlineArray3(expectedInlineArray3);
-		if (!expectedInlineArray3.Equals(actualInlineArray3))
-		{
-			Console.WriteLine("EchoInlineArray3 failed");
-			ok = false;
-		}
-
-		InlineArray4 expectedInlineArray4 = InlineArray4.Get();
-		InlineArray4 actualInlineArray4 = EchoInlineArray4(expectedInlineArray4);
-		if (!expectedInlineArray4.Equals(actualInlineArray4))
-		{
-			Console.WriteLine("EchoInlineArray4 failed");
-			ok = false;
-		}
-
-		InlineArray5 expectedInlineArray5 = InlineArray5.Get();
-		InlineArray5 actualInlineArray5 = EchoInlineArray5(expectedInlineArray5);
-		if (!expectedInlineArray5.Equals(actualInlineArray5))
-		{
-			Console.WriteLine("EchoInlineArray5 failed");
-			ok = false;
-		}
-
-		InlineArray6 expectedInlineArray6 = InlineArray6.Get();
-		InlineArray6 actualInlineArray6 = EchoInlineArray6(expectedInlineArray6);
-		if (!expectedInlineArray6.Equals(actualInlineArray6))
-		{
-			Console.WriteLine("EchoInlineArray6 failed");
-			ok = false;
-		}
-
-		Nested1 expectedNested1 = Nested1.Get();
-		Nested1 actualNested1 = EchoNested1(expectedNested1);
-		if (!expectedNested1.Equals(actualNested1))
-		{
-			Console.WriteLine("EchoNested1 failed");
-			ok = false;
-		}
-
-		Nested2 expectedNested2 = Nested2.Get();
-		Nested2 actualNested2 = EchoNested2(expectedNested2);
-		if (!expectedNested2.Equals(actualNested2))
-		{
-			Console.WriteLine("EchoNested2 failed");
-			ok = false;
-		}
-
-		Nested3 expectedNested3 = Nested3.Get();
-		Nested3 actualNested3 = EchoNested3(expectedNested3);
-		if (!expectedNested3.Equals(actualNested3))
-		{
-			Console.WriteLine("EchoNested3 failed");
-			ok = false;
-		}
-
-		Nested4 expectedNested4 = Nested4.Get();
-		Nested4 actualNested4 = EchoNested4(expectedNested4);
-		if (!expectedNested4.Equals(actualNested4))
-		{
-			Console.WriteLine("EchoNested4 failed");
-			ok = false;
-		}
-
-		Nested5 expectedNested5 = Nested5.Get();
-		Nested5 actualNested5 = EchoNested5(expectedNested5);
-		if (!expectedNested5.Equals(actualNested5))
-		{
-			Console.WriteLine("EchoNested5 failed");
-			ok = false;
-		}
-
-		Nested6 expectedNested6 = Nested6.Get();
-		Nested6 actualNested6 = EchoNested6(expectedNested6);
-		if (!expectedNested6.Equals(actualNested6))
-		{
-			Console.WriteLine("EchoNested6 failed");
-			ok = false;
-		}
-
-		Nested7 expectedNested7 = Nested7.Get();
-		Nested7 actualNested7 = EchoNested7(expectedNested7);
-		if (!expectedNested7.Equals(actualNested7))
-		{
-			Console.WriteLine("EchoNested7 failed");
-			ok = false;
-		}
-
-		Nested8 expectedNested8 = Nested8.Get();
-		Nested8 actualNested8 = EchoNested8(expectedNested8);
-		if (!expectedNested8.Equals(actualNested8))
-		{
-			Console.WriteLine("EchoNested8 failed");
-			ok = false;
-		}
-
-		Nested9 expectedNested9 = Nested9.Get();
-		Nested9 actualNested9 = EchoNested9(expectedNested9);
-		if (!expectedNested9.Equals(actualNested9))
-		{
-			Console.WriteLine("EchoNested9 failed");
-			ok = false;
-		}
-
-		TwoLongs expectedNotEnoughRegistersSysV1 = TwoLongs.Get();
-		TwoLongs actualNotEnoughRegistersSysV1 = NotEnoughRegistersSysV1(1, 2, 3, 4, 5, 6, expectedNotEnoughRegistersSysV1);
-		if (!expectedNotEnoughRegistersSysV1.Equals(actualNotEnoughRegistersSysV1))
-		{
-			Console.WriteLine("NotEnoughRegistersSysV1 failed");
-			ok = false;
-		}
-
-		TwoLongs expectedNotEnoughRegistersSysV2 = TwoLongs.Get();
-		TwoLongs actualNotEnoughRegistersSysV2 = NotEnoughRegistersSysV2(1, 2, 3, 4, 5, expectedNotEnoughRegistersSysV2);
-		if (!expectedNotEnoughRegistersSysV2.Equals(actualNotEnoughRegistersSysV2))
-		{
-			Console.WriteLine("NotEnoughRegistersSysV2 failed");
-			ok = false;
-		}
-
-		DoubleAndByte expectedNotEnoughRegistersSysV3 = DoubleAndByte.Get();
-		DoubleAndByte actualNotEnoughRegistersSysV3 = NotEnoughRegistersSysV3(1, 2, 3, 4, 5, 6, expectedNotEnoughRegistersSysV3);
-		if (!expectedNotEnoughRegistersSysV3.Equals(actualNotEnoughRegistersSysV3))
-		{
-			Console.WriteLine("NotEnoughRegistersSysV3 failed");
-			ok = false;
-		}
-
-		TwoDoubles expectedNotEnoughRegistersSysV4 = TwoDoubles.Get();
-		TwoDoubles actualNotEnoughRegistersSysV4 = NotEnoughRegistersSysV4(1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d, 8.0d, expectedNotEnoughRegistersSysV4);
-		if (!expectedNotEnoughRegistersSysV4.Equals(actualNotEnoughRegistersSysV4))
-		{
-			Console.WriteLine("NotEnoughRegistersSysV4 failed");
-			ok = false;
-		}
-
-		TwoDoubles expectedNotEnoughRegistersSysV5 = TwoDoubles.Get();
-		TwoDoubles actualNotEnoughRegistersSysV5 = NotEnoughRegistersSysV5(1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d, expectedNotEnoughRegistersSysV5);
-		if (!expectedNotEnoughRegistersSysV5.Equals(actualNotEnoughRegistersSysV5))
-		{
-			Console.WriteLine("NotEnoughRegistersSysV5 failed");
-			ok = false;
-		}
-
-		DoubleAndByte expectedNotEnoughRegistersSysV6 = DoubleAndByte.Get();
-		DoubleAndByte actualNotEnoughRegistersSysV6 = NotEnoughRegistersSysV6(1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d, 8.0d, expectedNotEnoughRegistersSysV6);
-		if (!expectedNotEnoughRegistersSysV6.Equals(actualNotEnoughRegistersSysV6))
-		{
-			Console.WriteLine("NotEnoughRegistersSysV6 failed");
-			ok = false;
-		}
-
-		TwoDoubles expectedEnoughRegistersSysV1 = TwoDoubles.Get();
-		TwoDoubles actualEnoughRegistersSysV1 = EnoughRegistersSysV1(1, 2, 3, 4, 5, 6, expectedEnoughRegistersSysV1);
-		if (!expectedEnoughRegistersSysV1.Equals(actualEnoughRegistersSysV1))
-		{
-			Console.WriteLine("EnoughRegistersSysV1 failed");
-			ok = false;
-		}
-
-		DoubleAndByte expectedEnoughRegistersSysV2 = DoubleAndByte.Get();
-		DoubleAndByte actualEnoughRegistersSysV2 = EnoughRegistersSysV2(1, 2, 3, 4, 5, expectedEnoughRegistersSysV2);
-		if (!expectedEnoughRegistersSysV2.Equals(actualEnoughRegistersSysV2))
-		{
-			Console.WriteLine("EnoughRegistersSysV2 failed");
-			ok = false;
-		}
-
-		TwoLongs expectedEnoughRegistersSysV3 = TwoLongs.Get();
-		TwoLongs actualEnoughRegistersSysV3 = EnoughRegistersSysV3(1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d, 8.0d, expectedEnoughRegistersSysV3);
-		if (!expectedEnoughRegistersSysV3.Equals(actualEnoughRegistersSysV3))
-		{
-			Console.WriteLine("EnoughRegistersSysV3 failed");
-			ok = false;
-		}
-
-		DoubleAndByte expectedEnoughRegistersSysV4 = DoubleAndByte.Get();
-		DoubleAndByte actualEnoughRegistersSysV4 = EnoughRegistersSysV4(1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d, expectedEnoughRegistersSysV4);
-		if (!expectedEnoughRegistersSysV4.Equals(actualEnoughRegistersSysV4))
-		{
-			Console.WriteLine("EnoughRegistersSysV4 failed");
-			ok = false;
-		}
+	
+		ok = EchoSingleByteWrapper();
+		ok = EchoSingleLongWrapper();
+		ok = EchoSingleFloatWrapper();
+		ok = EchoSingleDoubleWrapper();
+		ok = EchoByteAndFloatWrapper();
+		ok = EchoLongAndFloatWrapper();
+		ok = EchoByteAndDoubleWrapper();
+		ok = EchoDoubleAndByteWrapper();
+		ok = EchoPointerAndByteWrapper();
+		ok = EchoByteAndPointerWrapper();
+		ok = EchoByteFloatAndPointerWrapper();
+		ok = EchoPointerFloatAndByteWrapper();
+		ok = EchoShortIntFloatIntPtrWrapper();
+		ok = EchoTwoLongsWrapper();
+		ok = EchoTwoFloatsWrapper();
+		ok = EchoTwoDoublesWrapper();
+		ok = EchoFourLongsWrapper();
+		ok = EchoFourDoublesWrapper();
+		ok = EchoInlineArray1Wrapper();
+		ok = EchoInlineArray2Wrapper();
+		ok = EchoInlineArray3Wrapper();
+		ok = EchoInlineArray4Wrapper();
+		ok = EchoInlineArray5Wrapper();
+		ok = EchoInlineArray6Wrapper();
+		ok = EchoNested1Wrapper();
+		ok = EchoNested2Wrapper();
+		ok = EchoNested3Wrapper();
+		ok = EchoNested4Wrapper();
+		ok = EchoNested5Wrapper();
+		ok = EchoNested6Wrapper();
+		ok = EchoNested7Wrapper();
+		ok = EchoNested8Wrapper();
+		ok = EchoNested9Wrapper();
+		ok = NotEnoughRegistersSysV1Wrapper();
+		ok = NotEnoughRegistersSysV2Wrapper();
+		ok = NotEnoughRegistersSysV3Wrapper();
+		ok = NotEnoughRegistersSysV4Wrapper();
+		ok = NotEnoughRegistersSysV5Wrapper();
+		ok = NotEnoughRegistersSysV6Wrapper();
+		ok = EnoughRegistersSysV1Wrapper();
+		ok = EnoughRegistersSysV2Wrapper();
+		ok = EnoughRegistersSysV3Wrapper();
+		ok = EnoughRegistersSysV4Wrapper();
 
 		return ok ? 100 : -1;
 	}

--- a/tests/src/JIT/Directed/StructABI/StructABI.csproj
+++ b/tests/src/JIT/Directed/StructABI/StructABI.csproj
@@ -11,7 +11,6 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'"></PropertyGroup>

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -1,7 +1,6 @@
 baseservices/threading/paramthreadstart/ThreadStartString_1/ThreadStartString_1.sh
 CoreMangLib/cti/system/multicastdelegate/MulticastDelegateCtor/MulticastDelegateCtor.sh
 CoreMangLib/cti/system/runtime/interopservices/marshal/MarshalGetLastWin32Error_PSC/MarshalGetLastWin32Error_PSC.sh
-JIT/Directed/StructABI/StructABI/StructABI.sh
 JIT/Directed/UnrollLoop/loop6_cs_d/loop6_cs_d.sh
 JIT/Directed/UnrollLoop/loop6_cs_do/loop6_cs_do.sh
 JIT/Directed/UnrollLoop/loop6_cs_r/loop6_cs_r.sh


### PR DESCRIPTION
I have also doubled the callsites to test the managed-to-managed caller/callee pair.

This change will also set this test to run by default as an innerloop test.