### PR TITLE
Fix interop test targets

### DIFF
--- a/tests/src/Interop/Interop.settings.targets
+++ b/tests/src/Interop/Interop.settings.targets
@@ -1,7 +1,6 @@
 <Project>
   <!-- Properties for all Interop managed test assets -->
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <!-- Environment properties -->


### PR DESCRIPTION
Remove TargetFramework from Interop.settings.targets since it already gets handled by the build environment and 2.0 doesn't work.