### PR TITLE
Lowering: Atomic ops can produce a value

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1289,13 +1289,12 @@ void Lowering::LowerArg(GenTreeCall* call, GenTree** ppArg)
     // They are setting up temporary locals that will later be placed into
     // outgoing regs or stack.
     // Note that atomic ops may be stores and still produce a value.
-    if ((arg->OperIsStore() && !arg->IsValue()) || arg->IsArgPlaceHolderNode() || arg->IsNothingNode() ||
-        arg->OperIsCopyBlkOp())
+    if (!arg->IsValue())
     {
-        assert(!arg->IsValue());
+        assert((arg->OperIsStore() && !arg->IsValue()) || arg->IsArgPlaceHolderNode() || arg->IsNothingNode() ||
+               arg->OperIsCopyBlkOp());
         return;
     }
-    assert(arg->IsValue());
 
     fgArgTabEntry* info = comp->gtArgEntryByNode(call, arg);
     assert(info->node == arg);
@@ -5301,13 +5300,12 @@ void Lowering::DoPhase()
 //
 void Lowering::CheckCallArg(GenTree* arg)
 {
-    if ((arg->OperIsStore() && !arg->IsValue()) || arg->IsArgPlaceHolderNode() || arg->IsNothingNode() ||
-        arg->OperIsCopyBlkOp())
+    if (!arg->IsValue() && !arg->OperIsPutArgStk())
     {
-        assert(!arg->IsValue());
+        assert((arg->OperIsStore() && !arg->IsValue()) || arg->IsArgPlaceHolderNode() || arg->IsNothingNode() ||
+               arg->OperIsCopyBlkOp());
         return;
     }
-    assert(arg->IsValue() || arg->OperIsPutArgStk());
 
     switch (arg->OperGet())
     {

--- a/tests/src/JIT/Regression/JitBlue/GitHub_19171/GitHub_19171.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_19171/GitHub_19171.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+using System;
+using System.Threading;
+using System.Runtime.CompilerServices;
+public class GitHub_19171
+{
+    public static long g_static = -1;
+    public static int returnVal = 100;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool checkResult(long result)
+    {
+        return(result == g_static);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Function(long value)
+    {
+        g_static = value;
+
+        if (!checkResult(Interlocked.Read(ref g_static)))
+        {
+            returnVal = -1;
+        }
+    }
+    public static int Main()
+    {
+        Function(7);
+        Function(11);
+        Function(0x123456789abcdefL);
+        return returnVal;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_19171/GitHub_19171.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_19171/GitHub_19171.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{ADEEA3D1-B67B-456E-8F2B-6DCCACC2D34C}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
#18887 changed OperIsStore to include the atomic functions, but `Lowering::LowerArg()` and `Lowering::CheckCallArg()` assume that stores do not produce a value, so it doesn't correctly set the argument register (or build a `PUTARG_REG`) for the case where the result of an atomic op is passed to a call.
Fix this and add additional asserts.

Fix #19171