### PR TITLE
Enable ibc official build

### DIFF
--- a/buildpipeline/DotNet-CoreClr-Trusted-Windows-x86.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Windows-x86.json
@@ -122,7 +122,7 @@
       },
       "inputs": {
         "filename": "build.cmd",
-        "arguments": "$(Architecture) $(PB_BuildType) skiptests skipbuildpackages $(PB_EnforcePGO) -OfficialBuildId=$(OfficialBuildId) -skiprestore -Priority=$(Priority) -- /p:SignType=$(PB_SignType)",
+        "arguments": "$(Architecture) $(PB_BuildType) skiptests skipbuildpackages $(PB_IBCOptimize) $(PB_EnforcePGO) -OfficialBuildId=$(OfficialBuildId) -skiprestore -Priority=$(Priority) -- /p:SignType=$(PB_SignType)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -409,6 +409,10 @@
       "isSecret": true
     },
     "PB_EnforcePGO": {
+      "value": "",
+      "allowOverride": true
+    },
+    "PB_IBCOptimize": {
       "value": "",
       "allowOverride": true
     }

--- a/buildpipeline/DotNet-CoreClr-Trusted-Windows.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Windows.json
@@ -122,7 +122,7 @@
       },
       "inputs": {
         "filename": "build.cmd",
-        "arguments": "$(Architecture) $(PB_BuildType) skiptests skipbuildpackages $(PB_EnforcePGO) -OfficialBuildId=$(OfficialBuildId) -Priority=$(Priority) -skiprestore -- /p:SignType=$(PB_SignType) /flp:\"v=diag\"",
+        "arguments": "$(Architecture) $(PB_BuildType) skiptests skipbuildpackages $(PB_IBCOptimize) $(PB_EnforcePGO) -OfficialBuildId=$(OfficialBuildId) -Priority=$(Priority) -skiprestore -- /p:SignType=$(PB_SignType) /flp:\"v=diag\"",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -416,6 +416,10 @@
       "value": "DotNetCore"
     },
     "PB_EnforcePGO": {
+      "value": "",
+      "allowOverride": true
+    },
+    "PB_IBCOptimize": {
       "value": "",
       "allowOverride": true
     }

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -80,7 +80,8 @@
             "Type": "build/product/",
             "SubType" : "PortableBuild",
             "Architecture": "x64",
-            "PB_BuildType": null
+            "PB_BuildType": null,
+            "PB_IBCOptimize": "-ibcoptimize"
           }
         },
         {
@@ -119,7 +120,8 @@
             "Type": "build/product/",
             "SubType" : "PortableBuild",
             "Architecture": "x86",
-            "PB_BuildType": null
+            "PB_BuildType": null,
+            "PB_IBCOptimize": "-ibcoptimize"
           }
         }
       ]

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -80,14 +80,14 @@
             "Type": "build/product/",
             "SubType" : "PortableBuild",
             "Architecture": "x64",
-            "PB_BuildType": null,
-            "PB_IBCOptimize": "-ibcoptimize"
+            "PB_BuildType": null
           }
         },
         {
           "Name": "DotNet-CoreClr-Trusted-Windows",
           "Parameters": {
-            "Architecture": "arm64"
+            "Architecture": "arm64",
+            "PB_IBCOptimize": ""
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
@@ -100,7 +100,8 @@
         {
           "Name": "DotNet-CoreClr-Trusted-Windows",
           "Parameters": {
-            "Architecture": "arm"
+            "Architecture": "arm",
+            "PB_IBCOptimize": ""
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
@@ -120,8 +121,7 @@
             "Type": "build/product/",
             "SubType" : "PortableBuild",
             "Architecture": "x86",
-            "PB_BuildType": null,
-            "PB_IBCOptimize": "-ibcoptimize"
+            "PB_BuildType": null
           }
         }
       ]
@@ -177,7 +177,8 @@
       "BuildParameters": {
         "PB_BuildType": "Release",
         "PublishFlat": "false",
-        "PB_EnforcePGO": "enforcepgo"
+        "PB_EnforcePGO": "enforcepgo",
+        "PB_IBCOptimize": "-ibcoptimize"
       },
       "ReportingParameters": {
         "PB_BuildType": "Release"
@@ -193,8 +194,7 @@
       },
       "BuildParameters": {
         "PB_BuildType": "Debug",
-        "PublishFlat": "true",
-        "PB_IBCOptimize": ""
+        "PublishFlat": "true"
       },
       "ReportingParameters": {
         "PB_BuildType": "Debug"
@@ -210,8 +210,7 @@
       },
       "BuildParameters": {
         "PB_BuildType": "Checked",
-        "PublishFlat": "true",
-        "PB_IBCOptimize": ""
+        "PublishFlat": "true"
       },
       "ReportingParameters": {
         "PB_BuildType": "Checked"

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -80,7 +80,8 @@
             "Type": "build/product/",
             "SubType" : "PortableBuild",
             "Architecture": "x64",
-            "PB_BuildType": null
+            "PB_BuildType": null,
+            "PB_IBCOptimize": "-ibcoptimize"
           }
         },
         {
@@ -93,8 +94,7 @@
             "Type": "build/product/",
             "SubType" : "PortableBuild",
             "Architecture": "arm64",
-            "PB_BuildType": null,
-            "PB_IBCOptimize": ""
+            "PB_BuildType": null
           }
         },
         {
@@ -107,8 +107,7 @@
             "Type": "build/product/",
             "SubType" : "PortableBuild",
             "Architecture": "arm",
-            "PB_BuildType": null,
-            "PB_IBCOptimize": ""
+            "PB_BuildType": null
           }
         },
         {
@@ -121,7 +120,8 @@
             "Type": "build/product/",
             "SubType" : "PortableBuild",
             "Architecture": "x86",
-            "PB_BuildType": null
+            "PB_BuildType": null,
+            "PB_IBCOptimize": "-ibcoptimize"
           }
         }
       ]
@@ -177,8 +177,7 @@
       "BuildParameters": {
         "PB_BuildType": "Release",
         "PublishFlat": "false",
-        "PB_EnforcePGO": "enforcepgo",
-        "PB_IBCOptimize": "-ibcoptimize"
+        "PB_EnforcePGO": "enforcepgo"
       },
       "ReportingParameters": {
         "PB_BuildType": "Release"
@@ -194,7 +193,8 @@
       },
       "BuildParameters": {
         "PB_BuildType": "Debug",
-        "PublishFlat": "true"
+        "PublishFlat": "true",
+        "PB_IBCOptimize": ""
       },
       "ReportingParameters": {
         "PB_BuildType": "Debug"
@@ -210,7 +210,8 @@
       },
       "BuildParameters": {
         "PB_BuildType": "Checked",
-        "PublishFlat": "true"
+        "PublishFlat": "true",
+        "PB_IBCOptimize": ""
       },
       "ReportingParameters": {
         "PB_BuildType": "Checked"

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -80,8 +80,7 @@
             "Type": "build/product/",
             "SubType" : "PortableBuild",
             "Architecture": "x64",
-            "PB_BuildType": null,
-            "PB_IBCOptimize": "-ibcoptimize"
+            "PB_BuildType": null
           }
         },
         {
@@ -94,7 +93,8 @@
             "Type": "build/product/",
             "SubType" : "PortableBuild",
             "Architecture": "arm64",
-            "PB_BuildType": null
+            "PB_BuildType": null,
+            "PB_IBCOptimize": ""
           }
         },
         {
@@ -107,7 +107,8 @@
             "Type": "build/product/",
             "SubType" : "PortableBuild",
             "Architecture": "arm",
-            "PB_BuildType": null
+            "PB_BuildType": null,
+            "PB_IBCOptimize": ""
           }
         },
         {
@@ -120,8 +121,7 @@
             "Type": "build/product/",
             "SubType" : "PortableBuild",
             "Architecture": "x86",
-            "PB_BuildType": null,
-            "PB_IBCOptimize": "-ibcoptimize"
+            "PB_BuildType": null
           }
         }
       ]
@@ -177,7 +177,8 @@
       "BuildParameters": {
         "PB_BuildType": "Release",
         "PublishFlat": "false",
-        "PB_EnforcePGO": "enforcepgo"
+        "PB_EnforcePGO": "enforcepgo",
+        "PB_IBCOptimize": "-ibcoptimize"
       },
       "ReportingParameters": {
         "PB_BuildType": "Release"


### PR DESCRIPTION
This change fixes the issues with passing the -ibcoptimize flag in the official build so that it is only passed on configurations where IBC data is collected (Release x64 and x86).