### PR TITLE
Do not Constant-Prop immediate values that require relocation on ARM32

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -1109,6 +1109,11 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
                     if (op2->gtOper == GT_CNS_INT)
                     {
 #ifdef _TARGET_ARM_
+                        // Do not Constant-Prop immediate values that require relocation
+                        if (op2->gtIntCon.ImmedValNeedsReloc(this))
+                        {
+                            goto DONE_ASSERTION;
+                        }
                         // Do not Constant-Prop large constants for ARM
                         if (!codeGen->validImmForMov(op2->gtIntCon.gtIconVal))
                         {

--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -1115,7 +1115,9 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
                             goto DONE_ASSERTION;
                         }
                         // Do not Constant-Prop large constants for ARM
-                        if (!codeGen->validImmForMov(op2->gtIntCon.gtIconVal))
+                        // TODO-CrossBitness: we wouldn't need the cast below if GenTreeIntCon::gtIconVal had
+                        // target_ssize_t type.
+                        if (!codeGen->validImmForMov((target_ssize_t)op2->gtIntCon.gtIconVal))
                         {
                             goto DONE_ASSERTION; // Don't make an assertion
                         }


### PR DESCRIPTION
Two changes - one is functional, another is cosmetic (needed to get rid of a warning in cross-bitness compilation scenario) which depends on the first one:
1. Do not Constant-Prop immediate values that require relocation
2. Cast `gtIconVal` to `target_ssize_t` - since it's guaranteed not to be a relocatable immediate we can safely do this