### PR TITLE
Mark more structs as readonly

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Globalization/TimeSpanParse.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/TimeSpanParse.cs
@@ -804,7 +804,7 @@ namespace System.Globalization
                     }
                 }
 
-                result.parsedTimeSpan._ticks = ticks;
+                result.parsedTimeSpan = new TimeSpan(ticks);
                 return true;
             }
 
@@ -932,7 +932,7 @@ namespace System.Globalization
                     }
                 }
 
-                result.parsedTimeSpan._ticks = ticks;
+                result.parsedTimeSpan = new TimeSpan(ticks);
                 return true;
             }
 
@@ -1058,7 +1058,7 @@ namespace System.Globalization
                     }
                 }
 
-                result.parsedTimeSpan._ticks = ticks;
+                result.parsedTimeSpan = new TimeSpan(ticks);
                 return true;
             }
 
@@ -1130,7 +1130,7 @@ namespace System.Globalization
                     }
                 }
 
-                result.parsedTimeSpan._ticks = ticks;
+                result.parsedTimeSpan = new TimeSpan(ticks);
                 return true;
             }
 
@@ -1200,7 +1200,7 @@ namespace System.Globalization
                     }
                 }
 
-                result.parsedTimeSpan._ticks = ticks;
+                result.parsedTimeSpan = new TimeSpan(ticks);
                 return true;
             }
 
@@ -1399,7 +1399,7 @@ namespace System.Globalization
                     ticks = -ticks;
                 }
 
-                result.parsedTimeSpan._ticks = ticks;
+                result.parsedTimeSpan = new TimeSpan(ticks);
                 return true;
             }
             else
@@ -1494,7 +1494,7 @@ namespace System.Globalization
 
             internal bool TryParse(ReadOnlySpan<char> input, ref TimeSpanResult result)
             {
-                result.parsedTimeSpan._ticks = 0;
+                result.parsedTimeSpan = default;
 
                 _str = input;
                 _len = input.Length;
@@ -1563,7 +1563,7 @@ namespace System.Globalization
                     return result.SetBadTimeSpanFailure();
                 }
 
-                result.parsedTimeSpan._ticks = time;
+                result.parsedTimeSpan = new TimeSpan(time);
                 return true;
             }
 

--- a/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/HandleRef.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/HandleRef.cs
@@ -4,12 +4,12 @@
 
 namespace System.Runtime.InteropServices
 {
-    public struct HandleRef
+    public readonly struct HandleRef
     {
         // ! Do not add or rearrange fields as the EE depends on this layout.
         //------------------------------------------------------------------
-        private object _wrapper;
-        private IntPtr _handle;
+        private readonly object _wrapper;
+        private readonly IntPtr _handle;
         //------------------------------------------------------------------
 
         public HandleRef(object wrapper, IntPtr handle)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Serialization/SerializationInfoEnumerator.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Serialization/SerializationInfoEnumerator.cs
@@ -7,11 +7,11 @@ using System.Diagnostics;
 
 namespace System.Runtime.Serialization
 {
-    public struct SerializationEntry
+    public readonly struct SerializationEntry
     {
-        private string _name;
-        private object _value;
-        private Type _type;
+        private readonly string _name;
+        private readonly object _value;
+        private readonly Type _type;
 
         internal SerializationEntry(string entryName, object entryValue, Type entryType)
         {

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.BinarySearch.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.BinarySearch.cs
@@ -62,11 +62,11 @@ namespace System
         }
 
         // Helper to allow sharing all code via IComparable<T> inlineable
-        internal struct ComparerComparable<T, TComparer> : IComparable<T>
+        internal readonly struct ComparerComparable<T, TComparer> : IComparable<T>
             where TComparer : IComparer<T>
         {
-            readonly T _value;
-            readonly TComparer _comparer;
+            private readonly T _value;
+            private readonly TComparer _comparer;
 
             public ComparerComparable(T value, TComparer comparer)
             {

--- a/src/System.Private.CoreLib/shared/System/Threading/AsyncLocal.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/AsyncLocal.cs
@@ -86,19 +86,18 @@ namespace System.Threading
         void OnValueChanged(object previousValue, object currentValue, bool contextChanged);
     }
 
-    public struct AsyncLocalValueChangedArgs<T>
+    public readonly struct AsyncLocalValueChangedArgs<T>
     {
-        public T PreviousValue { get; private set; }
-        public T CurrentValue { get; private set; }
+        public T PreviousValue { get; }
+        public T CurrentValue { get; }
 
         //
         // If the value changed because we changed to a different ExecutionContext, this is true.  If it changed
         // because someone set the Value property, this is false.
         //
-        public bool ThreadContextChanged { get; private set; }
+        public bool ThreadContextChanged { get; }
 
         internal AsyncLocalValueChangedArgs(T previousValue, T currentValue, bool contextChanged)
-            : this()
         {
             PreviousValue = previousValue;
             CurrentValue = currentValue;

--- a/src/System.Private.CoreLib/shared/System/TimeSpan.cs
+++ b/src/System.Private.CoreLib/shared/System/TimeSpan.cs
@@ -28,7 +28,7 @@ namespace System
     // an appropriate custom ILMarshaler to keep WInRT interop scenarios enabled.
     //
     [Serializable]
-    public struct TimeSpan : IComparable, IComparable<TimeSpan>, IEquatable<TimeSpan>, IFormattable, ISpanFormattable
+    public readonly struct TimeSpan : IComparable, IComparable<TimeSpan>, IEquatable<TimeSpan>, IFormattable, ISpanFormattable
     {
         public const long TicksPerMillisecond = 10000;
         private const double MillisecondsPerTick = 1.0 / TicksPerMillisecond;
@@ -65,7 +65,7 @@ namespace System
 
         // internal so that DateTime doesn't have to call an extra get
         // method for some arithmetic operations.
-        internal long _ticks; // Do not rename (binary serialization)
+        internal readonly long _ticks; // Do not rename (binary serialization)
 
         public TimeSpan(long ticks)
         {

--- a/src/System.Private.CoreLib/src/System/Array.cs
+++ b/src/System.Private.CoreLib/src/System/Array.cs
@@ -1889,11 +1889,11 @@ namespace System
 
 
         // Private value type used by the Sort methods.
-        private struct SorterObjectArray
+        private readonly struct SorterObjectArray
         {
-            private object[] keys;
-            private object[] items;
-            private IComparer comparer;
+            private readonly object[] keys;
+            private readonly object[] items;
+            private readonly IComparer comparer;
 
             internal SorterObjectArray(object[] keys, object[] items, IComparer comparer)
             {
@@ -2095,11 +2095,11 @@ namespace System
         // Private value used by the Sort methods for instances of Array.
         // This is slower than the one for Object[], since we can't use the JIT helpers
         // to access the elements.  We must use GetValue & SetValue.
-        private struct SorterGenericArray
+        private readonly struct SorterGenericArray
         {
-            private Array keys;
-            private Array items;
-            private IComparer comparer;
+            private readonly Array keys;
+            private readonly Array items;
+            private readonly IComparer comparer;
 
             internal SorterGenericArray(Array keys, Array items, IComparer comparer)
             {

--- a/src/System.Private.CoreLib/src/System/ByReference.cs
+++ b/src/System.Private.CoreLib/src/System/ByReference.cs
@@ -11,9 +11,9 @@ namespace System
     // around lack of first class support for byref fields in C# and IL. The JIT and 
     // type loader has special handling for it that turns it into a thin wrapper around ref T.
     [NonVersionable]
-    internal ref struct ByReference<T>
+    internal readonly ref struct ByReference<T>
     {
-        private IntPtr _value;
+        private readonly IntPtr _value;
 
         public ByReference(ref T value)
         {

--- a/src/System.Private.CoreLib/src/System/RtType.cs
+++ b/src/System.Private.CoreLib/src/System/RtType.cs
@@ -186,11 +186,11 @@ namespace System
                 NestedType
             }
 
-            private struct Filter
+            private readonly struct Filter
             {
-                private MdUtf8String m_name;
-                private MemberListType m_listType;
-                private uint m_nameHash;
+                private readonly MdUtf8String m_name;
+                private readonly MemberListType m_listType;
+                private readonly uint m_nameHash;
 
                 public unsafe Filter(byte* pUtf8Name, int cUtf8Name, MemberListType listType)
                 {
@@ -4888,7 +4888,7 @@ namespace System
     }
 
     #region Library
-    internal unsafe struct MdUtf8String
+    internal readonly unsafe struct MdUtf8String
     {
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern unsafe bool EqualsCaseSensitive(void* szLhs, void* szRhs, int cSz);
@@ -4917,8 +4917,8 @@ namespace System
             return len;
         }
 
-        private void* m_pStringHeap;        // This is the raw UTF8 string.
-        private int m_StringHeapByteLength;
+        private readonly void* m_pStringHeap;        // This is the raw UTF8 string.
+        private readonly int m_StringHeapByteLength;
 
         internal MdUtf8String(void* pStringHeap)
         {


### PR DESCRIPTION
`TimeSpan` is probably the most useful; when `TimeSpan` is used as a `readonly` field and methods/properties are called on it.

```
System\Globalization\DateTimeFormat.cs(128):        internal static readonly TimeSpan NullOffset = TimeSpan.MinValue;
System\Globalization\DaylightTime.cs(12):        private readonly TimeSpan _delta;
System\Globalization\DaylightTime.cs(43):        public readonly TimeSpan Delta;
System\Threading\Timeout.cs(15):        public static readonly TimeSpan InfiniteTimeSpan = new TimeSpan(0, 0, 0, 0, Timeout.Infinite);
System\TimeSpan.cs(61):        public static readonly TimeSpan Zero = new TimeSpan(0);
System\TimeSpan.cs(63):        public static readonly TimeSpan MaxValue = new TimeSpan(long.MaxValue);
System\TimeSpan.cs(64):        public static readonly TimeSpan MinValue = new TimeSpan(long.MinValue);
System\TimeZoneInfo.AdjustmentRule.cs(14):            private static readonly TimeSpan DaylightDeltaAdjustment = TimeSpan.FromHours(24.0);
System\TimeZoneInfo.AdjustmentRule.cs(15):            private static readonly TimeSpan MaxDaylightDelta = TimeSpan.FromHours(12.0);
System\TimeZoneInfo.AdjustmentRule.cs(18):            private readonly TimeSpan _daylightDelta;
System\TimeZoneInfo.AdjustmentRule.cs(21):            private readonly TimeSpan _baseUtcOffsetDelta;   // delta from the default Utc offset (utcOffset = defaultUtcOffset + _baseUtcOffsetDelta)
System\TimeZoneInfo.cs(46):        private readonly TimeSpan _baseUtcOffset;
System\TimeZoneInfo.cs(1983):        private static readonly TimeSpan MaxOffset = TimeSpan.FromHours(14.0);
System\TimeZoneInfo.cs(1984):        private static readonly TimeSpan MinOffset = -MaxOffset;
System\TimeZoneInfo.Unix.cs(1581):            public readonly TimeSpan UtcOffset;
System\TimeZoneInfo.Win32.cs(74):            public readonly TimeSpan Offset;
```

/cc @jkotas @stephentoub 