### PR TITLE
Allow republishing of signed packages to Azure during official builds

### DIFF
--- a/src/publish.proj
+++ b/src/publish.proj
@@ -20,10 +20,7 @@
     <Error Condition="'@(ForPublishing)' == ''" Text="No items were found matching pattern '$(PublishPattern)'." />
   </Target>
 
-  <PropertyGroup>
-    <PublishPattern Condition="'$(PublishPattern)' == ''">$(PackagesBinDir)**\*.nupkg</PublishPattern>
-  </PropertyGroup>
-
+  <!-- Set up publish patterns for "final" package publish - that is, the pipeline packages we download & publish to myget during official builds -->
   <PropertyGroup>
     <PackageDownloadDirectory Condition="'$(DownloadDirectory)' == ''">$(PackagesDir)AzureTransfer\$(ConfigurationGroup)</PackageDownloadDirectory>
     <FinalPublishPattern>$(PackageDownloadDirectory)\**\*.nupkg</FinalPublishPattern>
@@ -31,6 +28,13 @@
     <FinalSymbolsPackagesPattern>$(PackageDownloadDirectory)\**\*.symbols.nupkg</FinalSymbolsPackagesPattern>
     <!-- The SignFiles target needs OutDir to be defined -->
     <OutDir>$(PackageDownloadDirectory)</OutDir>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- If we're re-publishing signed final packages, use the location of the downloaded pipeline packages -->
+    <PublishPattern Condition="'$(PublishPattern)' == '' and '$(RepublishSignedFinalPackages)' == 'true'">$(FinalPublishPattern)</PublishPattern>
+    <!-- Otherwise, publish the packages built locally -->
+    <PublishPattern Condition="'$(PublishPattern)' == ''">$(PackagesBinDir)**\*.nupkg</PublishPattern>
   </PropertyGroup>
 
   <Target Name="GetPackagesToSign">


### PR DESCRIPTION
This will allow us to push the signed packages back into intermediate Azure storage.

Will also require adding a step in https://devdiv.visualstudio.com/DefaultCollection/DevDiv/DevDiv%20Team/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=4181 to run `msbuild src\publish.proj /p:CloudDropAccountName=$(CloudDropAccountName) /p:CloudDropAccessToken=$(CloudDropAccessToken) /p:ContainerName=$(Label) /p:OverwriteOnPublish=true /p:RepublishSignedFinalPackages=true` (This is the same definition we use for CoreFx 1.1.0, so I'll only have to make this change once)

@weshaggard @dagood PTAL