### PR TITLE
build-test - fix ilasm warnings caused by missing/incorrect extern assembly declarations

### DIFF
--- a/tests/src/JIT/Directed/Convert/ldind_conv.il
+++ b/tests/src/JIT/Directed/Convert/ldind_conv.il
@@ -2,6 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+.assembly extern mscorlib
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 2:0:0:0
+}
+
 .assembly extern System.Private.CoreLib { auto }
 .assembly test { }
 
@@ -3022,7 +3028,7 @@
 
 FAIL:
     ldstr "FAILED"
-    call void Program::print(class [System.Private.CoreLib]System.String)    
+    call void Program::print(class [System.Private.CoreLib]System.String)
     ldc.i4 1
     ret
   }

--- a/tests/src/JIT/Directed/Convert/ldind_conv.il
+++ b/tests/src/JIT/Directed/Convert/ldind_conv.il
@@ -2,13 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-.assembly extern mscorlib
-{
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
-  .ver 2:0:0:0
-}
 
+.assembly extern mscorlib { auto }
 .assembly extern System.Private.CoreLib { auto }
+
 .assembly test { }
 
 .class auto Program extends [System.Private.CoreLib]System.Object

--- a/tests/src/JIT/Directed/Misc/function_pointer/MutualThdRecur-fptr.il
+++ b/tests/src/JIT/Directed/Misc/function_pointer/MutualThdRecur-fptr.il
@@ -7,6 +7,13 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+
+.assembly extern System.Threading.Thread
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern legacy library mscorlib {}
 .assembly mutualthdrecurfptr
 {

--- a/tests/src/JIT/Directed/Misc/function_pointer/MutualThdRecur-fptr.il
+++ b/tests/src/JIT/Directed/Misc/function_pointer/MutualThdRecur-fptr.il
@@ -2,19 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
 
-.assembly extern System.Threading.Thread
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Console { auto }
+.assembly extern System.Threading.Thread { auto }
+.assembly extern legacy library mscorlib { auto }
 
-.assembly extern legacy library mscorlib {}
 .assembly mutualthdrecurfptr
 {
 }

--- a/tests/src/JIT/Directed/pinvoke/preemptive_cooperative.il
+++ b/tests/src/JIT/Directed/pinvoke/preemptive_cooperative.il
@@ -3,26 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 
-
 .module extern kernel32.dll
+.assembly extern System.Console { auto }
+.assembly extern System.Threading.Thread { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern System.Threading.Thread
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern mscorlib
-{
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
-  .ver 4:0:0:0
-}
 .assembly preemptive_cooperative
 {
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 )

--- a/tests/src/JIT/Directed/pinvoke/preemptive_cooperative.il
+++ b/tests/src/JIT/Directed/pinvoke/preemptive_cooperative.il
@@ -11,16 +11,23 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+
+.assembly extern System.Threading.Thread
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
   .ver 4:0:0:0
 }
 .assembly preemptive_cooperative
 {
-  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
-  .custom instance void [mscorlib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   
-                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 )
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78
+                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
@@ -28,8 +35,8 @@
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
-.subsystem 0x0003       
-.corflags 0x00000001    
+.subsystem 0x0003
+.corflags 0x00000001
 
 
 
@@ -39,7 +46,7 @@
   .field private static class [mscorlib]System.Threading.EventWaitHandle e1
   .field private static class [mscorlib]System.Threading.EventWaitHandle e2
   .field private static object modreq([mscorlib]System.Runtime.CompilerServices.IsVolatile) garbage
-  .method private hidebysig specialname rtspecialname 
+  .method private hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     .maxstack  8
@@ -52,9 +59,9 @@
     IL_0012:  nop
     IL_0013:  nop
     IL_0014:  ret
-  } 
+  }
 
-  .method family hidebysig virtual instance void 
+  .method family hidebysig virtual instance void
           Finalize() cil managed
   {
     .maxstack  1
@@ -67,17 +74,17 @@
       IL_000c:  nop
       IL_000d:  leave.s    IL_0017
 
-    }  
+    }
     finally
     {
       IL_000f:  ldarg.0
       IL_0010:  call       instance void [mscorlib]System.Object::Finalize()
       IL_0015:  nop
       IL_0016:  endfinally
-    }  
+    }
     IL_0017:  nop
     IL_0018:  ret
-  } 
+  }
 
   .method private hidebysig static void  CreateGarbage() cil managed noinlining
   {
@@ -108,13 +115,13 @@
     IL_005a:  volatile.
     IL_005c:  stsfld     object modreq([mscorlib]System.Runtime.CompilerServices.IsVolatile) Repro::garbage
     IL_0061:  ret
-  } 
+  }
 
-  .method private hidebysig static pinvokeimpl("kernel32.dll" as "WaitForSingleObject" nomangle winapi) 
+  .method private hidebysig static pinvokeimpl("kernel32.dll" as "WaitForSingleObject" nomangle winapi)
           uint32 modopt([mscorlib]System.Runtime.CompilerServices.IsJitIntrinsic) atoi(native int handle,
                        uint32 dwMilliseconds) cil managed preservesig
   {
-    .custom instance void [mscorlib]System.Security.SuppressUnmanagedCodeSecurityAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Security.SuppressUnmanagedCodeSecurityAttribute::.ctor() = ( 01 00 00 00 )
   }
   .method private hidebysig static void  GCHole() cil managed
   {
@@ -144,7 +151,7 @@
     IL_0040:  call       void [System.Console]System.Console::WriteLine(object)
     IL_0045:  nop
     IL_0046:  ret
-  } 
+  }
 
   .method private hidebysig static void  Trigger() cil managed
   {
@@ -171,9 +178,9 @@
     IL_003f:  callvirt   instance bool [mscorlib]System.Threading.EventWaitHandle::Set()
     IL_0044:  pop
     IL_0045:  ret
-  } 
+  }
 
-  .method private hidebysig static int32 
+  .method private hidebysig static int32
           Main() cil managed
   {
     .entrypoint
@@ -201,9 +208,9 @@
 
     IL_002c:  ldloc.1
     IL_002d:  ret
-  } 
+  }
 
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     .maxstack  8
@@ -221,6 +228,6 @@
     IL_0019:  volatile.
     IL_001b:  stsfld     object modreq([mscorlib]System.Runtime.CompilerServices.IsVolatile) Repro::garbage
     IL_0020:  ret
-  } 
+  }
 
-} 
+}

--- a/tests/src/JIT/Directed/tailcall/tailcall.il
+++ b/tests/src/JIT/Directed/tailcall/tailcall.il
@@ -11,14 +11,21 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
   .ver 2:0:0:0
 }
 .assembly tailcall
 {
-  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 )
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
@@ -26,26 +33,26 @@
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
-.subsystem 0x0003       
-.corflags 0x00000001    
+.subsystem 0x0003
+.corflags 0x00000001
 
 
 
 .class interface private abstract auto ansi IFace1
 {
-  .method public hidebysig newslot abstract virtual 
+  .method public hidebysig newslot abstract virtual
           instance int32  Recurse3(int32 depth) cil managed
   {
-  } 
+  }
 
-  .method public hidebysig newslot abstract virtual 
+  .method public hidebysig newslot abstract virtual
           instance int32  Recurse4(int32 depth,
                                    object o1,
                                    object o2) cil managed
   {
-  } 
+  }
 
-} 
+}
 
 .class public auto ansi beforefieldinit Class1
        extends [mscorlib]System.Object
@@ -54,7 +61,7 @@
   .field private static int32 MaxDepth
   .field private static int32 Expected
   .field private int32 'value'
-  .method public hidebysig instance int32 
+  .method public hidebysig instance int32
           Recurse1(int32 depth) cil managed
   {
     .maxstack  5
@@ -98,9 +105,9 @@
                                                          object,
                                                          object)
     IL_0044:  ret
-  } 
+  }
 
-  .method public hidebysig instance int32 
+  .method public hidebysig instance int32
           Recurse2(int32 depth,
                    object o1,
                    object o2) cil managed
@@ -122,7 +129,7 @@
     IL_0014:  ldc.i4.s   100
     IL_0016:  bne.un.s   IL_0051
 
-    IL_0018:  call       string [system.runtime.extensions]System.Environment::get_StackTrace()
+    IL_0018:  call       string [System.Runtime.Extensions]System.Environment::get_StackTrace()
     IL_001d:  stloc.0
     IL_001e:  ldloc.0
     IL_001f:  ldstr      "Main"
@@ -138,7 +145,7 @@
     IL_003c:  ldstr      "Test Failed"
     IL_0041:  call       void [System.Console]System.Console::WriteLine(string)
     IL_0046:  ldc.i4.0
-    IL_0047:  call       void [system.runtime.extensions]System.Environment::Exit(int32)
+    IL_0047:  call       void [System.Runtime.Extensions]System.Environment::Exit(int32)
     IL_004c:  call       void [mscorlib]System.GC::Collect()
     IL_0051:  ldarg.0
     IL_0052:  dup
@@ -158,9 +165,9 @@
     IL_0070:  sub
     IL_0071:  tail. callvirt   instance int32 IFace1::Recurse3(int32)
     IL_0076:  ret
-  } 
+  }
 
-  .method public hidebysig newslot virtual 
+  .method public hidebysig newslot virtual
           instance int32  Recurse3(int32 depth) cil managed
   {
     .maxstack  8
@@ -200,9 +207,9 @@
                                                          object,
                                                          object)
     IL_0038:  ret
-  } 
+  }
 
-  .method public hidebysig newslot virtual 
+  .method public hidebysig newslot virtual
           instance int32  Recurse4(int32 depth,
                                    object o1,
                                    object o2) cil managed
@@ -225,7 +232,7 @@
     IL_0019:  bne.un.s   IL_0054
 
     IL_001b:  call       void [mscorlib]System.GC::Collect()
-    IL_0020:  call       string [system.runtime.extensions]System.Environment::get_StackTrace()
+    IL_0020:  call       string [System.Runtime.Extensions]System.Environment::get_StackTrace()
     IL_0025:  stloc.0
     IL_0026:  ldloc.0
     IL_0027:  ldstr      "Main"
@@ -241,7 +248,7 @@
     IL_0044:  ldstr      "Test Failed"
     IL_0049:  call       void [System.Console]System.Console::WriteLine(string)
     IL_004e:  ldc.i4.0
-    IL_004f:  call       void [system.runtime.extensions]System.Environment::Exit(int32)
+    IL_004f:  call       void [System.Runtime.Extensions]System.Environment::Exit(int32)
     IL_0054:  ldarg.0
     IL_0055:  dup
     IL_0056:  ldfld      int32 Class1::'value'
@@ -260,7 +267,7 @@
     IL_0073:  sub
     IL_0074:  tail. call       instance int32 Class1::Recurse1(int32)
     IL_0079:  ret
-  } 
+  }
 
   .method public hidebysig static int32  Main() cil managed
   {
@@ -315,9 +322,9 @@
     IL_0073:  call       void [System.Console]System.Console::WriteLine(string)
     IL_0078:  ldc.i4.s   100
     IL_007a:  ret
-  } 
+  }
 
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     .maxstack  8
@@ -326,15 +333,15 @@
     IL_000a:  ldc.i4     0x280000
     IL_000f:  stsfld     int32 Class1::Expected
     IL_0014:  ret
-  } 
+  }
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     .maxstack  8
     IL_0000:  ldarg.0
     IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
     IL_0006:  ret
-  } 
+  }
 
-} 
+}

--- a/tests/src/JIT/Directed/tailcall/tailcall.il
+++ b/tests/src/JIT/Directed/tailcall/tailcall.il
@@ -3,26 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Console { auto }
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-
-
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern mscorlib
-{
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
-  .ver 2:0:0:0
-}
 .assembly tailcall
 {
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 )

--- a/tests/src/JIT/Directed/tls/MutualRecurThd-TLS.il
+++ b/tests/src/JIT/Directed/tls/MutualRecurThd-TLS.il
@@ -7,23 +7,31 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+
+.assembly extern System.Threading.Thread
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern legacy library mscorlib {}
+
 .assembly  mutualrecurthdtls
 {
 }
 .data tls FieldData = int32(32)
 .data tls FieldData2 = int64(64)
 
-.class public auto ansi Thread_EA   
+.class public auto ansi Thread_EA
 {
   .field public static int32 TLSFieldData at FieldData
-  .method public instance void Run() il managed 
+  .method public instance void Run() il managed
   {
     .maxstack  3
     .locals (int32 i)
 
     IL_0000:  ldc.i4     0x1
-stsfld	int32 Thread_EA::TLSFieldData  
+stsfld	int32 Thread_EA::TLSFieldData
 ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
@@ -32,7 +40,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0007:  ldc.i4     0x1
     IL_000c:  add
     IL_000d:  call       void ?Function1_1@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -40,7 +48,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0013:  ldc.i4     0x1
     IL_0018:  add
     IL_0019:  call       void ?Function1_2@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -48,7 +56,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_001f:  ldc.i4     0x1
     IL_0024:  add
     IL_0025:  call       void ?Function1_3@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -56,7 +64,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_002b:  ldc.i4     0x1
     IL_0030:  add
     IL_0031:  call       void ?Function1_4@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -64,7 +72,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0037:  ldc.i4     0x1
     IL_003c:  add
     IL_003d:  call       void ?Function1_5@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -72,7 +80,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0043:  ldc.i4     0x1
     IL_0048:  add
     IL_0049:  call       void ?Function1_6@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -80,7 +88,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_004f:  ldc.i4     0x1
     IL_0054:  add
     IL_0055:  call       void ?Function1_7@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -88,7 +96,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_005b:  ldc.i4     0x1
     IL_0060:  add
     IL_0061:  call       void ?Function1_8@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -96,7 +104,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0067:  ldc.i4     0x1
     IL_006c:  add
     IL_006d:  call       void ?Function1_9@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -104,7 +112,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0073:  ldc.i4     0x1
     IL_0078:  add
     IL_0079:  call       void ?Function1_10@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -112,7 +120,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_007f:  ldc.i4     0x1
     IL_0084:  add
     IL_0085:  call       void ?Function1_11@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -120,7 +128,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_008b:  ldc.i4     0x1
     IL_0090:  add
     IL_0091:  call       void ?Function1_12@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -128,7 +136,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0097:  ldc.i4     0x1
     IL_009c:  add
     IL_009d:  call       void ?Function1_13@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -136,7 +144,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_00a3:  ldc.i4     0x1
     IL_00a8:  add
     IL_00a9:  call       void ?Function1_14@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -144,7 +152,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_00af:  ldc.i4     0x1
     IL_00b4:  add
     IL_00b5:  call       void ?Function1_15@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -152,7 +160,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_00bb:  ldc.i4     0x1
     IL_00c0:  add
     IL_00c1:  call       void ?Function1_16@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -160,7 +168,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_00c7:  ldc.i4     0x1
     IL_00cc:  add
     IL_00cd:  call       void ?Function1_17@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -168,7 +176,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_00d3:  ldc.i4     0x1
     IL_00d8:  add
     IL_00d9:  call       void ?Function1_18@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -176,7 +184,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_00df:  ldc.i4     0x1
     IL_00e4:  add
     IL_00e5:  call       void ?Function1_19@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -184,7 +192,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_00eb:  ldc.i4     0x1
     IL_00f0:  add
     IL_00f1:  call       void ?Function1_20@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -192,7 +200,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_00f7:  ldc.i4     0x1
     IL_00fc:  add
     IL_00fd:  call       void ?Function1_21@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -200,7 +208,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0103:  ldc.i4     0x1
     IL_0108:  add
     IL_0109:  call       void ?Function1_22@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -208,7 +216,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_010f:  ldc.i4     0x1
     IL_0114:  add
     IL_0115:  call       void ?Function1_23@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -216,7 +224,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_011b:  ldc.i4     0x1
     IL_0120:  add
     IL_0121:  call       void ?Function1_24@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -224,7 +232,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0127:  ldc.i4     0x1
     IL_012c:  add
     IL_012d:  call       void ?Function1_25@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -232,7 +240,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0133:  ldc.i4     0x1
     IL_0138:  add
     IL_0139:  call       void ?Function1_26@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -240,7 +248,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_013f:  ldc.i4     0x1
     IL_0144:  add
     IL_0145:  call       void ?Function1_27@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -248,7 +256,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_014b:  ldc.i4     0x1
     IL_0150:  add
     IL_0151:  call       void ?Function1_28@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -256,7 +264,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0157:  ldc.i4     0x1
     IL_015c:  add
     IL_015d:  call       void ?Function1_29@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -264,7 +272,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0163:  ldc.i4     0x1
     IL_0168:  add
     IL_0169:  call       void ?Function1_30@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -272,7 +280,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_016f:  ldc.i4     0x1
     IL_0174:  add
     IL_0175:  call       void ?Function1_31@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -280,7 +288,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_017b:  ldc.i4     0x1
     IL_0180:  add
     IL_0181:  call       void ?Function1_32@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -288,7 +296,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0187:  ldc.i4     0x1
     IL_018c:  add
     IL_018d:  call       void ?Function1_33@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -296,7 +304,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0193:  ldc.i4     0x1
     IL_0198:  add
     IL_0199:  call       void ?Function1_34@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -304,7 +312,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_019f:  ldc.i4     0x1
     IL_01a4:  add
     IL_01a5:  call       void ?Function1_35@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -312,7 +320,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_01ab:  ldc.i4     0x1
     IL_01b0:  add
     IL_01b1:  call       void ?Function1_36@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -320,7 +328,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_01b7:  ldc.i4     0x1
     IL_01bc:  add
     IL_01bd:  call       void ?Function1_37@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -328,7 +336,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_01c3:  ldc.i4     0x1
     IL_01c8:  add
     IL_01c9:  call       void ?Function1_38@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -336,7 +344,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_01cf:  ldc.i4     0x1
     IL_01d4:  add
     IL_01d5:  call       void ?Function1_39@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -344,7 +352,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_01db:  ldc.i4     0x1
     IL_01e0:  add
     IL_01e1:  call       void ?Function1_40@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -352,7 +360,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_01e7:  ldc.i4     0x1
     IL_01ec:  add
     IL_01ed:  call       void ?Function1_41@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -360,7 +368,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_01f3:  ldc.i4     0x1
     IL_01f8:  add
     IL_01f9:  call       void ?Function1_42@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -368,7 +376,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_01ff:  ldc.i4     0x1
     IL_0204:  add
     IL_0205:  call       void ?Function1_43@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -376,7 +384,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_020b:  ldc.i4     0x1
     IL_0210:  add
     IL_0211:  call       void ?Function1_44@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -384,7 +392,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0217:  ldc.i4     0x1
     IL_021c:  add
     IL_021d:  call       void ?Function1_45@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -392,7 +400,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0223:  ldc.i4     0x1
     IL_0228:  add
     IL_0229:  call       void ?Function1_46@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -400,7 +408,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_022f:  ldc.i4     0x1
     IL_0234:  add
     IL_0235:  call       void ?Function1_47@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -408,7 +416,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_023b:  ldc.i4     0x1
     IL_0240:  add
     IL_0241:  call       void ?Function1_48@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -416,7 +424,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0247:  ldc.i4     0x1
     IL_024c:  add
     IL_024d:  call       void ?Function1_49@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -424,7 +432,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0253:  ldc.i4     0x1
     IL_0258:  add
     IL_0259:  call       void ?Function1_50@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -432,7 +440,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_025f:  ldc.i4     0x1
     IL_0264:  add
     IL_0265:  call       void ?Function1_51@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -440,7 +448,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_026b:  ldc.i4     0x1
     IL_0270:  add
     IL_0271:  call       void ?Function1_52@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -448,7 +456,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0277:  ldc.i4     0x1
     IL_027c:  add
     IL_027d:  call       void ?Function1_53@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -456,7 +464,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0283:  ldc.i4     0x1
     IL_0288:  add
     IL_0289:  call       void ?Function1_54@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -464,7 +472,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_028f:  ldc.i4     0x1
     IL_0294:  add
     IL_0295:  call       void ?Function1_55@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -472,7 +480,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_029b:  ldc.i4     0x1
     IL_02a0:  add
     IL_02a1:  call       void ?Function1_56@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -480,7 +488,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_02a7:  ldc.i4     0x1
     IL_02ac:  add
     IL_02ad:  call       void ?Function1_57@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -488,7 +496,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_02b3:  ldc.i4     0x1
     IL_02b8:  add
     IL_02b9:  call       void ?Function1_58@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -496,7 +504,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_02bf:  ldc.i4     0x1
     IL_02c4:  add
     IL_02c5:  call       void ?Function1_59@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -504,7 +512,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_02cb:  ldc.i4     0x1
     IL_02d0:  add
     IL_02d1:  call       void ?Function1_60@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -512,7 +520,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_02d7:  ldc.i4     0x1
     IL_02dc:  add
     IL_02dd:  call       void ?Function1_61@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -520,7 +528,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_02e3:  ldc.i4     0x1
     IL_02e8:  add
     IL_02e9:  call       void ?Function1_62@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -528,7 +536,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_02ef:  ldc.i4     0x1
     IL_02f4:  add
     IL_02f5:  call       void ?Function1_63@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -536,7 +544,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_02fb:  ldc.i4     0x1
     IL_0300:  add
     IL_0301:  call       void ?Function1_64@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -544,7 +552,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0307:  ldc.i4     0x1
     IL_030c:  add
     IL_030d:  call       void ?Function1_65@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -552,7 +560,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0313:  ldc.i4     0x1
     IL_0318:  add
     IL_0319:  call       void ?Function1_66@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -560,7 +568,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_031f:  ldc.i4     0x1
     IL_0324:  add
     IL_0325:  call       void ?Function1_67@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -568,7 +576,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_032b:  ldc.i4     0x1
     IL_0330:  add
     IL_0331:  call       void ?Function1_68@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -576,7 +584,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0337:  ldc.i4     0x1
     IL_033c:  add
     IL_033d:  call       void ?Function1_69@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -584,7 +592,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0343:  ldc.i4     0x1
     IL_0348:  add
     IL_0349:  call       void ?Function1_70@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -592,7 +600,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_034f:  ldc.i4     0x1
     IL_0354:  add
     IL_0355:  call       void ?Function1_1@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -600,7 +608,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_035b:  ldc.i4     0x1
     IL_0360:  add
     IL_0361:  call       void ?Function1_2@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -608,7 +616,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0367:  ldc.i4     0x1
     IL_036c:  add
     IL_036d:  call       void ?Function1_3@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -616,7 +624,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0373:  ldc.i4     0x1
     IL_0378:  add
     IL_0379:  call       void ?Function1_4@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -624,7 +632,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_037f:  ldc.i4     0x1
     IL_0384:  add
     IL_0385:  call       void ?Function1_5@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -632,7 +640,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_038b:  ldc.i4     0x1
     IL_0390:  add
     IL_0391:  call       void ?Function1_6@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -640,7 +648,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0397:  ldc.i4     0x1
     IL_039c:  add
     IL_039d:  call       void ?Function1_7@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -648,7 +656,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_03a3:  ldc.i4     0x1
     IL_03a8:  add
     IL_03a9:  call       void ?Function1_8@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -656,7 +664,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_03af:  ldc.i4     0x1
     IL_03b4:  add
     IL_03b5:  call       void ?Function1_9@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -664,7 +672,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_03bb:  ldc.i4     0x1
     IL_03c0:  add
     IL_03c1:  call       void ?Function1_10@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -672,7 +680,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_03c7:  ldc.i4     0x1
     IL_03cc:  add
     IL_03cd:  call       void ?Function1_11@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -680,7 +688,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_03d3:  ldc.i4     0x1
     IL_03d8:  add
     IL_03d9:  call       void ?Function1_12@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -688,7 +696,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_03df:  ldc.i4     0x1
     IL_03e4:  add
     IL_03e5:  call       void ?Function1_13@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -696,7 +704,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_03eb:  ldc.i4     0x1
     IL_03f0:  add
     IL_03f1:  call       void ?Function1_14@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -704,7 +712,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_03f7:  ldc.i4     0x1
     IL_03fc:  add
     IL_03fd:  call       void ?Function1_15@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -712,7 +720,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0403:  ldc.i4     0x1
     IL_0408:  add
     IL_0409:  call       void ?Function1_16@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -720,7 +728,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_040f:  ldc.i4     0x1
     IL_0414:  add
     IL_0415:  call       void ?Function1_17@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -728,7 +736,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_041b:  ldc.i4     0x1
     IL_0420:  add
     IL_0421:  call       void ?Function1_18@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -736,7 +744,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0427:  ldc.i4     0x1
     IL_042c:  add
     IL_042d:  call       void ?Function1_19@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -744,7 +752,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0433:  ldc.i4     0x1
     IL_0438:  add
     IL_0439:  call       void ?Function1_20@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -752,7 +760,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_043f:  ldc.i4     0x1
     IL_0444:  add
     IL_0445:  call       void ?Function1_21@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -760,7 +768,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_044b:  ldc.i4     0x1
     IL_0450:  add
     IL_0451:  call       void ?Function1_22@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -768,7 +776,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0457:  ldc.i4     0x1
     IL_045c:  add
     IL_045d:  call       void ?Function1_23@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -776,7 +784,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0463:  ldc.i4     0x1
     IL_0468:  add
     IL_0469:  call       void ?Function1_24@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -784,7 +792,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_046f:  ldc.i4     0x1
     IL_0474:  add
     IL_0475:  call       void ?Function1_25@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -792,7 +800,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_047b:  ldc.i4     0x1
     IL_0480:  add
     IL_0481:  call       void ?Function1_26@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -800,7 +808,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0487:  ldc.i4     0x1
     IL_048c:  add
     IL_048d:  call       void ?Function1_27@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -808,7 +816,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_0493:  ldc.i4     0x1
     IL_0498:  add
     IL_0499:  call       void ?Function1_28@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -816,7 +824,7 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_049f:  ldc.i4     0x1
     IL_04a4:  add
     IL_04a5:  call       void ?Function1_29@@YAXH@Z(int32)
-ldsfld	int32 Thread_EA::TLSFieldData  
+ldsfld	int32 Thread_EA::TLSFieldData
 dup
 ldc.i4 0x1
 add
@@ -826,47 +834,47 @@ stsfld	int32 Thread_EA::TLSFieldData
     IL_04b1:  call       void ?Function1_30@@YAXH@Z(int32)
     IL_04b6:  	call	    class [mscorlib]System.IO.TextWriter [System.Console]System.Console::get_Out()
     IL_04bb:  ldstr "one thread finished"
-    IL_04c0:  
+    IL_04c0:
     IL_04c5:  callvirt   instance void [mscorlib]System.IO.TextWriter::WriteLine(class [mscorlib]System.String)
     IL_04ca:  ret
-  } 
+  }
 
-  .method public specialname rtspecialname instance void .ctor() il managed 
+  .method public specialname rtspecialname instance void .ctor() il managed
   {
     .maxstack  1
 
     IL_0000:  ldarg.0
     IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
     IL_0006:  ret
-  } 
+  }
 
-} 
+}
 
-.class value sealed public explicit ansi $MultiByte$42   
+.class value sealed public explicit ansi $MultiByte$42
 {
   .pack 1
   .size 42
-} 
+}
 
-.class value sealed public explicit ansi $MultiByte$26   
+.class value sealed public explicit ansi $MultiByte$26
 {
   .pack 1
   .size 26
-} 
+}
 
-.class value sealed public explicit ansi $MultiByte$54   
+.class value sealed public explicit ansi $MultiByte$54
 {
   .pack 1
   .size 54
-} 
+}
 
-.class value sealed public explicit ansi $MultiByte$0   
+.class value sealed public explicit ansi $MultiByte$0
 {
   .pack 1
   .size 0
-} 
+}
 
-.method public static void ?Function1_1@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_1@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -895,9 +903,9 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ret
-} 
+}
 
-.method public static void ?Function1_2@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_2@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -928,9 +936,9 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0037:  ldarg.0
   IL_0038:  call       void ?Function1_1@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_3@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_3@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -959,12 +967,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_2@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_4@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_4@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -995,9 +1003,9 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0037:  ldarg.0
   IL_0038:  call       void ?Function1_3@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_5@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_5@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1026,12 +1034,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_4@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_6@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_6@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1060,12 +1068,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_5@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_7@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_7@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1094,12 +1102,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_6@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_8@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_8@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1128,12 +1136,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_7@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_9@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_9@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1162,12 +1170,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_8@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_10@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_10@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1196,12 +1204,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_9@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_11@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_11@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1230,12 +1238,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_10@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_12@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_12@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1264,12 +1272,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_11@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_13@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_13@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1298,12 +1306,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_12@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_14@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_14@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1332,12 +1340,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_13@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_15@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_15@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1366,12 +1374,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_14@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_16@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_16@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1400,12 +1408,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_15@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_17@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_17@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1434,12 +1442,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_16@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_18@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_18@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1468,12 +1476,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_17@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_19@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_19@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1502,12 +1510,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_18@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_20@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_20@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1536,12 +1544,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_19@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_21@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_21@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1570,12 +1578,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_20@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_22@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_22@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1604,12 +1612,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_21@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_23@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_23@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1638,12 +1646,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_22@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_24@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_24@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1672,12 +1680,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_23@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_25@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_25@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1706,12 +1714,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_24@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_26@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_26@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1740,12 +1748,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_25@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_27@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_27@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1774,12 +1782,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_26@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_28@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_28@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1808,12 +1816,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_27@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_29@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_29@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1842,12 +1850,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_28@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_30@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_30@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1876,12 +1884,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_29@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_31@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_31@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1910,12 +1918,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_30@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_32@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_32@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1944,12 +1952,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_31@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_33@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_33@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -1978,12 +1986,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_32@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_34@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_34@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2012,12 +2020,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_33@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_35@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_35@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2046,12 +2054,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_34@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_36@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_36@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2080,12 +2088,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_35@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_37@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_37@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2114,12 +2122,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_36@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_38@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_38@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2148,12 +2156,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_37@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_39@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_39@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2182,12 +2190,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_38@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_40@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_40@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2216,12 +2224,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_39@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_41@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_41@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2250,12 +2258,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_40@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_42@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_42@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2284,12 +2292,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_41@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_43@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_43@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2318,12 +2326,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_42@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_44@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_44@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2352,12 +2360,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_43@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_45@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_45@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2386,12 +2394,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_44@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_46@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_46@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2420,12 +2428,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_45@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_47@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_47@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2454,12 +2462,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_46@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_48@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_48@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2488,12 +2496,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_47@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_49@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_49@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2522,12 +2530,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_48@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_50@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_50@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2556,12 +2564,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_49@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_51@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_51@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2590,12 +2598,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_50@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_52@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_52@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2624,12 +2632,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_51@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_53@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_53@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2658,12 +2666,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_52@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_54@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_54@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2692,12 +2700,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_53@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_55@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_55@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2726,12 +2734,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_54@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_56@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_56@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2760,12 +2768,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_55@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_57@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_57@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2794,12 +2802,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_56@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_58@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_58@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2828,12 +2836,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_57@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_59@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_59@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2862,12 +2870,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_58@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_60@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_60@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2896,12 +2904,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_59@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_61@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_61@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2930,12 +2938,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_60@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_62@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_62@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2964,12 +2972,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_61@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_63@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_63@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -2998,12 +3006,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_62@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_64@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_64@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -3032,12 +3040,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_63@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_65@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_65@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -3066,12 +3074,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_64@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_66@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_66@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -3100,12 +3108,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_65@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_67@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_67@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -3134,12 +3142,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_66@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_68@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_68@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -3168,12 +3176,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_67@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_69@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_69@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -3202,12 +3210,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_68@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static void ?Function1_70@@YAXH@Z(int32 A_0) il managed 
+.method public static void ?Function1_70@@YAXH@Z(int32 A_0) il managed
 {
   .maxstack  4
   .locals (unsigned int8[] mem)
@@ -3236,12 +3244,12 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_0034:  add
   IL_0035:  starg.s    A_0
   IL_0037:  ldarg.0
-	 
+
   IL_0038:  call       void ?Function1_69@@YAXH@Z(int32)
   IL_003d:  ret
-} 
+}
 
-.method public static int32 main() il managed 
+.method public static int32 main() il managed
 {
   .entrypoint
   .maxstack  4
@@ -3249,7 +3257,7 @@ stsfld	int32 Thread_EA::TLSFieldData
            class Thread_EA ThdObj,
            int32 V_2)
 
-	call	    class [mscorlib]System.IO.TextWriter [System.Console]System.Console::get_Out()
+    call	    class [mscorlib]System.IO.TextWriter [System.Console]System.Console::get_Out()
 call       class [mscorlib]System.IO.TextWriter [mscorlib]System.IO.TextWriter::Synchronized(class [mscorlib]System.IO.TextWriter)
 call       void [System.Console]System.Console::SetOut(class [mscorlib]System.IO.TextWriter)
 
@@ -3260,7 +3268,7 @@ call       void [System.Console]System.Console::SetOut(class [mscorlib]System.IO
   IL_0010:  stloc.1
   IL_0011: 	call	    class [mscorlib]System.IO.TextWriter [System.Console]System.Console::get_Out()
   IL_0016:  ldstr "test started"
-  IL_001b:  
+  IL_001b:
   IL_0020:  callvirt   instance void [mscorlib]System.IO.TextWriter::WriteLine(class [mscorlib]System.String)
   IL_0025:  ldc.i4     0x0
   IL_002a:  stloc.2
@@ -3307,8 +3315,8 @@ call       void [System.Console]System.Console::SetOut(class [mscorlib]System.IO
 
   IL_008f: 	call	    class [mscorlib]System.IO.TextWriter [System.Console]System.Console::get_Out()
   IL_0094:  ldstr "Mututalrecurthd test passed"
-  IL_0099:  
+  IL_0099:
   IL_009e:  callvirt   instance void [mscorlib]System.IO.TextWriter::WriteLine(class [mscorlib]System.String)
   IL_00a3:  ldc.i4     0x64
   IL_00a8:  ret
-} 
+}

--- a/tests/src/JIT/Directed/tls/MutualRecurThd-TLS.il
+++ b/tests/src/JIT/Directed/tls/MutualRecurThd-TLS.il
@@ -2,19 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
 
-.assembly extern System.Threading.Thread
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Console { auto }
+.assembly extern System.Threading.Thread { auto }
+.assembly extern legacy library mscorlib { auto }
 
-.assembly extern legacy library mscorlib {}
 
 .assembly  mutualrecurthdtls
 {

--- a/tests/src/JIT/IL_Conformance/Old/Base/tailcall.il
+++ b/tests/src/JIT/IL_Conformance/Old/Base/tailcall.il
@@ -2,13 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
 
-.assembly extern legacy library mscorlib {}
+.assembly extern System.Console { auto }
+.assembly extern legacy library mscorlib { auto }
+
 
 .assembly tailcall.exe{}
 

--- a/tests/src/JIT/Methodical/Boxing/boxunbox/tailcall.il
+++ b/tests/src/JIT/Methodical/Boxing/boxunbox/tailcall.il
@@ -2,13 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
 
-.assembly extern mscorlib { }
+.assembly extern System.Console { auto }
+.assembly extern mscorlib { auto }
+
 .assembly 'tailcall' { }
 .namespace JitTest
 {

--- a/tests/src/JIT/Methodical/Boxing/misc/concurgc.il
+++ b/tests/src/JIT/Methodical/Boxing/misc/concurgc.il
@@ -2,21 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
 
-.assembly extern System.Threading.Thread
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Console { auto }
+.assembly extern System.Threading.Thread { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib
-{
-}
 .assembly 'concur'// as "concur"
 {
 }

--- a/tests/src/JIT/Methodical/Boxing/misc/concurgc.il
+++ b/tests/src/JIT/Methodical/Boxing/misc/concurgc.il
@@ -8,6 +8,12 @@
   .ver 4:0:0:0
 }
 
+.assembly extern System.Threading.Thread
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib
 {
 }
@@ -57,7 +63,7 @@
                 ldc.i4.0
                 volatile.
                 stsfld     bool  Test.App::signal
-      IL_001a:  ldloc.2     
+      IL_001a:  ldloc.2
       IL_001b:  call       instance void [System.Threading.Thread]System.Threading.Thread::Start()
       IL_0020:  ldc.r8     11.
       IL_0029:  stloc.s    V_5
@@ -147,7 +153,7 @@
       IL_00d2:  ret
     } // end of method 'App::Main'
 
-    .method public hidebysig specialname rtspecialname 
+    .method public hidebysig specialname rtspecialname
             instance void .ctor() il managed
     {
       .maxstack  8

--- a/tests/src/JIT/Methodical/ldtoken/types.il
+++ b/tests/src/JIT/Methodical/ldtoken/types.il
@@ -2,6 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern System.Console
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
@@ -14,7 +21,7 @@
   .class private auto ansi beforefieldinit Test
          extends [mscorlib]System.Object
   {
-    .method private hidebysig static void 
+    .method private hidebysig static void
             test_token(object boxed_vt,
                        valuetype [mscorlib]System.RuntimeTypeHandle vt) cil managed
     {
@@ -25,7 +32,7 @@
       call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(
       													valuetype [mscorlib]System.RuntimeTypeHandle)
       beq.s      IL_EXIT
-      
+
       ldstr      "Test failed on "
       ldarg.1
       call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(
@@ -34,7 +41,7 @@
       call       string [mscorlib]System.String::Concat(string, string)
       call       void [System.Console]System.Console::WriteLine(string)
       ldc.i4.s   101
-      call       void [system.runtime.extensions]System.Environment::Exit(int32)
+      call       void [System.Runtime.Extensions]System.Environment::Exit(int32)
       IL_EXIT:
       ret
     }
@@ -57,17 +64,17 @@
       box        [mscorlib]System.Int16
       ldtoken    [mscorlib]System.Int16
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-      
+
       ldc.i4.1
       box        [mscorlib]System.UInt16
       ldtoken    [mscorlib]System.UInt16
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-      
+
       ldc.i4.1
       box        [mscorlib]System.Int32
       ldtoken    [mscorlib]System.Int32
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-      
+
       ldc.i4.1
       box        [mscorlib]System.UInt32
       ldtoken    [mscorlib]System.UInt32
@@ -77,22 +84,22 @@
       box        [mscorlib]System.Int64
       ldtoken    [mscorlib]System.Int64
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-      
+
       ldc.i8 1
       box        [mscorlib]System.UInt64
       ldtoken    [mscorlib]System.UInt64
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-      
+
       ldc.r8 1
       box        [mscorlib]System.Single
       ldtoken    [mscorlib]System.Single
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-      
+
       ldc.r4 1
       box        [mscorlib]System.Double
       ldtoken    [mscorlib]System.Double
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-      
+
       ldc.i4.1
       box        [mscorlib]System.IntPtr
       ldtoken    [mscorlib]System.IntPtr
@@ -102,7 +109,7 @@
       box        [mscorlib]System.UIntPtr
       ldtoken    [mscorlib]System.UIntPtr
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-      
+
       ldc.i4.1
       box        [mscorlib]System.Boolean
       ldtoken    [mscorlib]System.Boolean
@@ -112,11 +119,11 @@
       box        [mscorlib]System.Char
       ldtoken    [mscorlib]System.Char
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-		
+
       ldstr      "moo"
       ldtoken    [mscorlib]System.String
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-      
+
       newobj     instance void [mscorlib]System.Object::.ctor()
       ldtoken    [mscorlib]System.Object
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
@@ -125,78 +132,78 @@
       newarr     int8
       ldtoken    int8[]
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-      
+
       ldc.i4 10
       newarr     uint8
       ldtoken    uint8[]
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-      
+
       ldc.i4 10
       newarr     int16
       ldtoken    int16[]
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-      
+
       ldc.i4 10
       newarr     uint16
       ldtoken    uint16[]
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-      
+
       ldc.i4 10
       newarr     int32
       ldtoken    int32[]
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-      
+
       ldc.i4 10
       newarr     uint32
       ldtoken    uint32[]
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-      
+
       ldc.i4 10
       newarr     int64
       ldtoken    int64[]
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-      
+
       ldc.i4 10
       newarr     uint64
       ldtoken    uint64[]
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-      
+
       ldc.i4 10
       newarr     native int
       ldtoken    native int[]
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-      
+
       ldc.i4 10
       newarr     valuetype [mscorlib]System.UIntPtr
       ldtoken    valuetype [mscorlib]System.UIntPtr[]
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-      
+
       ldc.i4 10
       newarr     bool
       ldtoken    bool[]
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-      
+
       ldc.i4 10
       newarr     char
       ldtoken    char[]
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-      
+
       ldc.i4 10
       newarr     object
       ldtoken    object[]
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-      
+
       ldc.i4 10
       newarr     string
       ldtoken    string[]
       call       void JitTest.Test::test_token(object, valuetype [mscorlib]System.RuntimeTypeHandle)
-      
+
       ldstr      "Passed"
       call       void [System.Console]System.Console::WriteLine(string)
       ldc.i4.s   100
       ret
     }
-    .method public hidebysig specialname rtspecialname 
+    .method public hidebysig specialname rtspecialname
             instance void .ctor() cil managed
     {
       .maxstack  8

--- a/tests/src/JIT/Methodical/ldtoken/types.il
+++ b/tests/src/JIT/Methodical/ldtoken/types.il
@@ -3,18 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern System.Console { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-.assembly extern mscorlib { }
 .assembly types { }
 .namespace JitTest
 {

--- a/tests/src/JIT/Methodical/nonvirtualcall/tailcall.il
+++ b/tests/src/JIT/Methodical/nonvirtualcall/tailcall.il
@@ -2,22 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
 
-
-
-
-
+.assembly extern System.Console { auto }
 // Metadata version: v2.0.50509
-.assembly extern mscorlib
-{
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
-  .ver 2:0:0:0
-}
+.assembly extern mscorlib { auto }
+
 .assembly tailcall
 {
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 

--- a/tests/src/JIT/Methodical/switch/switch1.il
+++ b/tests/src/JIT/Methodical/switch/switch1.il
@@ -1,16 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+
 //simple switch
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern legacy library mscorlib { auto }
 
-
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern legacy library mscorlib {}
 .assembly 'switch1'
 {
 

--- a/tests/src/JIT/Methodical/switch/switch1.il
+++ b/tests/src/JIT/Methodical/switch/switch1.il
@@ -3,11 +3,18 @@
 // See the LICENSE file in the project root for more information.
 //simple switch
 
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern legacy library mscorlib {}
 .assembly 'switch1'
-{                                            
-  
-  
+{
+
+
 }
 
 .module 'switch1.exe'
@@ -24,13 +31,13 @@
     IL_0002:  ldloc.0
     IL_0003:  ldc.i4.1
     IL_0004:  sub
-    IL_0005:  switch     ( 
+    IL_0005:  switch     (
                           IL_0014,
                           IL_0027)
     IL_0012:  br.s       IL_0033
 
     IL_0014:  ldc.i4.s   100
-    IL_0016:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_0016:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_001b:  ldstr      "Test passed"
     IL_0020:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0025:  br.s       IL_003f
@@ -44,7 +51,7 @@
     IL_003d:  br.s       IL_003f
 
     IL_003f:  ret
-  } 
+  }
 
   .method public hidebysig static void Main() il managed
   {
@@ -52,10 +59,10 @@
     .maxstack  8
     IL_0000:  ldc.i4.1
     IL_0001:  call       void Test::DoSwitch(int32)
-    IL_0006:  call       int32 ['system.runtime.extensions']System.Environment::get_ExitCode()
-              call       void ['system.runtime.extensions']System.Environment::Exit(int32)
+    IL_0006:  call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
+              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
               ret
-  } 
+  }
 
-  
-} 
+
+}

--- a/tests/src/JIT/Methodical/switch/switch10.il
+++ b/tests/src/JIT/Methodical/switch/switch10.il
@@ -1,16 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+
 // check inlining
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern legacy library mscorlib { auto }
 
-
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern legacy library mscorlib {}
 .assembly 'switch10'
 {
 

--- a/tests/src/JIT/Methodical/switch/switch10.il
+++ b/tests/src/JIT/Methodical/switch/switch10.il
@@ -3,11 +3,18 @@
 // See the LICENSE file in the project root for more information.
 // check inlining
 
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern legacy library mscorlib {}
 .assembly 'switch10'
 {
-  
-  
+
+
 }
 
 .module 'switch10.exe'
@@ -15,7 +22,7 @@
 .class public auto ansi Test
        extends ['mscorlib']System.Object
 {
-  .method private hidebysig static int32 
+  .method private hidebysig static int32
           Square(int32 i) il managed
   {
     .maxstack  2
@@ -28,7 +35,7 @@
 
     IL_0006:  ldloc.0
     IL_0007:  ret
-  } 
+  }
 
   .method private hidebysig static void  DoSwitch(int32 'value') il managed
   {
@@ -57,17 +64,17 @@
     IL_0018:  bne.un.s   IL_002d
 
     IL_001a:  ldc.i4.s   100
-    IL_001c:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_001c:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_0021:  ldstr      "Test passed"
     IL_0026:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_002b:  br.s       IL_003d
 
     IL_002d:  ldc.i4.1
-    IL_002e:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_002e:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_0033:  ldstr      "Test failed"
     IL_0038:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_003d:  ret
-  } 
+  }
 
   .method public hidebysig static void Main() il managed
   {
@@ -75,10 +82,10 @@
     .maxstack  8
     IL_0000:  ldc.i4.1
     IL_0001:  call       void Test::DoSwitch(int32)
-    IL_0006:  call       int32 ['system.runtime.extensions']System.Environment::get_ExitCode()
-              call       void ['system.runtime.extensions']System.Environment::Exit(int32)
+    IL_0006:  call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
+              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
               ret
-  } 
+  }
 
-  
-} 
+
+}

--- a/tests/src/JIT/Methodical/switch/switch11.il
+++ b/tests/src/JIT/Methodical/switch/switch11.il
@@ -3,11 +3,18 @@
 // See the LICENSE file in the project root for more information.
 // non-empty stack before switch
 
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern legacy library mscorlib {}
 .assembly 'switch11'
 {
-  
-  
+
+
 }
 
 .module 'switch11.exe'
@@ -25,13 +32,13 @@
     IL_0002:  br.s       IL_0004
 
     IL_0004:  ldc.i4.s   100
-    IL_0006:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_0006:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_000b:  ldstr      "Test passed"
     IL_0010:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0015:  pop
-              call       int32 ['system.runtime.extensions']System.Environment::get_ExitCode()
-              call       void ['system.runtime.extensions']System.Environment::Exit(int32)
+              call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
+              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
               ret
-  } 
+  }
 
-} 
+}

--- a/tests/src/JIT/Methodical/switch/switch11.il
+++ b/tests/src/JIT/Methodical/switch/switch11.il
@@ -1,16 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+
 // non-empty stack before switch
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern legacy library mscorlib { auto }
 
-
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern legacy library mscorlib {}
 .assembly 'switch11'
 {
 

--- a/tests/src/JIT/Methodical/switch/switch2.il
+++ b/tests/src/JIT/Methodical/switch/switch2.il
@@ -3,11 +3,18 @@
 // See the LICENSE file in the project root for more information.
 // add and subtract integers
 
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern legacy library mscorlib {}
 .assembly 'switch2'
 {
-  
-  
+
+
 }
 .module 'switch2.exe'
 
@@ -30,7 +37,7 @@
     IL_0006:  ldloc.3
     IL_0007:  ldc.i4.1
     IL_0008:  sub
-    IL_0009:  switch     ( 
+    IL_0009:  switch     (
                           IL_0018,
                           IL_0033)
     IL_0016:  br.s       IL_004d
@@ -44,7 +51,7 @@
     IL_001e:  bne.un.s   IL_0031
 
     IL_0020:  ldc.i4.s   100
-    IL_0022:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_0022:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_0027:  ldstr      "Test passed"
     IL_002c:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0031:  br.s       IL_005f
@@ -58,19 +65,19 @@
     IL_0039:  bne.un.s   IL_004b
 
     IL_003b:  ldc.i4.1
-    IL_003c:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_003c:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_0041:  ldstr      "Test failed"
     IL_0046:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_004b:  br.s       IL_005f
 
     IL_004d:  ldc.i4.1
-    IL_004e:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_004e:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_0053:  ldstr      "Test failed"
     IL_0058:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_005d:  br.s       IL_005f
 
     IL_005f:  ret
-  } 
+  }
 
   .method public hidebysig static void Main() il managed
   {
@@ -78,9 +85,9 @@
     .maxstack  8
     IL_0000:  ldc.i4.1
     IL_0001:  call       void Test::DoSwitch(int32)
-    IL_0006:  call       int32 ['system.runtime.extensions']System.Environment::get_ExitCode()
-              call       void ['system.runtime.extensions']System.Environment::Exit(int32)
+    IL_0006:  call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
+              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
               ret
-  } 
+  }
 
- } 
+ }

--- a/tests/src/JIT/Methodical/switch/switch2.il
+++ b/tests/src/JIT/Methodical/switch/switch2.il
@@ -1,16 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+
 // add and subtract integers
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern legacy library mscorlib { auto }
 
-
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern legacy library mscorlib {}
 .assembly 'switch2'
 {
 

--- a/tests/src/JIT/Methodical/switch/switch3.il
+++ b/tests/src/JIT/Methodical/switch/switch3.il
@@ -2,16 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
 // checking fallthrough in switch
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern legacy library mscorlib { auto }
 
-
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern legacy library mscorlib {}
 .assembly 'switch3'
 {
 

--- a/tests/src/JIT/Methodical/switch/switch3.il
+++ b/tests/src/JIT/Methodical/switch/switch3.il
@@ -4,11 +4,18 @@
 
 // checking fallthrough in switch
 
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern legacy library mscorlib {}
 .assembly 'switch3'
 {
-  
-  
+
+
 }
 
 .module 'switch3.exe'
@@ -25,7 +32,7 @@
     IL_0002:  ldloc.0
     IL_0003:  ldc.i4.1
     IL_0004:  sub
-    IL_0005:  switch     ( 
+    IL_0005:  switch     (
                           IL_0014,
                           IL_0016)
     IL_0012:  br.s       IL_0029
@@ -33,19 +40,19 @@
     IL_0014:  br.s       IL_0016
 
     IL_0016:  ldc.i4.s   100
-    IL_0018:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_0018:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_001d:  ldstr      "Test passed"
     IL_0022:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0027:  br.s       IL_003b
 
     IL_0029:  ldc.i4.1
-    IL_002a:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_002a:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_002f:  ldstr      "Test failed"
     IL_0034:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0039:  br.s       IL_003b
 
     IL_003b:  ret
-  } 
+  }
 
   .method public hidebysig static void Main() il managed
   {
@@ -53,10 +60,10 @@
     .maxstack  8
     IL_0000:  ldc.i4.1
     IL_0001:  call       void Test::DoSwitch(int32)
-    IL_0006:  call       int32 ['system.runtime.extensions']System.Environment::get_ExitCode()
-              call       void ['system.runtime.extensions']System.Environment::Exit(int32)
+    IL_0006:  call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
+              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
               ret
-  } 
+  }
 
-  
-} 
+
+}

--- a/tests/src/JIT/Methodical/switch/switch4.il
+++ b/tests/src/JIT/Methodical/switch/switch4.il
@@ -3,11 +3,18 @@
 // See the LICENSE file in the project root for more information.
 // loop in switch
 
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern legacy library mscorlib {}
 .assembly 'switch4'
 {
-  
-  
+
+
 }
 
 .module 'switch4.exe'
@@ -56,17 +63,17 @@
     IL_002e:  bne.un.s   IL_0043
 
     IL_0030:  ldc.i4.s   100
-    IL_0032:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_0032:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_0037:  ldstr      "Test passed"
     IL_003c:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0041:  br.s       IL_0053
 
     IL_0043:  ldc.i4.1
-    IL_0044:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_0044:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_0049:  ldstr      "Test failed"
     IL_004e:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0053:  ret
-  } 
+  }
 
   .method public hidebysig static void Main() il managed
   {
@@ -74,9 +81,9 @@
     .maxstack  8
     IL_0000:  ldc.i4.1
     IL_0001:  call       void Test::DoSwitch(int32)
-    IL_0006:  call       int32 ['system.runtime.extensions']System.Environment::get_ExitCode()
-              call       void ['system.runtime.extensions']System.Environment::Exit(int32)
+    IL_0006:  call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
+              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
               ret
-  } 
+  }
 
-} 
+}

--- a/tests/src/JIT/Methodical/switch/switch4.il
+++ b/tests/src/JIT/Methodical/switch/switch4.il
@@ -1,16 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+
 // loop in switch
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern legacy library mscorlib { auto }
 
-
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern legacy library mscorlib {}
 .assembly 'switch4'
 {
 

--- a/tests/src/JIT/Methodical/switch/switch5.il
+++ b/tests/src/JIT/Methodical/switch/switch5.il
@@ -1,16 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+
 // Stack implementation
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern legacy library mscorlib { auto }
 
-
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern legacy library mscorlib {}
 .assembly 'switch5'
 {
 

--- a/tests/src/JIT/Methodical/switch/switch5.il
+++ b/tests/src/JIT/Methodical/switch/switch5.il
@@ -3,11 +3,18 @@
 // See the LICENSE file in the project root for more information.
 // Stack implementation
 
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern legacy library mscorlib {}
 .assembly 'switch5'
 {
-  
-  
+
+
 }
 
 .module 'switch5.exe'
@@ -17,7 +24,7 @@
 {
   .field public int32[] Stack
   .field public int32 top
-  .method public hidebysig instance void 
+  .method public hidebysig instance void
           DoSwitch(int32 'value') il managed
   {
     .maxstack  2
@@ -28,7 +35,7 @@
     IL_0002:  ldloc.1
     IL_0003:  ldc.i4.1
     IL_0004:  sub
-    IL_0005:  switch     ( 
+    IL_0005:  switch     (
                           IL_0014,
                           IL_001d)
     IL_0012:  br.s       IL_0026
@@ -56,21 +63,21 @@
     IL_003c:  brtrue.s   IL_0051
 
     IL_003e:  ldc.i4.s   100
-    IL_0040:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_0040:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_0045:  ldstr      "Test passed"
     IL_004a:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_004f:  br.s       IL_0061
 
     IL_0051:  ldc.i4.1
-    IL_0052:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_0052:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_0057:  ldstr      "Test failed"
     IL_005c:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0061:  br.s       IL_0063
 
     IL_0063:  ret
-  } 
+  }
 
-  .method public hidebysig instance void 
+  .method public hidebysig instance void
           push(int32 i) il managed
   {
     .maxstack  4
@@ -89,7 +96,7 @@
     IL_0017:  ldarg.1
     IL_0018:  stelem.i4
     IL_0019:  ret
-  } 
+  }
 
   .method public hidebysig instance int32
           'pop'() il managed
@@ -114,9 +121,9 @@
 
     IL_001b:  ldloc.0
     IL_001c:  ret
-  } 
+  }
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void .ctor() il managed
   {
     .maxstack  8
@@ -130,9 +137,9 @@
     IL_0013:  ldarg.0
     IL_0014:  call       instance void ['mscorlib']System.Object::.ctor()
     IL_0019:  ret
-  } 
+  }
 
-} 
+}
 
 .class public auto ansi Test
        extends ['mscorlib']System.Object
@@ -156,9 +163,9 @@
     IL_001b:  ldloc.0
     IL_001c:  ldc.i4.3
     IL_001d:  call       instance void TestStack::DoSwitch(int32)
-    IL_0022:  call       int32 ['system.runtime.extensions']System.Environment::get_ExitCode()
-              call       void ['system.runtime.extensions']System.Environment::Exit(int32)
+    IL_0022:  call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
+              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
               ret
-  } 
+  }
 
-} 
+}

--- a/tests/src/JIT/Methodical/switch/switch6.il
+++ b/tests/src/JIT/Methodical/switch/switch6.il
@@ -3,6 +3,13 @@
 // See the LICENSE file in the project root for more information.
 // try --  catch in switch
 
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern legacy library mscorlib {}
 .assembly extern System.Console
 {
@@ -11,8 +18,8 @@
 }
 .assembly 'switch6'
 {
-  
-  
+
+
 }
 
 .module 'switch6.exe'
@@ -48,8 +55,8 @@
       IL_0014:  stloc.1
       IL_0015:  leave.s    IL_0028
 
-    }  
-    catch ['mscorlib']System.Exception 
+    }
+    catch ['mscorlib']System.Exception
     {
       IL_0017:  stloc.2
       IL_0018:  ldstr      "Exception {0} caught"
@@ -60,7 +67,7 @@
       IL_0025:  stloc.1
       IL_0026:  leave.s    IL_0028
 
-    }  
+    }
     IL_0028:  br.s       IL_002c
 
     IL_002a:  br.s       IL_002c
@@ -70,17 +77,17 @@
     IL_002f:  bne.un.s   IL_0044
 
     IL_0031:  ldc.i4.s   100
-    IL_0033:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_0033:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_0038:  ldstr      "Test passed"
     IL_003d:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0042:  br.s       IL_0054
 
     IL_0044:  ldc.i4.1
-    IL_0045:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_0045:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_004a:  ldstr      "Test failed"
     IL_004f:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0054:  ret
-  } 
+  }
 
   .method public hidebysig static void Main() il managed
   {
@@ -88,9 +95,9 @@
     .maxstack  8
     IL_0000:  ldc.i4.1
     IL_0001:  call       void Test::DoSwitch(int32)
-    IL_0006:  call       int32 ['system.runtime.extensions']System.Environment::get_ExitCode()
-              call       void ['system.runtime.extensions']System.Environment::Exit(int32)
+    IL_0006:  call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
+              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
               ret
-  } 
+  }
 
-} 
+}

--- a/tests/src/JIT/Methodical/switch/switch6.il
+++ b/tests/src/JIT/Methodical/switch/switch6.il
@@ -1,21 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+
 // try --  catch in switch
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern legacy library mscorlib { auto }
+.assembly extern System.Console { auto }
 
-
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern legacy library mscorlib {}
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
 .assembly 'switch6'
 {
 

--- a/tests/src/JIT/Methodical/switch/switch7.il
+++ b/tests/src/JIT/Methodical/switch/switch7.il
@@ -1,16 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+
 // calling switch in a loop
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern legacy library mscorlib { auto }
 
-
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern legacy library mscorlib {}
 .assembly 'switch7'
 {
 

--- a/tests/src/JIT/Methodical/switch/switch7.il
+++ b/tests/src/JIT/Methodical/switch/switch7.il
@@ -3,11 +3,18 @@
 // See the LICENSE file in the project root for more information.
 // calling switch in a loop
 
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern legacy library mscorlib {}
 .assembly 'switch7'
 {
-  
-  
+
+
 }
 
 .module 'switch7.exe'
@@ -25,7 +32,7 @@
     IL_0002:  ldloc.0
     IL_0003:  ldc.i4.1
     IL_0004:  sub
-    IL_0005:  switch     ( 
+    IL_0005:  switch     (
                           IL_0018,
                           IL_0026,
                           IL_0034)
@@ -52,7 +59,7 @@
     IL_0042:  br.s       IL_0044
 
     IL_0044:  ret
-  } 
+  }
 
   .method public hidebysig static void Main() il managed
   {
@@ -78,18 +85,18 @@
     IL_0018:  bne.un.s   IL_002d
 
     IL_001a:  ldc.i4.s   100
-    IL_001c:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_001c:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_0021:  ldstr      "Test passed"
     IL_0026:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_002b:  br.s       IL_003d
 
     IL_002d:  ldc.i4.1
-    IL_002e:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_002e:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_0033:  ldstr      "Test failed"
     IL_0038:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
-    IL_003d:  call       int32 ['system.runtime.extensions']System.Environment::get_ExitCode()
-              call       void ['system.runtime.extensions']System.Environment::Exit(int32)
+    IL_003d:  call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
+              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
               ret
-  } 
+  }
 
-} 
+}

--- a/tests/src/JIT/Methodical/switch/switch8.il
+++ b/tests/src/JIT/Methodical/switch/switch8.il
@@ -1,16 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+
 // goto statements in switch
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern legacy library mscorlib { auto }
 
-
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern legacy library mscorlib {}
 .assembly 'switch8'
 {
 

--- a/tests/src/JIT/Methodical/switch/switch8.il
+++ b/tests/src/JIT/Methodical/switch/switch8.il
@@ -3,11 +3,18 @@
 // See the LICENSE file in the project root for more information.
 // goto statements in switch
 
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern legacy library mscorlib {}
 .assembly 'switch8'
 {
-  
-  
+
+
 }
 
 .module 'switch8.exe'
@@ -24,7 +31,7 @@
     IL_0002:  ldloc.0
     IL_0003:  ldc.i4.1
     IL_0004:  sub
-    IL_0005:  switch     ( 
+    IL_0005:  switch     (
                           IL_0014,
                           IL_0016)
     IL_0012:  br.s       IL_0018
@@ -36,17 +43,17 @@
     IL_0018:  br.s       IL_002d
 
     IL_001a:  ldc.i4.s   100
-    IL_001c:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_001c:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_0021:  ldstr      "Test passed"
     IL_0026:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_002b:  br.s       IL_003d
 
     IL_002d:  ldc.i4.1
-    IL_002e:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_002e:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_0033:  ldstr      "Test failed"
     IL_0038:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_003d:  ret
-  } 
+  }
 
   .method public hidebysig static void Main() il managed
   {
@@ -54,9 +61,9 @@
     .maxstack  8
     IL_0000:  ldc.i4.2
     IL_0001:  call       void Test::DoSwitch(int32)
-    IL_0006:  call       int32 ['system.runtime.extensions']System.Environment::get_ExitCode()
-              call       void ['system.runtime.extensions']System.Environment::Exit(int32)
+    IL_0006:  call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
+              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
               ret
-  } 
+  }
 
-} 
+}

--- a/tests/src/JIT/Methodical/switch/switch9.il
+++ b/tests/src/JIT/Methodical/switch/switch9.il
@@ -3,11 +3,18 @@
 // See the LICENSE file in the project root for more information.
 //Nested Switch
 
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern legacy library mscorlib {}
 .assembly 'switch9'
 {
-  
-  
+
+
 }
 
 .module 'switch9.exe'
@@ -25,7 +32,7 @@
     IL_0002:  ldloc.0
     IL_0003:  ldc.i4.1
     IL_0004:  sub
-    IL_0005:  switch     ( 
+    IL_0005:  switch     (
                           IL_0014,
                           IL_0061)
     IL_0012:  br.s       IL_0073
@@ -35,25 +42,25 @@
     IL_0016:  ldloc.0
     IL_0017:  ldc.i4.1
     IL_0018:  sub
-    IL_0019:  switch     ( 
+    IL_0019:  switch     (
                           IL_0028,
                           IL_003b)
     IL_0026:  br.s       IL_004d
 
     IL_0028:  ldc.i4.s   100
-    IL_002a:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_002a:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_002f:  ldstr      "Test passed"
     IL_0034:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0039:  br.s       IL_005f
 
     IL_003b:  ldc.i4.1
-    IL_003c:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_003c:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_0041:  ldstr      "Test failed"
     IL_0046:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_004b:  br.s       IL_005f
 
     IL_004d:  ldc.i4.1
-    IL_004e:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_004e:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_0053:  ldstr      "Test failed"
     IL_0058:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_005d:  br.s       IL_005f
@@ -61,19 +68,19 @@
     IL_005f:  br.s       IL_0085
 
     IL_0061:  ldc.i4.1
-    IL_0062:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_0062:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_0067:  ldstr      "Test failed"
     IL_006c:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0071:  br.s       IL_0085
 
     IL_0073:  ldc.i4.1
-    IL_0074:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
+    IL_0074:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
     IL_0079:  ldstr      "Test failed"
     IL_007e:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
     IL_0083:  br.s       IL_0085
 
     IL_0085:  ret
-  } 
+  }
 
   .method public hidebysig static void Main() il managed
   {
@@ -83,9 +90,9 @@
     IL_0001:  ldc.i4.1
     IL_0002:  call       void Test::DoSwitch(int32,
                                              int32)
-    IL_0007:  call       int32 ['system.runtime.extensions']System.Environment::get_ExitCode()
-              call       void ['system.runtime.extensions']System.Environment::Exit(int32)
+    IL_0007:  call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
+              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
               ret
-  } 
- 
-} 
+  }
+
+}

--- a/tests/src/JIT/Methodical/switch/switch9.il
+++ b/tests/src/JIT/Methodical/switch/switch9.il
@@ -1,16 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+
 //Nested Switch
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern legacy library mscorlib { auto }
 
-
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern legacy library mscorlib {}
 .assembly 'switch9'
 {
 

--- a/tests/src/JIT/Methodical/tailcall/recurse_ep_void.il
+++ b/tests/src/JIT/Methodical/tailcall/recurse_ep_void.il
@@ -2,11 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
 .assembly extern System.Console
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib { }
 .assembly recurse_ep_void { }
 .namespace JitTest
@@ -16,7 +24,7 @@
   {
     .field private static int32 m
     .field private static int32 n
-    .method private hidebysig static 
+    .method private hidebysig static
             void Main() il managed
     {
       .entrypoint
@@ -42,7 +50,7 @@
                                                                                class System.String)
       IL_0039:  call       void [System.Console]System.Console::WriteLine(class System.String)
       IL_003e:  ldc.i4     0x65
-      IL_0043:  call       void [system.runtime.extensions]System.Environment::Exit(int32)
+      IL_0043:  call       void [System.Runtime.Extensions]System.Environment::Exit(int32)
       IL_0048:  ret
 
       IL_0049:  ldsfld     int32 JitTest.Test::m
@@ -56,9 +64,9 @@
       IL_0061:  tail.
       IL_0063:  call       void JitTest.Test::Main()
       IL_0068:  ret
-    } 
+    }
 
-    .method private hidebysig specialname rtspecialname static 
+    .method private hidebysig specialname rtspecialname static
             void .cctor() il managed
     {
       .maxstack  8
@@ -67,17 +75,17 @@
       IL_0006:  ldc.i4.s   10
       IL_0008:  stsfld     int32 JitTest.Test::n
       IL_000d:  ret
-    } 
+    }
 
-    .method public hidebysig specialname rtspecialname 
+    .method public hidebysig specialname rtspecialname
             instance void .ctor() il managed
     {
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
       IL_0006:  ret
-    } 
+    }
 
-  } 
+  }
 
-} 
+}

--- a/tests/src/JIT/Methodical/tailcall/recurse_ep_void.il
+++ b/tests/src/JIT/Methodical/tailcall/recurse_ep_void.il
@@ -3,19 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Console { auto }
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern mscorlib { }
 .assembly recurse_ep_void { }
 .namespace JitTest
 {

--- a/tests/src/JIT/Methodical/tailcall/test_2a.il
+++ b/tests/src/JIT/Methodical/tailcall/test_2a.il
@@ -2,19 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Console { auto }
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib { }
 .assembly test_2a { }
 .namespace JitTest
 {

--- a/tests/src/JIT/Methodical/tailcall/test_2a.il
+++ b/tests/src/JIT/Methodical/tailcall/test_2a.il
@@ -2,12 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-.assembly extern mscorlib { }
 .assembly extern System.Console
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
+.assembly extern mscorlib { }
 .assembly test_2a { }
 .namespace JitTest
 {
@@ -22,7 +29,7 @@
       .maxstack  4
       .locals (int32 V_0)
       ldc.i4.1
-      call       void [system.runtime.extensions]System.Environment::set_ExitCode(int32)
+      call       void [System.Runtime.Extensions]System.Environment::set_ExitCode(int32)
       ldsfld     int32 JitTest.Test::n
       ldc.i4.1
       bne.un.s   IL_0047
@@ -62,7 +69,7 @@ IL_0047:
       br.s OUT
     } // end of method Test::Main
 
-    .method private hidebysig  specialname rtspecialname static 
+    .method private hidebysig  specialname rtspecialname static
             void .cctor() il managed
     {
       // Code size       14 (0xe)
@@ -74,7 +81,7 @@ IL_0047:
       IL_000d:  ret
     } // end of method Test::.cctor
 
-    .method public hidebysig  specialname rtspecialname 
+    .method public hidebysig  specialname rtspecialname
             instance void .ctor() il managed
     {
       // Code size       7 (0x7)

--- a/tests/src/JIT/Methodical/tailcall/test_2b.il
+++ b/tests/src/JIT/Methodical/tailcall/test_2b.il
@@ -2,6 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
+.assembly extern System.Console
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib { }
 .assembly extern System.Console
 {
@@ -22,7 +35,7 @@
       .maxstack  4
       .locals (int32 V_0)
       ldc.i4.1
-      call       void [system.runtime.extensions]System.Environment::set_ExitCode(int32)
+      call       void [System.Runtime.Extensions]System.Environment::set_ExitCode(int32)
       ldsfld     int32 JitTest.Test::n
       ldc.i4.1
       bne.un.s   IL_0047
@@ -50,7 +63,7 @@ IL_0047:
       ldsfld     int32 JitTest.Test::n
       ldc.i4.1
       beq        MERGE
-      
+
       ldsfld     int32 JitTest.Test::m
       ldsfld     int32 JitTest.Test::n
       dup
@@ -64,7 +77,7 @@ MERGE:
       ret
     } // end of method Test::Main
 
-    .method private hidebysig  specialname rtspecialname static 
+    .method private hidebysig  specialname rtspecialname static
             void .cctor() il managed
     {
       // Code size       14 (0xe)
@@ -76,7 +89,7 @@ MERGE:
       IL_000d:  ret
     } // end of method Test::.cctor
 
-    .method public hidebysig  specialname rtspecialname 
+    .method public hidebysig  specialname rtspecialname
             instance void .ctor() il managed
     {
       // Code size       7 (0x7)

--- a/tests/src/JIT/Methodical/tailcall/test_2b.il
+++ b/tests/src/JIT/Methodical/tailcall/test_2b.il
@@ -3,24 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Console { auto }
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
+.assembly extern System.Console { auto }
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern mscorlib { }
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
 .assembly test_2b { }
 .namespace JitTest
 {

--- a/tests/src/JIT/Methodical/tailcall/test_2c.il
+++ b/tests/src/JIT/Methodical/tailcall/test_2c.il
@@ -2,12 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-.assembly extern mscorlib { }
+
 .assembly extern System.Console
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
+.assembly extern mscorlib { }
 .assembly test_2c { }
 .namespace JitTest
 {
@@ -22,7 +30,7 @@
       .maxstack  4
       .locals (int32 V_0)
       ldc.i4.1
-      call       void [system.runtime.extensions]System.Environment::set_ExitCode(int32)
+      call       void [System.Runtime.Extensions]System.Environment::set_ExitCode(int32)
       ldsfld     int32 JitTest.Test::n
       ldc.i4.1
       bne.un.s   IL_0047
@@ -51,7 +59,7 @@ IL_0047:
       ldsfld     int32 JitTest.Test::n
       ldc.i4.1
       beq        MERGE
-      
+
       ldsfld     int32 JitTest.Test::m
       ldsfld     int32 JitTest.Test::n
       dup
@@ -66,7 +74,7 @@ RET:
       ret
     } // end of method Test::Main
 
-    .method private hidebysig  specialname rtspecialname static 
+    .method private hidebysig  specialname rtspecialname static
             void .cctor() il managed
     {
       // Code size       14 (0xe)
@@ -78,7 +86,7 @@ RET:
       IL_000d:  ret
     } // end of method Test::.cctor
 
-    .method public hidebysig  specialname rtspecialname 
+    .method public hidebysig  specialname rtspecialname
             instance void .ctor() il managed
     {
       // Code size       7 (0x7)

--- a/tests/src/JIT/Methodical/tailcall/test_2c.il
+++ b/tests/src/JIT/Methodical/tailcall/test_2c.il
@@ -3,19 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Console { auto }
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern mscorlib { }
 .assembly test_2c { }
 .namespace JitTest
 {

--- a/tests/src/JIT/Methodical/tailcall/test_implicit.il
+++ b/tests/src/JIT/Methodical/tailcall/test_implicit.il
@@ -3,25 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Console { auto }
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern mscorlib
-{
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
-  .hash = (5C EA 16 0E 69 C8 EE F2 C9 A5 6E 45 32 31 FA 61
-           19 8E E7 4D )
-  .ver 2:0:3600:0
-}
 .assembly tailcall
 {
 

--- a/tests/src/JIT/Methodical/tailcall/test_implicit.il
+++ b/tests/src/JIT/Methodical/tailcall/test_implicit.il
@@ -3,27 +3,30 @@
 // See the LICENSE file in the project root for more information.
 
 
-
-
-
-
 .assembly extern System.Console
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
-  .hash = (5C EA 16 0E 69 C8 EE F2 C9 A5 6E 45 32 31 FA 61   
-           19 8E E7 4D )                                     
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .hash = (5C EA 16 0E 69 C8 EE F2 C9 A5 6E 45 32 31 FA 61
+           19 8E E7 4D )
   .ver 2:0:3600:0
 }
 .assembly tailcall
 {
 
 
-  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 )
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
@@ -31,8 +34,8 @@
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
-.subsystem 0x0003       
-.corflags 0x00000001    
+.subsystem 0x0003
+.corflags 0x00000001
 
 
 
@@ -41,7 +44,7 @@
 {
   .field private static int32 MaxDepth
   .field private int32 'value'
-  .method public hidebysig instance int32 
+  .method public hidebysig instance int32
           Recurse1(int32 depth) cil managed
   {
     .maxstack  5
@@ -94,9 +97,9 @@ ret
 
     IL_004b:  ldloc.0
     IL_004c:  ret
-  } 
+  }
 
-  .method public hidebysig instance int32 
+  .method public hidebysig instance int32
           Recurse2(int32 depth,
                    object o1,
                    object o2) cil managed
@@ -120,7 +123,7 @@ ret
     IL_0016:  ldc.i4.s   100
     IL_0018:  bne.un.s   IL_0053
 
-    IL_001a:  call       string [system.runtime.extensions]System.Environment::get_StackTrace()
+    IL_001a:  call       string [System.Runtime.Extensions]System.Environment::get_StackTrace()
     IL_001f:  stloc.0
     IL_0020:  ldloc.0
     IL_0021:  ldstr      "Main"
@@ -136,7 +139,7 @@ ret
     IL_003e:  ldstr      "Test Failed"
     IL_0043:  call       void [System.Console]System.Console::WriteLine(string)
     IL_0048:  ldc.i4.0
-    IL_0049:  call       void [system.runtime.extensions]System.Environment::Exit(int32)
+    IL_0049:  call       void [System.Runtime.Extensions]System.Environment::Exit(int32)
     IL_004e:  call       void [mscorlib]System.GC::Collect()
     IL_0053:  ldarg.0
     IL_0054:  dup
@@ -161,9 +164,9 @@ ret
 
     IL_007b:  ldloc.1
     IL_007c:  ret
-  } 
+  }
 
-  .method public hidebysig newslot virtual 
+  .method public hidebysig newslot virtual
           instance int32  Recurse3(int32 depth) cil managed
   {
     .maxstack  5
@@ -212,9 +215,9 @@ ret
 
     IL_003f:  ldloc.0
     IL_0040:  ret
-  } 
+  }
 
-  .method public hidebysig newslot virtual 
+  .method public hidebysig newslot virtual
           instance int32  Recurse4(int32 depth,
                                    object o1,
                                    object o2) cil managed
@@ -239,7 +242,7 @@ ret
     IL_001b:  bne.un.s   IL_0056
 
     IL_001d:  call       void [mscorlib]System.GC::Collect()
-    IL_0022:  call       string [system.runtime.extensions]System.Environment::get_StackTrace()
+    IL_0022:  call       string [System.Runtime.Extensions]System.Environment::get_StackTrace()
     IL_0027:  stloc.0
     IL_0028:  ldloc.0
     IL_0029:  ldstr      "Main"
@@ -255,7 +258,7 @@ ret
     IL_0046:  ldstr      "Test Failed"
     IL_004b:  call       void [System.Console]System.Console::WriteLine(string)
     IL_0050:  ldc.i4.0
-    IL_0051:  call       void [system.runtime.extensions]System.Environment::Exit(int32)
+    IL_0051:  call       void [System.Runtime.Extensions]System.Environment::Exit(int32)
     IL_0056:  ldarg.0
     IL_0057:  dup
     IL_0058:  ldfld      int32 Class1::'value'
@@ -279,7 +282,7 @@ ret
 
     IL_007e:  ldloc.1
     IL_007f:  ret
-  } 
+  }
 
   .method public hidebysig static int32  Main() cil managed
   {
@@ -343,24 +346,24 @@ ret
 
     IL_007d:  ldloc.2
     IL_007e:  ret
-  } 
+  }
 
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     .maxstack  8
     IL_0000:  ldc.i4     0x2000
     IL_0005:  stsfld     int32 Class1::MaxDepth
     IL_000a:  ret
-  } 
+  }
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     .maxstack  8
     IL_0000:  ldarg.0
     IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
     IL_0006:  ret
-  } 
+  }
 
-} 
+}

--- a/tests/src/JIT/Methodical/tailcall/test_mutual_rec.il
+++ b/tests/src/JIT/Methodical/tailcall/test_mutual_rec.il
@@ -2,12 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-.assembly extern mscorlib { }
+
 .assembly extern System.Console
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
+.assembly extern mscorlib { }
 .assembly test_mutual_rec { }
 .namespace JitTest
 {
@@ -16,13 +24,13 @@
   {
     .field private static int32 m
     .field private static int32 n
-	.method private hidebysig  static int32 Main() il managed
+    .method private hidebysig  static int32 Main() il managed
     {
       .entrypoint
       .maxstack  4
       .locals (int32 V_0)
       ldc.i4.1
-      call       void [system.runtime.extensions]System.Environment::set_ExitCode(int32)
+      call       void [System.Runtime.Extensions]System.Environment::set_ExitCode(int32)
       ldsfld     int32 JitTest.Test::n
       ldc.i4.1
       bne.un.s   IL_0047
@@ -55,7 +63,7 @@ IL_0047:
       stsfld     int32 JitTest.Test::n
       mul
       stsfld     int32 JitTest.Test::m
-      
+
       ldsfld int32 JitTest.Test::n
       ldc.i4.3
       rem
@@ -71,12 +79,12 @@ MERGE1:
       tail. calli int32()
       ret
     } // end of method Test::Main
-	.method private hidebysig  static int32 Main1() il managed
+    .method private hidebysig  static int32 Main1() il managed
     {
       .maxstack  4
       .locals (int32 V_0)
       ldc.i4.1
-      call       void [system.runtime.extensions]System.Environment::set_ExitCode(int32)
+      call       void [System.Runtime.Extensions]System.Environment::set_ExitCode(int32)
       ldsfld     int32 JitTest.Test::n
       ldc.i4.1
       bne.un.s   IL_0047
@@ -109,7 +117,7 @@ IL_0047:
       stsfld     int32 JitTest.Test::n
       mul
       stsfld     int32 JitTest.Test::m
-      
+
       ldsfld int32 JitTest.Test::n
       ldc.i4.3
       rem
@@ -125,12 +133,12 @@ MERGE1:
       tail. calli int32()
       ret
     } // end of method Test::Main
-	.method private hidebysig  static int32 Main2() il managed
+    .method private hidebysig  static int32 Main2() il managed
     {
       .maxstack  4
       .locals (int32 V_0)
       ldc.i4.1
-      call       void [system.runtime.extensions]System.Environment::set_ExitCode(int32)
+      call       void [System.Runtime.Extensions]System.Environment::set_ExitCode(int32)
       ldsfld     int32 JitTest.Test::n
       ldc.i4.1
       bne.un.s   IL_0047
@@ -163,7 +171,7 @@ IL_0047:
       stsfld     int32 JitTest.Test::n
       mul
       stsfld     int32 JitTest.Test::m
-      
+
       ldsfld int32 JitTest.Test::n
       ldc.i4.3
       rem
@@ -180,7 +188,7 @@ MERGE1:
       ret
     } // end of method Test::Main
 
-    .method private hidebysig  specialname rtspecialname static 
+    .method private hidebysig  specialname rtspecialname static
             void .cctor() il managed
     {
       // Code size       14 (0xe)
@@ -192,7 +200,7 @@ MERGE1:
       IL_000d:  ret
     } // end of method Test::.cctor
 
-    .method public hidebysig  specialname rtspecialname 
+    .method public hidebysig  specialname rtspecialname
             instance void .ctor() il managed
     {
       // Code size       7 (0x7)

--- a/tests/src/JIT/Methodical/tailcall/test_mutual_rec.il
+++ b/tests/src/JIT/Methodical/tailcall/test_mutual_rec.il
@@ -3,19 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Console { auto }
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern mscorlib { }
 .assembly test_mutual_rec { }
 .namespace JitTest
 {

--- a/tests/src/JIT/Methodical/tailcall/test_switch.il
+++ b/tests/src/JIT/Methodical/tailcall/test_switch.il
@@ -3,19 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Console { auto }
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern mscorlib { }
 .assembly test_switch { }
 .namespace JitTest
 {

--- a/tests/src/JIT/Methodical/tailcall/test_switch.il
+++ b/tests/src/JIT/Methodical/tailcall/test_switch.il
@@ -2,12 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-.assembly extern mscorlib { }
+
 .assembly extern System.Console
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
+.assembly extern mscorlib { }
 .assembly test_switch { }
 .namespace JitTest
 {
@@ -18,21 +26,21 @@
     .field private static int32 n
     .method private hidebysig static int32 Main1() il managed
     {
-		.maxstack  4
-    	tail. call       int32 JitTest.Test::Main2()
-    	ret
+        .maxstack  4
+        tail. call       int32 JitTest.Test::Main2()
+        ret
     }
     .method private hidebysig static int32 Main2() il managed
     {
-		.maxstack  4
-    	tail. call       int32 JitTest.Test::Main3()
-    	ret
+        .maxstack  4
+        tail. call       int32 JitTest.Test::Main3()
+        ret
     }
     .method private hidebysig static int32 Main3() il managed
     {
-		.maxstack  4
-    	tail. call       int32 JitTest.Test::Main()
-    	ret
+        .maxstack  4
+        tail. call       int32 JitTest.Test::Main()
+        ret
     }
     .method private hidebysig static int32 Main() il managed
     {
@@ -40,7 +48,7 @@
       .maxstack  4
       .locals (int32 V_0)
       ldc.i4.1
-      call       void [system.runtime.extensions]System.Environment::set_ExitCode(int32)
+      call       void [System.Runtime.Extensions]System.Environment::set_ExitCode(int32)
       ldsfld     int32 JitTest.Test::n
       ldc.i4.1
       bne.un.s   IL_0047
@@ -94,7 +102,7 @@ MERGE1:
       ret
     } // end of method Test::Main
 
-    .method private hidebysig specialname rtspecialname static 
+    .method private hidebysig specialname rtspecialname static
             void .cctor() il managed
     {
       // Code size       14 (0xe)
@@ -106,7 +114,7 @@ MERGE1:
       IL_000d:  ret
     } // end of method Test::.cctor
 
-    .method public hidebysig specialname rtspecialname 
+    .method public hidebysig specialname rtspecialname
             instance void .ctor() il managed
     {
       // Code size       7 (0x7)

--- a/tests/src/JIT/Methodical/tailcall/test_virt.il
+++ b/tests/src/JIT/Methodical/tailcall/test_virt.il
@@ -3,19 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Console { auto }
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern mscorlib { }
 .assembly test_virt { }
 .namespace JitTest
 {

--- a/tests/src/JIT/Methodical/tailcall/test_virt.il
+++ b/tests/src/JIT/Methodical/tailcall/test_virt.il
@@ -2,12 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-.assembly extern mscorlib { }
+
 .assembly extern System.Console
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
+.assembly extern mscorlib { }
 .assembly test_virt { }
 .namespace JitTest
 {
@@ -20,7 +28,7 @@
       .maxstack  4
       .locals (int32 V_0)
       ldc.i4.1
-      call       void [system.runtime.extensions]System.Environment::set_ExitCode(int32)
+      call       void [System.Runtime.Extensions]System.Environment::set_ExitCode(int32)
       ldsfld     int32 JitTest.TestClass::n
       ldc.i4.1
       bne.un.s   IL_0047
@@ -66,7 +74,7 @@ IL_0047:
       tail. callvirt instance int32 JitTest.TestClass::Main()
       ret
      }
-    .method private hidebysig  specialname rtspecialname static 
+    .method private hidebysig  specialname rtspecialname static
             void .cctor() il managed
     {
       // Code size       14 (0xe)
@@ -78,7 +86,7 @@ IL_0047:
       IL_000d:  ret
     } // end of method Test::.cctor
 
-    .method public hidebysig  specialname rtspecialname 
+    .method public hidebysig  specialname rtspecialname
             instance void .ctor() il managed
     {
       // Code size       7 (0x7)

--- a/tests/src/JIT/Methodical/tailcall/test_void.il
+++ b/tests/src/JIT/Methodical/tailcall/test_void.il
@@ -2,11 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
 .assembly extern System.Console
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib { }
 .assembly test_void { }
 .namespace JitTest
@@ -31,7 +39,7 @@
       ldstr      "PASSED: 10! == 3628800"
       call       void [System.Console]System.Console::WriteLine(class System.String)
       ldc.i4.s   100
-      call       void [system.runtime.extensions]System.Environment::Exit(int32)
+      call       void [System.Runtime.Extensions]System.Environment::Exit(int32)
       ret
 
 IL_0029:
@@ -41,7 +49,7 @@ IL_0029:
       call       class System.String [mscorlib]System.String::Concat(class System.String, class System.String)
       call       void [System.Console]System.Console::WriteLine(class System.String)
       ldc.i4.s   101
-      call       void [system.runtime.extensions]System.Environment::Exit(int32)
+      call       void [System.Runtime.Extensions]System.Environment::Exit(int32)
       ret
 
 IL_0047:
@@ -55,9 +63,9 @@ IL_0047:
       stsfld     int32 JitTest.Test::m
       tail. call void JitTest.Test::Main()
       ret
-    } 
+    }
 
-    .method private hidebysig  specialname rtspecialname static 
+    .method private hidebysig  specialname rtspecialname static
             void .cctor() il managed
     {
       .maxstack  8
@@ -66,17 +74,17 @@ IL_0047:
       IL_0006:  ldc.i4.s   10
       IL_0008:  stsfld     int32 JitTest.Test::n
       IL_000d:  ret
-    } 
+    }
 
-    .method public hidebysig  specialname rtspecialname 
+    .method public hidebysig  specialname rtspecialname
             instance void .ctor() il managed
     {
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
       IL_0006:  ret
-    } 
+    }
 
-  } 
+  }
 
-} 
+}

--- a/tests/src/JIT/Methodical/tailcall/test_void.il
+++ b/tests/src/JIT/Methodical/tailcall/test_void.il
@@ -3,19 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Console { auto }
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern mscorlib { }
 .assembly test_void { }
 .namespace JitTest
 {

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b65423/b65423.il
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b65423/b65423.il
@@ -3,18 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
+.assembly extern Microsoft.VisualBasic { auto }
 
-.assembly extern mscorlib
-{
-}
-.assembly extern Microsoft.VisualBasic
-{
-}
 .assembly 'b1904'
 {
 }

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b65423/b65423.il
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b65423/b65423.il
@@ -3,7 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 
-
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
 
 .assembly extern mscorlib
 {
@@ -222,8 +226,8 @@
                                                                                       int32)
     IL_0078:  stloc.2
     IL_0079:  ret
-    IL_007a:  
-  } 
+    IL_007a:
+  }
 
   .method public static void Main() il managed forwardref
   {
@@ -236,24 +240,24 @@
     IL_0002:  stsfld     int32 b1904::Count
     .try{
         IL_0010:  call       void b1904::RunTest()
-		  leave.s IL_0083
-	}
-    catch [mscorlib]System.TypeLoadException
-    {	  
-	pop
-        IL_0029:  ldstr      "Caught TypeLoadException exception: "
-	IL_002e:  ldsfld     int32 b1904::Count
-	IL_0033:  call       class System.String [mscorlib]System.Convert::ToString(int32)
-	IL_0038:  call       class System.String ['mscorlib']System.String::Concat(class System.String,
-                                                                               class System.String)
-	IL_003d:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
-	IL_0042:  ldsfld     int32 b1904::Count
-	IL_0047:  call       void ['system.runtime.extensions']System.Environment::set_ExitCode(int32)
-	IL_004c:  leave.s    IL_0083 
+          leave.s IL_0083
     }
-    IL_0083:  call       int32 ['system.runtime.extensions']System.Environment::get_ExitCode()
-              call       void ['system.runtime.extensions']System.Environment::Exit(int32)
+    catch [mscorlib]System.TypeLoadException
+    {
+    pop
+        IL_0029:  ldstr      "Caught TypeLoadException exception: "
+    IL_002e:  ldsfld     int32 b1904::Count
+    IL_0033:  call       class System.String [mscorlib]System.Convert::ToString(int32)
+    IL_0038:  call       class System.String ['mscorlib']System.String::Concat(class System.String,
+                                                                               class System.String)
+    IL_003d:  call       void ['mscorlib']System.Console::WriteLine(class System.String)
+    IL_0042:  ldsfld     int32 b1904::Count
+    IL_0047:  call       void ['System.Runtime.Extensions']System.Environment::set_ExitCode(int32)
+    IL_004c:  leave.s    IL_0083
+    }
+    IL_0083:  call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
+              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
               ret
-  } 
+  }
 
-} 
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-QFE/b151440/static-none.il
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-QFE/b151440/static-none.il
@@ -2,14 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
 .assembly extern System.Console
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
   .ver 2:0:3600:0
 }
 .assembly template
@@ -36,7 +44,7 @@
              int32 V_7)
     IL_0000:  ldc.i4.1
     IL_0001:  stloc.0
-    IL_0002:  ldftn       string[] [system.runtime.extensions]System.Environment::GetCommandLineArgs()
+    IL_0002:  ldftn       string[] [System.Runtime.Extensions]System.Environment::GetCommandLineArgs()
     IL_0003:  calli       string[]()
     IL_0007:  stloc.1
     IL_0008:  ldloc.1
@@ -177,7 +185,7 @@
 
     IL_00e9:  ldloc.s    V_4
     IL_00eb:  ret
-  } 
+  }
 
   .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
@@ -186,6 +194,6 @@
     IL_0000:  ldarg.0
     IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
     IL_0006:  ret
-  } 
+  }
 
-} 
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-QFE/b151440/static-none.il
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-QFE/b151440/static-none.il
@@ -3,23 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Console { auto }
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern mscorlib
-{
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
-  .ver 2:0:3600:0
-}
 .assembly template
 {
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 )

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1.1-M1-Beta1/b143840/b143840.il
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1.1-M1-Beta1/b143840/b143840.il
@@ -3,25 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Console { auto }
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern System.Threading.Thread { auto }
+.assembly extern legacy library mscorlib { auto }
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern System.Threading.Thread
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern legacy library mscorlib {}
 .assembly ExternalException {}
 .class private auto ansi beforefieldinit ExternalClass
        extends [mscorlib]System.Object

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1.1-M1-Beta1/b143840/b143840.il
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1.1-M1-Beta1/b143840/b143840.il
@@ -2,27 +2,41 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
 .assembly extern System.Console
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
+.assembly extern System.Threading.Thread
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern legacy library mscorlib {}
 .assembly ExternalException {}
 .class private auto ansi beforefieldinit ExternalClass
        extends [mscorlib]System.Object
 {
   .field private class ExternalException ee
-  .method public hidebysig instance void 
-          ThrowException() cil managed synchronized 
+  .method public hidebysig instance void
+          ThrowException() cil managed synchronized
   {
     .maxstack  1
     IL_0000:  ldarg.0
     IL_0001:  ldfld      class ExternalException ExternalClass::ee
     IL_0006:  throw
-  } 
+  }
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     .maxstack  2
@@ -32,9 +46,9 @@
     IL_000b:  ldarg.0
     IL_000c:  call       instance void [mscorlib]System.Object::.ctor()
     IL_0011:  ret
-  } 
+  }
 
-} 
+}
 
 .class public auto ansi beforefieldinit ExternalException
        extends [mscorlib]System.Exception
@@ -64,15 +78,15 @@
       IL_001d:  callvirt   instance void [System.Threading.Thread]System.Threading.Thread::Start()
       IL_0022:  leave.s    IL_0031
 
-    }  
-    catch [mscorlib]System.Exception 
+    }
+    catch [mscorlib]System.Exception
     {
       IL_0024:  pop
       IL_0025:  ldstr      "Exception was caught in main"
       IL_002a:  call       void [System.Console]System.Console::WriteLine(string)
       IL_002f:  leave.s    IL_0031
 
-    }  
+    }
     IL_0031:  ldloc.2
     IL_0032:  ldc.i4.1
     IL_0033:  add
@@ -81,12 +95,12 @@
     IL_0036:  ldc.i4.s   10
     IL_0038:  blt.s      IL_000a
 
-    IL_003a:  
-		ldc.i4 100
-		ret
-  } 
+    IL_003a:
+        ldc.i4 100
+        ret
+  }
 
-  .method public hidebysig instance void 
+  .method public hidebysig instance void
           runtest() cil managed
   {
     .maxstack  3
@@ -121,8 +135,8 @@
         IL_0015:  call       instance void ExternalException::recurse(int32)
         IL_001a:  leave.s    IL_002a
 
-      }  
-      catch [mscorlib]System.ArithmeticException 
+      }
+      catch [mscorlib]System.ArithmeticException
       {
         IL_001c:  pop
         IL_001d:  ldloc.0
@@ -131,8 +145,8 @@
         IL_0020:  stloc.0
         IL_0021:  leave.s    IL_0031
 
-      }  
-      catch ExternalException 
+      }
+      catch ExternalException
       {
         IL_0023:  pop
         IL_0024:  ldloc.0
@@ -141,10 +155,10 @@
         IL_0027:  stloc.0
         IL_0028:  leave.s    IL_0031
 
-      }  
+      }
       IL_002a:  leave.s    IL_0031
 
-    }  
+    }
     finally
     {
       IL_002c:  ldloc.0
@@ -152,7 +166,7 @@
       IL_002e:  add
       IL_002f:  stloc.0
       IL_0030:  endfinally
-    }  
+    }
     IL_0031:  ldloc.1
     IL_0032:  ldc.i4.1
     IL_0033:  add
@@ -174,16 +188,16 @@
       IL_0047:  ldstr      "TryCatch Test Passed"
       IL_004c:  call       void [System.Console]System.Console::WriteLine(string)
       IL_0051:  ldc.i4 100
-      IL_0052:  call       void [system.runtime.extensions]System.Environment::set_ExitCode(int32)
+      IL_0052:  call       void [System.Runtime.Extensions]System.Environment::set_ExitCode(int32)
       IL_0057:  leave.s    IL_0060
 
-    }  
+    }
     finally
     {
       IL_0059:  ldloc.2
       IL_005a:  call       void [mscorlib]System.Threading.Monitor::Exit(object)
       IL_005f:  endfinally
-    }  
+    }
     IL_0060:  br.s       IL_0089
 
     IL_0062:  ldarg.0
@@ -197,20 +211,20 @@
       IL_0074:  ldloc.0
       IL_0075:  call       void [System.Console]System.Console::WriteLine(int32)
       IL_007a:  ldc.i4.1
-      IL_007b:  call       void [system.runtime.extensions]System.Environment::set_ExitCode(int32)
+      IL_007b:  call       void [System.Runtime.Extensions]System.Environment::set_ExitCode(int32)
       IL_0080:  leave.s    IL_0089
 
-    }  
+    }
     finally
     {
       IL_0082:  ldloc.2
       IL_0083:  call       void [mscorlib]System.Threading.Monitor::Exit(object)
       IL_0088:  endfinally
-    }  
+    }
     IL_0089:  ret
-  } 
+  }
 
-  .method public hidebysig instance void 
+  .method public hidebysig instance void
           recurse(int32 counter) cil managed
   {
     .maxstack  3
@@ -234,14 +248,14 @@
     IL_001e:  starg.s    counter
     IL_0020:  call       instance void ExternalException::recurse(int32)
     IL_0025:  ret
-  } 
+  }
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     .maxstack  1
     IL_0000:  ldarg.0
     IL_0001:  call       instance void [mscorlib]System.Exception::.ctor()
     IL_0006:  ret
-  } 
+  }
 }

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-M01/b08046/SyncGCHole.il
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-M01/b08046/SyncGCHole.il
@@ -3,25 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Console { auto }
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern System.Threading.Thread { auto }
+.assembly extern legacy library mscorlib { auto }
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern System.Threading.Thread
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern legacy library mscorlib {}
 .assembly ExternalException {}
 .class private auto ansi beforefieldinit ExternalClass
        extends [mscorlib]System.Object

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-M01/b08046/SyncGCHole.il
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-M01/b08046/SyncGCHole.il
@@ -2,27 +2,41 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
 .assembly extern System.Console
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
+.assembly extern System.Threading.Thread
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern legacy library mscorlib {}
 .assembly ExternalException {}
 .class private auto ansi beforefieldinit ExternalClass
        extends [mscorlib]System.Object
 {
   .field private class ExternalException ee
-  .method public hidebysig instance void 
-          ThrowException() cil managed synchronized 
+  .method public hidebysig instance void
+          ThrowException() cil managed synchronized
   {
     .maxstack  1
     IL_0000:  ldarg.0
     IL_0001:  ldfld      class ExternalException ExternalClass::ee
     IL_0006:  throw
-  } 
+  }
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     .maxstack  2
@@ -32,9 +46,9 @@
     IL_000b:  ldarg.0
     IL_000c:  call       instance void [mscorlib]System.Object::.ctor()
     IL_0011:  ret
-  } 
+  }
 
-} 
+}
 
 .class public auto ansi beforefieldinit ExternalException
        extends [mscorlib]System.Exception
@@ -64,15 +78,15 @@
       IL_001d:  callvirt   instance void [System.Threading.Thread]System.Threading.Thread::Start()
       IL_0022:  leave.s    IL_0031
 
-    }  
-    catch [mscorlib]System.Exception 
+    }
+    catch [mscorlib]System.Exception
     {
       IL_0024:  pop
       IL_0025:  ldstr      "Exception was caught in main"
       IL_002a:  call       void [System.Console]System.Console::WriteLine(string)
       IL_002f:  leave.s    IL_0031
 
-    }  
+    }
     IL_0031:  ldloc.2
     IL_0032:  ldc.i4.1
     IL_0033:  add
@@ -81,12 +95,12 @@
     IL_0036:  ldc.i4.s   10
     IL_0038:  blt.s      IL_000a
 
-    IL_003a:  call       int32 ['system.runtime.extensions']System.Environment::get_ExitCode()
-              call       void ['system.runtime.extensions']System.Environment::Exit(int32)
+    IL_003a:  call       int32 ['System.Runtime.Extensions']System.Environment::get_ExitCode()
+              call       void ['System.Runtime.Extensions']System.Environment::Exit(int32)
               ret
-  } 
+  }
 
-  .method public hidebysig instance void 
+  .method public hidebysig instance void
           runtest() cil managed
   {
     .maxstack  3
@@ -121,8 +135,8 @@
         IL_0015:  call       instance void ExternalException::recurse(int32)
         IL_001a:  leave.s    IL_002a
 
-      }  
-      catch [mscorlib]System.ArithmeticException 
+      }
+      catch [mscorlib]System.ArithmeticException
       {
         IL_001c:  pop
         IL_001d:  ldloc.0
@@ -131,8 +145,8 @@
         IL_0020:  stloc.0
         IL_0021:  leave.s    IL_0031
 
-      }  
-      catch ExternalException 
+      }
+      catch ExternalException
       {
         IL_0023:  pop
         IL_0024:  ldloc.0
@@ -141,10 +155,10 @@
         IL_0027:  stloc.0
         IL_0028:  leave.s    IL_0031
 
-      }  
+      }
       IL_002a:  leave.s    IL_0031
 
-    }  
+    }
     finally
     {
       IL_002c:  ldloc.0
@@ -152,7 +166,7 @@
       IL_002e:  add
       IL_002f:  stloc.0
       IL_0030:  endfinally
-    }  
+    }
     IL_0031:  ldloc.1
     IL_0032:  ldc.i4.1
     IL_0033:  add
@@ -174,16 +188,16 @@
       IL_0047:  ldstr      "TryCatch Test Passed"
       IL_004c:  call       void [System.Console]System.Console::WriteLine(string)
       IL_0051:  ldc.i4 100
-      IL_0052:  call       void [system.runtime.extensions]System.Environment::set_ExitCode(int32)
+      IL_0052:  call       void [System.Runtime.Extensions]System.Environment::set_ExitCode(int32)
       IL_0057:  leave.s    IL_0060
 
-    }  
+    }
     finally
     {
       IL_0059:  ldloc.2
       IL_005a:  call       void [mscorlib]System.Threading.Monitor::Exit(object)
       IL_005f:  endfinally
-    }  
+    }
     IL_0060:  br.s       IL_0089
 
     IL_0062:  ldarg.0
@@ -197,20 +211,20 @@
       IL_0074:  ldloc.0
       IL_0075:  call       void [System.Console]System.Console::WriteLine(int32)
       IL_007a:  ldc.i4.1
-      IL_007b:  call       void [system.runtime.extensions]System.Environment::set_ExitCode(int32)
+      IL_007b:  call       void [System.Runtime.Extensions]System.Environment::set_ExitCode(int32)
       IL_0080:  leave.s    IL_0089
 
-    }  
+    }
     finally
     {
       IL_0082:  ldloc.2
       IL_0083:  call       void [mscorlib]System.Threading.Monitor::Exit(object)
       IL_0088:  endfinally
-    }  
+    }
     IL_0089:  ret
-  } 
+  }
 
-  .method public hidebysig instance void 
+  .method public hidebysig instance void
           recurse(int32 counter) cil managed
   {
     .maxstack  3
@@ -234,14 +248,14 @@
     IL_001e:  starg.s    counter
     IL_0020:  call       instance void ExternalException::recurse(int32)
     IL_0025:  ret
-  } 
+  }
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     .maxstack  1
     IL_0000:  ldarg.0
     IL_0001:  call       instance void [mscorlib]System.Exception::.ctor()
     IL_0006:  ret
-  } 
+  }
 }

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b426654/b426654.il
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b426654/b426654.il
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 
-
-
 .module extern user32.dll
 .module extern kernel32
 
@@ -13,22 +11,29 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+
+.assembly extern System.Threading.Thread
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
   .ver 2:0:0:0
 }
 .assembly cs1
 {
-  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 )
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
 .module cs1.exe
 .imagebase 0x00400000
 .file alignment 0x00000200
-.subsystem 0x0003       
-.corflags 0x00000001    
+.subsystem 0x0003
+.corflags 0x00000001
 
 
 
@@ -44,7 +49,7 @@
   .field private object modreq([mscorlib]System.Runtime.CompilerServices.IsVolatile) m_objVolatile
   .field private object[] m_objs
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     .maxstack  3
@@ -82,9 +87,9 @@
     IL_0048:  stfld      object modreq([mscorlib]System.Runtime.CompilerServices.IsVolatile) cs1::m_objVolatile
     IL_004d:  nop
     IL_004e:  ret
-  } 
+  }
 
-  .method public hidebysig instance void 
+  .method public hidebysig instance void
           CheckVal() cil managed noinlining
   {
     .maxstack  2
@@ -103,28 +108,28 @@
       IL_0007:  ldarg.0
       IL_0008:  ldfld      object cs1::m_obj
       IL_000d:  unbox      [mscorlib]System.Int32
-		ldc.i4 0
-		stind.i4
+        ldc.i4 0
+        stind.i4
 
       IL_0032:  ldarg.0
       IL_0033:  volatile.
       IL_0035:  ldfld      object modreq([mscorlib]System.Runtime.CompilerServices.IsVolatile) cs1::m_objVolatile
       IL_003a:  unbox      [mscorlib]System.Int32
-		ldc.i4 0
-		stind.i4
+        ldc.i4 0
+        stind.i4
 
       IL_005f:  nop
       IL_0060:  leave.s    IL_0067
 
-    }  
-    catch [mscorlib]System.InvalidCastException 
+    }
+    catch [mscorlib]System.InvalidCastException
     {
       IL_0062:  pop
       IL_0063:  nop
       IL_0064:  nop
       IL_0065:  leave.s    IL_0067
 
-    }  
+    }
     IL_0067:  nop
     IL_0068:  nop
     IL_0069:  ldloc.0
@@ -139,9 +144,9 @@
     IL_0077:  brtrue.s   IL_0005
 
     IL_0079:  ret
-  } 
+  }
 
-  .method private hidebysig instance void 
+  .method private hidebysig instance void
           Flip() cil managed
   {
     .maxstack  4
@@ -202,7 +207,7 @@
     IL_005b:  brtrue.s   IL_0005
 
     IL_005d:  ret
-  } 
+  }
 
   .method private hidebysig static void  SignalTimeUp(object stateInfo) cil managed
   {
@@ -211,7 +216,7 @@
     IL_0001:  ldc.i4.1
     IL_0002:  stsfld     bool cs1::s_timeUp
     IL_0007:  ret
-  } 
+  }
 
   .method public hidebysig static int32 Main(string[] args) cil managed
   {
@@ -221,7 +226,7 @@
              class [System.Threading.Thread]System.Threading.Thread V_1,
              class [mscorlib]System.Threading.Timer V_2,
              class [System.Threading.Thread]System.Threading.Thread V_flip
-		)
+        )
     IL_0000:  nop
     IL_0001:  newobj     instance void cs1::.ctor()
     IL_0006:  stloc.0
@@ -273,11 +278,11 @@
     IL_004e:  ldstr      "Test SUCCESS"
     IL_0053:  call       void [System.Console]System.Console::WriteLine(string)
 
-	ldc.i4 100
+    ldc.i4 100
     IL_0059:  ret
-  } 
+  }
 
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     .maxstack  8
@@ -290,6 +295,6 @@
     IL_0016:  ldc.i4.0
     IL_0017:  stsfld     bool cs1::s_timeUp
     IL_001c:  ret
-  } 
+  }
 
-} 
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b426654/b426654.il
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b426654/b426654.il
@@ -5,24 +5,10 @@
 
 .module extern user32.dll
 .module extern kernel32
+.assembly extern System.Console { auto }
+.assembly extern System.Threading.Thread { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern System.Threading.Thread
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern mscorlib
-{
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
-  .ver 2:0:0:0
-}
 .assembly cs1
 {
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 )

--- a/tests/src/JIT/Regression/Dev11/dev11_10427/conv_ovf_i4.il
+++ b/tests/src/JIT/Regression/Dev11/dev11_10427/conv_ovf_i4.il
@@ -4,24 +4,10 @@
 
 
 .assembly Conv_ovf_u4_Bug {}
+.assembly extern System.Console { auto }
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern mscorlib
-{
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
-  .ver 2:0:0:0
-}
 
 .method static public int32 main() il managed
 {

--- a/tests/src/JIT/Regression/Dev11/dev11_10427/conv_ovf_i4.il
+++ b/tests/src/JIT/Regression/Dev11/dev11_10427/conv_ovf_i4.il
@@ -2,18 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-.assembly Conv_ovf_u4_Bug {}
 
+.assembly Conv_ovf_u4_Bug {}
 
 .assembly extern System.Console
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib
 {
-.publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
-.ver 2:0:0:0
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 2:0:0:0
 }
 
 .method static public int32 main() il managed
@@ -23,7 +30,7 @@
 
 .try
 {
-call int32 [system.runtime.extensions]System.Environment::get_TickCount()
+call int32 [System.Runtime.Extensions]System.Environment::get_TickCount()
 conv.i8
 ldc.i8 0x80000000
 or

--- a/tests/src/JIT/Regression/JitBlue/GitHub_11804/GitHub_11804.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_11804/GitHub_11804.il
@@ -3,22 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Private.CoreLib
-{
-  .publickeytoken = (7C EC 85 D7 BE A7 79 8E )                         // |.....y.
-  .ver 4:0:0:0
-}
-.assembly extern System.Numerics.Vectors
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:1:3:0
-}
-.assembly extern System.Runtime.CompilerServices.Unsafe
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
-  .ver 4:0:3:0
-}
-.assembly extern mscorlib{}
+.assembly extern System.Private.CoreLib { auto }
+.assembly extern System.Numerics.Vectors { auto }
+.assembly extern System.Runtime.CompilerServices.Unsafe { auto }
+.assembly extern mscorlib { auto }
+
 .assembly GitHub_11804
 {
   .custom instance void [System.Private.CoreLib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 )

--- a/tests/src/JIT/Regression/JitBlue/GitHub_11804/GitHub_11804.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_11804/GitHub_11804.il
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
 .assembly extern System.Private.CoreLib
 {
   .publickeytoken = (7C EC 85 D7 BE A7 79 8E )                         // |.....y.
@@ -17,9 +18,10 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
   .ver 4:0:3:0
 }
+.assembly extern mscorlib{}
 .assembly GitHub_11804
 {
-  .custom instance void [System.Private.CoreLib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
+  .custom instance void [System.Private.CoreLib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 )
   .custom instance void [System.Private.CoreLib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
                                                                                                                            63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
 
@@ -39,7 +41,7 @@
 .class private abstract auto ansi sealed beforefieldinit C
        extends [System.Private.CoreLib]System.Object
 {
-  .method private hidebysig static int32 
+  .method private hidebysig static int32
           UnsafeGrab() cil managed noinlining
   {
     // Code size       18 (0x12)
@@ -54,7 +56,7 @@
     IL_0011:  ret
   } // end of method C::UnsafeGrab
 
-  .method private hidebysig static int32 
+  .method private hidebysig static int32
           IndexerGrab() cil managed noinlining
   {
     // Code size       18 (0x12)
@@ -69,7 +71,7 @@
     IL_0011:  ret
   } // end of method C::IndexerGrab
 
-  .method private hidebysig static int32 
+  .method private hidebysig static int32
           Main() cil managed
   {
     .entrypoint

--- a/tests/src/JIT/Regression/JitBlue/GitHub_13501/GitHub_13501.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_13501/GitHub_13501.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
+.assembly extern System.Console { auto }
 .assembly extern mscorlib { auto }
+
 .assembly GitHub_13501 { }
 
 .class private Program extends [mscorlib]System.Object

--- a/tests/src/JIT/Regression/JitBlue/GitHub_13501/GitHub_13501.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_13501/GitHub_13501.il
@@ -2,12 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
+.assembly extern System.Console
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib { auto }
 .assembly GitHub_13501 { }
 
 .class private Program extends [mscorlib]System.Object
 {
-    .method hidebysig static int32 Main() cil managed 
+    .method hidebysig static int32 Main() cil managed
     {
         .entrypoint
         .maxstack 8
@@ -48,8 +55,8 @@
         ldc.i4 -1
         conv.u
         bne.un FAIL
-        
-    PASS: 
+
+    PASS:
         ldstr "PASS"
         call void [System.Console]System.Console::WriteLine(string)
         ldc.i4 100
@@ -60,7 +67,7 @@
         ldc.i4 1
         ret
     }
-  
+
     .method static native int Test_Cast_gtFoldExprConst(native int, bool) cil managed noinlining
     {
         .maxstack 4

--- a/tests/src/JIT/Regression/JitBlue/GitHub_13822/GitHub_13822.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_13822/GitHub_13822.il
@@ -2,8 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-.assembly extern mscorlib {}
 
+.assembly extern mscorlib {}
+.assembly extern System.Private.CoreLib{}
 .assembly GitHub_13822
 {
 }
@@ -20,7 +21,7 @@
   .field public int32 k
   .field public int32 l
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor(int32 i) cil managed aggressiveinlining
   {
     .maxstack  8
@@ -75,7 +76,7 @@
     L2:       ldarg.0
               ldc.i4.1
               add
-              call       int32 Test::A(int32)              
+              call       int32 Test::A(int32)
               ret
   } // end of method Test::A
 
@@ -86,7 +87,7 @@
               ret
   } // end of method Test::GetZero
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)

--- a/tests/src/JIT/Regression/JitBlue/GitHub_13822/GitHub_13822.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_13822/GitHub_13822.il
@@ -3,8 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern mscorlib {}
-.assembly extern System.Private.CoreLib{}
+.assembly extern mscorlib { auto }
+.assembly extern System.Private.CoreLib { auto }
+
 .assembly GitHub_13822
 {
 }

--- a/tests/src/JIT/Regression/JitBlue/GitHub_15291/GitHub_15291.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_15291/GitHub_15291.il
@@ -7,14 +7,26 @@
 // Same test cases as in GitHub_15077, but without the extra
 // and masking done by CSC.
 
+
+.assembly extern System.Console
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
+.assembly extern System.Runtime
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {auto}
-.assembly extern System.Console {auto}
 .assembly GitHub_15219 {}
 
 .class private auto ansi beforefieldinit P
        extends [mscorlib]System.Object
 {
-  .method public hidebysig static uint32 
+  .method public hidebysig static uint32
           G32() cil managed noinlining
   {
     IL_0003:  ldc.i4.1
@@ -28,7 +40,7 @@
     IL_000e:  ret
   }
 
-  .method public hidebysig static uint32 
+  .method public hidebysig static uint32
           G31() cil managed noinlining
   {
     IL_0003:  ldc.i4.1
@@ -42,7 +54,7 @@
     IL_000e:  ret
   }
 
-  .method public hidebysig static uint32 
+  .method public hidebysig static uint32
           G64() cil managed noinlining
   {
     IL_0003:  ldc.i4.1
@@ -56,7 +68,7 @@
     IL_000e:  ret
   }
 
-  .method public hidebysig static uint32 
+  .method public hidebysig static uint32
           G63() cil managed noinlining
   {
     IL_0003:  ldc.i4.1
@@ -70,7 +82,7 @@
     IL_000e:  ret
   }
 
-  .method public hidebysig static uint32 
+  .method public hidebysig static uint32
           GM1() cil managed noinlining
   {
     IL_0002:  ldc.i4.1
@@ -84,7 +96,7 @@
     IL_000d:  ret
   }
 
-  .method public hidebysig static uint32 
+  .method public hidebysig static uint32
           Gx(int32 q) cil managed noinlining
   {
     IL_0000:  ldc.i4.1

--- a/tests/src/JIT/Regression/JitBlue/GitHub_15291/GitHub_15291.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_15291/GitHub_15291.il
@@ -2,25 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
 // Test for casts of long shifts.
 //
 // Same test cases as in GitHub_15077, but without the extra
 // and masking done by CSC.
+.assembly extern System.Console { auto }
+.assembly extern System.Runtime { auto }
+.assembly extern mscorlib { auto }
 
-
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern System.Runtime
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern mscorlib {auto}
 .assembly GitHub_15219 {}
 
 .class private auto ansi beforefieldinit P

--- a/tests/src/JIT/Regression/JitBlue/GitHub_15319/GitHub_15319_1.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_15319/GitHub_15319_1.il
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
 // Test for remorphing subexpressions in casts of long shifts.
+.assembly extern System.Private.CoreLib { auto }
+.assembly extern mscorlib { auto }
 
-
-.assembly extern System.Private.CoreLib {}
-.assembly extern mscorlib {}
 .assembly GitHub_15319_1 {}
 
 .class private auto ansi beforefieldinit Q

--- a/tests/src/JIT/Regression/JitBlue/GitHub_15319/GitHub_15319_1.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_15319/GitHub_15319_1.il
@@ -4,7 +4,9 @@
 
 // Test for remorphing subexpressions in casts of long shifts.
 
+
 .assembly extern System.Private.CoreLib {}
+.assembly extern mscorlib {}
 .assembly GitHub_15319_1 {}
 
 .class private auto ansi beforefieldinit Q
@@ -13,12 +15,12 @@
   .method public hidebysig static int32  P(int64 x) cil managed noinlining
   {
        ldarg.s      0x0
-       dup         
+       dup
        ldarg.s      0x0
-       clt         
-       shl         
+       clt
+       shl
        conv.i4
-       ret 
+       ret
   }
 
   .method public hidebysig static int32  Main(string[] args) cil managed
@@ -29,4 +31,4 @@
        call       int32 Q::P(int64)
        ret
   }
-} 
+}

--- a/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-M02/b14364/life-annotated.il
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-M02/b14364/life-annotated.il
@@ -3,22 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Console { auto }
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern mscorlib
-{
-  .ver 0:0:0:0
-}
 .assembly Benchmark
 {
   .ver 0:0:0:0

--- a/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-M02/b14364/life-annotated.il
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-M02/b14364/life-annotated.il
@@ -3,14 +3,18 @@
 // See the LICENSE file in the project root for more information.
 
 
-
-
-
 .assembly extern System.Console
 {
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib
 {
   .ver 0:0:0:0
@@ -31,7 +35,7 @@
 {
   .field privatescope int32 a$PST04000001
   .field privatescope int32 b$PST04000002
-  .method public specialname rtspecialname 
+  .method public specialname rtspecialname
           instance void  .ctor(int32 A_0,
                                int32 A_1) cil managed
   {
@@ -45,16 +49,16 @@
     IL_000e:  ldarg.2
     IL_000f:  stfld      int32 c::b$PST04000002
     IL_0014:  ret
-  } 
+  }
 
-} 
+}
 
 .class public auto ansi sealed b
        extends [mscorlib]System.Object
 {
   .field privatescope class c a$PST04000003
   .field privatescope class b b$PST04000004
-  .method public specialname rtspecialname 
+  .method public specialname rtspecialname
           instance void  .ctor(class c A_0,
                                class b A_1) cil managed
   {
@@ -68,16 +72,16 @@
     IL_000e:  ldarg.2
     IL_000f:  stfld      class b b::b$PST04000004
     IL_0014:  ret
-  } 
+  }
 
-} 
+}
 
 .class public auto ansi sealed g
        extends [mscorlib]System.Object
 {
   .field privatescope string a$PST04000005
   .field privatescope class g b$PST04000006
-  .method public specialname rtspecialname 
+  .method public specialname rtspecialname
           instance void  .ctor(string A_0,
                                class g A_1) cil managed
   {
@@ -91,19 +95,19 @@
     IL_000e:  ldarg.2
     IL_000f:  stfld      class g g::b$PST04000006
     IL_0014:  ret
-  } 
+  }
 
-} 
+}
 
 .class public auto ansi Benchmark
        extends [mscorlib]System.Object
 {
-  .method public specialname rtspecialname static 
+  .method public specialname rtspecialname static
           void  .cctor() cil managed
   {
     .maxstack  0
     IL_0000:  ret
-  } 
+  }
 
   .method public static int32  main(string[] A_0) cil managed
   {
@@ -174,7 +178,7 @@
     IL_001d:  stloc.s    V_4
     IL_001f:  ldsfld     class a $::c$PST0400000E
     IL_0024:  stloc.s    V_5
-    IL_0026:  call       int32 [system.runtime.extensions]System.Environment::get_TickCount()
+    IL_0026:  call       int32 [System.Runtime.Extensions]System.Environment::get_TickCount()
     IL_002b:  stloc.s    V_6
     IL_002d:  ldloc.s    V_6
     IL_002f:  conv.i8
@@ -214,7 +218,7 @@
     IL_007a:  ldloc.s    V_37
     IL_007c:  call       void $::b(class a,
                                    class g)
-    IL_0081:  call       int32 [system.runtime.extensions]System.Environment::get_TickCount()
+    IL_0081:  call       int32 [System.Runtime.Extensions]System.Environment::get_TickCount()
     IL_0086:  stloc.s    V_38
     IL_0088:  ldloc.s    V_38
     IL_008a:  conv.i8
@@ -421,21 +425,21 @@
     IL_0268:  stloc.s    V_26
     IL_026a:  stloc.s    V_25
     IL_026c:  br         IL_022b
-  } 
+  }
 
-} 
+}
 
 .class public auto ansi a
        extends [mscorlib]System.Object
 {
-  .method public specialname rtspecialname 
+  .method public specialname rtspecialname
           instance void  .ctor() cil managed
   {
     .maxstack  2
     IL_0000:  ldarg.0
     IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
     IL_0006:  ret
-  } 
+  }
 
   .method public virtual instance int32  a(class c A_0,
                                            class c A_1) cil managed
@@ -443,37 +447,37 @@
     .maxstack  1
     IL_0000:  ldnull
     IL_0001:  throw
-  } 
+  }
 
   .method public virtual instance int32  b(class c A_0) cil managed
   {
     .maxstack  1
     IL_0000:  ldnull
     IL_0001:  throw
-  } 
+  }
 
-  .method public virtual instance class c 
+  .method public virtual instance class c
           c(class c A_0) cil managed
   {
     .maxstack  1
     IL_0000:  ldnull
     IL_0001:  throw
-  } 
+  }
 
   .method public virtual instance void  d(string A_0) cil managed
   {
     .maxstack  1
     IL_0000:  ldnull
     IL_0001:  throw
-  } 
+  }
 
-} 
+}
 
 .class public auto ansi sealed d
        extends a
 {
   .field privatescope class b a$PST04000007
-  .method public specialname rtspecialname 
+  .method public specialname rtspecialname
           instance void  .ctor(class b A_0) cil managed
   {
     .maxstack  2
@@ -483,9 +487,9 @@
     IL_0007:  ldarg.1
     IL_0008:  stfld      class b d::a$PST04000007
     IL_000d:  ret
-  } 
+  }
 
-  .method public virtual final instance int32 
+  .method public virtual final instance int32
           b(class c A_0) cil managed
   {
     .maxstack  5
@@ -504,15 +508,15 @@
                                     class b,
                                     class c)
     IL_0017:  ret
-  } 
+  }
 
-} 
+}
 
 .class public auto ansi sealed e
        extends a
 {
   .field privatescope class a a$PST04000008
-  .method public specialname rtspecialname 
+  .method public specialname rtspecialname
           instance void  .ctor(class a A_0) cil managed
   {
     .maxstack  2
@@ -522,9 +526,9 @@
     IL_0007:  ldarg.1
     IL_0008:  stfld      class a e::a$PST04000008
     IL_000d:  ret
-  } 
+  }
 
-  .method public virtual final instance int32 
+  .method public virtual final instance int32
           b(class c A_0) cil managed
   {
     .maxstack  5
@@ -599,15 +603,15 @@
     IL_006e:  stloc.s    V_6
     IL_0070:  stloc.s    V_5
     IL_0072:  br         IL_002d
-  } 
+  }
 
-} 
+}
 
 .class public auto ansi sealed f
        extends a
 {
   .field privatescope class b a$PST04000009
-  .method public specialname rtspecialname 
+  .method public specialname rtspecialname
           instance void  .ctor(class b A_0) cil managed
   {
     .maxstack  2
@@ -617,9 +621,9 @@
     IL_0007:  ldarg.1
     IL_0008:  stfld      class b f::a$PST04000009
     IL_000d:  ret
-  } 
+  }
 
-  .method public virtual final instance int32 
+  .method public virtual final instance int32
           b(class c A_0) cil managed
   {
     .maxstack  5
@@ -649,9 +653,9 @@
 
     IL_0024:  ldc.i4.0
     IL_0025:  ret
-  } 
+  }
 
-} 
+}
 
 .class public auto ansi $
        extends [mscorlib]System.Object
@@ -671,7 +675,7 @@
   .field static privatescope class [mscorlib]System.IO.TextWriter k$PST04000016
   .field static privatescope class [mscorlib]System.Exception l$PST04000017
   .field static privatescope class b m$PST04000018
-  .method public specialname rtspecialname static 
+  .method public specialname rtspecialname static
           void  .cctor() cil managed
   {
     .maxstack  12
@@ -1487,7 +1491,7 @@ call	void [System.Console]System.Console::WriteLine(string)
     IL_0597:  ldloc.s    V_132
     IL_0599:  stsfld     class [mscorlib]System.Exception $::l$PST04000017
     IL_059e:  ret
-  } 
+  }
 
   .method public static class b  a(class b A_0,
                                    class b A_1) cil managed
@@ -1531,7 +1535,7 @@ call	void [System.Console]System.Console::WriteLine(string)
     IL_0035:  stloc.s    V_4
     IL_0037:  ldloc.s    V_4
     IL_0039:  ret
-  } 
+  }
 
   .method public static void  b(class a A_0,
                                 class g A_1) cil managed
@@ -1569,7 +1573,7 @@ call	void [System.Console]System.Console::WriteLine(string)
     IL_002e:  call       void $::b(class a,
                                    class g)
     IL_0033:  ret
-  } 
+  }
 
   .method public static void  c(class [mscorlib]System.Text.StringBuilder A_0,
                                 int32 A_1,
@@ -1658,7 +1662,7 @@ call	void [System.Console]System.Console::WriteLine(string)
     IL_008e:  callvirt   instance class [mscorlib]System.Text.StringBuilder [mscorlib]System.Text.StringBuilder::Append(char)
     IL_0093:  stloc.s    V_8
     IL_0095:  ret
-  } 
+  }
 
   .method public static class b  d(class a A_0,
                                    class b A_1) cil managed
@@ -1732,7 +1736,7 @@ call	void [System.Console]System.Console::WriteLine(string)
 ldstr "really5"
 call	void [System.Console]System.Console::WriteLine(string)
     IL_0043:  ret
-  } 
+  }
 
   .method public static class b  e(class a A_0,
                                    class b A_1) cil managed
@@ -1829,7 +1833,7 @@ call	void [System.Console]System.Console::WriteLine(string)
     IL_0098:  starg.s    A_1
     IL_009a:  stloc.0
     IL_009b:  br         IL_0002
-  } 
+  }
 
   .method public static int32  f(class a A_0,
                                  class b A_1,
@@ -1878,7 +1882,7 @@ call	void [System.Console]System.Console::WriteLine(string)
     IL_003c:  ldloc.3
     IL_003d:  starg.s    A_1
     IL_003f:  br         IL_0000
-  } 
+  }
 
   .method public static int32  g(int32 A_0,
                                  int32 A_1,
@@ -1915,7 +1919,7 @@ call	void [System.Console]System.Console::WriteLine(string)
 
     IL_002d:  ldc.i4.0
     IL_002e:  ret
-  } 
+  }
 
   .method public static class b  h(class b A_0) cil managed
   {
@@ -2000,7 +2004,7 @@ call	void [System.Console]System.Console::WriteLine(string)
     IL_0087:  call       class b $::a(class b,
                                       class b)
     IL_008c:  ret
-  } 
+  }
 
   .method public static class b  i(int32 A_0,
                                    int32 A_1) cil managed
@@ -2164,7 +2168,7 @@ call	void [System.Console]System.Console::WriteLine(string)
     IL_00dd:  stloc.s    V_27
     IL_00df:  ldloc.s    V_27
     IL_00e1:  ret
-  } 
+  }
 
   .method public static class g  j(int32 A_0,
                                    int32 A_1,
@@ -2422,7 +2426,7 @@ call	void [System.Console]System.Console::WriteLine(string)
     IL_01ca:  stloc.1
     IL_01cb:  ldloc.1
     IL_01cc:  ret
-  } 
+  }
 
   .method public static class g  k(int32 A_0,
                                    class g A_1) cil managed
@@ -2454,7 +2458,7 @@ call	void [System.Console]System.Console::WriteLine(string)
     IL_0022:  call       class g $::k(int32,
                                       class g)
     IL_0027:  ret
-  } 
+  }
 
   .method public static class b  l(class b A_0,
                                    class c A_1) cil managed
@@ -2484,7 +2488,7 @@ call	void [System.Console]System.Console::WriteLine(string)
     IL_001a:  call       class b $::d(class a,
                                       class b)
     IL_001f:  ret
-  } 
+  }
 
   .method public static class b  m(int32 A_0) cil managed
   {
@@ -2571,7 +2575,7 @@ call	void [System.Console]System.Console::WriteLine(string)
     IL_006c:  stloc.s    V_13
     IL_006e:  ldloc.s    V_13
     IL_0070:  ret
-  } 
+  }
 
   .method public static class b  n(class a A_0,
                                    class b A_1,
@@ -2765,15 +2769,15 @@ call	void [System.Console]System.Console::WriteLine(string)
                                       class b,
                                       class b)
     IL_0103:  ret
-  } 
+  }
 
-} 
+}
 
 .class public abstract auto ansi h
        extends [mscorlib]System.Exception
 {
   .field privatescope string s$PST04000019
-  .method public specialname rtspecialname 
+  .method public specialname rtspecialname
           instance void  .ctor(string A_0) cil managed
   {
     .maxstack  3
@@ -2784,9 +2788,9 @@ call	void [System.Console]System.Console::WriteLine(string)
     IL_0008:  ldarg.1
     IL_0009:  stfld      string h::s$PST04000019
     IL_000e:  ret
-  } 
+  }
 
-  .method public virtual instance string 
+  .method public virtual instance string
           ToString() cil managed
   {
     .maxstack  6
@@ -2821,9 +2825,9 @@ call	void [System.Console]System.Console::WriteLine(string)
     IL_002c:  stloc.3
     IL_002d:  ldloc.3
     IL_002e:  ret
-  } 
+  }
 
-  .method public virtual instance string 
+  .method public virtual instance string
           ExnMessage() cil managed
   {
     .maxstack  6
@@ -2846,23 +2850,23 @@ call	void [System.Console]System.Console::WriteLine(string)
     IL_001c:  call       string [mscorlib]System.String::Concat(string,
                                                                 string)
     IL_0021:  ret
-  } 
+  }
 
-  .method public virtual instance string 
+  .method public virtual instance string
           ExnName() cil managed
   {
     .maxstack  2
     IL_0000:  ldstr      "SML exception"
     IL_0005:  ret
-  } 
+  }
 
-} 
+}
 
 .class public auto ansi sealed i
        extends a
 {
   .field privatescope class c a$PST0400001A
-  .method public specialname rtspecialname 
+  .method public specialname rtspecialname
           instance void  .ctor(class c A_0) cil managed
   {
     .maxstack  2
@@ -2872,9 +2876,9 @@ call	void [System.Console]System.Console::WriteLine(string)
     IL_0007:  ldarg.1
     IL_0008:  stfld      class c i::a$PST0400001A
     IL_000d:  ret
-  } 
+  }
 
-  .method public virtual final instance int32 
+  .method public virtual final instance int32
           b(class c A_0) cil managed
   {
     .maxstack  4
@@ -2898,16 +2902,16 @@ call	void [System.Console]System.Console::WriteLine(string)
                                     int32,
                                     class c)
     IL_001f:  ret
-  } 
+  }
 
-} 
+}
 
 .class public auto ansi sealed j
        extends a
 {
   .field privatescope int32 a$PST0400001B
   .field privatescope int32 b$PST0400001C
-  .method public specialname rtspecialname 
+  .method public specialname rtspecialname
           instance void  .ctor(int32 A_0,
                                int32 A_1) cil managed
   {
@@ -2925,9 +2929,9 @@ call	void [System.Console]System.Console::WriteLine(string)
 ldstr "now2"
 call	void [System.Console]System.Console::WriteLine(string)
     IL_0014:  ret
-  } 
+  }
 
-  .method public virtual final instance int32 
+  .method public virtual final instance int32
           b(class c A_0) cil managed
   {
     .maxstack  4
@@ -2947,9 +2951,9 @@ call	void [System.Console]System.Console::WriteLine(string)
                                     int32,
                                     class c)
     IL_0018:  ret
-  } 
+  }
 
-  .method public virtual final instance class c 
+  .method public virtual final instance class c
           c(class c A_0) cil managed
   {
     .maxstack  4
@@ -2984,16 +2988,16 @@ call	void [System.Console]System.Console::WriteLine(string)
     IL_002a:  newobj     instance void c::.ctor(int32,
                                                 int32)
     IL_002f:  ret
-  } 
+  }
 
-} 
+}
 
 .class public auto ansi sealed k
        extends a
 {
   .field privatescope class a a$PST0400001D
   .field privatescope class b b$PST0400001E
-  .method public specialname rtspecialname 
+  .method public specialname rtspecialname
           instance void  .ctor(class a A_0,
                                class b A_1) cil managed
   {
@@ -3007,9 +3011,9 @@ call	void [System.Console]System.Console::WriteLine(string)
     IL_000e:  ldarg.2
     IL_000f:  stfld      class b k::b$PST0400001E
     IL_0014:  ret
-  } 
+  }
 
-  .method public virtual final instance int32 
+  .method public virtual final instance int32
           b(class c A_0) cil managed
   {
     .maxstack  4
@@ -3040,23 +3044,23 @@ call	void [System.Console]System.Console::WriteLine(string)
 
     IL_0025:  ldc.i4.0
     IL_0026:  ret
-  } 
+  }
 
-} 
+}
 
 .class public auto ansi sealed l
        extends a
 {
-  .method public specialname rtspecialname 
+  .method public specialname rtspecialname
           instance void  .ctor() cil managed
   {
     .maxstack  2
     IL_0000:  ldarg.0
     IL_0001:  call       instance void a::.ctor()
     IL_0006:  ret
-  } 
+  }
 
-  .method public virtual final instance int32 
+  .method public virtual final instance int32
           a(class c A_0,
             class c A_1) cil managed
   {
@@ -3090,9 +3094,9 @@ call	void [System.Console]System.Console::WriteLine(string)
 
     IL_002d:  ldc.i4.0
     IL_002e:  ret
-  } 
+  }
 
-  .method public virtual final instance int32 
+  .method public virtual final instance int32
           b(class c A_0) cil managed
   {
     .maxstack  4
@@ -3138,9 +3142,9 @@ call	void [System.Console]System.Console::WriteLine(string)
 
     IL_0040:  ldc.i4.0
     IL_0041:  ret
-  } 
+  }
 
-  .method public virtual final instance class c 
+  .method public virtual final instance class c
           c(class c A_0) cil managed
   {
     .maxstack  4
@@ -3161,9 +3165,9 @@ call	void [System.Console]System.Console::WriteLine(string)
     IL_0013:  newobj     instance void c::.ctor(int32,
                                                 int32)
     IL_0018:  ret
-  } 
+  }
 
-  .method public virtual final instance void 
+  .method public virtual final instance void
           d(string A_0) cil managed
   {
     .maxstack  5
@@ -3180,14 +3184,14 @@ call	void [System.Console]System.Console::WriteLine(string)
     IL_0014:  ldstr      "\n"
     IL_0019:  callvirt   instance void [mscorlib]System.IO.TextWriter::Write(string)
     IL_001e:  ret
-  } 
+  }
 
-} 
+}
 
 .class public auto ansi sealed m
        extends h
 {
-  .method public specialname rtspecialname 
+  .method public specialname rtspecialname
           instance void  .ctor(string A_0) cil managed
   {
     .maxstack  3
@@ -3195,22 +3199,22 @@ call	void [System.Console]System.Console::WriteLine(string)
     IL_0001:  ldarg.1
     IL_0002:  call       instance void h::.ctor(string)
     IL_0007:  ret
-  } 
+  }
 
-  .method public virtual instance string 
+  .method public virtual instance string
           ExnName() cil managed
   {
     .maxstack  3
     IL_0000:  ldstr      "Main.ex_undefined"
     IL_0005:  ret
-  } 
+  }
 
-} 
+}
 
 .class public auto ansi sealed n
        extends h
 {
-  .method public specialname rtspecialname 
+  .method public specialname rtspecialname
           instance void  .ctor() cil managed
   {
     .maxstack  3
@@ -3218,22 +3222,22 @@ call	void [System.Console]System.Console::WriteLine(string)
     IL_0001:  ldnull
     IL_0002:  call       instance void h::.ctor(string)
     IL_0007:  ret
-  } 
+  }
 
-  .method public virtual instance string 
+  .method public virtual instance string
           ExnName() cil managed
   {
     .maxstack  3
     IL_0000:  ldstr      "Time.Time"
     IL_0005:  ret
-  } 
+  }
 
-} 
+}
 
 .class public auto ansi sealed o
        extends h
 {
-  .method public specialname rtspecialname 
+  .method public specialname rtspecialname
           instance void  .ctor() cil managed
   {
     .maxstack  3
@@ -3241,14 +3245,14 @@ call	void [System.Console]System.Console::WriteLine(string)
     IL_0001:  ldnull
     IL_0002:  call       instance void h::.ctor(string)
     IL_0007:  ret
-  } 
+  }
 
-  .method public virtual instance string 
+  .method public virtual instance string
           ExnName() cil managed
   {
     .maxstack  3
     IL_0000:  ldstr      "PrimUtils.Char.Chr"
     IL_0005:  ret
-  } 
+  }
 
-} 
+}

--- a/tests/src/JIT/jit64/localloc/common/common.il
+++ b/tests/src/JIT/jit64/localloc/common/common.il
@@ -3,16 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Console { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern mscorlib
-{
-}
 .assembly common
 {
   .hash algorithm 0x00008004

--- a/tests/src/JIT/jit64/mcc/common/common.il
+++ b/tests/src/JIT/jit64/mcc/common/common.il
@@ -2,20 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
 // Metadata version: v2.0.50727
+.assembly extern mscorlib { auto }
+.assembly extern System.Runtime.Extensions { auto }
 
-
-.assembly extern mscorlib
-{
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
-  .ver 2:0:0:0
-}
-
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
 
 .module common.netmodule
 // MVID: {8A774AEE-5C13-4F6C-8345-881D79617488}

--- a/tests/src/JIT/jit64/mcc/common/common.il
+++ b/tests/src/JIT/jit64/mcc/common/common.il
@@ -3,11 +3,20 @@
 // See the LICENSE file in the project root for more information.
 
 // Metadata version: v2.0.50727
+
+
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
   .ver 2:0:0:0
 }
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .module common.netmodule
 // MVID: {8A774AEE-5C13-4F6C-8345-881D79617488}
 .imagebase 0x00400000
@@ -23,7 +32,7 @@
 .class public auto ansi beforefieldinit MCCTest.FormatUtils
        extends [mscorlib]System.Object
 {
-  .method public hidebysig static string 
+  .method public hidebysig static string
           GetPadding(int32 level) cil managed
   {
     // Code size       32 (0x20)
@@ -51,7 +60,7 @@
     IL_001f:  ret
   } // end of method FormatUtils::GetPadding
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)
@@ -66,7 +75,7 @@
 .class public auto ansi beforefieldinit MCCTest.ResultVerificationException
        extends [mscorlib]System.Exception
 {
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor(string fieldName,
                                int64 actual,
                                int64 expected) cil managed
@@ -88,7 +97,7 @@
     IL_000e:  ret
   } // end of method ResultVerificationException::.ctor
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor(string fieldName,
                                float64 actual,
                                float64 expected) cil managed
@@ -115,7 +124,7 @@
     IL_0021:  ret
   } // end of method ResultVerificationException::.ctor
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor(string fieldName,
                                class [mscorlib]System.Type 'type',
                                class MCCTest.ResultVerificationException innerException) cil managed
@@ -139,7 +148,7 @@
     IL_001b:  ret
   } // end of method ResultVerificationException::.ctor
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor(string message) cil managed
   {
     // Code size       12 (0xc)
@@ -155,7 +164,7 @@
     IL_000b:  ret
   } // end of method ResultVerificationException::.ctor
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor(string message,
                                class MCCTest.ResultVerificationException innerException) cil managed
   {
@@ -172,7 +181,7 @@
     IL_000b:  ret
   } // end of method ResultVerificationException::.ctor
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           GetMessage() cil managed
   {
     // Code size       13 (0xd)
@@ -189,7 +198,7 @@
     IL_000c:  ret
   } // end of method ResultVerificationException::GetMessage
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           GetMessage(int32 level) cil managed
   {
     // Code size       67 (0x43)
@@ -207,7 +216,7 @@
     IL_0015:  ldsfld     string [mscorlib]System.String::Empty
     IL_001a:  br.s       IL_0039
 
-    IL_001c:  call       string [system.runtime.extensions]System.Environment::get_NewLine()
+    IL_001c:  call       string [System.Runtime.Extensions]System.Environment::get_NewLine()
     IL_0021:  ldarg.0
     IL_0022:  call       instance class [mscorlib]System.Exception [mscorlib]System.Exception::get_InnerException()
     IL_0027:  castclass  MCCTest.ResultVerificationException
@@ -231,22 +240,22 @@
 
 .class interface public abstract auto ansi MCCTest.CType`1<T>
 {
-  .method public hidebysig newslot abstract virtual 
+  .method public hidebysig newslot abstract virtual
           instance void  Init(int32 count) cil managed
   {
   } // end of method CType`1::Init
 
-  .method public hidebysig newslot abstract virtual 
+  .method public hidebysig newslot abstract virtual
           instance void  Init() cil managed
   {
   } // end of method CType`1::Init
 
-  .method public hidebysig newslot abstract virtual 
+  .method public hidebysig newslot abstract virtual
           instance void  Zero() cil managed
   {
   } // end of method CType`1::Zero
 
-  .method public hidebysig newslot abstract virtual 
+  .method public hidebysig newslot abstract virtual
           instance void  Check(!T expected) cil managed
   {
   } // end of method CType`1::Check
@@ -262,7 +271,7 @@
   .field public float64 average
   .field public int64 dummy1
   .field public float64 dummy2
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init(int32 count) cil managed
   {
     // Code size       54 (0x36)
@@ -306,7 +315,7 @@
     IL_0035:  ret
   } // end of method VType0::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init() cil managed
   {
     // Code size       10 (0xa)
@@ -319,7 +328,7 @@
     IL_0009:  ret
   } // end of method VType0::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Zero() cil managed
   {
     // Code size       10 (0xa)
@@ -332,7 +341,7 @@
     IL_0009:  ret
   } // end of method VType0::Zero
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Check(valuetype MCCTest.VType0 expected) cil managed
   {
     // Code size       224 (0xe0)
@@ -444,7 +453,7 @@
     IL_00df:  ret
   } // end of method VType0::Check
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump(int32 level) cil managed
   {
     // Code size       170 (0xaa)
@@ -522,7 +531,7 @@
     IL_00a9:  ret
   } // end of method VType0::Dump
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump() cil managed
   {
     // Code size       13 (0xd)
@@ -563,7 +572,7 @@
   .field public float32 count5
   .field public float32 sum5
   .field public float32 average5
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init(int32 count) cil managed
   {
     // Code size       159 (0x9f)
@@ -652,7 +661,7 @@
     IL_009e:  ret
   } // end of method VType1::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init() cil managed
   {
     // Code size       10 (0xa)
@@ -665,7 +674,7 @@
     IL_0009:  ret
   } // end of method VType1::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Zero() cil managed
   {
     // Code size       10 (0xa)
@@ -678,7 +687,7 @@
     IL_0009:  ret
   } // end of method VType1::Zero
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Check(valuetype MCCTest.VType1 expected) cil managed
   {
     // Code size       830 (0x33e)
@@ -1084,7 +1093,7 @@
     IL_033d:  ret
   } // end of method VType1::Check
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump(int32 level) cil managed
   {
     // Code size       547 (0x223)
@@ -1305,7 +1314,7 @@
     IL_0222:  ret
   } // end of method VType1::Dump
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump() cil managed
   {
     // Code size       13 (0xd)
@@ -1336,7 +1345,7 @@
   .field public float32 f6
   .field public float64 f7
   .field public char f8
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init(int32 count) cil managed
   {
     // Code size       65 (0x41)
@@ -1376,7 +1385,7 @@
     IL_0040:  ret
   } // end of method VType2::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init() cil managed
   {
     // Code size       10 (0xa)
@@ -1389,7 +1398,7 @@
     IL_0009:  ret
   } // end of method VType2::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Zero() cil managed
   {
     // Code size       10 (0xa)
@@ -1402,7 +1411,7 @@
     IL_0009:  ret
   } // end of method VType2::Zero
 
-  .method public hidebysig instance void 
+  .method public hidebysig instance void
           Add(valuetype MCCTest.VType2 val) cil managed
   {
     // Code size       164 (0xa4)
@@ -1469,7 +1478,7 @@
     IL_00a3:  ret
   } // end of method VType2::Add
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Check(valuetype MCCTest.VType2 expected) cil managed
   {
     // Code size       364 (0x16c)
@@ -1649,7 +1658,7 @@
     IL_016b:  ret
   } // end of method VType2::Check
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump(int32 level) cil managed
   {
     // Code size       257 (0x101)
@@ -1760,7 +1769,7 @@
     IL_0100:  ret
   } // end of method VType2::Dump
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump() cil managed
   {
     // Code size       13 (0xd)
@@ -1791,7 +1800,7 @@
   .field public float32 f6
   .field public float32 f7
   .field public float32 f8
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init(int32 count) cil managed
   {
     // Code size       66 (0x42)
@@ -1832,7 +1841,7 @@
     IL_0041:  ret
   } // end of method VType3::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init() cil managed
   {
     // Code size       10 (0xa)
@@ -1845,7 +1854,7 @@
     IL_0009:  ret
   } // end of method VType3::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Zero() cil managed
   {
     // Code size       10 (0xa)
@@ -1858,7 +1867,7 @@
     IL_0009:  ret
   } // end of method VType3::Zero
 
-  .method public hidebysig instance void 
+  .method public hidebysig instance void
           Add(valuetype MCCTest.VType3 val) cil managed
   {
     // Code size       162 (0xa2)
@@ -1923,7 +1932,7 @@
     IL_00a1:  ret
   } // end of method VType3::Add
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Check(valuetype MCCTest.VType3 expected) cil managed
   {
     // Code size       370 (0x172)
@@ -2109,7 +2118,7 @@
     IL_0171:  ret
   } // end of method VType3::Check
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump(int32 level) cil managed
   {
     // Code size       257 (0x101)
@@ -2220,7 +2229,7 @@
     IL_0100:  ret
   } // end of method VType3::Dump
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump() cil managed
   {
     // Code size       13 (0xd)
@@ -2251,7 +2260,7 @@
   .field public float32 f6
   .field public float32 f7
   .field public float32 f8
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init(int32 count) cil managed
   {
     // Code size       66 (0x42)
@@ -2292,7 +2301,7 @@
     IL_0041:  ret
   } // end of method RType4::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init() cil managed
   {
     // Code size       10 (0xa)
@@ -2305,7 +2314,7 @@
     IL_0009:  ret
   } // end of method RType4::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Zero() cil managed
   {
     // Code size       10 (0xa)
@@ -2318,7 +2327,7 @@
     IL_0009:  ret
   } // end of method RType4::Zero
 
-  .method public hidebysig instance void 
+  .method public hidebysig instance void
           Add(class MCCTest.RType4 val) cil managed
   {
     // Code size       154 (0x9a)
@@ -2383,7 +2392,7 @@
     IL_0099:  ret
   } // end of method RType4::Add
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Check(class MCCTest.RType4 expected) cil managed
   {
     // Code size       354 (0x162)
@@ -2569,7 +2578,7 @@
     IL_0161:  ret
   } // end of method RType4::Check
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump(int32 level) cil managed
   {
     // Code size       257 (0x101)
@@ -2680,7 +2689,7 @@
     IL_0100:  ret
   } // end of method RType4::Dump
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump() cil managed
   {
     // Code size       13 (0xd)
@@ -2697,7 +2706,7 @@
     IL_000c:  ret
   } // end of method RType4::Dump
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)
@@ -2731,7 +2740,7 @@
   .field public int64 f16
   .field public int64 f17
   .field public int64 f18
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init(int32 count) cil managed
   {
     // Code size       146 (0x92)
@@ -2812,7 +2821,7 @@
     IL_0091:  ret
   } // end of method VType5::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init() cil managed
   {
     // Code size       10 (0xa)
@@ -2825,7 +2834,7 @@
     IL_0009:  ret
   } // end of method VType5::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Zero() cil managed
   {
     // Code size       10 (0xa)
@@ -2838,7 +2847,7 @@
     IL_0009:  ret
   } // end of method VType5::Zero
 
-  .method public hidebysig instance void 
+  .method public hidebysig instance void
           Add(valuetype MCCTest.VType5 val) cil managed
   {
     // Code size       362 (0x16a)
@@ -2973,7 +2982,7 @@
     IL_0169:  ret
   } // end of method VType5::Add
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Check(valuetype MCCTest.VType5 expected) cil managed
   {
     // Code size       794 (0x31a)
@@ -3343,7 +3352,7 @@
     IL_0319:  ret
   } // end of method VType5::Check
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump(int32 level) cil managed
   {
     // Code size       547 (0x223)
@@ -3564,7 +3573,7 @@
     IL_0222:  ret
   } // end of method VType5::Dump
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump() cil managed
   {
     // Code size       13 (0xd)
@@ -3616,7 +3625,7 @@
   .field public float64 f27
   .field public float64 f28
   .field public float64 f29
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init(int32 count) cil managed
   {
     // Code size       234 (0xea)
@@ -3741,7 +3750,7 @@
     IL_00e9:  ret
   } // end of method VType6::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init() cil managed
   {
     // Code size       10 (0xa)
@@ -3754,7 +3763,7 @@
     IL_0009:  ret
   } // end of method VType6::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Zero() cil managed
   {
     // Code size       10 (0xa)
@@ -3767,7 +3776,7 @@
     IL_0009:  ret
   } // end of method VType6::Zero
 
-  .method public hidebysig instance void 
+  .method public hidebysig instance void
           Add(valuetype MCCTest.VType6 val) cil managed
   {
     // Code size       582 (0x246)
@@ -3979,7 +3988,7 @@
     IL_0245:  ret
   } // end of method VType6::Add
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Check(valuetype MCCTest.VType6 expected) cil managed
   {
     // Code size       1278 (0x4fe)
@@ -4569,7 +4578,7 @@
     IL_04fd:  ret
   } // end of method VType6::Check
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump(int32 level) cil managed
   {
     // Code size       866 (0x362)
@@ -4911,7 +4920,7 @@
     IL_0361:  ret
   } // end of method VType6::Dump
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump() cil managed
   {
     // Code size       13 (0xd)
@@ -5191,7 +5200,7 @@
   .field public float64 f255
   .field public float64 f256
   .field public float64 f257
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init(int32 count) cil managed
   {
     // Code size       2058 (0x80a)
@@ -6228,7 +6237,7 @@
     IL_0809:  ret
   } // end of method VType7::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init() cil managed
   {
     // Code size       10 (0xa)
@@ -6241,7 +6250,7 @@
     IL_0009:  ret
   } // end of method VType7::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Zero() cil managed
   {
     // Code size       10 (0xa)
@@ -6254,7 +6263,7 @@
     IL_0009:  ret
   } // end of method VType7::Zero
 
-  .method public hidebysig instance void 
+  .method public hidebysig instance void
           Add(valuetype MCCTest.VType7 val) cil managed
   {
     // Code size       5142 (0x1416)
@@ -8062,7 +8071,7 @@
     IL_1415:  ret
   } // end of method VType7::Add
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Check(valuetype MCCTest.VType7 expected) cil managed
   {
     // Code size       11310 (0x2c2e)
@@ -13212,7 +13221,7 @@
     IL_2c2d:  ret
   } // end of method VType7::Check
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump(int32 level) cil managed
   {
     // Code size       7478 (0x1d36)
@@ -16062,7 +16071,7 @@
     IL_1d35:  ret
   } // end of method VType7::Dump
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump() cil managed
   {
     // Code size       13 (0xd)
@@ -16085,7 +16094,7 @@
        extends [mscorlib]System.ValueType
        implements class MCCTest.CType`1<valuetype MCCTest.VType8>
 {
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init(int32 count) cil managed
   {
     // Code size       2 (0x2)
@@ -16094,7 +16103,7 @@
     IL_0001:  ret
   } // end of method VType8::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init() cil managed
   {
     // Code size       10 (0xa)
@@ -16107,7 +16116,7 @@
     IL_0009:  ret
   } // end of method VType8::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Zero() cil managed
   {
     // Code size       10 (0xa)
@@ -16120,7 +16129,7 @@
     IL_0009:  ret
   } // end of method VType8::Zero
 
-  .method public hidebysig instance void 
+  .method public hidebysig instance void
           Add(valuetype MCCTest.VType8 val) cil managed
   {
     // Code size       2 (0x2)
@@ -16129,7 +16138,7 @@
     IL_0001:  ret
   } // end of method VType8::Add
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Check(valuetype MCCTest.VType8 expected) cil managed
   {
     // Code size       22 (0x16)
@@ -16149,7 +16158,7 @@
       IL_0007:  leave.s    IL_0014
 
     }  // end .try
-    catch MCCTest.ResultVerificationException 
+    catch MCCTest.ResultVerificationException
     {
       IL_0009:  stloc.2
       IL_000a:  nop
@@ -16166,7 +16175,7 @@
     IL_0015:  ret
   } // end of method VType8::Check
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump(int32 level) cil managed
   {
     // Code size       25 (0x19)
@@ -16189,7 +16198,7 @@
     IL_0018:  ret
   } // end of method VType8::Dump
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump() cil managed
   {
     // Code size       13 (0xd)
@@ -16213,7 +16222,7 @@
        implements class MCCTest.CType`1<valuetype MCCTest.VType9>
 {
   .field public float32 f1
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init(int32 count) cil managed
   {
     // Code size       10 (0xa)
@@ -16226,7 +16235,7 @@
     IL_0009:  ret
   } // end of method VType9::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init() cil managed
   {
     // Code size       10 (0xa)
@@ -16239,7 +16248,7 @@
     IL_0009:  ret
   } // end of method VType9::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Zero() cil managed
   {
     // Code size       10 (0xa)
@@ -16252,7 +16261,7 @@
     IL_0009:  ret
   } // end of method VType9::Zero
 
-  .method public hidebysig instance void 
+  .method public hidebysig instance void
           Add(valuetype MCCTest.VType9 val) cil managed
   {
     // Code size       22 (0x16)
@@ -16268,7 +16277,7 @@
     IL_0015:  ret
   } // end of method VType9::Add
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Check(valuetype MCCTest.VType9 expected) cil managed
   {
     // Code size       68 (0x44)
@@ -16311,7 +16320,7 @@
       IL_0035:  leave.s    IL_0042
 
     }  // end .try
-    catch MCCTest.ResultVerificationException 
+    catch MCCTest.ResultVerificationException
     {
       IL_0037:  stloc.2
       IL_0038:  nop
@@ -16328,7 +16337,7 @@
     IL_0043:  ret
   } // end of method VType9::Check
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump(int32 level) cil managed
   {
     // Code size       54 (0x36)
@@ -16362,7 +16371,7 @@
     IL_0035:  ret
   } // end of method VType9::Dump
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump() cil managed
   {
     // Code size       13 (0xd)
@@ -16398,7 +16407,7 @@
   .field public class MCCTest.RType4 f11
   .field public class MCCTest.RType4 f12
   .field public class MCCTest.RType4 f13
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init(int32 count) cil managed
   {
     // Code size       314 (0x13a)
@@ -16511,7 +16520,7 @@
     IL_0139:  ret
   } // end of method VTypeA::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init() cil managed
   {
     // Code size       10 (0xa)
@@ -16524,7 +16533,7 @@
     IL_0009:  ret
   } // end of method VTypeA::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Zero() cil managed
   {
     // Code size       10 (0xa)
@@ -16537,7 +16546,7 @@
     IL_0009:  ret
   } // end of method VTypeA::Zero
 
-  .method public hidebysig instance void 
+  .method public hidebysig instance void
           Add(valuetype MCCTest.VTypeA val) cil managed
   {
     // Code size       249 (0xf9)
@@ -16624,7 +16633,7 @@
     IL_00f8:  ret
   } // end of method VTypeA::Add
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Check(valuetype MCCTest.VTypeA expected) cil managed
   {
     // Code size       503 (0x1f7)
@@ -16800,7 +16809,7 @@
       IL_01e8:  leave.s    IL_01f5
 
     }  // end .try
-    catch MCCTest.ResultVerificationException 
+    catch MCCTest.ResultVerificationException
     {
       IL_01ea:  stloc.2
       IL_01eb:  nop
@@ -16817,7 +16826,7 @@
     IL_01f6:  ret
   } // end of method VTypeA::Check
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump(int32 level) cil managed
   {
     // Code size       740 (0x2e4)
@@ -17113,7 +17122,7 @@
     IL_02e3:  ret
   } // end of method VTypeA::Dump
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump() cil managed
   {
     // Code size       13 (0xd)
@@ -17155,7 +17164,7 @@
   .field public valuetype MCCTest.VType5 f17
   .field public valuetype MCCTest.VType5 f18
   .field public valuetype MCCTest.VType5 f19
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init(int32 count) cil managed
   {
     // Code size       249 (0xf9)
@@ -17259,7 +17268,7 @@
     IL_00f8:  ret
   } // end of method VTypeB::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init() cil managed
   {
     // Code size       10 (0xa)
@@ -17272,7 +17281,7 @@
     IL_0009:  ret
   } // end of method VTypeB::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Zero() cil managed
   {
     // Code size       10 (0xa)
@@ -17285,7 +17294,7 @@
     IL_0009:  ret
   } // end of method VTypeB::Zero
 
-  .method public hidebysig instance void 
+  .method public hidebysig instance void
           Add(valuetype MCCTest.VTypeB val) cil managed
   {
     // Code size       363 (0x16b)
@@ -17408,7 +17417,7 @@
     IL_016a:  ret
   } // end of method VTypeB::Add
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Check(valuetype MCCTest.VTypeB expected) cil managed
   {
     // Code size       820 (0x334)
@@ -17675,7 +17684,7 @@
       IL_0325:  leave.s    IL_0332
 
     }  // end .try
-    catch MCCTest.ResultVerificationException 
+    catch MCCTest.ResultVerificationException
     {
       IL_0327:  stloc.2
       IL_0328:  nop
@@ -17692,7 +17701,7 @@
     IL_0333:  ret
   } // end of method VTypeB::Check
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump(int32 level) cil managed
   {
     // Code size       1165 (0x48d)
@@ -18133,7 +18142,7 @@
     IL_048c:  ret
   } // end of method VTypeB::Dump
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump() cil managed
   {
     // Code size       13 (0xd)
@@ -18168,7 +18177,7 @@
   .field public class MCCTest.RType4 f10
   .field public valuetype MCCTest.VType5 f11
   .field public valuetype MCCTest.VType6 f12
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init(int32 count) cil managed
   {
     // Code size       202 (0xca)
@@ -18249,7 +18258,7 @@
     IL_00c9:  ret
   } // end of method VTypeC::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init() cil managed
   {
     // Code size       10 (0xa)
@@ -18262,7 +18271,7 @@
     IL_0009:  ret
   } // end of method VTypeC::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Zero() cil managed
   {
     // Code size       10 (0xa)
@@ -18275,7 +18284,7 @@
     IL_0009:  ret
   } // end of method VTypeC::Zero
 
-  .method public hidebysig instance void 
+  .method public hidebysig instance void
           Add(valuetype MCCTest.VTypeC val) cil managed
   {
     // Code size       230 (0xe6)
@@ -18356,7 +18365,7 @@
     IL_00e5:  ret
   } // end of method VTypeC::Add
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Check(valuetype MCCTest.VTypeC expected) cil managed
   {
     // Code size       506 (0x1fa)
@@ -18528,7 +18537,7 @@
       IL_01eb:  leave.s    IL_01f8
 
     }  // end .try
-    catch MCCTest.ResultVerificationException 
+    catch MCCTest.ResultVerificationException
     {
       IL_01ed:  stloc.2
       IL_01ee:  nop
@@ -18545,7 +18554,7 @@
     IL_01f9:  ret
   } // end of method VTypeC::Check
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump(int32 level) cil managed
   {
     // Code size       725 (0x2d5)
@@ -18828,7 +18837,7 @@
     IL_02d4:  ret
   } // end of method VTypeC::Dump
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump() cil managed
   {
     // Code size       13 (0xd)
@@ -18868,7 +18877,7 @@
   .field public class MCCTest.RType4 f15
   .field public valuetype MCCTest.VType7 f16
   .field public uint32 f17
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init(int32 count) cil managed
   {
     // Code size       230 (0xe6)
@@ -18965,7 +18974,7 @@
     IL_00e5:  ret
   } // end of method VTypeD::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init() cil managed
   {
     // Code size       10 (0xa)
@@ -18978,7 +18987,7 @@
     IL_0009:  ret
   } // end of method VTypeD::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Zero() cil managed
   {
     // Code size       10 (0xa)
@@ -18991,7 +19000,7 @@
     IL_0009:  ret
   } // end of method VTypeD::Zero
 
-  .method public hidebysig instance void 
+  .method public hidebysig instance void
           Add(valuetype MCCTest.VTypeD val) cil managed
   {
     // Code size       333 (0x14d)
@@ -19110,7 +19119,7 @@
     IL_014c:  ret
   } // end of method VTypeD::Add
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Check(valuetype MCCTest.VTypeD expected) cil managed
   {
     // Code size       742 (0x2e6)
@@ -19409,7 +19418,7 @@
       IL_02d7:  leave.s    IL_02e4
 
     }  // end .try
-    catch MCCTest.ResultVerificationException 
+    catch MCCTest.ResultVerificationException
     {
       IL_02d9:  stloc.2
       IL_02da:  nop
@@ -19426,7 +19435,7 @@
     IL_02e5:  ret
   } // end of method VTypeD::Check
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump(int32 level) cil managed
   {
     // Code size       808 (0x328)
@@ -19742,7 +19751,7 @@
     IL_0327:  ret
   } // end of method VTypeD::Dump
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump() cil managed
   {
     // Code size       13 (0xd)
@@ -19788,7 +19797,7 @@
   .field public valuetype MCCTest.VType9 f21
   .field public valuetype MCCTest.VTypeC f22
   .field public valuetype MCCTest.VType8 f23
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init(int32 count) cil managed
   {
     // Code size       276 (0x114)
@@ -19907,7 +19916,7 @@
     IL_0113:  ret
   } // end of method VTypeE::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init() cil managed
   {
     // Code size       10 (0xa)
@@ -19920,7 +19929,7 @@
     IL_0009:  ret
   } // end of method VTypeE::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Zero() cil managed
   {
     // Code size       10 (0xa)
@@ -19933,7 +19942,7 @@
     IL_0009:  ret
   } // end of method VTypeE::Zero
 
-  .method public hidebysig instance void 
+  .method public hidebysig instance void
           Add(valuetype MCCTest.VTypeE val) cil managed
   {
     // Code size       448 (0x1c0)
@@ -20089,7 +20098,7 @@
     IL_01bf:  ret
   } // end of method VTypeE::Add
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Check(valuetype MCCTest.VTypeE expected) cil managed
   {
     // Code size       1009 (0x3f1)
@@ -20469,7 +20478,7 @@
       IL_03e2:  leave.s    IL_03ef
 
     }  // end .try
-    catch MCCTest.ResultVerificationException 
+    catch MCCTest.ResultVerificationException
     {
       IL_03e4:  stloc.2
       IL_03e5:  nop
@@ -20486,7 +20495,7 @@
     IL_03f0:  ret
   } // end of method VTypeE::Check
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump(int32 level) cil managed
   {
     // Code size       1183 (0x49f)
@@ -20937,7 +20946,7 @@
     IL_049e:  ret
   } // end of method VTypeE::Dump
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump() cil managed
   {
     // Code size       13 (0xd)
@@ -21004,7 +21013,7 @@
   .field public char f42
   .field public valuetype MCCTest.VTypeB f43
   .field public valuetype MCCTest.VType8 f44
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init(int32 count) cil managed
   {
     // Code size       547 (0x223)
@@ -21230,7 +21239,7 @@
     IL_0222:  ret
   } // end of method VTypeF::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Init() cil managed
   {
     // Code size       10 (0xa)
@@ -21243,7 +21252,7 @@
     IL_0009:  ret
   } // end of method VTypeF::Init
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Zero() cil managed
   {
     // Code size       10 (0xa)
@@ -21256,7 +21265,7 @@
     IL_0009:  ret
   } // end of method VTypeF::Zero
 
-  .method public hidebysig instance void 
+  .method public hidebysig instance void
           Add(valuetype MCCTest.VTypeF val) cil managed
   {
     // Code size       860 (0x35c)
@@ -21551,7 +21560,7 @@
     IL_035b:  ret
   } // end of method VTypeF::Add
 
-  .method public hidebysig newslot virtual final 
+  .method public hidebysig newslot virtual final
           instance void  Check(valuetype MCCTest.VTypeF expected) cil managed
   {
     // Code size       1901 (0x76d)
@@ -22275,7 +22284,7 @@
       IL_075e:  leave.s    IL_076b
 
     }  // end .try
-    catch MCCTest.ResultVerificationException 
+    catch MCCTest.ResultVerificationException
     {
       IL_0760:  stloc.2
       IL_0761:  nop
@@ -22292,7 +22301,7 @@
     IL_076c:  ret
   } // end of method VTypeF::Check
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump(int32 level) cil managed
   {
     // Code size       2144 (0x860)
@@ -23102,7 +23111,7 @@
     IL_085f:  ret
   } // end of method VTypeF::Dump
 
-  .method public hidebysig instance string 
+  .method public hidebysig instance string
           Dump() cil managed
   {
     // Code size       13 (0xd)
@@ -23412,7 +23421,7 @@
     IL_000c:  ret
   } // end of method Common::CheckResult
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)
@@ -23477,7 +23486,7 @@
       IL_0054:  leave.s    IL_0072
 
     }  // end .try
-    catch MCCTest.ResultVerificationException 
+    catch MCCTest.ResultVerificationException
     {
       IL_0056:  stloc.2
       IL_0057:  nop
@@ -23501,7 +23510,7 @@
     IL_0078:  ret
   } // end of method Common2`1::CheckResult
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i00.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i00.il
@@ -2,13 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
 
-.assembly extern mscorlib {}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
+
 .assembly MCCTest {}
 .module mcc_i00.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i00.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i00.il
@@ -2,6 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i00.exe
@@ -11,7 +17,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i0c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i0c" as "#1" cdecl)
         vararg valuetype MCCTest.VType0 Sum(unsigned int64) cil managed preservesig {
     }
 
@@ -23,7 +29,7 @@
         [0] valuetype MCCTest.VType0 res,
         [1] int32 rc
       )
-      
+
       ldc.i8 1
       ldc.i8 2
       ldc.i8 3
@@ -38,19 +44,19 @@
       ldc.i8 12
       ldc.i8 1
       neg
-      call   vararg valuetype MCCTest.VType0 MCCTest.MyClass::Sum(unsigned int64, ..., 
-																	unsigned int64, 
-																	unsigned int64, 
-																	unsigned int64, 
-																	unsigned int64, 
-																	unsigned int64, 
-																	unsigned int64, 
-																	unsigned int64, 
-																	unsigned int64, 
-																	unsigned int64, 
-																	unsigned int64, 
-																	unsigned int64, 
-																	unsigned int64)
+      call   vararg valuetype MCCTest.VType0 MCCTest.MyClass::Sum(unsigned int64, ...,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64)
 
       stloc.s    res
 
@@ -59,7 +65,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType0, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i01.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i01.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i01.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i01.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i01.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i01.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i0c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i0c" as "#1" cdecl)
         vararg valuetype MCCTest.VType0 Sum(unsigned int64) cil managed preservesig {
     }
 
@@ -24,7 +30,7 @@
         [0] valuetype MCCTest.VType0 res,
         [1] int32 rc
       )
-      
+
       ldc.i8 1
       ldc.i8 2
       ldc.i8 3
@@ -40,18 +46,18 @@
       ldc.i8 1
       neg
       ldftn   vararg valuetype MCCTest.VType0 MCCTest.MyClass::Sum(unsigned int64)
-      calli   vararg valuetype MCCTest.VType0(unsigned int64, ..., 
-                                                unsigned int64, 
-                                                unsigned int64, 
-                                                unsigned int64, 
-                                                unsigned int64, 
-                                                unsigned int64, 
-                                                unsigned int64, 
-                                                unsigned int64, 
-                                                unsigned int64, 
-                                                unsigned int64, 
-                                                unsigned int64, 
-                                                unsigned int64, 
+      calli   vararg valuetype MCCTest.VType0(unsigned int64, ...,
+                                                unsigned int64,
+                                                unsigned int64,
+                                                unsigned int64,
+                                                unsigned int64,
+                                                unsigned int64,
+                                                unsigned int64,
+                                                unsigned int64,
+                                                unsigned int64,
+                                                unsigned int64,
+                                                unsigned int64,
+                                                unsigned int64,
                                                 unsigned int64)
       stloc.s    res
 
@@ -60,7 +66,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType0, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i02.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i02.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i02.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i02.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i02.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i02.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i0c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i0c" as "#1" cdecl)
         vararg valuetype MCCTest.VType0 Sum(unsigned int64) cil managed preservesig {
     }
 
@@ -34,21 +40,21 @@
       ldc.i8 1
       neg
       tail.
-      call   vararg valuetype MCCTest.VType0 MCCTest.MyClass::Sum(unsigned int64, ..., 
-                                                                    unsigned int64, 
-                                                                    unsigned int64, 
-                                                                    unsigned int64, 
-                                                                    unsigned int64, 
-                                                                    unsigned int64, 
-                                                                    unsigned int64, 
-                                                                    unsigned int64, 
-                                                                    unsigned int64, 
-                                                                    unsigned int64, 
-                                                                    unsigned int64, 
-                                                                    unsigned int64, 
+      call   vararg valuetype MCCTest.VType0 MCCTest.MyClass::Sum(unsigned int64, ...,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
                                                                     unsigned int64)
-		ret
-	}
+        ret
+    }
 
     .method public specialname rtspecialname instance void  .ctor()
     {
@@ -67,10 +73,10 @@
         [1] valuetype MCCTest.VType0 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType0 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -80,7 +86,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType0, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i03.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i03.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i03.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i0c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i0c" as "#1" cdecl)
         vararg valuetype MCCTest.VType0 Sum(unsigned int64) cil managed preservesig {
     }
 
@@ -33,27 +39,27 @@
       ldc.i8 12
       ldc.i8 1
       neg
-      call   vararg valuetype MCCTest.VType0 MCCTest.MyClass::GetSum2(unsigned int64, ..., 
-                                                                        unsigned int64, 
-                                                                        unsigned int64, 
-                                                                        unsigned int64, 
-                                                                        unsigned int64, 
-                                                                        unsigned int64, 
-                                                                        unsigned int64, 
-                                                                        unsigned int64, 
-                                                                        unsigned int64, 
-                                                                        unsigned int64, 
-                                                                        unsigned int64, 
-                                                                        unsigned int64, 
+      call   vararg valuetype MCCTest.VType0 MCCTest.MyClass::GetSum2(unsigned int64, ...,
+                                                                        unsigned int64,
+                                                                        unsigned int64,
+                                                                        unsigned int64,
+                                                                        unsigned int64,
+                                                                        unsigned int64,
+                                                                        unsigned int64,
+                                                                        unsigned int64,
+                                                                        unsigned int64,
+                                                                        unsigned int64,
+                                                                        unsigned int64,
+                                                                        unsigned int64,
                                                                         unsigned int64)
-		ret
-	}
+        ret
+    }
 
     .method private static vararg valuetype MCCTest.VType0 GetSum2(unsigned int64)
     {
       jmp   vararg valuetype MCCTest.VType0 MCCTest.MyClass::Sum(unsigned int64)
     }
-    
+
     .method public specialname rtspecialname instance void  .ctor()
     {
       .maxstack  1
@@ -71,10 +77,10 @@
         [1] valuetype MCCTest.VType0 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call       instance valuetype MCCTest.VType0 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -84,7 +90,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType0, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i03.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i03.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i03.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i04.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i04.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i04.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i04.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i04.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i04.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i0s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i0s" as "#1" stdcall)
         valuetype MCCTest.VType0 Sum(unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64) cil managed preservesig {
     }
 
@@ -24,7 +30,7 @@
         [0] valuetype MCCTest.VType0 res,
         [1] int32 rc
       )
-      
+
       ldc.i8 1
       ldc.i8 2
       ldc.i8 3
@@ -38,17 +44,17 @@
       ldc.i8 11
       ldc.i8 12
       call       valuetype MCCTest.VType0 MCCTest.MyClass::Sum(unsigned int64,
-																unsigned int64,
-																unsigned int64,
-																unsigned int64,
-																unsigned int64,
-																unsigned int64,
-																unsigned int64,
-																unsigned int64,
-																unsigned int64,
-																unsigned int64,
-																unsigned int64,
-																unsigned int64)
+                                                                unsigned int64,
+                                                                unsigned int64,
+                                                                unsigned int64,
+                                                                unsigned int64,
+                                                                unsigned int64,
+                                                                unsigned int64,
+                                                                unsigned int64,
+                                                                unsigned int64,
+                                                                unsigned int64,
+                                                                unsigned int64,
+                                                                unsigned int64)
 
       stloc.s    res
 
@@ -57,7 +63,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType0, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i05.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i05.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i05.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i05.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i05.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i05.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i0s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i0s" as "#1" stdcall)
         valuetype MCCTest.VType0 Sum(unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64) cil managed preservesig {
     }
 
@@ -24,7 +30,7 @@
         [0] valuetype MCCTest.VType0 res,
         [1] int32 rc
       )
-      
+
       ldc.i8 1
       ldc.i8 2
       ldc.i8 3
@@ -38,18 +44,18 @@
       ldc.i8 11
       ldc.i8 12
       ldftn   valuetype MCCTest.VType0 MCCTest.MyClass::Sum(unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64)
-      calli   valuetype MCCTest.VType0(unsigned int64, 
-										unsigned int64, 
-										unsigned int64, 
-										unsigned int64, 
-										unsigned int64, 
-										unsigned int64, 
-										unsigned int64, 
-										unsigned int64, 
-										unsigned int64, 
-										unsigned int64, 
-										unsigned int64, 
-										unsigned int64)
+      calli   valuetype MCCTest.VType0(unsigned int64,
+                                        unsigned int64,
+                                        unsigned int64,
+                                        unsigned int64,
+                                        unsigned int64,
+                                        unsigned int64,
+                                        unsigned int64,
+                                        unsigned int64,
+                                        unsigned int64,
+                                        unsigned int64,
+                                        unsigned int64,
+                                        unsigned int64)
       stloc.s    res
 
       // Check Result
@@ -57,7 +63,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType0, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i06.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i06.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i06.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i0s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i0s" as "#1" stdcall)
         valuetype MCCTest.VType0 Sum(unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64) cil managed preservesig {
     }
 
@@ -32,20 +38,20 @@
       ldc.i8 11
       ldc.i8 12
       tail.
-      call        valuetype MCCTest.VType0 MCCTest.MyClass::Sum(unsigned int64, 
-                                                                unsigned int64, 
-                                                                unsigned int64, 
-                                                                unsigned int64, 
-                                                                unsigned int64, 
-                                                                unsigned int64, 
-                                                                unsigned int64, 
-                                                                unsigned int64, 
-                                                                unsigned int64, 
-                                                                unsigned int64, 
-                                                                unsigned int64, 
+      call        valuetype MCCTest.VType0 MCCTest.MyClass::Sum(unsigned int64,
+                                                                unsigned int64,
+                                                                unsigned int64,
+                                                                unsigned int64,
+                                                                unsigned int64,
+                                                                unsigned int64,
+                                                                unsigned int64,
+                                                                unsigned int64,
+                                                                unsigned int64,
+                                                                unsigned int64,
+                                                                unsigned int64,
                                                                 unsigned int64)
-		ret
-	}
+        ret
+    }
 
     .method public specialname rtspecialname instance void  .ctor()
     {
@@ -64,10 +70,10 @@
         [1] valuetype MCCTest.VType0 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType0 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -77,7 +83,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType0, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i06.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i06.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i06.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i07.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i07.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i07.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i07.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i07.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i07.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i0s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i0s" as "#1" stdcall)
         valuetype MCCTest.VType0 Sum(unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64) cil managed preservesig {
     }
 
@@ -31,26 +37,26 @@
       ldc.i8 10
       ldc.i8 11
       ldc.i8 12
-      call        valuetype MCCTest.VType0 MCCTest.MyClass::GetSum2(unsigned int64, 
-                                                                    unsigned int64, 
-                                                                    unsigned int64, 
-                                                                    unsigned int64, 
-                                                                    unsigned int64, 
-                                                                    unsigned int64, 
-                                                                    unsigned int64, 
-                                                                    unsigned int64, 
-                                                                    unsigned int64, 
-                                                                    unsigned int64, 
-                                                                    unsigned int64, 
+      call        valuetype MCCTest.VType0 MCCTest.MyClass::GetSum2(unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
+                                                                    unsigned int64,
                                                                     unsigned int64)
-		ret
-	}
+        ret
+    }
 
     .method private static valuetype MCCTest.VType0 GetSum2(unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64)
     {
       jmp   valuetype MCCTest.VType0 MCCTest.MyClass::Sum(unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64, unsigned int64)
     }
-    
+
     .method public specialname rtspecialname instance void  .ctor()
     {
       .maxstack  1
@@ -68,10 +74,10 @@
         [1] valuetype MCCTest.VType0 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call       instance valuetype MCCTest.VType0 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -81,7 +87,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType0, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i11.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i11.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i11.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i11.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i11.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i11.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i1c.dll" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i1c.dll" as "#1" cdecl)
        vararg valuetype MCCTest.VType1 Sum(float32) cil managed preservesig {
     }
 
@@ -24,7 +30,7 @@
         [0] valuetype MCCTest.VType1 res,
         [1] int32 rc
       )
-      
+
       ldc.r4     1
       ldc.r4     2
       ldc.r4     3
@@ -40,19 +46,19 @@
       ldc.r4     1
       neg
       ldftn      vararg valuetype MCCTest.VType1 MCCTest.MyClass::Sum(float32)
-      calli      vararg valuetype MCCTest.VType1(float32, ..., 
-													float32, 
-													float32, 
-													float32, 
-													float32, 
-													float32, 
-													float32, 
-													float32, 
-													float32, 
-													float32, 
-													float32, 
-													float32, 
-													float32)
+      calli      vararg valuetype MCCTest.VType1(float32, ...,
+                                                    float32,
+                                                    float32,
+                                                    float32,
+                                                    float32,
+                                                    float32,
+                                                    float32,
+                                                    float32,
+                                                    float32,
+                                                    float32,
+                                                    float32,
+                                                    float32,
+                                                    float32)
       stloc.s    res
 
       // Check Result
@@ -60,7 +66,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType1, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i12.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i12.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i12.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i12.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i12.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i12.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i1c.dll" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i1c.dll" as "#1" cdecl)
         vararg valuetype MCCTest.VType1 Sum(float32) cil managed preservesig {
     }
 
@@ -34,21 +40,21 @@
       ldc.r4     1
       neg
       tail.
-      call       vararg valuetype MCCTest.VType1 MCCTest.MyClass::Sum(float32, ..., 
-                                                                        float32, 
-                                                                        float32, 
-                                                                        float32, 
-                                                                        float32, 
-                                                                        float32, 
-                                                                        float32, 
-                                                                        float32, 
-                                                                        float32, 
-                                                                        float32, 
-                                                                        float32, 
-                                                                        float32, 
+      call       vararg valuetype MCCTest.VType1 MCCTest.MyClass::Sum(float32, ...,
+                                                                        float32,
+                                                                        float32,
+                                                                        float32,
+                                                                        float32,
+                                                                        float32,
+                                                                        float32,
+                                                                        float32,
+                                                                        float32,
+                                                                        float32,
+                                                                        float32,
+                                                                        float32,
                                                                         float32)
-		ret
-	}
+        ret
+    }
 
     .method public specialname rtspecialname instance void  .ctor()
     {
@@ -67,10 +73,10 @@
         [1] valuetype MCCTest.VType1 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType1 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -80,7 +86,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType1, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i13.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i13.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i13.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i13.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i13.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i13.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i1c.dll" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i1c.dll" as "#1" cdecl)
         vararg valuetype MCCTest.VType1 Sum(float32) cil managed preservesig {
     }
 
@@ -33,27 +39,27 @@
       ldc.r4     12
       ldc.r4     1
       neg
-      call       vararg valuetype MCCTest.VType1 MCCTest.MyClass::GetSum2(float32, ..., 
-																			float32, 
-																			float32, 
-																			float32, 
-																			float32, 
-																			float32, 
-																			float32, 
-																			float32, 
-																			float32, 
-																			float32, 
-																			float32, 
-																			float32, 
-																			float32)
-		ret
-	}
+      call       vararg valuetype MCCTest.VType1 MCCTest.MyClass::GetSum2(float32, ...,
+                                                                            float32,
+                                                                            float32,
+                                                                            float32,
+                                                                            float32,
+                                                                            float32,
+                                                                            float32,
+                                                                            float32,
+                                                                            float32,
+                                                                            float32,
+                                                                            float32,
+                                                                            float32,
+                                                                            float32)
+        ret
+    }
 
     .method private static vararg valuetype MCCTest.VType1 GetSum2(float32)
     {
       jmp   vararg valuetype MCCTest.VType1 MCCTest.MyClass::Sum(float32)
     }
-    
+
     .method public specialname rtspecialname instance void  .ctor()
     {
       .maxstack  1
@@ -71,10 +77,10 @@
         [1] valuetype MCCTest.VType1 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call       instance valuetype MCCTest.VType1 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -84,7 +90,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType1, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i14.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i14.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i14.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i1s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i1s" as "#1" stdcall)
         valuetype MCCTest.VType1 Sum(float32, float32, float32, float32, float32, float32, float32, float32, float32, float32, float32, float32) cil managed preservesig {
     }
 
@@ -24,7 +30,7 @@
         [0] valuetype MCCTest.VType1 res,
         [1] int32 rc
       )
-      
+
       ldc.r4     1
       ldc.r4     2
       ldc.r4     3
@@ -38,17 +44,17 @@
       ldc.r4     11
       ldc.r4     12
       call       valuetype MCCTest.VType1 MCCTest.MyClass::Sum(float32,
-																float32,
-																float32,
-																float32,
-																float32,
-																float32,
-																float32,
-																float32,
-																float32,
-																float32,
-																float32,
-																float32)
+                                                                float32,
+                                                                float32,
+                                                                float32,
+                                                                float32,
+                                                                float32,
+                                                                float32,
+                                                                float32,
+                                                                float32,
+                                                                float32,
+                                                                float32,
+                                                                float32)
 
       stloc.s    res
 
@@ -57,7 +63,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType1, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i14.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i14.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i14.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i15.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i15.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i15.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i15.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i15.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i15.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i1s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i1s" as "#1" stdcall)
         valuetype MCCTest.VType1 Sum(float32, float32, float32, float32, float32, float32, float32, float32, float32, float32, float32, float32) cil managed preservesig {
     }
 
@@ -24,7 +30,7 @@
         [0] valuetype MCCTest.VType1 res,
         [1] int32 rc
       )
-      
+
       ldc.r4     1
       ldc.r4     2
       ldc.r4     3
@@ -38,18 +44,18 @@
       ldc.r4     11
       ldc.r4     12
       ldftn      valuetype MCCTest.VType1 MCCTest.MyClass::Sum(float32, float32, float32, float32, float32, float32, float32, float32, float32, float32, float32, float32)
-      calli      valuetype MCCTest.VType1(float32, 
-											float32, 
-											float32, 
-											float32, 
-											float32, 
-											float32, 
-											float32, 
-											float32, 
-											float32, 
-											float32, 
-											float32, 
-											float32)
+      calli      valuetype MCCTest.VType1(float32,
+                                            float32,
+                                            float32,
+                                            float32,
+                                            float32,
+                                            float32,
+                                            float32,
+                                            float32,
+                                            float32,
+                                            float32,
+                                            float32,
+                                            float32)
       stloc.s    res
 
       // Check Result
@@ -57,7 +63,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType1, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i16.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i16.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i16.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i1s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i1s" as "#1" stdcall)
         valuetype MCCTest.VType1 Sum(float32, float32, float32, float32, float32, float32, float32, float32, float32, float32, float32, float32) cil managed preservesig {
     }
 
@@ -32,20 +38,20 @@
       ldc.r4     11
       ldc.r4     12
       tail.
-      call       valuetype MCCTest.VType1 MCCTest.MyClass::Sum(float32, 
-                                                                float32, 
-                                                                float32, 
-                                                                float32, 
-                                                                float32, 
-                                                                float32, 
-                                                                float32, 
-                                                                float32, 
-                                                                float32, 
-                                                                float32, 
-                                                                float32, 
+      call       valuetype MCCTest.VType1 MCCTest.MyClass::Sum(float32,
+                                                                float32,
+                                                                float32,
+                                                                float32,
+                                                                float32,
+                                                                float32,
+                                                                float32,
+                                                                float32,
+                                                                float32,
+                                                                float32,
+                                                                float32,
                                                                 float32)
-		ret
-	}
+        ret
+    }
 
     .method public specialname rtspecialname instance void  .ctor()
     {
@@ -64,10 +70,10 @@
         [1] valuetype MCCTest.VType1 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType1 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -77,7 +83,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType1, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i16.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i16.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i16.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i17.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i17.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i17.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i1s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i1s" as "#1" stdcall)
         valuetype MCCTest.VType1 Sum(float32, float32, float32, float32, float32, float32, float32, float32, float32, float32, float32, float32) cil managed preservesig {
     }
 
@@ -31,26 +37,26 @@
       ldc.r4     10
       ldc.r4     11
       ldc.r4     12
-      call       valuetype MCCTest.VType1 MCCTest.MyClass::GetSum2(float32, 
-                                                                    float32, 
-                                                                    float32, 
-                                                                    float32, 
-                                                                    float32, 
-                                                                    float32, 
-                                                                    float32, 
-                                                                    float32, 
-                                                                    float32, 
-                                                                    float32, 
-                                                                    float32, 
+      call       valuetype MCCTest.VType1 MCCTest.MyClass::GetSum2(float32,
+                                                                    float32,
+                                                                    float32,
+                                                                    float32,
+                                                                    float32,
+                                                                    float32,
+                                                                    float32,
+                                                                    float32,
+                                                                    float32,
+                                                                    float32,
+                                                                    float32,
                                                                     float32)
-		ret
-	}
+        ret
+    }
 
     .method private static valuetype MCCTest.VType1 GetSum2(float32, float32, float32, float32, float32, float32, float32, float32, float32, float32, float32, float32)
     {
       jmp   valuetype MCCTest.VType1 MCCTest.MyClass::Sum(float32, float32, float32, float32, float32, float32, float32, float32, float32, float32, float32, float32)
     }
-    
+
     .method public specialname rtspecialname instance void  .ctor()
     {
       .maxstack  1
@@ -68,10 +74,10 @@
         [1] valuetype MCCTest.VType1 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call       instance valuetype MCCTest.VType1 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -81,7 +87,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType1, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i17.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i17.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i17.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i30.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i30.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i30.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i3c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i3c" as "#1" cdecl)
         vararg valuetype MCCTest.VType3 Sum(float64, int32, int64, float32, int16, float64) cil managed preservesig {
     }
 
@@ -36,7 +42,7 @@
         [12] valuetype MCCTest.VType3 v12,
         [13] int32 rc
       )
-      
+
       // Initialize v1 thru v12
       ldloca.s   v1
       call       instance void MCCTest.VType3::Init()
@@ -82,19 +88,19 @@
       ldloc.s    v10
       ldloc.s    v11
       ldloc.s    v12
-      call   vararg valuetype MCCTest.VType3 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64, ..., 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3)
+      call   vararg valuetype MCCTest.VType3 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64, ...,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3)
 
       stloc.s    res
 
@@ -103,7 +109,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType3, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i30.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i30.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i30.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i31.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i31.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i31.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i31.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i31.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i31.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i3c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i3c" as "#1" cdecl)
         vararg valuetype MCCTest.VType3 Sum(float64, int32, int64, float32, int16, float64) cil managed preservesig {
     }
 
@@ -36,7 +42,7 @@
         [12] valuetype MCCTest.VType3 v12,
         [13] int32 rc
       )
-      
+
       // Initialize v1 thru v12
       ldloca.s   v1
       call       instance void MCCTest.VType3::Init()
@@ -83,19 +89,19 @@
       ldloc.s    v11
       ldloc.s    v12
       ldftn      vararg valuetype MCCTest.VType3 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64)
-      calli      vararg valuetype MCCTest.VType3(float64, int32, int64, float32, int16, float64, ..., 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3)
+      calli      vararg valuetype MCCTest.VType3(float64, int32, int64, float32, int16, float64, ...,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3)
 
       stloc.s    res
 
@@ -104,7 +110,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType3, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i32.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i32.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i32.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i32.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i32.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i32.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i3c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i3c" as "#1" cdecl)
         vararg valuetype MCCTest.VType3 Sum(float64, int32, int64, float32, int16, float64) cil managed preservesig {
     }
 
@@ -80,21 +86,21 @@
       ldloc.s    v11
       ldloc.s    v12
       tail.
-      call   vararg valuetype MCCTest.VType3 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64, ..., 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3)
-		ret
-	}
+      call   vararg valuetype MCCTest.VType3 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64, ...,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3)
+        ret
+    }
 
     .method public specialname rtspecialname instance void  .ctor()
     {
@@ -113,10 +119,10 @@
         [1] valuetype MCCTest.VType3 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType3 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -126,7 +132,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType3, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i33.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i33.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i33.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i3c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i3c" as "#1" cdecl)
         vararg valuetype MCCTest.VType3 Sum(float64, int32, int64, float32, int16, float64) cil managed preservesig {
     }
 
@@ -79,27 +85,27 @@
       ldloc.s    v10
       ldloc.s    v11
       ldloc.s    v12
-      call   vararg valuetype MCCTest.VType3 MCCTest.MyClass::GetSum2(float64, int32, int64, float32, int16, float64, ..., 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3, 
-																valuetype MCCTest.VType3)
-		ret
-	}
+      call   vararg valuetype MCCTest.VType3 MCCTest.MyClass::GetSum2(float64, int32, int64, float32, int16, float64, ...,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3,
+                                                                valuetype MCCTest.VType3)
+        ret
+    }
 
     .method private static vararg valuetype MCCTest.VType3 GetSum2(float64, int32, int64, float32, int16, float64)
     {
       jmp   vararg valuetype MCCTest.VType3 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64)
     }
-    
+
     .method public specialname rtspecialname instance void  .ctor()
     {
       .maxstack  1
@@ -117,10 +123,10 @@
         [1] valuetype MCCTest.VType3 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType3 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -130,7 +136,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType3, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i33.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i33.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i33.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i34.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i34.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i34.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i34.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i34.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i34.exe
@@ -12,11 +18,11 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i3s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i3s" as "#1" stdcall)
         valuetype MCCTest.VType3 Sum(unsigned int64, valuetype MCCTest.VType3, float64,	valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3,
-									int32, valuetype MCCTest.VType3, unsigned int16, valuetype MCCTest.VType3, unsigned int32, valuetype MCCTest.VType3, 
-									float32, valuetype MCCTest.VType3, int64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3,
-									float64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3, int16, valuetype MCCTest.VType3) cil managed preservesig {
+                                    int32, valuetype MCCTest.VType3, unsigned int16, valuetype MCCTest.VType3, unsigned int32, valuetype MCCTest.VType3,
+                                    float32, valuetype MCCTest.VType3, int64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3,
+                                    float64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3, int16, valuetype MCCTest.VType3) cil managed preservesig {
     }
 
     .method private static int32 Main(string[] args)
@@ -39,7 +45,7 @@
         [12] valuetype MCCTest.VType3 v12,
         [13] int32 rc
       )
-      
+
       // Initialize v1 thru v12
       ldloca.s   v1
       call       instance void MCCTest.VType3::Init()
@@ -65,7 +71,7 @@
       call       instance void MCCTest.VType3::Init()
       ldloca.s   v12
       call       instance void MCCTest.VType3::Init()
-      
+
       ldc.i8     1
       ldloc.s    v1
       ldc.r8     2
@@ -92,18 +98,18 @@
       ldc.i8     12
       conv.i2
       ldloc.s    v12
-      call       valuetype MCCTest.VType3 MCCTest.MyClass::Sum(	unsigned int64,	valuetype MCCTest.VType3, 
-																float64,		valuetype MCCTest.VType3,
-																float32,		valuetype MCCTest.VType3,
-																int32,			valuetype MCCTest.VType3,
-																unsigned int16,	valuetype MCCTest.VType3,
-																unsigned int32,	valuetype MCCTest.VType3,
-																float32,		valuetype MCCTest.VType3,
-																int64,			valuetype MCCTest.VType3,
-																float32,		valuetype MCCTest.VType3,
-																float64,		valuetype MCCTest.VType3,
-																float32,		valuetype MCCTest.VType3,
-																int16,			valuetype MCCTest.VType3)
+      call       valuetype MCCTest.VType3 MCCTest.MyClass::Sum(	unsigned int64,	valuetype MCCTest.VType3,
+                                                                float64,		valuetype MCCTest.VType3,
+                                                                float32,		valuetype MCCTest.VType3,
+                                                                int32,			valuetype MCCTest.VType3,
+                                                                unsigned int16,	valuetype MCCTest.VType3,
+                                                                unsigned int32,	valuetype MCCTest.VType3,
+                                                                float32,		valuetype MCCTest.VType3,
+                                                                int64,			valuetype MCCTest.VType3,
+                                                                float32,		valuetype MCCTest.VType3,
+                                                                float64,		valuetype MCCTest.VType3,
+                                                                float32,		valuetype MCCTest.VType3,
+                                                                int16,			valuetype MCCTest.VType3)
 
       stloc.s    res
 
@@ -112,7 +118,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType3, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i35.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i35.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i35.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i35.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i35.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i35.exe
@@ -12,11 +18,11 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i3s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i3s" as "#1" stdcall)
         valuetype MCCTest.VType3 Sum(unsigned int64, valuetype MCCTest.VType3, float64,	valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3,
-									int32, valuetype MCCTest.VType3, unsigned int16, valuetype MCCTest.VType3, unsigned int32, valuetype MCCTest.VType3, 
-									float32, valuetype MCCTest.VType3, int64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3,
-									float64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3, int16, valuetype MCCTest.VType3) cil managed preservesig {
+                                    int32, valuetype MCCTest.VType3, unsigned int16, valuetype MCCTest.VType3, unsigned int32, valuetype MCCTest.VType3,
+                                    float32, valuetype MCCTest.VType3, int64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3,
+                                    float64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3, int16, valuetype MCCTest.VType3) cil managed preservesig {
     }
 
     .method private static int32 Main(string[] args)
@@ -39,7 +45,7 @@
         [12] valuetype MCCTest.VType3 v12,
         [13] int32 rc
       )
-      
+
       // Initialize v1 thru v12
       ldloca.s   v1
       call       instance void MCCTest.VType3::Init()
@@ -65,7 +71,7 @@
       call       instance void MCCTest.VType3::Init()
       ldloca.s   v12
       call       instance void MCCTest.VType3::Init()
-      
+
       ldc.i8     1
       ldloc.s    v1
       ldc.r8     2
@@ -93,21 +99,21 @@
       conv.i2
       ldloc.s    v12
       ldftn      valuetype MCCTest.VType3 MCCTest.MyClass::Sum(unsigned int64, valuetype MCCTest.VType3, float64,	valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3,
-									int32, valuetype MCCTest.VType3, unsigned int16, valuetype MCCTest.VType3, unsigned int32, valuetype MCCTest.VType3, 
-									float32, valuetype MCCTest.VType3, int64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3,
-									float64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3, int16, valuetype MCCTest.VType3)
-      calli       valuetype MCCTest.VType3(	unsigned int64,	valuetype MCCTest.VType3, 
-											float64,		valuetype MCCTest.VType3,
-											float32,		valuetype MCCTest.VType3,
-											int32,			valuetype MCCTest.VType3,
-											unsigned int16,	valuetype MCCTest.VType3,
-											unsigned int32,	valuetype MCCTest.VType3,
-											float32,		valuetype MCCTest.VType3,
-											int64,			valuetype MCCTest.VType3,
-											float32,		valuetype MCCTest.VType3,
-											float64,		valuetype MCCTest.VType3,
-											float32,		valuetype MCCTest.VType3,
-											int16,			valuetype MCCTest.VType3)
+                                    int32, valuetype MCCTest.VType3, unsigned int16, valuetype MCCTest.VType3, unsigned int32, valuetype MCCTest.VType3,
+                                    float32, valuetype MCCTest.VType3, int64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3,
+                                    float64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3, int16, valuetype MCCTest.VType3)
+      calli       valuetype MCCTest.VType3(	unsigned int64,	valuetype MCCTest.VType3,
+                                            float64,		valuetype MCCTest.VType3,
+                                            float32,		valuetype MCCTest.VType3,
+                                            int32,			valuetype MCCTest.VType3,
+                                            unsigned int16,	valuetype MCCTest.VType3,
+                                            unsigned int32,	valuetype MCCTest.VType3,
+                                            float32,		valuetype MCCTest.VType3,
+                                            int64,			valuetype MCCTest.VType3,
+                                            float32,		valuetype MCCTest.VType3,
+                                            float64,		valuetype MCCTest.VType3,
+                                            float32,		valuetype MCCTest.VType3,
+                                            int16,			valuetype MCCTest.VType3)
 
       stloc.s    res
 
@@ -116,7 +122,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType3, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i36.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i36.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i36.exe
@@ -12,11 +18,11 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i3s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i3s" as "#1" stdcall)
         valuetype MCCTest.VType3 Sum(unsigned int64, valuetype MCCTest.VType3, float64,	valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3,
-									int32, valuetype MCCTest.VType3, unsigned int16, valuetype MCCTest.VType3, unsigned int32, valuetype MCCTest.VType3, 
-									float32, valuetype MCCTest.VType3, int64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3,
-									float64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3, int16, valuetype MCCTest.VType3) cil managed preservesig {
+                                    int32, valuetype MCCTest.VType3, unsigned int16, valuetype MCCTest.VType3, unsigned int32, valuetype MCCTest.VType3,
+                                    float32, valuetype MCCTest.VType3, int64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3,
+                                    float64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3, int16, valuetype MCCTest.VType3) cil managed preservesig {
     }
 
     .method private valuetype MCCTest.VType3 GetSum()
@@ -90,20 +96,20 @@
       conv.i2
       ldloc.s    v12
       tail.
-      call       valuetype MCCTest.VType3 MCCTest.MyClass::Sum(	unsigned int64,	valuetype MCCTest.VType3, 
-																float64,		valuetype MCCTest.VType3,
-																float32,		valuetype MCCTest.VType3,
-																int32,			valuetype MCCTest.VType3,
-																unsigned int16,	valuetype MCCTest.VType3,
-																unsigned int32,	valuetype MCCTest.VType3,
-																float32,		valuetype MCCTest.VType3,
-																int64,			valuetype MCCTest.VType3,
-																float32,		valuetype MCCTest.VType3,
-																float64,		valuetype MCCTest.VType3,
-																float32,		valuetype MCCTest.VType3,
-																int16,			valuetype MCCTest.VType3)
-		ret
-	}
+      call       valuetype MCCTest.VType3 MCCTest.MyClass::Sum(	unsigned int64,	valuetype MCCTest.VType3,
+                                                                float64,		valuetype MCCTest.VType3,
+                                                                float32,		valuetype MCCTest.VType3,
+                                                                int32,			valuetype MCCTest.VType3,
+                                                                unsigned int16,	valuetype MCCTest.VType3,
+                                                                unsigned int32,	valuetype MCCTest.VType3,
+                                                                float32,		valuetype MCCTest.VType3,
+                                                                int64,			valuetype MCCTest.VType3,
+                                                                float32,		valuetype MCCTest.VType3,
+                                                                float64,		valuetype MCCTest.VType3,
+                                                                float32,		valuetype MCCTest.VType3,
+                                                                int16,			valuetype MCCTest.VType3)
+        ret
+    }
 
     .method public specialname rtspecialname instance void  .ctor()
     {
@@ -122,10 +128,10 @@
         [1] valuetype MCCTest.VType3 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType3 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -135,7 +141,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType3, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i36.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i36.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i36.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i37.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i37.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i37.exe
@@ -12,11 +18,11 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i3s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i3s" as "#1" stdcall)
         valuetype MCCTest.VType3 Sum(unsigned int64, valuetype MCCTest.VType3, float64,	valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3,
-									int32, valuetype MCCTest.VType3, unsigned int16, valuetype MCCTest.VType3, unsigned int32, valuetype MCCTest.VType3, 
-									float32, valuetype MCCTest.VType3, int64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3,
-									float64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3, int16, valuetype MCCTest.VType3) cil managed preservesig {
+                                    int32, valuetype MCCTest.VType3, unsigned int16, valuetype MCCTest.VType3, unsigned int32, valuetype MCCTest.VType3,
+                                    float32, valuetype MCCTest.VType3, int64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3,
+                                    float64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3, int16, valuetype MCCTest.VType3) cil managed preservesig {
     }
 
     .method private valuetype MCCTest.VType3 GetSum()
@@ -89,32 +95,32 @@
       ldc.i8     12
       conv.i2
       ldloc.s    v12
-      call       valuetype MCCTest.VType3 MCCTest.MyClass::GetSum2(	unsigned int64,	valuetype MCCTest.VType3, 
-																float64,		valuetype MCCTest.VType3,
-																float32,		valuetype MCCTest.VType3,
-																int32,			valuetype MCCTest.VType3,
-																unsigned int16,	valuetype MCCTest.VType3,
-																unsigned int32,	valuetype MCCTest.VType3,
-																float32,		valuetype MCCTest.VType3,
-																int64,			valuetype MCCTest.VType3,
-																float32,		valuetype MCCTest.VType3,
-																float64,		valuetype MCCTest.VType3,
-																float32,		valuetype MCCTest.VType3,
-																int16,			valuetype MCCTest.VType3)
-		ret
-	}
+      call       valuetype MCCTest.VType3 MCCTest.MyClass::GetSum2(	unsigned int64,	valuetype MCCTest.VType3,
+                                                                float64,		valuetype MCCTest.VType3,
+                                                                float32,		valuetype MCCTest.VType3,
+                                                                int32,			valuetype MCCTest.VType3,
+                                                                unsigned int16,	valuetype MCCTest.VType3,
+                                                                unsigned int32,	valuetype MCCTest.VType3,
+                                                                float32,		valuetype MCCTest.VType3,
+                                                                int64,			valuetype MCCTest.VType3,
+                                                                float32,		valuetype MCCTest.VType3,
+                                                                float64,		valuetype MCCTest.VType3,
+                                                                float32,		valuetype MCCTest.VType3,
+                                                                int16,			valuetype MCCTest.VType3)
+        ret
+    }
 
     .method private static valuetype MCCTest.VType3 GetSum2(unsigned int64, valuetype MCCTest.VType3, float64,	valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3,
-									int32, valuetype MCCTest.VType3, unsigned int16, valuetype MCCTest.VType3, unsigned int32, valuetype MCCTest.VType3, 
-									float32, valuetype MCCTest.VType3, int64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3,
-									float64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3, int16, valuetype MCCTest.VType3)
+                                    int32, valuetype MCCTest.VType3, unsigned int16, valuetype MCCTest.VType3, unsigned int32, valuetype MCCTest.VType3,
+                                    float32, valuetype MCCTest.VType3, int64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3,
+                                    float64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3, int16, valuetype MCCTest.VType3)
     {
       jmp   valuetype MCCTest.VType3 MCCTest.MyClass::Sum(unsigned int64, valuetype MCCTest.VType3, float64,	valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3,
-									int32, valuetype MCCTest.VType3, unsigned int16, valuetype MCCTest.VType3, unsigned int32, valuetype MCCTest.VType3, 
-									float32, valuetype MCCTest.VType3, int64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3,
-									float64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3, int16, valuetype MCCTest.VType3)
+                                    int32, valuetype MCCTest.VType3, unsigned int16, valuetype MCCTest.VType3, unsigned int32, valuetype MCCTest.VType3,
+                                    float32, valuetype MCCTest.VType3, int64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3,
+                                    float64, valuetype MCCTest.VType3, float32, valuetype MCCTest.VType3, int16, valuetype MCCTest.VType3)
     }
-    
+
     .method public specialname rtspecialname instance void  .ctor()
     {
       .maxstack  1
@@ -132,10 +138,10 @@
         [1] valuetype MCCTest.VType3 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType3 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -145,7 +151,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType3, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i37.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i37.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i37.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i50.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i50.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i50.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i5c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i5c" as "#1" cdecl)
         vararg valuetype MCCTest.VType5 Sum(float64, int32, int64, float32, int16, float64) cil managed preservesig {
     }
 
@@ -36,7 +42,7 @@
         [12] valuetype MCCTest.VType5 v12,
         [13] int32 rc
       )
-      
+
       // Initialize v1 thru v12
       ldloca.s   v1
       call       instance void MCCTest.VType5::Init()
@@ -82,19 +88,19 @@
       ldloc.s    v10
       ldloc.s    v11
       ldloc.s    v12
-      call   vararg valuetype MCCTest.VType5 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64, ..., 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5)
+      call   vararg valuetype MCCTest.VType5 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64, ...,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5)
 
       stloc.s    res
 
@@ -103,7 +109,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType5, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i50.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i50.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i50.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i51.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i51.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i51.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i5c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i5c" as "#1" cdecl)
         vararg valuetype MCCTest.VType5 Sum(float64, int32, int64, float32, int16, float64) cil managed preservesig {
     }
 
@@ -36,7 +42,7 @@
         [12] valuetype MCCTest.VType5 v12,
         [13] int32 rc
       )
-      
+
       // Initialize v1 thru v12
       ldloca.s   v1
       call       instance void MCCTest.VType5::Init()
@@ -83,19 +89,19 @@
       ldloc.s    v11
       ldloc.s    v12
       ldftn      vararg valuetype MCCTest.VType5 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64)
-      calli      vararg valuetype MCCTest.VType5(float64, int32, int64, float32, int16, float64, ..., 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5)
+      calli      vararg valuetype MCCTest.VType5(float64, int32, int64, float32, int16, float64, ...,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5)
 
       stloc.s    res
 
@@ -104,7 +110,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType5, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i51.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i51.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i51.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i52.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i52.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i52.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i5c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i5c" as "#1" cdecl)
         vararg valuetype MCCTest.VType5 Sum(float64, int32, int64, float32, int16, float64) cil managed preservesig {
     }
 
@@ -80,21 +86,21 @@
       ldloc.s    v11
       ldloc.s    v12
       tail.
-      call   vararg valuetype MCCTest.VType5 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64, ..., 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5)
-		ret
-	}
+      call   vararg valuetype MCCTest.VType5 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64, ...,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5)
+        ret
+    }
 
     .method public specialname rtspecialname instance void  .ctor()
     {
@@ -113,10 +119,10 @@
         [1] valuetype MCCTest.VType5 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType5 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -126,7 +132,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType5, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i52.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i52.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i52.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i53.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i53.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i53.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i5c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i5c" as "#1" cdecl)
         vararg valuetype MCCTest.VType5 Sum(float64, int32, int64, float32, int16, float64) cil managed preservesig {
     }
 
@@ -79,27 +85,27 @@
       ldloc.s    v10
       ldloc.s    v11
       ldloc.s    v12
-      call   vararg valuetype MCCTest.VType5 MCCTest.MyClass::GetSum2(float64, int32, int64, float32, int16, float64, ..., 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5, 
-																valuetype MCCTest.VType5)
-		ret
-	}
+      call   vararg valuetype MCCTest.VType5 MCCTest.MyClass::GetSum2(float64, int32, int64, float32, int16, float64, ...,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5,
+                                                                valuetype MCCTest.VType5)
+        ret
+    }
 
     .method private static vararg valuetype MCCTest.VType5 GetSum2(float64, int32, int64, float32, int16, float64)
     {
       jmp   vararg valuetype MCCTest.VType5 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64)
     }
-    
+
     .method public specialname rtspecialname instance void  .ctor()
     {
       .maxstack  1
@@ -117,10 +123,10 @@
         [1] valuetype MCCTest.VType5 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType5 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -130,7 +136,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType5, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i53.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i53.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i53.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i54.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i54.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i54.exe
@@ -12,11 +18,11 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i5s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i5s" as "#1" stdcall)
         valuetype MCCTest.VType5 Sum(unsigned int64, valuetype MCCTest.VType5, float64,	valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5,
-									int32, valuetype MCCTest.VType5, unsigned int16, valuetype MCCTest.VType5, unsigned int32, valuetype MCCTest.VType5, 
-									float32, valuetype MCCTest.VType5, int64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5,
-									float64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5, int16, valuetype MCCTest.VType5) cil managed preservesig {
+                                    int32, valuetype MCCTest.VType5, unsigned int16, valuetype MCCTest.VType5, unsigned int32, valuetype MCCTest.VType5,
+                                    float32, valuetype MCCTest.VType5, int64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5,
+                                    float64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5, int16, valuetype MCCTest.VType5) cil managed preservesig {
     }
 
     .method private static int32 Main(string[] args)
@@ -39,7 +45,7 @@
         [12] valuetype MCCTest.VType5 v12,
         [13] int32 rc
       )
-      
+
       // Initialize v1 thru v12
       ldloca.s   v1
       call       instance void MCCTest.VType5::Init()
@@ -65,7 +71,7 @@
       call       instance void MCCTest.VType5::Init()
       ldloca.s   v12
       call       instance void MCCTest.VType5::Init()
-      
+
       ldc.i8     1
       ldloc.s    v1
       ldc.r8     2
@@ -92,18 +98,18 @@
       ldc.i8     12
       conv.i2
       ldloc.s    v12
-      call       valuetype MCCTest.VType5 MCCTest.MyClass::Sum(	unsigned int64,	valuetype MCCTest.VType5, 
-																float64,		valuetype MCCTest.VType5,
-																float32,		valuetype MCCTest.VType5,
-																int32,			valuetype MCCTest.VType5,
-																unsigned int16,	valuetype MCCTest.VType5,
-																unsigned int32,	valuetype MCCTest.VType5,
-																float32,		valuetype MCCTest.VType5,
-																int64,			valuetype MCCTest.VType5,
-																float32,		valuetype MCCTest.VType5,
-																float64,		valuetype MCCTest.VType5,
-																float32,		valuetype MCCTest.VType5,
-																int16,			valuetype MCCTest.VType5)
+      call       valuetype MCCTest.VType5 MCCTest.MyClass::Sum(	unsigned int64,	valuetype MCCTest.VType5,
+                                                                float64,		valuetype MCCTest.VType5,
+                                                                float32,		valuetype MCCTest.VType5,
+                                                                int32,			valuetype MCCTest.VType5,
+                                                                unsigned int16,	valuetype MCCTest.VType5,
+                                                                unsigned int32,	valuetype MCCTest.VType5,
+                                                                float32,		valuetype MCCTest.VType5,
+                                                                int64,			valuetype MCCTest.VType5,
+                                                                float32,		valuetype MCCTest.VType5,
+                                                                float64,		valuetype MCCTest.VType5,
+                                                                float32,		valuetype MCCTest.VType5,
+                                                                int16,			valuetype MCCTest.VType5)
 
       stloc.s    res
 
@@ -112,7 +118,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType5, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i54.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i54.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i54.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i55.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i55.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i55.exe
@@ -12,11 +18,11 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i5s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i5s" as "#1" stdcall)
         valuetype MCCTest.VType5 Sum(unsigned int64, valuetype MCCTest.VType5, float64,	valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5,
-									int32, valuetype MCCTest.VType5, unsigned int16, valuetype MCCTest.VType5, unsigned int32, valuetype MCCTest.VType5, 
-									float32, valuetype MCCTest.VType5, int64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5,
-									float64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5, int16, valuetype MCCTest.VType5) cil managed preservesig {
+                                    int32, valuetype MCCTest.VType5, unsigned int16, valuetype MCCTest.VType5, unsigned int32, valuetype MCCTest.VType5,
+                                    float32, valuetype MCCTest.VType5, int64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5,
+                                    float64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5, int16, valuetype MCCTest.VType5) cil managed preservesig {
     }
 
     .method private static int32 Main(string[] args)
@@ -39,7 +45,7 @@
         [12] valuetype MCCTest.VType5 v12,
         [13] int32 rc
       )
-      
+
       // Initialize v1 thru v12
       ldloca.s   v1
       call       instance void MCCTest.VType5::Init()
@@ -65,7 +71,7 @@
       call       instance void MCCTest.VType5::Init()
       ldloca.s   v12
       call       instance void MCCTest.VType5::Init()
-      
+
       ldc.i8     1
       ldloc.s    v1
       ldc.r8     2
@@ -93,21 +99,21 @@
       conv.i2
       ldloc.s    v12
       ldftn      valuetype MCCTest.VType5 MCCTest.MyClass::Sum(unsigned int64, valuetype MCCTest.VType5, float64,	valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5,
-									int32, valuetype MCCTest.VType5, unsigned int16, valuetype MCCTest.VType5, unsigned int32, valuetype MCCTest.VType5, 
-									float32, valuetype MCCTest.VType5, int64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5,
-									float64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5, int16, valuetype MCCTest.VType5)
-      calli       valuetype MCCTest.VType5(	unsigned int64,	valuetype MCCTest.VType5, 
-											float64,		valuetype MCCTest.VType5,
-											float32,		valuetype MCCTest.VType5,
-											int32,			valuetype MCCTest.VType5,
-											unsigned int16,	valuetype MCCTest.VType5,
-											unsigned int32,	valuetype MCCTest.VType5,
-											float32,		valuetype MCCTest.VType5,
-											int64,			valuetype MCCTest.VType5,
-											float32,		valuetype MCCTest.VType5,
-											float64,		valuetype MCCTest.VType5,
-											float32,		valuetype MCCTest.VType5,
-											int16,			valuetype MCCTest.VType5)
+                                    int32, valuetype MCCTest.VType5, unsigned int16, valuetype MCCTest.VType5, unsigned int32, valuetype MCCTest.VType5,
+                                    float32, valuetype MCCTest.VType5, int64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5,
+                                    float64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5, int16, valuetype MCCTest.VType5)
+      calli       valuetype MCCTest.VType5(	unsigned int64,	valuetype MCCTest.VType5,
+                                            float64,		valuetype MCCTest.VType5,
+                                            float32,		valuetype MCCTest.VType5,
+                                            int32,			valuetype MCCTest.VType5,
+                                            unsigned int16,	valuetype MCCTest.VType5,
+                                            unsigned int32,	valuetype MCCTest.VType5,
+                                            float32,		valuetype MCCTest.VType5,
+                                            int64,			valuetype MCCTest.VType5,
+                                            float32,		valuetype MCCTest.VType5,
+                                            float64,		valuetype MCCTest.VType5,
+                                            float32,		valuetype MCCTest.VType5,
+                                            int16,			valuetype MCCTest.VType5)
 
       stloc.s    res
 
@@ -116,7 +122,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType5, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i55.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i55.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i55.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i56.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i56.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i56.exe
@@ -12,11 +18,11 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i5s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i5s" as "#1" stdcall)
         valuetype MCCTest.VType5 Sum(unsigned int64, valuetype MCCTest.VType5, float64,	valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5,
-									int32, valuetype MCCTest.VType5, unsigned int16, valuetype MCCTest.VType5, unsigned int32, valuetype MCCTest.VType5, 
-									float32, valuetype MCCTest.VType5, int64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5,
-									float64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5, int16, valuetype MCCTest.VType5) cil managed preservesig {
+                                    int32, valuetype MCCTest.VType5, unsigned int16, valuetype MCCTest.VType5, unsigned int32, valuetype MCCTest.VType5,
+                                    float32, valuetype MCCTest.VType5, int64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5,
+                                    float64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5, int16, valuetype MCCTest.VType5) cil managed preservesig {
     }
 
     .method private valuetype MCCTest.VType5 GetSum()
@@ -90,20 +96,20 @@
       conv.i2
       ldloc.s    v12
       tail.
-      call       valuetype MCCTest.VType5 MCCTest.MyClass::Sum(	unsigned int64,	valuetype MCCTest.VType5, 
-																float64,		valuetype MCCTest.VType5,
-																float32,		valuetype MCCTest.VType5,
-																int32,			valuetype MCCTest.VType5,
-																unsigned int16,	valuetype MCCTest.VType5,
-																unsigned int32,	valuetype MCCTest.VType5,
-																float32,		valuetype MCCTest.VType5,
-																int64,			valuetype MCCTest.VType5,
-																float32,		valuetype MCCTest.VType5,
-																float64,		valuetype MCCTest.VType5,
-																float32,		valuetype MCCTest.VType5,
-																int16,			valuetype MCCTest.VType5)
-		ret
-	}
+      call       valuetype MCCTest.VType5 MCCTest.MyClass::Sum(	unsigned int64,	valuetype MCCTest.VType5,
+                                                                float64,		valuetype MCCTest.VType5,
+                                                                float32,		valuetype MCCTest.VType5,
+                                                                int32,			valuetype MCCTest.VType5,
+                                                                unsigned int16,	valuetype MCCTest.VType5,
+                                                                unsigned int32,	valuetype MCCTest.VType5,
+                                                                float32,		valuetype MCCTest.VType5,
+                                                                int64,			valuetype MCCTest.VType5,
+                                                                float32,		valuetype MCCTest.VType5,
+                                                                float64,		valuetype MCCTest.VType5,
+                                                                float32,		valuetype MCCTest.VType5,
+                                                                int16,			valuetype MCCTest.VType5)
+        ret
+    }
 
     .method public specialname rtspecialname instance void  .ctor()
     {
@@ -122,10 +128,10 @@
         [1] valuetype MCCTest.VType5 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType5 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -135,7 +141,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType5, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i56.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i56.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i56.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i57.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i57.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i57.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i57.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i57.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i57.exe
@@ -12,11 +18,11 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i5s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i5s" as "#1" stdcall)
         valuetype MCCTest.VType5 Sum(unsigned int64, valuetype MCCTest.VType5, float64,	valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5,
-									int32, valuetype MCCTest.VType5, unsigned int16, valuetype MCCTest.VType5, unsigned int32, valuetype MCCTest.VType5, 
-									float32, valuetype MCCTest.VType5, int64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5,
-									float64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5, int16, valuetype MCCTest.VType5) cil managed preservesig {
+                                    int32, valuetype MCCTest.VType5, unsigned int16, valuetype MCCTest.VType5, unsigned int32, valuetype MCCTest.VType5,
+                                    float32, valuetype MCCTest.VType5, int64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5,
+                                    float64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5, int16, valuetype MCCTest.VType5) cil managed preservesig {
     }
 
     .method private valuetype MCCTest.VType5 GetSum()
@@ -89,32 +95,32 @@
       ldc.i8     12
       conv.i2
       ldloc.s    v12
-      call       valuetype MCCTest.VType5 MCCTest.MyClass::GetSum2(	unsigned int64,	valuetype MCCTest.VType5, 
-																float64,		valuetype MCCTest.VType5,
-																float32,		valuetype MCCTest.VType5,
-																int32,			valuetype MCCTest.VType5,
-																unsigned int16,	valuetype MCCTest.VType5,
-																unsigned int32,	valuetype MCCTest.VType5,
-																float32,		valuetype MCCTest.VType5,
-																int64,			valuetype MCCTest.VType5,
-																float32,		valuetype MCCTest.VType5,
-																float64,		valuetype MCCTest.VType5,
-																float32,		valuetype MCCTest.VType5,
-																int16,			valuetype MCCTest.VType5)
-		ret
-	}
+      call       valuetype MCCTest.VType5 MCCTest.MyClass::GetSum2(	unsigned int64,	valuetype MCCTest.VType5,
+                                                                float64,		valuetype MCCTest.VType5,
+                                                                float32,		valuetype MCCTest.VType5,
+                                                                int32,			valuetype MCCTest.VType5,
+                                                                unsigned int16,	valuetype MCCTest.VType5,
+                                                                unsigned int32,	valuetype MCCTest.VType5,
+                                                                float32,		valuetype MCCTest.VType5,
+                                                                int64,			valuetype MCCTest.VType5,
+                                                                float32,		valuetype MCCTest.VType5,
+                                                                float64,		valuetype MCCTest.VType5,
+                                                                float32,		valuetype MCCTest.VType5,
+                                                                int16,			valuetype MCCTest.VType5)
+        ret
+    }
 
     .method private static valuetype MCCTest.VType5 GetSum2(unsigned int64, valuetype MCCTest.VType5, float64,	valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5,
-									int32, valuetype MCCTest.VType5, unsigned int16, valuetype MCCTest.VType5, unsigned int32, valuetype MCCTest.VType5, 
-									float32, valuetype MCCTest.VType5, int64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5,
-									float64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5, int16, valuetype MCCTest.VType5)
+                                    int32, valuetype MCCTest.VType5, unsigned int16, valuetype MCCTest.VType5, unsigned int32, valuetype MCCTest.VType5,
+                                    float32, valuetype MCCTest.VType5, int64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5,
+                                    float64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5, int16, valuetype MCCTest.VType5)
     {
       jmp   valuetype MCCTest.VType5 MCCTest.MyClass::Sum(unsigned int64, valuetype MCCTest.VType5, float64,	valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5,
-									int32, valuetype MCCTest.VType5, unsigned int16, valuetype MCCTest.VType5, unsigned int32, valuetype MCCTest.VType5, 
-									float32, valuetype MCCTest.VType5, int64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5,
-									float64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5, int16, valuetype MCCTest.VType5)
+                                    int32, valuetype MCCTest.VType5, unsigned int16, valuetype MCCTest.VType5, unsigned int32, valuetype MCCTest.VType5,
+                                    float32, valuetype MCCTest.VType5, int64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5,
+                                    float64, valuetype MCCTest.VType5, float32, valuetype MCCTest.VType5, int16, valuetype MCCTest.VType5)
     }
-    
+
     .method public specialname rtspecialname instance void  .ctor()
     {
       .maxstack  1
@@ -132,10 +138,10 @@
         [1] valuetype MCCTest.VType5 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType5 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -145,7 +151,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType5, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i60.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i60.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i60.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i60.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i60.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i60.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i6c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i6c" as "#1" cdecl)
         vararg valuetype MCCTest.VType6 Sum(float64, int32, int64, float32, int16, float64) cil managed preservesig {
     }
 
@@ -36,7 +42,7 @@
         [12] valuetype MCCTest.VType6 v12,
         [13] int32 rc
       )
-      
+
       // Initialize v1 thru v12
       ldloca.s   v1
       call       instance void MCCTest.VType6::Init()
@@ -82,19 +88,19 @@
       ldloc.s    v10
       ldloc.s    v11
       ldloc.s    v12
-      call   vararg valuetype MCCTest.VType6 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64, ..., 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6)
+      call   vararg valuetype MCCTest.VType6 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64, ...,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6)
 
       stloc.s    res
 
@@ -103,7 +109,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType6, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i61.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i61.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i61.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i61.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i61.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i61.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i6c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i6c" as "#1" cdecl)
         vararg valuetype MCCTest.VType6 Sum(float64, int32, int64, float32, int16, float64) cil managed preservesig {
     }
 
@@ -36,7 +42,7 @@
         [12] valuetype MCCTest.VType6 v12,
         [13] int32 rc
       )
-      
+
       // Initialize v1 thru v12
       ldloca.s   v1
       call       instance void MCCTest.VType6::Init()
@@ -83,19 +89,19 @@
       ldloc.s    v11
       ldloc.s    v12
       ldftn      vararg valuetype MCCTest.VType6 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64)
-      calli      vararg valuetype MCCTest.VType6(float64, int32, int64, float32, int16, float64, ..., 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6)
+      calli      vararg valuetype MCCTest.VType6(float64, int32, int64, float32, int16, float64, ...,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6)
 
       stloc.s    res
 
@@ -104,7 +110,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType6, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i62.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i62.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i62.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i62.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i62.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i62.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i6c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i6c" as "#1" cdecl)
         vararg valuetype MCCTest.VType6 Sum(float64, int32, int64, float32, int16, float64) cil managed preservesig {
     }
 
@@ -80,21 +86,21 @@
       ldloc.s    v11
       ldloc.s    v12
       tail.
-      call   vararg valuetype MCCTest.VType6 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64, ..., 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6)
-		ret
-	}
+      call   vararg valuetype MCCTest.VType6 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64, ...,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6)
+        ret
+    }
 
     .method public specialname rtspecialname instance void  .ctor()
     {
@@ -113,10 +119,10 @@
         [1] valuetype MCCTest.VType6 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType6 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -126,7 +132,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType6, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i63.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i63.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i63.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i63.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i63.il
@@ -2,6 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i63.exe
@@ -11,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i6c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i6c" as "#1" cdecl)
         vararg valuetype MCCTest.VType6 Sum(float64, int32, int64, float32, int16, float64) cil managed preservesig {
     }
 
@@ -78,27 +85,27 @@
       ldloc.s    v10
       ldloc.s    v11
       ldloc.s    v12
-      call   vararg valuetype MCCTest.VType6 MCCTest.MyClass::GetSum2(float64, int32, int64, float32, int16, float64, ..., 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6, 
-																valuetype MCCTest.VType6)
-		ret
-	}
+      call   vararg valuetype MCCTest.VType6 MCCTest.MyClass::GetSum2(float64, int32, int64, float32, int16, float64, ...,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6,
+                                                                valuetype MCCTest.VType6)
+        ret
+    }
 
     .method private static vararg valuetype MCCTest.VType6 GetSum2(float64, int32, int64, float32, int16, float64)
     {
       jmp   vararg valuetype MCCTest.VType6 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64)
     }
-    
+
     .method public specialname rtspecialname instance void  .ctor()
     {
       .maxstack  1
@@ -116,10 +123,10 @@
         [1] valuetype MCCTest.VType6 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType6 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -129,7 +136,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType6, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i64.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i64.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i64.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i64.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i64.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i64.exe
@@ -12,11 +18,11 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i6s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i6s" as "#1" stdcall)
         valuetype MCCTest.VType6 Sum(unsigned int64, valuetype MCCTest.VType6, float64,	valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6,
-									int32, valuetype MCCTest.VType6, unsigned int16, valuetype MCCTest.VType6, unsigned int32, valuetype MCCTest.VType6, 
-									float32, valuetype MCCTest.VType6, int64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6,
-									float64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6, int16, valuetype MCCTest.VType6) cil managed preservesig {
+                                    int32, valuetype MCCTest.VType6, unsigned int16, valuetype MCCTest.VType6, unsigned int32, valuetype MCCTest.VType6,
+                                    float32, valuetype MCCTest.VType6, int64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6,
+                                    float64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6, int16, valuetype MCCTest.VType6) cil managed preservesig {
     }
 
     .method private static int32 Main(string[] args)
@@ -39,7 +45,7 @@
         [12] valuetype MCCTest.VType6 v12,
         [13] int32 rc
       )
-      
+
       // Initialize v1 thru v12
       ldloca.s   v1
       call       instance void MCCTest.VType6::Init()
@@ -65,7 +71,7 @@
       call       instance void MCCTest.VType6::Init()
       ldloca.s   v12
       call       instance void MCCTest.VType6::Init()
-      
+
       ldc.i8     1
       ldloc.s    v1
       ldc.r8     2
@@ -92,18 +98,18 @@
       ldc.i8     12
       conv.i2
       ldloc.s    v12
-      call       valuetype MCCTest.VType6 MCCTest.MyClass::Sum(	unsigned int64,	valuetype MCCTest.VType6, 
-																float64,		valuetype MCCTest.VType6,
-																float32,		valuetype MCCTest.VType6,
-																int32,			valuetype MCCTest.VType6,
-																unsigned int16,	valuetype MCCTest.VType6,
-																unsigned int32,	valuetype MCCTest.VType6,
-																float32,		valuetype MCCTest.VType6,
-																int64,			valuetype MCCTest.VType6,
-																float32,		valuetype MCCTest.VType6,
-																float64,		valuetype MCCTest.VType6,
-																float32,		valuetype MCCTest.VType6,
-																int16,			valuetype MCCTest.VType6)
+      call       valuetype MCCTest.VType6 MCCTest.MyClass::Sum(	unsigned int64,	valuetype MCCTest.VType6,
+                                                                float64,		valuetype MCCTest.VType6,
+                                                                float32,		valuetype MCCTest.VType6,
+                                                                int32,			valuetype MCCTest.VType6,
+                                                                unsigned int16,	valuetype MCCTest.VType6,
+                                                                unsigned int32,	valuetype MCCTest.VType6,
+                                                                float32,		valuetype MCCTest.VType6,
+                                                                int64,			valuetype MCCTest.VType6,
+                                                                float32,		valuetype MCCTest.VType6,
+                                                                float64,		valuetype MCCTest.VType6,
+                                                                float32,		valuetype MCCTest.VType6,
+                                                                int16,			valuetype MCCTest.VType6)
 
       stloc.s    res
 
@@ -112,7 +118,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType6, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i65.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i65.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i65.exe
@@ -12,11 +18,11 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i6s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i6s" as "#1" stdcall)
         valuetype MCCTest.VType6 Sum(unsigned int64, valuetype MCCTest.VType6, float64,	valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6,
-									int32, valuetype MCCTest.VType6, unsigned int16, valuetype MCCTest.VType6, unsigned int32, valuetype MCCTest.VType6, 
-									float32, valuetype MCCTest.VType6, int64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6,
-									float64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6, int16, valuetype MCCTest.VType6) cil managed preservesig {
+                                    int32, valuetype MCCTest.VType6, unsigned int16, valuetype MCCTest.VType6, unsigned int32, valuetype MCCTest.VType6,
+                                    float32, valuetype MCCTest.VType6, int64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6,
+                                    float64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6, int16, valuetype MCCTest.VType6) cil managed preservesig {
     }
 
     .method private static int32 Main(string[] args)
@@ -39,7 +45,7 @@
         [12] valuetype MCCTest.VType6 v12,
         [13] int32 rc
       )
-      
+
       // Initialize v1 thru v12
       ldloca.s   v1
       call       instance void MCCTest.VType6::Init()
@@ -65,7 +71,7 @@
       call       instance void MCCTest.VType6::Init()
       ldloca.s   v12
       call       instance void MCCTest.VType6::Init()
-      
+
       ldc.i8     1
       ldloc.s    v1
       ldc.r8     2
@@ -93,21 +99,21 @@
       conv.i2
       ldloc.s    v12
       ldftn      valuetype MCCTest.VType6 MCCTest.MyClass::Sum(unsigned int64, valuetype MCCTest.VType6, float64,	valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6,
-									int32, valuetype MCCTest.VType6, unsigned int16, valuetype MCCTest.VType6, unsigned int32, valuetype MCCTest.VType6, 
-									float32, valuetype MCCTest.VType6, int64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6,
-									float64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6, int16, valuetype MCCTest.VType6)
-      calli       valuetype MCCTest.VType6(	unsigned int64,	valuetype MCCTest.VType6, 
-											float64,		valuetype MCCTest.VType6,
-											float32,		valuetype MCCTest.VType6,
-											int32,			valuetype MCCTest.VType6,
-											unsigned int16,	valuetype MCCTest.VType6,
-											unsigned int32,	valuetype MCCTest.VType6,
-											float32,		valuetype MCCTest.VType6,
-											int64,			valuetype MCCTest.VType6,
-											float32,		valuetype MCCTest.VType6,
-											float64,		valuetype MCCTest.VType6,
-											float32,		valuetype MCCTest.VType6,
-											int16,			valuetype MCCTest.VType6)
+                                    int32, valuetype MCCTest.VType6, unsigned int16, valuetype MCCTest.VType6, unsigned int32, valuetype MCCTest.VType6,
+                                    float32, valuetype MCCTest.VType6, int64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6,
+                                    float64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6, int16, valuetype MCCTest.VType6)
+      calli       valuetype MCCTest.VType6(	unsigned int64,	valuetype MCCTest.VType6,
+                                            float64,		valuetype MCCTest.VType6,
+                                            float32,		valuetype MCCTest.VType6,
+                                            int32,			valuetype MCCTest.VType6,
+                                            unsigned int16,	valuetype MCCTest.VType6,
+                                            unsigned int32,	valuetype MCCTest.VType6,
+                                            float32,		valuetype MCCTest.VType6,
+                                            int64,			valuetype MCCTest.VType6,
+                                            float32,		valuetype MCCTest.VType6,
+                                            float64,		valuetype MCCTest.VType6,
+                                            float32,		valuetype MCCTest.VType6,
+                                            int16,			valuetype MCCTest.VType6)
 
       stloc.s    res
 
@@ -116,7 +122,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType6, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i65.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i65.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i65.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i66.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i66.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i66.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i66.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i66.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i66.exe
@@ -12,11 +18,11 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i6s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i6s" as "#1" stdcall)
         valuetype MCCTest.VType6 Sum(unsigned int64, valuetype MCCTest.VType6, float64,	valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6,
-									int32, valuetype MCCTest.VType6, unsigned int16, valuetype MCCTest.VType6, unsigned int32, valuetype MCCTest.VType6, 
-									float32, valuetype MCCTest.VType6, int64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6,
-									float64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6, int16, valuetype MCCTest.VType6) cil managed preservesig {
+                                    int32, valuetype MCCTest.VType6, unsigned int16, valuetype MCCTest.VType6, unsigned int32, valuetype MCCTest.VType6,
+                                    float32, valuetype MCCTest.VType6, int64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6,
+                                    float64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6, int16, valuetype MCCTest.VType6) cil managed preservesig {
     }
 
     .method private valuetype MCCTest.VType6 GetSum()
@@ -90,20 +96,20 @@
       conv.i2
       ldloc.s    v12
       tail.
-      call       valuetype MCCTest.VType6 MCCTest.MyClass::Sum(	unsigned int64,	valuetype MCCTest.VType6, 
-																float64,		valuetype MCCTest.VType6,
-																float32,		valuetype MCCTest.VType6,
-																int32,			valuetype MCCTest.VType6,
-																unsigned int16,	valuetype MCCTest.VType6,
-																unsigned int32,	valuetype MCCTest.VType6,
-																float32,		valuetype MCCTest.VType6,
-																int64,			valuetype MCCTest.VType6,
-																float32,		valuetype MCCTest.VType6,
-																float64,		valuetype MCCTest.VType6,
-																float32,		valuetype MCCTest.VType6,
-																int16,			valuetype MCCTest.VType6)
-		ret
-	}
+      call       valuetype MCCTest.VType6 MCCTest.MyClass::Sum(	unsigned int64,	valuetype MCCTest.VType6,
+                                                                float64,		valuetype MCCTest.VType6,
+                                                                float32,		valuetype MCCTest.VType6,
+                                                                int32,			valuetype MCCTest.VType6,
+                                                                unsigned int16,	valuetype MCCTest.VType6,
+                                                                unsigned int32,	valuetype MCCTest.VType6,
+                                                                float32,		valuetype MCCTest.VType6,
+                                                                int64,			valuetype MCCTest.VType6,
+                                                                float32,		valuetype MCCTest.VType6,
+                                                                float64,		valuetype MCCTest.VType6,
+                                                                float32,		valuetype MCCTest.VType6,
+                                                                int16,			valuetype MCCTest.VType6)
+        ret
+    }
 
     .method public specialname rtspecialname instance void  .ctor()
     {
@@ -122,10 +128,10 @@
         [1] valuetype MCCTest.VType6 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType6 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -135,7 +141,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType6, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i67.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i67.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i67.exe
@@ -12,11 +18,11 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i6s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i6s" as "#1" stdcall)
         valuetype MCCTest.VType6 Sum(unsigned int64, valuetype MCCTest.VType6, float64,	valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6,
-									int32, valuetype MCCTest.VType6, unsigned int16, valuetype MCCTest.VType6, unsigned int32, valuetype MCCTest.VType6, 
-									float32, valuetype MCCTest.VType6, int64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6,
-									float64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6, int16, valuetype MCCTest.VType6) cil managed preservesig {
+                                    int32, valuetype MCCTest.VType6, unsigned int16, valuetype MCCTest.VType6, unsigned int32, valuetype MCCTest.VType6,
+                                    float32, valuetype MCCTest.VType6, int64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6,
+                                    float64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6, int16, valuetype MCCTest.VType6) cil managed preservesig {
     }
 
     .method private valuetype MCCTest.VType6 GetSum()
@@ -89,32 +95,32 @@
       ldc.i8     12
       conv.i2
       ldloc.s    v12
-      call       valuetype MCCTest.VType6 MCCTest.MyClass::GetSum2(	unsigned int64,	valuetype MCCTest.VType6, 
-																float64,		valuetype MCCTest.VType6,
-																float32,		valuetype MCCTest.VType6,
-																int32,			valuetype MCCTest.VType6,
-																unsigned int16,	valuetype MCCTest.VType6,
-																unsigned int32,	valuetype MCCTest.VType6,
-																float32,		valuetype MCCTest.VType6,
-																int64,			valuetype MCCTest.VType6,
-																float32,		valuetype MCCTest.VType6,
-																float64,		valuetype MCCTest.VType6,
-																float32,		valuetype MCCTest.VType6,
-																int16,			valuetype MCCTest.VType6)
-		ret
-	}
+      call       valuetype MCCTest.VType6 MCCTest.MyClass::GetSum2(	unsigned int64,	valuetype MCCTest.VType6,
+                                                                float64,		valuetype MCCTest.VType6,
+                                                                float32,		valuetype MCCTest.VType6,
+                                                                int32,			valuetype MCCTest.VType6,
+                                                                unsigned int16,	valuetype MCCTest.VType6,
+                                                                unsigned int32,	valuetype MCCTest.VType6,
+                                                                float32,		valuetype MCCTest.VType6,
+                                                                int64,			valuetype MCCTest.VType6,
+                                                                float32,		valuetype MCCTest.VType6,
+                                                                float64,		valuetype MCCTest.VType6,
+                                                                float32,		valuetype MCCTest.VType6,
+                                                                int16,			valuetype MCCTest.VType6)
+        ret
+    }
 
     .method private static valuetype MCCTest.VType6 GetSum2(unsigned int64, valuetype MCCTest.VType6, float64,	valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6,
-									int32, valuetype MCCTest.VType6, unsigned int16, valuetype MCCTest.VType6, unsigned int32, valuetype MCCTest.VType6, 
-									float32, valuetype MCCTest.VType6, int64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6,
-									float64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6, int16, valuetype MCCTest.VType6)
+                                    int32, valuetype MCCTest.VType6, unsigned int16, valuetype MCCTest.VType6, unsigned int32, valuetype MCCTest.VType6,
+                                    float32, valuetype MCCTest.VType6, int64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6,
+                                    float64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6, int16, valuetype MCCTest.VType6)
     {
       jmp   valuetype MCCTest.VType6 MCCTest.MyClass::Sum(unsigned int64, valuetype MCCTest.VType6, float64,	valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6,
-									int32, valuetype MCCTest.VType6, unsigned int16, valuetype MCCTest.VType6, unsigned int32, valuetype MCCTest.VType6, 
-									float32, valuetype MCCTest.VType6, int64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6,
-									float64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6, int16, valuetype MCCTest.VType6)
+                                    int32, valuetype MCCTest.VType6, unsigned int16, valuetype MCCTest.VType6, unsigned int32, valuetype MCCTest.VType6,
+                                    float32, valuetype MCCTest.VType6, int64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6,
+                                    float64, valuetype MCCTest.VType6, float32, valuetype MCCTest.VType6, int16, valuetype MCCTest.VType6)
     }
-    
+
     .method public specialname rtspecialname instance void  .ctor()
     {
       .maxstack  1
@@ -132,10 +138,10 @@
         [1] valuetype MCCTest.VType6 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType6 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -145,7 +151,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType6, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i67.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i67.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i67.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i70.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i70.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i70.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i70.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i70.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i70.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i7c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i7c" as "#1" cdecl)
         vararg valuetype MCCTest.VType7 Sum(float64, int32, int64, float32, int16, float64) cil managed preservesig {
     }
 
@@ -36,7 +42,7 @@
         [12] valuetype MCCTest.VType7 v12,
         [13] int32 rc
       )
-      
+
       // Initialize v1 thru v12
       ldloca.s   v1
       call       instance void MCCTest.VType7::Init()
@@ -82,19 +88,19 @@
       ldloc.s    v10
       ldloc.s    v11
       ldloc.s    v12
-      call   vararg valuetype MCCTest.VType7 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64, ..., 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7)
+      call   vararg valuetype MCCTest.VType7 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64, ...,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7)
 
       stloc.s    res
 
@@ -103,7 +109,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType7, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i71.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i71.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i71.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i7c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i7c" as "#1" cdecl)
         vararg valuetype MCCTest.VType7 Sum(float64, int32, int64, float32, int16, float64) cil managed preservesig {
     }
 
@@ -36,7 +42,7 @@
         [12] valuetype MCCTest.VType7 v12,
         [13] int32 rc
       )
-      
+
       // Initialize v1 thru v12
       ldloca.s   v1
       call       instance void MCCTest.VType7::Init()
@@ -83,19 +89,19 @@
       ldloc.s    v11
       ldloc.s    v12
       ldftn      vararg valuetype MCCTest.VType7 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64)
-      calli      vararg valuetype MCCTest.VType7(float64, int32, int64, float32, int16, float64, ..., 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7)
+      calli      vararg valuetype MCCTest.VType7(float64, int32, int64, float32, int16, float64, ...,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7)
 
       stloc.s    res
 
@@ -104,7 +110,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType7, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i71.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i71.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i71.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i72.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i72.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i72.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i72.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i72.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i72.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i7c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i7c" as "#1" cdecl)
         vararg valuetype MCCTest.VType7 Sum(float64, int32, int64, float32, int16, float64) cil managed preservesig {
     }
 
@@ -80,21 +86,21 @@
       ldloc.s    v11
       ldloc.s    v12
       tail.
-      call   vararg valuetype MCCTest.VType7 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64, ..., 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7)
-		ret
-	}
+      call   vararg valuetype MCCTest.VType7 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64, ...,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7)
+        ret
+    }
 
     .method public specialname rtspecialname instance void  .ctor()
     {
@@ -113,10 +119,10 @@
         [1] valuetype MCCTest.VType7 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType7 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -126,7 +132,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType7, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i73.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i73.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i73.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i73.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i73.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i73.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i7c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i7c" as "#1" cdecl)
         vararg valuetype MCCTest.VType7 Sum(float64, int32, int64, float32, int16, float64) cil managed preservesig {
     }
 
@@ -79,27 +85,27 @@
       ldloc.s    v10
       ldloc.s    v11
       ldloc.s    v12
-      call   vararg valuetype MCCTest.VType7 MCCTest.MyClass::GetSum2(float64, int32, int64, float32, int16, float64, ..., 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7, 
-																valuetype MCCTest.VType7)
-		ret
-	}
+      call   vararg valuetype MCCTest.VType7 MCCTest.MyClass::GetSum2(float64, int32, int64, float32, int16, float64, ...,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7,
+                                                                valuetype MCCTest.VType7)
+        ret
+    }
 
     .method private static vararg valuetype MCCTest.VType7 GetSum2(float64, int32, int64, float32, int16, float64)
     {
       jmp   vararg valuetype MCCTest.VType7 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64)
     }
-    
+
     .method public specialname rtspecialname instance void  .ctor()
     {
       .maxstack  1
@@ -117,10 +123,10 @@
         [1] valuetype MCCTest.VType7 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType7 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -130,7 +136,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType7, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i74.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i74.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i74.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i74.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i74.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i74.exe
@@ -12,11 +18,11 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i7s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i7s" as "#1" stdcall)
         valuetype MCCTest.VType7 Sum(unsigned int64, valuetype MCCTest.VType7, float64,	valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7,
-									int32, valuetype MCCTest.VType7, unsigned int16, valuetype MCCTest.VType7, unsigned int32, valuetype MCCTest.VType7, 
-									float32, valuetype MCCTest.VType7, int64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7,
-									float64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7, int16, valuetype MCCTest.VType7) cil managed preservesig {
+                                    int32, valuetype MCCTest.VType7, unsigned int16, valuetype MCCTest.VType7, unsigned int32, valuetype MCCTest.VType7,
+                                    float32, valuetype MCCTest.VType7, int64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7,
+                                    float64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7, int16, valuetype MCCTest.VType7) cil managed preservesig {
     }
 
     .method private static int32 Main(string[] args)
@@ -39,7 +45,7 @@
         [12] valuetype MCCTest.VType7 v12,
         [13] int32 rc
       )
-      
+
       // Initialize v1 thru v12
       ldloca.s   v1
       call       instance void MCCTest.VType7::Init()
@@ -65,7 +71,7 @@
       call       instance void MCCTest.VType7::Init()
       ldloca.s   v12
       call       instance void MCCTest.VType7::Init()
-      
+
       ldc.i8     1
       ldloc.s    v1
       ldc.r8     2
@@ -92,18 +98,18 @@
       ldc.i8     12
       conv.i2
       ldloc.s    v12
-      call       valuetype MCCTest.VType7 MCCTest.MyClass::Sum(	unsigned int64,	valuetype MCCTest.VType7, 
-																float64,		valuetype MCCTest.VType7,
-																float32,		valuetype MCCTest.VType7,
-																int32,			valuetype MCCTest.VType7,
-																unsigned int16,	valuetype MCCTest.VType7,
-																unsigned int32,	valuetype MCCTest.VType7,
-																float32,		valuetype MCCTest.VType7,
-																int64,			valuetype MCCTest.VType7,
-																float32,		valuetype MCCTest.VType7,
-																float64,		valuetype MCCTest.VType7,
-																float32,		valuetype MCCTest.VType7,
-																int16,			valuetype MCCTest.VType7)
+      call       valuetype MCCTest.VType7 MCCTest.MyClass::Sum(	unsigned int64,	valuetype MCCTest.VType7,
+                                                                float64,		valuetype MCCTest.VType7,
+                                                                float32,		valuetype MCCTest.VType7,
+                                                                int32,			valuetype MCCTest.VType7,
+                                                                unsigned int16,	valuetype MCCTest.VType7,
+                                                                unsigned int32,	valuetype MCCTest.VType7,
+                                                                float32,		valuetype MCCTest.VType7,
+                                                                int64,			valuetype MCCTest.VType7,
+                                                                float32,		valuetype MCCTest.VType7,
+                                                                float64,		valuetype MCCTest.VType7,
+                                                                float32,		valuetype MCCTest.VType7,
+                                                                int16,			valuetype MCCTest.VType7)
 
       stloc.s    res
 
@@ -112,7 +118,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType7, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i75.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i75.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i75.exe
@@ -12,11 +18,11 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i7s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i7s" as "#1" stdcall)
         valuetype MCCTest.VType7 Sum(unsigned int64, valuetype MCCTest.VType7, float64,	valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7,
-									int32, valuetype MCCTest.VType7, unsigned int16, valuetype MCCTest.VType7, unsigned int32, valuetype MCCTest.VType7, 
-									float32, valuetype MCCTest.VType7, int64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7,
-									float64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7, int16, valuetype MCCTest.VType7) cil managed preservesig {
+                                    int32, valuetype MCCTest.VType7, unsigned int16, valuetype MCCTest.VType7, unsigned int32, valuetype MCCTest.VType7,
+                                    float32, valuetype MCCTest.VType7, int64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7,
+                                    float64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7, int16, valuetype MCCTest.VType7) cil managed preservesig {
     }
 
     .method private static int32 Main(string[] args)
@@ -39,7 +45,7 @@
         [12] valuetype MCCTest.VType7 v12,
         [13] int32 rc
       )
-      
+
       // Initialize v1 thru v12
       ldloca.s   v1
       call       instance void MCCTest.VType7::Init()
@@ -65,7 +71,7 @@
       call       instance void MCCTest.VType7::Init()
       ldloca.s   v12
       call       instance void MCCTest.VType7::Init()
-      
+
       ldc.i8     1
       ldloc.s    v1
       ldc.r8     2
@@ -93,21 +99,21 @@
       conv.i2
       ldloc.s    v12
       ldftn      valuetype MCCTest.VType7 MCCTest.MyClass::Sum(unsigned int64, valuetype MCCTest.VType7, float64,	valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7,
-									int32, valuetype MCCTest.VType7, unsigned int16, valuetype MCCTest.VType7, unsigned int32, valuetype MCCTest.VType7, 
-									float32, valuetype MCCTest.VType7, int64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7,
-									float64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7, int16, valuetype MCCTest.VType7)
-      calli       valuetype MCCTest.VType7(	unsigned int64,	valuetype MCCTest.VType7, 
-											float64,		valuetype MCCTest.VType7,
-											float32,		valuetype MCCTest.VType7,
-											int32,			valuetype MCCTest.VType7,
-											unsigned int16,	valuetype MCCTest.VType7,
-											unsigned int32,	valuetype MCCTest.VType7,
-											float32,		valuetype MCCTest.VType7,
-											int64,			valuetype MCCTest.VType7,
-											float32,		valuetype MCCTest.VType7,
-											float64,		valuetype MCCTest.VType7,
-											float32,		valuetype MCCTest.VType7,
-											int16,			valuetype MCCTest.VType7)
+                                    int32, valuetype MCCTest.VType7, unsigned int16, valuetype MCCTest.VType7, unsigned int32, valuetype MCCTest.VType7,
+                                    float32, valuetype MCCTest.VType7, int64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7,
+                                    float64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7, int16, valuetype MCCTest.VType7)
+      calli       valuetype MCCTest.VType7(	unsigned int64,	valuetype MCCTest.VType7,
+                                            float64,		valuetype MCCTest.VType7,
+                                            float32,		valuetype MCCTest.VType7,
+                                            int32,			valuetype MCCTest.VType7,
+                                            unsigned int16,	valuetype MCCTest.VType7,
+                                            unsigned int32,	valuetype MCCTest.VType7,
+                                            float32,		valuetype MCCTest.VType7,
+                                            int64,			valuetype MCCTest.VType7,
+                                            float32,		valuetype MCCTest.VType7,
+                                            float64,		valuetype MCCTest.VType7,
+                                            float32,		valuetype MCCTest.VType7,
+                                            int16,			valuetype MCCTest.VType7)
 
       stloc.s    res
 
@@ -116,7 +122,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType7, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i75.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i75.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i75.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i76.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i76.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i76.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i76.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i76.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i76.exe
@@ -12,11 +18,11 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i7s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i7s" as "#1" stdcall)
         valuetype MCCTest.VType7 Sum(unsigned int64, valuetype MCCTest.VType7, float64,	valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7,
-									int32, valuetype MCCTest.VType7, unsigned int16, valuetype MCCTest.VType7, unsigned int32, valuetype MCCTest.VType7, 
-									float32, valuetype MCCTest.VType7, int64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7,
-									float64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7, int16, valuetype MCCTest.VType7) cil managed preservesig {
+                                    int32, valuetype MCCTest.VType7, unsigned int16, valuetype MCCTest.VType7, unsigned int32, valuetype MCCTest.VType7,
+                                    float32, valuetype MCCTest.VType7, int64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7,
+                                    float64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7, int16, valuetype MCCTest.VType7) cil managed preservesig {
     }
 
     .method private valuetype MCCTest.VType7 GetSum()
@@ -90,20 +96,20 @@
       conv.i2
       ldloc.s    v12
       tail.
-      call       valuetype MCCTest.VType7 MCCTest.MyClass::Sum(	unsigned int64,	valuetype MCCTest.VType7, 
-																float64,		valuetype MCCTest.VType7,
-																float32,		valuetype MCCTest.VType7,
-																int32,			valuetype MCCTest.VType7,
-																unsigned int16,	valuetype MCCTest.VType7,
-																unsigned int32,	valuetype MCCTest.VType7,
-																float32,		valuetype MCCTest.VType7,
-																int64,			valuetype MCCTest.VType7,
-																float32,		valuetype MCCTest.VType7,
-																float64,		valuetype MCCTest.VType7,
-																float32,		valuetype MCCTest.VType7,
-																int16,			valuetype MCCTest.VType7)
-		ret
-	}
+      call       valuetype MCCTest.VType7 MCCTest.MyClass::Sum(	unsigned int64,	valuetype MCCTest.VType7,
+                                                                float64,		valuetype MCCTest.VType7,
+                                                                float32,		valuetype MCCTest.VType7,
+                                                                int32,			valuetype MCCTest.VType7,
+                                                                unsigned int16,	valuetype MCCTest.VType7,
+                                                                unsigned int32,	valuetype MCCTest.VType7,
+                                                                float32,		valuetype MCCTest.VType7,
+                                                                int64,			valuetype MCCTest.VType7,
+                                                                float32,		valuetype MCCTest.VType7,
+                                                                float64,		valuetype MCCTest.VType7,
+                                                                float32,		valuetype MCCTest.VType7,
+                                                                int16,			valuetype MCCTest.VType7)
+        ret
+    }
 
     .method public specialname rtspecialname instance void  .ctor()
     {
@@ -122,10 +128,10 @@
         [1] valuetype MCCTest.VType7 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType7 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -135,7 +141,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType7, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i77.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i77.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i77.exe
@@ -12,11 +18,11 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i7s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i7s" as "#1" stdcall)
         valuetype MCCTest.VType7 Sum(unsigned int64, valuetype MCCTest.VType7, float64,	valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7,
-									int32, valuetype MCCTest.VType7, unsigned int16, valuetype MCCTest.VType7, unsigned int32, valuetype MCCTest.VType7, 
-									float32, valuetype MCCTest.VType7, int64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7,
-									float64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7, int16, valuetype MCCTest.VType7) cil managed preservesig {
+                                    int32, valuetype MCCTest.VType7, unsigned int16, valuetype MCCTest.VType7, unsigned int32, valuetype MCCTest.VType7,
+                                    float32, valuetype MCCTest.VType7, int64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7,
+                                    float64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7, int16, valuetype MCCTest.VType7) cil managed preservesig {
     }
 
     .method private valuetype MCCTest.VType7 GetSum()
@@ -89,32 +95,32 @@
       ldc.i8     12
       conv.i2
       ldloc.s    v12
-      call       valuetype MCCTest.VType7 MCCTest.MyClass::GetSum2(	unsigned int64,	valuetype MCCTest.VType7, 
-																float64,		valuetype MCCTest.VType7,
-																float32,		valuetype MCCTest.VType7,
-																int32,			valuetype MCCTest.VType7,
-																unsigned int16,	valuetype MCCTest.VType7,
-																unsigned int32,	valuetype MCCTest.VType7,
-																float32,		valuetype MCCTest.VType7,
-																int64,			valuetype MCCTest.VType7,
-																float32,		valuetype MCCTest.VType7,
-																float64,		valuetype MCCTest.VType7,
-																float32,		valuetype MCCTest.VType7,
-																int16,			valuetype MCCTest.VType7)
-		ret
-	}
+      call       valuetype MCCTest.VType7 MCCTest.MyClass::GetSum2(	unsigned int64,	valuetype MCCTest.VType7,
+                                                                float64,		valuetype MCCTest.VType7,
+                                                                float32,		valuetype MCCTest.VType7,
+                                                                int32,			valuetype MCCTest.VType7,
+                                                                unsigned int16,	valuetype MCCTest.VType7,
+                                                                unsigned int32,	valuetype MCCTest.VType7,
+                                                                float32,		valuetype MCCTest.VType7,
+                                                                int64,			valuetype MCCTest.VType7,
+                                                                float32,		valuetype MCCTest.VType7,
+                                                                float64,		valuetype MCCTest.VType7,
+                                                                float32,		valuetype MCCTest.VType7,
+                                                                int16,			valuetype MCCTest.VType7)
+        ret
+    }
 
     .method private static valuetype MCCTest.VType7 GetSum2(unsigned int64, valuetype MCCTest.VType7, float64,	valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7,
-									int32, valuetype MCCTest.VType7, unsigned int16, valuetype MCCTest.VType7, unsigned int32, valuetype MCCTest.VType7, 
-									float32, valuetype MCCTest.VType7, int64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7,
-									float64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7, int16, valuetype MCCTest.VType7)
+                                    int32, valuetype MCCTest.VType7, unsigned int16, valuetype MCCTest.VType7, unsigned int32, valuetype MCCTest.VType7,
+                                    float32, valuetype MCCTest.VType7, int64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7,
+                                    float64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7, int16, valuetype MCCTest.VType7)
     {
       jmp   valuetype MCCTest.VType7 MCCTest.MyClass::Sum(unsigned int64, valuetype MCCTest.VType7, float64,	valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7,
-									int32, valuetype MCCTest.VType7, unsigned int16, valuetype MCCTest.VType7, unsigned int32, valuetype MCCTest.VType7, 
-									float32, valuetype MCCTest.VType7, int64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7,
-									float64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7, int16, valuetype MCCTest.VType7)
+                                    int32, valuetype MCCTest.VType7, unsigned int16, valuetype MCCTest.VType7, unsigned int32, valuetype MCCTest.VType7,
+                                    float32, valuetype MCCTest.VType7, int64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7,
+                                    float64, valuetype MCCTest.VType7, float32, valuetype MCCTest.VType7, int16, valuetype MCCTest.VType7)
     }
-    
+
     .method public specialname rtspecialname instance void  .ctor()
     {
       .maxstack  1
@@ -132,10 +138,10 @@
         [1] valuetype MCCTest.VType7 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType7 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -145,7 +151,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType7, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i77.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i77.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i77.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i80.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i80.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i80.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i80.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i80.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i80.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i8c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i8c" as "#1" cdecl)
         vararg valuetype MCCTest.VType8 Sum(float64, int32, int64, float32, int16, float64) cil managed preservesig {
     }
 
@@ -36,7 +42,7 @@
         [12] valuetype MCCTest.VType8 v12,
         [13] int32 rc
       )
-      
+
       // Initialize v1 thru v12
       ldloca.s   v1
       call       instance void MCCTest.VType8::Init()
@@ -82,19 +88,19 @@
       ldloc.s    v10
       ldloc.s    v11
       ldloc.s    v12
-      call   vararg valuetype MCCTest.VType8 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64, ..., 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8)
+      call   vararg valuetype MCCTest.VType8 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64, ...,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8)
 
       stloc.s    res
 
@@ -103,7 +109,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType8, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i81.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i81.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i81.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i8c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i8c" as "#1" cdecl)
         vararg valuetype MCCTest.VType8 Sum(float64, int32, int64, float32, int16, float64) cil managed preservesig {
     }
 
@@ -36,7 +42,7 @@
         [12] valuetype MCCTest.VType8 v12,
         [13] int32 rc
       )
-      
+
       // Initialize v1 thru v12
       ldloca.s   v1
       call       instance void MCCTest.VType8::Init()
@@ -83,19 +89,19 @@
       ldloc.s    v11
       ldloc.s    v12
       ldftn      vararg valuetype MCCTest.VType8 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64)
-      calli      vararg valuetype MCCTest.VType8(float64, int32, int64, float32, int16, float64, ..., 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8)
+      calli      vararg valuetype MCCTest.VType8(float64, int32, int64, float32, int16, float64, ...,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8)
 
       stloc.s    res
 
@@ -104,7 +110,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType8, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i81.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i81.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i81.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i82.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i82.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i82.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i8c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i8c" as "#1" cdecl)
         vararg valuetype MCCTest.VType8 Sum(float64, int32, int64, float32, int16, float64) cil managed preservesig {
     }
 
@@ -80,21 +86,21 @@
       ldloc.s    v11
       ldloc.s    v12
       tail.
-      call   vararg valuetype MCCTest.VType8 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64, ..., 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8)
-		ret
-	}
+      call   vararg valuetype MCCTest.VType8 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64, ...,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8)
+        ret
+    }
 
     .method public specialname rtspecialname instance void  .ctor()
     {
@@ -113,10 +119,10 @@
         [1] valuetype MCCTest.VType8 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType8 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -126,7 +132,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType8, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i82.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i82.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i82.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i83.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i83.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i83.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i83.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i83.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i83.exe
@@ -12,7 +18,7 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i8c" as "#1" cdecl) 
+    .method assembly static pinvokeimpl("native_i8c" as "#1" cdecl)
         vararg valuetype MCCTest.VType8 Sum(float64, int32, int64, float32, int16, float64) cil managed preservesig {
     }
 
@@ -79,27 +85,27 @@
       ldloc.s    v10
       ldloc.s    v11
       ldloc.s    v12
-      call   vararg valuetype MCCTest.VType8 MCCTest.MyClass::GetSum2(float64, int32, int64, float32, int16, float64, ..., 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8, 
-																valuetype MCCTest.VType8)
-		ret
-	}
+      call   vararg valuetype MCCTest.VType8 MCCTest.MyClass::GetSum2(float64, int32, int64, float32, int16, float64, ...,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8,
+                                                                valuetype MCCTest.VType8)
+        ret
+    }
 
     .method private static vararg valuetype MCCTest.VType8 GetSum2(float64, int32, int64, float32, int16, float64)
     {
       jmp   vararg valuetype MCCTest.VType8 MCCTest.MyClass::Sum(float64, int32, int64, float32, int16, float64)
     }
-    
+
     .method public specialname rtspecialname instance void  .ctor()
     {
       .maxstack  1
@@ -117,10 +123,10 @@
         [1] valuetype MCCTest.VType8 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType8 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -130,7 +136,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType8, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i84.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i84.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i84.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i84.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i84.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i84.exe
@@ -12,11 +18,11 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i8s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i8s" as "#1" stdcall)
         valuetype MCCTest.VType8 Sum(unsigned int64, valuetype MCCTest.VType8, float64,	valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8,
-									int32, valuetype MCCTest.VType8, unsigned int16, valuetype MCCTest.VType8, unsigned int32, valuetype MCCTest.VType8, 
-									float32, valuetype MCCTest.VType8, int64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8,
-									float64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8, int16, valuetype MCCTest.VType8) cil managed preservesig {
+                                    int32, valuetype MCCTest.VType8, unsigned int16, valuetype MCCTest.VType8, unsigned int32, valuetype MCCTest.VType8,
+                                    float32, valuetype MCCTest.VType8, int64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8,
+                                    float64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8, int16, valuetype MCCTest.VType8) cil managed preservesig {
     }
 
     .method private static int32 Main(string[] args)
@@ -39,7 +45,7 @@
         [12] valuetype MCCTest.VType8 v12,
         [13] int32 rc
       )
-      
+
       // Initialize v1 thru v12
       ldloca.s   v1
       call       instance void MCCTest.VType8::Init()
@@ -65,7 +71,7 @@
       call       instance void MCCTest.VType8::Init()
       ldloca.s   v12
       call       instance void MCCTest.VType8::Init()
-      
+
       ldc.i8     1
       ldloc.s    v1
       ldc.r8     2
@@ -92,18 +98,18 @@
       ldc.i8     12
       conv.i2
       ldloc.s    v12
-      call       valuetype MCCTest.VType8 MCCTest.MyClass::Sum(	unsigned int64,	valuetype MCCTest.VType8, 
-																float64,		valuetype MCCTest.VType8,
-																float32,		valuetype MCCTest.VType8,
-																int32,			valuetype MCCTest.VType8,
-																unsigned int16,	valuetype MCCTest.VType8,
-																unsigned int32,	valuetype MCCTest.VType8,
-																float32,		valuetype MCCTest.VType8,
-																int64,			valuetype MCCTest.VType8,
-																float32,		valuetype MCCTest.VType8,
-																float64,		valuetype MCCTest.VType8,
-																float32,		valuetype MCCTest.VType8,
-																int16,			valuetype MCCTest.VType8)
+      call       valuetype MCCTest.VType8 MCCTest.MyClass::Sum(	unsigned int64,	valuetype MCCTest.VType8,
+                                                                float64,		valuetype MCCTest.VType8,
+                                                                float32,		valuetype MCCTest.VType8,
+                                                                int32,			valuetype MCCTest.VType8,
+                                                                unsigned int16,	valuetype MCCTest.VType8,
+                                                                unsigned int32,	valuetype MCCTest.VType8,
+                                                                float32,		valuetype MCCTest.VType8,
+                                                                int64,			valuetype MCCTest.VType8,
+                                                                float32,		valuetype MCCTest.VType8,
+                                                                float64,		valuetype MCCTest.VType8,
+                                                                float32,		valuetype MCCTest.VType8,
+                                                                int16,			valuetype MCCTest.VType8)
 
       stloc.s    res
 
@@ -112,7 +118,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType8, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i85.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i85.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i85.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i85.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i85.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i85.exe
@@ -12,11 +18,11 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i8s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i8s" as "#1" stdcall)
         valuetype MCCTest.VType8 Sum(unsigned int64, valuetype MCCTest.VType8, float64,	valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8,
-									int32, valuetype MCCTest.VType8, unsigned int16, valuetype MCCTest.VType8, unsigned int32, valuetype MCCTest.VType8, 
-									float32, valuetype MCCTest.VType8, int64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8,
-									float64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8, int16, valuetype MCCTest.VType8) cil managed preservesig {
+                                    int32, valuetype MCCTest.VType8, unsigned int16, valuetype MCCTest.VType8, unsigned int32, valuetype MCCTest.VType8,
+                                    float32, valuetype MCCTest.VType8, int64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8,
+                                    float64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8, int16, valuetype MCCTest.VType8) cil managed preservesig {
     }
 
     .method private static int32 Main(string[] args)
@@ -39,7 +45,7 @@
         [12] valuetype MCCTest.VType8 v12,
         [13] int32 rc
       )
-      
+
       // Initialize v1 thru v12
       ldloca.s   v1
       call       instance void MCCTest.VType8::Init()
@@ -65,7 +71,7 @@
       call       instance void MCCTest.VType8::Init()
       ldloca.s   v12
       call       instance void MCCTest.VType8::Init()
-      
+
       ldc.i8     1
       ldloc.s    v1
       ldc.r8     2
@@ -93,21 +99,21 @@
       conv.i2
       ldloc.s    v12
       ldftn      valuetype MCCTest.VType8 MCCTest.MyClass::Sum(unsigned int64, valuetype MCCTest.VType8, float64,	valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8,
-									int32, valuetype MCCTest.VType8, unsigned int16, valuetype MCCTest.VType8, unsigned int32, valuetype MCCTest.VType8, 
-									float32, valuetype MCCTest.VType8, int64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8,
-									float64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8, int16, valuetype MCCTest.VType8)
-      calli       valuetype MCCTest.VType8(	unsigned int64,	valuetype MCCTest.VType8, 
-											float64,		valuetype MCCTest.VType8,
-											float32,		valuetype MCCTest.VType8,
-											int32,			valuetype MCCTest.VType8,
-											unsigned int16,	valuetype MCCTest.VType8,
-											unsigned int32,	valuetype MCCTest.VType8,
-											float32,		valuetype MCCTest.VType8,
-											int64,			valuetype MCCTest.VType8,
-											float32,		valuetype MCCTest.VType8,
-											float64,		valuetype MCCTest.VType8,
-											float32,		valuetype MCCTest.VType8,
-											int16,			valuetype MCCTest.VType8)
+                                    int32, valuetype MCCTest.VType8, unsigned int16, valuetype MCCTest.VType8, unsigned int32, valuetype MCCTest.VType8,
+                                    float32, valuetype MCCTest.VType8, int64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8,
+                                    float64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8, int16, valuetype MCCTest.VType8)
+      calli       valuetype MCCTest.VType8(	unsigned int64,	valuetype MCCTest.VType8,
+                                            float64,		valuetype MCCTest.VType8,
+                                            float32,		valuetype MCCTest.VType8,
+                                            int32,			valuetype MCCTest.VType8,
+                                            unsigned int16,	valuetype MCCTest.VType8,
+                                            unsigned int32,	valuetype MCCTest.VType8,
+                                            float32,		valuetype MCCTest.VType8,
+                                            int64,			valuetype MCCTest.VType8,
+                                            float32,		valuetype MCCTest.VType8,
+                                            float64,		valuetype MCCTest.VType8,
+                                            float32,		valuetype MCCTest.VType8,
+                                            int16,			valuetype MCCTest.VType8)
 
       stloc.s    res
 
@@ -116,7 +122,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType8, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i86.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i86.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i86.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i86.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i86.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i86.exe
@@ -12,11 +18,11 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i8s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i8s" as "#1" stdcall)
         valuetype MCCTest.VType8 Sum(unsigned int64, valuetype MCCTest.VType8, float64,	valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8,
-									int32, valuetype MCCTest.VType8, unsigned int16, valuetype MCCTest.VType8, unsigned int32, valuetype MCCTest.VType8, 
-									float32, valuetype MCCTest.VType8, int64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8,
-									float64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8, int16, valuetype MCCTest.VType8) cil managed preservesig {
+                                    int32, valuetype MCCTest.VType8, unsigned int16, valuetype MCCTest.VType8, unsigned int32, valuetype MCCTest.VType8,
+                                    float32, valuetype MCCTest.VType8, int64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8,
+                                    float64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8, int16, valuetype MCCTest.VType8) cil managed preservesig {
     }
 
     .method private valuetype MCCTest.VType8 GetSum()
@@ -90,20 +96,20 @@
       conv.i2
       ldloc.s    v12
       tail.
-      call       valuetype MCCTest.VType8 MCCTest.MyClass::Sum(	unsigned int64,	valuetype MCCTest.VType8, 
-																float64,		valuetype MCCTest.VType8,
-																float32,		valuetype MCCTest.VType8,
-																int32,			valuetype MCCTest.VType8,
-																unsigned int16,	valuetype MCCTest.VType8,
-																unsigned int32,	valuetype MCCTest.VType8,
-																float32,		valuetype MCCTest.VType8,
-																int64,			valuetype MCCTest.VType8,
-																float32,		valuetype MCCTest.VType8,
-																float64,		valuetype MCCTest.VType8,
-																float32,		valuetype MCCTest.VType8,
-																int16,			valuetype MCCTest.VType8)
-		ret
-	}
+      call       valuetype MCCTest.VType8 MCCTest.MyClass::Sum(	unsigned int64,	valuetype MCCTest.VType8,
+                                                                float64,		valuetype MCCTest.VType8,
+                                                                float32,		valuetype MCCTest.VType8,
+                                                                int32,			valuetype MCCTest.VType8,
+                                                                unsigned int16,	valuetype MCCTest.VType8,
+                                                                unsigned int32,	valuetype MCCTest.VType8,
+                                                                float32,		valuetype MCCTest.VType8,
+                                                                int64,			valuetype MCCTest.VType8,
+                                                                float32,		valuetype MCCTest.VType8,
+                                                                float64,		valuetype MCCTest.VType8,
+                                                                float32,		valuetype MCCTest.VType8,
+                                                                int16,			valuetype MCCTest.VType8)
+        ret
+    }
 
     .method public specialname rtspecialname instance void  .ctor()
     {
@@ -122,10 +128,10 @@
         [1] valuetype MCCTest.VType8 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType8 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -135,7 +141,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType8, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i87.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i87.il
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime.Extensions
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime.Extensions { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i87.exe
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i87.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i87.il
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 
+.assembly extern System.Runtime.Extensions
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib {}
 .assembly MCCTest {}
 .module mcc_i87.exe
@@ -12,11 +18,11 @@
 {
   .class MyClass
   {
-    .method assembly static pinvokeimpl("native_i8s" as "#1" stdcall) 
+    .method assembly static pinvokeimpl("native_i8s" as "#1" stdcall)
         valuetype MCCTest.VType8 Sum(unsigned int64, valuetype MCCTest.VType8, float64,	valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8,
-									int32, valuetype MCCTest.VType8, unsigned int16, valuetype MCCTest.VType8, unsigned int32, valuetype MCCTest.VType8, 
-									float32, valuetype MCCTest.VType8, int64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8,
-									float64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8, int16, valuetype MCCTest.VType8) cil managed preservesig {
+                                    int32, valuetype MCCTest.VType8, unsigned int16, valuetype MCCTest.VType8, unsigned int32, valuetype MCCTest.VType8,
+                                    float32, valuetype MCCTest.VType8, int64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8,
+                                    float64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8, int16, valuetype MCCTest.VType8) cil managed preservesig {
     }
 
     .method private valuetype MCCTest.VType8 GetSum()
@@ -89,32 +95,32 @@
       ldc.i8     12
       conv.i2
       ldloc.s    v12
-      call       valuetype MCCTest.VType8 MCCTest.MyClass::GetSum2(	unsigned int64,	valuetype MCCTest.VType8, 
-																float64,		valuetype MCCTest.VType8,
-																float32,		valuetype MCCTest.VType8,
-																int32,			valuetype MCCTest.VType8,
-																unsigned int16,	valuetype MCCTest.VType8,
-																unsigned int32,	valuetype MCCTest.VType8,
-																float32,		valuetype MCCTest.VType8,
-																int64,			valuetype MCCTest.VType8,
-																float32,		valuetype MCCTest.VType8,
-																float64,		valuetype MCCTest.VType8,
-																float32,		valuetype MCCTest.VType8,
-																int16,			valuetype MCCTest.VType8)
-		ret
-	}
+      call       valuetype MCCTest.VType8 MCCTest.MyClass::GetSum2(	unsigned int64,	valuetype MCCTest.VType8,
+                                                                float64,		valuetype MCCTest.VType8,
+                                                                float32,		valuetype MCCTest.VType8,
+                                                                int32,			valuetype MCCTest.VType8,
+                                                                unsigned int16,	valuetype MCCTest.VType8,
+                                                                unsigned int32,	valuetype MCCTest.VType8,
+                                                                float32,		valuetype MCCTest.VType8,
+                                                                int64,			valuetype MCCTest.VType8,
+                                                                float32,		valuetype MCCTest.VType8,
+                                                                float64,		valuetype MCCTest.VType8,
+                                                                float32,		valuetype MCCTest.VType8,
+                                                                int16,			valuetype MCCTest.VType8)
+        ret
+    }
 
     .method private static valuetype MCCTest.VType8 GetSum2(unsigned int64, valuetype MCCTest.VType8, float64,	valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8,
-									int32, valuetype MCCTest.VType8, unsigned int16, valuetype MCCTest.VType8, unsigned int32, valuetype MCCTest.VType8, 
-									float32, valuetype MCCTest.VType8, int64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8,
-									float64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8, int16, valuetype MCCTest.VType8)
+                                    int32, valuetype MCCTest.VType8, unsigned int16, valuetype MCCTest.VType8, unsigned int32, valuetype MCCTest.VType8,
+                                    float32, valuetype MCCTest.VType8, int64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8,
+                                    float64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8, int16, valuetype MCCTest.VType8)
     {
       jmp   valuetype MCCTest.VType8 MCCTest.MyClass::Sum(unsigned int64, valuetype MCCTest.VType8, float64,	valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8,
-									int32, valuetype MCCTest.VType8, unsigned int16, valuetype MCCTest.VType8, unsigned int32, valuetype MCCTest.VType8, 
-									float32, valuetype MCCTest.VType8, int64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8,
-									float64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8, int16, valuetype MCCTest.VType8)
+                                    int32, valuetype MCCTest.VType8, unsigned int16, valuetype MCCTest.VType8, unsigned int32, valuetype MCCTest.VType8,
+                                    float32, valuetype MCCTest.VType8, int64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8,
+                                    float64, valuetype MCCTest.VType8, float32, valuetype MCCTest.VType8, int16, valuetype MCCTest.VType8)
     }
-    
+
     .method public specialname rtspecialname instance void  .ctor()
     {
       .maxstack  1
@@ -132,10 +138,10 @@
         [1] valuetype MCCTest.VType8 res,
         [2] int32 rc
       )
-      
+
       newobj     instance void MCCTest.MyClass::.ctor()
       stloc.s    me
-      
+
       ldloc.s    me
       call   instance valuetype MCCTest.VType8 MCCTest.MyClass::GetSum()
       stloc.s    res
@@ -145,7 +151,7 @@
       ldc.i4     12
       call       int32 MCCTest.Common::CheckResult(valuetype MCCTest.VType8, int32)
       stloc.s    rc
-      
+
       ldloc.s    rc
       ret
     } // end of method MyClass::Main

--- a/tests/src/Loader/classloader/TypeInitialization/CircularCctors/CircularCctorFourThreadsBFI.il
+++ b/tests/src/Loader/classloader/TypeInitialization/CircularCctors/CircularCctorFourThreadsBFI.il
@@ -2,28 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
 //  Microsoft (R) .NET Framework IL Disassembler.  Version 2.0.50103.00
 //  Copyright (C) Microsoft Corporation. All rights reserved.
-
-
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern System.Threading.Thread
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
+.assembly extern System.Console { auto }
+.assembly extern System.Threading.Thread { auto }
 // Metadata version: v2.0.50103
-.assembly extern mscorlib
-{
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
-  .ver 2:0:0:0
-}
+.assembly extern mscorlib { auto }
+
 .assembly CircularCctorFourThreads
 {
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 )

--- a/tests/src/Loader/classloader/TypeInitialization/CircularCctors/CircularCctorFourThreadsBFI.il
+++ b/tests/src/Loader/classloader/TypeInitialization/CircularCctors/CircularCctorFourThreadsBFI.il
@@ -2,12 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-.assembly extern System.Console { }
-
 //  Microsoft (R) .NET Framework IL Disassembler.  Version 2.0.50103.00
 //  Copyright (C) Microsoft Corporation. All rights reserved.
 
 
+.assembly extern System.Console
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
+.assembly extern System.Threading.Thread
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
 
 // Metadata version: v2.0.50103
 .assembly extern mscorlib
@@ -17,7 +26,7 @@
 }
 .assembly CircularCctorFourThreads
 {
-  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 )
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
@@ -39,7 +48,7 @@
   .pack 0
   .size 1
   .field public static int32 i
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     // Code size       50 (0x32)
@@ -82,7 +91,7 @@
        extends [mscorlib]System.Object
 {
   .field public static int32 i
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     // Code size       39 (0x27)
@@ -116,7 +125,7 @@
     IL_0016:  ret
   } // end of method B::SomeMethod
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)
@@ -134,7 +143,7 @@
   .pack 0
   .size 1
   .field public static int32 i
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     // Code size       50 (0x32)
@@ -177,7 +186,7 @@
        extends [mscorlib]System.Object
 {
   .field public static int32 i
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     // Code size       50 (0x32)
@@ -214,7 +223,7 @@
     IL_0016:  ret
   } // end of method D::SomeMethod
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)
@@ -232,7 +241,7 @@
   .pack 0
   .size 1
   .field public static int32 i
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     // Code size       40 (0x28)
@@ -444,7 +453,7 @@
     IL_012d:  ret
   } // end of method Test::Main
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)

--- a/tests/src/Loader/classloader/TypeInitialization/CircularCctors/CircularCctorThreeThreads01BFI.il
+++ b/tests/src/Loader/classloader/TypeInitialization/CircularCctors/CircularCctorThreeThreads01BFI.il
@@ -2,12 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-.assembly extern System.Console { }
-
 //  Microsoft (R) .NET Framework IL Disassembler.  Version 2.0.50103.00
 //  Copyright (C) Microsoft Corporation. All rights reserved.
 
 
+.assembly extern System.Console
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
+.assembly extern System.Threading.Thread
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
 
 // Metadata version: v2.0.50103
 .assembly extern mscorlib
@@ -17,7 +26,7 @@
 }
 .assembly CircularCctorThreeThreads01
 {
-  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 )
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
@@ -37,7 +46,7 @@
        extends [mscorlib]System.Object
 {
   .field public static int32 i
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     // Code size       39 (0x27)
@@ -71,7 +80,7 @@
     IL_0016:  ret
   } // end of method A::SomeMethod
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)
@@ -87,7 +96,7 @@
        extends [mscorlib]System.Object
 {
   .field public static int32 i
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     // Code size       39 (0x27)
@@ -121,7 +130,7 @@
     IL_0016:  ret
   } // end of method B::SomeMethod
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)
@@ -137,7 +146,7 @@
        extends [mscorlib]System.Object
 {
   .field public static int32 i
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     // Code size       39 (0x27)
@@ -171,7 +180,7 @@
     IL_0016:  ret
   } // end of method C::SomeMethod
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)
@@ -187,7 +196,7 @@
        extends [mscorlib]System.Object
 {
   .field public static int32 i
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     // Code size       39 (0x27)
@@ -221,7 +230,7 @@
     IL_0016:  ret
   } // end of method D::SomeMethod
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)
@@ -237,7 +246,7 @@
        extends [mscorlib]System.Object
 {
   .field public static int32 i
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     // Code size       40 (0x28)
@@ -271,7 +280,7 @@
     IL_0016:  ret
   } // end of method E::SomeMethod
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)
@@ -429,7 +438,7 @@
     IL_00f3:  ret
   } // end of method Test::Main
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)

--- a/tests/src/Loader/classloader/TypeInitialization/CircularCctors/CircularCctorThreeThreads01BFI.il
+++ b/tests/src/Loader/classloader/TypeInitialization/CircularCctors/CircularCctorThreeThreads01BFI.il
@@ -2,28 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
 //  Microsoft (R) .NET Framework IL Disassembler.  Version 2.0.50103.00
 //  Copyright (C) Microsoft Corporation. All rights reserved.
-
-
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern System.Threading.Thread
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
+.assembly extern System.Console { auto }
+.assembly extern System.Threading.Thread { auto }
 // Metadata version: v2.0.50103
-.assembly extern mscorlib
-{
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
-  .ver 2:0:0:0
-}
+.assembly extern mscorlib { auto }
+
 .assembly CircularCctorThreeThreads01
 {
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 )

--- a/tests/src/Loader/classloader/TypeInitialization/CircularCctors/CircularCctorThreeThreads02BFI.il
+++ b/tests/src/Loader/classloader/TypeInitialization/CircularCctors/CircularCctorThreeThreads02BFI.il
@@ -2,12 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-.assembly extern System.Console { }
-
 //  Microsoft (R) .NET Framework IL Disassembler.  Version 2.0.50103.00
 //  Copyright (C) Microsoft Corporation. All rights reserved.
 
 
+.assembly extern System.Console
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
+.assembly extern System.Threading.Thread
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
 
 // Metadata version: v2.0.50103
 .assembly extern mscorlib
@@ -17,7 +26,7 @@
 }
 .assembly CircularCctorThreeThreads02
 {
-  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 )
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
@@ -37,7 +46,7 @@
        extends [mscorlib]System.Object
 {
   .field public static int32 i
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     // Code size       50 (0x32)
@@ -74,7 +83,7 @@
     IL_0016:  ret
   } // end of method A::SomeMethod
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)
@@ -90,7 +99,7 @@
        extends [mscorlib]System.Object
 {
   .field public static int32 i
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     // Code size       39 (0x27)
@@ -124,7 +133,7 @@
     IL_0016:  ret
   } // end of method B::SomeMethod
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)
@@ -140,7 +149,7 @@
        extends [mscorlib]System.Object
 {
   .field public static int32 i
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     // Code size       39 (0x27)
@@ -174,7 +183,7 @@
     IL_0016:  ret
   } // end of method C::SomeMethod
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)
@@ -190,7 +199,7 @@
        extends [mscorlib]System.Object
 {
   .field public static int32 i
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     // Code size       39 (0x27)
@@ -224,7 +233,7 @@
     IL_0016:  ret
   } // end of method D::SomeMethod
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)
@@ -240,7 +249,7 @@
        extends [mscorlib]System.Object
 {
   .field public static int32 i
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     // Code size       40 (0x28)
@@ -274,7 +283,7 @@
     IL_0016:  ret
   } // end of method E::SomeMethod
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)
@@ -432,7 +441,7 @@
     IL_00f3:  ret
   } // end of method Test::Main
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)

--- a/tests/src/Loader/classloader/TypeInitialization/CircularCctors/CircularCctorThreeThreads02BFI.il
+++ b/tests/src/Loader/classloader/TypeInitialization/CircularCctors/CircularCctorThreeThreads02BFI.il
@@ -2,28 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
 //  Microsoft (R) .NET Framework IL Disassembler.  Version 2.0.50103.00
 //  Copyright (C) Microsoft Corporation. All rights reserved.
-
-
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern System.Threading.Thread
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
+.assembly extern System.Console { auto }
+.assembly extern System.Threading.Thread { auto }
 // Metadata version: v2.0.50103
-.assembly extern mscorlib
-{
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
-  .ver 2:0:0:0
-}
+.assembly extern mscorlib { auto }
+
 .assembly CircularCctorThreeThreads02
 {
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 )

--- a/tests/src/Loader/classloader/TypeInitialization/CircularCctors/CircularCctorThreeThreads03BFI.il
+++ b/tests/src/Loader/classloader/TypeInitialization/CircularCctors/CircularCctorThreeThreads03BFI.il
@@ -2,28 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
 //  Microsoft (R) .NET Framework IL Disassembler.  Version 2.0.50103.00
 //  Copyright (C) Microsoft Corporation. All rights reserved.
-
-
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
-.assembly extern System.Threading.Thread
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
-
+.assembly extern System.Console { auto }
+.assembly extern System.Threading.Thread { auto }
 // Metadata version: v2.0.50103
-.assembly extern mscorlib
-{
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
-  .ver 2:0:0:0
-}
+.assembly extern mscorlib { auto }
+
 .assembly CircularCctorThreeThreads03
 {
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 )

--- a/tests/src/Loader/classloader/TypeInitialization/CircularCctors/CircularCctorThreeThreads03BFI.il
+++ b/tests/src/Loader/classloader/TypeInitialization/CircularCctors/CircularCctorThreeThreads03BFI.il
@@ -2,12 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-.assembly extern System.Console { }
-
 //  Microsoft (R) .NET Framework IL Disassembler.  Version 2.0.50103.00
 //  Copyright (C) Microsoft Corporation. All rights reserved.
 
 
+.assembly extern System.Console
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
+.assembly extern System.Threading.Thread
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
 
 // Metadata version: v2.0.50103
 .assembly extern mscorlib
@@ -17,7 +26,7 @@
 }
 .assembly CircularCctorThreeThreads03
 {
-  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 )
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
@@ -37,7 +46,7 @@
        extends [mscorlib]System.Object
 {
   .field public static int32 i
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     // Code size       50 (0x32)
@@ -74,7 +83,7 @@
     IL_0016:  ret
   } // end of method A::SomeMethod
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)
@@ -90,7 +99,7 @@
        extends [mscorlib]System.Object
 {
   .field public static int32 i
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     // Code size       39 (0x27)
@@ -124,7 +133,7 @@
     IL_0016:  ret
   } // end of method B::SomeMethod
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)
@@ -140,7 +149,7 @@
        extends [mscorlib]System.Object
 {
   .field public static int32 i
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     // Code size       50 (0x32)
@@ -177,7 +186,7 @@
     IL_0016:  ret
   } // end of method C::SomeMethod
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)
@@ -193,7 +202,7 @@
        extends [mscorlib]System.Object
 {
   .field public static int32 i
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     // Code size       39 (0x27)
@@ -227,7 +236,7 @@
     IL_0016:  ret
   } // end of method D::SomeMethod
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)
@@ -243,7 +252,7 @@
        extends [mscorlib]System.Object
 {
   .field public static int32 i
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     // Code size       40 (0x28)
@@ -277,7 +286,7 @@
     IL_0016:  ret
   } // end of method E::SomeMethod
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)
@@ -435,7 +444,7 @@
     IL_00f3:  ret
   } // end of method Test::Main
 
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     // Code size       7 (0x7)

--- a/tests/src/Loader/classloader/nesting/Tests/nesting7.il
+++ b/tests/src/Loader/classloader/nesting/Tests/nesting7.il
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
 .assembly extern System.Console { }
+.assembly extern mscorlib {}
 // model revision #2
 // To compile: ilasm nesting7.il /err
 
@@ -11,7 +13,7 @@
 // Nesting module: PureManaged
 // Nesting location: MainModule
 
-// enclosing type 
+// enclosing type
 // kind: Interface
 // flag: abstract
 // visibility: private
@@ -20,7 +22,7 @@
 
 .class interface abstract private EnclType
 {
-  // nested type 
+  // nested type
   // kind: Delegate
   // flag: sealed
   // visibility: assembly
@@ -32,7 +34,7 @@
 
     // nested member visibility: assembly
 
-    .method assembly hidebysig specialname rtspecialname 
+    .method assembly hidebysig specialname rtspecialname
             instance void  .ctor(object 'object',
                                  native int 'method') runtime managed
     {}
@@ -41,7 +43,7 @@
             instance void  Invoke(int32 i) runtime managed
     {}
 
-    .method assembly hidebysig newslot virtual 
+    .method assembly hidebysig newslot virtual
             instance class [mscorlib]System.IAsyncResult
             BeginInvoke(int32 i,
                         class [mscorlib]System.AsyncCallback callback,
@@ -94,7 +96,7 @@
     ldarg.0
     ldftn      void class EnclType::DelegateFunction(int32)
     newobj     instance void class EnclType/NestedType::.ctor(object, native int)
-    
+
     stsfld     class EnclType/NestedType class EnclType::sNestClass
     ldsfld     class EnclType/NestedType class EnclType::sNestClass
     call       void class EnclType::TakesADelegate(class EnclType/NestedType)
@@ -122,7 +124,7 @@
     stloc.1
     leave.s    end
   }
-  catch [mscorlib]System.Exception 
+  catch [mscorlib]System.Exception
   {
     stloc.0
     ldstr      "{0}Caught unexpected exception."

--- a/tests/src/Loader/classloader/nesting/Tests/nesting7.il
+++ b/tests/src/Loader/classloader/nesting/Tests/nesting7.il
@@ -3,8 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Console { }
-.assembly extern mscorlib {}
+.assembly extern System.Console { auto }
+.assembly extern mscorlib { auto }
+
 // model revision #2
 // To compile: ilasm nesting7.il /err
 

--- a/tests/src/baseservices/compilerservices/RuntimeFeature/DefaultImplementationsOfInterfaces.il
+++ b/tests/src/baseservices/compilerservices/RuntimeFeature/DefaultImplementationsOfInterfaces.il
@@ -7,12 +7,18 @@
 // This needs to succeed no matter whether default interfaces are supported.
 //
 
+.assembly extern mscorlib
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 2:0:0:0
+}
+
 .assembly extern System.Runtime{}
 .assembly DefaultImplementationsOfInterfaces{}
 
 .class interface private abstract auto ansi DefaultInterface
 {
-  .method public hidebysig newslot virtual 
+  .method public hidebysig newslot virtual
           instance void  Method() cil managed
   {
     .maxstack  8
@@ -39,7 +45,7 @@
       leave.s    Supports
 
     }
-    catch [System.Runtime]System.TypeLoadException 
+    catch [System.Runtime]System.TypeLoadException
     {
       pop
       leave.s    DoesNotSupport
@@ -54,7 +60,7 @@
     ret
   }
 
-.method private hidebysig static int32 
+.method private hidebysig static int32
         Main() cil managed
 {
     .entrypoint

--- a/tests/src/baseservices/compilerservices/RuntimeFeature/DefaultImplementationsOfInterfaces.il
+++ b/tests/src/baseservices/compilerservices/RuntimeFeature/DefaultImplementationsOfInterfaces.il
@@ -2,18 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
 //
 // Verifies that RuntimeFeature::IsSupported("DefaultImplementationsOfInterfaces") matches reality.
 // This needs to succeed no matter whether default interfaces are supported.
 //
+.assembly extern mscorlib { auto }
+.assembly extern System.Runtime { auto }
 
-.assembly extern mscorlib
-{
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
-  .ver 2:0:0:0
-}
-
-.assembly extern System.Runtime{}
 .assembly DefaultImplementationsOfInterfaces{}
 
 .class interface private abstract auto ansi DefaultInterface

--- a/tests/src/baseservices/compilerservices/modulector/moduleCctor.il
+++ b/tests/src/baseservices/compilerservices/modulector/moduleCctor.il
@@ -9,13 +9,13 @@
 }
 
 .assembly moduleCctor {}
-.assembly extern FieldTypes 
+.assembly extern FieldTypes
 {
   .publickeytoken = (C0 30 5C 36 38 0B A4 29 )                         // .0\68..)
   .ver 0:0:0:0
 }
 
- .method private hidebysig specialname rtspecialname static 
+ .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     .maxstack  8
@@ -34,41 +34,41 @@
 
 // =============== CLASS MEMBERS DECLARATION ===================
 .class public auto ansi beforefieldinit IntHolder
-	extends [mscorlib]System.Object
+    extends [mscorlib]System.Object
 {
-	// Fields
-	.field public static int32 val
+    // Fields
+    .field public static int32 val
 
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2050
-		// Code size 8 (0x8)
-		.maxstack 8
+    // Methods
+    .method public hidebysig specialname rtspecialname
+        instance void .ctor () cil managed
+    {
+        // Method begins at RVA 0x2050
+        // Code size 8 (0x8)
+        .maxstack 8
 
-		IL_0000: ldarg.0
-		IL_0001: call instance void [mscorlib]System.Object::.ctor()
-		IL_0006: nop
-		IL_0007: ret
-	} // end of method IntHolder::.ctor
+        IL_0000: ldarg.0
+        IL_0001: call instance void [mscorlib]System.Object::.ctor()
+        IL_0006: nop
+        IL_0007: ret
+    } // end of method IntHolder::.ctor
 
-	.method private hidebysig specialname rtspecialname static 
-		void .cctor () cil managed 
-	{
-		// Method begins at RVA 0x2059
-		// Code size 7 (0x7)
-		.maxstack 8
+    .method private hidebysig specialname rtspecialname static
+        void .cctor () cil managed
+    {
+        // Method begins at RVA 0x2059
+        // Code size 7 (0x7)
+        .maxstack 8
 
-		IL_0000: ldc.i4.0
-		IL_0001: stsfld int32 IntHolder::val
-		IL_0006: ret
-	} // end of method IntHolder::.cctor
+        IL_0000: ldc.i4.0
+        IL_0001: stsfld int32 IntHolder::val
+        IL_0006: ret
+    } // end of method IntHolder::.cctor
 
-        .method public hidebysig static 
+        .method public hidebysig static
             void Assign (
                     int32 arg
-                    ) cil managed 
+                    ) cil managed
             {
                 // Method begins at RVA 0x2078
                 // Code size 8 (0x8)
@@ -79,10 +79,10 @@
                     IL_0002: stsfld int32 IntHolder::val
                     IL_0007: ret
             } // end of method IntHolder::Assign
-        .method public hidebysig static 
+        .method public hidebysig static
             void Check (
                     int32 arg
-                    ) cil managed 
+                    ) cil managed
             {
                 // Method begins at RVA 0x2050
                 // Code size 28 (0x1c)

--- a/tests/src/baseservices/compilerservices/modulector/moduleCctor.il
+++ b/tests/src/baseservices/compilerservices/modulector/moduleCctor.il
@@ -2,18 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-.assembly extern mscorlib
-{
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
-  .ver 2:0:0:0
-}
 
+.assembly extern mscorlib { auto }
 .assembly moduleCctor {}
-.assembly extern FieldTypes
-{
-  .publickeytoken = (C0 30 5C 36 38 0B A4 29 )                         // .0\68..)
-  .ver 0:0:0:0
-}
+.assembly extern FieldTypes { auto }
+
 
  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed

--- a/tests/src/reflection/ActivateStructDefCtor/ActivateStructDefCtor.il
+++ b/tests/src/reflection/ActivateStructDefCtor/ActivateStructDefCtor.il
@@ -3,17 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 
-.assembly extern System.Runtime
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
+.assembly extern System.Runtime { auto }
+.assembly extern mscorlib { auto }
 
-.assembly extern mscorlib
-{
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
-  .ver 2:0:0:0
-}
 
 .assembly ActivateStructDefCtor
 {

--- a/tests/src/reflection/ActivateStructDefCtor/ActivateStructDefCtor.il
+++ b/tests/src/reflection/ActivateStructDefCtor/ActivateStructDefCtor.il
@@ -1,8 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+.assembly extern System.Runtime
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
   .ver 2:0:0:0
 }
+
 .assembly ActivateStructDefCtor
 {
 }
@@ -17,7 +29,7 @@
   {
     .field public int32 x
 
-    .method public hidebysig specialname rtspecialname 
+    .method public hidebysig specialname rtspecialname
             instance void  .ctor() cil managed
     {
       // Code size       8 (0x8)
@@ -93,7 +105,7 @@
     IL_0058:  ret
   } // end of method Program::Main
 
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     // Code size       15 (0xf)


### PR DESCRIPTION
Fixes #14689

While working on #19109 fixed all ilasm warnings for priority 0 and 1 builds.

Since my editor is automatically enforcing .editorconfig coding style white space was fixed in all files which were edited (tabs -> spaces, no white space at the end of line)

Will create separate issue to track not fixed #14689 warnings - MSB3268