### PR TITLE
Update PreReleaseLabel

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -18,7 +18,7 @@
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <StableVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == ''">$(PackageVersion)</StableVersion>
 
-    <PreReleaseLabel>preview1</PreReleaseLabel>
+    <PreReleaseLabel>alphautf8string</PreReleaseLabel>
   </PropertyGroup>
 
   <!-- Source of truth for dependency tooling: the commit hash of the dotnet/versions master branch as of the last auto-upgrade. -->


### PR DESCRIPTION
to "alphautf8string" so it sorts before "preview1" and so it's under the nuget 20 character limit