### PR TITLE
The SIMD types must use the struct code path - Fixes issue 19022

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8064,7 +8064,7 @@ void Compiler::fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCa
                 {
                     GenTree* lcl  = gtNewLclvNode(varNum, lclType);
                     GenTree* init = nullptr;
-                    if (lclType == TYP_STRUCT)
+                    if (varTypeIsStruct(lclType))
                     {
                         const bool isVolatile  = false;
                         const bool isCopyBlock = false;

--- a/tests/src/JIT/Regression/JitBlue/GitHub_19022/GitHub_19022.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_19022/GitHub_19022.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Numerics;
+
+namespace JitCrashPOC
+{
+    class Program
+    {
+        static public int s_res;
+
+        static int Main(string[] args)
+        {
+            var map = new ItemRunner();
+
+            s_res = 0;
+            map.UpdateItem(0,10);            
+
+            if (s_res == 300)
+            {
+                Console.WriteLine("Passed");
+                return 100;
+            }
+            else
+            {
+                Console.WriteLine("Failed");
+                return 101;
+            }
+        }
+    }
+
+    class Item
+    {
+        public Vector3 _Position = new Vector3(0.0f, 0.0f, 0.0f);
+    }
+
+    class ItemRunner
+    {
+        public ItemRunner()
+        {
+            for (int i = 0; i < _Pool.Length; ++i) { _Pool[i] = new Item(); }
+        }
+
+        private const float _LenghtZ = 1000.0f;
+
+        private static readonly Vector3 _Start = new Vector3(0.0f, -1021.7f, -3451.3f);
+        private static readonly Vector3 _Slope = new Vector3(0.0f, 0.286f, 0.958f);
+
+        private Item[] _Pool = new Item[30];
+
+        private Item _LastGenerated;        
+
+
+        // This method qualifies for the optimization:
+        // fgMorphRecursiveFastTailCallIntoLoop : Transform a recursive fast tail call into a loop.
+        //
+        // It also has a Vector3 TYP_SIMD12 local variable that needs initializtion across the tailcall-loop
+        // The JIT was asserting or crashing when dealing with this case
+        //
+        public void UpdateItem(float fDelta, int depth)
+        {
+            if (depth == 0)
+            {
+                return;
+            }
+
+            Vector3 vDelta;
+
+            for (int i = 0; i < _Pool.Length; i++)
+            {
+                vDelta = _Slope * fDelta;
+
+                if (_LastGenerated != null) _Pool[i]._Position = _LastGenerated._Position - _Slope * _LenghtZ;
+                else _Pool[i]._Position = _Start - vDelta;
+
+                _LastGenerated = _Pool[i];
+                Program.s_res++;
+            }
+
+            UpdateItem(0, depth-1);
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_19022/GitHub_19022.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_19022/GitHub_19022.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
The SIMD types needed to use the struct code path when we are building
the zero-initializations in fgMorphRecursiveFastTailCallIntoLoop