### PR TITLE
Don't build and publish libcoreclr libeventprovider libeventpipe as crosscomponents on ARM

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -220,7 +220,7 @@ generate_event_logging_sources()
     fi
 
     echo "Laying out dynamically generated EventPipe Implementation"
-    $PYTHON -B $__PythonWarningFlags "$__ProjectRoot/src/scripts/genEventPipe.py" --man "$__ProjectRoot/src/vm/ClrEtwAll.man" --intermediate "$__OutputEventingDir/eventpipe" --nonextern
+    $PYTHON -B $__PythonWarningFlags "$__ProjectRoot/src/scripts/genEventPipe.py" --man "$__ProjectRoot/src/vm/ClrEtwAll.man" --intermediate "$__OutputEventingDir/eventpipe"
 
     echo "Laying out dynamically generated EventSource classes"
     $PYTHON -B $__PythonWarningFlags "$__ProjectRoot/src/scripts/genRuntimeEventSources.py" --man "$__ProjectRoot/src/vm/ClrEtwAll.man" --intermediate "$__OutputEventingDir"

--- a/build.sh
+++ b/build.sh
@@ -220,7 +220,7 @@ generate_event_logging_sources()
     fi
 
     echo "Laying out dynamically generated EventPipe Implementation"
-    $PYTHON -B $__PythonWarningFlags "$__ProjectRoot/src/scripts/genEventPipe.py" --man "$__ProjectRoot/src/vm/ClrEtwAll.man" --intermediate "$__OutputEventingDir/eventpipe"
+    $PYTHON -B $__PythonWarningFlags "$__ProjectRoot/src/scripts/genEventPipe.py" --man "$__ProjectRoot/src/vm/ClrEtwAll.man" --intermediate "$__OutputEventingDir/eventpipe" --nonextern
 
     echo "Laying out dynamically generated EventSource classes"
     $PYTHON -B $__PythonWarningFlags "$__ProjectRoot/src/scripts/genRuntimeEventSources.py" --man "$__ProjectRoot/src/vm/ClrEtwAll.man" --intermediate "$__OutputEventingDir"

--- a/src/ToolBox/SOS/Strike/CMakeLists.txt
+++ b/src/ToolBox/SOS/Strike/CMakeLists.txt
@@ -220,5 +220,5 @@ target_link_libraries(sos ${SOS_LIBRARY})
 install_clr(sos)
 
 if(NOT WIN32)
-  install(FILES sosdocsunix.txt DESTINATION .)
+  _install(FILES sosdocsunix.txt DESTINATION .)
 endif(NOT WIN32)

--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -396,4 +396,4 @@ if(FEATURE_EVENT_TRACE)
 endif(FEATURE_EVENT_TRACE)
 
 # Install the static PAL library for VS
-install (TARGETS coreclrpal DESTINATION lib)
+_install (TARGETS coreclrpal DESTINATION lib)

--- a/src/scripts/genEventPipe.py
+++ b/src/scripts/genEventPipe.py
@@ -249,12 +249,8 @@ def generateEventPipeCmakeFile(etwmanifest, eventpipe_directory, extern):
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 include_directories(${CLR_DIR}/src/vm)
 
+add_library_clr(eventpipe STATIC
 """)
-        if extern: cmake_file.write("add_library")
-        else: cmake_file.write("add_library_clr")
-        cmake_file.write("""(eventpipe
-    STATIC\n""")
-
         for providerNode in tree.getElementsByTagName('provider'):
             providerName = providerNode.getAttribute('name')
             providerName = providerName.replace("Windows-", '')
@@ -268,7 +264,7 @@ include_directories(${CLR_DIR}/src/vm)
         if extern: cmake_file.write("""
 
 # Install the static eventpipe library
-install(TARGETS eventpipe DESTINATION lib)
+_install(TARGETS eventpipe DESTINATION lib)
 """)
 
 def generateEventPipeHelperFile(etwmanifest, eventpipe_directory, extern):

--- a/src/scripts/genLttngProvider.py
+++ b/src/scripts/genLttngProvider.py
@@ -521,7 +521,7 @@ def generateLttngFiles(etwmanifest,eventprovider_directory):
         add_subdirectory(tracepointprovider)
 
         # Install the static eventprovider library
-        install(TARGETS eventprovider DESTINATION lib)
+        _install(TARGETS eventprovider DESTINATION lib)
         """)
 
 #TracepointProvider  Cmake


### PR DESCRIPTION
Right now during Linux/arm build the following static libraries
1. libcoreclrpal.a
2. libeventprovider.a
3. libeventpipe.a
got built as crosscomponents (meaning x86 libraries) and copied over to `bin/Product/Linux.arm.{BuildType}/x86/lib` directory

For example,
```
root@0b69c9cb7f07:/opt/code/bin/Product/Linux.arm.Checked/x86# ls *
crossgen  libclrjit.so  sosdocsunix.txt

lib:
libcoreclrpal.a  libeventpipe.a  libeventprovider.a
```
I assume, the same would happen during Linux/arm64 build.

Libraries **eventpipe** and **eventprovider** are never built during Windows/arm build. The all **three** also are never got published as NuGet packages, so I presume they are never consumed during official build pipeline.

They also causes compilation errors in cross-bitness scenario. 

This PR excludes the three aforementioned libraries from crosscomponent build and stop copying sosdocsunix.txt to crosscomponent dir, so the directory look like this after the change
```
root@b3006300c1bd:/opt/code/bin/Product/Linux.arm.Checked/x86# ls
crossgen  libclrjit.so
```
@BruceForstall @jashook PTAL
@brianrob (please review **eventing** related change in build.sh and src/scripts/genLttngProvider.py)
