### PR TITLE
Address issues with COM tests in the helix build.

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -433,6 +433,10 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\BenchmarksGame\reverse-complement\reverse-complement-6\reverse-complement-6.cmd">
             <Issue>9314</Issue>
         </ExcludeList>
+        <!-- Disable COM tests since they don't properly run on Windows.Nano and at present there is no way to special case that OS flavor. -->
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\COM\NETClients\Primitives\NETClientPrimitives\NETClientPrimitives.cmd">
+            <Issue>Fails on Windows.Nano</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- The following are tests that fail on non-Windows, which we must not run when building against packages -->
@@ -548,6 +552,9 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\Interop\StructMarshalling\PInvoke\MarshalStructAsLayoutExp\MarshalStructAsLayoutExp.cmd">
             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\COM\NETClients\Primitives\NETClientPrimitives\NETClientPrimitives.cmd">
+            <Issue>by design Windows only</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\IL\PInvokeTail\PInvokeTail\PInvokeTail.cmd">
             <Issue>needs triage</Issue>

--- a/tests/src/Interop/COM/NETClients/Primitives/Program.cs
+++ b/tests/src/Interop/COM/NETClients/Primitives/Program.cs
@@ -19,7 +19,7 @@ namespace NetClient
             }
             catch (Exception e)
             {
-                Console.WriteLine($"Test Failure: {e.Message}\n{e.StackTrace}");
+                Console.WriteLine($"Test Failure: {e}");
                 return 101;
             }
 


### PR DESCRIPTION
Presently COM tests does not appear to run properly on Windows.Nano but
there is no way to special case that OS so disabling them on all builds.

see #19017