### PR TITLE
Switch to using MicrosoftNETCorePlatformsPackageVersion 

### DIFF
--- a/tests/dir.sdkbuild.props
+++ b/tests/dir.sdkbuild.props
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <RuntimeFrameworkVersion>$(MicrosoftNETCoreRuntimeCoreCLRPackageVersion)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>$(MicrosoftNETCorePlatformsPackageVersion)</RuntimeFrameworkVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
    

--- a/tests/runtest.proj
+++ b/tests/runtest.proj
@@ -80,7 +80,7 @@ $(_XunitEpilog)
 
   <PropertyGroup>
     <OutputPath>$(XUnitTestBinBase)\$(CategoryWithSlash)</OutputPath>
-    <RuntimeFrameworkVersion>$(MicrosoftNETCoreRuntimeCoreCLRPackageVersion)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>$(MicrosoftNETCorePlatformsPackageVersion)</RuntimeFrameworkVersion>
  </PropertyGroup>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />


### PR DESCRIPTION
Switch to using MicrosoftNETCorePlatformsPackageVersion as the RuntimeFrameworkVersion parameter in the test wrappers and SDK props file.

Ensures there is always the correct version of netcoreapp selected during restore + build, and prevents the tests from failing to build because they were restored against a different version.