### PR TITLE
Fix issue with signed/unsigned comparison

### DIFF
--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -8292,7 +8292,7 @@ void emitter::emitDispIns(
             val = emitGetInsSC(id);
 #ifdef _TARGET_AMD64_
             // no 8-byte immediates allowed here!
-            assert((val >= 0xFFFFFFFF80000000LL) && (val <= 0x000000007FFFFFFFLL));
+            assert((val >= (ssize_t)0xFFFFFFFF80000000LL) && (val <= 0x000000007FFFFFFFLL));
 #endif
             if (id->idIsCnsReloc())
             {
@@ -8492,7 +8492,7 @@ void emitter::emitDispIns(
             val = cnsVal.cnsVal;
 #ifdef _TARGET_AMD64_
             // no 8-byte immediates allowed here!
-            assert((val >= 0xFFFFFFFF80000000LL) && (val <= 0x000000007FFFFFFFLL));
+            assert((val >= (ssize_t)0xFFFFFFFF80000000LL) && (val <= 0x000000007FFFFFFFLL));
 #endif
             if (id->idInsFmt() == IF_ARW_SHF)
             {
@@ -8560,7 +8560,7 @@ void emitter::emitDispIns(
             val = cnsVal.cnsVal;
 #ifdef _TARGET_AMD64_
             // no 8-byte immediates allowed here!
-            assert((val >= 0xFFFFFFFF80000000LL) && (val <= 0x000000007FFFFFFFLL));
+            assert((val >= (ssize_t)0xFFFFFFFF80000000LL) && (val <= 0x000000007FFFFFFFLL));
 #endif
             if (id->idInsFmt() == IF_SRW_SHF)
             {
@@ -8760,7 +8760,7 @@ void emitter::emitDispIns(
             val = emitGetInsSC(id);
 #ifdef _TARGET_AMD64_
             // no 8-byte immediates allowed here!
-            assert((val >= 0xFFFFFFFF80000000LL) && (val <= 0x000000007FFFFFFFLL));
+            assert((val >= (ssize_t)0xFFFFFFFF80000000LL) && (val <= 0x000000007FFFFFFFLL));
 #endif
             printf(", ");
             if (id->idIsCnsReloc())
@@ -8928,7 +8928,7 @@ void emitter::emitDispIns(
             val = cnsVal.cnsVal;
 #ifdef _TARGET_AMD64_
             // no 8-byte immediates allowed here!
-            assert((val >= 0xFFFFFFFF80000000LL) && (val <= 0x000000007FFFFFFFLL));
+            assert((val >= (ssize_t)0xFFFFFFFF80000000LL) && (val <= 0x000000007FFFFFFFLL));
 #endif
             if (cnsVal.cnsReloc)
             {


### PR DESCRIPTION
On Mac (maybe on other platforms using clang?) the following set of
comparisons in the emitter were done as unsigned:
```
(val >= 0xFFFFFFFF80000000LL)
```
even though 'val' is signed. This led to assertion failures. On Windows,
the comparisons were signed.

To fix this, cast the constant to the signed `ssize_t` type (to match `val`).

Fixes #18341