### PR TITLE
CallDescr/TransitionBlock changes for ARM64 calling convention

### DIFF
--- a/src/pal/inc/unixasmmacrosarm64.inc
+++ b/src/pal/inc/unixasmmacrosarm64.inc
@@ -162,6 +162,7 @@ C_FUNC(\Name\()_End):
 
         __PWTB_StackAlloc = __PWTB_TransitionBlock
         __PWTB_ArgumentRegisters = __PWTB_StackAlloc + 96
+        __PWTB_ArgumentRegister_FirstArg = __PWTB_ArgumentRegisters + 8
 
         PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, -176
         // Spill callee saved registers

--- a/src/vm/arm64/CallDescrWorkerARM64.asm
+++ b/src/vm/arm64/CallDescrWorkerARM64.asm
@@ -62,15 +62,18 @@ Ldonestack
         ldp     d6, d7, [x9, #48]
 LNoFloatingPoint
 
-        ;; Copy [pArgumentRegisters, ..., pArgumentRegisters + 64]
-        ;; into x0, ..., x7, x8
+        ;; Copy [pArgumentRegisters, ..., pArgumentRegisters + 56]
+        ;; into x0, ..., x7
 
         ldr     x9, [x19,#CallDescrData__pArgumentRegisters]
         ldp     x0, x1, [x9]
         ldp     x2, x3, [x9, #16]
         ldp     x4, x5, [x9, #32]
         ldp     x6, x7, [x9, #48]
-        ldr     x8, [x9, #64]
+
+        ;; Copy pRetBuffArg into x8
+        ldr     x9, [x19,#CallDescrData__pRetBuffArg]
+        ldr     x8, [x9]
 
         ;; call pTarget
         ldr     x9, [x19,#CallDescrData__pTarget]

--- a/src/vm/arm64/asmconstants.h
+++ b/src/vm/arm64/asmconstants.h
@@ -55,19 +55,20 @@ ASMCONSTANTS_C_ASSERT(AppDomain__m_dwId == offsetof(AppDomain, m_dwId));
 
 #define METHODDESC_REGISTER            x12
 
-#define SIZEOF__ArgumentRegisters 0x48
+#define SIZEOF__ArgumentRegisters 0x40
 ASMCONSTANTS_C_ASSERT(SIZEOF__ArgumentRegisters == sizeof(ArgumentRegisters))
 
 #define SIZEOF__FloatArgumentRegisters 0x40
 ASMCONSTANTS_C_ASSERT(SIZEOF__FloatArgumentRegisters == sizeof(FloatArgumentRegisters))
 
-#define CallDescrData__pSrc                0x00
-#define CallDescrData__numStackSlots       0x08
-#define CallDescrData__pArgumentRegisters  0x10
-#define CallDescrData__pFloatArgumentRegisters 0x18
-#define CallDescrData__fpReturnSize        0x20
-#define CallDescrData__pTarget             0x28
-#define CallDescrData__returnValue         0x30
+#define CallDescrData__pSrc                     0x00
+#define CallDescrData__numStackSlots            0x08
+#define CallDescrData__pArgumentRegisters       0x10
+#define CallDescrData__pFloatArgumentRegisters  0x18
+#define CallDescrData__fpReturnSize             0x20
+#define CallDescrData__pTarget                  0x28
+#define CallDescrData__pRetBuffArg              0x30
+#define CallDescrData__returnValue              0x38
 
 ASMCONSTANTS_C_ASSERT(CallDescrData__pSrc                 == offsetof(CallDescrData, pSrc))
 ASMCONSTANTS_C_ASSERT(CallDescrData__numStackSlots        == offsetof(CallDescrData, numStackSlots))
@@ -75,6 +76,7 @@ ASMCONSTANTS_C_ASSERT(CallDescrData__pArgumentRegisters   == offsetof(CallDescrD
 ASMCONSTANTS_C_ASSERT(CallDescrData__pFloatArgumentRegisters == offsetof(CallDescrData, pFloatArgumentRegisters))
 ASMCONSTANTS_C_ASSERT(CallDescrData__fpReturnSize         == offsetof(CallDescrData, fpReturnSize))
 ASMCONSTANTS_C_ASSERT(CallDescrData__pTarget              == offsetof(CallDescrData, pTarget))
+ASMCONSTANTS_C_ASSERT(CallDescrData__pRetBuffArg          == offsetof(CallDescrData, pRetBuffArg))
 ASMCONSTANTS_C_ASSERT(CallDescrData__returnValue          == offsetof(CallDescrData, returnValue))
 
 #define                  CORINFO_NullReferenceException_ASM 0

--- a/src/vm/arm64/asmhelpers.S
+++ b/src/vm/arm64/asmhelpers.S
@@ -1253,7 +1253,7 @@ DelayLoad_Helper\suffix:
     mov x4, \frameFlags
     bl DynamicHelperWorker
     cbnz x0, LOCAL_LABEL(FakeProlog\suffix\()_0)
-    ldr x0, [sp, #__PWTB_ArgumentRegisters]
+    ldr x0, [sp, #__PWTB_ArgumentRegister_FirstArg]
     EPILOG_WITH_TRANSITION_BLOCK_RETURN
 LOCAL_LABEL(FakeProlog\suffix\()_0):
     mov x12, x0

--- a/src/vm/arm64/asmhelpers.S
+++ b/src/vm/arm64/asmhelpers.S
@@ -562,7 +562,7 @@ LEAF_END SinglecastDelegateInvokeStub, _TEXT
 #ifdef FEATURE_COMINTEROP
 
 #define ComCallPreStub_FrameSize (SIZEOF__GSCookie + SIZEOF__ComMethodFrame)
-#define ComCallPreStub_FirstStackAdjust  (SIZEOF__ArgumentRegisters + 2 * 8) // reg args , fp & lr already pushed
+#define ComCallPreStub_FirstStackAdjust  (8 + SIZEOF__ArgumentRegisters + 2 * 8) // x8, reg args , fp & lr already pushed
 #define ComCallPreStub_StackAlloc0        (ComCallPreStub_FrameSize - ComCallPreStub_FirstStackAdjust)
 #define ComCallPreStub_StackAlloc1        (ComCallPreStub_StackAlloc0 + SIZEOF__FloatArgumentRegisters + 8)// 8 for ErrorReturn
 #define ComCallPreStub_StackAlloc    (ComCallPreStub_StackAlloc1 + (ComCallPreStub_StackAlloc1 & 8))
@@ -692,7 +692,7 @@ COMToCLRDispatchHelper_RegSetup
     ldp x2, x3, [x1, #(SIZEOF__ComMethodFrame - SIZEOF__ArgumentRegisters + 16)]
     ldp x4, x5, [x1, #(SIZEOF__ComMethodFrame - SIZEOF__ArgumentRegisters + 32)]
     ldp x6, x7, [x1, #(SIZEOF__ComMethodFrame - SIZEOF__ArgumentRegisters + 48)]
-    ldr x8, [x1, #(SIZEOF__ComMethodFrame - SIZEOF__ArgumentRegisters + 64)]
+    ldr x8, [x1, #(SIZEOF__ComMethodFrame - SIZEOF__ArgumentRegisters - 8)]
 
     ldr x1, [x1, #(SIZEOF__ComMethodFrame - SIZEOF__ArgumentRegisters + 8)]
 

--- a/src/vm/arm64/asmhelpers.asm
+++ b/src/vm/arm64/asmhelpers.asm
@@ -533,7 +533,7 @@ LNullThis
     GBLA ComCallPreStub_FirstStackAdjust
 
 ComCallPreStub_FrameSize         SETA (SIZEOF__GSCookie + SIZEOF__ComMethodFrame)
-ComCallPreStub_FirstStackAdjust  SETA (SIZEOF__ArgumentRegisters + 2 * 8) ; reg args , fp & lr already pushed
+ComCallPreStub_FirstStackAdjust  SETA (8 + SIZEOF__ArgumentRegisters + 2 * 8) ; x8, reg args , fp & lr already pushed
 ComCallPreStub_StackAlloc        SETA ComCallPreStub_FrameSize - ComCallPreStub_FirstStackAdjust 
 ComCallPreStub_StackAlloc        SETA ComCallPreStub_StackAlloc + SIZEOF__FloatArgumentRegisters + 8; 8 for ErrorReturn
     IF ComCallPreStub_StackAlloc:MOD:16 != 0
@@ -603,7 +603,7 @@ ComCallPreStub_ErrorExit
     GBLA GenericComCallStub_FirstStackAdjust
 
 GenericComCallStub_FrameSize         SETA (SIZEOF__GSCookie + SIZEOF__ComMethodFrame)
-GenericComCallStub_FirstStackAdjust  SETA (SIZEOF__ArgumentRegisters + 2 * 8)
+GenericComCallStub_FirstStackAdjust  SETA (8 + SIZEOF__ArgumentRegisters + 2 * 8)
 GenericComCallStub_StackAlloc        SETA GenericComCallStub_FrameSize - GenericComCallStub_FirstStackAdjust
 GenericComCallStub_StackAlloc        SETA GenericComCallStub_StackAlloc + SIZEOF__FloatArgumentRegisters
 
@@ -676,7 +676,7 @@ COMToCLRDispatchHelper_RegSetup
     ldp x2, x3, [x1, #(SIZEOF__ComMethodFrame - SIZEOF__ArgumentRegisters + 16)]
     ldp x4, x5, [x1, #(SIZEOF__ComMethodFrame - SIZEOF__ArgumentRegisters + 32)]
     ldp x6, x7, [x1, #(SIZEOF__ComMethodFrame - SIZEOF__ArgumentRegisters + 48)]
-    ldr x8, [x1, #(SIZEOF__ComMethodFrame - SIZEOF__ArgumentRegisters + 64)]
+    ldr x8, [x1, #(SIZEOF__ComMethodFrame - SIZEOF__ArgumentRegisters - 8)]
 
     ldr x1, [x1, #(SIZEOF__ComMethodFrame - SIZEOF__ArgumentRegisters + 8)]
 

--- a/src/vm/arm64/asmhelpers.asm
+++ b/src/vm/arm64/asmhelpers.asm
@@ -1262,9 +1262,9 @@ Fail
         mov x4, $frameFlags
         bl DynamicHelperWorker
         cbnz x0, %FT0
-        ldr x0, [sp, #__PWTB_ArgumentRegisters]
+        ldr x0, [sp, #__PWTB_ArgumentRegister_FirstArg]
         EPILOG_WITH_TRANSITION_BLOCK_RETURN
-0		
+0
         mov x12, x0
         EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
         EPILOG_BRANCH_REG  x12

--- a/src/vm/arm64/asmmacros.h
+++ b/src/vm/arm64/asmmacros.h
@@ -72,7 +72,7 @@ __PWTB_TransitionBlock SETA __PWTB_FloatArgumentRegisters
         ENDIF
 
 __PWTB_StackAlloc SETA __PWTB_TransitionBlock
-__PWTB_ArgumentRegisters SETA __PWTB_StackAlloc + 96 
+__PWTB_ArgumentRegisters SETA __PWTB_StackAlloc + 104
 
         PROLOG_SAVE_REG_PAIR   fp, lr, #-176!
         ; Spill callee saved registers 
@@ -172,11 +172,12 @@ __PWTB_SAVE_ARGUMENT_REGISTERS_OFFSET SETA $offset
 __PWTB_SAVE_ARGUMENT_REGISTERS_OFFSET SETA 0
        ENDIF
 
-        stp                    x0, x1, [$reg, #(__PWTB_SAVE_ARGUMENT_REGISTERS_OFFSET)]
-        stp                    x2, x3, [$reg, #(__PWTB_SAVE_ARGUMENT_REGISTERS_OFFSET + 16)]
-        stp                    x4, x5, [$reg, #(__PWTB_SAVE_ARGUMENT_REGISTERS_OFFSET + 32)]
-        stp                    x6, x7, [$reg, #(__PWTB_SAVE_ARGUMENT_REGISTERS_OFFSET + 48)]
-        str                    x8, [$reg, #(__PWTB_SAVE_ARGUMENT_REGISTERS_OFFSET + 64)]
+        str                    x8, [$reg, #(__PWTB_SAVE_ARGUMENT_REGISTERS_OFFSET)]
+        stp                    x0, x1, [$reg, #(__PWTB_SAVE_ARGUMENT_REGISTERS_OFFSET + 8)]
+        stp                    x2, x3, [$reg, #(__PWTB_SAVE_ARGUMENT_REGISTERS_OFFSET + 24)]
+        stp                    x4, x5, [$reg, #(__PWTB_SAVE_ARGUMENT_REGISTERS_OFFSET + 40)]
+        stp                    x6, x7, [$reg, #(__PWTB_SAVE_ARGUMENT_REGISTERS_OFFSET + 56)]
+
     MEND
 
 ; Reserve 64 bytes of memory before calling  SAVE_FLOAT_ARGUMENT_REGISTERS
@@ -208,11 +209,12 @@ __PWTB_RESTORE_ARGUMENT_REGISTERS_OFFSET SETA $offset
 __PWTB_RESTORE_ARGUMENT_REGISTERS_OFFSET SETA 0
        ENDIF
 
-        ldp                    x0, x1, [$reg, #(__PWTB_RESTORE_ARGUMENT_REGISTERS_OFFSET)]
-        ldp                    x2, x3, [$reg, #(__PWTB_RESTORE_ARGUMENT_REGISTERS_OFFSET + 16)]
-        ldp                    x4, x5, [$reg, #(__PWTB_RESTORE_ARGUMENT_REGISTERS_OFFSET + 32)]
-        ldp                    x6, x7, [$reg, #(__PWTB_RESTORE_ARGUMENT_REGISTERS_OFFSET + 48)]
-        ldr                    x8, [$reg, #(__PWTB_RESTORE_ARGUMENT_REGISTERS_OFFSET + 64)]
+        ldr                    x8, [$reg, #(__PWTB_RESTORE_ARGUMENT_REGISTERS_OFFSET)]
+        ldp                    x0, x1, [$reg, #(__PWTB_RESTORE_ARGUMENT_REGISTERS_OFFSET + 8)]
+        ldp                    x2, x3, [$reg, #(__PWTB_RESTORE_ARGUMENT_REGISTERS_OFFSET + 24)]
+        ldp                    x4, x5, [$reg, #(__PWTB_RESTORE_ARGUMENT_REGISTERS_OFFSET + 40)]
+        ldp                    x6, x7, [$reg, #(__PWTB_RESTORE_ARGUMENT_REGISTERS_OFFSET + 56)]
+
     MEND
 
     MACRO

--- a/src/vm/arm64/asmmacros.h
+++ b/src/vm/arm64/asmmacros.h
@@ -44,7 +44,9 @@ $name   SETS    "|$symbol|"
         PROLOG_WITH_TRANSITION_BLOCK $extraLocals, $SaveFPArgs
 
         GBLA __PWTB_FloatArgumentRegisters
-        GBLA __PWTB_ArgumentRegisters 
+        GBLA __PWTB_ArgumentRegisters
+        GBLA __PWTB_ArgumentRegister_FirstArg ; We save the x8 register ahead of the first argument, so this
+                                              ; is different from the start of the argument register save area.
         GBLA __PWTB_StackAlloc
         GBLA __PWTB_TransitionBlock
         GBLL __PWTB_SaveFPArgs
@@ -73,6 +75,7 @@ __PWTB_TransitionBlock SETA __PWTB_FloatArgumentRegisters
 
 __PWTB_StackAlloc SETA __PWTB_TransitionBlock
 __PWTB_ArgumentRegisters SETA __PWTB_StackAlloc + 104
+__PWTB_ArgumentRegister_FirstArg SETA __PWTB_ArgumentRegisters + 8
 
         PROLOG_SAVE_REG_PAIR   fp, lr, #-176!
         ; Spill callee saved registers 

--- a/src/vm/arm64/calldescrworkerarm64.S
+++ b/src/vm/arm64/calldescrworkerarm64.S
@@ -62,7 +62,10 @@ LOCAL_LABEL(NoFloatingPoint):
     ldp     x2, x3, [x9, #16]
     ldp     x4, x5, [x9, #32]
     ldp     x6, x7, [x9, #48]
-    ldr     x8, [x9, #64]
+
+    // Copy pRetBuffArg into x8
+    ldr     x9, [x19,#CallDescrData__pRetBuffArg]
+    ldr     x8, [x9]
 
     // call pTarget
     ldr     x9, [x19,#CallDescrData__pTarget]

--- a/src/vm/arm64/cgencpu.h
+++ b/src/vm/arm64/cgencpu.h
@@ -57,6 +57,7 @@ extern PCODE GetPreStubEntryPoint();
 
 #define CALLDESCR_ARGREGS                       1   // CallDescrWorker has ArgumentRegister parameter
 #define CALLDESCR_FPARGREGS                     1   // CallDescrWorker has FloatArgumentRegisters parameter
+#define CALLDESCR_RETBUFFARGREG                 1   // CallDescrWorker has RetBuffArg parameter that's separate from arg regs
 
 // Given a return address retrieved during stackwalk,
 // this is the offset by which it should be decremented to arrive at the callsite.
@@ -77,7 +78,9 @@ extern PCODE GetPreStubEntryPoint();
 typedef INT64 StackElemType;
 #define STACK_ELEM_SIZE sizeof(StackElemType)
 
-// !! This expression assumes STACK_ELEM_SIZE is a power of 2.
+// The expression below assumes STACK_ELEM_SIZE is a power of 2, so check that.
+static_assert(((STACK_ELEM_SIZE & (STACK_ELEM_SIZE-1)) == 0), "STACK_ELEM_SIZE must be a power of 2");
+
 #define StackElemSize(parmSize) (((parmSize) + STACK_ELEM_SIZE - 1) & ~((ULONG)(STACK_ELEM_SIZE - 1)))
 
 //
@@ -115,11 +118,11 @@ struct CalleeSavedRegisters {
 // will probably have to communicate this back to the PromoteCallerStack
 // routine to avoid a double promotion.
 //--------------------------------------------------------------------
+#define NUM_ARGUMENT_REGISTERS 8
 typedef DPTR(struct ArgumentRegisters) PTR_ArgumentRegisters;
 struct ArgumentRegisters {
-    INT64 x[9]; // x0 ....x7 & x8 can contain return buffer address
+    INT64 x[NUM_ARGUMENT_REGISTERS]; // x0 ....x7. Note that x8 (return buffer address) is not included.
 };
-#define NUM_ARGUMENT_REGISTERS 9
 
 #define ARGUMENTREGISTERS_SIZE sizeof(ArgumentRegisters)
 

--- a/src/vm/callhelpers.cpp
+++ b/src/vm/callhelpers.cpp
@@ -208,6 +208,12 @@ void * DispatchCallSimple(
     callDescrData.pSrc = pSrc;
     callDescrData.numStackSlots = numStackSlotsToCopy;
 #endif
+
+#ifdef CALLDESCR_RETBUFFARGREG
+    UINT64 retBuffArgPlaceholder = 0;
+    callDescrData.pRetBuffArg = &retBuffArgPlaceholder;
+#endif
+
 #ifdef CALLDESCR_FPARGREGS
     callDescrData.pFloatArgumentRegisters = NULL;
 #endif
@@ -596,6 +602,9 @@ void MethodDescCallSite::CallTargetWorker(const ARG_SLOT *pArguments, ARG_SLOT *
     callDescrData.numStackSlots = nStackBytes / STACK_ELEM_SIZE;
 #ifdef CALLDESCR_ARGREGS
     callDescrData.pArgumentRegisters = (ArgumentRegisters*)(pTransitionBlock + TransitionBlock::GetOffsetOfArgumentRegisters());
+#endif
+#ifdef CALLDESCR_RETBUFFARGREG
+    callDescrData.pRetBuffArg = (UINT64*)(pTransitionBlock + TransitionBlock::GetOffsetOfRetBuffArgReg());
 #endif
 #ifdef CALLDESCR_FPARGREGS
     callDescrData.pFloatArgumentRegisters = pFloatArgumentRegisters;

--- a/src/vm/callhelpers.h
+++ b/src/vm/callhelpers.h
@@ -30,6 +30,11 @@ struct CallDescrData
     UINT32                      fpReturnSize;
     PCODE                       pTarget;
 
+#ifdef CALLDESCR_RETBUFFARGREG
+    // Pointer to return buffer arg location
+    UINT64*                     pRetBuffArg;
+#endif
+
     //
     // Return value
     //

--- a/src/vm/comdelegate.cpp
+++ b/src/vm/comdelegate.cpp
@@ -405,6 +405,10 @@ VOID GenerateShuffleArray(MethodDesc* pInvoke, MethodDesc *pTargetMeth, SArray<S
     {
         // The return buffer argument is implicit in both signatures.
 
+#if !defined(_TARGET_ARM64_) || !defined(CALLDESCR_RETBUFFARGREG)
+        // The ifdef above disables this code if the ret buff arg is always in the same register, which
+        // means that we don't need to do any shuffling for it.
+
         sArgPlacerSrc.GetRetBuffArgLoc(&sArgSrc);
         sArgPlacerDst.GetRetBuffArgLoc(&sArgDst);
 
@@ -419,6 +423,7 @@ VOID GenerateShuffleArray(MethodDesc* pInvoke, MethodDesc *pTargetMeth, SArray<S
         // along) in the case where it's not a no-op (i.e. the source and destination ops are different).
         if (entry.srcofs != entry.dstofs)
             pShuffleEntryArray->Append(entry);
+#endif // !defined(_TARGET_ARM64_) || !defined(CALLDESCR_RETBUFFARGREG)
     }
 
     // Iterate all the regular arguments. mapping source registers and stack locations to the corresponding

--- a/src/vm/frames.h
+++ b/src/vm/frames.h
@@ -2004,6 +2004,7 @@ protected:
 #elif defined (_TARGET_ARM64_)
     TADDR           m_fp;
     TADDR           m_ReturnAddress;
+    TADDR           m_x8; // ret buff arg
     ArgumentRegisters m_argumentRegisters;
 #else
     TADDR           m_ReturnAddress;  // return address into unmanaged code

--- a/src/vm/reflectioninvocation.cpp
+++ b/src/vm/reflectioninvocation.cpp
@@ -1061,6 +1061,9 @@ FCIMPL5(Object*, RuntimeMethodHandle::InvokeMethod,
 #ifdef CALLDESCR_ARGREGS
     callDescrData.pArgumentRegisters = (ArgumentRegisters*)(pTransitionBlock + TransitionBlock::GetOffsetOfArgumentRegisters());
 #endif
+#ifdef CALLDESCR_RETBUFFARGREG
+    callDescrData.pRetBuffArg = (UINT64*)(pTransitionBlock + TransitionBlock::GetOffsetOfRetBuffArgReg());
+#endif
 #ifdef CALLDESCR_FPARGREGS
     callDescrData.pFloatArgumentRegisters = NULL;
 #endif


### PR DESCRIPTION
This change moves the padding field in the TransitionBlock before the argument registers so that the stack arguments directly follow the register arguments in the layout of the block.

In addition, the Windows ARM64 varargs calling convention allows an argument to be split such that part of it is in x7 and part of it is on the stack, so the return buffer register has also been separated from the rest of the argument registers.

The rest of the changes are fallout from those two (updating various asm stubs, offsets, etc.).
