### PR TITLE
Fix incorrect usage of ILCodeVersion::AsNode (issue #18602)

### DIFF
--- a/src/debug/daccess/dacdbiimpl.cpp
+++ b/src/debug/daccess/dacdbiimpl.cpp
@@ -7169,7 +7169,7 @@ HRESULT DacDbiInterfaceImpl::GetActiveRejitILCodeVersionNode(VMPTR_Module vmModu
     // manager's active IL version hasn't yet asked the profiler for the IL body to use, in which case we want to filter it
     //  out from the return in this method.
     ILCodeVersion activeILVersion = pCodeVersionManager->GetActiveILCodeVersion(pModule, methodTk);
-    if (activeILVersion.IsNull() || activeILVersion.GetRejitState() != ILCodeVersion::kStateActive)
+    if (activeILVersion.IsNull() || activeILVersion.IsDefaultVersion() || activeILVersion.GetRejitState() != ILCodeVersion::kStateActive)
     {
         pVmILCodeVersionNode->SetDacTargetPtr(0);
     }

--- a/src/vm/codeversion.cpp
+++ b/src/vm/codeversion.cpp
@@ -940,6 +940,9 @@ HRESULT ILCodeVersion::SetActiveNativeCodeVersion(NativeCodeVersion activeNative
 ILCodeVersionNode* ILCodeVersion::AsNode()
 {
     LIMITED_METHOD_CONTRACT;
+    //This is dangerous - NativeCodeVersion coerces non-explicit versions to NULL but ILCodeVersion assumes the caller
+    //will never invoke AsNode() on a non-explicit node. Asserting for now as a minimal fix, but we should revisit this.
+    _ASSERTE(m_storageKind == StorageKind::Explicit);
     return m_pVersionNode;
 }
 #endif //DACCESS_COMPILE
@@ -947,6 +950,9 @@ ILCodeVersionNode* ILCodeVersion::AsNode()
 PTR_ILCodeVersionNode ILCodeVersion::AsNode() const
 {
     LIMITED_METHOD_DAC_CONTRACT;
+    //This is dangerous - NativeCodeVersion coerces non-explicit versions to NULL but ILCodeVersion assumes the caller
+    //will never invoke AsNode() on a non-explicit node. Asserting for now as a minimal fix, but we should revisit this.
+    _ASSERTE(m_storageKind == StorageKind::Explicit);
     return m_pVersionNode;
 }
 


### PR DESCRIPTION
When the debugger is querying the active rejit IL for an IL method that has not been rejitted, it incorrectly creates a VMPTR_ILCodeVersionNode for a code version that shouldn't have one.


Fixes #18602 
PTAL @kouvel 

I'm starting with a minimal fix that we could look at cherry picking for 2.1 servicing, then we can come back with potentially a more aggressive fix that would only go into v.next.