### PR TITLE
JIT: remove incremental ref count updates

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -430,12 +430,6 @@ void Compiler::optAddCopies()
             {
                 stmt = fgInsertStmtNearEnd(bestBlock, copyAsgn);
             }
-
-            /* Increment its lvRefCnt and lvRefCntWtd */
-            lvaTable[lclNum].incRefCnts(fgFirstBB->getBBWeight(this), this);
-
-            /* Increment its lvRefCnt and lvRefCntWtd */
-            lvaTable[copyLclNum].incRefCnts(fgFirstBB->getBBWeight(this), this);
         }
         else
         {
@@ -460,10 +454,6 @@ void Compiler::optAddCopies()
 
             /*  TODO-Review: BB_UNITY_WEIGHT is not the correct block weight */
             unsigned blockWeight = BB_UNITY_WEIGHT;
-
-            /* Increment its lvRefCnt and lvRefCntWtd twice */
-            lvaTable[copyLclNum].incRefCnts(blockWeight, this);
-            lvaTable[copyLclNum].incRefCnts(blockWeight, this);
 
             /* Assign the old expression into the new temp */
 
@@ -2698,10 +2688,6 @@ GenTree* Compiler::optConstantAssertionProp(AssertionDsc* curAssertion,
         gtDispTree(newTree, nullptr, nullptr, true);
     }
 #endif
-    if (lvaLocalVarRefCounted())
-    {
-        lvaTable[lclNum].decRefCnts(compCurBB->getBBWeight(this), this);
-    }
 
     return optAssertionProp_Update(newTree, tree, stmt);
 }
@@ -2811,13 +2797,7 @@ GenTree* Compiler::optCopyAssertionProp(AssertionDsc* curAssertion,
         return nullptr;
     }
 
-    // If global assertion prop, by now we should have ref counts, fix them.
-    if (lvaLocalVarRefCounted())
-    {
-        lvaTable[lclNum].decRefCnts(compCurBB->getBBWeight(this), this);
-        lvaTable[copyLclNum].incRefCnts(compCurBB->getBBWeight(this), this);
-        tree->gtLclVarCommon.SetSsaNum(copySsaNum);
-    }
+    tree->gtLclVarCommon.SetSsaNum(copySsaNum);
     tree->gtLclVarCommon.SetLclNum(copyLclNum);
 
 #ifdef DEBUG
@@ -3097,9 +3077,6 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
             gtDispTree(tree, nullptr, nullptr, true);
         }
 #endif
-        // Decrement the ref counts, before we change the oper.
-        lvaTable[op1->gtLclVar.gtLclNum].decRefCnts(compCurBB->getBBWeight(this), this);
-
         // Change the oper to const.
         if (genActualType(op1->TypeGet()) == TYP_INT)
         {
@@ -3158,8 +3135,6 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
             gtDispTree(tree, nullptr, nullptr, true);
         }
 #endif
-        lvaTable[op1->gtLclVar.gtLclNum].decRefCnts(compCurBB->getBBWeight(this), this);
-
         // If floating point, don't just substitute op1 with op2, this won't work if
         // op2 is NaN. Just turn it into a "true" or "false" yielding expression.
         if (op1->TypeGet() == TYP_DOUBLE || op1->TypeGet() == TYP_FLOAT)
@@ -3169,7 +3144,6 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
             // point only on JTrue nodes, so if the condition held earlier, it will hold
             // now. We don't create OAK_EQUAL assertion on floating point from GT_ASG
             // because we depend on value num which would constant prop the NaN.
-            lvaTable[op2->gtLclVar.gtLclNum].decRefCnts(compCurBB->getBBWeight(this), this);
             op1->ChangeOperConst(GT_CNS_DBL);
             op1->gtDblCon.gtDconVal = 0;
             op2->ChangeOperConst(GT_CNS_DBL);
@@ -3179,7 +3153,6 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
         else
         {
             noway_assert(varTypeIsIntegralOrI(op1->TypeGet()));
-            lvaTable[op2->gtLclVar.gtLclNum].incRefCnts(compCurBB->getBBWeight(this), this);
             op1->AsLclVarCommon()->SetLclNum(op2->AsLclVarCommon()->GetLclNum());
             op1->AsLclVarCommon()->SetSsaNum(op2->AsLclVarCommon()->GetSsaNum());
         }
@@ -4631,12 +4604,10 @@ GenTree* Compiler::optPrepareTreeForReplacement(GenTree* oldTree, GenTree* newTr
 
         gtExtractSideEffList(oldTree, &sideEffList, GTF_SIDE_EFFECT, ignoreRoot);
     }
+
     if (sideEffList != nullptr)
     {
         noway_assert((sideEffList->gtFlags & GTF_SIDE_EFFECT) != 0);
-
-        // Increment the ref counts as we want to keep the side effects.
-        lvaRecursiveIncRefCounts(sideEffList);
 
         if (newTree != nullptr)
         {
@@ -4648,8 +4619,6 @@ GenTree* Compiler::optPrepareTreeForReplacement(GenTree* oldTree, GenTree* newTr
         }
     }
 
-    // Decrement the ref counts as the oldTree is going to be dropped.
-    lvaRecursiveDecRefCounts(oldTree);
     return newTree;
 }
 
@@ -5169,12 +5138,4 @@ void Compiler::optAssertionPropMain()
     fgDebugCheckBBlist();
     fgDebugCheckLinks();
 #endif
-
-    // Assertion propagation may have changed the reference counts
-    // We need to resort the variable table
-
-    if (optAssertionPropagated)
-    {
-        lvaSortAgain = true;
-    }
 }

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -3668,7 +3668,12 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
             {
                 if (varDsc->lvTrackedNonStruct())
                 {
-                    noway_assert(!VarSetOps::IsMember(compiler, compiler->fgFirstBB->bbLiveIn, varDsc->lvVarIndex));
+                    // We may now see some tracked locals with zero refs.
+                    // See Lowering::DoPhase. Tolerate these.
+                    if (varDsc->lvRefCnt() > 0)
+                    {
+                        noway_assert(!VarSetOps::IsMember(compiler, compiler->fgFirstBB->bbLiveIn, varDsc->lvVarIndex));
+                    }
                 }
                 else
                 {

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4912,8 +4912,7 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
     StackLevelSetter stackLevelSetter(this); // PHASE_STACK_LEVEL_SETTER
     stackLevelSetter.Run();
 
-    assert(lvaSortAgain == false); // We should have re-run fgLocalVarLiveness() in lower.Run()
-    lvaTrackedFixed = true;        // We can not add any new tracked variables after this point.
+    lvaTrackedFixed = true; // We can not add any new tracked variables after this point.
 
     /* Now that lowering is completed we can proceed to perform register allocation */
     m_pLinearScan->doLinearScan();

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -613,12 +613,10 @@ private:
 public:
     unsigned short lvRefCnt(RefCountState state = RCS_NORMAL) const;
     void incLvRefCnt(unsigned short delta, RefCountState state = RCS_NORMAL);
-    void decLvRefCnt(unsigned short delta, RefCountState state = RCS_NORMAL);
     void setLvRefCnt(unsigned short newValue, RefCountState state = RCS_NORMAL);
 
     BasicBlock::weight_t lvRefCntWtd(RefCountState state = RCS_NORMAL) const;
     void incLvRefCntWtd(BasicBlock::weight_t delta, RefCountState state = RCS_NORMAL);
-    void decLvRefCntWtd(BasicBlock::weight_t delta, RefCountState state = RCS_NORMAL);
     void setLvRefCntWtd(BasicBlock::weight_t newValue, RefCountState state = RCS_NORMAL);
 
     int      lvStkOffs;   // stack offset of home
@@ -711,11 +709,6 @@ public:
                !(lvIsParam || lvAddrExposed || lvIsStructField);
     }
 
-    void lvaResetSortAgainFlag(Compiler* pComp, RefCountState = RCS_NORMAL);
-    void decRefCnts(BasicBlock::weight_t weight,
-                    Compiler*            pComp,
-                    RefCountState        state     = RCS_NORMAL,
-                    bool                 propagate = true);
     void incRefCnts(BasicBlock::weight_t weight,
                     Compiler*            pComp,
                     RefCountState        state     = RCS_NORMAL,
@@ -2541,7 +2534,6 @@ public:
         return lvaRefCountState == RCS_NORMAL;
     }
 
-    bool     lvaSortAgain;    // true: We need to sort the lvaTable
     bool     lvaTrackedFixed; // true: We cannot add new 'tracked' variable
     unsigned lvaCount;        // total number of locals
 
@@ -2797,13 +2789,6 @@ public:
     void lvaAllocOutgoingArgSpaceVar(); // Set up lvaOutgoingArgSpaceVar
 
     VARSET_VALRET_TP lvaStmtLclMask(GenTree* stmt);
-
-    void lvaIncRefCnts(GenTree* tree);
-    void lvaDecRefCnts(GenTree* tree);
-
-    void lvaDecRefCnts(BasicBlock* basicBlock, GenTree* tree);
-    void lvaRecursiveDecRefCounts(GenTree* tree);
-    void lvaRecursiveIncRefCounts(GenTree* tree);
 
 #ifdef DEBUG
     struct lvaStressLclFldArgs
@@ -3970,10 +3955,6 @@ public:
 
     void fgLiveVarAnalysis(bool updateInternalOnly = false);
 
-    void fgUpdateRefCntForClone(BasicBlock* addedToBlock, GenTree* clonedTree);
-
-    void fgUpdateRefCntForExtract(GenTree* wholeTree, GenTree* keptTree);
-
     void fgComputeLifeCall(VARSET_TP& life, GenTreeCall* call);
 
     void fgComputeLifeTrackedLocalUse(VARSET_TP& life, LclVarDsc& varDsc, GenTreeLclVarCommon* node);
@@ -4488,7 +4469,7 @@ public:
 
     void fgRemoveEmptyBlocks();
 
-    void fgRemoveStmt(BasicBlock* block, GenTree* stmt, bool updateRefCnt = true);
+    void fgRemoveStmt(BasicBlock* block, GenTree* stmt);
 
     bool fgCheckRemoveStmt(BasicBlock* block, GenTree* stmt);
 

--- a/src/jit/copyprop.cpp
+++ b/src/jit/copyprop.cpp
@@ -266,8 +266,6 @@ void Compiler::optCopyProp(BasicBlock* block, GenTree* stmt, GenTree* tree, LclN
         }
 #endif
 
-        lvaTable[lclNum].decRefCnts(block->getBBWeight(this), this);
-        lvaTable[newLclNum].incRefCnts(block->getBBWeight(this), this);
         tree->gtLclVarCommon.SetLclNum(newLclNum);
         tree->AsLclVarCommon()->SetSsaNum(newSsaNum);
         gtUpdateSideEffects(stmt, tree);

--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -141,10 +141,8 @@ GenTree* DecomposeLongs::DecomposeNode(GenTree* tree)
                 m_compiler->gtDispTreeRange(Range(), tree);
             }
 #endif // DEBUG
-            m_compiler->lvaDecRefCnts(tree);
             unsigned loVarNum = varDsc->lvFieldLclStart;
             tree->AsLclVarCommon()->SetLclNum(loVarNum);
-            m_compiler->lvaIncRefCnts(tree);
             return tree->gtNext;
         }
     }
@@ -343,13 +341,11 @@ GenTree* DecomposeLongs::DecomposeLclVar(LIR::Use& use)
     assert(use.IsInitialized());
     assert(use.Def()->OperGet() == GT_LCL_VAR);
 
-    GenTree*   tree   = use.Def();
-    unsigned   varNum = tree->AsLclVarCommon()->gtLclNum;
-    LclVarDsc* varDsc = m_compiler->lvaTable + varNum;
-    m_compiler->lvaDecRefCnts(tree);
-
-    GenTree* loResult = tree;
-    loResult->gtType  = TYP_INT;
+    GenTree*   tree     = use.Def();
+    unsigned   varNum   = tree->AsLclVarCommon()->gtLclNum;
+    LclVarDsc* varDsc   = m_compiler->lvaTable + varNum;
+    GenTree*   loResult = tree;
+    loResult->gtType    = TYP_INT;
 
     GenTree* hiResult = m_compiler->gtNewLclLNode(varNum, TYP_INT);
     Range().InsertAfter(loResult, hiResult);
@@ -372,9 +368,6 @@ GenTree* DecomposeLongs::DecomposeLclVar(LIR::Use& use)
         hiResult->AsLclFld()->gtLclOffs  = 4;
         hiResult->AsLclFld()->gtFieldSeq = FieldSeqStore::NotAField();
     }
-
-    m_compiler->lvaIncRefCnts(loResult);
-    m_compiler->lvaIncRefCnts(hiResult);
 
     return FinalizeDecomposition(use, loResult, hiResult, hiResult);
 }
@@ -399,8 +392,6 @@ GenTree* DecomposeLongs::DecomposeLclFld(LIR::Use& use)
 
     GenTree* hiResult = m_compiler->gtNewLclFldNode(loResult->gtLclNum, TYP_INT, loResult->gtLclOffs + 4);
     Range().InsertAfter(loResult, hiResult);
-
-    m_compiler->lvaIncRefCnts(hiResult);
 
     return FinalizeDecomposition(use, loResult, hiResult, hiResult);
 }
@@ -472,8 +463,6 @@ GenTree* DecomposeLongs::DecomposeStoreLclVar(LIR::Use& use)
     }
 
     assert(varDsc->lvFieldCnt == 2);
-    m_compiler->lvaDecRefCnts(tree);
-
     GenTreeOp* value = rhs->AsOp();
     Range().Remove(value);
 
@@ -488,9 +477,6 @@ GenTree* DecomposeLongs::DecomposeStoreLclVar(LIR::Use& use)
     hiStore->SetOper(GT_STORE_LCL_VAR);
     hiStore->gtOp.gtOp1 = value->gtOp2;
     hiStore->gtFlags |= GTF_VAR_DEF;
-
-    m_compiler->lvaIncRefCnts(loStore);
-    m_compiler->lvaIncRefCnts(hiStore);
 
     Range().InsertAfter(tree, hiStore);
 
@@ -528,9 +514,6 @@ GenTree* DecomposeLongs::DecomposeStoreLclFld(LIR::Use& use)
     hiStore->SetOper(GT_STORE_LCL_FLD);
     hiStore->gtOp1 = value->gtOp2;
     hiStore->gtFlags |= (GTF_VAR_DEF | GTF_VAR_USEASG);
-
-    // Bump the ref count for the destination.
-    m_compiler->lvaIncRefCnts(hiStore);
 
     Range().InsertAfter(loStore, hiStore);
 
@@ -653,8 +636,6 @@ GenTree* DecomposeLongs::DecomposeCast(LIR::Use& use)
                 hiResult         = m_compiler->gtNewOperNode(GT_RSH, TYP_INT, loCopy, shiftBy);
 
                 Range().InsertAfter(cast, loCopy, shiftBy, hiResult);
-                m_compiler->lvaIncRefCnts(loCopy);
-
                 Range().Remove(cast);
             }
         }
@@ -830,8 +811,6 @@ GenTree* DecomposeLongs::DecomposeStoreInd(LIR::Use& use)
     GenTree* storeIndHigh = new (m_compiler, GT_STOREIND) GenTreeStoreInd(TYP_INT, addrHigh, dataHigh);
     storeIndHigh->gtFlags = (storeIndLow->gtFlags & (GTF_ALL_EFFECT | GTF_LIVENESS_MASK));
 
-    m_compiler->lvaIncRefCnts(addrBaseHigh);
-
     Range().InsertAfter(storeIndLow, dataHigh, addrBaseHigh, addrHigh, storeIndHigh);
 
     return storeIndHigh;
@@ -883,8 +862,6 @@ GenTree* DecomposeLongs::DecomposeInd(LIR::Use& use)
         new (m_compiler, GT_LEA) GenTreeAddrMode(TYP_REF, addrBaseHigh, nullptr, 0, genTypeSize(TYP_INT));
     GenTree* indHigh = new (m_compiler, GT_IND) GenTreeIndir(GT_IND, TYP_INT, addrHigh, nullptr);
     indHigh->gtFlags |= (indLow->gtFlags & (GTF_GLOB_REF | GTF_EXCEPT | GTF_IND_FLAGS));
-
-    m_compiler->lvaIncRefCnts(addrBaseHigh);
 
     Range().InsertAfter(indLow, addrBaseHigh, addrHigh, indHigh);
 
@@ -1149,8 +1126,6 @@ GenTree* DecomposeLongs::DecomposeShift(LIR::Use& use)
                     GenTree* hiOp   = new (m_compiler, GT_LONG) GenTreeOp(GT_LONG, TYP_LONG, loCopy, hiOp1);
                     hiResult        = m_compiler->gtNewOperNode(GT_LSH_HI, TYP_INT, hiOp, shiftByHi);
 
-                    m_compiler->lvaIncRefCnts(loCopy);
-
                     Range().InsertBefore(shift, loOp1, shiftByLo, loResult);
                     Range().InsertBefore(shift, loCopy, hiOp, shiftByHi, hiResult);
 
@@ -1226,8 +1201,6 @@ GenTree* DecomposeLongs::DecomposeShift(LIR::Use& use)
                     GenTree* shiftByHi = m_compiler->gtNewIconNode(count, TYP_INT);
                     GenTree* shiftByLo = m_compiler->gtNewIconNode(count, TYP_INT);
 
-                    m_compiler->lvaIncRefCnts(hiCopy);
-
                     hiResult = m_compiler->gtNewOperNode(GT_RSZ, TYP_INT, hiOp1, shiftByHi);
 
                     // Create a GT_LONG that contains loOp1 and hiCopy. This will be used in codegen to
@@ -1298,7 +1271,6 @@ GenTree* DecomposeLongs::DecomposeShift(LIR::Use& use)
 
                     GenTree* shiftByHi = m_compiler->gtNewIconNode(count, TYP_INT);
                     GenTree* shiftByLo = m_compiler->gtNewIconNode(count, TYP_INT);
-                    m_compiler->lvaIncRefCnts(hiCopy);
 
                     hiResult = m_compiler->gtNewOperNode(GT_RSH, TYP_INT, hiOp1, shiftByHi);
 
@@ -1349,8 +1321,6 @@ GenTree* DecomposeLongs::DecomposeShift(LIR::Use& use)
                     GenTree* shiftBy = m_compiler->gtNewIconNode(31, TYP_INT);
                     hiResult         = m_compiler->gtNewOperNode(GT_RSH, TYP_INT, hiCopy, shiftBy);
                     Range().InsertBefore(shift, shiftBy, hiCopy, hiResult);
-
-                    m_compiler->lvaIncRefCnts(hiCopy);
                 }
 
                 insertAfter = hiResult;
@@ -1542,9 +1512,6 @@ GenTree* DecomposeLongs::DecomposeRotate(LIR::Use& use)
         GenTree* loCopy = m_compiler->gtNewLclvNode(loOp1LclNum, TYP_INT);
         GenTree* hiOp   = new (m_compiler, GT_LONG) GenTreeOp(GT_LONG, TYP_LONG, loCopy, hiOp1);
         hiResult        = m_compiler->gtNewOperNode(oper, TYP_INT, hiOp, rotateByHi);
-
-        m_compiler->lvaIncRefCnts(loCopy);
-        m_compiler->lvaIncRefCnts(hiCopy);
 
         Range().InsertBefore(tree, hiCopy, loOp1, loOp);
         Range().InsertBefore(tree, rotateByLo, loResult);

--- a/src/jit/earlyprop.cpp
+++ b/src/jit/earlyprop.cpp
@@ -361,10 +361,8 @@ GenTree* Compiler::optEarlyPropRewriteTree(GenTree* tree)
             actualValClone->LabelIndex(this);
         }
 
-        DecLclVarRefCountsVisitor::WalkTree(this, tree);
         // actualValClone has small tree node size, it is safe to use CopyFrom here.
         tree->ReplaceWith(actualValClone, this);
-        IncLclVarRefCountsVisitor::WalkTree(this, tree);
 
 #ifdef DEBUG
         if (verbose)

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -12015,9 +12015,6 @@ GenTree* Compiler::gtFoldExpr(GenTree* tree)
                 GenTree* sideEffList = nullptr;
                 gtExtractSideEffList(op1, &sideEffList);
 
-                fgUpdateRefCntForExtract(op1, sideEffList);   // Decrement refcounts for op1, Keeping any side-effects
-                fgUpdateRefCntForExtract(colon_op1, nullptr); // Decrement refcounts for colon_op1
-
                 // Clear colon flags only if the qmark itself is not conditionaly executed
                 if ((tree->gtFlags & GTF_COLON_COND) == 0)
                 {
@@ -12228,10 +12225,7 @@ GenTree* Compiler::gtFoldExprCompare(GenTree* tree)
         cons->gtNext = tree->gtNext;
         cons->gtPrev = tree->gtPrev;
     }
-    if (lvaLocalVarRefCounted())
-    {
-        lvaRecursiveDecRefCounts(tree);
-    }
+
     return cons;
 }
 
@@ -12669,10 +12663,6 @@ GenTree* Compiler::gtFoldExprSpecial(GenTree* tree)
                 /* Multiply by zero - return the 'zero' node, but not if side effects */
                 if (!(op->gtFlags & GTF_SIDE_EFFECT))
                 {
-                    if (lvaLocalVarRefCounted())
-                    {
-                        lvaRecursiveDecRefCounts(op);
-                    }
                     op = cons;
                     goto DONE_FOLD;
                 }
@@ -12701,10 +12691,6 @@ GenTree* Compiler::gtFoldExprSpecial(GenTree* tree)
 
                 if (!(op->gtFlags & GTF_SIDE_EFFECT))
                 {
-                    if (lvaLocalVarRefCounted())
-                    {
-                        lvaRecursiveDecRefCounts(op);
-                    }
                     op = cons;
                     goto DONE_FOLD;
                 }
@@ -12741,10 +12727,6 @@ GenTree* Compiler::gtFoldExprSpecial(GenTree* tree)
 
                 if (!(op->gtFlags & GTF_SIDE_EFFECT))
                 {
-                    if (lvaLocalVarRefCounted())
-                    {
-                        lvaRecursiveDecRefCounts(op);
-                    }
                     op = cons;
                     goto DONE_FOLD;
                 }
@@ -12764,10 +12746,6 @@ GenTree* Compiler::gtFoldExprSpecial(GenTree* tree)
                 }
                 else if (!(op->gtFlags & GTF_SIDE_EFFECT))
                 {
-                    if (lvaLocalVarRefCounted())
-                    {
-                        lvaRecursiveDecRefCounts(op);
-                    }
                     op = cons;
                     goto DONE_FOLD;
                 }
@@ -12791,10 +12769,6 @@ GenTree* Compiler::gtFoldExprSpecial(GenTree* tree)
             {
                 op         = op2->AsColon()->ElseNode();
                 opToDelete = op2->AsColon()->ThenNode();
-            }
-            if (lvaLocalVarRefCounted())
-            {
-                lvaRecursiveDecRefCounts(opToDelete);
             }
 
             // Clear colon flags only if the qmark itself is not conditionaly executed

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2333,18 +2333,9 @@ void fgArgInfo::EvalArgsToTemps()
                 {
                     setupArg = compiler->gtNewTempAssign(tmpVarNum, argx);
 
-                    LclVarDsc* varDsc = compiler->lvaTable + tmpVarNum;
-
-                    if (compiler->fgOrder == Compiler::FGOrderLinear)
-                    {
-                        // We'll reference this temporary variable just once
-                        // when we perform the function call after
-                        // setting up this argument.
-                        varDsc->setLvRefCnt(1);
-                    }
-
-                    var_types lclVarType = genActualType(argx->gtType);
-                    var_types scalarType = TYP_UNKNOWN;
+                    LclVarDsc* varDsc     = compiler->lvaTable + tmpVarNum;
+                    var_types  lclVarType = genActualType(argx->gtType);
+                    var_types  scalarType = TYP_UNKNOWN;
 
                     if (setupArg->OperIsCopyBlkOp())
                     {
@@ -2628,28 +2619,11 @@ GenTree* Compiler::fgMakeMultiUse(GenTree** pOp)
     GenTree* tree = *pOp;
     if (tree->IsLocal())
     {
-        auto result = gtClone(tree);
-        if (lvaLocalVarRefCounted())
-        {
-            lvaTable[tree->gtLclVarCommon.gtLclNum].incRefCnts(compCurBB->getBBWeight(this), this);
-        }
-        return result;
+        return gtClone(tree);
     }
     else
     {
-        GenTree* result = fgInsertCommaFormTemp(pOp);
-
-        // At this point, *pOp is GT_COMMA(GT_ASG(V01, *pOp), V01) and result = V01
-        // Therefore, the ref count has to be incremented 3 times for *pOp and result, if result will
-        // be added by the caller.
-        if (lvaLocalVarRefCounted())
-        {
-            lvaTable[result->gtLclVarCommon.gtLclNum].incRefCnts(compCurBB->getBBWeight(this), this);
-            lvaTable[result->gtLclVarCommon.gtLclNum].incRefCnts(compCurBB->getBBWeight(this), this);
-            lvaTable[result->gtLclVarCommon.gtLclNum].incRefCnts(compCurBB->getBBWeight(this), this);
-        }
-
-        return result;
+        return fgInsertCommaFormTemp(pOp);
     }
 }
 
@@ -5905,13 +5879,6 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
             GenTreeBoundsChk(GT_ARR_BOUNDS_CHECK, TYP_VOID, index, arrLen, SCK_RNGCHK_FAIL);
 
         bndsChk = arrBndsChk;
-
-        // Make sure to increment ref-counts if already ref-counted.
-        if (lvaLocalVarRefCounted())
-        {
-            lvaRecursiveIncRefCounts(index);
-            lvaRecursiveIncRefCounts(arrRef);
-        }
 
         // Now we'll switch to using the second copies for arrRef and index
         // to compute the address expression
@@ -12569,21 +12536,6 @@ DONE_MORPHING_CHILDREN:
 
                     DEBUG_DESTROY_NODE(asg->gtOp.gtOp1);
                     DEBUG_DESTROY_NODE(lcl);
-
-                    /* This local variable should never be used again */
-                    // <BUGNUM>
-                    // VSW 184221: Make RefCnt to zero to indicate that this local var
-                    // is not used any more. (Keey the lvType as is.)
-                    // Otherwise lvOnFrame will be set to true in Compiler::raMarkStkVars
-                    // And then emitter::emitEndCodeGen will assert in the following line:
-                    //        noway_assert( dsc->lvTracked);
-                    // </BUGNUM>
-                    noway_assert(varDsc->lvRefCnt() == 0 || // lvRefCnt may not have been set yet.
-                                 varDsc->lvRefCnt() == 2    // Or, we assume this tmp should only be used here,
-                                                            // and it only shows up twice.
-                                 );
-                    lvaTable[lclNum].setLvRefCnt(0);
-                    lvaTable[lclNum].lvaResetSortAgainFlag(this);
                 }
 
                 if (op1->OperIsCompare())
@@ -12592,9 +12544,9 @@ DONE_MORPHING_CHILDREN:
                     //
                     //                        EQ/NE           ->      RELOP/!RELOP
                     //                        /  \                       /    \
-                        //                     RELOP  CNS 0/1
+                    //                     RELOP  CNS 0/1
                     //                     /   \
-                        //
+                    //
                     // Note that we will remove/destroy the EQ/NE node and move
                     // the RELOP up into it's location.
 
@@ -13748,11 +13700,6 @@ DONE_MORPHING_CHILDREN:
                 }
                 else
                 {
-                    /* The left operand is worthless, throw it away */
-                    if (lvaLocalVarRefCounted())
-                    {
-                        lvaRecursiveDecRefCounts(op1);
-                    }
                     op2->gtFlags |= (tree->gtFlags & (GTF_DONT_CSE | GTF_LATE_ARG));
                     DEBUG_DESTROY_NODE(tree);
                     DEBUG_DESTROY_NODE(op1);
@@ -14321,20 +14268,10 @@ GenTree* Compiler::fgMorphModToSubMulDiv(GenTreeOp* tree)
     {
         numerator = fgMakeMultiUse(&tree->gtOp1);
     }
-    else if (lvaLocalVarRefCounted() && numerator->OperIsLocal())
-    {
-        // Morphing introduces new lclVar references. Increase ref counts
-        lvaIncRefCnts(numerator);
-    }
 
     if (!denominator->OperIsLeaf())
     {
         denominator = fgMakeMultiUse(&tree->gtOp2);
-    }
-    else if (lvaLocalVarRefCounted() && denominator->OperIsLocal())
-    {
-        // Morphing introduces new lclVar references. Increase ref counts
-        lvaIncRefCnts(denominator);
     }
 
     // The numerator and denominator may have been assigned to temps, in which case
@@ -15690,12 +15627,6 @@ bool Compiler::fgMorphBlockStmt(BasicBlock* block, GenTreeStmt* stmt DEBUGARG(co
     }
 
     stmt->gtStmtExpr = morph;
-
-    if (lvaLocalVarRefCounted())
-    {
-        // fgMorphTree may have introduced new lclVar references. Bump the ref counts if requested.
-        lvaRecursiveIncRefCounts(stmt->gtStmtExpr);
-    }
 
     // Can the entire tree be removed?
     bool removedStmt = false;

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -283,28 +283,6 @@ Compiler::fgWalkResult Compiler::optUnmarkCSEs(GenTree** pTree, fgWalkData* data
         // The call to optUnmarkCSE(tree) should have cleared any CSE info
         //
         assert(!IS_CSE_INDEX(tree->gtCSEnum));
-
-        // This node is to be removed from the graph of GenTree*
-        // next decrement any LclVar references.
-        //
-        if (tree->gtOper == GT_LCL_VAR)
-        {
-            unsigned   lclNum;
-            LclVarDsc* varDsc;
-
-            // This variable ref is going away, decrease its ref counts
-
-            lclNum = tree->gtLclVarCommon.gtLclNum;
-            assert(lclNum < comp->lvaCount);
-            varDsc = comp->lvaTable + lclNum;
-
-            // make sure it's been initialized
-            assert(comp->optCSEweight <= BB_MAX_WEIGHT);
-
-            //  Decrement its lvRefCnt and lvRefCntWtd
-
-            varDsc->decRefCnts(comp->optCSEweight, comp);
-        }
     }
     else // optUnmarkCSE(tree) returned false
     {
@@ -2337,15 +2315,6 @@ public:
                                                // cannot add any new exceptions
             }
 
-            // Increment ref count for the CSE ref
-            m_pCompiler->lvaTable[cseLclVarNum].incRefCnts(blk->getBBWeight(m_pCompiler), m_pCompiler);
-
-            if (isDef)
-            {
-                // Also increment ref count for the CSE assignment
-                m_pCompiler->lvaTable[cseLclVarNum].incRefCnts(blk->getBBWeight(m_pCompiler), m_pCompiler);
-            }
-
             // Walk the statement 'stm' and find the pointer
             // in the tree is pointing to 'exp'
             //
@@ -2462,11 +2431,7 @@ public:
     //
     void Cleanup()
     {
-        if (m_addCSEcount > 0)
-        {
-            /* We've added new local variables to the lvaTable so note that we need to recreate the sorted table */
-            m_pCompiler->lvaSortAgain = true;
-        }
+        // Nothing to do, currently.
     }
 };
 

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -6225,16 +6225,10 @@ void Compiler::optPerformHoistExpr(GenTree* origExpr, unsigned lnum)
     BasicBlock* preHead = optLoopTable[lnum].lpHead;
     assert(preHead->bbJumpKind == BBJ_NONE);
 
-    // fgMorphTree and lvaRecursiveIncRefCounts requires that compCurBB be the block that contains
+    // fgMorphTree requires that compCurBB be the block that contains
     // (or in this case, will contain) the expression.
     compCurBB = preHead;
-
-    // Increment the ref counts of any local vars appearing in "hoist".
-    // Note that we need to do this before fgMorphTree() as fgMorph() could constant
-    // fold away some of the lcl vars referenced by "hoist".
-    lvaRecursiveIncRefCounts(hoist);
-
-    hoist = fgMorphTree(hoist);
+    hoist     = fgMorphTree(hoist);
 
     GenTree* hoistStmt = gtNewStmt(hoist);
     hoistStmt->gtFlags |= GTF_STMT_CMPADD;
@@ -7937,32 +7931,6 @@ Compiler::fgWalkResult Compiler::optRemoveTreeVisitor(GenTree** pTree, fgWalkDat
         }
     }
 
-    // This node is being removed from the graph of GenTree*
-
-    // Look for any local variable references
-
-    if (tree->gtOper == GT_LCL_VAR && comp->lvaLocalVarRefCounted())
-    {
-        unsigned   lclNum;
-        LclVarDsc* varDsc;
-
-        /* This variable ref is going away, decrease its ref counts */
-
-        lclNum = tree->gtLclVarCommon.gtLclNum;
-        assert(lclNum < comp->lvaCount);
-        varDsc = comp->lvaTable + lclNum;
-
-        // make sure it's been initialized
-        assert(comp->compCurBB != nullptr);
-        assert(comp->compCurBB->bbWeight <= BB_MAX_WEIGHT);
-
-        /* Decrement its lvRefCnt and lvRefCntWtd */
-
-        // Use getBBWeight to determine the proper block weight.
-        // This impacts the block weights when we have IBC data.
-        varDsc->decRefCnts(comp->compCurBB->getBBWeight(comp), comp);
-    }
-
     return WALK_CONTINUE;
 }
 
@@ -8785,10 +8753,6 @@ void Compiler::optOptimizeBoolsGcStress(BasicBlock* condBlock)
     }
 
     GenTree* comparandClone = gtCloneExpr(comparand);
-
-    // Bump up the ref-counts of any variables in 'comparandClone'
-    compCurBB = condBlock;
-    IncLclVarRefCountsVisitor::WalkTree(this, comparandClone);
 
     noway_assert(relop->gtOp.gtOp1 == comparand);
     genTreeOps oper   = compStressCompile(STRESS_OPT_BOOLS_GC, 50) ? GT_OR : GT_AND;

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -931,7 +931,6 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, ArrayStack<G
     {
         if (use.IsDummyUse())
         {
-            comp->lvaDecRefCnts(node);
             BlockRange().Remove(node);
         }
         else

--- a/src/jit/regalloc.cpp
+++ b/src/jit/regalloc.cpp
@@ -335,17 +335,18 @@ void Compiler::raMarkStkVars()
             /*
               For Debug Code, we have to reserve space even if the variable is never
               in scope. We will also need to initialize it if it is a GC var.
-              So we set lvMustInit and artifically bump up the ref-cnt.
+              So we set lvMustInit and verify it has a nonzero ref-cnt.
              */
 
             if (opts.compDbgCode && !stkFixedArgInVarArgs && lclNum < info.compLocalsCount)
             {
-                needSlot |= true;
-
-                if (lvaTypeIsGC(lclNum))
+                if (varDsc->lvRefCnt() == 0)
                 {
-                    varDsc->setLvRefCnt(1);
+                    assert(!"unreferenced local in debug codegen");
+                    varDsc->lvImplicitlyReferenced = 1;
                 }
+
+                needSlot |= true;
 
                 if (!varDsc->lvIsParam)
                 {


### PR DESCRIPTION
Remove almost all of the code in the jit that tries to maintain local ref
counts incrementally. Also remove `lvaSortAgain` and related machinery.

Explicitly sort locals before post-lower-liveness when optimizing to get the
best set of tracked locals.

Explicitly recount after post-lower liveness to get accurate counts after
dead stores. This can lead to tracked unreferenced arguments; tolerate this
during codegen.