### PR TITLE
ExcludeList for R2RDumpTests in wrong ItemGroup

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -199,6 +199,9 @@
         <ExcludeList Include="$(XunitTestBinBase)\Interop\COM\NETClients\Primitives\NETClientPrimitives\NETClientPrimitives.cmd">
             <Issue>19164</Issue>
         </ExcludeList>
+		<ExcludeList Include="$(XunitTestBinBase)\readytorun\r2rdump\R2RDumpTest\R2RDumpTest.cmd">
+            <Issue>19441</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- The following are x86 failures -->
@@ -1730,9 +1733,6 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\tracing\eventsource\eventpipeandetw\eventpipeandetw\eventpipeandetw.cmd">
             <Issue>by design Windows only</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\readytorun\r2rdump\R2RDumpTest\R2RDumpTest.cmd">
-            <Issue>19441</Issue>
         </ExcludeList>
     </ItemGroup>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/19441
The previous change https://github.com/dotnet/coreclr/pull/19475 didn't disable R2RDumpTests because the ExcludeList was added to the wrong ItemGroup.