### PR TITLE
Set function size to -1 if sizing info unavailable

### DIFF
--- a/src/tools/r2rdump/R2RMethod.cs
+++ b/src/tools/r2rdump/R2RMethod.cs
@@ -71,6 +71,10 @@ namespace R2RDump
             {
                 Size = gcInfo.CodeLength;
             }
+            else
+            {
+                Size = -1;
+            }
             CodeOffset = codeOffset;
             method.GcInfo = gcInfo;
         }


### PR DESCRIPTION
If GCInfo and RVA information is unavailable, Size needs to be set to `-1` to properly display `Unavailable` in dump output. Currently it displays a misleading `Size: 0`.