### PR TITLE
Fix disabled test name

### DIFF
--- a/tests/CoreFX/CoreFX.issues.json
+++ b/tests/CoreFX/CoreFX.issues.json
@@ -418,7 +418,7 @@
         }
     },
     {
-        "name": "System.ComponentModel.Composition",
+        "name": "System.ComponentModel.Composition.Tests",
         "enabled": false,
         "exclusions": {
             "namespaces": null,


### PR DESCRIPTION
System.ComponentModel.Composition.Tests use friends visibility. The fixed drop does not work well for testing of the live bits.