### PR TITLE
Fix value number update in fgMorphCast.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -600,6 +600,10 @@ OPTIMIZECAST:
                             case GT_LCL_FLD:
                             case GT_ARR_ELEM:
                                 oper->gtType = dstType;
+                                // We're changing the type here so we need to update the VN;
+                                // in other cases we discard the cast without modifying oper
+                                // so the VN doesn't change.
+                                oper->SetVNsFromNode(tree);
                                 goto REMOVE_CAST;
                             default:
                                 break;
@@ -753,8 +757,6 @@ OPTIMIZECAST:
     return tree;
 
 REMOVE_CAST:
-    oper->SetVNsFromNode(tree);
-
     /* Here we've eliminated the cast, so just return it's operand */
     assert(!gtIsActiveCSE_Candidate(tree)); // tree cannot be a CSE candidate
 

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_653853/DevDiv_653853.cs
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_653853/DevDiv_653853.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+using System;
+using System.Runtime.CompilerServices;
+
+public static class Test
+{
+    public static int Main()
+    {        
+        if (RunTest(0) == 5)
+        {
+            Console.WriteLine("SUCCESS");
+            return 100;
+        }
+        else
+        {
+            Console.WriteLine("FAILURE");
+            return -1;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int RunTest(int arg)
+    {
+        float f = 0.0F;
+        // The bug was that after removing the cast and
+        // replacing the right-hand side of the comparison
+        // with 0, its value number was changed to the value number
+        // of the initial right-hand side tree. That broke the
+        // assumption that constant nodes have known constant value numbers.
+        if (arg != (sbyte)f)
+        {
+            return 2*arg;
+        }
+        else
+        {
+            return arg + 5;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_653853/DevDiv_653853.csproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_653853/DevDiv_653853.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{ADEEA3D1-B67B-456E-8F2B-6DCCACC2D34C}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
#18816 was too aggressive in updating value numbers when
removing GT_CAST nodes. It caused a problem for cases
where GT_CAST operand is a constant (e.g., GT_CNS_INT). In these
cases the value number shouldn't change since there is an
assumption that constant nodes have known constant value numbers.

The bug was found by ILGEN, I created a corresponding C# repro.
Without the fix this assert fires: https://github.com/dotnet/coreclr/blob/1f28125ad1f9975fbe68dd6839908aa6e63fc43b#gitext://gotocommit/1f28125ad1f9975fbe68dd6839908aa6e63fc43b/src/jit/assertionprop.cpp#L2687

The fix is to update value numbers only when we changed the operand of GT_CAST and
value number wasn't updated otherwise (e.g., in optNarrowTree).

I verified no x64 diffs in
jit-diff diff  --pmi --tests --frameworks
(with pri0 and pri1 tests).