### PR TITLE
Eliminate arm64 contract asserts

### DIFF
--- a/src/vm/arm64/cgencpu.h
+++ b/src/vm/arm64/cgencpu.h
@@ -578,7 +578,7 @@ struct StubPrecode {
         CONTRACTL
         {
             THROWS;
-            GC_TRIGGERS;
+            GC_NOTRIGGER;
         }
         CONTRACTL_END;
 
@@ -591,7 +591,7 @@ struct StubPrecode {
         CONTRACTL
         {
             THROWS;
-            GC_TRIGGERS;
+            GC_NOTRIGGER;
         }
         CONTRACTL_END;
 
@@ -704,7 +704,7 @@ struct FixupPrecode {
         CONTRACTL
         {
             THROWS;
-            GC_TRIGGERS;
+            GC_NOTRIGGER;
         }
         CONTRACTL_END;
 
@@ -717,7 +717,7 @@ struct FixupPrecode {
         CONTRACTL
         {
             THROWS;
-            GC_TRIGGERS;
+            GC_NOTRIGGER;
         }
         CONTRACTL_END;
 
@@ -778,7 +778,7 @@ struct ThisPtrRetBufPrecode {
         CONTRACTL
         {
             THROWS;
-            GC_TRIGGERS;
+            GC_NOTRIGGER;
         }
         CONTRACTL_END;
 


### PR DESCRIPTION
These methods don't trigger GC but were previously marked as if they did. Correcting the marking will eliminate spurious asserts.

PTAL @BruceForstall @kouvel 