### PR TITLE
Reupload signed packages to intermediate Azure drop

### DIFF
--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -198,6 +198,26 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "Reupload signed packages to Azure",
+      "timeoutInMinutes": 0,
+      "condition": "and(succeeded(), eq(variables.ConfigurationGroup, 'Release'))",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "msbuild",
+        "arguments": "src\\publish.proj /p:CloudDropAccountName=$(CloudDropAccountName) /p:CloudDropAccessToken=$(CloudDropAccessToken) /p:ContainerName=$(Label) /p:OverwriteOnPublish=true",
+        "workingFolder": "$(Pipeline.SourcesDirectory)",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
       "displayName": "packages -> dotnet.myget.org",
       "condition": "and(succeeded(), eq(variables.ConfigurationGroup, 'Release'), ne(variables.PB_SecurityBuild, 'true'))",
       "timeoutInMinutes": 0,


### PR DESCRIPTION
Part of dotnet/core-eng#3872.

We want all package drops to contain signed packages - right now, the intermediate Azure drops wind up containing unsigned packages, which can cause issues during the final Nuget.org push.

@weshaggard @dagood @MattGal PTAL