### PR TITLE
Build with python3 on unix

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,9 +7,9 @@ export ghprbCommentBody=
 
 # resolve python-version to use
 if [ "$PYTHON" == "" ] ; then
-    if ! PYTHON=$(command -v python2.7 || command -v python2 || command -v python)
+    if ! PYTHON=$(command -v python3 || command -v python2 || command -v python)
     then
-       echo "Unable to locate build-dependency python2.x!" 1>&2
+       echo "Unable to locate build-dependency python!" 1>&2
        exit 1
     fi
 fi
@@ -18,7 +18,7 @@ fi
 # useful in case of explicitly set option.
 if ! command -v $PYTHON > /dev/null
 then
-   echo "Unable to locate build-dependency python2.x ($PYTHON)!" 1>&2
+   echo "Unable to locate build-dependency python ($PYTHON)!" 1>&2
    exit 1
 fi
 


### PR DESCRIPTION
If I am reading it correctly, the windows build scripts (`build.cmd`) try finding python in order of `python3`, `python2` and then `python`: https://github.com/dotnet/coreclr/blob/b4131b9f9dc9c73e47b315fff886db66374b1b21/build.cmd#L379

The unix build scripts don't. They just try `python2` variants and then fail. This change makes brings them closer together by letting users build using only `python3` on unix.

The support for using python3 for Windows was added here: https://github.com/dotnet/coreclr/pull/15611/commits/54a362cbf6c3a835bcd8afe7076944a86ceee981 (https://github.com/dotnet/coreclr/pull/15611)

As an side, I see both the unix build scripts and Windows build scripts test for python and fail if it's not found. However `CMakeLists.txt` also tests for python again (and then doesn't use it?): https://github.com/dotnet/coreclr/blob/b4131b9f9dc9c73e47b315fff886db66374b1b21/CMakeLists.txt#L40-L43

Is that useful to keep? It will prevent someone from building when `python3` is available but not `python2` or `python`.