### PR TITLE
Update interop test xplat header

### DIFF
--- a/tests/src/Interop/ArrayMarshalling/BoolArray/CMakeLists.txt
+++ b/tests/src/Interop/ArrayMarshalling/BoolArray/CMakeLists.txt
@@ -5,7 +5,7 @@ set(SOURCES MarshalBoolArrayNative.cpp)
 
 # add the executable
 add_library (MarshalBoolArrayNative SHARED ${SOURCES})
-target_link_libraries(MarshalBoolArrayNative ${LINK_LIBRARIES_ADDITIONAL}) 
+target_link_libraries(MarshalBoolArrayNative ${LINK_LIBRARIES_ADDITIONAL})
 
 # add the install targets
 install (TARGETS MarshalBoolArrayNative DESTINATION bin)

--- a/tests/src/Interop/ArrayMarshalling/BoolArray/MarshalBoolArrayNative.cpp
+++ b/tests/src/Interop/ArrayMarshalling/BoolArray/MarshalBoolArrayNative.cpp
@@ -23,7 +23,7 @@ typedef BOOL (CALLBACK *CallBackIn)(int size,bool arr[]);
 extern "C" DLL_EXPORT BOOL DoCallBackIn(CallBackIn callback)
 {
 	//Init
-	bool * arr = (bool*)CoTaskMemAlloc(ArraySIZE);
+	bool * arr = (bool*)CoreClrAlloc(ArraySIZE);
 	for(int i = 0;i < ArraySIZE; i++ )
 	{
 		if( 0 == i%2) 
@@ -48,24 +48,24 @@ extern "C" DLL_EXPORT BOOL DoCallBackIn(CallBackIn callback)
 		if((0 == (i%2)) && !arr[i]) //expect true
 		{
 			printf("Native Side:Error in DoCallBackIn.The Item is %d\n",i+1);
-			CoTaskMemFree(arr);
+			CoreClrFree(arr);
 			return false;
 		}
 		else if((1 == (i%2))&&arr[i]) //expect false
 		{
 			printf("Native Side:Error in DoCallBackIn.The Item is %d\n",i+1);
-			CoTaskMemFree(arr);
+			CoreClrFree(arr);
 			return false;
 		}	
 	}
-	CoTaskMemFree(arr);
+	CoreClrFree(arr);
 	return true;
 }
 
 typedef BOOL (CALLBACK *CallBackOut)(int size,bool arr[]);
 extern "C" DLL_EXPORT BOOL DoCallBackOut(CallBackOut callback)
 {
-	bool * arr =(bool *)CoTaskMemAlloc(ArraySIZE);
+	bool * arr =(bool *)CoreClrAlloc(ArraySIZE);
 
 	if(!callback(ArraySIZE,arr))
     {
@@ -79,11 +79,11 @@ extern "C" DLL_EXPORT BOOL DoCallBackOut(CallBackOut callback)
 		if(!arr[i]) //expect true
 		{
 			printf("Native Side:Error in DoCallBackOut.The Item is %d\n",i+1);
-			CoTaskMemFree(arr);
+			CoreClrFree(arr);
 			return false;
 		}	
 	}
-	CoTaskMemFree(arr);
+	CoreClrFree(arr);
 	return true;
 }
 
@@ -91,7 +91,7 @@ typedef BOOL (CALLBACK *CallBackInOut)(int size,bool arr[]);
 extern "C" DLL_EXPORT BOOL DoCallBackInOut(CallBackInOut callback)
 {
 	//Init
-	bool * arr =(bool *)CoTaskMemAlloc(ArraySIZE);
+	bool * arr =(bool *)CoreClrAlloc(ArraySIZE);
 	for(int i = 0;i < ArraySIZE; i++ )
 	{
 		if( 0 == i%2)
@@ -117,11 +117,11 @@ extern "C" DLL_EXPORT BOOL DoCallBackInOut(CallBackInOut callback)
 		if(!arr[i]) //expect true
 		{
 			printf("Native Side:Error in DoCallBackInOut.The Item is %d\n",i+1);
-			CoTaskMemFree(arr);
+			CoreClrFree(arr);
 			return false;
 		}	
 	}
-	CoTaskMemFree(arr);
+	CoreClrFree(arr);
 	return true;
 }
 
@@ -132,7 +132,7 @@ typedef BOOL (CALLBACK *CallBackRefIn)(int size,bool ** arr);
 extern "C" DLL_EXPORT BOOL DoCallBackRefIn(CallBackRefIn callback)
 {
 	//Init:true,false,true,false,true
-	bool *parr = (bool *)CoTaskMemAlloc(ArraySIZE);
+	bool *parr = (bool *)CoreClrAlloc(ArraySIZE);
 
 	for(int i = 0;i < ArraySIZE;++i)
 	{
@@ -158,17 +158,17 @@ extern "C" DLL_EXPORT BOOL DoCallBackRefIn(CallBackRefIn callback)
 		if((0==(i%2)) && !parr[i]) //expect true
 		{
 			printf("Native Side:Error in DoCallBackInOut.The Item is %d\n",i+1);
-			CoTaskMemFree(parr);
+			CoreClrFree(parr);
 			return false;
 		}
 		else if((1==(i%2))&&parr[i]) //expect false
 		{
 			printf("Native Side:Error in DoCallBackInOut.The Item is %d\n",i+1);
-			CoTaskMemFree(parr);
+			CoreClrFree(parr);
 			return false;
 		}
 	}
-	CoTaskMemFree(parr);
+	CoreClrFree(parr);
 	return true;
 }
 
@@ -190,11 +190,11 @@ extern "C" DLL_EXPORT BOOL DoCallBackRefOut(CallBackRefOut callback)
 		if(!(*(parr + i))) //expect true
 		{
 			printf("Native Side:Error in DoCallBackRefOut.The Item is %d\n",i+1);
-			CoTaskMemFree(parr);
+			CoreClrFree(parr);
 			return false;
 		}
 	}
-	CoTaskMemFree(parr);
+	CoreClrFree(parr);
 	return true;
 }
 
@@ -202,7 +202,7 @@ typedef BOOL (CALLBACK *CallBackRefInOut)(int size,bool ** arr);
 extern "C" DLL_EXPORT BOOL DoCallBackRefInOut(CallBackRefInOut callback)
 {
 	//Init,true,false,true,false
-	bool* parr = (bool*)CoTaskMemAlloc(ArraySIZE);
+	bool* parr = (bool*)CoreClrAlloc(ArraySIZE);
 	for(int i = 0;i<ArraySIZE;++i)
 	{
 		if( 0 == i%2)
@@ -227,10 +227,10 @@ extern "C" DLL_EXPORT BOOL DoCallBackRefInOut(CallBackRefInOut callback)
 		if(!(parr[i])) //expect true
 		{
 			printf("Native Side:Error in DoCallBackRefOut.The Item is %d\n",i+1);
-			CoTaskMemFree(parr);
+			CoreClrFree(parr);
 			return false;
 		}
 	}
-	CoTaskMemFree(parr);
+	CoreClrFree(parr);
 	return true;
 }

--- a/tests/src/Interop/ArrayMarshalling/ByValArray/MarshalArrayByValNative.cpp
+++ b/tests/src/Interop/ArrayMarshalling/ByValArray/MarshalArrayByValNative.cpp
@@ -28,7 +28,7 @@ macro definition
     expected[i] = (__type)i
 
 #define INIT_EXPECTED_STRUCT(__type, __size, __array_type) \
-    __type *expected = (__type *)::CoTaskMemAlloc( sizeof(__type) ); \
+    __type *expected = (__type *)CoreClrAlloc( sizeof(__type) ); \
     for ( size_t i = 0; i < (__size); ++i) \
     expected->arr[i] = (__array_type)i
 
@@ -70,7 +70,7 @@ helper function
 
 LPSTR ToString(int i)
 {
-    CHAR *pBuffer = (CHAR *)::CoTaskMemAlloc(10 * sizeof(CHAR)); // 10 is enough for our case, WCHAR for BSTR
+    CHAR *pBuffer = (CHAR *)CoreClrAlloc(10 * sizeof(CHAR)); // 10 is enough for our case, WCHAR for BSTR
 	snprintf(pBuffer, 10, "%d", i);
     return pBuffer;
 }
@@ -79,7 +79,7 @@ LPSTR ToString(int i)
 
 TestStruct* InitTestStruct()
 {
-    TestStruct *expected = (TestStruct *)CoTaskMemAlloc( sizeof(TestStruct) * ARRAY_SIZE );
+    TestStruct *expected = (TestStruct *)CoreClrAlloc( sizeof(TestStruct) * ARRAY_SIZE );
 
     for ( int i = 0; i < ARRAY_SIZE; i++)
     {
@@ -579,7 +579,7 @@ extern "C" DLL_EXPORT S_CHARArray* NATIVEAPI S_CHARArray_Ret()
 
 extern "C" DLL_EXPORT S_LPSTRArray* NATIVEAPI S_LPSTRArray_Ret()
 {        
-    S_LPSTRArray *expected = (S_LPSTRArray *)::CoTaskMemAlloc( sizeof(S_LPSTRArray) );
+    S_LPSTRArray *expected = (S_LPSTRArray *)CoreClrAlloc( sizeof(S_LPSTRArray) );
     for ( int i = 0; i < ARRAY_SIZE; ++i )
         expected->arr[i] = ToString(i);
 
@@ -589,7 +589,7 @@ extern "C" DLL_EXPORT S_LPSTRArray* NATIVEAPI S_LPSTRArray_Ret()
 
 extern "C" DLL_EXPORT S_StructArray* NATIVEAPI S_StructArray_Ret()
 {
-    S_StructArray *expected = (S_StructArray *)::CoTaskMemAlloc( sizeof(S_StructArray) );
+    S_StructArray *expected = (S_StructArray *)CoreClrAlloc( sizeof(S_StructArray) );
     for ( int i = 0; i < ARRAY_SIZE; ++i )
     {
         expected->arr[i].x = i;

--- a/tests/src/Interop/BestFitMapping/BestFitMappingNative.cpp
+++ b/tests/src/Interop/BestFitMapping/BestFitMappingNative.cpp
@@ -68,7 +68,7 @@ bool CheckInput(LPSTR str)
     p[2] = (char)0xbc;
     p[3] = (char)0;
 #endif
-    if (0 != _tcsncmp(str, p, 4))
+    if (0 != strncmp(str, p, 4))
     {
         printf("CheckInput:Expected:%s,Actual:%d\n", p, str[0]);
         delete[]p;

--- a/tests/src/Interop/BestFitMapping/BestFitMappingNative.cpp
+++ b/tests/src/Interop/BestFitMapping/BestFitMappingNative.cpp
@@ -90,7 +90,7 @@ extern "C" DLL_EXPORT LPSTR _cdecl CLPStr_In(LPSTR pStr)
 
     //alloc,copy, since we cannot depend the Marshaler's activity.
     size_t len = strlen(pStr) + 1; //+1, Include the NULL Character.
-    LPSTR pBack = (LPSTR)CoTaskMemAlloc(sizeof(char) * len);
+    LPSTR pBack = (LPSTR)CoreClrAlloc(sizeof(char) * len);
     strncpy(pBack, pStr, len);
 
     return pBack;
@@ -100,7 +100,7 @@ extern "C" DLL_EXPORT LPSTR _cdecl CLPStr_Out(LPSTR pStr)
 {
     const char* pTemp = "AAAA";
     size_t len = strlen(pTemp) + 1; //+1, Include the NULL Character.
-    LPSTR pBack = (LPSTR)CoTaskMemAlloc(sizeof(char) * len);
+    LPSTR pBack = (LPSTR)CoreClrAlloc(sizeof(char) * len);
     strncpy(pBack, pTemp, strlen(pTemp) + 1);
 
     strncpy(pStr, pTemp, strlen(pTemp) + 1);
@@ -118,7 +118,7 @@ extern "C" DLL_EXPORT LPSTR _cdecl CLPStr_InOut(LPSTR pStr)
 
     //alloc,copy, since we cannot depend the Marshaler's activity.
     size_t len = strlen(pStr) + 1; //+1, Include the NULL Character.
-    LPSTR pBack = (LPSTR)CoTaskMemAlloc(len);
+    LPSTR pBack = (LPSTR)CoreClrAlloc(len);
     strncpy(pBack, pStr, len);
 
     return pBack;
@@ -134,7 +134,7 @@ extern "C" DLL_EXPORT LPSTR _cdecl CLPStr_InByRef(LPSTR* ppStr)
 
     //alloc,copy, since we cannot depend the Marshaler's activity.
     size_t len = strlen(*ppStr) + 1; //+1, Include the NULL Character.
-    LPSTR pBack = (LPSTR)CoTaskMemAlloc(len);
+    LPSTR pBack = (LPSTR)CoreClrAlloc(len);
     strncpy(pBack, *ppStr, len);
 
     return pBack;
@@ -144,10 +144,10 @@ extern "C" DLL_EXPORT LPSTR _cdecl CLPStr_OutByRef(LPSTR* ppStr)
 {
     const char* pTemp = "AAAA";
     size_t len = strlen(pTemp) + 1; //+1, Include the NULL Character.
-    LPSTR pBack = (LPSTR)CoTaskMemAlloc(sizeof(char) * len);
+    LPSTR pBack = (LPSTR)CoreClrAlloc(sizeof(char) * len);
     strncpy(pBack, pTemp, strlen(pTemp) + 1);
 
-    *ppStr = (LPSTR)CoTaskMemAlloc(sizeof(char) * len);
+    *ppStr = (LPSTR)CoreClrAlloc(sizeof(char) * len);
     strncpy(*ppStr, pTemp, strlen(pTemp) + 1);
     return pBack;
 }
@@ -162,7 +162,7 @@ extern "C" DLL_EXPORT LPSTR _cdecl CLPStr_InOutByRef(LPSTR* ppStr)
 
     //alloc,copy, since we cannot depend the Marshaler's activity.
     size_t len = strlen(*ppStr) + 1; //+1, Include the NULL Character.
-    LPSTR pBack = (LPSTR)CoTaskMemAlloc(len);
+    LPSTR pBack = (LPSTR)CoreClrAlloc(len);
     strncpy(pBack, *ppStr, len);
     return pBack;
 }
@@ -186,7 +186,7 @@ extern "C" DLL_EXPORT LPSTR __stdcall SLPStr_In(LPSTR pStr)
 
     //alloc,copy, since we cannot depend the Marshaler's activity.
     size_t len = strlen(pStr) + 1; //+1, Include the NULL Character.
-    LPSTR pBack = (LPSTR)CoTaskMemAlloc(len);
+    LPSTR pBack = (LPSTR)CoreClrAlloc(len);
     strncpy(pBack, pStr, len);
     return pBack;
 }
@@ -195,7 +195,7 @@ extern "C" DLL_EXPORT LPSTR __stdcall SLPStr_Out(LPSTR pStr)
 {
     const char* pTemp = "AAAA";
     size_t len = strlen(pTemp) + 1; //+1, Include the NULL Character.
-    LPSTR pBack = (LPSTR)CoTaskMemAlloc(sizeof(char) * len);
+    LPSTR pBack = (LPSTR)CoreClrAlloc(sizeof(char) * len);
     strncpy(pBack, pTemp, strlen(pTemp) + 1);
 
     strncpy(pStr, pTemp, strlen(pTemp) + 1);
@@ -212,7 +212,7 @@ extern "C" DLL_EXPORT LPSTR __stdcall SLPStr_InOut(LPSTR pStr)
 
     //alloc,copy, since we cannot depend the Marshaler's activity.
     size_t len = strlen(pStr) + 1; //+1, Include the NULL Character.
-    LPSTR pBack = (LPSTR)CoTaskMemAlloc(len);
+    LPSTR pBack = (LPSTR)CoreClrAlloc(len);
     strncpy(pBack, pStr, len);
     return pBack;
 }
@@ -226,7 +226,7 @@ extern "C" DLL_EXPORT LPSTR __stdcall SLPStr_InByRef(LPSTR* ppStr)
     }
     //alloc,copy, since we cannot depend the Marshaler's activity.
     size_t len = strlen(*ppStr) + 1; //+1, Include the NULL Character.
-    LPSTR pBack = (LPSTR)CoTaskMemAlloc(len);
+    LPSTR pBack = (LPSTR)CoreClrAlloc(len);
     strncpy(pBack, *ppStr, len);
     return pBack;
 }
@@ -235,10 +235,10 @@ extern "C" DLL_EXPORT LPSTR __stdcall SLPStr_OutByRef(LPSTR* ppStr)
 {
     const char* pTemp = "AAAA";
     size_t len = strlen(pTemp) + 1; //+1, Include the NULL Character.
-    LPSTR pBack = (LPSTR)CoTaskMemAlloc(sizeof(char) * len);
+    LPSTR pBack = (LPSTR)CoreClrAlloc(sizeof(char) * len);
     strncpy(pBack, pTemp, strlen(pTemp) + 1);
 
-    *ppStr = (LPSTR)CoTaskMemAlloc(sizeof(char) * len);
+    *ppStr = (LPSTR)CoreClrAlloc(sizeof(char) * len);
     strncpy(*ppStr, pTemp, strlen(pTemp) + 1);
 
     return pBack;
@@ -254,7 +254,7 @@ extern "C" DLL_EXPORT LPSTR __stdcall SLPStr_InOutByRef(LPSTR* ppStr)
 
     //alloc,copy, since we cannot depend the Marshaler's activity.
     size_t len = strlen(*ppStr) + 1; //+1, Include the NULL Character.
-    LPSTR pBack = (LPSTR)CoTaskMemAlloc(len);
+    LPSTR pBack = (LPSTR)CoreClrAlloc(len);
     strncpy(pBack, *ppStr, len);
     return pBack;
 }
@@ -272,21 +272,21 @@ extern "C" DLL_EXPORT void _cdecl DoCCallBack_LPSTR_In(CCallBackIn callback)
 {
   const char* pTemp = "AAAA";
   size_t len = strlen(pTemp)+1;
-  LPSTR pStr = (LPSTR)CoTaskMemAlloc(len);
+  LPSTR pStr = (LPSTR)CoreClrAlloc(len);
   strncpy(pStr,pTemp,len);
 
   if(!CheckInput(callback(pStr)))
   {
   	ReportFailure("DoCCallBack_LPSTR_In:NativeSide");
   }
-  CoTaskMemFree(pStr);
+  CoreClrFree(pStr);
 }
 
 typedef LPSTR (_cdecl *CCallBackOut)(LPSTR pstr);
 extern "C" DLL_EXPORT void _cdecl DoCCallBack_LPSTR_Out(CCallBackOut callback)
 {
     size_t len = 10;
-    LPSTR pStr = (LPSTR)CoTaskMemAlloc(len);
+    LPSTR pStr = (LPSTR)CoreClrAlloc(len);
 
     //Check the return value
     if (!CheckInput(callback(pStr)))
@@ -297,7 +297,7 @@ extern "C" DLL_EXPORT void _cdecl DoCCallBack_LPSTR_Out(CCallBackOut callback)
     {
         ReportFailure("DoCCallBack_LPSTR_Out:NativeSide,the Second Check");
     }
-    CoTaskMemFree(pStr);
+    CoreClrFree(pStr);
 }
 
 typedef LPSTR (_cdecl *CCallBackInOut)(LPSTR pstr);
@@ -305,7 +305,7 @@ extern "C" DLL_EXPORT void _cdecl DoCCallBack_LPSTR_InOut(CCallBackInOut callbac
 {
     const char* pTemp = "AAAA";
     size_t len = strlen(pTemp) + 1;
-    LPSTR pStr = (LPSTR)CoTaskMemAlloc(len);
+    LPSTR pStr = (LPSTR)CoreClrAlloc(len);
     strncpy(pStr, pTemp, len);
 
     if (!CheckInput(callback(pStr)))
@@ -316,7 +316,7 @@ extern "C" DLL_EXPORT void _cdecl DoCCallBack_LPSTR_InOut(CCallBackInOut callbac
     {
         ReportFailure("DoCCallBack_LPSTR_InOut:NativeSide,the Second Check");
     }
-    CoTaskMemFree(pStr);
+    CoreClrFree(pStr);
 }
 
 typedef LPSTR (_cdecl *CallBackInByRef)(LPSTR* pstr);
@@ -324,21 +324,21 @@ extern "C" DLL_EXPORT void _cdecl DoCCallBack_LPSTR_InByRef(CallBackInByRef call
 {
     const char* pTemp = "AAAA";
     size_t len = strlen(pTemp) + 1;
-    LPSTR pStr = (LPSTR)CoTaskMemAlloc(len);
+    LPSTR pStr = (LPSTR)CoreClrAlloc(len);
     strncpy(pStr, pTemp, len);
 
     if (!CheckInput(callback(&pStr)))
     {
         ReportFailure("DoCCallBack_LPSTR_InByRef:NativeSide");
     }
-    CoTaskMemFree(pStr);
+    CoreClrFree(pStr);
 }
 
 typedef LPSTR (_cdecl *CCallBackOutByRef)(LPSTR* pstr);
 extern "C" DLL_EXPORT void _cdecl DoCCallBack_LPSTR_OutByRef(CCallBackOutByRef callback)
 {
     size_t len = 10;
-    LPSTR pStr = (LPSTR)CoTaskMemAlloc(len);
+    LPSTR pStr = (LPSTR)CoreClrAlloc(len);
 
     if (!CheckInput(callback(&pStr)))
     {
@@ -348,7 +348,7 @@ extern "C" DLL_EXPORT void _cdecl DoCCallBack_LPSTR_OutByRef(CCallBackOutByRef c
     {
         ReportFailure("DoCCallBack_LPSTR_OutByRef:NativeSide,the Second Check");
     }
-    CoTaskMemFree(pStr);
+    CoreClrFree(pStr);
 }
 
 typedef LPSTR (_cdecl *CCallBackInOutByRef)(LPSTR* pstr);
@@ -356,7 +356,7 @@ extern "C" DLL_EXPORT void _cdecl DoCCallBack_LPSTR_InOutByRef(CCallBackInOutByR
 {
     const char* pTemp = "AAAA";
     size_t len = strlen(pTemp) + 1;
-    LPSTR pStr = (LPSTR)CoTaskMemAlloc(len);
+    LPSTR pStr = (LPSTR)CoreClrAlloc(len);
     strncpy(pStr, pTemp, len);
 
     if (!CheckInput(callback(&pStr)))
@@ -367,7 +367,7 @@ extern "C" DLL_EXPORT void _cdecl DoCCallBack_LPSTR_InOutByRef(CCallBackInOutByR
     {
         ReportFailure("DoCCallBack_LPSTR_InOutByRef:NativeSide,the Second Check");
     }
-    CoTaskMemFree(pStr);
+    CoreClrFree(pStr);
 }
 
 ///STDCALL Reverse PInvoke
@@ -376,14 +376,14 @@ extern "C" DLL_EXPORT void _cdecl DoSCallBack_LPSTR_In(SCallBackIn callback)
 {
     const char* pTemp = "AAAA";
     size_t len = strlen(pTemp) + 1;
-    LPSTR pStr = (LPSTR)CoTaskMemAlloc(len);
+    LPSTR pStr = (LPSTR)CoreClrAlloc(len);
     strncpy(pStr, pTemp, len);
 
     if (!CheckInput(callback(pStr)))
     {
         ReportFailure("DoSCallBack_LPSTR_In:NativeSide");
     }
-    CoTaskMemFree(pStr);
+    CoreClrFree(pStr);
 }
 
 typedef LPSTR (__stdcall *SCallBackOut)(LPSTR pstr);
@@ -391,7 +391,7 @@ extern "C" DLL_EXPORT void _cdecl DoSCallBack_LPSTR_Out(SCallBackOut callback)
 {
 
     size_t len = 10;
-    LPSTR pStr = (LPSTR)CoTaskMemAlloc(len);
+    LPSTR pStr = (LPSTR)CoreClrAlloc(len);
 
     if (!CheckInput(callback(pStr)))
     {
@@ -401,7 +401,7 @@ extern "C" DLL_EXPORT void _cdecl DoSCallBack_LPSTR_Out(SCallBackOut callback)
     {
         ReportFailure("DoSCallBack_LPSTR_Out:NativeSide,the Second Check");
     }
-    CoTaskMemFree(pStr);
+    CoreClrFree(pStr);
 }
 
 typedef LPSTR (__stdcall *SCallBackInOut)(LPSTR pstr);
@@ -409,7 +409,7 @@ extern "C" DLL_EXPORT void _cdecl DoSCallBack_LPSTR_InOut(SCallBackInOut callbac
 {
     const char* pTemp = "AAAA";
     size_t len = strlen(pTemp) + 1;
-    LPSTR pStr = (LPSTR)CoTaskMemAlloc(len);
+    LPSTR pStr = (LPSTR)CoreClrAlloc(len);
     strncpy(pStr, pTemp, len);
 
     if (!CheckInput(callback(pStr)))
@@ -420,7 +420,7 @@ extern "C" DLL_EXPORT void _cdecl DoSCallBack_LPSTR_InOut(SCallBackInOut callbac
     {
         ReportFailure("DoSCallBack_LPSTR_InOut:NativeSide,the second Check");
     }
-    CoTaskMemFree(pStr);
+    CoreClrFree(pStr);
 }
 
 typedef LPSTR (__stdcall *SCallBackInByRef)(LPSTR* pstr);
@@ -428,21 +428,21 @@ extern "C" DLL_EXPORT void _cdecl DoSCallBack_LPSTR_InByRef(SCallBackInByRef cal
 {
     const char* pTemp = "AAAA";
     size_t len = strlen(pTemp) + 1;
-    LPSTR pStr = (LPSTR)CoTaskMemAlloc(len);
+    LPSTR pStr = (LPSTR)CoreClrAlloc(len);
     strncpy(pStr, pTemp, len);
 
     if (!CheckInput(callback(&pStr)))
     {
         ReportFailure("DoSCallBack_LPSTR_InByRef:NativeSide");
     }
-    CoTaskMemFree(pStr);
+    CoreClrFree(pStr);
 }
 
 typedef LPSTR (__stdcall *SCallBackOutByRef)(LPSTR* pstr);
 extern "C" DLL_EXPORT void _cdecl DoSCallBack_LPSTR_OutByRef(SCallBackOutByRef callback)
 {
     size_t len = 10;
-    LPSTR pStr = (LPSTR)CoTaskMemAlloc(len);
+    LPSTR pStr = (LPSTR)CoreClrAlloc(len);
 
     if (!CheckInput(callback(&pStr)))
     {
@@ -452,7 +452,7 @@ extern "C" DLL_EXPORT void _cdecl DoSCallBack_LPSTR_OutByRef(SCallBackOutByRef c
     {
         ReportFailure("DoSCallBack_LPSTR_OutByRef:NativeSide,the second Check");
     }
-    CoTaskMemFree(pStr);
+    CoreClrFree(pStr);
 }
 
 typedef LPSTR (__stdcall *SCallBackInOutByRef)(LPSTR* pstr);
@@ -460,7 +460,7 @@ extern "C" DLL_EXPORT void _cdecl DoSCallBack_LPSTR_InOutByRef(SCallBackInOutByR
 {
     const char* pTemp = "AAAA";
     size_t len = strlen(pTemp) + 1;
-    LPSTR pStr = (LPSTR)CoTaskMemAlloc(len);
+    LPSTR pStr = (LPSTR)CoreClrAlloc(len);
     strncpy(pStr, pTemp, len);
 
     if (!CheckInput(callback(&pStr)))
@@ -471,6 +471,6 @@ extern "C" DLL_EXPORT void _cdecl DoSCallBack_LPSTR_InOutByRef(SCallBackInOutByR
     {
         ReportFailure("DoSCallBack_LPSTR_InOutByRef:NativeSide,the second Check");
     }
-    CoTaskMemFree(pStr);
+    CoreClrFree(pStr);
 }
 #pragma warning( pop )

--- a/tests/src/Interop/MarshalAPI/FunctionPointer/CMakeLists.txt
+++ b/tests/src/Interop/MarshalAPI/FunctionPointer/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES FunctionPointerNative.cpp)
 
 # add the executable
 add_library (FunctionPointerNative SHARED ${SOURCES})
+target_link_libraries(FunctionPointerNative ${LINK_LIBRARIES_ADDITIONAL})
 
 # add the install targets
 install (TARGETS FunctionPointerNative DESTINATION bin)

--- a/tests/src/Interop/MarshalAPI/IUnknown/CMakeLists.txt
+++ b/tests/src/Interop/MarshalAPI/IUnknown/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES IUnknownNative.cpp)
 
 # add the executable
 add_library (IUnknownNative SHARED ${SOURCES})
+target_link_libraries(IUnknownNative ${LINK_LIBRARIES_ADDITIONAL})
 
 # add the install targets
 install (TARGETS IUnknownNative DESTINATION bin)

--- a/tests/src/Interop/RefCharArray/RefCharArrayNative.cpp
+++ b/tests/src/Interop/RefCharArray/RefCharArrayNative.cpp
@@ -49,7 +49,7 @@ extern "C" BOOL DLL_EXPORT __stdcall MarshalRefCharArray_Stdcall(char ** pstr)
 typedef BOOL(_cdecl *CdeclCallBack)(char ** pstr);
 extern "C" BOOL DLL_EXPORT _cdecl DoCallBack_MarshalRefCharArray_Cdecl(CdeclCallBack caller)
 {
-    char * str = (char*)CoTaskMemAlloc(LEN);
+    char * str = (char*)CoreClrAlloc(LEN);
     for(int i = 0;i<LEN;i++)
     {
         str[i] = 'z';
@@ -61,7 +61,7 @@ extern "C" BOOL DLL_EXPORT _cdecl DoCallBack_MarshalRefCharArray_Cdecl(CdeclCall
     }
     if(str[0]!='a')
     {
-        CoTaskMemFree(str);
+        CoreClrFree(str);
         return FALSE;
     }
     return TRUE;
@@ -70,7 +70,7 @@ extern "C" BOOL DLL_EXPORT _cdecl DoCallBack_MarshalRefCharArray_Cdecl(CdeclCall
 typedef BOOL(__stdcall *StdCallBack)(char ** pstr);
 extern "C" BOOL DLL_EXPORT __stdcall DoCallBack_MarshalRefCharArray_Stdcall(StdCallBack caller)
 {
-    char * str = (char*)CoTaskMemAlloc(LEN);
+    char * str = (char*)CoreClrAlloc(LEN);
     for(int i = 0;i<LEN;i++)
     {
         str[i] = 'z';
@@ -83,7 +83,7 @@ extern "C" BOOL DLL_EXPORT __stdcall DoCallBack_MarshalRefCharArray_Stdcall(StdC
     if(str[0]!='a')
     {
 
-        CoTaskMemFree(str);
+        CoreClrFree(str);
         return FALSE;
     }
     return TRUE;

--- a/tests/src/Interop/RefInt/CMakeLists.txt
+++ b/tests/src/Interop/RefInt/CMakeLists.txt
@@ -3,15 +3,8 @@ project (RefIntNative)
 set(SOURCES RefIntNative.cpp )
 
 # add the executable
-add_library (RefIntNative SHARED ${SOURCES})
-
-#get_cmake_property(_variableNames VARIABLES)
-#foreach (_variableName ${_variableNames})
-#    message(STATUS "${_variableName}=${${_variableName}}")
-#endforeach()
- 
-
-#SET(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
+add_library(RefIntNative SHARED ${SOURCES})
+target_link_libraries(RefIntNative ${LINK_LIBRARIES_ADDITIONAL})
 
 # add the install targets
 install (TARGETS RefIntNative DESTINATION bin)

--- a/tests/src/Interop/SimpleStruct/SimpleStructNative.cpp
+++ b/tests/src/Interop/SimpleStruct/SimpleStructNative.cpp
@@ -56,7 +56,7 @@ DLL_EXPORT Sstr_simple* _cdecl CdeclSimpleStruct(Sstr_simple p,BOOL *result)
 		*(result)= FALSE;
 		return NULL;
 	}
-	pSimpleStruct = (Sstr_simple*) TP_CoTaskMemAlloc(sizeof(Sstr_simple) * 1);
+	pSimpleStruct = (Sstr_simple*) CoreClrAlloc(sizeof(Sstr_simple) * 1);
 	pSimpleStruct->a = 101;
 	pSimpleStruct->b = TRUE;
 	pSimpleStruct->c = 10.11;
@@ -73,7 +73,7 @@ DLL_EXPORT ExplStruct* _cdecl CdeclSimpleExplStruct(ExplStruct p,BOOL *result)
 		*(result)= FALSE;
 		return NULL;
 	}
-	pExplStruct = (ExplStruct*) TP_CoTaskMemAlloc(sizeof(ExplStruct) * 1);
+	pExplStruct = (ExplStruct*) CoreClrAlloc(sizeof(ExplStruct) * 1);
 	pExplStruct->a = 2;
 	pExplStruct->udata.d = 3.142;
 	*(result)= TRUE;

--- a/tests/src/Interop/SizeConst/CMakeLists.txt
+++ b/tests/src/Interop/SizeConst/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES SizeConstNative.cpp)
 
 # add the executable
 add_library (SizeConstNative SHARED ${SOURCES})
+target_link_libraries(SizeConstNative ${LINK_LIBRARIES_ADDITIONAL})
 
 # add the install targets
 install (TARGETS SizeConstNative DESTINATION bin)

--- a/tests/src/Interop/StringMarshalling/LPSTR/LPSTRTestNative.cpp
+++ b/tests/src/Interop/StringMarshalling/LPSTR/LPSTRTestNative.cpp
@@ -17,7 +17,7 @@ size_t lenstrNative = 7; //the len of strNative
 extern "C" LPSTR ReturnString()
 {
     size_t strLength = strlen(strReturn);
-    LPSTR ret = (LPSTR)(CoTaskMemAlloc(sizeof(char)* (strLength +1)));
+    LPSTR ret = (LPSTR)(CoreClrAlloc(sizeof(char)* (strLength +1)));
     memset(ret,'\0',strLength+1);
     strncpy_s(ret,strLength + 1, strReturn, strLength);
     return ret;
@@ -26,7 +26,7 @@ extern "C" LPSTR ReturnString()
 extern "C" LPSTR ReturnErrorString()
 {
     size_t strLength = strlen(strerrReturn);
-    LPSTR ret = (LPSTR)(CoTaskMemAlloc(sizeof(char)*(strLength + 1)));
+    LPSTR ret = (LPSTR)(CoreClrAlloc(sizeof(char)*(strLength + 1)));
     memset(ret,'\0',strLength + 1);
     strncpy_s(ret,strLength + 1,strerrReturn,strLength);
     return ret;
@@ -60,7 +60,7 @@ extern "C" DLL_EXPORT LPSTR Marshal_InOut(/*[In,Out]*/LPSTR s)
 
 extern "C" DLL_EXPORT LPSTR Marshal_Out(/*[Out]*/LPSTR s)
 {
-    s = (LPSTR)(CoTaskMemAlloc(sizeof(char)*(lenstrNative+1)));
+    s = (LPSTR)(CoreClrAlloc(sizeof(char)*(lenstrNative+1)));
 
     memset(s,0,lenstrNative+1);
     //In-Place Change
@@ -90,8 +90,8 @@ extern "C" DLL_EXPORT LPSTR MarshalPointer_InOut(/*[in,out]*/LPSTR *s)
     }
 
     //Allocate New
-    CoTaskMemFree(*s);
-    *s = (LPSTR)CoTaskMemAlloc(sizeof(char)*(lenstrNative+1));
+    CoreClrFree(*s);
+    *s = (LPSTR)CoreClrAlloc(sizeof(char)*(lenstrNative+1));
     memset(*s,0,lenstrNative+1);
     strncpy_s(*s,len + 1,strNative,lenstrNative);
 
@@ -101,7 +101,7 @@ extern "C" DLL_EXPORT LPSTR MarshalPointer_InOut(/*[in,out]*/LPSTR *s)
 
 extern "C" DLL_EXPORT LPSTR MarshalPointer_Out(/*[out]*/ LPSTR *s)
 {
-    *s = (LPSTR)CoTaskMemAlloc(sizeof(char)*(lenstrNative+1));
+    *s = (LPSTR)CoreClrAlloc(sizeof(char)*(lenstrNative+1));
     memset(*s,0,lenstrNative+1);
     strncpy_s(*s,lenstrNative+1,strNative,lenstrNative);
 
@@ -138,7 +138,7 @@ extern "C" DLL_EXPORT BOOL __cdecl RPinvoke_DelMarshal_InOut(Test_DelMarshal_InO
         return FALSE;
     }
     
-    CoTaskMemFree((LPVOID)str);
+    CoreClrFree((LPVOID)str);
 
     return TRUE;
 }

--- a/tests/src/Interop/StringMarshalling/LPTSTR/LPTSTRTestNative.cpp
+++ b/tests/src/Interop/StringMarshalling/LPTSTR/LPTSTRTestNative.cpp
@@ -17,7 +17,7 @@ size_t lenstrNative = 7; //the len of strNative
 extern "C" LPWSTR ReturnString()
 {
 	size_t length = wcslen(strReturn)+1;
-    LPWSTR ret = (LPWSTR)CoTaskMemAlloc(sizeof(WCHAR)*length);
+    LPWSTR ret = (LPWSTR)CoreClrAlloc(sizeof(WCHAR)*length);
     memset(ret,'\0', sizeof(WCHAR)*length);
     wcsncpy_s(ret,length,strReturn,length-1);
     return ret;
@@ -26,7 +26,7 @@ extern "C" LPWSTR ReturnString()
 extern "C" LPWSTR ReturnErrString()
 {
 	size_t length = wcslen(strErrReturn)+1;
-    LPWSTR ret = (LPWSTR)CoTaskMemAlloc(sizeof(WCHAR)*length);
+    LPWSTR ret = (LPWSTR)CoreClrAlloc(sizeof(WCHAR)*length);
     memset(ret,'\0', sizeof(WCHAR)*length);
     wcsncpy_s(ret,length,strErrReturn,length-1);
     return ret;
@@ -56,7 +56,7 @@ extern "C" DLL_EXPORT LPWSTR Marshal_InOut(/*[In,Out]*/LPWSTR s)
 
 extern "C" DLL_EXPORT LPWSTR Marshal_Out(/*[Out]*/LPWSTR s)
 {
-    s = (LPWSTR)CoTaskMemAlloc(sizeof(WCHAR)*(lenstrNative+1));;
+    s = (LPWSTR)CoreClrAlloc(sizeof(WCHAR)*(lenstrNative+1));;
     memset(s,0, sizeof(WCHAR)*(lenstrNative + 1));
 
     //In-Place Change
@@ -78,11 +78,11 @@ extern "C" DLL_EXPORT LPWSTR MarshalPointer_InOut(/*[in,out]*/LPWSTR *s)
     }
 
     //Allocate New
-    CoTaskMemFree(*s);
+    CoreClrFree(*s);
 
     //Alloc New
 	size_t length = lenstrNative + 1;
-    *s = (LPWSTR)CoTaskMemAlloc(length * sizeof(WCHAR));
+    *s = (LPWSTR)CoreClrAlloc(length * sizeof(WCHAR));
     memset(*s,'\0',length  * sizeof(WCHAR));
     wcsncpy_s(*s,length,strNative,lenstrNative);
 
@@ -93,7 +93,7 @@ extern "C" DLL_EXPORT LPWSTR MarshalPointer_InOut(/*[in,out]*/LPWSTR *s)
 extern "C" DLL_EXPORT LPWSTR MarshalPointer_Out(/*[out]*/ LPWSTR *s)
 {
 	size_t length = lenstrNative+1;
-    *s = (LPWSTR)CoTaskMemAlloc(sizeof(WCHAR)*length);
+    *s = (LPWSTR)CoreClrAlloc(sizeof(WCHAR)*length);
 	memset(*s, '\0', length  * sizeof(WCHAR));
     wcsncpy_s(*s,length,strNative,lenstrNative);
 

--- a/tests/src/Interop/StringMarshalling/UTF8/UTF8TestNative.cpp
+++ b/tests/src/Interop/StringMarshalling/UTF8/UTF8TestNative.cpp
@@ -31,7 +31,7 @@ char* utf16_to_utf8(const wchar_t *srcstring)
         NULL,
         NULL);
 
-    char *pszUTF8 = (char*)CoTaskMemAlloc(sizeof(char) * (cbUTF8 + 1));
+    char *pszUTF8 = (char*)CoreClrAlloc(sizeof(char) * (cbUTF8 + 1));
     int nc = WideCharToMultiByte(CP_UTF8, // convert to UTF-8
         0,       //default flags 
         srcstring, //source wide string
@@ -69,7 +69,7 @@ wchar_t* utf8_to_utf16(const char *utf8)
         0                   // request size of destination buffer, in wchar_t's
     );
 
-    wszTextUTF16 = (wchar_t*)(CoTaskMemAlloc((cbUTF16 + 1) * sizeof(wchar_t)));
+    wszTextUTF16 = (wchar_t*)(CoreClrAlloc((cbUTF16 + 1) * sizeof(wchar_t)));
     // Do the actual conversion from UTF-8 to UTF-16
     int nc = ::MultiByteToWideChar(
         CP_UTF8,            // convert from UTF-8
@@ -95,7 +95,7 @@ char *get_utf8_string(int index) {
 
 void free_utf8_string(char *str)
 {
-    CoTaskMemFree(str);
+    CoreClrFree(str);
 }
 
 #else //Not WIndows
@@ -128,7 +128,7 @@ LPSTR build_return_string(const char* pReturn)
         return ret;
 
     size_t strLength = strlen(pReturn);
-    ret = (LPSTR)(CoTaskMemAlloc(sizeof(char)* (strLength + 1)));
+    ret = (LPSTR)(CoreClrAlloc(sizeof(char)* (strLength + 1)));
     memset(ret, '\0', strLength + 1);
     strncpy_s(ret, strLength + 1, pReturn, strLength);
     return ret;
@@ -181,7 +181,7 @@ extern "C" DLL_EXPORT char* __cdecl  StringBuilderParameterReturn(int index)
 {
     char *pszTextutf8 = get_utf8_string(index);
     size_t strLength = strlen(pszTextutf8);
-    LPSTR ret = (LPSTR)(CoTaskMemAlloc(sizeof(char)* (strLength + 1)));
+    LPSTR ret = (LPSTR)(CoreClrAlloc(sizeof(char)* (strLength + 1)));
     memcpy(ret, pszTextutf8, strLength);
     ret[strLength] = '\0';
     free_utf8_string(pszTextutf8);
@@ -238,7 +238,7 @@ extern "C" DLL_EXPORT void __cdecl StringParameterRefOut(/*out*/ char **s, int i
 {
     char *pszTextutf8 = get_utf8_string(index);
     size_t strLength = strlen(pszTextutf8);
-     *s = (LPSTR)(CoTaskMemAlloc(sizeof(char)* (strLength + 1)));
+     *s = (LPSTR)(CoreClrAlloc(sizeof(char)* (strLength + 1)));
     memcpy(*s, pszTextutf8, strLength);
     (*s)[strLength] = '\0';
     free_utf8_string(pszTextutf8);
@@ -262,10 +262,10 @@ extern "C" DLL_EXPORT void __cdecl StringParameterRef(/*ref*/ char **s, int inde
 
     if (*s)
     {
-       CoTaskMemFree(*s);
+       CoreClrFree(*s);
     }
     // overwrite the orginal 
-    *s = (LPSTR)(CoTaskMemAlloc(sizeof(char)* (strLength + 1)));
+    *s = (LPSTR)(CoreClrAlloc(sizeof(char)* (strLength + 1)));
     memcpy(*s, pszTextutf8, strLength);
     (*s)[strLength] = '\0';
     free_utf8_string(pszTextutf8);

--- a/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsParamDLL.cpp
+++ b/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsParamDLL.cpp
@@ -167,7 +167,7 @@ extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByValOut3(CharSet
 }
 extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefOut3(CharSetAnsiSequential* str1)
 {
-	CoTaskMemFree((void*)(str1->f1));
+	CoreClrFree((void*)(str1->f1));
 	str1->f1 = CoStrDup("change string");
 	str1->f2 = 'n';
 	return TRUE;

--- a/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsParamDLL.h
+++ b/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsParamDLL.h
@@ -4,7 +4,7 @@
 inline char* CoStrDup(const char* str)
 {
 	size_t size = strlen(str) + 1;
-	char* dup = (char *)CoTaskMemAlloc(size);
+	char* dup = (char *)CoreClrAlloc(size);
     if (dup != nullptr)
     {
         strcpy_s(dup, size, str);
@@ -294,7 +294,7 @@ void ChangeCharSetUnicodeSequential(CharSetUnicodeSequential* p)
 	LPCWSTR strSource = u"change string";
 #endif
 	size_t len = wcslen(strSource);
-	LPCWSTR temp = (LPCWSTR)CoTaskMemAlloc(sizeof(WCHAR)*(len+1));
+	LPCWSTR temp = (LPCWSTR)CoreClrAlloc(sizeof(WCHAR)*(len+1));
 	if(temp != NULL)
 	{
 		wcscpy_s((WCHAR*)temp, (len+1), strSource);
@@ -405,7 +405,7 @@ void ChangeS3(S3* p)
 {
 	p->flag = false;
 
-	/*CoTaskMemFree((void *)p->str);*/
+	/*CoreClrFree((void *)p->str);*/
 	p->str = CoStrDup("change string");
 
     for(int i = 1;i<257;i++)
@@ -505,8 +505,8 @@ bool IsCorrectStringStructSequentialAnsi(StringStructSequentialAnsi* str)
 
 void ChangeStringStructSequentialAnsi(StringStructSequentialAnsi* str)
 {
-	char* newFirst = (char*)CoTaskMemAlloc(sizeof(char)*513);
-	char* newLast = (char*)CoTaskMemAlloc(sizeof(char)*513);
+	char* newFirst = (char*)CoreClrAlloc(sizeof(char)*513);
+	char* newLast = (char*)CoreClrAlloc(sizeof(char)*513);
 	for (int i = 0; i < 512; ++i)
 	{
 		newFirst[i] = 'b';
@@ -558,8 +558,8 @@ bool IsCorrectStringStructSequentialUnicode(StringStructSequentialUnicode* str)
 
 void ChangeStringStructSequentialUnicode(StringStructSequentialUnicode* str)
 {
-	WCHAR* newFirst = (WCHAR*)CoTaskMemAlloc(sizeof(WCHAR)*257);
-	WCHAR* newLast = (WCHAR*)CoTaskMemAlloc(sizeof(WCHAR)*257);
+	WCHAR* newFirst = (WCHAR*)CoreClrAlloc(sizeof(WCHAR)*257);
+	WCHAR* newLast = (WCHAR*)CoreClrAlloc(sizeof(WCHAR)*257);
 	for (int i = 0; i < 256; ++i)
 	{
 		newFirst[i] = L'b';

--- a/tests/src/Interop/common/xplatform.h
+++ b/tests/src/Interop/common/xplatform.h
@@ -74,51 +74,32 @@
 #endif
 #endif
 
-
-
-
-
 // Ensure that both UNICODE and _UNICODE are set.
-#ifdef UNICODE
 #ifndef _UNICODE
-#define _UNICODE
+    #define _UNICODE
 #endif
-#else
-#ifdef _UNICODE
-#define UNICODE
+#ifndef UNICODE
+    #define UNICODE
 #endif
-#endif
-
-
-// redirected functions
-#ifdef UNICODE
-#define _tcslen	wcslen
-#define _tcsncmp wcsncmp
-#else
-#define _tcslen strlen
-#define _tcsncmp strncmp
-#endif // UNICODE
-
-
 
 // redirected types not-windows only
 #ifndef  _WIN32
 
 typedef union tagCY {
-	struct {
-		unsigned long Lo;
-		long          Hi;
-	};
-	long int64;
+    struct {
+        unsigned long Lo;
+        long          Hi;
+    };
+    long int64;
 } CY, CURRENCY;
 
 
 class IUnknown
 {
 public:
-  virtual int  QueryInterface(void* riid,void** ppvObject);
-  virtual unsigned long  AddRef();
-  virtual unsigned long  Release();
+    virtual int  QueryInterface(void* riid,void** ppvObject);
+    virtual unsigned long  AddRef();
+    virtual unsigned long  Release();
 };
 
 #define CoTaskMemAlloc(p) malloc(p)

--- a/tests/src/Interop/common/xplatform.h
+++ b/tests/src/Interop/common/xplatform.h
@@ -28,10 +28,15 @@
 
 //  include 
 #ifdef _WIN32
-	#include <windows.h>
-	#include <tchar.h>
+    #include <windows.h>
+
+    #ifndef snprintf
+    #define snprintf _snprintf
+    #endif //snprintf
+
 #else
-	#include "types.h"
+    #include "types.h"
+
 #endif
 #include <wchar.h>
 
@@ -40,12 +45,9 @@
 #if defined _WIN32
 #define DLL_EXPORT __declspec(dllexport)
 
-#ifndef snprintf
-#define snprintf _snprintf
-#endif //snprintf
-
 #else //!_Win32
-#if __GNUC__ >= 4    
+
+#if __GNUC__ >= 4
 #define DLL_EXPORT __attribute__ ((visibility ("default")))
 #else
 #define DLL_EXPORT
@@ -82,6 +84,24 @@
     #define UNICODE
 #endif
 
+inline void *CoreClrAlloc(size_t cb)
+{
+#ifdef _WIN32
+    return ::CoTaskMemAlloc(cb);
+#else
+    return ::malloc(cb);
+#endif
+}
+
+inline void CoreClrFree(void *p)
+{
+#ifdef _WIN32
+    return ::CoTaskMemFree(p);
+#else
+    return ::free(p);
+#endif
+}
+
 // redirected types not-windows only
 #ifndef  _WIN32
 
@@ -101,9 +121,6 @@ public:
     virtual unsigned long  AddRef();
     virtual unsigned long  Release();
 };
-
-#define CoTaskMemAlloc(p) malloc(p)
-#define CoTaskMemFree(p) free(p)
 
 // function implementation
 size_t strncpy_s(char* strDest, size_t numberOfElements, const char *strSource, size_t count)


### PR DESCRIPTION
This work is attempting to make a more stable platform for porting legacy interop tests to coreclr.

cc @luqunl 