### PR TITLE
Optimize number formatting

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Byte.cs
+++ b/src/System.Private.CoreLib/shared/System/Byte.cs
@@ -174,27 +174,27 @@ namespace System
 
         public override string ToString()
         {
-            return Number.FormatInt32(m_value, null, null);
+            return Number.FormatUInt32(m_value, null, null);
         }
 
         public string ToString(string format)
         {
-            return Number.FormatInt32(m_value, format, null);
+            return Number.FormatUInt32(m_value, format, null);
         }
 
         public string ToString(IFormatProvider provider)
         {
-            return Number.FormatInt32(m_value, null, provider);
+            return Number.FormatUInt32(m_value, null, provider);
         }
 
         public string ToString(string format, IFormatProvider provider)
         {
-            return Number.FormatInt32(m_value, format, provider);
+            return Number.FormatUInt32(m_value, format, provider);
         }
 
         public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider provider = null)
         {
-            return Number.TryFormatInt32(m_value, format, provider, destination, out charsWritten);
+            return Number.TryFormatUInt32(m_value, format, provider, destination, out charsWritten);
         }
 
         //

--- a/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
@@ -582,14 +582,12 @@ namespace System
             }
 
             char fmt = ParseFormatSpecifier(format, out int digits);
-            NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
-
             char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
             if ((fmtUpper == 'G' && digits < 1) || fmtUpper == 'D')
             {
                 return value >= 0 ?
                     UInt32ToDecStr((uint)value, digits) :
-                    NegativeInt32ToDecStr(value, digits, info.NegativeSign);
+                    NegativeInt32ToDecStr(value, digits, NumberFormatInfo.GetInstance(provider).NegativeSign);
             }
             else if (fmtUpper == 'X')
             {
@@ -599,6 +597,7 @@ namespace System
             }
             else
             {
+                NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
                 NumberBuffer number = default;
                 Int32ToNumber(value, ref number);
                 ValueStringBuilder sb;
@@ -628,14 +627,12 @@ namespace System
             }
 
             char fmt = ParseFormatSpecifier(format, out int digits);
-            NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
-
             char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
             if ((fmtUpper == 'G' && digits < 1) || fmtUpper == 'D')
             {
                 return value >= 0 ?
                     TryUInt32ToDecStr((uint)value, digits, destination, out charsWritten) :
-                    TryNegativeInt32ToDecStr(value, digits, info.NegativeSign, destination, out charsWritten);
+                    TryNegativeInt32ToDecStr(value, digits, NumberFormatInfo.GetInstance(provider).NegativeSign, destination, out charsWritten);
             }
             else if (fmtUpper == 'X')
             {
@@ -645,6 +642,7 @@ namespace System
             }
             else
             {
+                NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
                 NumberBuffer number = default;
                 Int32ToNumber(value, ref number);
                 ValueStringBuilder sb;
@@ -674,8 +672,6 @@ namespace System
             }
 
             char fmt = ParseFormatSpecifier(format, out int digits);
-            NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
-
             char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
             if ((fmtUpper == 'G' && digits < 1) || fmtUpper == 'D')
             {
@@ -689,6 +685,7 @@ namespace System
             }
             else
             {
+                NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
                 NumberBuffer number = default;
                 UInt32ToNumber(value, ref number);
                 ValueStringBuilder sb;
@@ -718,8 +715,6 @@ namespace System
             }
 
             char fmt = ParseFormatSpecifier(format, out int digits);
-            NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
-
             char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
             if ((fmtUpper == 'G' && digits < 1) || fmtUpper == 'D')
             {
@@ -733,6 +728,7 @@ namespace System
             }
             else
             {
+                NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
                 NumberBuffer number = default;
                 UInt32ToNumber(value, ref number);
                 ValueStringBuilder sb;
@@ -762,14 +758,12 @@ namespace System
             }
 
             char fmt = ParseFormatSpecifier(format, out int digits);
-            NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
-
             char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
             if ((fmtUpper == 'G' && digits < 1) || fmtUpper == 'D')
             {
                 return value >= 0 ?
                     UInt64ToDecStr((ulong)value, digits) :
-                    NegativeInt64ToDecStr(value, digits, info.NegativeSign);
+                    NegativeInt64ToDecStr(value, digits, NumberFormatInfo.GetInstance(provider).NegativeSign);
             }
             else if (fmtUpper == 'X')
             {
@@ -780,6 +774,7 @@ namespace System
             }
             else
             {
+                NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
                 NumberBuffer number = default;
                 Int64ToNumber(value, ref number);
                 ValueStringBuilder sb;
@@ -809,14 +804,12 @@ namespace System
             }
 
             char fmt = ParseFormatSpecifier(format, out int digits);
-            NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
-
             char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
             if ((fmtUpper == 'G' && digits < 1) || fmtUpper == 'D')
             {
                 return value >= 0 ?
                     TryUInt64ToDecStr((ulong)value, digits, destination, out charsWritten) :
-                    TryNegativeInt64ToDecStr(value, digits, info.NegativeSign, destination, out charsWritten);
+                    TryNegativeInt64ToDecStr(value, digits, NumberFormatInfo.GetInstance(provider).NegativeSign, destination, out charsWritten);
             }
             else if (fmtUpper == 'X')
             {
@@ -827,6 +820,7 @@ namespace System
             }
             else
             {
+                NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
                 NumberBuffer number = default;
                 Int64ToNumber(value, ref number);
                 ValueStringBuilder sb;
@@ -856,8 +850,6 @@ namespace System
             }
 
             char fmt = ParseFormatSpecifier(format, out int digits);
-            NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
-
             char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
             if ((fmtUpper == 'G' && digits < 1) || fmtUpper == 'D')
             {
@@ -872,6 +864,7 @@ namespace System
             }
             else
             {
+                NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
                 NumberBuffer number = default;
                 UInt64ToNumber(value, ref number);
                 ValueStringBuilder sb;
@@ -901,8 +894,6 @@ namespace System
             }
 
             char fmt = ParseFormatSpecifier(format, out int digits);
-            NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
-
             char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
             if ((fmtUpper == 'G' && digits < 1) || fmtUpper == 'D')
             {
@@ -917,6 +908,7 @@ namespace System
             }
             else
             {
+                NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
                 NumberBuffer number = default;
                 UInt64ToNumber(value, ref number);
                 ValueStringBuilder sb;


### PR DESCRIPTION
Moved `NumberFormatInfo.GetInstance` calls further down so that it can be skipped for more format variants. Changed byte to use uint for formatting.
I plan to move byte parsing also to uint for consistency, but that has some unexpected performance issues that I need to resolve first.

Stats for hex format (X):

|          Method |     Old | New |
|---------------- |---------:|---------:|
|   x64 TryFormatByte | 30.95 ns | 21.30 ns |
|  x64 TryFormatInt32 | 45.08 ns | 36.05 ns |
| x64 TryFormatUInt32 | 43.85 ns | 36.36 ns |
|   x86 TryFormatByte | 27.48 ns | 17.51 ns |
|  x86 TryFormatInt32 | 43.52 ns | 32.34 ns |
| x86 TryFormatUInt32 | 43.32 ns | 31.96 ns |