### PR TITLE
Revert "Temporarily flag a SIMD test as optimization-sensitive (#19163)"

### DIFF
--- a/tests/src/JIT/SIMD/VectorExp_ro.csproj
+++ b/tests/src/JIT/SIMD/VectorExp_ro.csproj
@@ -21,8 +21,6 @@
   <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <!-- Temporarily flagged as optimization-sensitive due to https://github.com/dotnet/coreclr/issues/19124 -->
-    <JitOptimizationSensitive>True</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />


### PR DESCRIPTION
This reverts commit 855ddf52c7b05994cf6728b9169fa6cdc694a537 (PR https://github.com/dotnet/coreclr/pull/19163). Issue https://github.com/dotnet/coreclr/issues/19124 was fixed by PR https://github.com/dotnet/coreclr/pull/19234, so re-enabling the test in minopts and with tiering.