### PR TITLE
Add r2r logging for method entrypoints

### DIFF
--- a/src/vm/readytoruninfo.cpp
+++ b/src/vm/readytoruninfo.cpp
@@ -16,6 +16,7 @@
 #include "versionresilienthashcode.h"
 #include "typehashingalgorithms.h"
 #include "method.hpp"
+#include "typestring.h"
 
 using namespace NativeFormat;
 
@@ -399,7 +400,7 @@ static void LogR2r(const char *msg, PEFile *pFile)
     fflush(r2rLogFile);
 }
 
-#define DoLog(msg) if (s_r2rLogFile != NULL) LogR2r(msg, pFile)
+#define DoLog(msg, pModule) if (s_r2rLogFile != NULL) LogR2r(msg, pModule->GetFile())
 
 // Try to acquire an R2R image for exclusive use by a particular module.
 // Returns true if successful. Returns false if the image is already been used
@@ -459,39 +460,39 @@ PTR_ReadyToRunInfo ReadyToRunInfo::Initialize(Module * pModule, AllocMemTracker 
     if (!IsReadyToRunEnabled())
     {
         // Log message is ignored in this case.
-        DoLog(NULL);
+        DoLog(NULL, pModule);
         return NULL;
     }
 
     // Ignore ReadyToRun for introspection-only loads
     if (pFile->IsIntrospectionOnly())
     {
-        DoLog("Ready to Run disabled - module loaded for reflection");
+        DoLog("Ready to Run disabled - module loaded for reflection", pModule);
         return NULL;
     }
 
     if (!pFile->HasLoadedIL())
     {
-        DoLog("Ready to Run disabled - no loaded IL image");
+        DoLog("Ready to Run disabled - no loaded IL image", pModule);
         return NULL;
     }
 
     PEImageLayout * pLayout = pFile->GetLoadedIL();
     if (!pLayout->HasReadyToRunHeader())
     {
-        DoLog("Ready to Run header not found");
+        DoLog("Ready to Run header not found", pModule);
         return NULL;
     }
 
     if (CORProfilerDisableAllNGenImages() || CORProfilerUseProfileImages())
     {
-        DoLog("Ready to Run disabled - profiler disabled native images");
+        DoLog("Ready to Run disabled - profiler disabled native images", pModule);
         return NULL;
     }
 
     if (g_pConfig->ExcludeReadyToRun(pModule->GetSimpleName()))
     {
-        DoLog("Ready to Run disabled - module on exclusion list");
+        DoLog("Ready to Run disabled - module on exclusion list", pModule);
         return NULL;
     }
 
@@ -499,7 +500,7 @@ PTR_ReadyToRunInfo ReadyToRunInfo::Initialize(Module * pModule, AllocMemTracker 
     // Ignore ReadyToRun during NGen
     if (IsCompilationProcess() && !IsNgenPDBCompilationProcess())
     {
-        DoLog("Ready to Run disabled - compilation process");
+        DoLog("Ready to Run disabled - compilation process", pModule);
         return NULL;
     }
 #endif
@@ -514,7 +515,7 @@ PTR_ReadyToRunInfo ReadyToRunInfo::Initialize(Module * pModule, AllocMemTracker 
     // The file must have been loaded using LoadLibrary
     if (!pLayout->IsRelocated())
     {
-        DoLog("Ready to Run disabled - module not loaded for execution");
+        DoLog("Ready to Run disabled - module not loaded for execution", pModule);
         return NULL;
     }
 #endif
@@ -524,20 +525,20 @@ PTR_ReadyToRunInfo ReadyToRunInfo::Initialize(Module * pModule, AllocMemTracker 
     // Ignore the content if the image major version is higher than the major version currently supported by the runtime
     if (pHeader->MajorVersion > READYTORUN_MAJOR_VERSION)
     {
-        DoLog("Ready to Run disabled - unsupported header version");
+        DoLog("Ready to Run disabled - unsupported header version", pModule);
         return NULL;
     }
 
     if (!AcquireImage(pModule, pLayout, pHeader))
     {
-        DoLog("Ready to Run disabled - module already loaded in another AppDomain");
+        DoLog("Ready to Run disabled - module already loaded in another AppDomain", pModule);
         return NULL;
     }
 
     LoaderHeap *pHeap = pModule->GetLoaderAllocator()->GetHighFrequencyHeap();
     void * pMemory = pamTracker->Track(pHeap->AllocMem((S_SIZE_T)sizeof(ReadyToRunInfo)));
 
-    DoLog("Ready to Run initialized successfully");
+    DoLog("Ready to Run initialized successfully", pModule);
 
     return new (pMemory) ReadyToRunInfo(pModule, pLayout, pHeader, pamTracker);
 }
@@ -790,6 +791,15 @@ PCODE ReadyToRunInfo::GetEntryPoint(MethodDesc * pMD, PrepareCodeConfig* pConfig
         g_pDebugInterface->JITComplete(pMD, pEntryPoint);
     }
 
+    if (s_r2rLogFile != nullptr)
+    {
+        SString methodEntryPointName(W("Found entrypoint for method %s"));
+        TypeString::AppendMethodDebug(methodEntryPointName, pMD);
+        StackScratchBuffer scratch;
+        const UTF8 *utf8 = methodEntryPointName.GetUTF8(scratch);
+        DoLog(utf8, m_pModule);
+    }
+    
     return pEntryPoint;
 }
 


### PR DESCRIPTION
Log each method entrypoint and its containing PEFile when it is looked up from the image. This serves as a quick check for ready-to-run images being successfully used (as opposed to falling back to Jit silently).