### PR TITLE
JIT: fix handling of newarr size

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -14280,6 +14280,23 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 op2 = impPopStack().val;
                 assertImp(genActualTypeIsIntOrI(op2->gtType));
 
+#ifdef _TARGET_64BIT_
+                // The array helper takes a native int for array length.
+                // So if we have an int, explicitly extend it to be a native int.
+                if (genActualType(op2->TypeGet()) != TYP_I_IMPL)
+                {
+                    if (op2->IsIntegralConst())
+                    {
+                        op2->gtType = TYP_I_IMPL;
+                    }
+                    else
+                    {
+                        bool isUnsigned = false;
+                        op2             = gtNewCastNode(TYP_I_IMPL, op2, isUnsigned, TYP_I_IMPL);
+                    }
+                }
+#endif // _TARGET_64BIT_
+
 #ifdef FEATURE_READYTORUN_COMPILER
                 if (opts.IsReadyToRun())
                 {


### PR DESCRIPTION
`newarr` accepts either an int or native int for array size, and the
newarr helper the jit invokes takes a native int.

If the value on the stack is an int and the jit is running on a platform
where native int is larger than int, the jit must explicitly widen the
int to native int.

Found this while running some code through the interpreter -- the path
the interpreter uses to invoke jitted code doesn't guarantee that int args
are 64 bit clean.