### PR TITLE
[release/2.1] Arm stepping fix

### DIFF
--- a/src/debug/ee/controller.cpp
+++ b/src/debug/ee/controller.cpp
@@ -6319,8 +6319,8 @@ void DebuggerStepper::TrapStepOut(ControllerStackInfo *info, bool fForceTraditio
         _ASSERTE(IsCloserToLeaf(dbgLastFP, info->m_activeFrame.fp));
 #endif
 
-#ifdef FEATURE_STUBS_AS_IL
-        if (info->m_activeFrame.md->IsILStub() && info->m_activeFrame.md->AsDynamicMethodDesc()->IsMulticastStub())
+#ifdef FEATURE_MULTICASTSTUB_AS_IL
+        if (info->m_activeFrame.md != nullptr && info->m_activeFrame.md->IsILStub() && info->m_activeFrame.md->AsDynamicMethodDesc()->IsMulticastStub())
         {
             LOG((LF_CORDB, LL_INFO10000,
                  "DS::TSO: multicast frame.\n"));
@@ -6347,7 +6347,7 @@ void DebuggerStepper::TrapStepOut(ControllerStackInfo *info, bool fForceTraditio
                 break;          
         }
         else 
-#endif // FEATURE_STUBS_AS_IL
+#endif // FEATURE_MULTICASTSTUB_AS_IL
         if (info->m_activeFrame.managed)
         {
             LOG((LF_CORDB, LL_INFO10000,

--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -3221,10 +3221,7 @@ CodeRegionInfo CodeRegionInfo::GetCodeRegionInfo(DebuggerJitInfo *dji, MethodDes
 
         if (addr)
         {
-            PCODE pCode = (PCODE)dac_cast<TADDR>(addr);
-#ifdef _TARGET_ARM_
-            pCode |= THUMB_CODE;
-#endif
+            PCODE pCode = PINSTRToPCODE(dac_cast<TADDR>(addr));
             codeRegionInfo.InitializeFromStartAddress(pCode);
         }
 
@@ -11118,7 +11115,7 @@ bool Debugger::HandleIPCEvent(DebuggerIPCEvent * pEvent)
                     // In the EnC case, if we look for an older version, we need to find the DJI by starting 
                     // address, rather than just by MethodDesc. In the case of generics, we may need to create a DJI, so we 
                     pDJI = pDMI->FindOrCreateInitAndAddJitInfo(pEvent->SetIP.vmMethodDesc.GetRawPtr(),
-                                                               (TADDR)pEvent->SetIP.startAddress);
+                                                               PINSTRToPCODE((TADDR)pEvent->SetIP.startAddress));
                 }
 
                 if ((pDJI != NULL) && (pThread != NULL) && (pModule != NULL))

--- a/src/debug/ee/debugger.h
+++ b/src/debug/ee/debugger.h
@@ -1324,7 +1324,7 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
 
-        PCODE address = (PCODE)addr;
+        PCODE address = PINSTRToPCODE((TADDR)addr);
 
         if ((address >= m_addrOfHotCode) &&
             (address <  m_addrOfHotCode + m_sizeOfHotCode))
@@ -1346,7 +1346,7 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
 
-        PCODE address = (PCODE)addr;
+        PCODE address = PINSTRToPCODE((TADDR)addr);
         return (((address >= m_addrOfHotCode) &&
                  (address <  m_addrOfHotCode + m_sizeOfHotCode)) ||
                 ((address >= m_addrOfColdCode) &&

--- a/src/debug/ee/frameinfo.cpp
+++ b/src/debug/ee/frameinfo.cpp
@@ -1563,7 +1563,7 @@ StackWalkAction DebuggerWalkStackProc(CrawlFrame *pCF, void *data)
     // The only exception is dynamic methods.  We want to report them when SIS is turned on.
     if ((md != NULL) && md->IsILStub() && pCF->IsFrameless())
     {
-#ifdef FEATURE_STUBS_AS_IL
+#ifdef FEATURE_MULTICASTSTUB_AS_IL
         if(md->AsDynamicMethodDesc()->IsMulticastStub())
         {
             use = true;

--- a/src/debug/ee/functioninfo.cpp
+++ b/src/debug/ee/functioninfo.cpp
@@ -1228,7 +1228,7 @@ void DebuggerJitInfo::Init(TADDR newAddress)
     this->m_addrOfCode = (ULONG_PTR)PTR_TO_CORDB_ADDRESS((BYTE*) newAddress);
     this->m_jitComplete = true;
 
-    this->m_codeRegionInfo.InitializeFromStartAddress((PCODE)this->m_addrOfCode);
+    this->m_codeRegionInfo.InitializeFromStartAddress(PINSTRToPCODE((TADDR)this->m_addrOfCode));
     this->m_sizeOfCode =  this->m_codeRegionInfo.getSizeOfTotalCode();
 
     this->m_encVersion = this->m_methodInfo->GetCurrentEnCVersion();
@@ -1586,6 +1586,7 @@ DebuggerJitInfo *DebuggerMethodInfo::FindOrCreateInitAndAddJitInfo(MethodDesc* f
     //
     // We haven't got the lock yet so we'll repeat this lookup once
     // we've taken the lock.
+    ARM_ONLY(_ASSERTE((startAddr & THUMB_CODE) == 1));
     DebuggerJitInfo * pResult = FindJitInfo(fd, startAddr);
     if (pResult != NULL)
     {

--- a/src/inc/daccess.h
+++ b/src/inc/daccess.h
@@ -2414,7 +2414,7 @@ typedef DPTR(RUNTIME_FUNCTION) PTR_RUNTIME_FUNCTION;
 //----------------------------------------------------------------------------
 //
 // A PCODE is a valid PC/IP value -- a pointer to an instruction, possibly including some processor mode bits.
-// (On ARM, for example, a PCODE value should should have the low-order THUMB_CODE bit set if the code should
+// (On ARM, for example, a PCODE value should have the low-order THUMB_CODE bit set if the code should
 // be executed in that mode.)
 //
 typedef TADDR PCODE;

--- a/src/vm/codeman.cpp
+++ b/src/vm/codeman.cpp
@@ -4166,7 +4166,7 @@ PCODE ExecutionManager::GetCodeStartAddress(PCODE currentPC)
     EECodeInfo codeInfo(currentPC);
     if (!codeInfo.IsValid())
         return NULL;
-    return (PCODE)codeInfo.GetStartAddress();
+    return PINSTRToPCODE(codeInfo.GetStartAddress());
 }
 
 //**************************************************************************

--- a/src/vm/comdelegate.cpp
+++ b/src/vm/comdelegate.cpp
@@ -2448,6 +2448,12 @@ FCIMPL1(PCODE, COMDelegate::GetMulticastInvoke, Object* refThisIn)
         //Label_nextDelegate:
         pCode->EmitLabel(nextDelegate);
 
+#ifdef DEBUGGING_SUPPORTED
+        pCode->EmitLoadThis();
+        pCode->EmitLDLOC(dwLoopCounterNum);
+        pCode->EmitCALL(METHOD__STUBHELPERS__MULTICAST_DEBUGGER_TRACE_HELPER, 2, 0);
+#endif // DEBUGGING_SUPPORTED
+
         // compare LoopCounter with InvocationCount. If equal then branch to Label_endOfMethod
         pCode->EmitLDLOC(dwLoopCounterNum);
         pCode->EmitLDLOC(dwInvocationCountNum);
@@ -2477,11 +2483,6 @@ FCIMPL1(PCODE, COMDelegate::GetMulticastInvoke, Object* refThisIn)
         pCode->EmitADD();
         pCode->EmitSTLOC(dwLoopCounterNum);
 
-#ifdef DEBUGGING_SUPPORTED
-        pCode->EmitLoadThis();
-        pCode->EmitLDLOC(dwLoopCounterNum);
-        pCode->EmitCALL(METHOD__STUBHELPERS__MULTICAST_DEBUGGER_TRACE_HELPER, 2, 0);
-#endif // DEBUGGING_SUPPORTED
 
         // branch to next delegate
         pCode->EmitBR(nextDelegate);

--- a/src/vm/stubmgr.h
+++ b/src/vm/stubmgr.h
@@ -976,7 +976,7 @@ public:
         Thread::VirtualUnwindCallFrame(&context);
         Thread::VirtualUnwindCallFrame(&context);
 
-        return pContext->Rip;
+        return context.Rip;
 #elif defined(_TARGET_ARM_)
         return *((PCODE *)pContext->R11 + 1);      
 #elif defined(_TARGET_ARM64_)


### PR DESCRIPTION
#### Description

A bit ago @chsienki and @davidwrighton made some fixes to debugging that ended up in master after the release/2.2 branch was created. In particular, the castings from `PISNTR` to `PCODE` were not preserving the thumb bit, causing stepping in ARM debugging to break. Issue #19255 is requesting to port these fixes to 2.1 for servicing.

This PR ports the following PR's from master to 2.1 as requested:
- #17617
- #17879
- #17990
- #18129
- #18247
#### Customer Impact

Currently, our debugging experience in ARM is not working as expected. In some scenarios stepping will fall into incorrect locations, sometimes during testing we find breakpoints that will fire up twice. Some customers have asked us to address this (issue #19255).
#### Regression?

Not a regression.		 
#### Risk

The risk taken from this change should be fairly low. Mostly castings were fixed that were fixed which only turn the thumb bit for ARM (while having no change in other architectures) appropriately on code paths used by the debugger in the VM. 