### PR TITLE
Fix invalid IntPtr == null comparisons, set strict mode for Roslyn

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,4 +2,8 @@
   <PropertyGroup>
     <CL_MPCount>$(NumberOfCores)</CL_MPCount>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- Enables Strict mode for Roslyn compiler -->
+    <Features>strict</Features>
+  </PropertyGroup>
 </Project>

--- a/src/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -200,7 +200,7 @@ namespace System.StubHelpers
 
         internal static unsafe void ConvertToManaged(StringBuilder sb, IntPtr pNative)
         {
-            if (pNative == null)
+            if (pNative == IntPtr.Zero)
                 return;
 
             int nbBytes = StubHelpers.strlen((sbyte*)pNative);


### PR DESCRIPTION
Issue reported in https://github.com/dotnet/corefx/issues/31456
Solution is to compare always against IntPtr.Zero and use Roslyn
stric mode for reporting warnings for IntPtr == null comparisons

Does not seem to have any security impact