### PR TITLE
Add public implementation CultureDataSupport

### DIFF
--- a/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -303,8 +303,9 @@
     <Compile Include="$(BclSourcesRoot)\Internal\Console.cs" />
     <Compile Condition="'$(FeatureCominterop)' == 'true'" Include="$(BclSourcesRoot)\Internal\Threading\Tasks\AsyncCausalitySupport.cs" />
     <Compile Condition="'$(FeatureCominterop)' == 'true'" Include="$(BclSourcesRoot)\Internal\Runtime\InteropServices\WindowsRuntime\ExceptionSupport.cs" />
-    <Compile Condition="'$(FeatureAppX)' == 'true'" Include="$(BclSourcesRoot)\Internal\Resources\WindowsRuntimeResourceManagerBase.cs" />
+    <Compile Condition="'$(FeatureAppX)' == 'true'" Include="$(BclSourcesRoot)\Internal\Globalization\CultureDataSupport.cs" />
     <Compile Condition="'$(FeatureAppX)' == 'true'" Include="$(BclSourcesRoot)\Internal\Resources\PRIExceptionInfo.cs" />
+    <Compile Condition="'$(FeatureAppX)' == 'true'" Include="$(BclSourcesRoot)\Internal\Resources\WindowsRuntimeResourceManagerBase.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(BclSourcesRoot)\System\Reflection\Assembly.CoreCLR.cs" />

--- a/src/System.Private.CoreLib/src/Internal/Globalization/CultureDataSupport.cs
+++ b/src/System.Private.CoreLib/src/Internal/Globalization/CultureDataSupport.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+
+namespace Internal.Globalization
+{
+    public static class CultureDataSupport
+    {
+        /// <summary>
+        /// Check whether CultureData exists for specified language
+        /// This API is used for WindowsRuntimeResourceManager in System.Runtime.WindowsRuntime
+        /// </summary>
+        public static bool IsCultureDataExists(string language)
+        {
+            return CultureData.GetCultureData(language, /* useUserOverride */ true) != null;
+        }
+    }
+}


### PR DESCRIPTION
WindowsRuntimeResourceManager  need to access CultureData to see whether a language is supported or not.
Add a public implementation CultureDataSupport for WindowsRuntimeResourceManager  