### PR TITLE
JIT: refactor ref count computation into a reusable utility method

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2789,9 +2789,9 @@ public:
     void lvaSortByRefCount();
     void lvaDumpRefCounts();
 
-    void lvaMarkLocalVars(BasicBlock* block);
-
     void lvaMarkLocalVars(); // Local variable ref-counting
+    void lvaComputeRefCounts(bool isRecompute, bool setSlotNumbers);
+    void lvaMarkLocalVars(BasicBlock* block, bool isRecompute);
 
     void lvaAllocOutgoingArgSpaceVar(); // Set up lvaOutgoingArgSpaceVar
 
@@ -2971,7 +2971,7 @@ public:
 protected:
     //---------------- Local variable ref-counting ----------------------------
 
-    void lvaMarkLclRefs(GenTree* tree, BasicBlock* block, GenTreeStmt* stmt);
+    void lvaMarkLclRefs(GenTree* tree, BasicBlock* block, GenTreeStmt* stmt, bool isRecompute);
     bool IsDominatedByExceptionalEntry(BasicBlock* block);
     void SetVolatileHint(LclVarDsc* varDsc);
 


### PR DESCRIPTION
Extract out the basic ref count computation into a method that we
can conceptually call later on if we want to recompute counts.

Move one existing RCS_EARLY count for promoted fields of register
args into this recomputation since losing this count bump causes
quite a few diffs.

The hope is to eventually call this method again later in the jit
phase pipeline and then possibly get rid of all the (non-early)
incremental count maintenance we do currently.

Part of #18969