### PR TITLE
Pass __BuildType to publish.proj when reuploading signed packages

### DIFF
--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -208,7 +208,7 @@
       },
       "inputs": {
         "filename": "msbuild",
-        "arguments": "src\\publish.proj /p:CloudDropAccountName=$(CloudDropAccountName) /p:CloudDropAccessToken=$(CloudDropAccessToken) /p:ContainerName=$(Label) /p:OverwriteOnPublish=true /p:RepublishSignedFinalPackages=true",
+        "arguments": "src\\publish.proj /p:CloudDropAccountName=$(CloudDropAccountName) /p:CloudDropAccessToken=$(CloudDropAccessToken) /p:ContainerName=$(Label) /p:OverwriteOnPublish=true /p:RepublishSignedFinalPackages=true /p:ConfigurationGroup=$(ConfigurationGroup) /p:__BuildType=$(ConfigurationGroup)",
         "workingFolder": "$(Pipeline.SourcesDirectory)",
         "failOnStandardError": "false"
       }


### PR DESCRIPTION
We need to pass `__BuildType` to publish.proj when republishing signed packages, because of https://github.com/dotnet/coreclr/blob/release/2.0.0/src/publish.proj#L17-L18. Without this change, we've been publishing into a folder with no name in Azure blob storage, instead of overwriting the unsigned packages we were trying to overwrite.

CC @MattGal @weshaggard 

@dagood PTAL