### PR TITLE
Fix syntax error in build-test.sh

### DIFF
--- a/build-test.sh
+++ b/build-test.sh
@@ -356,7 +356,7 @@ build_MSBuild_projects()
         export __TestGroupToBuild=1
         __AppendToLog=false
 
-        if [ -n __priority1 ]; then
+        if [ -n "$__priority1" ]; then
             export __BuildLoopCount=16
             export __TestGroupToBuild=2
         fi


### PR DESCRIPTION
There was a syntax error that resulted in the check for priority 1 to always evaluate to true.

CC @sdmaclea 
