### PR TITLE
Dict add StringComparer.Ordinal{IgnoreCase} non-randomized optimization

### DIFF
--- a/src/System.Private.CoreLib/shared/System/String.Comparison.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Comparison.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
@@ -781,20 +782,151 @@ namespace System
                 {
                     length -= 4;
                     // Where length is 4n-1 (e.g. 3,7,11,15,19) this additionally consumes the null terminator
-                    hash1 = (((hash1 << 5) | (hash1 >> 27)) + hash1) ^ ptr[0];
-                    hash2 = (((hash2 << 5) | (hash2 >> 27)) + hash2) ^ ptr[1];
+                    hash1 = NonRandomizedHashCodeCombine(hash1, ptr[0]);
+                    hash2 = NonRandomizedHashCodeCombine(hash2, ptr[1]);
                     ptr += 2;
                 }
 
                 if (length > 0)
                 {
                     // Where length is 4n-3 (e.g. 1,5,9,13,17) this additionally consumes the null terminator
-                    hash2 = (((hash2 << 5) | (hash2 >> 27)) + hash2) ^ ptr[0];
+                    hash2 = NonRandomizedHashCodeCombine(hash2, ptr[0]);
                 }
 
-                return (int)(hash1 + (hash2 * 1566083941));
+                return NonRandomizedHashCodeFinalize(hash1, hash2);
             }
         }
+
+        // Use this if and only if 'Denial of Service' attacks are not a concern (i.e. never used for free-form user input),
+        // or are otherwise mitigated
+        internal unsafe int GetNonRandomizedIgnoreCaseHashCode()
+        {
+            fixed (char* src = &_firstChar)
+            {
+                Debug.Assert(src[this.Length] == '\0', "src[this.Length] == '\\0'");
+                Debug.Assert(((int)src) % 4 == 0, "Managed string should start at 4 bytes boundary");
+
+                uint hash1 = (5381 << 16) + 5381;
+                uint hash2 = hash1;
+
+                uint* ptr = (uint*)src;
+                int length = this.Length;
+
+                while (length > 2)
+                {
+                    uint value1 = ptr[0];
+                    uint value2 = ptr[1];
+
+                    if (((value1 | value2) & 0xff80ff80) != 0)
+                    {
+                        // Non-ascii detected, fallback to non-ascii aware casing
+                        return GetRemainingIgnoreCaseHashCode((char*)ptr, length, hash1, hash2);
+                    }
+
+                    length -= 4;
+                    // Where length is 4n-1 (e.g. 3,7,11,15,19) this additionally consumes the null terminator
+
+                    // Branchless double char (uint) ascii lowercase 
+                    uint upper = value1 + 0x_0025_0025u; // Ignore chars > 'Z'
+                    uint lower = upper + 0x_001a_001au;  // Ignore chars < 'A'
+                    // Keep high bit for range, and shift into case bit, xor to flip case
+                    value1 ^= (~(value1 | upper) & lower & 0x0080_0080u) >> 2;
+
+                    upper = value2 + 0x_0025_0025u; // repeat for next uint
+                    lower = upper + 0x_001a_001au;
+                    value2 ^= (~(value2 | upper) & lower & 0x0080_0080u) >> 2;
+
+                    hash1 = NonRandomizedHashCodeCombine(hash1, value1);
+                    hash2 = NonRandomizedHashCodeCombine(hash2, value2);
+                    ptr += 2;
+                }
+
+                if (length > 0)
+                {
+                    uint value = ptr[0];
+                    if ((value & 0xff80ff80) != 0)
+                    {
+                        // Non-ascii detected, fallback to non-ascii aware casing
+                        return GetRemainingIgnoreCaseHashCode((char*)ptr, length, hash1, hash2);
+                    }
+
+                    // Where length is 4n-3 (e.g. 1,5,9,13,17) this additionally consumes the null terminator
+
+                    // Branchless double char (uint) ascii lowercase 
+                    uint upper = value + 0x_0025_0025u; // Ignore chars > 'Z'
+                    uint lower = upper + 0x_001a_001au; // Ignore chars < 'A'
+                    // Keep high bit for range, and shift into case bit, xor to flip case
+                    value ^= (~(value | upper) & lower & 0x0080_0080u) >> 2;
+
+                    hash2 = NonRandomizedHashCodeCombine(hash2, value);
+                }
+
+                return NonRandomizedHashCodeFinalize(hash1, hash2);
+            }
+        }
+
+        private static unsafe int GetRemainingIgnoreCaseHashCode(char* str, int remainingLength, uint hash1, uint hash2)
+        {
+            Debug.Assert(remainingLength > 0);
+            Debug.Assert(str[remainingLength] == '\0', "str[remainingLength] == '\\0'");
+
+            char[] rentedArray = null;
+            Span<char> span = remainingLength <= 255 ?
+                stackalloc char[255] :
+                (rentedArray = ArrayPool<char>.Shared.Rent(remainingLength));
+
+            int charsWritten = new ReadOnlySpan<char>(str, remainingLength).ToLowerInvariant(span);
+            span = span.Slice(0, charsWritten);
+
+            fixed (char* src = span)
+            {
+                str = src;
+                int length = span.Length;
+
+                Debug.Assert(((int)str) % 4 == 0, "Array and stackalloc should start at 4 bytes boundary");
+
+                uint* ptr = (uint*)str;
+
+                while (length >= 4)
+                {
+                    length -= 4;
+                    hash1 = NonRandomizedHashCodeCombine(hash1, ptr[0]);
+                    hash2 = NonRandomizedHashCodeCombine(hash2, ptr[1]);
+                    ptr += 2;
+                }
+
+                if (length >= 2)
+                {
+                    length -= 2;
+                    hash2 = NonRandomizedHashCodeCombine(hash2, ptr[0]);
+                    ptr += 1;
+                }
+
+                if (length == 1)
+                {
+                    // Need to process any remaining single char individually as there is no null terminator
+                    // in lowercased temporary char array that we can consume at the same time.
+                    // (Unlike in GetNonRandomizedHashCode which operates directly on the string)
+                    hash2 = NonRandomizedHashCodeCombine(hash2, *(char*)ptr);
+                }
+            }
+
+            // Return the borrowed array if necessary.
+            if (rentedArray != null)
+            {
+                ArrayPool<char>.Shared.Return(rentedArray);
+            }
+
+            return NonRandomizedHashCodeFinalize(hash1, hash2);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint NonRandomizedHashCodeCombine(uint hash, uint value)
+            => (((hash << 5) | (hash >> 27)) + hash) ^ value;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int NonRandomizedHashCodeFinalize(uint hash1, uint hash2)
+            => (int)(hash1 + (hash2 * 1566083941));
 
         // Determines whether a specified string is a prefix of the current instance
         //


### PR DESCRIPTION
+473% / x5.7 speed up for hashing 10 char `StringComparer.OrdinalIgnoreCase` ascii keys in used  `Dictionary<string, TValue>`

+116% / x2.2 speed up for hashing 10 char `StringComparer.Ordinal` keys in used  `Dictionary<string, TValue>`

Fast path for ascii `StringComparer.OrdinalIgnoreCase` before collisions become high, when it switches to randomised hashing.

Recognise `StringComparer.Ordinal` in addition to `EqualityComparer<string>.Default` for non-randomized optimization. 

[apisof.net](https://apisof.net/catalog/System.StringComparer.Ordinal) says `StringComparer.Ordinal` has 4.8% usage on NuGet.

`StringComparer.OrdinalIgnoreCase` version 7.8% usage on NuGet

Resolves dotnet/corefx#28834

For ascii input https://github.com/dotnet/coreclr/pull/19436#issuecomment-412384276
```
                      Method |                 Input |       Mean |          Op/s | Scaled |
---------------------------- |---------------------- |-----------:|--------------:|-------:|
     NonRandomizedIgnoreCase |                       |   2.543 ns | 393,239,898.3 |   0.16 |
 RandomizedOrdinalIgnoreCase |                       |  16.365 ns |  61,107,451.3 |   1.00 |
                             |                       |            |               |        |
     NonRandomizedIgnoreCase |                     1 |   3.677 ns | 271,977,635.4 |   0.09 |
 RandomizedOrdinalIgnoreCase |                     1 |  39.840 ns |  25,100,712.8 |   1.00 |
                             |                       |            |               |        |
     NonRandomizedIgnoreCase |                    12 |   3.681 ns | 271,684,906.0 |   0.09 |
 RandomizedOrdinalIgnoreCase |                    12 |  42.557 ns |  23,497,789.0 |   1.00 |
                             |                       |            |               |        |
     NonRandomizedIgnoreCase |                   123 |   5.090 ns | 196,459,260.6 |   0.12 |
 RandomizedOrdinalIgnoreCase |                   123 |  42.889 ns |  23,315,996.0 |   1.00 |
                             |                       |            |               |        |
     NonRandomizedIgnoreCase |                  1234 |   5.090 ns | 196,451,630.3 |   0.11 |
 RandomizedOrdinalIgnoreCase |                  1234 |  44.283 ns |  22,582,258.6 |   1.00 |
                             |                       |            |               |        |
     NonRandomizedIgnoreCase |                 12345 |   6.220 ns | 160,783,055.6 |   0.14 |
 RandomizedOrdinalIgnoreCase |                 12345 |  45.369 ns |  22,041,264.4 |   1.00 |
                             |                       |            |               |        |
     NonRandomizedIgnoreCase |                123456 |   6.226 ns | 160,609,477.0 |   0.13 |
 RandomizedOrdinalIgnoreCase |                123456 |  46.565 ns |  21,475,384.8 |   1.00 |
                             |                       |            |               |        |
     NonRandomizedIgnoreCase |               1234567 |   7.879 ns | 126,919,960.7 |   0.17 |
 RandomizedOrdinalIgnoreCase |               1234567 |  47.166 ns |  21,201,895.8 |   1.00 |
                             |                       |            |               |        |
     NonRandomizedIgnoreCase |              12345678 |   7.879 ns | 126,916,990.6 |   0.16 |
 RandomizedOrdinalIgnoreCase |              12345678 |  48.925 ns |  20,439,378.7 |   1.00 |
                             |                       |            |               |        |
     NonRandomizedIgnoreCase |             123456789 |   8.995 ns | 111,169,928.0 |   0.18 |
 RandomizedOrdinalIgnoreCase |             123456789 |  49.784 ns |  20,086,888.1 |   1.00 |
                             |                       |            |               |        |
     NonRandomizedIgnoreCase |            1234567890 |   8.995 ns | 111,173,636.8 |   0.17 |
 RandomizedOrdinalIgnoreCase |            1234567890 |  51.606 ns |  19,377,588.1 |   1.00 |
                             |                       |            |               |        |
     NonRandomizedIgnoreCase |  12345678901234567890 |  16.321 ns |  61,271,112.6 |   0.25 |
 RandomizedOrdinalIgnoreCase |  12345678901234567890 |  66.322 ns |  15,077,973.9 |   1.00 |
                             |                       |            |               |        |
     NonRandomizedIgnoreCase |  12345(...)67890 [40] |  30.431 ns |  32,861,074.5 |   0.29 |
 RandomizedOrdinalIgnoreCase |  12345(...)67890 [40] | 105.175 ns |   9,507,940.1 |   1.00 |
                             |                       |            |               |        |
     NonRandomizedIgnoreCase |  12345(...)67890 [80] |  59.670 ns |  16,758,837.1 |   0.37 |
 RandomizedOrdinalIgnoreCase |  12345(...)67890 [80] | 162.946 ns |   6,137,005.6 |   1.00 |
                             |                       |            |               |        |
     NonRandomizedIgnoreCase | 12345(...)67890 [160] | 118.589 ns |   8,432,479.1 |   0.41 |
 RandomizedOrdinalIgnoreCase | 12345(...)67890 [160] | 288.826 ns |   3,462,290.7 |   1.00 |
```

/cc @jkotas @danmosemsft @GrabYourPitchforks @stephentoub @safern