### PR TITLE
Remove dead/unreachable code from ARM32 and ARM64 emitters

### DIFF
--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -1297,13 +1297,6 @@ protected:
 #endif                                     // MULTIREG_HAS_SECOND_GC_RET
     };
 
-    struct instrDescArmFP : instrDesc
-    {
-        regNumber r1;
-        regNumber r2;
-        regNumber r3;
-    };
-
     insUpdateModes emitInsUpdateMode(instruction ins);
     insFormat emitInsModeFormat(instruction ins, insFormat base);
 

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -1255,6 +1255,8 @@ protected:
         int     iddcDspVal;
     };
 
+#ifdef _TARGET_XARCH_
+
     struct instrDescAmd : instrDesc // large addrmode disp
     {
         ssize_t idaAmdVal;
@@ -1265,6 +1267,8 @@ protected:
         ssize_t idacCnsVal;
         ssize_t idacAmdVal;
     };
+
+#endif // _TARGET_XARCH_
 
     struct instrDescCGCA : instrDesc // call with ...
     {
@@ -1308,17 +1312,22 @@ protected:
     size_t emitGetInstrDescSize(const instrDesc* id);
     size_t emitGetInstrDescSizeSC(const instrDesc* id);
 
+#ifdef _TARGET_XARCH_
+
     ssize_t emitGetInsCns(instrDesc* id);
     ssize_t emitGetInsDsp(instrDesc* id);
     ssize_t emitGetInsAmd(instrDesc* id);
     ssize_t emitGetInsCnsDsp(instrDesc* id, ssize_t* dspPtr);
-    ssize_t emitGetInsSC(instrDesc* id);
+
     ssize_t emitGetInsCIdisp(instrDesc* id);
     unsigned emitGetInsCIargs(instrDesc* id);
 
     // Return the argument count for a direct call "id".
     int emitGetInsCDinfo(instrDesc* id);
 
+#endif // _TARGET_XARCH_
+
+    ssize_t emitGetInsSC(instrDesc* id);
     unsigned emitInsCount;
 
 /************************************************************************/
@@ -1784,6 +1793,8 @@ private:
         return (instrDescCnsDsp*)emitAllocInstr(sizeof(instrDescCnsDsp), attr);
     }
 
+#ifdef _TARGET_XARCH_
+
     instrDescAmd* emitAllocInstrAmd(emitAttr attr)
     {
         return (instrDescAmd*)emitAllocInstr(sizeof(instrDescAmd), attr);
@@ -1793,6 +1804,8 @@ private:
     {
         return (instrDescCnsAmd*)emitAllocInstr(sizeof(instrDescCnsAmd), attr);
     }
+
+#endif // _TARGET_XARCH_
 
     instrDescCGCA* emitAllocInstrCGCA(emitAttr attr)
     {
@@ -2416,6 +2429,8 @@ inline size_t emitter::emitGetInstrDescSizeSC(const instrDesc* id)
     }
 }
 
+#ifdef _TARGET_XARCH_
+
 /*****************************************************************************
  *
  *  The following helpers should be used to access the various values that
@@ -2491,6 +2506,8 @@ inline unsigned emitter::emitGetInsCIargs(instrDesc* id)
         return (unsigned)cns;
     }
 }
+
+#endif // _TARGET_XARCH_
 
 /*****************************************************************************
  *

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -1317,7 +1317,6 @@ protected:
     ssize_t emitGetInsCns(instrDesc* id);
     ssize_t emitGetInsDsp(instrDesc* id);
     ssize_t emitGetInsAmd(instrDesc* id);
-    ssize_t emitGetInsCnsDsp(instrDesc* id, ssize_t* dspPtr);
 
     ssize_t emitGetInsCIdisp(instrDesc* id);
     unsigned emitGetInsCIargs(instrDesc* id);
@@ -2453,36 +2452,6 @@ inline ssize_t emitter::emitGetInsDsp(instrDesc* id)
         return ((instrDescDsp*)id)->iddDspVal;
     }
     return 0;
-}
-
-inline ssize_t emitter::emitGetInsCnsDsp(instrDesc* id, ssize_t* dspPtr)
-{
-    if (id->idIsLargeCns())
-    {
-        if (id->idIsLargeDsp())
-        {
-            *dspPtr = ((instrDescCnsDsp*)id)->iddcDspVal;
-            return ((instrDescCnsDsp*)id)->iddcCnsVal;
-        }
-        else
-        {
-            *dspPtr = 0;
-            return ((instrDescCns*)id)->idcCnsVal;
-        }
-    }
-    else
-    {
-        if (id->idIsLargeDsp())
-        {
-            *dspPtr = ((instrDescDsp*)id)->iddDspVal;
-            return id->idSmallCns();
-        }
-        else
-        {
-            *dspPtr = 0;
-            return id->idSmallCns();
-        }
-    }
 }
 
 /*****************************************************************************

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -6443,27 +6443,6 @@ void emitter::emitDispInst(instruction ins, insFlags flags)
     } while (len < 8);
 }
 
-/*****************************************************************************
- *
- *  Display an reloc value
- *  If we are formatting for an assembly listing don't print the hex value
- *  since it will prevent us from doing assembly diffs
- */
-void emitter::emitDispReloc(int value, bool addComma)
-{
-    if (emitComp->opts.disAsm)
-    {
-        printf("(reloc)");
-    }
-    else
-    {
-        printf("(reloc 0x%x)", dspPtr(value));
-    }
-
-    if (addComma)
-        printf(", ");
-}
-
 #define STRICT_ARM_ASM 0
 
 /*****************************************************************************

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -5455,20 +5455,6 @@ BYTE* emitter::emitOutputIT(BYTE* dst, instruction ins, insFormat fmt, code_t co
 #endif // FEATURE_ITINSTRUCTION
 
 /*****************************************************************************
- *
- *  Output a 32-bit nop instruction.
- */
-
-BYTE* emitter::emitOutputNOP(BYTE* dst, instruction ins, insFormat fmt)
-{
-    code_t code = emitInsCode(ins, fmt);
-
-    dst += emitOutput_Thumb2Instr(dst, code);
-
-    return dst;
-}
-
-/*****************************************************************************
 *
  *  Append the machine code corresponding to the given instruction descriptor
  *  to the code block at '*dp'; the base of the code block is 'bp', and 'ig'

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -6612,10 +6612,6 @@ void emitter::emitDispReg(regNumber reg, emitAttr attr, bool addComma)
         printf(", ");
 }
 
-void emitter::emitDispFloatReg(regNumber reg, emitAttr attr, bool addComma)
-{
-}
-
 /*****************************************************************************
  *
  *  Display an addressing operand [reg]

--- a/src/jit/emitarm.h
+++ b/src/jit/emitarm.h
@@ -23,7 +23,6 @@ insSize emitInsSize(insFormat insFmt);
 #ifdef FEATURE_ITINSTRUCTION
 BYTE* emitOutputIT(BYTE* dst, instruction ins, insFormat fmt, code_t condcode);
 #endif // FEATURE_ITINSTRUCTION
-BYTE* emitOutputNOP(BYTE* dst, instruction ins, insFormat fmt);
 
 BYTE* emitOutputLJ(insGroup* ig, BYTE* dst, instrDesc* id);
 BYTE* emitOutputShortBranch(BYTE* dst, instruction ins, insFormat fmt, ssize_t distVal, instrDescJmp* id);

--- a/src/jit/emitarm.h
+++ b/src/jit/emitarm.h
@@ -101,9 +101,7 @@ emitter::code_t emitInsCode(instruction ins, insFormat fmt);
 void emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataReg, GenTreeIndir* indir);
 void emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataReg, GenTreeIndir* indir, int offset);
 
-
 static bool isModImmConst(int imm);
-
 static int encodeModImmConst(int imm);
 
 static int insUnscaleImm(int imm, emitAttr size);

--- a/src/jit/emitarm.h
+++ b/src/jit/emitarm.h
@@ -20,14 +20,6 @@ struct CnsVal
 
 insSize emitInsSize(insFormat insFmt);
 
-BYTE* emitOutputAM(BYTE* dst, instrDesc* id, code_t code, CnsVal* addc = NULL);
-BYTE* emitOutputSV(BYTE* dst, instrDesc* id, code_t code, CnsVal* addc = NULL);
-BYTE* emitOutputCV(BYTE* dst, instrDesc* id, code_t code, CnsVal* addc = NULL);
-
-BYTE* emitOutputR(BYTE* dst, instrDesc* id);
-BYTE* emitOutputRI(BYTE* dst, instrDesc* id);
-BYTE* emitOutputRR(BYTE* dst, instrDesc* id);
-BYTE* emitOutputIV(BYTE* dst, instrDesc* id);
 #ifdef FEATURE_ITINSTRUCTION
 BYTE* emitOutputIT(BYTE* dst, instruction ins, insFormat fmt, code_t condcode);
 #endif // FEATURE_ITINSTRUCTION
@@ -44,8 +36,6 @@ static unsigned emitOutput_Thumb2Instr(BYTE* dst, code_t code);
 /************************************************************************/
 
 #ifdef DEBUG
-
-const char* emitFPregName(unsigned reg, bool varName = true);
 
 void emitDispInst(instruction ins, insFlags flags);
 void emitDispReloc(int value, bool addComma);
@@ -111,25 +101,6 @@ emitter::code_t emitInsCode(instruction ins, insFormat fmt);
 void emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataReg, GenTreeIndir* indir);
 void emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataReg, GenTreeIndir* indir, int offset);
 
-/*****************************************************************************
-*
-*  Convert between an index scale in bytes to a smaller encoding used for
-*  storage in instruction descriptors.
-*/
-
-inline emitter::opSize emitEncodeScale(size_t scale)
-{
-    assert(scale == 1 || scale == 2 || scale == 4 || scale == 8);
-
-    return emitSizeEncode[scale - 1];
-}
-
-inline emitAttr emitDecodeScale(unsigned ensz)
-{
-    assert(ensz < 4);
-
-    return emitter::emitSizeDecode[ensz];
-}
 
 static bool isModImmConst(int imm);
 

--- a/src/jit/emitarm.h
+++ b/src/jit/emitarm.h
@@ -37,7 +37,6 @@ static unsigned emitOutput_Thumb2Instr(BYTE* dst, code_t code);
 #ifdef DEBUG
 
 void emitDispInst(instruction ins, insFlags flags);
-void emitDispReloc(int value, bool addComma);
 void emitDispImm(int imm, bool addComma, bool alwaysHex = false);
 void emitDispCond(int cond);
 void emitDispShiftOpts(insOpts opt);

--- a/src/jit/emitarm.h
+++ b/src/jit/emitarm.h
@@ -287,7 +287,7 @@ void emitIns_R_C(instruction ins, emitAttr attr, regNumber reg, CORINFO_FIELD_HA
 
 void emitIns_C_R(instruction ins, emitAttr attr, CORINFO_FIELD_HANDLE fldHnd, regNumber reg, int offs);
 
-void emitIns_C_I(instruction ins, emitAttr attr, CORINFO_FIELD_HANDLE fdlHnd, ssize_t offs, ssize_t val);
+void emitIns_C_I(instruction ins, emitAttr attr, CORINFO_FIELD_HANDLE fdlHnd, int offs, ssize_t val);
 
 void emitIns_R_L(instruction ins, emitAttr attr, BasicBlock* dst, regNumber reg);
 

--- a/src/jit/emitarm.h
+++ b/src/jit/emitarm.h
@@ -87,19 +87,11 @@ void emitDispIns(instrDesc* id,
 /************************************************************************/
 
 private:
-instrDesc* emitNewInstrAmd(emitAttr attr, int dsp);
-instrDesc* emitNewInstrAmdCns(emitAttr attr, int dsp, int cns);
-
 instrDesc* emitNewInstrCallDir(
     int argCnt, VARSET_VALARG_TP GCvars, regMaskTP gcrefRegs, regMaskTP byrefRegs, emitAttr retSize);
 
 instrDesc* emitNewInstrCallInd(
     int argCnt, ssize_t disp, VARSET_VALARG_TP GCvars, regMaskTP gcrefRegs, regMaskTP byrefRegs, emitAttr retSize);
-
-void emitGetInsCns(instrDesc* id, CnsVal* cv);
-int emitGetInsAmdCns(instrDesc* id, CnsVal* cv);
-void emitGetInsDcmCns(instrDesc* id, CnsVal* cv);
-int emitGetInsAmdAny(instrDesc* id);
 
 /************************************************************************/
 /*               Private helpers for instruction output                 */

--- a/src/jit/emitarm.h
+++ b/src/jit/emitarm.h
@@ -44,7 +44,6 @@ void emitDispShiftOpts(insOpts opt);
 void emitDispRegmask(int imm, bool encodedPC_LR);
 void emitDispRegRange(regNumber reg, int len, emitAttr attr);
 void emitDispReg(regNumber reg, emitAttr attr, bool addComma);
-void emitDispFloatReg(regNumber reg, emitAttr attr, bool addComma);
 void emitDispAddrR(regNumber reg, emitAttr attr);
 void emitDispAddrRI(regNumber reg, int imm, emitAttr attr);
 void emitDispAddrRR(regNumber reg1, regNumber reg2, emitAttr attr);

--- a/src/jit/emitarm64.h
+++ b/src/jit/emitarm64.h
@@ -67,9 +67,6 @@ void emitDispIns(instrDesc* id,
 /************************************************************************/
 
 private:
-instrDesc* emitNewInstrAmd(emitAttr attr, int dsp);
-instrDesc* emitNewInstrAmdCns(emitAttr attr, int dsp, int cns);
-
 instrDesc* emitNewInstrCallDir(int              argCnt,
                                VARSET_VALARG_TP GCvars,
                                regMaskTP        gcrefRegs,
@@ -84,11 +81,6 @@ instrDesc* emitNewInstrCallInd(int              argCnt,
                                regMaskTP        byrefRegs,
                                emitAttr         retSize,
                                emitAttr         secondRetSize);
-
-void emitGetInsCns(instrDesc* id, CnsVal* cv);
-ssize_t emitGetInsAmdCns(instrDesc* id, CnsVal* cv);
-void emitGetInsDcmCns(instrDesc* id, CnsVal* cv);
-ssize_t emitGetInsAmdAny(instrDesc* id);
 
 /************************************************************************/
 /*               Private helpers for instruction output                 */

--- a/src/jit/emitinl.h
+++ b/src/jit/emitinl.h
@@ -118,6 +118,8 @@ inline regNumber emitter::inst3opImulReg(instruction ins)
  *  get stored in different places within the instruction descriptor.
  */
 
+#ifdef _TARGET_XARCH_
+
 inline ssize_t emitter::emitGetInsAmd(instrDesc* id)
 {
     return id->idIsLargeDsp() ? ((instrDescAmd*)id)->idaAmdVal : id->idAddr()->iiaAddrMode.amDisp;
@@ -219,6 +221,8 @@ inline ssize_t emitter::emitGetInsAmdAny(instrDesc* id)
 
     return id->idAddr()->iiaAddrMode.amDisp;
 }
+
+#endif // _TARGET_XARCH_
 
 /*****************************************************************************
  *


### PR DESCRIPTION
While working on crossbitness crossgen found with @BruceForstall some code in emitters that either used only when `_TARGET_XARCH_` or never used (such as `instrDescArmFP` struct and `emitter::emitGetInsCnsDsp`). Cleaning this up