### PR TITLE
Fix a comment in string.ChangeCase() method

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Globalization/TextInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/TextInfo.cs
@@ -302,7 +302,7 @@ namespace System.Globalization
                                     source.AsSpan(0, sourcePos).CopyTo(new Span<char>(pResult, sourcePos));
                                 }
 
-                                // And store the current character, upper-cased.
+                                // And store the current character, lower-cased.
                                 char* d = pResult + sourcePos;
                                 *d++ = (char)(c | 0x20);
                                 sourcePos++;


### PR DESCRIPTION
Fix a comment in string ChangeCase method.

Looks like a code block was written for upper-casing characters, then
copied and edited for lower-casing, but one of the comments was
not edited to match.

Line 307 is lowercasing code but the comment says "store the current 
character, upper-cased". Fixed comment to say "lower-cased".

(Equivalent and correct "upper-cased" comment is on line 252).
