### PR TITLE
Some fixes for the interpreter

### DIFF
--- a/src/vm/interpreter.h
+++ b/src/vm/interpreter.h
@@ -1764,6 +1764,9 @@ private:
     void DoStringLength();
     void DoStringGetChar();
     void DoGetTypeFromHandle();
+    void DoByReferenceCtor();
+    void DoByReferenceValue();
+    void DoSIMDHwAccelerated();
 
     // Returns the proper generics context for use in resolving tokens ("precise" in the sense of including generic instantiation
     // information).


### PR DESCRIPTION
A number of fixes to the interpreter so it can run many pri0 basic tests.

* fix build break
* fix new array
* fix small struct return assert
* implement must-expand `ByReference<T>` intrinsics
* add some missing null checks
* fix `stobj` type check assert
* basic SIMD support
* obey `COMPlus_FeatureSIMD` setting

HW Intrinsics are still not supported / implemented.