### PR TITLE
optimize fgMorphTree for GenTreeArgList

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4901,6 +4901,7 @@ private:
     GenTree* fgUnwrapProxy(GenTree* objRef);
     GenTreeFieldList* fgMorphLclArgToFieldlist(GenTreeLclVarCommon* lcl);
     GenTreeCall* fgMorphArgs(GenTreeCall* call);
+    GenTreeArgList* fgMorphArgList(GenTreeArgList* args, MorphAddrContext* mac);
 
     void fgMakeOutgoingStructArgCopy(GenTreeCall*         call,
                                      GenTree*             args,

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -14929,6 +14929,13 @@ GenTree* Compiler::fgMorphTree(GenTree* tree, MorphAddrContext* mac)
         goto DONE;
     }
 
+    // a special handling for ArgList.
+    if (tree->OperIsList())
+    {
+        tree = fgMorphArgList(tree->AsArgList(), mac);
+        goto DONE;
+    }
+
     /* Is it a 'simple' unary/binary operator? */
 
     if (kind & GTK_SMPOP)
@@ -18887,4 +18894,65 @@ bool Compiler::fgCheckStmtAfterTailCall()
         }
     }
     return nextMorphStmt == nullptr;
+}
+
+//------------------------------------------------------------------------
+// fgMorphArgList: morph argument list tree without recursion.
+//
+// Arguments:
+//    args - argument list tree to morph;
+//    mac  - morph address context, used to morph children.
+//
+// Return Value:
+//    morphed argument list.
+//
+GenTreeArgList* Compiler::fgMorphArgList(GenTreeArgList* args, MorphAddrContext* mac)
+{
+    // Use non-recursive algorithm that morph all actual list values,
+    // memorize the last node for each effect flag and reset
+    // them during the second iteration.
+    constexpr int      numberOfTrackedFlags               = 5;
+    constexpr unsigned trackedFlags[numberOfTrackedFlags] = {GTF_ASG, GTF_CALL, GTF_EXCEPT, GTF_GLOB_REF,
+                                                             GTF_ORDER_SIDEEFF};
+    static_assert_no_msg((trackedFlags[0] | trackedFlags[1] | trackedFlags[2] | trackedFlags[3] | trackedFlags[4]) ==
+                         GTF_ALL_EFFECT);
+
+    GenTree* memorizedLastNodes[numberOfTrackedFlags] = {nullptr};
+
+    for (GenTreeArgList* listNode = args; listNode != nullptr; listNode = listNode->Rest())
+    {
+        // Morph actual list values.
+        GenTree*& arg = listNode->Current();
+        arg           = fgMorphTree(arg, mac);
+
+        // Remember the last list node with each flag.
+        for (int i = 0; i < numberOfTrackedFlags; ++i)
+        {
+            if ((arg->gtFlags & trackedFlags[i]) != 0)
+            {
+                memorizedLastNodes[i] = listNode;
+            }
+        }
+    }
+
+    for (GenTreeArgList* listNode = args; listNode != nullptr; listNode = listNode->Rest())
+    {
+        // Clear all old effects from the list node.
+        listNode->gtFlags &= ~GTF_ALL_EFFECT;
+
+        // Spread each flag to all list nodes (to the prefix) before the memorized last node.
+        for (int i = 0; i < numberOfTrackedFlags; ++i)
+        {
+            if (memorizedLastNodes[i] != nullptr)
+            {
+                listNode->gtFlags |= trackedFlags[i];
+            }
+            if (listNode == memorizedLastNodes[i])
+            {
+                memorizedLastNodes[i] = nullptr;
+            }
+        }
+    }
+
+    return args;
 }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -11861,6 +11861,9 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac)
             }
             break;
 #endif
+        case GT_LIST:
+            // Special handling for the arg list.
+            return fgMorphArgList(tree->AsArgList(), mac);
 
         default:
             break;
@@ -14926,13 +14929,6 @@ GenTree* Compiler::fgMorphTree(GenTree* tree, MorphAddrContext* mac)
     if (kind & GTK_LEAF)
     {
         tree = fgMorphLeaf(tree);
-        goto DONE;
-    }
-
-    // a special handling for ArgList.
-    if (tree->OperIsList())
-    {
-        tree = fgMorphArgList(tree->AsArgList(), mac);
         goto DONE;
     }
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -18904,8 +18904,8 @@ bool Compiler::fgCheckStmtAfterTailCall()
 //
 GenTreeArgList* Compiler::fgMorphArgList(GenTreeArgList* args, MorphAddrContext* mac)
 {
-    // Use non-recursive algorithm that morph all actual list values,
-    // memorize the last node for each effect flag and reset
+    // Use a non-recursive algorithm that morphs all actual list values,
+    // memorizes the last node for each effect flag and resets
     // them during the second iteration.
     constexpr int      numberOfTrackedFlags               = 5;
     constexpr unsigned trackedFlags[numberOfTrackedFlags] = {GTF_ASG, GTF_CALL, GTF_EXCEPT, GTF_GLOB_REF,


### PR DESCRIPTION
We can't usually have deep trees, because importer restricts trees depth:
https://github.com/dotnet/coreclr/blob/da40cb1ca8779566ca53ed6bd2fa67a926b29b38/src/jit/importer.cpp#L10173-L10178

However, it doesn't restrict depth of `GT_LIST` trees, so we can hit a stack overflow if there is a method with huge number of arguments.

This PR adds non-recursive morph for `GenTreeArgList`.

Fixes DevDiv_635180.


No asm diffs, no measurable instruction retired diff for System.Private.CoreLib.
