### PR TITLE
Improve struct promotion for 256-bit SIMD fields

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1497,8 +1497,9 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE    typeHnd,
         CLANG_FORMAT_COMMENT_ANCHOR;
 #if defined(FEATURE_SIMD)
 #if defined(_TARGET_XARCH_)
-        // This will allow promotion of 2 Vector<T> fields on AVX2, or 4 Vector<T> fields on SSE2.
-        const int MaxOffset = MAX_NumOfFieldsInPromotableStruct * XMM_REGSIZE_BYTES;
+        // This will allow promotion of 4 Vector<T> fields on AVX2 or Vector256<T> on AVX,
+        // or 8 Vector<T>/Vector128<T> fields on SSE2.
+        const int MaxOffset = MAX_NumOfFieldsInPromotableStruct * YMM_REGSIZE_BYTES;
 #elif defined(_TARGET_ARM64_)
         const int MaxOffset = MAX_NumOfFieldsInPromotableStruct * FP_REGSIZE_BYTES;
 #endif // defined(_TARGET_XARCH_) || defined(_TARGET_ARM64_)


### PR DESCRIPTION
This PR improves struct promotion to unwrap more 256-bit SIMD fields, which makes PacketTracer benchmark 31% faster with https://github.com/dotnet/coreclr/pull/19662

## Performance data (rendering a 2k image)

|      Execution time     |    Windows    |    Linux    |
|:-----------------------:|:-----------------------:|:---------------------:|
|      PacketTracer (class)     |           1.20s          |         1.35s         |
|      PacketTracer (struct)   |          0.83s          |         0.93s         |
|    Performance Gains    |          31%         |         31%          |

The data collected on
- Intel Core i9 7900X (Skylake-X) @ 3.3GHz, HT on, Turbo on, 16GB DDR4 2666MHz
- Windows 10 and Ubuntu 16.04

## VTune characterization (module level) 
### Windows
![image](https://user-images.githubusercontent.com/1263030/44608174-b1d98600-a7a7-11e8-8de5-f1b7ae140aaf.png)
### Linux
![image](https://user-images.githubusercontent.com/1263030/44608217-db92ad00-a7a7-11e8-908a-460cb8c192e8.png)

The most obvious module-level change is the runtime (GC) overhead gets reduced (~33% -> ~11%) and managed code also gets better path-length (code size).

## VTune characterization (managed code) 
### Windows
![image](https://user-images.githubusercontent.com/1263030/44608359-3c21ea00-a7a8-11e8-8d61-93d5ac79d052.png)
### Linux
![image](https://user-images.githubusercontent.com/1263030/44608374-5065e700-a7a8-11e8-8a61-ba886568af51.png)

Overall, managed code gets improvement by the better code size, but there still are some inefficient codgen that I will continue to investigate and open other issues to discuss (mainly related to https://github.com/dotnet/coreclr/issues/16619)

## VTune characterization (CoreCLR runtime) 
### Windows
![image](https://user-images.githubusercontent.com/1263030/44608620-32e54d00-a7a9-11e8-9a9c-fdbd4311411a.png)
### Linux
![image](https://user-images.githubusercontent.com/1263030/44608639-45f81d00-a7a9-11e8-87bf-ce6fb767ba5b.png)

