### PR TITLE
Update package version to 3.0.0

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -12,7 +12,7 @@
 
   <PropertyGroup>
     <!-- Central place to set the versions of all nuget packages produced in the repo -->
-    <PackageVersion Condition="'$(PackageVersion)' == ''">2.2.0</PackageVersion>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">3.0.0</PackageVersion>
 
     <!-- Set the boolean below to true to generate packages with stabilized versions -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>


### PR DESCRIPTION
This doesn't make much practical difference since CoreCLR's packages aren't
intended for any consumers other than core-setup, but we might as well try
to be consistent with our peer repos in case it provides a useful hint when
something goes wrong.