### PR TITLE
spmi: exclude methods using a file with saved md5 hashes.

### DIFF
--- a/src/ToolBox/superpmi/superpmi-shared/methodcontextreader.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontextreader.cpp
@@ -570,13 +570,16 @@ void MethodContextReader::CleanExcludedMethods()
 // Return should this method context be excluded from the replay or not.
 bool MethodContextReader::IsMethodExcluded(MethodContext* mc)
 {
-    char md5HashBuf[MD5_HASH_BUFFER_SIZE] = {0};
-    mc->dumpMethodMD5HashToBuffer(md5HashBuf, MD5_HASH_BUFFER_SIZE);
-    for (StringList* node = excludedMethodsList; node != nullptr; node = node->next)
+    if (excludedMethodsList != nullptr)
     {
-        if (strcmp(node->hash.c_str(), md5HashBuf) == 0)
+        char md5HashBuf[MD5_HASH_BUFFER_SIZE] = {0};
+        mc->dumpMethodMD5HashToBuffer(md5HashBuf, MD5_HASH_BUFFER_SIZE);
+        for (StringList* node = excludedMethodsList; node != nullptr; node = node->next)
         {
-            return true;
+            if (strcmp(node->hash.c_str(), md5HashBuf) == 0)
+            {
+                return true;
+            }
         }
     }
     return false;

--- a/src/ToolBox/superpmi/superpmi-shared/methodcontextreader.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontextreader.cpp
@@ -116,6 +116,8 @@ MethodContextReader::MethodContextReader(
     {
         GetFileSizeEx(this->fileHandle, (PLARGE_INTEGER) & this->fileSize);
     }
+
+    ReadExcludedMethods(mchFileName);
 }
 
 MethodContextReader::~MethodContextReader()
@@ -130,6 +132,8 @@ MethodContextReader::~MethodContextReader()
     }
 
     CloseHandle(this->mutex);
+
+    CleanExcludedMethods();
 }
 
 bool MethodContextReader::AcquireLock()
@@ -476,4 +480,74 @@ MethodContextBuffer MethodContextReader::GetSpecificMethodContext(unsigned int m
         this->ReleaseLock();
         return MethodContextBuffer(-4);
     }
+}
+
+// Read the file with excluded methods hashes and save them.
+void MethodContextReader::ReadExcludedMethods(std::string mchFileName)
+{
+    excludedMethodsList = nullptr;
+
+    size_t suffix_offset = mchFileName.find_last_of('.');
+    if (suffix_offset == std::string::npos)
+    {
+        LogError("Failed to get file extension from %s", mchFileName.c_str());
+        return;
+    }
+    std::string suffix          = mchFileName.substr(suffix_offset);
+    std::string excludeFileName = MethodContextReader::CheckForPairedFile(mchFileName, suffix.c_str(), ".exc");
+
+    if (excludeFileName.empty())
+    {
+        return;
+    }
+    FILE* fp = fopen(excludeFileName.c_str(), "r");
+    if (fp != nullptr)
+    {
+        int counter = 0;
+        while (!feof(fp))
+        {
+            char buf[MD5_HASH_BUFFER_SIZE];
+            int  readItems                = fscanf(fp, "%s", buf);
+            buf[MD5_HASH_BUFFER_SIZE - 1] = 0; // In case if we read more then we wanted.
+            if (readItems != 1 || strlen(buf) + 1 != MD5_HASH_BUFFER_SIZE)
+            {
+                LogInfo("The exclude file contains wrong values: %s.", buf);
+                break;
+            }
+
+            StringList* node    = new StringList();
+            node->hash          = buf;
+            node->next          = excludedMethodsList;
+            excludedMethodsList = node;
+            counter++;
+        }
+        fclose(fp);
+        LogInfo("Exclude file %s contains %d methods.", excludeFileName.c_str(), counter);
+    }
+}
+
+// Free memory used for excluded methods.
+void MethodContextReader::CleanExcludedMethods()
+{
+    while (excludedMethodsList != nullptr)
+    {
+        StringList* next = excludedMethodsList->next;
+        delete excludedMethodsList;
+        excludedMethodsList = next;
+    }
+}
+
+// Return should this method context be excluded from the replay or not.
+bool MethodContextReader::IsMethodExcluded(MethodContext* mc)
+{
+    char md5HashBuf[MD5_HASH_BUFFER_SIZE] = {0};
+    mc->dumpMethodMD5HashToBuffer(md5HashBuf, MD5_HASH_BUFFER_SIZE);
+    for (StringList* node = excludedMethodsList; node != nullptr; node = node->next)
+    {
+        if (strcmp(node->hash.c_str(), md5HashBuf) == 0)
+        {
+            return true;
+        }
+    }
+    return false;
 }

--- a/src/ToolBox/superpmi/superpmi-shared/methodcontextreader.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontextreader.cpp
@@ -503,18 +503,18 @@ void MethodContextReader::ReadExcludedMethods(std::string mchFileName)
     HANDLE excludeFileHandle = OpenFile(excludeFileName.c_str());
     if (excludeFileHandle != INVALID_HANDLE_VALUE)
     {
-        LARGE_INTEGER excludeFileSizeStruct;
-        GetFileSizeEx(excludeFileHandle, &excludeFileSizeStruct);
-        DWORD excludeFileSize = excludeFileSizeStruct.LowPart;
+        __int64 excludeFileSizeLong;
+        GetFileSizeEx(excludeFileHandle, (PLARGE_INTEGER)&excludeFileSizeLong);
+        unsigned excludeFileSize = (unsigned)excludeFileSizeLong;
 
         char* buffer = new char[excludeFileSize + 1];
         DWORD bytesRead;
-        bool success = (ReadFile(excludeFileHandle, buffer, excludeFileSize, &bytesRead, NULL) == TRUE);
+        bool  success = (ReadFile(excludeFileHandle, buffer, excludeFileSize, &bytesRead, NULL) == TRUE);
         CloseHandle(excludeFileHandle);
 
         if (!success || excludeFileSize != bytesRead)
         {
-            LogError("Failed to read the exclude file");
+            LogError("Failed to read the exclude file.");
             delete[] buffer;
             return;
         }
@@ -530,7 +530,7 @@ void MethodContextReader::ReadExcludedMethods(std::string mchFileName)
             {
                 curr++;
             }
-            
+
             std::string hash;
             while (*curr != 0 && !isspace(*curr))
             {

--- a/src/ToolBox/superpmi/superpmi-shared/methodcontextreader.h
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontextreader.h
@@ -83,6 +83,13 @@ private:
     int Offset;
     int Increment;
 
+    struct StringList
+    {
+        StringList* next;
+        std::string hash;
+    };
+    StringList* excludedMethodsList;
+
     // Binary search to get this method number from the index
     // Returns -1 for not found, or -2 for not indexed
     __int64 GetOffset(unsigned int methodNumber);
@@ -114,6 +121,9 @@ private:
     // Do we have a valid index?
     bool hasIndex();
 
+    void ReadExcludedMethods(std::string mchFileName);
+    void CleanExcludedMethods();
+
 public:
     MethodContextReader(const char* inputFileName,
                         const int*  indexes    = nullptr,
@@ -137,11 +147,7 @@ public:
     }
 
     // Return should this method context be excluded from the replay or not.
-    bool IsMethodExcluded(MethodContext* mc)
-    {
-        // Right now it is just a stub.
-        return false;
-    }
+    bool IsMethodExcluded(MethodContext* mc);
 };
 #pragma pack(pop)
 

--- a/src/inc/clr_std/string
+++ b/src/inc/clr_std/string
@@ -146,6 +146,14 @@ public:
         return (*this);
     }
 
+    basic_string<T>& operator+=(value_type _Ch)
+    {
+        size_type oldsize = size();         // doesn't include null terminator
+        m_string[oldsize] = _Ch; // Replace the null terminator with the new symbol.
+        m_string.push_back(T()); // Return the replaced terminator again.
+        return (*this);
+    }
+
     ~basic_string()
     {
         // vector destructor does all the work
@@ -155,6 +163,11 @@ public:
     {
         assert(m_string.size() > 0);
         return m_string.size() - 1;      // Don't report the null terminator.
+    }
+
+    size_t length() const
+    {
+        return size();
     }
 
     T& operator[](size_t iIndex)


### PR DESCRIPTION
Exclude methods are presented in a file with the same name as `*.mc\*.mch` that we are running, but with `*.exc` extension.
For example: `chaos2131.mc` and `chaos2131.exc`.

We do not expect many methods to be excluded, right now we need to exclude at maximum 1 method for 10% of our '*.mch` files. It is why we can start with a linear search and fix it later if we need to.

The '*.exc' file has to contain MD5 hashes with `MD5_HASH_BUFFER_SIZE-1` length, they should be separated with newlines or spaces, if we find a value with incorrect length then we ignore this value.