### PR TITLE
Change type of EnumLocaleData to struct

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Globalization/CultureData.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CultureData.Windows.cs
@@ -517,7 +517,7 @@ namespace System.Globalization
 
 
         // Context for EnumCalendarInfoExEx callback.
-        private class EnumLocaleData
+        private struct EnumLocaleData
         {
             public string regionName;
             public string cultureName;


### PR DESCRIPTION
Saves allocation and makes the code smaller. It had to be class before we had ref locals.