### PR TITLE
Fix Linux/x86 altjit

### DIFF
--- a/src/gcinfo/CMakeLists.txt
+++ b/src/gcinfo/CMakeLists.txt
@@ -28,6 +28,11 @@ if (CLR_CMAKE_PLATFORM_ARCH_I386)
     add_subdirectory(gcinfo_arm)
 endif ()
 
+if (CLR_CMAKE_PLATFORM_ARCH_I386 AND WIN32)
+    # On x86, build Linux x86 cross-compiling altjit.
+    add_subdirectory(gcinfo_linuxx86)
+endif ()
+
 if (CLR_CMAKE_PLATFORM_ARCH_AMD64)
     # On amd64, build RyuJIT/ARM64 cross-compiling altjit.
     add_subdirectory(gcinfo_arm64)

--- a/src/gcinfo/gcinfo_linuxx86/CMakeLists.txt
+++ b/src/gcinfo/gcinfo_linuxx86/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_definitions(-DUNIX_X86_ABI)
+
+add_library_clr(gcinfo_linuxx86
+    STATIC
+    ${GCINFO_SOURCES}
+)

--- a/src/jit/linuxnonjit/CMakeLists.txt
+++ b/src/jit/linuxnonjit/CMakeLists.txt
@@ -14,9 +14,11 @@ if (CLR_CMAKE_PLATFORM_ARCH_I386)
     remove_definitions(-DFEATURE_HW_INTRINSICS)
     add_definitions(-DUNIX_X86_ABI)
     set(JIT_ARCH_ALTJIT_SOURCES ${JIT_I386_SOURCES})
+    set(JIT_ARCH_LINK_LIBRARIES gcinfo_linuxx86)
 elseif(CLR_CMAKE_PLATFORM_ARCH_AMD64)
     add_definitions(-DUNIX_AMD64_ABI)
     set(JIT_ARCH_ALTJIT_SOURCES ${JIT_AMD64_SOURCES})
+    set(JIT_ARCH_LINK_LIBRARIES gcinfo)
 else()
     clr_unknown_arch()
 endif()
@@ -38,7 +40,7 @@ set_property(TARGET linuxnonjit APPEND_STRING PROPERTY LINK_DEPENDS ${JIT_EXPORT
 
 set(RYUJIT_LINK_LIBRARIES
    utilcodestaticnohost
-   gcinfo
+   ${JIT_ARCH_LINK_LIBRARIES}
 )
 
 if(CLR_CMAKE_PLATFORM_UNIX)


### PR DESCRIPTION
This is a Linux/x86-targeting, Windows/x86-hosted altjit.
Fix the build so it uses an appropriate gcinfo library, built
with the appropriate defines. Currently, this eliminates a single assert.