### PR TITLE
Remove coreclr.*txt upload

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -3368,7 +3368,6 @@ ${runScript} \\
         Utilities.addXUnitDotNETResults(newJob, "${workspaceRelativeFxRootLinux}/bin/**/testResults.xml")
     }
     else {
-        Utilities.addArchival(newJob, "bin/tests/${osGroup}.${architecture}.${configuration}/coreclrtests.*.txt")
         Utilities.addXUnitDotNETResults(newJob, '**/coreclrtests.xml')
     }
 


### PR DESCRIPTION
This change unblocks #19213, with runtest.sh changing, we will no longer be creating coreclrtests.fail.txt, coreclrtests.skip.txt, coreclrtests.pass.txt.