### PR TITLE
Disable System.Numerics.Vectors.Tests 

### DIFF
--- a/tests/arm/corefx_linux_test_exclusions.txt
+++ b/tests/arm/corefx_linux_test_exclusions.txt
@@ -9,4 +9,5 @@ System.Linq.Expressions.Tests        # https://github.com/dotnet/corefx/issues/2
 System.Management.Tests              # https://github.com/dotnet/coreclr/issues/16001
 System.Net.Http.Functional.Tests     # https://github.com/dotnet/coreclr/issues/17739
 System.Net.NameResolution.Pal.Tests  # https://github.com/dotnet/coreclr/issues/17740
+System.Numerics.Vectors.Tests        # https://github.com/dotnet/coreclr/issues/19537
 System.Text.RegularExpressions.Tests # https://github.com/dotnet/coreclr/issues/17754 -- timeout -- JitMinOpts only

--- a/tests/arm/corefx_test_exclusions.txt
+++ b/tests/arm/corefx_test_exclusions.txt
@@ -11,5 +11,6 @@ System.IO.Ports.Tests                # https://github.com/dotnet/coreclr/issues/
 System.Management.Tests              # https://github.com/dotnet/coreclr/issues/16001
 System.Linq.Expressions.Tests        # JitStress=1 https://github.com/dotnet/coreclr/issues/19457
 System.Net.HttpListener.Tests        # https://github.com/dotnet/coreclr/issues/17584
+System.Numerics.Vectors.Tests        # https://github.com/dotnet/coreclr/issues/19537
 System.Runtime.Numerics.Tests        # https://github.com/dotnet/coreclr/issues/18362 -- JitStress=1 JitStress=2
 System.Text.RegularExpressions.Tests # https://github.com/dotnet/coreclr/issues/17754 -- timeout -- JitMinOpts only


### PR DESCRIPTION
Disable failing `System.Numerics.Vectors.Tests` test assembly on Windows/arm and Linux/arm.

**Related issue:** #19537 