### PR TITLE
Revert "Remove not necessary type forwarded from attributes when type comes from mscorlib in netfx"

### DIFF
--- a/src/System.Private.CoreLib/shared/System/AccessViolationException.cs
+++ b/src/System.Private.CoreLib/shared/System/AccessViolationException.cs
@@ -17,6 +17,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class AccessViolationException : SystemException
     {
         public AccessViolationException()

--- a/src/System.Private.CoreLib/shared/System/AggregateException.cs
+++ b/src/System.Private.CoreLib/shared/System/AggregateException.cs
@@ -22,6 +22,7 @@ namespace System
     /// </remarks>
     [Serializable]
     [DebuggerDisplay("Count = {InnerExceptionCount}")]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class AggregateException : Exception
     {
         private ReadOnlyCollection<Exception> m_innerExceptions; // Complete set of exceptions. Do not rename (binary serialization)

--- a/src/System.Private.CoreLib/shared/System/ApplicationException.cs
+++ b/src/System.Private.CoreLib/shared/System/ApplicationException.cs
@@ -23,6 +23,7 @@ namespace System
     // ApplicationException extends but adds no new functionality to 
     // RecoverableException.
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class ApplicationException : Exception
     {
         // Creates a new ApplicationException with its message string set to

--- a/src/System.Private.CoreLib/shared/System/ArgumentException.cs
+++ b/src/System.Private.CoreLib/shared/System/ArgumentException.cs
@@ -20,6 +20,7 @@ namespace System
     // the contract of the method.  Ideally it should give a meaningful error
     // message describing what was wrong and which parameter is incorrect.
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class ArgumentException : SystemException
     {
         private string _paramName;

--- a/src/System.Private.CoreLib/shared/System/ArgumentNullException.cs
+++ b/src/System.Private.CoreLib/shared/System/ArgumentNullException.cs
@@ -18,6 +18,7 @@ namespace System
     // The ArgumentException is thrown when an argument 
     // is null when it shouldn't be.
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class ArgumentNullException : ArgumentException
     {
         // Creates a new ArgumentNullException with its message 

--- a/src/System.Private.CoreLib/shared/System/ArgumentOutOfRangeException.cs
+++ b/src/System.Private.CoreLib/shared/System/ArgumentOutOfRangeException.cs
@@ -19,6 +19,7 @@ namespace System
     // The ArgumentOutOfRangeException is thrown when an argument 
     // is outside the legal range for that argument.
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class ArgumentOutOfRangeException : ArgumentException
     {
         private object _actualValue;

--- a/src/System.Private.CoreLib/shared/System/ArithmeticException.cs
+++ b/src/System.Private.CoreLib/shared/System/ArithmeticException.cs
@@ -18,6 +18,7 @@ namespace System
     // The ArithmeticException is thrown when overflow or underflow
     // occurs.
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class ArithmeticException : SystemException
     {
         // Creates a new ArithmeticException with its message string set to

--- a/src/System.Private.CoreLib/shared/System/ArraySegment.cs
+++ b/src/System.Private.CoreLib/shared/System/ArraySegment.cs
@@ -25,6 +25,7 @@ namespace System
     // three fields from an ArraySegment may not see the same ArraySegment from one call to another
     // (ie, users could assign a new value to the old location).  
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public readonly struct ArraySegment<T> : IList<T>, IReadOnlyList<T>
     {
         // Do not replace the array allocation with Array.Empty. We don't want to have the overhead of

--- a/src/System.Private.CoreLib/shared/System/ArrayTypeMismatchException.cs
+++ b/src/System.Private.CoreLib/shared/System/ArrayTypeMismatchException.cs
@@ -18,6 +18,7 @@ namespace System
     // The ArrayMismatchException is thrown when an attempt to store
     // an object of the wrong type within an array occurs.
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class ArrayTypeMismatchException : SystemException
     {
         // Creates a new ArrayMismatchException with its message string set to

--- a/src/System.Private.CoreLib/shared/System/BadImageFormatException.cs
+++ b/src/System.Private.CoreLib/shared/System/BadImageFormatException.cs
@@ -18,6 +18,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public partial class BadImageFormatException : SystemException
     {
         private string _fileName;  // The name of the corrupt PE file.

--- a/src/System.Private.CoreLib/shared/System/Boolean.cs
+++ b/src/System.Private.CoreLib/shared/System/Boolean.cs
@@ -18,6 +18,7 @@ using System.Runtime.Versioning;
 namespace System
 {
     [Serializable]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public readonly struct Boolean : IComparable, IConvertible, IComparable<bool>, IEquatable<bool>
     {
         //

--- a/src/System.Private.CoreLib/shared/System/Byte.cs
+++ b/src/System.Private.CoreLib/shared/System/Byte.cs
@@ -11,6 +11,7 @@ namespace System
 {
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public readonly struct Byte : IComparable, IConvertible, IFormattable, IComparable<byte>, IEquatable<byte>, ISpanFormattable
     {
         private readonly byte m_value; // Do not rename (binary serialization)

--- a/src/System.Private.CoreLib/shared/System/Char.cs
+++ b/src/System.Private.CoreLib/shared/System/Char.cs
@@ -20,6 +20,7 @@ namespace System
 {
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
     public readonly struct Char : IComparable, IComparable<char>, IEquatable<char>, IConvertible
     {
         //

--- a/src/System.Private.CoreLib/shared/System/Collections/Comparer.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Comparer.cs
@@ -14,6 +14,7 @@ using System.Runtime.Serialization;
 namespace System.Collections
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class Comparer : IComparer, ISerializable
     {
         private CompareInfo _compareInfo;

--- a/src/System.Private.CoreLib/shared/System/Collections/DictionaryEntry.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/DictionaryEntry.cs
@@ -9,6 +9,7 @@ namespace System.Collections
     // A DictionaryEntry holds a key and a value from a dictionary.
     // It is returned by IDictionaryEnumerator::GetEntry().
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public struct DictionaryEntry
     {
         private object _key; // Do not rename (binary serialization)

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -33,6 +33,7 @@ namespace System.Collections.Generic
     [DebuggerTypeProxy(typeof(IDictionaryDebugView<,>))]
     [DebuggerDisplay("Count = {Count}")]
     [Serializable]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Dictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue>, ISerializable, IDeserializationCallback
     {
         private struct Entry

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/KeyNotFoundException.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/KeyNotFoundException.cs
@@ -8,6 +8,7 @@ using System.Runtime.Serialization;
 namespace System.Collections.Generic
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class KeyNotFoundException : SystemException
     {
         public KeyNotFoundException()

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/KeyValuePair.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/KeyValuePair.cs
@@ -46,6 +46,7 @@ namespace System.Collections.Generic
     // It is used by the IEnumerable<T> implementation for both IDictionary<TKey, TValue>
     // and IReadOnlyDictionary<TKey, TValue>.
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public readonly struct KeyValuePair<TKey, TValue>
     {
         private readonly TKey key; // Do not rename (binary serialization)

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/List.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/List.cs
@@ -18,6 +18,7 @@ namespace System.Collections.Generic
     [DebuggerTypeProxy(typeof(ICollectionDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
     [Serializable]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class List<T> : IList<T>, IList, IReadOnlyList<T>
     {
         private const int DefaultCapacity = 4;

--- a/src/System.Private.CoreLib/shared/System/Collections/Hashtable.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Hashtable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -56,6 +56,7 @@ namespace System.Collections
     [DebuggerTypeProxy(typeof(System.Collections.Hashtable.HashtableDebugView))]
     [DebuggerDisplay("Count = {Count}")]
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Hashtable : IDictionary, ISerializable, IDeserializationCallback, ICloneable
     {
         /*

--- a/src/System.Private.CoreLib/shared/System/Collections/IHashCodeProvider.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/IHashCodeProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -9,6 +9,7 @@ namespace System.Collections
     /// GetHashCode() function on Objects, providing their own hash function.
     /// </summary>
     [Obsolete("Please use IEqualityComparer instead.")]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public interface IHashCodeProvider
     {
         /// <summary>Returns a hash code for the given object.</summary>

--- a/src/System.Private.CoreLib/shared/System/Collections/ListDictionaryInternal.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ListDictionaryInternal.cs
@@ -19,6 +19,7 @@ namespace System.Collections
     ///    will be smaller and faster than a Hashtable if the number of elements is 10 or less.
     ///    This should not be used if performance is important for large numbers of elements.
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     // Needs to be public to support binary serialization compatibility
     public class ListDictionaryInternal : IDictionary
     {

--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
@@ -10,6 +10,7 @@ namespace System.Collections.ObjectModel
     [Serializable]
     [DebuggerTypeProxy(typeof(ICollectionDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Collection<T> : IList<T>, IList, IReadOnlyList<T>
     {
         private IList<T> items; // Do not rename (binary serialization)

--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/ReadOnlyCollection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/ReadOnlyCollection.cs
@@ -10,6 +10,7 @@ namespace System.Collections.ObjectModel
     [Serializable]
     [DebuggerTypeProxy(typeof(ICollectionDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class ReadOnlyCollection<T> : IList<T>, IList, IReadOnlyList<T>
     {
         private IList<T> list; // Do not rename (binary serialization)

--- a/src/System.Private.CoreLib/shared/System/DataMisalignedException.cs
+++ b/src/System.Private.CoreLib/shared/System/DataMisalignedException.cs
@@ -14,6 +14,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class DataMisalignedException : SystemException
     {
         public DataMisalignedException()

--- a/src/System.Private.CoreLib/shared/System/DateTime.cs
+++ b/src/System.Private.CoreLib/shared/System/DateTime.cs
@@ -52,6 +52,7 @@ namespace System
     // 
     [StructLayout(LayoutKind.Auto)]
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
     public readonly partial struct DateTime : IComparable, IFormattable, IConvertible, IComparable<DateTime>, IEquatable<DateTime>, ISerializable, ISpanFormattable
     {
         // Number of 100ns ticks per time unit

--- a/src/System.Private.CoreLib/shared/System/DateTimeOffset.cs
+++ b/src/System.Private.CoreLib/shared/System/DateTimeOffset.cs
@@ -30,6 +30,7 @@ namespace System
 
     [StructLayout(LayoutKind.Auto)]
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
     public readonly struct DateTimeOffset : IComparable, IFormattable, IComparable<DateTimeOffset>, IEquatable<DateTimeOffset>, ISerializable, IDeserializationCallback, ISpanFormattable
     {
         // Constants

--- a/src/System.Private.CoreLib/shared/System/Decimal.cs
+++ b/src/System.Private.CoreLib/shared/System/Decimal.cs
@@ -55,6 +55,7 @@ namespace System
     [StructLayout(LayoutKind.Sequential)]
     [Serializable]
     [System.Runtime.Versioning.NonVersionable] // This only applies to field layout
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public readonly partial struct Decimal : IFormattable, IComparable, IConvertible, IComparable<decimal>, IEquatable<decimal>, IDeserializationCallback, ISpanFormattable
     {
         // Sign mask for the flags field. A value of zero in this bit indicates a

--- a/src/System.Private.CoreLib/shared/System/DivideByZeroException.cs
+++ b/src/System.Private.CoreLib/shared/System/DivideByZeroException.cs
@@ -16,6 +16,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class DivideByZeroException : ArithmeticException
     {
         public DivideByZeroException()

--- a/src/System.Private.CoreLib/shared/System/DllNotFoundException.cs
+++ b/src/System.Private.CoreLib/shared/System/DllNotFoundException.cs
@@ -17,6 +17,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class DllNotFoundException : TypeLoadException
     {
         public DllNotFoundException()

--- a/src/System.Private.CoreLib/shared/System/Double.cs
+++ b/src/System.Private.CoreLib/shared/System/Double.cs
@@ -23,6 +23,7 @@ namespace System
 {
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public readonly struct Double : IComparable, IConvertible, IFormattable, IComparable<double>, IEquatable<double>, ISpanFormattable
     {
         private readonly double m_value; // Do not rename (binary serialization)

--- a/src/System.Private.CoreLib/shared/System/DuplicateWaitObjectException.cs
+++ b/src/System.Private.CoreLib/shared/System/DuplicateWaitObjectException.cs
@@ -18,6 +18,7 @@ namespace System
     // The DuplicateWaitObjectException is thrown when an object 
     // appears more than once in the list of objects to WaitAll or WaitAny.
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class DuplicateWaitObjectException : ArgumentException
     {
         private static volatile string s_duplicateWaitObjectMessage = null;

--- a/src/System.Private.CoreLib/shared/System/EntryPointNotFoundException.cs
+++ b/src/System.Private.CoreLib/shared/System/EntryPointNotFoundException.cs
@@ -17,6 +17,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class EntryPointNotFoundException : TypeLoadException
     {
         public EntryPointNotFoundException()

--- a/src/System.Private.CoreLib/shared/System/EventArgs.cs
+++ b/src/System.Private.CoreLib/shared/System/EventArgs.cs
@@ -8,6 +8,7 @@ namespace System
 {
     // The base class for all event classes.
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class EventArgs
     {
         public static readonly EventArgs Empty = new EventArgs();

--- a/src/System.Private.CoreLib/shared/System/ExecutionEngineException.cs
+++ b/src/System.Private.CoreLib/shared/System/ExecutionEngineException.cs
@@ -22,6 +22,7 @@ namespace System
 {
     [Obsolete("This type previously indicated an unspecified fatal error in the runtime. The runtime no longer raises this exception so this type is obsolete.")]
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class ExecutionEngineException : SystemException
     {
         public ExecutionEngineException()

--- a/src/System.Private.CoreLib/shared/System/FieldAccessException.cs
+++ b/src/System.Private.CoreLib/shared/System/FieldAccessException.cs
@@ -14,6 +14,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class FieldAccessException : MemberAccessException
     {
         public FieldAccessException()

--- a/src/System.Private.CoreLib/shared/System/FormatException.cs
+++ b/src/System.Private.CoreLib/shared/System/FormatException.cs
@@ -16,6 +16,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class FormatException : SystemException
     {
         public FormatException()

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
@@ -36,6 +36,7 @@ namespace System.Globalization
     }
 
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public partial class CompareInfo : IDeserializationCallback
     {
         // Mask used to check if IndexOf()/LastIndexOf()/IsPrefix()/IsPostfix() has the right flags.

--- a/src/System.Private.CoreLib/shared/System/Globalization/CultureNotFoundException.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CultureNotFoundException.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization;
 namespace System.Globalization
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class CultureNotFoundException : ArgumentException
     {
         private string _invalidCultureName; // unrecognized culture name

--- a/src/System.Private.CoreLib/shared/System/Globalization/SortVersion.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/SortVersion.cs
@@ -5,6 +5,7 @@
 namespace System.Globalization
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class SortVersion : IEquatable<SortVersion>
     {
         private int m_NlsVersion; // Do not rename (binary serialization)

--- a/src/System.Private.CoreLib/shared/System/Guid.cs
+++ b/src/System.Private.CoreLib/shared/System/Guid.cs
@@ -14,6 +14,7 @@ namespace System
     [StructLayout(LayoutKind.Sequential)]
     [Serializable]
     [Runtime.Versioning.NonVersionable] // This only applies to field layout
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public partial struct Guid : IFormattable, IComparable, IComparable<Guid>, IEquatable<Guid>, ISpanFormattable
     {
         public static readonly Guid Empty = new Guid();

--- a/src/System.Private.CoreLib/shared/System/IO/DirectoryNotFoundException.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/DirectoryNotFoundException.cs
@@ -13,6 +13,7 @@ namespace System.IO
      * and STG_E_PATHNOTFOUND (0x80030003).
      */
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class DirectoryNotFoundException : IOException
     {
         public DirectoryNotFoundException()

--- a/src/System.Private.CoreLib/shared/System/IO/EndOfStreamException.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/EndOfStreamException.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization;
 namespace System.IO
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class EndOfStreamException : IOException
     {
         public EndOfStreamException()

--- a/src/System.Private.CoreLib/shared/System/IO/FileLoadException.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileLoadException.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization;
 namespace System.IO
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public partial class FileLoadException : IOException
     {
         public FileLoadException()

--- a/src/System.Private.CoreLib/shared/System/IO/FileNotFoundException.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileNotFoundException.cs
@@ -8,6 +8,7 @@ namespace System.IO
 {
     // Thrown when trying to access a file that doesn't exist on disk.
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public partial class FileNotFoundException : IOException
     {
         public FileNotFoundException()

--- a/src/System.Private.CoreLib/shared/System/IO/IOException.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/IOException.cs
@@ -8,6 +8,7 @@ using System.Runtime.Serialization;
 namespace System.IO
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class IOException : SystemException
     {
         public IOException()

--- a/src/System.Private.CoreLib/shared/System/IO/PathTooLongException.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/PathTooLongException.cs
@@ -9,6 +9,7 @@ using System.Runtime.Serialization;
 namespace System.IO
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class PathTooLongException : IOException
     {
         public PathTooLongException()

--- a/src/System.Private.CoreLib/shared/System/IndexOutOfRangeException.cs
+++ b/src/System.Private.CoreLib/shared/System/IndexOutOfRangeException.cs
@@ -16,6 +16,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class IndexOutOfRangeException : SystemException
     {
         public IndexOutOfRangeException()

--- a/src/System.Private.CoreLib/shared/System/InsufficientExecutionStackException.cs
+++ b/src/System.Private.CoreLib/shared/System/InsufficientExecutionStackException.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class InsufficientExecutionStackException : SystemException
     {
         public InsufficientExecutionStackException()

--- a/src/System.Private.CoreLib/shared/System/InsufficientMemoryException.cs
+++ b/src/System.Private.CoreLib/shared/System/InsufficientMemoryException.cs
@@ -16,6 +16,7 @@ namespace System
     /// want to recover from these errors.
     /// </summary>
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class InsufficientMemoryException : OutOfMemoryException
     {
         public InsufficientMemoryException() : base(

--- a/src/System.Private.CoreLib/shared/System/Int16.cs
+++ b/src/System.Private.CoreLib/shared/System/Int16.cs
@@ -11,6 +11,7 @@ namespace System
 {
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public readonly struct Int16 : IComparable, IConvertible, IFormattable, IComparable<short>, IEquatable<short>, ISpanFormattable
     {
         private readonly short m_value; // Do not rename (binary serialization)

--- a/src/System.Private.CoreLib/shared/System/Int32.cs
+++ b/src/System.Private.CoreLib/shared/System/Int32.cs
@@ -11,6 +11,7 @@ namespace System
 {
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public readonly struct Int32 : IComparable, IConvertible, IFormattable, IComparable<int>, IEquatable<int>, ISpanFormattable
     {
         private readonly int m_value; // Do not rename (binary serialization)

--- a/src/System.Private.CoreLib/shared/System/Int64.cs
+++ b/src/System.Private.CoreLib/shared/System/Int64.cs
@@ -11,6 +11,7 @@ namespace System
 {
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public readonly struct Int64 : IComparable, IConvertible, IFormattable, IComparable<long>, IEquatable<long>, ISpanFormattable
     {
         private readonly long m_value; // Do not rename (binary serialization)

--- a/src/System.Private.CoreLib/shared/System/IntPtr.cs
+++ b/src/System.Private.CoreLib/shared/System/IntPtr.cs
@@ -16,6 +16,7 @@ using nint = System.Int32;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public readonly struct IntPtr : IEquatable<IntPtr>, ISerializable
     {
         // WARNING: We allow diagnostic tools to directly inspect this member (_value). 

--- a/src/System.Private.CoreLib/shared/System/InvalidCastException.cs
+++ b/src/System.Private.CoreLib/shared/System/InvalidCastException.cs
@@ -13,6 +13,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class InvalidCastException : SystemException
     {
         public InvalidCastException()

--- a/src/System.Private.CoreLib/shared/System/InvalidOperationException.cs
+++ b/src/System.Private.CoreLib/shared/System/InvalidOperationException.cs
@@ -17,6 +17,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class InvalidOperationException : SystemException
     {
         public InvalidOperationException()

--- a/src/System.Private.CoreLib/shared/System/InvalidProgramException.cs
+++ b/src/System.Private.CoreLib/shared/System/InvalidProgramException.cs
@@ -16,6 +16,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class InvalidProgramException : SystemException
     {
         public InvalidProgramException()

--- a/src/System.Private.CoreLib/shared/System/MemberAccessException.cs
+++ b/src/System.Private.CoreLib/shared/System/MemberAccessException.cs
@@ -15,6 +15,7 @@ namespace System
     // The MemberAccessException is thrown when trying to access a class
     // member fails.
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class MemberAccessException : SystemException
     {
         // Creates a new MemberAccessException with its message string set to

--- a/src/System.Private.CoreLib/shared/System/MethodAccessException.cs
+++ b/src/System.Private.CoreLib/shared/System/MethodAccessException.cs
@@ -14,6 +14,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class MethodAccessException : MemberAccessException
     {
         public MethodAccessException()

--- a/src/System.Private.CoreLib/shared/System/MissingFieldException.cs
+++ b/src/System.Private.CoreLib/shared/System/MissingFieldException.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class MissingFieldException : MissingMemberException, ISerializable
     {
         public MissingFieldException()

--- a/src/System.Private.CoreLib/shared/System/MissingMemberException.cs
+++ b/src/System.Private.CoreLib/shared/System/MissingMemberException.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public partial class MissingMemberException : MemberAccessException
     {
         public MissingMemberException()

--- a/src/System.Private.CoreLib/shared/System/MissingMethodException.cs
+++ b/src/System.Private.CoreLib/shared/System/MissingMethodException.cs
@@ -16,6 +16,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class MissingMethodException : MissingMemberException
     {
         public MissingMethodException()

--- a/src/System.Private.CoreLib/shared/System/MulticastNotSupportedException.cs
+++ b/src/System.Private.CoreLib/shared/System/MulticastNotSupportedException.cs
@@ -12,6 +12,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class MulticastNotSupportedException : SystemException
     {
         public MulticastNotSupportedException()

--- a/src/System.Private.CoreLib/shared/System/NotFiniteNumberException.cs
+++ b/src/System.Private.CoreLib/shared/System/NotFiniteNumberException.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class NotFiniteNumberException : ArithmeticException
     {
         private double _offendingNumber;

--- a/src/System.Private.CoreLib/shared/System/NotImplementedException.cs
+++ b/src/System.Private.CoreLib/shared/System/NotImplementedException.cs
@@ -17,6 +17,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class NotImplementedException : SystemException
     {
         public NotImplementedException()

--- a/src/System.Private.CoreLib/shared/System/NotSupportedException.cs
+++ b/src/System.Private.CoreLib/shared/System/NotSupportedException.cs
@@ -16,6 +16,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class NotSupportedException : SystemException
     {
         public NotSupportedException()

--- a/src/System.Private.CoreLib/shared/System/NullReferenceException.cs
+++ b/src/System.Private.CoreLib/shared/System/NullReferenceException.cs
@@ -16,6 +16,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class NullReferenceException : SystemException
     {
         public NullReferenceException()

--- a/src/System.Private.CoreLib/shared/System/Nullable.cs
+++ b/src/System.Private.CoreLib/shared/System/Nullable.cs
@@ -13,6 +13,7 @@ namespace System
     //
     [Serializable]
     [NonVersionable] // This only applies to field layout
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public struct Nullable<T> where T : struct
     {
         private readonly bool hasValue; // Do not rename (binary serialization)

--- a/src/System.Private.CoreLib/shared/System/ObjectDisposedException.cs
+++ b/src/System.Private.CoreLib/shared/System/ObjectDisposedException.cs
@@ -12,6 +12,7 @@ namespace System
     ///       disposed.</para>
     /// </devdoc>
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class ObjectDisposedException : InvalidOperationException
     {
         private string _objectName;

--- a/src/System.Private.CoreLib/shared/System/OperationCanceledException.cs
+++ b/src/System.Private.CoreLib/shared/System/OperationCanceledException.cs
@@ -18,6 +18,7 @@ using System.Threading;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class OperationCanceledException : SystemException
     {
         [NonSerialized]

--- a/src/System.Private.CoreLib/shared/System/OutOfMemoryException.cs
+++ b/src/System.Private.CoreLib/shared/System/OutOfMemoryException.cs
@@ -10,6 +10,7 @@ namespace System
     /// The exception class for OOM.
     /// </summary>
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class OutOfMemoryException : SystemException
     {
         public OutOfMemoryException() : base(

--- a/src/System.Private.CoreLib/shared/System/OverflowException.cs
+++ b/src/System.Private.CoreLib/shared/System/OverflowException.cs
@@ -16,6 +16,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class OverflowException : ArithmeticException
     {
         public OverflowException()

--- a/src/System.Private.CoreLib/shared/System/PlatformNotSupportedException.cs
+++ b/src/System.Private.CoreLib/shared/System/PlatformNotSupportedException.cs
@@ -16,6 +16,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class PlatformNotSupportedException : NotSupportedException
     {
         public PlatformNotSupportedException()

--- a/src/System.Private.CoreLib/shared/System/RankException.cs
+++ b/src/System.Private.CoreLib/shared/System/RankException.cs
@@ -17,6 +17,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class RankException : SystemException
     {
         public RankException()

--- a/src/System.Private.CoreLib/shared/System/Reflection/AmbiguousMatchException.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/AmbiguousMatchException.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization;
 namespace System.Reflection
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class AmbiguousMatchException : SystemException
     {
         public AmbiguousMatchException()

--- a/src/System.Private.CoreLib/shared/System/Reflection/CustomAttributeFormatException.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/CustomAttributeFormatException.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization;
 namespace System.Reflection
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class CustomAttributeFormatException : FormatException
     {
         public CustomAttributeFormatException()

--- a/src/System.Private.CoreLib/shared/System/Reflection/InvalidFilterCriteriaException.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/InvalidFilterCriteriaException.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization;
 namespace System.Reflection
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class InvalidFilterCriteriaException : ApplicationException
     {
         public InvalidFilterCriteriaException()

--- a/src/System.Private.CoreLib/shared/System/Reflection/ReflectionTypeLoadException.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/ReflectionTypeLoadException.cs
@@ -8,6 +8,7 @@ using System.Text;
 namespace System.Reflection
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class ReflectionTypeLoadException : SystemException, ISerializable
     {
         public ReflectionTypeLoadException(Type[] classes, Exception[] exceptions)

--- a/src/System.Private.CoreLib/shared/System/Reflection/TargetException.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/TargetException.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization;
 namespace System.Reflection
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class TargetException : ApplicationException
     {
         public TargetException()

--- a/src/System.Private.CoreLib/shared/System/Reflection/TargetInvocationException.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/TargetInvocationException.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization;
 namespace System.Reflection
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class TargetInvocationException : ApplicationException
     {
         public TargetInvocationException(Exception inner)

--- a/src/System.Private.CoreLib/shared/System/Reflection/TargetParameterCountException.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/TargetParameterCountException.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization;
 namespace System.Reflection
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class TargetParameterCountException : ApplicationException
     {
         public TargetParameterCountException()

--- a/src/System.Private.CoreLib/shared/System/Resources/MissingManifestResourceException.cs
+++ b/src/System.Private.CoreLib/shared/System/Resources/MissingManifestResourceException.cs
@@ -8,6 +8,7 @@ using System.Runtime.Serialization;
 namespace System.Resources
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class MissingManifestResourceException : SystemException
     {
         public MissingManifestResourceException()

--- a/src/System.Private.CoreLib/shared/System/Resources/MissingSatelliteAssemblyException.cs
+++ b/src/System.Private.CoreLib/shared/System/Resources/MissingSatelliteAssemblyException.cs
@@ -21,6 +21,7 @@ using System.Runtime.Serialization;
 namespace System.Resources
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class MissingSatelliteAssemblyException : SystemException
     {
         private string _cultureName;

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/RuntimeWrappedException.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/RuntimeWrappedException.cs
@@ -10,6 +10,7 @@ namespace System.Runtime.CompilerServices
     /// Exception used to wrap all non-CLS compliant exceptions.
     /// </summary>
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class RuntimeWrappedException : Exception
     {
         private object _wrappedException; // EE expects this name

--- a/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/ExternalException.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/ExternalException.cs
@@ -21,6 +21,7 @@ namespace System.Runtime.InteropServices
     // Base exception for COM Interop errors &; Structured Exception Handler
     // exceptions.
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class ExternalException : SystemException
     {
         public ExternalException()

--- a/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/MarshalDirectiveException.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/MarshalDirectiveException.cs
@@ -18,6 +18,7 @@ using System.Runtime.Serialization;
 namespace System.Runtime.InteropServices
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class MarshalDirectiveException : SystemException
     {
         public MarshalDirectiveException()

--- a/src/System.Private.CoreLib/shared/System/Runtime/Serialization/SerializationException.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Serialization/SerializationException.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization;
 namespace System.Runtime.Serialization
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class SerializationException : SystemException
     {
         private static string s_nullMessage = SR.SerializationException;

--- a/src/System.Private.CoreLib/shared/System/SByte.cs
+++ b/src/System.Private.CoreLib/shared/System/SByte.cs
@@ -11,6 +11,7 @@ namespace System
 {
     [Serializable]
     [CLSCompliant(false)]    [StructLayout(LayoutKind.Sequential)]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public readonly struct SByte : IComparable, IConvertible, IFormattable, IComparable<sbyte>, IEquatable<sbyte>, ISpanFormattable
     {
         private readonly sbyte m_value; // Do not rename (binary serialization)

--- a/src/System.Private.CoreLib/shared/System/Security/CryptographicException.cs
+++ b/src/System.Private.CoreLib/shared/System/Security/CryptographicException.cs
@@ -8,6 +8,7 @@ using System.Runtime.Serialization;
 namespace System.Security.Cryptography
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class CryptographicException : SystemException
     {
         public CryptographicException()

--- a/src/System.Private.CoreLib/shared/System/Security/SecurityException.cs
+++ b/src/System.Private.CoreLib/shared/System/Security/SecurityException.cs
@@ -8,6 +8,7 @@ using System.Runtime.Serialization;
 namespace System.Security
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class SecurityException : SystemException
     {
         private const string DemandedName = "Demanded";

--- a/src/System.Private.CoreLib/shared/System/Security/VerificationException.cs
+++ b/src/System.Private.CoreLib/shared/System/Security/VerificationException.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization;
 namespace System.Security
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class VerificationException : SystemException
     {
         public VerificationException()

--- a/src/System.Private.CoreLib/shared/System/Single.cs
+++ b/src/System.Private.CoreLib/shared/System/Single.cs
@@ -22,6 +22,7 @@ namespace System
 {
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public readonly struct Single : IComparable, IConvertible, IFormattable, IComparable<float>, IEquatable<float>, ISpanFormattable
     {
         private readonly float m_value; // Do not rename (binary serialization)

--- a/src/System.Private.CoreLib/shared/System/StackOverflowException.cs
+++ b/src/System.Private.CoreLib/shared/System/StackOverflowException.cs
@@ -16,6 +16,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class StackOverflowException : SystemException
     {
         public StackOverflowException()

--- a/src/System.Private.CoreLib/shared/System/String.cs
+++ b/src/System.Private.CoreLib/shared/System/String.cs
@@ -20,6 +20,7 @@ namespace System
     // positions (indices) are zero-based.
 
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed partial class String : IComparable, IEnumerable, IConvertible, IEnumerable<char>, IComparable<string>, IEquatable<string>, ICloneable
     {
         // String constructors

--- a/src/System.Private.CoreLib/shared/System/StringComparer.cs
+++ b/src/System.Private.CoreLib/shared/System/StringComparer.cs
@@ -10,6 +10,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public abstract class StringComparer : IComparer, IEqualityComparer, IComparer<string>, IEqualityComparer<string>
     {
         private static readonly CultureAwareComparer s_invariantCulture = new CultureAwareComparer(CultureInfo.InvariantCulture, CompareOptions.None);
@@ -170,6 +171,7 @@ namespace System
     }
 
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class CultureAwareComparer : StringComparer, ISerializable
     {
         private const CompareOptions ValidCompareMaskOffFlags = ~(CompareOptions.IgnoreCase | CompareOptions.IgnoreSymbols | CompareOptions.IgnoreNonSpace | CompareOptions.IgnoreWidth | CompareOptions.IgnoreKanaType | CompareOptions.StringSort);
@@ -251,6 +253,7 @@ namespace System
     }
 
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class OrdinalComparer : StringComparer 
     {
         private readonly bool _ignoreCase; // Do not rename (binary serialization)

--- a/src/System.Private.CoreLib/shared/System/SystemException.cs
+++ b/src/System.Private.CoreLib/shared/System/SystemException.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class SystemException : Exception
     {
         public SystemException()

--- a/src/System.Private.CoreLib/shared/System/Text/DecoderExceptionFallback.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/DecoderExceptionFallback.cs
@@ -100,6 +100,7 @@ namespace System.Text
 
     // Exception for decoding unknown byte sequences.
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class DecoderFallbackException : ArgumentException
     {
         private byte[] _bytesUnknown = null;

--- a/src/System.Private.CoreLib/shared/System/Text/EncoderExceptionFallback.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/EncoderExceptionFallback.cs
@@ -97,6 +97,7 @@ namespace System.Text
     }
 
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class EncoderFallbackException : ArgumentException
     {
         private char _charUnknown;

--- a/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
@@ -26,6 +26,7 @@ namespace System.Text
     // object unless specified otherwise.  This class may be used in conjunction with the String
     // class to carry out modifications upon strings.
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed partial class StringBuilder : ISerializable
     {
         // A StringBuilder is internally represented as a linked list of blocks each of which holds

--- a/src/System.Private.CoreLib/shared/System/Threading/AbandonedMutexException.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/AbandonedMutexException.cs
@@ -15,6 +15,7 @@ using System.Runtime.Serialization;
 namespace System.Threading
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class AbandonedMutexException : SystemException
     {
         private int _mutexIndex = -1;

--- a/src/System.Private.CoreLib/shared/System/Threading/SynchronizationLockException.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/SynchronizationLockException.cs
@@ -17,6 +17,7 @@ using System.Runtime.Serialization;
 namespace System.Threading
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class SynchronizationLockException : SystemException
     {
         public SynchronizationLockException()

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskCanceledException.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskCanceledException.cs
@@ -20,6 +20,7 @@ namespace System.Threading.Tasks
     /// Represents an exception used to communicate task cancellation.
     /// </summary>
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class TaskCanceledException : OperationCanceledException
     {
         [NonSerialized]

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskSchedulerException.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskSchedulerException.cs
@@ -21,6 +21,7 @@ namespace System.Threading.Tasks
     /// <see cref="T:System.Threading.Tasks.TaskScheduler"/>.
     /// </summary>
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class TaskSchedulerException : Exception
     {
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Threading/ThreadAbortException.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ThreadAbortException.cs
@@ -19,6 +19,7 @@ using System.Runtime.Serialization;
 namespace System.Threading
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class ThreadAbortException : SystemException
     {
         internal ThreadAbortException()

--- a/src/System.Private.CoreLib/shared/System/Threading/ThreadInterruptedException.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ThreadInterruptedException.cs
@@ -10,6 +10,7 @@ namespace System.Threading
     /// An exception class to indicate that the thread was interrupted from a waiting state.
     /// </summary>
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class ThreadInterruptedException : SystemException
     {
         public ThreadInterruptedException() : base(

--- a/src/System.Private.CoreLib/shared/System/Threading/ThreadStartException.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ThreadStartException.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization;
 namespace System.Threading
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class ThreadStartException : SystemException
     {
         internal ThreadStartException()

--- a/src/System.Private.CoreLib/shared/System/Threading/ThreadStateException.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ThreadStateException.cs
@@ -17,6 +17,7 @@ using System.Runtime.Serialization;
 namespace System.Threading
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class ThreadStateException : SystemException
     {
         public ThreadStateException()

--- a/src/System.Private.CoreLib/shared/System/Threading/WaitHandleCannotBeOpenedException.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/WaitHandleCannotBeOpenedException.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization;
 namespace System.Threading
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class WaitHandleCannotBeOpenedException : ApplicationException
     {
         public WaitHandleCannotBeOpenedException() : base(SR.Threading_WaitHandleCannotBeOpenedException)

--- a/src/System.Private.CoreLib/shared/System/TimeoutException.cs
+++ b/src/System.Private.CoreLib/shared/System/TimeoutException.cs
@@ -16,6 +16,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class TimeoutException : SystemException
     {
         public TimeoutException()

--- a/src/System.Private.CoreLib/shared/System/Tuple.cs
+++ b/src/System.Private.CoreLib/shared/System/Tuple.cs
@@ -103,6 +103,7 @@ namespace System
     }
 
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Tuple<T1> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
         private readonly T1 m_Item1; // Do not rename (binary serialization)
@@ -202,6 +203,7 @@ namespace System
     }
 
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Tuple<T1, T2> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
         private readonly T1 m_Item1; // Do not rename (binary serialization)
@@ -316,6 +318,7 @@ namespace System
     }
 
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Tuple<T1, T2, T3> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
         private readonly T1 m_Item1; // Do not rename (binary serialization)
@@ -441,6 +444,7 @@ namespace System
     }
 
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Tuple<T1, T2, T3, T4> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
         private readonly T1 m_Item1; // Do not rename (binary serialization)
@@ -577,6 +581,7 @@ namespace System
     }
 
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Tuple<T1, T2, T3, T4, T5> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
         private readonly T1 m_Item1; // Do not rename (binary serialization)
@@ -724,6 +729,7 @@ namespace System
     }
 
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Tuple<T1, T2, T3, T4, T5, T6> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
         private readonly T1 m_Item1; // Do not rename (binary serialization)
@@ -882,6 +888,7 @@ namespace System
     }
 
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Tuple<T1, T2, T3, T4, T5, T6, T7> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
         private readonly T1 m_Item1; // Do not rename (binary serialization)
@@ -1051,6 +1058,7 @@ namespace System
     }
 
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Tuple<T1, T2, T3, T4, T5, T6, T7, TRest> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
     {
         private readonly T1 m_Item1; // Do not rename (binary serialization)

--- a/src/System.Private.CoreLib/shared/System/TypeAccessException.cs
+++ b/src/System.Private.CoreLib/shared/System/TypeAccessException.cs
@@ -9,6 +9,7 @@ namespace System
     // TypeAccessException derives from TypeLoadException rather than MemberAccessException because in
     // pre-v4 releases of the runtime TypeLoadException was used in lieu of a TypeAccessException.
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class TypeAccessException : TypeLoadException
     {
         public TypeAccessException()

--- a/src/System.Private.CoreLib/shared/System/TypeInitializationException.cs
+++ b/src/System.Private.CoreLib/shared/System/TypeInitializationException.cs
@@ -20,6 +20,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class TypeInitializationException : SystemException
     {
         private string _typeName;

--- a/src/System.Private.CoreLib/shared/System/TypeUnloadedException.cs
+++ b/src/System.Private.CoreLib/shared/System/TypeUnloadedException.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class TypeUnloadedException : SystemException
     {
         public TypeUnloadedException()

--- a/src/System.Private.CoreLib/shared/System/UInt16.cs
+++ b/src/System.Private.CoreLib/shared/System/UInt16.cs
@@ -12,6 +12,7 @@ namespace System
     [Serializable]
     [CLSCompliant(false)]
     [StructLayout(LayoutKind.Sequential)]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public readonly struct UInt16 : IComparable, IConvertible, IFormattable, IComparable<ushort>, IEquatable<ushort>, ISpanFormattable
     {
         private readonly ushort m_value; // Do not rename (binary serialization)

--- a/src/System.Private.CoreLib/shared/System/UInt32.cs
+++ b/src/System.Private.CoreLib/shared/System/UInt32.cs
@@ -12,6 +12,7 @@ namespace System
     [Serializable]
     [CLSCompliant(false)]
     [StructLayout(LayoutKind.Sequential)]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public readonly struct UInt32 : IComparable, IConvertible, IFormattable, IComparable<uint>, IEquatable<uint>, ISpanFormattable
     {
         private readonly uint m_value; // Do not rename (binary serialization)

--- a/src/System.Private.CoreLib/shared/System/UInt64.cs
+++ b/src/System.Private.CoreLib/shared/System/UInt64.cs
@@ -12,6 +12,7 @@ namespace System
     [Serializable]
     [CLSCompliant(false)]
     [StructLayout(LayoutKind.Sequential)]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public readonly struct UInt64 : IComparable, IConvertible, IFormattable, IComparable<ulong>, IEquatable<ulong>, ISpanFormattable
     {
         private readonly ulong m_value; // Do not rename (binary serialization)

--- a/src/System.Private.CoreLib/shared/System/UIntPtr.cs
+++ b/src/System.Private.CoreLib/shared/System/UIntPtr.cs
@@ -17,6 +17,7 @@ namespace System
 {
     [Serializable]
     [CLSCompliant(false)]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public readonly struct UIntPtr : IEquatable<UIntPtr>, ISerializable
     {
         private readonly unsafe void* _value; // Do not rename (binary serialization)

--- a/src/System.Private.CoreLib/shared/System/UnauthorizedAccessException.cs
+++ b/src/System.Private.CoreLib/shared/System/UnauthorizedAccessException.cs
@@ -20,6 +20,7 @@ namespace System
     // The UnauthorizedAccessException is thrown when access errors 
     // occur from IO or other OS methods.
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class UnauthorizedAccessException : SystemException
     {
         public UnauthorizedAccessException()

--- a/src/System.Private.CoreLib/shared/System/ValueTuple.cs
+++ b/src/System.Private.CoreLib/shared/System/ValueTuple.cs
@@ -29,6 +29,7 @@ namespace System
     /// - their members (such as Item1, Item2, etc) are fields rather than properties.
     /// </summary>
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]  
     public struct ValueTuple
         : IEquatable<ValueTuple>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple>, IValueTupleInternal, ITuple
     {
@@ -298,6 +299,7 @@ namespace System
     /// <summary>Represents a 1-tuple, or singleton, as a value type.</summary>
     /// <typeparam name="T1">The type of the tuple's only component.</typeparam>
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]  
     public struct ValueTuple<T1>
         : IEquatable<ValueTuple<T1>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1>>, IValueTupleInternal, ITuple
     {
@@ -464,6 +466,7 @@ namespace System
     /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
     [Serializable]
     [StructLayout(LayoutKind.Auto)]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]  
     public struct ValueTuple<T1, T2>
         : IEquatable<ValueTuple<T1, T2>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2>>, IValueTupleInternal, ITuple
     {
@@ -674,6 +677,7 @@ namespace System
     /// <typeparam name="T3">The type of the tuple's third component.</typeparam>
     [Serializable]
     [StructLayout(LayoutKind.Auto)]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]  
     public struct ValueTuple<T1, T2, T3>
         : IEquatable<ValueTuple<T1, T2, T3>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3>>, IValueTupleInternal, ITuple
     {
@@ -882,6 +886,7 @@ namespace System
     /// <typeparam name="T4">The type of the tuple's fourth component.</typeparam>
     [Serializable]
     [StructLayout(LayoutKind.Auto)]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]  
     public struct ValueTuple<T1, T2, T3, T4>
         : IEquatable<ValueTuple<T1, T2, T3, T4>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4>>, IValueTupleInternal, ITuple
     {
@@ -1109,6 +1114,7 @@ namespace System
     /// <typeparam name="T5">The type of the tuple's fifth component.</typeparam>
     [Serializable]
     [StructLayout(LayoutKind.Auto)]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]  
     public struct ValueTuple<T1, T2, T3, T4, T5>
         : IEquatable<ValueTuple<T1, T2, T3, T4, T5>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5>>, IValueTupleInternal, ITuple
     {
@@ -1355,6 +1361,7 @@ namespace System
     /// <typeparam name="T6">The type of the tuple's sixth component.</typeparam>
     [Serializable]
     [StructLayout(LayoutKind.Auto)]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]  
     public struct ValueTuple<T1, T2, T3, T4, T5, T6>
         : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6>>, IValueTupleInternal, ITuple
     {
@@ -1620,6 +1627,7 @@ namespace System
     /// <typeparam name="T7">The type of the tuple's seventh component.</typeparam>
     [Serializable]
     [StructLayout(LayoutKind.Auto)]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]  
     public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7>
         : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, IValueTupleInternal, ITuple
     {
@@ -1904,6 +1912,7 @@ namespace System
     /// <typeparam name="TRest">The type of the tuple's eighth component.</typeparam>
     [Serializable]
     [StructLayout(LayoutKind.Auto)]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]  
     public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>
     : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, IValueTupleInternal, ITuple
     where TRest : struct

--- a/src/System.Private.CoreLib/shared/System/Version.cs
+++ b/src/System.Private.CoreLib/shared/System/Version.cs
@@ -15,6 +15,7 @@ namespace System
     // specified component.
 
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class Version : ICloneable, IComparable, IComparable<Version>, IEquatable<Version>, ISpanFormattable
     {
         // AssemblyName depends on the order staying the same

--- a/src/System.Private.CoreLib/src/System/AppDomainUnloadedException.cs
+++ b/src/System.Private.CoreLib/src/System/AppDomainUnloadedException.cs
@@ -17,6 +17,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     internal class AppDomainUnloadedException : SystemException
     {
         public AppDomainUnloadedException()

--- a/src/System.Private.CoreLib/src/System/Array.cs
+++ b/src/System.Private.CoreLib/src/System/Array.cs
@@ -32,6 +32,7 @@ namespace System
     // Note that we make a T[] (single-dimensional w/ zero as the lower bound) implement both 
     // IList<U> and IReadOnlyList<U>, where T : U dynamically.  See the SZArrayHelper class for details.
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public abstract class Array : ICloneable, IList, IStructuralComparable, IStructuralEquatable
     {
         // This ctor exists solely to prevent C# from generating a protected .ctor that violates the surface area. I really want this to be a

--- a/src/System.Private.CoreLib/src/System/Attribute.cs
+++ b/src/System.Private.CoreLib/src/System/Attribute.cs
@@ -16,6 +16,7 @@ namespace System
 {
     [Serializable]
     [AttributeUsageAttribute(AttributeTargets.All, Inherited = true, AllowMultiple = false)]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public abstract class Attribute
     {
         #region Private Statics

--- a/src/System.Private.CoreLib/src/System/Collections/Generic/Comparer.cs
+++ b/src/System.Private.CoreLib/src/System/Collections/Generic/Comparer.cs
@@ -11,6 +11,7 @@ namespace System.Collections.Generic
 {
     [Serializable]
     [TypeDependencyAttribute("System.Collections.Generic.ObjectComparer`1")]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
     public abstract class Comparer<T> : IComparer, IComparer<T>
     {
         // To minimize generic instantiation overhead of creating the comparer per type, we keep the generic portion of the code as small
@@ -43,6 +44,7 @@ namespace System.Collections.Generic
     // means another generic instantiation, which can be costly esp.
     // for value types.
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     // Needs to be public to support binary serialization compatibility
     public sealed class GenericComparer<T> : Comparer<T> where T : IComparable<T>
     {
@@ -66,6 +68,7 @@ namespace System.Collections.Generic
     }
 
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     // Needs to be public to support binary serialization compatibility
     public sealed class NullableComparer<T> : Comparer<T?> where T : struct, IComparable<T>
     {
@@ -89,6 +92,7 @@ namespace System.Collections.Generic
     }
 
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     // Needs to be public to support binary serialization compatibility
     public sealed class ObjectComparer<T> : Comparer<T>
     {

--- a/src/System.Private.CoreLib/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/System.Private.CoreLib/src/System/Collections/Generic/EqualityComparer.cs
@@ -16,6 +16,7 @@ namespace System.Collections.Generic
 {
     [Serializable]
     [TypeDependencyAttribute("System.Collections.Generic.ObjectEqualityComparer`1")]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
     public abstract class EqualityComparer<T> : IEqualityComparer, IEqualityComparer<T>
     {
         // To minimize generic instantiation overhead of creating the comparer per type, we keep the generic portion of the code as small
@@ -66,6 +67,7 @@ namespace System.Collections.Generic
     // The methods in this class look identical to the inherited methods, but the calls
     // to Equal bind to IEquatable<T>.Equals(T) instead of Object.Equals(Object)
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     // Needs to be public to support binary serialization compatibility
     public sealed class GenericEqualityComparer<T> : EqualityComparer<T> where T : IEquatable<T>
     {
@@ -135,6 +137,7 @@ namespace System.Collections.Generic
     }
 
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     // Needs to be public to support binary serialization compatibility
     public sealed class NullableEqualityComparer<T> : EqualityComparer<T?> where T : struct, IEquatable<T>
     {
@@ -202,6 +205,7 @@ namespace System.Collections.Generic
     }
 
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     // Needs to be public to support binary serialization compatibility
     public sealed class ObjectEqualityComparer<T> : EqualityComparer<T>
     {
@@ -271,6 +275,7 @@ namespace System.Collections.Generic
     // Performance of IndexOf on byte array is very important for some scenarios.
     // We will call the C runtime function memchr, which is optimized.
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     // Needs to be public to support binary serialization compatibility
     public sealed class ByteEqualityComparer : EqualityComparer<byte>
     {
@@ -308,6 +313,7 @@ namespace System.Collections.Generic
     }
 
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     // Needs to be public to support binary serialization compatibility
     public sealed class EnumEqualityComparer<T> : EqualityComparer<T>, ISerializable where T : struct
     {

--- a/src/System.Private.CoreLib/src/System/Diagnostics/Contracts/Contracts.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Contracts/Contracts.cs
@@ -651,6 +651,7 @@ namespace System.Diagnostics.Contracts
         #endregion User Methods
     }
 
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public enum ContractFailureKind
     {
         Precondition,

--- a/src/System.Private.CoreLib/src/System/Diagnostics/Contracts/ContractsBCL.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Contracts/ContractsBCL.cs
@@ -146,6 +146,7 @@ namespace System.Diagnostics.Contracts
     }
 
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     // Needs to be public to support binary serialization compatibility
     public sealed class ContractException : Exception
     {

--- a/src/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/System.Private.CoreLib/src/System/Enum.cs
@@ -26,6 +26,7 @@ using System.Diagnostics;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public abstract class Enum : ValueType, IComparable, IFormattable, IConvertible
     {
         #region Private Constants

--- a/src/System.Private.CoreLib/src/System/Exception.cs
+++ b/src/System.Private.CoreLib/src/System/Exception.cs
@@ -27,6 +27,7 @@ namespace System
     using System.Globalization;
 
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Exception : ISerializable
     {
         private void Init()

--- a/src/System.Private.CoreLib/src/System/Object.cs
+++ b/src/System.Private.CoreLib/src/System/Object.cs
@@ -34,6 +34,7 @@ namespace System
     [Serializable]
     [ClassInterface(ClassInterfaceType.AutoDual)]
     [System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Object
     {
         // Creates a new instance of an Object.

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/COMException.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/COMException.cs
@@ -14,6 +14,7 @@ namespace System.Runtime.InteropServices
     /// recognize the HResult.
     /// </summary>
     [Serializable]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class COMException : ExternalException
     {
         public COMException()

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/InvalidComObjectException.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/InvalidComObjectException.cs
@@ -13,6 +13,7 @@ namespace System.Runtime.InteropServices
     /// class factory.
     /// </summary>
     [Serializable]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class InvalidComObjectException : SystemException
     {
         public InvalidComObjectException()

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/InvalidOleVariantTypeException.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/InvalidOleVariantTypeException.cs
@@ -12,6 +12,7 @@ namespace System.Runtime.InteropServices
     /// runtime is invalid.
     /// </summary>
     [Serializable]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class InvalidOleVariantTypeException : SystemException
     {
         public InvalidOleVariantTypeException()

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/SEHException.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/SEHException.cs
@@ -20,6 +20,7 @@ namespace System.Runtime.InteropServices
     /// Exception for Structured Exception Handler exceptions.
     /// </summary>
     [Serializable]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class SEHException : ExternalException
     {
         public SEHException()

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeArrayRankMismatchException.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeArrayRankMismatchException.cs
@@ -12,6 +12,7 @@ namespace System.Runtime.InteropServices
     /// than the array rank specified in the metadata.
     /// </summary>
     [Serializable]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class SafeArrayRankMismatchException : SystemException
     {
         public SafeArrayRankMismatchException()

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeArrayTypeMismatchException.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeArrayTypeMismatchException.cs
@@ -12,6 +12,7 @@ namespace System.Runtime.InteropServices
     /// than the safe array sub type specified in the metadata.
     /// </summary>
     [Serializable]
+    [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class SafeArrayTypeMismatchException : SystemException
     {
         public SafeArrayTypeMismatchException()

--- a/src/System.Private.CoreLib/src/System/TypeLoadException.cs
+++ b/src/System.Private.CoreLib/src/System/TypeLoadException.cs
@@ -23,6 +23,7 @@ using System.Diagnostics.Contracts;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class TypeLoadException : SystemException, ISerializable
     {
         public TypeLoadException()

--- a/src/System.Private.CoreLib/src/System/ValueType.cs
+++ b/src/System.Private.CoreLib/src/System/ValueType.cs
@@ -19,6 +19,7 @@ using System.Runtime.Versioning;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
     public abstract class ValueType
     {
         public override bool Equals(object obj)

--- a/src/System.Private.CoreLib/src/System/WeakReference.cs
+++ b/src/System.Private.CoreLib/src/System/WeakReference.cs
@@ -19,6 +19,7 @@ using System.Diagnostics;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
     public class WeakReference : ISerializable
     {
         // If you fix bugs here, please fix them in WeakReference<T> at the same time.

--- a/src/System.Private.CoreLib/src/System/WeakReferenceOfT.cs
+++ b/src/System.Private.CoreLib/src/System/WeakReferenceOfT.cs
@@ -19,6 +19,7 @@ using System.Runtime.Versioning;
 namespace System
 {
     [Serializable]
+    [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")] 
     // This class is sealed to mitigate security issues caused by Object::MemberwiseClone.
     public sealed class WeakReference<T> : ISerializable
         where T : class


### PR DESCRIPTION
Revert: https://github.com/dotnet/coreclr/pull/19660

I updated the blobs for .NET Core and for NETFX the tests would fail to deserialize objects with errors like: 
```
System.Runtime.Serialization.SerializationException : Unable to load type System.Collections.Generic.SortedSet`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0,
   Culture=neutral, PublicKeyToken=7cec85d7bea7798e]] required for deserialization.
        Stack Trace:
             at System.Runtime.Serialization.ObjectManager.DoFixups()
             at System.Runtime.Serialization.Formatters.Binary.ObjectReader.Deserialize(HeaderHandler handler, __BinaryParser serParser, Boolean fCheck, Boolean isCrossAppDomai
  n, IMethodCallMessage methodCallMessage)
             at System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Deserialize(Stream serializationStream, HeaderHandler handler, Boolean fCheck, Boolean isCrossApp
  Domain, IMethodCallMessage methodCallMessage)
             at System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Deserialize(Stream serializationStream)
          E:\repos\corefx3\corefx\src\Common\tests\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs(118,0): at System.Runtime.Serialization.Formatters.Tests.Bi
  naryFormatterHelpers.FromByteArray(Byte[] raw, FormatterAssemblyStyle assemblyStyle)
          E:\repos\corefx3\corefx\src\Common\tests\System\Runtime\Serialization\Formatters\BinaryFormatterHelpers.cs(126,0): at System.Runtime.Serialization.Formatters.Tests.Bi
  naryFormatterHelpers.FromBase64String(String base64Str, FormatterAssemblyStyle assemblyStyle)
          E:\repos\corefx3\corefx\src\System.Runtime.Serialization.Formatters\tests\BinaryFormatterTests.cs(140,0): at System.Runtime.Serialization.Formatters.Tests.BinaryForma
  tterTests.ValidateAndRoundtrip(Object obj, TypeSerializableValue[] blobs, Boolean isEqualityComparer)
          E:\repos\corefx3\corefx\src\System.Runtime.Serialization.Formatters\tests\BinaryFormatterTests.cs(84,0): at System.Runtime.Serialization.Formatters.Tests.BinaryFormat
  terTests.ValidateAgainstBlobs(Object obj, TypeSerializableValue[] blobs)
```

It seems like we actually do need the TypeForwardedFromAttributes because NETFX code doesn't have the change to default to mscorlib when the type lives in System.Private.CoreLib so it would fail to load the type when trying to deserialize it. 

Whenever we're serialize some types in core, the blob will contain S.Private.CoreLib in it, and if we to deserialize it in NETFX we would fail to load it, is this a REAL COSTUMER scenario?
> if it is not, then the tests should skip cases when [`isSamePlatform == true and PlatformDetection.IsFullFramework`](https://github.com/dotnet/corefx/blob/master/src/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs#L126)

This is needed to unblock: https://github.com/dotnet/corefx/pull/31994

cc: @jkotas @ViktorHofer @weshaggard 