### PR TITLE
Remove Reflection from RuntimeEventSource Test

### DIFF
--- a/tests/src/tracing/runtimeeventsource/RuntimeEventSourceTest.cs
+++ b/tests/src/tracing/runtimeeventsource/RuntimeEventSourceTest.cs
@@ -1,15 +1,9 @@
-#define REFLECTION
-
 using System;
 using System.IO;
 using System.Diagnostics.Tracing;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Tracing.Tests.Common;
-
-#if REFLECTION
-using System.Reflection;
-#endif
 
 namespace Tracing.Tests
 {
@@ -99,29 +93,17 @@ namespace Tracing.Tests
 
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
-            long osThreadId = -1;
-            DateTime timeStamp;
-#if REFLECTION
-            PropertyInfo threadProperty = typeof(EventWrittenEventArgs).GetProperty("OSThreadId");
-            MethodInfo threadMethod = threadProperty.GetGetMethod();
-            osThreadId = (long)threadMethod.Invoke(eventData, null);
-            PropertyInfo timeStampProperty = typeof(EventWrittenEventArgs).GetProperty("TimeStamp");
-            MethodInfo timeStampMethod = timeStampProperty.GetGetMethod();
-            timeStamp = (DateTime)timeStampMethod.Invoke(eventData, null);
-#endif
-
-            Console.WriteLine($"[{m_name}] ThreadID = {osThreadId} ID = {eventData.EventId} Name = {eventData.EventName}");
-            Console.WriteLine($"TimeStamp: {timeStamp.ToLocalTime()}");
+            Console.WriteLine($"[{m_name}] ThreadID = {eventData.OSThreadId} ID = {eventData.EventId} Name = {eventData.EventName}");
+            Console.WriteLine($"TimeStamp: {eventData.TimeStamp.ToLocalTime()}");
             Console.WriteLine($"LocalTime: {DateTime.Now}");
-            Console.WriteLine($"Difference: {DateTime.UtcNow - timeStamp}");
-            Assert.True("timeStamp < DateTime.UtcNow", timeStamp < DateTime.UtcNow);
+            Console.WriteLine($"Difference: {DateTime.UtcNow - eventData.TimeStamp}");
+            Assert.True("eventData.TimeStamp < DateTime.UtcNow", eventData.TimeStamp < DateTime.UtcNow);
             for (int i = 0; i < eventData.Payload.Count; i++)
             {
                 string payloadString = eventData.Payload[i] != null ? eventData.Payload[i].ToString() : string.Empty;
                 Console.WriteLine($"\tName = \"{eventData.PayloadNames[i]}\" Value = \"{payloadString}\"");
             }
             Console.WriteLine("\n");
-
 
             EventCount++;
         }


### PR DESCRIPTION
Now that the new public API surface area is available in the contracts and has been consumed by the CoreCLR build, we can use it rather than using reflection.