### PR TITLE
Fix MaskMove_r test build configuration to not optimized

### DIFF
--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MaskMove_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MaskMove_r.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>
-    <Optimize>True</Optimize>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />


### PR DESCRIPTION
~~Fixes #19000 issue~~

~~Fix is masked by #19075.~~

PR cannot be tested as long as #19075 issues is not fixed.

Confirmed locally that solution works, however it is unclear to me what is the mechanism which fixes it - I am not sufficiently familiar with test framework to workout intricacies of _r project type interactions with optimised C# compilation.