### PR TITLE
Reduce the number of innerloop CoreFX jobs

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1820,7 +1820,6 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                     }
                     switch (scenario) {
                         case 'innerloop':
-                        case 'corefx_innerloop':
                             isDefaultTrigger = true
                             break
 
@@ -1875,8 +1874,14 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                     switch (scenario) {
                         case 'innerloop':
                         case 'no_tiered_compilation_innerloop':
-                        case 'corefx_innerloop':
                             isDefaultTrigger = true
+                            break
+
+                        case 'corefx_innerloop':
+                            if (configuration == 'Checked' || configuration == 'Release') {
+                                isDefaultTrigger = true
+                            }
+                            break
 
                         default:
                             break


### PR DESCRIPTION
1. Stop doing any OSX CoreFX jobs; they're too unreliable.
2. Stop running Debug jobs.