### PR TITLE
Fix Complus_JitMinOpts for the first method

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4078,7 +4078,8 @@ void Compiler::compSetOptimizationLevel()
 
     if (!theMinOptsValue && (jitMinOpts > 0))
     {
-        unsigned methodCount     = Compiler::jitTotalMethodCompiled;
+        // jitTotalMethodCompiled does not include the method that is being compiled now, so make +1.
+        unsigned methodCount     = Compiler::jitTotalMethodCompiled + 1;
         unsigned methodCountMask = methodCount & 0xFFF;
         unsigned kind            = (jitMinOpts & 0xF000000) >> 24;
         switch (kind)


### PR DESCRIPTION
Before when we set `COMPLUS_JITMinOpts=1` the first method was skipped from MinOpts because `if (jitMinOpts <= methodCount)` fails (`1 <= 0`).

The fix is to include the current method into `methodCount`.

Then:
`COMPLUS_JITMinOpts=0`: no min_opts;
`COMPLUS_JITMinOpts=1`: all methods with min_opts;
`COMPLUS_JITMinOpts=2`: all methods except the first one are compiled with min_opts;
`COMPLUS_JITMinOpts=N`: all methods starting from the Nth method are compiler with min_opts.