### PR TITLE
SuperPMI: add ability to exclude failing method contexts from replays

### DIFF
--- a/src/ToolBox/superpmi/mcs/verbremovedup.cpp
+++ b/src/ToolBox/superpmi/mcs/verbremovedup.cpp
@@ -11,8 +11,8 @@
 #include "methodcontextiterator.h"
 
 // We use a hash to limit the number of comparisons we need to do.
- //The first level key to our hash map is ILCodeSize and the second
- //level map key is just an index and the value is an existing MC Hash.
+// The first level key to our hash map is ILCodeSize and the second
+// level map key is just an index and the value is an existing MC Hash.
 
 LightWeightMap<int, DenseLightWeightMap<char*>*>* inFile = nullptr;
 

--- a/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -2436,7 +2436,7 @@ InfoAccessType MethodContext::repConstructStringLiteral(CORINFO_MODULE_HANDLE mo
     return (InfoAccessType)temp2.B;
 }
 
-void MethodContext::recConvertPInvokeCalliToCall(CORINFO_RESOLVED_TOKEN * pResolvedToken, bool fMustConvert, bool result)
+void MethodContext::recConvertPInvokeCalliToCall(CORINFO_RESOLVED_TOKEN* pResolvedToken, bool fMustConvert, bool result)
 {
     if (ConvertPInvokeCalliToCall == nullptr)
         ConvertPInvokeCalliToCall = new LightWeightMap<DLD, DWORDLONG>();
@@ -2456,7 +2456,7 @@ void MethodContext::dmpConvertPInvokeCalliToCall(DLD key, DWORDLONG value)
 {
     printf("ConvertPInvokeCalliToCall key mod-%016llX tok-%08X, value %016llX", key.A, key.B, value);
 }
-bool MethodContext::repConvertPInvokeCalliToCall(CORINFO_RESOLVED_TOKEN * pResolvedToken, bool fMustConvert)
+bool MethodContext::repConvertPInvokeCalliToCall(CORINFO_RESOLVED_TOKEN* pResolvedToken, bool fMustConvert)
 {
     DLD key;
     ZeroMemory(&key, sizeof(DLD)); // We use the input structs as a key and use memcmp to compare.. so we need to zero
@@ -4362,7 +4362,8 @@ void MethodContext::dmpCanInlineTypeCheckWithObjectVTable(DWORDLONG key, DWORD v
 }
 BOOL MethodContext::repCanInlineTypeCheckWithObjectVTable(CORINFO_CLASS_HANDLE cls)
 {
-    AssertCodeMsg(CanInlineTypeCheckWithObjectVTable != nullptr, EXCEPTIONCODE_MC, "No map for CanInlineTypeCheckWithObjectVTable");
+    AssertCodeMsg(CanInlineTypeCheckWithObjectVTable != nullptr, EXCEPTIONCODE_MC,
+                  "No map for CanInlineTypeCheckWithObjectVTable");
     return (BOOL)CanInlineTypeCheckWithObjectVTable->Get((DWORDLONG)cls);
 }
 

--- a/src/ToolBox/superpmi/superpmi-shared/methodcontext.h
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontext.h
@@ -805,9 +805,9 @@ public:
     void dmpConstructStringLiteral(DLD key, DLD value);
     InfoAccessType repConstructStringLiteral(CORINFO_MODULE_HANDLE module, mdToken metaTok, void** ppValue);
 
-    void recConvertPInvokeCalliToCall(CORINFO_RESOLVED_TOKEN * pResolvedToken, bool fMustConvert, bool result);
+    void recConvertPInvokeCalliToCall(CORINFO_RESOLVED_TOKEN* pResolvedToken, bool fMustConvert, bool result);
     void dmpConvertPInvokeCalliToCall(DLD key, DWORDLONG value);
-    bool repConvertPInvokeCalliToCall(CORINFO_RESOLVED_TOKEN * pResolvedToken, bool fMustConvert);
+    bool repConvertPInvokeCalliToCall(CORINFO_RESOLVED_TOKEN* pResolvedToken, bool fMustConvert);
 
     void recEmptyStringLiteral(void** ppValue, InfoAccessType result);
     void dmpEmptyStringLiteral(DWORD key, DLD value);

--- a/src/ToolBox/superpmi/superpmi-shared/methodcontextreader.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontextreader.cpp
@@ -83,26 +83,26 @@ MethodContextReader::MethodContextReader(
 {
     this->mutex = CreateMutexA(NULL, FALSE, nullptr);
 
-    std::string tocFileName, mchFile;
+    std::string tocFileName, mchFileName;
 
     // First, check to see if they passed an MCH file (look for a paired MCT file)
     tocFileName = MethodContextReader::CheckForPairedFile(inputFileName, ".mch", ".mct");
     if (!tocFileName.empty())
     {
-        mchFile = inputFileName;
+        mchFileName = inputFileName;
     }
     else
     {
         // Okay, it wasn't an MCH file, let's check to see if it was an MCT file
         // so check for a paired MCH file instead
-        mchFile = MethodContextReader::CheckForPairedFile(inputFileName, ".mct", ".mch");
-        if (!mchFile.empty())
+        mchFileName = MethodContextReader::CheckForPairedFile(inputFileName, ".mct", ".mch");
+        if (!mchFileName.empty())
         {
             tocFileName = inputFileName;
         }
         else
         {
-            mchFile = inputFileName;
+            mchFileName = inputFileName;
         }
     }
 
@@ -110,8 +110,8 @@ MethodContextReader::MethodContextReader(
         this->tocFile.LoadToc(tocFileName.c_str());
 
     // we'll get here even if we don't have a valid index file
-    this->fileHandle = OpenFile(mchFile.c_str(), (this->hasTOC() && this->hasIndex()) ? FILE_ATTRIBUTE_NORMAL
-                                                                                      : FILE_FLAG_SEQUENTIAL_SCAN);
+    this->fileHandle = OpenFile(mchFileName.c_str(), (this->hasTOC() && this->hasIndex()) ? FILE_ATTRIBUTE_NORMAL
+                                                                                          : FILE_FLAG_SEQUENTIAL_SCAN);
     if (this->fileHandle != INVALID_HANDLE_VALUE)
     {
         GetFileSizeEx(this->fileHandle, (PLARGE_INTEGER) & this->fileSize);

--- a/src/ToolBox/superpmi/superpmi-shared/methodcontextreader.h
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontextreader.h
@@ -135,6 +135,13 @@ public:
     {
         return curMCIndex;
     }
+
+    // Return should this method context be excluded from the replay or not.
+    bool IsMethodExcluded(MethodContext* mc)
+    {
+        // Right now it is just a stub.
+        return false;
+    }
 };
 #pragma pack(pop)
 

--- a/src/ToolBox/superpmi/superpmi-shim-collector/icorjitinfo.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-collector/icorjitinfo.cpp
@@ -1825,7 +1825,7 @@ InfoAccessType interceptor_ICJI::constructStringLiteral(CORINFO_MODULE_HANDLE mo
     return temp;
 }
 
-bool interceptor_ICJI::convertPInvokeCalliToCall(CORINFO_RESOLVED_TOKEN * pResolvedToken, bool fMustConvert)
+bool interceptor_ICJI::convertPInvokeCalliToCall(CORINFO_RESOLVED_TOKEN* pResolvedToken, bool fMustConvert)
 {
     mc->cr->AddCall("convertPInvokeCalliToCall");
     bool result = original_ICorJitInfo->convertPInvokeCalliToCall(pResolvedToken, fMustConvert);

--- a/src/ToolBox/superpmi/superpmi-shim-counter/icorjitinfo.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-counter/icorjitinfo.cpp
@@ -1412,7 +1412,7 @@ InfoAccessType interceptor_ICJI::constructStringLiteral(CORINFO_MODULE_HANDLE mo
     return original_ICorJitInfo->constructStringLiteral(module, metaTok, ppValue);
 }
 
-bool interceptor_ICJI::convertPInvokeCalliToCall(CORINFO_RESOLVED_TOKEN * pResolvedToken, bool fMustConvert)
+bool interceptor_ICJI::convertPInvokeCalliToCall(CORINFO_RESOLVED_TOKEN* pResolvedToken, bool fMustConvert)
 {
     mcs->AddCall("convertPInvokeCalliToCall");
     return original_ICorJitInfo->convertPInvokeCalliToCall(pResolvedToken, fMustConvert);

--- a/src/ToolBox/superpmi/superpmi-shim-simple/icorjitinfo.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-simple/icorjitinfo.cpp
@@ -1266,7 +1266,7 @@ InfoAccessType interceptor_ICJI::constructStringLiteral(CORINFO_MODULE_HANDLE mo
     return original_ICorJitInfo->constructStringLiteral(module, metaTok, ppValue);
 }
 
-bool interceptor_ICJI::convertPInvokeCalliToCall(CORINFO_RESOLVED_TOKEN * pResolvedToken, bool fMustConvert)
+bool interceptor_ICJI::convertPInvokeCalliToCall(CORINFO_RESOLVED_TOKEN* pResolvedToken, bool fMustConvert)
 {
     return original_ICorJitInfo->convertPInvokeCalliToCall(pResolvedToken, fMustConvert);
 }

--- a/src/ToolBox/superpmi/superpmi/icorjitinfo.cpp
+++ b/src/ToolBox/superpmi/superpmi/icorjitinfo.cpp
@@ -1580,7 +1580,7 @@ void* MyICJI::getTailCallCopyArgsThunk(CORINFO_SIG_INFO* pSig, CorInfoHelperTail
     return jitInstance->mc->repGetTailCallCopyArgsThunk(pSig, flags);
 }
 
-bool MyICJI::convertPInvokeCalliToCall(CORINFO_RESOLVED_TOKEN * pResolvedToken, bool fMustConvert)
+bool MyICJI::convertPInvokeCalliToCall(CORINFO_RESOLVED_TOKEN* pResolvedToken, bool fMustConvert)
 {
     jitInstance->mc->cr->AddCall("convertPInvokeCalliToCall");
     return jitInstance->mc->repConvertPInvokeCalliToCall(pResolvedToken, fMustConvert);

--- a/src/ToolBox/superpmi/superpmi/parallelsuperpmi.cpp
+++ b/src/ToolBox/superpmi/superpmi/parallelsuperpmi.cpp
@@ -238,44 +238,40 @@ void ProcessChildStdOut(const CommandLine::Options& o,
         }
         else if (strncmp(buff, g_AllFormatStringFixedPrefix, strlen(g_AllFormatStringFixedPrefix)) == 0)
         {
+            int childLoaded = 0, childJitted = 0, childFailed = 0;
             if (o.applyDiff)
             {
-                int temp1 = 0, temp2 = 0, temp3 = 0, temp4 = 0;
-                int converted = sscanf_s(buff, g_AsmDiffsSummaryFormatString, &temp1, &temp2, &temp3, &temp4);
+                int childDiffs = 0;
+                int converted  = sscanf_s(buff, g_AsmDiffsSummaryFormatString, &childLoaded, &childJitted, &childFailed,
+                                         &childDiffs);
                 if (converted != 4)
                 {
                     LogError("Couldn't parse status message: \"%s\"", buff);
+                    continue;
                 }
-                else
-                {
-                    *loaded += temp1;
-                    *jitted += temp2;
-                    *failed += temp3;
-                    *diffs += temp4;
-                }
+                *diffs += childDiffs;
             }
             else
             {
-                int temp1 = 0, temp2 = 0, temp3 = 0;
-                int converted = sscanf_s(buff, g_SummaryFormatString, &temp1, &temp2, &temp3);
+                int converted = sscanf_s(buff, g_SummaryFormatString, &childLoaded, &childJitted, &childFailed);
                 if (converted != 3)
                 {
                     LogError("Couldn't parse status message: \"%s\"", buff);
+                    continue;
                 }
-                else
-                {
-                    *loaded += temp1;
-                    *jitted += temp2;
-                    *failed += temp3;
-                    *diffs = -1;
-                }
+                *diffs = -1;
             }
+            *loaded += childLoaded;
+            *jitted += childJitted;
+            *failed += childFailed;
         }
     }
 
 Cleanup:
     if (fp != NULL)
+    {
         fclose(fp);
+    }
 }
 
 #ifndef FEATURE_PAL // TODO-Porting: handle Ctrl-C signals gracefully on Unix


### PR DESCRIPTION
The first 3 commits are only refactoring.
The fourth adds a stub and ability to print number of excluded methods.