### PR TITLE
Fix two issues in Marshal.SecureStringToBSTR

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Security/SecureString.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Security/SecureString.Unix.cs
@@ -70,14 +70,6 @@ namespace System.Security
             }
         }
 
-        private void EnsureNotDisposed()
-        {
-            if (_buffer == null)
-            {
-                throw new ObjectDisposedException(GetType().Name);
-            }
-        }
-
         private void ClearCore()
         {
             _decryptedLength = 0;
@@ -143,7 +135,7 @@ namespace System.Security
             _buffer.Write((ulong)(index * sizeof(char)), c);
         }
 
-        internal unsafe IntPtr MarshalToBSTR()
+        internal unsafe IntPtr MarshalToBSTRCore()
         {
             int length = _decryptedLength;
             IntPtr ptr = IntPtr.Zero;

--- a/src/System.Private.CoreLib/shared/System/Security/SecureString.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Security/SecureString.Windows.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Runtime;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
-using Microsoft.Win32;
 
 namespace System.Security
 {
@@ -145,7 +144,7 @@ namespace System.Security
             }
         }
 
-        internal unsafe IntPtr MarshalToBSTR()
+        internal unsafe IntPtr MarshalToBSTRCore()
         {
             int length = _decryptedLength;
             IntPtr ptr = IntPtr.Zero;
@@ -230,14 +229,6 @@ namespace System.Security
                 }
             }
             return result;
-        }
-
-        private void EnsureNotDisposed()
-        {
-            if (_buffer == null)
-            {
-                throw new ObjectDisposedException(GetType().Name);
-            }
         }
 
         // -----------------------------

--- a/src/System.Private.CoreLib/shared/System/Security/SecureString.cs
+++ b/src/System.Private.CoreLib/shared/System/Security/SecureString.cs
@@ -156,6 +156,23 @@ namespace System.Security
             }
         }
 
+        private void EnsureNotDisposed()
+        {
+            if (_buffer == null)
+            {
+                throw new ObjectDisposedException(GetType().Name);
+            }
+        }
+
+        internal IntPtr MarshalToBSTR()
+        {
+            lock (_methodLock)
+            {
+                EnsureNotDisposed();
+                return MarshalToBSTRCore();
+            }
+        }
+
         internal unsafe IntPtr MarshalToString(bool globalAlloc, bool unicode)
         {
             lock (_methodLock)


### PR DESCRIPTION
1. It wasn't synchronized, even though other operations on SecureString are in order to avoid concurrency problems leading to memory corruption issues (and it's synchronized on netfx).

2. It wasn't throwing an ObjectDisposedException if the instance was disposed.

Fixes https://github.com/dotnet/corefx/issues/30938
cc: @hughbe, @bartonjs, @luqunl 