### PR TITLE
Workaround to remove unnecessary bounds checks when using {ReadOnly}Span.IsEmpty

### DIFF
--- a/src/System.Private.CoreLib/shared/System/ReadOnlySpan.cs
+++ b/src/System.Private.CoreLib/shared/System/ReadOnlySpan.cs
@@ -40,7 +40,8 @@ namespace System
             [NonVersionable]
             get
             {
-                return _length == 0;
+                // Workaround for https://github.com/dotnet/coreclr/issues/19620
+                return 0 >= (uint)_length;
             }
         }
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Span.cs
+++ b/src/System.Private.CoreLib/shared/System/Span.cs
@@ -40,7 +40,8 @@ namespace System
             [NonVersionable]
             get
             {
-                return _length == 0;
+                // Workaround for https://github.com/dotnet/coreclr/issues/19620
+                return 0 >= (uint)_length;
             }
         }
 


### PR DESCRIPTION
Workaround for https://github.com/dotnet/coreclr/issues/19620

```C#
public static bool IsFirstSpace(ReadOnlySpan<byte> buffer)
{
    if (buffer.IsEmpty || buffer[0] != ' ')
        return false;
    return true;
}
```

Disassembly for before/after:
![image](https://user-images.githubusercontent.com/6527137/44555124-90fe2b80-a6e8-11e8-882a-c2504ed34924.png)


cc @AndyAyersMS, @benaadams, @GrabYourPitchforks, @mikedn  
