### PR TITLE
Cross-bitness in ZapRelocs

### DIFF
--- a/src/zap/common.h
+++ b/src/zap/common.h
@@ -27,6 +27,12 @@
 #endif
 #endif // !_TARGET_X86_ || FEATURE_PAL
 
+#ifdef _TARGET_64BIT_
+typedef unsigned __int64 target_size_t;
+#else
+typedef unsigned int target_size_t;
+#endif
+
 #include "utilcode.h"
 #include "corjit.h"
 #include "jithost.h"

--- a/src/zap/common.h
+++ b/src/zap/common.h
@@ -28,9 +28,9 @@
 #endif // !_TARGET_X86_ || FEATURE_PAL
 
 #ifdef _TARGET_64BIT_
-typedef unsigned __int64 target_size_t;
+typedef unsigned __int64 TARGET_POINTER_TYPE;
 #else
-typedef unsigned int target_size_t;
+typedef unsigned int TARGET_POINTER_TYPE;
 #endif
 
 #include "utilcode.h"

--- a/src/zap/zapimport.cpp
+++ b/src/zap/zapimport.cpp
@@ -362,12 +362,12 @@ void ZapImport::Save(ZapWriter * pZapWriter)
 {
     if (IsReadyToRunCompilation())
     {
-        target_size_t value = 0;
+        TARGET_POINTER_TYPE value = 0;
         pZapWriter->Write(&value, sizeof(value));
         return;
     }
 
-    target_size_t token = CORCOMPILE_TAG_TOKEN(GetBlob()->GetRVA());
+    TARGET_POINTER_TYPE token = CORCOMPILE_TAG_TOKEN(GetBlob()->GetRVA());
     pZapWriter->Write(&token, sizeof(token));
 }
 
@@ -639,7 +639,7 @@ public:
     {
         ZapImage * pImage = ZapImage::GetImage(pZapWriter);
 
-        target_size_t cell;
+        TARGET_POINTER_TYPE cell;
         pImage->WriteReloc(&cell, 0, m_pDelayLoadHelper, 0, IMAGE_REL_BASED_PTR);
         pZapWriter->Write(&cell, sizeof(cell));
     }
@@ -745,7 +745,7 @@ public:
     {
         ZapImage * pImage = ZapImage::GetImage(pZapWriter);
 
-        target_size_t cell;
+        TARGET_POINTER_TYPE cell;
         pImage->WriteReloc(&cell, 0, m_pDelayLoadHelper, 0, IMAGE_REL_BASED_PTR);
         pZapWriter->Write(&cell, sizeof(cell));
     }
@@ -1725,7 +1725,7 @@ public:
     {
         ZapImage * pImage = ZapImage::GetImage(pZapWriter);
 
-        target_size_t cell;
+        TARGET_POINTER_TYPE cell;
         pImage->WriteReloc(&cell, 0, m_pDelayLoadHelper, 0, IMAGE_REL_BASED_PTR);
         pZapWriter->Write(&cell, sizeof(cell));
     }

--- a/src/zap/zapimport.cpp
+++ b/src/zap/zapimport.cpp
@@ -362,13 +362,13 @@ void ZapImport::Save(ZapWriter * pZapWriter)
 {
     if (IsReadyToRunCompilation())
     {
-        SIZE_T value = 0;
-        pZapWriter->Write(&value, TARGET_POINTER_SIZE);
+        target_size_t value = 0;
+        pZapWriter->Write(&value, sizeof(value));
         return;
     }
 
-    SIZE_T token = CORCOMPILE_TAG_TOKEN(GetBlob()->GetRVA());
-    pZapWriter->Write(&token, TARGET_POINTER_SIZE);
+    target_size_t token = CORCOMPILE_TAG_TOKEN(GetBlob()->GetRVA());
+    pZapWriter->Write(&token, sizeof(token));
 }
 
 //
@@ -639,9 +639,9 @@ public:
     {
         ZapImage * pImage = ZapImage::GetImage(pZapWriter);
 
-        PVOID cell;
+        target_size_t cell;
         pImage->WriteReloc(&cell, 0, m_pDelayLoadHelper, 0, IMAGE_REL_BASED_PTR);
-        pZapWriter->Write(&cell, TARGET_POINTER_SIZE);
+        pZapWriter->Write(&cell, sizeof(cell));
     }
 };
 
@@ -745,9 +745,9 @@ public:
     {
         ZapImage * pImage = ZapImage::GetImage(pZapWriter);
 
-        PVOID cell;
+        target_size_t cell;
         pImage->WriteReloc(&cell, 0, m_pDelayLoadHelper, 0, IMAGE_REL_BASED_PTR);
-        pZapWriter->Write(&cell, TARGET_POINTER_SIZE);
+        pZapWriter->Write(&cell, sizeof(cell));
     }
 };
 
@@ -1725,9 +1725,9 @@ public:
     {
         ZapImage * pImage = ZapImage::GetImage(pZapWriter);
 
-        PVOID cell;
+        target_size_t cell;
         pImage->WriteReloc(&cell, 0, m_pDelayLoadHelper, 0, IMAGE_REL_BASED_PTR);
-        pZapWriter->Write(&cell, TARGET_POINTER_SIZE);
+        pZapWriter->Write(&cell, sizeof(cell));
     }
 };
 

--- a/src/zap/zapimport.cpp
+++ b/src/zap/zapimport.cpp
@@ -363,12 +363,12 @@ void ZapImport::Save(ZapWriter * pZapWriter)
     if (IsReadyToRunCompilation())
     {
         SIZE_T value = 0;
-        pZapWriter->Write(&value, sizeof(value));
+        pZapWriter->Write(&value, TARGET_POINTER_SIZE);
         return;
     }
 
     SIZE_T token = CORCOMPILE_TAG_TOKEN(GetBlob()->GetRVA());
-    pZapWriter->Write(&token, sizeof(token));
+    pZapWriter->Write(&token, TARGET_POINTER_SIZE);
 }
 
 //
@@ -641,7 +641,7 @@ public:
 
         PVOID cell;
         pImage->WriteReloc(&cell, 0, m_pDelayLoadHelper, 0, IMAGE_REL_BASED_PTR);
-        pZapWriter->Write(&cell, sizeof(cell));
+        pZapWriter->Write(&cell, TARGET_POINTER_SIZE);
     }
 };
 
@@ -747,7 +747,7 @@ public:
 
         PVOID cell;
         pImage->WriteReloc(&cell, 0, m_pDelayLoadHelper, 0, IMAGE_REL_BASED_PTR);
-        pZapWriter->Write(&cell, sizeof(cell));
+        pZapWriter->Write(&cell, TARGET_POINTER_SIZE);
     }
 };
 
@@ -1727,7 +1727,7 @@ public:
 
         PVOID cell;
         pImage->WriteReloc(&cell, 0, m_pDelayLoadHelper, 0, IMAGE_REL_BASED_PTR);
-        pZapWriter->Write(&cell, sizeof(cell));
+        pZapWriter->Write(&cell, TARGET_POINTER_SIZE);
     }
 };
 

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -2574,7 +2574,7 @@ void ZapInfo::recordRelocation(void *location, void *target,
         break;
 
     case IMAGE_REL_BASED_PTR:
-        *(UNALIGNED target_size_t *)location = (target_size_t)targetOffset;
+        *(UNALIGNED TARGET_POINTER_TYPE *)location = (TARGET_POINTER_TYPE)targetOffset;
         break;
 
 #if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -2574,11 +2574,7 @@ void ZapInfo::recordRelocation(void *location, void *target,
         break;
 
     case IMAGE_REL_BASED_PTR:
-#ifdef _TARGET_64BIT_
-        *(UNALIGNED TADDR *)location = (TADDR)targetOffset;
-#else
-        *(UNALIGNED DWORD *)location = (DWORD)targetOffset;
-#endif // _TARGET_64BIT_
+        *(UNALIGNED target_size_t *)location = (target_size_t)targetOffset;
         break;
 
 #if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -2574,7 +2574,11 @@ void ZapInfo::recordRelocation(void *location, void *target,
         break;
 
     case IMAGE_REL_BASED_PTR:
+#ifdef _TARGET_64BIT_
         *(UNALIGNED TADDR *)location = (TADDR)targetOffset;
+#else
+        *(UNALIGNED DWORD *)location = (DWORD)targetOffset;
+#endif // _TARGET_64BIT_
         break;
 
 #if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)

--- a/src/zap/zaprelocs.cpp
+++ b/src/zap/zaprelocs.cpp
@@ -47,8 +47,10 @@ void ZapBaseRelocs::WriteReloc(PVOID pSrc, int offset, ZapNode * pTarget, int ta
 #ifdef _TARGET_ARM_
         // Misaligned relocs disable ASLR on ARM. We should never ever emit them.
         _ASSERTE(IS_ALIGNED(rva, TARGET_POINTER_SIZE));
-#endif
+        *(UNALIGNED DWORD *)pLocation = (DWORD)pActualTarget;
+#else
         *(UNALIGNED TADDR *)pLocation = pActualTarget;
+#endif
         break;
 
     case IMAGE_REL_BASED_RELPTR:
@@ -122,7 +124,7 @@ void ZapBaseRelocs::WriteReloc(PVOID pSrc, int offset, ZapNode * pTarget, int ta
         }
         // IMAGE_REL_BASED_THUMB_BRANCH24 does not need base reloc entry
         return;
-#endif
+#endif // defined(_TARGET_ARM_)
 #if defined(_TARGET_ARM64_)
     case IMAGE_REL_ARM64_BRANCH26:
         {

--- a/src/zap/zaprelocs.cpp
+++ b/src/zap/zaprelocs.cpp
@@ -92,7 +92,7 @@ void ZapBaseRelocs::WriteReloc(PVOID pSrc, int offset, ZapNode * pTarget, int ta
             // description of IMAGE_REL_BASED_REL_THUMB_MOV32_PCREL
             const UINT32 offsetCorrection = 12;
 
-            UINT32 imm32 = pActualTarget - (pSite + offsetCorrection);
+            UINT32 imm32 = UINT32(pActualTarget - (pSite + offsetCorrection));
 
             PutThumb2Mov32((UINT16 *)pLocation, imm32);
 

--- a/src/zap/zaprelocs.cpp
+++ b/src/zap/zaprelocs.cpp
@@ -48,7 +48,7 @@ void ZapBaseRelocs::WriteReloc(PVOID pSrc, int offset, ZapNode * pTarget, int ta
         // Misaligned relocs disable ASLR on ARM. We should never ever emit them.
         _ASSERTE(IS_ALIGNED(rva, TARGET_POINTER_SIZE));
 #endif
-        *(UNALIGNED target_size_t *)pLocation = (target_size_t)pActualTarget;
+        *(UNALIGNED TARGET_POINTER_TYPE *)pLocation = (TARGET_POINTER_TYPE)pActualTarget;
         break;
 
     case IMAGE_REL_BASED_RELPTR:

--- a/src/zap/zaprelocs.cpp
+++ b/src/zap/zaprelocs.cpp
@@ -47,10 +47,8 @@ void ZapBaseRelocs::WriteReloc(PVOID pSrc, int offset, ZapNode * pTarget, int ta
 #ifdef _TARGET_ARM_
         // Misaligned relocs disable ASLR on ARM. We should never ever emit them.
         _ASSERTE(IS_ALIGNED(rva, TARGET_POINTER_SIZE));
-        *(UNALIGNED DWORD *)pLocation = (DWORD)pActualTarget;
-#else
-        *(UNALIGNED TADDR *)pLocation = pActualTarget;
 #endif
+        *(UNALIGNED target_size_t *)pLocation = (target_size_t)pActualTarget;
         break;
 
     case IMAGE_REL_BASED_RELPTR:


### PR DESCRIPTION
`TADDR` is defined as `typedef ULONG_PTR TADDR` in VM and it seems to me that it's almost impossible to use target-specific typedef for `TADDR`. In this PR I identified small number of places in src/zap where `TADDR` is used for writing relocation records to PE image and replaced those with `DWORD` keeping the rest of CoreCLR untouched. As usually, I validated these changes on CoreLib and CoreFX assemblies (incl. test assemblies) by checking that output of x86_arm and x64_arm crossgens are identical.


@jkotas Do you think this is a right approach?

