### PR TITLE
Remove unuseful null check on Activator.CreateInstance

### DIFF
--- a/src/System.Private.CoreLib/src/System/Activator.cs
+++ b/src/System.Private.CoreLib/src/System/Activator.cs
@@ -149,11 +149,7 @@ namespace System
             }
 
             if (type == null)
-            {
-                // It's classic managed type (not WinRT type)
-                if (assembly == null)
-                    return null;
-
+            {                
                 type = assembly.GetType(typeName, true /*throwOnError*/, ignoreCase);
             }
 
@@ -164,7 +160,7 @@ namespace System
                                                 culture,
                                                 activationAttributes);
 
-            return new ObjectHandle(o);          
+            return (o != null) ? new ObjectHandle(o) : null;          
         }
 
         public static ObjectHandle CreateInstanceFrom(string assemblyFile, string typeName)
@@ -215,7 +211,7 @@ namespace System
                                                 culture,
                                                 activationAttributes);
 
-            return new ObjectHandle(o);
+            return (o != null) ? new ObjectHandle(o) : null;
         }
 
         public static T CreateInstance<T>()

--- a/src/System.Private.CoreLib/src/System/Activator.cs
+++ b/src/System.Private.CoreLib/src/System/Activator.cs
@@ -164,7 +164,7 @@ namespace System
                                                 culture,
                                                 activationAttributes);
 
-            return (o != null) ? new ObjectHandle(o) : null;          
+            return new ObjectHandle(o);          
         }
 
         public static ObjectHandle CreateInstanceFrom(string assemblyFile, string typeName)
@@ -215,7 +215,7 @@ namespace System
                                                 culture,
                                                 activationAttributes);
 
-            return (o != null) ? new ObjectHandle(o) : null;
+            return new ObjectHandle(o);
         }
 
         public static T CreateInstance<T>()


### PR DESCRIPTION
During the developing/testing of new Activator.CreateInstance apis we found unuseful null check.

Comment https://github.com/dotnet/corefx/pull/30809#discussion_r200356834

/cc @jkotas 

