### PR TITLE
Moving the ilproj sdk to be built/published under the TargetsWindows condition

### DIFF
--- a/src/.nuget/packages.builds
+++ b/src/.nuget/packages.builds
@@ -12,6 +12,7 @@
 
   <ItemGroup Condition="'$(TargetsWindows)'=='true'">
     <Project Include="Microsoft.TargetingPack.Private.CoreCLR\Microsoft.TargetingPack.Private.CoreCLR.pkgproj" />
+    <Project Include="Microsoft.NET.Sdk.IL\Microsoft.NET.Sdk.IL.pkgproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(__SkipNativeBuild)'==''">
@@ -23,10 +24,6 @@
   <ItemGroup>
     <Project Include="Microsoft.NETCore.ILAsm\Microsoft.NETCore.ILAsm.builds" />
     <Project Include="Microsoft.NETCore.ILDAsm\Microsoft.NETCore.ILDAsm.builds" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(BuildIdentityPackage)' == 'true'">
-    <Project Include="Microsoft.NET.Sdk.IL\Microsoft.NET.Sdk.IL.pkgproj" />
   </ItemGroup>
 
   <Import Project="$(ToolsDir)versioning.targets" />


### PR DESCRIPTION
CC. @eerhardt, @weshaggard.

Previous condition was incorrect and the package was never published.