### PR TITLE
Remove MaskLoad tests from arm and arm64 lst files

### DIFF
--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -90876,14 +90876,6 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;NEW;EXCLUDED
 HostStyle=0
 
-[MaskLoad_r.cmd_11417]
-RelativePath=JIT\HardwareIntrinsics\X86\Avx\MaskLoad_r\MaskLoad_r.cmd
-WorkingDir=JIT\HardwareIntrinsics\X86\Avx\MaskLoad_r
-Expected=0
-MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW;EXCLUDED
-HostStyle=0
-
 [sharedgenerics_r.cmd_11418]
 RelativePath=Loader\classloader\DefaultInterfaceMethods\sharedgenerics\sharedgenerics_r\sharedgenerics_r.cmd
 WorkingDir=Loader\classloader\DefaultInterfaceMethods\sharedgenerics\sharedgenerics_r
@@ -91783,14 +91775,6 @@ HostStyle=0
 [CompareEqualOrderedScalar_r.cmd_11530]
 RelativePath=JIT\HardwareIntrinsics\X86\Sse2\CompareEqualOrderedScalar_r\CompareEqualOrderedScalar_r.cmd
 WorkingDir=JIT\HardwareIntrinsics\X86\Sse2\CompareEqualOrderedScalar_r
-Expected=0
-MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW;EXCLUDED
-HostStyle=0
-
-[MaskLoad_ro.cmd_11531]
-RelativePath=JIT\HardwareIntrinsics\X86\Avx\MaskLoad_ro\MaskLoad_ro.cmd
-WorkingDir=JIT\HardwareIntrinsics\X86\Avx\MaskLoad_ro
 Expected=0
 MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;NEW;EXCLUDED

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -90884,14 +90884,6 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;NEW;EXCLUDED
 HostStyle=0
 
-[MaskLoad_r.cmd_11736]
-RelativePath=JIT\HardwareIntrinsics\X86\Avx\MaskLoad_r\MaskLoad_r.cmd
-WorkingDir=JIT\HardwareIntrinsics\X86\Avx\MaskLoad_r
-Expected=0
-MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW;EXCLUDED
-HostStyle=0
-
 [sharedgenerics_r.cmd_11737]
 RelativePath=Loader\classloader\DefaultInterfaceMethods\sharedgenerics\sharedgenerics_r\sharedgenerics_r.cmd
 WorkingDir=Loader\classloader\DefaultInterfaceMethods\sharedgenerics\sharedgenerics_r
@@ -91775,14 +91767,6 @@ HostStyle=0
 [CompareNotLessThanOrEqualScalar_r.cmd_11847]
 RelativePath=JIT\HardwareIntrinsics\X86\Sse2\CompareNotLessThanOrEqualScalar_r\CompareNotLessThanOrEqualScalar_r.cmd
 WorkingDir=JIT\HardwareIntrinsics\X86\Sse2\CompareNotLessThanOrEqualScalar_r
-Expected=0
-MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW;EXCLUDED
-HostStyle=0
-
-[MaskLoad_ro.cmd_11848]
-RelativePath=JIT\HardwareIntrinsics\X86\Avx\MaskLoad_ro\MaskLoad_ro.cmd
-WorkingDir=JIT\HardwareIntrinsics\X86\Avx\MaskLoad_ro
 Expected=0
 MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS;NEW;EXCLUDED


### PR DESCRIPTION
This will disable the test from being run with smart in our windows arm
testing. This corresponds to the tests being deleted in #17637.

/cc @dotnet/jit-contrib 