### PR TITLE
Remove System.Security.Cryptography.X509Certificates.Tests from exclusion list

### DIFF
--- a/tests/arm/corefx_test_exclusions.txt
+++ b/tests/arm/corefx_test_exclusions.txt
@@ -12,5 +12,4 @@ System.Management.Tests              # https://github.com/dotnet/coreclr/issues/
 System.Net.HttpListener.Tests        # https://github.com/dotnet/coreclr/issues/17584
 System.Runtime.Numerics.Tests        # https://github.com/dotnet/coreclr/issues/18362 -- JitStress=1 JitStress=2
 System.Runtime.Tests                 # https://github.com/dotnet/coreclr/issues/17585
-System.Security.Cryptography.X509Certificates.Tests # https://github.com/dotnet/coreclr/issues/17801
 System.Text.RegularExpressions.Tests # https://github.com/dotnet/coreclr/issues/17754 -- timeout -- JitMinOpts only


### PR DESCRIPTION
The troublesome machine `ARM64-AMD-053` was taking offline and will be re-imaged before connecting back. Since the issue #17801 was the machine specific I am removing `System.Security.Cryptography.X509Certificates.Tests` from Windows/arm tests exclusion list.

Closes #17801