### PR TITLE
Support O_DIRECT file open option handling for FileStream.Unix

### DIFF
--- a/src/System.Private.CoreLib/shared/Interop/Unix/System.Native/Interop.OpenFlags.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Unix/System.Native/Interop.OpenFlags.cs
@@ -22,6 +22,7 @@ internal static partial class Interop
             O_EXCL    = 0x0040,
             O_TRUNC   = 0x0080,
             O_SYNC    = 0x0100,
+            O_DIRECT  = 0x4000,
         }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/IO/FileStream.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStream.Unix.cs
@@ -183,6 +183,12 @@ namespace System.IO
                 flags |= Interop.Sys.OpenFlags.O_SYNC;
             }
 
+            // NoBuffering
+            if ((options & (FileOptions)0x20000000) != 0)
+            {
+                flags |= Interop.Sys.OpenFlags.O_DIRECT;
+            }
+
             return flags;
         }
 


### PR DESCRIPTION
As discussed in #19229, changes are very small. The value 0x4000 is [from Mono](https://github.com/mono/mono/blob/78eb8324b20b29544233c3fe42f6c12e78041ba7/mcs/class/Mono.Posix/Mono.Unix.Native/Syscall.cs#L150) and cross-checked with some Google search.

