### PR TITLE
Mark RuntimeEventSourceTest as GCStressIncompatible

### DIFF
--- a/tests/src/tracing/runtimeeventsource/runtimeeventsource.csproj
+++ b/tests/src/tracing/runtimeeventsource/runtimeeventsource.csproj
@@ -13,6 +13,7 @@
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">


### PR DESCRIPTION
Temporary mark `RuntimeEventSourceTest` as `GCStressIncompatible` to unblock Ubuntu arm GCStress runs due to #18907 (as suggested in https://github.com/dotnet/coreclr/issues/18907#issuecomment-404968663)