### PR TITLE
pal/loader: load dynamic libraries with RTLD_GLOBAL flag enabled

### DIFF
--- a/src/pal/src/loader/module.cpp
+++ b/src/pal/src/loader/module.cpp
@@ -1400,7 +1400,7 @@ static void *LOADLoadLibraryDirect(LPCSTR libraryNameOrPath)
     _ASSERTE(libraryNameOrPath != nullptr);
     _ASSERTE(libraryNameOrPath[0] != '\0');
 
-    void *dl_handle = dlopen(libraryNameOrPath, RTLD_LAZY);
+    void *dl_handle = dlopen(libraryNameOrPath, RTLD_LAZY | RTLD_GLOBAL);
     if (dl_handle == nullptr)
     {
         SetLastError(ERROR_MOD_NOT_FOUND);

--- a/src/pal/tests/palsuite/loader/LoadLibraryA/CMakeLists.txt
+++ b/src/pal/tests/palsuite/loader/LoadLibraryA/CMakeLists.txt
@@ -5,4 +5,5 @@ add_subdirectory(test2)
 add_subdirectory(test3)
 add_subdirectory(test5)
 add_subdirectory(test7)
+add_subdirectory(test9)
 

--- a/src/pal/tests/palsuite/loader/LoadLibraryA/test9/Addon.c
+++ b/src/pal/tests/palsuite/loader/LoadLibraryA/test9/Addon.c
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "MainLibrary.h"
+
+extern int GetIntAddon()
+{
+    return GetInt() + 123;
+}

--- a/src/pal/tests/palsuite/loader/LoadLibraryA/test9/CMakeLists.txt
+++ b/src/pal/tests/palsuite/loader/LoadLibraryA/test9/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 2.8.12.2)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(SOURCES
+  LoadLibraryA.cpp
+)
+
+add_executable(paltest_loadlibrarya_test9
+  ${SOURCES}
+)
+
+add_library(addon
+  SHARED
+  Addon.c
+)
+
+add_library(mainlibrary
+  SHARED
+  MainLibrary.c
+)
+
+add_dependencies(paltest_loadlibrarya_test9 coreclrpal)
+
+target_link_libraries(paltest_loadlibrarya_test9
+  ${COMMON_TEST_LIBRARIES}
+)

--- a/src/pal/tests/palsuite/loader/LoadLibraryA/test9/LoadLibraryA.cpp
+++ b/src/pal/tests/palsuite/loader/LoadLibraryA/test9/LoadLibraryA.cpp
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+/*=============================================================
+**
+** Source:  LoadLibraryA.cpp
+**
+** Purpose: Test loading of two libraries when one use extern
+**          symbols without linking
+**
+**============================================================*/
+#include <palsuite.h>
+
+/* SHLEXT is defined only for Unix variants */
+
+#if defined(SHLEXT)
+#define ModuleName    "librotor_pal"SHLEXT
+#else
+#define ModuleName    "rotor_pal.dll"
+#endif
+
+typedef int (__cdecl *AddonFunction)();
+
+int __cdecl main(int argc, char *argv[])
+{
+    int err;
+    const char *libs[] = {
+        "./libmainlibrary.so",
+        "./libaddon.so"
+    };
+    int libsNr = sizeof(libs) / sizeof(libs[0]);
+    HMODULE *ModuleHandles = new HMODULE[libsNr];
+
+    /* Initialize the PAL environment */
+    err = PAL_Initialize(argc, argv);
+    if(0 != err)
+    {
+        ExitProcess(FAIL);
+    }
+
+    for (int i = 0; i < libsNr; i++)
+    {
+        /* load a module */
+        ModuleHandles[i] = LoadLibrary(libs[i]);
+        if(!ModuleHandles[i])
+        {
+            Fail("Failed to call LoadLibrary API on %s!\n", libs[i]);
+        }
+    }
+
+    AddonFunction testFunction =
+        (AddonFunction)GetProcAddress(ModuleHandles[1], "GetIntAddon");
+    testFunction();
+
+    for (int i = 0; i < libsNr; i++)
+    {
+        /* decrement the reference count of the loaded dll */
+        err = FreeLibrary(ModuleHandles[i]);
+        if(0 == err)
+        {
+            Fail("\nFailed to all FreeLibrary API!\n");
+        }
+    }
+
+    PAL_Terminate();
+
+    delete[] ModuleHandles;
+
+    return PASS;
+}

--- a/src/pal/tests/palsuite/loader/LoadLibraryA/test9/MainLibrary.c
+++ b/src/pal/tests/palsuite/loader/LoadLibraryA/test9/MainLibrary.c
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+int GetInt()
+{
+    return 123;
+}

--- a/src/pal/tests/palsuite/loader/LoadLibraryA/test9/MainLibrary.h
+++ b/src/pal/tests/palsuite/loader/LoadLibraryA/test9/MainLibrary.h
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef MAIN_LIBRARY_H
+#define MAIN_LIBRARY_H
+
+extern int GetInt();
+
+#endif // MAIN_LIBRARY_H


### PR DESCRIPTION
Addons for this library http://www.un4seen.com (such as fx) cannot be loaded with DllImport, the only soultion is to DllImport dlopen and manually load libbass.so it with RTLD_GLOBAL. Closes #18599