### PR TITLE
Partial R2R IBC fixes

### DIFF
--- a/src/tools/crossgen/crossgen.cpp
+++ b/src/tools/crossgen/crossgen.cpp
@@ -422,6 +422,7 @@ int _cdecl wmain(int argc, __in_ecount(argc) WCHAR **argv)
     LPWSTR pwzSearchPathForManagedPDB = NULL;
     LPCWSTR pwzOutputFilename = NULL;
     LPCWSTR pwzPublicKeys = nullptr;
+    bool fExplicitReadyToRunSwitch = true;
 
 #if !defined(FEATURE_MERGE_JIT_AND_ENGINE)
     LPCWSTR pwszCLRJITPath = nullptr;
@@ -513,6 +514,7 @@ int _cdecl wmain(int argc, __in_ecount(argc) WCHAR **argv)
         else if (MatchParameter(*argv, W("ReadyToRun")))
         {
             dwFlags |= NGENWORKER_FLAGS_READYTORUN;
+            fExplicitReadyToRunSwitch = true;
         }
         else if (MatchParameter(*argv, W("FragileNonVersionable")))
         {
@@ -835,7 +837,7 @@ int _cdecl wmain(int argc, __in_ecount(argc) WCHAR **argv)
 
 // Disable fragile NGen when compiling Mscorlib for ARM.
 #if !(defined(_TARGET_ARM_) || defined(_TARGET_ARM64_))
-    if (fCompilingMscorlib)
+    if (fCompilingMscorlib && !fExplicitReadyToRunSwitch)
         dwFlags &= ~NGENWORKER_FLAGS_READYTORUN;
 #endif // !(_TARGET_ARM_ || _TARGET_ARM64_)
 

--- a/src/tools/crossgen/crossgen.cpp
+++ b/src/tools/crossgen/crossgen.cpp
@@ -422,7 +422,7 @@ int _cdecl wmain(int argc, __in_ecount(argc) WCHAR **argv)
     LPWSTR pwzSearchPathForManagedPDB = NULL;
     LPCWSTR pwzOutputFilename = NULL;
     LPCWSTR pwzPublicKeys = nullptr;
-    bool fExplicitReadyToRunSwitch = true;
+    bool fExplicitReadyToRunSwitch = false;
 
 #if !defined(FEATURE_MERGE_JIT_AND_ENGINE)
     LPCWSTR pwszCLRJITPath = nullptr;

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -1718,6 +1718,7 @@ void STDMETHODCALLTYPE EEShutDownHelper(BOOL fIsDllUnloading)
                     {
                         IBCLoggingDisabler disableLogging( pInfo );  // runs IBCLoggingDisabler::DisableLogging
                         
+                        CONTRACT_VIOLATION(GCViolation);
                         Module::WriteAllModuleProfileData(true);
                     }
                 }

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -315,10 +315,11 @@ PCODE MethodDesc::PrepareILBasedCode(PrepareCodeConfig* pConfig)
     {
         LOG((LF_CLASSLOADER, LL_INFO1000000,
             "    In PrepareILBasedCode, calling JitCompileCode\n"));
-        // Mark the code as hot in case the method ends up in the native image
-        g_IBCLogger.LogMethodCodeAccess(this);
         pCode = JitCompileCode(pConfig);
     }
+
+    // Mark the code as hot in case the method ends up in the native image
+    g_IBCLogger.LogMethodCodeAccess(this);
 
     return pCode;
 }


### PR DESCRIPTION
- Log use method code access in all cases, not just when the method is JITed
- Add workaround for CONTRACT_VIOLATION that shows up in checked builds when collecting IBC data
- Make /ReadyToRun switch work for CoreLib