### PR TITLE
Fix EventPipe failures due to unaligned argument to QueryPerformanceCounter

### DIFF
--- a/src/vm/eventpipeeventinstance.cpp
+++ b/src/vm/eventpipeeventinstance.cpp
@@ -53,7 +53,15 @@ EventPipeEventInstance::EventPipeEventInstance(
 
     m_pData = pData;
     m_dataLength = length;
-    QueryPerformanceCounter(&m_timeStamp);
+
+    // Declare the timeStamp as a local and require that it be 4-byte aligned.
+    // If the timeStamp is not 4-byte aligned, QueryPerformanceCounter will return E_NOACCESS on some versions of Windows.
+    // This codepath is more susceptible to having an unaligned m_timeStamp because EventPipeEventInstance
+    // is initialized via placement-new into the EventPipe circular buffer.
+    DECLSPEC_ALIGN(4) LARGE_INTEGER timeStamp;
+    QueryPerformanceCounter(&timeStamp);
+    m_timeStamp.QuadPart = timeStamp.QuadPart;
+    _ASSERTE(m_timeStamp.QuadPart > 0);
 
     if(event.NeedStack() && !session.RundownEnabled())
     {


### PR DESCRIPTION
Some of the EventPipe tests are failing on our official runs because calls to ```QueryPerformanceCounter``` are failing.  This occurs when the argument passed to ```QueryPerformanceCounter``` is not 4-byte aligned, which is fairly common for the timeStamp field, which is part of an object that is initialized via placement-new into the EventPipe circular buffer.

The fix is to create a stack-allocated timeStamp field whose alignment is guaranteed to be 4-bytes.

I am investigating separately whether this needs to be fixed more consistently across the codebase.

Fixes #19268.