### PR TITLE
Fix value numbering when selecting a constant

### DIFF
--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -2568,49 +2568,41 @@ ValueNum ValueNumStore::VNApplySelectorsTypeCheck(ValueNum elem, var_types indTy
 
     if (indType != elemTyp)
     {
-        bool isConstant = IsVNConstant(elem);
-        if (isConstant && (elemTyp == genActualType(indType)))
+        // We are trying to read from an 'elem' of type 'elemType' using 'indType' read
+
+        size_t elemTypSize = (elemTyp == TYP_STRUCT) ? elemStructSize : genTypeSize(elemTyp);
+        size_t indTypeSize = genTypeSize(indType);
+
+        if ((indType == TYP_REF) && (varTypeIsStruct(elemTyp)))
         {
-            // (i.e. We recorded a constant of TYP_INT for a TYP_BYTE field)
+            // indType is TYP_REF and elemTyp is TYP_STRUCT
+            //
+            // We have a pointer to a static that is a Boxed Struct
+            //
+            return elem;
+        }
+        else if (indTypeSize > elemTypSize)
+        {
+            // Reading beyong the end of 'elem'
+
+            // return a new unique value number
+            elem = VNForExpr(nullptr, indType);
+            JITDUMP("    *** Mismatched types in VNApplySelectorsTypeCheck (reading beyond the end)\n");
+        }
+        else if (varTypeIsStruct(indType))
+        {
+            // indType is TYP_STRUCT
+
+            // return a new unique value number
+            elem = VNForExpr(nullptr, indType);
+            JITDUMP("    *** Mismatched types in VNApplySelectorsTypeCheck (indType is TYP_STRUCT)\n");
         }
         else
         {
-            // We are trying to read from an 'elem' of type 'elemType' using 'indType' read
+            // We are trying to read an 'elem' of type 'elemType' using 'indType' read
 
-            size_t elemTypSize = (elemTyp == TYP_STRUCT) ? elemStructSize : genTypeSize(elemTyp);
-            size_t indTypeSize = genTypeSize(indType);
-
-            if ((indType == TYP_REF) && (varTypeIsStruct(elemTyp)))
-            {
-                // indType is TYP_REF and elemTyp is TYP_STRUCT
-                //
-                // We have a pointer to a static that is a Boxed Struct
-                //
-                return elem;
-            }
-            else if (indTypeSize > elemTypSize)
-            {
-                // Reading beyong the end of 'elem'
-
-                // return a new unique value number
-                elem = VNForExpr(nullptr, indType);
-                JITDUMP("    *** Mismatched types in VNApplySelectorsTypeCheck (reading beyond the end)\n");
-            }
-            else if (varTypeIsStruct(indType))
-            {
-                // indType is TYP_STRUCT
-
-                // return a new unique value number
-                elem = VNForExpr(nullptr, indType);
-                JITDUMP("    *** Mismatched types in VNApplySelectorsTypeCheck (indType is TYP_STRUCT)\n");
-            }
-            else
-            {
-                // We are trying to read an 'elem' of type 'elemType' using 'indType' read
-
-                // insert a cast of elem to 'indType'
-                elem = VNForCast(elem, indType, elemTyp);
-            }
+            // insert a cast of elem to 'indType'
+            elem = VNForCast(elem, indType, elemTyp);
         }
     }
     return elem;

--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -94724,3 +94724,19 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS
 HostStyle=0
 
+[GitHub_18235_1.cmd_11901]
+RelativePath=JIT\Regression\JitBlue\GitHub_18235\GitHub_18235_1\GitHub_18235_1.cmd
+WorkingDir=JIT\Regression\JitBlue\GitHub_18235\GitHub_18235_1
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0
+
+[GitHub_18235_2.cmd_11902]
+RelativePath=JIT\Regression\JitBlue\GitHub_18235\GitHub_18235_2\GitHub_18235_2.cmd
+WorkingDir=JIT\Regression\JitBlue\GitHub_18235\GitHub_18235_2
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0
+

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -94748,3 +94748,18 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS
 HostStyle=0
 
+[GitHub_18235_1.cmd_12221]
+RelativePath=JIT\Regression\JitBlue\GitHub_18235\GitHub_18235_1\GitHub_18235_1.cmd
+WorkingDir=JIT\Regression\JitBlue\GitHub_18235\GitHub_18235_1
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0
+
+[GitHub_18235_2.cmd_12222]
+RelativePath=JIT\Regression\JitBlue\GitHub_18235\GitHub_18235_2\GitHub_18235_2.cmd
+WorkingDir=JIT\Regression\JitBlue\GitHub_18235\GitHub_18235_2
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0

--- a/tests/src/JIT/Regression/JitBlue/GitHub_18235/GitHub_18235_1.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_18235/GitHub_18235_1.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+class C0
+{
+    public sbyte F;
+}
+
+public class Program
+{
+    public static int Main()
+    {
+        C0 var0 = new C0 { F = -1 };
+        // The JIT was giving (byte)var0.F the same value number as the -1 assigned
+        // above, which was causing the OR below to be discarded.
+        ulong var1 = (ulong)(1000 | (byte)var0.F);
+        return var1 == 1023 ? 100 : 0;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_18235/GitHub_18235_1.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_18235/GitHub_18235_1.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_18235/GitHub_18235_2.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_18235/GitHub_18235_2.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+struct S0
+{
+    public uint F0;
+    public byte F2;
+    public int F3;
+    public sbyte F5;
+    public long F8;
+}
+
+public class Program
+{
+    static uint s_0;
+    public static int Main()
+    {
+        S0 vr3 = new S0();
+        vr3.F0 = 0x10001;
+        // The JIT was giving the RHS below the same value-number as
+        // 0x10001 above, which was then constant propagated to
+        // usages of vr4, even though it should be narrowed.
+        uint vr4 = (ushort)vr3.F0;
+        s_0 = vr4;
+        return vr4 == 1 ? 100 : 0;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_18235/GitHub_18235_2.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_18235/GitHub_18235_2.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
When applying selectors, constants were special-cased to not require any
type casts. However this is wrong if a narrowing needs to be performed.

Fix #18235 

I have fixed this problem by removing the special casing. The diff is easier to read without whitespace (there should only be deletions).