### PR TITLE
JIT: bail out in optExtractArrIndex for constant array length

### DIFF
--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -8366,11 +8366,9 @@ bool Compiler::optExtractArrIndex(GenTree* tree, ArrIndex* result, unsigned lhsN
         return false;
     }
 
-    // For span we may see gtArrLen is a local var or local field.
+    // For span we may see gtArrLen is a local var or local field or constant.
     // We won't try and extract those.
-    const genTreeOps arrayOp = arrBndsChk->gtArrLen->gtOper;
-
-    if ((arrayOp == GT_LCL_VAR) || (arrayOp == GT_LCL_FLD))
+    if (arrBndsChk->gtArrLen->OperIs(GT_LCL_VAR, GT_LCL_FLD, GT_CNS_INT))
     {
         return false;
     }

--- a/tests/src/JIT/Regression/JitBlue/GitHub_19454/Github_19454.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_19454/Github_19454.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+// This test was extracted from the corefx System.Numerics.Vectors tests,
+// and was failing with minOpts because a SIMD12 was being spilled using
+// a 16-byte load, but only a 12-byte location had been allocated.
+
+using System;
+
+public struct MyStruct
+{
+    public Span<byte> Span1
+    {
+        get { return Span<byte>.Empty; }
+    }
+}
+
+public struct MyReader
+{
+    public void ReadBytesInner(int batch)
+    {
+        MyStruct value = new MyStruct();
+        for (int i = 0; i < batch; i++)
+        {
+            value.Span1[i] = 0;
+        }
+    }
+}
+
+class GitHub_19454
+{
+    static int Main()
+    {
+        MyReader r = new MyReader();
+        r.ReadBytesInner(0);
+        return 100;
+    }
+}
+

--- a/tests/src/JIT/Regression/JitBlue/GitHub_19454/Github_19454.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_19454/Github_19454.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{ADEEA3D1-B67B-456E-8F2B-6DCCACC2D34C}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Generalize the bail out pattern to handle cases from spans where we may
see a known array length in a bounds check.

Fixes #19454