### PR TITLE
[release/uwp6.0] Port removals of unix configurations from CI/Official Builds

### DIFF
--- a/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
+++ b/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
@@ -253,7 +253,7 @@
       "value": "linux-x64"
     },
     "TargetQueues": {
-      "value": "debian.82.amd64,fedora.23.amd64,redhat.72.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1610.amd64"
+      "value": "debian.82.amd64,fedora.27.amd64,fedora.28.amd64,redhat.73.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1710.amd64,ubuntu.1804.amd64,opensuse.423.amd64,sles.12.amd64"
     },
     "TestProduct": {
       "value": "coreclr"

--- a/buildpipeline/README.md
+++ b/buildpipeline/README.md
@@ -1,4 +1,4 @@
-These are the checked in build definitions used by BuildPipeline.
+These are the checked-in build definitions used by BuildPipeline.
 
 You may edit build steps, variables, and other artifacts of the definition directly to modify the BuildPipeline builds.
 

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -432,7 +432,7 @@
             "HelixJobType": "test/functional/cli/",
             "TargetsWindows": "false",
             "Rid": "linux-x64",
-            "TargetQueues": "debian.82.amd64,fedora.25.amd64,redhat.72.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64",
+            "TargetQueues": "debian.82.amd64,fedora.27.amd64,fedora.28.amd64,redhat.73.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1710.amd64,ubuntu.1804.amd64,opensuse.423.amd64,sles.12.amd64", 
             "TestContainerSuffix": "linux",
             "TargetsNonWindowsArg": "TargetsNonWindows "
           },
@@ -449,7 +449,7 @@
             "HelixJobType": "test/functional/r2r/cli/",
             "TargetsWindows": "false",
             "Rid": "linux-x64",
-            "TargetQueues": "debian.82.amd64,fedora.25.amd64,redhat.72.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64",
+            "TargetQueues": "debian.82.amd64,fedora.27.amd64,fedora.28.amd64,redhat.73.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1710.amd64,ubuntu.1804.amd64,opensuse.423.amd64,sles.12.amd64",
             "TestContainerSuffix": "linux-r2r",
             "CrossgenArg": "Crossgen ",
             "TargetsNonWindowsArg": "TargetsNonWindows "

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -432,7 +432,7 @@
             "HelixJobType": "test/functional/cli/",
             "TargetsWindows": "false",
             "Rid": "linux-x64",
-            "TargetQueues": "debian.82.amd64,fedora.27.amd64,fedora.28.amd64,redhat.73.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1710.amd64,ubuntu.1804.amd64,opensuse.423.amd64,sles.12.amd64", 
+            "TargetQueues": "debian.82.amd64,fedora.27.amd64,fedora.28.amd64,redhat.73.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1804.amd64,opensuse.423.amd64,sles.12.amd64", 
             "TestContainerSuffix": "linux",
             "TargetsNonWindowsArg": "TargetsNonWindows "
           },
@@ -449,7 +449,7 @@
             "HelixJobType": "test/functional/r2r/cli/",
             "TargetsWindows": "false",
             "Rid": "linux-x64",
-            "TargetQueues": "debian.82.amd64,fedora.27.amd64,fedora.28.amd64,redhat.73.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1710.amd64,ubuntu.1804.amd64,opensuse.423.amd64,sles.12.amd64",
+            "TargetQueues": "debian.82.amd64,fedora.27.amd64,fedora.28.amd64,redhat.73.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1804.amd64,opensuse.423.amd64,sles.12.amd64",
             "TestContainerSuffix": "linux-r2r",
             "CrossgenArg": "Crossgen ",
             "TargetsNonWindowsArg": "TargetsNonWindows "


### PR DESCRIPTION
- Port 01569f304c291e77968d854efe857a9a44c4efe7 "Remove Fedora 26, add Fedora 28"
- Port dc50510d750c5b246e7743569c03054fd7eed50b "Remove EOL Ubuntu 17.10"