### PR TITLE
Fix alternate stack cleanup on MUSL

### DIFF
--- a/src/pal/src/exception/signal.cpp
+++ b/src/pal/src/exception/signal.cpp
@@ -199,6 +199,10 @@ Return :
 void FreeSignalAlternateStack()
 {
     stack_t ss, oss;
+    // The man page for sigaltstack says that when the ss.ss_flags is set to SS_DISABLE,
+    // all other ss fields are ignored. However, MUSL implementation checks that the 
+    // ss_size is >= MINSIGSTKSZ even in this case.
+    ss.ss_size = MINSIGSTKSZ;
     ss.ss_flags = SS_DISABLE;
     int st = sigaltstack(&ss, &oss);
     if ((st == 0) && (oss.ss_flags != SS_DISABLE))


### PR DESCRIPTION
The MUSL implementation of sigaltstack checks that the ss.ss_size is
larger or equal than the MINSIGSTKSZ even when the ss_flags is set
to SS_DISABLE even though Linux man page for sigaltstack states that
when this flag is set, all other ss fields are ignored.

We were not setting the ss_size in this case and it was causing a memory
leak for each thread that has terminated on MUSL based Linux distros
like Alpine.

Glibc implementation doesn't check the ss_size when the SS_DISABLE is set
so the problem was really MUSL specific.