### PR TITLE
Enable Tiered Compilation by default

### DIFF
--- a/Documentation/project-docs/clr-configuration-knobs.md
+++ b/Documentation/project-docs/clr-configuration-knobs.md
@@ -17,7 +17,7 @@ Name | Description | Type
 
 ## Environment/Registry Configuration Knobs
 
-This table was machine-generated using `clr-configuration-knobs.csx` script from repository commit [8611986](https://github.com/dotnet/coreclr/commit/861198647dc232ecaf05b4a8e2f10605e7a22537) on 4/30/2018. It might be out of date. To generate latest documentation run `{dotnet} csi clr-configuration-knobs.csx` from this file directory.
+This table was machine-generated using `clr-configuration-knobs.csx` script from repository commit [79aadb8](https://github.com/dotnet/coreclr/commit/79aadb8c6455e30065cbd817e3ec5b52d17f3dce) on 6/12/2018. It might be out of date. To generate latest documentation run `{dotnet} csi clr-configuration-knobs.csx` from this file directory.
 
 When using these configurations from environment variables, the variables need to have the `COMPlus_` prefix in their names. e.g. To set DumpJittedMethods to 1, add the environment variable `COMPlus_DumpJittedMethods=1`.
 
@@ -769,8 +769,7 @@ Name | Description | Type | Class | Default Value | Flags
 
 Name | Description | Type | Class | Default Value | Flags 
 -----|-------------|------|-------|---------------|-------
-`EXPERIMENTAL_TieredCompilation` | Deprecated - Use COMPLUS_TieredCompilation | `DWORD` | `UNSUPPORTED` | `0` | 
-`TieredCompilation` | Enables tiered compilation | `DWORD` | `EXTERNAL` | `0` | 
+`TieredCompilation` | Enables tiered compilation | `DWORD` | `EXTERNAL` | `1` | 
 `TieredCompilation_Test_CallCounting` | Enabled by default (only activates when TieredCompilation is also enabled). If disabled immediately backpatches prestub, and likely prevents any tier1 promotion | `DWORD` | `UNSUPPORTED` | `1` | 
 `TieredCompilation_Test_OptimizeTier0` | Use optimized codegen (normally used by tier1) in tier0 | `DWORD` | `UNSUPPORTED` | `0` | 
 `TieredCompilation_Tier1CallCountingDelayMs` | Delay in milliseconds since process startup or the last tier 0 JIT before call counting begins for tier 1 promotion. | `DWORD` | `UNSUPPORTED` | `100` | 

--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -650,8 +650,7 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_HillClimbing_GainExponent,                    
 /// Tiered Compilation
 ///
 #ifdef FEATURE_TIERED_COMPILATION
-RETAIL_CONFIG_DWORD_INFO(EXTERNAL_TieredCompilation, W("TieredCompilation"), 0, "Enables tiered compilation")
-RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_LEGACY_TieredCompilation, W("EXPERIMENTAL_TieredCompilation"), 0, "Deprecated - Use COMPLUS_TieredCompilation")
+RETAIL_CONFIG_DWORD_INFO(EXTERNAL_TieredCompilation, W("TieredCompilation"), 1, "Enables tiered compilation")
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_TieredCompilation_Tier1CallCountThreshold, W("TieredCompilation_Tier1CallCountThreshold"), 30, "Number of times a method must be called after which it is promoted to tier 1.")
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_TieredCompilation_Tier1CallCountingDelayMs, W("TieredCompilation_Tier1CallCountingDelayMs"), 100, "A perpetual delay in milliseconds that is applied to tier 1 call counting and jitting, while there is tier 0 activity.")
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_TieredCompilation_Tier1DelaySingleProcMultiplier, W("TieredCompilation_Tier1DelaySingleProcMultiplier"), 10, "Multiplier for TieredCompilation_Tier1CallCountingDelayMs that is applied on a single-processor machine or when the process is affinitized to a single processor.")

--- a/src/vm/eeconfig.cpp
+++ b/src/vm/eeconfig.cpp
@@ -1237,9 +1237,7 @@ HRESULT EEConfig::sync()
     dwSleepOnExit = CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_SleepOnExit);
 
 #if defined(FEATURE_TIERED_COMPILATION)
-    fTieredCompilation = Configuration::GetKnobBooleanValue(W("System.Runtime.TieredCompilation"), CLRConfig::EXTERNAL_TieredCompilation) ||
-        //this older name is deprecated, but still accepted for a time. Preserving it is a very small overhead not to needlessly break things.
-        CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_LEGACY_TieredCompilation) != 0;
+    fTieredCompilation = Configuration::GetKnobBooleanValue(W("System.Runtime.TieredCompilation"), CLRConfig::EXTERNAL_TieredCompilation) != 0;
 
     fTieredCompilation_CallCounting = CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_TieredCompilation_Test_CallCounting) != 0;
     fTieredCompilation_OptimizeTier0 = CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_TieredCompilation_Test_OptimizeTier0) != 0;

--- a/src/vm/tieredcompilation.cpp
+++ b/src/vm/tieredcompilation.cpp
@@ -20,15 +20,6 @@
 // handles logistics of getting new code created and installed.
 //
 //
-// # Current feature state
-//
-// This feature is a work in progress. It should be functionally correct for a 
-// good range of scenarios, but performance varies by scenario. To enable it
-// you need to set COMPLUS_TieredCompilation = 1. This feature has been
-// tested with all of our runtime and CoreFX functional tests, as well as
-// diagnostics tests and various partner testing in Visual Studio. 
-//
-//
 // # Important entrypoints in this code:
 //
 // 

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -85,6 +85,7 @@ if /i "%1" == "CoreFXTestsAll"        (set __CoreFXTests=true&set __CoreFXTestsR
 if /i "%1" == "CoreFXTestList"        (set __CoreFXTests=true&set __CoreFXTestList=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "runcrossgentests"      (set RunCrossGen=true&shift&goto Arg_Loop)
 if /i "%1" == "link"                  (set DoLink=true&set ILLINK=%2&shift&shift&goto Arg_Loop)
+REM tieredcompilation is on by default now, but setting this environment variable is harmless and I didn't want to break any automation that might be using it just yet
 if /i "%1" == "tieredcompilation"     (set COMPLUS_TieredCompilation=1&shift&goto Arg_Loop)
 if /i "%1" == "gcname"                (set COMPlus_GCName=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "timeout"               (set __TestTimeout=%2&shift&shift&goto Arg_Loop)

--- a/tests/scripts/run-xunit-perf.py
+++ b/tests/scripts/run-xunit-perf.py
@@ -457,8 +457,9 @@ def main(args):
     # Set up environment for running tests
     if optLevel == 'min_opts':
         myEnv['COMPlus_JITMinOpts'] = '1'
-    elif optLevel == 'tiered':
-        myEnv['COMPLUS_TieredCompilation'] = '1'
+        myEnv['COMPLUS_TieredCompilation'] = '0'
+    elif optLevel == 'full_opt':
+        myEnv['COMPLUS_TieredCompilation'] = '0'
 
     if not 'XUNIT_PERFORMANCE_MAX_ITERATION' in myEnv:
         myEnv['XUNIT_PERFORMANCE_MAX_ITERATION'] = '21'

--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -81,11 +81,17 @@ then
   exit $(GCBashScriptExitCode)
 fi
       ]]></BashCLRTestEnvironmentCompatibilityCheck>
-      <BashCLRTestEnvironmentCompatibilityCheck Condition="'$(JitOptimizationSensitive)' == 'true'"><![CDATA[
+      <BashCLRTestEnvironmentCompatibilityCheck Condition="'$(JitOptimizationSensitive)' == 'true'">
+    <![CDATA[
 $(BashCLRTestEnvironmentCompatibilityCheck)
-if [[ ( ! -z "$COMPlus_JitStress" ) || ( ! -z "$COMPlus_JitStressRegs" ) || ( ! -z "$COMPlus_JITMinOpts" ) || ( ! -z "$COMPlus_TailcallStress" ) || ( ! -z "$COMPlus_EXPERIMENTAL_TieredCompilation" ) || ( ! -z "$COMPlus_TieredCompilation" ) ]]
+if [[ ( ! -z "$COMPlus_JitStress" ) || ( ! -z "$COMPlus_JitStressRegs" ) || ( ! -z "$COMPlus_JITMinOpts" ) || ( ! -z "$COMPlus_TailcallStress" ) ]]
 then
-  echo "SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts, COMPlus_TailcallStress, COMPlus_EXPERIMENTAL_TieredCompilation, COMPlus_TieredCompilation) IS SET"
+  echo "SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts, COMPlus_TailcallStress) IS SET"
+  exit $(GCBashScriptExitCode)
+fi
+if [[ "$COMPlus_TieredCompilation" != "0" ]]
+then
+  echo "SKIPPING EXECUTION BECAUSE COMPlus_TieredCompilation has not been disabled and this test is marked JitOptimizationSensitive"
   exit $(GCBashScriptExitCode)
 fi
       ]]></BashCLRTestEnvironmentCompatibilityCheck>

--- a/tests/src/CLRTest.Execute.Batch.targets
+++ b/tests/src/CLRTest.Execute.Batch.targets
@@ -76,13 +76,19 @@ IF NOT "%COMPlus_GCStress%"=="" (
   Exit /b 0
 )
       ]]></BatchCLRTestEnvironmentCompatibilityCheck>
-      <BatchCLRTestEnvironmentCompatibilityCheck Condition="'$(JitOptimizationSensitive)' == 'true'"><![CDATA[
+      <BatchCLRTestEnvironmentCompatibilityCheck Condition="'$(JitOptimizationSensitive)' == 'true'">
+    <![CDATA[
 $(BatchCLRTestEnvironmentCompatibilityCheck)
-IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_JITMinOpts%"=="" IF "%COMPlus_TailcallStress%"=="" IF "%COMPlus_EXPERIMENTAL_TieredCompilation%"=="" IF "%COMPlus_TieredCompilation%"=="" goto :Compatible1
-  ECHO SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts, COMPlus_TailcallStress, COMPlus_EXPERIMENTAL_TieredCompilation, COMPlus_TieredCompilation) IS SET
+IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_JITMinOpts%"=="" IF "%COMPlus_TailcallStress%"=="" IF "%COMPlus_TieredCompilation%"=="" goto :Compatible1
+  ECHO SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts, COMPlus_TailcallStress, COMPlus_TieredCompilation) IS SET
   popd
   Exit /b 0
 :Compatible1
+IF "%COMPlus_TieredCompilation%"=="0" goto :Compatible2
+  ECHO SKIPPING EXECUTION BECAUSE COMPlus_TieredCompilation has not been disabled and this test is marked JitOptimizationSensitive
+  popd
+  Exit /b 0
+:Compatible2
       ]]></BatchCLRTestEnvironmentCompatibilityCheck>
       <BatchCLRTestEnvironmentCompatibilityCheck Condition="'$(HeapVerifyIncompatible)' == 'true'"><![CDATA[
 $(BatchCLRTestEnvironmentCompatibilityCheck)

--- a/tests/src/baseservices/exceptions/stacktrace/Tier1StackTrace.csproj
+++ b/tests/src/baseservices/exceptions/stacktrace/Tier1StackTrace.csproj
@@ -19,15 +19,5 @@
   <ItemGroup>
     <Compile Include="Tier1StackTrace.cs" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/tests/src/performance/Scenario/JitBench/Runner/BenchmarkConfiguration.cs
+++ b/tests/src/performance/Scenario/JitBench/Runner/BenchmarkConfiguration.cs
@@ -15,9 +15,9 @@ namespace JitBench
         public string Name { get; set; }
         public Dictionary<string, string> EnvironmentVariables { get; private set; }
 
-        public BenchmarkConfiguration WithTiering()
+        public BenchmarkConfiguration WithoutTiering()
         {
-            return WithModifier("Tiering", "COMPLUS_TieredCompilation", "1");
+            return WithModifier("NoTiering", "COMPLUS_TieredCompilation", "0");
         }
 
         public BenchmarkConfiguration WithMinOpts()

--- a/tests/src/performance/Scenario/JitBench/Runner/Program.cs
+++ b/tests/src/performance/Scenario/JitBench/Runner/Program.cs
@@ -168,15 +168,15 @@ namespace JitBench
             string r2rEnv = Environment.GetEnvironmentVariable("COMPLUS_ReadyToRun");
             string ngenEnv = Environment.GetEnvironmentVariable("COMPLUS_ZapDisable");
             BenchmarkConfiguration envConfig = new BenchmarkConfiguration();
-            if(tieredEnv != null && tieredEnv != "0")
+            if(tieredEnv != null && tieredEnv == "0")
             {
-                envConfig.WithTiering();
+                envConfig.WithoutTiering();
             }
             if (minoptsEnv != null && minoptsEnv != "0")
             {
                 envConfig.WithMinOpts();
             }
-            if(r2rEnv != null && r2rEnv != "1")
+            if(r2rEnv != null && r2rEnv == "0")
             {
                 envConfig.WithNoR2R();
             }
@@ -199,10 +199,10 @@ namespace JitBench
             BenchmarkConfiguration[] possibleConfigs = new BenchmarkConfiguration[]
             {
                 new BenchmarkConfiguration(),
-                new BenchmarkConfiguration().WithTiering(),
-                new BenchmarkConfiguration().WithMinOpts(),
-                new BenchmarkConfiguration().WithNoR2R(),
-                new BenchmarkConfiguration().WithNoNgen()
+                new BenchmarkConfiguration().WithoutTiering(),
+                new BenchmarkConfiguration().WithoutTiering().WithMinOpts(),
+                new BenchmarkConfiguration().WithoutTiering().WithNoR2R(),
+                new BenchmarkConfiguration().WithoutTiering().WithNoNgen()
             };
             foreach(string configName in configNames)
             {

--- a/tests/src/reflection/Tier1Collectible/Tier1Collectible.csproj
+++ b/tests/src/reflection/Tier1Collectible/Tier1Collectible.csproj
@@ -18,15 +18,5 @@
   <ItemGroup>
     <Compile Include="Tier1Collectible.cs" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
1) Changes the default state of the tiered compilation feature check to be ON BY DEFAULT
2) Removed comments about the source about this being a work in progress. Although it will surely continue to evolve and improve, remaining issues would be better tracked in our issue tracking system with the same default presumption as other runtime features - assume it works unless noted otherwise.
3) Adjusts a number of tests and automated scripts that made assumptions that the default setting of this feature is off.
4) Stop accepting the deprecated env var COMPLUS_EXPERIMENTAL_TieredCompilation. I'm not aware it has any remaining usage but if so we're going to find out.