### PR TITLE
Handle multiReg COPY

### DIFF
--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -1947,3 +1947,57 @@ void CodeGen::genCodeForCast(GenTreeOp* tree)
     }
     // The per-case functions call genProduceReg()
 }
+
+#if !defined(_TARGET_64BIT_)
+//------------------------------------------------------------------------
+// genStoreLongLclVar: Generate code to store a non-enregistered long lclVar
+//
+// Arguments:
+//    treeNode - A TYP_LONG lclVar node.
+//
+// Return Value:
+//    None.
+//
+// Assumptions:
+//    'treeNode' must be a TYP_LONG lclVar node for a lclVar that has NOT been promoted.
+//    Its operand must be a GT_LONG node.
+//
+void CodeGen::genStoreLongLclVar(GenTree* treeNode)
+{
+    emitter* emit = getEmitter();
+
+    GenTreeLclVarCommon* lclNode = treeNode->AsLclVarCommon();
+    unsigned             lclNum  = lclNode->gtLclNum;
+    LclVarDsc*           varDsc  = &(compiler->lvaTable[lclNum]);
+    assert(varDsc->TypeGet() == TYP_LONG);
+    assert(!varDsc->lvPromoted);
+    GenTree* op1 = treeNode->gtOp.gtOp1;
+
+    // A GT_LONG is always contained, so it cannot have RELOAD or COPY inserted between it and its consumer,
+    // but a MUL_LONG may.
+    noway_assert(op1->OperIs(GT_LONG) || op1->gtSkipReloadOrCopy()->OperIs(GT_MUL_LONG));
+    genConsumeRegs(op1);
+
+    if (op1->OperGet() == GT_LONG)
+    {
+        GenTree* loVal = op1->gtGetOp1();
+        GenTree* hiVal = op1->gtGetOp2();
+
+        noway_assert((loVal->gtRegNum != REG_NA) && (hiVal->gtRegNum != REG_NA));
+
+        emit->emitIns_S_R(ins_Store(TYP_INT), EA_4BYTE, loVal->gtRegNum, lclNum, 0);
+        emit->emitIns_S_R(ins_Store(TYP_INT), EA_4BYTE, hiVal->gtRegNum, lclNum, genTypeSize(TYP_INT));
+    }
+    else
+    {
+        assert((op1->gtSkipReloadOrCopy()->gtFlags & GTF_MUL_64RSLT) != 0);
+        // This is either a multi-reg MUL_LONG, or a multi-reg reload or copy.
+        assert(op1->IsMultiRegNode() && (op1->GetMultiRegCount() == 2));
+
+        // Stack store
+        emit->emitIns_S_R(ins_Store(TYP_INT), emitTypeSize(TYP_INT), op1->GetRegByIndex(0), lclNum, 0);
+        emit->emitIns_S_R(ins_Store(TYP_INT), emitTypeSize(TYP_INT), op1->GetRegByIndex(1), lclNum,
+                          genTypeSize(TYP_INT));
+    }
+}
+#endif // !defined(_TARGET_64BIT_)

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -1213,13 +1213,18 @@ public:
 
     bool OperIsMultiRegOp() const
     {
-#if defined(_TARGET_ARM_)
-        if ((gtOper == GT_MUL_LONG) || (gtOper == GT_PUTARG_REG) || (gtOper == GT_BITCAST))
+#if !defined(_TARGET_64BIT_)
+        if (OperIs(GT_MUL_LONG))
         {
             return true;
         }
-#endif
-
+#if defined(_TARGET_ARM_)
+        if (OperIs(GT_PUTARG_REG, GT_BITCAST))
+        {
+            return true;
+        }
+#endif // _TARGET_ARM_
+#endif // _TARGET_64BIT_
         return false;
     }
 
@@ -3839,7 +3844,7 @@ struct GenTreeCmpXchg : public GenTree
 #endif
 };
 
-#if defined(_TARGET_ARM_)
+#if !defined(_TARGET_64BIT_)
 struct GenTreeMultiRegOp : public GenTreeOp
 {
     regNumber gtOtherReg;
@@ -3994,7 +3999,7 @@ struct GenTreeMultiRegOp : public GenTreeOp
     }
 #endif
 };
-#endif // defined(_TARGET_ARM_)
+#endif // !defined(_TARGET_64BIT_)
 
 struct GenTreeFptrVal : public GenTree
 {
@@ -5425,6 +5430,11 @@ struct GenTreePutArgSplit : public GenTreePutArgStk
 #endif // FEATURE_ARG_SPLIT
 
 // Represents GT_COPY or GT_RELOAD node
+//
+// As it turns out, these are only needed on targets that happen to have multi-reg returns.
+// However, they are actually needed on any target that has any multi-reg ops. It is just
+// coincidence that those are the same (and there isn't a FEATURE_MULTIREG_OPS).
+//
 struct GenTreeCopyOrReload : public GenTreeUnOp
 {
 #if FEATURE_MULTIREG_RET
@@ -6031,7 +6041,7 @@ inline bool GenTree::IsMultiRegNode() const
         return true;
     }
 
-#if defined(_TARGET_ARM_)
+#if !defined(_TARGET_64BIT_)
     if (OperIsMultiRegOp() || OperIsPutArgSplit() || (gtOper == GT_COPY))
     {
         return true;
@@ -6061,7 +6071,7 @@ inline unsigned GenTree::GetMultiRegCount()
         return AsPutArgSplit()->gtNumRegs;
     }
 #endif
-#if defined(_TARGET_ARM_)
+#if !defined(_TARGET_64BIT_)
     if (OperIsMultiRegOp())
     {
         return AsMultiRegOp()->GetRegCount();
@@ -6102,7 +6112,7 @@ inline regNumber GenTree::GetRegByIndex(int regIndex)
         return AsPutArgSplit()->GetRegNumByIdx(regIndex);
     }
 #endif
-#if defined(_TARGET_ARM_)
+#if !defined(_TARGET_64BIT_)
     if (OperIsMultiRegOp())
     {
         return AsMultiRegOp()->GetRegNumByIdx(regIndex);
@@ -6143,7 +6153,7 @@ inline var_types GenTree::GetRegTypeByIndex(int regIndex)
         return AsPutArgSplit()->GetRegType(regIndex);
     }
 #endif
-#if defined(_TARGET_ARM_)
+#if !defined(_TARGET_64BIT_)
     if (OperIsMultiRegOp())
     {
         return AsMultiRegOp()->GetRegType(regIndex);

--- a/src/jit/gtlist.h
+++ b/src/jit/gtlist.h
@@ -181,9 +181,7 @@ GTNODE(SUB_HI           , GenTreeOp          ,0,GTK_BINOP)
 // with long results are morphed into helper calls. It is similar to GT_MULHI,
 // the difference being that GT_MULHI drops the lo part of the result, whereas
 // GT_MUL_LONG keeps both parts of the result.
-#if defined(_TARGET_X86_)
-GTNODE(MUL_LONG         , GenTreeOp          ,1,GTK_BINOP)
-#elif defined (_TARGET_ARM_)
+#if !defined(_TARGET_64BIT_)
 GTNODE(MUL_LONG         , GenTreeMultiRegOp  ,1,GTK_BINOP)
 #endif
 

--- a/src/jit/gtstructs.h
+++ b/src/jit/gtstructs.h
@@ -121,7 +121,9 @@ GTSTRUCT_1(HWIntrinsic , GT_HWIntrinsic)
 GTSTRUCT_1(AllocObj    , GT_ALLOCOBJ)
 GTSTRUCT_1(RuntimeLookup, GT_RUNTIMELOOKUP)
 GTSTRUCT_2(CC          , GT_JCC, GT_SETCC)
-#if defined(_TARGET_ARM_)
+#if defined(_TARGET_X86_)
+GTSTRUCT_1(MultiRegOp  , GT_MUL_LONG)
+#elif defined (_TARGET_ARM_)
 GTSTRUCT_3(MultiRegOp  , GT_MUL_LONG, GT_PUTARG_REG, GT_BITCAST)
 #endif
 /*****************************************************************************/

--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -2826,18 +2826,9 @@ int LinearScan::BuildStoreLoc(GenTreeLclVarCommon* storeLoc)
     {
         if (op1->OperIs(GT_MUL_LONG))
         {
-#ifdef _TARGET_X86_
-            // This is actually a bug. A GT_MUL_LONG produces two registers, but is modeled as only producing
-            // eax (and killing edx). This only works because it always occurs as var = GT_MUL_LONG (ensured by
-            // DecomposeMul), and therefore edx won't be reused before the store.
-            // TODO-X86-Cleanup: GT_MUL_LONG should be a multireg node on x86, just as on ARM.
-            srcCount     = 1;
-            singleUseRef = BuildUse(op1);
-#else
             srcCount = 2;
             BuildUse(op1, allRegs(TYP_INT), 0);
             BuildUse(op1, allRegs(TYP_INT), 1);
-#endif
         }
         else
         {

--- a/tests/arm/Tests.lst
+++ b/tests/arm/Tests.lst
@@ -94619,3 +94619,11 @@ Expected=0
 MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS
 HostStyle=0
+
+[GitHub_19397.cmd_11916]
+RelativePath=JIT\Regression\JitBlue\GitHub_19397\GitHub_19397\GitHub_19397.cmd
+WorkingDir=JIT\Regression\JitBlue\GitHub_19397\GitHub_19397
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -94635,3 +94635,11 @@ Expected=0
 MaxAllowedDurationSeconds=600
 Categories=EXPECTED_PASS
 HostStyle=0
+
+[GitHub_19397.cmd_12235]
+RelativePath=JIT\Regression\JitBlue\GitHub_19397\GitHub_19397\GitHub_19397.cmd
+WorkingDir=JIT\Regression\JitBlue\GitHub_19397\GitHub_19397
+Expected=0
+MaxAllowedDurationSeconds=600
+Categories=EXPECTED_PASS
+HostStyle=0

--- a/tests/src/JIT/Regression/JitBlue/GitHub_19397/GitHub_19397.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_19397/GitHub_19397.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+using System.Runtime.CompilerServices;
+
+// This is a regression test for a bug that was exposed with jitStressRegs=8 in
+// System.Text.ConsoleEncoding::GetMaxByteCount, due to the lack of handling
+// of a register-allocator-added COPY of a multi-reg multiply.
+
+namespace GitHub_19397
+{
+    public class Program
+    {
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static long getValue()
+        {
+            return(0x0101010101010101L);
+        }
+        static int Main()
+        {
+            long value = getValue();
+            Console.WriteLine($"Result is {value}");
+            if (value == 0x0101010101010101L)
+            {
+                Console.WriteLine("PASS");
+                return 100;
+            }
+            else
+            {
+                Console.WriteLine("FAIL");
+                return -1;
+            }
+        }
+
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_19397/GitHub_19397.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_19397/GitHub_19397.csproj
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{76E69AA0-8C5A-4F76-8561-B8089FFA8D79}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
On x86, `MUL_LONG` wasn't considered a multi-reg node, as it should be, so that when it gets spilled or copied, the additional register will be correctly handled.
Also, the ARM and X86 versions of genStoreLongLclVar should be identical and shared (neither version were handling the copy of a `MUL_LONG`).
Finally, fix the LSRA dumping of multi-reg nodes.

Fix #19397