### PR TITLE
Only register signals and create alt exception stack in coreclr

### DIFF
--- a/dac.cmake
+++ b/dac.cmake
@@ -1,7 +1,6 @@
 # Contains the dac build specific definitions. Included by the leaf dac cmake files.
 
 add_definitions(-DDACCESS_COMPILE)
-add_definitions(-DFEATURE_ENABLE_HARDWARE_EXCEPTIONS)
 if(WIN32)    
     add_definitions(-MT)
 endif(WIN32)

--- a/src/ToolBox/SOS/Strike/CMakeLists.txt
+++ b/src/ToolBox/SOS/Strike/CMakeLists.txt
@@ -105,7 +105,6 @@ if(WIN32)
     ntdll.lib
   )
 else(WIN32)
-  add_definitions(-DFEATURE_ENABLE_HARDWARE_EXCEPTIONS)
   add_definitions(-DPAL_STDCPP_COMPAT=1)
   add_compile_options(-Wno-null-arithmetic)
   add_compile_options(-Wno-format)

--- a/src/ToolBox/SOS/lldbplugin/services.cpp
+++ b/src/ToolBox/SOS/lldbplugin/services.cpp
@@ -771,7 +771,7 @@ exit:
     {
         *bytesRead = read;
     }
-    return error.Success() ? S_OK : E_FAIL;
+    return error.Success() || (read != 0) ? S_OK : E_FAIL;
 }
 
 HRESULT 
@@ -800,7 +800,7 @@ exit:
     {
         *bytesWritten = written;
     }
-    return error.Success() ? S_OK : E_FAIL;
+    return error.Success() || (written != 0) ? S_OK : E_FAIL;
 }
 
 //----------------------------------------------------------------------------

--- a/src/debug/daccess/dacdbiimpl.cpp
+++ b/src/debug/daccess/dacdbiimpl.cpp
@@ -6804,24 +6804,28 @@ bool DacDbiInterfaceImpl::IsValidObject(CORDB_ADDRESS addr)
     DD_ENTER_MAY_THROW;
     
     bool isValid = false;
-    EX_TRY
+
+    if (addr != 0 && addr != (CORDB_ADDRESS)-1)
     {
-        PTR_Object obj(TO_TADDR(addr));
-        
-        PTR_MethodTable mt = obj->GetMethodTable();
-        PTR_EEClass cls = mt->GetClass();
-        
-        if (mt == cls->GetMethodTable())
-            isValid = true;
-        else if (!mt->IsCanonicalMethodTable())
-            isValid = cls->GetMethodTable()->GetClass() == cls;
+        EX_TRY
+        {
+            PTR_Object obj(TO_TADDR(addr));
+
+            PTR_MethodTable mt = obj->GetMethodTable();
+            PTR_EEClass cls = mt->GetClass();
+
+            if (mt == cls->GetMethodTable())
+                isValid = true;
+            else if (!mt->IsCanonicalMethodTable())
+                isValid = cls->GetMethodTable()->GetClass() == cls;
+        }
+        EX_CATCH
+        {
+            isValid = false;
+        }
+        EX_END_CATCH(SwallowAllExceptions)
     }
-    EX_CATCH
-    {
-        isValid = false;
-    }
-    EX_END_CATCH(SwallowAllExceptions)
-    
+
     return isValid;
 }
 
@@ -6830,6 +6834,11 @@ bool DacDbiInterfaceImpl::GetAppDomainForObject(CORDB_ADDRESS addr, OUT VMPTR_Ap
 {
     DD_ENTER_MAY_THROW;
     
+    if (addr == 0 || addr == (CORDB_ADDRESS)-1)
+    {
+        return false;
+    }
+
     PTR_Object obj(TO_TADDR(addr));
     MethodTable *mt = obj->GetMethodTable();
 

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -321,15 +321,22 @@ typedef long time_t;
 #define PAL_INITIALIZE_REGISTER_SIGTERM_HANDLER     0x08
 #define PAL_INITIALIZE_DEBUGGER_EXCEPTIONS          0x10
 #define PAL_INITIALIZE_ENSURE_STACK_SIZE            0x20
+#define PAL_INITIALIZE_REGISTER_SIGNALS             0x40
 
 // PAL_Initialize() flags
-#define PAL_INITIALIZE                 (PAL_INITIALIZE_SYNC_THREAD | PAL_INITIALIZE_STD_HANDLES)
+#define PAL_INITIALIZE                 (PAL_INITIALIZE_SYNC_THREAD | \
+                                        PAL_INITIALIZE_STD_HANDLES)
 
-// PAL_InitializeDLL() flags - don't start any of the helper threads
-#define PAL_INITIALIZE_DLL             PAL_INITIALIZE_NONE       
+// PAL_InitializeDLL() flags - don't start any of the helper threads or register any exceptions
+#define PAL_INITIALIZE_DLL              PAL_INITIALIZE_NONE       
 
 // PAL_InitializeCoreCLR() flags
-#define PAL_INITIALIZE_CORECLR         (PAL_INITIALIZE | PAL_INITIALIZE_EXEC_ALLOCATOR | PAL_INITIALIZE_REGISTER_SIGTERM_HANDLER | PAL_INITIALIZE_DEBUGGER_EXCEPTIONS | PAL_INITIALIZE_ENSURE_STACK_SIZE)
+#define PAL_INITIALIZE_CORECLR         (PAL_INITIALIZE | \
+                                        PAL_INITIALIZE_EXEC_ALLOCATOR | \
+                                        PAL_INITIALIZE_REGISTER_SIGTERM_HANDLER | \
+                                        PAL_INITIALIZE_DEBUGGER_EXCEPTIONS | \
+                                        PAL_INITIALIZE_ENSURE_STACK_SIZE | \
+                                        PAL_INITIALIZE_REGISTER_SIGNALS)
 
 typedef DWORD (PALAPI *PTHREAD_START_ROUTINE)(LPVOID lpThreadParameter);
 typedef PTHREAD_START_ROUTINE LPTHREAD_START_ROUTINE;
@@ -344,9 +351,22 @@ PAL_Initialize(
     const char * const argv[]);
 
 PALIMPORT
+void
+PALAPI
+PAL_InitializeWithFlags(
+    DWORD flags);
+
+PALIMPORT
 int
 PALAPI
-PAL_InitializeDLL(VOID);
+PAL_InitializeDLL(
+    VOID);
+
+PALIMPORT
+void
+PALAPI
+PAL_SetInitializeDLLFlags(
+    DWORD flags);
 
 PALIMPORT
 DWORD

--- a/src/pal/src/exception/seh.cpp
+++ b/src/pal/src/exception/seh.cpp
@@ -81,7 +81,7 @@ Return value :
 BOOL 
 SEHInitialize (CPalThread *pthrCurrent, DWORD flags)
 {
-    if (!SEHInitializeSignals(flags))
+    if (!SEHInitializeSignals(pthrCurrent, flags))
     {
         ERROR("SEHInitializeSignals failed!\n");
         SEHCleanup();

--- a/src/pal/src/exception/signal.cpp
+++ b/src/pal/src/exception/signal.cpp
@@ -103,6 +103,9 @@ static void restore_signal(int signal_id, struct sigaction *previousAction);
 
 /* internal data declarations *********************************************/
 
+#if !HAVE_MACH_EXCEPTIONS
+static bool registered_signal_handlers = false;
+#endif // !HAVE_MACH_EXCEPTIONS
 static bool registered_sigterm_handler = false;
 
 struct sigaction g_previous_sigterm;
@@ -141,42 +144,47 @@ Return :
 --*/
 BOOL EnsureSignalAlternateStack()
 {
-    stack_t oss;
+    int st = 0;
 
-    // Query the current alternate signal stack
-    int st = sigaltstack(NULL, &oss);
-
-    if ((st == 0) && (oss.ss_flags == SS_DISABLE))
+    if (registered_signal_handlers)
     {
-        // There is no alternate stack for SIGSEGV handling installed yet so allocate one
+        stack_t oss;
 
-        // We include the size of the SignalHandlerWorkerReturnPoint in the alternate stack size since the 
-        // context contained in it is large and the SIGSTKSZ was not sufficient on ARM64 during testing.
-        int altStackSize = SIGSTKSZ + ALIGN_UP(sizeof(SignalHandlerWorkerReturnPoint), 16) + GetVirtualPageSize();
-#ifdef HAS_ASAN
-        // Asan also uses alternate stack so we increase its size on the SIGSTKSZ * 4 that enough for asan
-        // (see kAltStackSize in compiler-rt/lib/sanitizer_common/sanitizer_posix_libcdep.cc)
-        altStackSize += SIGSTKSZ * 4;
-#endif
-        altStackSize = ALIGN_UP(altStackSize, GetVirtualPageSize());
-        void* altStack = mmap(NULL, altStackSize, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_STACK | MAP_PRIVATE, -1, 0);
-        if (altStack != MAP_FAILED)
+        // Query the current alternate signal stack
+        st = sigaltstack(NULL, &oss);
+
+        if ((st == 0) && (oss.ss_flags == SS_DISABLE))
         {
-            // create a guard page for the alternate stack
-            st = mprotect(altStack, GetVirtualPageSize(), PROT_NONE);
-            if (st == 0)
-            {
-                stack_t ss;
-                ss.ss_sp = (char*)altStack;
-                ss.ss_size = altStackSize;
-                ss.ss_flags = 0;
-                st = sigaltstack(&ss, NULL);
-            }
+            // There is no alternate stack for SIGSEGV handling installed yet so allocate one
 
-            if (st != 0)
+            // We include the size of the SignalHandlerWorkerReturnPoint in the alternate stack size since the 
+            // context contained in it is large and the SIGSTKSZ was not sufficient on ARM64 during testing.
+            int altStackSize = SIGSTKSZ + ALIGN_UP(sizeof(SignalHandlerWorkerReturnPoint), 16) + GetVirtualPageSize();
+#ifdef HAS_ASAN
+            // Asan also uses alternate stack so we increase its size on the SIGSTKSZ * 4 that enough for asan
+            // (see kAltStackSize in compiler-rt/lib/sanitizer_common/sanitizer_posix_libcdep.cc)
+            altStackSize += SIGSTKSZ * 4;
+#endif
+            altStackSize = ALIGN_UP(altStackSize, GetVirtualPageSize());
+            void* altStack = mmap(NULL, altStackSize, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_STACK | MAP_PRIVATE, -1, 0);
+            if (altStack != MAP_FAILED)
             {
-               int st2 = munmap(altStack, altStackSize);
-               _ASSERTE(st2 == 0);
+                // create a guard page for the alternate stack
+                st = mprotect(altStack, GetVirtualPageSize(), PROT_NONE);
+                if (st == 0)
+                {
+                    stack_t ss;
+                    ss.ss_sp = (char*)altStack;
+                    ss.ss_size = altStackSize;
+                    ss.ss_flags = 0;
+                    st = sigaltstack(&ss, NULL);
+                }
+
+                if (st != 0)
+                {
+                    int st2 = munmap(altStack, altStackSize);
+                    _ASSERTE(st2 == 0);
+                }
             }
         }
     }
@@ -198,17 +206,20 @@ Return :
 --*/
 void FreeSignalAlternateStack()
 {
-    stack_t ss, oss;
-    // The man page for sigaltstack says that when the ss.ss_flags is set to SS_DISABLE,
-    // all other ss fields are ignored. However, MUSL implementation checks that the 
-    // ss_size is >= MINSIGSTKSZ even in this case.
-    ss.ss_size = MINSIGSTKSZ;
-    ss.ss_flags = SS_DISABLE;
-    int st = sigaltstack(&ss, &oss);
-    if ((st == 0) && (oss.ss_flags != SS_DISABLE))
+    if (registered_signal_handlers)
     {
-        int st = munmap(oss.ss_sp, oss.ss_size);
-        _ASSERTE(st == 0);
+        stack_t ss, oss;
+        // The man page for sigaltstack says that when the ss.ss_flags is set to SS_DISABLE,
+        // all other ss fields are ignored. However, MUSL implementation checks that the 
+        // ss_size is >= MINSIGSTKSZ even in this case.
+        ss.ss_size = MINSIGSTKSZ;
+        ss.ss_flags = SS_DISABLE;
+        int st = sigaltstack(&ss, &oss);
+        if ((st == 0) && (oss.ss_flags != SS_DISABLE))
+        {
+            int st = munmap(oss.ss_sp, oss.ss_size);
+            _ASSERTE(st == 0);
+        }
     }
 }
 #endif // !HAVE_MACH_EXCEPTIONS
@@ -230,47 +241,43 @@ BOOL SEHInitializeSignals(DWORD flags)
     TRACE("Initializing signal handlers\n");
 
 #if !HAVE_MACH_EXCEPTIONS
-    /* we call handle_signal for every possible signal, even
-       if we don't provide a signal handler.
-
-       handle_signal will set SA_RESTART flag for specified signal.
-       Therefore, all signals will have SA_RESTART flag set, preventing
-       slow Unix system calls from being interrupted. On systems without
-       siginfo_t, SIGKILL and SIGSTOP can't be restarted, so we don't
-       handle those signals. Both the Darwin and FreeBSD man pages say
-       that SIGKILL and SIGSTOP can't be handled, but FreeBSD allows us
-       to register a handler for them anyway. We don't do that.
-
-       see sigaction man page for more details
-       */
-    handle_signal(SIGILL, sigill_handler, &g_previous_sigill);
-    handle_signal(SIGTRAP, sigtrap_handler, &g_previous_sigtrap);
-    handle_signal(SIGFPE, sigfpe_handler, &g_previous_sigfpe);
-    handle_signal(SIGBUS, sigbus_handler, &g_previous_sigbus);
-    // SIGSEGV handler runs on a separate stack so that we can handle stack overflow
-    handle_signal(SIGSEGV, sigsegv_handler, &g_previous_sigsegv, SA_ONSTACK);
-    // We don't setup a handler for SIGINT/SIGQUIT when those signals are ignored.
-    // Otherwise our child processes would reset to the default on exec causing them
-    // to terminate on these signals.
-    handle_signal(SIGINT, sigint_handler, &g_previous_sigint   , 0 /* additionalFlags */, true /* skipIgnored */);
-    handle_signal(SIGQUIT, sigquit_handler, &g_previous_sigquit, 0 /* additionalFlags */, true /* skipIgnored */);
-
-    if (!EnsureSignalAlternateStack())
+    if (flags & PAL_INITIALIZE_REGISTER_SIGNALS)
     {
-        return FALSE;
-    }
-#endif // !HAVE_MACH_EXCEPTIONS
+        registered_signal_handlers = true;
 
-    if (flags & PAL_INITIALIZE_REGISTER_SIGTERM_HANDLER)
-    {
-        handle_signal(SIGTERM, sigterm_handler, &g_previous_sigterm);
-        registered_sigterm_handler = true;
-    }
+        /* we call handle_signal for every possible signal, even
+           if we don't provide a signal handler.
 
-#if !HAVE_MACH_EXCEPTIONS
+           handle_signal will set SA_RESTART flag for specified signal.
+           Therefore, all signals will have SA_RESTART flag set, preventing
+           slow Unix system calls from being interrupted. On systems without
+           siginfo_t, SIGKILL and SIGSTOP can't be restarted, so we don't
+           handle those signals. Both the Darwin and FreeBSD man pages say
+           that SIGKILL and SIGSTOP can't be handled, but FreeBSD allows us
+           to register a handler for them anyway. We don't do that.
+
+           see sigaction man page for more details
+           */
+        handle_signal(SIGILL, sigill_handler, &g_previous_sigill);
+        handle_signal(SIGTRAP, sigtrap_handler, &g_previous_sigtrap);
+        handle_signal(SIGFPE, sigfpe_handler, &g_previous_sigfpe);
+        handle_signal(SIGBUS, sigbus_handler, &g_previous_sigbus);
+        // SIGSEGV handler runs on a separate stack so that we can handle stack overflow
+        handle_signal(SIGSEGV, sigsegv_handler, &g_previous_sigsegv, SA_ONSTACK);
+        // We don't setup a handler for SIGINT/SIGQUIT when those signals are ignored.
+        // Otherwise our child processes would reset to the default on exec causing them
+        // to terminate on these signals.
+        handle_signal(SIGINT, sigint_handler, &g_previous_sigint, 0 /* additionalFlags */, true /* skipIgnored */);
+        handle_signal(SIGQUIT, sigquit_handler, &g_previous_sigquit, 0 /* additionalFlags */, true /* skipIgnored */);
+
 #ifdef INJECT_ACTIVATION_SIGNAL
-    handle_signal(INJECT_ACTIVATION_SIGNAL, inject_activation_handler, &g_previous_activation);
+        handle_signal(INJECT_ACTIVATION_SIGNAL, inject_activation_handler, &g_previous_activation);
 #endif
+        if (!EnsureSignalAlternateStack())
+        {
+            return FALSE;
+        }
+    }
 
     /* The default action for SIGPIPE is process termination.
        Since SIGPIPE can be signaled when trying to write on a socket for which
@@ -282,6 +289,12 @@ BOOL SEHInitializeSignals(DWORD flags)
     */
     signal(SIGPIPE, SIG_IGN);
 #endif // !HAVE_MACH_EXCEPTIONS
+
+    if (flags & PAL_INITIALIZE_REGISTER_SIGTERM_HANDLER)
+    {
+        registered_sigterm_handler = true;
+        handle_signal(SIGTERM, sigterm_handler, &g_previous_sigterm);
+    }
 
     return TRUE;
 }
@@ -307,25 +320,25 @@ void SEHCleanupSignals()
     TRACE("Restoring default signal handlers\n");
 
 #if !HAVE_MACH_EXCEPTIONS
-    restore_signal(SIGILL, &g_previous_sigill);
-    restore_signal(SIGTRAP, &g_previous_sigtrap);
-    restore_signal(SIGFPE, &g_previous_sigfpe);
-    restore_signal(SIGBUS, &g_previous_sigbus);
-    restore_signal(SIGSEGV, &g_previous_sigsegv);
-    restore_signal(SIGINT, &g_previous_sigint);
-    restore_signal(SIGQUIT, &g_previous_sigquit);
+    if (registered_signal_handlers)
+    {
+        restore_signal(SIGILL, &g_previous_sigill);
+        restore_signal(SIGTRAP, &g_previous_sigtrap);
+        restore_signal(SIGFPE, &g_previous_sigfpe);
+        restore_signal(SIGBUS, &g_previous_sigbus);
+        restore_signal(SIGSEGV, &g_previous_sigsegv);
+        restore_signal(SIGINT, &g_previous_sigint);
+        restore_signal(SIGQUIT, &g_previous_sigquit);
+#ifdef INJECT_ACTIVATION_SIGNAL
+        restore_signal(INJECT_ACTIVATION_SIGNAL, &g_previous_activation);
+#endif
+    }
 #endif // !HAVE_MACH_EXCEPTIONS
 
     if (registered_sigterm_handler)
     {
         restore_signal(SIGTERM, &g_previous_sigterm);
     }
-
-#if !HAVE_MACH_EXCEPTIONS
-#ifdef INJECT_ACTIVATION_SIGNAL
-    restore_signal(INJECT_ACTIVATION_SIGNAL, &g_previous_activation);
-#endif
-#endif // !HAVE_MACH_EXCEPTIONS
 }
 
 /* internal function definitions **********************************************/

--- a/src/pal/src/exception/signal.cpp
+++ b/src/pal/src/exception/signal.cpp
@@ -70,15 +70,6 @@ typedef void *siginfo_t;
 #endif  /* !HAVE_SIGINFO_T */
 typedef void (*SIGFUNC)(int, siginfo_t *, void *);
 
-#if !HAVE_MACH_EXCEPTIONS
-// Return context and status for the signal_handler_worker.
-struct SignalHandlerWorkerReturnPoint
-{
-    bool returnFromHandler;
-    CONTEXT context;
-};
-#endif // !HAVE_MACH_EXCEPTIONS
-
 /* internal function declarations *********************************************/
 
 static void sigterm_handler(int code, siginfo_t *siginfo, void *context);
@@ -104,9 +95,9 @@ static void restore_signal(int signal_id, struct sigaction *previousAction);
 /* internal data declarations *********************************************/
 
 #if !HAVE_MACH_EXCEPTIONS
-static bool registered_signal_handlers = false;
+bool g_registered_signal_handlers = false;
 #endif // !HAVE_MACH_EXCEPTIONS
-static bool registered_sigterm_handler = false;
+static bool g_registered_sigterm_handler = false;
 
 struct sigaction g_previous_sigterm;
 #if !HAVE_MACH_EXCEPTIONS
@@ -129,101 +120,6 @@ int g_common_signal_handler_context_locvar_offset = 0;
 
 /* public function definitions ************************************************/
 
-#if !HAVE_MACH_EXCEPTIONS
-/*++
-Function :
-    EnsureSignalAlternateStack
-
-    Ensure that alternate stack for signal handling is allocated for the current thread
-
-Parameters :
-    None
-
-Return :
-    TRUE in case of a success, FALSE otherwise
---*/
-BOOL EnsureSignalAlternateStack()
-{
-    int st = 0;
-
-    if (registered_signal_handlers)
-    {
-        stack_t oss;
-
-        // Query the current alternate signal stack
-        st = sigaltstack(NULL, &oss);
-
-        if ((st == 0) && (oss.ss_flags == SS_DISABLE))
-        {
-            // There is no alternate stack for SIGSEGV handling installed yet so allocate one
-
-            // We include the size of the SignalHandlerWorkerReturnPoint in the alternate stack size since the 
-            // context contained in it is large and the SIGSTKSZ was not sufficient on ARM64 during testing.
-            int altStackSize = SIGSTKSZ + ALIGN_UP(sizeof(SignalHandlerWorkerReturnPoint), 16) + GetVirtualPageSize();
-#ifdef HAS_ASAN
-            // Asan also uses alternate stack so we increase its size on the SIGSTKSZ * 4 that enough for asan
-            // (see kAltStackSize in compiler-rt/lib/sanitizer_common/sanitizer_posix_libcdep.cc)
-            altStackSize += SIGSTKSZ * 4;
-#endif
-            altStackSize = ALIGN_UP(altStackSize, GetVirtualPageSize());
-            void* altStack = mmap(NULL, altStackSize, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_STACK | MAP_PRIVATE, -1, 0);
-            if (altStack != MAP_FAILED)
-            {
-                // create a guard page for the alternate stack
-                st = mprotect(altStack, GetVirtualPageSize(), PROT_NONE);
-                if (st == 0)
-                {
-                    stack_t ss;
-                    ss.ss_sp = (char*)altStack;
-                    ss.ss_size = altStackSize;
-                    ss.ss_flags = 0;
-                    st = sigaltstack(&ss, NULL);
-                }
-
-                if (st != 0)
-                {
-                    int st2 = munmap(altStack, altStackSize);
-                    _ASSERTE(st2 == 0);
-                }
-            }
-        }
-    }
-
-    return (st == 0);
-}
-
-/*++
-Function :
-    FreeSignalAlternateStack
-
-    Free alternate stack for signal handling
-
-Parameters :
-    None
-
-Return :
-    None
---*/
-void FreeSignalAlternateStack()
-{
-    if (registered_signal_handlers)
-    {
-        stack_t ss, oss;
-        // The man page for sigaltstack says that when the ss.ss_flags is set to SS_DISABLE,
-        // all other ss fields are ignored. However, MUSL implementation checks that the 
-        // ss_size is >= MINSIGSTKSZ even in this case.
-        ss.ss_size = MINSIGSTKSZ;
-        ss.ss_flags = SS_DISABLE;
-        int st = sigaltstack(&ss, &oss);
-        if ((st == 0) && (oss.ss_flags != SS_DISABLE))
-        {
-            int st = munmap(oss.ss_sp, oss.ss_size);
-            _ASSERTE(st == 0);
-        }
-    }
-}
-#endif // !HAVE_MACH_EXCEPTIONS
-
 /*++
 Function :
     SEHInitializeSignals
@@ -236,14 +132,14 @@ Parameters :
 Return :
     TRUE in case of a success, FALSE otherwise
 --*/
-BOOL SEHInitializeSignals(DWORD flags)
+BOOL SEHInitializeSignals(CorUnix::CPalThread *pthrCurrent, DWORD flags)
 {
     TRACE("Initializing signal handlers\n");
 
 #if !HAVE_MACH_EXCEPTIONS
     if (flags & PAL_INITIALIZE_REGISTER_SIGNALS)
     {
-        registered_signal_handlers = true;
+        g_registered_signal_handlers = true;
 
         /* we call handle_signal for every possible signal, even
            if we don't provide a signal handler.
@@ -273,7 +169,7 @@ BOOL SEHInitializeSignals(DWORD flags)
 #ifdef INJECT_ACTIVATION_SIGNAL
         handle_signal(INJECT_ACTIVATION_SIGNAL, inject_activation_handler, &g_previous_activation);
 #endif
-        if (!EnsureSignalAlternateStack())
+        if (!pthrCurrent->EnsureSignalAlternateStack())
         {
             return FALSE;
         }
@@ -292,7 +188,7 @@ BOOL SEHInitializeSignals(DWORD flags)
 
     if (flags & PAL_INITIALIZE_REGISTER_SIGTERM_HANDLER)
     {
-        registered_sigterm_handler = true;
+        g_registered_sigterm_handler = true;
         handle_signal(SIGTERM, sigterm_handler, &g_previous_sigterm);
     }
 
@@ -320,7 +216,7 @@ void SEHCleanupSignals()
     TRACE("Restoring default signal handlers\n");
 
 #if !HAVE_MACH_EXCEPTIONS
-    if (registered_signal_handlers)
+    if (g_registered_signal_handlers)
     {
         restore_signal(SIGILL, &g_previous_sigill);
         restore_signal(SIGTRAP, &g_previous_sigtrap);
@@ -335,7 +231,7 @@ void SEHCleanupSignals()
     }
 #endif // !HAVE_MACH_EXCEPTIONS
 
-    if (registered_sigterm_handler)
+    if (g_registered_sigterm_handler)
     {
         restore_signal(SIGTERM, &g_previous_sigterm);
     }

--- a/src/pal/src/include/pal/signal.hpp
+++ b/src/pal/src/include/pal/signal.hpp
@@ -22,7 +22,14 @@ Abstract:
 
 #if !HAVE_MACH_EXCEPTIONS
 
-struct SignalHandlerWorkerReturnPoint;
+// Return context and status for the signal_handler_worker.
+struct SignalHandlerWorkerReturnPoint
+{
+    bool returnFromHandler;
+    CONTEXT context;
+};
+
+extern bool g_registered_signal_handlers;
 
 /*++
 Function :
@@ -83,34 +90,6 @@ Parameters :
 --*/
 void ExecuteHandlerOnOriginalStack(int code, siginfo_t *siginfo, void *context, SignalHandlerWorkerReturnPoint* returnPoint);
 
-/*++
-Function :
-    EnsureSignalAlternateStack
-
-    Ensure that alternate stack for signal handling is allocated for the current thread
-
-Parameters :
-    None
-
-Return :
-    TRUE in case of a success, FALSE otherwise
---*/
-BOOL EnsureSignalAlternateStack();
-
-/*++
-Function :
-    FreeSignalAlternateStack
-
-    Free alternate stack for signal handling
-
-Parameters :
-    None
-
-Return :
-    None
---*/
-void FreeSignalAlternateStack();
-
 #endif // !HAVE_MACH_EXCEPTIONS
 
 /*++
@@ -125,7 +104,7 @@ Parameters :
 Return :
     TRUE in case of a success, FALSE otherwise
 --*/
-BOOL SEHInitializeSignals(DWORD flags);
+BOOL SEHInitializeSignals(CorUnix::CPalThread *pthrCurrent, DWORD flags);
 
 /*++
 Function :

--- a/src/pal/src/include/pal/thread.hpp
+++ b/src/pal/src/include/pal/thread.hpp
@@ -324,6 +324,8 @@ namespace CorUnix
         void* m_stackBase;
         // Limit address of the stack of this thread
         void* m_stackLimit;
+        // Signal handler's alternate stack to help with stack overflow
+        void* m_alternateStack;
 
         //
         // The thread entry routine (called from InternalCreateThread)
@@ -387,7 +389,8 @@ namespace CorUnix
             m_fStartStatus(FALSE),
             m_fStartStatusSet(FALSE),
             m_stackBase(NULL),
-            m_stackLimit(NULL)
+            m_stackLimit(NULL),
+            m_alternateStack(NULL)
 #ifdef FEATURE_PAL_SXS
           , m_fInPal(TRUE)
 #endif // FEATURE_PAL_SXS
@@ -633,6 +636,18 @@ namespace CorUnix
         {
             m_pNext = pNext;
         };
+
+#if !HAVE_MACH_EXCEPTIONS
+        BOOL
+        EnsureSignalAlternateStack(
+            void
+            );
+
+        void 
+        FreeSignalAlternateStack(
+            void
+            );
+#endif // !HAVE_MACH_EXCEPTIONS
 
         void
         AddThreadReference(

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -94,7 +94,6 @@ using namespace CorUnix;
 
 extern "C" BOOL CRTInitStdStreams( void );
 
-
 Volatile<INT> init_count = 0;
 Volatile<BOOL> shutdown_intent = 0;
 Volatile<LONG> g_coreclrInitialized = 0;
@@ -107,6 +106,8 @@ SIZE_T g_defaultStackSize = 0;
 /* critical section to protect access to init_count. This is allocated on the
    very first PAL_Initialize call, and is freed afterward. */
 static PCRITICAL_SECTION init_critsec = NULL;
+
+static DWORD g_initializeDLLFlags = PAL_INITIALIZE_DLL;
 
 static int Initialize(int argc, const char *const argv[], DWORD flags);
 static BOOL INIT_IncreaseDescriptorLimit(void);
@@ -157,6 +158,30 @@ PAL_Initialize(
 
 /*++
 Function:
+  PAL_InitializeWithFlags
+
+Abstract:
+  This function is the first function of the PAL to be called.
+  Internal structure initialization is done here. It could be called
+  several time by the same process, a reference count is kept.
+
+Return:
+  0 if successful
+  -1 if it failed
+
+--*/
+int
+PALAPI
+PAL_InitializeWithFlags(
+    int argc,
+    const char *const argv[],
+    DWORD flags)
+{
+    return Initialize(argc, argv, flags);
+}
+
+/*++
+Function:
   PAL_InitializeDLL
 
 Abstract:
@@ -171,7 +196,29 @@ int
 PALAPI
 PAL_InitializeDLL()
 {
-    return Initialize(0, NULL, PAL_INITIALIZE_DLL);
+    return Initialize(0, NULL, g_initializeDLLFlags);
+}
+
+/*++
+Function:
+  PAL_SetInitializeDLLFlags
+
+Abstract:
+  This sets the global PAL_INITIALIZE flags that PAL_InitializeDLL
+  will use. It needs to be called before any PAL_InitializeDLL call
+  is made so typical it is used in a __attribute__((constructor))
+  function to make sure. 
+
+Return:
+  none
+
+--*/
+void
+PALAPI
+PAL_SetInitializeDLLFlags(
+    DWORD flags)
+{
+    g_initializeDLLFlags = flags;
 }
 
 #ifdef ENSURE_PRIMARY_STACK_SIZE

--- a/src/pal/src/init/sxs.cpp
+++ b/src/pal/src/init/sxs.cpp
@@ -109,22 +109,22 @@ AllocatePalThread(CPalThread **ppThread)
     CPalThread *pThread = NULL;
     PAL_ERROR palError;
 
+    palError = CreateThreadData(&pThread);
+    if (NO_ERROR != palError)
+    {
+        goto exit;
+    }
+
 #if !HAVE_MACH_EXCEPTIONS
     // Ensure alternate stack for SIGSEGV handling. Our SIGSEGV handler is set to
     // run on an alternate stack and the stack needs to be allocated per thread.
-    if (!EnsureSignalAlternateStack())
+    if (!pThread->EnsureSignalAlternateStack())
     {
         ERROR("Cannot allocate alternate stack for SIGSEGV handler!\n");
         palError = ERROR_NOT_ENOUGH_MEMORY;
         goto exit;
     }
 #endif // !HAVE_MACH_EXCEPTIONS
-
-    palError = CreateThreadData(&pThread);
-    if (NO_ERROR != palError)
-    {
-        goto exit;
-    }
 
     HANDLE hThread;
     palError = CreateThreadObject(pThread, pThread, &hThread);

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -1589,9 +1589,12 @@ public:
 
         // See semaphore name format for details about this value. We store it so that
         // it can be used by the cleanup code that removes the semaphore with sem_unlink.
-        INDEBUG(BOOL disambiguationKeyRet = )
-        GetProcessIdDisambiguationKey(m_processId, &m_processIdDisambiguationKey);
-        _ASSERTE(disambiguationKeyRet == TRUE || m_processIdDisambiguationKey == 0);
+        BOOL ret = GetProcessIdDisambiguationKey(m_processId, &m_processIdDisambiguationKey);
+
+        // If GetProcessIdDisambiguationKey failed for some reason, it should set the value 
+        // to 0. We expect that anyone else opening the semaphore name will also fail and thus 
+        // will also try to use 0 as the value.
+        _ASSERTE(ret == TRUE || m_processIdDisambiguationKey == 0);
 
         sprintf_s(startupSemName,
                   sizeof(startupSemName),
@@ -1901,7 +1904,12 @@ PAL_NotifyRuntimeStarted()
     BOOL launched = FALSE;
 
     UINT64 processIdDisambiguationKey = 0;
-    GetProcessIdDisambiguationKey(gPID, &processIdDisambiguationKey);
+    BOOL ret = GetProcessIdDisambiguationKey(gPID, &processIdDisambiguationKey);
+
+    // If GetProcessIdDisambiguationKey failed for some reason, it should set the value 
+    // to 0. We expect that anyone else making the semaphore name will also fail and thus 
+    // will also try to use 0 as the value.
+    _ASSERTE(ret == TRUE || processIdDisambiguationKey == 0);
 
     sprintf_s(startupSemName, sizeof(startupSemName), RuntimeStartupSemaphoreName, HashSemaphoreName(gPID, processIdDisambiguationKey));
     sprintf_s(continueSemName, sizeof(continueSemName), RuntimeContinueSemaphoreName, HashSemaphoreName(gPID, processIdDisambiguationKey));
@@ -2040,6 +2048,7 @@ GetProcessIdDisambiguationKey(DWORD processId, UINT64 *disambiguationKey)
     FILE *statFile = fopen(statFileName, "r");
     if (statFile == nullptr) 
     {
+        TRACE("GetProcessIdDisambiguationKey: fopen() FAILED");
         SetLastError(ERROR_INVALID_HANDLE);
         return FALSE;
     }
@@ -2048,7 +2057,8 @@ GetProcessIdDisambiguationKey(DWORD processId, UINT64 *disambiguationKey)
     size_t lineLen = 0;
     if (getline(&line, &lineLen, statFile) == -1)
     {
-        _ASSERTE(!"Failed to getline from the stat file for a process.");
+        TRACE("GetProcessIdDisambiguationKey: getline() FAILED");
+        SetLastError(ERROR_INVALID_HANDLE);
         return FALSE;
     }
 

--- a/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/dlltest1.cpp
+++ b/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/dlltest1.cpp
@@ -17,6 +17,7 @@
 extern "C"
 int InitializeDllTest1()
 {
+    PAL_SetInitializeDLLFlags(PAL_INITIALIZE_DLL | PAL_INITIALIZE_REGISTER_SIGNALS);
     return PAL_InitializeDLL();
 }
 

--- a/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/dlltest2.cpp
+++ b/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/dlltest2.cpp
@@ -17,6 +17,7 @@
 extern "C"
 int InitializeDllTest2()
 {
+    PAL_SetInitializeDLLFlags(PAL_INITIALIZE_DLL | PAL_INITIALIZE_REGISTER_SIGNALS);
     return PAL_InitializeDLL();
 }
 


### PR DESCRIPTION
Only register signals and create alt exception stack in coreclr. (#19309)

There was a couple of places where the DAC (IsValidObject, GetAppDomainForObject)
assumed that a NULL target/debuggee address would throw an exception that would
be caught by try/catch. Any other invalid address is handled with a software
exception throwed by the read memory functions. In general it is a better overall
design not to have any of the DBI/DAC, etc. code depend on hardware exceptions
being caught. On Linux the C++ runtime sometimes can't handle it. There is a
slight risk that there are other places in the DAC that make the NULL address
assumption but testing so far has found any.

Added PAL_SetInitializeDLLFlags as a fallback to allow the PAL_InitializeDLL flags
to be set for a PAL instance for the DAC where we could still register h/w signals
but not the altstack switching to reduce this risk. The flags can't be build time
conditional because we only build one coreclrpal.a library that all the modules
used. Having a PAL_InitializeWithFlags function doesn't really help either because of
the PAL_RegisterModule call to PAL_IntializeDLL and the LoadLibrary dance/protocol
that uses it to call the loading module's DLLMain.

Add PAL_SetInitializeFlags; remove flags from PAL_INITIALIZE and PAL_INITIALIZE_DLL
default. Add PAL_InitializeWithFlags() to allowing the default to be overriden.