### PR TITLE
 Free the alternate signal stack if this PAL's thread allocated it.

### DIFF
--- a/src/pal/src/exception/seh.cpp
+++ b/src/pal/src/exception/seh.cpp
@@ -81,7 +81,7 @@ Return value :
 BOOL 
 SEHInitialize (CPalThread *pthrCurrent, DWORD flags)
 {
-    if (!SEHInitializeSignals(flags))
+    if (!SEHInitializeSignals(pthrCurrent, flags))
     {
         ERROR("SEHInitializeSignals failed!\n");
         SEHCleanup();

--- a/src/pal/src/exception/signal.cpp
+++ b/src/pal/src/exception/signal.cpp
@@ -142,7 +142,7 @@ Parameters :
 Return :
     TRUE in case of a success, FALSE otherwise
 --*/
-BOOL EnsureSignalAlternateStack(CPalThread *pthrCurrent)
+BOOL EnsureSignalAlternateStack(CorUnix::CPalThread *pthrCurrent)
 {
     int st = 0;
 
@@ -243,7 +243,7 @@ Parameters :
 Return :
     TRUE in case of a success, FALSE otherwise
 --*/
-BOOL SEHInitializeSignals(CPalThread *pthrCurrent, DWORD flags)
+BOOL SEHInitializeSignals(CorUnix::CPalThread *pthrCurrent, DWORD flags)
 {
     TRACE("Initializing signal handlers\n");
 

--- a/src/pal/src/exception/signal.cpp
+++ b/src/pal/src/exception/signal.cpp
@@ -70,15 +70,6 @@ typedef void *siginfo_t;
 #endif  /* !HAVE_SIGINFO_T */
 typedef void (*SIGFUNC)(int, siginfo_t *, void *);
 
-#if !HAVE_MACH_EXCEPTIONS
-// Return context and status for the signal_handler_worker.
-struct SignalHandlerWorkerReturnPoint
-{
-    bool returnFromHandler;
-    CONTEXT context;
-};
-#endif // !HAVE_MACH_EXCEPTIONS
-
 /* internal function declarations *********************************************/
 
 static void sigterm_handler(int code, siginfo_t *siginfo, void *context);
@@ -104,7 +95,7 @@ static void restore_signal(int signal_id, struct sigaction *previousAction);
 /* internal data declarations *********************************************/
 
 #if !HAVE_MACH_EXCEPTIONS
-static bool g_registered_signal_handlers = false;
+bool g_registered_signal_handlers = false;
 #endif // !HAVE_MACH_EXCEPTIONS
 static bool g_registered_sigterm_handler = false;
 
@@ -128,108 +119,6 @@ int g_common_signal_handler_context_locvar_offset = 0;
 #endif // !HAVE_MACH_EXCEPTIONS
 
 /* public function definitions ************************************************/
-
-#if !HAVE_MACH_EXCEPTIONS
-/*++
-Function :
-    EnsureSignalAlternateStack
-
-    Ensure that alternate stack for signal handling is allocated for the current thread
-
-Parameters :
-    None
-
-Return :
-    TRUE in case of a success, FALSE otherwise
---*/
-BOOL EnsureSignalAlternateStack(CorUnix::CPalThread *pthrCurrent)
-{
-    int st = 0;
-
-    if (g_registered_signal_handlers)
-    {
-        stack_t oss;
-
-        // Query the current alternate signal stack
-        st = sigaltstack(NULL, &oss);
-        if ((st == 0) && (oss.ss_flags == SS_DISABLE))
-        {
-            // There is no alternate stack for SIGSEGV handling installed yet so allocate one
-
-            // We include the size of the SignalHandlerWorkerReturnPoint in the alternate stack size since the 
-            // context contained in it is large and the SIGSTKSZ was not sufficient on ARM64 during testing.
-            int altStackSize = SIGSTKSZ + ALIGN_UP(sizeof(SignalHandlerWorkerReturnPoint), 16) + GetVirtualPageSize();
-#ifdef HAS_ASAN
-            // Asan also uses alternate stack so we increase its size on the SIGSTKSZ * 4 that enough for asan
-            // (see kAltStackSize in compiler-rt/lib/sanitizer_common/sanitizer_posix_libcdep.cc)
-            altStackSize += SIGSTKSZ * 4;
-#endif
-            altStackSize = ALIGN_UP(altStackSize, GetVirtualPageSize());
-            void* altStack = mmap(NULL, altStackSize, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_STACK | MAP_PRIVATE, -1, 0);
-            if (altStack != MAP_FAILED)
-            {
-                // create a guard page for the alternate stack
-                st = mprotect(altStack, GetVirtualPageSize(), PROT_NONE);
-                if (st == 0)
-                {
-                    stack_t ss;
-                    ss.ss_sp = (char*)altStack;
-                    ss.ss_size = altStackSize;
-                    ss.ss_flags = 0;
-                    st = sigaltstack(&ss, NULL);
-                }
-
-                if (st == 0)
-                {
-                    pthrCurrent->SetAlternateStack(altStack);
-                }
-                else 
-                {
-                    int st2 = munmap(altStack, altStackSize);
-                    _ASSERTE(st2 == 0);
-                }
-            }
-        }
-    }
-
-    return (st == 0);
-}
-
-/*++
-Function :
-    FreeSignalAlternateStack
-
-    Free alternate stack for signal handling
-
-Parameters :
-    None
-
-Return :
-    None
---*/
-void FreeSignalAlternateStack(void *altstack)
-{
-    if (altstack != nullptr)
-    {
-        stack_t ss, oss;
-        // The man page for sigaltstack says that when the ss.ss_flags is set to SS_DISABLE,
-        // all other ss fields are ignored. However, MUSL implementation checks that the 
-        // ss_size is >= MINSIGSTKSZ even in this case.
-        ss.ss_size = MINSIGSTKSZ;
-        ss.ss_flags = SS_DISABLE;
-        int st = sigaltstack(&ss, &oss);
-        if ((st == 0) && (oss.ss_flags != SS_DISABLE))
-        {
-            // Make sure this altstack is this PAL's before freeing.
-            if (oss.ss_sp == altstack)
-            {
-                int st = munmap(oss.ss_sp, oss.ss_size);
-                _ASSERTE(st == 0);
-            }
-        }
-    }
-}
-#endif // !HAVE_MACH_EXCEPTIONS
 
 /*++
 Function :
@@ -280,7 +169,7 @@ BOOL SEHInitializeSignals(CorUnix::CPalThread *pthrCurrent, DWORD flags)
 #ifdef INJECT_ACTIVATION_SIGNAL
         handle_signal(INJECT_ACTIVATION_SIGNAL, inject_activation_handler, &g_previous_activation);
 #endif
-        if (!EnsureSignalAlternateStack(pthrCurrent))
+        if (!pthrCurrent->EnsureSignalAlternateStack())
         {
             return FALSE;
         }

--- a/src/pal/src/include/pal/signal.hpp
+++ b/src/pal/src/include/pal/signal.hpp
@@ -22,7 +22,14 @@ Abstract:
 
 #if !HAVE_MACH_EXCEPTIONS
 
-struct SignalHandlerWorkerReturnPoint;
+// Return context and status for the signal_handler_worker.
+struct SignalHandlerWorkerReturnPoint
+{
+    bool returnFromHandler;
+    CONTEXT context;
+};
+
+extern bool g_registered_signal_handlers = false;
 
 /*++
 Function :
@@ -82,34 +89,6 @@ Parameters :
     (no return value)
 --*/
 void ExecuteHandlerOnOriginalStack(int code, siginfo_t *siginfo, void *context, SignalHandlerWorkerReturnPoint* returnPoint);
-
-/*++
-Function :
-    EnsureSignalAlternateStack
-
-    Ensure that alternate stack for signal handling is allocated for the current thread
-
-Parameters :
-    None
-
-Return :
-    TRUE in case of a success, FALSE otherwise
---*/
-BOOL EnsureSignalAlternateStack(CorUnix::CPalThread *pthrCurrent);
-
-/*++
-Function :
-    FreeSignalAlternateStack
-
-    Free alternate stack for signal handling
-
-Parameters :
-    None
-
-Return :
-    None
---*/
-void FreeSignalAlternateStack(void *altstack);
 
 #endif // !HAVE_MACH_EXCEPTIONS
 

--- a/src/pal/src/include/pal/signal.hpp
+++ b/src/pal/src/include/pal/signal.hpp
@@ -29,7 +29,7 @@ struct SignalHandlerWorkerReturnPoint
     CONTEXT context;
 };
 
-extern bool g_registered_signal_handlers = false;
+extern bool g_registered_signal_handlers;
 
 /*++
 Function :

--- a/src/pal/src/include/pal/signal.hpp
+++ b/src/pal/src/include/pal/signal.hpp
@@ -95,7 +95,7 @@ Parameters :
 Return :
     TRUE in case of a success, FALSE otherwise
 --*/
-BOOL EnsureSignalAlternateStack(CPalThread *pthrCurrent);
+BOOL EnsureSignalAlternateStack(CorUnix::CPalThread *pthrCurrent);
 
 /*++
 Function :
@@ -125,7 +125,7 @@ Parameters :
 Return :
     TRUE in case of a success, FALSE otherwise
 --*/
-BOOL SEHInitializeSignals(CPalThread *pthrCurrent, DWORD flags);
+BOOL SEHInitializeSignals(CorUnix::CPalThread *pthrCurrent, DWORD flags);
 
 /*++
 Function :

--- a/src/pal/src/include/pal/signal.hpp
+++ b/src/pal/src/include/pal/signal.hpp
@@ -95,7 +95,7 @@ Parameters :
 Return :
     TRUE in case of a success, FALSE otherwise
 --*/
-BOOL EnsureSignalAlternateStack();
+BOOL EnsureSignalAlternateStack(CPalThread *pthrCurrent);
 
 /*++
 Function :
@@ -109,7 +109,7 @@ Parameters :
 Return :
     None
 --*/
-void FreeSignalAlternateStack();
+void FreeSignalAlternateStack(void *altstack);
 
 #endif // !HAVE_MACH_EXCEPTIONS
 
@@ -125,7 +125,7 @@ Parameters :
 Return :
     TRUE in case of a success, FALSE otherwise
 --*/
-BOOL SEHInitializeSignals(DWORD flags);
+BOOL SEHInitializeSignals(CPalThread *pthrCurrent, DWORD flags);
 
 /*++
 Function :

--- a/src/pal/src/include/pal/thread.hpp
+++ b/src/pal/src/include/pal/thread.hpp
@@ -637,23 +637,17 @@ namespace CorUnix
             m_pNext = pNext;
         };
 
-        void *
-        FreeAlternateStack(
+#if !HAVE_MACH_EXCEPTIONS
+        BOOL
+        EnsureSignalAlternateStack(
             void
-            )
-        {
-            void *altstack = m_alternateStack;
-            m_alternateStack = nullptr;
-            return altstack;
-        };
+            );
 
-        void
-        SetAlternateStack(
-            void *altstack
-            )
-        {
-            m_alternateStack = altstack;
-        };
+        void 
+        FreeSignalAlternateStack(
+            void
+            );
+#endif // !HAVE_MACH_EXCEPTIONS
 
         void
         AddThreadReference(

--- a/src/pal/src/include/pal/thread.hpp
+++ b/src/pal/src/include/pal/thread.hpp
@@ -324,6 +324,8 @@ namespace CorUnix
         void* m_stackBase;
         // Limit address of the stack of this thread
         void* m_stackLimit;
+        // Signal handler's alternate stack to help with stack overflow
+        void* m_alternateStack;
 
         //
         // The thread entry routine (called from InternalCreateThread)
@@ -387,7 +389,8 @@ namespace CorUnix
             m_fStartStatus(FALSE),
             m_fStartStatusSet(FALSE),
             m_stackBase(NULL),
-            m_stackLimit(NULL)
+            m_stackLimit(NULL),
+            m_alternateStack(NULL)
 #ifdef FEATURE_PAL_SXS
           , m_fInPal(TRUE)
 #endif // FEATURE_PAL_SXS
@@ -632,6 +635,24 @@ namespace CorUnix
             )
         {
             m_pNext = pNext;
+        };
+
+        void *
+        FreeAlternateStack(
+            void
+            )
+        {
+            void *altstack = m_alternateStack;
+            m_alternateStack = nullptr;
+            return altstack;
+        };
+
+        void
+        SetAlternateStack(
+            void *altstack
+            )
+        {
+            m_alternateStack = altstack;
         };
 
         void

--- a/src/pal/src/init/sxs.cpp
+++ b/src/pal/src/init/sxs.cpp
@@ -118,7 +118,7 @@ AllocatePalThread(CPalThread **ppThread)
 #if !HAVE_MACH_EXCEPTIONS
     // Ensure alternate stack for SIGSEGV handling. Our SIGSEGV handler is set to
     // run on an alternate stack and the stack needs to be allocated per thread.
-    if (!EnsureSignalAlternateStack(pThread))
+    if (!pThread->EnsureSignalAlternateStack())
     {
         ERROR("Cannot allocate alternate stack for SIGSEGV handler!\n");
         palError = ERROR_NOT_ENOUGH_MEMORY;

--- a/src/pal/src/init/sxs.cpp
+++ b/src/pal/src/init/sxs.cpp
@@ -109,22 +109,22 @@ AllocatePalThread(CPalThread **ppThread)
     CPalThread *pThread = NULL;
     PAL_ERROR palError;
 
+    palError = CreateThreadData(&pThread);
+    if (NO_ERROR != palError)
+    {
+        goto exit;
+    }
+
 #if !HAVE_MACH_EXCEPTIONS
     // Ensure alternate stack for SIGSEGV handling. Our SIGSEGV handler is set to
     // run on an alternate stack and the stack needs to be allocated per thread.
-    if (!EnsureSignalAlternateStack())
+    if (!EnsureSignalAlternateStack(pThread))
     {
         ERROR("Cannot allocate alternate stack for SIGSEGV handler!\n");
         palError = ERROR_NOT_ENOUGH_MEMORY;
         goto exit;
     }
 #endif // !HAVE_MACH_EXCEPTIONS
-
-    palError = CreateThreadData(&pThread);
-    if (NO_ERROR != palError)
-    {
-        goto exit;
-    }
 
     HANDLE hThread;
     palError = CreateThreadObject(pThread, pThread, &hThread);

--- a/src/pal/src/thread/thread.cpp
+++ b/src/pal/src/thread/thread.cpp
@@ -163,6 +163,7 @@ Function:
 static void InternalEndCurrentThreadWrapper(void *arg)
 {
     CPalThread *pThread = (CPalThread *) arg;
+    void *altstack = pThread->FreeAlternateStack();
 
     // When pthread_exit calls us, it has already removed the PAL thread
     // from TLS.  Since InternalEndCurrentThread calls functions that assert
@@ -183,7 +184,7 @@ static void InternalEndCurrentThreadWrapper(void *arg)
     pthread_setspecific(thObjKey, NULL);
 
 #if !HAVE_MACH_EXCEPTIONS
-    FreeSignalAlternateStack();
+    FreeSignalAlternateStack(altstack);
 #endif // !HAVE_MACH_EXCEPTIONS
 }
 
@@ -1623,7 +1624,7 @@ CPalThread::ThreadEntry(
     }
 
 #if !HAVE_MACH_EXCEPTIONS
-    if (!EnsureSignalAlternateStack())
+    if (!EnsureSignalAlternateStack(pThread))
     {
         ASSERT("Cannot allocate alternate stack for SIGSEGV!\n");
         goto fail;

--- a/src/pal/src/thread/thread.cpp
+++ b/src/pal/src/thread/thread.cpp
@@ -54,6 +54,7 @@ SET_DEFAULT_DEBUG_CHANNEL(THREAD); // some headers have code with asserts, so do
 #include <errno.h>
 #include <stddef.h>
 #include <sys/stat.h>
+#include <sys/mman.h>
 #if HAVE_MACH_THREADS
 #include <mach/mach.h>
 #endif // HAVE_MACH_THREADS
@@ -163,7 +164,6 @@ Function:
 static void InternalEndCurrentThreadWrapper(void *arg)
 {
     CPalThread *pThread = (CPalThread *) arg;
-    void *altstack = pThread->FreeAlternateStack();
 
     // When pthread_exit calls us, it has already removed the PAL thread
     // from TLS.  Since InternalEndCurrentThread calls functions that assert
@@ -178,14 +178,14 @@ static void InternalEndCurrentThreadWrapper(void *arg)
        will lock its own critical section */
     LOADCallDllMain(DLL_THREAD_DETACH, NULL);
 
+#if !HAVE_MACH_EXCEPTIONS
+    pThread->FreeSignalAlternateStack();
+#endif // !HAVE_MACH_EXCEPTIONS
+
     // PAL_Leave will be called just before we release the thread reference
     // in InternalEndCurrentThread.
     InternalEndCurrentThread(pThread);
     pthread_setspecific(thObjKey, NULL);
-
-#if !HAVE_MACH_EXCEPTIONS
-    FreeSignalAlternateStack(altstack);
-#endif // !HAVE_MACH_EXCEPTIONS
 }
 
 /*++
@@ -1624,7 +1624,7 @@ CPalThread::ThreadEntry(
     }
 
 #if !HAVE_MACH_EXCEPTIONS
-    if (!EnsureSignalAlternateStack(pThread))
+    if (!pThread->EnsureSignalAlternateStack())
     {
         ASSERT("Cannot allocate alternate stack for SIGSEGV!\n");
         goto fail;
@@ -2391,6 +2391,114 @@ CPalThread::WaitForStartStatus(
 
     return m_fStartStatus;
 }
+
+#if !HAVE_MACH_EXCEPTIONS
+/*++
+Function :
+    EnsureSignalAlternateStack
+
+    Ensure that alternate stack for signal handling is allocated for the current thread
+
+Parameters :
+    None
+
+Return :
+    TRUE in case of a success, FALSE otherwise
+--*/
+BOOL 
+CPalThread::EnsureSignalAlternateStack()
+{
+    int st = 0;
+
+    if (g_registered_signal_handlers)
+    {
+        stack_t oss;
+
+        // Query the current alternate signal stack
+        st = sigaltstack(NULL, &oss);
+        if ((st == 0) && (oss.ss_flags == SS_DISABLE))
+        {
+            // There is no alternate stack for SIGSEGV handling installed yet so allocate one
+
+            // We include the size of the SignalHandlerWorkerReturnPoint in the alternate stack size since the 
+            // context contained in it is large and the SIGSTKSZ was not sufficient on ARM64 during testing.
+            int altStackSize = SIGSTKSZ + ALIGN_UP(sizeof(SignalHandlerWorkerReturnPoint), 16) + GetVirtualPageSize();
+#ifdef HAS_ASAN
+            // Asan also uses alternate stack so we increase its size on the SIGSTKSZ * 4 that enough for asan
+            // (see kAltStackSize in compiler-rt/lib/sanitizer_common/sanitizer_posix_libcdep.cc)
+            altStackSize += SIGSTKSZ * 4;
+#endif
+            altStackSize = ALIGN_UP(altStackSize, GetVirtualPageSize());
+            void* altStack = mmap(NULL, altStackSize, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_STACK | MAP_PRIVATE, -1, 0);
+            if (altStack != MAP_FAILED)
+            {
+                // create a guard page for the alternate stack
+                st = mprotect(altStack, GetVirtualPageSize(), PROT_NONE);
+                if (st == 0)
+                {
+                    stack_t ss;
+                    ss.ss_sp = (char*)altStack;
+                    ss.ss_size = altStackSize;
+                    ss.ss_flags = 0;
+                    st = sigaltstack(&ss, NULL);
+                }
+
+                if (st == 0)
+                {
+                    m_alternateStack = altStack;
+                }
+                else 
+                {
+                    int st2 = munmap(altStack, altStackSize);
+                    _ASSERTE(st2 == 0);
+                }
+            }
+        }
+    }
+
+    return (st == 0);
+}
+
+/*++
+Function :
+    FreeSignalAlternateStack
+
+    Free alternate stack for signal handling
+
+Parameters :
+    None
+
+Return :
+    None
+--*/
+void 
+CPalThread::FreeSignalAlternateStack()
+{
+    void *altstack = m_alternateStack;
+    m_alternateStack = nullptr;
+
+    if (altstack != nullptr)
+    {
+        stack_t ss, oss;
+        // The man page for sigaltstack says that when the ss.ss_flags is set to SS_DISABLE,
+        // all other ss fields are ignored. However, MUSL implementation checks that the 
+        // ss_size is >= MINSIGSTKSZ even in this case.
+        ss.ss_size = MINSIGSTKSZ;
+        ss.ss_flags = SS_DISABLE;
+        int st = sigaltstack(&ss, &oss);
+        if ((st == 0) && (oss.ss_flags != SS_DISABLE))
+        {
+            // Make sure this altstack is this PAL's before freeing.
+            if (oss.ss_sp == altstack)
+            {
+                int st = munmap(oss.ss_sp, oss.ss_size);
+                _ASSERTE(st == 0);
+            }
+        }
+    }
+}
+
+#endif // !HAVE_MACH_EXCEPTIONS
 
 /* IncrementEndingThreadCount and DecrementEndingThreadCount are used
 to control a global counter that indicates if any threads are about to die.


### PR DESCRIPTION
Pass the CPalThread instance through to EnsureSignalAlternateStack and save the altstack pointer allocated.   And in FreeSignalAlternateStack use this pointer to ensure that only the proper PAL frees the stack.