### PR TITLE
Ensure BuildUse uses the correct reg number

### DIFF
--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -6030,16 +6030,18 @@ inline regNumber GenTree::GetRegByIndex(int regIndex)
         return AsCall()->GetRegNumByIdx(regIndex);
     }
 
+#if defined(_TARGET_ARMARCH_)
+    if (OperIsPutArgSplit())
+    {
+        return AsPutArgSplit()->GetRegNumByIdx(regIndex);
+    }
+#endif
 #if defined(_TARGET_ARM_)
     if (OperIsMultiRegOp())
     {
         return AsMultiRegOp()->GetRegNumByIdx(regIndex);
     }
-    else if (OperIsPutArgSplit())
-    {
-        return AsPutArgSplit()->GetRegNumByIdx(regIndex);
-    }
-    else if (OperIs(GT_COPY, GT_RELOAD))
+    if (OperIs(GT_COPY, GT_RELOAD))
     {
         return AsCopyOrReload()->GetRegNumByIdx(regIndex);
     }

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -1721,6 +1721,9 @@ public:
     // Returns true if it is a node returning its value in more than one register
     inline bool IsMultiRegNode() const;
 
+    // Returns the regIndex'th register defined by a possibly-multireg node.
+    regNumber GetRegByIndex(int regIndex);
+
     // Returns true if it is a GT_COPY or GT_RELOAD node
     inline bool IsCopyOrReload() const;
 
@@ -6004,6 +6007,45 @@ inline bool GenTree::IsMultiRegNode() const
 #endif
 
     return false;
+}
+
+//-----------------------------------------------------------------------------------
+// GetRegByIndex: Get a specific register, based on regIndex, that is produced
+//                by this node.
+//
+// Arguments:
+//     regIndex - which register to return (must be 0 for non-multireg nodes)
+//
+// Return Value:
+//     The register, if any, assigned to this index for this node.
+//
+inline regNumber GenTree::GetRegByIndex(int regIndex)
+{
+    if (regIndex == 0)
+    {
+        return gtRegNum;
+    }
+    if (IsMultiRegCall())
+    {
+        return AsCall()->GetRegNumByIdx(regIndex);
+    }
+
+#if defined(_TARGET_ARM_)
+    if (OperIsMultiRegOp())
+    {
+        return AsMultiRegOp()->GetRegNumByIdx(regIndex);
+    }
+    else if (OperIsPutArgSplit())
+    {
+        return AsPutArgSplit()->GetRegNumByIdx(regIndex);
+    }
+    else if (OperIs(GT_COPY, GT_RELOAD))
+    {
+        return AsCopyOrReload()->GetRegNumByIdx(regIndex);
+    }
+#endif
+    assert(!"Invalid regIndex for GetRegFromMultiRegNode");
+    return REG_NA;
 }
 
 //-------------------------------------------------------------------------

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -6030,7 +6030,7 @@ inline regNumber GenTree::GetRegByIndex(int regIndex)
         return AsCall()->GetRegNumByIdx(regIndex);
     }
 
-#if defined(_TARGET_ARMARCH_)
+#if FEATURE_ARG_SPLIT
     if (OperIsPutArgSplit())
     {
         return AsPutArgSplit()->GetRegNumByIdx(regIndex);

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1055,13 +1055,17 @@ GenTree* Lowering::NewPutArg(GenTreeCall* call, GenTree* arg, fgArgTabEntry* inf
         putArg = new (comp, GT_PUTARG_SPLIT)
             GenTreePutArgSplit(arg, info->slotNum PUT_STRUCT_ARG_STK_ONLY_ARG(info->numSlots), info->numRegs,
                                call->IsFastTailCall(), call);
-        putArg->gtRegNum = info->regNum;
 
         // If struct argument is morphed to GT_FIELD_LIST node(s),
         // we can know GC info by type of each GT_FIELD_LIST node.
         // So we skip setting GC Pointer info.
         //
         GenTreePutArgSplit* argSplit = putArg->AsPutArgSplit();
+        for (unsigned regIndex = 0; regIndex < info->numRegs; regIndex++)
+        {
+            argSplit->SetRegNumByIdx(info->getRegNum(regIndex), regIndex);
+        }
+
         if (arg->OperGet() == GT_OBJ)
         {
             BYTE*       gcLayout = nullptr;

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -9109,7 +9109,7 @@ void LinearScan::TupleStyleDump(LsraTupleDumpMode mode)
                                 printf("\n                               Use:");
                                 interval->microDump();
                                 printf("(#%d)", currentRefPosition->rpNum);
-                                if (currentRefPosition->isFixedRegRef)
+                                if (currentRefPosition->isFixedRegRef && !interval->isInternal)
                                 {
                                     assert(genMaxOneBit(currentRefPosition->registerAssignment));
                                     assert(lastFixedRegRefPos != nullptr);

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -283,7 +283,7 @@ int LinearScan::BuildCall(GenTreeCall* call)
             assert(regCount == curArgTabEntry->numRegs);
             for (unsigned int i = 0; i < regCount; i++)
             {
-                BuildUse(argNode, genRegMask(argNode->gtRegNum), i);
+                BuildUse(argNode, genRegMask(argNode->AsPutArgSplit()->GetRegNumByIdx(i)), i);
             }
             srcCount += regCount;
         }


### PR DESCRIPTION
`BuildUse` was setting the regNumber for all of the uses of a multi-reg  node to the main/first regNum. This was missed because this results in a def/use conflict on that reg (the def was set correctly), which is generally resolved in favor of the def. The exception is when there is a kill of the register in between, in which case the use tries to allocate the register its been assigned, causing the `farthestRefPhysRegRecord != nullptr` assert (aka "a register can't be found to spill").
This fixes the specific issue, and adds additional asserts to identify future/additional such issues.
The new asserts depend upon all the regNums being appropriately when/if any are set, which wasn't always the case prior to register allocation.

Fix #18153