### PR TITLE
Delete dead code

### DIFF
--- a/src/System.Private.CoreLib/src/System/AppDomain.cs
+++ b/src/System.Private.CoreLib/src/System/AppDomain.cs
@@ -267,11 +267,6 @@ namespace System
             return nGetAssemblies(forIntrospection);
         }
 
-        // this is true when we've just started going through the finalizers and are forcing objects to finalize
-        // so must be aware that certain infrastructure may have gone away
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        public extern bool IsFinalizingForUnload();
-
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern void PublishAnonymouslyHostedDynamicMethodsAssembly(RuntimeAssembly assemblyHandle);
 

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
@@ -641,8 +641,7 @@ namespace System.Reflection.Emit
                 // We go over all DynamicMethodDesc during AppDomain shutdown and make sure
                 // that everything associated with them is released. So it is ok to skip reregistration
                 // for finalization during appdomain shutdown
-                if (!Environment.HasShutdownStarted &&
-                    !AppDomain.CurrentDomain.IsFinalizingForUnload())
+                if (!Environment.HasShutdownStarted)
                 {
                     // Try again later.
                     GC.ReRegisterForFinalize(this);
@@ -667,8 +666,7 @@ namespace System.Reflection.Emit
                 // It is not safe to destroy the method if the managed resolver is alive.
                 if (RuntimeMethodHandle.GetResolver(m_methodHandle) != null)
                 {
-                    if (!Environment.HasShutdownStarted &&
-                        !AppDomain.CurrentDomain.IsFinalizingForUnload())
+                    if (!Environment.HasShutdownStarted)
                     {
                         // Somebody might have been holding a reference on us via weak handle.
                         // We will keep trying. It will be hopefully released eventually.

--- a/src/System.Private.CoreLib/src/System/Reflection/LoaderAllocator.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/LoaderAllocator.cs
@@ -43,10 +43,9 @@ namespace System.Reflection
 
             // Assemblies and LoaderAllocators will be cleaned up during AppDomain shutdown in
             // unmanaged code
-            // So it is ok to skip reregistration and cleanup for finalization during appdomain shutdown.
+            // So it is ok to skip reregistration and cleanup for finalization during shutdown.
             // We also avoid early finalization of LoaderAllocatorScout due to AD unload when the object was inside DelayedFinalizationList.
-            if (!Environment.HasShutdownStarted &&
-                !AppDomain.CurrentDomain.IsFinalizingForUnload())
+            if (!Environment.HasShutdownStarted)
             {
                 // Destroy returns false if the managed LoaderAllocator is still alive.
                 if (!Destroy(m_nativeLoaderAllocator))

--- a/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
@@ -697,7 +697,7 @@ namespace System.Threading
             // if we're in the process of shutting down or unloading the AD.  In those cases, the work won't
             // execute anyway.  And there are subtle race conditions involved there that would lead us to do the wrong
             // thing anyway.  So we'll only clean up if this is a "normal" finalization.
-            if (!(Environment.HasShutdownStarted || AppDomain.CurrentDomain.IsFinalizingForUnload()))
+            if (!Environment.HasShutdownStarted)
                 CleanUp();
         }
     }
@@ -902,7 +902,7 @@ namespace System.Threading
         ~QueueUserWorkItemCallbackBase()
         {
             Debug.Assert(
-                executed != 0 || Environment.HasShutdownStarted || AppDomain.CurrentDomain.IsFinalizingForUnload(),
+                executed != 0 || Environment.HasShutdownStarted,
                 "A QueueUserWorkItemCallback was never called!");
         }
 

--- a/src/System.Private.CoreLib/src/System/Threading/Timer.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Timer.cs
@@ -650,7 +650,7 @@ namespace System.Threading
             // Note that in either case, the Timer still won't fire, because ThreadPool threads won't be
             // allowed to run in this AppDomain.
             //
-            if (Environment.HasShutdownStarted || AppDomain.CurrentDomain.IsFinalizingForUnload())
+            if (Environment.HasShutdownStarted)
                 return;
 
             m_timer.Close();

--- a/src/vm/appdomainnative.cpp
+++ b/src/vm/appdomainnative.cpp
@@ -419,22 +419,6 @@ FCIMPL1(Object*, AppDomainNative::GetDynamicDir, AppDomainBaseObject* refThisUNS
 }
 FCIMPLEND
 
-FCIMPL1(FC_BOOL_RET, AppDomainNative::IsFinalizingForUnload, AppDomainBaseObject* refThisUNSAFE)
-{
-    FCALL_CONTRACT;
-
-    BOOL            retVal = FALSE;
-    APPDOMAINREF    refThis = (APPDOMAINREF) refThisUNSAFE;
-    HELPER_METHOD_FRAME_BEGIN_RET_1(refThis);
-
-    AppDomain* pApp = ValidateArg(refThis);
-    retVal = pApp->IsFinalizing();
-
-    HELPER_METHOD_FRAME_END();
-    FC_RETURN_BOOL(retVal);
-}
-FCIMPLEND
-
 FCIMPL2(StringObject*, AppDomainNative::nApplyPolicy, AppDomainBaseObject* refThisUNSAFE, AssemblyNameBaseObject* refAssemblyNameUNSAFE)
 {
     FCALL_CONTRACT;

--- a/src/vm/appdomainnative.hpp
+++ b/src/vm/appdomainnative.hpp
@@ -33,7 +33,6 @@ public:
     static FCDECL1(INT32, GetId, AppDomainBaseObject* refThisUNSAFE);
     static FCDECL1(INT32, GetIdForUnload, AppDomainBaseObject* refDomainUNSAFE);
     static FCDECL1(FC_BOOL_RET, IsDomainIdValid, INT32 dwId);
-    static FCDECL1(FC_BOOL_RET, IsFinalizingForUnload, AppDomainBaseObject* refThisUNSAFE);
     static FCDECL1(void, ForceToSharedDomain, Object* pObjectUNSAFE);
     static FCDECL1(LPVOID,  GetFusionContext, AppDomainBaseObject* refThis);
     static FCDECL2(Object*, IsStringInterned, AppDomainBaseObject* refThis, StringObject* pString);

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -461,7 +461,6 @@ FCFuncStart(gAppDomainFuncs)
     FCFuncElement("GetOrInternString", AppDomainNative::GetOrInternString)
     QCFuncElement("nSetupBindingPaths", AppDomainNative::SetupBindingPaths)
     QCFuncElement("nSetNativeDllSearchDirectories", AppDomainNative::SetNativeDllSearchDirectories)
-    FCFuncElement("IsFinalizingForUnload", AppDomainNative::IsFinalizingForUnload)
     FCFuncElement("PublishAnonymouslyHostedDynamicMethodsAssembly", AppDomainNative::PublishAnonymouslyHostedDynamicMethodsAssembly)
 #ifdef FEATURE_APPDOMAIN_RESOURCE_MONITORING
     FCFuncElement("nEnableMonitoring", AppDomainNative::EnableMonitoring)


### PR DESCRIPTION
- Leftover from unobserved exception desktop quirk
- Unnecessary calls to AppDomain.IsFinalizingForUnload(). They were actually never required even with AppDomain support because of Environment.HasShutdownStarted returns true during AppDomain unload.