### PR TITLE
Define T_RUNTIME_FUNCTION in cross-bitness crossgen ARM32

### DIFF
--- a/src/inc/clrnt.h
+++ b/src/inc/clrnt.h
@@ -933,6 +933,7 @@ typedef struct _UNWIND_INFO {
     // dummy
 } UNWIND_INFO, *PUNWIND_INFO;
 
+#if defined(FEATURE_PAL) || defined(_X86_)
 EXTERN_C
 NTSYSAPI
 VOID
@@ -960,7 +961,7 @@ RtlVirtualUnwind (
     __out PDWORD EstablisherFrame,
     __inout_opt PT_KNONVOLATILE_CONTEXT_POINTERS ContextPointers
     );
-
+#endif // FEATURE_PAL || _X86_
 #define UNW_FLAG_NHANDLER 0x0
 
 #endif // _TARGET_ARM_

--- a/src/inc/clrnt.h
+++ b/src/inc/clrnt.h
@@ -962,6 +962,7 @@ RtlVirtualUnwind (
     __inout_opt PT_KNONVOLATILE_CONTEXT_POINTERS ContextPointers
     );
 #endif // FEATURE_PAL || _X86_
+
 #define UNW_FLAG_NHANDLER 0x0
 
 #endif // _TARGET_ARM_

--- a/src/inc/crosscomp.h
+++ b/src/inc/crosscomp.h
@@ -12,7 +12,7 @@
 #define CROSSBITNESS_COMPILE
 #endif
 
-#if defined(_X86_) && defined(_TARGET_ARM_)      // Host X86 managing ARM related code
+#if (defined(_X86_) || defined(_AMD64_)) && defined(_TARGET_ARM_) // Host X86 or AMD64 managing ARM related code
 
 #ifndef CROSS_COMPILE
 #define CROSS_COMPILE
@@ -93,6 +93,7 @@ typedef struct DECLSPEC_ALIGN(8) _T_CONTEXT {
 //
 
 #ifndef FEATURE_PAL
+#ifdef _X86_
 typedef struct _RUNTIME_FUNCTION {
     DWORD BeginAddress;
     DWORD UnwindData;
@@ -119,6 +120,7 @@ typedef struct _UNWIND_HISTORY_TABLE {
     DWORD HighAddress;
     UNWIND_HISTORY_TABLE_ENTRY Entry[UNWIND_HISTORY_TABLE_SIZE];
 } UNWIND_HISTORY_TABLE, *PUNWIND_HISTORY_TABLE;
+#endif // _X86_
 #endif // !FEATURE_PAL
 
 
@@ -175,8 +177,15 @@ typedef struct _T_DISPATCHER_CONTEXT {
     PUCHAR NonVolatileRegisters;
 } T_DISPATCHER_CONTEXT, *PT_DISPATCHER_CONTEXT;
 
+#if defined(FEATURE_PAL) || defined(_X86_)
 #define T_RUNTIME_FUNCTION RUNTIME_FUNCTION
 #define PT_RUNTIME_FUNCTION PRUNTIME_FUNCTION
+#else
+typedef struct _T_RUNTIME_FUNCTION {
+    DWORD BeginAddress;
+    DWORD UnwindData;
+} T_RUNTIME_FUNCTION, *PT_RUNTIME_FUNCTION;
+#endif
 
 #elif defined(_AMD64_) && defined(_TARGET_ARM64_)  // Host amd64 managing ARM64 related code
 
@@ -347,7 +356,7 @@ typedef struct _T_KNONVOLATILE_CONTEXT_POINTERS {
 
 } T_KNONVOLATILE_CONTEXT_POINTERS, *PT_KNONVOLATILE_CONTEXT_POINTERS;
 
-#else  // !(defined(_X86_) && defined(_TARGET_ARM_)) && !(defined(_AMD64_) && defined(_TARGET_ARM64_))
+#else  // !((defined(_X86_) || (defined(_AMD64_)) && defined(_TARGET_ARM_)) && !(defined(_AMD64_) && defined(_TARGET_ARM64_))
 
 #define T_CONTEXT CONTEXT
 #define PT_CONTEXT PCONTEXT

--- a/src/inc/crosscomp.h
+++ b/src/inc/crosscomp.h
@@ -12,7 +12,7 @@
 #define CROSSBITNESS_COMPILE
 #endif
 
-#if (defined(_X86_) || defined(_AMD64_)) && defined(_TARGET_ARM_) // Host X86 or AMD64 managing ARM related code
+#if !defined(_ARM_) && defined(_TARGET_ARM_) // Non-ARM Host managing ARM related code
 
 #ifndef CROSS_COMPILE
 #define CROSS_COMPILE
@@ -356,7 +356,7 @@ typedef struct _T_KNONVOLATILE_CONTEXT_POINTERS {
 
 } T_KNONVOLATILE_CONTEXT_POINTERS, *PT_KNONVOLATILE_CONTEXT_POINTERS;
 
-#else  // !((defined(_X86_) || (defined(_AMD64_)) && defined(_TARGET_ARM_)) && !(defined(_AMD64_) && defined(_TARGET_ARM64_))
+#else
 
 #define T_CONTEXT CONTEXT
 #define PT_CONTEXT PCONTEXT

--- a/src/inc/daccess.h
+++ b/src/inc/daccess.h
@@ -2408,7 +2408,7 @@ typedef DPTR(union _UNWIND_CODE)       PTR_UNWIND_CODE;
 #endif // _TARGET_64BIT_
 
 #ifdef _TARGET_ARM_
-typedef DPTR(RUNTIME_FUNCTION) PTR_RUNTIME_FUNCTION;
+typedef DPTR(T_RUNTIME_FUNCTION) PTR_RUNTIME_FUNCTION;
 #endif
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
In cross-bitness scenario `T_RUNTIME_FUNCTION` should be defined separately (`RUNTIME_FUNCTION` defined on amd64 host can not be used due to its different layout).
Also enable definitions of `RtlUnwindEx` `RtlVirtualUnwind` if host is either non-Windows or Windows/x86 and use host definitions on Windows/x64.