### PR TITLE
Enable Windows ARM32 and ARM64 Debug builds as default PR triggered

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -174,9 +174,11 @@ class Constants {
                 'Release'
             ], 
             'arm': [
-                'Checked',
+                'Debug',
+                'Checked'
             ],
             'arm64': [
+                'Debug',
                 'Checked'
             ]
         ],
@@ -1990,7 +1992,12 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
 
                     switch (scenario) {
                         case 'innerloop':
-                            if (configuration == 'Checked') {
+                            if (configuration == 'Debug') {
+                                // Add default PR trigger for Windows arm Debug builds. This is a build only -- no tests are run --
+                                // so the private test hardware is not used. Thus, it can be run by all users, not just arm64Users.
+                                // People in arm64Users will get both this and the Checked Build and Test job.
+                                Utilities.addGithubPRTriggerForBranch(job, branch, contextString)
+                            } else if (configuration == 'Checked') {
                                 Utilities.addDefaultPrivateGithubPRTriggerForBranch(job, branch, contextString, null, arm64Users)
                             }
                             break
@@ -2064,7 +2071,12 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
 
                     switch (scenario) {
                         case 'innerloop':
-                            if (configuration == 'Checked') {
+                            if (configuration == 'Debug') {
+                                // Add default PR trigger for Windows arm64 Debug builds. This is a build only -- no tests are run --
+                                // so the private test hardware is not used. Thus, it can be run by all users, not just arm64Users.
+                                // People in arm64Users will get both this and the Checked Build and Test job.
+                                Utilities.addGithubPRTriggerForBranch(job, branch, contextString)
+                            } else if (configuration == 'Checked') {
                                 Utilities.addDefaultPrivateGithubPRTriggerForBranch(job, branch, contextString, null, arm64Users)
                             }
                             break


### PR DESCRIPTION
These will be PR triggered for all users, not just those on the
arm64Users list. Since these are Build only, and do no testing,
with the change to use public VS2017 build tools, they can be run
by anyone.

Users on the arm64Users list will still get Checked Build and Test
jobs, which require using the private test machines.