### PR TITLE
Fix non-lclVar odd-byte struct passing

### DIFF
--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -94828,3 +94828,10 @@ MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS
 HostStyle=0
 
+[GitHub_19288.cmd_11915]
+RelativePath=JIT\Regression\JitBlue\GitHub_19288\GitHub_19288\GitHub_19288.cmd
+WorkingDir=JIT\Regression\JitBlue\GitHub_19288\GitHub_19288
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -94843,3 +94843,11 @@ Expected=0
 MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS
 HostStyle=0
+
+[GitHub_19288.cmd_12234]
+RelativePath=JIT\Regression\JitBlue\GitHub_19288\GitHub_19288\GitHub_19288.cmd
+WorkingDir=JIT\Regression\JitBlue\GitHub_19288\GitHub_19288
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0

--- a/tests/src/JIT/Regression/JitBlue/GitHub_19288/GitHub_19288.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_19288/GitHub_19288.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+// This test exhibits a case where the JIT was passing a 3-byte struct
+// by loading 4-bytes, which is not always safe.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+public class GitHub_19288
+{
+    static int returnVal = 100;
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct PixelData
+    {
+        public byte blue;
+        public byte green;
+        public byte red;
+    }
+
+    public unsafe class MyClass
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        unsafe void CheckPointer(PixelData p)
+        {
+            if (&p == null)
+            {
+                Console.WriteLine("FAIL");
+                returnVal = -1;
+            }
+        }
+
+        unsafe int DoStuff()
+        {
+            IntPtr pBase = Marshal.AllocCoTaskMem(0x40000 * 3);
+            PixelData* foo = (PixelData*)(pBase + 511 * (512 * sizeof(PixelData)) + 511 * sizeof(PixelData));
+
+            CheckPointer(*foo);
+
+            return 0;
+        }
+
+        static int Main()
+        {
+            try
+            {
+                new MyClass().DoStuff();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Failed with exception: " + e.Message);
+                returnVal = -1;
+            }
+            return returnVal;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_19288/GitHub_19288.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_19288/GitHub_19288.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{ADEEA3D1-B67B-456E-8F2B-6DCCACC2D34C}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
When a non-power-of-2 struct is passed, we can only use an IND if the arg is a local.

Fix #19288