### PR TITLE
Make Compiler and CodeGen objects smaller

### DIFF
--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -626,7 +626,7 @@ protected:
 
     // Tracks the last entry for each tracked register variable
 
-    siScope* siLatestTrackedScopes[lclMAX_TRACKED];
+    siScope** siLatestTrackedScopes;
 
     IL_OFFSET siLastEndOffs; // IL offset of the (exclusive) end of the last block processed
 

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -121,7 +121,7 @@ CodeGen::CodeGen(Compiler* theCompiler) : CodeGenInterface(theCompiler)
     setVerbose(compiler->verbose);
 #endif // DEBUG
 
-    compiler->tmpInit();
+    regSet.tmpInit();
 
     instInit();
 
@@ -2314,7 +2314,7 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
 
     genFinalizeFrame();
 
-    unsigned maxTmpSize = compiler->tmpSize; // This is precise after LSRA has pre-allocated the temps.
+    unsigned maxTmpSize = regSet.tmpGetTotalSize(); // This is precise after LSRA has pre-allocated the temps.
 
     getEmitter()->emitBegFN(isFramePointerUsed()
 #if defined(DEBUG)
@@ -2581,7 +2581,7 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
 
     /* Shut down the temp logic */
 
-    compiler->tmpDone();
+    regSet.tmpDone();
 
 #if DISPLAY_SIZES
 
@@ -4781,8 +4781,8 @@ void CodeGen::genCheckUseBlockInit()
 
     if (!TRACK_GC_TEMP_LIFETIMES)
     {
-        assert(compiler->tmpAllFree());
-        for (TempDsc* tempThis = compiler->tmpListBeg(); tempThis != nullptr; tempThis = compiler->tmpListNxt(tempThis))
+        assert(regSet.tmpAllFree());
+        for (TempDsc* tempThis = regSet.tmpListBeg(); tempThis != nullptr; tempThis = regSet.tmpListNxt(tempThis))
         {
             if (varTypeIsGC(tempThis->tdTempType()))
             {
@@ -6542,9 +6542,8 @@ void CodeGen::genZeroInitFrame(int untrLclHi, int untrLclLo, regNumber initReg, 
 
         if (!TRACK_GC_TEMP_LIFETIMES)
         {
-            assert(compiler->tmpAllFree());
-            for (TempDsc* tempThis = compiler->tmpListBeg(); tempThis != nullptr;
-                 tempThis          = compiler->tmpListNxt(tempThis))
+            assert(regSet.tmpAllFree());
+            for (TempDsc* tempThis = regSet.tmpListBeg(); tempThis != nullptr; tempThis = regSet.tmpListNxt(tempThis))
             {
                 if (!varTypeIsGC(tempThis->tdTempType()))
                 {
@@ -7695,7 +7694,7 @@ void CodeGen::genFinalizeFrame()
        here (where we have committed to the final numbers for the frame offsets)
        This will ensure that the prolog size is always correct
     */
-    getEmitter()->emitMaxTmpSize = compiler->tmpSize;
+    getEmitter()->emitMaxTmpSize = regSet.tmpGetTotalSize();
 
 #ifdef DEBUG
     if (compiler->opts.dspCode || compiler->opts.disAsm || compiler->opts.disAsm2 || verbose)
@@ -7970,8 +7969,8 @@ void CodeGen::genFnProlog()
 
     if (!TRACK_GC_TEMP_LIFETIMES)
     {
-        assert(compiler->tmpAllFree());
-        for (TempDsc* tempThis = compiler->tmpListBeg(); tempThis != nullptr; tempThis = compiler->tmpListNxt(tempThis))
+        assert(regSet.tmpAllFree());
+        for (TempDsc* tempThis = regSet.tmpListBeg(); tempThis != nullptr; tempThis = regSet.tmpListNxt(tempThis))
         {
             if (!varTypeIsGC(tempThis->tdTempType()))
             {
@@ -8552,7 +8551,7 @@ void CodeGen::genFnProlog()
     getEmitter()->emitEndProlog();
     compiler->unwindEndProlog();
 
-    noway_assert(getEmitter()->emitMaxTmpSize == compiler->tmpSize);
+    noway_assert(getEmitter()->emitMaxTmpSize == regSet.tmpGetTotalSize());
 }
 #ifdef _PREFAST_
 #pragma warning(pop)

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -676,7 +676,7 @@ void CodeGen::genCodeForBBlist()
 
     /* Finalize the temp   tracking logic */
 
-    compiler->tmpEnd();
+    regSet.tmpEnd();
 
 #ifdef DEBUG
     if (compiler->verbose)
@@ -991,7 +991,7 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
                     TempDsc* t = regSet.rsUnspillInPlace(call, unspillTreeReg, i);
                     getEmitter()->emitIns_R_S(ins_Load(dstType), emitActualTypeSize(dstType), dstReg, t->tdTempNum(),
                                               0);
-                    compiler->tmpRlsTemp(t);
+                    regSet.tmpRlsTemp(t);
                     gcInfo.gcMarkRegPtrVal(dstReg, dstType);
                 }
             }
@@ -1019,7 +1019,7 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
                     TempDsc* t = regSet.rsUnspillInPlace(splitArg, dstReg, i);
                     getEmitter()->emitIns_R_S(ins_Load(dstType), emitActualTypeSize(dstType), dstReg, t->tdTempNum(),
                                               0);
-                    compiler->tmpRlsTemp(t);
+                    regSet.tmpRlsTemp(t);
                     gcInfo.gcMarkRegPtrVal(dstReg, dstType);
                 }
             }
@@ -1046,7 +1046,7 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
                     TempDsc* t = regSet.rsUnspillInPlace(multiReg, dstReg, i);
                     getEmitter()->emitIns_R_S(ins_Load(dstType), emitActualTypeSize(dstType), dstReg, t->tdTempNum(),
                                               0);
-                    compiler->tmpRlsTemp(t);
+                    regSet.tmpRlsTemp(t);
                     gcInfo.gcMarkRegPtrVal(dstReg, dstType);
                 }
             }
@@ -1060,7 +1060,7 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
             TempDsc* t = regSet.rsUnspillInPlace(unspillTree, unspillTree->gtRegNum);
             getEmitter()->emitIns_R_S(ins_Load(unspillTree->gtType), emitActualTypeSize(unspillTree->TypeGet()), dstReg,
                                       t->tdTempNum(), 0);
-            compiler->tmpRlsTemp(t);
+            regSet.tmpRlsTemp(t);
 
             unspillTree->gtFlags &= ~GTF_SPILLED;
             gcInfo.gcMarkRegPtrVal(dstReg, unspillTree->TypeGet());

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -1294,7 +1294,7 @@ void CodeGen::genFloatReturn(GenTree* treeNode)
         TempDsc* t = regSet.rsUnspillInPlace(op1, op1->gtRegNum);
         inst_FS_ST(INS_fld, emitActualTypeSize(op1->gtType), t, 0);
         op1->gtFlags &= ~GTF_SPILLED;
-        compiler->tmpRlsTemp(t);
+        regSet.tmpRlsTemp(t);
     }
 }
 #endif // _TARGET_X86_
@@ -7277,7 +7277,7 @@ void CodeGen::genSSE41RoundOp(GenTreeOp* treeNode)
             varNum = tmpDsc->tdTempNum();
             offset = 0;
 
-            compiler->tmpRlsTemp(tmpDsc);
+            regSet.tmpRlsTemp(tmpDsc);
         }
         else if (srcNode->isIndir())
         {
@@ -7766,7 +7766,7 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
                     assert(fieldNode->IsRegOptional());
                     TempDsc* tmp = getSpillTempDsc(fieldNode);
                     getEmitter()->emitIns_S(INS_push, emitActualTypeSize(fieldNode->TypeGet()), tmp->tdTempNum(), 0);
-                    compiler->tmpRlsTemp(tmp);
+                    regSet.tmpRlsTemp(tmp);
                 }
                 else
                 {

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -2071,54 +2071,7 @@ void Compiler::compInit(ArenaAllocator* pAlloc, InlineInfo* inlineInfo)
     fgOrder = FGOrderTree;
 
 #ifdef FEATURE_SIMD
-    // SIMD Types
-    SIMDFloatHandle   = nullptr;
-    SIMDDoubleHandle  = nullptr;
-    SIMDIntHandle     = nullptr;
-    SIMDUShortHandle  = nullptr;
-    SIMDUByteHandle   = nullptr;
-    SIMDShortHandle   = nullptr;
-    SIMDByteHandle    = nullptr;
-    SIMDLongHandle    = nullptr;
-    SIMDUIntHandle    = nullptr;
-    SIMDULongHandle   = nullptr;
-    SIMDVector2Handle = nullptr;
-    SIMDVector3Handle = nullptr;
-    SIMDVector4Handle = nullptr;
-    SIMDVectorHandle  = nullptr;
-#ifdef FEATURE_HW_INTRINSICS
-#if defined(_TARGET_ARM64_)
-    Vector64FloatHandle  = nullptr;
-    Vector64UIntHandle   = nullptr;
-    Vector64UShortHandle = nullptr;
-    Vector64UByteHandle  = nullptr;
-    Vector64IntHandle    = nullptr;
-    Vector64ShortHandle  = nullptr;
-    Vector64ByteHandle   = nullptr;
-#endif // defined(_TARGET_ARM64_)
-    Vector128FloatHandle  = nullptr;
-    Vector128DoubleHandle = nullptr;
-    Vector128IntHandle    = nullptr;
-    Vector128UShortHandle = nullptr;
-    Vector128UByteHandle  = nullptr;
-    Vector128ShortHandle  = nullptr;
-    Vector128ByteHandle   = nullptr;
-    Vector128LongHandle   = nullptr;
-    Vector128UIntHandle   = nullptr;
-    Vector128ULongHandle  = nullptr;
-#if defined(_TARGET_XARCH_)
-    Vector256FloatHandle  = nullptr;
-    Vector256DoubleHandle = nullptr;
-    Vector256IntHandle    = nullptr;
-    Vector256UShortHandle = nullptr;
-    Vector256UByteHandle  = nullptr;
-    Vector256ShortHandle  = nullptr;
-    Vector256ByteHandle   = nullptr;
-    Vector256LongHandle   = nullptr;
-    Vector256UIntHandle   = nullptr;
-    Vector256ULongHandle  = nullptr;
-#endif // defined(_TARGET_XARCH_)
-#endif // FEATURE_HW_INTRINSICS
+    m_simdHandleCache = nullptr;
 #endif // FEATURE_SIMD
 
     compUsesThrowHelper = false;

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -2035,11 +2035,6 @@ void Compiler::compInit(ArenaAllocator* pAlloc, InlineInfo* inlineInfo)
     // Used to track when we should consider running EarlyProp
     optMethodFlags = 0;
 
-    for (unsigned i = 0; i < MAX_LOOP_NUM; i++)
-    {
-        AllVarSetOps::AssignNoCopy(this, optLoopTable[i].lpAsgVars, AllVarSetOps::UninitVal());
-    }
-
 #ifdef DEBUG
     m_nodeTestData      = nullptr;
     m_loopHoistCSEClass = FIRST_LOOP_HOIST_CSE_CLASS;

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -1486,13 +1486,6 @@ void Compiler::compShutdown()
     }
 #endif // FEATURE_JIT_METHOD_PERF
 
-#if COUNT_RANGECHECKS
-    if (optRangeChkAll > 0)
-    {
-        fprintf(fout, "Removed %u of %u range checks\n", optRangeChkRmv, optRangeChkAll);
-    }
-#endif // COUNT_RANGECHECKS
-
 #if COUNT_AST_OPERS
 
     // Add up all the counts so that we can show percentages of total
@@ -2007,9 +2000,7 @@ void Compiler::compInit(ArenaAllocator* pAlloc, InlineInfo* inlineInfo)
     compQmarkUsed         = false;
     compFloatingPointUsed = false;
     compUnsafeCastUsed    = false;
-#if CPU_USES_BLOCK_MOVE
-    compBlkOpUsed = false;
-#endif
+
     compNeedsGSSecurityCookie = false;
     compGSReorderStackLayout  = false;
 #if STACK_PROBES

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7268,6 +7268,13 @@ private:
     // Get the handle for a SIMD type.
     CORINFO_CLASS_HANDLE gtGetStructHandleForSIMD(var_types simdType, var_types simdBaseType)
     {
+        if (m_simdHandleCache == nullptr)
+        {
+            // This may happen if the JIT generates SIMD node on its own, without importing them.
+            // Otherwise getBaseTypeAndSizeOfSIMDType should have created the cache.
+            return NO_CLASS_HANDLE;
+        }
+
         if (simdBaseType == TYP_FLOAT)
         {
             switch (simdType)

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3758,19 +3758,13 @@ public:
 
     unsigned fgMeasureIR();
 
-#if OPT_BOOL_OPS // Used to detect multiple logical "not" assignments.
-    bool fgMultipleNots;
-#endif
-
     bool fgModified;         // True if the flow graph has been modified recently
     bool fgComputePredsDone; // Have we computed the bbPreds list
     bool fgCheapPredsValid;  // Is the bbCheapPreds list valid?
     bool fgDomsComputed;     // Have we computed the dominator sets?
     bool fgOptimizedFinally; // Did we optimize any try-finallys?
 
-    bool     fgHasSwitch;  // any BBJ_SWITCH jumps?
-    bool     fgHasPostfix; // any postfix ++/-- found?
-    unsigned fgIncrCount;  // number of increment nodes found
+    bool fgHasSwitch; // any BBJ_SWITCH jumps?
 
     BlockSet fgEnterBlks; // Set of blocks which have a special transfer of control; the "entry" blocks plus EH handler
                           // begin blocks.
@@ -3947,11 +3941,6 @@ public:
     VARSET_VALRET_TP fgGetHandlerLiveVars(BasicBlock* block);
 
     void fgLiveVarAnalysis(bool updateInternalOnly = false);
-
-    // This is used in the liveness computation, as a temporary.  When we use the
-    // arbitrary-length VarSet representation, it is better not to allocate a new one
-    // at each call.
-    VARSET_TP fgMarkIntfUnionVS;
 
     void fgUpdateRefCntForClone(BasicBlock* addedToBlock, GenTree* clonedTree);
 
@@ -6320,33 +6309,7 @@ public:
                                               BasicBlock*       slow);
     void optInsertLoopCloningStress(BasicBlock* head);
 
-#if COUNT_RANGECHECKS
-    static unsigned optRangeChkRmv;
-    static unsigned optRangeChkAll;
-#endif
-
 protected:
-    struct arraySizes
-    {
-        unsigned arrayVar;
-        int      arrayDim;
-
-#define MAX_ARRAYS 4 // a magic max number of arrays tracked for bounds check elimination
-    };
-
-    struct RngChkDsc
-    {
-        RngChkDsc* rcdNextInBucket; // used by the hash table
-
-        unsigned short rcdHashValue; // to make matching faster
-        unsigned short rcdIndex;     // 0..optRngChkCount-1
-
-        GenTree* rcdTree; // the array index tree
-    };
-
-    unsigned            optRngChkCount;
-    static const size_t optRngChkHashSize;
-
     ssize_t optGetArrayRefScaleAndIndex(GenTree* mul, GenTree** pIndex DEBUGARG(bool bRngChk));
     GenTree* optFindLocalInit(BasicBlock* block, GenTree* local, VARSET_TP* pKilledInOut, bool* isKilledAfterInit);
 
@@ -7825,10 +7788,6 @@ public:
 
 // NOTE: These values are only reliable after
 //       the importing is completely finished.
-
-#if CPU_USES_BLOCK_MOVE
-    bool compBlkOpUsed; // Does the method do a COPYBLK or INITBLK
-#endif
 
 #ifdef DEBUG
     // State information - which phases have completed?

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5506,8 +5506,8 @@ protected:
     bool fgHasLoops;        // True if this method has any loops, set in fgComputeReachability
 
 public:
-    LoopDsc       optLoopTable[MAX_LOOP_NUM]; // loop descriptor table
-    unsigned char optLoopCount;               // number of tracked loops
+    LoopDsc*      optLoopTable; // loop descriptor table
+    unsigned char optLoopCount; // number of tracked loops
 
     bool optRecordLoop(BasicBlock*   head,
                        BasicBlock*   first,

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -128,17 +128,6 @@ unsigned ReinterpretHexAsDecimal(unsigned);
 
 /*****************************************************************************/
 
-#if defined(FEATURE_SIMD)
-#if defined(_TARGET_XARCH_)
-const unsigned TEMP_MAX_SIZE = YMM_REGSIZE_BYTES;
-#elif defined(_TARGET_ARM64_)
-const unsigned       TEMP_MAX_SIZE = FP_REGSIZE_BYTES;
-#endif // defined(_TARGET_XARCH_) || defined(_TARGET_ARM64_)
-#else  // !FEATURE_SIMD
-const unsigned TEMP_MAX_SIZE = sizeof(double);
-#endif // !FEATURE_SIMD
-const unsigned TEMP_SLOT_COUNT = (TEMP_MAX_SIZE / sizeof(int));
-
 const unsigned FLG_CCTOR = (CORINFO_FLG_CONSTRUCTOR | CORINFO_FLG_STATIC);
 
 #ifdef DEBUG
@@ -1331,7 +1320,7 @@ public:
 #ifdef _TARGET_ARM_
         unsigned int regSize = (hfaType == TYP_DOUBLE) ? 2 : 1;
 #else
-        unsigned int regSize       = 1;
+        unsigned int regSize = 1;
 #endif
         for (unsigned int regIndex = 1; regIndex < numRegs; regIndex++)
         {
@@ -6870,45 +6859,6 @@ public:
     static int eeGetJitDataOffs(CORINFO_FIELD_HANDLE field);
 
     /*****************************************************************************/
-
-public:
-    void tmpInit();
-
-    enum TEMP_USAGE_TYPE
-    {
-        TEMP_USAGE_FREE,
-        TEMP_USAGE_USED
-    };
-
-    static var_types tmpNormalizeType(var_types type);
-    TempDsc* tmpGetTemp(var_types type); // get temp for the given type
-    void tmpRlsTemp(TempDsc* temp);
-    TempDsc* tmpFindNum(int temp, TEMP_USAGE_TYPE usageType = TEMP_USAGE_FREE) const;
-
-    void     tmpEnd();
-    TempDsc* tmpListBeg(TEMP_USAGE_TYPE usageType = TEMP_USAGE_FREE) const;
-    TempDsc* tmpListNxt(TempDsc* curTemp, TEMP_USAGE_TYPE usageType = TEMP_USAGE_FREE) const;
-    void tmpDone();
-
-#ifdef DEBUG
-    bool tmpAllFree() const;
-#endif // DEBUG
-
-    void tmpPreAllocateTemps(var_types type, unsigned count);
-
-protected:
-    unsigned tmpCount; // Number of temps
-    unsigned tmpSize;  // Size of all the temps
-#ifdef DEBUG
-public:
-    // Used by RegSet::rsSpillChk()
-    unsigned tmpGetCount; // Temps which haven't been released yet
-#endif
-private:
-    static unsigned tmpSlot(unsigned size); // which slot in tmpFree[] or tmpUsed[] to use
-
-    TempDsc* tmpFree[TEMP_MAX_SIZE / sizeof(int)];
-    TempDsc* tmpUsed[TEMP_MAX_SIZE / sizeof(int)];
 
     /*
     XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7244,55 +7244,65 @@ private:
     // by the hardware.  It is allocated when/if such situations are encountered during Lowering.
     unsigned lvaSIMDInitTempVarNum;
 
-    // SIMD Types
-    CORINFO_CLASS_HANDLE SIMDFloatHandle;
-    CORINFO_CLASS_HANDLE SIMDDoubleHandle;
-    CORINFO_CLASS_HANDLE SIMDIntHandle;
-    CORINFO_CLASS_HANDLE SIMDUShortHandle;
-    CORINFO_CLASS_HANDLE SIMDUByteHandle;
-    CORINFO_CLASS_HANDLE SIMDShortHandle;
-    CORINFO_CLASS_HANDLE SIMDByteHandle;
-    CORINFO_CLASS_HANDLE SIMDLongHandle;
-    CORINFO_CLASS_HANDLE SIMDUIntHandle;
-    CORINFO_CLASS_HANDLE SIMDULongHandle;
-    CORINFO_CLASS_HANDLE SIMDVector2Handle;
-    CORINFO_CLASS_HANDLE SIMDVector3Handle;
-    CORINFO_CLASS_HANDLE SIMDVector4Handle;
-    CORINFO_CLASS_HANDLE SIMDVectorHandle;
+    struct SIMDHandlesCache
+    {
+        // SIMD Types
+        CORINFO_CLASS_HANDLE SIMDFloatHandle;
+        CORINFO_CLASS_HANDLE SIMDDoubleHandle;
+        CORINFO_CLASS_HANDLE SIMDIntHandle;
+        CORINFO_CLASS_HANDLE SIMDUShortHandle;
+        CORINFO_CLASS_HANDLE SIMDUByteHandle;
+        CORINFO_CLASS_HANDLE SIMDShortHandle;
+        CORINFO_CLASS_HANDLE SIMDByteHandle;
+        CORINFO_CLASS_HANDLE SIMDLongHandle;
+        CORINFO_CLASS_HANDLE SIMDUIntHandle;
+        CORINFO_CLASS_HANDLE SIMDULongHandle;
+        CORINFO_CLASS_HANDLE SIMDVector2Handle;
+        CORINFO_CLASS_HANDLE SIMDVector3Handle;
+        CORINFO_CLASS_HANDLE SIMDVector4Handle;
+        CORINFO_CLASS_HANDLE SIMDVectorHandle;
 
 #ifdef FEATURE_HW_INTRINSICS
 #if defined(_TARGET_ARM64_)
-    CORINFO_CLASS_HANDLE Vector64FloatHandle;
-    CORINFO_CLASS_HANDLE Vector64UIntHandle;
-    CORINFO_CLASS_HANDLE Vector64UShortHandle;
-    CORINFO_CLASS_HANDLE Vector64UByteHandle;
-    CORINFO_CLASS_HANDLE Vector64ShortHandle;
-    CORINFO_CLASS_HANDLE Vector64ByteHandle;
-    CORINFO_CLASS_HANDLE Vector64IntHandle;
+        CORINFO_CLASS_HANDLE Vector64FloatHandle;
+        CORINFO_CLASS_HANDLE Vector64UIntHandle;
+        CORINFO_CLASS_HANDLE Vector64UShortHandle;
+        CORINFO_CLASS_HANDLE Vector64UByteHandle;
+        CORINFO_CLASS_HANDLE Vector64ShortHandle;
+        CORINFO_CLASS_HANDLE Vector64ByteHandle;
+        CORINFO_CLASS_HANDLE Vector64IntHandle;
 #endif // defined(_TARGET_ARM64_)
-    CORINFO_CLASS_HANDLE Vector128FloatHandle;
-    CORINFO_CLASS_HANDLE Vector128DoubleHandle;
-    CORINFO_CLASS_HANDLE Vector128IntHandle;
-    CORINFO_CLASS_HANDLE Vector128UShortHandle;
-    CORINFO_CLASS_HANDLE Vector128UByteHandle;
-    CORINFO_CLASS_HANDLE Vector128ShortHandle;
-    CORINFO_CLASS_HANDLE Vector128ByteHandle;
-    CORINFO_CLASS_HANDLE Vector128LongHandle;
-    CORINFO_CLASS_HANDLE Vector128UIntHandle;
-    CORINFO_CLASS_HANDLE Vector128ULongHandle;
+        CORINFO_CLASS_HANDLE Vector128FloatHandle;
+        CORINFO_CLASS_HANDLE Vector128DoubleHandle;
+        CORINFO_CLASS_HANDLE Vector128IntHandle;
+        CORINFO_CLASS_HANDLE Vector128UShortHandle;
+        CORINFO_CLASS_HANDLE Vector128UByteHandle;
+        CORINFO_CLASS_HANDLE Vector128ShortHandle;
+        CORINFO_CLASS_HANDLE Vector128ByteHandle;
+        CORINFO_CLASS_HANDLE Vector128LongHandle;
+        CORINFO_CLASS_HANDLE Vector128UIntHandle;
+        CORINFO_CLASS_HANDLE Vector128ULongHandle;
 #if defined(_TARGET_XARCH_)
-    CORINFO_CLASS_HANDLE Vector256FloatHandle;
-    CORINFO_CLASS_HANDLE Vector256DoubleHandle;
-    CORINFO_CLASS_HANDLE Vector256IntHandle;
-    CORINFO_CLASS_HANDLE Vector256UShortHandle;
-    CORINFO_CLASS_HANDLE Vector256UByteHandle;
-    CORINFO_CLASS_HANDLE Vector256ShortHandle;
-    CORINFO_CLASS_HANDLE Vector256ByteHandle;
-    CORINFO_CLASS_HANDLE Vector256LongHandle;
-    CORINFO_CLASS_HANDLE Vector256UIntHandle;
-    CORINFO_CLASS_HANDLE Vector256ULongHandle;
+        CORINFO_CLASS_HANDLE Vector256FloatHandle;
+        CORINFO_CLASS_HANDLE Vector256DoubleHandle;
+        CORINFO_CLASS_HANDLE Vector256IntHandle;
+        CORINFO_CLASS_HANDLE Vector256UShortHandle;
+        CORINFO_CLASS_HANDLE Vector256UByteHandle;
+        CORINFO_CLASS_HANDLE Vector256ShortHandle;
+        CORINFO_CLASS_HANDLE Vector256ByteHandle;
+        CORINFO_CLASS_HANDLE Vector256LongHandle;
+        CORINFO_CLASS_HANDLE Vector256UIntHandle;
+        CORINFO_CLASS_HANDLE Vector256ULongHandle;
 #endif // defined(_TARGET_XARCH_)
 #endif // FEATURE_HW_INTRINSICS
+
+        SIMDHandlesCache()
+        {
+            memset(this, 0, sizeof(*this));
+        }
+    };
+
+    SIMDHandlesCache* m_simdHandleCache;
 
     // Get the handle for a SIMD type.
     CORINFO_CLASS_HANDLE gtGetStructHandleForSIMD(var_types simdType, var_types simdBaseType)
@@ -7302,13 +7312,14 @@ private:
             switch (simdType)
             {
                 case TYP_SIMD8:
-                    return SIMDVector2Handle;
+                    return m_simdHandleCache->SIMDVector2Handle;
                 case TYP_SIMD12:
-                    return SIMDVector3Handle;
+                    return m_simdHandleCache->SIMDVector3Handle;
                 case TYP_SIMD16:
-                    if ((getSIMDVectorType() == TYP_SIMD32) || (SIMDVector4Handle != NO_CLASS_HANDLE))
+                    if ((getSIMDVectorType() == TYP_SIMD32) ||
+                        (m_simdHandleCache->SIMDVector4Handle != NO_CLASS_HANDLE))
                     {
-                        return SIMDVector4Handle;
+                        return m_simdHandleCache->SIMDVector4Handle;
                     }
                     break;
                 case TYP_SIMD32:
@@ -7321,35 +7332,30 @@ private:
         switch (simdBaseType)
         {
             case TYP_FLOAT:
-                return SIMDFloatHandle;
+                return m_simdHandleCache->SIMDFloatHandle;
             case TYP_DOUBLE:
-                return SIMDDoubleHandle;
+                return m_simdHandleCache->SIMDDoubleHandle;
             case TYP_INT:
-                return SIMDIntHandle;
+                return m_simdHandleCache->SIMDIntHandle;
             case TYP_USHORT:
-                return SIMDUShortHandle;
+                return m_simdHandleCache->SIMDUShortHandle;
             case TYP_UBYTE:
-                return SIMDUByteHandle;
+                return m_simdHandleCache->SIMDUByteHandle;
             case TYP_SHORT:
-                return SIMDShortHandle;
+                return m_simdHandleCache->SIMDShortHandle;
             case TYP_BYTE:
-                return SIMDByteHandle;
+                return m_simdHandleCache->SIMDByteHandle;
             case TYP_LONG:
-                return SIMDLongHandle;
+                return m_simdHandleCache->SIMDLongHandle;
             case TYP_UINT:
-                return SIMDUIntHandle;
+                return m_simdHandleCache->SIMDUIntHandle;
             case TYP_ULONG:
-                return SIMDULongHandle;
+                return m_simdHandleCache->SIMDULongHandle;
             default:
                 assert(!"Didn't find a class handle for simdType");
         }
         return NO_CLASS_HANDLE;
     }
-
-    // SIMD Methods
-    CORINFO_METHOD_HANDLE SIMDVectorFloat_set_Item;
-    CORINFO_METHOD_HANDLE SIMDVectorFloat_get_Length;
-    CORINFO_METHOD_HANDLE SIMDVectorFloat_op_Addition;
 
     // Returns true if the tree corresponds to a TYP_SIMD lcl var.
     // Note that both SIMD vector args and locals are mared as lvSIMDType = true, but

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2546,7 +2546,7 @@ public:
     }
 
     // reverse map of tracked number to var number
-    unsigned lvaTrackedToVarNum[lclMAX_TRACKED];
+    unsigned* lvaTrackedToVarNum;
 
 #if DOUBLE_ALIGN
 #ifdef DEBUG

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3004,8 +3004,6 @@ protected:
 
 #define SMALL_STACK_SIZE 16 // number of elements in impSmallStack
 
-    StackEntry impSmallStack[SMALL_STACK_SIZE]; // Use this array if possible
-
     struct SavedStack // used to save/restore stack contents.
     {
         unsigned    ssDepth; // number of values on stack

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -2354,11 +2354,11 @@ inline
         FPbased = isFramePointerUsed();
         if (lvaDoneFrameLayout == Compiler::FINAL_FRAME_LAYOUT)
         {
-            TempDsc* tmpDsc = tmpFindNum(varNum);
+            TempDsc* tmpDsc = codeGen->regSet.tmpFindNum(varNum);
             // The temp might be in use, since this might be during code generation.
             if (tmpDsc == nullptr)
             {
-                tmpDsc = tmpFindNum(varNum, Compiler::TEMP_USAGE_USED);
+                tmpDsc = codeGen->regSet.tmpFindNum(varNum, RegSet::TEMP_USAGE_USED);
             }
             assert(tmpDsc != nullptr);
             offset = tmpDsc->tdTempOffs();
@@ -3063,7 +3063,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 /*****************************************************************************/
 
-/* static */ inline unsigned Compiler::tmpSlot(unsigned size)
+/* static */ inline unsigned RegSet::tmpSlot(unsigned size)
 {
     noway_assert(size >= sizeof(int));
     noway_assert(size <= TEMP_MAX_SIZE);
@@ -3079,10 +3079,10 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
  *  over a function body.
  */
 
-inline void Compiler::tmpEnd()
+inline void RegSet::tmpEnd()
 {
 #ifdef DEBUG
-    if (verbose && (tmpCount > 0))
+    if (m_rsCompiler->verbose && (tmpCount > 0))
     {
         printf("%d tmps used\n", tmpCount);
     }
@@ -3095,7 +3095,7 @@ inline void Compiler::tmpEnd()
  *  compiled.
  */
 
-inline void Compiler::tmpDone()
+inline void RegSet::tmpDone()
 {
 #ifdef DEBUG
     unsigned count;

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -6351,7 +6351,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             }
             else
             {
-                TempDsc* tmpDsc = emitComp->tmpFindNum(varNum);
+                TempDsc* tmpDsc = codeGen->regSet.tmpFindNum(varNum);
                 vt              = tmpDsc->tdTempType();
             }
             if (vt == TYP_REF || vt == TYP_BYREF)

--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -10164,7 +10164,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             }
             else
             {
-                TempDsc* tmpDsc = emitComp->tmpFindNum(varNum);
+                TempDsc* tmpDsc = codeGen->regSet.tmpFindNum(varNum);
                 vt              = tmpDsc->tdTempType();
             }
             if (vt == TYP_REF || vt == TYP_BYREF)
@@ -10188,7 +10188,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
                 }
                 else
                 {
-                    TempDsc* tmpDsc = emitComp->tmpFindNum(varNum);
+                    TempDsc* tmpDsc = codeGen->regSet.tmpFindNum(varNum);
                     vt              = tmpDsc->tdTempType();
                 }
                 if (vt == TYP_REF || vt == TYP_BYREF)

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -1865,11 +1865,11 @@ inline UNATIVE_OFFSET emitter::emitInsSizeSV(code_t code, int var, int dsp)
         }
 
         // The offset is already assigned. Find the temp.
-        TempDsc* tmp = emitComp->tmpFindNum(var, Compiler::TEMP_USAGE_USED);
+        TempDsc* tmp = codeGen->regSet.tmpFindNum(var, RegSet::TEMP_USAGE_USED);
         if (tmp == nullptr)
         {
             // It might be in the free lists, if we're working on zero initializing the temps.
-            tmp = emitComp->tmpFindNum(var, Compiler::TEMP_USAGE_FREE);
+            tmp = codeGen->regSet.tmpFindNum(var, RegSet::TEMP_USAGE_FREE);
         }
         assert(tmp != nullptr);
         offs = tmp->tdTempOffs();
@@ -3131,7 +3131,7 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
             varNum = tmpDsc->tdTempNum();
             offset = 0;
 
-            emitComp->tmpRlsTemp(tmpDsc);
+            codeGen->regSet.tmpRlsTemp(tmpDsc);
         }
         else if (memOp->isIndir())
         {

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -126,8 +126,6 @@ void Compiler::fgInit()
     /* This global flag is set whenever we add a throw block for a RngChk */
     fgRngChkThrowAdded = false; /* reset flag for fgIsCodeAdded() */
 
-    fgIncrCount = 0;
-
     /* We will record a list of all BBJ_RETURN blocks here */
     fgReturnBlocks = nullptr;
 
@@ -6808,8 +6806,6 @@ unsigned Compiler::fgGetNestingLevel(BasicBlock* block, unsigned* pFinallyNestin
 
 void Compiler::fgImport()
 {
-    fgHasPostfix = false;
-
     impImport(fgFirstBB);
 
     if (!opts.jitFlags->IsSet(JitFlags::JIT_FLAG_SKIP_VERIFICATION))

--- a/src/jit/gcencode.cpp
+++ b/src/jit/gcencode.cpp
@@ -2365,8 +2365,9 @@ size_t GCInfo::gcMakeRegPtrTable(BYTE* dest, int mask, const InfoHdr& header, un
 
         /* Count&Write spill temps that hold pointers */
 
-        assert(compiler->tmpAllFree());
-        for (TempDsc* tempItem = compiler->tmpListBeg(); tempItem != nullptr; tempItem = compiler->tmpListNxt(tempItem))
+        assert(compiler->codeGen->regSet.tmpAllFree());
+        for (TempDsc* tempItem = compiler->codeGen->regSet.tmpListBeg(); tempItem != nullptr;
+             tempItem          = compiler->codeGen->regSet.tmpListNxt(tempItem))
         {
             if (varTypeIsGC(tempItem->tdTempType()))
             {
@@ -4330,8 +4331,9 @@ void GCInfo::gcMakeRegPtrTable(
     {
         // Count&Write spill temps that hold pointers.
 
-        assert(compiler->tmpAllFree());
-        for (TempDsc* tempItem = compiler->tmpListBeg(); tempItem != nullptr; tempItem = compiler->tmpListNxt(tempItem))
+        assert(compiler->codeGen->regSet.tmpAllFree());
+        for (TempDsc* tempItem = compiler->codeGen->regSet.tmpListBeg(); tempItem != nullptr;
+             tempItem          = compiler->codeGen->regSet.tmpListNxt(tempItem))
         {
             if (varTypeIsGC(tempItem->tdTempType()))
             {

--- a/src/jit/gcinfo.cpp
+++ b/src/jit/gcinfo.cpp
@@ -499,8 +499,8 @@ void GCInfo::gcCountForHeader(UNALIGNED unsigned int* untrackedCount, UNALIGNED 
 
     /* Also count spill temps that hold pointers */
 
-    assert(compiler->tmpAllFree());
-    for (TempDsc* tempThis = compiler->tmpListBeg(); tempThis != nullptr; tempThis = compiler->tmpListNxt(tempThis))
+    assert(regSet->tmpAllFree());
+    for (TempDsc* tempThis = regSet->tmpListBeg(); tempThis != nullptr; tempThis = regSet->tmpListNxt(tempThis))
     {
         if (varTypeIsGC(tempThis->tdTempType()) == false)
         {

--- a/src/jit/hashbv.cpp
+++ b/src/jit/hashbv.cpp
@@ -358,7 +358,7 @@ bool hashBvNode::sameAs(hashBvNode* other)
 hashBv::hashBv(Compiler* comp)
 {
     this->compiler      = comp;
-    this->log2_hashSize = globalData()->hbvHashSizeLog2;
+    this->log2_hashSize = 0;
 
     int hts = hashtable_size();
     nodeArr = getNewVector(hts);
@@ -422,20 +422,6 @@ hashBvNode*& hashBv::nodeFreeList(hashBvGlobalData* data)
 hashBv*& hashBv::hbvFreeList(hashBvGlobalData* data)
 {
     return data->hbvFreeList;
-}
-
-void hashBv::freeVector(hashBvNode* vect, int vectorLength)
-{
-    // not enough space to do anything with it
-    if (vectorLength < 2)
-    {
-        return;
-    }
-
-    hbvFreeListNode* f              = (hbvFreeListNode*)vect;
-    f->next                         = globalData()->hbvFreeVectorList;
-    globalData()->hbvFreeVectorList = f;
-    f->size                         = vectorLength;
 }
 
 void hashBv::hbvFree()
@@ -547,7 +533,6 @@ void hashBv::Resize(int newSize)
         return;
     }
 
-    int oldSizeLog2  = log2_hashSize;
     int log2_newSize = genLog2((unsigned)newSize);
 
     hashBvNode** newNodes = this->getNewVector(newSize);
@@ -1297,7 +1282,6 @@ bool hashBv::MultiTraverseLHSBigger(hashBv* other)
 
     // this is larger
     hashBvNode*** cursors;
-    int           shiftFactor     = this->log2_hashSize - other->log2_hashSize;
     int           expansionFactor = hts / ots;
     cursors                       = (hashBvNode***)alloca(expansionFactor * sizeof(void*));
 
@@ -2015,13 +1999,4 @@ more_data:
         }
         goto more_data;
     }
-}
-
-indexType HbvNext(hashBv* bv, Compiler* comp)
-{
-    if (bv)
-    {
-        bv->globalData()->hashBvNextIterator.initFrom(bv);
-    }
-    return bv->globalData()->hashBvNextIterator.nextBit();
 }

--- a/src/jit/hashbv.h
+++ b/src/jit/hashbv.h
@@ -186,8 +186,6 @@ public:
 
 public:
     hashBv(Compiler* comp);
-    hashBv(hashBv* other);
-    // hashBv() {}
     static hashBv* Create(Compiler* comp);
     static void Init(Compiler* comp);
     static hashBv* CreateFrom(hashBv* other, Compiler* comp);
@@ -215,10 +213,7 @@ private:
 
     // maintain free lists for vectors
     hashBvNode** getNewVector(int vectorLength);
-    void freeVector(hashBvNode* vect, int vectorLength);
     int getNodeCount();
-
-    hashBvNode* getFreeList();
 
 public:
     inline hashBvNode* getOrAddNodeForIndex(indexType index)
@@ -281,16 +276,6 @@ public:
 // --------------------------------------------------------------------
 // --------------------------------------------------------------------
 
-class hbvFreeListNode
-{
-public:
-    hbvFreeListNode* next;
-    int              size;
-};
-
-// --------------------------------------------------------------------
-// --------------------------------------------------------------------
-
 class hashBvIterator
 {
 public:
@@ -318,16 +303,9 @@ class hashBvGlobalData
     friend class hashBv;
     friend class hashBvNode;
 
-    hashBvNode*      hbvNodeFreeList;
-    hashBv*          hbvFreeList;
-    unsigned short   hbvHashSizeLog2;
-    hbvFreeListNode* hbvFreeVectorList;
-
-public:
-    hashBvIterator hashBvNextIterator;
+    hashBvNode* hbvNodeFreeList;
+    hashBv*     hbvFreeList;
 };
-
-indexType HbvNext(hashBv* bv, Compiler* comp);
 
 // clang-format off
 #define FOREACH_HBV_BIT_SET(index, bv) \

--- a/src/jit/hwintrinsic.cpp
+++ b/src/jit/hwintrinsic.cpp
@@ -57,25 +57,25 @@ CORINFO_CLASS_HANDLE Compiler::gtGetStructHandleForHWSIMD(var_types simdType, va
         switch (simdBaseType)
         {
             case TYP_FLOAT:
-                return Vector128FloatHandle;
+                return m_simdHandleCache->Vector128FloatHandle;
             case TYP_DOUBLE:
-                return Vector128DoubleHandle;
+                return m_simdHandleCache->Vector128DoubleHandle;
             case TYP_INT:
-                return Vector128IntHandle;
+                return m_simdHandleCache->Vector128IntHandle;
             case TYP_USHORT:
-                return Vector128UShortHandle;
+                return m_simdHandleCache->Vector128UShortHandle;
             case TYP_UBYTE:
-                return Vector128UByteHandle;
+                return m_simdHandleCache->Vector128UByteHandle;
             case TYP_SHORT:
-                return Vector128ShortHandle;
+                return m_simdHandleCache->Vector128ShortHandle;
             case TYP_BYTE:
-                return Vector128ByteHandle;
+                return m_simdHandleCache->Vector128ByteHandle;
             case TYP_LONG:
-                return Vector128LongHandle;
+                return m_simdHandleCache->Vector128LongHandle;
             case TYP_UINT:
-                return Vector128UIntHandle;
+                return m_simdHandleCache->Vector128UIntHandle;
             case TYP_ULONG:
-                return Vector128ULongHandle;
+                return m_simdHandleCache->Vector128ULongHandle;
             default:
                 assert(!"Didn't find a class handle for simdType");
         }
@@ -86,25 +86,25 @@ CORINFO_CLASS_HANDLE Compiler::gtGetStructHandleForHWSIMD(var_types simdType, va
         switch (simdBaseType)
         {
             case TYP_FLOAT:
-                return Vector256FloatHandle;
+                return m_simdHandleCache->Vector256FloatHandle;
             case TYP_DOUBLE:
-                return Vector256DoubleHandle;
+                return m_simdHandleCache->Vector256DoubleHandle;
             case TYP_INT:
-                return Vector256IntHandle;
+                return m_simdHandleCache->Vector256IntHandle;
             case TYP_USHORT:
-                return Vector256UShortHandle;
+                return m_simdHandleCache->Vector256UShortHandle;
             case TYP_UBYTE:
-                return Vector256UByteHandle;
+                return m_simdHandleCache->Vector256UByteHandle;
             case TYP_SHORT:
-                return Vector256ShortHandle;
+                return m_simdHandleCache->Vector256ShortHandle;
             case TYP_BYTE:
-                return Vector256ByteHandle;
+                return m_simdHandleCache->Vector256ByteHandle;
             case TYP_LONG:
-                return Vector256LongHandle;
+                return m_simdHandleCache->Vector256LongHandle;
             case TYP_UINT:
-                return Vector256UIntHandle;
+                return m_simdHandleCache->Vector256UIntHandle;
             case TYP_ULONG:
-                return Vector256ULongHandle;
+                return m_simdHandleCache->Vector256ULongHandle;
             default:
                 assert(!"Didn't find a class handle for simdType");
         }
@@ -116,19 +116,19 @@ CORINFO_CLASS_HANDLE Compiler::gtGetStructHandleForHWSIMD(var_types simdType, va
         switch (simdBaseType)
         {
             case TYP_FLOAT:
-                return Vector64FloatHandle;
+                return m_simdHandleCache->Vector64FloatHandle;
             case TYP_UINT:
-                return Vector64UIntHandle;
+                return m_simdHandleCache->Vector64UIntHandle;
             case TYP_USHORT:
-                return Vector64UShortHandle;
+                return m_simdHandleCache->Vector64UShortHandle;
             case TYP_UBYTE:
-                return Vector64UByteHandle;
+                return m_simdHandleCache->Vector64UByteHandle;
             case TYP_SHORT:
-                return Vector64ShortHandle;
+                return m_simdHandleCache->Vector64ShortHandle;
             case TYP_BYTE:
-                return Vector64ByteHandle;
+                return m_simdHandleCache->Vector64ByteHandle;
             case TYP_INT:
-                return Vector64IntHandle;
+                return m_simdHandleCache->Vector64IntHandle;
             default:
                 assert(!"Didn't find a class handle for simdType");
         }

--- a/src/jit/hwintrinsiccodegenxarch.cpp
+++ b/src/jit/hwintrinsiccodegenxarch.cpp
@@ -410,7 +410,7 @@ void CodeGen::genHWIntrinsic_R_RM(GenTreeHWIntrinsic* node, instruction ins, emi
             varNum = tmpDsc->tdTempNum();
             offset = 0;
 
-            compiler->tmpRlsTemp(tmpDsc);
+            regSet.tmpRlsTemp(tmpDsc);
         }
         else if (op1->OperIsHWIntrinsic())
         {
@@ -534,7 +534,7 @@ void CodeGen::genHWIntrinsic_R_RM_I(GenTreeHWIntrinsic* node, instruction ins, i
             varNum = tmpDsc->tdTempNum();
             offset = 0;
 
-            compiler->tmpRlsTemp(tmpDsc);
+            regSet.tmpRlsTemp(tmpDsc);
         }
         else if (op1->OperIsHWIntrinsic())
         {
@@ -658,7 +658,7 @@ void CodeGen::genHWIntrinsic_R_R_RM(GenTreeHWIntrinsic* node, instruction ins)
             varNum = tmpDsc->tdTempNum();
             offset = 0;
 
-            compiler->tmpRlsTemp(tmpDsc);
+            regSet.tmpRlsTemp(tmpDsc);
         }
         else if (op2->OperIsHWIntrinsic())
         {
@@ -814,7 +814,7 @@ void CodeGen::genHWIntrinsic_R_R_RM_I(GenTreeHWIntrinsic* node, instruction ins,
             varNum = tmpDsc->tdTempNum();
             offset = 0;
 
-            compiler->tmpRlsTemp(tmpDsc);
+            regSet.tmpRlsTemp(tmpDsc);
         }
         else if (op2->OperIsHWIntrinsic())
         {
@@ -970,7 +970,7 @@ void CodeGen::genHWIntrinsic_R_R_RM_R(GenTreeHWIntrinsic* node, instruction ins)
             varNum = tmpDsc->tdTempNum();
             offset = 0;
 
-            compiler->tmpRlsTemp(tmpDsc);
+            regSet.tmpRlsTemp(tmpDsc);
         }
         else if (op2->OperIsHWIntrinsic())
         {
@@ -1089,7 +1089,7 @@ void CodeGen::genHWIntrinsic_R_R_R_RM(
             varNum = tmpDsc->tdTempNum();
             offset = 0;
 
-            compiler->tmpRlsTemp(tmpDsc);
+            regSet.tmpRlsTemp(tmpDsc);
         }
         else if (op3->OperIsHWIntrinsic())
         {

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -17438,26 +17438,39 @@ void Compiler::impImport(BasicBlock* method)
     }
 #endif
 
-    /* Allocate the stack contents */
+    Compiler* inlineRoot = impInlineRoot();
 
-    if (info.compMaxStack <= _countof(impSmallStack))
+    if (info.compMaxStack <= SMALL_STACK_SIZE)
     {
-        /* Use local variable, don't waste time allocating on the heap */
-
-        impStkSize              = _countof(impSmallStack);
-        verCurrentState.esStack = impSmallStack;
+        impStkSize = SMALL_STACK_SIZE;
     }
     else
     {
-        impStkSize              = info.compMaxStack;
+        impStkSize = info.compMaxStack;
+    }
+
+    if (this == inlineRoot)
+    {
+        // Allocate the stack contents
         verCurrentState.esStack = new (this, CMK_ImpStack) StackEntry[impStkSize];
+    }
+    else
+    {
+        // This is the inlinee compiler, steal the stack from the inliner compiler
+        // (after ensuring that it is large enough).
+        if (inlineRoot->impStkSize < impStkSize)
+        {
+            inlineRoot->impStkSize              = impStkSize;
+            inlineRoot->verCurrentState.esStack = new (this, CMK_ImpStack) StackEntry[impStkSize];
+        }
+
+        verCurrentState.esStack = inlineRoot->verCurrentState.esStack;
     }
 
     // initialize the entry state at start of method
     verInitCurrentState();
 
     // Initialize stuff related to figuring "spill cliques" (see spec comment for impGetSpillTmpBase).
-    Compiler* inlineRoot = impInlineRoot();
     if (this == inlineRoot) // These are only used on the root of the inlining tree.
     {
         // We have initialized these previously, but to size 0.  Make them larger.

--- a/src/jit/jit.h
+++ b/src/jit/jit.h
@@ -471,7 +471,6 @@ typedef ptrdiff_t ssize_t;
                               // case of single block methods.
 #define COUNT_LOOPS 0         // Collect stats about loops, such as the total number of natural loops, a histogram of
                               // the number of loop exits, etc.
-#define COUNT_RANGECHECKS 0   // Count range checks removed (in lexical CSE?).
 #define DATAFLOW_ITER 0       // Count iterations in lexical CSE and constant folding dataflow.
 #define DISPLAY_SIZES 0       // Display generated code, data, and GC information sizes.
 #define MEASURE_BLOCK_SIZE 0  // Collect stats about basic block and flowList node sizes and memory allocations.

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -3512,7 +3512,7 @@ void Compiler::lvaSortByRefCount()
 
     if (lvaTrackedToVarNum == nullptr)
     {
-        lvaTrackedToVarNum = static_cast<unsigned*>(compGetMemArray(lclMAX_TRACKED, sizeof(unsigned), CMK_LvaTable));
+        lvaTrackedToVarNum = new (getAllocator(CMK_LvaTable)) unsigned[lclMAX_TRACKED];
     }
 
 #ifdef DEBUG

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -4233,7 +4233,7 @@ unsigned Compiler::lvaGetMaxSpillTempSize()
 
     if (lvaDoneFrameLayout >= REGALLOC_FRAME_LAYOUT)
     {
-        result = tmpSize;
+        result = codeGen->regSet.tmpGetTotalSize();
     }
     else
     {
@@ -4802,8 +4802,8 @@ void Compiler::lvaFixVirtualFrameOffsets()
         }
     }
 
-    assert(tmpAllFree());
-    for (TempDsc* temp = tmpListBeg(); temp != nullptr; temp = tmpListNxt(temp))
+    assert(codeGen->regSet.tmpAllFree());
+    for (TempDsc* temp = codeGen->regSet.tmpListBeg(); temp != nullptr; temp = codeGen->regSet.tmpListNxt(temp))
     {
         temp->tdAdjustTempOffs(delta);
     }
@@ -6518,11 +6518,11 @@ int Compiler::lvaAllocateTemps(int stkOffs, bool mustDoubleAlign)
             assignDone = true;
         }
 
-        assert(tmpAllFree());
+        assert(codeGen->regSet.tmpAllFree());
 
     AGAIN2:
 
-        for (TempDsc* temp = tmpListBeg(); temp != nullptr; temp = tmpListNxt(temp))
+        for (TempDsc* temp = codeGen->regSet.tmpListBeg(); temp != nullptr; temp = codeGen->regSet.tmpListNxt(temp))
         {
             var_types tempType = temp->tdTempType();
             unsigned  size;
@@ -7004,8 +7004,8 @@ void Compiler::lvaTableDump(FrameLayoutState curState)
     //-------------------------------------------------------------------------
     // Display the code-gen temps
 
-    assert(tmpAllFree());
-    for (TempDsc* temp = tmpListBeg(); temp != nullptr; temp = tmpListNxt(temp))
+    assert(codeGen->regSet.tmpAllFree());
+    for (TempDsc* temp = codeGen->regSet.tmpListBeg(); temp != nullptr; temp = codeGen->regSet.tmpListNxt(temp))
     {
         printf(";  TEMP_%02u %26s%*s%7s  -> ", -temp->tdTempNum(), " ", refCntWtdWidth, " ",
                varTypeName(temp->tdTempType()));

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -3517,7 +3517,7 @@ void Compiler::lvaSortByRefCount()
 
 #ifdef DEBUG
     // Re-Initialize to -1 for safety in debug build.
-    memset(lvaTrackedToVarNum, -1, lclMAX_TRACKED);
+    memset(lvaTrackedToVarNum, -1, lclMAX_TRACKED * sizeof(unsigned));
 #endif
 
     /* Assign indices to all the variables we've decided to track */

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -40,6 +40,8 @@ void Compiler::lvaInit()
 
     lvaGenericsContextUseCount = 0;
 
+    lvaTrackedToVarNum = nullptr;
+
     lvaSortAgain    = false; // false: We don't need to call lvaSortOnly()
     lvaTrackedFixed = false; // false: We can still add new tracked variables
 
@@ -3508,9 +3510,14 @@ void Compiler::lvaSortByRefCount()
         }
     }
 
+    if (lvaTrackedToVarNum == nullptr)
+    {
+        lvaTrackedToVarNum = static_cast<unsigned*>(compGetMemArray(lclMAX_TRACKED, sizeof(unsigned), CMK_LvaTable));
+    }
+
 #ifdef DEBUG
     // Re-Initialize to -1 for safety in debug build.
-    memset(lvaTrackedToVarNum, -1, sizeof(lvaTrackedToVarNum));
+    memset(lvaTrackedToVarNum, -1, lclMAX_TRACKED);
 #endif
 
     /* Assign indices to all the variables we've decided to track */

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -2511,9 +2511,6 @@ void Compiler::fgInterBlockLocalVarLiveness()
      * Now fill in liveness info within each basic block - Backward DataFlow
      */
 
-    // This is used in the liveness computation, as a temporary.
-    VarSetOps::AssignNoCopy(this, fgMarkIntfUnionVS, VarSetOps::MakeEmpty(this));
-
     for (block = fgFirstBB; block; block = block->bbNext)
     {
         /* Tell everyone what block we're working on */

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -6352,7 +6352,7 @@ void LinearScan::recordMaxSpill()
     // only a few types should actually be seen here.
     JITDUMP("Recording the maximum number of concurrent spills:\n");
 #ifdef _TARGET_X86_
-    var_types returnType = compiler->tmpNormalizeType(compiler->info.compRetType);
+    var_types returnType = RegSet::tmpNormalizeType(compiler->info.compRetType);
     if (needDoubleTmpForFPCall || (returnType == TYP_DOUBLE))
     {
         JITDUMP("Adding a spill temp for moving a double call/return value between xmm reg and x87 stack.\n");
@@ -6366,7 +6366,7 @@ void LinearScan::recordMaxSpill()
 #endif // _TARGET_X86_
     for (int i = 0; i < TYP_COUNT; i++)
     {
-        if (var_types(i) != compiler->tmpNormalizeType(var_types(i)))
+        if (var_types(i) != RegSet::tmpNormalizeType(var_types(i)))
         {
             // Only normalized types should have anything in the maxSpill array.
             // We assume here that if type 'i' does not normalize to itself, then
@@ -6376,7 +6376,7 @@ void LinearScan::recordMaxSpill()
         if (maxSpill[i] != 0)
         {
             JITDUMP("  %s: %d\n", varTypeName(var_types(i)), maxSpill[i]);
-            compiler->tmpPreAllocateTemps(var_types(i), maxSpill[i]);
+            compiler->codeGen->regSet.tmpPreAllocateTemps(var_types(i), maxSpill[i]);
         }
     }
     JITDUMP("\n");
@@ -6458,7 +6458,7 @@ void LinearScan::updateMaxSpill(RefPosition* refPosition)
                 {
                     typ = treeNode->TypeGet();
                 }
-                typ = compiler->tmpNormalizeType(typ);
+                typ = RegSet::tmpNormalizeType(typ);
             }
 
             if (refPosition->spillAfter && !refPosition->reload)

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -9644,9 +9644,6 @@ GenTree* Compiler::fgMorphInitBlock(GenTree* tree)
         //
         if (!destDoFldAsg)
         {
-#if CPU_USES_BLOCK_MOVE
-            compBlkOpUsed = true;
-#endif
             dest             = fgMorphBlockOperand(dest, dest->TypeGet(), blockWidth, true);
             tree->gtOp.gtOp1 = dest;
             tree->gtFlags |= (dest->gtFlags & GTF_ALL_EFFECT);
@@ -10588,9 +10585,6 @@ GenTree* Compiler::fgMorphCopyBlock(GenTree* tree)
 
         if (requiresCopyBlock)
         {
-#if CPU_USES_BLOCK_MOVE
-            compBlkOpUsed = true;
-#endif
             var_types asgType = dest->TypeGet();
             dest              = fgMorphBlockOperand(dest, asgType, blockWidth, true /*isDest*/);
             asg->gtOp.gtOp1   = dest;
@@ -17061,10 +17055,6 @@ void Compiler::fgMorph()
     /* Add any internal blocks/trees we may need */
 
     fgAddInternal();
-
-#if OPT_BOOL_OPS
-    fgMultipleNots = false;
-#endif
 
 #ifdef DEBUG
     /* Inliner could add basic blocks. Check that the flowgraph data is up-to-date */

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -19,15 +19,6 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 /*****************************************************************************/
 
-#if COUNT_RANGECHECKS
-/* static */
-unsigned Compiler::optRangeChkRmv = 0;
-/* static */
-unsigned Compiler::optRangeChkAll = 0;
-#endif
-
-/*****************************************************************************/
-
 void Compiler::optInit()
 {
     optLoopsMarked = false;

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -1146,7 +1146,7 @@ bool Compiler::optRecordLoop(BasicBlock*   head,
     if (optLoopTable == nullptr)
     {
         assert(loopInd == 0);
-        optLoopTable = static_cast<LoopDsc*>(compGetMemArray(MAX_LOOP_NUM, sizeof(LoopDsc), CMK_LoopOpt));
+        optLoopTable = getAllocator(CMK_LoopOpt).allocate<LoopDsc>(MAX_LOOP_NUM);
     }
     else
     {

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -393,13 +393,7 @@ void CodeGen::siInit()
         }
         else
         {
-            siLatestTrackedScopes =
-                static_cast<siScope**>(compiler->compGetMemArray(scopeCount, sizeof(siScope*), CMK_SiScope));
-
-            for (unsigned i = 0; i < scopeCount; i++)
-            {
-                siLatestTrackedScopes[i] = nullptr;
-            }
+            siLatestTrackedScopes = new (compiler->getAllocator(CMK_SiScope)) siScope* [scopeCount] {};
         }
 
         compiler->compResetScopeLists();

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -377,19 +377,33 @@ void CodeGen::siInit()
 
     if (compiler->info.compVarScopesCount == 0)
     {
-        return;
+        siLatestTrackedScopes = nullptr;
     }
-
+    else
+    {
 #if FEATURE_EH_FUNCLETS
-    siInFuncletRegion = false;
+        siInFuncletRegion = false;
 #endif // FEATURE_EH_FUNCLETS
 
-    for (unsigned i = 0; i < lclMAX_TRACKED; i++)
-    {
-        siLatestTrackedScopes[i] = nullptr;
-    }
+        unsigned scopeCount = compiler->lvaTrackedCount;
 
-    compiler->compResetScopeLists();
+        if (scopeCount == 0)
+        {
+            siLatestTrackedScopes = nullptr;
+        }
+        else
+        {
+            siLatestTrackedScopes =
+                static_cast<siScope**>(compiler->compGetMemArray(scopeCount, sizeof(siScope*), CMK_SiScope));
+
+            for (unsigned i = 0; i < scopeCount; i++)
+            {
+                siLatestTrackedScopes[i] = nullptr;
+            }
+        }
+
+        compiler->compResetScopeLists();
+    }
 }
 
 /*****************************************************************************
@@ -669,8 +683,6 @@ void CodeGen::siUpdate()
         LclVarDsc* lclVar = &compiler->lvaTable[lclNum];
         assert(lclVar->lvTracked);
 #endif
-
-        siScope* scope = siLatestTrackedScopes[varIndex];
         siEndTrackedScope(varIndex);
     }
 

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -225,7 +225,6 @@ typedef unsigned char   regNumberSmall;
   #define CPU_HAS_FP_SUPPORT       1
   #define ROUND_FLOAT              1       // round intermed float expression results
   #define CPU_HAS_BYTE_REGS        1
-  #define CPU_USES_BLOCK_MOVE      1 
 
   // TODO-CQ: Fine tune the following xxBlk threshold values:
 
@@ -513,7 +512,6 @@ typedef unsigned char   regNumberSmall;
   #define CPU_HAS_FP_SUPPORT       1
   #define ROUND_FLOAT              0       // Do not round intermed float expression results
   #define CPU_HAS_BYTE_REGS        0
-  #define CPU_USES_BLOCK_MOVE      1 
 
   #define CPBLK_MOVS_LIMIT         16      // When generating code for CpBlk, this is the buffer size 
                                            // threshold to stop generating rep movs and switch to the helper call.
@@ -918,7 +916,6 @@ typedef unsigned char   regNumberSmall;
   #define CPU_HAS_FP_SUPPORT       1
   #define ROUND_FLOAT              0       // Do not round intermed float expression results
   #define CPU_HAS_BYTE_REGS        0
-  #define CPU_USES_BLOCK_MOVE      0
 
   #define CPBLK_UNROLL_LIMIT       32      // Upper bound to let the code generator to loop unroll CpBlk.
   #define INITBLK_UNROLL_LIMIT     32      // Upper bound to let the code generator to loop unroll InitBlk.
@@ -1219,7 +1216,6 @@ typedef unsigned char   regNumberSmall;
   #define CPU_HAS_FP_SUPPORT       1
   #define ROUND_FLOAT              0       // Do not round intermed float expression results
   #define CPU_HAS_BYTE_REGS        0
-  #define CPU_USES_BLOCK_MOVE      0
 
   #define CPBLK_UNROLL_LIMIT       64      // Upper bound to let the code generator to loop unroll CpBlk.
   #define INITBLK_UNROLL_LIMIT     64      // Upper bound to let the code generator to loop unroll InitBlk.


### PR DESCRIPTION
This brings down the size of `Compiler` from around 7.2 kbytes to around 1.9 kbytes. Some data members have moved to `CodeGen` but then the `siLatestTrackedScopes` change also brings down the size of `CodeGen` from around 5 kbytes to around 1 kbyte.

This decreases the JIT memory usage by 11.5% (14.9% with minopts) for crossgen corelib.

Mem stats diff: https://gist.github.com/mikedn/eabe00eb09a785a4d2fe24d07f80d820

This also results in 0.5% decrease in instructions retired: https://1drv.ms/x/s!Av4baJYSo5pjgr8Qa-DKqXP_4mJE6g Most of this comes from `siLatestTrackedScopes`, we no longer zero out a 512 element array. Though it's seems a bit too good to be true, maybe PIN gets confused by the `memset` call or something.