### PR TITLE
An UnusedValue still requires a target reg

### DIFF
--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -2901,7 +2901,7 @@ int LinearScan::BuildSimple(GenTree* tree)
         assert((kind & GTK_SMPOP) != 0);
         srcCount = BuildBinaryUses(tree->AsOp());
     }
-    if (tree->IsValue() && !tree->IsUnusedValue())
+    if (tree->IsValue())
     {
         BuildDef(tree);
     }

--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -94732,3 +94732,11 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS
 HostStyle=0
 
+[GitHub_18295.cmd_11900]
+RelativePath=JIT\Regression\JitBlue\GitHub_18295\GitHub_18295\GitHub_18295.cmd
+WorkingDir=JIT\Regression\JitBlue\GitHub_18295\GitHub_18295
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0
+

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -94756,3 +94756,11 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS
 HostStyle=0
 
+[GitHub_18295.cmd_12220]
+RelativePath=JIT\Regression\JitBlue\GitHub_18295\GitHub_18295\GitHub_18295.cmd
+WorkingDir=JIT\Regression\JitBlue\GitHub_18295\GitHub_18295
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0
+

--- a/tests/src/JIT/Regression/JitBlue/GitHub_18295/GitHub_18295.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_18295/GitHub_18295.il
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib { auto }
+.assembly extern System.Console {auto}
+.assembly UnusedValueBug { }
+
+// This bug was found on desktop CLR using ILGEN.
+// The expression ending in the 'mul' below is all dead, but not all the dead code
+// gets eliminated. On ARM, there is a SETCC resulting from the first 'cgt' that remains,
+// and it is marked as an 'UnusedValue', but the BuildSimple method wasn't creating a def
+// for an unused value. This led to an assert in the code generator.
+// 
+.class private auto ansi beforefieldinit GitHub_18295
+       extends [mscorlib]System.Object
+{
+    .method private hidebysig static int32 Test(int64 l, int32 i) cil managed
+    {
+      .locals init ([0]  int32   loc6,
+                    [1]  float32 loc8)
+
+        ldloc 0
+        ldloc 1
+        conv.ovf.i8.un
+        ldarg 0
+        not
+        cgt
+        cgt.un
+        ldloc 0
+        nop
+        not
+        not
+        mul
+        ret
+    }
+
+    .method private hidebysig static int32 Main() cil managed
+    {
+        .entrypoint
+      .vtentry 11 : 1
+      // Code size       131 (0x83)
+      .maxstack  4
+      .locals ([0] int32     returnVal)
+
+        // returnVal = 100;
+        ldc.i4.s   100
+        stloc      returnVal
+
+        // if (Test(1,1) != 1) goto F1
+        ldc.i4     1
+        ldc.i8     1
+        call       int32 GitHub_18295::Test(int64, int32)
+
+        ldc.i4.0
+        beq.s      L2
+    
+    F1:
+        // Console.WriteLine("FAIL");
+        ldstr "FAIL"
+        call void [System.Console]System.Console::WriteLine(string)
+        // returnVal = -1;
+        ldc.i4.m1
+        stloc      returnVal
+        br         L3
+    
+    L2:
+        // Console.WriteLine("PASS");
+        ldstr "PASS"
+        call void [System.Console]System.Console::WriteLine(string)
+
+    L3:
+        ldloc     returnVal
+        ret
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_18295/GitHub_18295.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_18295/GitHub_18295.ilproj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
The BuildSimple method wasn't creating a def for an unused value. Although (in this case) the code is dead, the code generator must still be able to generate code for it.