### PR TITLE
Updating floatdouble and floatsingle to work around an incorrect result under /fp:fast

### DIFF
--- a/src/classlibnative/float/floatdouble.cpp
+++ b/src/classlibnative/float/floatdouble.cpp
@@ -123,6 +123,11 @@ FCIMPL1_V(double, COMDouble::Cbrt, double x)
     return (double)cbrt(x);
 FCIMPLEND
 
+#if defined(_MSC_VER) && defined(_TARGET_AMD64_)
+// The /fp:fast form of `ceil` for AMD64 does not correctly handle: `-1.0 < value <= -0.0`
+#pragma float_control(precise, on )
+#endif
+
 /*====================================Ceil======================================
 **
 ==============================================================================*/
@@ -131,6 +136,10 @@ FCIMPL1_V(double, COMDouble::Ceil, double x)
 
     return (double)ceil(x);
 FCIMPLEND
+
+#if defined(_MSC_VER) && defined(_TARGET_AMD64_)
+#pragma float_control(precise, off)
+#endif
 
 /*=====================================Cos======================================
 **
@@ -159,6 +168,11 @@ FCIMPL1_V(double, COMDouble::Exp, double x)
     return (double)exp(x);
 FCIMPLEND
 
+#if defined(_MSC_VER) && defined(_TARGET_X86_)
+// The /fp:fast form of `floor` for x86 does not correctly handle: `-0.0`
+#pragma float_control(precise, on )
+#endif
+
 /*====================================Floor=====================================
 **
 ==============================================================================*/
@@ -167,6 +181,10 @@ FCIMPL1_V(double, COMDouble::Floor, double x)
 
     return (double)floor(x);
 FCIMPLEND
+
+#if defined(_MSC_VER) && defined(_TARGET_X86_)
+#pragma float_control(precise, off)
+#endif
 
 /*=====================================FMod=====================================
 **

--- a/src/classlibnative/float/floatdouble.cpp
+++ b/src/classlibnative/float/floatdouble.cpp
@@ -39,6 +39,7 @@
 ////////////////////////////////////////////////////////////////////////////////////
 
 #ifdef _MSC_VER
+#pragma float_control(push)
 #pragma float_control(precise, off)
 #endif
 
@@ -125,7 +126,9 @@ FCIMPLEND
 
 #if defined(_MSC_VER) && defined(_TARGET_AMD64_)
 // The /fp:fast form of `ceil` for AMD64 does not correctly handle: `-1.0 < value <= -0.0`
-#pragma float_control(precise, on )
+// https://github.com/dotnet/coreclr/issues/19739
+#pragma float_control(push)
+#pragma float_control(precise, on)
 #endif
 
 /*====================================Ceil======================================
@@ -138,7 +141,7 @@ FCIMPL1_V(double, COMDouble::Ceil, double x)
 FCIMPLEND
 
 #if defined(_MSC_VER) && defined(_TARGET_AMD64_)
-#pragma float_control(precise, off)
+#pragma float_control(pop)
 #endif
 
 /*=====================================Cos======================================
@@ -170,7 +173,9 @@ FCIMPLEND
 
 #if defined(_MSC_VER) && defined(_TARGET_X86_)
 // The /fp:fast form of `floor` for x86 does not correctly handle: `-0.0`
-#pragma float_control(precise, on )
+// https://github.com/dotnet/coreclr/issues/19739
+#pragma float_control(push)
+#pragma float_control(precise, on)
 #endif
 
 /*====================================Floor=====================================
@@ -183,7 +188,7 @@ FCIMPL1_V(double, COMDouble::Floor, double x)
 FCIMPLEND
 
 #if defined(_MSC_VER) && defined(_TARGET_X86_)
-#pragma float_control(precise, off)
+#pragma float_control(pop)
 #endif
 
 /*=====================================FMod=====================================
@@ -277,7 +282,7 @@ FCIMPL1_V(double, COMDouble::Tanh, double x)
 FCIMPLEND
 
 #ifdef _MSC_VER
-#pragma float_control(precise, on )
+#pragma float_control(pop)
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////

--- a/src/classlibnative/float/floatsingle.cpp
+++ b/src/classlibnative/float/floatsingle.cpp
@@ -121,6 +121,11 @@ FCIMPL1_V(float, COMSingle::Cbrt, float x)
     return (float)cbrtf(x);
 FCIMPLEND
 
+#if defined(_MSC_VER) && defined(_TARGET_AMD64_)
+// The /fp:fast form of `ceilf` for AMD64 does not correctly handle: `-1.0 < value <= -0.0`
+#pragma float_control(precise, on )
+#endif
+
 /*====================================Ceil======================================
 **
 ==============================================================================*/
@@ -129,6 +134,10 @@ FCIMPL1_V(float, COMSingle::Ceil, float x)
 
     return (float)ceilf(x);
 FCIMPLEND
+
+#if defined(_MSC_VER) && defined(_TARGET_AMD64_)
+#pragma float_control(precise, off)
+#endif
 
 /*=====================================Cos======================================
 **

--- a/src/classlibnative/float/floatsingle.cpp
+++ b/src/classlibnative/float/floatsingle.cpp
@@ -37,6 +37,7 @@
 ////////////////////////////////////////////////////////////////////////////////////
 
 #ifdef _MSC_VER
+#pragma float_control(push)
 #pragma float_control(precise, off)
 #endif
 
@@ -123,7 +124,9 @@ FCIMPLEND
 
 #if defined(_MSC_VER) && defined(_TARGET_AMD64_)
 // The /fp:fast form of `ceilf` for AMD64 does not correctly handle: `-1.0 < value <= -0.0`
-#pragma float_control(precise, on )
+// https://github.com/dotnet/coreclr/issues/19739
+#pragma float_control(push)
+#pragma float_control(precise, on)
 #endif
 
 /*====================================Ceil======================================
@@ -136,7 +139,7 @@ FCIMPL1_V(float, COMSingle::Ceil, float x)
 FCIMPLEND
 
 #if defined(_MSC_VER) && defined(_TARGET_AMD64_)
-#pragma float_control(precise, off)
+#pragma float_control(pop)
 #endif
 
 /*=====================================Cos======================================
@@ -266,7 +269,7 @@ FCIMPL1_V(float, COMSingle::Tanh, float x)
 FCIMPLEND
 
 #ifdef _MSC_VER
-#pragma float_control(precise, on )
+#pragma float_control(pop)
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
`/fp:fast` breaks `Ceiling` and `Floor` handling for certain inputs