### PR TITLE
Zeroing stack by rep stosb instead of rep stosd

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -6435,9 +6435,9 @@ void CodeGen::genZeroInitFrame(int untrLclHi, int untrLclLo, regNumber initReg, 
         getEmitter()->emitIns_R_AR(INS_lea, EA_PTRSIZE, REG_EDI, genFramePointerReg(), untrLclLo);
         regSet.verifyRegUsed(REG_EDI);
 
-        inst_RV_IV(INS_mov, REG_ECX, (untrLclHi - untrLclLo) / sizeof(int), EA_4BYTE);
+        inst_RV_IV(INS_mov, REG_ECX, untrLclHi - untrLclLo, EA_4BYTE);
         instGen_Set_Reg_To_Zero(EA_PTRSIZE, REG_EAX);
-        instGen(INS_r_stosd);
+        instGen(INS_r_stosb);
 
 #ifdef UNIX_AMD64_ABI
         // Move back the argument registers


### PR DESCRIPTION
Intel improved the performance of `rep stosb` and `rep movsb` (not `rep stosd/q`/``rep movsd/q``)since Sandy Bridge (indicated by CPUID “enhanced strings”), and will continue to improve them in the future.

![image](https://user-images.githubusercontent.com/1263030/44600424-1c7dc800-a78e-11e8-8832-163032da1f99.png)

So, we should consistently use `rep stosb` instead of `rep stosd\q` (actually `genCodeForStoreBlk` is using `rep stosb` now), which won't be slower than `rep stosd/q` and even faster on some platforms.

related to https://github.com/dotnet/coreclr/issues/19076
