### PR TITLE
Work around cmd command length limit in xunit Exec task

### DIFF
--- a/tests/src/dir.props
+++ b/tests/src/dir.props
@@ -33,7 +33,7 @@
 
 <!-- Setup the default output and intermediate paths -->
   <PropertyGroup>
-    <BaseOutputPath>$(ProjectDir)\..\bin\tests</BaseOutputPath>
+    <BaseOutputPath>$(ProjectDir)..\bin\tests</BaseOutputPath>
     <BaseOutputPath Condition="'$(__TestRootDir)' != ''">$(__TestRootDir)</BaseOutputPath>
     <BaseOutputPathWithConfig>$(BaseOutputPath)\$(OSPlatformConfig)\</BaseOutputPathWithConfig>
     <BinDir>$(BaseOutputPathWithConfig)</BinDir>

--- a/tests/tests.targets
+++ b/tests/tests.targets
@@ -50,9 +50,24 @@
 
       <CorerunExecutable Condition="'$(RunningOnUnix)' == 'true'">$(CORE_ROOT)\corerun</CorerunExecutable>
       <CorerunExecutable Condition="'$(RunningOnUnix)' != 'true'">$(CORE_ROOT)\corerun.exe</CorerunExecutable>
+    </PropertyGroup>
+
+    <!-- Work around cmd command length limit by using relative paths
+         from working directory instead of full paths (see
+         https://github.com/Microsoft/msbuild/issues/2530) -->
+    <ItemGroup Condition="'$(RunningOnUnix)' != 'true'">
+      <_TestAssembliesRelative Include="@(TestAssemblies -> Replace('$(BaseOutputPathWithConfig)', '.\'))" />
+      <TestAssemblies Remove="@(TestAssemblies)" />
+      <TestAssemblies Include="@(_TestAssembliesRelative)" />
+    </ItemGroup>
+
+    <PropertyGroup>
       <XunitCommandLine>$(CorerunExecutable) $(XunitConsoleRunner) @(TestAssemblies->'%(Identity)', ' ') $(XunitArgs)</XunitCommandLine>
     </PropertyGroup>
-    <Exec Command="$(XunitCommandLine)" />
+
+    <Error Condition="$(XunitCommandLine.Length) > 8191" Text="Xunit command line is too long." />
+    <Exec Command="$(XunitCommandLine)"
+          WorkingDirectory="$(BaseOutputPathWithConfig)"/>
 
   </Target>
 


### PR DESCRIPTION
On Windows, the Exec task passes the command to cmd, so long commands
run into the command length limit (see
https://github.com/Microsoft/msbuild/issues/2530). This workaround
shortens the xunit command line by replacing the path to the test
binary directory with an environment variable.

This is an attempt to fix https://github.com/dotnet/coreclr/issues/19075.