### PR TITLE
CORDbgSetInstruction: clear thumb bit of the address before flushing icache

### DIFF
--- a/src/debug/inc/arm/primitives.h
+++ b/src/debug/inc/arm/primitives.h
@@ -166,7 +166,7 @@ inline void CORDbgSetInstruction(CORDB_ADDRESS_TYPE* address,
 
     *(PRD_TYPE *)ptraddr = instruction;
     FlushInstructionCache(GetCurrentProcess(),
-                          address,
+                          _ClearThumbBit(address),
                           sizeof(PRD_TYPE));
 }
 


### PR DESCRIPTION
We should clear thumb bit of the address before flushing icache otherwise we may not flush the cache for the first byte of the instruction.

This patch should fix unexpected SIGILLs during debugging:
```
Program received signal SIGILL, Illegal instruction.
[Switching to Thread 0xac98e040 (LWP 3917)]
0xaeaee076 in ?? ()
(gdb) bt
#0  0xaeaee076 in ?? ()
#1  0xb67ad588 in update_get_addr () from /lib/ld-linux.so.3
#2  0x00000000 in ?? ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
(gdb) x/5i $pc - 2
   0xaeaee074:  blx     r3
=> 0xaeaee076:  nop
   0xaeaee078:  nop
   0xaeaee07a:  add     sp, #32
   0xaeaee07c:  ldmia.w sp!, {r4, r5, r6, r10, r11, pc}
```