### PR TITLE
Don't trim compiler-generated anonymous types

### DIFF
--- a/src/System.Private.CoreLib/ILLinkTrim.xml
+++ b/src/System.Private.CoreLib/ILLinkTrim.xml
@@ -37,5 +37,7 @@
     <type fullname="System.Diagnostics.Tracing.EventPipe*" />
     <!-- Accessed via private reflection and by native code. -->
     <type fullname="System.Diagnostics.Tracing.RuntimeEventSource" />
+    <!-- Accessed via reflection in TraceLogging-style EventSource events. -->
+    <type fullname="*f__AnonymousType*" />
   </assembly>
 </linker>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/30876.

Trimming compiler-generated anonymous types breaks EventSource tracelogging events where anonymous types are used but the properties are not directly consumed by non-EventSource code. 
 EventSource uses reflection to generically operate on all input types.

An example callsite that gets broken is: https://github.com/dotnet/coreclr/blob/master/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs#L2086.