### PR TITLE
Clean up build.cmd/build-test.cmd/runtest.cmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -6,6 +6,7 @@ setlocal EnableDelayedExpansion EnableExtensions
 set "__MsgPrefix=BUILD: "
 
 echo %__MsgPrefix%Starting Build at %TIME%
+
 set __ThisScriptFull="%~f0"
 set __ThisScriptDir="%~dp0"
 
@@ -13,13 +14,13 @@ call "%__ThisScriptDir%"\setup_vs_tools.cmd
 if NOT '%ERRORLEVEL%' == '0' exit /b 1
 
 if defined VS150COMNTOOLS (
-  set "__VSToolsRoot=%VS150COMNTOOLS%"
-  set "__VCToolsRoot=%VS150COMNTOOLS%\..\..\VC\Auxiliary\Build"
-  set __VSVersion=vs2017
+    set "__VSToolsRoot=%VS150COMNTOOLS%"
+    set "__VCToolsRoot=%VS150COMNTOOLS%\..\..\VC\Auxiliary\Build"
+    set __VSVersion=vs2017
 ) else (
-  set "__VSToolsRoot=%VS140COMNTOOLS%"
-  set "__VCToolsRoot=%VS140COMNTOOLS%\..\..\VC"
-  set __VSVersion=vs2015
+    set "__VSToolsRoot=%VS140COMNTOOLS%"
+    set "__VCToolsRoot=%VS140COMNTOOLS%\..\..\VC"
+    set __VSVersion=vs2015
 )
 
 :: Work around Jenkins CI + msbuild problem: Jenkins sometimes creates very large environment
@@ -57,8 +58,6 @@ set "__PackagesDir=%DotNetRestorePackagesPath%"
 if [%__PackagesDir%]==[] set "__PackagesDir=%__ProjectDir%\packages"
 set "__RootBinDir=%__ProjectDir%\bin"
 set "__LogsDir=%__RootBinDir%\Logs"
-set "__PgoOptDataVersion="
-set "__IbcOptDataVersion="
 
 set __BuildAll=
 
@@ -89,6 +88,7 @@ set __RunArgs=
 set __BuildCoreLib=1
 set __BuildSOS=1
 set __BuildNative=1
+set __BuildCrossArchNative=0
 set __BuildTests=1
 set __BuildPackages=1
 set __BuildNativeCoreLib=1
@@ -96,6 +96,10 @@ set __BuildManagedTools=1
 set __RestoreOptData=1
 set __GenerateLayout=0
 set __CrossgenAltJit=
+set __CrossArch=
+set __SkipNugetPackage=0
+set __PgoOptDataVersion=
+set __IbcOptDataVersion=
 
 @REM CMD has a nasty habit of eating "=" on the argument list, so passing:
 @REM    -priority=1
@@ -106,11 +110,13 @@ set __Priority=
 :Arg_Loop
 if "%1" == "" goto ArgsDone
 
-if /i "%1" == "-?"    goto Usage
-if /i "%1" == "-h"    goto Usage
-if /i "%1" == "-help" goto Usage
+if /i "%1" == "/?"     goto Usage
+if /i "%1" == "-?"     goto Usage
+if /i "%1" == "/h"     goto Usage
+if /i "%1" == "-h"     goto Usage
+if /i "%1" == "/help"  goto Usage
+if /i "%1" == "-help"  goto Usage
 if /i "%1" == "--help" goto Usage
-
 
 if /i "%1" == "-all"                 (set __BuildAll=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "-x64"                 (set __BuildArchX64=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
@@ -198,12 +204,12 @@ if /i "%1" == "enforcepgo"          (set __EnforcePgo=1&set processedArgs=!proce
 if /i "%1" == "ibcinstrument"       (set __IbcTuning=/Tuning&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 
 if [!processedArgs!]==[] (
-  set __UnprocessedBuildArgs=%__args%
+    set __UnprocessedBuildArgs=%__args%
 ) else (
-  set __UnprocessedBuildArgs=%__args%
-  for %%t in (!processedArgs!) do (
-    set __UnprocessedBuildArgs=!__UnprocessedBuildArgs:*%%t=!
-  )
+    set __UnprocessedBuildArgs=%__args%
+    for %%t in (!processedArgs!) do (
+        set __UnprocessedBuildArgs=!__UnprocessedBuildArgs:*%%t=!
+    )
 )
 
 :ArgsDone
@@ -217,8 +223,6 @@ if defined __Priority (
     )
     set __UnprocessedBuildArgs=!__UnprocessedBuildArgs! -priority=%__Priority%
 )
-
-if %__PgoOptimize%==0 set __RestoreOptData=0
 
 if defined __BuildAll goto BuildAll
 
@@ -260,24 +264,29 @@ if %__EnforcePgo%==1 (
     )
 )
 
-REM Determine if this is a cross-arch build
+REM Determine if this is a cross-arch build. Only do cross-arch build if we're also building native.
 
-if /i "%__BuildArch%"=="arm64" (
-    set __DoCrossArchBuild=1
+if %__BuildNative% EQU 1 (
+    if /i "%__BuildArch%"=="arm64" (
+        set __BuildCrossArchNative=1
     )
-
-if /i "%__BuildArch%"=="arm" (
-    set __DoCrossArchBuild=1
+    if /i "%__BuildArch%"=="arm" (
+        set __BuildCrossArchNative=1
     )
+)
 
-:: Set the remaining variables based upon the determined build configuration
+REM Set the remaining variables based upon the determined build configuration
+
+if %__PgoOptimize%==0 set __RestoreOptData=0
+if /i %__BuildType% NEQ Release set __RestoreOptData=0
+
+REM REVIEW: why no System.Private.CoreLib NuGet package build for ARM64?
+if /i "%__BuildArch%"=="arm64" set __SkipNugetPackage=0
+
 set "__BinDir=%__RootBinDir%\Product\%__BuildOS%.%__BuildArch%.%__BuildType%"
 set "__IntermediatesDir=%__RootBinDir%\obj\%__BuildOS%.%__BuildArch%.%__BuildType%"
 if "%__NMakeMakefiles%"=="1" (set "__IntermediatesDir=%__RootBinDir%\nmakeobj\%__BuildOS%.%__BuildArch%.%__BuildType%")
 set "__PackagesBinDir=%__BinDir%\.nuget"
-set "__TestRootDir=%__RootBinDir%\tests"
-set "__TestBinDir=%__TestRootDir%\%__BuildOS%.%__BuildArch%.%__BuildType%"
-set "__TestIntermediatesDir=%__RootBinDir%\tests\obj\%__BuildOS%.%__BuildArch%.%__BuildType%"
 set "__CrossComponentBinDir=%__BinDir%"
 set "__CrossCompIntermediatesDir=%__IntermediatesDir%\crossgen"
 
@@ -286,7 +295,7 @@ if NOT "%__CrossArch%" == "" set __CrossComponentBinDir=%__CrossComponentBinDir%
 set "__CrossGenCoreLibLog=%__LogsDir%\CrossgenCoreLib_%__BuildOS%__%__BuildArch%__%__BuildType%.log"
 set "__CrossgenExe=%__CrossComponentBinDir%\crossgen.exe"
 
-:: Generate path to be set for CMAKE_INSTALL_PREFIX to contain forward slash
+REM Generate path to be set for CMAKE_INSTALL_PREFIX to contain forward slash
 set "__CMakeBinDir=%__BinDir%"
 set "__CMakeBinDir=%__CMakeBinDir:\=/%"
 
@@ -299,20 +308,21 @@ REM will place packages.  However nuget used during the build will fail if that 
 REM does not exist.   Avoid this in at least one case by aggressively creating the directory.
 if not exist "%__BinDir%\.nuget\pkg"           md "%__BinDir%\.nuget\pkg"
 
-echo %__MsgPrefix%Commencing CoreCLR Repo build
+echo %__MsgPrefix%Commencing CoreCLR product build
 
-:: Set the remaining variables based upon the determined build configuration
+REM Set the remaining variables based upon the determined build configuration
 
 echo %__MsgPrefix%Checking prerequisites
-:: Eval the output from probe-win1.ps1
+
+REM Eval the output from probe-win1.ps1
 for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy ByPass "& ""%__SourceDir%\pal\tools\probe-win.ps1"""') do %%a
 
 REM NumberOfCores is an WMI property providing number of physical cores on machine
 REM processor(s). It is used to set optimal level of CL parallelism during native build step
 if not defined NumberOfCores (
-REM Determine number of physical processor cores available on machine
-for /f "tokens=*" %%I in (
-    'wmic cpu get NumberOfCores /value ^| find "=" 2^>NUL'
+    REM Determine number of physical processor cores available on machine
+    for /f "tokens=*" %%I in (
+        'wmic cpu get NumberOfCores /value ^| find "=" 2^>NUL'
     ) do set %%I
 )
 echo %__MsgPrefix%Number of processor cores %NumberOfCores%
@@ -333,7 +343,7 @@ REM === Restore optimization profile data
 REM ===
 REM =========================================================================================
 
-if %__RestoreOptData% EQU 1 if %__BuildTypeRelease% EQU 1 (
+if %__RestoreOptData% EQU 1 (
     echo %__MsgPrefix%Restoring the OptimizationData Package
     call %__ProjectDir%\run.cmd build -optdata %__RunArgs% %__UnprocessedBuildArgs%
     if not !errorlevel! == 0 (
@@ -345,14 +355,14 @@ if %__RestoreOptData% EQU 1 if %__BuildTypeRelease% EQU 1 (
 REM Parse the optdata package versions out of msbuild so that we can pass them on to CMake
 set DotNetCli=%__ProjectDir%\Tools\dotnetcli\dotnet.exe
 if not exist "%DotNetCli%" (
-    echo %__MsgPrefix%Assertion failed: dotnet.exe not found at path "%DotNetCli%"
+    echo %__MsgPrefix%Error: "%DotNetCli%" not found
     exit /b 1
 )
 set OptDataProjectFilePath=%__ProjectDir%\src\.nuget\optdata\optdata.csproj
-for /f "tokens=*" %%s in ('%DotNetCli% msbuild "%OptDataProjectFilePath%" /t:DumpPgoDataPackageVersion /nologo') do @(
+for /f "tokens=*" %%s in ('%DotNetCli% msbuild "%OptDataProjectFilePath%" /t:DumpPgoDataPackageVersion /nologo') do (
     set __PgoOptDataVersion=%%s
 )
-for /f "tokens=*" %%s in ('%DotNetCli% msbuild "%OptDataProjectFilePath%" /t:DumpIbcDataPackageVersion /nologo') do @(
+for /f "tokens=*" %%s in ('%DotNetCli% msbuild "%OptDataProjectFilePath%" /t:DumpIbcDataPackageVersion /nologo') do (
     set __IbcOptDataVersion=%%s
 )
 
@@ -374,7 +384,7 @@ if NOT DEFINED PYTHON (
     exit /b 1
 )
 
-if /i "%__BuildNative%"=="1" (
+if %__BuildNative% EQU 1 (
 
     echo %__MsgPrefix%Laying out dynamically generated files consumed by the native build system
     echo %__MsgPrefix%Laying out dynamically generated Event test files and etmdummy stub functions
@@ -387,17 +397,13 @@ if /i "%__BuildNative%"=="1" (
     "!PYTHON!" -B -Wall %__SourceDir%\scripts\genEtwProvider.py --man %__SourceDir%\vm\ClrEtwAll.man --intermediate %__IntermediatesIncDir% --exc %__SourceDir%\vm\ClrEtwAllMeta.lst || exit /b 1
 )
 
-if /i "%__BuildCoreLib%"=="1" (
+if %__BuildCoreLib% EQU 1 (
 
     echo %__MsgPrefix%Laying out dynamically generated EventSource classes
     "!PYTHON!" -B -Wall %__SourceDir%\scripts\genRuntimeEventSources.py --man %__SourceDir%\vm\ClrEtwAll.man --intermediate %__IntermediatesEventingDir% || exit /b 1
 )
 
-if /i "%__DoCrossArchBuild%"=="1" (
-    if NOT DEFINED PYTHON (
-        echo %__MsgPrefix%Error: Could not find a python installation
-        exit /b 1
-    )
+if %__BuildCrossArchNative% EQU 1 (
 
     set __CrossCompIntermediatesIncDir=%__CrossCompIntermediatesDir%\src\inc
     set __CrossCompIntermediatesEventingDir=%__CrossCompIntermediatesDir%\eventing
@@ -428,7 +434,7 @@ if %__BuildNative% EQU 1 (
 
     echo %__MsgPrefix%Commencing build of native components for %__BuildOS%.%__BuildArch%.%__BuildType%
 
-    :: Set the environment for the native build
+    REM Set the environment for the native build
     set __VCBuildArch=x86_amd64
     if /i "%__BuildArch%" == "x86" ( set __VCBuildArch=x86 )
     if /i "%__BuildArch%" == "arm" (
@@ -459,18 +465,18 @@ if %__BuildNative% EQU 1 (
     echo %__MsgPrefix%Regenerating the Visual Studio solution
 
     pushd "%__IntermediatesDir%"
-    set __ExtraCmakeArgs=!___SDKVersion! "-DCLR_CMAKE_TARGET_OS=%__BuildOs%" "-DCLR_CMAKE_PACKAGES_DIR=%__PackagesDir%" "-DCLR_CMAKE_PGO_INSTRUMENT=%__PgoInstrument%" "-DCLR_CMAKE_OPTDATA_VERSION=%__PgoOptDataVersion%" "-DCLR_CMAKE_PGO_OPTIMIZE=%__PgoOptimize%"
+    set __ExtraCmakeArgs=!___SDKVersion! "-DCLR_CMAKE_TARGET_OS=%__BuildOS%" "-DCLR_CMAKE_PACKAGES_DIR=%__PackagesDir%" "-DCLR_CMAKE_PGO_INSTRUMENT=%__PgoInstrument%" "-DCLR_CMAKE_OPTDATA_VERSION=%__PgoOptDataVersion%" "-DCLR_CMAKE_PGO_OPTIMIZE=%__PgoOptimize%"
     call "%__SourceDir%\pal\tools\gen-buildsys-win.bat" "%__ProjectDir%" %__VSVersion% %__BuildArch% !__ExtraCmakeArgs!
     @if defined _echo @echo on
     popd
 
 :SkipConfigure
-    if defined __ConfigureOnly goto SkipNativeBuild
-
     if not exist "%__IntermediatesDir%\install.vcxproj" (
         echo %__MsgPrefix%Error: failed to generate native component build project!
         exit /b 1
     )
+
+    if defined __ConfigureOnly goto SkipNativeBuild
 
     set __BuildLogRootName=CoreCLR
     set __BuildLog="%__LogsDir%\!__BuildLogRootName!_%__BuildOS%__%__BuildArch%__%__BuildType%.log"
@@ -479,8 +485,9 @@ if %__BuildNative% EQU 1 (
     set __MsbuildLog=/flp:Verbosity=normal;LogFile=!__BuildLog!
     set __MsbuildWrn=/flp1:WarningsOnly;LogFile=!__BuildWrn!
     set __MsbuildErr=/flp2:ErrorsOnly;LogFile=!__BuildErr!
+    set __Logging=-MsBuildLog=!__MsbuildLog! -MsBuildWrn=!__MsbuildWrn! -MsBuildErr=!__MsbuildErr!
 
-    call %__ProjectDir%\run.cmd build -Project=%__IntermediatesDir%\install.vcxproj -MsBuildLog=!__MsbuildLog! -MsBuildWrn=!__MsbuildWrn! -MsBuildErr=!__MsbuildErr! -configuration=%__BuildType% -platform=%__BuildArch% %__RunArgs% -MSBuildNodeCount="/m:2" %__UnprocessedBuildArgs%
+    call %__ProjectDir%\run.cmd build -Project=%__IntermediatesDir%\install.vcxproj !__Logging! -configuration=%__BuildType% -platform=%__BuildArch% %__RunArgs% -MSBuildNodeCount="/m:2" %__UnprocessedBuildArgs%
 
     if not !errorlevel! == 0 (
         echo %__MsgPrefix%Error: native component build failed. Refer to the build log files for details:
@@ -501,13 +508,13 @@ REM === Build Cross-Architecture Native Components (if applicable)
 REM ===
 REM =========================================================================================
 
-if /i "%__DoCrossArchBuild%"=="1" (
+if %__BuildCrossArchNative% EQU 1 (
     REM Scope environment changes start {
     setlocal
 
     echo %__MsgPrefix%Commencing build of cross architecture native components for %__BuildOS%.%__BuildArch%.%__BuildType%
 
-    :: Set the environment for the native build
+    REM Set the environment for the cross-arch native build
     set __VCBuildArch=x86_amd64
     if /i "%__CrossArch%" == "x86" ( set __VCBuildArch=x86 )
 
@@ -521,7 +528,7 @@ if /i "%__DoCrossArchBuild%"=="1" (
     pushd "%__CrossCompIntermediatesDir%"
     set __CMakeBinDir=%__CrossComponentBinDir%
     set "__CMakeBinDir=!__CMakeBinDir:\=/!"
-    set __ExtraCmakeArgs="-DCLR_CROSS_COMPONENTS_BUILD=1" "-DCLR_CMAKE_TARGET_ARCH=%__BuildArch%" "-DCLR_CMAKE_TARGET_OS=%__BuildOs%" "-DCLR_CMAKE_PACKAGES_DIR=%__PackagesDir%" "-DCLR_CMAKE_PGO_INSTRUMENT=%__PgoInstrument%" "-DCLR_CMAKE_OPTDATA_VERSION=%__PgoOptDataVersion%" "-DCLR_CMAKE_PGO_OPTIMIZE=%__PgoOptimize%" "-DCMAKE_SYSTEM_VERSION=10.0"
+    set __ExtraCmakeArgs="-DCLR_CROSS_COMPONENTS_BUILD=1" "-DCLR_CMAKE_TARGET_ARCH=%__BuildArch%" "-DCLR_CMAKE_TARGET_OS=%__BuildOS%" "-DCLR_CMAKE_PACKAGES_DIR=%__PackagesDir%" "-DCLR_CMAKE_PGO_INSTRUMENT=%__PgoInstrument%" "-DCLR_CMAKE_OPTDATA_VERSION=%__PgoOptDataVersion%" "-DCLR_CMAKE_PGO_OPTIMIZE=%__PgoOptimize%" "-DCMAKE_SYSTEM_VERSION=10.0"
     call "%__SourceDir%\pal\tools\gen-buildsys-win.bat" "%__ProjectDir%" %__VSVersion% %__CrossArch% !__ExtraCmakeArgs!
     @if defined _echo @echo on
     popd
@@ -541,8 +548,9 @@ if /i "%__DoCrossArchBuild%"=="1" (
     set __MsbuildLog=/flp:Verbosity=normal;LogFile=!__BuildLog!
     set __MsbuildWrn=/flp1:WarningsOnly;LogFile=!__BuildWrn!
     set __MsbuildErr=/flp2:ErrorsOnly;LogFile=!__BuildErr!
+    set __Logging=-MsBuildLog=!__MsbuildLog! -MsBuildWrn=!__MsbuildWrn! -MsBuildErr=!__MsbuildErr!
 
-    call %__ProjectDir%\run.cmd build -Project=%__CrossCompIntermediatesDir%\install.vcxproj -configuration=%__BuildType% -platform=%__CrossArch% -MsBuildLog=!__MsbuildLog! -MsBuildWrn=!__MsbuildWrn! -MsBuildErr=!__MsbuildErr! %__RunArgs% -MSBuildNodeCount="/m:2" %__UnprocessedBuildArgs%
+    call %__ProjectDir%\run.cmd build -Project=%__CrossCompIntermediatesDir%\install.vcxproj !__Logging! -configuration=%__BuildType% -platform=%__CrossArch% %__RunArgs% -MSBuildNodeCount="/m:2" %__UnprocessedBuildArgs%
 
     if not !errorlevel! == 0 (
         echo %__MsgPrefix%Error: cross-arch components build failed. Refer to the build log files for details:
@@ -573,8 +581,8 @@ if %__BuildCoreLib% EQU 1 (
 
     set __ExtraBuildArgs=
     if not defined __IbcTuning (
-      set __ExtraBuildArgs=!__ExtraBuildArgs! -OptimizationDataDir="%__PackagesDir%/optimization.%__BuildOS%-%__BuildArch%.IBC.CoreCLR/%__IbcOptDataVersion%/data/"
-      set __ExtraBuildArgs=!__ExtraBuildArgs! -EnableProfileGuidedOptimization=true
+        set __ExtraBuildArgs=!__ExtraBuildArgs! -OptimizationDataDir="%__PackagesDir%/optimization.%__BuildOS%-%__BuildArch%.IBC.CoreCLR/%__IbcOptDataVersion%/data/"
+        set __ExtraBuildArgs=!__ExtraBuildArgs! -EnableProfileGuidedOptimization=true
     )
 
     if "%__BuildSOS%" == "0" (
@@ -585,12 +593,10 @@ if %__BuildCoreLib% EQU 1 (
         set __ExtraBuildArgs=!__ExtraBuildArgs! -BuildManagedTools=true
     )
 
-    if /i "%__BuildArch%" == "arm64" (
-        set __nugetBuildArgs=-buildNugetPackage=false
-    ) else if "%__SkipNugetPackage%" == "1" (
-        set __nugetBuildArgs=-buildNugetPackage=false
+    if "%__SkipNugetPackage%" == "1" (
+        set __ExtraBuildArgs=!__ExtraBuildArgs! -buildNugetPackage=false
     ) else (
-        set __nugetBuildArgs=-buildNugetPackage=true
+        set __ExtraBuildArgs=!__ExtraBuildArgs! -buildNugetPackage=true
     )
 
     set __BuildLogRootName=System.Private.CoreLib
@@ -600,8 +606,9 @@ if %__BuildCoreLib% EQU 1 (
     set __MsbuildLog=/flp:Verbosity=normal;LogFile=!__BuildLog!
     set __MsbuildWrn=/flp1:WarningsOnly;LogFile=!__BuildWrn!
     set __MsbuildErr=/flp2:ErrorsOnly;LogFile=!__BuildErr!
+    set __Logging=-MsBuildLog=!__MsbuildLog! -MsBuildWrn=!__MsbuildWrn! -MsBuildErr=!__MsbuildErr!
 
-    call %__ProjectDir%\run.cmd build -Project=%__ProjectDir%\build.proj -MsBuildLog=!__MsbuildLog! -MsBuildWrn=!__MsbuildWrn! -MsBuildErr=!__MsbuildErr! !__nugetBuildArgs! %__RunArgs% !__ExtraBuildArgs! %__UnprocessedBuildArgs%
+    call %__ProjectDir%\run.cmd build -Project=%__ProjectDir%\build.proj !__Logging! %__RunArgs% !__ExtraBuildArgs! %__UnprocessedBuildArgs%
 
     if not !errorlevel! == 0 (
         echo %__MsgPrefix%Error: System.Private.CoreLib build failed. Refer to the build log files for details:
@@ -614,6 +621,12 @@ if %__BuildCoreLib% EQU 1 (
     REM } Scope environment changes end
     endlocal
 )
+
+REM =========================================================================================
+REM ===
+REM === Build native System.Private.CoreLib.
+REM ===
+REM =========================================================================================
 
 REM Scope environment changes start {
 setlocal
@@ -640,12 +653,12 @@ if %__BuildNativeCoreLib% EQU 1 (
         REM HACK: Workaround for [dotnet/coreclr#13970](https://github.com/dotnet/coreclr/issues/13970)
         set __PgoRtPath=
         for /f "tokens=*" %%f in ('where pgort*.dll') do (
-          if not defined __PgoRtPath set "__PgoRtPath=%%~f"
+            if not defined __PgoRtPath set "__PgoRtPath=%%~f"
         )
         echo %__MsgPrefix%Copying "!__PgoRtPath!" into "%__BinDir%"
         copy /y "!__PgoRtPath!" "%__BinDir%" || (
-          echo %__MsgPrefix%Error: copy failed
-          goto CrossgenFailure
+            echo %__MsgPrefix%Error: copy failed
+            goto CrossgenFailure
         )
         REM End HACK
     )
@@ -669,7 +682,7 @@ if %__BuildNativeCoreLib% EQU 1 (
     !NEXTCMD! >> "%__CrossGenCoreLibLog%" 2>&1
     if NOT !errorlevel! == 0 (
         echo %__MsgPrefix%Error: CrossGen System.Private.CoreLib build failed. Refer to %__CrossGenCoreLibLog%
-        :: Put it in the same log, helpful for Jenkins
+        REM Put it in the same log, helpful for Jenkins
         type %__CrossGenCoreLibLog%
         goto CrossgenFailure
     )
@@ -680,7 +693,7 @@ if %__BuildNativeCoreLib% EQU 1 (
     !NEXTCMD! >> "%__CrossGenCoreLibLog%" 2>&1
     if NOT !errorlevel! == 0 (
         echo %__MsgPrefix%Error: CrossGen /CreatePdb System.Private.CoreLib build failed. Refer to %__CrossGenCoreLibLog%
-        :: Put it in the same log, helpful for Jenkins
+        REM Put it in the same log, helpful for Jenkins
         type %__CrossGenCoreLibLog%
         goto CrossgenFailure
     )
@@ -689,6 +702,11 @@ if %__BuildNativeCoreLib% EQU 1 (
 REM } Scope environment changes end
 endlocal
 
+REM =========================================================================================
+REM ===
+REM === Build packages
+REM ===
+REM =========================================================================================
 
 if %__BuildPackages% EQU 1 (
     REM Scope environment changes start {
@@ -703,12 +721,13 @@ if %__BuildPackages% EQU 1 (
     set __MsbuildLog=/flp:Verbosity=normal;LogFile=!__BuildLog!
     set __MsbuildWrn=/flp1:WarningsOnly;LogFile=!__BuildWrn!
     set __MsbuildErr=/flp2:ErrorsOnly;LogFile=!__BuildErr!
+    set __Logging=-MsBuildLog=!__MsbuildLog! -MsBuildWrn=!__MsbuildWrn! -MsBuildErr=!__MsbuildErr!
 
     REM The conditions as to what to build are captured in the builds file.
-    call %__ProjectDir%\run.cmd build -Project=%__SourceDir%\.nuget\packages.builds -platform=%__BuildArch% -MsBuildLog=!__MsbuildLog! -MsBuildWrn=!__MsbuildWrn! -MsBuildErr=!__MsbuildErr! %__RunArgs% %__UnprocessedBuildArgs%
+    call %__ProjectDir%\run.cmd build -Project=%__SourceDir%\.nuget\packages.builds !__Logging! -platform=%__BuildArch% %__RunArgs% %__UnprocessedBuildArgs%
 
     if not !errorlevel! == 0 (
-        echo %__MsgPrefix%Error: Nuget package generation failed build failed. Refer to the build log files for details:
+        echo %__MsgPrefix%Error: Nuget package generation failed. Refer to the build log files for details:
         echo     !__BuildLog!
         echo     !__BuildWrn!
         echo     !__BuildErr!
@@ -755,11 +774,8 @@ REM === All builds complete!
 REM ===
 REM =========================================================================================
 
-echo %__MsgPrefix%Repo successfully built.  Finished at %TIME%
+echo %__MsgPrefix%Build succeeded.  Finished at %TIME%
 echo %__MsgPrefix%Product binaries are available at !__BinDir!
-if %__BuildTests% EQU 1 (
-    echo %__MsgPrefix%Test binaries are available at !__TestBinDir!
-)
 exit /b 0
 
 REM =========================================================================================
@@ -851,7 +867,7 @@ echo.
 echo Usage:
 echo     build.cmd [option1] [option2]
 echo or:
-echo     build.cmd all [option1] [option2] -- ...
+echo     build.cmd all [option1] [option2]
 echo.
 echo All arguments are optional. The options are:
 echo.
@@ -859,7 +875,6 @@ echo.-? -h -help --help: view this message.
 echo -all: Builds all configurations and platforms.
 echo Build architecture: one of -x64, -x86, -arm, -arm64 ^(default: -x64^).
 echo Build type: one of -Debug, -Checked, -Release ^(default: -Debug^).
-echo -- ... : all arguments following this tag will be passed directly to msbuild.
 echo mscorlib version: one of -freebsdmscorlib, -linuxmscorlib, -netbsdmscorlib, -osxmscorlib,
 echo     or -windowsmscorlib. If one of these is passed, only System.Private.CoreLib is built,
 echo     for the specified platform ^(FreeBSD, Linux, NetBSD, OS X or Windows,
@@ -901,7 +916,7 @@ echo Error: DIA SDK is missing at "%VSINSTALLDIR%DIA SDK". ^
 This is due to a bug in the Visual Studio installer. It does not install DIA SDK at "%VSINSTALLDIR%" but rather ^
 at the install location of previous Visual Studio version. The workaround is to copy the DIA SDK folder from the Visual Studio install location ^
 of the previous version to "%VSINSTALLDIR%" and then build.
-:: DIA SDK not included in Express editions
+REM DIA SDK not included in Express editions
 echo Visual Studio Express does not include the DIA SDK. ^
 You need Visual Studio 2015 or 2017 (Community is free).
 echo See: https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/developer-guide.md#prerequisites


### PR DESCRIPTION
Various minor cleanups:
1. Use the same naming/style for all three.
2. Make the style consistent throughout each. E.g., consistent indents,
   capitalization.
3. Add more consistent output, including the prefix tag used everywhere.
4. build.cmd: only build cross components if native build is enabled.
5. Use new __Logging variable to consolidate all logging arguments,
   to reduce large (unexpanded) command line lengths.