### PR TITLE
Fix build-test.sh wrapper build

### DIFF
--- a/build-test.cmd
+++ b/build-test.cmd
@@ -482,6 +482,8 @@ if errorlevel 1 (
     exit /b 1
 )
 
+echo { "build_os": "%__BuildOS%", "build_arch": "%__BuildArch%", "build_type": "%__BuildType%" } > "%__TestBinDir%/build_info.json"
+
 :SkipBuildingWrappers
 
 REM =========================================================================================

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -1914,6 +1914,23 @@ def do_setup(host_os,
 
     if unprocessed_args.build_test_wrappers:
         build_test_wrappers(host_os, arch, build_type, coreclr_repo_location, test_location)
+    else:
+        # We will write out build information into the test directory. This is used
+        # by runtest.py to determine whether we need to rebuild to test wrappers.
+        if os.path.isfile(os.path.join(test_location, "build_info.json")):
+            build_info = None
+            with open(os.path.join(test_location, "build_info.json")) as file_handle:
+                build_info = json.load(file_handle)
+
+            is_same_os = build_info["build_os"] == host_os
+            is_same_arch = build_info["build_arch"] == arch
+            is_same_build_type = build_info["build_type"] == build_type
+
+            # We will force a build of the test wrappers if they were cross built
+            if not (is_same_os and is_same_arch and is_same_build_type):
+                build_test_wrappers(host_os, arch, build_type, coreclr_repo_location, test_location)
+        else:
+            build_test_wrappers(host_os, arch, build_type, coreclr_repo_location, test_location)
 
     run_tests(host_os, 
               arch,

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -40,7 +40,7 @@ function print_usage {
     echo '  --tieredcompilation              : Runs the tests with COMPlus_TieredCompilation=1'
     echo '  --link <ILlink>                  : Runs the tests after linking via ILlink'
     echo '  --xunitOutputPath=<path>         : Create xUnit XML report at the specifed path (default: <test root>/coreclrtests.xml)'
-    echo '  --skipXunitWrapperBuild          : Skip creating the xunit wrapper'
+    echo '  --buildXUnitWrappers             : Force creating the xunit wrappers, this is useful if there have been changes to issues.targets'
     echo '  --printLastResultsOnly           : Print the results of the last run'
     echo ''
     echo 'CoreFX Test Options '
@@ -219,7 +219,7 @@ verbose=0
 doCrossgen=0
 jitdisasm=0
 ilasmroundtrip=
-skipXunitWrapperBuild=
+buildXUnitWrappers=
 printLastResultsOnly=
 generateLayoutOnly=
 generateLayout=
@@ -255,8 +255,8 @@ do
         release|Release)
             buildConfiguration="Release"
             ;;
-        --skipXunitWrapperBuild)
-            skipXunitWrapperBuild=1
+        --buildXUnitWrappers)
+            buildXUnitWrappers=1
             ;;
         --printLastResultsOnly)
             printLastResultsOnly=1
@@ -515,20 +515,11 @@ if [ ! -z "$ilasmroundtrip" ]; then
     runtestPyArguments+=("--ilasmroundtrip")
 fi
 
-if [ ! -z "$skipXunitWrapperBuild" ]; then
+if [ ! -z "$buildXUnitWrappers" ]; then
+    runtestPyArguments+=("--build_xunit_test_wrappers")
+else
     echo "Skipping xunit wrapper build. If build-test was called on a different"
     echo "host_os or arch the test run will most likely have failures."
-else
-    # By default rebuild the test wrappers, as we cannot gaurentee the following
-    # is true:
-    #   1) There are no added or removed excludes since the tests were built
-    #   2) That the wrapper generation happened on the same host_os and arch
-    #      as where we are running now
-    #
-    # Note that the wrapper generation is slow. To skip this pass --skipXunitWrapperBuild
-    # if the above requirements are met.
-
-    runtestPyArguments+=("--build_xunit_test_wrappers")
 fi
 
 if (($verbose!=0)); then


### PR DESCRIPTION
In addition this change creates a json file with the build info so that the wrapper build
may be skipped if it was built on the same os/arch/buildtype.