### PR TITLE
Skip Crossgen of S.R.WindowsRuntime.dll

### DIFF
--- a/tests/skipCrossGenFiles.arm.txt
+++ b/tests/skipCrossGenFiles.arm.txt
@@ -1,4 +1,5 @@
 mscorlib.dll
+System.Runtime.WindowsRuntime.dll
 System.Runtime.WindowsRuntime.UI.Xaml.dll
 System.Private.CoreLib.dll
 xunit.performance.api.dll

--- a/tests/skipCrossGenFiles.arm64.txt
+++ b/tests/skipCrossGenFiles.arm64.txt
@@ -1,3 +1,4 @@
+System.Runtime.WindowsRuntime.dll
 System.Runtime.WindowsRuntime.UI.Xaml.dll
 Microsoft.CodeAnalysis.VisualBasic.dll
 System.Net.NameResolution.dll

--- a/tests/skipCrossGenFiles.x64.txt
+++ b/tests/skipCrossGenFiles.x64.txt
@@ -1,4 +1,5 @@
 mscorlib.dll
+System.Runtime.WindowsRuntime.dll
 System.Runtime.WindowsRuntime.UI.Xaml.dll
 System.Private.CoreLib.dll
 xunit.performance.api.dll

--- a/tests/skipCrossGenFiles.x86.txt
+++ b/tests/skipCrossGenFiles.x86.txt
@@ -1,4 +1,5 @@
 mscorlib.dll
+System.Runtime.WindowsRuntime.dll
 System.Runtime.WindowsRuntime.UI.Xaml.dll
 System.Private.CoreLib.dll
 xunit.performance.api.dll


### PR DESCRIPTION
System.Runtime.WindowsRuntime contains assembly refs to Windows platform WinMD types which are not available on Unix and required to crossgen the assembly. Fixes https://github.com/dotnet/coreclr/issues/19347