### PR TITLE
Improve TimeSpan.ToString/TryFormat throughput for default format

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Math.cs
+++ b/src/System.Private.CoreLib/shared/System/Math.cs
@@ -123,11 +123,21 @@ namespace System
 
         public static long DivRem(long a, long b, out long result)
         {
-            // TODO https://github.com/dotnet/coreclr/issues/3439:
-            // Restore to using % and / when the JIT is able to eliminate one of the idivs.
-            // In the meantime, a * and - is measurably faster than an extra /.
-
             long div = a / b;
+            result = a - (div * b);
+            return div;
+        }
+
+        internal static uint DivRem(uint a, uint b, out uint result)
+        {
+            uint div = a / b;
+            result = a - (div * b);
+            return div;
+        }
+
+        internal static ulong DivRem(ulong a, ulong b, out ulong result)
+        {
+            ulong div = a / b;
             result = a - (div * b);
             return div;
         }

--- a/src/System.Private.CoreLib/shared/System/TimeSpan.cs
+++ b/src/System.Private.CoreLib/shared/System/TimeSpan.cs
@@ -450,7 +450,7 @@ namespace System
         }
         public override string ToString()
         {
-            return TimeSpanFormat.Format(this, null, null);
+            return TimeSpanFormat.FormatC(this);
         }
         public string ToString(string format)
         {


### PR DESCRIPTION
Improves the throughput of the null/"c"/"t"/"T" default format for TimeSpan.ToString/TryFormat, porting over the approach/specialization from Utf8Formatter.

Contributes to https://github.com/dotnet/corefx/issues/30612
cc: @jkotas, @danmosemsft, @ahsonkhan 

Benchmark:
```C#
using System;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Attributes.Jobs;
using BenchmarkDotNet.Running;

[MemoryDiagnoser]
[InProcess]
public class Benchmark
{
    private static void Main() => BenchmarkRunner.Run<Benchmark>();

    private TimeSpan _simple = new TimeSpan(1, 2, 3);
    private TimeSpan _maxValue = new TimeSpan(long.MaxValue);
    private char[] _tmp = new char[100];

    [Benchmark] public string SimpleToString() => _simple.ToString();
    [Benchmark] public bool SimpleTryFormat() => _simple.TryFormat(_tmp, out int charsWritten);

    [Benchmark] public string MaxToString() => _maxValue.ToString();
    [Benchmark] public bool MaxTryFormat() => _maxValue.TryFormat(_tmp, out int charsWritten);
}
```

Before/After:

| Benchmark       | Before (ns) | After (ns) | Improvement | 
|-----------------|-------------|------------|-------------| 
|  SimpleToString | 126.8       | 44.76      | 2.83x       | 
| SimpleTryFormat | 147.2       | 30.25      | 4.87x       | 
|     MaxToString | 391.9       | 111.56     | 3.51x       | 
|    MaxTryFormat | 282.7       | 106.23     | 2.66x       | 
