### PR TITLE
Update vc-runtime package used by Windows ARM/ARM64 testing

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -41,7 +41,7 @@
     <XunitPerformanceApiPackageVersion>1.0.0-beta-build0015</XunitPerformanceApiPackageVersion>
     <MicrosoftDiagnosticsTracingTraceEventPackageVersion>2.0.4</MicrosoftDiagnosticsTracingTraceEventPackageVersion>
     <CommandLineParserVersion>2.2.0</CommandLineParserVersion>
-    <VCRuntimeVersion>1.2.0</VCRuntimeVersion>
+    <VCRuntimeVersion>2.0.0</VCRuntimeVersion>
     
     <!-- Scenario tests install this version of Microsoft.NetCore.App, then patch coreclr binaries via xcopy. At the moment it is
          updated manually whenever breaking changes require it to move forward, but it would be nice if we could update it automatically

--- a/netci.groovy
+++ b/netci.groovy
@@ -3227,12 +3227,6 @@ def static CreateWindowsArmTestJob(def dslFactory, def project, def architecture
                 def archLocation = testListArch[architecture]
 
                 addCommand("copy %WORKSPACE%\\tests\\${archLocation}\\Tests.lst bin\\tests\\${osGroup}.${architecture}.${configuration}")
-
-                if (architecture == "arm64") {
-                    addCommand("copy C:\\Jenkins\\vcruntime140.dll bin\\tests\\${osGroup}.${architecture}.${configuration}\\Tests\\Core_Root")
-                    addCommand("copy C:\\Jenkins\\vcruntime140d.dll bin\\tests\\${osGroup}.${architecture}.${configuration}\\Tests\\Core_Root")
-                }
-
                 addCommand("pushd bin\\tests\\${osGroup}.${architecture}.${configuration}")
                 addCommand("${smartyCommand}")
 

--- a/src/vm/i386/gmsx86.cpp
+++ b/src/vm/i386/gmsx86.cpp
@@ -126,7 +126,7 @@ static bool shouldEnterCall(PTR_BYTE ip) {
 
     int pushes = 0;
 
-    // we should start unbalenced pops within 48 instrs. If not, it is not a special epilog function
+    // we should start unbalanced pops within 48 instrs. If not, it is not a special epilog function
     // the only reason we need as many instructions as we have below is because  coreclr
     // gets instrumented for profiling, code coverage, BBT etc, and we want these things to
     // just work.
@@ -134,6 +134,7 @@ static bool shouldEnterCall(PTR_BYTE ip) {
         switch(*ip) {
             case 0xF2:              // repne
             case 0xF3:              // repe
+            case 0x90:              // nop
                 ip++;
                 break;
 

--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -10417,7 +10417,7 @@ RelativePath=Exceptions\ForeignThread\ForeignThreadExceptions\ForeignThreadExcep
 WorkingDir=Exceptions\ForeignThread\ForeignThreadExceptions
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;12898
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [box-unbox-generics013.cmd_1310]

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -89585,7 +89585,7 @@ RelativePath=Exceptions\ForeignThread\ForeignThreadExceptions\ForeignThreadExcep
 WorkingDir=Exceptions\ForeignThread\ForeignThreadExceptions
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;10636;NEW
+Categories=EXPECTED_PASS;NEW
 HostStyle=0
 
 [MathFExp.cmd_11575]

--- a/tests/build.proj
+++ b/tests/build.proj
@@ -26,7 +26,7 @@
     <RestoreProjects Include="$(MSBuildThisFileDirectory)src\Common\targeting_pack_ref\targeting_pack_ref.csproj" />
     <RestoreProjects Include="$(MSBuildThisFileDirectory)src\Common\test_dependencies\test_dependencies.csproj" />
     <RestoreProjects Include="$(MSBuildThisFileDirectory)src\Common\test_runtime\test_runtime.csproj" />
-    <RestoreProjects Include="$(MSBuildThisFileDirectory)src\Common\vc_runtime\vc_runtime.csproj" Condition="'$(__BuildArch)' == 'arm'"/>
+    <RestoreProjects Include="$(MSBuildThisFileDirectory)src\Common\vc_runtime\vc_runtime.csproj" Condition="'$(__BuildArch)' == 'arm' or '$(__BuildArch)' == 'arm64'"/>
     <RestoreProjects Include="$(MSBuildThisFileDirectory)src\JIT\config\benchmark+roslyn\benchmark+roslyn.csproj" />
     <RestoreProjects Include="$(MSBuildThisFileDirectory)src\JIT\config\benchmark+serialize\benchmark+serialize.csproj" />
     <RestoreProjects Include="$(MSBuildThisFileDirectory)src\JIT\config\benchmark\benchmark.csproj" />

--- a/tests/publishdependency.targets
+++ b/tests/publishdependency.targets
@@ -32,7 +32,7 @@
 
   <ItemGroup>
     <CrossGenFiles Include="..\packages\runtime.$(TargetRid).Microsoft.NETCore.Runtime.CoreCLR\$(DesiredPackageVersionArg)\tools\crossgen*"/>
-    <VCRuntimeFiles Include="..\packages\vc-runtime\$(VCRuntimeVersion)\lib\netcoreapp1.1\*.dll"/>
+    <VCRuntimeFiles Include="..\packages\vc-runtime\$(VCRuntimeVersion)\content\VC\Redist\MSVC\14.14.26405\onecore\$(BuildArch)\Microsoft.VC141.CRT\*"/>
   </ItemGroup>
 
   <PropertyGroup>
@@ -162,7 +162,7 @@
   <Target Name="CopyVCRuntimeToCoreRoot"
     AfterTargets="CopyDependecyToCoreRoot"
     Outputs="$(CORE_ROOT)\*.*"
-    Condition="'$(BuildArch)' == 'arm'">
+    Condition="'$(BuildArch)' == 'arm' or '$(BuildArch)' == 'arm64'">
 
     <Copy
       SourceFiles="@(VCRuntimeFiles)"

--- a/tests/src/Common/vc_runtime/vc_runtime.csproj
+++ b/tests/src/Common/vc_runtime/vc_runtime.csproj
@@ -5,8 +5,8 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <NugetTargetMoniker>.NETCoreApp,Version=v1.1</NugetTargetMoniker>
-    <NugetTargetMonikerShort>netcoreapp1.1</NugetTargetMonikerShort>
+    <NugetTargetMoniker>.NETCoreApp,Version=v3.0</NugetTargetMoniker>
+    <NugetTargetMonikerShort>netcoreapp3.0</NugetTargetMonikerShort>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
@@ -15,10 +15,10 @@
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;netcoreapp1.1;portable-net45+win8</PackageTargetFallback>
-    <RuntimeIdentifiers>win-arm</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-arm;win-arm64</RuntimeIdentifiers>
     <ContainsPackageReferences>true</ContainsPackageReferences>
     <PrereleaseResolveNuGetPackages>false</PrereleaseResolveNuGetPackages>
   </PropertyGroup>


### PR DESCRIPTION
This package contains VC++ redistributable CRT binaries necessary for running native code on Windows ARM and ARM64. It already existed for ARM. Extend it to support ARM64, now that ARM64 tools are public.

Update both to the current versions shipped by Visual Studio 2017.

The package is published here: https://dotnet.myget.org/feed/dotnet-core/package/nuget/vc-runtime/2.0.0

It was created by creating the following directory structure:
```
vc-runtime.nuspec
content\VC\Redist\MSVC\14.14.26405\onecore\arm\Microsoft.VC141.CRT\concrt140.dll
content\VC\Redist\MSVC\14.14.26405\onecore\arm\Microsoft.VC141.CRT\msvcp140.dll
content\VC\Redist\MSVC\14.14.26405\onecore\arm\Microsoft.VC141.CRT\msvcp140_1.dll
content\VC\Redist\MSVC\14.14.26405\onecore\arm\Microsoft.VC141.CRT\msvcp140_2.dll
content\VC\Redist\MSVC\14.14.26405\onecore\arm\Microsoft.VC141.CRT\vccorlib140.dll
content\VC\Redist\MSVC\14.14.26405\onecore\arm\Microsoft.VC141.CRT\vcruntime140.dll
content\VC\Redist\MSVC\14.14.26405\onecore\arm64\Microsoft.VC141.CRT\concrt140.dll
content\VC\Redist\MSVC\14.14.26405\onecore\arm64\Microsoft.VC141.CRT\msvcp140.dll
content\VC\Redist\MSVC\14.14.26405\onecore\arm64\Microsoft.VC141.CRT\msvcp140_1.dll
content\VC\Redist\MSVC\14.14.26405\onecore\arm64\Microsoft.VC141.CRT\msvcp140_2.dll
content\VC\Redist\MSVC\14.14.26405\onecore\arm64\Microsoft.VC141.CRT\vccorlib140.dll
content\VC\Redist\MSVC\14.14.26405\onecore\arm64\Microsoft.VC141.CRT\vcruntime140.dll
```

and using "nuget.exe pack".
