### PR TITLE
Optimize {Try}FormatDecimal

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Text/ValueStringBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/ValueStringBuilder.cs
@@ -132,7 +132,7 @@ namespace System.Text
         public void Append(char c)
         {
             int pos = _pos;
-            if (pos < _chars.Length)
+            if ((uint)pos < (uint)_chars.Length)
             {
                 _chars[pos] = c;
                 _pos = pos + 1;
@@ -147,7 +147,7 @@ namespace System.Text
         public void Append(string s)
         {
             int pos = _pos;
-            if (s.Length == 1 && pos < _chars.Length) // very common case, e.g. appending strings from NumberFormatInfo like separators, percent symbols, etc.
+            if (s.Length == 1 && (uint)pos < (uint)_chars.Length) // very common case, e.g. appending strings from NumberFormatInfo like separators, percent symbols, etc.
             {
                 _chars[pos] = s[0];
                 _pos = pos + 1;


### PR DESCRIPTION
This improves decimal formatting performance by 1.09x and removes an unused `nMinDigits` parameter from many functions.
Moved from https://github.com/dotnet/corert/pull/6099#issuecomment-405143387