### PR TITLE
Disable System.Linq.Expressions.Tests against #19457

### DIFF
--- a/tests/arm/corefx_test_exclusions.txt
+++ b/tests/arm/corefx_test_exclusions.txt
@@ -9,6 +9,7 @@ System.Drawing.Common.Tests          # https://github.com/dotnet/coreclr/issues/
 System.IO.FileSystem.Tests           # https://github.com/dotnet/coreclr/issues/16001
 System.IO.Ports.Tests                # https://github.com/dotnet/coreclr/issues/16001
 System.Management.Tests              # https://github.com/dotnet/coreclr/issues/16001
+System.Linq.Expressions.Tests        # JitStress=1 https://github.com/dotnet/coreclr/issues/19457
 System.Net.HttpListener.Tests        # https://github.com/dotnet/coreclr/issues/17584
 System.Runtime.Numerics.Tests        # https://github.com/dotnet/coreclr/issues/18362 -- JitStress=1 JitStress=2
 System.Text.RegularExpressions.Tests # https://github.com/dotnet/coreclr/issues/17754 -- timeout -- JitMinOpts only


### PR DESCRIPTION
For Windows ARM corefx testing