### PR TITLE
Determine memory load based on cgroup usage.

### DIFF
--- a/src/gc/unix/gcenv.unix.cpp
+++ b/src/gc/unix/gcenv.unix.cpp
@@ -56,7 +56,7 @@ static uint8_t* g_helperPage = 0;
 static pthread_mutex_t g_flushProcessWriteBuffersMutex;
 
 size_t GetRestrictedPhysicalMemoryLimit();
-bool GetWorkingSetSize(size_t* val);
+bool GetPhysicalMemoryUsed(size_t* val);
 bool GetCpuLimit(uint32_t* val);
 
 static size_t g_RestrictedPhysicalMemoryLimit = 0;
@@ -623,7 +623,7 @@ void GCToOSInterface::GetMemoryStatus(uint32_t* memory_load, uint64_t* available
 
         // Get the physical memory in use - from it, we can get the physical memory available.
         // We do this only when we have the total physical memory available.
-        if (total > 0 && GetWorkingSetSize(&used))
+        if (total > 0 && GetPhysicalMemoryUsed(&used))
         {
             available = total > used ? total-used : 0; 
             load = (uint32_t)(((float)used * 100) / (float)total);

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -2396,7 +2396,7 @@ PAL_GetRestrictedPhysicalMemoryLimit(VOID);
 PALIMPORT
 BOOL
 PALAPI
-PAL_GetWorkingSetSize(size_t* val);
+PAL_GetPhysicalMemoryUsed(size_t* val);
 
 PALIMPORT
 BOOL

--- a/src/vm/gcenv.os.cpp
+++ b/src/vm/gcenv.os.cpp
@@ -605,7 +605,7 @@ void GCToOSInterface::GetMemoryStatus(uint32_t* memory_load, uint64_t* available
             workingSetSize = pmc.WorkingSetSize;
         }
 #else
-        status = PAL_GetWorkingSetSize(&workingSetSize);
+        status = PAL_GetPhysicalMemoryUsed(&workingSetSize);
 #endif
         if(status)
         {


### PR DESCRIPTION
cgroup usage is used to trigger oom kills. It includes rss and file cache of the cgroup.

The implementation was only using the process rss to determine memory load.
This is less than the cgroup usage and leads to oom kills due to GC not being triggered soon enough.

Fixes https://github.com/dotnet/coreclr/issues/19060

CC @janvorli 