### PR TITLE
Sign xstate binary from correct location

### DIFF
--- a/src/sign.builds
+++ b/src/sign.builds
@@ -18,7 +18,7 @@
     <WindowsNativeLocation Include="$(BinDir)$(CrossTargetComponentFolder)\*.exe" />
     <WindowsNativeLocation Include="$(BinDir)$(CrossTargetComponentFolder)\*.dll" />
     <!-- Sign api-ms-win-core-xstate-l2-1-0 binary as it is only catalog signed in the current SDK. -->
-    <WindowsNativeLocation Include="$(BinDir)Redist\ucrt\DLLs\api-ms-win-core-xstate-l2-1-0.dll" />
+    <WindowsNativeLocation Include="$(BinDir)Redist\ucrt\DLLs\$(BuildArch)\api-ms-win-core-xstate-l2-1-0.dll" />
   </ItemGroup>
   <!-- sign the cross targeted files as well -->
   <ItemGroup Condition="'$(CrossTargetComponentFolder)' != ''">

--- a/src/sign.builds
+++ b/src/sign.builds
@@ -17,9 +17,13 @@
     <!-- Ensure cross targeting components are signed properly -->
     <WindowsNativeLocation Include="$(BinDir)$(CrossTargetComponentFolder)\*.exe" />
     <WindowsNativeLocation Include="$(BinDir)$(CrossTargetComponentFolder)\*.dll" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(BuildArch)' == 'x86'">
     <!-- Sign api-ms-win-core-xstate-l2-1-0 binary as it is only catalog signed in the current SDK. -->
     <WindowsNativeLocation Include="$(BinDir)Redist\ucrt\DLLs\$(BuildArch)\api-ms-win-core-xstate-l2-1-0.dll" />
   </ItemGroup>
+
   <!-- sign the cross targeted files as well -->
   <ItemGroup Condition="'$(CrossTargetComponentFolder)' != ''">
     <WindowsNativeLocation Include="$(BinDir)$(CrossTargetComponentFolder)/*.dll" />


### PR DESCRIPTION
Binary gets copied to BuildArch dir, should be signed from there, as well as only for x86.

Missed in previous verification because of stale files in workspace and stubbed out