### PR TITLE
Fix VSTS build's tests on Alpine

### DIFF
--- a/buildpipeline/tests/test_pipelines.json
+++ b/buildpipeline/tests/test_pipelines.json
@@ -196,7 +196,7 @@
                 "Parameters": {
                 "HelixJobType": "test/functional/cli/",
                 "TargetsWindows": "false",
-                "Rid": "alpine.3.6",
+                "Rid": "linux-musl-x64",
                 "TargetQueues": "Alpine.36.Amd64",
                 "TestContainerSuffix": "alpine36",
                 "TargetsNonWindowsArg": "TargetsNonWindows "
@@ -213,7 +213,7 @@
                 "Parameters": {
                 "HelixJobType": "test/functional/r2r/cli/",
                 "TargetsWindows": "false",
-                "Rid": "alpine.3.6",
+                "Rid": "linux-musl-x64",
                 "TargetQueues": "Alpine.36.Amd64",
                 "TestContainerSuffix": "alpine36-r2r",
                 "CrossgenArg": "Crossgen ",


### PR DESCRIPTION
Earlier changes to rename alpine stuff to musl seems to have missed this change

Fixes #19179