### PR TITLE
Add back in code deleted in .NET Core port.

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -4049,6 +4049,8 @@ namespace System.Diagnostics.Tracing
                 if (!s_EventSourceShutdownRegistered)
                 {
                     s_EventSourceShutdownRegistered = true;
+                    AppDomain.CurrentDomain.ProcessExit += DisposeOnShutdown;
+                    AppDomain.CurrentDomain.DomainUnload += DisposeOnShutdown;
                 }
 
 


### PR DESCRIPTION
This fixes shutdown race bug that CoreCLR port reintroduced.
Basically the fix needed some Appdomain APIs that were probably
not in .NET Core 1.0 so they were removed.   However they are
back in .NET Core 2.0 so it is trivial to simply 'do the right thing', and
put the shutdown logic back.

See comment in front of DisposeOnShutdown for more.

@brianrob.

I checked and this is the code that exists on the desktop runtime.   
You will note that in the current code DisposeOnShutdown is present
but never used (Because the code in the #ifdef was lost).  
```
                if (!s_EventSourceShutdownRegistered)
                {
                    s_EventSourceShutdownRegistered = true;
#if !ES_BUILD_PCL && !FEATURE_CORECLR
                    AppDomain.CurrentDomain.ProcessExit += DisposeOnShutdown;
                    AppDomain.CurrentDomain.DomainUnload += DisposeOnShutdown;
#endif
                }
```

Note that this fix also has the side effect of insuring that all EventSource logging
is flushed at process / appdomain exit, which is also a very good thing.  