### PR TITLE
Improve bool.TryFormat perf

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Boolean.cs
+++ b/src/System.Private.CoreLib/shared/System/Boolean.cs
@@ -97,18 +97,34 @@ namespace System
 
         public bool TryFormat(Span<char> destination, out int charsWritten)
         {
-            string s = m_value ? TrueLiteral : FalseLiteral;
-
-            if (s.AsSpan().TryCopyTo(destination))
+            if (m_value)
             {
-                charsWritten = s.Length;
-                return true;
+                if ((uint)destination.Length > 3)
+                {
+                    destination[0] = 'T';
+                    destination[1] = 'r';
+                    destination[2] = 'u';
+                    destination[3] = 'e';
+                    charsWritten = 4;
+                    return true;
+                }
             }
             else
             {
-                charsWritten = 0;
-                return false;
+                if ((uint)destination.Length > 4)
+                {
+                    destination[0] = 'F';
+                    destination[1] = 'a';
+                    destination[2] = 'l';
+                    destination[3] = 's';
+                    destination[4] = 'e';
+                    charsWritten = 5;
+                    return true;
+                }
             }
+
+            charsWritten = 0;
+            return false;
         }
 
         // Determines whether two Boolean objects are equal.

--- a/src/System.Private.CoreLib/shared/System/Boolean.cs
+++ b/src/System.Private.CoreLib/shared/System/Boolean.cs
@@ -99,7 +99,7 @@ namespace System
         {
             if (m_value)
             {
-                if ((uint)destination.Length > 3)
+                if ((uint)destination.Length > 3) // uint cast, per https://github.com/dotnet/coreclr/issues/18688
                 {
                     destination[0] = 'T';
                     destination[1] = 'r';


### PR DESCRIPTION
Improves throughput by ~50%, by avoiding AsSpan().CopyTo and just writing out the characters one-by-one.  I experimented with playing the same tricks as Utf8Formatter around storing the data in a ulong and blitting it out to the destination span of chars reinterpreted, but it didn't make a measurable improvement and increased the code complexity.

I also tried porting the TryParse changes from Utf8Parser, but depending on the input to a benchmark, the new version(s) wasn't necessarily faster.  For example, it helped a bit when the input was all caps, but it actually hurt when the input was all lowercase.  The code was also significantly more complex, especially once endianness was factored in.  In the end, I decided to leave it as is.

Contributes to https://github.com/dotnet/corefx/issues/30612
cc: @jkotas, @ahsonkhan 