### PR TITLE
Add missing FlushInstructionCache to CommitGCStressInstructionUpdate

### DIFF
--- a/src/vm/threadsuspend.cpp
+++ b/src/vm/threadsuspend.cpp
@@ -5078,6 +5078,8 @@ void Thread::CommitGCStressInstructionUpdate()
         *pbDestCode = *pbSrcCode;
 
 #endif
+
+        FlushInstructionCache(GetCurrentProcess(), (LPCVOID)pbDestCode, 4);
     }
 }
 


### PR DESCRIPTION
It's my understanding that missing `FlushInstructionCache` in `Thread::CommitGCStressInstructionUpdate` was the reason of the assertion failures we observed in https://github.com/dotnet/coreclr/issues/17570#issuecomment-382913069. 
```
BEGIN EXECUTION
 "C:\Users\robox\j\workspace\arm_cross_che---88fcf6b1\bin\tests\Windows_NT.arm.Checked\Tests\Core_Root\corerun.exe" thread22.exe 

Assert failure(PID 16144 [0x00003f10], Thread: 17188 [0x4324]): instrVal32 == *(DWORD*)(gcCover->savedCode + offset)

<no module>! <no symbol> + 0x0 (0x00000000)
    File: d:\j\workspace\arm_cross_che---9fe37e18\src\vm\gccover.cpp Line: 1451
    Image: C:\Users\robox\j\workspace\arm_cross_che---88fcf6b1\bin\tests\Windows_NT.arm.Checked\Tests\Core_Root\CoreRun.exe

Expected: 100
Actual: 123456789
END EXECUTION - FAILED
FAILED
```
I have done proper testing of this change with threading tests (running them 10000 times in a loop) previous failing under `GCStress=0xC` and the issue is not reproducible anymore.

Fixes #17570