### PR TITLE
Fix some failures when using build-test.sh

### DIFF
--- a/tests/src/CLRTest.Jit.targets
+++ b/tests/src/CLRTest.Jit.targets
@@ -23,11 +23,9 @@ WARNING:   When setting properties based on their current state (for example:
   <Target Name="GetJitDisasmBashScript"
           Returns="$(JitDisasmBashScript)">
     <PropertyGroup>
-      <InputAssemblyName Condition="('$(CLRTestKind)' == 'RunOnly') and ('$(RunningOnUnix)' == 'true')">$([MSBuild]::MakeRelative($(OutputPath.Replace("/","\\")), $(_CLRTestToRunFileFullPath.Replace("/","\\"))).Replace("\\","/"))</InputAssemblyName>
-      <InputAssemblyName Condition="('$(CLRTestKind)' == 'RunOnly') and ('$(RunningOnUnix)' != 'true')">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)).Replace("\","/"))</InputAssemblyName>
+      <InputAssemblyName Condition="'$(CLRTestKind)' == 'RunOnly'">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)).Replace("\","/"))</InputAssemblyName>
       <InputAssemblyName Condition="'$(CLRTestKind)' == 'BuildAndRun'">$(MSBuildProjectName).exe</InputAssemblyName>
-      <JitDisasmOut Condition="'$(RunningOnUnix)' == 'true'">$([MSBuild]::MakeRelative($(OutputPath.Replace("/","\\")), $(BaseOutputPathWithConfig.Replace("/","\\"))dasm\$(BuildProjectRelativeDir.Replace("/","\\"))).Replace("\\","/"))</JitDisasmOut>
-      <JitDisasmOut Condition="'$(RunningOnUnix)' != 'true'">$([MSBuild]::MakeRelative($(OutputPath), $(BaseOutputPathWithConfig)dasm\$(BuildProjectRelativeDir)).Replace("\","/"))</JitDisasmOut>
+      <JitDisasmOut>$([MSBuild]::MakeRelative($(OutputPath), $(BaseOutputPathWithConfig)dasm\$(BuildProjectRelativeDir)).Replace("\","/"))</JitDisasmOut>
       <JitDisasmBashScript>
 <![CDATA[
 # JitDisasm Script
@@ -50,11 +48,9 @@ fi
   <Target Name="GetJitDisasmBatchScript"
           Returns="$(JitDisasmBatchScript)">
     <PropertyGroup>
-      <InputAssemblyName Condition="('$(CLRTestKind)' == 'RunOnly') and ('$(RunningOnUnix)' == 'true')">$([MSBuild]::MakeRelative($(OutputPath.Replace("/","\\")), $(_CLRTestToRunFileFullPath.Replace("/","\\"))).Replace("\\","/"))</InputAssemblyName>
-      <InputAssemblyName Condition="('$(CLRTestKind)' == 'RunOnly') and ('$(RunningOnUnix)' != 'true')">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)))</InputAssemblyName>
+      <InputAssemblyName Condition="'$(CLRTestKind)' == 'RunOnly'">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)))</InputAssemblyName>
       <InputAssemblyName Condition="'$(CLRTestKind)' == 'BuildAndRun'">$(MSBuildProjectName).exe</InputAssemblyName>
-      <JitDisasmOut Condition="'$(RunningOnUnix)' == 'true'">$([MSBuild]::MakeRelative($(OutputPath.Replace("/","\\")), $(BaseOutputPathWithConfig.Replace("/","\\"))dasm\$(BuildProjectRelativeDir.Replace("/","\\"))).Replace("\\","/"))</JitDisasmOut>
-      <JitDisasmOut Condition="'$(RunningOnUnix)' != 'true'">$([MSBuild]::MakeRelative($(OutputPath), $(BaseOutputPathWithConfig)dasm\$(BuildProjectRelativeDir)))</JitDisasmOut>
+      <JitDisasmOut>$([MSBuild]::MakeRelative($(OutputPath), $(BaseOutputPathWithConfig)dasm\$(BuildProjectRelativeDir)))</JitDisasmOut>
       <JitDisasmBatchScript>
 <![CDATA[
 REM JitDisasm Script
@@ -76,8 +72,7 @@ if defined RunningJitDisasm (
       Name="GetIlasmRoundTripBashScript"
       Returns="$(IlasmRoundTripBashScript)">
     <PropertyGroup>
-      <InputAssemblyName Condition="('$(CLRTestKind)' == 'RunOnly') and ('$(RunningOnUnix)' == 'true')">$([MSBuild]::MakeRelative($(OutputPath.Replace("/","\\")), $(_CLRTestToRunFileFullPath.Replace("/","\\"))).Replace("\\","/"))</InputAssemblyName>
-      <InputAssemblyName Condition="('$(CLRTestKind)' == 'RunOnly') and ('$(RunningOnUnix)' != 'true')">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)).Replace("\","/"))</InputAssemblyName>
+      <InputAssemblyName Condition="'$(CLRTestKind)' == 'RunOnly'">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)).Replace("\","/"))</InputAssemblyName>
       <InputAssemblyName Condition="'$(CLRTestKind)' == 'BuildAndRun'">$(MSBuildProjectName).exe</InputAssemblyName>
       <DisassemblyName>$(MSBuildProjectName).dasm.il</DisassemblyName>
       <TargetAssemblyName>$(MSBuildProjectName).asm.exe</TargetAssemblyName>

--- a/tests/src/JIT/jit64/eh/basics/throwinfinallyintryfilter1.ilproj
+++ b/tests/src/JIT/jit64/eh/basics/throwinfinallyintryfilter1.ilproj
@@ -31,7 +31,7 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\common\common.csproj" />
+    <ProjectReference Include="..\Common\common.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>

--- a/tests/src/JIT/jit64/eh/basics/throwinfinallyintryfilter2.ilproj
+++ b/tests/src/JIT/jit64/eh/basics/throwinfinallyintryfilter2.ilproj
@@ -30,7 +30,7 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\common\common.csproj" />
+    <ProjectReference Include="..\Common\common.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>

--- a/tests/src/JIT/jit64/eh/basics/throwinfinallyintryfilter3.ilproj
+++ b/tests/src/JIT/jit64/eh/basics/throwinfinallyintryfilter3.ilproj
@@ -31,7 +31,7 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\common\common.csproj" />
+    <ProjectReference Include="..\Common\common.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>

--- a/tests/src/JIT/jit64/eh/basics/throwisfirstinstruction.ilproj
+++ b/tests/src/JIT/jit64/eh/basics/throwisfirstinstruction.ilproj
@@ -31,7 +31,7 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\common\common.csproj" />
+    <ProjectReference Include="..\Common\common.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>


### PR DESCRIPTION
1) Remove a workaround for broken msbuild RelativePath API that is
   apparently no longer necessary and doesn't seem to work anymore anyway.
2) Fix a casing issue in some test projects.  I'm not sure why this hasn't
   been fixed yet.

Fixes #18381
