### PR TITLE
Fix callKillSet for CORINFO_HELP_ASSIGN_BYREF on x64.

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -639,6 +639,19 @@ regMaskTP Compiler::compNoGCHelperCallKillSet(CorInfoHelpFunc helper)
 
     switch (helper)
     {
+        case CORINFO_HELP_ASSIGN_BYREF:
+#if defined(_TARGET_X86_)
+            // This helper only trashes ECX.
+            return RBM_ECX;
+#elif defined(_TARGET_AMD64_)
+            // This uses and defs rdi and rci.
+            return RBM_CALLEE_TRASH_NOGC & ~(RBM_RDI | RBM_RSI);
+#elif defined(_TARGET_ARMARCH_)
+            return RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF;
+#else
+            assert(!"unknown arch");
+#endif
+
 #if defined(_TARGET_XARCH_)
         case CORINFO_HELP_PROF_FCN_ENTER:
             return RBM_PROFILER_ENTER_TRASH;
@@ -650,16 +663,7 @@ regMaskTP Compiler::compNoGCHelperCallKillSet(CorInfoHelpFunc helper)
             return RBM_PROFILER_TAILCALL_TRASH;
 #endif // defined(_TARGET_XARCH_)
 
-#if defined(_TARGET_X86_)
-        case CORINFO_HELP_ASSIGN_BYREF:
-            // This helper only trashes ECX.
-            return RBM_ECX;
-#endif // defined(_TARGET_X86_)
-
 #if defined(_TARGET_ARMARCH_)
-        case CORINFO_HELP_ASSIGN_BYREF:
-            return RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF;
-
         case CORINFO_HELP_ASSIGN_REF:
         case CORINFO_HELP_CHECKED_ASSIGN_REF:
             return RBM_CALLEE_GCTRASH_WRITEBARRIER;

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -644,7 +644,7 @@ regMaskTP Compiler::compNoGCHelperCallKillSet(CorInfoHelpFunc helper)
             // This helper only trashes ECX.
             return RBM_ECX;
 #elif defined(_TARGET_AMD64_)
-            // This uses and defs rdi and rci.
+            // This uses and defs RDI and RSI.
             return RBM_CALLEE_TRASH_NOGC & ~(RBM_RDI | RBM_RSI);
 #elif defined(_TARGET_ARMARCH_)
             return RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF;

--- a/src/vm/amd64/jithelpers_fast.S
+++ b/src/vm/amd64/jithelpers_fast.S
@@ -228,8 +228,9 @@ LEAF_END JIT_PatchedCodeLast, _TEXT
 //   RSI - address of the data  (source)
 //
 //   Note: RyuJIT assumes that all volatile registers can be trashed by
-//   the CORINFO_HELP_ASSIGN_BYREF helper (i.e. JIT_ByRefWriteBarrier).
-//   The precise set is defined by RBM_CALLEE_TRASH.
+//   the CORINFO_HELP_ASSIGN_BYREF helper (i.e. JIT_ByRefWriteBarrier)
+//   except RDI and RCI that are incoming and outgoing registers.
+//
 //
 //   RCX is trashed
 //   RAX is trashed

--- a/src/vm/amd64/jithelpers_fast.S
+++ b/src/vm/amd64/jithelpers_fast.S
@@ -229,7 +229,8 @@ LEAF_END JIT_PatchedCodeLast, _TEXT
 //
 //   Note: RyuJIT assumes that all volatile registers can be trashed by
 //   the CORINFO_HELP_ASSIGN_BYREF helper (i.e. JIT_ByRefWriteBarrier)
-//   except RDI and RCI that are incoming and outgoing registers.
+//   except RDI and RSI. This helper uses and defines RDI and RSI, so 
+//   they remain as live GC refs or byrefs, and are not killed.
 //
 //
 //   RCX is trashed


### PR DESCRIPTION
Our emitter doesn't check liveness information consistency, so when we generate a LIR node that expands to a several machine instructions there is no way to check that nobody corrupts the data.

In this case `STORE_OBJ` generated
```
IN0006:        mov      rdi, r15
IN0007:        mov      rsi, r12
							Byref regs: 00009000 {r12 r15} => 00009040 {rsi r12 r15}
							Byref regs: 00009040 {rsi r12 r15} => 000090C0 {rsi rdi r12 r15}
							Call: GCvars=0000000000000000 {}, gcrefRegs=00000000 {}, byrefRegs=00009000 {r12 r15}
IN0008:        call     CORINFO_HELP_ASSIGN_BYREF
IN0009:        mov      ecx, 7
IN000a:        rep movsq 
```
where `byrefRegs` after call did not include `rsi, rdi`, because we trashed `RBM_CALLEE_TRASH_NOGC` that on Linux x64 incudes `rci, rdi`. https://github.com/dotnet/coreclr/blob/1c47703a3d548e5f3293a11d98747dd83bf429f1/src/jit/emitxarch.cpp#L6880-L6884 

Fixes #19361.