### PR TITLE
Use 16 bytes to spill SIMD12

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -660,6 +660,7 @@ public:
         // For 32-bit architectures, we make local variable SIMD12 types 16 bytes instead of just 12. We can't do
         // this for arguments, which must be passed according the defined ABI. We don't want to do this for
         // dependently promoted struct fields, but we don't know that here. See lvaMapSimd12ToSimd16().
+        // (Note that for 64-bits, we are already rounding up to 16.)
         if ((lvType == TYP_SIMD12) && !lvIsParam)
         {
             assert(lvExactSize == 12);

--- a/src/jit/regset.cpp
+++ b/src/jit/regset.cpp
@@ -619,10 +619,11 @@ var_types RegSet::tmpNormalizeType(var_types type)
 {
     type = genActualType(type);
 
-#if defined(FEATURE_SIMD) && !defined(_TARGET_64BIT_)
-    // For SIMD on 32-bit platforms, we always spill SIMD12 to a 16-byte SIMD16 temp.
-    // This is because we don't have a single instruction to store 12 bytes. We also
-    // allocate non-argument locals as 16 bytes; see lvSize().
+#if defined(FEATURE_SIMD)
+    // We always spill SIMD12 to a 16-byte SIMD16 temp.
+    // This is because we don't have a single instruction to store 12 bytes, so we want
+    // to ensure that we always have the full 16 bytes for loading & storing the value.
+    // We also allocate non-argument locals as 16 bytes; see lvSize().
     if (type == TYP_SIMD12)
     {
         type = TYP_SIMD16;

--- a/tests/src/JIT/Regression/JitBlue/GitHub_19197/GitHub_19197.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_19197/GitHub_19197.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+// This test was extracted from the corefx System.Numerics.Vectors tests,
+// and was failing with minOpts because a SIMD12 was being spilled using
+// a 16-byte load, but only a 12-byte location had been allocated.
+
+using System;
+using System.Numerics;
+
+public class GitHub_19171
+{
+    static int returnVal = 100;
+
+    static public void Vector3EqualsTest()
+    {
+        Vector3 a = new Vector3(1.0f, 2.0f, 3.0f);
+        Vector3 b = new Vector3(1.0f, 2.0f, 3.0f);
+
+        // case 1: compare between same values
+        object obj = b;
+
+        bool expected = true;
+        bool actual = a.Equals(obj);
+        Equal(expected, actual);
+
+        // case 2: compare between different values
+        b.X = 10.0f;
+        obj = b;
+        expected = false;
+        actual = a.Equals(obj);
+        Equal(expected, actual);
+
+        // case 3: compare between different types.
+        obj = new Quaternion();
+        expected = false;
+        actual = a.Equals(obj);
+        Equal(expected, actual);
+
+        // case 3: compare against null.
+        obj = null;
+        expected = false;
+        actual = a.Equals(obj);
+        Equal(expected, actual);
+    }
+
+    static void Equal(bool a, bool b)
+    {
+        Console.WriteLine(a == b ? "ok" : "bad");
+        if (a != b)
+        {
+            returnVal = -1;
+        }
+    }
+
+    public static int Main()
+    {
+        Vector3EqualsTest();
+        return returnVal;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_19197/GitHub_19197.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_19197/GitHub_19197.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{ADEEA3D1-B67B-456E-8F2B-6DCCACC2D34C}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
On 64-bit systems, SIMD12 locals are naturally rounded to 16 bytes, but the spill temp logic was not doing the same.

Fix #19197