### PR TITLE
Mask shift value for shift [mem], const

### DIFF
--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -3585,6 +3585,8 @@ void emitter::emitInsRMW(instruction ins, emitAttr attr, GenTreeStoreInd* storeI
             case INS_sar_N:
                 iconVal &= 0x7F;
                 break;
+            default:
+                break;
         }
 
         id = emitNewInstrAmdCns(attr, offset, iconVal);

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -3573,10 +3573,24 @@ void emitter::emitInsRMW(instruction ins, emitAttr attr, GenTreeStoreInd* storeI
     if (src->isContainedIntOrIImmed())
     {
         GenTreeIntConCommon* intConst = src->AsIntConCommon();
-        id                            = emitNewInstrAmdCns(attr, offset, (int)intConst->IconValue());
+        int                  iconVal  = (int)intConst->IconValue();
+        switch (ins)
+        {
+            case INS_rcl_N:
+            case INS_rcr_N:
+            case INS_rol_N:
+            case INS_ror_N:
+            case INS_shl_N:
+            case INS_shr_N:
+            case INS_sar_N:
+                iconVal &= 0x7F;
+                break;
+        }
+
+        id = emitNewInstrAmdCns(attr, offset, iconVal);
         emitHandleMemOp(storeInd, id, IF_ARW_CNS, ins);
         id->idIns(ins);
-        sz = emitInsSizeAM(id, insCodeMI(ins), (int)intConst->IconValue());
+        sz = emitInsSizeAM(id, insCodeMI(ins), iconVal);
     }
     else
     {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -13108,7 +13108,7 @@ DONE_MORPHING_CHILDREN:
                         // The type of the new GT_NEG node cannot just be op1->TypeGet().
                         // Otherwise we may sign-extend incorrectly in cases where the GT_NEG
                         // node ends up feeding directly a cast, for example in
-                        // GT_CAST<ubyte>(GT_MUL(-1, s_1.ubyte)
+                        // GT_CAST<ubyte>(GT_MUL(-1, s_1.ubyte))
                         tree->gtOp.gtOp1 = op1 = gtNewOperNode(GT_NEG, genActualType(op1->TypeGet()), op1);
                         fgMorphTreeDone(op1);
                     }

--- a/tests/src/JIT/Regression/JitBlue/GitHub_19601/Github_19601.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_19601/Github_19601.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+class GitHub_19601
+{
+    static ushort s_2;
+    static short[] s_5 = new short[]{1};
+    static ulong s_8;
+    public static int Main()
+    {
+        var vr2 = s_5[0];
+        M9();
+        return 100;
+    }
+
+	// The JIT was emitting a 4-byte immediate for the shift in M9, but this form is invalid.
+	// This lead to NullReferenceException or AccessViolationException when the last part of
+	// the immediate was treated as instructions.
+    static void M9()
+    {
+        s_8 <<= (0 & s_2) + 186;
+    }
+}
+

--- a/tests/src/JIT/Regression/JitBlue/GitHub_19601/Github_19601.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_19601/Github_19601.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{ADEEA3D1-B67B-456E-8F2B-6DCCACC2D34C}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>False</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
The shift value needs to be masked as otherwise the emitter may end up
believing it needs 4 bytes for constants >= 128. Since an encoding with
4-byte immediate does not exist for shifts, the last part of the
immediate would be interpreted as code and executed.

This was only a problem for constants between 128 and 256 as other
constants are not currently contained.

Fixes #19601 