### PR TITLE
JitDump improvements

### DIFF
--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -8304,8 +8304,8 @@ void emitter::emitDispIns(
                 // Munge any pointers if we want diff-able disassembly
                 if (emitComp->opts.disDiffable)
                 {
-                    ssize_t top12bits = (val >> 20);
-                    if ((top12bits != 0) && (top12bits != -1))
+                    ssize_t top14bits = (val >> 18);
+                    if ((top14bits != 0) && (top14bits != -1))
                     {
                         val = 0xD1FFAB1E;
                     }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2759,6 +2759,8 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
     bool     callHasRetBuffArg       = call->HasRetBufArg();
     bool     callIsVararg            = call->IsVarargs();
 
+    JITDUMP("%sMorphing args for %d.%s:\n", (reMorphing) ? "Re" : "", call->gtTreeID, GenTree::OpName(call->gtOper));
+
 #ifdef _TARGET_UNIX_
     if (callIsVararg)
     {


### PR DESCRIPTION
- Reduce the size of "diffable" values (I've been encountering a number of diffs on x86; 2 bits seems to take care of it)
- Dump a note when we start morphing args for a call.