### PR TITLE
Fix serialization type in NotFiniteNumberException

### DIFF
--- a/src/System.Private.CoreLib/shared/System/NotFiniteNumberException.cs
+++ b/src/System.Private.CoreLib/shared/System/NotFiniteNumberException.cs
@@ -55,13 +55,13 @@ namespace System
 
         protected NotFiniteNumberException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
-            _offendingNumber = info.GetInt32("OffendingNumber");
+            _offendingNumber = info.GetDouble("OffendingNumber"); // Do not rename (binary serialization)
         }
 
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
-            info.AddValue("OffendingNumber", _offendingNumber, typeof(int));
+            info.AddValue("OffendingNumber", _offendingNumber, typeof(double)); // Do not rename (binary serialization)
         }
 
         public double OffendingNumber


### PR DESCRIPTION
Good news: This is the only serializable type that passes a different type than the value's type in.
Bad news: No bad news today :)