### PR TITLE
disable NETClientPrimitives test for all platforms.

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -47,6 +47,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_11408/GitHub_11408/*">
             <Issue>11408</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\COM\NETClients\Primitives\NETClientPrimitives\NETClientPrimitives.cmd">
+            <Issue>19164</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- All Unix targets -->
@@ -248,9 +251,6 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/varargs/varargsupport_r/*">
             <Issue>Varargs supported on this platform</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\Interop\COM\NETClients\Primitives\NETClientPrimitives\NETClientPrimitives.cmd">
-            <Issue>19164</Issue>
         </ExcludeList>
     </ItemGroup>
 


### PR DESCRIPTION
As it was before.

Fixes R2R jobs like https://ci.dot.net/job/dotnet_coreclr/job/master/job/x86_checked_windows_nt_r2r/.


