### PR TITLE
Using struct for VectorPacket in PacketTracer benchmark

### DIFF
--- a/tests/src/JIT/Performance/CodeQuality/HWIntrinsic/X86/PacketTracer/VectorPacket.cs
+++ b/tests/src/JIT/Performance/CodeQuality/HWIntrinsic/X86/PacketTracer/VectorPacket.cs
@@ -10,7 +10,7 @@ using System.Runtime.Intrinsics;
 using System.Runtime.CompilerServices;
 using System;
 
-internal class VectorPacket256
+internal struct VectorPacket256
 {
     public Vector256<float> Xs;
     public Vector256<float> Ys;


### PR DESCRIPTION
This PR changes the PacketTracer benchmark to use `struct` instead of `class` for `VectorPacket`.

This will make the benchmark **31% faster** with JIT change https://github.com/dotnet/coreclr/pull/19663 (2x slower without the JIT change) of struct promotion because it reduces the GC overhead mentioned in https://github.com/dotnet/coreclr/issues/19116.