### PR TITLE
Use generic win-x86/win-x64 RIDs in stress_dependencies

### DIFF
--- a/tests/setup-stress-dependencies.cmd
+++ b/tests/setup-stress-dependencies.cmd
@@ -81,7 +81,7 @@ if errorlevel 1 goto Fail
 
 REM Get downloaded dll path
 echo Locating coredistools.dll
-FOR /F "delims=" %%i IN ('dir %__PackageDir%\coredistools.dll /b/s ^| findstr /R "win[0-9]*-%__Arch%"') DO set __LibPath=%%i
+FOR /F "delims=" %%i IN ('dir %__PackageDir%\coredistools.dll /b/s ^| findstr /R "win-%__Arch%"') DO set __LibPath=%%i
 echo CoreDisTools library path: %__LibPath%
 if not exist "%__LibPath%" (
     echo Failed to locate the downloaded library: %__LibPath%

--- a/tests/src/Common/stress_dependencies/stress_dependencies.csproj
+++ b/tests/src/Common/stress_dependencies/stress_dependencies.csproj
@@ -18,7 +18,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
-    <RuntimeIdentifiers>win7-x64;ubuntu.14.04-x64;osx.10.10-x64;win7-x86;ubuntu.14.04-x86;osx.10.10-x86</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;ubuntu.14.04-x64;osx.10.10-x64;win-x86;ubuntu.14.04-x86;osx.10.10-x86</RuntimeIdentifiers>
     <ContainsPackageReferences>true</ContainsPackageReferences>
     <PrereleaseResolveNuGetPackages>false</PrereleaseResolveNuGetPackages>
   </PropertyGroup>


### PR DESCRIPTION
Update Windows Stress Dependencies to match the changes in https://github.com/dotnet/llilc/pull/1087