### PR TITLE
JIT: handle implicit local var references via local var attribute bit

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -307,6 +307,9 @@ public:
     unsigned char lvClassInfoUpdated : 1; // true if this var has updated class handle or exactness
 #endif
 
+    unsigned char lvImplicitlyReferenced : 1; // true if there are non-IR references to this local (prolog, epilog, gc,
+                                              // eh)
+
     union {
         unsigned lvFieldLclStart; // The index of the local var representing the first field in the promoted struct
                                   // local.  For implicit byref parameters, this gets hijacked between
@@ -604,6 +607,11 @@ private:
 public:
     unsigned short lvRefCnt() const
     {
+        if (lvImplicitlyReferenced && (m_lvRefCnt == 0))
+        {
+            return 1;
+        }
+
         return m_lvRefCnt;
     }
 
@@ -627,6 +635,11 @@ public:
 
     unsigned lvRefCntWtd() const
     {
+        if (lvImplicitlyReferenced && (m_lvRefCntWtd == 0))
+        {
+            return BB_UNITY_WEIGHT;
+        }
+
         return m_lvRefCntWtd;
     }
 

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -1797,9 +1797,8 @@ inline unsigned Compiler::lvaGrabTempWithImplicitUse(bool shortLifetime DEBUGARG
     // address-exposed -- DoNotEnregister should suffice?
     lvaSetVarAddrExposed(lclNum);
 
-    // We need lvRefCnt to be non-zero to prevent various asserts from firing.
-    varDsc->setLvRefCnt(1);
-    varDsc->setLvRefCntWtd(BB_UNITY_WEIGHT);
+    // Note the implicit use
+    varDsc->lvImplicitlyReferenced = 1;
 
     return lclNum;
 }

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -4026,10 +4026,8 @@ void Compiler::lvaMarkLocalVars()
 
             lvaTable[info.compLvFrameListRoot].lvType = TYP_I_IMPL;
 
-            /* Set the refCnt, it is used in the prolog and return block(s) */
-
-            lvaTable[info.compLvFrameListRoot].setLvRefCnt(2);
-            lvaTable[info.compLvFrameListRoot].setLvRefCntWtd(2 * BB_UNITY_WEIGHT);
+            // This local has implicit prolog and epilog references
+            lvaTable[info.compLvFrameListRoot].lvImplicitlyReferenced = 1;
         }
     }
 
@@ -4148,16 +4146,16 @@ void Compiler::lvaMarkLocalVars()
     }
 #endif
 
-    if (lvaKeepAliveAndReportThis() && lvaTable[0].lvRefCnt() == 0)
+    if (lvaKeepAliveAndReportThis())
     {
-        lvaTable[0].setLvRefCnt(1);
+        lvaTable[0].lvImplicitlyReferenced = 1;
         // This isn't strictly needed as we will make a copy of the param-type-arg
         // in the prolog. However, this ensures that the LclVarDsc corresponding to
         // info.compTypeCtxtArg is valid.
     }
-    else if (lvaReportParamTypeArg() && lvaTable[info.compTypeCtxtArg].lvRefCnt() == 0)
+    else if (lvaReportParamTypeArg())
     {
-        lvaTable[info.compTypeCtxtArg].setLvRefCnt(1);
+        lvaTable[info.compTypeCtxtArg].lvImplicitlyReferenced = 1;
     }
 
     lvaLocalVarRefCounted = true;
@@ -4176,12 +4174,8 @@ void Compiler::lvaAllocOutgoingArgSpaceVar()
     {
         lvaOutgoingArgSpaceVar = lvaGrabTemp(false DEBUGARG("OutgoingArgSpace"));
 
-        lvaTable[lvaOutgoingArgSpaceVar].lvType = TYP_LCLBLK;
-
-        /* Set the refCnts */
-
-        lvaTable[lvaOutgoingArgSpaceVar].setLvRefCnt(1);
-        lvaTable[lvaOutgoingArgSpaceVar].setLvRefCntWtd(BB_UNITY_WEIGHT);
+        lvaTable[lvaOutgoingArgSpaceVar].lvType                 = TYP_LCLBLK;
+        lvaTable[lvaOutgoingArgSpaceVar].lvImplicitlyReferenced = 1;
     }
 
     noway_assert(lvaOutgoingArgSpaceVar >= info.compLocalsCount && lvaOutgoingArgSpaceVar < lvaCount);

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -1047,9 +1047,14 @@ void Compiler::fgExtendDbgLifetimes()
     unsigned lclNum = 0;
     for (LclVarDsc *varDsc = lvaTable; lclNum < lvaCount; lclNum++, varDsc++)
     {
-        if (varDsc->lvRefCnt() == 0 && varDsc->lvIsRegArg)
+        if (lclNum >= info.compArgsCount)
         {
-            varDsc->setLvRefCnt(1);
+            break; // early exit for loop
+        }
+
+        if (varDsc->lvIsRegArg)
+        {
+            varDsc->lvImplicitlyReferenced = true;
         }
     }
 


### PR DESCRIPTION
Instead of relying on ref count bumps, add a new attribute bit to local
vars to indicate that they may have implicit references (prolog, epilog,
gc, eh) and may not have any IR references.

Use this attribute bit to ensure that the ref count and weighted ref count for
such variables are never reported as zero, and as a result that these variables
end up being allocated and reportable.

This is another preparatory step for #18969 and frees the jit to recompute
explicit ref counts via an IR scan without having to special case the counts
for these variables.

The jit can no longer describe implicit counts other than 1 and implicit weights
otehr than BB_UNITY_WEIGHT, but that currently doesn't seem to be very important.

The new bit fits into an existing padding void so LclVarDsc remains at 128 bytes
(for windows x64).