### PR TITLE
Re-enable jit regression test DevDiv_590771

### DIFF
--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -94812,3 +94812,19 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS
 HostStyle=0
 
+[DevDiv_590771.cmd_11912]
+RelativePath=JIT\Regression\JitBlue\DevDiv_590771\DevDiv_590771\DevDiv_590771.cmd
+WorkingDir=JIT\Regression\JitBlue\DevDiv_590771\DevDiv_590771
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0
+
+[GitHub_18522_8.cmd_11913]
+RelativePath=JIT\Regression\JitBlue\GitHub_18522\GitHub_18522_8\GitHub_18522_8.cmd
+WorkingDir=JIT\Regression\JitBlue\GitHub_18522\GitHub_18522_8
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0
+

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -94729,7 +94729,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_590771\DevDiv_590771\DevDiv_590771.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_590771\DevDiv_590771
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;17967;EXCLUDED
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [GitHub_18482.cmd_12219]
@@ -94827,6 +94827,7 @@ Expected=0
 MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS
 HostStyle=0
+
 [GitHub_18362.cmd_12231]
 RelativePath=JIT\Regression\JitBlue\GitHub_18362\GitHub_18362\GitHub_18362.cmd
 WorkingDir=JIT\Regression\JitBlue\GitHub_18362\GitHub_18362
@@ -94835,3 +94836,10 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS
 HostStyle=0
 
+[GitHub_18522_8.cmd_12232]
+RelativePath=JIT\Regression\JitBlue\GitHub_18522\GitHub_18522_8\GitHub_18522_8.cmd
+WorkingDir=JIT\Regression\JitBlue\GitHub_18522\GitHub_18522_8
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -238,9 +238,6 @@
     <!-- The following are ARM64_altjit crossgen failures. For x64_arm64_altjit buildArm==x64. -->
 
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(BuildArch)' == 'x64'">
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_590771\DevDiv_590771\DevDiv_590771.cmd">
-            <Issue>17967</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- Tests that need to be triaged for vararg usage as that is not supported -->


### PR DESCRIPTION
The issue the test was hitting was worked around in #18292.

Fixes #17967.

Also add GitHub_18522_8 to the arm/arm64 lists (from #18708).