### PR TITLE
[x86/Linux] Fix crashes during unwinding with DAC

### DIFF
--- a/src/unwinder/i386/unwinder_i386.cpp
+++ b/src/unwinder/i386/unwinder_i386.cpp
@@ -30,7 +30,7 @@ BOOL OOPStackUnwinderX86::Unwind(T_CONTEXT* pContextRecord, T_KNONVOLATILE_CONTE
     EECodeInfo codeInfo;
     codeInfo.Init((PCODE) ControlPc);
 
-    if (!UnwindStackFrame(&rd, &codeInfo, UpdateAllRegs, &codeManState, NULL))
+    if (!codeInfo.IsValid() || !UnwindStackFrame(&rd, &codeInfo, UpdateAllRegs, &codeManState, NULL))
     {
         return FALSE;
     }

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -6022,7 +6022,8 @@ TADDR EECodeManager::GetAmbientSP(PREGDISPLAY     pContext,
 #endif // _DEBUG && !DACCESS_COMPILE
 
     if ((stateBuf->hdrInfoBody.prologOffs != hdrInfo::NOT_IN_PROLOG) ||
-        (stateBuf->hdrInfoBody.epilogOffs != hdrInfo::NOT_IN_EPILOG))
+        (stateBuf->hdrInfoBody.epilogOffs != hdrInfo::NOT_IN_EPILOG) ||
+        (GetRegdisplayFPAddress(pContext) == NULL))
     {
         return NULL;
     }


### PR DESCRIPTION
This PR fixes a couple of crashes when context does not contain all register values. This happens when unwinding is performed through DAC by ICorDebug-based debugger on x86 linux.

@janvorli PTAL

CC @alpencolt 
