### PR TITLE
Enable ARM64 builds using release product tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,24 @@ if (WIN32)
       # Enable generic assembly compilation to avoid CMake generate VS proj files that explicitly
       # use ml[64].exe as the assembler.
       enable_language(ASM)
+    elseif(CLR_CMAKE_HOST_ARCH STREQUAL arm64)
+
+      # Confirm that Windows SDK is present
+      if(NOT DEFINED CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION OR CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION STREQUAL "" )
+	      message(FATAL_ERROR "Windows SDK is required for the ARM64 build.")
+      else()
+	      message("Using Windows SDK version ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
+      endif()
+
+      # Explicitly specify the assembler to be used for Arm64 compile
+      file(TO_CMAKE_PATH "$ENV{VCToolsInstallDir}\\bin\\HostX86\\arm64\\armasm64.exe" CMAKE_ASM_COMPILER)
+
+      set(CMAKE_ASM_MASM_COMPILER ${CMAKE_ASM_COMPILER})
+      message("CMAKE_ASM_MASM_COMPILER explicitly set to: ${CMAKE_ASM_MASM_COMPILER}")
+
+      # Enable generic assembly compilation to avoid CMake generate VS proj files that explicitly
+      # use ml[64].exe as the assembler.
+      enable_language(ASM)
     else()
       enable_language(ASM_MASM)
     endif()
@@ -74,16 +92,6 @@ if (WIN32)
     find_program(MC mc)
     if (MC STREQUAL "MC-NOTFOUND")
         message(FATAL_ERROR "MC not found")
-    endif()
-
-    if (CLR_CMAKE_HOST_ARCH STREQUAL arm64)
-      # CMAKE_CXX_COMPILER will default to the compiler installed with
-      # Visual studio. Overwrite it to the compiler on the path.
-      # TODO, remove when cmake generator supports Arm64 as a target.
-      find_program(PATH_CXX_COMPILER cl)
-      set(CMAKE_CXX_COMPILER ${PATH_CXX_COMPILER})
-      message("Overwriting the CMAKE_CXX_COMPILER.")
-      message(CMAKE_CXX_COMPILER found:${CMAKE_CXX_COMPILER})
     endif()
 
 else (WIN32)
@@ -375,13 +383,6 @@ if (WIN32)
   set(CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO} /LTCG /OPT:REF /OPT:ICF ${NO_INCREMENTAL_LINKER_FLAGS}")
   set(CMAKE_STATIC_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_STATIC_LINKER_FLAGS_RELWITHDEBINFO} /LTCG")
   set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} /LTCG /OPT:REF /OPT:ICF ${NO_INCREMENTAL_LINKER_FLAGS}")
-
-  # Temporary until cmake has VS generators for arm64
-  if(CLR_CMAKE_PLATFORM_ARCH_ARM64)
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /machine:arm64")
-    set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /machine:arm64")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /machine:arm64")
-  endif(CLR_CMAKE_PLATFORM_ARCH_ARM64)
 
   # Force uCRT to be dynamically linked for Release build
   set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib")

--- a/build-test.cmd
+++ b/build-test.cmd
@@ -40,10 +40,10 @@ set "__LogsDir=%__RootBinDir%\Logs"
 :: Default __Exclude to issues.targets
 set __Exclude=%__TestDir%\issues.targets
 
-REM __unprocessedBuildArgs are args that we pass to msbuild (e.g. /p:__BuildArch=x64)
+REM __UnprocessedBuildArgs are args that we pass to msbuild (e.g. /p:__BuildArch=x64)
 set "__args= %*"
 set processedArgs=
-set __unprocessedBuildArgs=
+set __UnprocessedBuildArgs=
 set __RunArgs=
 set __BuildAgainstPackagesArg=
 set __SkipRestorePackages=
@@ -79,7 +79,6 @@ if /i "%1" == "checked"               (set __BuildType=Checked&set processedArgs
 if /i "%1" == "skipmanaged"           (set __SkipManaged=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "skipnative"            (set __SkipNative=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "buildtesthostonly"     (set __SkipNative=1&set __SkipManaged=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
-if /i "%1" == "toolset_dir"           (set __ToolsetDir=%2&set __PassThroughArgs=%__PassThroughArgs% %2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)
 if /i "%1" == "buildagainstpackages"  (set __ZipTests=1&set __BuildAgainstPackagesArg=-BuildTestsAgainstPackages&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "skiprestorepackages"   (set __SkipRestorePackages=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "ziptests"              (set __ZipTests=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
@@ -88,6 +87,14 @@ if /i "%1" == "runtimeid"             (set __RuntimeId=%2&set processedArgs=!pro
 if /i "%1" == "targetsNonWindows"     (set __TargetsWindows=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "Exclude"               (set __Exclude=%2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)
 if /i "%1" == "-priority"             (set __Priority=%2&shift&set processedArgs=!processedArgs! %1=%2&shift&goto Arg_Loop)
+
+if /i "%1" == "toolset_dir" (
+    echo %__MsgPrefix%Warning: Ignoring toolset_dir argument
+    set processedArgs=!processedArgs! %1 %2
+    shift
+    shift
+    goto Arg_Loop
+)
 
 if [!processedArgs!]==[] (
   set __UnprocessedBuildArgs=%__args%
@@ -113,12 +120,6 @@ if defined __BuildAgainstPackagesArg (
 @if defined _echo @echo on
 
 set __RunArgs=-BuildOS=%__BuildOS% -BuildType=%__BuildType% -BuildArch=%__BuildArch%
-
-if defined __ToolsetDir (
-    rem arm64 builds currently use private toolset which has not been released yet
-    REM TODO, remove once the toolset is open.
-    call :PrivateToolSet
-)
 
 echo %__MsgPrefix%Commencing CoreCLR repo test build
 
@@ -176,11 +177,6 @@ REM ============================================================================
 
 echo %__MsgPrefix%Commencing build of native test components for %__BuildArch%/%__BuildType%
 
-if defined __ToolsetDir (
-    echo %__MsgPrefix%ToolsetDir is defined to be %__ToolsetDir%
-    goto GenVSSolution :: Private ToolSet is Defined
-)
-
 :: Set the environment for the native build
 echo %__MsgPrefix%Using environment: "%__VCToolsRoot%\vcvarsall.bat" %__VCBuildArch%
 call                                 "%__VCToolsRoot%\vcvarsall.bat" %__VCBuildArch%
@@ -192,8 +188,6 @@ if not defined VSINSTALLDIR (
 )
 if not exist "%VSINSTALLDIR%DIA SDK" goto NoDIA
 
-:GenVSSolution
-
 pushd "%__NativeTestIntermediatesDir%"
 call "%__SourceDir%\pal\tools\gen-buildsys-win.bat" ""%__ProjectFilesDir%"" %__VSVersion% %__BuildArch%
 @if defined _echo @echo on
@@ -204,14 +198,6 @@ if not exist "%__NativeTestIntermediatesDir%\install.vcxproj" (
     exit /b 1
 )
 
-set __msbuildNativeArgs=-configuration=%__BuildType%
-
-if defined __ToolsetDir (
-    set __msbuildNativeArgs=%__msbuildNativeArgs% -UseEnv
-) else (
-    set __msbuildNativeArgs=%__msbuildNativeArgs% -platform=%__BuildArch%
-)
-
 set __BuildLogRootName=Tests_Native
 set __BuildLog=%__LogsDir%\%__BuildLogRootName%_%__BuildOS%__%__BuildArch%__%__BuildType%.log
 set __BuildWrn=%__LogsDir%\%__BuildLogRootName%_%__BuildOS%__%__BuildArch%__%__BuildType%.wrn
@@ -220,7 +206,7 @@ set __msbuildLog=/flp:Verbosity=normal;LogFile="%__BuildLog%"
 set __msbuildWrn=/flp1:WarningsOnly;LogFile="%__BuildWrn%"
 set __msbuildErr=/flp2:ErrorsOnly;LogFile="%__BuildErr%"
 
-call "%__ProjectDir%\run.cmd" build -Project="%__NativeTestIntermediatesDir%\install.vcxproj" -MsBuildLog=!__msbuildLog! -MsBuildWrn=!__msbuildWrn! -MsBuildErr=!__msbuildErr! %__msbuildNativeArgs% %__RunArgs% %__unprocessedBuildArgs%
+call "%__ProjectDir%\run.cmd" build -Project="%__NativeTestIntermediatesDir%\install.vcxproj" -MsBuildLog=!__msbuildLog! -MsBuildWrn=!__msbuildWrn! -MsBuildErr=!__msbuildErr! -configuration=%__BuildType% -platform=%__BuildArch% %__RunArgs% %__UnprocessedBuildArgs%
 if errorlevel 1 (
     echo %__MsgPrefix%Error: build failed. Refer to the build log files for details:
     echo     %__BuildLog%
@@ -250,7 +236,7 @@ set __msbuildLog=/flp:Verbosity=normal;LogFile="%__BuildLog%"
 set __msbuildWrn=/flp1:WarningsOnly;LogFile="%__BuildWrn%"
 set __msbuildErr=/flp2:ErrorsOnly;LogFile="%__BuildErr%"
 
-call "%__ProjectDir%\run.cmd" build -Project=%__ProjectDir%\tests\build.proj -BatchRestorePackages -MsBuildLog=!__msbuildLog! -MsBuildWrn=!__msbuildWrn! -MsBuildErr=!__msbuildErr! %__RunArgs% %__BuildAgainstPackagesArg% %__unprocessedBuildArgs%
+call "%__ProjectDir%\run.cmd" build -Project=%__ProjectDir%\tests\build.proj -BatchRestorePackages -MsBuildLog=!__msbuildLog! -MsBuildWrn=!__msbuildWrn! -MsBuildErr=!__msbuildErr! %__RunArgs% %__BuildAgainstPackagesArg% %__UnprocessedBuildArgs%
 
 if not defined __BuildAgainstPackagesArg goto SkipRestoreProduct
 set __BuildLogRootName=Tests_GenerateRuntimeLayout
@@ -261,7 +247,7 @@ set __msbuildLog=/flp:Verbosity=normal;LogFile="%__BuildLog%"
 set __msbuildWrn=/flp1:WarningsOnly;LogFile="%__BuildWrn%"
 set __msbuildErr=/flp2:ErrorsOnly;LogFile="%__BuildErr%"
 
-call "%__ProjectDir%\run.cmd" build -Project=%__ProjectDir%\tests\runtest.proj -BinPlaceRef -BinPlaceProduct -CopyCrossgenToProduct -RuntimeId="%__RuntimeId%" -MsBuildLog=!__msbuildLog! -MsBuildWrn=!__msbuildWrn! -MsBuildErr=!__msbuildErr! %__RunArgs% %__BuildAgainstPackagesArg% %__unprocessedBuildArgs%
+call "%__ProjectDir%\run.cmd" build -Project=%__ProjectDir%\tests\runtest.proj -BinPlaceRef -BinPlaceProduct -CopyCrossgenToProduct -RuntimeId="%__RuntimeId%" -MsBuildLog=!__msbuildLog! -MsBuildWrn=!__msbuildWrn! -MsBuildErr=!__msbuildErr! %__RunArgs% %__BuildAgainstPackagesArg% %__UnprocessedBuildArgs%
 if errorlevel 1 (
     echo BinPlace of mscorlib.dll failed
     exit /b 1
@@ -309,7 +295,7 @@ for /l %%G in (1, 1, %__BuildLoopCount%) do (
     set __msbuildErr=/flp2:ErrorsOnly;LogFile="%__BuildErr%";Append=!__AppendToLog!
 
     set TestBuildSlice=%%G
-    call "%__ProjectDir%\run.cmd" build -Project=%__ProjectDir%\tests\build.proj -MsBuildLog=!__msbuildLog! -MsBuildWrn=!__msbuildWrn! -MsBuildErr=!__msbuildErr! %__RunArgs% %__BuildAgainstPackagesArg% %__unprocessedBuildArgs%
+    call "%__ProjectDir%\run.cmd" build -Project=%__ProjectDir%\tests\build.proj -MsBuildLog=!__msbuildLog! -MsBuildWrn=!__msbuildWrn! -MsBuildErr=!__msbuildErr! %__RunArgs% %__BuildAgainstPackagesArg% %__UnprocessedBuildArgs%
 
     if errorlevel 1 (
         echo %__MsgPrefix%Error: build failed. Refer to the build log files for details:
@@ -381,7 +367,7 @@ set __msbuildLog=/flp:Verbosity=normal;LogFile="%__BuildLog%"
 set __msbuildWrn=/flp1:WarningsOnly;LogFile="%__BuildWrn%"
 set __msbuildErr=/flp2:ErrorsOnly;LogFile="%__BuildErr%"
 
-call %__ProjectDir%\run.cmd build -Project=%__ProjectDir%\tests\runtest.proj -testOverlay -MsBuildLog=!__msbuildLog! -MsBuildWrn=!__msbuildWrn! -MsBuildErr=!__msbuildErr! %__RunArgs% %RuntimeIdArg% %__unprocessedBuildArgs%
+call %__ProjectDir%\run.cmd build -Project=%__ProjectDir%\tests\runtest.proj -testOverlay -MsBuildLog=!__msbuildLog! -MsBuildWrn=!__msbuildWrn! -MsBuildErr=!__msbuildErr! %__RunArgs% %RuntimeIdArg% %__UnprocessedBuildArgs%
 if errorlevel 1 (
     echo %__MsgPrefix%Error: build failed. Refer to the build log files for details:
     echo     %__BuildLog%
@@ -403,7 +389,7 @@ set __msbuildLog=/flp:Verbosity=normal;LogFile="%__BuildLog%"
 set __msbuildWrn=/flp1:WarningsOnly;LogFile="%__BuildWrn%"
 set __msbuildErr=/flp2:ErrorsOnly;LogFile="%__BuildErr%"
 
-call %__ProjectDir%\run.cmd build -Project=%__ProjectDir%\tests\runtest.proj -testHost -MsBuildLog=!__msbuildLog! -MsBuildWrn=!__msbuildWrn! -MsBuildErr=!__msbuildErr! %__RunArgs% %RuntimeIdArg% %__unprocessedBuildArgs%
+call %__ProjectDir%\run.cmd build -Project=%__ProjectDir%\tests\runtest.proj -testHost -MsBuildLog=!__msbuildLog! -MsBuildWrn=!__msbuildWrn! -MsBuildErr=!__msbuildErr! %__RunArgs% %RuntimeIdArg% %__UnprocessedBuildArgs%
 if errorlevel 1 (
     echo %__MsgPrefix%Error: build failed. Refer to the build log files for details:
     echo     %__BuildLog%
@@ -424,7 +410,7 @@ set __msbuildLog=/flp:Verbosity=normal;LogFile="%__BuildLog%"
 set __msbuildWrn=/flp1:WarningsOnly;LogFile="%__BuildWrn%"
 set __msbuildErr=/flp2:ErrorsOnly;LogFile="%__BuildErr%"
 
-call %__ProjectDir%\run.cmd build -Project=%__ProjectDir%\tests\runtest.proj -BuildWrappers -MsBuildEventLogging=" " -MsBuildLog=!__msbuildLog! -MsBuildWrn=!__msbuildWrn! -MsBuildErr=!__msbuildErr! %__RunArgs% %__BuildAgainstPackagesArg% %TargetsWindowsArg% %__unprocessedBuildArgs%
+call %__ProjectDir%\run.cmd build -Project=%__ProjectDir%\tests\runtest.proj -BuildWrappers -MsBuildEventLogging=" " -MsBuildLog=!__msbuildLog! -MsBuildWrn=!__msbuildWrn! -MsBuildErr=!__msbuildErr! %__RunArgs% %__BuildAgainstPackagesArg% %TargetsWindowsArg% %__UnprocessedBuildArgs%
 if errorlevel 1 (
     echo Xunit Wrapper build failed
     exit /b 1
@@ -459,7 +445,7 @@ REM === Prep test binaries for Helix publishing
 REM ===
 REM =========================================================================================
 
-call %__ProjectDir%\run.cmd build -Project=%__ProjectDir%\tests\helixprep.proj  -MsBuildLog=!__msbuildLog! -MsBuildWrn=!__msbuildWrn! -MsBuildErr=!__msbuildErr! %__RunArgs% %__BuildAgainstPackagesArg% %RuntimeIdArg% %TargetsWindowsArg% %__CrossgenArg% %__unprocessedBuildArgs%
+call %__ProjectDir%\run.cmd build -Project=%__ProjectDir%\tests\helixprep.proj  -MsBuildLog=!__msbuildLog! -MsBuildWrn=!__msbuildWrn! -MsBuildErr=!__msbuildErr! %__RunArgs% %__BuildAgainstPackagesArg% %RuntimeIdArg% %TargetsWindowsArg% %__CrossgenArg% %__UnprocessedBuildArgs%
 if errorlevel 1 (
     echo %__MsgPrefix%Error: build failed. Refer to the build log files for details:
     echo     %__BuildLog%
@@ -484,15 +470,21 @@ exit /b 0
 
 :Usage
 echo.
+echo Build the CoreCLR tests.
+echo.
 echo Usage:
 echo     %0 [option1] [option2] ...
 echo All arguments are optional. Options are case-insensitive. The options are:
 echo.
 echo. -? -h -help: view this message.
-echo Build architecture: -buildArch: only x64 is currently allowed ^(default: x64^).
-echo Build type: -buildType: one of Debug, Checked, Release ^(default: Debug^).
+echo Build architecture: one of x64, x86, arm, arm64 ^(default: x64^).
+echo Build type: one of Debug, Checked, Release ^(default: Debug^).
+echo skipmanaged: skip the managed tests build
+echo skipnative: skip the native tests build
+echo buildtesthostonly: build the CoreFX testhost only
 echo buildagainstpackages: builds tests against restored packages, instead of against a built product.
-echo runtimeid ^<ID^>: Builds a test overlay for the specified OS (Only supported when building against packages). Supported IDs are:
+echo skiprestorepackages: skip package restore
+echo runtimeid ^<ID^>: Builds a test overlay for the specified OS ^(Only supported when building against packages^). Supported IDs are:
 echo     alpine.3.4.3-x64: Builds overlay for Alpine 3.4.3
 echo     debian.8-x64: Builds overlay for Debian 8
 echo     fedora.24-x64: Builds overlay for Fedora 24
@@ -506,9 +498,10 @@ echo     ubuntu.16.04-x64: Builds overlay for Ubuntu 16.04
 echo     ubuntu.16.10-x64: Builds overlay for Ubuntu 16.10
 echo     win-x64: Builds overlay for portable Windows
 echo     win7-x64: Builds overlay for Windows 7
-echo ziptests: zips CoreCLR tests & Core_Root for a Helix run
+echo ziptests: zips CoreCLR tests and Core_Root for a Helix run
 echo crossgen: Precompiles the framework managed assemblies
-echo Exclude- Optional parameter - specify location of default exclusion file (defaults to tests\issues.targets if not specified)
+echo targetsNonWindows: 
+echo Exclude- Optional parameter - specify location of default exclusion file ^(defaults to tests\issues.targets if not specified^)
 echo     Set to "" to disable default exclusion file.
 echo -- ... : all arguments following this tag will be passed directly to msbuild.
 echo -priority=^<N^> : specify a set of test that will be built and run, with priority N.
@@ -528,36 +521,6 @@ echo Visual Studio Express does not include the DIA SDK. ^
 You need Visual Studio 2015 or 2017 (Community is free).
 echo See: https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/developer-guide.md#prerequisites
 exit /b 1
-
-
-:PrivateToolSet
-
-echo %__MsgPrefix%Setting up the usage of __ToolsetDir:%__ToolsetDir%
-
-if /i "%__ToolsetDir%" == "" (
-    echo %__MsgPrefix%Error: A toolset directory is required for the Arm64 Windows build. Use the toolset_dir argument.
-    exit /b 1
-)
-
-if not exist "%__ToolsetDir%"\buildenv_arm64.cmd goto :Not_EWDK
-call "%__ToolsetDir%"\buildenv_arm64.cmd
-exit /b 0
-
-:Not_EWDK
-set PATH=%__ToolsetDir%\VC_sdk\bin;%PATH%
-set LIB=%__ToolsetDir%\VC_sdk\lib\arm64;%__ToolsetDir%\sdpublic\sdk\lib\arm64
-set INCLUDE=^
-%__ToolsetDir%\VC_sdk\inc;^
-%__ToolsetDir%\sdpublic\sdk\inc;^
-%__ToolsetDir%\sdpublic\shared\inc;^
-%__ToolsetDir%\sdpublic\shared\inc\minwin;^
-%__ToolsetDir%\sdpublic\sdk\inc\ucrt;^
-%__ToolsetDir%\sdpublic\sdk\inc\minwin;^
-%__ToolsetDir%\sdpublic\sdk\inc\mincore;^
-%__ToolsetDir%\sdpublic\sdk\inc\abi;^
-%__ToolsetDir%\sdpublic\sdk\inc\clientcore;^
-%__ToolsetDir%\diasdk\include
-exit /b 0
 
 :PrecompileFX
 for %%F in (%CORE_ROOT%\*.dll) do call :PrecompileAssembly "%%F" %%~nF%%~xF

--- a/build.cmd
+++ b/build.cmd
@@ -173,7 +173,6 @@ if /i "%1" == "-pgoinstrument"       (set __PgoInstrument=1&set processedArgs=!p
 if /i "%1" == "-enforcepgo"          (set __EnforcePgo=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "-nopgooptimize"       (set __PgoOptimize=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "-ibcinstrument"       (set __IbcTuning=/Tuning&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
-if /i "%1" == "-toolset_dir"         (set __ToolsetDir=%2&set __PassThroughArgs=%__PassThroughArgs% %2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)
 if /i "%1" == "-crossgenaltjit"      (set __CrossgenAltJit=%2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)
 
 REM TODO these are deprecated remove them eventually
@@ -197,7 +196,21 @@ if /i "%1" == "pgoinstrument"       (set __PgoInstrument=1&set processedArgs=!pr
 if /i "%1" == "nopgooptimize"       (set __PgoOptimize=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "enforcepgo"          (set __EnforcePgo=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "ibcinstrument"       (set __IbcTuning=/Tuning&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
-if /i "%1" == "toolset_dir"         (set __ToolsetDir=%2&set __PassThroughArgs=%__PassThroughArgs% %2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)
+
+if /i "%1" == "-toolset_dir" (
+    echo %__MsgPrefix%Warning: Ignoring -toolset_dir argument
+    set processedArgs=!processedArgs! %1 %2
+    shift
+    shift
+    goto Arg_Loop
+)
+if /i "%1" == "toolset_dir" (
+    echo %__MsgPrefix%Warning: Ignoring toolset_dir argument
+    set processedArgs=!processedArgs! %1 %2
+    shift
+    shift
+    goto Arg_Loop
+)
 
 if [!processedArgs!]==[] (
   set __UnprocessedBuildArgs=%__args%
@@ -327,7 +340,7 @@ REM ============================================================================
 
 @if defined _echo @echo on
 
-@call %__ProjectDir%\run.cmd build -Project=%__ProjectDir%\build.proj -generateHeaderWindows -NativeVersionHeaderFile="%__RootBinDir%\obj\_version.h" %__RunArgs% %__UnprocessedBuildArgs%
+call %__ProjectDir%\run.cmd build -Project=%__ProjectDir%\build.proj -generateHeaderWindows -NativeVersionHeaderFile="%__RootBinDir%\obj\_version.h" %__RunArgs% %__UnprocessedBuildArgs%
 
 REM =========================================================================================
 REM ===
@@ -337,7 +350,7 @@ REM ============================================================================
 
 if %__RestoreOptData% EQU 1 if %__BuildTypeRelease% EQU 1 (
     echo %__MsgPrefix%Restoring the OptimizationData Package
-    @call %__ProjectDir%\run.cmd build -optdata %__RunArgs% %__UnprocessedBuildArgs%
+    call %__ProjectDir%\run.cmd build -optdata %__RunArgs% %__UnprocessedBuildArgs%
     if not !errorlevel! == 0 (
         echo %__MsgPrefix%Error: Failed to restore the optimization data package.
         exit /b 1
@@ -430,16 +443,6 @@ if %__BuildNative% EQU 1 (
 
     echo %__MsgPrefix%Commencing build of native components for %__BuildOS%.%__BuildArch%.%__BuildType%
 
-    set __NativePlatformArgs=-platform=%__BuildArch%
-    if not "%__ToolsetDir%" == "" ( set __NativePlatformArgs=-useEnv )
-
-    if not "%__ToolsetDir%" == "" (
-        rem arm64 builds currently use private toolset which has not been released yet
-        REM TODO, remove once the toolset is open.
-        call :PrivateToolSet
-        goto GenVSSolution
-    )
-
     :: Set the environment for the native build
     set __VCBuildArch=x86_amd64
     if /i "%__BuildArch%" == "x86" ( set __VCBuildArch=x86 )
@@ -460,13 +463,36 @@ if %__BuildNative% EQU 1 (
     call                                 "%__VCToolsRoot%\vcvarsall.bat" !__VCBuildArch!
     @if defined _echo @echo on
 
+if /i "%__BuildArch%" == "arm64" (
+@echo TEMPORARY: see what is on the CI machine ==========================================================================
+set INCLUDE
+set LIB
+set PATH
+set UCRTVersion
+set WindowsSDKVersion
+@echo Does it have the ARM64 files needed, from the 10.0.17134.0 SDK?
+where $INCLUDE:ksarm64.h
+where $INCLUDE:kxarm64.h
+where $INCLUDE:kxarm64unw.h
+@echo Does it have the ARM32 ones?
+where $INCLUDE:ksarm.h
+where $INCLUDE:kxarm.h
+where $INCLUDE:kxarmunw.h
+@echo What compiler?
+cl /Bv
+@echo What version of cmake?
+cmake --version
+@echo What version of Visual Studio?
+set VSCMD_VER
+@echo ===================================================================================================================
+)
+
     if not defined VSINSTALLDIR (
         echo %__MsgPrefix%Error: VSINSTALLDIR variable not defined.
         exit /b 1
     )
     if not exist "!VSINSTALLDIR!DIA SDK" goto NoDIA
 
-:GenVSSolution
     if defined __SkipConfigure goto SkipConfigure
 
     echo %__MsgPrefix%Regenerating the Visual Studio solution
@@ -493,7 +519,7 @@ if %__BuildNative% EQU 1 (
     set __MsbuildWrn=/flp1:WarningsOnly;LogFile=!__BuildWrn!
     set __MsbuildErr=/flp2:ErrorsOnly;LogFile=!__BuildErr!
 
-    @call %__ProjectDir%\run.cmd build -Project=%__IntermediatesDir%\install.vcxproj -MsBuildLog=!__MsbuildLog! -MsBuildWrn=!__MsbuildWrn! -MsBuildErr=!__MsbuildErr! -configuration=%__BuildType% %__NativePlatformArgs% %__RunArgs% -MSBuildNodeCount="/m:2" %__UnprocessedBuildArgs%
+    call %__ProjectDir%\run.cmd build -Project=%__IntermediatesDir%\install.vcxproj -MsBuildLog=!__MsbuildLog! -MsBuildWrn=!__MsbuildWrn! -MsBuildErr=!__MsbuildErr! -configuration=%__BuildType% -platform=%__BuildArch% %__RunArgs% -MSBuildNodeCount="/m:2" %__UnprocessedBuildArgs%
 
     if not !errorlevel! == 0 (
         echo %__MsgPrefix%Error: native component build failed. Refer to the build log files for details:
@@ -555,7 +581,7 @@ if /i "%__DoCrossArchBuild%"=="1" (
     set __MsbuildWrn=/flp1:WarningsOnly;LogFile=!__BuildWrn!
     set __MsbuildErr=/flp2:ErrorsOnly;LogFile=!__BuildErr!
 
-    @call %__ProjectDir%\run.cmd build -Project=%__CrossCompIntermediatesDir%\install.vcxproj -configuration=%__BuildType% -platform=%__CrossArch% -MsBuildLog=!__MsbuildLog! -MsBuildWrn=!__MsbuildWrn! -MsBuildErr=!__MsbuildErr! %__RunArgs% -MSBuildNodeCount="/m:2" %__UnprocessedBuildArgs%
+    call %__ProjectDir%\run.cmd build -Project=%__CrossCompIntermediatesDir%\install.vcxproj -configuration=%__BuildType% -platform=%__CrossArch% -MsBuildLog=!__MsbuildLog! -MsBuildWrn=!__MsbuildWrn! -MsBuildErr=!__MsbuildErr! %__RunArgs% -MSBuildNodeCount="/m:2" %__UnprocessedBuildArgs%
 
     if not !errorlevel! == 0 (
         echo %__MsgPrefix%Error: cross-arch components build failed. Refer to the build log files for details:
@@ -614,7 +640,7 @@ if %__BuildCoreLib% EQU 1 (
     set __MsbuildWrn=/flp1:WarningsOnly;LogFile=!__BuildWrn!
     set __MsbuildErr=/flp2:ErrorsOnly;LogFile=!__BuildErr!
 
-    @call %__ProjectDir%\run.cmd build -Project=%__ProjectDir%\build.proj -MsBuildLog=!__MsbuildLog! -MsBuildWrn=!__MsbuildWrn! -MsBuildErr=!__MsbuildErr! !__nugetBuildArgs! %__RunArgs% !__ExtraBuildArgs! %__UnprocessedBuildArgs%
+    call %__ProjectDir%\run.cmd build -Project=%__ProjectDir%\build.proj -MsBuildLog=!__MsbuildLog! -MsBuildWrn=!__MsbuildWrn! -MsBuildErr=!__MsbuildErr! !__nugetBuildArgs! %__RunArgs% !__ExtraBuildArgs! %__UnprocessedBuildArgs%
 
     if not !errorlevel! == 0 (
         echo %__MsgPrefix%Error: System.Private.CoreLib build failed. Refer to the build log files for details:
@@ -718,7 +744,7 @@ if %__BuildPackages% EQU 1 (
     set __MsbuildErr=/flp2:ErrorsOnly;LogFile=!__BuildErr!
 
     REM The conditions as to what to build are captured in the builds file.
-    @call %__ProjectDir%\run.cmd build -Project=%__SourceDir%\.nuget\packages.builds -platform=%__BuildArch% -MsBuildLog=!__MsbuildLog! -MsBuildWrn=!__MsbuildWrn! -MsBuildErr=!__MsbuildErr! %__RunArgs% %__UnprocessedBuildArgs%
+    call %__ProjectDir%\run.cmd build -Project=%__SourceDir%\.nuget\packages.builds -platform=%__BuildArch% -MsBuildLog=!__MsbuildLog! -MsBuildWrn=!__MsbuildWrn! -MsBuildErr=!__MsbuildErr! %__RunArgs% %__UnprocessedBuildArgs%
 
     if not !errorlevel! == 0 (
         echo %__MsgPrefix%Error: Nuget package generation failed build failed. Refer to the build log files for details:
@@ -741,12 +767,6 @@ REM ============================================================================
 if %__BuildTests% EQU 1 (
     echo %__MsgPrefix%Commencing build of tests for %__BuildOS%.%__BuildArch%.%__BuildType%
 
-    REM Construct the arguments to pass to the test build script.
-
-    rem arm64 builds currently use private toolset which has not been released yet
-    REM TODO, remove once the toolset is open.
-    if not "%__ToolsetDir%" == "" call :PrivateToolSet
-
     set NEXTCMD=call %__ProjectDir%\build-test.cmd %__BuildArch% %__BuildType% %__UnprocessedBuildArgs%
     echo %__MsgPrefix%!NEXTCMD!
     !NEXTCMD!
@@ -757,12 +777,6 @@ if %__BuildTests% EQU 1 (
     )
 ) else if %__GenerateLayout% EQU 1 (
     echo %__MsgPrefix%Generating layout for %__BuildOS%.%__BuildArch%.%__BuildType%
-
-    REM Construct the arguments to pass to the runtest build script.
-
-    rem arm64 builds currently use private toolset which has not been released yet
-    REM TODO, remove once the toolset is open.
-    if not "%__ToolsetDir%" == "" call :PrivateToolSet
 
     set NEXTCMD=call %__ProjectDir%\tests\runtest.cmd %__BuildArch% %__BuildType% GenerateLayoutOnly %__UnprocessedBuildArgs%
     echo %__MsgPrefix%!NEXTCMD!
@@ -890,7 +904,6 @@ echo     or -windowsmscorlib. If one of these is passed, only System.Private.Cor
 echo     for the specified platform ^(FreeBSD, Linux, NetBSD, OS X or Windows,
 echo     respectively^).
 echo     add nativemscorlib to go further and build the native image for designated mscorlib.
-echo -toolset_dir ^<dir^> : set the toolset directory -- Arm64 use only. Required for Arm64 builds.
 echo -nopgooptimize: do not use profile guided optimizations.
 echo -enforcepgo: verify after the build that PGO was used for key DLLs, and fail the build if not
 echo -pgoinstrument: generate instrumented code for profile guided optimization enabled binaries.
@@ -932,32 +945,3 @@ echo Visual Studio Express does not include the DIA SDK. ^
 You need Visual Studio 2015 or 2017 (Community is free).
 echo See: https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/developer-guide.md#prerequisites
 exit /b 1
-
-:PrivateToolSet
-
-echo %__MsgPrefix%Setting up the usage of __ToolsetDir:%__ToolsetDir%
-
-if /i "%__ToolsetDir%" == "" (
-    echo %__MsgPrefix%Error: A toolset directory is required for the Arm64 Windows build. Use the toolset_dir argument.
-    exit /b 1
-)
-
-if not exist "%__ToolsetDir%"\buildenv_arm64.cmd goto :Not_EWDK
-call "%__ToolsetDir%"\buildenv_arm64.cmd
-exit /b 0
-
-:Not_EWDK
-set PATH=%__ToolsetDir%\VC_sdk\bin;%PATH%
-set LIB=%__ToolsetDir%\VC_sdk\lib\arm64;%__ToolsetDir%\sdpublic\sdk\lib\arm64
-set INCLUDE=^
-%__ToolsetDir%\VC_sdk\inc;^
-%__ToolsetDir%\sdpublic\sdk\inc;^
-%__ToolsetDir%\sdpublic\shared\inc;^
-%__ToolsetDir%\sdpublic\shared\inc\minwin;^
-%__ToolsetDir%\sdpublic\sdk\inc\ucrt;^
-%__ToolsetDir%\sdpublic\sdk\inc\minwin;^
-%__ToolsetDir%\sdpublic\sdk\inc\mincore;^
-%__ToolsetDir%\sdpublic\sdk\inc\abi;^
-%__ToolsetDir%\sdpublic\sdk\inc\clientcore;^
-%__ToolsetDir%\diasdk\include
-exit /b 0

--- a/netci.groovy
+++ b/netci.groovy
@@ -2417,10 +2417,6 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
 
                     def buildOpts = ''
 
-                    if (architecture == 'arm64') {
-                        buildOpts += " toolset_dir C:\\ats2"
-                    }
-
                     if (doCoreFxTesting) {
                         buildOpts += ' skiptests'
                     } else {
@@ -2447,12 +2443,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                         def absoluteFxRoot = "%WORKSPACE%\\_\\fx"
                         def fxBranch = getFxBranch(branch)
 
-                        def toolsetDirOpt = ''
-                        if (architecture == 'arm64') {
-                            toolsetDirOpt = "-toolset_dir C:\\ats2"
-                        }
-
-                        buildCommands += "python -u %WORKSPACE%\\tests\\scripts\\run-corefx-tests.py -arch ${architecture} -ci_arch ${architecture} -build_type ${configuration} -fx_root ${absoluteFxRoot} -fx_branch ${fxBranch} -env_script ${envScriptPath} -no_run_tests ${toolsetDirOpt}"
+                        buildCommands += "python -u %WORKSPACE%\\tests\\scripts\\run-corefx-tests.py -arch ${architecture} -ci_arch ${architecture} -build_type ${configuration} -fx_root ${absoluteFxRoot} -fx_branch ${fxBranch} -env_script ${envScriptPath} -no_run_tests"
 
                         // Zip up the CoreFx runtime and tests. We don't need the CoreCLR binaries; they have been copied to the CoreFX tree.
                         buildCommands += "powershell -NoProfile -Command \"Add-Type -Assembly 'System.IO.Compression.FileSystem'; [System.IO.Compression.ZipFile]::CreateFromDirectory('${workspaceRelativeFxRootWin}\\bin\\testhost\\netcoreapp-Windows_NT-Release-${architecture}', '${workspaceRelativeFxRootWin}\\fxruntime.zip')\"";

--- a/netci.groovy
+++ b/netci.groovy
@@ -708,7 +708,13 @@ def static setMachineAffinity(def job, def os, def architecture, def options = n
         def isBuild = options['use_arm64_build_machine'] == true
 
         if (isBuild == true) {
-            Utilities.setMachineAffinity(job, os, 'latest-arm64')
+            // Current set of machines with private Windows arm64 toolset:
+            // Utilities.setMachineAffinity(job, os, 'latest-arm64')
+            //
+            // New set of machines with public Windows arm64 toolset, coming from Helix:
+            job.with {
+                label('Windows.10.Amd64.ClientRS4.DevEx.Open')
+            }
         } else {
             Utilities.setMachineAffinity(job, os, 'arm64-windows_nt')
         }

--- a/src/ToolBox/SOS/DacTableGen/CMakeLists.txt
+++ b/src/ToolBox/SOS/DacTableGen/CMakeLists.txt
@@ -5,9 +5,13 @@ set(DACTABLEGEN_SOURCES
     MapSymbolProvider.cs
 )
 
-# Cmake does not support csharp sources so add custom command
+# Cmake does not support C# sources so add custom command
+# Disable:
+#   warning CS1668: Invalid search path 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.14.26428\atlmfc\lib\ARM64' specified in 'LIB environment variable' -- 'The system cannot find the path specified. '
+# There are several problems here: (1) the C++ project files are adding non-existent directories to the LIB path, especially for ARM and ARM64,
+# (2) This CSC is invoking the desktop .NET Framework CSC, not the buildtools version.
 add_custom_target(dactablegen ALL 
-    COMMAND csc.exe /t:exe /platform:anycpu32bitpreferred /r:System.dll /r:DiaLib.dll /out:${CMAKE_CURRENT_BINARY_DIR}/dactablegen.exe ${DACTABLEGEN_SOURCES}
+    COMMAND csc.exe /t:exe /platform:anycpu32bitpreferred /r:System.dll /r:DiaLib.dll /nowarn:1668 /out:${CMAKE_CURRENT_BINARY_DIR}/dactablegen.exe ${DACTABLEGEN_SOURCES}
     COMMAND ${CMAKE_COMMAND} -E copy DIAlib.dll ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS ${DACTABLEGEN_SOURCES} DIAlib.dll
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/debug/di/CMakeLists.txt
+++ b/src/debug/di/CMakeLists.txt
@@ -37,28 +37,10 @@ if(WIN32)
     if (CLR_CMAKE_TARGET_ARCH_AMD64 OR CLR_CMAKE_TARGET_ARCH_ARM64 OR CLR_CMAKE_TARGET_ARCH_ARM)
         set(CORDBDI_SOURCES_ASM_FILE ${ARCH_SOURCES_DIR}/floatconversion.asm)
     endif()
-    if (CLR_CMAKE_TARGET_ARCH_AMD64)
-        set(CORDBDI_SOURCES
-          ${CORDBDI_SOURCES}
-          ${CORDBDI_SOURCES_ASM_FILE}
-        )
-    elseif (CLR_CMAKE_TARGET_ARCH_ARM64 AND NOT DEFINED CLR_CROSS_COMPONENTS_BUILD)
-        convert_to_absolute_path(CORDBDI_SOURCES_ASM_FILE ${CORDBDI_SOURCES_ASM_FILE})
-        get_compile_definitions(ASM_DEFINITIONS)
-        set(ASM_OPTIONS /c /Zi /W3 /errorReport:prompt)
-        # asm files require preprocessing using cl.exe on arm64
-        get_filename_component(name ${CORDBDI_SOURCES_ASM_FILE} NAME_WE)
-        set(ASM_PREPROCESSED_FILE ${CMAKE_CURRENT_BINARY_DIR}/${name}.asm)
-        preprocess_def_file(${CORDBDI_SOURCES_ASM_FILE} ${ASM_PREPROCESSED_FILE})
-        set(CORDBDI_SOURCES_WKS_PREPROCESSED_ASM  ${ASM_PREPROCESSED_FILE})
 
-        set_property(SOURCE ${CORDBDI_SOURCES_WKS_PREPROCESSED_ASM} PROPERTY COMPILE_DEFINITIONS ${ASM_DEFINITIONS})
-        set_property(SOURCE ${CORDBDI_SOURCES_WKS_PREPROCESSED_ASM} PROPERTY COMPILE_DEFINITIONS ${ASM_OPTIONS})
-        set(CORDBDI_SOURCES
-              ${CORDBDI_SOURCES}
-              ${CORDBDI_SOURCES_WKS_PREPROCESSED_ASM}
-            )
-    elseif (CLR_CMAKE_TARGET_ARCH_ARM AND NOT DEFINED CLR_CROSS_COMPONENTS_BUILD)
+    if (CLR_CMAKE_TARGET_ARCH_AMD64)
+        set(CORDBDI_SOURCES ${CORDBDI_SOURCES} ${CORDBDI_SOURCES_ASM_FILE})
+    elseif ((CLR_CMAKE_TARGET_ARCH_ARM OR CLR_CMAKE_TARGET_ARCH_ARM64) AND NOT DEFINED CLR_CROSS_COMPONENTS_BUILD)
           convert_to_absolute_path(CORDBDI_SOURCES_ASM_FILE ${CORDBDI_SOURCES_ASM_FILE})  
       
           # Inserts a custom command in CMake build to preprocess each asm source file
@@ -66,15 +48,14 @@ if(WIN32)
           file(TO_CMAKE_PATH "${CMAKE_CURRENT_BINARY_DIR}/${name}.asm" ASM_PREPROCESSED_FILE)
           preprocess_def_file(${CORDBDI_SOURCES_ASM_FILE} ${ASM_PREPROCESSED_FILE})
 
-          # On Arm32, compile the preprocessed binary to .obj
           # We do not pass any defines since we have already done pre-processing above
           set (ASM_CMDLINE "-o ${CMAKE_CURRENT_BINARY_DIR}/${name}.obj ${ASM_PREPROCESSED_FILE}")
 
           # Generate the batch file that will invoke the assembler
-          file(TO_CMAKE_PATH "${CMAKE_CURRENT_BINARY_DIR}/runasm_${name}_${CMAKE_BUILD_TYPE}.cmd" ASM_SCRIPT_FILE)
+          file(TO_CMAKE_PATH "${CMAKE_CURRENT_BINARY_DIR}/runasm_${name}.cmd" ASM_SCRIPT_FILE)
 
           file(GENERATE OUTPUT "${ASM_SCRIPT_FILE}"
-                    CONTENT "\"${CMAKE_ASM_MASM_COMPILER}\" -g ${ASM_INCLUDE_DIRECTORIES} ${ASM_DEFINITIONS} ${ASM_CMDLINE}")
+               CONTENT "\"${CMAKE_ASM_MASM_COMPILER}\" -g ${ASM_CMDLINE}")
 
           message("Generated  - ${ASM_SCRIPT_FILE}")
 

--- a/src/debug/ee/wks/CMakeLists.txt
+++ b/src/debug/ee/wks/CMakeLists.txt
@@ -1,66 +1,63 @@
 if (WIN32)
 
-add_precompiled_header(stdafx.h ../stdafx.cpp CORDBEE_SOURCES_WKS)
+  add_precompiled_header(stdafx.h ../stdafx.cpp CORDBEE_SOURCES_WKS)
 
-get_include_directories(ASM_INCLUDE_DIRECTORIES)
-get_compile_definitions(ASM_DEFINITIONS)
-set(ASM_OPTIONS /c /Zi /W3 /errorReport:prompt)
+  get_include_directories(ASM_INCLUDE_DIRECTORIES)
+  get_compile_definitions(ASM_DEFINITIONS)
 
-if (CLR_CMAKE_PLATFORM_ARCH_I386)
-  list (APPEND ASM_OPTIONS /safeseh)
-endif (CLR_CMAKE_PLATFORM_ARCH_I386)
+  set(ASM_FILE ${CORDBEE_DIR}/${ARCH_SOURCES_DIR}/dbghelpers.asm)
 
-set(ASM_FILE ${CORDBEE_DIR}/${ARCH_SOURCES_DIR}/dbghelpers.asm)
-# asm files require preprocessing using cl.exe on arm64
-if(CLR_CMAKE_PLATFORM_ARCH_ARM64)
+  if(CLR_CMAKE_PLATFORM_ARCH_ARM OR CLR_CMAKE_PLATFORM_ARCH_ARM64)
+
     get_filename_component(name ${ASM_FILE} NAME_WE)
-    set(ASM_PREPROCESSED_FILE ${CMAKE_CURRENT_BINARY_DIR}/${name}.asm)
+    file(TO_CMAKE_PATH "${CMAKE_CURRENT_BINARY_DIR}/${name}.asm" ASM_PREPROCESSED_FILE)
     preprocess_def_file(${ASM_FILE} ${ASM_PREPROCESSED_FILE})
-    set(CORDBEE_SOURCES_WKS_PREPROCESSED_ASM  ${ASM_PREPROCESSED_FILE})
-    set_property(SOURCE ${CORDBEE_SOURCES_WKS_PREPROCESSED_ASM} PROPERTY COMPILE_DEFINITIONS ${ASM_DEFINITIONS})
-    set_property(SOURCE ${CORDBEE_SOURCES_WKS_PREPROCESSED_ASM} PROPERTY COMPILE_DEFINITIONS ${ASM_OPTIONS})
-    add_library_clr(cordbee_wks ${CORDBEE_SOURCES_WKS} ${CORDBEE_SOURCES_WKS_PREPROCESSED_ASM})
-elseif(CLR_CMAKE_PLATFORM_ARCH_ARM)
-    
-    # On Arm32 for Windows, use C++ compiler to process the .asm since it includes C-style headers.
-    set(DBGHELPERS_ASM ${CMAKE_CURRENT_BINARY_DIR}/dbghelpers.asm)
-    set(ASM_OPTIONS " -g ")
-    
-    preprocess_def_file(${ASM_FILE} ${DBGHELPERS_ASM})
-    
+
     # We do not pass any defines since we have already done pre-processing above
-    set (DBGHELPERS_ASM_CMDLINE "-o ${CMAKE_CURRENT_BINARY_DIR}/dbghelpers.obj ${DBGHELPERS_ASM}")
+    set (ASM_CMDLINE "-o ${CMAKE_CURRENT_BINARY_DIR}/${name}.obj ${ASM_PREPROCESSED_FILE}")
 
-    file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/runasm.cmd"
-                CONTENT "\"${CMAKE_ASM_MASM_COMPILER}\" ${ASM_OPTIONS} ${DBGHELPERS_ASM_CMDLINE}")
+    # Generate the batch file that will invoke the assembler
+    file(TO_CMAKE_PATH "${CMAKE_CURRENT_BINARY_DIR}/runasm_${name}.cmd" ASM_SCRIPT_FILE)
+
+    file(GENERATE OUTPUT "${ASM_SCRIPT_FILE}"
+         CONTENT "\"${CMAKE_ASM_MASM_COMPILER}\" -g ${ASM_CMDLINE}")
+
+    message("Generated  - ${ASM_SCRIPT_FILE}")
+
+    # Need to compile asm file using custom command as include directories are not provided to asm compiler
+    add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${name}.obj
+                       COMMAND ${ASM_SCRIPT_FILE}
+                       DEPENDS ${ASM_PREPROCESSED_FILE}
+                       COMMENT "Assembling ${ASM_PREPROCESSED_FILE} - ${ASM_SCRIPT_FILE}")
+
+    add_library_clr(cordbee_wks ${CORDBEE_SOURCES_WKS} ${CMAKE_CURRENT_BINARY_DIR}/${name}.obj)
+
+  else ()
+
+    set(ASM_OPTIONS /c /Zi /W3 /errorReport:prompt)
+
+    if (CLR_CMAKE_PLATFORM_ARCH_I386)
+      list (APPEND ASM_OPTIONS /safeseh)
+    endif (CLR_CMAKE_PLATFORM_ARCH_I386)
 
     # Need to compile asm file using custom command as include directories are not provided to asm compiler
     add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dbghelpers.obj
-                       COMMAND ${CMAKE_CURRENT_BINARY_DIR}/runasm.cmd
-                       DEPENDS ${DBGHELPERS_ASM}
-                       COMMENT "Compiling dbghelpers.asm - ${CMAKE_CURRENT_BINARY_DIR}/runasm.cmd")
-    add_library_clr(cordbee_wks ${CORDBEE_SOURCES_WKS} ${CMAKE_CURRENT_BINARY_DIR}/dbghelpers.obj)
-else ()
-
-    # Need to compile asm file using custom command as include directories are not provided to asm compiler
-    add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dbghelpers.obj
-                         COMMAND ${CMAKE_ASM_MASM_COMPILER} ${ASM_INCLUDE_DIRECTORIES} ${ASM_DEFINITIONS} ${ASM_OPTIONS} /Fo${CMAKE_CURRENT_BINARY_DIR}/dbghelpers.obj /Ta${ASM_FILE}
-                         DEPENDS ${ASM_FILE}
-                         COMMENT "Compiling dbghelpers.asm")
+                       COMMAND ${CMAKE_ASM_MASM_COMPILER} ${ASM_INCLUDE_DIRECTORIES} ${ASM_DEFINITIONS} ${ASM_OPTIONS} /Fo${CMAKE_CURRENT_BINARY_DIR}/dbghelpers.obj /Ta${ASM_FILE}
+                       DEPENDS ${ASM_FILE}
+                       COMMENT "Compiling dbghelpers.asm")
 
     add_library_clr(cordbee_wks ${CORDBEE_SOURCES_WKS} ${CMAKE_CURRENT_BINARY_DIR}/dbghelpers.obj)
-endif(CLR_CMAKE_PLATFORM_ARCH_ARM64)
+
+  endif()
 
 else ()
 
-add_compile_options(-fPIC)
+  add_compile_options(-fPIC)
 
-if(CLR_CMAKE_PLATFORM_ARCH_AMD64 OR CLR_CMAKE_PLATFORM_ARCH_ARM OR CLR_CMAKE_PLATFORM_ARCH_ARM64 OR CLR_CMAKE_PLATFORM_ARCH_I386)
-  add_library_clr(cordbee_wks ${CORDBEE_SOURCES_WKS} ../${ARCH_SOURCES_DIR}/dbghelpers.S)
-elseif(CLR_CMAKE_PLATFORM_ARCH_ARM64)
-  add_library_clr(cordbee_wks ${CORDBEE_SOURCES_WKS} ../${ARCH_SOURCES_DIR}/dbghelpers.S)
-else()
-  message(FATAL_ERROR "Only ARM and AMD64 is supported")
-endif()
+  if(CLR_CMAKE_PLATFORM_ARCH_AMD64 OR CLR_CMAKE_PLATFORM_ARCH_ARM OR CLR_CMAKE_PLATFORM_ARCH_ARM64 OR CLR_CMAKE_PLATFORM_ARCH_I386)
+    add_library_clr(cordbee_wks ${CORDBEE_SOURCES_WKS} ../${ARCH_SOURCES_DIR}/dbghelpers.S)
+  else()
+    message(FATAL_ERROR "Unknown platform")
+  endif()
 
 endif (WIN32)

--- a/src/pal/tools/gen-buildsys-win.bat
+++ b/src/pal/tools/gen-buildsys-win.bat
@@ -1,4 +1,4 @@
-@if not defined __echo @echo off
+@if not defined _echo @echo off
 rem
 rem This file invokes cmake and generates the build system for windows.
 
@@ -22,8 +22,8 @@ set __CmakeGenerator=Visual Studio
 if /i "%__VSVersion%" == "vs2017" (set __CmakeGenerator=%__CmakeGenerator% 15 2017)
 if /i "%__VSVersion%" == "vs2015" (set __CmakeGenerator=%__CmakeGenerator% 14 2015)
 if /i "%__Arch%" == "x64" (set __CmakeGenerator=%__CmakeGenerator% Win64)
-if /i "%__Arch%" == "arm64" (set __CmakeGenerator=%__CmakeGenerator% Win64)
 if /i "%__Arch%" == "arm" (set __CmakeGenerator=%__CmakeGenerator% ARM)
+if /i "%__Arch%" == "arm64" (set __ExtraCmakeParams=%__ExtraCmakeParams% -A ARM64)
 
 if /i "%__NMakeMakefiles%" == "1" (set __CmakeGenerator=NMake Makefiles)
 

--- a/src/vm/wks/CMakeLists.txt
+++ b/src/vm/wks/CMakeLists.txt
@@ -5,22 +5,7 @@ if (WIN32)
   set_source_files_properties(../mscorlib.cpp PROPERTIES COMPILE_FLAGS "/Y-") 
 
   # asm files require preprocessing using cl.exe on arm32 and arm64
-  if(CLR_CMAKE_PLATFORM_ARCH_ARM64)
-
-      foreach(ASM_FILE ${VM_SOURCES_WKS_ARCH_ASM})
-
-          # Preprocess each asm source file
-          get_filename_component(name ${ASM_FILE} NAME_WE)
-          set(ASM_PREPROCESSED_FILE ${CMAKE_CURRENT_BINARY_DIR}/${name}.asm)
-          preprocess_def_file(${ASM_FILE} ${ASM_PREPROCESSED_FILE})
-
-          set(VM_SOURCES_WKS_ARM64_PREPROCESSED_ASM ${VM_SOURCES_WKS_ARM64_PREPROCESSED_ASM} ${ASM_PREPROCESSED_FILE})
-
-      endforeach()
-
-      set(VM_SOURCES_WKS_ARCH_ASM ${VM_SOURCES_WKS_ARM64_PREPROCESSED_ASM})
-
-  elseif(CLR_CMAKE_PLATFORM_ARCH_ARM)
+  if(CLR_CMAKE_PLATFORM_ARCH_ARM OR CLR_CMAKE_PLATFORM_ARCH_ARM64)
 
       get_include_directories_asm(ASM_INCLUDE_DIRECTORIES)
 
@@ -31,15 +16,14 @@ if (WIN32)
           file(TO_CMAKE_PATH "${CMAKE_CURRENT_BINARY_DIR}/${name}.asm" ASM_PREPROCESSED_FILE)
           preprocess_def_file(${ASM_FILE} ${ASM_PREPROCESSED_FILE})
 
-          # On Arm32, compile the preprocessed binary to .obj
           # We do not pass any defines since we have already done pre-processing above
           set (ASM_CMDLINE "-o ${CMAKE_CURRENT_BINARY_DIR}/${name}.obj ${ASM_PREPROCESSED_FILE}")
 
           # Generate the batch file that will invoke the assembler
-          file(TO_CMAKE_PATH "${CMAKE_CURRENT_BINARY_DIR}/runasm_${name}_${CMAKE_BUILD_TYPE}.cmd" ASM_SCRIPT_FILE)
+          file(TO_CMAKE_PATH "${CMAKE_CURRENT_BINARY_DIR}/runasm_${name}.cmd" ASM_SCRIPT_FILE)
 
           file(GENERATE OUTPUT "${ASM_SCRIPT_FILE}"
-                    CONTENT "\"${CMAKE_ASM_MASM_COMPILER}\" -g ${ASM_INCLUDE_DIRECTORIES} ${ASM_DEFINITIONS} ${ASM_CMDLINE}")
+               CONTENT "\"${CMAKE_ASM_MASM_COMPILER}\" -g ${ASM_INCLUDE_DIRECTORIES} ${ASM_CMDLINE}")
 
           message("Generated  - ${ASM_SCRIPT_FILE}")
 
@@ -57,7 +41,7 @@ if (WIN32)
 
       endforeach()
 
-  endif(CLR_CMAKE_PLATFORM_ARCH_ARM64)
+  endif()
 
 endif (WIN32)
 
@@ -65,7 +49,7 @@ add_library_clr(cee_wks ${VM_SOURCES_WKS} ${VM_SOURCES_WKS_ARCH_ASM})
 
 if (WIN32)
 
-  if(NOT CLR_CMAKE_PLATFORM_ARCH_ARM)
+  if(NOT CLR_CMAKE_PLATFORM_ARCH_ARM AND NOT CLR_CMAKE_PLATFORM_ARCH_ARM64)
     # Get the current list of definitions
     get_compile_definitions(DEFINITIONS)
 
@@ -118,6 +102,6 @@ if (WIN32)
 
     add_dependencies(cee_wks asmconstants_inc)
 
-  endif(NOT CLR_CMAKE_PLATFORM_ARCH_ARM)
+  endif(NOT CLR_CMAKE_PLATFORM_ARCH_ARM AND NOT CLR_CMAKE_PLATFORM_ARCH_ARM64)
 
 endif (WIN32)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,23 +14,6 @@ set(CLR_CMAKE_TARGET_ARCH ${CLR_CMAKE_HOST_ARCH})
 set(INC_PLATFORM_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/Common/Platform)
 if (WIN32)
     add_definitions(-DWINDOWS=1)
-
-    if (DEFINED ENV{__ToolsetDir})
-        # Hack for private Tool Set
-        # CMAKE_CXX_COMPILER will default to the compiler installed with
-        # Visual studio. Overwrite it to the compiler on the path.
-
-        find_program(PATH_CXX_COMPILER cl)
-        set(CMAKE_CXX_COMPILER ${PATH_CXX_COMPILER})
-
-        message("Overwriting the CMAKE_CXX_COMPILER.")
-        message("CMAKE_CXX_COMPILER found:${CMAKE_CXX_COMPILER}")
-      
-        # Temporary until cmake has VS generators for hacky toolsets [arm64]
-        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /machine:${CLR_CMAKE_TARGET_ARCH}")
-        set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /machine:${CLR_CMAKE_TARGET_ARCH}")
-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /machine:${CLR_CMAKE_TARGET_ARCH}")
-    endif()
 endif()
 
 # Compile options

--- a/tests/src/Interop/CMakeLists.txt
+++ b/tests/src/Interop/CMakeLists.txt
@@ -1,10 +1,9 @@
-
 if(WIN32)
-	if(CLR_CMAKE_HOST_ARCH STREQUAL arm)
+    if((CLR_CMAKE_HOST_ARCH STREQUAL arm) OR (CLR_CMAKE_HOST_ARCH STREQUAL arm64))
 	    list(APPEND LINK_LIBRARIES_ADDITIONAL
 	        ole32.lib
 	    )
-	endif(CLR_CMAKE_HOST_ARCH STREQUAL arm)
+	endif()
 endif(WIN32)
 
 include_directories(common)


### PR DESCRIPTION
Remove support for specifying the toolset directory for arm64,
which was used to point to an internal toolset.

Building for arm64 now works just like the other platforms, e.g.
invoke `build arm64`.

The requirements:
- Visual Studio 2017 Update 4 or later, with ARM64 toolset installed
- Windows SDK 10.0.17134.0 or later
- CMake 3.10 or later