### PR TITLE
R2RDump - Skip R2RDumpTests in crossgen tests

### DIFF
--- a/tests/skipCrossGenFiles.arm.txt
+++ b/tests/skipCrossGenFiles.arm.txt
@@ -2,3 +2,4 @@ mscorlib.dll
 System.Runtime.WindowsRuntime.UI.Xaml.dll
 System.Private.CoreLib.dll
 xunit.performance.api.dll
+R2RDump.dll

--- a/tests/skipCrossGenFiles.arm64.txt
+++ b/tests/skipCrossGenFiles.arm64.txt
@@ -5,3 +5,4 @@ System.Net.Sockets.dll
 System.Net.Primitives.dll
 System.Private.CoreLib.dll
 xunit.performance.api.dll
+R2RDump.dll

--- a/tests/skipCrossGenFiles.x64.txt
+++ b/tests/skipCrossGenFiles.x64.txt
@@ -2,3 +2,4 @@ mscorlib.dll
 System.Runtime.WindowsRuntime.UI.Xaml.dll
 System.Private.CoreLib.dll
 xunit.performance.api.dll
+R2RDump.dll

--- a/tests/skipCrossGenFiles.x86.txt
+++ b/tests/skipCrossGenFiles.x86.txt
@@ -2,3 +2,4 @@ mscorlib.dll
 System.Runtime.WindowsRuntime.UI.Xaml.dll
 System.Private.CoreLib.dll
 xunit.performance.api.dll
+R2RDump.dll

--- a/tests/testsUnsupported.arm.txt
+++ b/tests/testsUnsupported.arm.txt
@@ -15,3 +15,4 @@ GC/Regressions/v2.0-beta2/460373/460373/460373.sh
 GC/Regressions/v2.0-beta1/149926/149926/149926.sh
 GC/Regressions/v2.0-rtm/494226/494226/494226.sh
 GC/Regressions/dev10bugs/536168/536168/536168.sh
+readytorun/r2rdump/R2RDumpTest/R2RDumpTest.sh


### PR DESCRIPTION
Fixing issue https://github.com/dotnet/coreclr/issues/19030