### PR TITLE
Delete code that tracks stack level in morph.

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -6968,14 +6968,8 @@ void CodeGen::genProfilingEnterCallback(regNumber initReg, bool* pInitRegZeroed)
                       EA_UNKNOWN); // retSize
 
 #if defined(_TARGET_X86_)
-    //
-    // Adjust the number of stack slots used by this managed method if necessary.
-    //
-    if (compiler->fgPtrArgCntMax < 1)
-    {
-        JITDUMP("Upping fgPtrArgCntMax from %d to 1\n", compiler->fgPtrArgCntMax);
-        compiler->fgPtrArgCntMax = 1;
-    }
+    // Check that we have place for the push.
+    assert(compiler->fgPtrArgCntMax >= 1);
 #elif defined(_TARGET_ARM_)
     if (initReg == argReg)
     {
@@ -7168,14 +7162,8 @@ void CodeGen::genProfilingLeaveCallback(unsigned helper /*= CORINFO_HELP_PROF_FC
                       sizeof(int) * 1, // argSize
                       EA_UNKNOWN);     // retSize
 
-    //
-    // Adjust the number of stack slots used by this managed method if necessary.
-    //
-    if (compiler->fgPtrArgCntMax < 1)
-    {
-        JITDUMP("Upping fgPtrArgCntMax from %d to 1\n", compiler->fgPtrArgCntMax);
-        compiler->fgPtrArgCntMax = 1;
-    }
+    // Check that we have place for the push.
+    assert(compiler->fgPtrArgCntMax >= 1);
 
 #elif defined(_TARGET_ARM_)
     //

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4001,7 +4001,6 @@ public:
 
     bool fgMorphBlockStmt(BasicBlock* block, GenTreeStmt* stmt DEBUGARG(const char* msg));
 
-    void fgCheckArgCnt();
     void fgSetOptions();
 
 #ifdef DEBUG
@@ -4916,11 +4915,11 @@ public:
         fgPtrArgCntMax = argCntMax;
     }
 
+    bool compCanEncodePtrArgCntMax();
+
 private:
     hashBv* fgOutgoingArgTemps;
     hashBv* fgCurrentlyInUseArgTemps;
-
-    bool compCanEncodePtrArgCntMax();
 
     void fgSetRngChkTarget(GenTree* tree, bool delay = true);
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1580,9 +1580,6 @@ public:
 
     void EvalArgsToTemps();
 
-    void RecordStkLevel(unsigned stkLvl);
-    unsigned RetrieveStkLevel();
-
     unsigned ArgCount()
     {
         return argCount;
@@ -4890,7 +4887,6 @@ private:
 
     //------------------------- Morphing --------------------------------------
 
-    unsigned fgPtrArgCntCur;
     unsigned fgPtrArgCntMax;
 
 public:
@@ -4923,7 +4919,7 @@ private:
 
     void fgSetRngChkTarget(GenTree* tree, bool delay = true);
 
-    BasicBlock* fgSetRngChkTargetInner(SpecialCodeKind kind, bool delay, unsigned* stkDepth);
+    BasicBlock* fgSetRngChkTargetInner(SpecialCodeKind kind, bool delay);
 
 #if REARRANGE_ADDS
     void fgMoveOpsLeft(GenTree* tree);
@@ -5115,9 +5111,9 @@ private:
     bool        fgRngChkThrowAdded;
     AddCodeDsc* fgExcptnTargetCache[SCK_COUNT];
 
-    BasicBlock* fgRngChkTarget(BasicBlock* block, unsigned stkDepth, SpecialCodeKind kind);
+    BasicBlock* fgRngChkTarget(BasicBlock* block, SpecialCodeKind kind);
 
-    BasicBlock* fgAddCodeRef(BasicBlock* srcBlk, unsigned refData, SpecialCodeKind kind, unsigned stkDepth = 0);
+    BasicBlock* fgAddCodeRef(BasicBlock* srcBlk, unsigned refData, SpecialCodeKind kind);
 
 public:
     AddCodeDsc* fgFindExcptnTarget(SpecialCodeKind kind, unsigned refData);

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -18117,12 +18117,17 @@ unsigned Compiler::acdHelper(SpecialCodeKind codeKind)
     }
 }
 
-/*****************************************************************************
- *
- *  Find/create an added code entry associated with the given block and with
- *  the given kind.
- */
-
+//------------------------------------------------------------------------
+// fgAddCodeRef: Find/create an added code entry associated with the given block and with the given kind.
+//
+// Arguments:
+//   srcBlk  - the block that needs an entry;
+//   refData - the index to use as the cache key for sharing throw blocks;
+//   kind    - the kind of exception;
+//
+// Return Value:
+//   The target throw helper block or nullptr if throw helper blocks are disabled.
+//
 BasicBlock* Compiler::fgAddCodeRef(BasicBlock* srcBlk, unsigned refData, SpecialCodeKind kind)
 {
     // Record that the code will call a THROW_HELPER
@@ -18340,6 +18345,16 @@ Compiler::AddCodeDsc* Compiler::fgFindExcptnTarget(SpecialCodeKind kind, unsigne
  *  range check is to jump to upon failure.
  */
 
+//------------------------------------------------------------------------
+// fgRngChkTarget: Create/find the appropriate "range-fail" label for the block.
+//
+// Arguments:
+//   srcBlk  - the block that needs an entry;
+//   kind    - the kind of exception;
+//
+// Return Value:
+//   The target throw helper block this check jumps to upon failure.
+//
 BasicBlock* Compiler::fgRngChkTarget(BasicBlock* block, SpecialCodeKind kind)
 {
 #ifdef DEBUG

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -7439,7 +7439,6 @@ GenTree* Compiler::gtCloneExpr(
                                      asIndAddr->gtStructElemClass, asIndAddr->gtElemSize, asIndAddr->gtLenOffset,
                                      asIndAddr->gtElemOffset);
                 copy->AsIndexAddr()->gtIndRngFailBB = asIndAddr->gtIndRngFailBB;
-                copy->AsIndexAddr()->gtStkDepth     = asIndAddr->gtStkDepth;
             }
             break;
 
@@ -7778,7 +7777,6 @@ GenTree* Compiler::gtCloneExpr(
                                  gtCloneExpr(tree->gtBoundsChk.gtArrLen, addFlags, deepVarNum, deepVarVal),
                                  tree->gtBoundsChk.gtThrowKind);
             copy->gtBoundsChk.gtIndRngFailBB = tree->gtBoundsChk.gtIndRngFailBB;
-            copy->gtBoundsChk.gtStkDepth     = tree->gtBoundsChk.gtStkDepth;
             break;
 
         case GT_STORE_DYN_BLK:

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -4218,7 +4218,6 @@ struct GenTreeIndexAddr : public GenTreeOp
     CORINFO_CLASS_HANDLE gtStructElemClass; // If the element type is a struct, this is the struct type.
 
     GenTree* gtIndRngFailBB; // Label to jump to for array-index-out-of-range
-    unsigned gtStkDepth;     // Stack depth at which the jump occurs (required for fgSetRngChkTarget)
 
     var_types gtElemType;   // The element type of the array.
     unsigned  gtElemSize;   // size of elements in the array
@@ -4235,7 +4234,6 @@ struct GenTreeIndexAddr : public GenTreeOp
         : GenTreeOp(GT_INDEX_ADDR, TYP_BYREF, arr, ind)
         , gtStructElemClass(structElemClass)
         , gtIndRngFailBB(nullptr)
-        , gtStkDepth(0)
         , gtElemType(elemType)
         , gtElemSize(elemSize)
         , gtLenOffset(lenOffset)
@@ -4309,18 +4307,8 @@ struct GenTreeBoundsChk : public GenTree
     GenTree*        gtIndRngFailBB; // Label to jump to for array-index-out-of-range
     SpecialCodeKind gtThrowKind;    // Kind of throw block to branch to on failure
 
-    /* Only out-of-ranges at same stack depth can jump to the same label (finding return address is easier)
-       For delayed calling of fgSetRngChkTarget() so that the
-       optimizer has a chance of eliminating some of the rng checks */
-    unsigned gtStkDepth;
-
     GenTreeBoundsChk(genTreeOps oper, var_types type, GenTree* index, GenTree* arrLen, SpecialCodeKind kind)
-        : GenTree(oper, type)
-        , gtIndex(index)
-        , gtArrLen(arrLen)
-        , gtIndRngFailBB(nullptr)
-        , gtThrowKind(kind)
-        , gtStkDepth(0)
+        : GenTree(oper, type), gtIndex(index), gtArrLen(arrLen), gtIndRngFailBB(nullptr), gtThrowKind(kind)
     {
         // Effects flags propagate upwards.
         gtFlags |= (arrLen->gtFlags & GTF_ALL_EFFECT);

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -751,7 +751,7 @@ OPTIMIZECAST:
 
     if (tree->gtOverflow())
     {
-        fgAddCodeRef(compCurBB, bbThrowIndex(compCurBB), SCK_OVERFLOW, fgPtrArgCntCur);
+        fgAddCodeRef(compCurBB, bbThrowIndex(compCurBB), SCK_OVERFLOW);
     }
 
     return tree;
@@ -2563,18 +2563,6 @@ GenTree* fgArgInfo::GetLateArg(unsigned argIndex)
     unreached();
 }
 
-void fgArgInfo::RecordStkLevel(unsigned stkLvl)
-{
-    assert(!IsUninitialized(stkLvl));
-    this->stkLevel = stkLvl;
-}
-
-unsigned fgArgInfo::RetrieveStkLevel()
-{
-    assert(!IsUninitialized(stkLevel));
-    return stkLevel;
-}
-
 // Return a conservative estimate of the stack size in bytes.
 // It will be used only on the intercepted-for-host code path to copy the arguments.
 int Compiler::fgEstimateCallStackSize(GenTreeCall* call)
@@ -2711,8 +2699,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
     GenTree* args;
     GenTree* argx;
 
-    unsigned flagsSummary    = 0;
-    unsigned genPtrArgCntSav = fgPtrArgCntCur;
+    unsigned flagsSummary = 0;
 
     unsigned argIndex = 0;
 
@@ -2859,11 +2846,13 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
     // On remorph, we grab it from the arg table.
     unsigned numArgs = 0;
 
+    // TODO: this comment is no longer correct, do an approptiate fix.
     // Process the late arguments (which were determined by a previous caller).
     // Do this before resetting fgPtrArgCntCur as fgMorphTree(call->gtCallLateArgs)
     // may need to refer to it.
     if (reMorphing)
     {
+        // TODO: this comment is no longer correct, do an approptiate fix.
         // We need to reMorph the gtCallLateArgs early since that is what triggers
         // the expression folding and we need to have the final folded gtCallLateArgs
         // available when we call RemorphRegArg so that we correctly update the fgArgInfo
@@ -2881,11 +2870,8 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
         //
         if (call->gtCallLateArgs != nullptr)
         {
-            unsigned callStkLevel = call->fgArgInfo->RetrieveStkLevel();
-            fgPtrArgCntCur += callStkLevel;
             call->gtCallLateArgs = fgMorphTree(call->gtCallLateArgs)->AsArgList();
             flagsSummary |= call->gtCallLateArgs->gtFlags;
-            fgPtrArgCntCur -= callStkLevel;
         }
         assert(call->fgArgInfo != nullptr);
         call->fgArgInfo->RemorphReset();
@@ -4191,7 +4177,6 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                         unsigned numRegsPartial = MAX_REG_ARG - intArgRegNum;
                         assert((unsigned char)numRegsPartial == numRegsPartial);
                         call->fgArgInfo->SplitArg(argIndex, numRegsPartial, size - numRegsPartial);
-                        fgPtrArgCntCur += size - numRegsPartial;
                     }
 #endif // FEATURE_ARG_SPLIT
 
@@ -4222,8 +4207,6 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
         }
         else // We have an argument that is not passed in a register
         {
-            fgPtrArgCntCur += size;
-
             // If the register arguments have not been determined then we must fill in the argInfo
 
             if (reMorphing)
@@ -4355,22 +4338,6 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
     {
         call->gtCallAddr = fgMorphTree(call->gtCallAddr);
     }
-
-    call->fgArgInfo->RecordStkLevel(fgPtrArgCntCur);
-
-    if ((call->gtCallType == CT_INDIRECT) && (call->gtCallCookie != nullptr))
-    {
-        fgPtrArgCntCur++;
-    }
-
-    assert(fgPtrArgCntCur >= genPtrArgCntSav);
-#if defined(UNIX_X86_ABI)
-    call->fgArgInfo->SetStkSizeBytes((fgPtrArgCntCur - genPtrArgCntSav) * TARGET_POINTER_SIZE);
-#endif // UNIX_X86_ABI
-
-    /* The call will pop all the arguments we pushed */
-
-    fgPtrArgCntCur = genPtrArgCntSav;
 
 #if FEATURE_FIXED_OUT_ARGS
 
@@ -5604,7 +5571,7 @@ void Compiler::fgSetRngChkTarget(GenTree* tree, bool delay)
     if (tree->OperIsBoundsCheck())
     {
         GenTreeBoundsChk* const boundsChk = tree->AsBoundsChk();
-        BasicBlock* const failBlock = fgSetRngChkTargetInner(boundsChk->gtThrowKind, delay, &boundsChk->gtStkDepth);
+        BasicBlock* const       failBlock = fgSetRngChkTargetInner(boundsChk->gtThrowKind, delay);
         if (failBlock != nullptr)
         {
             boundsChk->gtIndRngFailBB = gtNewCodeRef(failBlock);
@@ -5613,7 +5580,7 @@ void Compiler::fgSetRngChkTarget(GenTree* tree, bool delay)
     else if (tree->OperIs(GT_INDEX_ADDR))
     {
         GenTreeIndexAddr* const indexAddr = tree->AsIndexAddr();
-        BasicBlock* const       failBlock = fgSetRngChkTargetInner(SCK_RNGCHK_FAIL, delay, &indexAddr->gtStkDepth);
+        BasicBlock* const       failBlock = fgSetRngChkTargetInner(SCK_RNGCHK_FAIL, delay);
         if (failBlock != nullptr)
         {
             indexAddr->gtIndRngFailBB = gtNewCodeRef(failBlock);
@@ -5622,51 +5589,23 @@ void Compiler::fgSetRngChkTarget(GenTree* tree, bool delay)
     else
     {
         noway_assert(tree->OperIs(GT_ARR_ELEM, GT_ARR_INDEX));
-        fgSetRngChkTargetInner(SCK_RNGCHK_FAIL, delay, nullptr);
+        fgSetRngChkTargetInner(SCK_RNGCHK_FAIL, delay);
     }
 }
 
-BasicBlock* Compiler::fgSetRngChkTargetInner(SpecialCodeKind kind, bool delay, unsigned* stkDepth)
+BasicBlock* Compiler::fgSetRngChkTargetInner(SpecialCodeKind kind, bool delay)
 {
     if (opts.MinOpts())
     {
         delay = false;
-
-#if !FEATURE_FIXED_OUT_ARGS
-        // we need to initialize this field
-        if (fgGlobalMorph && (stkDepth != nullptr))
-        {
-            *stkDepth = fgPtrArgCntCur;
-        }
-#endif // !FEATURE_FIXED_OUT_ARGS
     }
 
     if (!opts.compDbgCode)
     {
-        if (delay || compIsForInlining())
+        if (!delay && !compIsForInlining())
         {
-#if !FEATURE_FIXED_OUT_ARGS
-            // We delay this until after loop-oriented range check analysis. For now we merely store the current stack
-            // level in the tree node.
-            if (stkDepth != nullptr)
-            {
-                *stkDepth = fgPtrArgCntCur;
-            }
-#endif // !FEATURE_FIXED_OUT_ARGS
-        }
-        else
-        {
-#if !FEATURE_FIXED_OUT_ARGS
-            // fgPtrArgCntCur is only valid for global morph or if we walk full stmt.
-            noway_assert(fgGlobalMorph || (stkDepth != nullptr));
-            const unsigned theStkDepth = fgGlobalMorph ? fgPtrArgCntCur : *stkDepth;
-#else
-            // only x86 pushes args
-            const unsigned theStkDepth = 0;
-#endif
-
             // Create/find the appropriate "range-fail" label
-            return fgRngChkTarget(compCurBB, theStkDepth, kind);
+            return fgRngChkTarget(compCurBB, kind);
         }
     }
 
@@ -11749,6 +11688,7 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac)
 
         USE_HELPER_FOR_ARITH:
         {
+            // TODO: this comment is wrong now, do an appropriate fix.
             /* We have to morph these arithmetic operations into helper calls
                before morphing the arguments (preorder), else the arguments
                won't get correct values of fgPtrArgCntCur.
@@ -12888,13 +12828,13 @@ DONE_MORPHING_CHILDREN:
             if (!varTypeIsFloating(tree->gtType))
             {
                 // Codegen for this instruction needs to be able to throw two exceptions:
-                fgAddCodeRef(compCurBB, bbThrowIndex(compCurBB), SCK_OVERFLOW, fgPtrArgCntCur);
-                fgAddCodeRef(compCurBB, bbThrowIndex(compCurBB), SCK_DIV_BY_ZERO, fgPtrArgCntCur);
+                fgAddCodeRef(compCurBB, bbThrowIndex(compCurBB), SCK_OVERFLOW);
+                fgAddCodeRef(compCurBB, bbThrowIndex(compCurBB), SCK_DIV_BY_ZERO);
             }
             break;
         case GT_UDIV:
             // Codegen for this instruction needs to be able to throw one exception:
-            fgAddCodeRef(compCurBB, bbThrowIndex(compCurBB), SCK_DIV_BY_ZERO, fgPtrArgCntCur);
+            fgAddCodeRef(compCurBB, bbThrowIndex(compCurBB), SCK_DIV_BY_ZERO);
             break;
 #endif
 
@@ -12907,7 +12847,7 @@ DONE_MORPHING_CHILDREN:
 
                 // Add the excptn-throwing basic block to jump to on overflow
 
-                fgAddCodeRef(compCurBB, bbThrowIndex(compCurBB), SCK_OVERFLOW, fgPtrArgCntCur);
+                fgAddCodeRef(compCurBB, bbThrowIndex(compCurBB), SCK_OVERFLOW);
 
                 // We can't do any commutative morphing for overflow instructions
 
@@ -13203,7 +13143,7 @@ DONE_MORPHING_CHILDREN:
 
             noway_assert(varTypeIsFloating(op1->TypeGet()));
 
-            fgAddCodeRef(compCurBB, bbThrowIndex(compCurBB), SCK_ARITH_EXCPN, fgPtrArgCntCur);
+            fgAddCodeRef(compCurBB, bbThrowIndex(compCurBB), SCK_ARITH_EXCPN);
             break;
 
         case GT_OBJ:
@@ -14566,7 +14506,6 @@ GenTree* Compiler::fgMorphToEmulatedFP(GenTree* tree)
     {
         int      helper;
         GenTree* args;
-        size_t   argc = genTypeStSz(typ);
 
         /* Not all FP operations need helper calls */
 
@@ -14592,17 +14531,10 @@ GenTree* Compiler::fgMorphToEmulatedFP(GenTree* tree)
 
         /* Keep track of how many arguments we're passing */
 
-        fgPtrArgCntCur += argc;
-
         /* Is this a binary operator? */
 
         if (op2)
         {
-            /* Add the second operand to the argument count */
-
-            fgPtrArgCntCur += argc;
-            argc *= 2;
-
             /* What kind of an operator do we have? */
 
             switch (oper)
@@ -14701,7 +14633,6 @@ GenTree* Compiler::fgMorphToEmulatedFP(GenTree* tree)
 
         tree = fgMorphIntoHelperCall(tree, helper, args);
 
-        fgPtrArgCntCur -= argc;
         return tree;
 
         case GT_RETURN:
@@ -15850,8 +15781,6 @@ void Compiler::fgMorphStmts(BasicBlock* block, bool* lnot, bool* loadw)
         }
 
         stmt->gtStmtExpr = tree = morph;
-
-        noway_assert(fgPtrArgCntCur == 0);
 
         if (fgRemoveRestOfBlock)
         {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2846,13 +2846,13 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
     // On remorph, we grab it from the arg table.
     unsigned numArgs = 0;
 
-    // TODO: this comment is no longer correct, do an approptiate fix.
+    // TODO: this comment is no longer correct, do an appropriate fix.
     // Process the late arguments (which were determined by a previous caller).
     // Do this before resetting fgPtrArgCntCur as fgMorphTree(call->gtCallLateArgs)
     // may need to refer to it.
     if (reMorphing)
     {
-        // TODO: this comment is no longer correct, do an approptiate fix.
+        // TODO: this comment is no longer correct, do an appropriate fix.
         // We need to reMorph the gtCallLateArgs early since that is what triggers
         // the expression folding and we need to have the final folded gtCallLateArgs
         // available when we call RemorphRegArg so that we correctly update the fgArgInfo

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -164,8 +164,6 @@ void Rationalizer::RewriteNodeAsCall(GenTree**             use,
 #endif
 
     call = comp->fgMorphArgs(call);
-    // Determine if this call has changed any codegen requirements.
-    comp->fgCheckArgCnt();
 
     // Replace "tree" with "call"
     if (parents.Height() > 1)

--- a/src/jit/stacklevelsetter.cpp
+++ b/src/jit/stacklevelsetter.cpp
@@ -56,6 +56,7 @@ void StackLevelSetter::DoPhase()
                 comp->fgGetPtrArgCntMax(), maxStackLevel);
         comp->fgSetPtrArgCntMax(maxStackLevel);
     }
+    CheckArgCnt();
 }
 
 //------------------------------------------------------------------------
@@ -267,4 +268,44 @@ void StackLevelSetter::SubStackLevel(unsigned value)
 {
     assert(currentStackLevel >= value);
     currentStackLevel -= value;
+}
+
+//------------------------------------------------------------------------
+// fgCheckArgCnt: Check whether the maximum arg size will change codegen requirements
+//
+// Notes:
+//    fpPtrArgCntMax records the maximum number of pushed arguments.
+//    Depending upon this value of the maximum number of pushed arguments
+//    we may need to use an EBP frame or be partially interuptible.
+//    This functionality has been factored out of fgSetOptions() because
+//    the Rationalizer can create new calls.
+//
+// Assumptions:
+//    This must be called before isFramePointerRequired() is called, because it is a
+//    phased variable (can only be written before it has been read).
+//
+void StackLevelSetter::CheckArgCnt()
+{
+    if (!comp->compCanEncodePtrArgCntMax())
+    {
+#ifdef DEBUG
+        if (comp->verbose)
+        {
+            printf("Too many pushed arguments for fully interruptible encoding, marking method as partially "
+                   "interruptible\n");
+        }
+#endif
+        comp->genInterruptible = false;
+    }
+    if (maxStackLevel >= sizeof(unsigned))
+    {
+#ifdef DEBUG
+        if (comp->verbose)
+        {
+            printf("Too many pushed arguments for an ESP based encoding, forcing an EBP frame\n");
+        }
+#endif
+        comp->codeGen->resetWritePhaseForFramePointerRequired();
+        comp->codeGen->setFramePointerRequired(true);
+    }
 }

--- a/src/jit/stacklevelsetter.cpp
+++ b/src/jit/stacklevelsetter.cpp
@@ -294,17 +294,16 @@ void StackLevelSetter::SubStackLevel(unsigned value)
 }
 
 //------------------------------------------------------------------------
-// fgCheckArgCnt: Check whether the maximum arg size will change codegen requirements
+// CheckArgCnt: Check whether the maximum arg size will change codegen requirements.
 //
 // Notes:
-//    fpPtrArgCntMax records the maximum number of pushed arguments.
+//    CheckArgCnt records the maximum number of pushed arguments.
 //    Depending upon this value of the maximum number of pushed arguments
 //    we may need to use an EBP frame or be partially interuptible.
-//    This functionality has been factored out of fgSetOptions() because
-//    the Rationalizer can create new calls.
+//    This functionality has to be called after maxStackLevel is set.
 //
 // Assumptions:
-//    This must be called before isFramePointerRequired() is called, because it is a
+//    This must be called when isFramePointerRequired() is in a write phase, because it is a
 //    phased variable (can only be written before it has been read).
 //
 void StackLevelSetter::CheckArgCnt()
@@ -332,6 +331,12 @@ void StackLevelSetter::CheckArgCnt()
     }
 }
 
+//------------------------------------------------------------------------
+// CheckAdditionalArgs: Check if there are additional args that need stack slots.
+//
+// Notes:
+//    Currently only x86 profiler hook needs it.
+//
 void StackLevelSetter::CheckAdditionalArgs()
 {
 #if defined(_TARGET_X86_)

--- a/src/jit/stacklevelsetter.cpp
+++ b/src/jit/stacklevelsetter.cpp
@@ -50,12 +50,10 @@ void StackLevelSetter::DoPhase()
         comp->codeGen->setFramePointerRequired(true);
     }
 #endif // !FEATURE_FIXED_OUT_ARGS
-    if (maxStackLevel != comp->fgGetPtrArgCntMax())
-    {
-        JITDUMP("fgPtrArgCntMax was calculated wrong during the morph, the old value: %u, the right value: %u.\n",
-                comp->fgGetPtrArgCntMax(), maxStackLevel);
-        comp->fgSetPtrArgCntMax(maxStackLevel);
-    }
+
+    CheckAdditionalArgs();
+
+    comp->fgSetPtrArgCntMax(maxStackLevel);
     CheckArgCnt();
 }
 
@@ -308,4 +306,18 @@ void StackLevelSetter::CheckArgCnt()
         comp->codeGen->resetWritePhaseForFramePointerRequired();
         comp->codeGen->setFramePointerRequired(true);
     }
+}
+
+void StackLevelSetter::CheckAdditionalArgs()
+{
+#if defined(_TARGET_X86_)
+    if (comp->compIsProfilerHookNeeded())
+    {
+        if (maxStackLevel == 0)
+        {
+            JITDUMP("Upping fgPtrArgCntMax from %d to 1\n", maxStackLevel);
+            maxStackLevel = 1;
+        }
+    }
+#endif // _TARGET_X86_
 }

--- a/src/jit/stacklevelsetter.h
+++ b/src/jit/stacklevelsetter.h
@@ -26,6 +26,8 @@ private:
     void AddStackLevel(unsigned value);
     void SubStackLevel(unsigned value);
 
+    void CheckArgCnt();
+
 private:
     unsigned currentStackLevel; // current number of stack slots used by arguments.
     unsigned maxStackLevel;     // max number of stack slots for arguments.

--- a/src/jit/stacklevelsetter.h
+++ b/src/jit/stacklevelsetter.h
@@ -27,6 +27,7 @@ private:
     void SubStackLevel(unsigned value);
 
     void CheckArgCnt();
+    void CheckAdditionalArgs();
 
 private:
     unsigned currentStackLevel; // current number of stack slots used by arguments.


### PR DESCRIPTION
The responsibilities of the old code that tracked stack level were:
1) Set `fgPtrArgCntMax` and check that we can encode it (in `fgCheckArgCnt`);
2) Set ` call->fgArgInfo->SetStkSizeBytes`;
3) Set `AddCodeDsc->acdStkLvl`;
4) Set `setFramePointerRequired`;
now we do it all in `StackLevelSetter` when we have the finalized correct information about the stack levels.

No windows x86/x64 CoreCLR libraries diffs.
There are few spmi diffs: 30 functions were optimized to have an esp based frame.
There were cases were we forced an ebp based frame because of the calls that were later marked as useless and were deleted. Now such cases recieve esp based frames.
For example:
Old code:
```
; Total bytes of code 12, prolog size 3 for method *
; ebp based frame
G_M65471_IG01:
       push     ebp
       mov      ebp, esp

G_M65471_IG02:
       cmp      byte  ptr [ecx+29], 0
       je       SHORT G_M65471_IG03
       mov      eax, gword ptr [ecx+24]
       mov      eax, dword ptr [eax]

G_M65471_IG03:
       xor      eax, eax

G_M65471_IG04:
       pop      ebp
       ret 

```
new code:
```
; Total bytes of code 8, prolog size 0 for method *
; esp based frame
G_M65471_IG01:
				   
						

G_M65471_IG02:
       cmp      byte  ptr [ecx+29], 0
       je       SHORT G_M65471_IG03
       mov      eax, gword ptr [ecx+24]
       mov      eax, dword ptr [eax]

G_M65471_IG03:
       xor      eax, eax

G_M65471_IG04:
				   
       ret 

```
Fixes #16411.