### PR TITLE
Fix CoreCLR debug launch

### DIFF
--- a/src/dlls/dbgshim/dbgshim.cpp
+++ b/src/dlls/dbgshim/dbgshim.cpp
@@ -1144,13 +1144,12 @@ EnumerateCLRs(
 
     // The modules in the array returned don't need to be closed
     DWORD countModules;
-    HMODULE* pModules;
-    HRESULT hr = EnumProcessModulesInternal(hProcess, &countModules, &pModules);
+    ArrayHolder<HMODULE> modules = nullptr;
+    HRESULT hr = EnumProcessModulesInternal(hProcess, &countModules, &modules);
     if (FAILED(hr))
     {
         return hr;
     }
-    ArrayHolder<HMODULE> modules(pModules);
 
     //
     // count the number of coreclr.dll entries
@@ -1324,13 +1323,12 @@ GetRemoteModuleBaseAddress(
 
     // The modules in the array returned don't need to be closed
     DWORD countModules;
-    HMODULE* pModules;
-    HRESULT hr = EnumProcessModulesInternal(hProcess, &countModules, &pModules);    
+    ArrayHolder<HMODULE> modules = nullptr;
+    HRESULT hr = EnumProcessModulesInternal(hProcess, &countModules, &modules);    
     if (FAILED(hr))
     {
         ThrowHR(hr);
     }
-    ArrayHolder<HMODULE> modules(pModules);
 
     for(DWORD i = 0; i < countModules; i++)
     {

--- a/src/inc/clrhost.h
+++ b/src/inc/clrhost.h
@@ -44,7 +44,7 @@
 //
 #ifdef _DEBUG
 
-#define LAST_ERROR_TRASH_VALUE 42424
+#define LAST_ERROR_TRASH_VALUE 42424 /* = 0xa5b8 */
 
 #define TRASH_LASTERROR \
     SetLastError(LAST_ERROR_TRASH_VALUE)


### PR DESCRIPTION
The new/delete operator can potentially trash last error (in debug build, it always happens), therefore we should obtain the last error code right after the kernel32!EnumProcessModules() call.