### PR TITLE
Conditionally disable publishing for internal builds

### DIFF
--- a/buildpipeline/DotNet-Trusted-Publish-Symbols.json
+++ b/buildpipeline/DotNet-Trusted-Publish-Symbols.json
@@ -45,6 +45,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Extract symbol packages; if release branch, archive",
+      "condition": "and(succeeded(), ne(variables.PB_SecurityBuild, 'true'))",
       "timeoutInMinutes": 0,
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
@@ -65,6 +66,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Publish Symbols to Artifact Services",
+      "condition": "and(succeeded(), ne(variables.PB_SecurityBuild, 'true'))",
       "timeoutInMinutes": 0,
       "task": {
         "id": "29827cd1-5c33-4ff0-a817-abd46970ffc4",

--- a/buildpipeline/DotNet-Trusted-Publish-Symbols.json
+++ b/buildpipeline/DotNet-Trusted-Publish-Symbols.json
@@ -191,6 +191,10 @@
       "value": "passed-by-pipebuild",
       "allowOverride": true
     },
+    "PB_SecurityBuild": {
+      "value": "true",
+      "allowOverride": true
+    },
     "SymbolsProject": {
       "value": "CLR"
     },

--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -451,6 +451,10 @@
       "value": "$(Build.BuildNumber)",
       "allowOverride": true
     },
+    "PB_SecurityBuild": {
+      "value": "true",
+      "allowOverride": true
+    },
     "MyGetFeedUrl": {
       "value": "https://dotnet.myget.org/F/dotnet-core-test/api/v2/package",
       "allowOverride": true

--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -199,6 +199,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "packages -> dotnet.myget.org",
+      "condition": "and(succeeded(), eq(variables.ConfigurationGroup, 'Release'), ne(variables.PB_SecurityBuild, 'true'))",
       "timeoutInMinutes": 0,
       "refName": "Task8",
       "task": {
@@ -209,9 +210,9 @@
       "inputs": {
         "scriptType": "inlineScript",
         "scriptName": "",
-        "arguments": "-ApiKey $(MyGetApiKey) -ConfigurationGroup $(ConfigurationGroup) -PackagesGlob $(Pipeline.SourcesDirectory)\\packages\\AzureTransfer\\$(ConfigurationGroup)\\$(AzureContainerPackageGlob) -MyGetFeedUrl $(MyGetFeedUrl)",
+        "arguments": "-ApiKey $(MyGetApiKey) -PackagesGlob $(Pipeline.SourcesDirectory)\\packages\\AzureTransfer\\$(ConfigurationGroup)\\$(AzureContainerPackageGlob) -MyGetFeedUrl $(MyGetFeedUrl)",
         "workingFolder": "$(Pipeline.SourcesDirectory)",
-        "inlineScript": "param($ApiKey, $ConfigurationGroup, $PackagesGlob, $MyGetFeedUrl)\n\nif ($ConfigurationGroup.ToLower() -ne \"release\") { Write-host \"Chose not to publish\"; exit }\n\nmsbuild /t:NuGetPush /v:Normal `\n/p:NuGetExePath=$env:CustomNuGetPath `\n/p:NuGetApiKey=$ApiKey `\n/p:NuGetSource=$MyGetFeedUrl `\n/p:PackagesGlob=$PackagesGlob",
+        "inlineScript": "param($ApiKey, $PackagesGlob, $MyGetFeedUrl)\n\nmsbuild /t:NuGetPush /v:Normal `\n/p:NuGetExePath=$env:CustomNuGetPath `\n/p:NuGetApiKey=$ApiKey `\n/p:NuGetSource=$MyGetFeedUrl `\n/p:PackagesGlob=$PackagesGlob",
         "failOnStandardError": "true"
       }
     },
@@ -221,6 +222,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "symbol packages -> dotnet.myget.org",
+      "condition": "and(succeeded(), eq(variables.ConfigurationGroup, 'Release'), ne(variables.PB_SecurityBuild, 'true'))",
       "timeoutInMinutes": 0,
       "refName": "Task9",
       "task": {
@@ -231,9 +233,9 @@
       "inputs": {
         "scriptType": "inlineScript",
         "scriptName": "",
-        "arguments": "-ApiKey $(MyGetApiKey) -ConfigurationGroup $(ConfigurationGroup) -PackagesGlob $(Build.StagingDirectory)\\IndexedSymbolPackages\\*.nupkg -MyGetFeedUrl $(MyGetFeedUrl)",
+        "arguments": "-ApiKey $(MyGetApiKey) -PackagesGlob $(Build.StagingDirectory)\\IndexedSymbolPackages\\*.nupkg -MyGetFeedUrl $(MyGetFeedUrl)",
         "workingFolder": "$(Pipeline.SourcesDirectory)",
-        "inlineScript": "param($ApiKey, $ConfigurationGroup, $PackagesGlob, $MyGetFeedUrl)\n\nif ($ConfigurationGroup.ToLower() -ne \"release\") { Write-host \"Chose not to publish\"; exit }\nif ($env:SourceBranch.StartsWith(\"release/\")) { exit }\n\nmsbuild /t:NuGetPush /v:Normal `\n/p:NuGetExePath=$env:CustomNuGetPath `\n/p:NuGetApiKey=$ApiKey `\n/p:NuGetSource=$MyGetFeedUrl `\n/p:PackagesGlob=$PackagesGlob",
+        "inlineScript": "param($ApiKey, $PackagesGlob, $MyGetFeedUrl)\n\nif ($env:SourceBranch.StartsWith(\"release/\")) { exit }\n\nmsbuild /t:NuGetPush /v:Normal `\n/p:NuGetExePath=$env:CustomNuGetPath `\n/p:NuGetApiKey=$ApiKey `\n/p:NuGetSource=$MyGetFeedUrl `\n/p:PackagesGlob=$PackagesGlob",
         "failOnStandardError": "true"
       }
     },
@@ -243,6 +245,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Update versions repository",
+      "condition": "and(succeeded(), eq(variables.ConfigurationGroup, 'Release'), ne(variables.PB_SecurityBuild, 'true'))",
       "timeoutInMinutes": 0,
       "refName": "Task10",
       "task": {
@@ -253,8 +256,8 @@
       "inputs": {
         "scriptType": "inlineScript",
         "scriptName": "",
-        "arguments": "-gitHubAuthToken $(UpdatePublishedVersions.AuthToken) -root $(Pipeline.SourcesDirectory) -configGroup $(ConfigurationGroup)",
-        "inlineScript": "param($gitHubAuthToken, $root, $configGroup)\nif ($configGroup -ne \"Release\" ) { exit }\ncd $root\n. $root\\UpdatePublishedVersions.ps1 `\n  -gitHubUser dotnet-build-bot -gitHubEmail dotnet-build-bot@microsoft.com `\n  -gitHubAuthToken $gitHubAuthToken `\n  -versionsRepoOwner $env:VersionsRepoOwner -versionsRepo versions `\n  -versionsRepoPath build-info/dotnet/$env:GitHubRepositoryName/$env:SourceBranch `\n  -nupkgPath $root\\packages\\AzureTransfer\\$env:ConfigurationGroup\\$env:AzureContainerPackageGlob",
+        "arguments": "-gitHubAuthToken $(UpdatePublishedVersions.AuthToken) -root $(Pipeline.SourcesDirectory)",
+        "inlineScript": "param($gitHubAuthToken, $root)\ncd $root\n. $root\\UpdatePublishedVersions.ps1 `\n  -gitHubUser dotnet-build-bot -gitHubEmail dotnet-build-bot@microsoft.com `\n  -gitHubAuthToken $gitHubAuthToken `\n  -versionsRepoOwner $env:VersionsRepoOwner -versionsRepo versions `\n  -versionsRepoPath build-info/dotnet/$env:GitHubRepositoryName/$env:SourceBranch `\n  -nupkgPath $root\\packages\\AzureTransfer\\$env:ConfigurationGroup\\$env:AzureContainerPackageGlob",
         "workingFolder": "",
         "failOnStandardError": "true"
       }


### PR DESCRIPTION
@MattGal @weshaggard PTAL

Part of https://github.com/dotnet/core-eng/issues/1784

I've already updated the internal build definition to pass `PB_SecurityBuild=true`.