### PR TITLE
genPutArgStk needs to check for FIELD_LIST first

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -7903,17 +7903,17 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* putArgStk)
 
 #ifdef UNIX_AMD64_ABI
 
-        if (varTypeIsStruct(targetType))
+        if (data->OperIs(GT_FIELD_LIST))
+        {
+            genPutArgStkFieldList(putArgStk, baseVarNum);
+            return;
+        }
+        else if (varTypeIsStruct(targetType))
         {
             m_stkArgVarNum = baseVarNum;
             m_stkArgOffset = putArgStk->getArgOffset();
             genPutStructArgStk(putArgStk);
             m_stkArgVarNum = BAD_VAR_NUM;
-            return;
-        }
-        else if (data->OperIs(GT_FIELD_LIST))
-        {
-            genPutArgStkFieldList(putArgStk, baseVarNum);
             return;
         }
 #endif // UNIX_AMD64_ABI

--- a/tests/src/JIT/Regression/JitBlue/GitHub_18497/GitHub_18497.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_18497/GitHub_18497.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+struct S
+{
+    public Vector<float> v1;
+    public Vector<float> v2;
+};
+
+static class GitHub_18497
+{
+    static S sStatic;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<float> Sum(S s)
+    {
+        return s.v1 + s.v2;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<float> Test()
+    {
+        S sLocal = sStatic;
+        return Sum(sLocal);
+    }
+
+    static int Main()
+    {
+        bool pass = true;
+        sStatic.v1 = new Vector<float>(0.0F);
+        sStatic.v2 = new Vector<float>(1.0F);
+        Vector<float> v = Test();
+
+        for (int i = 0; i < Vector<float>.Count; i++)
+        {
+            if (Math.Abs((double)(v[i] - 1.0F)) > (double)Single.Epsilon)
+            {
+                pass = false;
+            }
+        }
+        if (!pass)
+        {
+            Console.WriteLine("Failed: v = " + v.ToString());
+            return -1;
+        }
+        return 100;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_18497/GitHub_18497.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_18497/GitHub_18497.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
When a struct is passed on the stack using `FIELD_LIST`, the type of the `FIELD_LIST` is the type of its first field. If that type was a struct type (i.e. a SIMD type), `genPutArgStk` would assume that it was the non-`FIELD_LIST` case.

Fix #18497