### PR TITLE
compGSReorderStackLayout is not supported when EnC is on

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -14381,10 +14381,13 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                                 op1              = gtNewOperNode(GT_ADDR, TYP_I_IMPL, op1);
                                 convertedToLocal = true;
 
-                                // Ensure we have stack security for this method.
-                                // Reorder layout since the converted localloc is treated as an unsafe buffer.
-                                setNeedsGSSecurityCookie();
-                                compGSReorderStackLayout = true;
+                                if (!this->opts.compDbgEnC)
+                                {
+                                    // Ensure we have stack security for this method.
+                                    // Reorder layout since the converted localloc is treated as an unsafe buffer.
+                                    setNeedsGSSecurityCookie();
+                                    compGSReorderStackLayout = true;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
This is a random bug I found during development with check build. 

If we enable compGSReorderStackLayout when EnC is on, we will eventually reach [this ](https://github.com/dotnet/coreclr/blob/65d31999eb89e11a74fe8cbf25982a3ed33a564f/src/jit/lclvars.cpp#L5770) assert.

There are various existing place where we do not turn on compGSReorderStackLayout during EnC, for example, [here](https://github.com/dotnet/coreclr/blob/65d31999eb89e11a74fe8cbf25982a3ed33a564f/src/jit/lclvars.cpp#L273), so I think it is fine for us to not turn on compGSReorderStackLayout there as well.

@BruceForstall 