### PR TITLE
Temporarily flag a SIMD test as optimization-sensitive

### DIFF
--- a/tests/src/JIT/SIMD/VectorExp_ro.csproj
+++ b/tests/src/JIT/SIMD/VectorExp_ro.csproj
@@ -21,6 +21,8 @@
   <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
+    <!-- Temporarily flagged as optimization-sensitive due to https://github.com/dotnet/coreclr/issues/19124 -->
+    <JitOptimizationSensitive>True</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />


### PR DESCRIPTION
The test runs in several PR-triggered jobs. It fails with minopts and once tiering is enabled it would fail in every PR. See https://github.com/dotnet/coreclr/issues/19124.

CC @dotnet/jit-contrib 