### PR TITLE
LastIndexOf corner case fix when span is empty

### DIFF
--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
@@ -188,7 +188,7 @@ namespace System
 
             if (value.Length == 0)
             {
-                return span.Length - 1;
+                return span.Length > 0 ? span.Length - 1 : 0;
             }
 
             if (span.Length == 0)


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/pull/30896#discussion_r200843575

Thanks for spotting! I shouldn't have rushed fixing the initial issue.