### PR TITLE
Fix superpmi-shim-counter

### DIFF
--- a/src/ToolBox/superpmi/superpmi-shim-counter/icorjitcompiler.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-counter/icorjitcompiler.cpp
@@ -27,7 +27,6 @@ CorJitResult __stdcall interceptor_ICJC::compileMethod(ICorJitInfo*             
     CorJitResult temp =
         original_ICorJitCompiler->compileMethod(&our_ICorJitInfo, info, flags, nativeEntry, nativeSizeOfCode);
 
-    mcs->SaveTextFile();
     return temp;
 }
 

--- a/src/ToolBox/superpmi/superpmi-shim-counter/methodcallsummarizer.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-counter/methodcallsummarizer.cpp
@@ -5,6 +5,7 @@
 
 #include "standardpch.h"
 #include "methodcallsummarizer.h"
+#include "logging.h"
 
 MethodCallSummarizer::MethodCallSummarizer(WCHAR* logPath)
 {
@@ -132,6 +133,12 @@ void MethodCallSummarizer::SaveTextFile()
     DWORD  bytesWritten = 0;
     HANDLE hFile        = CreateFileW(dataFileName, GENERIC_READ | GENERIC_WRITE, 0, NULL, CREATE_ALWAYS,
                                FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL);
+
+    if (hFile == INVALID_HANDLE_VALUE)
+    {
+        LogError("Couldn't open file '%ws': error %d", dataFileName, ::GetLastError());
+        return;
+    }
 
     DWORD len = (DWORD)sprintf_s(buff, 512, "FunctionName,Count\n");
     WriteFile(hFile, buff, len, &bytesWritten, NULL);

--- a/src/ToolBox/superpmi/superpmi-shim-counter/superpmi-shim-counter.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-counter/superpmi-shim-counter.cpp
@@ -96,6 +96,11 @@ extern "C" BOOL
             delete[] g_logFilePath;
             g_logFilePath = nullptr;
 
+            if (g_globalContext != nullptr)
+            {
+                g_globalContext->SaveTextFile();
+            }
+
             break;
 
         case DLL_THREAD_ATTACH:

--- a/src/ToolBox/superpmi/superpmi-shim-counter/superpmi-shim-counter.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-counter/superpmi-shim-counter.cpp
@@ -17,12 +17,13 @@
 #include "spmiutil.h"
 #include "jithost.h"
 
-HMODULE g_hRealJit           = 0;       // We leak this currently (could do the proper shutdown in process_detach)
-WCHAR*  g_realJitPath        = nullptr; // We leak this (could do the proper shutdown in process_detach)
-WCHAR*  g_logPath            = nullptr; // Again, we leak this one too...
-char*   g_logFilePath        = nullptr; // We *don't* leak this, hooray!
-WCHAR*  g_HomeDirectory      = nullptr;
-WCHAR*  g_DefaultRealJitPath = nullptr;
+HMODULE               g_hRealJit      = 0; // We leak this currently (could do the proper shutdown in process_detach)
+WCHAR*                g_realJitPath   = nullptr; // We leak this (could do the proper shutdown in process_detach)
+WCHAR*                g_logPath       = nullptr; // Again, we leak this one too...
+char*                 g_logFilePath   = nullptr; // We *don't* leak this, hooray!
+WCHAR*                g_HomeDirectory = nullptr;
+WCHAR*                g_DefaultRealJitPath = nullptr;
+MethodCallSummarizer* g_globalContext      = nullptr;
 
 void SetDefaultPaths()
 {
@@ -131,6 +132,15 @@ extern "C" void __stdcall jitStartup(ICorJitHost* host)
     }
 
     g_ourJitHost = new JitHost(host);
+
+    if (g_globalContext == nullptr)
+    {
+        SetLogPath();
+        g_globalContext = new MethodCallSummarizer(g_logPath);
+    }
+
+    g_ourJitHost->setMethodCallSummarizer(g_globalContext);
+
     pnjitStartup(g_ourJitHost);
 }
 
@@ -144,7 +154,6 @@ extern "C" ICorJitCompiler* __stdcall getJit()
 
     SetDefaultPaths();
     SetLibName();
-    SetLogPath();
 
     // Load Library
     if (g_hRealJit == 0)
@@ -174,11 +183,13 @@ extern "C" ICorJitCompiler* __stdcall getJit()
 
     pJitInstance                           = new interceptor_ICJC();
     pJitInstance->original_ICorJitCompiler = tICJI;
-    pJitInstance->mcs                      = new MethodCallSummarizer(g_logPath);
-    if (g_ourJitHost != nullptr)
+
+    if (g_globalContext == nullptr)
     {
-        g_ourJitHost->setMethodCallSummarizer(pJitInstance->mcs);
+        SetLogPath();
+        g_globalContext = new MethodCallSummarizer(g_logPath);
     }
+    pJitInstance->mcs = g_globalContext;
     return pJitInstance;
 }
 


### PR DESCRIPTION
The first commit fixes #19317.

The second commit deletes rewriting of the output file each time when we compile method. It had awful effect on performance (for example system private corelib has 28k+ methods and we delete/create the output file each time). Now we write the output file only once on detach. 

cc @dotnet/jit-contrib 