### PR TITLE
Updating the x86 HWIntrinsics program to print out the list of supported ISAs

### DIFF
--- a/tests/src/JIT/HardwareIntrinsics/X86/Shared/Program.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Shared/Program.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Intrinsics.X86;
 
 namespace JIT.HardwareIntrinsics.X86
 {
@@ -18,6 +19,8 @@ namespace JIT.HardwareIntrinsics.X86
         public static int Main(string[] args)
         {
             var isPassing = true;
+
+            PrintSupportedIsa();
 
             foreach (string testToRun in GetTestsToRun(args))
             {
@@ -62,6 +65,27 @@ namespace JIT.HardwareIntrinsics.X86
             }
 
             return (testsToRun.Count == 0) ? TestList.Keys : testsToRun;
+        }
+
+        private static void PrintSupportedIsa()
+        {
+            TestLibrary.TestFramework.LogInformation("Supported ISAs:");
+            TestLibrary.TestFramework.LogInformation($"  AES:       {Aes.IsSupported}");
+            TestLibrary.TestFramework.LogInformation($"  AVX:       {Avx.IsSupported}");
+            TestLibrary.TestFramework.LogInformation($"  AVX2:      {Avx2.IsSupported}");
+            TestLibrary.TestFramework.LogInformation($"  BMI1:      {Bmi1.IsSupported}");
+            TestLibrary.TestFramework.LogInformation($"  BMI2:      {Bmi2.IsSupported}");
+            TestLibrary.TestFramework.LogInformation($"  FMA:       {Fma.IsSupported}");
+            TestLibrary.TestFramework.LogInformation($"  LZCNT:     {Lzcnt.IsSupported}");
+            TestLibrary.TestFramework.LogInformation($"  PCLMULQDQ: {Pclmulqdq.IsSupported}");
+            TestLibrary.TestFramework.LogInformation($"  POPCNT:    {Popcnt.IsSupported}");
+            TestLibrary.TestFramework.LogInformation($"  SSE:       {Sse.IsSupported}");
+            TestLibrary.TestFramework.LogInformation($"  SSE2:      {Sse2.IsSupported}");
+            TestLibrary.TestFramework.LogInformation($"  SSE3:      {Sse3.IsSupported}");
+            TestLibrary.TestFramework.LogInformation($"  SSE4.1:    {Sse41.IsSupported}");
+            TestLibrary.TestFramework.LogInformation($"  SSE4.2:    {Sse42.IsSupported}");
+            TestLibrary.TestFramework.LogInformation($"  SSSE3:     {Ssse3.IsSupported}");
+            TestLibrary.TestFramework.LogInformation(string.Empty);
         }
 
         private static void PrintUsage()


### PR DESCRIPTION
This updates the templated x86 HWIntrinsic tests to print out the "IsSupported" status for each ISA in order to help diagnose the state of CI machines in the case of failure.