### PR TITLE
Delete redundant broken offsetof definitions

### DIFF
--- a/src/debug/daccess/stdafx.h
+++ b/src/debug/daccess/stdafx.h
@@ -21,6 +21,7 @@
 
 #define USE_COM_CONTEXT_DEF
 
+#include <stddef.h>
 #include <stdint.h>
 #include <windows.h>
 

--- a/src/gc/env/volatile.h
+++ b/src/gc/env/volatile.h
@@ -448,32 +448,6 @@ public:
     }
 };
 
-
-//
-// Warning: workaround
-// 
-// At the bottom of this file, we are going to #define the "volatile" keyword such that it is illegal
-// to use it.  Unfortunately, VC++ uses the volatile keyword in stddef.h, in the definition of "offsetof".
-// GCC does not use volatile in its definition.
-// 
-// To get around this, we include stddef.h here (even if we're on GCC, for consistency).  We then need
-// to redefine offsetof such that it does not use volatile, if we're building with VC++.
-//
-#include <stddef.h>
-#ifdef _MSC_VER
-#undef offsetof
-#ifdef  _WIN64
-#define offsetof(s,m)   (size_t)( (ptrdiff_t)&reinterpret_cast<const char&>((((s *)0)->m)) )
-#else
-#define offsetof(s,m)   (size_t)&reinterpret_cast<const char&>((((s *)0)->m))
-#endif //_WIN64
-
-// These also use volatile, so we'll include them here.
-//#include <intrin.h>
-//#include <memory>
-
-#endif //_MSC_VER
-
 #define VOLATILE(T) Volatile<T>
 
 #endif //_VOLATILE_H_

--- a/src/inc/corinfo.h
+++ b/src/inc/corinfo.h
@@ -1963,9 +1963,6 @@ struct DelegateCtorArgs
 
 // use offsetof to get the offset of the fields above
 #include <stddef.h> // offsetof
-#ifndef offsetof
-#define offsetof(s,m)   ((size_t)&(((s *)0)->m))
-#endif
 
 // Guard-stack cookie for preventing against stack buffer overruns
 typedef SIZE_T GSCookie;

--- a/src/inc/corpriv.h
+++ b/src/inc/corpriv.h
@@ -309,9 +309,6 @@ typedef enum CorOpenFlagsInternal
 #endif
 
 // %%Classes: ----------------------------------------------------------------
-#ifndef offsetof
-#define offsetof(s,f)   ((ULONG)(&((s*)0)->f))
-#endif
 #ifndef lengthof
 #define lengthof(rg)    (sizeof(rg)/sizeof(rg[0]))
 #endif

--- a/src/inc/gcinfotypes.h
+++ b/src/inc/gcinfotypes.h
@@ -331,9 +331,6 @@ inline const char *ReturnKindToString(ReturnKind returnKind)
 
 // we use offsetof to get the offset of a field
 #include <stddef.h> // offsetof
-#ifndef offsetof
-#define offsetof(s,m)   ((size_t)&(((s *)0)->m))
-#endif
 
 enum infoHdrAdjustConstants {
     // Constants

--- a/src/inc/slist.h
+++ b/src/inc/slist.h
@@ -136,14 +136,14 @@ protected:
         }
         else
         {
-#ifdef __GNUC__
-            // GCC defines offsetof to be __builtin_offsetof, which doesn't use the
+#if 1
+            // Newer compiliers define offsetof to be __builtin_offsetof, which doesn't use the
             // old-school memory model trick to determine offset.
             const UINT_PTR offset = (((UINT_PTR)&(((T *)0x1000)->*LinkPtr))-0x1000);
             return (T*)__PTR(dac_cast<TADDR>(pLink) - offset);
 #else
-            return (T*)__PTR(dac_cast<TADDR>(pLink) - offsetof(T, *LinkPtr));         
-#endif // __GNUC__
+            return (T*)__PTR(dac_cast<TADDR>(pLink) - offsetof(T, *LinkPtr));
+#endif
         }
     }
 

--- a/src/inc/slist.h
+++ b/src/inc/slist.h
@@ -137,7 +137,7 @@ protected:
         else
         {
 #if 1
-            // Newer compiliers define offsetof to be __builtin_offsetof, which doesn't use the
+            // Newer compilers define offsetof to be __builtin_offsetof, which doesn't use the
             // old-school memory model trick to determine offset.
             const UINT_PTR offset = (((UINT_PTR)&(((T *)0x1000)->*LinkPtr))-0x1000);
             return (T*)__PTR(dac_cast<TADDR>(pLink) - offset);

--- a/src/inc/volatile.h
+++ b/src/inc/volatile.h
@@ -474,32 +474,6 @@ public:
     }
 };
 
-
-//
-// Warning: workaround
-// 
-// At the bottom of this file, we are going to #define the "volatile" keyword such that it is illegal
-// to use it.  Unfortunately, VC++ uses the volatile keyword in stddef.h, in the definition of "offsetof".
-// GCC does not use volatile in its definition.
-// 
-// To get around this, we include stddef.h here (even if we're on GCC, for consistency).  We then need
-// to redefine offsetof such that it does not use volatile, if we're building with VC++.
-//
-#include <stddef.h>
-#ifdef _MSC_VER
-#undef offsetof
-#ifdef  _WIN64
-#define offsetof(s,m)   (size_t)( (ptrdiff_t)&reinterpret_cast<const char&>((((s *)0)->m)) )
-#else
-#define offsetof(s,m)   (size_t)&reinterpret_cast<const char&>((((s *)0)->m))
-#endif //_WIN64
-
-// These also use volatile, so we'll include them here.
-//#include <intrin.h>
-//#include <memory>
-
-#endif //_MSC_VER
-
 //
 // From here on out, we ban the use of the "volatile" keyword.  If you found this while trying to define
 // a volatile variable, go to the top of this file and start reading.

--- a/src/pal/src/map/map.cpp
+++ b/src/pal/src/map/map.cpp
@@ -31,6 +31,7 @@ Abstract:
 #include "pal/file.hpp"
 #include "pal/malloc.hpp"
 
+#include <stddef.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/mman.h>

--- a/src/vm/common.h
+++ b/src/vm/common.h
@@ -66,6 +66,7 @@
 
 
 #include <stdint.h>
+#include <stddef.h>
 #include <winwrap.h>
 
 

--- a/src/zap/common.h
+++ b/src/zap/common.h
@@ -13,11 +13,11 @@
 #define __COMMON_H__
 
 #include <stdint.h>
+#include <stddef.h>
 #include <winwrap.h>
 #include <windows.h>
 #include <stdlib.h>
 #include <objbase.h>
-#include <stddef.h>
 #include <float.h>
 #include <limits.h>
 


### PR DESCRIPTION
Fixes build breaks with latest Visual Studio Preview.

Fixes #18338