### PR TITLE
Some test fixes for the x86 HWIntrinsics

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx.cs
@@ -241,6 +241,10 @@ namespace System.Runtime.Intrinsics.X86
         /// </summary>
         public static byte Extract(Vector256<byte> value, byte index)
         {
+            if (!IsSupported)
+            {
+                throw new PlatformNotSupportedException();
+            }
             return Unsafe.Add<byte>(ref Unsafe.As<Vector256<byte>, byte>(ref value), index & 0x1F);
         }
 
@@ -251,6 +255,10 @@ namespace System.Runtime.Intrinsics.X86
         /// </summary>
         public static ushort Extract(Vector256<ushort> value, byte index)
         {
+            if (!IsSupported)
+            {
+                throw new PlatformNotSupportedException();
+            }
             return Unsafe.Add<ushort>(ref Unsafe.As<Vector256<ushort>, ushort>(ref value), index & 0xF);
         }
 
@@ -260,6 +268,10 @@ namespace System.Runtime.Intrinsics.X86
         /// </summary>
         public static int Extract(Vector256<int> value, byte index)
         {
+            if (!IsSupported)
+            {
+                throw new PlatformNotSupportedException();
+            }
             return Unsafe.Add<int>(ref Unsafe.As<Vector256<int>, int>(ref value), index & 0x7);
         }
 
@@ -269,6 +281,10 @@ namespace System.Runtime.Intrinsics.X86
         /// </summary>
         public static uint Extract(Vector256<uint> value, byte index)
         {
+            if (!IsSupported)
+            {
+                throw new PlatformNotSupportedException();
+            }
             return Unsafe.Add<uint>(ref Unsafe.As<Vector256<uint>, uint>(ref value), index & 0x7);
         }
 
@@ -278,7 +294,7 @@ namespace System.Runtime.Intrinsics.X86
         /// </summary>
         public static long Extract(Vector256<long> value, byte index)
         {
-            if (IntPtr.Size != 8)
+            if (!IsSupported || (IntPtr.Size != 8))
             {
                 throw new PlatformNotSupportedException();
             }
@@ -291,7 +307,7 @@ namespace System.Runtime.Intrinsics.X86
         /// </summary>
         public static ulong Extract(Vector256<ulong> value, byte index)
         {
-            if (IntPtr.Size != 8)
+            if (!IsSupported || (IntPtr.Size != 8))
             {
                 throw new PlatformNotSupportedException();
             }
@@ -523,6 +539,11 @@ namespace System.Runtime.Intrinsics.X86
         /// </summary>
         public static Vector256<long> Insert(Vector256<long> value, long data, byte index)
         {
+            if (IntPtr.Size != 8)
+            {
+                throw new PlatformNotSupportedException();
+            }
+
             unsafe
             {
                 index &= 0x3;
@@ -539,6 +560,11 @@ namespace System.Runtime.Intrinsics.X86
         /// </summary>
         public static Vector256<ulong> Insert(Vector256<ulong> value, ulong data, byte index)
         {
+            if (IntPtr.Size != 8)
+            {
+                throw new PlatformNotSupportedException();
+            }
+
             unsafe
             {
                 index &= 0x3;

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.Byte.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.Byte.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractByte1()
         {
             var test = new SimpleUnaryOpTest__ExtractByte1();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Byte, Byte>(_data, new Byte[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(Byte) != typeof(long)) && (typeof(Byte) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.Byte.20.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.Byte.20.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractByte20()
         {
             var test = new SimpleUnaryOpTest__ExtractByte20();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Byte, Byte>(_data, new Byte[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(Byte) != typeof(long)) && (typeof(Byte) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.Byte.52.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.Byte.52.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractByte52()
         {
             var test = new SimpleUnaryOpTest__ExtractByte52();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Byte, Byte>(_data, new Byte[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(Byte) != typeof(long)) && (typeof(Byte) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.Int32.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.Int32.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractInt321()
         {
             var test = new SimpleUnaryOpTest__ExtractInt321();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int32, Int32>(_data, new Int32[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(Int32) != typeof(long)) && (typeof(Int32) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.Int32.22.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.Int32.22.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractInt3222()
         {
             var test = new SimpleUnaryOpTest__ExtractInt3222();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int32, Int32>(_data, new Int32[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(Int32) != typeof(long)) && (typeof(Int32) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.Int32.6.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.Int32.6.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractInt326()
         {
             var test = new SimpleUnaryOpTest__ExtractInt326();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int32, Int32>(_data, new Int32[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(Int32) != typeof(long)) && (typeof(Int32) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.Int64.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.Int64.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractInt641()
         {
             var test = new SimpleUnaryOpTest__ExtractInt641();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int64, Int64>(_data, new Int64[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(Int64) != typeof(long)) && (typeof(Int64) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.Int64.19.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.Int64.19.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractInt6419()
         {
             var test = new SimpleUnaryOpTest__ExtractInt6419();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int64, Int64>(_data, new Int64[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(Int64) != typeof(long)) && (typeof(Int64) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.Int64.3.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.Int64.3.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractInt643()
         {
             var test = new SimpleUnaryOpTest__ExtractInt643();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int64, Int64>(_data, new Int64[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(Int64) != typeof(long)) && (typeof(Int64) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.UInt16.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.UInt16.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractUInt161()
         {
             var test = new SimpleUnaryOpTest__ExtractUInt161();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt16, UInt16>(_data, new UInt16[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt16) != typeof(long)) && (typeof(UInt16) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.UInt16.11.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.UInt16.11.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractUInt1611()
         {
             var test = new SimpleUnaryOpTest__ExtractUInt1611();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt16, UInt16>(_data, new UInt16[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt16) != typeof(long)) && (typeof(UInt16) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.UInt16.27.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.UInt16.27.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractUInt1627()
         {
             var test = new SimpleUnaryOpTest__ExtractUInt1627();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt16, UInt16>(_data, new UInt16[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt16) != typeof(long)) && (typeof(UInt16) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.UInt32.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.UInt32.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractUInt321()
         {
             var test = new SimpleUnaryOpTest__ExtractUInt321();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt32, UInt32>(_data, new UInt32[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt32) != typeof(long)) && (typeof(UInt32) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.UInt32.22.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.UInt32.22.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractUInt3222()
         {
             var test = new SimpleUnaryOpTest__ExtractUInt3222();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt32, UInt32>(_data, new UInt32[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt32) != typeof(long)) && (typeof(UInt32) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.UInt32.6.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.UInt32.6.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractUInt326()
         {
             var test = new SimpleUnaryOpTest__ExtractUInt326();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt32, UInt32>(_data, new UInt32[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt32) != typeof(long)) && (typeof(UInt32) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.UInt64.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.UInt64.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractUInt641()
         {
             var test = new SimpleUnaryOpTest__ExtractUInt641();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt64, UInt64>(_data, new UInt64[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt64) != typeof(long)) && (typeof(UInt64) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.UInt64.19.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.UInt64.19.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractUInt6419()
         {
             var test = new SimpleUnaryOpTest__ExtractUInt6419();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt64, UInt64>(_data, new UInt64[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt64) != typeof(long)) && (typeof(UInt64) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.UInt64.3.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Extract.UInt64.3.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractUInt643()
         {
             var test = new SimpleUnaryOpTest__ExtractUInt643();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt64, UInt64>(_data, new UInt64[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt64) != typeof(long)) && (typeof(UInt64) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Byte.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Byte.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertByte1()
         {
             var test = new SimpleUnaryOpTest__InsertByte1();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Byte, Byte>(_data, new Byte[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(Byte) != typeof(long)) && (typeof(Byte) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Byte.20.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Byte.20.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertByte20()
         {
             var test = new SimpleUnaryOpTest__InsertByte20();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Byte, Byte>(_data, new Byte[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(Byte) != typeof(long)) && (typeof(Byte) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Byte.52.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Byte.52.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertByte52()
         {
             var test = new SimpleUnaryOpTest__InsertByte52();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Byte, Byte>(_data, new Byte[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(Byte) != typeof(long)) && (typeof(Byte) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Int16.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Int16.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertInt161()
         {
             var test = new SimpleUnaryOpTest__InsertInt161();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int16, Int16>(_data, new Int16[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(Int16) != typeof(long)) && (typeof(Int16) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Int16.11.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Int16.11.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertInt1611()
         {
             var test = new SimpleUnaryOpTest__InsertInt1611();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int16, Int16>(_data, new Int16[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(Int16) != typeof(long)) && (typeof(Int16) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Int16.27.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Int16.27.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertInt1627()
         {
             var test = new SimpleUnaryOpTest__InsertInt1627();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int16, Int16>(_data, new Int16[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(Int16) != typeof(long)) && (typeof(Int16) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Int32.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Int32.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertInt321()
         {
             var test = new SimpleUnaryOpTest__InsertInt321();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int32, Int32>(_data, new Int32[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(Int32) != typeof(long)) && (typeof(Int32) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Int32.22.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Int32.22.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertInt3222()
         {
             var test = new SimpleUnaryOpTest__InsertInt3222();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int32, Int32>(_data, new Int32[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(Int32) != typeof(long)) && (typeof(Int32) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Int32.6.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Int32.6.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertInt326()
         {
             var test = new SimpleUnaryOpTest__InsertInt326();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int32, Int32>(_data, new Int32[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(Int32) != typeof(long)) && (typeof(Int32) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Int64.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Int64.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertInt641()
         {
             var test = new SimpleUnaryOpTest__InsertInt641();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int64, Int64>(_data, new Int64[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(Int64) != typeof(long)) && (typeof(Int64) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Int64.19.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Int64.19.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertInt6419()
         {
             var test = new SimpleUnaryOpTest__InsertInt6419();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int64, Int64>(_data, new Int64[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(Int64) != typeof(long)) && (typeof(Int64) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Int64.3.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.Int64.3.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertInt643()
         {
             var test = new SimpleUnaryOpTest__InsertInt643();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int64, Int64>(_data, new Int64[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(Int64) != typeof(long)) && (typeof(Int64) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.SByte.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.SByte.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertSByte1()
         {
             var test = new SimpleUnaryOpTest__InsertSByte1();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<SByte, SByte>(_data, new SByte[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(SByte) != typeof(long)) && (typeof(SByte) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.SByte.20.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.SByte.20.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertSByte20()
         {
             var test = new SimpleUnaryOpTest__InsertSByte20();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<SByte, SByte>(_data, new SByte[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(SByte) != typeof(long)) && (typeof(SByte) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.SByte.52.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.SByte.52.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertSByte52()
         {
             var test = new SimpleUnaryOpTest__InsertSByte52();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<SByte, SByte>(_data, new SByte[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(SByte) != typeof(long)) && (typeof(SByte) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.UInt16.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.UInt16.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertUInt161()
         {
             var test = new SimpleUnaryOpTest__InsertUInt161();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt16, UInt16>(_data, new UInt16[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt16) != typeof(long)) && (typeof(UInt16) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.UInt16.11.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.UInt16.11.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertUInt1611()
         {
             var test = new SimpleUnaryOpTest__InsertUInt1611();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt16, UInt16>(_data, new UInt16[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt16) != typeof(long)) && (typeof(UInt16) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.UInt16.27.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.UInt16.27.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertUInt1627()
         {
             var test = new SimpleUnaryOpTest__InsertUInt1627();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt16, UInt16>(_data, new UInt16[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt16) != typeof(long)) && (typeof(UInt16) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.UInt32.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.UInt32.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertUInt321()
         {
             var test = new SimpleUnaryOpTest__InsertUInt321();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt32, UInt32>(_data, new UInt32[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt32) != typeof(long)) && (typeof(UInt32) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.UInt32.22.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.UInt32.22.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertUInt3222()
         {
             var test = new SimpleUnaryOpTest__InsertUInt3222();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt32, UInt32>(_data, new UInt32[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt32) != typeof(long)) && (typeof(UInt32) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.UInt32.6.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.UInt32.6.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertUInt326()
         {
             var test = new SimpleUnaryOpTest__InsertUInt326();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt32, UInt32>(_data, new UInt32[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt32) != typeof(long)) && (typeof(UInt32) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.UInt64.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.UInt64.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertUInt641()
         {
             var test = new SimpleUnaryOpTest__InsertUInt641();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt64, UInt64>(_data, new UInt64[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt64) != typeof(long)) && (typeof(UInt64) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.UInt64.19.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.UInt64.19.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertUInt6419()
         {
             var test = new SimpleUnaryOpTest__InsertUInt6419();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt64, UInt64>(_data, new UInt64[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt64) != typeof(long)) && (typeof(UInt64) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.UInt64.3.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Insert.UInt64.3.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertUInt643()
         {
             var test = new SimpleUnaryOpTest__InsertUInt643();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt64, UInt64>(_data, new UInt64[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Avx.IsSupported;
+        public bool IsSupported => Avx.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt64) != typeof(long)) && (typeof(UInt64) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/MaskLoad.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/MaskLoad.cs
@@ -24,7 +24,7 @@ namespace IntelHardwareIntrinsicTest
             {
                 using (TestTable<float, uint> floatTable = new TestTable<float, uint>(new float[8] { 1, -5, 100, 0, 1, 2, 3, 4 }, new uint[8] { uint.MaxValue, uint.MaxValue, 0, 0, uint.MaxValue, uint.MaxValue, 0, 0 }, new float[8]))
                 {
-                    Vector256<float> vf = Avx.MaskLoad((float*)(floatTable.inArrayPtr), Avx.LoadVector256((uint*)(floatTable.maskArrayPtr)));
+                    Vector256<float> vf = Avx.MaskLoad((float*)(floatTable.inArrayPtr), Avx.LoadVector256((float*)(floatTable.maskArrayPtr)));
                     Unsafe.Write(floatTable.outArrayPtr, vf);
 
                     if (!floatTable.CheckResult((x, m, y) => m == uint.MaxValue ? BitConverter.SingleToInt32Bits(x) == BitConverter.SingleToInt32Bits(y) : BitConverter.SingleToInt32Bits(y) == 0))
@@ -41,7 +41,7 @@ namespace IntelHardwareIntrinsicTest
 
                 using (TestTable<double, ulong> doubleTable = new TestTable<double, ulong>(new double[4] { 1, -5, 100, 0}, new ulong[4] { 0, ulong.MaxValue, ulong.MaxValue, 0}, new double[4]))
                 {
-                    Vector256<double> vf = Avx.MaskLoad((double*)(doubleTable.inArrayPtr), Avx.LoadVector256((ulong*)(doubleTable.maskArrayPtr)));
+                    Vector256<double> vf = Avx.MaskLoad((double*)(doubleTable.inArrayPtr), Avx.LoadVector256((double*)(doubleTable.maskArrayPtr)));
                     Unsafe.Write(doubleTable.outArrayPtr, vf);
 
                     if (!doubleTable.CheckResult((x, m, y) =>  m == ulong.MaxValue ? BitConverter.DoubleToInt64Bits(x) == BitConverter.DoubleToInt64Bits(y) : BitConverter.DoubleToInt64Bits(y) == 0))
@@ -58,7 +58,7 @@ namespace IntelHardwareIntrinsicTest
 
                 using (TestTable<float, uint> floatTable = new TestTable<float, uint>(new float[4] { 1, -5, 100, 0 }, new uint[4] { uint.MaxValue, 0, 0, uint.MaxValue }, new float[4]))
                 {
-                    Vector128<float> vf = Avx.MaskLoad((float*)(floatTable.inArrayPtr), Sse2.LoadVector128((uint*)(floatTable.maskArrayPtr)));
+                    Vector128<float> vf = Avx.MaskLoad((float*)(floatTable.inArrayPtr), Sse.LoadVector128((float*)(floatTable.maskArrayPtr)));
                     Unsafe.Write(floatTable.outArrayPtr, vf);
 
                     if (!floatTable.CheckResult((x, m, y) => m == uint.MaxValue ? BitConverter.SingleToInt32Bits(x) == BitConverter.SingleToInt32Bits(y) : BitConverter.SingleToInt32Bits(y) == 0))
@@ -75,7 +75,7 @@ namespace IntelHardwareIntrinsicTest
 
                 using (TestTable<double, ulong> doubleTable = new TestTable<double, ulong>(new double[2] { 1, -5}, new ulong[2] { 0, ulong.MaxValue}, new double[2]))
                 {
-                    Vector128<double> vf = Avx.MaskLoad((double*)(doubleTable.inArrayPtr), Sse2.LoadVector128((ulong*)(doubleTable.maskArrayPtr)));
+                    Vector128<double> vf = Avx.MaskLoad((double*)(doubleTable.inArrayPtr), Sse2.LoadVector128((double*)(doubleTable.maskArrayPtr)));
                     Unsafe.Write(doubleTable.outArrayPtr, vf);
 
                     if (!doubleTable.CheckResult((x, m, y) =>  m == ulong.MaxValue ? BitConverter.DoubleToInt64Bits(x) == BitConverter.DoubleToInt64Bits(y) : BitConverter.DoubleToInt64Bits(y) == 0))

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/MaskLoad_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/MaskLoad_r.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>	
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">	
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />	
+  <PropertyGroup>	
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>	
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>	
+    <SchemaVersion>2.0</SchemaVersion>	
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>	
+    <OutputType>Exe</OutputType>	
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>	
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>	
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>	
+  </PropertyGroup>	
+  <!-- Default configurations to help VS understand the configurations -->	
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>	
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />	
+  <ItemGroup>	
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">	
+      <Visible>False</Visible>	
+    </CodeAnalysisDependentAssemblyPaths>	
+  </ItemGroup>	
+  <PropertyGroup>	
+    <DebugType>None</DebugType>	
+    <Optimize></Optimize>	
+  </PropertyGroup>	
+  <ItemGroup>	
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />	
+  </ItemGroup>	
+  <ItemGroup>	
+    <Compile Include="MaskLoad.cs" />	
+  </ItemGroup>	
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />	
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>	
+</Project>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/MaskLoad_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/MaskLoad_ro.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>	
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">	
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />	
+  <PropertyGroup>	
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>	
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>	
+    <SchemaVersion>2.0</SchemaVersion>	
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>	
+    <OutputType>Exe</OutputType>	
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>	
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>	
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>	
+  </PropertyGroup>	
+  <!-- Default configurations to help VS understand the configurations -->	
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>	
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />	
+  <ItemGroup>	
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">	
+      <Visible>False</Visible>	
+    </CodeAnalysisDependentAssemblyPaths>	
+  </ItemGroup>	
+  <PropertyGroup>	
+    <DebugType>None</DebugType>	
+    <Optimize>True</Optimize>	
+  </PropertyGroup>	
+  <ItemGroup>	
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />	
+  </ItemGroup>	
+  <ItemGroup>	
+    <Compile Include="MaskLoad.cs" />	
+  </ItemGroup>	
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />	
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>	
+</Project>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Shared/ExtractScalarTest.template
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Shared/ExtractScalarTest.template
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void {Method}{RetBaseType}{Imm}()
         {
             var test = new SimpleUnaryOpTest__{Method}{RetBaseType}{Imm}();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<{RetBaseType}, {Op1BaseType}>(_data, new {RetBaseType}[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => {Isa}.IsSupported;
+        public bool IsSupported => {Isa}.IsSupported && (Environment.Is64BitProcess || ((typeof({RetBaseType}) != typeof(long)) && (typeof({RetBaseType}) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Shared/InsertScalarTest.template
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Shared/InsertScalarTest.template
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void {Method}{RetBaseType}{Imm}()
         {
             var test = new SimpleUnaryOpTest__{Method}{RetBaseType}{Imm}();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<{RetBaseType}, {Op1BaseType}>(_data, new {RetBaseType}[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => {Isa}.IsSupported;
+        public bool IsSupported => {Isa}.IsSupported && (Environment.Is64BitProcess || ((typeof({RetBaseType}) != typeof(long)) && (typeof({RetBaseType}) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Extract.UInt16.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Extract.UInt16.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractUInt161()
         {
             var test = new SimpleUnaryOpTest__ExtractUInt161();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt16, UInt16>(_data, new UInt16[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse2.IsSupported;
+        public bool IsSupported => Sse2.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt16) != typeof(long)) && (typeof(UInt16) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Extract.UInt16.129.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Extract.UInt16.129.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractUInt16129()
         {
             var test = new SimpleUnaryOpTest__ExtractUInt16129();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt16, UInt16>(_data, new UInt16[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse2.IsSupported;
+        public bool IsSupported => Sse2.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt16) != typeof(long)) && (typeof(UInt16) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Insert.Int16.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Insert.Int16.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertInt161()
         {
             var test = new SimpleUnaryOpTest__InsertInt161();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int16, Int16>(_data, new Int16[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse2.IsSupported;
+        public bool IsSupported => Sse2.IsSupported && (Environment.Is64BitProcess || ((typeof(Int16) != typeof(long)) && (typeof(Int16) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Insert.Int16.129.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Insert.Int16.129.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertInt16129()
         {
             var test = new SimpleUnaryOpTest__InsertInt16129();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int16, Int16>(_data, new Int16[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse2.IsSupported;
+        public bool IsSupported => Sse2.IsSupported && (Environment.Is64BitProcess || ((typeof(Int16) != typeof(long)) && (typeof(Int16) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Insert.UInt16.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Insert.UInt16.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertUInt161()
         {
             var test = new SimpleUnaryOpTest__InsertUInt161();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt16, UInt16>(_data, new UInt16[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse2.IsSupported;
+        public bool IsSupported => Sse2.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt16) != typeof(long)) && (typeof(UInt16) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Insert.UInt16.129.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Insert.UInt16.129.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertUInt16129()
         {
             var test = new SimpleUnaryOpTest__InsertUInt16129();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt16, UInt16>(_data, new UInt16[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse2.IsSupported;
+        public bool IsSupported => Sse2.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt16) != typeof(long)) && (typeof(UInt16) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.Byte.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.Byte.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractByte1()
         {
             var test = new SimpleUnaryOpTest__ExtractByte1();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Byte, Byte>(_data, new Byte[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(Byte) != typeof(long)) && (typeof(Byte) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.Byte.129.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.Byte.129.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractByte129()
         {
             var test = new SimpleUnaryOpTest__ExtractByte129();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Byte, Byte>(_data, new Byte[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(Byte) != typeof(long)) && (typeof(Byte) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.Int32.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.Int32.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractInt321()
         {
             var test = new SimpleUnaryOpTest__ExtractInt321();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int32, Int32>(_data, new Int32[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(Int32) != typeof(long)) && (typeof(Int32) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.Int32.129.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.Int32.129.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractInt32129()
         {
             var test = new SimpleUnaryOpTest__ExtractInt32129();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int32, Int32>(_data, new Int32[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(Int32) != typeof(long)) && (typeof(Int32) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.Int64.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.Int64.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractInt641()
         {
             var test = new SimpleUnaryOpTest__ExtractInt641();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int64, Int64>(_data, new Int64[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(Int64) != typeof(long)) && (typeof(Int64) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.Int64.129.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.Int64.129.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractInt64129()
         {
             var test = new SimpleUnaryOpTest__ExtractInt64129();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int64, Int64>(_data, new Int64[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(Int64) != typeof(long)) && (typeof(Int64) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.Single.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.Single.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractSingle1()
         {
             var test = new SimpleUnaryOpTest__ExtractSingle1();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Single, Single>(_data, new Single[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(Single) != typeof(long)) && (typeof(Single) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.Single.129.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.Single.129.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractSingle129()
         {
             var test = new SimpleUnaryOpTest__ExtractSingle129();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Single, Single>(_data, new Single[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(Single) != typeof(long)) && (typeof(Single) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.UInt32.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.UInt32.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractUInt321()
         {
             var test = new SimpleUnaryOpTest__ExtractUInt321();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt32, UInt32>(_data, new UInt32[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt32) != typeof(long)) && (typeof(UInt32) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.UInt32.129.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.UInt32.129.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractUInt32129()
         {
             var test = new SimpleUnaryOpTest__ExtractUInt32129();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt32, UInt32>(_data, new UInt32[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt32) != typeof(long)) && (typeof(UInt32) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.UInt64.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.UInt64.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractUInt641()
         {
             var test = new SimpleUnaryOpTest__ExtractUInt641();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt64, UInt64>(_data, new UInt64[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt64) != typeof(long)) && (typeof(UInt64) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.UInt64.129.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Extract.UInt64.129.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void ExtractUInt64129()
         {
             var test = new SimpleUnaryOpTest__ExtractUInt64129();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt64, UInt64>(_data, new UInt64[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt64) != typeof(long)) && (typeof(UInt64) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.Byte.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.Byte.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertByte1()
         {
             var test = new SimpleUnaryOpTest__InsertByte1();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Byte, Byte>(_data, new Byte[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(Byte) != typeof(long)) && (typeof(Byte) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.Byte.129.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.Byte.129.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertByte129()
         {
             var test = new SimpleUnaryOpTest__InsertByte129();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Byte, Byte>(_data, new Byte[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(Byte) != typeof(long)) && (typeof(Byte) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.Int32.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.Int32.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertInt321()
         {
             var test = new SimpleUnaryOpTest__InsertInt321();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int32, Int32>(_data, new Int32[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(Int32) != typeof(long)) && (typeof(Int32) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.Int32.129.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.Int32.129.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertInt32129()
         {
             var test = new SimpleUnaryOpTest__InsertInt32129();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int32, Int32>(_data, new Int32[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(Int32) != typeof(long)) && (typeof(Int32) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.Int64.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.Int64.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertInt641()
         {
             var test = new SimpleUnaryOpTest__InsertInt641();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int64, Int64>(_data, new Int64[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(Int64) != typeof(long)) && (typeof(Int64) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.Int64.129.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.Int64.129.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertInt64129()
         {
             var test = new SimpleUnaryOpTest__InsertInt64129();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<Int64, Int64>(_data, new Int64[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(Int64) != typeof(long)) && (typeof(Int64) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.SByte.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.SByte.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertSByte1()
         {
             var test = new SimpleUnaryOpTest__InsertSByte1();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<SByte, SByte>(_data, new SByte[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(SByte) != typeof(long)) && (typeof(SByte) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.SByte.129.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.SByte.129.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertSByte129()
         {
             var test = new SimpleUnaryOpTest__InsertSByte129();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<SByte, SByte>(_data, new SByte[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(SByte) != typeof(long)) && (typeof(SByte) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.UInt32.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.UInt32.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertUInt321()
         {
             var test = new SimpleUnaryOpTest__InsertUInt321();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt32, UInt32>(_data, new UInt32[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt32) != typeof(long)) && (typeof(UInt32) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.UInt32.129.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.UInt32.129.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertUInt32129()
         {
             var test = new SimpleUnaryOpTest__InsertUInt32129();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt32, UInt32>(_data, new UInt32[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt32) != typeof(long)) && (typeof(UInt32) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.UInt64.1.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.UInt64.1.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertUInt641()
         {
             var test = new SimpleUnaryOpTest__InsertUInt641();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt64, UInt64>(_data, new UInt64[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt64) != typeof(long)) && (typeof(UInt64) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.UInt64.129.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Insert.UInt64.129.cs
@@ -22,9 +22,7 @@ namespace JIT.HardwareIntrinsics.X86
         private static void InsertUInt64129()
         {
             var test = new SimpleUnaryOpTest__InsertUInt64129();
-            
-            try
-            {
+
             if (test.IsSupported)
             {
                 // Validates basic functionality works, using Unsafe.Read
@@ -77,11 +75,6 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates we throw on unsupported hardware
                 test.RunUnsupportedScenario();
             }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                test.Succeeded = true;
-            }
 
             if (!test.Succeeded)
             {
@@ -126,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
             _dataTable = new SimpleUnaryOpTest__DataTable<UInt64, UInt64>(_data, new UInt64[RetElementCount], LargestVectorSize);
         }
 
-        public bool IsSupported => Sse41.IsSupported;
+        public bool IsSupported => Sse41.IsSupported && (Environment.Is64BitProcess || ((typeof(UInt64) != typeof(long)) && (typeof(UInt64) != typeof(ulong))));
 
         public bool Succeeded { get; set; }
 


### PR DESCRIPTION
* This adds back the `Avx.MaskLoad` tests (temporarily removed due to the API changes made in https://github.com/dotnet/coreclr/pull/17637)
* This removes unnecessary `try/catch` blocks from the `ExtractScalar` and `InsertScalar` tests
  * The only time `PNSE` should be thrown is in the `UnsupportedScenario` test, which is the only test run when `IsSupported` is false. The `UnsupportedScenario` itself catches the PNSE and sets the test to pass if the exception was caught
* This fixes the `Avx.Extract` methods to throw PNSE when `IsSupported` is false
  * This is the source of the current `Avx` test failures for `COMPlus_FeatureSIMD=0` and `COMPlus_EnableAVX=0`