### PR TITLE
Deal with cross-bitness JIT compilation warnings

### DIFF
--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -420,7 +420,7 @@ protected:
                      CORINFO_METHOD_HANDLE methHnd,
                      INDEBUG_LDISASM_COMMA(CORINFO_SIG_INFO* sigInfo)
                      void*                 addr
-                     X86_ARG(ssize_t argSize),
+                     X86_ARG(int  argSize),
                      emitAttr              retSize
                      MULTIREG_HAS_SECOND_GC_RET_ONLY_ARG(emitAttr secondRetSize),
                      IL_OFFSETX            ilOffset,
@@ -434,7 +434,7 @@ protected:
                      CORINFO_METHOD_HANDLE methHnd,
                      INDEBUG_LDISASM_COMMA(CORINFO_SIG_INFO* sigInfo)
                      GenTreeIndir*         indir
-                     X86_ARG(ssize_t argSize),
+                     X86_ARG(int  argSize),
                      emitAttr              retSize
                      MULTIREG_HAS_SECOND_GC_RET_ONLY_ARG(emitAttr secondRetSize),
                      IL_OFFSETX            ilOffset);

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -902,7 +902,7 @@ void CodeGen::genCodeForShiftLong(GenTree* tree)
 
     assert(shiftBy->isContainedIntOrIImmed());
 
-    unsigned int count = shiftBy->AsIntConCommon()->IconValue();
+    unsigned count = (unsigned)shiftBy->AsIntConCommon()->IconValue();
 
     regNumber regResult = (oper == GT_LSH_HI) ? regHi : regLo;
 

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -360,14 +360,14 @@ void CodeGen::genLclHeap(GenTree* tree)
     if (size->IsCnsIntOrI())
     {
         // 'amount' is the total number of bytes to localloc to properly STACK_ALIGN
-        size_t amount = size->gtIntCon.gtIconVal;
-        amount        = AlignUp(amount, STACK_ALIGN);
+        target_size_t amount = (target_size_t)size->gtIntCon.gtIconVal;
+        amount               = AlignUp(amount, STACK_ALIGN);
 
         // For small allocations we will generate up to four push instructions (either 2 or 4, exactly,
         // since STACK_ALIGN is 8, and REGSIZE_BYTES is 4).
         static_assert_no_msg(STACK_ALIGN == (REGSIZE_BYTES * 2));
         assert(amount % REGSIZE_BYTES == 0);
-        size_t pushCount = amount / REGSIZE_BYTES;
+        target_size_t pushCount = amount / REGSIZE_BYTES;
         if (pushCount <= 4)
         {
             instGen_Set_Reg_To_Zero(EA_PTRSIZE, regCnt);

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -1573,7 +1573,7 @@ void CodeGen::genCodeForShift(GenTree* tree)
     else
     {
         unsigned immWidth   = emitter::getBitWidth(size); // For ARM64, immWidth will be set to 32 or 64
-        ssize_t  shiftByImm = shiftBy->gtIntCon.gtIconVal & (immWidth - 1);
+        unsigned shiftByImm = (unsigned)shiftBy->gtIntCon.gtIconVal & (immWidth - 1);
 
         getEmitter()->emitIns_R_R_I(ins, size, tree->gtRegNum, operand->gtRegNum, shiftByImm);
     }

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -6340,7 +6340,7 @@ void CodeGen::genZeroInitFrame(int untrLclHi, int untrLclLo, regNumber initReg, 
 #if defined(_TARGET_ARM_)
         rZero1 = genGetZeroReg(initReg, pInitRegZeroed);
         instGen_Set_Reg_To_Zero(EA_PTRSIZE, rZero2);
-        ssize_t stmImm = (ssize_t)(genRegMask(rZero1) | genRegMask(rZero2));
+        target_ssize_t stmImm = (target_ssize_t)(genRegMask(rZero1) | genRegMask(rZero2));
 #endif // _TARGET_ARM_
 
         if (!useLoop)

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -5258,7 +5258,7 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
         return;
     }
 
-    const size_t pageSize = compiler->eeGetPageSize();
+    const target_size_t pageSize = compiler->eeGetPageSize();
 
 #ifdef _TARGET_ARM_
     assert(!compiler->info.compPublishStubParam || (REG_SECRET_STUB_PARAM != initReg));

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -1844,7 +1844,7 @@ void CodeGen::genEmitCall(int                   callType,
                           CORINFO_METHOD_HANDLE methHnd,
                           INDEBUG_LDISASM_COMMA(CORINFO_SIG_INFO* sigInfo)
                           void*                 addr
-                          X86_ARG(ssize_t argSize),
+                          X86_ARG(int argSize),
                           emitAttr              retSize
                           MULTIREG_HAS_SECOND_GC_RET_ONLY_ARG(emitAttr secondRetSize),
                           IL_OFFSETX            ilOffset,
@@ -1853,7 +1853,7 @@ void CodeGen::genEmitCall(int                   callType,
                           bool                  isNoGC)
 {
 #if !defined(_TARGET_X86_)
-    ssize_t argSize = 0;
+    int argSize = 0;
 #endif // !defined(_TARGET_X86_)
     getEmitter()->emitIns_Call(emitter::EmitCallType(callType),
                                methHnd,
@@ -1879,13 +1879,13 @@ void CodeGen::genEmitCall(int                   callType,
                           CORINFO_METHOD_HANDLE methHnd,
                           INDEBUG_LDISASM_COMMA(CORINFO_SIG_INFO* sigInfo)
                           GenTreeIndir*         indir
-                          X86_ARG(ssize_t argSize),
+                          X86_ARG(int argSize),
                           emitAttr              retSize
                           MULTIREG_HAS_SECOND_GC_RET_ONLY_ARG(emitAttr secondRetSize),
                           IL_OFFSETX            ilOffset)
 {
 #if !defined(_TARGET_X86_)
-    ssize_t argSize = 0;
+    int argSize = 0;
 #endif // !defined(_TARGET_X86_)
     genConsumeAddress(indir->Addr());
 

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -1382,7 +1382,7 @@ void CodeGen::genConsumePutStructArgStk(GenTreePutArgStk* putArgNode,
     assert((src->gtOper == GT_OBJ) || ((src->gtOper == GT_IND && varTypeIsSIMD(src))));
     GenTree* srcAddr = src->gtGetOp1();
 
-    size_t size = putArgNode->getArgSize();
+    unsigned int size = putArgNode->getArgSize();
 
     assert(dstReg != REG_NA);
     assert(srcReg != REG_NA);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -6712,13 +6712,13 @@ public:
     GenTree* eeGetPInvokeCookie(CORINFO_SIG_INFO* szMetaSig);
 
     // Returns the page size for the target machine as reported by the EE.
-    inline size_t eeGetPageSize()
+    inline target_size_t eeGetPageSize()
     {
-        return eeGetEEInfo()->osPageSize;
+        return (target_size_t)eeGetEEInfo()->osPageSize;
     }
 
     // Returns the frame size at which we will generate a loop to probe the stack.
-    inline size_t getVeryLargeFrameSize()
+    inline target_size_t getVeryLargeFrameSize()
     {
 #ifdef _TARGET_ARM_
         // The looping probe code is 40 bytes, whereas the straight-line probing for

--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -1431,7 +1431,7 @@ GenTree* DecomposeLongs::DecomposeRotate(LIR::Use& use)
         oper = GT_RSH_LO;
     }
 
-    unsigned int count = rotateByOp->gtIntCon.gtIconVal;
+    unsigned count = (unsigned)rotateByOp->gtIntCon.gtIconVal;
     Range().Remove(rotateByOp);
 
     // Make sure the rotate amount is between 0 and 63.

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -6498,7 +6498,7 @@ static bool insAlwaysSetFlags(instruction ins)
 void emitter::emitDispInst(instruction ins, insFlags flags)
 {
     const char* insstr = codeGen->genInsName(ins);
-    int         len    = strlen(insstr);
+    size_t      len    = strlen(insstr);
 
     /* Display the instruction name */
 

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -6268,10 +6268,10 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
                 addr = (BYTE*)((size_t)addr & ~1); // Clear the lowest bit from target address
 
                 /* Calculate PC relative displacement */
-                int  disp = addr - (dst + 4);
-                bool S    = (disp < 0);
-                bool I1   = ((disp & 0x00800000) == 0);
-                bool I2   = ((disp & 0x00400000) == 0);
+                ptrdiff_t disp = addr - (dst + 4);
+                bool      S    = (disp < 0);
+                bool      I1   = ((disp & 0x00800000) == 0);
+                bool      I2   = ((disp & 0x00400000) == 0);
 
                 if (S)
                     code |= (1 << 26); // S bit

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -4402,7 +4402,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
                            CORINFO_METHOD_HANDLE methHnd,                   // used for pretty printing
                            INDEBUG_LDISASM_COMMA(CORINFO_SIG_INFO* sigInfo) // used to report call sites to the EE
                            void*            addr,
-                           ssize_t          argSize,
+                           int              argSize,
                            emitAttr         retSize,
                            VARSET_VALARG_TP ptrVars,
                            regMaskTP        gcrefRegs,
@@ -4487,8 +4487,8 @@ void emitter::emitIns_Call(EmitCallType          callType,
     }
 #endif
 
-    assert(argSize % (int)REGSIZE_BYTES == 0);
-    argCnt = argSize / (int)REGSIZE_BYTES;
+    assert(argSize % REGSIZE_BYTES == 0);
+    argCnt = argSize / REGSIZE_BYTES;
 
     /* Managed RetVal: emit sequence point for the call */
     if (emitComp->opts.compDbgInfo && ilOffset != BAD_IL_OFFSET)

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -7398,7 +7398,7 @@ void emitter::emitDispInsHelp(
             {
                 if (id->idIsDspReloc())
                     printf("reloc ");
-                printf("%p", addr);
+                printf("%p", dspPtr(addr));
             }
             else
             {

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -6882,7 +6882,6 @@ void emitter::emitDispInsHelp(
     switch (fmt)
     {
         int         imm;
-        int         offs;
         const char* methodName;
 
         case IF_T1_A: // None
@@ -7382,29 +7381,31 @@ void emitter::emitDispInsHelp(
         break;
 
         case IF_T2_J3:
+        {
+            BYTE* addr;
             if (id->idIsCallAddr())
             {
-                offs       = (ssize_t)id->idAddr()->iiaAddr;
+                addr       = id->idAddr()->iiaAddr;
                 methodName = "";
             }
             else
             {
-                offs       = 0;
+                addr       = nullptr;
                 methodName = emitComp->eeGetMethodFullName((CORINFO_METHOD_HANDLE)id->idDebugOnlyInfo()->idMemCookie);
             }
 
-            if (offs)
+            if (addr)
             {
                 if (id->idIsDspReloc())
                     printf("reloc ");
-                printf("%08X", offs);
+                printf("%p", addr);
             }
             else
             {
                 printf("%s", methodName);
             }
-
-            break;
+        }
+        break;
 
         default:
             printf("unexpected format %s", emitIfName(id->idInsFmt()));

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -4411,7 +4411,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
                            regNumber        ireg /* = REG_NA */,
                            regNumber        xreg /* = REG_NA */,
                            unsigned         xmul /* = 0     */,
-                           int              disp /* = 0     */,
+                           ssize_t          disp /* = 0     */,
                            bool             isJump /* = false */,
                            bool             isNoGC /* = false */,
                            bool             isProfLeaveCB /* = false */)

--- a/src/jit/emitarm.h
+++ b/src/jit/emitarm.h
@@ -329,7 +329,7 @@ void emitIns_Call(EmitCallType          callType,
                   CORINFO_METHOD_HANDLE methHnd,                   // used for pretty printing
                   INDEBUG_LDISASM_COMMA(CORINFO_SIG_INFO* sigInfo) // used to report call sites to the EE
                   void*            addr,
-                  ssize_t          argSize,
+                  int              argSize,
                   emitAttr         retSize,
                   VARSET_VALARG_TP ptrVars,
                   regMaskTP        gcrefRegs,

--- a/src/jit/emitarm.h
+++ b/src/jit/emitarm.h
@@ -338,7 +338,7 @@ void emitIns_Call(EmitCallType          callType,
                   regNumber        ireg          = REG_NA,
                   regNumber        xreg          = REG_NA,
                   unsigned         xmul          = 0,
-                  int              disp          = 0,
+                  ssize_t          disp          = 0,
                   bool             isJump        = false,
                   bool             isNoGC        = false,
                   bool             isProfLeaveCB = false);

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -1899,17 +1899,17 @@ AGAIN:
                 break;
             case GT_CNS_LNG:
                 bits = (UINT64)tree->gtLngCon.gtLconVal;
-#ifdef _TARGET_64BIT_
+#ifdef _HOST_64BIT_
                 add = bits;
-#else // 32-bit target
+#else // 32-bit host
                 add = genTreeHashAdd(uhi32(bits), ulo32(bits));
 #endif
                 break;
             case GT_CNS_DBL:
                 bits = *(UINT64*)(&tree->gtDblCon.gtDconVal);
-#ifdef _TARGET_64BIT_
+#ifdef _HOST_64BIT_
                 add = bits;
-#else // 32-bit target
+#else // 32-bit host
                 add = genTreeHashAdd(uhi32(bits), ulo32(bits));
 #endif
                 break;
@@ -1929,9 +1929,9 @@ AGAIN:
         // clang-format off
         // narrow 'add' into a 32-bit 'val'
         unsigned val;
-#ifdef _TARGET_64BIT_
+#ifdef _HOST_64BIT_
         val = genTreeHashAdd(uhi32(add), ulo32(add));
-#else // 32-bit target
+#else // 32-bit host
         val = add;
 #endif
         // clang-format on

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -3153,7 +3153,8 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                 //
                 GenTreeIntConCommon* con = tree->AsIntConCommon();
 
-                if (con->ImmedValNeedsReloc(this) || !codeGen->validImmForInstr(INS_mov, tree->gtIntCon.gtIconVal))
+                if (con->ImmedValNeedsReloc(this) ||
+                    !codeGen->validImmForInstr(INS_mov, (target_ssize_t)tree->gtIntCon.gtIconVal))
                 {
                     // Uses movw/movt
                     costSz = 7;

--- a/src/jit/lowerarmarch.cpp
+++ b/src/jit/lowerarmarch.cpp
@@ -59,7 +59,7 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode)
         // Make sure we have an actual immediate
         if (!childNode->IsCnsIntOrI())
             return false;
-        if (childNode->IsIconHandle() && comp->opts.compReloc)
+        if (childNode->gtIntCon.ImmedValNeedsReloc(comp))
             return false;
 
         ssize_t  immVal = childNode->gtIntCon.gtIconVal;

--- a/src/jit/lowerarmarch.cpp
+++ b/src/jit/lowerarmarch.cpp
@@ -62,9 +62,10 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode)
         if (childNode->gtIntCon.ImmedValNeedsReloc(comp))
             return false;
 
-        ssize_t  immVal = childNode->gtIntCon.gtIconVal;
-        emitAttr attr   = emitActualTypeSize(childNode->TypeGet());
-        emitAttr size   = EA_SIZE(attr);
+        // TODO-CrossBitness: we wouldn't need the cast below if GenTreeIntCon::gtIconVal had target_ssize_t type.
+        target_ssize_t immVal = (target_ssize_t)childNode->gtIntCon.gtIconVal;
+        emitAttr       attr   = emitActualTypeSize(childNode->TypeGet());
+        emitAttr       size   = EA_SIZE(attr);
 #ifdef _TARGET_ARM_
         insFlags flags = parentNode->gtSetFlags() ? INS_FLAGS_SET : INS_FLAGS_DONT_CARE;
 #endif

--- a/src/jit/unwindarm.cpp
+++ b/src/jit/unwindarm.cpp
@@ -2172,7 +2172,7 @@ DWORD DumpRegSetRange(const char* const rtype, DWORD start, DWORD end, DWORD lr)
 {
     assert(start <= end);
     DWORD printed  = 0;
-    DWORD rtypeLen = strlen(rtype);
+    DWORD rtypeLen = (DWORD)strlen(rtype);
 
     printf("{");
     ++printed;


### PR DESCRIPTION
Deal with the compilation warnings during cross-bitness JIT compilation by doing casts where it's safe, changing types of variables to the appropriate ones.

There is only "semantical" change here - "make `Compiler::gtHashValue` depending on host-bitness".