### PR TITLE
Fix wrong sprinf_s format string in gtGetArgMsg getGetLateArgMsg on ARM32

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -11496,7 +11496,8 @@ void Compiler::gtGetArgMsg(
                     else
                     {
                         unsigned stackSlot = listCount - curArgTabEntry->numRegs;
-                        sprintf_s(bufp, bufLength, "arg%d m%d out+%02x%c", argNum, listCount, stackSlot * TARGET_POINTER_SIZE, 0);
+                        sprintf_s(bufp, bufLength, "arg%d m%d out+%02x%c", argNum, listCount,
+                                  stackSlot * TARGET_POINTER_SIZE, 0);
                     }
                 }
                 return;
@@ -11625,7 +11626,8 @@ void Compiler::gtGetLateArgMsg(
                 else
                 {
                     unsigned stackSlot = listCount - curArgTabEntry->numRegs;
-                    sprintf_s(bufp, bufLength, "arg%d m%d out+%02x%c", argNum, listCount, stackSlot * TARGET_POINTER_SIZE, 0);
+                    sprintf_s(bufp, bufLength, "arg%d m%d out+%02x%c", argNum, listCount,
+                              stackSlot * TARGET_POINTER_SIZE, 0);
                 }
             }
             return;

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -11496,7 +11496,7 @@ void Compiler::gtGetArgMsg(
                     else
                     {
                         unsigned stackSlot = listCount - curArgTabEntry->numRegs;
-                        sprintf_s(bufp, bufLength, "arg%d m%d out+%s%c", argNum, listCount, stackSlot, 0);
+                        sprintf_s(bufp, bufLength, "arg%d m%d out+%02x%c", argNum, listCount, stackSlot * TARGET_POINTER_SIZE, 0);
                     }
                 }
                 return;
@@ -11625,7 +11625,7 @@ void Compiler::gtGetLateArgMsg(
                 else
                 {
                     unsigned stackSlot = listCount - curArgTabEntry->numRegs;
-                    sprintf_s(bufp, bufLength, "arg%d m%d out+%s%c", argNum, listCount, stackSlot, 0);
+                    sprintf_s(bufp, bufLength, "arg%d m%d out+%02x%c", argNum, listCount, stackSlot * TARGET_POINTER_SIZE, 0);
                 }
             }
             return;


### PR DESCRIPTION
One liner that fixes typo in `Compiler::gtGetArgMsg` and `Compiler::gtGetLateArgMsg` for arguments passed on stack