### PR TITLE
Silence WinRT type assert in crossgen

### DIFF
--- a/src/vm/assembly.cpp
+++ b/src/vm/assembly.cpp
@@ -1219,7 +1219,6 @@ Module * Assembly::FindModuleByTypeRef(
             if (pModule->HasBindableIdentity(tkType))
 #endif// FEATURE_COMINTEROP
             {
-                _ASSERTE(!IsAfContentType_WindowsRuntime(pModule->GetAssemblyRefFlags(tkType)));
                 if (loadFlag == Loader::SafeLookup)
                 {
                     pAssembly = pModule->LookupAssemblyRef(tkType);


### PR DESCRIPTION
Disable type loader assert that fires when resolving a type from a WinMD during crossgen. Instead, compilation should fail gracefully.

Fixes https://github.com/dotnet/coreclr/issues/19347.