### PR TITLE
Fix batch syntax error in help text

### DIFF
--- a/build-test.cmd
+++ b/build-test.cmd
@@ -506,7 +506,7 @@ echo     ubuntu.16.04-x64: Builds overlay for Ubuntu 16.04
 echo     ubuntu.16.10-x64: Builds overlay for Ubuntu 16.10
 echo     win-x64: Builds overlay for portable Windows
 echo     win7-x64: Builds overlay for Windows 7
-echo ziptests: zips CoreCLR tests & Core_Root for a Helix run
+echo ziptests: zips CoreCLR tests and Core_Root for a Helix run
 echo crossgen: Precompiles the framework managed assemblies
 echo Exclude- Optional parameter - specify location of default exclusion file (defaults to tests\issues.targets if not specified)
 echo     Set to "" to disable default exclusion file.


### PR DESCRIPTION
Was trying to read the help text to see the options for building and noticed this:
```
    win-x64: Builds overlay for portable Windows
    win7-x64: Builds overlay for Windows 7
ziptests: zips CoreCLR tests
'Core_Root' is not recognized as an internal or external command,
operable program or batch file.
crossgen: Precompiles the framework managed assemblies
```