### PR TITLE
JIT: recompute local ref counts after lower

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -5249,6 +5249,12 @@ void Lowering::DoPhase()
     }
 #endif
 
+    // Recompute local var ref counts before potentially sorting.
+    // Note this does minimal work in cases where we are not going to sort.
+    const bool isRecompute    = true;
+    const bool setSlotNumbers = false;
+    comp->lvaComputeRefCounts(isRecompute, setSlotNumbers);
+
     // TODO-Throughput: We re-sort local variables to get the goodness of enregistering recently
     // introduced local variables both by Rationalize and Lower; downside is we need to
     // recompute standard local variable liveness in order to get Linear CodeGen working.


### PR DESCRIPTION
Update `lvaComputeRefCounts` to encapsulate running ref counts post-lower
and to also handle the fast jitting cases.

Invoke this after lower to provide recomputed (and more accurate) counts.

Part of #18969.