### PR TITLE
Exclude 437044.cmd_10304 from GCStress runs

### DIFF
--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -82033,7 +82033,7 @@ RelativePath=baseservices\threading\regressions\beta2\437044\437044.cmd
 WorkingDir=baseservices\threading\regressions\beta2\437044
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;Pri1
+Categories=EXPECTED_PASS;Pri1;GCSTRESS_EXCLUDE
 HostStyle=0
 
 [KeyCollectionCtor.cmd_10305]


### PR DESCRIPTION
This test times out on ARM Windows R2R GCStress15 runs.