### PR TITLE
Update EventPipe StackWalker usage to specify ALLOW_INVALID_OBJECTS

### DIFF
--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -785,7 +785,7 @@ bool EventPipe::WalkManagedStackForThread(Thread *pThread, StackContents &stackC
     StackWalkAction swaRet = pThread->StackWalkFrames(
         (PSTACKWALKFRAMESCALLBACK) &StackWalkCallback,
         &stackContents,
-        ALLOW_ASYNC_STACK_WALK | FUNCTIONSONLY | HANDLESKIPPEDFRAMES);
+        ALLOW_ASYNC_STACK_WALK | FUNCTIONSONLY | HANDLESKIPPEDFRAMES | ALLOW_INVALID_OBJECTS);
 
     return ((swaRet == SWA_DONE) || (swaRet == SWA_CONTINUE));
 }


### PR DESCRIPTION
Fix for Windows x86 test failure uncovered by https://github.com/dotnet/coreclr/pull/18927.

Valid objects are not required for stack walking performed by EventPipe.