### PR TITLE
Use new Windows VMs for all Windows builds

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -2436,10 +2436,10 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                     // Basic archiving of the build, no pal tests
                     Utilities.addArchival(newJob, "bin/Product/**,bin/obj/*/tests/**/*.dylib,bin/obj/*/tests/**/*.so", "bin/Product/**/.nuget/**")
 
-                    job.with {
+                    newJob.with {
                         publishers {
                             azureVMAgentPostBuildAction {
-                                agentPostBuildAction('Delete agent if the build was not successful (when idle).')
+                                agentPostBuildAction('Delete agent after build execution (when idle).')
                             }
                         }
                     }


### PR DESCRIPTION
These new VMs have been used for Windows arm32/arm64 builds, because
they have new enough VS2017 toolsets for that. However, they
can be used for all Windows builds, so we have consistency of our
build tools for all builds.

Also,
1. stop doing cron and push jobs in the dev/unix_test_workflow branch; it
is a waste of machine resources.
2. simplify the Tizen machine cleanup setting to match what arm32/arm64 do.