### PR TITLE
Disable R2RDumpTests

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -1731,6 +1731,9 @@
         <ExcludeList Include="$(XunitTestBinBase)\tracing\eventsource\eventpipeandetw\eventpipeandetw\eventpipeandetw.cmd">
             <Issue>by design Windows only</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\readytorun\r2rdump\R2RDumpTest\R2RDumpTest.cmd">
+            <Issue>19441</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- Failures while testing via ILLINK -->


### PR DESCRIPTION
Fix for issue https://github.com/dotnet/coreclr/issues/19441
Disable R2RDumpTests for now because it's too fragile