### PR TITLE
Make `Vector64<T>`, `Vector128<T>`, and `Vector256<T>` readonly

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128.cs
@@ -13,12 +13,12 @@ namespace System.Runtime.Intrinsics
     [DebuggerDisplay("{DisplayString,nq}")]
     [DebuggerTypeProxy(typeof(Vector128DebugView<>))]
     [StructLayout(LayoutKind.Sequential, Size = 16)]
-    public struct Vector128<T> where T : struct
+    public readonly struct Vector128<T> where T : struct
     {
         // These fields exist to ensure the alignment is 8, rather than 1.
         // This also allows the debug view to work https://github.com/dotnet/coreclr/issues/15694)
-        private ulong _00;
-        private ulong _01;
+        private readonly ulong _00;
+        private readonly ulong _01;
 
         private unsafe string DisplayString
         {

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128DebugView.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128DebugView.cs
@@ -6,9 +6,9 @@ using Internal.Runtime.CompilerServices;
 
 namespace System.Runtime.Intrinsics
 {
-    internal struct Vector128DebugView<T> where T : struct
+    internal readonly struct Vector128DebugView<T> where T : struct
     {
-        private Vector128<T> _value;
+        private readonly Vector128<T> _value;
 
         public Vector128DebugView(Vector128<T> value)
         {

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256.cs
@@ -13,14 +13,14 @@ namespace System.Runtime.Intrinsics
     [DebuggerDisplay("{DisplayString,nq}")]
     [DebuggerTypeProxy(typeof(Vector256DebugView<>))]
     [StructLayout(LayoutKind.Sequential, Size = 32)]
-    public struct Vector256<T> where T : struct
+    public readonly struct Vector256<T> where T : struct
     {
         // These fields exist to ensure the alignment is 8, rather than 1.
         // This also allows the debug view to work https://github.com/dotnet/coreclr/issues/15694)
-        private ulong _00;
-        private ulong _01;
-        private ulong _02;
-        private ulong _03;
+        private readonly ulong _00;
+        private readonly ulong _01;
+        private readonly ulong _02;
+        private readonly ulong _03;
 
         private unsafe string DisplayString
         {

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256DebugView.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256DebugView.cs
@@ -6,9 +6,9 @@ using Internal.Runtime.CompilerServices;
 
 namespace System.Runtime.Intrinsics
 {
-    internal struct Vector256DebugView<T> where T : struct
+    internal readonly struct Vector256DebugView<T> where T : struct
     {
-        private Vector256<T> _value;
+        private readonly Vector256<T> _value;
 
         public Vector256DebugView(Vector256<T> value)
         {

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector64.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector64.cs
@@ -13,11 +13,11 @@ namespace System.Runtime.Intrinsics
     [DebuggerDisplay("{DisplayString,nq}")]
     [DebuggerTypeProxy(typeof(Vector64DebugView<>))]
     [StructLayout(LayoutKind.Sequential, Size = 8)]
-    public struct Vector64<T> where T : struct
+    public readonly struct Vector64<T> where T : struct
     {
         // These fields exist to ensure the alignment is 8, rather than 1.
         // This also allows the debug view to work https://github.com/dotnet/coreclr/issues/15694)
-        private ulong _00;
+        private readonly ulong _00;
 
         private unsafe string DisplayString
         {

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector64DebugView.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector64DebugView.cs
@@ -6,9 +6,9 @@ using Internal.Runtime.CompilerServices;
 
 namespace System.Runtime.Intrinsics
 {
-    internal struct Vector64DebugView<T> where T : struct
+    internal readonly struct Vector64DebugView<T> where T : struct
     {
-        private Vector64<T> _value;
+        private readonly Vector64<T> _value;
 
         public Vector64DebugView(Vector64<T> value)
         {


### PR DESCRIPTION
This marks the HWIntrinsic types as `readonly`. This allows the C# compiler to assume the type is immutable and it can then perform certain optimizations when used in the context of other readonly types, fields, etc.