### PR TITLE
Cross-bitness in GcInfoEncoder::Build()

### DIFF
--- a/src/gcinfo/gcinfoencoder.cpp
+++ b/src/gcinfo/gcinfoencoder.cpp
@@ -121,11 +121,6 @@ public:
 #endif
     }
 
-    inline size_t* DataPtr()
-    {
-        return m_pData;
-    }
-    
     inline void SetBit( size_t pos )
     {
         size_t element = pos / BITS_PER_SIZE_T;
@@ -915,21 +910,6 @@ void BitStreamWriter::MemoryBlockList::Dispose(IAllocator* allocator)
     m_head = nullptr;
     m_tail = nullptr;
 #endif
-}
-
-void BitStreamWriter::Write(BitArray& a, UINT32 count)
-{
-    size_t* dataPtr = a.DataPtr();
-    for(;;)
-    {
-        if(count <= BITS_PER_SIZE_T)
-        {
-            Write(*dataPtr, count);
-            break;
-        }
-        Write(*(dataPtr++), BITS_PER_SIZE_T);
-        count -= BITS_PER_SIZE_T;
-    }   
 }
 
 void GcInfoEncoder::FinalizeSlotIds()

--- a/src/gcinfo/gcinfoencoder.cpp
+++ b/src/gcinfo/gcinfoencoder.cpp
@@ -111,7 +111,7 @@
 class BitArray
 {
     friend class BitArrayIterator;
-    typedef unsigned __int32 ChunkType;
+    typedef uint32_t ChunkType;
     static constexpr size_t NumBitsPerChunk = sizeof(ChunkType) * CHAR_BIT;
 public:
     BitArray(IAllocator* pJitAllocator, size_t numBits)
@@ -160,7 +160,7 @@ public:
             ClearBit(pos);
     }
     
-    inline unsigned __int32 ReadBit( size_t pos ) const
+    inline uint32_t ReadBit( size_t pos ) const
     {
         size_t element = pos / NumBitsPerChunk;
         int bpos = (int)(pos % NumBitsPerChunk);
@@ -1968,7 +1968,7 @@ void GcInfoEncoder::Build()
             LifetimeTransition *pFirstPreserved = pFirstAfterStart;
             for(UINT32 slotIndex = 0; slotIndex < m_NumSlots; slotIndex++)
             {
-                unsigned __int32 isLive = liveState.ReadBit(slotIndex);
+                uint32_t isLive = liveState.ReadBit(slotIndex);
                 if(isLive != liveStateAtPrevRange.ReadBit(slotIndex))
                 {
                     pFirstPreserved--;

--- a/src/inc/gcinfoencoder.h
+++ b/src/inc/gcinfoencoder.h
@@ -199,7 +199,6 @@ public:
 
     // bit 0 is the least significative bit
     void Write( size_t data, UINT32 count );
-    void Write( BitArray& a, UINT32 count );
 
     inline size_t GetBitCount()
     {

--- a/src/inc/gcinfotypes.h
+++ b/src/inc/gcinfotypes.h
@@ -810,18 +810,5 @@ PORTABILITY_WARNING("Please specialize these definitions for your platform!")
 
 #endif
 
-#ifdef _TARGET_64BIT_
-typedef unsigned __int64 target_size_t;
-typedef __int64          target_ssize_t;
-#else
-typedef unsigned int target_size_t;
-typedef int          target_ssize_t;
-#endif
-
-C_ASSERT(sizeof(target_size_t) == TARGET_POINTER_SIZE);
-C_ASSERT(sizeof(target_ssize_t) == TARGET_POINTER_SIZE);
-
-#define BITS_PER_TARGET_SIZE_T (TARGET_POINTER_SIZE*CHAR_BIT)
-
 #endif // !__GCINFOTYPES_H__
 

--- a/src/inc/gcinfotypes.h
+++ b/src/inc/gcinfotypes.h
@@ -810,5 +810,18 @@ PORTABILITY_WARNING("Please specialize these definitions for your platform!")
 
 #endif
 
+#ifdef _TARGET_64BIT_
+typedef unsigned __int64 target_size_t;
+typedef __int64          target_ssize_t;
+#else
+typedef unsigned int target_size_t;
+typedef int          target_ssize_t;
+#endif
+
+C_ASSERT(sizeof(target_size_t) == TARGET_POINTER_SIZE);
+C_ASSERT(sizeof(target_ssize_t) == TARGET_POINTER_SIZE);
+
+#define BITS_PER_TARGET_SIZE_T (TARGET_POINTER_SIZE*CHAR_BIT)
+
 #endif // !__GCINFOTYPES_H__
 


### PR DESCRIPTION
`BitArray` class in `GcInfoEncoder` uses array of `size_t` internally.

In the cross-bitness scenario (#16513) this causes situations when `BitArray::GetHashCode` in cross-bitness mode computes different hash (in comparison with non cross-bitness mode) for semantically equivalent bit-arrays (meaning having same number of bits and the same values). 

It turned out that the order in which `LiveStateHashTable hashMap` is iterated in `GcInfoEncoder::Build` depends  on the `BitArray::GetHashCode` (via `SimplerHashTable::GetIndexForKey`) which causes binary differences in outputs of cross-bitness crossgen and native crossgen.

This PR makes `BitArray::GetHashCode` target-bitness specific.