### PR TITLE
Updating the x86 HWIntrinsic tests to include embedded pdbs

### DIFF
--- a/tests/src/JIT/CheckProjects/CheckProjects.cs
+++ b/tests/src/JIT/CheckProjects/CheckProjects.cs
@@ -217,7 +217,8 @@ internal class ScanProjectFiles
                     {
                         if (debugVal.Equals("pdbonly", StringComparison.OrdinalIgnoreCase)
                             || debugVal.Equals("none", StringComparison.OrdinalIgnoreCase)
-                            || debugVal.Equals("blank", StringComparison.OrdinalIgnoreCase))
+                            || debugVal.Equals("blank", StringComparison.OrdinalIgnoreCase)
+                            || debugVal.Equals("embedded", StringComparison.OrdinalIgnoreCase))
                         {
                             suffixNote = "SuffixRelOk";
                         }

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Avx_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Avx_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Avx_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Avx_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Blend_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Blend_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Blend_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Blend_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/BroadcastScalarToVector128_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/BroadcastScalarToVector128_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/BroadcastScalarToVector128_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/BroadcastScalarToVector128_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/BroadcastScalarToVector256_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/BroadcastScalarToVector256_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/BroadcastScalarToVector256_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/BroadcastScalarToVector256_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/BroadcastVector128ToVector256_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/BroadcastVector128ToVector256_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/BroadcastVector128ToVector256_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/BroadcastVector128ToVector256_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/CompareScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/CompareScalar_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/CompareScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/CompareScalar_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Compare_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Compare_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Compare_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Compare_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/ConvertToSingle_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/ConvertToSingle_r.csproj
@@ -6,7 +6,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/ConvertToSingle_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/ConvertToSingle_ro.csproj
@@ -6,7 +6,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/ConvertToVector_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/ConvertToVector_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/ConvertToVector_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/ConvertToVector_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/DotProduct_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/DotProduct_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/DotProduct_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/DotProduct_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/HorizontalAdd_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/HorizontalAdd_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/HorizontalAdd_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/HorizontalAdd_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/HorizontalSubtract_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/HorizontalSubtract_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/HorizontalSubtract_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/HorizontalSubtract_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/InsertExtractVector128_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/InsertExtractVector128_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/InsertExtractVector128_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/InsertExtractVector128_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/LoadAlignedVector256_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/LoadAlignedVector256_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/LoadAlignedVector256_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/LoadAlignedVector256_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/LoadDquVector256_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/LoadDquVector256_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/LoadDquVector256_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/LoadDquVector256_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/LoadVector256_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/LoadVector256_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/LoadVector256_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/LoadVector256_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/MaskLoad_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/MaskLoad_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>	
   </ItemGroup>	
   <PropertyGroup>	
-    <DebugType>None</DebugType>	
+    <DebugType>Embedded</DebugType>	
     <Optimize></Optimize>	
   </PropertyGroup>	
   <ItemGroup>	

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/MaskLoad_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/MaskLoad_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>	
   </ItemGroup>	
   <PropertyGroup>	
-    <DebugType>None</DebugType>	
+    <DebugType>Embedded</DebugType>	
     <Optimize>True</Optimize>	
   </PropertyGroup>	
   <ItemGroup>	

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/MoveMask_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/MoveMask_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/MoveMask_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/MoveMask_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Permute2x128.Avx_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Permute2x128.Avx_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Permute2x128.Avx_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Permute2x128.Avx_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/SetAllVector256_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/SetAllVector256_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/SetAllVector256_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/SetAllVector256_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/SetVector256_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/SetVector256_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/SetVector256_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/SetVector256_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/SetZeroVector256_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/SetZeroVector256_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/SetZeroVector256_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/SetZeroVector256_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Sqrt_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Sqrt_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Sqrt_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Sqrt_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/StaticCast_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/StaticCast_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/StaticCast_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/StaticCast_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/StoreAlignedNonTemporal_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/StoreAlignedNonTemporal_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/StoreAlignedNonTemporal_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/StoreAlignedNonTemporal_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/StoreAligned_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/StoreAligned_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/StoreAligned_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/StoreAligned_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Store_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Store_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/Store_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/Store_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/UnpackHigh_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/UnpackHigh_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/UnpackHigh_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/UnpackHigh_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/UnpackLow_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/UnpackLow_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx/UnpackLow_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx/UnpackLow_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/AddSaturate_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/AddSaturate_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/AddSaturate_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/AddSaturate_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/Avx2_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/Avx2_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/Avx2_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/Avx2_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/BroadcastVector128ToVector256_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/BroadcastVector128ToVector256_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/BroadcastVector128ToVector256_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/BroadcastVector128ToVector256_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/ConvertToVector256_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/ConvertToVector256_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/ConvertToVector256_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/ConvertToVector256_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/HorizontalAdd_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/HorizontalAdd_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/HorizontalAdd_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/HorizontalAdd_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/HorizontalSubtract_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/HorizontalSubtract_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/HorizontalSubtract_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/HorizontalSubtract_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/LoadAlignedVector256NonTemporal_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/LoadAlignedVector256NonTemporal_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/LoadAlignedVector256NonTemporal_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/LoadAlignedVector256NonTemporal_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/MoveMask_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/MoveMask_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/MoveMask_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/MoveMask_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/Multiply_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/Multiply_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/Multiply_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/Multiply_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>true</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/ShiftLeftLogicalVariable_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/ShiftLeftLogicalVariable_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/ShiftLeftLogicalVariable_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/ShiftLeftLogicalVariable_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/ShiftRightLogicalVariable_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/ShiftRightLogicalVariable_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/ShiftRightLogicalVariable_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/ShiftRightLogicalVariable_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/SubtractSaturate_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/SubtractSaturate_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/SubtractSaturate_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/SubtractSaturate_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/UnpackHigh_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/UnpackHigh_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/UnpackHigh_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/UnpackHigh_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/UnpackLow_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/UnpackLow_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/UnpackLow_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/UnpackLow_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2_Vector128/Avx2_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2_Vector128/Avx2_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2_Vector128/Avx2_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2_Vector128/Avx2_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Bmi1/Bmi1_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Bmi1/Bmi1_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Bmi1/Bmi1_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Bmi1/Bmi1_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Bmi2/Bmi2_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Bmi2/Bmi2_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Bmi2/Bmi2_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Bmi2/Bmi2_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Fma_Vector128/Fma_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Fma_Vector128/Fma_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Fma_Vector128/Fma_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Fma_Vector128/Fma_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Fma_Vector256/Fma_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Fma_Vector256/Fma_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Fma_Vector256/Fma_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Fma_Vector256/Fma_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/General/IsSupported_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/IsSupported_r.csproj
@@ -19,7 +19,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/General/IsSupported_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/IsSupported_ro.csproj
@@ -19,7 +19,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/General/VectorArgs_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/VectorArgs_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/General/VectorArgs_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/VectorArgs_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/General/VectorArray_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/VectorArray_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/General/VectorArray_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/VectorArray_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/General/VectorRet_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/VectorRet_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/General/VectorRet_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/VectorRet_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/General/VectorUnused_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/VectorUnused_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/General/VectorUnused_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/General/VectorUnused_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Lzcnt/Lzcnt_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Lzcnt/Lzcnt_r.csproj
@@ -19,7 +19,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Lzcnt/Lzcnt_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Lzcnt/Lzcnt_ro.csproj
@@ -19,7 +19,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Popcnt/Popcnt_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Popcnt/Popcnt_r.csproj
@@ -19,7 +19,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Popcnt/Popcnt_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Popcnt/Popcnt_ro.csproj
@@ -19,7 +19,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Regression/GitHub_17435/GitHub_17435.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Regression/GitHub_17435/GitHub_17435.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertScalarToVector128Single_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertScalarToVector128Single_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertScalarToVector128Single_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertScalarToVector128Single_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertToInt32WithTruncation_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertToInt32WithTruncation_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertToInt32WithTruncation_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertToInt32WithTruncation_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertToInt32_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertToInt32_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertToInt32_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertToInt32_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertToInt64WithTruncation_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertToInt64WithTruncation_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertToInt64WithTruncation_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertToInt64WithTruncation_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertToInt64_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertToInt64_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertToInt64_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertToInt64_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertToSingle_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertToSingle_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertToSingle_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/ConvertToSingle_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/LoadAlignedVector128_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/LoadAlignedVector128_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/LoadAlignedVector128_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/LoadAlignedVector128_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/LoadHigh_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/LoadHigh_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/LoadHigh_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/LoadHigh_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/LoadLow_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/LoadLow_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/LoadLow_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/LoadLow_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/LoadScalarVector128_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/LoadScalarVector128_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/LoadScalarVector128_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/LoadScalarVector128_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/LoadVector128_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/LoadVector128_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/LoadVector128_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/LoadVector128_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/MoveHighToLow_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/MoveHighToLow_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/MoveHighToLow_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/MoveHighToLow_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/MoveLowToHigh_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/MoveLowToHigh_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/MoveLowToHigh_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/MoveLowToHigh_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/MoveMask_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/MoveMask_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/MoveMask_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/MoveMask_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/MoveScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/MoveScalar_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/MoveScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/MoveScalar_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/Prefetch_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/Prefetch_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/Prefetch_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/Prefetch_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/ReciprocalScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/ReciprocalScalar_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/ReciprocalScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/ReciprocalScalar_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/ReciprocalSqrtScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/ReciprocalSqrtScalar_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/ReciprocalSqrtScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/ReciprocalSqrtScalar_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/ReciprocalSqrt_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/ReciprocalSqrt_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/ReciprocalSqrt_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/ReciprocalSqrt_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/Reciprocal_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/Reciprocal_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/Reciprocal_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/Reciprocal_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/SetAllVector128_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/SetAllVector128_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/SetAllVector128_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/SetAllVector128_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/SetScalarVector128_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/SetScalarVector128_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/SetScalarVector128_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/SetScalarVector128_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/SetVector128_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/SetVector128_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/SetVector128_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/SetVector128_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/SetZeroVector128_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/SetZeroVector128_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/SetZeroVector128_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/SetZeroVector128_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/Shuffle_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/Shuffle_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/Shuffle_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/Shuffle_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/SqrtScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/SqrtScalar_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/SqrtScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/SqrtScalar_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/Sqrt_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/Sqrt_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/Sqrt_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/Sqrt_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/Sse_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/Sse_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/Sse_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/Sse_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/StaticCast_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/StaticCast_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/StaticCast_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/StaticCast_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreAlignedNonTemporal_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreAlignedNonTemporal_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreAlignedNonTemporal_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreAlignedNonTemporal_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreAligned_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreAligned_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreAligned_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreAligned_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreFence_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreFence_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreFence_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreFence_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreHigh_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreHigh_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreHigh_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreHigh_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreLow_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreLow_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreLow_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreLow_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreScalar_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/StoreScalar_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/Store_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/Store_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/Store_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/Store_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/UnpackHigh_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/UnpackHigh_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/UnpackHigh_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/UnpackHigh_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/UnpackLow_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/UnpackLow_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse/UnpackLow_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse/UnpackLow_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareEqualOrderedScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareEqualOrderedScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareEqualOrderedScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareEqualOrderedScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareEqualScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareEqualScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareEqualScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareEqualScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareEqualUnorderedScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareEqualUnorderedScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareEqualUnorderedScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareEqualUnorderedScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanOrEqualOrderedScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanOrEqualOrderedScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanOrEqualOrderedScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanOrEqualOrderedScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanOrEqualScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanOrEqualScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanOrEqualScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanOrEqualScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>
     </Optimize>
   </PropertyGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanOrEqualUnorderedScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanOrEqualUnorderedScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanOrEqualUnorderedScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanOrEqualUnorderedScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanOrderedScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanOrderedScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanOrderedScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanOrderedScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanUnorderedScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanUnorderedScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanUnorderedScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareGreaterThanUnorderedScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanOrEqualOrderedScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanOrEqualOrderedScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanOrEqualOrderedScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanOrEqualOrderedScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanOrEqualScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanOrEqualScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanOrEqualScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanOrEqualScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanOrEqualUnorderedScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanOrEqualUnorderedScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanOrEqualUnorderedScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanOrEqualUnorderedScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanOrderedScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanOrderedScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanOrderedScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanOrderedScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanUnorderedScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanUnorderedScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanUnorderedScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareLessThanUnorderedScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotEqualOrderedScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotEqualOrderedScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotEqualOrderedScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotEqualOrderedScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotEqualScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotEqualScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotEqualScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotEqualScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotEqualUnorderedScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotEqualUnorderedScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotEqualUnorderedScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotEqualUnorderedScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotGreaterThanOrEqualScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotGreaterThanOrEqualScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotGreaterThanOrEqualScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotGreaterThanOrEqualScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotGreaterThanScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotGreaterThanScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotGreaterThanScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotGreaterThanScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotLessThanOrEqualScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotLessThanOrEqualScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotLessThanOrEqualScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotLessThanOrEqualScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotLessThanScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotLessThanScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotLessThanScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareNotLessThanScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareOrderedScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareOrderedScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareOrderedScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareOrderedScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareUnorderedScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareUnorderedScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareUnorderedScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/CompareUnorderedScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128Double_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128Double_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128Double_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128Double_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128Int32_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128Int32_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128Int32_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128Int32_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128Int64_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128Int64_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128Int64_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128Int64_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128Single_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128Single_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128Single_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128Single_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128UInt32_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128UInt32_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128UInt32_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128UInt32_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128UInt64_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128UInt64_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128UInt64_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertScalarToVector128UInt64_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToDouble_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToDouble_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToDouble_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToDouble_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToInt32WithTruncation_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToInt32WithTruncation_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToInt32WithTruncation_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToInt32WithTruncation_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToInt32_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToInt32_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToInt32_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToInt32_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToInt64WithTruncation_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToInt64WithTruncation_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToInt64WithTruncation_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToInt64WithTruncation_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToInt64_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToInt64_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToInt64_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToInt64_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToUInt32_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToUInt32_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToUInt32_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToUInt32_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToUInt64_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToUInt64_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToUInt64_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToUInt64_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToVector128Double_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToVector128Double_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToVector128Double_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToVector128Double_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToVector128Int32WithTruncation_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToVector128Int32WithTruncation_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToVector128Int32WithTruncation_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToVector128Int32WithTruncation_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToVector128Int32_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToVector128Int32_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToVector128Int32_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToVector128Int32_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToVector128Single_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToVector128Single_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToVector128Single_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ConvertToVector128Single_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadAlignedVector128_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadAlignedVector128_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadAlignedVector128_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadAlignedVector128_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadFence_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadFence_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadFence_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadFence_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadHigh_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadHigh_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadHigh_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadHigh_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadLow_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadLow_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadLow_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadLow_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadScalarVector128_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadScalarVector128_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadScalarVector128_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadScalarVector128_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadVector128_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadVector128_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadVector128_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/LoadVector128_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MaskMove_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MaskMove_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MaskMove_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MaskMove_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MemoryFence_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MemoryFence_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MemoryFence_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MemoryFence_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MoveMask_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MoveMask_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MoveMask_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MoveMask_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MoveScalar.Int64_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MoveScalar.Int64_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MoveScalar.Int64_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MoveScalar.Int64_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MoveScalar.UInt64_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MoveScalar.UInt64_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MoveScalar.UInt64_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MoveScalar.UInt64_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MoveScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MoveScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MoveScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MoveScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MultiplyHigh_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MultiplyHigh_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MultiplyHigh_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MultiplyHigh_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MultiplyHorizontalAdd_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MultiplyHorizontalAdd_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MultiplyHorizontalAdd_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MultiplyHorizontalAdd_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MultiplyLow_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MultiplyLow_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MultiplyLow_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/MultiplyLow_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Multiply_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Multiply_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Multiply_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Multiply_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/PackSignedSaturate_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/PackSignedSaturate_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/PackSignedSaturate_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/PackSignedSaturate_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/PackUnsignedSaturate_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/PackUnsignedSaturate_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/PackUnsignedSaturate_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/PackUnsignedSaturate_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/SetScalarVector128_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/SetScalarVector128_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/SetScalarVector128_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/SetScalarVector128_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/SetVector128_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/SetVector128_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/SetVector128_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/SetVector128_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/SetZeroVector128_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/SetZeroVector128_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/SetZeroVector128_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/SetZeroVector128_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ShuffleHigh_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ShuffleHigh_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ShuffleHigh_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ShuffleHigh_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ShuffleLow_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ShuffleLow_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ShuffleLow_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/ShuffleLow_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Shuffle_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Shuffle_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Shuffle_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Shuffle_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/SqrtScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/SqrtScalar_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/SqrtScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/SqrtScalar_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Sqrt_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Sqrt_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Sqrt_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Sqrt_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Sse2_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Sse2_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Sse2_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Sse2_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreAlignedNonTemporal_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreAlignedNonTemporal_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreAlignedNonTemporal_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreAlignedNonTemporal_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreAligned_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreAligned_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreAligned_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreAligned_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreHigh_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreHigh_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreHigh_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreHigh_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreLow_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreLow_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreLow_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreLow_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreNonTemporal_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreNonTemporal_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreNonTemporal_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreNonTemporal_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreScalar_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreScalar_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreScalar_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/StoreScalar_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Store_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Store_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Store_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/Store_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/SumAbsoluteDifferences_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/SumAbsoluteDifferences_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>
     </Optimize>
   </PropertyGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/SumAbsoluteDifferences_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/SumAbsoluteDifferences_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/UnpackHigh_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/UnpackHigh_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/UnpackHigh_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/UnpackHigh_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/UnpackLow_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/UnpackLow_r.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse2/UnpackLow_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse2/UnpackLow_ro.csproj
@@ -21,7 +21,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse3/LoadAndDuplicateToVector128_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse3/LoadAndDuplicateToVector128_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse3/LoadAndDuplicateToVector128_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse3/LoadAndDuplicateToVector128_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse3/LoadDquVector128_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse3/LoadDquVector128_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse3/LoadDquVector128_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse3/LoadDquVector128_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse3/MoveAndDuplicate_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse3/MoveAndDuplicate_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse3/MoveAndDuplicate_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse3/MoveAndDuplicate_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse3/MoveHighAndDuplicate_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse3/MoveHighAndDuplicate_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse3/MoveHighAndDuplicate_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse3/MoveHighAndDuplicate_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse3/MoveLowAndDuplicate_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse3/MoveLowAndDuplicate_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse3/MoveLowAndDuplicate_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse3/MoveLowAndDuplicate_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse3/Sse3_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse3/Sse3_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse3/Sse3_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse3/Sse3_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Blend_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Blend_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Blend_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Blend_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/ConvertToVector128_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/ConvertToVector128_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/ConvertToVector128_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/ConvertToVector128_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/DotProduct_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/DotProduct_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/DotProduct_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/DotProduct_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/LoadAlignedVector128NonTemporal_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/LoadAlignedVector128NonTemporal_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/LoadAlignedVector128NonTemporal_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/LoadAlignedVector128NonTemporal_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/MinHorizontal_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/MinHorizontal_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/MinHorizontal_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/MinHorizontal_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/MultipleSumAbsoluteDifferences_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/MultipleSumAbsoluteDifferences_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/MultipleSumAbsoluteDifferences_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/MultipleSumAbsoluteDifferences_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Multiply_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Multiply_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Multiply_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Multiply_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>true</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Sse41_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Sse41_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Sse41_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse41/Sse41_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse42/Crc32_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse42/Crc32_r.csproj
@@ -19,7 +19,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse42/Crc32_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse42/Crc32_ro.csproj
@@ -19,7 +19,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse42/Sse42_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse42/Sse42_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Sse42/Sse42_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Sse42/Sse42_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Ssse3/AlignRight_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Ssse3/AlignRight_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Ssse3/AlignRight_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Ssse3/AlignRight_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Ssse3/Ssse3_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Ssse3/Ssse3_r.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Ssse3/Ssse3_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Ssse3/Ssse3_ro.csproj
@@ -20,7 +20,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>None</DebugType>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This updates all 379 x86 HWIntrinsic test projects to include embedded pdbs.

This results in a size increase of ~2.09MB (or ~5.64kb per project), but ensures that any crashes/etc include enough information to assist with debugging.