### PR TITLE
Updating init-tools to be inline with the CoreFX copy

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -102,6 +102,12 @@ if [ ! -e "$__DOTNET_PATH" ]; then
                         __PKG_RID=rhel.6
                     fi
                 fi
+                OSArch=$(uname -m)
+                if [ $OSArch == 'armv7l' ];then
+                    __PKG_ARCH=arm
+                elif [ $OSArch == 'aarch64' ]; then
+                    __PKG_ARCH=arm64
+                fi
 
                 ;;
 


### PR DESCRIPTION
The file had gotten out of sync on a minor (but potentially important) change.