### PR TITLE
Use identified python when checking for PGO

### DIFF
--- a/src/build.proj
+++ b/src/build.proj
@@ -55,6 +55,6 @@
     </ItemGroup>
 
     <Message Text="Checking if the following DLLs are properly compiled with PGO" Importance="High" />
-    <Exec Command="python $(MSBuildThisFileDirectory)scripts\pgocheck.py @(PGOEnforcedFiles)" />
+    <Exec Command="&quot;$(PYTHON)&quot; $(MSBuildThisFileDirectory)scripts\pgocheck.py @(PGOEnforcedFiles)" />
   </Target>
 </Project>


### PR DESCRIPTION
`build.sh` and `build.cmd` contain logic to identify a working version of python to use. `src/build.proj` ignores that and directly invokes 'python', which may not work, or even execute a different program.

See https://github.com/dotnet/coreclr/pull/19043 and https://github.com/dotnet/coreclr/pull/19356

cc @BruceForstall 