### PR TITLE
Update Vector<T> T4 templates to match generated code

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Numerics/ConstantHelper.tt
+++ b/src/System.Private.CoreLib/shared/System/Numerics/ConstantHelper.tt
@@ -25,14 +25,14 @@ namespace System.Numerics
         string hexValue = "0x" + new string('f', Marshal.SizeOf(type) * 2);
 #>
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
-        public static <#= type.Name #> Get<#= type.Name #>WithAllBitsSet()
+        public static <#= typeAliases[type] #> Get<#= type.Name #>WithAllBitsSet()
         {
-            <#= type.Name #> value = 0;
+            <#= typeAliases[type] #> value = 0;
             unsafe
             {
                 unchecked
                 {
-                    *((<#= GetIntegralEquivalent(type).Name #>*)&value) = (<#=GetIntegralEquivalent(type).Name#>)<#= hexValue #>;
+                    *((<#= typeAliases[GetIntegralEquivalent(type)] #>*)&value) = (<#= typeAliases[GetIntegralEquivalent(type)] #>)<#= hexValue #>;
                 }
             }
             return value;
@@ -44,13 +44,13 @@ namespace System.Numerics
 }<#+
     public Type GetIntegralEquivalent(Type type)
     {
-        if (type == typeof(Single))
+        if (type == typeof(float))
         {
-            return typeof(Int32);
+            return typeof(int);
         }
         else if (type == typeof(double))
         {
-            return typeof(Int64);
+            return typeof(long);
         }
         else 
         {

--- a/src/System.Private.CoreLib/shared/System/Numerics/ConstantHelper.tt
+++ b/src/System.Private.CoreLib/shared/System/Numerics/ConstantHelper.tt
@@ -20,7 +20,8 @@ namespace System.Numerics
 {
     internal class ConstantHelper
     {
-<#    foreach (var type in supportedTypes)
+<#
+    foreach (var type in supportedTypes)
     {
         string hexValue = "0x" + new string('f', Marshal.SizeOf(type) * 2);
 #>

--- a/src/System.Private.CoreLib/shared/System/Numerics/GenerationConfig.ttinclude
+++ b/src/System.Private.CoreLib/shared/System/Numerics/GenerationConfig.ttinclude
@@ -8,27 +8,40 @@
     // The set of supported numeric types to compile
     public static Type[] supportedTypes = new[] 
     { 
-        typeof(Byte), typeof(SByte), typeof(UInt16), typeof(Int16),
-        typeof(UInt32), typeof(Int32), typeof(UInt64), typeof(Int64),
-        typeof(Single), typeof(Double)
+        typeof(byte), typeof(sbyte), typeof(ushort), typeof(short),
+        typeof(uint), typeof(int), typeof(ulong), typeof(long),
+        typeof(float), typeof(double)
     };
 
     // The set of unsigned types, a subset of the above. Used for excluding from certain methods, i.e. Abs and Negate
     public static Type[] unsignedTypes = new[]
     {
-        typeof(Byte), typeof(UInt16), typeof(UInt32), typeof(UInt64)
+        typeof(byte), typeof(ushort), typeof(uint), typeof(ulong)
     };
 
     public static Type[] integralTypes = new[]
     {
-        typeof(Byte), typeof(SByte), typeof(UInt16), typeof(Int16),
-        typeof(UInt32), typeof(Int32), typeof(UInt64), typeof(Int64)
+        typeof(byte), typeof(sbyte), typeof(ushort), typeof(short),
+        typeof(uint), typeof(int), typeof(ulong), typeof(long)
     };
 
     public static Type[] nonClsCompliantTypes = new[]
     {
-        typeof(SByte), typeof(UInt16), 
-        typeof(UInt32), typeof(UInt64)
+        typeof(sbyte), typeof(ushort), typeof(uint), typeof(ulong)
+    };
+
+    public static Dictionary<Type, string> typeAliases = new Dictionary<Type, string>()
+    {
+        { typeof(byte), "byte" },
+        { typeof(sbyte), "sbyte" },
+        { typeof(ushort), "ushort" },
+        { typeof(short), "short" },
+        { typeof(uint), "uint" },
+        { typeof(int), "int" },
+        { typeof(ulong), "ulong" },
+        { typeof(long), "long" },
+        { typeof(float), "float" },
+        { typeof(double), "double" }
     };
 
     // The total register size, in bytes. 16 for SSE2, 32 for AVX, 64 for AVX512
@@ -137,18 +150,18 @@
     public string GenerateIfStatementHeader(Type type)
     {
         string keyword = (type == supportedTypes[0]) ? "if" : "else if";
-        return string.Format("{0} (typeof(T) == typeof({1}))", keyword, type.Name);
+        return string.Format("{0} (typeof(T) == typeof({1}))", keyword, typeAliases[type]);
     }
 
     public string GenerateIfStatementHeader(Type type, IEnumerable<Type> allTypes)
     {
         string keyword = (type == allTypes.ToArray()[0]) ? "if" : "else if";
-        return string.Format("{0} (typeof(T) == typeof({1}))", keyword, type.Name);
+        return string.Format("{0} (typeof(T) == typeof({1}))", keyword, typeAliases[type]);
     }
 
     public string MakeTypeComparisonCondition(Type type)
     {
-        return string.Format("(typeof(T) == typeof({0}))", type.Name);
+        return string.Format("(typeof(T) == typeof({0}))", typeAliases[type]);
     }
 
     public string GenerateIfConditionAllTypes(IEnumerable<Type> allTypes)

--- a/src/System.Private.CoreLib/shared/System/Numerics/Register.tt
+++ b/src/System.Private.CoreLib/shared/System/Numerics/Register.tt
@@ -34,7 +34,7 @@ namespace System.Numerics
         {
 #>
         [FieldOffset(<#=Marshal.SizeOf(type) * g#>)]
-        internal <#=type.Name#> <#= type.Name.ToLowerInvariant() + "_" + g #>;
+        internal <#= typeAliases[type] #> <#= type.Name.ToLowerInvariant() + "_" + g #>;
 <#
         }
 #>

--- a/src/System.Private.CoreLib/shared/System/Numerics/Vector.cs
+++ b/src/System.Private.CoreLib/shared/System/Numerics/Vector.cs
@@ -16,8 +16,8 @@ namespace System.Numerics
     /* Note: The following patterns are used throughout the code here and are described here
     *
     * PATTERN:
-    *    if (typeof(T) == typeof(Int32)) { ... }
-    *    else if (typeof(T) == typeof(Single)) { ... }
+    *    if (typeof(T) == typeof(int)) { ... }
+    *    else if (typeof(T) == typeof(float)) { ... }
     * EXPLANATION:
     *    At runtime, each instantiation of Vector<T> will be type-specific, and each of these typeof blocks will be eliminated,
     *    as typeof(T) is a (JIT) compile-time constant for each instantiation. This design was chosen to eliminate any overhead from

--- a/src/System.Private.CoreLib/shared/System/Numerics/Vector.cs
+++ b/src/System.Private.CoreLib/shared/System/Numerics/Vector.cs
@@ -100,7 +100,7 @@ namespace System.Numerics
             internal byte _byte;
         }
 
-		// Calculates the size of this struct in bytes, by computing the offset of a field in a structure
+        // Calculates the size of this struct in bytes, by computing the offset of a field in a structure
         private static unsafe int InitializeCount()
         {
             VectorSizeHelper vsh;
@@ -5182,21 +5182,21 @@ namespace System.Numerics
         [Intrinsic]
         public static unsafe Vector<byte> Narrow(Vector<ushort> low, Vector<ushort> high)
         {
-		    unchecked
-		    {
-				int elements = Vector<byte>.Count;
+            unchecked
+            {
+                int elements = Vector<byte>.Count;
                 byte* retPtr = stackalloc byte[elements];
-				for (int i = 0; i < elements / 2; i++)
-				{
-					retPtr[i] = (byte)low[i];
-				}
-				for (int i = 0; i < elements / 2; i++)
-				{
-					retPtr[i + (elements / 2)] = (byte)high[i];
-				}
+                for (int i = 0; i < elements / 2; i++)
+                {
+                    retPtr[i] = (byte)low[i];
+                }
+                for (int i = 0; i < elements / 2; i++)
+                {
+                    retPtr[i + (elements / 2)] = (byte)high[i];
+                }
 
-				return new Vector<byte>(retPtr);
-		    }
+                return new Vector<byte>(retPtr);
+            }
         }
 
         /// <summary>
@@ -5209,21 +5209,21 @@ namespace System.Numerics
         [Intrinsic]
         public static unsafe Vector<ushort> Narrow(Vector<uint> low, Vector<uint> high)
         {
-		    unchecked
-		    {
-				int elements = Vector<ushort>.Count;
+            unchecked
+            {
+                int elements = Vector<ushort>.Count;
                 ushort* retPtr = stackalloc ushort[elements];
-				for (int i = 0; i < elements / 2; i++)
-				{
-					retPtr[i] = (ushort)low[i];
-				}
-				for (int i = 0; i < elements / 2; i++)
-				{
-					retPtr[i + (elements / 2)] = (ushort)high[i];
-				}
+                for (int i = 0; i < elements / 2; i++)
+                {
+                    retPtr[i] = (ushort)low[i];
+                }
+                for (int i = 0; i < elements / 2; i++)
+                {
+                    retPtr[i + (elements / 2)] = (ushort)high[i];
+                }
 
-				return new Vector<ushort>(retPtr);
-		    }
+                return new Vector<ushort>(retPtr);
+            }
         }
 
         /// <summary>
@@ -5236,21 +5236,21 @@ namespace System.Numerics
         [Intrinsic]
         public static unsafe Vector<uint> Narrow(Vector<ulong> low, Vector<ulong> high)
         {
-		    unchecked
-		    {
-				int elements = Vector<uint>.Count;
+            unchecked
+            {
+                int elements = Vector<uint>.Count;
                 uint* retPtr = stackalloc uint[elements];
-				for (int i = 0; i < elements / 2; i++)
-				{
-					retPtr[i] = (uint)low[i];
-				}
-				for (int i = 0; i < elements / 2; i++)
-				{
-					retPtr[i + (elements / 2)] = (uint)high[i];
-				}
+                for (int i = 0; i < elements / 2; i++)
+                {
+                    retPtr[i] = (uint)low[i];
+                }
+                for (int i = 0; i < elements / 2; i++)
+                {
+                    retPtr[i + (elements / 2)] = (uint)high[i];
+                }
 
-				return new Vector<uint>(retPtr);
-		    }
+                return new Vector<uint>(retPtr);
+            }
         }
 
         /// <summary>
@@ -5263,21 +5263,21 @@ namespace System.Numerics
         [Intrinsic]
         public static unsafe Vector<sbyte> Narrow(Vector<short> low, Vector<short> high)
         {
-		    unchecked
-		    {
-				int elements = Vector<sbyte>.Count;
+            unchecked
+            {
+                int elements = Vector<sbyte>.Count;
                 sbyte* retPtr = stackalloc sbyte[elements];
-				for (int i = 0; i < elements / 2; i++)
-				{
-					retPtr[i] = (sbyte)low[i];
-				}
-				for (int i = 0; i < elements / 2; i++)
-				{
-					retPtr[i + (elements / 2)] = (sbyte)high[i];
-				}
+                for (int i = 0; i < elements / 2; i++)
+                {
+                    retPtr[i] = (sbyte)low[i];
+                }
+                for (int i = 0; i < elements / 2; i++)
+                {
+                    retPtr[i + (elements / 2)] = (sbyte)high[i];
+                }
 
-				return new Vector<sbyte>(retPtr);
-		    }
+                return new Vector<sbyte>(retPtr);
+            }
         }
 
         /// <summary>
@@ -5289,21 +5289,21 @@ namespace System.Numerics
         [Intrinsic]
         public static unsafe Vector<short> Narrow(Vector<int> low, Vector<int> high)
         {
-		    unchecked
-		    {
-				int elements = Vector<short>.Count;
+            unchecked
+            {
+                int elements = Vector<short>.Count;
                 short* retPtr = stackalloc short[elements];
-				for (int i = 0; i < elements / 2; i++)
-				{
-					retPtr[i] = (short)low[i];
-				}
-				for (int i = 0; i < elements / 2; i++)
-				{
-					retPtr[i + (elements / 2)] = (short)high[i];
-				}
+                for (int i = 0; i < elements / 2; i++)
+                {
+                    retPtr[i] = (short)low[i];
+                }
+                for (int i = 0; i < elements / 2; i++)
+                {
+                    retPtr[i + (elements / 2)] = (short)high[i];
+                }
 
-				return new Vector<short>(retPtr);
-		    }
+                return new Vector<short>(retPtr);
+            }
         }
 
         /// <summary>
@@ -5315,21 +5315,21 @@ namespace System.Numerics
         [Intrinsic]
         public static unsafe Vector<int> Narrow(Vector<long> low, Vector<long> high)
         {
-		    unchecked
-		    {
-				int elements = Vector<int>.Count;
+            unchecked
+            {
+                int elements = Vector<int>.Count;
                 int* retPtr = stackalloc int[elements];
-				for (int i = 0; i < elements / 2; i++)
-				{
-					retPtr[i] = (int)low[i];
-				}
-				for (int i = 0; i < elements / 2; i++)
-				{
-					retPtr[i + (elements / 2)] = (int)high[i];
-				}
+                for (int i = 0; i < elements / 2; i++)
+                {
+                    retPtr[i] = (int)low[i];
+                }
+                for (int i = 0; i < elements / 2; i++)
+                {
+                    retPtr[i + (elements / 2)] = (int)high[i];
+                }
 
-				return new Vector<int>(retPtr);
-		    }
+                return new Vector<int>(retPtr);
+            }
         }
 
         /// <summary>
@@ -5341,21 +5341,21 @@ namespace System.Numerics
         [Intrinsic]
         public static unsafe Vector<float> Narrow(Vector<double> low, Vector<double> high)
         {
-		    unchecked
-		    {
-				int elements = Vector<float>.Count;
+            unchecked
+            {
+                int elements = Vector<float>.Count;
                 float* retPtr = stackalloc float[elements];
-				for (int i = 0; i < elements / 2; i++)
-				{
-					retPtr[i] = (float)low[i];
-				}
-				for (int i = 0; i < elements / 2; i++)
-				{
-					retPtr[i + (elements / 2)] = (float)high[i];
-				}
+                for (int i = 0; i < elements / 2; i++)
+                {
+                    retPtr[i] = (float)low[i];
+                }
+                for (int i = 0; i < elements / 2; i++)
+                {
+                    retPtr[i + (elements / 2)] = (float)high[i];
+                }
 
-				return new Vector<float>(retPtr);
-		    }
+                return new Vector<float>(retPtr);
+            }
         }
 
         #endregion Widen/Narrow
@@ -5369,17 +5369,17 @@ namespace System.Numerics
         [Intrinsic]
         public static unsafe Vector<float> ConvertToSingle(Vector<int> value)
         {
-			unchecked
-			{
-				int elements = Vector<float>.Count;
+            unchecked
+            {
+                int elements = Vector<float>.Count;
                 float* retPtr = stackalloc float[elements];
-				for (int i = 0; i < elements; i++)
-				{
-					retPtr[i] = (float)value[i];
-				}
+                for (int i = 0; i < elements; i++)
+                {
+                    retPtr[i] = (float)value[i];
+                }
 
-				return new Vector<float>(retPtr);
-			}
+                return new Vector<float>(retPtr);
+            }
         }
 
         /// <summary>
@@ -5391,17 +5391,17 @@ namespace System.Numerics
         [Intrinsic]
         public static unsafe Vector<float> ConvertToSingle(Vector<uint> value)
         {
-			unchecked
-			{
-				int elements = Vector<float>.Count;
+            unchecked
+            {
+                int elements = Vector<float>.Count;
                 float* retPtr = stackalloc float[elements];
-				for (int i = 0; i < elements; i++)
-				{
-					retPtr[i] = (float)value[i];
-				}
+                for (int i = 0; i < elements; i++)
+                {
+                    retPtr[i] = (float)value[i];
+                }
 
-				return new Vector<float>(retPtr);
-			}
+                return new Vector<float>(retPtr);
+            }
         }
 
         /// <summary>
@@ -5412,17 +5412,17 @@ namespace System.Numerics
         [Intrinsic]
         public static unsafe Vector<double> ConvertToDouble(Vector<long> value)
         {
-			unchecked
-			{
-				int elements = Vector<double>.Count;
+            unchecked
+            {
+                int elements = Vector<double>.Count;
                 double* retPtr = stackalloc double[elements];
-				for (int i = 0; i < elements; i++)
-				{
-					retPtr[i] = (double)value[i];
-				}
+                for (int i = 0; i < elements; i++)
+                {
+                    retPtr[i] = (double)value[i];
+                }
 
-				return new Vector<double>(retPtr);
-			}
+                return new Vector<double>(retPtr);
+            }
         }
 
         /// <summary>
@@ -5434,17 +5434,17 @@ namespace System.Numerics
         [Intrinsic]
         public static unsafe Vector<double> ConvertToDouble(Vector<ulong> value)
         {
-			unchecked
-			{
-				int elements = Vector<double>.Count;
+            unchecked
+            {
+                int elements = Vector<double>.Count;
                 double* retPtr = stackalloc double[elements];
-				for (int i = 0; i < elements; i++)
-				{
-					retPtr[i] = (double)value[i];
-				}
+                for (int i = 0; i < elements; i++)
+                {
+                    retPtr[i] = (double)value[i];
+                }
 
-				return new Vector<double>(retPtr);
-			}
+                return new Vector<double>(retPtr);
+            }
         }
 
         /// <summary>
@@ -5455,17 +5455,17 @@ namespace System.Numerics
         [Intrinsic]
         public static unsafe Vector<int> ConvertToInt32(Vector<float> value)
         {
-			unchecked
-			{
-				int elements = Vector<int>.Count;
+            unchecked
+            {
+                int elements = Vector<int>.Count;
                 int* retPtr = stackalloc int[elements];
-				for (int i = 0; i < elements; i++)
-				{
-					retPtr[i] = (int)value[i];
-				}
+                for (int i = 0; i < elements; i++)
+                {
+                    retPtr[i] = (int)value[i];
+                }
 
-				return new Vector<int>(retPtr);
-			}
+                return new Vector<int>(retPtr);
+            }
         }
 
         /// <summary>
@@ -5477,17 +5477,17 @@ namespace System.Numerics
         [Intrinsic]
         public static unsafe Vector<uint> ConvertToUInt32(Vector<float> value)
         {
-			unchecked
-			{
-				int elements = Vector<uint>.Count;
+            unchecked
+            {
+                int elements = Vector<uint>.Count;
                 uint* retPtr = stackalloc uint[elements];
-				for (int i = 0; i < elements; i++)
-				{
-					retPtr[i] = (uint)value[i];
-				}
+                for (int i = 0; i < elements; i++)
+                {
+                    retPtr[i] = (uint)value[i];
+                }
 
-				return new Vector<uint>(retPtr);
-			}
+                return new Vector<uint>(retPtr);
+            }
         }
 
         /// <summary>
@@ -5498,17 +5498,17 @@ namespace System.Numerics
         [Intrinsic]
         public static unsafe Vector<long> ConvertToInt64(Vector<double> value)
         {
-			unchecked
-			{
-				int elements = Vector<long>.Count;
+            unchecked
+            {
+                int elements = Vector<long>.Count;
                 long* retPtr = stackalloc long[elements];
-				for (int i = 0; i < elements; i++)
-				{
-					retPtr[i] = (long)value[i];
-				}
+                for (int i = 0; i < elements; i++)
+                {
+                    retPtr[i] = (long)value[i];
+                }
 
-				return new Vector<long>(retPtr);
-			}
+                return new Vector<long>(retPtr);
+            }
         }
 
         /// <summary>
@@ -5520,17 +5520,17 @@ namespace System.Numerics
         [Intrinsic]
         public static unsafe Vector<ulong> ConvertToUInt64(Vector<double> value)
         {
-			unchecked
-			{
-				int elements = Vector<ulong>.Count;
+            unchecked
+            {
+                int elements = Vector<ulong>.Count;
                 ulong* retPtr = stackalloc ulong[elements];
-				for (int i = 0; i < elements; i++)
-				{
-					retPtr[i] = (ulong)value[i];
-				}
+                for (int i = 0; i < elements; i++)
+                {
+                    retPtr[i] = (ulong)value[i];
+                }
 
-				return new Vector<ulong>(retPtr);
-			}
+                return new Vector<ulong>(retPtr);
+            }
         }
 
         #endregion Same-Size Conversion

--- a/src/System.Private.CoreLib/shared/System/Numerics/Vector.tt
+++ b/src/System.Private.CoreLib/shared/System/Numerics/Vector.tt
@@ -21,8 +21,8 @@ namespace System.Numerics
     /* Note: The following patterns are used throughout the code here and are described here
     *
     * PATTERN:
-    *    if (typeof(T) == typeof(Int32)) { ... }
-    *    else if (typeof(T) == typeof(Single)) { ... }
+    *    if (typeof(T) == typeof(int)) { ... }
+    *    else if (typeof(T) == typeof(float)) { ... }
     * EXPLANATION:
     *    At runtime, each instantiation of Vector<T> will be type-specific, and each of these typeof blocks will be eliminated,
     *    as typeof(T) is a (JIT) compile-time constant for each instantiation. This design was chosen to eliminate any overhead from
@@ -119,7 +119,7 @@ namespace System.Numerics
 #>
             <#=GenerateIfStatementHeader(type)#>
             {
-                typeSizeInBytes = sizeof(<#=type.Name#>);
+                typeSizeInBytes = sizeof(<#=typeAliases[type]#>);
             }
 <#
       }
@@ -148,11 +148,11 @@ namespace System.Numerics
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
-                    fixed (<#=type.Name#>* basePtr = &this.<#=GetRegisterFieldName(type, 0)#>)
+                    fixed (<#=typeAliases[type]#>* basePtr = &this.<#=GetRegisterFieldName(type, 0)#>)
                     {
                         for (int g = 0; g < Count; g++)
                         {
-                            *(basePtr + g) = (<#=type.Name#>)(object)value;
+                            *(basePtr + g) = (<#=typeAliases[type]#>)(object)value;
                         }
                     }
                 }
@@ -171,7 +171,7 @@ namespace System.Numerics
             for (int g = 0; g < totalSize / Marshal.SizeOf(type); g++)
             {
 #>
-                    <#=GetRegisterFieldName(type, g)#> = (<#=type.Name#>)(object)value;
+                    <#=GetRegisterFieldName(type, g)#> = (<#=typeAliases[type]#>)(object)value;
 <#
             }
 #>
@@ -212,11 +212,11 @@ namespace System.Numerics
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
-                    fixed (<#=type.Name#>* basePtr = &this.<#=GetRegisterFieldName(type, 0)#>)
+                    fixed (<#=typeAliases[type]#>* basePtr = &this.<#=GetRegisterFieldName(type, 0)#>)
                     {
                         for (int g = 0; g < Count; g++)
                         {
-                            *(basePtr + g) = (<#=type.Name#>)(object)values[g + index];
+                            *(basePtr + g) = (<#=typeAliases[type]#>)(object)values[g + index];
                         }
                     }
                 }
@@ -231,13 +231,13 @@ namespace System.Numerics
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
-                    fixed (<#=type.Name#>* basePtr = &this.<#=GetRegisterFieldName(type, 0)#>)
+                    fixed (<#=typeAliases[type]#>* basePtr = &this.<#=GetRegisterFieldName(type, 0)#>)
                     {
 <#
             for (int g = 0; g < GetNumFields(type, totalSize); g++)
             {
 #>
-                        *(basePtr + <#=g#>) = (<#=type.Name#>)(object)values[<#=g#> + index];
+                        *(basePtr + <#=g#>) = (<#=typeAliases[type]#>)(object)values[<#=g#> + index];
 <#
             }
 #>
@@ -263,9 +263,9 @@ namespace System.Numerics
 #>
             <#=GenerateIfStatementHeader(type)#>
             {
-                <#=type.Name#>* castedPtr = (<#=type.Name#>*)dataPointer;
+                <#=typeAliases[type]#>* castedPtr = (<#=typeAliases[type]#>*)dataPointer;
                 castedPtr += offset;
-                fixed (<#=type.Name#>* registerBase = &this.<#=GetRegisterFieldName(type, 0)#>)
+                fixed (<#=typeAliases[type]#>* registerBase = &this.<#=GetRegisterFieldName(type, 0)#>)
                 {
                     for (int g = 0; g < Count; g++)
                     {
@@ -356,12 +356,12 @@ namespace System.Numerics
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
-                    <#=type.Name#>[] <#=type.Name.ToLowerInvariant()#>Array = (<#=type.Name#>[])(object)destination;
-                    fixed (<#=type.Name#>* destinationBase = <#=type.Name.ToLowerInvariant()#>Array)
+                    <#=typeAliases[type]#>[] <#=type.Name.ToLowerInvariant()#>Array = (<#=typeAliases[type]#>[])(object)destination;
+                    fixed (<#=typeAliases[type]#>* destinationBase = <#=type.Name.ToLowerInvariant()#>Array)
                     {
                         for (int g = 0; g < Count; g++)
                         {
-                            destinationBase[startIndex + g] = (<#=type.Name#>)(object)this[g];
+                            destinationBase[startIndex + g] = (<#=typeAliases[type]#>)(object)this[g];
                         }
                     }
                 }
@@ -376,8 +376,8 @@ namespace System.Numerics
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
-                    <#=type.Name#>[] <#=type.Name.ToLowerInvariant()#>Array = (<#=type.Name#>[])(object)destination;
-                    fixed (<#=type.Name#>* destinationBase = <#=type.Name.ToLowerInvariant()#>Array)
+                    <#=typeAliases[type]#>[] <#=type.Name.ToLowerInvariant()#>Array = (<#=typeAliases[type]#>[])(object)destination;
+                    fixed (<#=typeAliases[type]#>* destinationBase = <#=type.Name.ToLowerInvariant()#>Array)
                     {
 <#
             for (int g = 0; g < GetNumFields(type, totalSize); g++)
@@ -412,7 +412,7 @@ namespace System.Numerics
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
-                    fixed (<#=type.Name#>* basePtr = &this.<#=GetRegisterFieldName(type, 0)#>)
+                    fixed (<#=typeAliases[type]#>* basePtr = &this.<#=GetRegisterFieldName(type, 0)#>)
                     {
                         return (T)(object)*(basePtr + index);
                     }
@@ -518,7 +518,7 @@ namespace System.Numerics
                 {
                     for (int g = 0; g < Count; g++)
                     {
-                        hash = HashHelpers.Combine(hash, ((<#=type.Name#>)(object)this[g]).GetHashCode());
+                        hash = HashHelpers.Combine(hash, ((<#=typeAliases[type]#>)(object)this[g]).GetHashCode());
                     }
                     return hash;
                 }
@@ -619,10 +619,10 @@ namespace System.Numerics
 #>
                     <#=GenerateIfStatementHeader(type)#>
                     {
-                        <#=type.Name#>* dataPtr = stackalloc <#=type.Name#>[Count];
+                        <#=typeAliases[type]#>* dataPtr = stackalloc <#=typeAliases[type]#>[Count];
                         for (int g = 0; g < Count; g++)
                         {
-                            dataPtr[g] = (<#=type.Name#>)(object)ScalarAdd(left[g], right[g]);
+                            dataPtr[g] = (<#=typeAliases[type]#>)(object)ScalarAdd(left[g], right[g]);
                         }
                         return new Vector<T>(dataPtr);
                     }
@@ -646,7 +646,7 @@ namespace System.Numerics
                 for (int g = 0; g < GetNumFields(type, totalSize); g++)
                 {
 #>
-                        sum.<#= GetRegisterFieldName(type, g) #> = (<#=type.Name#>)(left.<#= GetRegisterFieldName(type, g) #> + right.<#= GetRegisterFieldName(type, g) #>);
+                        sum.<#= GetRegisterFieldName(type, g) #> = (<#=typeAliases[type]#>)(left.<#= GetRegisterFieldName(type, g) #> + right.<#= GetRegisterFieldName(type, g) #>);
 <#
                 }
 #>
@@ -676,10 +676,10 @@ namespace System.Numerics
 #>
                     <#=GenerateIfStatementHeader(type)#>
                     {
-                        <#=type.Name#>* dataPtr = stackalloc <#=type.Name#>[Count];
+                        <#=typeAliases[type]#>* dataPtr = stackalloc <#=typeAliases[type]#>[Count];
                         for (int g = 0; g < Count; g++)
                         {
-                            dataPtr[g] = (<#=type.Name#>)(object)ScalarSubtract(left[g], right[g]);
+                            dataPtr[g] = (<#=typeAliases[type]#>)(object)ScalarSubtract(left[g], right[g]);
                         }
                         return new Vector<T>(dataPtr);
                     }
@@ -703,7 +703,7 @@ namespace System.Numerics
                 for (int g = 0; g < GetNumFields(type, totalSize); g++)
                 {
 #>
-                        difference.<#= GetRegisterFieldName(type, g) #> = (<#=type.Name#>)(left.<#= GetRegisterFieldName(type, g) #> - right.<#= GetRegisterFieldName(type, g) #>);
+                        difference.<#= GetRegisterFieldName(type, g) #> = (<#=typeAliases[type]#>)(left.<#= GetRegisterFieldName(type, g) #> - right.<#= GetRegisterFieldName(type, g) #>);
 <#
                 }
 #>
@@ -734,10 +734,10 @@ namespace System.Numerics
 #>
                     <#=GenerateIfStatementHeader(type)#>
                     {
-                        <#=type.Name#>* dataPtr = stackalloc <#=type.Name#>[Count];
+                        <#=typeAliases[type]#>* dataPtr = stackalloc <#=typeAliases[type]#>[Count];
                         for (int g = 0; g < Count; g++)
                         {
-                            dataPtr[g] = (<#=type.Name#>)(object)ScalarMultiply(left[g], right[g]);
+                            dataPtr[g] = (<#=typeAliases[type]#>)(object)ScalarMultiply(left[g], right[g]);
                         }
                         return new Vector<T>(dataPtr);
                     }
@@ -761,7 +761,7 @@ namespace System.Numerics
                 for (int g = 0; g < GetNumFields(type, totalSize); g++)
                 {
 #>
-                        product.<#= GetRegisterFieldName(type, g) #> = (<#=type.Name#>)(left.<#= GetRegisterFieldName(type, g) #> * right.<#= GetRegisterFieldName(type, g) #>);
+                        product.<#= GetRegisterFieldName(type, g) #> = (<#=typeAliases[type]#>)(left.<#= GetRegisterFieldName(type, g) #> * right.<#= GetRegisterFieldName(type, g) #>);
 <#
                 }
 #>
@@ -801,7 +801,7 @@ namespace System.Numerics
                 for (int g = 0; g < GetNumFields(type, totalSize); g++)
                 {
 #>
-                        product.<#= GetRegisterFieldName(type, g) #> = (<#=type.Name#>)(value.<#= GetRegisterFieldName(type, g) #> * (<#=type.Name#>)(object)factor);
+                        product.<#= GetRegisterFieldName(type, g) #> = (<#=typeAliases[type]#>)(value.<#= GetRegisterFieldName(type, g) #> * (<#=typeAliases[type]#>)(object)factor);
 <#
                 }
 #>
@@ -841,7 +841,7 @@ namespace System.Numerics
                 for (int g = 0; g < GetNumFields(type, totalSize); g++)
                 {
 #>
-                        product.<#= GetRegisterFieldName(type, g) #> = (<#=type.Name#>)(value.<#= GetRegisterFieldName(type, g) #> * (<#=type.Name#>)(object)factor);
+                        product.<#= GetRegisterFieldName(type, g) #> = (<#=typeAliases[type]#>)(value.<#= GetRegisterFieldName(type, g) #> * (<#=typeAliases[type]#>)(object)factor);
 <#
                 }
 #>
@@ -872,10 +872,10 @@ namespace System.Numerics
 #>
                     <#=GenerateIfStatementHeader(type)#>
                     {
-                        <#=type.Name#>* dataPtr = stackalloc <#=type.Name#>[Count];
+                        <#=typeAliases[type]#>* dataPtr = stackalloc <#=typeAliases[type]#>[Count];
                         for (int g = 0; g < Count; g++)
                         {
-                            dataPtr[g] = (<#=type.Name#>)(object)ScalarDivide(left[g], right[g]);
+                            dataPtr[g] = (<#=typeAliases[type]#>)(object)ScalarDivide(left[g], right[g]);
                         }
                         return new Vector<T>(dataPtr);
                     }
@@ -899,7 +899,7 @@ namespace System.Numerics
                 for (int g = 0; g < GetNumFields(type, totalSize); g++)
                 {
 #>
-                        quotient.<#= GetRegisterFieldName(type, g) #> = (<#=type.Name#>)(left.<#= GetRegisterFieldName(type, g) #> / right.<#= GetRegisterFieldName(type, g) #>);
+                        quotient.<#= GetRegisterFieldName(type, g) #> = (<#=typeAliases[type]#>)(left.<#= GetRegisterFieldName(type, g) #> / right.<#= GetRegisterFieldName(type, g) #>);
 <#
                 }
 #>
@@ -938,18 +938,18 @@ namespace System.Numerics
             {
                 if (Vector.IsHardwareAccelerated)
                 {
-                    Int64* resultBase = &result.register.int64_0;
-                    Int64* leftBase = &left.register.int64_0;
-                    Int64* rightBase = &right.register.int64_0;
-                    for (int g = 0; g < Vector<Int64>.Count; g++)
+                    long* resultBase = &result.register.int64_0;
+                    long* leftBase = &left.register.int64_0;
+                    long* rightBase = &right.register.int64_0;
+                    for (int g = 0; g < Vector<long>.Count; g++)
                     {
                         resultBase[g] = leftBase[g] & rightBase[g];
                     }
                 }
                 else
                 {
-                    result.<#=GetRegisterFieldName(typeof(Int64), 0)#> = left.<#=GetRegisterFieldName(typeof(Int64), 0)#> & right.<#=GetRegisterFieldName(typeof(Int64), 0)#>;
-                    result.<#=GetRegisterFieldName(typeof(Int64), 1)#> = left.<#=GetRegisterFieldName(typeof(Int64), 1)#> & right.<#=GetRegisterFieldName(typeof(Int64), 1)#>;
+                    result.<#=GetRegisterFieldName(typeof(long), 0)#> = left.<#=GetRegisterFieldName(typeof(long), 0)#> & right.<#=GetRegisterFieldName(typeof(long), 0)#>;
+                    result.<#=GetRegisterFieldName(typeof(long), 1)#> = left.<#=GetRegisterFieldName(typeof(long), 1)#> & right.<#=GetRegisterFieldName(typeof(long), 1)#>;
                 }
             }
             return result;
@@ -969,18 +969,18 @@ namespace System.Numerics
             {
                 if (Vector.IsHardwareAccelerated)
                 {
-                    Int64* resultBase = &result.register.int64_0;
-                    Int64* leftBase = &left.register.int64_0;
-                    Int64* rightBase = &right.register.int64_0;
-                    for (int g = 0; g < Vector<Int64>.Count; g++)
+                    long* resultBase = &result.register.int64_0;
+                    long* leftBase = &left.register.int64_0;
+                    long* rightBase = &right.register.int64_0;
+                    for (int g = 0; g < Vector<long>.Count; g++)
                     {
                         resultBase[g] = leftBase[g] | rightBase[g];
                     }
                 }
                 else
                 {
-                    result.<#=GetRegisterFieldName(typeof(Int64), 0)#> = left.<#=GetRegisterFieldName(typeof(Int64), 0)#> | right.<#=GetRegisterFieldName(typeof(Int64), 0)#>;
-                    result.<#=GetRegisterFieldName(typeof(Int64), 1)#> = left.<#=GetRegisterFieldName(typeof(Int64), 1)#> | right.<#=GetRegisterFieldName(typeof(Int64), 1)#>;
+                    result.<#=GetRegisterFieldName(typeof(long), 0)#> = left.<#=GetRegisterFieldName(typeof(long), 0)#> | right.<#=GetRegisterFieldName(typeof(long), 0)#>;
+                    result.<#=GetRegisterFieldName(typeof(long), 1)#> = left.<#=GetRegisterFieldName(typeof(long), 1)#> | right.<#=GetRegisterFieldName(typeof(long), 1)#>;
                 }
             }
             return result;
@@ -1000,18 +1000,18 @@ namespace System.Numerics
             {
                 if (Vector.IsHardwareAccelerated)
                 {
-                    Int64* resultBase = &result.register.int64_0;
-                    Int64* leftBase = &left.register.int64_0;
-                    Int64* rightBase = &right.register.int64_0;
-                    for (int g = 0; g < Vector<Int64>.Count; g++)
+                    long* resultBase = &result.register.int64_0;
+                    long* leftBase = &left.register.int64_0;
+                    long* rightBase = &right.register.int64_0;
+                    for (int g = 0; g < Vector<long>.Count; g++)
                     {
                         resultBase[g] = leftBase[g] ^ rightBase[g];
                     }
                 }
                 else
                 {
-                    result.<#=GetRegisterFieldName(typeof(Int64), 0)#> = left.<#=GetRegisterFieldName(typeof(Int64), 0)#> ^ right.<#=GetRegisterFieldName(typeof(Int64), 0)#>;
-                    result.<#=GetRegisterFieldName(typeof(Int64), 1)#> = left.<#=GetRegisterFieldName(typeof(Int64), 1)#> ^ right.<#=GetRegisterFieldName(typeof(Int64), 1)#>;
+                    result.<#=GetRegisterFieldName(typeof(long), 0)#> = left.<#=GetRegisterFieldName(typeof(long), 0)#> ^ right.<#=GetRegisterFieldName(typeof(long), 0)#>;
+                    result.<#=GetRegisterFieldName(typeof(long), 1)#> = left.<#=GetRegisterFieldName(typeof(long), 1)#> ^ right.<#=GetRegisterFieldName(typeof(long), 1)#>;
                 }
             }
             return result;
@@ -1073,9 +1073,9 @@ namespace System.Numerics
         }
 #>
         [Intrinsic]
-        public static explicit operator Vector<<#=type.Name#>>(Vector<T> value)
+        public static explicit operator Vector<<#=typeAliases[type]#>>(Vector<T> value)
         {
-            return new Vector<<#=type.Name#>>(ref value.register);
+            return new Vector<<#=typeAliases[type]#>>(ref value.register);
         }
 
 <#
@@ -1095,10 +1095,10 @@ namespace System.Numerics
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
-                    <#=type.Name#>* dataPtr = stackalloc <#=type.Name#>[Count];
+                    <#=typeAliases[type]#>* dataPtr = stackalloc <#=typeAliases[type]#>[Count];
                     for (int g = 0; g < Count; g++)
                     {
-                        dataPtr[g] = ScalarEquals(left[g], right[g]) ? ConstantHelper.Get<#=type.Name#>WithAllBitsSet() : (<#=type.Name#>)0;
+                        dataPtr[g] = ScalarEquals(left[g], right[g]) ? ConstantHelper.Get<#=type.Name#>WithAllBitsSet() : (<#=typeAliases[type]#>)0;
                     }
                     return new Vector<T>(dataPtr);
                 }
@@ -1122,7 +1122,7 @@ namespace System.Numerics
                 for (int g = 0; g < GetNumFields(type, totalSize); g++)
                 {
 #>
-                    <#= GetRegisterFieldName(type, g) #> = left.<#= GetRegisterFieldName(type, g) #> == right.<#= GetRegisterFieldName(type, g) #> ? ConstantHelper.Get<#=type.Name#>WithAllBitsSet() : (<#=type.Name#>)0;
+                    <#= GetRegisterFieldName(type, g) #> = left.<#= GetRegisterFieldName(type, g) #> == right.<#= GetRegisterFieldName(type, g) #> ? ConstantHelper.Get<#=type.Name#>WithAllBitsSet() : (<#=typeAliases[type]#>)0;
 <#
                 }
 #>
@@ -1149,10 +1149,10 @@ namespace System.Numerics
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
-                    <#=type.Name#>* dataPtr = stackalloc <#=type.Name#>[Count];
+                    <#=typeAliases[type]#>* dataPtr = stackalloc <#=typeAliases[type]#>[Count];
                     for (int g = 0; g < Count; g++)
                     {
-                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? ConstantHelper.Get<#=type.Name#>WithAllBitsSet() : (<#=type.Name#>)0;
+                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? ConstantHelper.Get<#=type.Name#>WithAllBitsSet() : (<#=typeAliases[type]#>)0;
                     }
                     return new Vector<T>(dataPtr);
                 }
@@ -1176,7 +1176,7 @@ namespace System.Numerics
                 for (int g = 0; g < GetNumFields(type, totalSize); g++)
                 {
 #>
-                    <#= GetRegisterFieldName(type, g) #> = left.<#= GetRegisterFieldName(type, g) #> < right.<#= GetRegisterFieldName(type, g) #> ? ConstantHelper.Get<#=type.Name#>WithAllBitsSet() : (<#=type.Name#>)0;
+                    <#= GetRegisterFieldName(type, g) #> = left.<#= GetRegisterFieldName(type, g) #> < right.<#= GetRegisterFieldName(type, g) #> ? ConstantHelper.Get<#=type.Name#>WithAllBitsSet() : (<#=typeAliases[type]#>)0;
 <#
                 }
 #>
@@ -1203,10 +1203,10 @@ namespace System.Numerics
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
-                    <#=type.Name#>* dataPtr = stackalloc <#=type.Name#>[Count];
+                    <#=typeAliases[type]#>* dataPtr = stackalloc <#=typeAliases[type]#>[Count];
                     for (int g = 0; g < Count; g++)
                     {
-                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? ConstantHelper.Get<#=type.Name#>WithAllBitsSet() : (<#=type.Name#>)0;
+                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? ConstantHelper.Get<#=type.Name#>WithAllBitsSet() : (<#=typeAliases[type]#>)0;
                     }
                     return new Vector<T>(dataPtr);
                 }
@@ -1230,7 +1230,7 @@ namespace System.Numerics
                 for (int g = 0; g < GetNumFields(type, totalSize); g++)
                 {
 #>
-                    <#= GetRegisterFieldName(type, g) #> = left.<#= GetRegisterFieldName(type, g) #> > right.<#= GetRegisterFieldName(type, g) #> ? ConstantHelper.Get<#=type.Name#>WithAllBitsSet() : (<#=type.Name#>)0;
+                    <#= GetRegisterFieldName(type, g) #> = left.<#= GetRegisterFieldName(type, g) #> > right.<#= GetRegisterFieldName(type, g) #> ? ConstantHelper.Get<#=type.Name#>WithAllBitsSet() : (<#=typeAliases[type]#>)0;
 <#
                 }
 #>
@@ -1291,10 +1291,10 @@ namespace System.Numerics
 #>
                 <#=GenerateIfStatementHeader(type, supportedTypes.Except(unsignedTypes))#>
                 {
-                    <#=type.Name#>* dataPtr = stackalloc <#=type.Name#>[Count];
+                    <#=typeAliases[type]#>* dataPtr = stackalloc <#=typeAliases[type]#>[Count];
                     for (int g = 0; g < Count; g++)
                     {
-                        dataPtr[g] = (<#=type.Name#>)(object)(Math.Abs((<#=type.Name#>)(object)value[g]));
+                        dataPtr[g] = (<#=typeAliases[type]#>)(object)(Math.Abs((<#=typeAliases[type]#>)(object)value[g]));
                     }
                     return new Vector<T>(dataPtr);
                 }
@@ -1318,7 +1318,7 @@ namespace System.Numerics
         for (int g = 0; g < GetNumFields(type, totalSize); g++)
         {
 #>
-                    value.<#=GetRegisterFieldName(type, g)#> = (<#=type.Name#>)(Math.Abs(value.<#=GetRegisterFieldName(type, g)#>));
+                    value.<#=GetRegisterFieldName(type, g)#> = (<#=typeAliases[type]#>)(Math.Abs(value.<#=GetRegisterFieldName(type, g)#>));
 <#
         }
 #>
@@ -1344,10 +1344,10 @@ namespace System.Numerics
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
-                    <#=type.Name#>* dataPtr = stackalloc <#=type.Name#>[Count];
+                    <#=typeAliases[type]#>* dataPtr = stackalloc <#=typeAliases[type]#>[Count];
                     for (int g = 0; g < Count; g++)
                     {
-                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? (<#=type.Name#>)(object)left[g] : (<#=type.Name#>)(object)right[g];
+                        dataPtr[g] = ScalarLessThan(left[g], right[g]) ? (<#=typeAliases[type]#>)(object)left[g] : (<#=typeAliases[type]#>)(object)right[g];
                     }
                     return new Vector<T>(dataPtr);
                 }
@@ -1397,10 +1397,10 @@ namespace System.Numerics
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
-                    <#=type.Name#>* dataPtr = stackalloc <#=type.Name#>[Count];
+                    <#=typeAliases[type]#>* dataPtr = stackalloc <#=typeAliases[type]#>[Count];
                     for (int g = 0; g < Count; g++)
                     {
-                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? (<#=type.Name#>)(object)left[g] : (<#=type.Name#>)(object)right[g];
+                        dataPtr[g] = ScalarGreaterThan(left[g], right[g]) ? (<#=typeAliases[type]#>)(object)left[g] : (<#=typeAliases[type]#>)(object)right[g];
                     }
                     return new Vector<T>(dataPtr);
                 }
@@ -1459,12 +1459,12 @@ namespace System.Numerics
     #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
-                    <#=type.Name#> product = 0;
+                    <#=typeAliases[type]#> product = 0;
 <#
                 for (int g = 0; g < GetNumFields(type, totalSize); g++)
                 {
 #>
-                    product += (<#=type.Name#>)(left.<#=GetRegisterFieldName(type, g)#> * right.<#=GetRegisterFieldName(type, g)#>);
+                    product += (<#=typeAliases[type]#>)(left.<#=GetRegisterFieldName(type, g)#> * right.<#=GetRegisterFieldName(type, g)#>);
 <#
                 }
 #>
@@ -1490,10 +1490,10 @@ namespace System.Numerics
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
-                    <#=type.Name#>* dataPtr = stackalloc <#=type.Name#>[Count];
+                    <#=typeAliases[type]#>* dataPtr = stackalloc <#=typeAliases[type]#>[Count];
                     for (int g = 0; g < Count; g++)
                     {
-                        dataPtr[g] = unchecked((<#=type.Name#>)Math.Sqrt((<#=type.Name#>)(object)value[g]));
+                        dataPtr[g] = unchecked((<#=typeAliases[type]#>)Math.Sqrt((<#=typeAliases[type]#>)(object)value[g]));
                     }
                     return new Vector<T>(dataPtr);
                 }
@@ -1516,7 +1516,7 @@ namespace System.Numerics
                 for (int g = 0; g < GetNumFields(type, totalSize); g++)
                 {
 #>
-                    value.<#=GetRegisterFieldName(type, g)#> = (<#=type.Name#>)Math.Sqrt(value.<#=GetRegisterFieldName(type, g)#>);
+                    value.<#=GetRegisterFieldName(type, g)#> = (<#=typeAliases[type]#>)Math.Sqrt(value.<#=GetRegisterFieldName(type, g)#>);
 <#
                 }
 #>
@@ -1542,7 +1542,7 @@ namespace System.Numerics
 #>
             <#=GenerateIfStatementHeader(type)#>
             {
-                return (<#=type.Name#>)(object)left == (<#=type.Name#>)(object)right;
+                return (<#=typeAliases[type]#>)(object)left == (<#=typeAliases[type]#>)(object)right;
             }
 <#
    }
@@ -1561,7 +1561,7 @@ namespace System.Numerics
 #>
             <#=GenerateIfStatementHeader(type)#>
             {
-                return (<#=type.Name#>)(object)left < (<#=type.Name#>)(object)right;
+                return (<#=typeAliases[type]#>)(object)left < (<#=typeAliases[type]#>)(object)right;
             }
 <#
    }
@@ -1580,7 +1580,7 @@ namespace System.Numerics
 #>
             <#=GenerateIfStatementHeader(type)#>
             {
-                return (<#=type.Name#>)(object)left > (<#=type.Name#>)(object)right;
+                return (<#=typeAliases[type]#>)(object)left > (<#=typeAliases[type]#>)(object)right;
             }
 <#
    }
@@ -1599,7 +1599,7 @@ namespace System.Numerics
 #>
             <#=GenerateIfStatementHeader(type)#>
             {
-                return (T)(object)unchecked((<#=type.Name#>)((<#=type.Name#>)(object)left + (<#=type.Name#>)(object)right));
+                return (T)(object)unchecked((<#=typeAliases[type]#>)((<#=typeAliases[type]#>)(object)left + (<#=typeAliases[type]#>)(object)right));
             }
 <#
    }
@@ -1618,7 +1618,7 @@ namespace System.Numerics
 #>
             <#=GenerateIfStatementHeader(type)#>
             {
-                return (T)(object)(<#=type.Name#>)((<#=type.Name#>)(object)left - (<#=type.Name#>)(object)right);
+                return (T)(object)(<#=typeAliases[type]#>)((<#=typeAliases[type]#>)(object)left - (<#=typeAliases[type]#>)(object)right);
             }
 <#
    }
@@ -1637,7 +1637,7 @@ namespace System.Numerics
 #>
             <#=GenerateIfStatementHeader(type)#>
             {
-                return (T)(object)unchecked((<#=type.Name#>)((<#=type.Name#>)(object)left * (<#=type.Name#>)(object)right));
+                return (T)(object)unchecked((<#=typeAliases[type]#>)((<#=typeAliases[type]#>)(object)left * (<#=typeAliases[type]#>)(object)right));
             }
 <#
    }
@@ -1656,7 +1656,7 @@ namespace System.Numerics
 #>
             <#=GenerateIfStatementHeader(type)#>
             {
-                return (T)(object)(<#=type.Name#>)((<#=type.Name#>)(object)left / (<#=type.Name#>)(object)right);
+                return (T)(object)(<#=typeAliases[type]#>)((<#=typeAliases[type]#>)(object)left / (<#=typeAliases[type]#>)(object)right);
             }
 <#
    }
@@ -1675,7 +1675,7 @@ namespace System.Numerics
 #>
             <#=GenerateIfStatementHeader(type)#>
             {
-                <#=type.Name#> value = 1;
+                <#=typeAliases[type]#> value = 1;
                 return (T)(object)value;
             }
 <#
@@ -1731,22 +1731,22 @@ namespace System.Numerics
         }
 #>
         [Intrinsic]
-        public static unsafe void Widen(Vector<<#=type.Name#>> source, out Vector<<#=widenTarget.Name#>> low, out Vector<<#=widenTarget.Name#>> high)
+        public static unsafe void Widen(Vector<<#=typeAliases[type]#>> source, out Vector<<#=typeAliases[widenTarget]#>> low, out Vector<<#=typeAliases[widenTarget]#>> high)
         {
-            int elements = Vector<<#=type.Name#>>.Count;
-            <#=widenTarget.Name#>* lowPtr = stackalloc <#=widenTarget.Name#>[elements / 2];
+            int elements = Vector<<#=typeAliases[type]#>>.Count;
+            <#=typeAliases[widenTarget]#>* lowPtr = stackalloc <#=typeAliases[widenTarget]#>[elements / 2];
             for (int i = 0; i < elements / 2; i++)
             {
-                lowPtr[i] = (<#=widenTarget.Name#>)source[i];
+                lowPtr[i] = (<#=typeAliases[widenTarget]#>)source[i];
             }
-            <#=widenTarget.Name#>* highPtr = stackalloc <#=widenTarget.Name#>[elements / 2];
+            <#=typeAliases[widenTarget]#>* highPtr = stackalloc <#=typeAliases[widenTarget]#>[elements / 2];
             for (int i = 0; i < elements / 2; i++)
             {
-                highPtr[i] = (<#=widenTarget.Name#>)source[i + (elements / 2)];
+                highPtr[i] = (<#=typeAliases[widenTarget]#>)source[i + (elements / 2)];
             }
 
-            low = new Vector<<#=widenTarget.Name#>>(lowPtr);
-            high = new Vector<<#=widenTarget.Name#>>(highPtr);
+            low = new Vector<<#=typeAliases[widenTarget]#>>(lowPtr);
+            high = new Vector<<#=typeAliases[widenTarget]#>>(highPtr);
         }
 
 <#
@@ -1771,22 +1771,22 @@ namespace System.Numerics
         }
 #>
         [Intrinsic]
-        public static unsafe Vector<<#=narrowTarget.Name#>> Narrow(Vector<<#=narrowSource.Name#>> low, Vector<<#=narrowSource.Name#>> high)
+        public static unsafe Vector<<#=typeAliases[narrowTarget]#>> Narrow(Vector<<#=typeAliases[narrowSource]#>> low, Vector<<#=typeAliases[narrowSource]#>> high)
         {
 		    unchecked
 		    {
-				int elements = Vector<<#=narrowTarget.Name#>>.Count;
-				<#=narrowTarget.Name#>* retPtr = stackalloc <#=narrowTarget.Name#>[elements];
+				int elements = Vector<<#=typeAliases[narrowTarget]#>>.Count;
+                <#=typeAliases[narrowTarget]#>* retPtr = stackalloc <#=typeAliases[narrowTarget]#>[elements];
 				for (int i = 0; i < elements / 2; i++)
 				{
-					retPtr[i] = (<#=narrowTarget.Name#>)low[i];
+					retPtr[i] = (<#=typeAliases[narrowTarget]#>)low[i];
 				}
 				for (int i = 0; i < elements / 2; i++)
 				{
-					retPtr[i + (elements / 2)] = (<#=narrowTarget.Name#>)high[i];
+					retPtr[i + (elements / 2)] = (<#=typeAliases[narrowTarget]#>)high[i];
 				}
 
-				return new Vector<<#=narrowTarget.Name#>>(retPtr);
+				return new Vector<<#=typeAliases[narrowTarget]#>>(retPtr);
 		    }
         }
 
@@ -1813,18 +1813,18 @@ namespace System.Numerics
         }
 #>
         [Intrinsic]
-        public static unsafe Vector<<#=pair.Value.Name#>> ConvertTo<#=pair.Value.Name#>(Vector<<#=pair.Key.Name#>> value)
+        public static unsafe Vector<<#=typeAliases[pair.Value]#>> ConvertTo<#=pair.Value.Name#>(Vector<<#=typeAliases[pair.Key]#>> value)
         {
 			unchecked
 			{
-				int elements = Vector<<#=pair.Value.Name#>>.Count;
-				<#=pair.Value.Name#>* retPtr = stackalloc <#=pair.Value.Name#>[elements];
+				int elements = Vector<<#=typeAliases[pair.Value]#>>.Count;
+                <#=typeAliases[pair.Value]#>* retPtr = stackalloc <#=typeAliases[pair.Value]#>[elements];
 				for (int i = 0; i < elements; i++)
 				{
-					retPtr[i] = (<#=pair.Value.Name#>)value[i];
+					retPtr[i] = (<#=typeAliases[pair.Value]#>)value[i];
 				}
 
-				return new Vector<<#=pair.Value.Name#>>(retPtr);
+				return new Vector<<#=typeAliases[pair.Value]#>>(retPtr);
 			}
         }
 

--- a/src/System.Private.CoreLib/shared/System/Numerics/Vector.tt
+++ b/src/System.Private.CoreLib/shared/System/Numerics/Vector.tt
@@ -105,7 +105,7 @@ namespace System.Numerics
             internal byte _byte;
         }
 
-		// Calculates the size of this struct in bytes, by computing the offset of a field in a structure
+        // Calculates the size of this struct in bytes, by computing the offset of a field in a structure
         private static unsafe int InitializeCount()
         {
             VectorSizeHelper vsh;
@@ -114,15 +114,16 @@ namespace System.Numerics
             int vectorSizeInBytes = (int)(byteBase - vectorBase);
 
             int typeSizeInBytes = -1;
-<#    foreach (Type type in supportedTypes)
-      {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
             <#=GenerateIfStatementHeader(type)#>
             {
                 typeSizeInBytes = sizeof(<#=typeAliases[type]#>);
             }
 <#
-      }
+    }
 #>
             else
             {
@@ -143,7 +144,8 @@ namespace System.Numerics
         {
             if (Vector.IsHardwareAccelerated)
             {
-<#    foreach (Type type in supportedTypes)
+<#
+    foreach (Type type in supportedTypes)
     {
 #>
                 <#=GenerateIfStatementHeader(type)#>
@@ -157,27 +159,28 @@ namespace System.Numerics
                     }
                 }
 <#
-        }
+    }
 #>
             }
             else
             {
-<#    foreach (Type type in supportedTypes)
-        {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
 <#
-            for (int g = 0; g < totalSize / Marshal.SizeOf(type); g++)
-            {
+        for (int g = 0; g < totalSize / Marshal.SizeOf(type); g++)
+        {
 #>
                     <#=GetRegisterFieldName(type, g)#> = (<#=typeAliases[type]#>)(object)value;
 <#
-            }
+        }
 #>
                 }
 <#
-        }
+    }
 #>
             }
         }
@@ -207,7 +210,8 @@ namespace System.Numerics
 
             if (Vector.IsHardwareAccelerated)
             {
-<#    foreach (Type type in supportedTypes)
+<#
+    foreach (Type type in supportedTypes)
     {
 #>
                 <#=GenerateIfStatementHeader(type)#>
@@ -221,12 +225,13 @@ namespace System.Numerics
                     }
                 }
 <#
-        }
+    }
 #>
             }
             else
             {
-<#    foreach (Type type in supportedTypes)
+<#
+    foreach (Type type in supportedTypes)
     {
 #>
                 <#=GenerateIfStatementHeader(type)#>
@@ -234,17 +239,17 @@ namespace System.Numerics
                     fixed (<#=typeAliases[type]#>* basePtr = &this.<#=GetRegisterFieldName(type, 0)#>)
                     {
 <#
-            for (int g = 0; g < GetNumFields(type, totalSize); g++)
-            {
+        for (int g = 0; g < GetNumFields(type, totalSize); g++)
+        {
 #>
                         *(basePtr + <#=g#>) = (<#=typeAliases[type]#>)(object)values[<#=g#> + index];
 <#
-            }
+        }
 #>
                     }
                 }
 <#
-        }
+    }
 #>
             }
         }
@@ -258,8 +263,9 @@ namespace System.Numerics
         internal unsafe Vector(void* dataPointer, int offset)
             : this()
         {
-<# foreach (Type type in supportedTypes)
- {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
             <#=GenerateIfStatementHeader(type)#>
             {
@@ -274,7 +280,7 @@ namespace System.Numerics
                 }
             }
 <#
- }
+    }
 #>
             else
             {
@@ -351,8 +357,9 @@ namespace System.Numerics
 
             if (Vector.IsHardwareAccelerated)
             {
-<#    foreach (Type type in supportedTypes)
-        {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
@@ -366,13 +373,14 @@ namespace System.Numerics
                     }
                 }
 <#
-        }
+    }
 #>
             }
             else
             {
-<#    foreach (Type type in supportedTypes)
-        {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
@@ -380,17 +388,17 @@ namespace System.Numerics
                     fixed (<#=typeAliases[type]#>* destinationBase = <#=type.Name.ToLowerInvariant()#>Array)
                     {
 <#
-            for (int g = 0; g < GetNumFields(type, totalSize); g++)
-            {
+        for (int g = 0; g < GetNumFields(type, totalSize); g++)
+        {
 #>
                         destinationBase[startIndex + <#=g#>] = this.<#=GetRegisterFieldName(type, g)#>;
 <#
-            }
+        }
 #>
                     }
                 }
 <#
-        }
+    }
 #>
             }
         }
@@ -407,7 +415,8 @@ namespace System.Numerics
                 {
                     throw new IndexOutOfRangeException(SR.Format(SR.Arg_ArgumentOutOfRangeException, index));
                 }
-<#    foreach (Type type in supportedTypes)
+<#
+    foreach (Type type in supportedTypes)
     {
 #>
                 <#=GenerateIfStatementHeader(type)#>
@@ -463,36 +472,37 @@ namespace System.Numerics
             }
             else
             {
-<#    foreach (Type type in supportedTypes)
-        {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
                     return
 <#
-            for (int g = 0; g < GetNumFields(type, totalSize); g++)
-            {
+        for (int g = 0; g < GetNumFields(type, totalSize); g++)
+        {
 #>
 <#
-                if (g == 0)
-                {
+            if (g == 0)
+            {
 #>
                         this.<#=GetRegisterFieldName(type, g)#> == other.<#=GetRegisterFieldName(type, g)#>
 <#
-                }
-                else
-                {
+            }
+            else
+            {
 #>
                         && this.<#=GetRegisterFieldName(type, g)#> == other.<#=GetRegisterFieldName(type, g)#><#=(g == (GetNumFields(type, totalSize) -1)) ? ";" : ""#>
 <#
-                }
-#>
-<#
             }
 #>
-                }
 <#
         }
+#>
+                }
+<#
+    }
 #>
                 else
                 {
@@ -511,7 +521,8 @@ namespace System.Numerics
 
             if (Vector.IsHardwareAccelerated)
             {
-<#    foreach (Type type in supportedTypes)
+<#
+    foreach (Type type in supportedTypes)
     {
 #>
                 <#=GenerateIfStatementHeader(type)#>
@@ -523,7 +534,7 @@ namespace System.Numerics
                     return hash;
                 }
 <#
-        }
+    }
 #>
                 else
                 {
@@ -532,23 +543,24 @@ namespace System.Numerics
             }
             else
             {
-<#    foreach (Type type in supportedTypes)
+<#
+    foreach (Type type in supportedTypes)
     {
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
 <#
-            for (int g = 0; g < GetNumFields(type, totalSize); g++)
-            {
+        for (int g = 0; g < GetNumFields(type, totalSize); g++)
+        {
 #>
                     hash = HashHelpers.Combine(hash, this.<#=GetRegisterFieldName(type, g)#>.GetHashCode());
 <#
-            }
+        }
 #>
                     return hash;
                 }
 <#
-        }
+    }
 #>
                 else
                 {
@@ -614,8 +626,9 @@ namespace System.Numerics
             {
                 if (Vector.IsHardwareAccelerated)
                 {
-<#    foreach (Type type in supportedTypes)
-        {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
                     <#=GenerateIfStatementHeader(type)#>
                     {
@@ -627,7 +640,7 @@ namespace System.Numerics
                         return new Vector<T>(dataPtr);
                     }
 <#
-        }
+    }
 #>
                     else
                     {
@@ -637,8 +650,9 @@ namespace System.Numerics
                 else
                 {
                     Vector<T> sum = new Vector<T>();
-<#    foreach (Type type in supportedTypes)
-        {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
                     <#=GenerateIfStatementHeader(type)#>
                     {
@@ -652,7 +666,7 @@ namespace System.Numerics
 #>
                     }
 <#
-        }
+    }
 #>
                     return sum;
                 }
@@ -671,8 +685,9 @@ namespace System.Numerics
             {
                 if (Vector.IsHardwareAccelerated)
                 {
-<#    foreach (Type type in supportedTypes)
-        {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
                     <#=GenerateIfStatementHeader(type)#>
                     {
@@ -684,7 +699,7 @@ namespace System.Numerics
                         return new Vector<T>(dataPtr);
                     }
 <#
-        }
+    }
 #>
                     else
                     {
@@ -694,22 +709,23 @@ namespace System.Numerics
                 else
                 {
                     Vector<T> difference = new Vector<T>();
-<#    foreach (Type type in supportedTypes)
-        {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
                     <#=GenerateIfStatementHeader(type)#>
                     {
 <#
-                for (int g = 0; g < GetNumFields(type, totalSize); g++)
-                {
+        for (int g = 0; g < GetNumFields(type, totalSize); g++)
+        {
 #>
                         difference.<#= GetRegisterFieldName(type, g) #> = (<#=typeAliases[type]#>)(left.<#= GetRegisterFieldName(type, g) #> - right.<#= GetRegisterFieldName(type, g) #>);
 <#
-                }
+        }
 #>
                     }
 <#
-        }
+    }
 #>
                     return difference;
                 }
@@ -729,8 +745,9 @@ namespace System.Numerics
             {
                 if (Vector.IsHardwareAccelerated)
                 {
-<#    foreach (Type type in supportedTypes)
-        {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
                     <#=GenerateIfStatementHeader(type)#>
                     {
@@ -742,7 +759,7 @@ namespace System.Numerics
                         return new Vector<T>(dataPtr);
                     }
 <#
-        }
+    }
 #>
                     else
                     {
@@ -752,18 +769,19 @@ namespace System.Numerics
                 else
                 {
                     Vector<T> product = new Vector<T>();
-<#    foreach (Type type in supportedTypes)
+<#
+    foreach (Type type in supportedTypes)
     {
 #>
                     <#=GenerateIfStatementHeader(type)#>
                     {
 <#
-                for (int g = 0; g < GetNumFields(type, totalSize); g++)
-                {
+        for (int g = 0; g < GetNumFields(type, totalSize); g++)
+        {
 #>
                         product.<#= GetRegisterFieldName(type, g) #> = (<#=typeAliases[type]#>)(left.<#= GetRegisterFieldName(type, g) #> * right.<#= GetRegisterFieldName(type, g) #>);
 <#
-                }
+        }
 #>
                     }
 <#
@@ -792,18 +810,19 @@ namespace System.Numerics
                 else
                 {
                     Vector<T> product = new Vector<T>();
-<#    foreach (Type type in supportedTypes)
+<#
+    foreach (Type type in supportedTypes)
     {
 #>
                     <#=GenerateIfStatementHeader(type)#>
                     {
 <#
-                for (int g = 0; g < GetNumFields(type, totalSize); g++)
-                {
+        for (int g = 0; g < GetNumFields(type, totalSize); g++)
+        {
 #>
                         product.<#= GetRegisterFieldName(type, g) #> = (<#=typeAliases[type]#>)(value.<#= GetRegisterFieldName(type, g) #> * (<#=typeAliases[type]#>)(object)factor);
 <#
-                }
+        }
 #>
                     }
 <#
@@ -832,18 +851,19 @@ namespace System.Numerics
                 else
                 {
                     Vector<T> product = new Vector<T>();
-<#    foreach (Type type in supportedTypes)
+<#
+    foreach (Type type in supportedTypes)
     {
 #>
                     <#=GenerateIfStatementHeader(type)#>
                     {
 <#
-                for (int g = 0; g < GetNumFields(type, totalSize); g++)
-                {
+        for (int g = 0; g < GetNumFields(type, totalSize); g++)
+        {
 #>
                         product.<#= GetRegisterFieldName(type, g) #> = (<#=typeAliases[type]#>)(value.<#= GetRegisterFieldName(type, g) #> * (<#=typeAliases[type]#>)(object)factor);
 <#
-                }
+        }
 #>
                     }
 <#
@@ -867,8 +887,9 @@ namespace System.Numerics
             {
                 if (Vector.IsHardwareAccelerated)
                 {
-<#    foreach (Type type in supportedTypes)
-        {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
                     <#=GenerateIfStatementHeader(type)#>
                     {
@@ -880,7 +901,7 @@ namespace System.Numerics
                         return new Vector<T>(dataPtr);
                     }
 <#
-        }
+    }
 #>
                     else
                     {
@@ -890,18 +911,19 @@ namespace System.Numerics
                 else
                 {
                     Vector<T> quotient = new Vector<T>();
-<#    foreach (Type type in supportedTypes)
+<#
+    foreach (Type type in supportedTypes)
     {
 #>
                     <#=GenerateIfStatementHeader(type)#>
                     {
 <#
-                for (int g = 0; g < GetNumFields(type, totalSize); g++)
-                {
+        for (int g = 0; g < GetNumFields(type, totalSize); g++)
+        {
 #>
                         quotient.<#= GetRegisterFieldName(type, g) #> = (<#=typeAliases[type]#>)(left.<#= GetRegisterFieldName(type, g) #> / right.<#= GetRegisterFieldName(type, g) #>);
 <#
-                }
+        }
 #>
                     }
 <#
@@ -1056,7 +1078,8 @@ namespace System.Numerics
         #endregion Logical Operators
 
         #region Conversions
-<#    foreach (Type type in supportedTypes)
+<#
+    foreach (Type type in supportedTypes)
     {
 #>
         /// <summary>
@@ -1090,7 +1113,8 @@ namespace System.Numerics
         {
             if (Vector.IsHardwareAccelerated)
             {
-<#    foreach (Type type in supportedTypes)
+<#
+    foreach (Type type in supportedTypes)
     {
 #>
                 <#=GenerateIfStatementHeader(type)#>
@@ -1113,23 +1137,24 @@ namespace System.Numerics
             else
             {
                 Register register = new Register();
-<#    foreach (Type type in supportedTypes)
-        {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
 <#
-                for (int g = 0; g < GetNumFields(type, totalSize); g++)
-                {
+        for (int g = 0; g < GetNumFields(type, totalSize); g++)
+        {
 #>
                     <#= GetRegisterFieldName(type, g) #> = left.<#= GetRegisterFieldName(type, g) #> == right.<#= GetRegisterFieldName(type, g) #> ? ConstantHelper.Get<#=type.Name#>WithAllBitsSet() : (<#=typeAliases[type]#>)0;
 <#
-                }
+        }
 #>
                     return new Vector<T>(ref register);
                 }
 <#
-        }
+    }
 #>
                 else
                 {
@@ -1144,7 +1169,8 @@ namespace System.Numerics
         {
             if (Vector.IsHardwareAccelerated)
             {
-<#    foreach (Type type in supportedTypes)
+<#
+    foreach (Type type in supportedTypes)
     {
 #>
                 <#=GenerateIfStatementHeader(type)#>
@@ -1167,8 +1193,9 @@ namespace System.Numerics
             else
             {
                 Register register = new Register();
-<#    foreach (Type type in supportedTypes)
-        {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
@@ -1183,7 +1210,7 @@ namespace System.Numerics
                     return new Vector<T>(ref register);
                 }
 <#
-        }
+    }
 #>
                 else
                 {
@@ -1198,7 +1225,8 @@ namespace System.Numerics
         {
             if (Vector.IsHardwareAccelerated)
             {
-<#    foreach (Type type in supportedTypes)
+<#
+    foreach (Type type in supportedTypes)
     {
 #>
                 <#=GenerateIfStatementHeader(type)#>
@@ -1221,23 +1249,24 @@ namespace System.Numerics
             else
             {
                 Register register = new Register();
-<#    foreach (Type type in supportedTypes)
-        {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
 <#
-                for (int g = 0; g < GetNumFields(type, totalSize); g++)
-                {
+        for (int g = 0; g < GetNumFields(type, totalSize); g++)
+        {
 #>
                     <#= GetRegisterFieldName(type, g) #> = left.<#= GetRegisterFieldName(type, g) #> > right.<#= GetRegisterFieldName(type, g) #> ? ConstantHelper.Get<#=type.Name#>WithAllBitsSet() : (<#=typeAliases[type]#>)0;
 <#
-                }
+        }
 #>
                     return new Vector<T>(ref register);
                 }
 <#
-        }
+    }
 #>
                 else
                 {
@@ -1339,7 +1368,8 @@ namespace System.Numerics
         {
             if (Vector.IsHardwareAccelerated)
             {
-<#    foreach (Type type in supportedTypes)
+<#
+    foreach (Type type in supportedTypes)
     {
 #>
                 <#=GenerateIfStatementHeader(type)#>
@@ -1362,23 +1392,24 @@ namespace System.Numerics
             else
             {
                 Vector<T> vec = new Vector<T>();
-<#    foreach (Type type in supportedTypes)
-        {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
 <#
-                for (int g = 0; g < GetNumFields(type, totalSize); g++)
-                {
+        for (int g = 0; g < GetNumFields(type, totalSize); g++)
+        {
 #>
                     vec.<#=GetRegisterFieldName(type, g)#> = left.<#=GetRegisterFieldName(type, g)#> < right.<#=GetRegisterFieldName(type, g)#> ? left.<#=GetRegisterFieldName(type, g)#> : right.<#=GetRegisterFieldName(type, g)#>;
 <#
-                }
+        }
 #>
                     return vec;
                 }
 <#
-        }
+    }
 #>
                 else
                 {
@@ -1392,7 +1423,8 @@ namespace System.Numerics
         {
             if (Vector.IsHardwareAccelerated)
             {
-<#    foreach (Type type in supportedTypes)
+<#
+    foreach (Type type in supportedTypes)
     {
 #>
                 <#=GenerateIfStatementHeader(type)#>
@@ -1415,23 +1447,24 @@ namespace System.Numerics
             else
             {
                 Vector<T> vec = new Vector<T>();
-<#    foreach (Type type in supportedTypes)
-        {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
 <#
-                for (int g = 0; g < GetNumFields(type, totalSize); g++)
-                {
+        for (int g = 0; g < GetNumFields(type, totalSize); g++)
+        {
 #>
                     vec.<#=GetRegisterFieldName(type, g)#> = left.<#=GetRegisterFieldName(type, g)#> > right.<#=GetRegisterFieldName(type, g)#> ? left.<#=GetRegisterFieldName(type, g)#> : right.<#=GetRegisterFieldName(type, g)#>;
 <#
-                }
+        }
 #>
                     return vec;
                 }
 <#
-        }
+    }
 #>
                 else
                 {
@@ -1454,24 +1487,25 @@ namespace System.Numerics
             }
             else
             {
-<#    foreach (Type type in supportedTypes)
-        {
-    #>
+<#
+    foreach (Type type in supportedTypes)
+    {
+#>
                 <#=GenerateIfStatementHeader(type)#>
                 {
                     <#=typeAliases[type]#> product = 0;
 <#
-                for (int g = 0; g < GetNumFields(type, totalSize); g++)
-                {
+        for (int g = 0; g < GetNumFields(type, totalSize); g++)
+        {
 #>
                     product += (<#=typeAliases[type]#>)(left.<#=GetRegisterFieldName(type, g)#> * right.<#=GetRegisterFieldName(type, g)#>);
 <#
-                }
+        }
 #>
                     return (T)(object)product;
                 }
 <#
-        }
+    }
 #>
                 else
                 {
@@ -1485,8 +1519,9 @@ namespace System.Numerics
         {
             if (Vector.IsHardwareAccelerated)
             {
-<#    foreach (Type type in supportedTypes)
-        {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
@@ -1498,7 +1533,7 @@ namespace System.Numerics
                     return new Vector<T>(dataPtr);
                 }
 <#
-        }
+    }
 #>
                 else
                 {
@@ -1507,23 +1542,24 @@ namespace System.Numerics
             }
             else
             {
-<#    foreach (Type type in supportedTypes)
-        {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
                 <#=GenerateIfStatementHeader(type)#>
                 {
 <#
-                for (int g = 0; g < GetNumFields(type, totalSize); g++)
-                {
+        for (int g = 0; g < GetNumFields(type, totalSize); g++)
+        {
 #>
                     value.<#=GetRegisterFieldName(type, g)#> = (<#=typeAliases[type]#>)Math.Sqrt(value.<#=GetRegisterFieldName(type, g)#>);
 <#
-                }
+        }
 #>
                     return value;
                 }
 <#
-        }
+    }
 #>
                 else
                 {
@@ -1537,15 +1573,16 @@ namespace System.Numerics
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
         private static bool ScalarEquals(T left, T right)
         {
-<# foreach (Type type in supportedTypes)
-   {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
             <#=GenerateIfStatementHeader(type)#>
             {
                 return (<#=typeAliases[type]#>)(object)left == (<#=typeAliases[type]#>)(object)right;
             }
 <#
-   }
+    }
 #>
             else
             {
@@ -1556,15 +1593,16 @@ namespace System.Numerics
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
         private static bool ScalarLessThan(T left, T right)
         {
-<# foreach (Type type in supportedTypes)
-   {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
             <#=GenerateIfStatementHeader(type)#>
             {
                 return (<#=typeAliases[type]#>)(object)left < (<#=typeAliases[type]#>)(object)right;
             }
 <#
-   }
+    }
 #>
             else
             {
@@ -1575,15 +1613,16 @@ namespace System.Numerics
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
         private static bool ScalarGreaterThan(T left, T right)
         {
-<# foreach (Type type in supportedTypes)
-   {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
             <#=GenerateIfStatementHeader(type)#>
             {
                 return (<#=typeAliases[type]#>)(object)left > (<#=typeAliases[type]#>)(object)right;
             }
 <#
-   }
+    }
 #>
             else
             {
@@ -1594,15 +1633,16 @@ namespace System.Numerics
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
         private static T ScalarAdd(T left, T right)
         {
-<# foreach (Type type in supportedTypes)
-   {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
             <#=GenerateIfStatementHeader(type)#>
             {
                 return (T)(object)unchecked((<#=typeAliases[type]#>)((<#=typeAliases[type]#>)(object)left + (<#=typeAliases[type]#>)(object)right));
             }
 <#
-   }
+    }
 #>
             else
             {
@@ -1613,15 +1653,16 @@ namespace System.Numerics
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
         private static T ScalarSubtract(T left, T right)
         {
-<# foreach (Type type in supportedTypes)
-   {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
             <#=GenerateIfStatementHeader(type)#>
             {
                 return (T)(object)(<#=typeAliases[type]#>)((<#=typeAliases[type]#>)(object)left - (<#=typeAliases[type]#>)(object)right);
             }
 <#
-   }
+    }
 #>
             else
             {
@@ -1632,15 +1673,16 @@ namespace System.Numerics
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
         private static T ScalarMultiply(T left, T right)
         {
-<# foreach (Type type in supportedTypes)
-   {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
             <#=GenerateIfStatementHeader(type)#>
             {
                 return (T)(object)unchecked((<#=typeAliases[type]#>)((<#=typeAliases[type]#>)(object)left * (<#=typeAliases[type]#>)(object)right));
             }
 <#
-   }
+    }
 #>
             else
             {
@@ -1651,15 +1693,16 @@ namespace System.Numerics
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
         private static T ScalarDivide(T left, T right)
         {
-<# foreach (Type type in supportedTypes)
-   {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
             <#=GenerateIfStatementHeader(type)#>
             {
                 return (T)(object)(<#=typeAliases[type]#>)((<#=typeAliases[type]#>)(object)left / (<#=typeAliases[type]#>)(object)right);
             }
 <#
-   }
+    }
 #>
             else
             {
@@ -1670,8 +1713,9 @@ namespace System.Numerics
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
         private static T GetOneValue()
         {
-<# foreach (Type type in supportedTypes)
-   {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
             <#=GenerateIfStatementHeader(type)#>
             {
@@ -1679,7 +1723,7 @@ namespace System.Numerics
                 return (T)(object)value;
             }
 <#
-   }
+    }
 #>
             else
             {
@@ -1690,15 +1734,16 @@ namespace System.Numerics
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
         private static T GetAllBitsSetValue()
         {
-<# foreach (Type type in supportedTypes)
-   {
+<#
+    foreach (Type type in supportedTypes)
+    {
 #>
             <#=GenerateIfStatementHeader(type)#>
             {
                 return (T)(object)ConstantHelper.Get<#=type.Name#>WithAllBitsSet();
             }
 <#
-   }
+    }
 #>
             else
             {
@@ -1712,7 +1757,8 @@ namespace System.Numerics
     public static partial class Vector
     {
         #region Widen/Narrow
-<#    foreach (Type type in WidenableTypes)
+<#
+    foreach (Type type in WidenableTypes)
     {
         Type widenTarget = GetWidenTarget(type);
 #>
@@ -1751,8 +1797,8 @@ namespace System.Numerics
 
 <#
     }
-#>
-<#    foreach (Type narrowSource in NarrowableTypes)
+
+    foreach (Type narrowSource in NarrowableTypes)
     {
         Type narrowTarget = GetNarrowTarget(narrowSource);
 #>
@@ -1773,21 +1819,21 @@ namespace System.Numerics
         [Intrinsic]
         public static unsafe Vector<<#=typeAliases[narrowTarget]#>> Narrow(Vector<<#=typeAliases[narrowSource]#>> low, Vector<<#=typeAliases[narrowSource]#>> high)
         {
-		    unchecked
-		    {
-				int elements = Vector<<#=typeAliases[narrowTarget]#>>.Count;
+            unchecked
+            {
+                int elements = Vector<<#=typeAliases[narrowTarget]#>>.Count;
                 <#=typeAliases[narrowTarget]#>* retPtr = stackalloc <#=typeAliases[narrowTarget]#>[elements];
-				for (int i = 0; i < elements / 2; i++)
-				{
-					retPtr[i] = (<#=typeAliases[narrowTarget]#>)low[i];
-				}
-				for (int i = 0; i < elements / 2; i++)
-				{
-					retPtr[i + (elements / 2)] = (<#=typeAliases[narrowTarget]#>)high[i];
-				}
+                for (int i = 0; i < elements / 2; i++)
+                {
+                    retPtr[i] = (<#=typeAliases[narrowTarget]#>)low[i];
+                }
+                for (int i = 0; i < elements / 2; i++)
+                {
+                    retPtr[i + (elements / 2)] = (<#=typeAliases[narrowTarget]#>)high[i];
+                }
 
-				return new Vector<<#=typeAliases[narrowTarget]#>>(retPtr);
-		    }
+                return new Vector<<#=typeAliases[narrowTarget]#>>(retPtr);
+            }
         }
 
 <#
@@ -1796,7 +1842,8 @@ namespace System.Numerics
         #endregion Widen/Narrow
 
         #region Same-Size Conversion
-<#    foreach (var pair in SameSizeConversionPairs)
+<#
+    foreach (var pair in SameSizeConversionPairs)
     {
 #>
         /// <summary>
@@ -1815,20 +1862,22 @@ namespace System.Numerics
         [Intrinsic]
         public static unsafe Vector<<#=typeAliases[pair.Value]#>> ConvertTo<#=pair.Value.Name#>(Vector<<#=typeAliases[pair.Key]#>> value)
         {
-			unchecked
-			{
-				int elements = Vector<<#=typeAliases[pair.Value]#>>.Count;
+            unchecked
+            {
+                int elements = Vector<<#=typeAliases[pair.Value]#>>.Count;
                 <#=typeAliases[pair.Value]#>* retPtr = stackalloc <#=typeAliases[pair.Value]#>[elements];
-				for (int i = 0; i < elements; i++)
-				{
-					retPtr[i] = (<#=typeAliases[pair.Value]#>)value[i];
-				}
+                for (int i = 0; i < elements; i++)
+                {
+                    retPtr[i] = (<#=typeAliases[pair.Value]#>)value[i];
+                }
 
-				return new Vector<<#=typeAliases[pair.Value]#>>(retPtr);
-			}
+                return new Vector<<#=typeAliases[pair.Value]#>>(retPtr);
+            }
         }
 
-<# } #>
+<#
+    }
+#>
         #endregion Same-Size Conversion
     }
 }


### PR DESCRIPTION
https://github.com/dotnet/coreclr/pull/18623 updated the Vector<T> .cs files to use simplified type names, but the T4 templates that generate them weren't updated to match.  This updates the templates so that they generate the correct code.

There was also some inconsistent whitespace (mixed tabs and spaces) and inconsistent indentation in `Vector.tt` that made it difficult to read.  I normalized that and converted all tabs to spaces.