### PR TITLE
Fix some build breaks seen with the older VS we use to build with on …

### DIFF
--- a/src/jit/alloc.cpp
+++ b/src/jit/alloc.cpp
@@ -110,7 +110,7 @@ public:
     }
 };
 
-ArenaAllocator::SinglePagePool ArenaAllocator::s_pagePool;
+ArenaAllocator::SinglePagePool ArenaAllocator::s_pagePool = {};
 
 //------------------------------------------------------------------------
 // ArenaAllocator::bypassHostAllocator:
@@ -200,7 +200,6 @@ void* ArenaAllocator::allocateNewPage(size_t size)
     if (pageSize < size)
     {
         NOMEM();
-        return nullptr;
     }
 
     // If the current page is now full, update a few statistics
@@ -247,7 +246,6 @@ void* ArenaAllocator::allocateNewPage(size_t size)
         if (newPage == nullptr)
         {
             NOMEM();
-            return nullptr;
         }
 
         if (tryPoolNewPage)

--- a/src/jit/disasm.cpp
+++ b/src/jit/disasm.cpp
@@ -864,7 +864,6 @@ AddrToMethodHandleMap* DisAssembler::GetAddrToMethodHandleMap()
 {
     if (disAddrToMethodHandleMap == nullptr)
     {
-        assert(disComp->getAllocator() != nullptr);
         disAddrToMethodHandleMap = new (disComp->getAllocator()) AddrToMethodHandleMap(disComp->getAllocator());
     }
     return disAddrToMethodHandleMap;
@@ -877,7 +876,6 @@ AddrToMethodHandleMap* DisAssembler::GetHelperAddrToMethodHandleMap()
 {
     if (disHelperAddrToMethodHandleMap == nullptr)
     {
-        assert(disComp->getAllocator() != nullptr);
         disHelperAddrToMethodHandleMap = new (disComp->getAllocator()) AddrToMethodHandleMap(disComp->getAllocator());
     }
     return disHelperAddrToMethodHandleMap;
@@ -890,7 +888,6 @@ AddrToAddrMap* DisAssembler::GetRelocationMap()
 {
     if (disRelocationMap == nullptr)
     {
-        assert(disComp->getAllocator() != nullptr);
         disRelocationMap = new (disComp->getAllocator()) AddrToAddrMap(disComp->getAllocator());
     }
     return disRelocationMap;


### PR DESCRIPTION
…desktop.

```
src\jit\alloc.cpp(113): warning C4815: 's_pagePool' : zero-sized array in stack object will have no elements (unless the object is an aggregate that has been aggregate initialized)
src\jit\disasm.cpp(867): error C2678: binary '!=' : no operator found which takes a left-hand operand of type 'CompAllocator' (or there is no acceptable conversion)
src\jit\alloc.cpp(203): warning C4702: unreachable code
```