### PR TITLE
[ARM32] Split IF_T2_N3 into relocatable and non-relocatable cases

### DIFF
--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -5391,11 +5391,7 @@ BYTE* emitter::emitOutputLJ(insGroup* ig, BYTE* dst, instrDesc* i)
             }
             ((instrDescJmp*)id)->idjTemp.idjAddr = (dstOffs > srcOffs) ? dst : NULL;
 
-            assert((imm & 0x0000ffff) == imm);
-            code |= (imm & 0x00ff);
-            code |= ((imm & 0x0700) << 4);
-            code |= ((imm & 0x0800) << 15);
-            code |= ((imm & 0xf000) << 4);
+            code |= insEncodeImmT2_Mov(imm);
             dst += emitOutput_Thumb2Instr(dst, code);
 
             if (id->idIsCnsReloc() || id->idIsDspReloc())

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -5382,26 +5382,30 @@ BYTE* emitter::emitOutputLJ(insGroup* ig, BYTE* dst, instrDesc* i)
         }
         else if (fmt == IF_T2_N1)
         {
+            assert(ins == INS_movt || ins == INS_movw);
             code |= insEncodeRegT2_D(id->idReg1());
-            unsigned imm = distVal;
-            if (ins == INS_movw)
+            ((instrDescJmp*)id)->idjTemp.idjAddr = (dstOffs > srcOffs) ? dst : NULL;
+
+            if (id->idIsReloc())
             {
-                imm &= 0xffff;
+                dst += emitOutput_Thumb2Instr(dst, code);
+                if ((ins == INS_movt) && emitComp->info.compMatchedVM)
+                    emitHandlePCRelativeMov32((void*)(dst - 8), (void*)distVal);
             }
             else
             {
-                imm = (imm >> 16) & 0xffff;
-            }
-            ((instrDescJmp*)id)->idjTemp.idjAddr = (dstOffs > srcOffs) ? dst : NULL;
-
-            code |= insEncodeImmT2_Mov(imm);
-            dst += emitOutput_Thumb2Instr(dst, code);
-
-            if (id->idIsCnsReloc() || id->idIsDspReloc())
-            {
-                assert(ins == INS_movt || ins == INS_movw);
-                if ((ins == INS_movt) && emitComp->info.compMatchedVM)
-                    emitHandlePCRelativeMov32((void*)(dst - 8), (void*)distVal);
+                assert(sizeof(size_t) == sizeof(target_size_t));
+                target_size_t imm = (target_size_t)distVal;
+                if (ins == INS_movw)
+                {
+                    imm &= 0xffff;
+                }
+                else
+                {
+                    imm = (imm >> 16) & 0xffff;
+                }
+                code |= insEncodeImmT2_Mov(imm);
+                dst += emitOutput_Thumb2Instr(dst, code);
             }
         }
         else

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -4290,9 +4290,12 @@ void emitter::emitIns_R_L(instruction ins, emitAttr attr, BasicBlock* dst, regNu
     id->idjNext      = emitCurIGjmpList;
     emitCurIGjmpList = id;
 
-    // Set the relocation flags - these give hint to zap to perform
-    // relocation of the specified 32bit address.
-    id->idSetRelocFlags(attr);
+    if (emitComp->opts.compReloc)
+    {
+        // Set the relocation flags - these give hint to zap to perform
+        // relocation of the specified 32bit address.
+        id->idSetRelocFlags(attr);
+    }
 
 #if EMITTER_STATS
     emitTotalIGjmps++;


### PR DESCRIPTION
This PR splits `emitOutputLJ` logic for IF_T2_N1 fmt (i.e. movw/movt reg, displacement) into relocatable and non-relocatable cases. 

Also found that `emitter::emitIns_R_L` was always setting the relocation flags for instruction descriptor - without checking opts.compReloc first. Fixing this as well.

The similar work was done in https://github.com/dotnet/coreclr/pull/19013 