### PR TITLE
add missing files to package properly on FreeBSD

### DIFF
--- a/src/.nuget/Microsoft.NETCore.ILAsm/runtime.FreeBSD.Microsoft.NETCore.ILAsm.props
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/runtime.FreeBSD.Microsoft.NETCore.ILAsm.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <SupportedPackageOSGroups>Linux;OSX;FreeBSD</SupportedPackageOSGroups>
-  </PropertyGroup>
+  <ItemGroup>
+    <NativeBinary Include="$(BinDir)ilasm" />
+  </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/runtime.FreeBSD.Microsoft.NETCore.ILDAsm.props
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/runtime.FreeBSD.Microsoft.NETCore.ILDAsm.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <SupportedPackageOSGroups>Linux;OSX;FreeBSD</SupportedPackageOSGroups>
-  </PropertyGroup>
+  <ItemGroup>
+    <NativeBinary Include="$(BinDir)ildasm" />
+  </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/runtime.FreeBSD.Microsoft.NETCore.Jit.props
+++ b/src/.nuget/Microsoft.NETCore.Jit/runtime.FreeBSD.Microsoft.NETCore.Jit.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <SupportedPackageOSGroups>Linux;OSX;FreeBSD</SupportedPackageOSGroups>
-  </PropertyGroup>
+  <ItemGroup>
+    <NativeBinary Include="$(BinDir)libclrjit.so" />
+  </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Native/runtime.FreeBSD.Microsoft.NETCore.Native.props
+++ b/src/.nuget/Microsoft.NETCore.Native/runtime.FreeBSD.Microsoft.NETCore.Native.props
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <NativeBinary Include="$(BinDir)System.Globalization.Native.a" />
+    <NativeBinary Include="$(BinDir)System.Globalization.Native.so" />
+  </ItemGroup>
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.FreeBSD.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.FreeBSD.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <NativeBinary Include="$(BinDir)libcoreclr.so" />
+    <NativeBinary Condition="'$(_PlatformDoesNotSupportEventTrace)' != 'true'" Include="$(BinDir)libcoreclrtraceptprovider.so" />
+    <NativeBinary Include="$(BinDir)libdbgshim.so" />
+    <NativeBinary Include="$(BinDir)libmscordaccore.so" />
+    <NativeBinary Include="$(BinDir)libmscordbi.so" />
+    <NativeBinary Include="$(BinDir)libsos.so" />
+    <NativeBinary Condition="'$(_PlatformDoesNotSupportSosPlugin)' != 'true'" Include="$(BinDir)libsosplugin.so" />
+    <NativeBinary Include="$(BinDir)System.Globalization.Native.so" />
+    <NativeBinary Include="$(BinDir)sosdocsunix.txt" />
+    <CrossGenBinary Include="$(BinDir)System.Private.CoreLib.dll" />
+    <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
+    <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
+    <CrossArchitectureSpecificToolFile Condition="'$(HasCrossTargetComponents)' == 'true'" Include="$(BinDir)$(CrossTargetComponentFolder)\crossgen" />
+  </ItemGroup>
+</Project>

--- a/src/.nuget/Microsoft.NETCore.TestHost/runtime.FreeBSD.Microsoft.NETCore.TestHost.props
+++ b/src/.nuget/Microsoft.NETCore.TestHost/runtime.FreeBSD.Microsoft.NETCore.TestHost.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <SupportedPackageOSGroups>Linux;OSX;FreeBSD</SupportedPackageOSGroups>
-  </PropertyGroup>
+  <ItemGroup>
+    <NativeBinary Include="$(BinDir)corerun" />
+  </ItemGroup>
 </Project>

--- a/src/.nuget/dir.props
+++ b/src/.nuget/dir.props
@@ -23,7 +23,7 @@
 
     <RuntimeOS Condition="'$(RuntimeOS)' == ''">$(OSRid)</RuntimeOS>
 
-    <SupportedPackageOSGroups Condition="'$(SupportedPackageOSGroups)' == ''">Windows_NT;OSX;Android;Linux</SupportedPackageOSGroups>
+    <SupportedPackageOSGroups Condition="'$(SupportedPackageOSGroups)' == ''">Windows_NT;OSX;Android;Linux;FreeBSD</SupportedPackageOSGroups>
     <SupportedPackageOSGroups>;$(SupportedPackageOSGroups);</SupportedPackageOSGroups>
 
     <!-- Identify OS family based upon the RuntimeOS, which could be distro specific (e.g. osx.10.12) or


### PR DESCRIPTION
This is my best guess based on existing Linux and OSX files. 
It creates missing packages expected by core-setup.