### PR TITLE
Align the Contents of EventPipeBuffers

### DIFF
--- a/src/vm/eventpipebuffer.h
+++ b/src/vm/eventpipebuffer.h
@@ -20,6 +20,10 @@ class EventPipeBuffer
 
 private:
 
+    // Instances of EventPipeEventInstance in the buffer must be 4-byte aligned.
+    // It is OK for the data payloads to be unaligned because they are opaque blobs that are copied via memcpy.
+    const size_t AlignmentSize = 4;
+
     // A pointer to the actual buffer.
     BYTE *m_pBuffer;
 
@@ -70,6 +74,20 @@ private:
     {
         LIMITED_METHOD_CONTRACT;
         m_pNextBuffer = pBuffer;
+    }
+
+    FORCEINLINE BYTE* GetNextAlignedAddress(BYTE *pAddress)
+    {
+        LIMITED_METHOD_CONTRACT;
+        _ASSERTE(m_pBuffer <= pAddress && m_pLimit > pAddress);
+
+        if((size_t)pAddress % AlignmentSize != 0)
+        {
+            pAddress = pAddress + (AlignmentSize - ((size_t)pAddress % AlignmentSize));
+        }
+
+        _ASSERTE((size_t)pAddress % AlignmentSize == 0);
+        return pAddress;
     }
 
 public:

--- a/src/vm/eventpipeeventinstance.cpp
+++ b/src/vm/eventpipeeventinstance.cpp
@@ -54,6 +54,7 @@ EventPipeEventInstance::EventPipeEventInstance(
     m_pData = pData;
     m_dataLength = length;
     QueryPerformanceCounter(&m_timeStamp);
+    _ASSERTE(m_timeStamp.QuadPart > 0);
 
     if(event.NeedStack() && !session.RundownEnabled())
     {


### PR DESCRIPTION
Some of the EventPipe tests are failing on our official runs because calls to ```QueryPerformanceCounter``` are failing. This occurs when the argument passed to ```QueryPerformanceCounter``` is not 4-byte aligned, which is fairly common for the timeStamp field, which is part of an object that is initialized via placement-new into the EventPipe circular buffer.

The fix is to 4-byte align the ```EventPipeEventInstance``` objects that are initialized via placement-new directly into the buffers.

Fixes #19268.