### PR TITLE
Expose the x86 HWIntrinsics via a set of class hierarchies matching the underlying ISA hierarchies

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Aes.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Aes.PlatformNotSupported.cs
@@ -11,10 +11,12 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel AES hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Aes 
+    public abstract class Aes : Sse2
     {
-        public static bool IsSupported { get { return false; } }
-        
+        internal Aes() { }
+
+        public new static bool IsSupported { get { return false; } }
+
         /// <summary>
         /// __m128i _mm_aesdec_si128 (__m128i a, __m128i RoundKey)
         ///   AESDEC xmm, xmm/m128

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Aes.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Aes.cs
@@ -11,10 +11,12 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel AES hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Aes 
+    public abstract class Aes : Sse2
     {
-        public static bool IsSupported { get => IsSupported; }
-        
+        internal Aes() { }
+
+        public new static bool IsSupported { get => IsSupported; }
+
         /// <summary>
         /// __m128i _mm_aesdec_si128 (__m128i a, __m128i RoundKey)
         ///   AESDEC xmm, xmm/m128

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx.PlatformNotSupported.cs
@@ -11,10 +11,12 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel AVX hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Avx
+    public abstract class Avx : Sse42
     {
-        public static bool IsSupported { get { return false; } }
-        
+        internal Avx() { }
+
+        public new static bool IsSupported { get { return false; } }
+
         /// <summary>
         /// __m256 _mm256_add_ps (__m256 a, __m256 b)
         ///   VADDPS ymm, ymm, ymm/m256

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx.cs
@@ -12,9 +12,11 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel AVX hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Avx
+    public abstract class Avx : Sse42
     {
-        public static bool IsSupported { get => IsSupported; }
+        internal Avx() { }
+
+        public new static bool IsSupported { get => IsSupported; }
 
         /// <summary>
         /// __m256 _mm256_add_ps (__m256 a, __m256 b)
@@ -468,7 +470,7 @@ namespace System.Runtime.Intrinsics.X86
                 return LoadVector256(buffer);
             }
         }
-        
+
         /// <summary>
         /// __m256i _mm256_insert_epi16 (__m256i a, __int16 i, const int index)
         ///   HELPER
@@ -516,7 +518,7 @@ namespace System.Runtime.Intrinsics.X86
                 return LoadVector256(buffer);
             }
         }
-        
+
         /// <summary>
         /// __m256i _mm256_insert_epi32 (__m256i a, __int32 i, const int index)
         ///   HELPER

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx2.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx2.PlatformNotSupported.cs
@@ -11,9 +11,11 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel AVX2 hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Avx2
+    public abstract class Avx2 : Avx
     {
-        public static bool IsSupported { get { return false; } }
+        internal Avx2() { }
+
+        public new static bool IsSupported { get { return false; } }
 
         /// <summary>
         /// __m256i _mm256_abs_epi8 (__m256i a)
@@ -455,7 +457,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
         ///   VEXTRACTI128 m128, ymm, imm8
         /// </summary>
-        public static unsafe void ExtractVector128(sbyte* address, Vector256<sbyte> value, byte index) { throw new PlatformNotSupportedException(); }
+        public new static unsafe void ExtractVector128(sbyte* address, Vector256<sbyte> value, byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
@@ -466,7 +468,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
         ///   VEXTRACTI128 m128, ymm, imm8
         /// </summary>
-        public static unsafe void ExtractVector128(byte* address, Vector256<byte> value, byte index) { throw new PlatformNotSupportedException(); }
+        public new static unsafe void ExtractVector128(byte* address, Vector256<byte> value, byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
@@ -477,7 +479,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
         ///   VEXTRACTI128 m128, ymm, imm8
         /// </summary>
-        public static unsafe void ExtractVector128(short* address, Vector256<short> value, byte index) { throw new PlatformNotSupportedException(); }
+        public new static unsafe void ExtractVector128(short* address, Vector256<short> value, byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
@@ -488,7 +490,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
         ///   VEXTRACTI128 m128, ymm, imm8
         /// </summary>
-        public static unsafe void ExtractVector128(ushort* address, Vector256<ushort> value, byte index) { throw new PlatformNotSupportedException(); }
+        public new static unsafe void ExtractVector128(ushort* address, Vector256<ushort> value, byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
@@ -499,7 +501,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
         ///   VEXTRACTI128 m128, ymm, imm8
         /// </summary>
-        public static unsafe void ExtractVector128(int* address, Vector256<int> value, byte index) { throw new PlatformNotSupportedException(); }
+        public new static unsafe void ExtractVector128(int* address, Vector256<int> value, byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
@@ -510,7 +512,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
         ///   VEXTRACTI128 m128, ymm, imm8
         /// </summary>
-        public static unsafe void ExtractVector128(uint* address, Vector256<uint> value, byte index) { throw new PlatformNotSupportedException(); }
+        public new static unsafe void ExtractVector128(uint* address, Vector256<uint> value, byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
@@ -521,7 +523,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
         ///   VEXTRACTI128 m128, ymm, imm8
         /// </summary>
-        public static unsafe void ExtractVector128(long* address, Vector256<long> value, byte index) { throw new PlatformNotSupportedException(); }
+        public new static unsafe void ExtractVector128(long* address, Vector256<long> value, byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
@@ -532,7 +534,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
         ///   VEXTRACTI128 m128, ymm, imm8
         /// </summary>
-        public static unsafe void ExtractVector128(ulong* address, Vector256<ulong> value, byte index) { throw new PlatformNotSupportedException(); }
+        public new static unsafe void ExtractVector128(ulong* address, Vector256<ulong> value, byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm_i32gather_epi32 (int const* base_addr, __m128i vindex, const int scale)
@@ -819,7 +821,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
         ///   VINSERTI128 ymm, ymm, xm128, imm8
         /// </summary>
-        public static unsafe Vector256<sbyte> InsertVector128(Vector256<sbyte> value, sbyte* address, byte index) { throw new PlatformNotSupportedException(); }
+        public new static unsafe Vector256<sbyte> InsertVector128(Vector256<sbyte> value, sbyte* address, byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
@@ -830,7 +832,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
         ///   VINSERTI128 ymm, ymm, m128, imm8
         /// </summary>
-        public static unsafe Vector256<byte> InsertVector128(Vector256<byte> value, byte* address, byte index) { throw new PlatformNotSupportedException(); }
+        public new static unsafe Vector256<byte> InsertVector128(Vector256<byte> value, byte* address, byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
@@ -841,7 +843,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
         ///   VINSERTI128 ymm, ymm, m128, imm8
         /// </summary>
-        public static unsafe Vector256<short> InsertVector128(Vector256<short> value, short* address, byte index) { throw new PlatformNotSupportedException(); }
+        public new static unsafe Vector256<short> InsertVector128(Vector256<short> value, short* address, byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
@@ -852,7 +854,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
         ///   VINSERTI128 ymm, ymm, m128, imm8
         /// </summary>
-        public static unsafe Vector256<ushort> InsertVector128(Vector256<ushort> value, ushort* address, byte index) { throw new PlatformNotSupportedException(); }
+        public new static unsafe Vector256<ushort> InsertVector128(Vector256<ushort> value, ushort* address, byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
@@ -863,7 +865,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
         ///   VINSERTI128 ymm, ymm, m128, imm8
         /// </summary>
-        public static unsafe Vector256<int> InsertVector128(Vector256<int> value, int* address, byte index) { throw new PlatformNotSupportedException(); }
+        public new static unsafe Vector256<int> InsertVector128(Vector256<int> value, int* address, byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
@@ -874,7 +876,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
         ///   VINSERTI128 ymm, ymm, m128, imm8
         /// </summary>
-        public static unsafe Vector256<uint> InsertVector128(Vector256<uint> value, uint* address, byte index) { throw new PlatformNotSupportedException(); }
+        public new static unsafe Vector256<uint> InsertVector128(Vector256<uint> value, uint* address, byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
@@ -885,7 +887,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
         ///   VINSERTI128 ymm, ymm, m128, imm8
         /// </summary>
-        public static unsafe Vector256<long> InsertVector128(Vector256<long> value, long* address, byte index) { throw new PlatformNotSupportedException(); }
+        public new static unsafe Vector256<long> InsertVector128(Vector256<long> value, long* address, byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
@@ -896,7 +898,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
         ///   VINSERTI128 ymm, ymm, m128, imm8
         /// </summary>
-        public static unsafe Vector256<ulong> InsertVector128(Vector256<ulong> value, ulong* address, byte index) { throw new PlatformNotSupportedException(); }
+        public new static unsafe Vector256<ulong> InsertVector128(Vector256<ulong> value, ulong* address, byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m256i _mm256_stream_load_si256 (__m256i const* mem_addr)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx2.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx2.cs
@@ -11,9 +11,11 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel AVX2 hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Avx2
+    public abstract class Avx2 : Avx
     {
-        public static bool IsSupported { get => IsSupported; }
+        internal Avx2() { }
+
+        public new static bool IsSupported { get => IsSupported; }
 
         /// <summary>
         /// __m256i _mm256_abs_epi8 (__m256i a)
@@ -461,7 +463,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
         ///   VEXTRACTI128 m128, ymm, imm8
         /// </summary>
-        public static unsafe void ExtractVector128(sbyte* address, Vector256<sbyte> value, byte index) => ExtractVector128(address, value, index);
+        public new static unsafe void ExtractVector128(sbyte* address, Vector256<sbyte> value, byte index) => ExtractVector128(address, value, index);
 
         /// <summary>
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
@@ -472,7 +474,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
         ///   VEXTRACTI128 m128, ymm, imm8
         /// </summary>
-        public static unsafe void ExtractVector128(byte* address, Vector256<byte> value, byte index) => ExtractVector128(address, value, index);
+        public new static unsafe void ExtractVector128(byte* address, Vector256<byte> value, byte index) => ExtractVector128(address, value, index);
 
         /// <summary>
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
@@ -483,7 +485,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
         ///   VEXTRACTI128 m128, ymm, imm8
         /// </summary>
-        public static unsafe void ExtractVector128(short* address, Vector256<short> value, byte index) => ExtractVector128(address, value, index);
+        public new static unsafe void ExtractVector128(short* address, Vector256<short> value, byte index) => ExtractVector128(address, value, index);
 
         /// <summary>
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
@@ -494,7 +496,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
         ///   VEXTRACTI128 m128, ymm, imm8
         /// </summary>
-        public static unsafe void ExtractVector128(ushort* address, Vector256<ushort> value, byte index) => ExtractVector128(address, value, index);
+        public new static unsafe void ExtractVector128(ushort* address, Vector256<ushort> value, byte index) => ExtractVector128(address, value, index);
 
         /// <summary>
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
@@ -505,7 +507,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
         ///   VEXTRACTI128 m128, ymm, imm8
         /// </summary>
-        public static unsafe void ExtractVector128(int* address, Vector256<int> value, byte index) => ExtractVector128(address, value, index);
+        public new static unsafe void ExtractVector128(int* address, Vector256<int> value, byte index) => ExtractVector128(address, value, index);
 
         /// <summary>
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
@@ -516,7 +518,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
         ///   VEXTRACTI128 m128, ymm, imm8
         /// </summary>
-        public static unsafe void ExtractVector128(uint* address, Vector256<uint> value, byte index) => ExtractVector128(address, value, index);
+        public new static unsafe void ExtractVector128(uint* address, Vector256<uint> value, byte index) => ExtractVector128(address, value, index);
 
         /// <summary>
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
@@ -527,7 +529,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
         ///   VEXTRACTI128 m128, ymm, imm8
         /// </summary>
-        public static unsafe void ExtractVector128(long* address, Vector256<long> value, byte index) => ExtractVector128(address, value, index);
+        public new static unsafe void ExtractVector128(long* address, Vector256<long> value, byte index) => ExtractVector128(address, value, index);
 
         /// <summary>
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
@@ -538,7 +540,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
         ///   VEXTRACTI128 m128, ymm, imm8
         /// </summary>
-        public static unsafe void ExtractVector128(ulong* address, Vector256<ulong> value, byte index) => ExtractVector128(address, value, index);
+        public new static unsafe void ExtractVector128(ulong* address, Vector256<ulong> value, byte index) => ExtractVector128(address, value, index);
 
         /// <summary>
         /// __m128i _mm_i32gather_epi32 (int const* base_addr, __m128i vindex, const int scale)
@@ -825,7 +827,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
         ///   VINSERTI128 ymm, ymm, xm128, imm8
         /// </summary>
-        public static unsafe Vector256<sbyte> InsertVector128(Vector256<sbyte> value, sbyte* address, byte index) => InsertVector128(value, address, index);
+        public new static unsafe Vector256<sbyte> InsertVector128(Vector256<sbyte> value, sbyte* address, byte index) => InsertVector128(value, address, index);
 
         /// <summary>
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
@@ -836,7 +838,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
         ///   VINSERTI128 ymm, ymm, m128, imm8
         /// </summary>
-        public static unsafe Vector256<byte> InsertVector128(Vector256<byte> value, byte* address, byte index) => InsertVector128(value, address, index);
+        public new static unsafe Vector256<byte> InsertVector128(Vector256<byte> value, byte* address, byte index) => InsertVector128(value, address, index);
 
         /// <summary>
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
@@ -847,7 +849,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
         ///   VINSERTI128 ymm, ymm, m128, imm8
         /// </summary>
-        public static unsafe Vector256<short> InsertVector128(Vector256<short> value, short* address, byte index) => InsertVector128(value, address, index);
+        public new static unsafe Vector256<short> InsertVector128(Vector256<short> value, short* address, byte index) => InsertVector128(value, address, index);
 
         /// <summary>
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
@@ -858,7 +860,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
         ///   VINSERTI128 ymm, ymm, m128, imm8
         /// </summary>
-        public static unsafe Vector256<ushort> InsertVector128(Vector256<ushort> value, ushort* address, byte index) => InsertVector128(value, address, index);
+        public new static unsafe Vector256<ushort> InsertVector128(Vector256<ushort> value, ushort* address, byte index) => InsertVector128(value, address, index);
 
         /// <summary>
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
@@ -869,7 +871,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
         ///   VINSERTI128 ymm, ymm, m128, imm8
         /// </summary>
-        public static unsafe Vector256<int> InsertVector128(Vector256<int> value, int* address, byte index) => InsertVector128(value, address, index);
+        public new static unsafe Vector256<int> InsertVector128(Vector256<int> value, int* address, byte index) => InsertVector128(value, address, index);
 
         /// <summary>
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
@@ -880,7 +882,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
         ///   VINSERTI128 ymm, ymm, m128, imm8
         /// </summary>
-        public static unsafe Vector256<uint> InsertVector128(Vector256<uint> value, uint* address, byte index) => InsertVector128(value, address, index);
+        public new static unsafe Vector256<uint> InsertVector128(Vector256<uint> value, uint* address, byte index) => InsertVector128(value, address, index);
 
         /// <summary>
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
@@ -891,7 +893,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
         ///   VINSERTI128 ymm, ymm, m128, imm8
         /// </summary>
-        public static unsafe Vector256<long> InsertVector128(Vector256<long> value, long* address, byte index) => InsertVector128(value, address, index);
+        public new static unsafe Vector256<long> InsertVector128(Vector256<long> value, long* address, byte index) => InsertVector128(value, address, index);
 
         /// <summary>
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
@@ -902,7 +904,7 @@ namespace System.Runtime.Intrinsics.X86
         /// __m256i _mm256_inserti128_si256 (__m256i a, __m128i b, const int imm8)
         ///   VINSERTI128 ymm, ymm, m128, imm8
         /// </summary>
-        public static unsafe Vector256<ulong> InsertVector128(Vector256<ulong> value, ulong* address, byte index) => InsertVector128(value, address, index);
+        public new static unsafe Vector256<ulong> InsertVector128(Vector256<ulong> value, ulong* address, byte index) => InsertVector128(value, address, index);
 
         /// <summary>
         /// __m256i _mm256_stream_load_si256 (__m256i const* mem_addr)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Bmi1.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Bmi1.PlatformNotSupported.cs
@@ -11,8 +11,10 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel BMI1 hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Bmi1
+    public abstract class Bmi1
     {
+        internal Bmi1() { }
+
         public static bool IsSupported { get { return false; } }
 
         /// <summary>
@@ -46,7 +48,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   BEXTR r64a, reg/m64, r64b
         /// </summary>
         public static ulong BitFieldExtract(ulong value, ushort control) { throw new PlatformNotSupportedException(); }
-        
+
         /// <summary>
         /// unsigned int _blsi_u32 (unsigned int a)
         ///   BLSI reg, reg/m32
@@ -68,7 +70,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   BLSMSK reg, reg/m64
         /// </summary>
         public static ulong GetMaskUpToLowestSetBit(ulong value) { throw new PlatformNotSupportedException(); }
-        
+
         /// <summary>
         /// unsigned int _blsr_u32 (unsigned int a)
         ///   BLSR reg, reg/m32

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Bmi1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Bmi1.cs
@@ -11,8 +11,10 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel BMI1 hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Bmi1
+    public abstract class Bmi1
     {
+        internal Bmi1() { }
+
         public static bool IsSupported { get => IsSupported; }
 
         /// <summary>
@@ -46,7 +48,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   BEXTR r64a, reg/m64, r64b
         /// </summary>
         public static ulong BitFieldExtract(ulong value, ushort control) => BitFieldExtract(value, control);
-        
+
         /// <summary>
         /// unsigned int _blsi_u32 (unsigned int a)
         ///   BLSI reg, reg/m32
@@ -68,7 +70,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   BLSMSK reg, reg/m64
         /// </summary>
         public static ulong GetMaskUpToLowestSetBit(ulong value) => GetMaskUpToLowestSetBit(value);
-        
+
         /// <summary>
         /// unsigned int _blsr_u32 (unsigned int a)
         ///   BLSR reg, reg/m32

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Bmi2.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Bmi2.PlatformNotSupported.cs
@@ -11,8 +11,10 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel BMI2 hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Bmi2
+    public abstract class Bmi2
     {
+        internal Bmi2() { }
+
         public static bool IsSupported { get { return false; } }
 
         /// <summary>
@@ -57,6 +59,6 @@ namespace System.Runtime.Intrinsics.X86
         /// unsigned __int64 _pext_u64 (unsigned __int64 a, unsigned __int64 mask)
         ///   PEXT r64a, r64b, reg/m64
         /// </summary>
-        public static ulong ParallelBitExtract(ulong value, ulong mask) { throw new PlatformNotSupportedException(); }        
+        public static ulong ParallelBitExtract(ulong value, ulong mask) { throw new PlatformNotSupportedException(); }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Bmi2.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Bmi2.cs
@@ -11,8 +11,10 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel BMI2 hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Bmi2
+    public abstract class Bmi2
     {
+        internal Bmi2() { }
+
         public static bool IsSupported { get => IsSupported; }
 
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Enums.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Enums.cs
@@ -95,7 +95,7 @@ namespace System.Runtime.Intrinsics.X86
         /// _CMP_LT_OQ
         /// </summary>
         LessThanOrderedNonSignaling = 17,
-        
+
         /// <summary>
         /// _CMP_LE_OQ
         /// </summary>
@@ -132,17 +132,17 @@ namespace System.Runtime.Intrinsics.X86
         EqualUnorderedSignaling = 24,
 
         /// <summary>
-        /// _CMP_NGE_UQ 
+        /// _CMP_NGE_UQ
         /// </summary>
         NotGreaterThanOrEqualUnorderedNonSignaling = 25,
 
         /// <summary>
-        /// _CMP_NGT_UQ 
+        /// _CMP_NGT_UQ
         /// </summary>
         NotGreaterThanUnorderedNonSignaling = 26,
 
         /// <summary>
-        /// _CMP_FALSE_OS 
+        /// _CMP_FALSE_OS
         /// </summary>
         FalseOrderedSignaling = 27,
 

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Fma.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Fma.PlatformNotSupported.cs
@@ -10,9 +10,11 @@ namespace System.Runtime.Intrinsics.X86
     /// <summary>
     /// This class provides access to Intel FMA hardware instructions via intrinsics
     /// </summary>
-    public static class Fma
+    public abstract class Fma : Avx
     {
-        public static bool IsSupported { get { return false; } }
+        internal Fma() { }
+
+        public new static bool IsSupported { get { return false; } }
 
         /// <summary>
         /// __m128 _mm_fmadd_ps (__m128 a, __m128 b, __m128 c)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Fma.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Fma.cs
@@ -10,9 +10,11 @@ namespace System.Runtime.Intrinsics.X86
     /// <summary>
     /// This class provides access to Intel FMA hardware instructions via intrinsics
     /// </summary>
-    public static class Fma
+    public abstract class Fma : Avx
     {
-        public static bool IsSupported { get => IsSupported; }
+        internal Fma() { }
+
+        public new static bool IsSupported { get => IsSupported; }
 
         /// <summary>
         /// __m128 _mm_fmadd_ps (__m128 a, __m128 b, __m128 c)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Lzcnt.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Lzcnt.PlatformNotSupported.cs
@@ -10,8 +10,10 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel LZCNT hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Lzcnt
+    public abstract class Lzcnt
     {
+        internal Lzcnt() { }
+
         public static bool IsSupported { get { return false; } }
 
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Lzcnt.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Lzcnt.cs
@@ -11,8 +11,10 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel LZCNT hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Lzcnt
+    public abstract class Lzcnt
     {
+        internal Lzcnt() { }
+
         public static bool IsSupported { get => IsSupported; }
 
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Pclmulqdq.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Pclmulqdq.PlatformNotSupported.cs
@@ -11,9 +11,11 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel PCLMULQDQ hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Pclmulqdq
+    public abstract class Pclmulqdq : Sse2
     {
-        public static bool IsSupported { get { return false; } }
+        internal Pclmulqdq() { }
+
+        public new static bool IsSupported { get { return false; } }
 
         /// <summary>
         /// __m128i _mm_clmulepi64_si128 (__m128i a, __m128i b, const int imm8)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Pclmulqdq.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Pclmulqdq.cs
@@ -11,9 +11,11 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel PCLMULQDQ hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Pclmulqdq
+    public abstract class Pclmulqdq : Sse2
     {
-        public static bool IsSupported { get => IsSupported; }
+        internal Pclmulqdq() { }
+
+        public new static bool IsSupported { get => IsSupported; }
 
         /// <summary>
         /// __m128i _mm_clmulepi64_si128 (__m128i a, __m128i b, const int imm8)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Popcnt.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Popcnt.PlatformNotSupported.cs
@@ -10,9 +10,11 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel POPCNT hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Popcnt
+    public abstract class Popcnt : Sse42
     {
-        public static bool IsSupported { get { return false; } }
+        internal Popcnt() { }
+
+        public new static bool IsSupported { get { return false; } }
 
         /// <summary>
         /// int _mm_popcnt_u32 (unsigned int a)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Popcnt.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Popcnt.cs
@@ -11,9 +11,11 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel POPCNT hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Popcnt
+    public abstract class Popcnt : Sse42
     {
-        public static bool IsSupported { get => IsSupported; }
+        internal Popcnt() { }
+
+        public new static bool IsSupported { get => IsSupported; }
 
         /// <summary>
         /// int _mm_popcnt_u32 (unsigned int a)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse.PlatformNotSupported.cs
@@ -11,8 +11,10 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel SSE hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Sse
+    public abstract class Sse
     {
+        internal Sse() { }
+
         public static bool IsSupported { get { return false; } }
 
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse.cs
@@ -12,8 +12,10 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel SSE hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Sse
+    public abstract class Sse
     {
+        internal Sse() { }
+
         public static bool IsSupported { get => IsSupported; }
 
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse2.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse2.PlatformNotSupported.cs
@@ -11,10 +11,12 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel SSE2 hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Sse2
+    public abstract class Sse2 : Sse
     {
-        public static bool IsSupported { get { return false; } }
-        
+        internal Sse2() { }
+
+        public new static bool IsSupported { get { return false; } }
+
                 /// <summary>
         /// __m128i _mm_add_epi8 (__m128i a,  __m128i b)
         ///   PADDB xmm, xmm/m128

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse2.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse2.cs
@@ -12,9 +12,11 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel SSE2 hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Sse2
+    public abstract class Sse2 : Sse
     {
-        public static bool IsSupported { get => IsSupported; }
+        internal Sse2() { }
+
+        public new static bool IsSupported { get => IsSupported; }
 
         /// <summary>
         /// __m128i _mm_add_epi8 (__m128i a,  __m128i b)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse3.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse3.PlatformNotSupported.cs
@@ -11,10 +11,12 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel SSE3 hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Sse3
+    public abstract class Sse3 : Sse2
     {
-        public static bool IsSupported { get { return false; } }
-        
+        internal Sse3() { }
+
+        public new static bool IsSupported { get { return false; } }
+
         /// <summary>
         /// __m128 _mm_addsub_ps (__m128 a, __m128 b)
         ///   ADDSUBPS xmm, xmm/m128

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse3.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse3.cs
@@ -11,10 +11,12 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel SSE3 hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Sse3
+    public abstract class Sse3 : Sse2
     {
-        public static bool IsSupported { get => IsSupported; }
-        
+        internal Sse3() { }
+
+        public new static bool IsSupported { get => IsSupported; }
+
         /// <summary>
         /// __m128 _mm_addsub_ps (__m128 a, __m128 b)
         ///   ADDSUBPS xmm, xmm/m128

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse41.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse41.PlatformNotSupported.cs
@@ -11,9 +11,11 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel SSE4.1 hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Sse41
+    public abstract class Sse41 : Ssse3
     {
-        public static bool IsSupported { get { return false; } }
+        internal Sse41() { }
+
+        public new static bool IsSupported { get { return false; } }
 
         /// <summary>
         /// __m128i _mm_blend_epi16 (__m128i a, __m128i b, const int imm8)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse41.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse41.cs
@@ -11,10 +11,12 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel SSE4.1 hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Sse41
+    public abstract class Sse41 : Ssse3
     {
-        public static bool IsSupported { get => IsSupported; }
-        
+        internal Sse41() { }
+
+        public new static bool IsSupported { get => IsSupported; }
+
         /// <summary>
         /// __m128i _mm_blend_epi16 (__m128i a, __m128i b, const int imm8)
         ///   PBLENDW xmm, xmm/m128 imm8

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse42.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse42.PlatformNotSupported.cs
@@ -11,9 +11,11 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel SSE4.2 hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Sse42
+    public abstract class Sse42 : Sse41
     {
-        public static bool IsSupported { get { return false; } }
+        internal Sse42() { }
+
+        public new static bool IsSupported { get { return false; } }
 
         /// <summary>
         /// int _mm_cmpistra (__m128i a, __m128i b, const int imm8)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse42.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse42.cs
@@ -11,9 +11,11 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel SSE4.2 hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Sse42
+    public abstract class Sse42 : Sse41
     {
-        public static bool IsSupported { get => IsSupported; }
+        internal Sse42() { }
+
+        public new static bool IsSupported { get => IsSupported; }
 
         /// <summary>
         /// int _mm_cmpistra (__m128i a, __m128i b, const int imm8)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Ssse3.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Ssse3.PlatformNotSupported.cs
@@ -11,10 +11,12 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel SSSE3 hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Ssse3
+    public abstract class Ssse3 : Sse3
     {
-        public static bool IsSupported { get { return false; } }
-        
+        internal Ssse3() { }
+
+        public new static bool IsSupported { get { return false; } }
+
         /// <summary>
         /// __m128i _mm_abs_epi8 (__m128i a)
         ///   PABSB xmm, xmm/m128

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Ssse3.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Ssse3.cs
@@ -11,10 +11,12 @@ namespace System.Runtime.Intrinsics.X86
     /// This class provides access to Intel SSSE3 hardware instructions via intrinsics
     /// </summary>
     [CLSCompliant(false)]
-    public static class Ssse3
+    public abstract class Ssse3 : Sse3
     {
-        public static bool IsSupported { get => IsSupported; }
-        
+        internal Ssse3() { }
+
+        public new static bool IsSupported { get => IsSupported; }
+
         /// <summary>
         /// __m128i _mm_abs_epi8 (__m128i a)
         ///   PABSB xmm, xmm/m128


### PR DESCRIPTION
This implements https://github.com/dotnet/corefx/issues/29247 -- It was indicated that we would like to move forward with this.