### PR TITLE
Fix Sync.sh to Property Handle Positional Parameters and Remove Conditional DotNETRuntimeEventSource.cs Compilation

### DIFF
--- a/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -443,7 +443,7 @@
     <Compile Include="$(BclSourcesRoot)\System\Diagnostics\Eventing\EventPipe.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Diagnostics\Eventing\EventPipeEventProvider.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Diagnostics\Eventing\EventPipeMetadataGenerator.cs" />
-    <Compile Condition="Exists('$(IntermediateOutputPath)..\eventing\DotNETRuntimeEventSource.cs')" Include="$(IntermediateOutputPath)..\eventing\DotNETRuntimeEventSource.cs" />
+    <Compile Include="$(IntermediateOutputPath)..\eventing\DotNETRuntimeEventSource.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Diagnostics\Eventing\TraceLogging\TraceLoggingEventHandleTable.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/sync.sh
+++ b/sync.sh
@@ -13,7 +13,9 @@ working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 unprocessedBuildArgs=
 
 # Parse arguments
-if [ $# == 0 ]; then
+# Assume the default '-p' argument if the only arguments specified are specified after double dash.
+# Only position parameters can be specified after the double dash.
+if [ $# == 0 ] || [ $1 == '--' ]; then
     buildArgs="-p"
 fi
 


### PR DESCRIPTION
Fixes #18661.

Official builds call sync.sh using the following command line:
```
./sync.sh -- /p:BuildType=Debug
```

Due to a bug in sync.sh, instead of just doing a sync operation, this does a full build of the managed components - System.Private.CoreLib and SOS.NETCore.  This used to work and wasn't a huge deal, but now is broken because we generate DotNETRuntimeEventSource.cs as part of the build and this occurs after the sync operation.

The root cause of the bug is that sync.sh does not specify the default argument ```-p``` to run.exe if any arguments are specified to sync.sh.  This includes positional parameters after the double dash.  If -p is not specified then ```/t:sync``` is not passed to msbuild, thus causing the full managed build instead of just the restore operation.

The solution is to detect this case (no args other than positional parameters after ```--```) and assume ```-p```.