### PR TITLE
Start moving testing documentation into a single location

### DIFF
--- a/Documentation/building/test-configuration.md
+++ b/Documentation/building/test-configuration.md
@@ -1,41 +1,54 @@
-## General Test Infrastructure Notes ##
+# General Test Infrastructure
 
-### Kinds of Build Properties ###
+## Test "Kind"
+
 * Build Only
-> `<CLRTestKind>BuildOnly</CLRTestKind>`
-
- * Builds an executable. 
- * Will not execute it. 
-
+  * Builds an executable.
+  * Will not execute.
+  * e.g. `<CLRTestKind>BuildOnly</CLRTestKind>`
 * Run Only
-> `<CLRTestKind>RunOnly</CLRTestKind>`
-
- * Can use Ouput of Build and Run Project with different command line arguments. 
-* Build and Run
-> `<CLRTestKind>BuildAndRun</CLRTestKind>`
-
- * Builds an executable.
- * Will execute said executable. 
+  * Can use Output of Build and Run Project with different command line arguments.
+  * e.g. `<CLRTestKind>RunOnly</CLRTestKind>`
+* Build And Run
+  * Builds an executable.
+  * Will execute said executable.
+  * e.g. `<CLRTestKind>BuildAndRun</CLRTestKind>`
 * Shared Libraries
-> `<CLRTestKind>SharedLibrary</CLRTestKind>`
+  * For building libraries common to zero or more tests.
+  * e.g. `<CLRTestKind>SharedLibrary</CLRTestKind>`
 
- * For building libraries common to zero or more tests. 
+By default (i.e. if not specified explicitly), test "Kind" is `BuildAndRun`.
 
+## Priority
 
-By default (i.e. if not specified explicitly) a project file is BuildAndRun.
+Test cases are categorized by priority level. The most important subset should be and is the smallest subset. This subset is called priority 0.
 
-### Priority ###
-Testcases are categorized by their priority levels. The most important subset should be and is the smallest subset. This subset is called priority 0.
- * By default, a testcase is priority 0. You must elect to de-prioritize a test.
-  * To de-prioritize a test, add a property _CLRTestPriority_ to the test's project file.
-> `<CLRTestPriority>2</CLRTestPriority>`
- * Lower priority values are always run in conjunction when running higher priority value tests. I.e. if a developer elects to do a priority 2 test run, then all priority 0, 1 and 2 tests are run.
+* By default, a test case is priority 0. Tests must be explicitly de-prioritized.
+* Set the priority of a test by setting the property `<CLRTestPriority>` to the test's project file.
+  * e.g. `<CLRTestPriority>2</CLRTestPriority>`
+* Lower priority values are always run in conjunction when running higher priority value tests.
+  * i.e. if a developer elects to do a priority 2 test run, then all priority 0, 1 and 2 tests are run.
 
-### Adding Tests ###
-#### Converting an existing C# project ####
-  * Remove AssemblyName
-  * Swap in dir.props
-  * Swap in dir.targets
-  * Assign a CLRTestKind
+## Adding Test Guidelines
+
+* All test source files should include the following banner:
+```
+    // Licensed to the .NET Foundation under one or more agreements.
+    // The .NET Foundation licenses this file to you under the MIT license.
+    // See the LICENSE file in the project root for more information.
+```
+* Disable building of a test by conditionally settings the `<DisableProjectBuild>` property.
+	* e.g. `<DisableProjectBuild Condition=" '$(Platform)' == 'arm64' ">true</DisableProjectBuild>`
+* Add NuGet/MyGet references by updating the following [project file](https://github.com/dotnet/coreclr/blob/master/tests/src/Common/test_dependencies/test_dependencies.csproj).
+* Build against the `mscorlib` facade by adding `<ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>` to the test project.
+
+### Creating a new C# test project
+
+**TODO**
+
+### Converting an existing C# project
+  * Remove the `<AssemblyName>` property
+  * Import `dir.props`
+  * Import `dir.targets`
+  * Assign a `<CLRTestKind>`
   * (optional) Assign a priority value
-

--- a/Documentation/building/test-configuration.md
+++ b/Documentation/building/test-configuration.md
@@ -7,7 +7,7 @@
   * Will not execute.
   * e.g. `<CLRTestKind>BuildOnly</CLRTestKind>`
 * Run Only
-  * Can use Output of Build and Run Project with different command line arguments.
+  * Can use output of `BuildOnly` or `BuildAndRun` projects with different command line arguments.
   * e.g. `<CLRTestKind>RunOnly</CLRTestKind>`
 * Build And Run
   * Builds an executable.
@@ -24,7 +24,7 @@ By default (i.e. if not specified explicitly), test "Kind" is `BuildAndRun`.
 Test cases are categorized by priority level. The most important subset should be and is the smallest subset. This subset is called priority 0.
 
 * By default, a test case is priority 0. Tests must be explicitly de-prioritized.
-* Set the priority of a test by setting the property `<CLRTestPriority>` to the test's project file.
+* Set the priority of a test by setting the property `<CLRTestPriority>` in the test's project file.
   * e.g. `<CLRTestPriority>2</CLRTestPriority>`
 * Lower priority values are always run in conjunction when running higher priority value tests.
   * i.e. if a developer elects to do a priority 2 test run, then all priority 0, 1 and 2 tests are run.
@@ -37,7 +37,7 @@ Test cases are categorized by priority level. The most important subset should b
     // The .NET Foundation licenses this file to you under the MIT license.
     // See the LICENSE file in the project root for more information.
 ```
-* Disable building of a test by conditionally settings the `<DisableProjectBuild>` property.
+* Disable building of a test by conditionally setting the `<DisableProjectBuild>` property.
 	* e.g. `<DisableProjectBuild Condition=" '$(Platform)' == 'arm64' ">true</DisableProjectBuild>`
 * Add NuGet/MyGet references by updating the following [project file](https://github.com/dotnet/coreclr/blob/master/tests/src/Common/test_dependencies/test_dependencies.csproj).
 * Build against the `mscorlib` facade by adding `<ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>` to the test project.

--- a/Documentation/workflow/RunningTests.md
+++ b/Documentation/workflow/RunningTests.md
@@ -1,10 +1,42 @@
-
 # Running .NET Core Tests
 
-TODO - Incomplete. 
+Details on test metadata can be found in [test-configuration.md](https://github.com/dotnet/coreclr/blob/master/Documentation/building/test-configuration.md).
 
-See [Windows Instructions](../building/windows-test-instructions.md)
-See [Unix Instructions](../building/unix-test-instructions.md)
+## Build All Tests
 
+1) Build the CoreCLR product
+    * [Unix](https://github.com/dotnet/coreclr/blob/master/Documentation/building/linux-instructions.md)
+    * [OSX](https://github.com/dotnet/coreclr/blob/master/Documentation/building/osx-instructions.md)
+    * [Windows](https://github.com/dotnet/coreclr/blob/master/Documentation/building/windows-instructions.md)
+1) From the root directory run the following command:
+    * Non-Windows - `./build-test.sh`
+    * Windows - `build-test.cmd`
+    * Supply `-h` for usage flags
 
+### Examples
 
+* Build all tests priority `2` and higher
+  * `build-test.cmd -priority=2`
+
+## Build Individual Test
+
+Note: The CoreCLR must be built prior to building an individual test. See first step for building all tests.
+
+* Native Test: Build the generated CMake projects
+  * Projects are auto-generated when the `build-test.sh`/`build-test.cmd` script is run
+* Managed Test: Invoke MSBuild on the project directly
+  * Non-Windows - All of the necessary tools to build are under `coreclr/Tools`. It is possible to use `coreclr/Tools/MSBuild.dll` as you would normally use MSBuild with a few caveats. The `coreclr/Tools/msbuild.sh` script exists to make the call shorter.
+    * **Note:** Passing `/p:__BuildOs=`[`OSX`|`Linux`] is required. Otherwise the following error will occur: `error MSB4801: The task factory "CodeTaskFactory" could not be loaded because this version of MSBuild does not support it.`
+  * Windows - Use Visual Studio Developer command prompt
+
+### Examples
+
+* Using the `msbuild.sh` script
+  * `coreclr/Tools/msbuild.sh /maxcpucount coreclr/tests/src/JIT/CodeGenBringUpTests/Array1.csproj /p:__BuildType=Release /p:__BuildOS=OSX`
+* Calling `MSBuild.dll` directly
+  * `coreclr/Tools/dotnetcli/dotnet coreclr/Tools/MSBuild.dll /maxcpucount coreclr/tests/src/JIT/CodeGenBringUpTests/Array1.csproj /p:__BuildType=Release /p:__BuildOS=OSX`
+
+## Additional Documents
+
+* [Windows](https://github.com/dotnet/coreclr/blob/master/Documentation/building/windows-test-instructions.md)
+* [Non-Windows](https://github.com/dotnet/coreclr/blob/master/Documentation/building/unix-test-instructions.md)


### PR DESCRIPTION
Start moving testing documentation into a single location
Update `test-configuration.md` with more details on creating a test and requirements

Working on #18594