### PR TITLE
JIT: don't allocate promoted struct death vars map for clear or lookup

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7126,6 +7126,27 @@ public:
         return m_promotedStructDeathVars;
     }
 
+    void ClearPromotedStructDeathVars()
+    {
+        if (m_promotedStructDeathVars != nullptr)
+        {
+            m_promotedStructDeathVars->RemoveAll();
+        }
+    }
+
+    bool LookupPromotedStructDeathVars(GenTree* tree, VARSET_TP** bits)
+    {
+        bits        = nullptr;
+        bool result = false;
+
+        if (m_promotedStructDeathVars != nullptr)
+        {
+            result = m_promotedStructDeathVars->Lookup(tree, bits);
+        }
+
+        return result;
+    }
+
 /*
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -138,7 +138,7 @@ void Compiler::fgLocalVarLiveness()
     EndPhase(PHASE_LCLVARLIVENESS_INIT);
 
     // Make sure we haven't noted any partial last uses of promoted structs.
-    GetPromotedStructDeathVars()->RemoveAll();
+    ClearPromotedStructDeathVars();
 
     // Initialize the per-block var sets.
     fgInitBlockVarSets();
@@ -1340,7 +1340,7 @@ VARSET_VALRET_TP Compiler::fgUpdateLiveSet(VARSET_VALARG_TP liveSet, GenTree* tr
                 // We maintain the invariant that if the lclVarTree is a promoted struct, but the
                 // the lookup fails, then all the field vars (i.e., "varBits") are dying.
                 VARSET_TP* deadVarBits = nullptr;
-                if (varTypeIsStruct(lclVarTree) && GetPromotedStructDeathVars()->Lookup(lclVarTree, &deadVarBits))
+                if (varTypeIsStruct(lclVarTree) && LookupPromotedStructDeathVars(lclVarTree, &deadVarBits))
                 {
                     VarSetOps::DiffD(this, newLiveSet, *deadVarBits);
                 }

--- a/src/jit/treelifeupdater.cpp
+++ b/src/jit/treelifeupdater.cpp
@@ -115,7 +115,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
             {
                 assert(!isBorn); // GTF_VAR_DEATH only set for LDOBJ last use.
                 hasDeadTrackedFieldVars =
-                    compiler->GetPromotedStructDeathVars()->Lookup(indirAddrLocal, &deadTrackedFieldVars);
+                    compiler->LookupPromotedStructDeathVars(indirAddrLocal, &deadTrackedFieldVars);
                 if (hasDeadTrackedFieldVars)
                 {
                     VarSetOps::Assign(compiler, varDeltaSet, *deadTrackedFieldVars);


### PR DESCRIPTION
Only allocate this map if we're adding something. Refactor clearing and
lookup to do minimal work if the map hasn't been allocated (and it won't
have been in debug / minopts).

Saves a tiny bit of throughput and memory.