### PR TITLE
Fix version of System.Runtime.Intrinsics.Experimental

### DIFF
--- a/tests/src/Common/test_dependencies/test_dependencies.csproj
+++ b/tests/src/Common/test_dependencies/test_dependencies.csproj
@@ -22,8 +22,9 @@
     <PackageReference Include="System.Security.Permissions">
       <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
     </PackageReference>
+    <!-- If we ever service this package, update this version manually. -->
     <PackageReference Include="System.Runtime.Intrinsics.Experimental">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
+      <Version>4.5.0-rtm</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>


### PR DESCRIPTION
Since there is no servicing version for this package, the 2.1 build was upgrading
to an incompatible 4.6 prerelease which caused test build breaks.

This package is only needed to build tests. We don't expect to service it
for 2.1, given it was an experemental prerelease package.

So fix its version at 4.5.0-rtm.

Closes #19138.