### PR TITLE
Handle null byref in helper

### DIFF
--- a/src/vm/amd64/JitHelpers_Fast.asm
+++ b/src/vm/amd64/JitHelpers_Fast.asm
@@ -722,7 +722,7 @@ endif
         add     rdi, 8h
         add     rsi, 8h
         ret
-LEAF_END JIT_ByRefWriteBarrier, _TEXT
+LEAF_END_MARKED JIT_ByRefWriteBarrier, _TEXT
 
 
 g_pObjectClass      equ     ?g_pObjectClass@@3PEAVMethodTable@@EA

--- a/src/vm/amd64/jithelpers_fast.S
+++ b/src/vm/amd64/jithelpers_fast.S
@@ -384,7 +384,7 @@ LEAF_ENTRY JIT_ByRefWriteBarrier, _TEXT
         add     rdi, 8h
         add     rsi, 8h
         ret
-LEAF_END JIT_ByRefWriteBarrier, _TEXT
+LEAF_END_MARKED JIT_ByRefWriteBarrier, _TEXT
 
 // TODO: put definition for this in asmconstants.h
 #define CanCast 1

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -6951,6 +6951,7 @@ EXTERN_C void JIT_MemCpy_End();
 
 EXTERN_C void JIT_WriteBarrier_End();
 EXTERN_C void JIT_CheckedWriteBarrier_End();
+EXTERN_C void JIT_ByRefWriteBarrier_End();
 #endif // _TARGET_X86_
 
 #if defined(_TARGET_AMD64_) && defined(_DEBUG)
@@ -6977,6 +6978,7 @@ bool IsIPInMarkedJitHelper(UINT_PTR uControlPc)
 
     CHECK_RANGE(JIT_WriteBarrier)
     CHECK_RANGE(JIT_CheckedWriteBarrier)
+    CHECK_RANGE(JIT_ByRefWriteBarrier)
 #else
 #ifdef FEATURE_PAL
     CHECK_RANGE(JIT_WriteBarrierGroup)

--- a/tests/src/JIT/Regression/JitBlue/GitHub_19444/GitHub_19444.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_19444/GitHub_19444.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// This test case illustrates a bug where the JIT_ByRefWriteBarrier was not
+// included in IsIPInMarkedJitHelper on non-32-bit-x86 platforms.
+
+using System;
+
+class C0
+{
+}
+
+struct S0
+{
+    public C0 F0;
+    public ulong F4;
+}
+
+class C1
+{
+    public S0 F3;
+}
+
+struct S1
+{
+    public S0 F3;
+}
+
+struct S2
+{
+    public C0 F0;
+    public uint F4;
+}
+
+class C3
+{
+    public S2 F3;
+}
+
+struct S3
+{
+    public S2 F3;
+}
+
+public class GitHub_19444
+{
+    static S1 s_38;
+    static C1 s_43;
+    static S3 s_1;
+    static C3 s_2;
+
+    public static int Main()
+    {
+        try
+        {
+            s_38.F3 = s_43.F3;
+            s_1.F3 = s_2.F3;
+        }
+        catch (System.NullReferenceException)
+        {
+            Console.WriteLine("PASS");
+            return 100;
+        }
+        Console.WriteLine("FAIL");
+        return -1;
+    }
+}
+

--- a/tests/src/JIT/Regression/JitBlue/GitHub_19444/GitHub_19444.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_19444/GitHub_19444.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Add JIT_ByRefWriteBarrier to IsIPInMarkedJitHelper so that a null dereference will be handled.

Fix #19444