### PR TITLE
JIT: fix value numbering to handle GT_NULLCHECK more generally

### DIFF
--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -7035,7 +7035,7 @@ void Compiler::fgValueNumberTree(GenTree* tree, bool evalAsgLhsInd)
                 case GT_NULLCHECK:
                 {
                     // Explicit null check.
-                    // Handle case where operand tree also may case exceptions.
+                    // Handle case where operand tree also may cause exceptions.
                     ValueNumPair excSet = vnStore->VNPExcSetSingleton(
                         vnStore->VNPairForFunc(TYP_REF, VNF_NullPtrExc,
                                                vnStore->VNPNormVal(tree->gtOp.gtOp1->gtVNPair)));

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -7039,9 +7039,10 @@ void Compiler::fgValueNumberTree(GenTree* tree, bool evalAsgLhsInd)
                     ValueNumPair excSet = vnStore->VNPExcSetSingleton(
                         vnStore->VNPairForFunc(TYP_REF, VNF_NullPtrExc,
                                                vnStore->VNPNormVal(tree->gtOp.gtOp1->gtVNPair)));
+                    ValueNumPair excSetBoth =
+                        vnStore->VNPExcSetUnion(excSet, vnStore->VNPExcVal(tree->gtOp.gtOp1->gtVNPair));
 
-                    excSet         = vnStore->VNPExcSetUnion(excSet, vnStore->VNPExcVal(tree->gtOp.gtOp1->gtVNPair));
-                    tree->gtVNPair = vnStore->VNPWithExc(vnStore->VNPForVoid(), excSet);
+                    tree->gtVNPair = vnStore->VNPWithExc(vnStore->VNPForVoid(), excSetBoth);
                 }
                 break;
 


### PR DESCRIPTION
With the advent of #18819 we may now see GT_NULLCHECK nodes with operands
that also can cause exceptions.

Handle this in value numbering.

Closes #18937.