### PR TITLE
Enable Windows ARM64 builds using release product tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,24 @@ if (WIN32)
       # Enable generic assembly compilation to avoid CMake generate VS proj files that explicitly
       # use ml[64].exe as the assembler.
       enable_language(ASM)
+    elseif(CLR_CMAKE_HOST_ARCH STREQUAL arm64)
+
+      # Confirm that Windows SDK is present
+      if(NOT DEFINED CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION OR CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION STREQUAL "" )
+	      message(FATAL_ERROR "Windows SDK is required for the ARM64 build.")
+      else()
+	      message("Using Windows SDK version ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
+      endif()
+
+      # Explicitly specify the assembler to be used for Arm64 compile
+      file(TO_CMAKE_PATH "$ENV{VCToolsInstallDir}\\bin\\HostX86\\arm64\\armasm64.exe" CMAKE_ASM_COMPILER)
+
+      set(CMAKE_ASM_MASM_COMPILER ${CMAKE_ASM_COMPILER})
+      message("CMAKE_ASM_MASM_COMPILER explicitly set to: ${CMAKE_ASM_MASM_COMPILER}")
+
+      # Enable generic assembly compilation to avoid CMake generate VS proj files that explicitly
+      # use ml[64].exe as the assembler.
+      enable_language(ASM)
     else()
       enable_language(ASM_MASM)
     endif()
@@ -74,16 +92,6 @@ if (WIN32)
     find_program(MC mc)
     if (MC STREQUAL "MC-NOTFOUND")
         message(FATAL_ERROR "MC not found")
-    endif()
-
-    if (CLR_CMAKE_HOST_ARCH STREQUAL arm64)
-      # CMAKE_CXX_COMPILER will default to the compiler installed with
-      # Visual studio. Overwrite it to the compiler on the path.
-      # TODO, remove when cmake generator supports Arm64 as a target.
-      find_program(PATH_CXX_COMPILER cl)
-      set(CMAKE_CXX_COMPILER ${PATH_CXX_COMPILER})
-      message("Overwriting the CMAKE_CXX_COMPILER.")
-      message(CMAKE_CXX_COMPILER found:${CMAKE_CXX_COMPILER})
     endif()
 
 else (WIN32)
@@ -375,13 +383,6 @@ if (WIN32)
   set(CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO} /LTCG /OPT:REF /OPT:ICF ${NO_INCREMENTAL_LINKER_FLAGS}")
   set(CMAKE_STATIC_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_STATIC_LINKER_FLAGS_RELWITHDEBINFO} /LTCG")
   set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} /LTCG /OPT:REF /OPT:ICF ${NO_INCREMENTAL_LINKER_FLAGS}")
-
-  # Temporary until cmake has VS generators for arm64
-  if(CLR_CMAKE_PLATFORM_ARCH_ARM64)
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /machine:arm64")
-    set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /machine:arm64")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /machine:arm64")
-  endif(CLR_CMAKE_PLATFORM_ARCH_ARM64)
 
   # Force uCRT to be dynamically linked for Release build
   set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib")

--- a/buildpipeline/DotNet-CoreClr-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Windows.json
@@ -122,7 +122,7 @@
       },
       "inputs": {
         "filename": "build.cmd",
-        "arguments": "$(Architecture) $(PB_BuildType) skiptests skipbuildpackages $(PB_EnforcePGO) $(ToolsetArgs) -OfficialBuildId=$(OfficialBuildId) -Priority=$(Priority) -skiprestore -- /p:SignType=$(PB_SignType) /flp:\"v=diag\"",
+        "arguments": "$(Architecture) $(PB_BuildType) skiptests skipbuildpackages $(PB_EnforcePGO) -OfficialBuildId=$(OfficialBuildId) -Priority=$(Priority) -skiprestore -- /p:SignType=$(PB_SignType) /flp:\"v=diag\"",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -368,10 +368,6 @@
     },
     "Architecture": {
       "value": "x64",
-      "allowOverride": true
-    },
-    "ToolsetArgs": {
-      "value": "",
       "allowOverride": true
     },
     "Priority": {

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -86,8 +86,7 @@
         {
           "Name": "DotNet-CoreClr-Trusted-Windows",
           "Parameters": {
-            "Architecture": "arm64",
-            "ToolsetArgs": "toolset_dir C:\\tools\\clr"
+            "Architecture": "arm64"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",

--- a/netci.groovy
+++ b/netci.groovy
@@ -174,9 +174,11 @@ class Constants {
                 'Release'
             ], 
             'arm': [
-                'Checked',
+                'Debug',
+                'Checked'
             ],
             'arm64': [
+                'Debug',
                 'Checked'
             ]
         ],
@@ -2005,7 +2007,12 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
 
                     switch (scenario) {
                         case 'innerloop':
-                            if (configuration == 'Checked') {
+                            if (configuration == 'Debug') {
+                                // Add default PR trigger for Windows arm Debug builds. This is a build only -- no tests are run --
+                                // so the private test hardware is not used. Thus, it can be run by all users, not just arm64Users.
+                                // People in arm64Users will get both this and the Checked Build and Test job.
+                                Utilities.addGithubPRTriggerForBranch(job, branch, contextString)
+                            } else if (configuration == 'Checked') {
                                 Utilities.addDefaultPrivateGithubPRTriggerForBranch(job, branch, contextString, null, arm64Users)
                             }
                             break
@@ -2079,7 +2086,12 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
 
                     switch (scenario) {
                         case 'innerloop':
-                            if (configuration == 'Checked') {
+                            if (configuration == 'Debug') {
+                                // Add default PR trigger for Windows arm64 Debug builds. This is a build only -- no tests are run --
+                                // so the private test hardware is not used. Thus, it can be run by all users, not just arm64Users.
+                                // People in arm64Users will get both this and the Checked Build and Test job.
+                                Utilities.addGithubPRTriggerForBranch(job, branch, contextString)
+                            } else if (configuration == 'Checked') {
                                 Utilities.addDefaultPrivateGithubPRTriggerForBranch(job, branch, contextString, null, arm64Users)
                             }
                             break

--- a/netci.groovy
+++ b/netci.groovy
@@ -708,7 +708,13 @@ def static setMachineAffinity(def job, def os, def architecture, def options = n
         def isBuild = options['use_arm64_build_machine'] == true
 
         if (isBuild == true) {
-            Utilities.setMachineAffinity(job, os, 'latest-arm64')
+            // Current set of machines with private Windows arm64 toolset:
+            // Utilities.setMachineAffinity(job, os, 'latest-arm64')
+            //
+            // New set of machines with public Windows arm64 toolset, coming from Helix:
+            job.with {
+                label('Windows.10.Amd64.ClientRS4.DevEx.Open')
+            }
         } else {
             Utilities.setMachineAffinity(job, os, 'arm64-windows_nt')
         }
@@ -2423,10 +2429,6 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
 
                     def buildOpts = ''
 
-                    if (architecture == 'arm64') {
-                        buildOpts += " toolset_dir C:\\ats2"
-                    }
-
                     if (doCoreFxTesting) {
                         buildOpts += ' skiptests'
                     } else {
@@ -2453,12 +2455,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                         def absoluteFxRoot = "%WORKSPACE%\\_\\fx"
                         def fxBranch = getFxBranch(branch)
 
-                        def toolsetDirOpt = ''
-                        if (architecture == 'arm64') {
-                            toolsetDirOpt = "-toolset_dir C:\\ats2"
-                        }
-
-                        buildCommands += "python -u %WORKSPACE%\\tests\\scripts\\run-corefx-tests.py -arch ${architecture} -ci_arch ${architecture} -build_type ${configuration} -fx_root ${absoluteFxRoot} -fx_branch ${fxBranch} -env_script ${envScriptPath} -no_run_tests ${toolsetDirOpt}"
+                        buildCommands += "python -u %WORKSPACE%\\tests\\scripts\\run-corefx-tests.py -arch ${architecture} -ci_arch ${architecture} -build_type ${configuration} -fx_root ${absoluteFxRoot} -fx_branch ${fxBranch} -env_script ${envScriptPath} -no_run_tests"
 
                         // Zip up the CoreFx runtime and tests. We don't need the CoreCLR binaries; they have been copied to the CoreFX tree.
                         buildCommands += "powershell -NoProfile -Command \"Add-Type -Assembly 'System.IO.Compression.FileSystem'; [System.IO.Compression.ZipFile]::CreateFromDirectory('${workspaceRelativeFxRootWin}\\bin\\testhost\\netcoreapp-Windows_NT-Release-${architecture}', '${workspaceRelativeFxRootWin}\\fxruntime.zip')\"";

--- a/src/ToolBox/SOS/DacTableGen/CMakeLists.txt
+++ b/src/ToolBox/SOS/DacTableGen/CMakeLists.txt
@@ -5,9 +5,13 @@ set(DACTABLEGEN_SOURCES
     MapSymbolProvider.cs
 )
 
-# Cmake does not support csharp sources so add custom command
+# Cmake does not support C# sources so add custom command
+# Disable:
+#   warning CS1668: Invalid search path 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.14.26428\atlmfc\lib\ARM64' specified in 'LIB environment variable' -- 'The system cannot find the path specified. '
+# There are several problems here: (1) the C++ project files are adding non-existent directories to the LIB path, especially for ARM and ARM64,
+# (2) This CSC is invoking the desktop .NET Framework CSC, not the buildtools version.
 add_custom_target(dactablegen ALL 
-    COMMAND csc.exe /t:exe /platform:anycpu32bitpreferred /r:System.dll /r:DiaLib.dll /out:${CMAKE_CURRENT_BINARY_DIR}/dactablegen.exe ${DACTABLEGEN_SOURCES}
+    COMMAND csc.exe /t:exe /platform:anycpu32bitpreferred /r:System.dll /r:DiaLib.dll /nowarn:1668 /out:${CMAKE_CURRENT_BINARY_DIR}/dactablegen.exe ${DACTABLEGEN_SOURCES}
     COMMAND ${CMAKE_COMMAND} -E copy DIAlib.dll ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS ${DACTABLEGEN_SOURCES} DIAlib.dll
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/debug/di/CMakeLists.txt
+++ b/src/debug/di/CMakeLists.txt
@@ -37,28 +37,10 @@ if(WIN32)
     if (CLR_CMAKE_TARGET_ARCH_AMD64 OR CLR_CMAKE_TARGET_ARCH_ARM64 OR CLR_CMAKE_TARGET_ARCH_ARM)
         set(CORDBDI_SOURCES_ASM_FILE ${ARCH_SOURCES_DIR}/floatconversion.asm)
     endif()
-    if (CLR_CMAKE_TARGET_ARCH_AMD64)
-        set(CORDBDI_SOURCES
-          ${CORDBDI_SOURCES}
-          ${CORDBDI_SOURCES_ASM_FILE}
-        )
-    elseif (CLR_CMAKE_TARGET_ARCH_ARM64 AND NOT DEFINED CLR_CROSS_COMPONENTS_BUILD)
-        convert_to_absolute_path(CORDBDI_SOURCES_ASM_FILE ${CORDBDI_SOURCES_ASM_FILE})
-        get_compile_definitions(ASM_DEFINITIONS)
-        set(ASM_OPTIONS /c /Zi /W3 /errorReport:prompt)
-        # asm files require preprocessing using cl.exe on arm64
-        get_filename_component(name ${CORDBDI_SOURCES_ASM_FILE} NAME_WE)
-        set(ASM_PREPROCESSED_FILE ${CMAKE_CURRENT_BINARY_DIR}/${name}.asm)
-        preprocess_def_file(${CORDBDI_SOURCES_ASM_FILE} ${ASM_PREPROCESSED_FILE})
-        set(CORDBDI_SOURCES_WKS_PREPROCESSED_ASM  ${ASM_PREPROCESSED_FILE})
 
-        set_property(SOURCE ${CORDBDI_SOURCES_WKS_PREPROCESSED_ASM} PROPERTY COMPILE_DEFINITIONS ${ASM_DEFINITIONS})
-        set_property(SOURCE ${CORDBDI_SOURCES_WKS_PREPROCESSED_ASM} PROPERTY COMPILE_DEFINITIONS ${ASM_OPTIONS})
-        set(CORDBDI_SOURCES
-              ${CORDBDI_SOURCES}
-              ${CORDBDI_SOURCES_WKS_PREPROCESSED_ASM}
-            )
-    elseif (CLR_CMAKE_TARGET_ARCH_ARM AND NOT DEFINED CLR_CROSS_COMPONENTS_BUILD)
+    if (CLR_CMAKE_TARGET_ARCH_AMD64)
+        set(CORDBDI_SOURCES ${CORDBDI_SOURCES} ${CORDBDI_SOURCES_ASM_FILE})
+    elseif ((CLR_CMAKE_TARGET_ARCH_ARM OR CLR_CMAKE_TARGET_ARCH_ARM64) AND NOT DEFINED CLR_CROSS_COMPONENTS_BUILD)
           convert_to_absolute_path(CORDBDI_SOURCES_ASM_FILE ${CORDBDI_SOURCES_ASM_FILE})  
       
           # Inserts a custom command in CMake build to preprocess each asm source file
@@ -66,15 +48,14 @@ if(WIN32)
           file(TO_CMAKE_PATH "${CMAKE_CURRENT_BINARY_DIR}/${name}.asm" ASM_PREPROCESSED_FILE)
           preprocess_def_file(${CORDBDI_SOURCES_ASM_FILE} ${ASM_PREPROCESSED_FILE})
 
-          # On Arm32, compile the preprocessed binary to .obj
           # We do not pass any defines since we have already done pre-processing above
           set (ASM_CMDLINE "-o ${CMAKE_CURRENT_BINARY_DIR}/${name}.obj ${ASM_PREPROCESSED_FILE}")
 
           # Generate the batch file that will invoke the assembler
-          file(TO_CMAKE_PATH "${CMAKE_CURRENT_BINARY_DIR}/runasm_${name}_${CMAKE_BUILD_TYPE}.cmd" ASM_SCRIPT_FILE)
+          file(TO_CMAKE_PATH "${CMAKE_CURRENT_BINARY_DIR}/runasm_${name}.cmd" ASM_SCRIPT_FILE)
 
           file(GENERATE OUTPUT "${ASM_SCRIPT_FILE}"
-                    CONTENT "\"${CMAKE_ASM_MASM_COMPILER}\" -g ${ASM_INCLUDE_DIRECTORIES} ${ASM_DEFINITIONS} ${ASM_CMDLINE}")
+               CONTENT "\"${CMAKE_ASM_MASM_COMPILER}\" -g ${ASM_CMDLINE}")
 
           message("Generated  - ${ASM_SCRIPT_FILE}")
 

--- a/src/debug/ee/wks/CMakeLists.txt
+++ b/src/debug/ee/wks/CMakeLists.txt
@@ -1,66 +1,63 @@
 if (WIN32)
 
-add_precompiled_header(stdafx.h ../stdafx.cpp CORDBEE_SOURCES_WKS)
+  add_precompiled_header(stdafx.h ../stdafx.cpp CORDBEE_SOURCES_WKS)
 
-get_include_directories(ASM_INCLUDE_DIRECTORIES)
-get_compile_definitions(ASM_DEFINITIONS)
-set(ASM_OPTIONS /c /Zi /W3 /errorReport:prompt)
+  get_include_directories(ASM_INCLUDE_DIRECTORIES)
+  get_compile_definitions(ASM_DEFINITIONS)
 
-if (CLR_CMAKE_PLATFORM_ARCH_I386)
-  list (APPEND ASM_OPTIONS /safeseh)
-endif (CLR_CMAKE_PLATFORM_ARCH_I386)
+  set(ASM_FILE ${CORDBEE_DIR}/${ARCH_SOURCES_DIR}/dbghelpers.asm)
 
-set(ASM_FILE ${CORDBEE_DIR}/${ARCH_SOURCES_DIR}/dbghelpers.asm)
-# asm files require preprocessing using cl.exe on arm64
-if(CLR_CMAKE_PLATFORM_ARCH_ARM64)
+  if(CLR_CMAKE_PLATFORM_ARCH_ARM OR CLR_CMAKE_PLATFORM_ARCH_ARM64)
+
     get_filename_component(name ${ASM_FILE} NAME_WE)
-    set(ASM_PREPROCESSED_FILE ${CMAKE_CURRENT_BINARY_DIR}/${name}.asm)
+    file(TO_CMAKE_PATH "${CMAKE_CURRENT_BINARY_DIR}/${name}.asm" ASM_PREPROCESSED_FILE)
     preprocess_def_file(${ASM_FILE} ${ASM_PREPROCESSED_FILE})
-    set(CORDBEE_SOURCES_WKS_PREPROCESSED_ASM  ${ASM_PREPROCESSED_FILE})
-    set_property(SOURCE ${CORDBEE_SOURCES_WKS_PREPROCESSED_ASM} PROPERTY COMPILE_DEFINITIONS ${ASM_DEFINITIONS})
-    set_property(SOURCE ${CORDBEE_SOURCES_WKS_PREPROCESSED_ASM} PROPERTY COMPILE_DEFINITIONS ${ASM_OPTIONS})
-    add_library_clr(cordbee_wks ${CORDBEE_SOURCES_WKS} ${CORDBEE_SOURCES_WKS_PREPROCESSED_ASM})
-elseif(CLR_CMAKE_PLATFORM_ARCH_ARM)
-    
-    # On Arm32 for Windows, use C++ compiler to process the .asm since it includes C-style headers.
-    set(DBGHELPERS_ASM ${CMAKE_CURRENT_BINARY_DIR}/dbghelpers.asm)
-    set(ASM_OPTIONS " -g ")
-    
-    preprocess_def_file(${ASM_FILE} ${DBGHELPERS_ASM})
-    
+
     # We do not pass any defines since we have already done pre-processing above
-    set (DBGHELPERS_ASM_CMDLINE "-o ${CMAKE_CURRENT_BINARY_DIR}/dbghelpers.obj ${DBGHELPERS_ASM}")
+    set (ASM_CMDLINE "-o ${CMAKE_CURRENT_BINARY_DIR}/${name}.obj ${ASM_PREPROCESSED_FILE}")
 
-    file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/runasm.cmd"
-                CONTENT "\"${CMAKE_ASM_MASM_COMPILER}\" ${ASM_OPTIONS} ${DBGHELPERS_ASM_CMDLINE}")
+    # Generate the batch file that will invoke the assembler
+    file(TO_CMAKE_PATH "${CMAKE_CURRENT_BINARY_DIR}/runasm_${name}.cmd" ASM_SCRIPT_FILE)
+
+    file(GENERATE OUTPUT "${ASM_SCRIPT_FILE}"
+         CONTENT "\"${CMAKE_ASM_MASM_COMPILER}\" -g ${ASM_CMDLINE}")
+
+    message("Generated  - ${ASM_SCRIPT_FILE}")
+
+    # Need to compile asm file using custom command as include directories are not provided to asm compiler
+    add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${name}.obj
+                       COMMAND ${ASM_SCRIPT_FILE}
+                       DEPENDS ${ASM_PREPROCESSED_FILE}
+                       COMMENT "Assembling ${ASM_PREPROCESSED_FILE} - ${ASM_SCRIPT_FILE}")
+
+    add_library_clr(cordbee_wks ${CORDBEE_SOURCES_WKS} ${CMAKE_CURRENT_BINARY_DIR}/${name}.obj)
+
+  else ()
+
+    set(ASM_OPTIONS /c /Zi /W3 /errorReport:prompt)
+
+    if (CLR_CMAKE_PLATFORM_ARCH_I386)
+      list (APPEND ASM_OPTIONS /safeseh)
+    endif (CLR_CMAKE_PLATFORM_ARCH_I386)
 
     # Need to compile asm file using custom command as include directories are not provided to asm compiler
     add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dbghelpers.obj
-                       COMMAND ${CMAKE_CURRENT_BINARY_DIR}/runasm.cmd
-                       DEPENDS ${DBGHELPERS_ASM}
-                       COMMENT "Compiling dbghelpers.asm - ${CMAKE_CURRENT_BINARY_DIR}/runasm.cmd")
-    add_library_clr(cordbee_wks ${CORDBEE_SOURCES_WKS} ${CMAKE_CURRENT_BINARY_DIR}/dbghelpers.obj)
-else ()
-
-    # Need to compile asm file using custom command as include directories are not provided to asm compiler
-    add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dbghelpers.obj
-                         COMMAND ${CMAKE_ASM_MASM_COMPILER} ${ASM_INCLUDE_DIRECTORIES} ${ASM_DEFINITIONS} ${ASM_OPTIONS} /Fo${CMAKE_CURRENT_BINARY_DIR}/dbghelpers.obj /Ta${ASM_FILE}
-                         DEPENDS ${ASM_FILE}
-                         COMMENT "Compiling dbghelpers.asm")
+                       COMMAND ${CMAKE_ASM_MASM_COMPILER} ${ASM_INCLUDE_DIRECTORIES} ${ASM_DEFINITIONS} ${ASM_OPTIONS} /Fo${CMAKE_CURRENT_BINARY_DIR}/dbghelpers.obj /Ta${ASM_FILE}
+                       DEPENDS ${ASM_FILE}
+                       COMMENT "Compiling dbghelpers.asm")
 
     add_library_clr(cordbee_wks ${CORDBEE_SOURCES_WKS} ${CMAKE_CURRENT_BINARY_DIR}/dbghelpers.obj)
-endif(CLR_CMAKE_PLATFORM_ARCH_ARM64)
+
+  endif()
 
 else ()
 
-add_compile_options(-fPIC)
+  add_compile_options(-fPIC)
 
-if(CLR_CMAKE_PLATFORM_ARCH_AMD64 OR CLR_CMAKE_PLATFORM_ARCH_ARM OR CLR_CMAKE_PLATFORM_ARCH_ARM64 OR CLR_CMAKE_PLATFORM_ARCH_I386)
-  add_library_clr(cordbee_wks ${CORDBEE_SOURCES_WKS} ../${ARCH_SOURCES_DIR}/dbghelpers.S)
-elseif(CLR_CMAKE_PLATFORM_ARCH_ARM64)
-  add_library_clr(cordbee_wks ${CORDBEE_SOURCES_WKS} ../${ARCH_SOURCES_DIR}/dbghelpers.S)
-else()
-  message(FATAL_ERROR "Only ARM and AMD64 is supported")
-endif()
+  if(CLR_CMAKE_PLATFORM_ARCH_AMD64 OR CLR_CMAKE_PLATFORM_ARCH_ARM OR CLR_CMAKE_PLATFORM_ARCH_ARM64 OR CLR_CMAKE_PLATFORM_ARCH_I386)
+    add_library_clr(cordbee_wks ${CORDBEE_SOURCES_WKS} ../${ARCH_SOURCES_DIR}/dbghelpers.S)
+  else()
+    message(FATAL_ERROR "Unknown platform")
+  endif()
 
 endif (WIN32)

--- a/src/pal/tools/gen-buildsys-win.bat
+++ b/src/pal/tools/gen-buildsys-win.bat
@@ -1,4 +1,4 @@
-@if not defined __echo @echo off
+@if not defined _echo @echo off
 rem
 rem This file invokes cmake and generates the build system for windows.
 
@@ -22,8 +22,8 @@ set __CmakeGenerator=Visual Studio
 if /i "%__VSVersion%" == "vs2017" (set __CmakeGenerator=%__CmakeGenerator% 15 2017)
 if /i "%__VSVersion%" == "vs2015" (set __CmakeGenerator=%__CmakeGenerator% 14 2015)
 if /i "%__Arch%" == "x64" (set __CmakeGenerator=%__CmakeGenerator% Win64)
-if /i "%__Arch%" == "arm64" (set __CmakeGenerator=%__CmakeGenerator% Win64)
 if /i "%__Arch%" == "arm" (set __CmakeGenerator=%__CmakeGenerator% ARM)
+if /i "%__Arch%" == "arm64" (set __ExtraCmakeParams=%__ExtraCmakeParams% -A ARM64)
 
 if /i "%__NMakeMakefiles%" == "1" (set __CmakeGenerator=NMake Makefiles)
 

--- a/src/vm/wks/CMakeLists.txt
+++ b/src/vm/wks/CMakeLists.txt
@@ -5,22 +5,7 @@ if (WIN32)
   set_source_files_properties(../mscorlib.cpp PROPERTIES COMPILE_FLAGS "/Y-") 
 
   # asm files require preprocessing using cl.exe on arm32 and arm64
-  if(CLR_CMAKE_PLATFORM_ARCH_ARM64)
-
-      foreach(ASM_FILE ${VM_SOURCES_WKS_ARCH_ASM})
-
-          # Preprocess each asm source file
-          get_filename_component(name ${ASM_FILE} NAME_WE)
-          set(ASM_PREPROCESSED_FILE ${CMAKE_CURRENT_BINARY_DIR}/${name}.asm)
-          preprocess_def_file(${ASM_FILE} ${ASM_PREPROCESSED_FILE})
-
-          set(VM_SOURCES_WKS_ARM64_PREPROCESSED_ASM ${VM_SOURCES_WKS_ARM64_PREPROCESSED_ASM} ${ASM_PREPROCESSED_FILE})
-
-      endforeach()
-
-      set(VM_SOURCES_WKS_ARCH_ASM ${VM_SOURCES_WKS_ARM64_PREPROCESSED_ASM})
-
-  elseif(CLR_CMAKE_PLATFORM_ARCH_ARM)
+  if(CLR_CMAKE_PLATFORM_ARCH_ARM OR CLR_CMAKE_PLATFORM_ARCH_ARM64)
 
       get_include_directories_asm(ASM_INCLUDE_DIRECTORIES)
 
@@ -31,15 +16,14 @@ if (WIN32)
           file(TO_CMAKE_PATH "${CMAKE_CURRENT_BINARY_DIR}/${name}.asm" ASM_PREPROCESSED_FILE)
           preprocess_def_file(${ASM_FILE} ${ASM_PREPROCESSED_FILE})
 
-          # On Arm32, compile the preprocessed binary to .obj
           # We do not pass any defines since we have already done pre-processing above
           set (ASM_CMDLINE "-o ${CMAKE_CURRENT_BINARY_DIR}/${name}.obj ${ASM_PREPROCESSED_FILE}")
 
           # Generate the batch file that will invoke the assembler
-          file(TO_CMAKE_PATH "${CMAKE_CURRENT_BINARY_DIR}/runasm_${name}_${CMAKE_BUILD_TYPE}.cmd" ASM_SCRIPT_FILE)
+          file(TO_CMAKE_PATH "${CMAKE_CURRENT_BINARY_DIR}/runasm_${name}.cmd" ASM_SCRIPT_FILE)
 
           file(GENERATE OUTPUT "${ASM_SCRIPT_FILE}"
-                    CONTENT "\"${CMAKE_ASM_MASM_COMPILER}\" -g ${ASM_INCLUDE_DIRECTORIES} ${ASM_DEFINITIONS} ${ASM_CMDLINE}")
+               CONTENT "\"${CMAKE_ASM_MASM_COMPILER}\" -g ${ASM_INCLUDE_DIRECTORIES} ${ASM_CMDLINE}")
 
           message("Generated  - ${ASM_SCRIPT_FILE}")
 
@@ -57,7 +41,7 @@ if (WIN32)
 
       endforeach()
 
-  endif(CLR_CMAKE_PLATFORM_ARCH_ARM64)
+  endif()
 
 endif (WIN32)
 
@@ -65,7 +49,7 @@ add_library_clr(cee_wks ${VM_SOURCES_WKS} ${VM_SOURCES_WKS_ARCH_ASM})
 
 if (WIN32)
 
-  if(NOT CLR_CMAKE_PLATFORM_ARCH_ARM)
+  if(NOT CLR_CMAKE_PLATFORM_ARCH_ARM AND NOT CLR_CMAKE_PLATFORM_ARCH_ARM64)
     # Get the current list of definitions
     get_compile_definitions(DEFINITIONS)
 
@@ -118,6 +102,6 @@ if (WIN32)
 
     add_dependencies(cee_wks asmconstants_inc)
 
-  endif(NOT CLR_CMAKE_PLATFORM_ARCH_ARM)
+  endif(NOT CLR_CMAKE_PLATFORM_ARCH_ARM AND NOT CLR_CMAKE_PLATFORM_ARCH_ARM64)
 
 endif (WIN32)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,23 +14,6 @@ set(CLR_CMAKE_TARGET_ARCH ${CLR_CMAKE_HOST_ARCH})
 set(INC_PLATFORM_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/Common/Platform)
 if (WIN32)
     add_definitions(-DWINDOWS=1)
-
-    if (DEFINED ENV{__ToolsetDir})
-        # Hack for private Tool Set
-        # CMAKE_CXX_COMPILER will default to the compiler installed with
-        # Visual studio. Overwrite it to the compiler on the path.
-
-        find_program(PATH_CXX_COMPILER cl)
-        set(CMAKE_CXX_COMPILER ${PATH_CXX_COMPILER})
-
-        message("Overwriting the CMAKE_CXX_COMPILER.")
-        message("CMAKE_CXX_COMPILER found:${CMAKE_CXX_COMPILER}")
-      
-        # Temporary until cmake has VS generators for hacky toolsets [arm64]
-        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /machine:${CLR_CMAKE_TARGET_ARCH}")
-        set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /machine:${CLR_CMAKE_TARGET_ARCH}")
-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /machine:${CLR_CMAKE_TARGET_ARCH}")
-    endif()
 endif()
 
 # Compile options

--- a/tests/scripts/run-corefx-tests.py
+++ b/tests/scripts/run-corefx-tests.py
@@ -70,7 +70,6 @@ parser.add_argument('-fx_branch', dest='fx_branch', default='master')
 parser.add_argument('-fx_commit', dest='fx_commit', default=None)
 parser.add_argument('-env_script', dest='env_script', default=None)
 parser.add_argument('-no_run_tests', dest='no_run_tests', action="store_true", default=False)
-parser.add_argument('-toolset_dir', dest='toolset_dir', default='c:\\ats2')
 
 
 ##########################################################################
@@ -82,7 +81,7 @@ def validate_args(args):
     Args:
         args (argparser.ArgumentParser): Args parsed by the argument parser.
     Returns:
-        (arch, ci_arch, build_type, clr_root, fx_root, fx_branch, fx_commit, env_script, no_run_tests, toolset_dir)
+        (arch, ci_arch, build_type, clr_root, fx_root, fx_branch, fx_commit, env_script, no_run_tests)
             (str, str, str, str, str, str, str, str, str)
     Notes:
     If the arguments are valid then return them all in a tuple. If not, raise
@@ -98,7 +97,6 @@ def validate_args(args):
     fx_commit = args.fx_commit
     env_script = args.env_script
     no_run_tests = args.no_run_tests
-    toolset_dir = args.toolset_dir
 
     def validate_arg(arg, check):
         """ Validate an individual arg
@@ -144,7 +142,7 @@ def validate_args(args):
         validate_arg(env_script, lambda item: os.path.isfile(env_script))
         env_script = os.path.abspath(env_script)
 
-    args = (arch, ci_arch, build_type, clr_root, fx_root, fx_branch, fx_commit, env_script, no_run_tests, toolset_dir)
+    args = (arch, ci_arch, build_type, clr_root, fx_root, fx_branch, fx_commit, env_script, no_run_tests)
 
     log('Configuration:')
     log(' arch: %s' % arch)
@@ -156,7 +154,6 @@ def validate_args(args):
     log(' fx_commit: %s' % fx_commit)
     log(' env_script: %s' % env_script)
     log(' no_run_tests: %s' % no_run_tests)
-    log(' toolset_dir: %s' % toolset_dir)
 
     return args
 
@@ -218,7 +215,7 @@ def main(args):
     global Unix_name_map
     global testing
 
-    arch, ci_arch, build_type, clr_root, fx_root, fx_branch, fx_commit, env_script, no_run_tests, toolset_dir = validate_args(
+    arch, ci_arch, build_type, clr_root, fx_root, fx_branch, fx_commit, env_script, no_run_tests = validate_args(
         args)
 
     clr_os = 'Windows_NT' if Is_windows else Unix_name_map[os.uname()[0]]
@@ -312,11 +309,6 @@ def main(args):
         # We need to pass "-cross", but we also pass "-portable", which build-native.sh normally
         # passes (there doesn't appear to be a way to pass these individually).
         build_native_args += ' -AdditionalArgs:"-portable -cross"'
-
-    if Is_windows and arch == 'arm64' :
-        # We need to pass toolsetDir to specify the arm64 private toolset.
-        # This is temporary, until private toolset is no longer used. So hard-code the CI toolset dir.
-        build_native_args += ' -ToolSetDir:"toolsetDir=%s"' % toolset_dir
 
     command = ' '.join(('build-native.cmd' if Is_windows else './build-native.sh',
                         config_args,

--- a/tests/src/Interop/CMakeLists.txt
+++ b/tests/src/Interop/CMakeLists.txt
@@ -1,11 +1,10 @@
-
 if(WIN32)
-    if(CLR_CMAKE_HOST_ARCH STREQUAL arm)
+    if((CLR_CMAKE_HOST_ARCH STREQUAL arm) OR (CLR_CMAKE_HOST_ARCH STREQUAL arm64))
         list(APPEND LINK_LIBRARIES_ADDITIONAL
             ole32.lib
             advapi32.lib
         )
-    endif(CLR_CMAKE_HOST_ARCH STREQUAL arm)
+    endif()
 endif(WIN32)
 
 # Consumed by native test assets


### PR DESCRIPTION
Remove support for specifying the toolset directory for arm64,
which was used to point to an internal toolset.

Building for arm64 now works just like the other platforms, e.g.
invoke `build arm64`.

The requirements:
. Visual Studio 2017 Update 4 or later, with ARM64 toolset installed
. Windows SDK 10.0.17134.0 or later
. CMake 3.10 or later