### PR TITLE
Make Number.Parsing.cs BigEndian friendly

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
@@ -941,33 +941,19 @@ namespace System
         private static bool NumberBufferToDouble(ref NumberBuffer number, ref double value)
         {
             double d = NumberToDouble(ref number);
-            uint e = DoubleHelper.Exponent(d);
-            ulong m = DoubleHelper.Mantissa(d);
-
-            if (e == 0x7FF)
+            if (!Double.IsFinite(d))
             {
+                value = default;
                 return false;
             }
 
-            if (e == 0 && m == 0)
+            if (d == 0.0)
             {
-                d = 0;
+                d = 0.0;
             }
 
             value = d;
             return true;
-        }
-
-        private static class DoubleHelper
-        {
-            public static unsafe uint Exponent(double d) =>
-                (*((uint*)&d + (BitConverter.IsLittleEndian ? 1 : 0)) >> 20) & 0x000007ff;
-
-            public static unsafe ulong Mantissa(double d) =>
-                *((ulong*)&d) & 0x000fffffffffffff;
-
-            public static unsafe bool Sign(double d) =>
-                (*((uint*)&d + (BitConverter.IsLittleEndian ? 1 : 0)) >> 31) != 0;
         }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
@@ -947,12 +947,7 @@ namespace System
                 return false;
             }
 
-            if (d == 0.0)
-            {
-                d = 0.0;
-            }
-
-            value = d;
+            value = (d == 0.0) ? 0.0 : d;
             return true;
         }
     }

--- a/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
@@ -947,7 +947,13 @@ namespace System
                 return false;
             }
 
-            value = (d == 0.0) ? 0.0 : d;
+            if (d == 0.0)
+            {
+                // normalize -0.0 to 0.0
+                d = 0.0;
+            }
+
+            value = d;
             return true;
         }
     }

--- a/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
@@ -961,13 +961,13 @@ namespace System
         private static class DoubleHelper
         {
             public static unsafe uint Exponent(double d) =>
-                (*((uint*)&d + 1) >> 20) & 0x000007ff;
+                (*((uint*)&d + (BitConverter.IsLittleEndian ? 1 : 0)) >> 20) & 0x000007ff;
 
             public static unsafe ulong Mantissa(double d) =>
                 *((ulong*)&d) & 0x000fffffffffffff;
 
             public static unsafe bool Sign(double d) =>
-                (*((uint*)&d + 1) >> 31) != 0;
+                (*((uint*)&d + (BitConverter.IsLittleEndian ? 1 : 0)) >> 31) != 0;
         }
     }
 }

--- a/src/pal/src/cruntime/misctls.cpp
+++ b/src/pal/src/cruntime/misctls.cpp
@@ -127,8 +127,3 @@ done:
 
     return retval;
 }
-
-UINT GetExponent(double d)
-{
-    return (*((UINT*)&d + 1) >> 20) & 0x000007ff;
-}


### PR DESCRIPTION
I imported .NET Core sources for all primitive types to Mono (+ managed implementation of Number.X.cs and Decimal.cs from CoreRT) and it turns out that `DoubleHelper` is not Big Endian friendly (tested on 
@NattyNarwhal 's ppc64be machine), here is a small repro I used on that machine https://gist.github.com/EgorBo/e0cb42e7724f6653bee563318386be25 
Also, it seems `GetExponent` from misctls.cpp is not used anywhere.

PS: about BE in .NET Core: https://github.com/dotnet/corefx/issues/16036#issuecomment-279533179