### PR TITLE
Remove unnecessary R2R jobs

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -2731,9 +2731,28 @@ def static shouldGenerateJob(def scenario, def isPR, def architecture, def confi
         if (os != 'Windows_NT') {
             return false
         }
-        // Stress scenarios only run with Checked builds, not Release (they would work with Debug, but be slow).
-        if ((configuration != 'Checked') && isR2RStressScenario(scenario)) {
-            return false
+
+        if (isR2RBaselineScenario(scenario)) {
+            // no need for Debug scenario; Checked is sufficient
+            if (configuration != 'Checked' && configuration != 'Release') {
+                return false
+            }
+        }
+        else if (isR2RStressScenario(scenario)) {
+            // Stress scenarios only run with Checked builds, not Release (they would work with Debug, but be slow).
+            if (configuration != 'Checked') {
+                return false
+            }
+        }
+
+        switch (architecture) {
+            case 'arm':
+            case 'arm64':
+                // Windows arm/arm64 ready-to-run jobs use flow jobs and test jobs, but depend on "normal" (not R2R specific) build jobs.
+                return false
+
+            default:
+                break
         }
     }
     else {


### PR DESCRIPTION
We were generating "build" jobs for arm/arm64 R2R jobs, but we don't need (or use) them because the flow job depends on a normal/innerloop build, not on a R2R-specific build.

Also, remove Debug R2R jobs -- Checked is specific. (We were already only creating non-DEBUG flow jobs.)
