### PR TITLE
Fix compiler warnings in test wrapper generation

### DIFF
--- a/tests/runtest.proj
+++ b/tests/runtest.proj
@@ -256,7 +256,7 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
                     {
                         sErrorText = System.IO.File.ReadAllText(errorFile)%3B
                     }
-                    catch(Exception ex)
+                    catch(Exception)
                     {
                       sErrorText = "Unable to read error file: " + errorFile%3B
                     }
@@ -268,7 +268,7 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
                         outputText = outputReader.ReadToEnd()%3B
                         outputReader.Close()%3B
                     }
-                    catch(Exception ex)
+                    catch(Exception)
                     {
                         outputText = "Unable to read output file: " + outputFile%3B
                     }


### PR DESCRIPTION
There were lots of warnings like the following:
```
Loader.classloader.XUnitWrapper.cs(96333,37): warning CS0168: The variable 'ex' is declared but never used
```