### PR TITLE
Make file handle checks accurate on Windows

### DIFF
--- a/src/System.Private.CoreLib/shared/Interop/Windows/Interop.Libraries.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Windows/Interop.Libraries.cs
@@ -13,5 +13,6 @@ internal static partial class Interop
         internal const string Ole32 = "ole32.dll";
         internal const string OleAut32 = "oleaut32.dll";
         internal const string User32 = "user32.dll";
+        internal const string NtDll = "ntdll.dll";
     }
 }

--- a/src/System.Private.CoreLib/shared/Interop/Windows/NtDll/NtQueryInformationFile.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Windows/NtDll/NtQueryInformationFile.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class NtDll
+    {
+        [DllImport(Libraries.NtDll, ExactSpelling = true)]
+        unsafe internal static extern int NtQueryInformationFile(
+            SafeFileHandle FileHandle,
+            out IO_STATUS_BLOCK IoStatusBlock,
+            void* FileInformation,
+            uint Length,
+            uint FileInformationClass);
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct IO_STATUS_BLOCK
+        {
+            IO_STATUS Status;
+            IntPtr Information;
+        }
+
+        // This isn't an actual Windows type, we have to separate it out as the size of IntPtr varies by architecture
+        // and we can't specify the size at compile time to offset the Information pointer in the status block.
+        [StructLayout(LayoutKind.Explicit)]
+        internal struct IO_STATUS
+        {
+            [FieldOffset(0)]
+            int Status;
+
+            [FieldOffset(0)]
+            IntPtr Pointer;
+        }
+
+        internal const uint FileModeInformation = 16;
+        internal const uint FILE_SYNCHRONOUS_IO_ALERT = 0x00000010;
+        internal const uint FILE_SYNCHRONOUS_IO_NONALERT = 0x00000020;
+
+        internal const int STATUS_INVALID_HANDLE = unchecked((int)0xC0000008);
+    }
+}

--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -805,6 +805,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Security\SecureString.Windows.cs" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetsWindows) and '$(EnableWinRT)' != 'true'">
+    <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\NtDll\NtQueryInformationFile.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\FileStream.Win32.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\TimeZoneInfo.Win32.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs" />

--- a/src/System.Private.CoreLib/shared/System/IO/FileStream.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStream.Unix.cs
@@ -61,10 +61,15 @@ namespace System.IO
             return SafeFileHandle.Open(_path, openFlags, (int)OpenPermissions);
         }
 
+        private static bool GetDefaultIsAsync(SafeFileHandle handle)
+        {
+            return handle.IsAsync.HasValue ? handle.IsAsync.Value : false;
+        }
+
         /// <summary>Initializes a stream for reading or writing a Unix file.</summary>
         /// <param name="mode">How the file should be opened.</param>
         /// <param name="share">What other access to the file should be allowed.  This is currently ignored.</param>
-        private void Init(FileMode mode, FileShare share)
+        private void Init(FileMode mode, FileShare share, string originalPath)
         {
             _fileHandle.IsAsync = _useAsyncIO;
 

--- a/src/System.Private.CoreLib/shared/System/IO/FileStream.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStream.Unix.cs
@@ -61,10 +61,7 @@ namespace System.IO
             return SafeFileHandle.Open(_path, openFlags, (int)OpenPermissions);
         }
 
-        private static bool GetDefaultIsAsync(SafeFileHandle handle)
-        {
-            return handle.IsAsync.HasValue ? handle.IsAsync.Value : false;
-        }
+        private static bool GetDefaultIsAsync(SafeFileHandle handle) => handle.IsAsync ?? DefaultIsAsync;
 
         /// <summary>Initializes a stream for reading or writing a Unix file.</summary>
         /// <param name="mode">How the file should be opened.</param>

--- a/src/System.Private.CoreLib/shared/System/IO/FileStream.Win32.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStream.Win32.cs
@@ -76,7 +76,6 @@ namespace System.IO
                     }
                     else
                     {
-                        fileHandle.Dispose();
                         return null;
                     }
                 default:

--- a/src/System.Private.CoreLib/shared/System/IO/FileStream.Win32.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStream.Win32.cs
@@ -93,7 +93,7 @@ namespace System.IO
 
             // If we can't check the handle, just assume it is ok.
             if (!(IsHandleSynchronous(handle) ?? true))
-                throw new ArgumentException(SR.Arg_HandleNotSync, "handle");
+                throw new ArgumentException(SR.Arg_HandleNotSync, nameof(handle));
         }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/IO/FileStream.Win32.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStream.Win32.cs
@@ -70,13 +70,13 @@ namespace System.IO
                     // We we're successful
                     break;
                 case Interop.NtDll.STATUS_INVALID_HANDLE:
-                    fileHandle.Dispose();
                     if (!ignoreInvalid)
                     {
                         throw Win32Marshal.GetExceptionForWin32Error(Interop.Errors.ERROR_INVALID_HANDLE);
                     }
                     else
                     {
+                        fileHandle.Dispose();
                         return null;
                     }
                 default:

--- a/src/System.Private.CoreLib/shared/System/IO/FileStream.Win32.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStream.Win32.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using Microsoft.Win32.SafeHandles;
 
 namespace System.IO
@@ -42,6 +43,57 @@ namespace System.IO
                 return ValidateFileHandle(
                     Interop.Kernel32.CreateFile(_path, fAccess, share, ref secAttrs, mode, flagsAndAttributes, IntPtr.Zero));
             }
+        }
+
+        private static bool GetDefaultIsAsync(SafeFileHandle handle)
+        {
+            return handle.IsAsync ?? !IsHandleSynchronous(handle) ?? DefaultIsAsync;
+        }
+
+        private static unsafe bool? IsHandleSynchronous(SafeFileHandle fileHandle)
+        {
+            if (fileHandle.IsInvalid)
+                return null;
+
+            uint fileMode;
+
+            int status = Interop.NtDll.NtQueryInformationFile(
+                FileHandle: fileHandle,
+                IoStatusBlock: out Interop.NtDll.IO_STATUS_BLOCK ioStatus,
+                FileInformation: &fileMode,
+                Length: sizeof(uint),
+                FileInformationClass: Interop.NtDll.FileModeInformation);
+
+            switch (status)
+            {
+                case 0:
+                    // We we're successful
+                    break;
+                case Interop.NtDll.STATUS_INVALID_HANDLE:
+                    fileHandle.Dispose();
+                    throw Win32Marshal.GetExceptionForWin32Error(Interop.Errors.ERROR_INVALID_HANDLE);
+                default:
+                    // Something else is preventing access
+                    Debug.Fail("Unable to get the file mode information, status was" + status.ToString());
+                    return null;
+            }
+
+            // If either of these two flags are set, the file handle is synchronous (not overlapped)
+            return (fileMode & (Interop.NtDll.FILE_SYNCHRONOUS_IO_ALERT | Interop.NtDll.FILE_SYNCHRONOUS_IO_NONALERT)) > 0;
+        }
+
+        private static void VerifyHandleIsSync(SafeFileHandle handle, int fileType)
+        {
+            // As we can accurately check the handle type when we have access to NtQueryInformationFile we don't need to skip for
+            // any particular file handle type.
+
+            // If the handle was passed in without an explicit async setting, we already looked it up in GetDefaultIsAsync
+            if (!handle.IsAsync.HasValue)
+                return;
+
+            // If we can't check the handle, just assume it is ok.
+            if (!(IsHandleSynchronous(handle) ?? true))
+                throw new ArgumentException(SR.Arg_HandleNotSync, "handle");
         }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/IO/FileStream.WinRT.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStream.WinRT.cs
@@ -41,10 +41,7 @@ namespace System.IO
             }
         }
 
-        private static bool GetDefaultIsAsync(SafeFileHandle handle)
-        {
-            return handle.IsAsync.HasValue ? handle.IsAsync.Value : DefaultIsAsync;
-        }
+        private static bool GetDefaultIsAsync(SafeFileHandle handle) => handle.IsAsync ?? DefaultIsAsync;
 
         private static unsafe bool? IsHandleSynchronous(SafeFileHandle handle)
         {
@@ -89,7 +86,7 @@ namespace System.IO
             {
                 // If we can't check the handle, just assume it is ok.
                 if (!(IsHandleSynchronous() ?? true))
-                    throw new ArgumentException(SR.Arg_HandleNotSync, "handle");
+                    throw new ArgumentException(SR.Arg_HandleNotSync, nameof(handle));
             }
         }
     }

--- a/src/System.Private.CoreLib/shared/System/IO/FileStream.WinRT.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStream.WinRT.cs
@@ -40,5 +40,57 @@ namespace System.IO
                     pCreateExParams: ref parameters));
             }
         }
+
+        private static bool GetDefaultIsAsync(SafeFileHandle handle)
+        {
+            return handle.IsAsync.HasValue ? handle.IsAsync.Value : DefaultIsAsync;
+        }
+
+        private static unsafe bool? IsHandleSynchronous(SafeFileHandle handle)
+        {
+            // Do NOT use this method on any type other than DISK. Reading or writing to a pipe may
+            // cause an app to block incorrectly, introducing a deadlock (depending on whether a write
+            // will wake up an already-blocked thread or this Win32FileStream's thread).
+
+            byte* bytes = stackalloc byte[1];
+            int numBytesReadWritten;
+            int r = -1;
+
+            // If the handle is a pipe, ReadFile will block until there
+            // has been a write on the other end.  We'll just have to deal with it,
+            // For the read end of a pipe, you can mess up and 
+            // accidentally read synchronously from an async pipe.
+            if (_canRead)
+                r = Interop.Kernel32.ReadFile(handle, bytes, 0, out numBytesReadWritten, IntPtr.Zero);
+            else if (_canWrite)
+                r = Interop.Kernel32.WriteFile(handle, bytes, 0, out numBytesReadWritten, IntPtr.Zero);
+
+            if (r == 0)
+            {
+                int errorCode = Marshal.GetLastWin32Error();
+                switch (errorCode)
+                {
+                    case Interop.Errors.ERROR_INVALID_PARAMETER:
+                        return false;
+                    case Interop.Errors.ERROR_INVALID_HANDLE:
+                        throw Win32Marshal.GetExceptionForWin32Error(errorCode);
+                }
+            }
+
+            return true;
+        }
+
+        private static void VerifyHandleIsSync(SafeFileHandle handle, int fileType)
+        {
+            // The technique here only really works for FILE_TYPE_DISK. FileMode is the right thing to check, but it currently
+            // isn't available in WinRT.
+
+            if (fileType == Interop.mincore.FileTypes.FILE_TYPE_DISK)
+            {
+                // If we can't check the handle, just assume it is ok.
+                if (!(IsHandleSynchronous() ?? true))
+                    throw new ArgumentException(SR.Arg_HandleNotSync, "handle");
+            }
+        }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/IO/FileStream.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStream.cs
@@ -233,7 +233,7 @@ namespace System.IO
 
             try
             {
-                Init(mode, share);
+                Init(mode, share, path);
             }
             catch
             {
@@ -243,12 +243,6 @@ namespace System.IO
                 _fileHandle = null;
                 throw;
             }
-        }
-
-        private static bool GetDefaultIsAsync(SafeFileHandle handle)
-        {
-            // This will eventually get more complicated as we can actually check the underlying handle type on Windows
-            return handle.IsAsync.HasValue ? handle.IsAsync.Value : false;
         }
 
         [Obsolete("This property has been deprecated.  Please use FileStream's SafeFileHandle property instead.  http://go.microsoft.com/fwlink/?linkid=14202")]

--- a/src/System.Private.CoreLib/shared/System/IO/FileStream.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStream.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
 using System.Diagnostics;
-using System.Security;
 
 namespace System.IO
 {


### PR DESCRIPTION
We can actually check the async state of a handle on Windows, so check directly when we have the API available. It is faster and more reliable as the state is literally a flag on the handle.

Also allow all filetypes through when explicitly using extended syntax `\\?\` . This unblocks a number of advanced customer scenarios.

Fixes https://github.com/dotnet/corefx/issues/187.
