### PR TITLE
[WIP] build-test - fix several thousands C# and NuGet warnings

### DIFF
--- a/tests/runtest.proj
+++ b/tests/runtest.proj
@@ -258,7 +258,7 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
                     }
                     catch(Exception ex)
                     {
-                      sErrorText = "Unable to read error file: " + errorFile%3B
+                      sErrorText = $"Unable to read error file: {errorFile}\n{ex}"%3B
                     }
 
                     string outputText = null%3B
@@ -270,7 +270,7 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
                     }
                     catch(Exception ex)
                     {
-                        outputText = "Unable to read output file: " + outputFile%3B
+                        outputText = $"Unable to read error file: {outputFile}\n{ex}"%3B
                     }
 
                     string msg = infraEx != null ? "Test Infrastructure Failure: " + infraEx.ToString()

--- a/tests/scripts/scripts.csproj
+++ b/tests/scripts/scripts.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.xunit.performance.run.core">
@@ -18,7 +18,7 @@
       <Version>$(XunitPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.DotNet.BuildTools.TestSuite">
-      <Version>1.0.0-prerelease-00629-04</Version>
+      <Version>1.0.0-prerelease-00704-04</Version>
     </PackageReference> 
   </ItemGroup>
   <PropertyGroup>

--- a/tests/src/Common/CoreFX/CoreFX.depproj
+++ b/tests/src/Common/CoreFX/CoreFX.depproj
@@ -10,8 +10,8 @@
       <CLRTestKind>SharedLibrary</CLRTestKind>
       <IsTestProject>false</IsTestProject>
       <!-- System.Composition and System.Composition.AttributedModel use different versioning conventions -->
-      <SystemCompositionVersions>1.3.0-preview3-26501-04</SystemCompositionVersions>
-      <XUnitNetcoreExtensionsVersion>2.2.0-preview1-02902-01</XUnitNetcoreExtensionsVersion>
+      <SystemCompositionVersions>1.3.0-$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion.Substring(6))</SystemCompositionVersions>
+      <XUnitNetcoreExtensionsVersion>2.2.0-preview1-03025-01</XUnitNetcoreExtensionsVersion>
       <!-- Xunit Abstractions is differently versioned then the rest of XUnit -->
       <XUnitAbstractionsVersion>2.0.1</XUnitAbstractionsVersion>
       <CoreFXXUnitPackageVersion>2.2.0-beta2-build3300</CoreFXXUnitPackageVersion>
@@ -28,14 +28,25 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions">
+      <Version>$(MicrosoftDotnetPlatformAbstractionsVersion)</Version>
+    </PackageReference>    
+    <PackageReference Include="Microsoft.Private.CoreFx.NETCoreApp">
+      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
+    </PackageReference>  
+    <PackageReference Include="Microsoft.DotNet.BuildTools.TestSuite">
+      <Version>1.0.0-prerelease-00704-04</Version>
+    </PackageReference>   
     <PackageReference Include="xunit">
       <Version>$(CoreFXXUnitPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="xunit.core">
       <Version>$(CoreFXXUnitPackageVersion)</Version>
+      <NoWarn>NU1605</NoWarn>
     </PackageReference>
     <PackageReference Include="xunit.assert">
       <Version>$(CoreFXXUnitPackageVersion)</Version>
+      <NoWarn>NU1605</NoWarn>
     </PackageReference>
     <PackageReference Include="xunit.abstractions">
       <Version>$(XUnitAbstractionsVersion)</Version>
@@ -49,11 +60,17 @@
     <PackageReference Include="xunit.runner.utility">
       <Version>$(CoreFXXUnitPackageVersion)</Version>
     </PackageReference>
-    <PackageReference Include="microsoft.xunit.netcore.extensions">
-      <Version>$(XUnitNetcoreExtensionsVersion)</Version>
-    </PackageReference>
     <PackageReference Include="CoreFx.Private.TestUtilities">
       <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
+    </PackageReference>    
+    <PackageReference Include="System.Linq.Expressions">
+      <Version>4.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.Text.RegularExpressions">
+      <Version>4.3.0</Version>
+    </PackageReference>        
+    <PackageReference Include="Microsoft.xunit.netcore.extensions">
+      <Version>$(XUnitNetcoreExtensionsVersion)</Version>
     </PackageReference>
     <PackageReference Include="System.CodeDom">
       <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
@@ -132,7 +149,7 @@
     </PackageReference>
     <PackageReference Include="System.Security.Cryptography.Pkcs">
       <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
-    </PackageReference>
+    </PackageReference>   
     <PackageReference Include="System.Security.Cryptography.Xml">
       <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
     </PackageReference>

--- a/tests/src/Common/test_dependencies/test_dependencies.csproj
+++ b/tests/src/Common/test_dependencies/test_dependencies.csproj
@@ -13,9 +13,6 @@
     <PackageReference Include="Microsoft.Private.CoreFx.NETCoreApp">
       <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
     </PackageReference>
-    <PackageReference Include="System.Memory">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
-    </PackageReference>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
       <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
     </PackageReference>
@@ -28,7 +25,7 @@
   </ItemGroup>
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <TargetFrameworkIdentifier>.NETCoreApp,Version=v3.0</TargetFrameworkIdentifier>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;netcoreapp1.1;portable-net45+win8</PackageTargetFallback>
     <RuntimeIdentifiers>win-arm;win-arm64;win-x64;win-x86;$(TargetRid)</RuntimeIdentifiers>
     <ContainsPackageReferences>true</ContainsPackageReferences>

--- a/tests/src/Common/test_runtime/test_runtime.csproj
+++ b/tests/src/Common/test_runtime/test_runtime.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -13,6 +13,12 @@
     <PackageReference Include="Microsoft.NETCore.Platforms">
       <Version>$(MicrosoftNETCorePlatformsPackageVersion)</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.Private.CoreFx.NETCoreApp">
+      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
+    </PackageReference>    
+    <PackageReference Include="Microsoft.DotNet.Cli.Utils">
+      <Version>1.0.0-preview2-003121</Version>
+    </PackageReference>    
     <PackageReference Include="Microsoft.DotNet.CoreCLR.TestDependencies">
       <Version>1.0.0-prerelease</Version>
     </PackageReference>
@@ -28,8 +34,8 @@
   </ItemGroup>
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
+    <TargetFrameworkIdentifier>.NETCoreApp,Version=v3.0</TargetFrameworkIdentifier>
+        <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
     <RuntimeIdentifiers>win-arm;win-arm64;win-x64;win-x86;$(TargetRid)</RuntimeIdentifiers>
     <ContainsPackageReferences>true</ContainsPackageReferences>
     <PrereleaseResolveNuGetPackages>false</PrereleaseResolveNuGetPackages>

--- a/tests/src/Interop/MarshalAPI/GetNativeVariantForObject/GetNativeVariantForObject.csproj
+++ b/tests/src/Interop/MarshalAPI/GetNativeVariantForObject/GetNativeVariantForObject.csproj
@@ -12,7 +12,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
 
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
-    <NoWarn>0618;0649</NoWarn>
+    <NoWarn>0618;0649;$(NoWarn)</NoWarn>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">

--- a/tests/src/Interop/MarshalAPI/Miscellaneous/MarshalClassTests.csproj
+++ b/tests/src/Interop/MarshalAPI/Miscellaneous/MarshalClassTests.csproj
@@ -12,7 +12,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
 
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
-    <NoWarn>0618;0649</NoWarn>
+    <NoWarn>0618;0649;$(NoWarn)</NoWarn>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">

--- a/tests/src/Interop/MarshalAPI/OffsetOf/OffsetOf.csproj
+++ b/tests/src/Interop/MarshalAPI/OffsetOf/OffsetOf.csproj
@@ -12,7 +12,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
 
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
-    <NoWarn>0618;0649;0169</NoWarn>
+    <NoWarn>0618;0649;0169;$(NoWarn)</NoWarn>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">

--- a/tests/src/JIT/HardwareIntrinsics/X86/dir.props
+++ b/tests/src/JIT/HardwareIntrinsics/X86/dir.props
@@ -2,6 +2,6 @@
   <Import Condition="Exists('..\dir.props')" Project="..\dir.props"/>
 
   <ItemGroup>
-    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(SourceDir)/Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/src/JIT/config/benchmark/benchmark.csproj
+++ b/tests/src/JIT/config/benchmark/benchmark.csproj
@@ -7,24 +7,9 @@
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="xunit.performance.api">
-      <Version>$(XunitPerformanceApiPackageVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="xunit.performance.core">
-      <Version>$(XunitPerformanceApiPackageVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="xunit.performance.execution">
-      <Version>$(XunitPerformanceApiPackageVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="xunit.performance.metrics">
-      <Version>$(XunitPerformanceApiPackageVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent">
-      <Version>$(MicrosoftDiagnosticsTracingTraceEventPackageVersion)</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.NETCore.Platforms">
       <Version>$(MicrosoftNETCorePlatformsPackageVersion)</Version>
-    </PackageReference>
+    </PackageReference>    
     <PackageReference Include="System.Collections.NonGeneric">
       <Version>4.4.0-beta-24913-02</Version>
     </PackageReference>
@@ -43,8 +28,15 @@
     <PackageReference Include="System.Linq.Expressions">
       <Version>4.4.0-beta-24913-02</Version>
     </PackageReference>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
+      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
+      <NoWarn>NU1605</NoWarn>
+    </PackageReference>    
     <PackageReference Include="System.Memory">
       <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
+      <NoWarn>NU1603</NoWarn>
+      <!-- Warnings NU1603 and NU1605 are raised due to the presence of v4.6.0-preview3-2650x-xx assemblies on myget-->
+      <!-- They prevent usage of newer 4.6.0-preview1 assemblies since NuGet treats preview3 as version always higher than preview1 -->
     </PackageReference>
     <PackageReference Include="System.Numerics.Vectors">
       <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
@@ -60,9 +52,6 @@
     </PackageReference>
     <PackageReference Include="System.Runtime">
       <Version>4.4.0-beta-24913-02</Version>
-    </PackageReference>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime.Extensions">
       <Version>4.4.0-beta-24913-02</Version>
@@ -103,13 +92,28 @@
     <PackageReference Include="xunit.runner.utility">
       <Version>$(XunitPackageVersion)</Version>
     </PackageReference>
+    <PackageReference Include="xunit.performance.api">
+      <Version>$(XunitPerformanceApiPackageVersion)</Version>
+    </PackageReference>
+    <PackageReference Include="xunit.performance.core">
+      <Version>$(XunitPerformanceApiPackageVersion)</Version>
+    </PackageReference>
+    <PackageReference Include="xunit.performance.execution">
+      <Version>$(XunitPerformanceApiPackageVersion)</Version>
+    </PackageReference>
+    <PackageReference Include="xunit.performance.metrics">
+      <Version>$(XunitPerformanceApiPackageVersion)</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent">
+      <Version>$(MicrosoftDiagnosticsTracingTraceEventPackageVersion)</Version>
+    </PackageReference>    
   </ItemGroup>
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>
-    <TargetFrameworkIdentifier>.NETStandard</TargetFrameworkIdentifier>
+    <TargetFrameworkIdentifier>.NETStandard,Version=v1.4</TargetFrameworkIdentifier>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
     <ContainsPackageReferences>true</ContainsPackageReferences>
-    <PrereleaseResolveNuGetPackages>false</PrereleaseResolveNuGetPackages>
+    <PrereleaseResolveNuGetPackages>false</PrereleaseResolveNuGetPackages>    
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <Target Name="Build"

--- a/tests/src/dir.props
+++ b/tests/src/dir.props
@@ -55,7 +55,7 @@
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <!-- Disable some C# warnings for the tests. -->
-    <NoWarn>78,162,164,168,169,219,251,252,414,429,642,649,652,675,1691,1717,1718,3001,3002,3003,3005,3008</NoWarn>
+    <NoWarn>78,162,164,168,169,219,251,252,414,429,618,642,649,652,675,1685,1691,1717,1718,3001,3002,3003,3005,3008</NoWarn>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SkipSigning Condition="'$(CrossGen)' == 'true'">true</SkipSigning>
     <AssemblyKey>Test</AssemblyKey>

--- a/tests/src/performance/performance.csproj
+++ b/tests/src/performance/performance.csproj
@@ -7,24 +7,9 @@
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="xunit.performance.api">
-      <Version>$(XunitPerformanceApiPackageVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="xunit.performance.core">
-      <Version>$(XunitPerformanceApiPackageVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="xunit.performance.execution">
-      <Version>$(XunitPerformanceApiPackageVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="xunit.performance.metrics">
-      <Version>$(XunitPerformanceApiPackageVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent">
-      <Version>$(MicrosoftDiagnosticsTracingTraceEventPackageVersion)</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.NETCore.Platforms">
       <Version>$(MicrosoftNETCorePlatformsPackageVersion)</Version>
-    </PackageReference>
+    </PackageReference>  
     <PackageReference Include="System.Collections.NonGeneric">
       <Version>4.4.0-beta-24913-02</Version>
     </PackageReference>
@@ -91,6 +76,9 @@
     <PackageReference Include="System.Xml.XPath.XmlDocument">
       <Version>4.4.0-beta-24913-02</Version>
     </PackageReference>
+    <PackageReference Include="System.Security.Principal.Windows">
+      <Version>4.4.0</Version>
+    </PackageReference>    
     <PackageReference Include="xunit">
       <Version>$(XunitPackageVersion)</Version>
     </PackageReference>
@@ -100,9 +88,21 @@
     <PackageReference Include="xunit.runner.utility">
       <Version>$(XunitPackageVersion)</Version>
     </PackageReference>
-    <PackageReference Include="System.Security.Principal.Windows">
-      <Version>4.4.0</Version>
+    <PackageReference Include="xunit.performance.api">
+      <Version>$(XunitPerformanceApiPackageVersion)</Version>
     </PackageReference>
+    <PackageReference Include="xunit.performance.core">
+      <Version>$(XunitPerformanceApiPackageVersion)</Version>
+    </PackageReference>
+    <PackageReference Include="xunit.performance.execution">
+      <Version>$(XunitPerformanceApiPackageVersion)</Version>
+    </PackageReference>
+    <PackageReference Include="xunit.performance.metrics">
+      <Version>$(XunitPerformanceApiPackageVersion)</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent">
+      <Version>$(MicrosoftDiagnosticsTracingTraceEventPackageVersion)</Version>
+    </PackageReference>     
   </ItemGroup>
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>


### PR DESCRIPTION
Recent changes to test harness introduced several thousands new warnings from both C# code and NuGet references. This PR fixes most of them.