### PR TITLE
[WIP] Fix CSE side effect and definition extraction

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5815,12 +5815,6 @@ protected:
     bool optCSE_canSwap(GenTree* firstNode, GenTree* secondNode);
     bool optCSE_canSwap(GenTree* tree);
 
-    static fgWalkPostFn optPropagateNonCSE;
-    static fgWalkPreFn  optHasNonCSEChild;
-
-    static fgWalkPreFn optUnmarkCSEs;
-    static fgWalkPreFn optHasCSEdefWithSideeffect;
-
     static int __cdecl optCSEcostCmpEx(const void* op1, const void* op2);
     static int __cdecl optCSEcostCmpSz(const void* op1, const void* op2);
 
@@ -5848,7 +5842,6 @@ protected:
     void     optValnumCSE_DataFlow();
     void     optValnumCSE_Availablity();
     void     optValnumCSE_Heuristic();
-    bool optValnumCSE_UnmarkCSEs(GenTree* deadTree, GenTree** wbKeepList);
 
 #endif // FEATURE_VALNUM_CSE
 

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -706,7 +706,6 @@ public:
 // The only requirement of this flag is that it not overlap any of the
 // side-effect flags. The actual bit used is otherwise arbitrary.
 #define GTF_IS_IN_CSE GTF_BOOLEAN
-#define GTF_PERSISTENT_SIDE_EFFECTS_IN_CSE (GTF_ASG | GTF_CALL | GTF_IS_IN_CSE)
 
 // Can any side-effects be observed externally, say by a caller method?
 // For assignments, only assignments to global memory can be observed

--- a/tests/src/JIT/Regression/JitBlue/GitHub_18770/GitHub_18770.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_18770/GitHub_18770.cs
@@ -1,0 +1,116 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    static int Main()
+    {
+        return (Test1.Run() & Test2.Run() & Test3.Run()) ? 100 : -1;
+    }
+}
+
+class Test1
+{
+    class C0
+    {
+        public sbyte F0;
+        public ushort F7;
+        public uint F8;
+    }
+
+    static C0 s_1;
+
+    public static bool Run()
+    {
+        s_1 = new C0();
+        try
+        {
+            M0();
+            return true;
+        }
+        catch (NullReferenceException)
+        {
+            return false;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void M0()
+    {
+#pragma warning disable 1717, 1718
+        bool vr0 = (s_1.F7 < s_1.F0) ^ (s_1.F8 != s_1.F8);
+        if (vr0)
+        {
+            s_1.F7 = s_1.F7;
+        }
+    }
+}
+
+class Test2
+{
+    class C0
+    {
+        public long F0;
+        public C0(long f0)
+        {
+            F0 = f0;
+        }
+    }
+
+    static char s_1;
+    static ulong s_2 = 1;
+    static int s_6;
+    static C0 s_7;
+    static C0 s_9 = new C0(-1L);
+
+    public static bool Run()
+    {
+        s_6 = 0;
+        M1();
+        return s_7.F0 == 0;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void M1()
+    {
+        long vr1 = ((0 & (M2() + s_9.F0)) | s_1) / (long)s_2;
+        s_7 = s_9;
+    }
+
+    static int M2()
+    {
+        s_9 = new C0(0);
+        return s_6;
+    }
+}
+
+class Test3
+{
+    public static bool Run()
+    {
+        try
+        {
+            M5(new ulong[0]);
+            return false;
+        }
+        catch (IndexOutOfRangeException)
+        {
+            return true;
+        }
+        catch (DivideByZeroException)
+        {
+            return false;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static byte M5(ulong[] arg0)
+    {
+        int var0 = (ushort)((0 % arg0[0]) | (byte)(-32768 * (int)(0 & arg0[0])));
+        return (byte)var0;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_18770/GitHub_18770.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_18770/GitHub_18770.csproj
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
When performing CSE on an use both side effects and CSE defs need to be preserved. Their ordering must be preserved as well because side effect trees (as extracted by `gtExtractSideEffList`) may contain CSE defs (potential assignments) and uses. 

However, the current implementation extracts side effects and CSE defs during 2 separate tree traversals and this makes preserving the original order difficult or downright impossible. The implementation contains a workaround for a specific case - a CSE def having a child side effect. Since the side effect tree was already extracted, attempting to also extract the CSE def would result in the side effect tree having multiple uses. The workaround simply rejects CSE in such cases.

Incorrect reordering can still occur as the following example shows:
```
     ( 47, 69)              [000017] ------------              *  STMT      void  (IL 0x000...0x030)
N026 ( 47, 69)              [000016] ---XG-------              \--*  JTRUE     void  
N024 (  1,  1)              [000014] ------------                 |  /--*  CNS_INT   int    0 $82
N025 ( 45, 67)              [000015] J--XG--N----                 \--*  EQ        int    <l:$347, c:$346>
N021 (  8, 15) CSE #02 (use)[000009] ---XG-------                    |     /--*  IND       int    <l:$343, c:$381>
N019 (  1,  1)              [000037] ------------                    |     |  |  /--*  CNS_INT   long   8 field offset Fseq[F8] $1c2
N020 (  6, 13)              [000038] ----G--N----                    |     |  \--*  ADD       byref  <l:$205, c:$206>
N018 (  5, 12) CSE #01 (use)[000008] x---G-------                    |     |     \--*  IND       ref    <l:$140, c:$183>
N017 (  3, 10)              [000039] ------------                    |     |        \--*  CNS_INT(h) long   0x1b210002970 static Fseq[s_1] $100
N022 ( 20, 31)              [000010] ---XG-------                    |  /--*  NE        int    <l:$82, c:$344>
N016 (  8, 15) CSE #02 (def)[000007] ---XG-------                    |  |  \--*  IND       int    <l:$343, c:$380>
N014 (  1,  1)              [000034] ------------                    |  |     |  /--*  CNS_INT   long   8 field offset Fseq[F8] $1c2
N015 (  6, 13)              [000035] ----G--N----                    |  |     \--*  ADD       byref  <l:$205, c:$204>
N013 (  5, 12) CSE #01 (use)[000006] x---G-------                    |  |        \--*  IND       ref    <l:$140, c:$182>
N012 (  3, 10)              [000036] ------------                    |  |           \--*  CNS_INT(h) long   0x1b210002970 static Fseq[s_1] $100
N023 ( 43, 65) CSE #03 (use)[000013] ---XG-------                    \--*  XOR       int    <l:$341, c:$345>
N010 (  9, 16)              [000004] ---XG-------                       |  /--*  IND       byte   <l:$2c1, c:$300>
N008 (  1,  1)              [000031] ------------                       |  |  |  /--*  CNS_INT   long   14 field offset Fseq[F0] $1c1
N009 (  6, 13)              [000032] ----G--N----                       |  |  \--*  ADD       byref  <l:$203, c:$202>
N007 (  5, 12) CSE #01 (use)[000003] x---G-------                       |  |     \--*  IND       ref    <l:$140, c:$181>
N006 (  3, 10)              [000033] ------------                       |  |        \--*  CNS_INT(h) long   0x1b210002970 static Fseq[s_1] $100
N011 ( 22, 33) CSE #03 (def)[000005] ---XG-------                       \--*  LT        int    <l:$341, c:$340>
N005 (  9, 16) CSE #04 (def)[000002] ---XG-------                          \--*  IND       ushort <l:$241, c:$280>
N003 (  1,  1)              [000028] ------------                             |  /--*  CNS_INT   long   12 field offset Fseq[F7] $1c0
N004 (  6, 13)              [000029] ----G--N----                             \--*  ADD       byref  <l:$201, c:$200>
N002 (  5, 12) CSE #01 (def)[000001] x---G-------                                \--*  IND       ref    <l:$140, c:$180>
N001 (  3, 10)              [000030] ------------                                   \--*  CNS_INT(h) long   0x1b210002970 static Fseq[s_1] $100
```
Performing CSE on use #03 first extracts the LT subtree due to it having an assignment side effect (the assignment just introduced for CSE #03 def). The remaining NE subtree has a CSE def (CSE #02) that will be extracted separately and appended to the side effect list. This yields:
```
This CSE use has side effects and/or nested CSE defs. The sideEffectList:
N010 (  9, 16)              [000004] ---XG-------                    /--*  IND       byte   <l:$2c1, c:$300>
N008 (  1,  1)              [000031] ------------                    |  |  /--*  CNS_INT   long   14 field offset Fseq[F0] $1c1
N009 (  6, 13)              [000032] ----G--N----                    |  \--*  ADD       byref  <l:$203, c:$202>
N007 (  5, 12) CSE #01 (use)[000003] x---G-------                    |     \--*  IND       ref    <l:$140, c:$181>
N006 (  3, 10)              [000033] ------------                    |        \--*  CNS_INT(h) long   0x1b210002970 static Fseq[s_1] $100
N011 ( 22, 33)              [000005] ---XG-------                 /--*  LT        int    <l:$341, c:$340>
N005 (  9, 16) CSE #04 (def)[000002] ---XG-------                 |  \--*  IND       ushort <l:$241, c:$280>
N003 (  1,  1)              [000028] ------------                 |     |  /--*  CNS_INT   long   12 field offset Fseq[F7] $1c0
N004 (  6, 13)              [000029] ----G--N----                 |     \--*  ADD       byref  <l:$201, c:$200>
N002 (  5, 12) CSE #01 (def)[000001] x---G-------                 |        \--*  IND       ref    <l:$140, c:$180>
N001 (  3, 10)              [000030] ------------                 |           \--*  CNS_INT(h) long   0x1b210002970 static Fseq[s_1] $100
N013 ( 22, 33)              [000047] -A-XG---R---              /--*  ASG       int    $VN.Void
N012 (  1,  1)              [000046] D------N----              |  \--*  LCL_VAR   int    V01 cse0          <l:$341, c:$340>
                            [000051] -A-XG-------              *  COMMA     void   $VN.Void
N020 (  8, 15) CSE #02 (def)[000007] ---XG-------              \--*  IND       int    <l:$343, c:$380>
N018 (  1,  1)              [000034] ------------                 |  /--*  CNS_INT   long   8 field offset Fseq[F8] $1c2
N019 (  6, 13)              [000035] ----G--N----                 \--*  ADD       byref  <l:$205, c:$204>
N017 (  5, 12) CSE #01 (use)[000006] x---G-------                    \--*  IND       ref    <l:$140, c:$182>
N016 (  3, 10)              [000036] ------------                       \--*  CNS_INT(h) long   0x1b210002970 static Fseq[s_1] $100
```
But these 2 trees are now in reverse order so CSE use #01 occurs before CSE def #01.

The only reasonable way to preserve the correct order seems to be extracting side effects and CSE defs at the same time, during a single tree traversal. `gtExtractSideEffList` can be extended rather easily to also look at CSE defs when the already existing `GTF_IS_IN_CSE` is specified. Additionally, CSE uses can be unmarked during the same traversal, avoiding the need for another traversal that needs to look at removed trees.

While working on this I noticed that `optPropagateNonCSE` and `optHasNonCSEChild` were not used so I deleted them. I also deleted `GTF_PERSISTENT_SIDE_EFFECTS_IN_CSE`, it's used only in 2 places and it's IMO more confusing than ORing `GTF_IS_IN_CSE` explicitly.

Fixes #18770 