### PR TITLE
Add another test for #17971

### DIFF
--- a/tests/src/JIT/Methodical/structs/ExplicitLayout.cs
+++ b/tests/src/JIT/Methodical/structs/ExplicitLayout.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+class ExplicitLayout
+{
+    [StructLayout(LayoutKind.Explicit, Size = SIZE)]
+    internal unsafe struct TestStruct
+    {
+        public const int SIZE = 32;
+
+        [FieldOffset(0)]
+        private fixed byte _data[SIZE];
+
+        [FieldOffset(0), MarshalAs(UnmanagedType.Struct, SizeConst = 16)]
+        public Guid Guid1;
+
+        [FieldOffset(16), MarshalAs(UnmanagedType.Struct, SizeConst = 16)]
+        public Guid Guid2;
+    }
+
+    internal class Program
+    {
+        private static int Main()
+        {
+            int returnVal = 100;
+
+            TestStruct t = new TestStruct();
+            t.Guid1 = Guid.NewGuid();
+            t.Guid2 = t.Guid1;
+
+            if (t.Guid1 != t.Guid2)
+            {
+                Console.WriteLine("FAIL self-copy");
+                returnVal = -1;
+            }
+
+            TestStruct t2 = new TestStruct();
+            Guid newGuid = Guid.NewGuid();
+            t2.Guid1 = newGuid;
+            t2.Guid2 = newGuid;
+
+            if (t2.Guid1 != t2.Guid2)
+            {
+                Console.WriteLine("FAIL other-copy");
+                returnVal = -1;
+            }
+
+            return returnVal;
+        }
+    }
+}

--- a/tests/src/JIT/Methodical/structs/ExplicitLayout.csproj
+++ b/tests/src/JIT/Methodical/structs/ExplicitLayout.csproj
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{0B8F1AF4-9355-4307-BC68-08A2947AD3B9}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <IlasmRoundTrip>true</IlasmRoundTrip>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ExplicitLayout.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
This was a customer-reported test case. The first (self-copy) fails without #17971, which was a fix for #17969. The second (other-copy) passes, and illustrates one way to workaround the bug in versions without this fix.