### PR TITLE
Fixing encodeXmmRegAsIval to ensure the result meets the 'fits in imm8' check

### DIFF
--- a/src/jit/emitfmtsxarch.h
+++ b/src/jit/emitfmtsxarch.h
@@ -111,7 +111,7 @@ IF_DEF(RRW_RRW_CNS, IS_R1_RW|IS_R2_RW,          SCNS)     // r/w    reg , r/w  r
 IF_DEF(RWR_RRD_RRD, IS_R1_WR|IS_R2_RD|IS_R3_RD, NONE)     // write  reg , read reg2 , read reg3
 IF_DEF(RWR_RRD_RRD_CNS, IS_R1_WR|IS_R2_RD|IS_R3_RD, SCNS) // write  reg , read reg2 , read reg3, const
 
-IF_DEF(RWR_RRD_RRD_RRD, IS_R1_WR|IS_R2_RD|IS_R3_RD|IS_R4_RD, NONE)     // write  reg , read reg2 , read reg3 , read reg4
+IF_DEF(RWR_RRD_RRD_RRD, IS_R1_WR|IS_R2_RD|IS_R3_RD|IS_R4_RD, CNS)     // write  reg , read reg2 , read reg3 , read reg4
 //----------------------------------------------------------------------------
 // The following formats are used for direct addresses (e.g. static data members)
 //----------------------------------------------------------------------------

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -4512,10 +4512,13 @@ void emitter::emitIns_R_R_S_I(
 //    opReg encoded in imm[7:4]
 static int encodeXmmRegAsIval(regNumber opReg)
 {
-    assert(opReg >= XMMBASE);
     // AVX/AVX2 supports 4-reg format for vblendvps/vblendvpd/vpblendvb,
     // which encodes the fourth register into imm8[7:4]
-    return (opReg - XMMBASE) << 4;
+    assert(opReg >= XMMBASE);
+    int ival = (opReg - XMMBASE) << 4;
+
+    assert((ival >= 0) && (ival <= 255));
+    return (int8_t)ival;
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
FYI. @CarolEidt, @fiigii, @eerhardt

This resolves #18815