### PR TITLE
Reduce a few allocations in string.Normalize 

### DIFF
--- a/src/System.Private.CoreLib/shared/Interop/Unix/System.Globalization.Native/Interop.Normalization.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Unix/System.Globalization.Native/Interop.Normalization.cs
@@ -14,6 +14,6 @@ internal static partial class Interop
         internal static extern int IsNormalized(NormalizationForm normalizationForm, string src, int srcLen);
 
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_NormalizeString")]
-        internal static extern int NormalizeString(NormalizationForm normalizationForm, string src, int srcLen, [Out] char[] dstBuffer, int dstBufferCapacity);
+        internal static extern unsafe int NormalizeString(NormalizationForm normalizationForm, string src, int srcLen, char* dstBuffer, int dstBufferCapacity);
     }
 }

--- a/src/System.Private.CoreLib/shared/Interop/Windows/Normaliz/Interop.Normalization.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Windows/Normaliz/Interop.Normalization.cs
@@ -13,12 +13,11 @@ internal partial class Interop
         internal static extern bool IsNormalizedString(int normForm, string source, int length);
 
         [DllImport("Normaliz.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern int NormalizeString(
+        internal static extern unsafe int NormalizeString(
                                         int normForm,
                                         string source,
                                         int sourceLength,
-                                        [System.Runtime.InteropServices.OutAttribute()]
-                                        char[] destination,
+                                        char* destination,
                                         int destinationLength);
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Globalization/Normalization.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/Normalization.Unix.cs
@@ -41,23 +41,23 @@ namespace System.Globalization
 
             ValidateArguments(strInput, normalizationForm);
 
-            char[] buf = new char[strInput.Length];
+            var buf = stackalloc char[strInput.Length];
 
             for (int attempts = 2; attempts > 0; attempts--)
             {
-                int realLen = Interop.Globalization.NormalizeString(normalizationForm, strInput, strInput.Length, buf, buf.Length);
+                int realLen = Interop.Globalization.NormalizeString(normalizationForm, strInput, strInput.Length, buf, strInput.Length);
 
                 if (realLen == -1)
                 {
                     throw new ArgumentException(SR.Argument_InvalidCharSequenceNoIndex, nameof(strInput));
                 }
 
-                if (realLen <= buf.Length)
+                if (realLen <= strInput.Length)
                 {
                     return new string(buf, 0, realLen);
                 }
 
-                buf = new char[realLen];
+                buf = stackalloc char[realLen];
             }
 
             throw new ArgumentException(SR.Argument_InvalidCharSequenceNoIndex, nameof(strInput));


### PR DESCRIPTION
Boosts `string.Normailize` by a few percents.
E.g. `"ắḉ¾ḉ".Normalize(NormalizationForm.FormKD)` 

Benchmark:
```csharp
public class StringNormalizeBenchmarks
{
	[ParamsSource(nameof(StringsToNormalize))]
	public string Str { get; set; }

	public IEnumerable<string> StringsToNormalize()
	{
		yield return "ắ"; // see https://msdn.microsoft.com/en-us/library/8eaxk1x2(v=vs.110).aspx#Anchor_3
		yield return "ắḉ¾ḉắ¾ḉ¾ắắ";
		yield return string.Join("", Enumerable.Repeat("ắḉприветWorld", 1024));
	}

	[Benchmark] public string Normalize_FormC() => Str.Normalize(NormalizationForm.FormC);
	[Benchmark] public string Normalize_FormD() => Str.Normalize(NormalizationForm.FormD);
	[Benchmark] public string Normalize_FormKC() => Str.Normalize(NormalizationForm.FormKC);
	[Benchmark] public string Normalize_FormKD() => Str.Normalize(NormalizationForm.FormKD);
}
```

|           Method |    Toolchain |     Mean | Scaled |  Gen 0 | Allocated |
|----------------- |------------- |---------:|-------:|-------:|----------:|
|  Normalize_FormD |      Default | 459.8 ns |   1.03 | 0.0415 |     264 B |
|  Normalize_FormD | CoreCLR-Egor | 446.7 ns |   1.00 | 0.0405 |     256 B |