### PR TITLE
Don't early terminate on null for 64bit NR HashCode

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/NonRandomizedStringEqualityComparer.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/NonRandomizedStringEqualityComparer.cs
@@ -23,7 +23,7 @@ namespace System.Collections.Generic
 
         public sealed override bool Equals(string x, string y) => string.Equals(x, y);
 
-        public sealed override int GetHashCode(string obj) => obj?.GetLegacyNonRandomizedHashCode() ?? 0;
+        public sealed override int GetHashCode(string obj) => obj?.GetNonRandomizedHashCode() ?? 0;
 
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {

--- a/src/System.Private.CoreLib/shared/System/String.Comparison.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Comparison.cs
@@ -771,16 +771,18 @@ namespace System
                     int hash2 = hash1;
 
 #if BIT64
-                    int c;
-                    char* s = src;
-                    while ((c = s[0]) != 0)
+                    char* current = src;
+                    char* end = current + this.Length;
+                    while (current < end - 1)
                     {
-                        hash1 = ((hash1 << 5) + hash1) ^ c;
-                        c = s[1];
-                        if (c == 0)
-                            break;
-                        hash2 = ((hash2 << 5) + hash2) ^ c;
-                        s += 2;
+                        hash1 = ((hash1 << 5) + hash1) ^ current[0];
+                        hash2 = ((hash2 << 5) + hash2) ^ current[1];
+                        current += 2;
+                    }
+
+                    if (current < end)
+                    {
+                        hash1 = ((hash1 << 5) + hash1) ^ current[0];
                     }
 #else // !BIT64 (32)
                     // 32 bit machines.

--- a/src/System.Private.CoreLib/shared/System/String.Comparison.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Comparison.cs
@@ -753,8 +753,8 @@ namespace System
         // that string.Equals(A, B, C), then they will return the same hash code with this comparison C.
         public int GetHashCode(StringComparison comparisonType) => StringComparer.FromComparison(comparisonType).GetHashCode(this);
 
-        // Use this if and only if you need the hashcode to not change across app domains (e.g. you have an app domain agile
-        // hash table).
+        // Use this if and only if 'Denial of Service' attacks are not a concern (i.e. never used for free-form user input),
+        // or are otherwise mitigated
         internal unsafe int GetNonRandomizedHashCode()
         {
             fixed (char* src = &_firstChar)

--- a/src/System.Private.CoreLib/src/System/RtType.cs
+++ b/src/System.Private.CoreLib/src/System/RtType.cs
@@ -5100,7 +5100,7 @@ namespace System.Reflection
             }
             else
             {
-                return sKey.GetLegacyNonRandomizedHashCode();
+                return sKey.GetNonRandomizedHashCode();
             }
         }
 


### PR DESCRIPTION
As used by `NonRandomizedStringEqualityComparer` in `Dictionary<string, TValue>` before it moves to randomized hashing when collisions become high.

Resolves https://github.com/dotnet/coreclr/issues/4681

Merges 32 and 64 bit paths and improves performance ~x2 for longer strings https://github.com/dotnet/coreclr/pull/19331#issuecomment-412242360

Using the 466,544 word from words.txt from https://github.com/dwyl/english-words; and discounting high bit from hashcode (as per Dictionary key)

**Current HashCode**: 90 single collisions, 466364 no collisions
**Improved HashCode**: 119 single collision, 466306 no collisions

```
               Method |                 Input |       Mean | Scaled |
--------------------- |---------------------- |-----------:|-------:|
 Current64BitHashCode |                     1 |   3.037 ns |   1.00 |
     ImprovedHashCode |                     1 |   2.660 ns |   0.88 |
                      |                       |            |        |
 Current64BitHashCode |                    12 |   3.342 ns |   1.00 |
     ImprovedHashCode |                    12 |   2.663 ns |   0.80 |
                      |                       |            |        |
 Current64BitHashCode |                   123 |   3.909 ns |   1.00 |
     ImprovedHashCode |                   123 |   3.189 ns |   0.82 |
                      |                       |            |        |
 Current64BitHashCode |                  1234 |   4.359 ns |   1.00 |
     ImprovedHashCode |                  1234 |   3.183 ns |   0.73 |
                      |                       |            |        |
 Current64BitHashCode |                 12345 |   5.053 ns |   1.00 |
     ImprovedHashCode |                 12345 |   3.489 ns |   0.69 |
                      |                       |            |        |
 Current64BitHashCode |                123456 |   5.453 ns |   1.00 |
     ImprovedHashCode |                123456 |   3.514 ns |   0.64 |
                      |                       |            |        |
 Current64BitHashCode |               1234567 |   6.058 ns |   1.00 |
     ImprovedHashCode |               1234567 |   4.299 ns |   0.71 |
                      |                       |            |        |
 Current64BitHashCode |              12345678 |   6.581 ns |   1.00 |
     ImprovedHashCode |              12345678 |   4.294 ns |   0.65 |
                      |                       |            |        |
 Current64BitHashCode |             123456789 |   7.148 ns |   1.00 |
     ImprovedHashCode |             123456789 |   4.617 ns |   0.65 |
                      |                       |            |        |
 Current64BitHashCode |            1234567890 |   7.693 ns |   1.00 |
     ImprovedHashCode |            1234567890 |   4.619 ns |   0.60 |
                      |                       |            |        |
 Current64BitHashCode |  12345678901234567890 |  13.321 ns |   1.00 |
     ImprovedHashCode |  12345678901234567890 |   7.900 ns |   0.59 |
                      |                       |            |        |
 Current64BitHashCode |  12345(...)67890 [40] |  25.748 ns |   1.00 |
     ImprovedHashCode |  12345(...)67890 [40] |  13.409 ns |   0.52 |
                      |                       |            |        |
 Current64BitHashCode |  12345(...)67890 [80] |  54.932 ns |   1.00 |
     ImprovedHashCode |  12345(...)67890 [80] |  25.713 ns |   0.47 |
                      |                       |            |        |
 Current64BitHashCode | 12345(...)67890 [160] | 100.144 ns |   1.00 |
     ImprovedHashCode | 12345(...)67890 [160] |  50.712 ns |   0.51 |
```

@jkotas @GrabYourPitchforks its also used by `RtType.GetHashCodeHelper` https://github.com/dotnet/coreclr/blob/ab9b4511180d1dfde09d1480c29a7bbacf3587dd/src/System.Private.CoreLib/src/System/RtType.cs#L5096-L5104 would this be a concern (e.g changed behaviour for `abcd\0efgh`)

/cc @IDisposable @jamesqo 