### PR TITLE
Dump4sos

### DIFF
--- a/src/debug/createdump/crashinfo.cpp
+++ b/src/debug/createdump/crashinfo.cpp
@@ -197,6 +197,10 @@ CrashInfo::GatherCrashInfo(MINIDUMP_TYPE minidumpType)
     // Add all the heap (read/write) memory regions (m_otherMappings contains the heaps)
     else if (minidumpType & MiniDumpWithPrivateReadWriteMemory)
     {
+        for (const MemoryRegion& region : m_moduleMappings)
+        {
+            InsertMemoryBackedRegion(region);
+        }
         for (const MemoryRegion& region : m_otherMappings)
         {
             if (region.Permissions() == (PF_R | PF_W))


### PR DESCRIPTION
With the current implementation, an LLDB analysis of a dump generated with the -h option leads to UNKNOWN instead of type/method names in dumpheap -stat or dumpstack commands.
This is due to missing assemblies from which the sos/mscordac plugin are extracting metadata. 

With this pull request, the assemblies are now part of the dump without increasing too much the size: on a dual core machine, full=11GB, withheap=226MB, withheap(+patch)=269MB

It is especially important to decrease the size of a "usable" memory dump in the context of containers for which disk space is restricted and time during which an application does not respond to help check is limited.