### PR TITLE
Update test netcoreapp references to 2.2

### DIFF
--- a/tests/publishdependency.targets
+++ b/tests/publishdependency.targets
@@ -3,8 +3,8 @@
 
   <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <ItemGroup>
-    <TestTargetFramework Include=".NETCoreApp,Version=v2.1">
-      <Folder>netcoreapp2.1</Folder>
+    <TestTargetFramework Include=".NETCoreApp,Version=v2.2">
+      <Folder>netcoreapp2.2</Folder>
     </TestTargetFramework>
   </ItemGroup>
 

--- a/tests/src/Common/build_against_pkg_dependencies/build_against_pkg_dependencies.csproj
+++ b/tests/src/Common/build_against_pkg_dependencies/build_against_pkg_dependencies.csproj
@@ -25,7 +25,7 @@
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8</PackageTargetFallback>
     <RuntimeIdentifiers>win-arm;win-arm64;win-x64;win-x86;$(TargetRid)</RuntimeIdentifiers>

--- a/tests/src/Common/test_dependencies/test_dependencies.csproj
+++ b/tests/src/Common/test_dependencies/test_dependencies.csproj
@@ -5,8 +5,8 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <NugetTargetMoniker>.NETCoreApp,Version=v2.1</NugetTargetMoniker>
-    <NugetTargetMonikerShort>netcoreapp2.1</NugetTargetMonikerShort>
+    <NugetTargetMoniker>.NETCoreApp,Version=v2.2</NugetTargetMoniker>
+    <NugetTargetMonikerShort>netcoreapp2.2</NugetTargetMonikerShort>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
@@ -28,7 +28,7 @@
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;netcoreapp1.1;portable-net45+win8</PackageTargetFallback>
     <RuntimeIdentifiers>win-arm;win-arm64;win-x64;win-x86;$(TargetRid)</RuntimeIdentifiers>

--- a/tests/src/Common/test_runtime/test_runtime.csproj
+++ b/tests/src/Common/test_runtime/test_runtime.csproj
@@ -5,8 +5,8 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <NugetTargetMoniker>.NETCoreApp,Version=v2.1</NugetTargetMoniker>
-    <NugetTargetMonikerShort>netcoreapp2.1</NugetTargetMonikerShort>
+    <NugetTargetMoniker>.NETCoreApp,Version=v2.2</NugetTargetMoniker>
+    <NugetTargetMonikerShort>netcoreapp2.2</NugetTargetMonikerShort>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
@@ -27,7 +27,7 @@
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
     <RuntimeIdentifiers>win-arm;win-arm64;win-x64;win-x86;$(TargetRid)</RuntimeIdentifiers>

--- a/tests/src/dir.props
+++ b/tests/src/dir.props
@@ -95,8 +95,8 @@
     <RestoreOutputPath>$(MSBuildProjectDirectory)\obj</RestoreOutputPath>
 
     <!-- Specify the target framework of the common test dependency project.json. -->
-    <NuGetTargetMoniker>.NETCoreApp,Version=v2.1</NuGetTargetMoniker>
-    <NuGetTargetMonikerShort>netcoreapp2.1</NuGetTargetMonikerShort>
+    <NuGetTargetMoniker>.NETCoreApp,Version=v2.2</NuGetTargetMoniker>
+    <NuGetTargetMonikerShort>netcoreapp2.2</NuGetTargetMonikerShort>
     <PrereleaseResolveNuGetPackages>true</PrereleaseResolveNuGetPackages>
   </PropertyGroup>
 


### PR DESCRIPTION
In order to unblock #19532, we need to change the test csproj files to reference netcoreapp2.2 and Version=v2.2.