### PR TITLE
[release/2.1] Sign api-ms-win-core-xstate-l2-1-0.dll

### DIFF
--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Windows_NT.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Windows_NT.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -19,7 +19,7 @@
     <NativeBinary Include="$(BinDir)mscorrc.debug.dll" />
     <NativeBinary Include="$(BinDir)mscorrc.dll" />
     <NativeBinary Include="$(BinDir)sos.dll" />
-    <NativeBinary Include="$(UniversalCRTSDKDir)Redist\ucrt\DLLs\$(BuildArch)\*.dll" Condition="'$(BuildType)'=='Release' AND '$(BuildArch)' != 'arm64'" />
+    <NativeBinary Include="$(BinDir)Redist\ucrt\DLLs\$(BuildArch)\*.dll" Condition="'$(BuildType)'=='Release' AND '$(BuildArch)' != 'arm64'" />
     <NativeBinary Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen.exe" />

--- a/src/build.proj
+++ b/src/build.proj
@@ -38,6 +38,17 @@
         DestinationFolder="$(BinDir)PDB" />
   </Target>
 
+  <ItemGroup>
+    <UcrtFilesToCopy Include="$(UniversalCRTSDKDir)Redist\ucrt\DLLs\$(BuildArch)\*.dll" />
+  </ItemGroup>
+  <!-- Copy the UCRT files from the windows kit directory to the local directory.
+       The api-*xstate.dll binary needs to be signed. -->
+  <Target Name="CopyUcrtFiles" AfterTargets="Build">
+    <Copy Condition="'$(BuildType)'=='Release' AND '$(BuildArch)' != 'arm64'"
+        SourceFiles="@(UcrtFilesToCopy)"
+        DestinationFolder="$(BinDir)Redist\ucrt\DLLs\$(BuildArch)" />
+  </Target>
+
   <PropertyGroup>
     <RunEnforcePGO Condition="$(__EnforcePgo) == '1'">true</RunEnforcePGO>
     <RunEnforcePGO Condition="$(__BuildArch) == 'arm' OR $(__BuildArch) == 'arm64'">false</RunEnforcePGO>

--- a/src/sign.builds
+++ b/src/sign.builds
@@ -17,6 +17,8 @@
     <!-- Ensure cross targeting components are signed properly -->
     <WindowsNativeLocation Include="$(BinDir)$(CrossTargetComponentFolder)\*.exe" />
     <WindowsNativeLocation Include="$(BinDir)$(CrossTargetComponentFolder)\*.dll" />
+    <!-- Sign api-ms-win-core-xstate-l2-1-0 binary as it is only catalog signed in the current SDK. -->
+    <WindowsNativeLocation Include="$(BinDir)Redist\ucrt\DLLs\api-ms-win-core-xstate-l2-1-0.dll" />
   </ItemGroup>
   <!-- sign the cross targeted files as well -->
   <ItemGroup Condition="'$(CrossTargetComponentFolder)' != ''">


### PR DESCRIPTION
This file is only catalog signed in RS4.  Sign during the build. To achieve this copy the CRT binaries locally rather than referencing from the UCRT location directly.