### PR TITLE
Use mcontext_t instead of sigcontext

### DIFF
--- a/src/pal/src/arch/arm/signalhandlerhelper.cpp
+++ b/src/pal/src/arch/arm/signalhandlerhelper.cpp
@@ -59,7 +59,7 @@ void ExecuteHandlerOnOriginalStack(int code, siginfo_t *siginfo, void *context, 
 #else
     size_t size = ALIGN_UP(sizeof(ucontext->uc_mcontext), 8);
     sp -= size / sizeof(size_t);
-    *(sigcontext *)sp = ucontext->uc_mcontext;
+    *(mcontext_t *)sp = ucontext->uc_mcontext;
 #endif
 
     // Switch the current context to the signal_handler_worker and the original stack


### PR DESCRIPTION
The type of uc_mcontext has always been `mcontext_t`, but earlier versions of Glibc just typedef'ed this to `sigcontext`.

Newer versions of Glibc (since 2.27) [introduced an explicit struct type](https://sourceware.org/git/?p=glibc.git;a=blobdiff;f=sysdeps/unix/sysv/linux/arm/sys/ucontext.h;h=192d1bdeac3e62e13110f68614f7af624047c3a9;hp=2abceef2a4ca9bbb6e42208eaee548228b041e5b;hb=4fa9b3bfe6759c82beb4b043a54a3598ca467289;hpb=5898f4548efdcd7c0fd437a74eeb80facc51a117) and now compilation fails.