### PR TITLE
Clean CodeGen::genEmitCall

### DIFF
--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -425,8 +425,7 @@ protected:
                      MULTIREG_HAS_SECOND_GC_RET_ONLY_ARG(emitAttr secondRetSize),
                      IL_OFFSETX            ilOffset,
                      regNumber             base   = REG_NA,
-                     bool                  isJump = false,
-                     bool                  isNoGC = false);
+                     bool                  isJump = false);
     // clang-format on
 
     // clang-format off

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -1616,8 +1616,7 @@ void CodeGen::genEmitHelperCall(unsigned helper, int argSize, emitAttr retSize, 
                                    callTargetReg, // ireg
                                    REG_NA, 0, 0,  // xreg, xmul, disp
                                    false,         // isJump
-                                   emitter::emitNoGChelper(helper),
-                                   (CorInfoHelpFunc)helper == CORINFO_HELP_PROF_FCN_LEAVE);
+                                   emitter::emitNoGChelper(helper));
     }
     else
     {
@@ -1626,8 +1625,7 @@ void CodeGen::genEmitHelperCall(unsigned helper, int argSize, emitAttr retSize, 
                                    gcInfo.gcRegGCrefSetCur, gcInfo.gcRegByrefSetCur, BAD_IL_OFFSET, REG_NA, REG_NA, 0,
                                    0,     /* ilOffset, ireg, xreg, xmul, disp */
                                    false, /* isJump */
-                                   emitter::emitNoGChelper(helper),
-                                   (CorInfoHelpFunc)helper == CORINFO_HELP_PROF_FCN_LEAVE);
+                                   emitter::emitNoGChelper(helper));
     }
 
     regSet.verifyRegistersUsed(RBM_CALLEE_TRASH);

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -1615,17 +1615,17 @@ void CodeGen::genEmitHelperCall(unsigned helper, int argSize, emitAttr retSize, 
                                    BAD_IL_OFFSET, // ilOffset
                                    callTargetReg, // ireg
                                    REG_NA, 0, 0,  // xreg, xmul, disp
-                                   false,         // isJump
-                                   emitter::emitNoGChelper(helper));
+                                   false          // isJump
+                                   );
     }
     else
     {
         getEmitter()->emitIns_Call(emitter::EC_FUNC_TOKEN, compiler->eeFindHelper(helper),
                                    INDEBUG_LDISASM_COMMA(nullptr) addr, argSize, retSize, gcInfo.gcVarPtrSetCur,
                                    gcInfo.gcRegGCrefSetCur, gcInfo.gcRegByrefSetCur, BAD_IL_OFFSET, REG_NA, REG_NA, 0,
-                                   0,     /* ilOffset, ireg, xreg, xmul, disp */
-                                   false, /* isJump */
-                                   emitter::emitNoGChelper(helper));
+                                   0,    /* ilOffset, ireg, xreg, xmul, disp */
+                                   false /* isJump */
+                                   );
     }
 
     regSet.verifyRegistersUsed(RBM_CALLEE_TRASH);

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -3712,8 +3712,8 @@ void CodeGen::genEmitHelperCall(unsigned helper, int argSize, emitAttr retSize, 
                                gcInfo.gcRegByrefSetCur, BAD_IL_OFFSET, /* IL offset */
                                callTarget,                             /* ireg */
                                REG_NA, 0, 0,                           /* xreg, xmul, disp */
-                               false,                                  /* isJump */
-                               emitter::emitNoGChelper(helper));
+                               false                                   /* isJump */
+                               );
 
     regMaskTP killMask = compiler->compHelperCallKillSet((CorInfoHelpFunc)helper);
     regSet.verifyRegistersUsed(killMask);

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -9109,7 +9109,8 @@ void CodeGen::genFnEpilog(BasicBlock* block)
                                        gcInfo.gcRegGCrefSetCur,
                                        gcInfo.gcRegByrefSetCur,
                                        BAD_IL_OFFSET, REG_NA, REG_NA, 0, 0,  /* iloffset, ireg, xreg, xmul, disp */
-                                       true); /* isJump */
+                                       true /* isJump */
+            );
             // clang-format on
         }
 #if FEATURE_FASTTAILCALL

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -667,6 +667,9 @@ regMaskTP Compiler::compNoGCHelperCallKillSet(CorInfoHelpFunc helper)
         case CORINFO_HELP_ASSIGN_REF:
         case CORINFO_HELP_CHECKED_ASSIGN_REF:
             return RBM_CALLEE_GCTRASH_WRITEBARRIER;
+        case CORINFO_HELP_PROF_FCN_LEAVE:
+            // In case of Leave profiler callback, we need to preserve liveness of REG_PROFILER_RET_SCRATCH on ARMARCH.
+            return RBM_CALLEE_TRASH_NOGC & ~RBM_PROFILER_RET_SCRATCH;
 #endif
 
 #if defined(_TARGET_X86_)

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -506,9 +506,7 @@ void CodeGenInterface::genUpdateRegLife(const LclVarDsc* varDsc, bool isBorn, bo
 }
 
 //----------------------------------------------------------------------
-// compNoGCHelperCallKillSet:
-//
-// Gets a register mask that represents the kill set for a helper call.
+// compHelperCallKillSet: Gets a register mask that represents the kill set for a helper call.
 // Not all JIT Helper calls follow the standard ABI on the target architecture.
 //
 // TODO-CQ: Currently this list is incomplete (not all helpers calls are

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -1849,8 +1849,7 @@ void CodeGen::genEmitCall(int                   callType,
                           MULTIREG_HAS_SECOND_GC_RET_ONLY_ARG(emitAttr secondRetSize),
                           IL_OFFSETX            ilOffset,
                           regNumber             base,
-                          bool                  isJump,
-                          bool                  isNoGC)
+                          bool                  isJump)
 {
 #if !defined(_TARGET_X86_)
     int argSize = 0;

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -1865,8 +1865,7 @@ void CodeGen::genEmitCall(int                   callType,
                                gcInfo.gcVarPtrSetCur,
                                gcInfo.gcRegGCrefSetCur,
                                gcInfo.gcRegByrefSetCur,
-                               ilOffset, base, REG_NA, 0, 0, isJump,
-                               emitter::emitNoGChelper(compiler->eeGetHelperNum(methHnd)));
+                               ilOffset, base, REG_NA, 0, 0, isJump);
 }
 // clang-format on
 

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -8625,8 +8625,8 @@ void CodeGen::genEmitHelperCall(unsigned helper, int argSize, emitAttr retSize, 
                                BAD_IL_OFFSET, // IL offset
                                callTarget,    // ireg
                                REG_NA, 0, 0,  // xreg, xmul, disp
-                               false,         // isJump
-                               emitter::emitNoGChelper(helper));
+                               false         // isJump
+                               );
     // clang-format on
 
     regSet.verifyRegistersUsed(killMask);

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -7305,7 +7305,12 @@ const char* emitter::emitOffsetToLabel(unsigned offs)
 #endif // DEBUG
 
 //------------------------------------------------------------------------
-// emitGetSavedGCRegsSet: Returns the set of registers that keeps gcrefs and byrefs across the call.
+// emitGetGCRegsSavedOrModified: Returns the set of registers that keeps gcrefs and byrefs across the call.
+//
+// Notes: it returns union of two sets:
+//        1) registers that could contain GC/byRefs before the call and call doesn't touch them;
+//        2) registers that contain GC/byRefs before the call and call modifies them, but they still
+//           contain GC/byRefs.
 //
 // Arguments:
 //   methHnd - the method handler of the call.
@@ -7313,7 +7318,7 @@ const char* emitter::emitOffsetToLabel(unsigned offs)
 // Return value:
 //   the saved set of registers.
 //
-regMaskTP emitter::emitGetSavedGCRegsSet(CORINFO_METHOD_HANDLE methHnd)
+regMaskTP emitter::emitGetGCRegsSavedOrModified(CORINFO_METHOD_HANDLE methHnd)
 {
     // Is it a helper with a special saved set?
     bool isNoGCHelper = emitNoGChelper(methHnd);

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -2223,13 +2223,13 @@ emitter::instrDesc* emitter::emitNewInstrCnsDsp(emitAttr size, target_ssize_t cn
 }
 
 //------------------------------------------------------------------------
-// emitNoGChelper: Returns true if garbage-collection won't happen within the helper call.
+// emitNoGChelper: Returns true if garbage collection won't happen within the helper call.
 //
 // Notes:
 //  There is no need to record live pointers for such call sites.
 //
 // Arguments:
-//   helpFunc - a helper signature for the call, can be CORINFO_HELP_UNDEF, that means that the call is not a helper;
+//   helpFunc - a helper signature for the call, can be CORINFO_HELP_UNDEF, that means that the call is not a helper.
 //
 // Return value:
 //   true if GC can't happen within this call, false otherwise.
@@ -2289,13 +2289,13 @@ bool emitter::emitNoGChelper(CorInfoHelpFunc helpFunc)
 }
 
 //------------------------------------------------------------------------
-// emitNoGChelper: Returns true if garbage-collection won't happen within the helper call.
+// emitNoGChelper: Returns true if garbage collection won't happen within the helper call.
 //
 // Notes:
 //  There is no need to record live pointers for such call sites.
 //
 // Arguments:
-//   methHnd - a method handle for the call;
+//   methHnd - a method handle for the call.
 //
 // Return value:
 //   true if GC can't happen within this call, false otherwise.
@@ -7305,7 +7305,7 @@ const char* emitter::emitOffsetToLabel(unsigned offs)
 #endif // DEBUG
 
 //------------------------------------------------------------------------
-// GetSavedSet: Returns the set of registers that live across the call.
+// emitGetSavedGCRegsSet: Returns the set of registers that keeps gcrefs and byrefs across the call.
 //
 // Arguments:
 //   methHnd - the method handler of the call.
@@ -7313,7 +7313,7 @@ const char* emitter::emitOffsetToLabel(unsigned offs)
 // Return value:
 //   the saved set of registers.
 //
-regMaskTP emitter::GetSavedSet(CORINFO_METHOD_HANDLE methHnd)
+regMaskTP emitter::emitGetSavedGCRegsSet(CORINFO_METHOD_HANDLE methHnd)
 {
     // Is it a helper with a special saved set?
     bool isNoGCHelper = emitNoGChelper(methHnd);

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -2276,11 +2276,11 @@ bool emitter::emitNoGChelper(CorInfoHelpFunc helpFunc)
         case CORINFO_HELP_GETSHARED_NONGCSTATIC_BASE_NOCTOR:
 
         case CORINFO_HELP_INIT_PINVOKE_FRAME:
-
             return true;
-    }
 
-    return false;
+        default:
+            return false;
+    }
 }
 
 bool emitter::emitNoGChelper(CORINFO_METHOD_HANDLE methHnd)

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -7277,3 +7277,31 @@ const char* emitter::emitOffsetToLabel(unsigned offs)
 }
 
 #endif // DEBUG
+
+regMaskTP emitter::GetSavedSet(CORINFO_METHOD_HANDLE methHnd)
+{
+    CorInfoHelpFunc helpFunc = Compiler::eeGetHelperNum(methHnd);
+    // Is it a helper with a special saved set?
+    bool isNoGCHelper = ((helpFunc != CORINFO_HELP_UNDEF) && emitNoGChelper(helpFunc));
+    if (isNoGCHelper)
+    {
+        // Get the set of registers that this call kills and remove it from the saved set.
+        regMaskTP savedSet = RBM_ALLINT & ~emitComp->compNoGCHelperCallKillSet(helpFunc);
+
+#ifdef DEBUG
+        if (emitComp->verbose)
+        {
+            printf("NoGC Call: savedSet=");
+            printRegMaskInt(savedSet);
+            emitDispRegSet(savedSet);
+            printf("\n");
+        }
+#endif
+        return savedSet;
+    }
+    else
+    {
+        // This is the saved set of registers after a normal call.
+        return RBM_CALLEE_SAVED;
+    }
+}

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -2222,12 +2222,17 @@ emitter::instrDesc* emitter::emitNewInstrCnsDsp(emitAttr size, target_ssize_t cn
     }
 }
 
-/*****************************************************************************
- *
- *  Returns true if garbage-collection won't happen within the helper call.
- *  Don't need to record live pointers for such call sites.
- */
-
+//------------------------------------------------------------------------
+// emitNoGChelper: Returns true if garbage-collection won't happen within the helper call.
+//
+// Notes:
+//  There is no need to record live pointers for such call sites.
+//
+// Arguments:
+//   helpFunc - a helper signature for the call, can be CORINFO_HELP_UNDEF, that means that the call is not a helper;
+//
+// Return value:
+//   true if GC can't happen within this call, false otherwise.
 bool emitter::emitNoGChelper(CorInfoHelpFunc helpFunc)
 {
     // TODO-Throughput: Make this faster (maybe via a simple table of bools?)
@@ -2283,6 +2288,17 @@ bool emitter::emitNoGChelper(CorInfoHelpFunc helpFunc)
     }
 }
 
+//------------------------------------------------------------------------
+// emitNoGChelper: Returns true if garbage-collection won't happen within the helper call.
+//
+// Notes:
+//  There is no need to record live pointers for such call sites.
+//
+// Arguments:
+//   methHnd - a method handle for the call;
+//
+// Return value:
+//   true if GC can't happen within this call, false otherwise.
 bool emitter::emitNoGChelper(CORINFO_METHOD_HANDLE methHnd)
 {
     CorInfoHelpFunc helpFunc = Compiler::eeGetHelperNum(methHnd);
@@ -7288,6 +7304,15 @@ const char* emitter::emitOffsetToLabel(unsigned offs)
 
 #endif // DEBUG
 
+//------------------------------------------------------------------------
+// GetSavedSet: Returns the set of registers that live across the call.
+//
+// Arguments:
+//   methHnd - the method handler of the call.
+//
+// Return value:
+//   the saved set of registers.
+//
 regMaskTP emitter::GetSavedSet(CORINFO_METHOD_HANDLE methHnd)
 {
     // Is it a helper with a special saved set?

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -1920,7 +1920,7 @@ public:
     bool emitFullGCinfo;  // full GC pointer maps?
     bool emitFullyInt;    // fully interruptible code?
 
-    regMaskTP emitGetSavedGCRegsSet(CORINFO_METHOD_HANDLE methHnd);
+    regMaskTP emitGetGCRegsSavedOrModified(CORINFO_METHOD_HANDLE methHnd);
 
 #if EMIT_TRACK_STACK_DEPTH
     unsigned emitCntStackDepth; // 0 in prolog/epilog, One DWORD elsewhere

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -1909,7 +1909,8 @@ public:
     /*    The following is used to distinguish helper vs non-helper calls   */
     /************************************************************************/
 
-    static bool emitNoGChelper(unsigned IHX);
+    static bool emitNoGChelper(CorInfoHelpFunc helpFunc);
+    static bool emitNoGChelper(CORINFO_METHOD_HANDLE methHnd);
 
     /************************************************************************/
     /*         The following logic keeps track of live GC ref values        */

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -2122,6 +2122,8 @@ public:
         VarSetOps::AssignNoCopy(emitComp, emitInitGCrefVars, VarSetOps::MakeEmpty(emitComp));
         VarSetOps::AssignNoCopy(emitComp, emitThisGCrefVars, VarSetOps::MakeEmpty(emitComp));
     }
+
+    regMaskTP GetSavedSet(CORINFO_METHOD_HANDLE methHnd);
 };
 
 /*****************************************************************************

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -1920,6 +1920,8 @@ public:
     bool emitFullGCinfo;  // full GC pointer maps?
     bool emitFullyInt;    // fully interruptible code?
 
+    regMaskTP emitGetSavedGCRegsSet(CORINFO_METHOD_HANDLE methHnd);
+
 #if EMIT_TRACK_STACK_DEPTH
     unsigned emitCntStackDepth; // 0 in prolog/epilog, One DWORD elsewhere
     unsigned emitMaxStackDepth; // actual computed max. stack depth
@@ -2123,8 +2125,6 @@ public:
         VarSetOps::AssignNoCopy(emitComp, emitInitGCrefVars, VarSetOps::MakeEmpty(emitComp));
         VarSetOps::AssignNoCopy(emitComp, emitThisGCrefVars, VarSetOps::MakeEmpty(emitComp));
     }
-
-    regMaskTP GetSavedSet(CORINFO_METHOD_HANDLE methHnd);
 };
 
 /*****************************************************************************

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -4500,12 +4500,11 @@ void emitter::emitIns_Call(EmitCallType          callType,
     emitThisGCrefRegs = gcrefRegs;
     emitThisByrefRegs = byrefRegs;
 
+    id->idSetIsNoGC(emitNoGChelper(methHnd));
+
     /* Set the instruction - special case jumping a function */
     instruction ins;
     insFormat   fmt = IF_NONE;
-
-    bool isNoGCHelper = emitNoGChelper(Compiler::eeGetHelperNum(methHnd));
-    id->idSetIsNoGC(isNoGCHelper);
 
     /* Record the address: method, indirection, or funcptr */
 

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -4415,8 +4415,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
                            regNumber        xreg /* = REG_NA */,
                            unsigned         xmul /* = 0     */,
                            ssize_t          disp /* = 0     */,
-                           bool             isJump /* = false */,
-                           bool             isNoGC /* = false */)
+                           bool             isJump /* = false */)
 {
     /* Sanity check the arguments depending on callType */
 

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -4433,7 +4433,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
     assert((unsigned)abs(argSize) <= codeGen->genStackLevel);
 
     // Trim out any callee-trashed registers from the live set.
-    regMaskTP savedSet = GetSavedSet(methHnd);
+    regMaskTP savedSet = emitGetSavedGCRegsSet(methHnd);
     gcrefRegs &= savedSet;
     byrefRegs &= savedSet;
 

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -4507,7 +4507,8 @@ void emitter::emitIns_Call(EmitCallType          callType,
     instruction ins;
     insFormat   fmt = IF_NONE;
 
-    id->idSetIsNoGC(isNoGC);
+    bool isNoGCHelper = emitNoGChelper(Compiler::eeGetHelperNum(methHnd));
+    id->idSetIsNoGC(isNoGCHelper);
 
     /* Record the address: method, indirection, or funcptr */
 

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -4436,35 +4436,8 @@ void emitter::emitIns_Call(EmitCallType          callType,
     int        argCnt;
     instrDesc* id;
 
-    /* This is the saved set of registers after a normal call */
-    regMaskTP savedSet = RBM_CALLEE_SAVED;
-
-    /* some special helper calls have a different saved set registers */
-
-    if (isNoGC)
-    {
-        assert(emitNoGChelper(Compiler::eeGetHelperNum(methHnd)));
-
-        // Get the set of registers that this call kills and remove it from the saved set.
-        savedSet = RBM_ALLINT & ~emitComp->compNoGCHelperCallKillSet(Compiler::eeGetHelperNum(methHnd));
-
-#ifdef DEBUG
-        if (emitComp->verbose)
-        {
-            printf("NOGC Call: savedSet=");
-            printRegMaskInt(savedSet);
-            emitDispRegSet(savedSet);
-            printf("\n");
-        }
-#endif
-    }
-    else
-    {
-        assert(!emitNoGChelper(Compiler::eeGetHelperNum(methHnd)));
-    }
-
-    /* Trim out any callee-trashed registers from the live set */
-
+    // Trim out any callee-trashed registers from the live set.
+    regMaskTP savedSet = GetSavedSet(methHnd);
     gcrefRegs &= savedSet;
     byrefRegs &= savedSet;
 

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -4432,9 +4432,6 @@ void emitter::emitIns_Call(EmitCallType          callType,
     // a sanity test.
     assert((unsigned)abs(argSize) <= codeGen->genStackLevel);
 
-    int        argCnt;
-    instrDesc* id;
-
     // Trim out any callee-trashed registers from the live set.
     regMaskTP savedSet = GetSavedSet(methHnd);
     gcrefRegs &= savedSet;
@@ -4455,9 +4452,6 @@ void emitter::emitIns_Call(EmitCallType          callType,
     }
 #endif
 
-    assert(argSize % REGSIZE_BYTES == 0);
-    argCnt = argSize / REGSIZE_BYTES;
-
     /* Managed RetVal: emit sequence point for the call */
     if (emitComp->opts.compDbgInfo && ilOffset != BAD_IL_OFFSET)
     {
@@ -4477,6 +4471,10 @@ void emitter::emitIns_Call(EmitCallType          callType,
             Direct call with GC vars          9,440
             Indir. call with GC vars          5,768
      */
+    instrDesc* id;
+
+    assert(argSize % REGSIZE_BYTES == 0);
+    int argCnt = argSize / REGSIZE_BYTES;
 
     if (callType >= EC_INDIR_R)
     {

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -4416,8 +4416,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
                            unsigned         xmul /* = 0     */,
                            ssize_t          disp /* = 0     */,
                            bool             isJump /* = false */,
-                           bool             isNoGC /* = false */,
-                           bool             isProfLeaveCB /* = false */)
+                           bool             isNoGC /* = false */)
 {
     /* Sanity check the arguments depending on callType */
 
@@ -4448,12 +4447,6 @@ void emitter::emitIns_Call(EmitCallType          callType,
 
         // Get the set of registers that this call kills and remove it from the saved set.
         savedSet = RBM_ALLINT & ~emitComp->compNoGCHelperCallKillSet(Compiler::eeGetHelperNum(methHnd));
-
-        // In case of Leave profiler callback, we need to preserve liveness of REG_PROFILER_RET_SCRATCH
-        if (isProfLeaveCB)
-        {
-            savedSet |= RBM_PROFILER_RET_SCRATCH;
-        }
 
 #ifdef DEBUG
         if (emitComp->verbose)

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -4433,7 +4433,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
     assert((unsigned)abs(argSize) <= codeGen->genStackLevel);
 
     // Trim out any callee-trashed registers from the live set.
-    regMaskTP savedSet = emitGetSavedGCRegsSet(methHnd);
+    regMaskTP savedSet = emitGetGCRegsSavedOrModified(methHnd);
     gcrefRegs &= savedSet;
     byrefRegs &= savedSet;
 

--- a/src/jit/emitarm.h
+++ b/src/jit/emitarm.h
@@ -339,8 +339,7 @@ void emitIns_Call(EmitCallType          callType,
                   regNumber        xreg     = REG_NA,
                   unsigned         xmul     = 0,
                   ssize_t          disp     = 0,
-                  bool             isJump   = false,
-                  bool             isNoGC   = false);
+                  bool             isJump   = false);
 
 /*****************************************************************************
  *

--- a/src/jit/emitarm.h
+++ b/src/jit/emitarm.h
@@ -334,14 +334,13 @@ void emitIns_Call(EmitCallType          callType,
                   VARSET_VALARG_TP ptrVars,
                   regMaskTP        gcrefRegs,
                   regMaskTP        byrefRegs,
-                  IL_OFFSETX       ilOffset      = BAD_IL_OFFSET,
-                  regNumber        ireg          = REG_NA,
-                  regNumber        xreg          = REG_NA,
-                  unsigned         xmul          = 0,
-                  ssize_t          disp          = 0,
-                  bool             isJump        = false,
-                  bool             isNoGC        = false,
-                  bool             isProfLeaveCB = false);
+                  IL_OFFSETX       ilOffset = BAD_IL_OFFSET,
+                  regNumber        ireg     = REG_NA,
+                  regNumber        xreg     = REG_NA,
+                  unsigned         xmul     = 0,
+                  ssize_t          disp     = 0,
+                  bool             isJump   = false,
+                  bool             isNoGC   = false);
 
 /*****************************************************************************
  *

--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -7393,8 +7393,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
                            unsigned         xmul /* = 0     */,
                            ssize_t          disp /* = 0     */,
                            bool             isJump /* = false */,
-                           bool             isNoGC /* = false */,
-                           bool             isProfLeaveCB /* = false */)
+                           bool             isNoGC /* = false */)
 {
     /* Sanity check the arguments depending on callType */
 
@@ -7425,12 +7424,6 @@ void emitter::emitIns_Call(EmitCallType          callType,
 
         // Get the set of registers that this call kills and remove it from the saved set.
         savedSet = RBM_ALLINT & ~emitComp->compNoGCHelperCallKillSet(Compiler::eeGetHelperNum(methHnd));
-
-        // In case of Leave profiler callback, we need to preserve liveness of REG_PROFILER_RET_SCRATCH
-        if (isProfLeaveCB)
-        {
-            savedSet |= RBM_PROFILER_RET_SCRATCH;
-        }
 
 #ifdef DEBUG
         if (emitComp->verbose)

--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -7476,7 +7476,8 @@ void emitter::emitIns_Call(EmitCallType          callType,
     instruction ins;
     insFormat   fmt = IF_NONE;
 
-    id->idSetIsNoGC(isNoGC);
+    bool isNoGCHelper = emitNoGChelper(Compiler::eeGetHelperNum(methHnd));
+    id->idSetIsNoGC(isNoGCHelper);
 
     /* Record the address: method, indirection, or funcptr */
 

--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -7392,8 +7392,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
                            regNumber        xreg /* = REG_NA */,
                            unsigned         xmul /* = 0     */,
                            ssize_t          disp /* = 0     */,
-                           bool             isJump /* = false */,
-                           bool             isNoGC /* = false */)
+                           bool             isJump /* = false */)
 {
     /* Sanity check the arguments depending on callType */
 

--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -7409,9 +7409,6 @@ void emitter::emitIns_Call(EmitCallType          callType,
     // a sanity test.
     assert((unsigned)abs(argSize) <= codeGen->genStackLevel);
 
-    int        argCnt;
-    instrDesc* id;
-
     // Trim out any callee-trashed registers from the live set.
     regMaskTP savedSet = GetSavedSet(methHnd);
     gcrefRegs &= savedSet;
@@ -7432,9 +7429,6 @@ void emitter::emitIns_Call(EmitCallType          callType,
     }
 #endif
 
-    assert(argSize % REGSIZE_BYTES == 0);
-    argCnt = (int)(argSize / (int)REGSIZE_BYTES);
-
     /* Managed RetVal: emit sequence point for the call */
     if (emitComp->opts.compDbgInfo && ilOffset != BAD_IL_OFFSET)
     {
@@ -7446,6 +7440,10 @@ void emitter::emitIns_Call(EmitCallType          callType,
         on whether this is a direct/indirect call, and whether we need to
         record an updated set of live GC variables.
      */
+    instrDesc* id;
+
+    assert(argSize % REGSIZE_BYTES == 0);
+    int argCnt = (int)(argSize / (int)REGSIZE_BYTES);
 
     if (callType >= EC_INDIR_R)
     {
@@ -7471,12 +7469,12 @@ void emitter::emitIns_Call(EmitCallType          callType,
     emitThisGCrefRegs = gcrefRegs;
     emitThisByrefRegs = byrefRegs;
 
+    bool isNoGCHelper = emitNoGChelper(Compiler::eeGetHelperNum(methHnd));
+    id->idSetIsNoGC(isNoGCHelper);
+
     /* Set the instruction - special case jumping a function */
     instruction ins;
     insFormat   fmt = IF_NONE;
-
-    bool isNoGCHelper = emitNoGChelper(Compiler::eeGetHelperNum(methHnd));
-    id->idSetIsNoGC(isNoGCHelper);
 
     /* Record the address: method, indirection, or funcptr */
 

--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -7413,35 +7413,8 @@ void emitter::emitIns_Call(EmitCallType          callType,
     int        argCnt;
     instrDesc* id;
 
-    /* This is the saved set of registers after a normal call */
-    regMaskTP savedSet = RBM_CALLEE_SAVED;
-
-    /* some special helper calls have a different saved set registers */
-
-    if (isNoGC)
-    {
-        assert(emitNoGChelper(Compiler::eeGetHelperNum(methHnd)));
-
-        // Get the set of registers that this call kills and remove it from the saved set.
-        savedSet = RBM_ALLINT & ~emitComp->compNoGCHelperCallKillSet(Compiler::eeGetHelperNum(methHnd));
-
-#ifdef DEBUG
-        if (emitComp->verbose)
-        {
-            printf("NOGC Call: savedSet=");
-            printRegMaskInt(savedSet);
-            emitDispRegSet(savedSet);
-            printf("\n");
-        }
-#endif
-    }
-    else
-    {
-        assert(!emitNoGChelper(Compiler::eeGetHelperNum(methHnd)));
-    }
-
-    /* Trim out any callee-trashed registers from the live set */
-
+    // Trim out any callee-trashed registers from the live set.
+    regMaskTP savedSet = GetSavedSet(methHnd);
     gcrefRegs &= savedSet;
     byrefRegs &= savedSet;
 

--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -7410,7 +7410,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
     assert((unsigned)abs(argSize) <= codeGen->genStackLevel);
 
     // Trim out any callee-trashed registers from the live set.
-    regMaskTP savedSet = GetSavedSet(methHnd);
+    regMaskTP savedSet = emitGetSavedGCRegsSet(methHnd);
     gcrefRegs &= savedSet;
     byrefRegs &= savedSet;
 

--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -7410,7 +7410,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
     assert((unsigned)abs(argSize) <= codeGen->genStackLevel);
 
     // Trim out any callee-trashed registers from the live set.
-    regMaskTP savedSet = emitGetSavedGCRegsSet(methHnd);
+    regMaskTP savedSet = emitGetGCRegsSavedOrModified(methHnd);
     gcrefRegs &= savedSet;
     byrefRegs &= savedSet;
 

--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -7469,8 +7469,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
     emitThisGCrefRegs = gcrefRegs;
     emitThisByrefRegs = byrefRegs;
 
-    bool isNoGCHelper = emitNoGChelper(Compiler::eeGetHelperNum(methHnd));
-    id->idSetIsNoGC(isNoGCHelper);
+    id->idSetIsNoGC(emitNoGChelper(methHnd));
 
     /* Set the instruction - special case jumping a function */
     instruction ins;

--- a/src/jit/emitarm64.h
+++ b/src/jit/emitarm64.h
@@ -821,8 +821,7 @@ void emitIns_Call(EmitCallType          callType,
                   regNumber        xreg     = REG_NA,
                   unsigned         xmul     = 0,
                   ssize_t          disp     = 0,
-                  bool             isJump   = false,
-                  bool             isNoGC   = false);
+                  bool             isJump   = false);
 
 BYTE* emitOutputLJ(insGroup* ig, BYTE* dst, instrDesc* i);
 unsigned emitOutputCall(insGroup* ig, BYTE* dst, instrDesc* i, code_t code);

--- a/src/jit/emitarm64.h
+++ b/src/jit/emitarm64.h
@@ -816,14 +816,13 @@ void emitIns_Call(EmitCallType          callType,
                   VARSET_VALARG_TP ptrVars,
                   regMaskTP        gcrefRegs,
                   regMaskTP        byrefRegs,
-                  IL_OFFSETX       ilOffset      = BAD_IL_OFFSET,
-                  regNumber        ireg          = REG_NA,
-                  regNumber        xreg          = REG_NA,
-                  unsigned         xmul          = 0,
-                  ssize_t          disp          = 0,
-                  bool             isJump        = false,
-                  bool             isNoGC        = false,
-                  bool             isProfLeaveCB = false);
+                  IL_OFFSETX       ilOffset = BAD_IL_OFFSET,
+                  regNumber        ireg     = REG_NA,
+                  regNumber        xreg     = REG_NA,
+                  unsigned         xmul     = 0,
+                  ssize_t          disp     = 0,
+                  bool             isJump   = false,
+                  bool             isNoGC   = false);
 
 BYTE* emitOutputLJ(insGroup* ig, BYTE* dst, instrDesc* i);
 unsigned emitOutputCall(insGroup* ig, BYTE* dst, instrDesc* i, code_t code);

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -6858,7 +6858,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
 #endif // STACK_PROBES
 
     // Trim out any callee-trashed registers from the live set.
-    regMaskTP savedSet = emitGetSavedGCRegsSet(methHnd);
+    regMaskTP savedSet = emitGetGCRegsSavedOrModified(methHnd);
     gcrefRegs &= savedSet;
     byrefRegs &= savedSet;
 

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -6863,23 +6863,8 @@ void emitter::emitIns_Call(EmitCallType          callType,
     UNATIVE_OFFSET sz;
     instrDesc*     id;
 
-    /* This is the saved set of registers after a normal call */
-    unsigned savedSet = RBM_CALLEE_SAVED;
-
-    /* some special helper calls have a different saved set registers */
-
-    if (isNoGC)
-    {
-        // Get the set of registers that this call kills and remove it from the saved set.
-        savedSet = RBM_ALLINT & ~emitComp->compNoGCHelperCallKillSet(Compiler::eeGetHelperNum(methHnd));
-    }
-    else
-    {
-        assert(!emitNoGChelper(Compiler::eeGetHelperNum(methHnd)));
-    }
-
-    /* Trim out any callee-trashed registers from the live set */
-
+    // Trim out any callee-trashed registers from the live set.
+    regMaskTP savedSet = GetSavedSet(methHnd);
     gcrefRegs &= savedSet;
     byrefRegs &= savedSet;
 

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -6858,7 +6858,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
 #endif // STACK_PROBES
 
     // Trim out any callee-trashed registers from the live set.
-    regMaskTP savedSet = GetSavedSet(methHnd);
+    regMaskTP savedSet = emitGetSavedGCRegsSet(methHnd);
     gcrefRegs &= savedSet;
     byrefRegs &= savedSet;
 

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -6950,7 +6950,8 @@ void emitter::emitIns_Call(EmitCallType          callType,
     }
     id->idIns(ins);
 
-    id->idSetIsNoGC(isNoGC);
+    bool isNoGCHelper = emitNoGChelper(Compiler::eeGetHelperNum(methHnd));
+    id->idSetIsNoGC(isNoGCHelper);
 
     // Record the address: method, indirection, or funcptr
     if (callType >= EC_FUNC_VIRTUAL)

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -6857,11 +6857,6 @@ void emitter::emitIns_Call(EmitCallType          callType,
     }
 #endif // STACK_PROBES
 
-    int argCnt;
-
-    UNATIVE_OFFSET sz;
-    instrDesc*     id;
-
     // Trim out any callee-trashed registers from the live set.
     regMaskTP savedSet = GetSavedSet(methHnd);
     gcrefRegs &= savedSet;
@@ -6882,9 +6877,6 @@ void emitter::emitIns_Call(EmitCallType          callType,
     }
 #endif
 
-    assert(argSize % REGSIZE_BYTES == 0);
-    argCnt = (int)(argSize / (int)REGSIZE_BYTES); // we need a signed-divide
-
     /* Managed RetVal: emit sequence point for the call */
     if (emitComp->opts.compDbgInfo && ilOffset != BAD_IL_OFFSET)
     {
@@ -6904,6 +6896,11 @@ void emitter::emitIns_Call(EmitCallType          callType,
             Direct call with GC vars          9,440
             Indir. call with GC vars          5,768
      */
+
+    instrDesc* id;
+
+    assert(argSize % REGSIZE_BYTES == 0);
+    int argCnt = (int)(argSize / (int)REGSIZE_BYTES); // we need a signed-divide
 
     if (callType >= EC_FUNC_VIRTUAL)
     {
@@ -6951,6 +6948,8 @@ void emitter::emitIns_Call(EmitCallType          callType,
 
     bool isNoGCHelper = emitNoGChelper(Compiler::eeGetHelperNum(methHnd));
     id->idSetIsNoGC(isNoGCHelper);
+
+    UNATIVE_OFFSET sz;
 
     // Record the address: method, indirection, or funcptr
     if (callType >= EC_FUNC_VIRTUAL)

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -6752,8 +6752,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
                            regNumber             xreg,     // = REG_NA
                            unsigned              xmul,     // = 0
                            ssize_t               disp,     // = 0
-                           bool                  isJump,   // = false
-                           bool                  isNoGC)   // = false
+                           bool                  isJump)   // = false
 // clang-format on
 {
     /* Sanity check the arguments depending on callType */

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -6946,8 +6946,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
     }
     id->idIns(ins);
 
-    bool isNoGCHelper = emitNoGChelper(Compiler::eeGetHelperNum(methHnd));
-    id->idSetIsNoGC(isNoGCHelper);
+    id->idSetIsNoGC(emitNoGChelper(methHnd));
 
     UNATIVE_OFFSET sz;
 

--- a/src/jit/emitxarch.h
+++ b/src/jit/emitxarch.h
@@ -503,21 +503,6 @@ enum EmitCallType
 // clang-format off
 void emitIns_Call(EmitCallType          callType,
                   CORINFO_METHOD_HANDLE methHnd,
-                  CORINFO_SIG_INFO*     sigInfo, // used to report call sites to the EE
-                  void*                 addr,
-                  ssize_t               argSize,
-                  emitAttr              retSize
-                  MULTIREG_HAS_SECOND_GC_RET_ONLY_ARG(emitAttr secondRetSize),
-                  VARSET_VALARG_TP      ptrVars,
-                  regMaskTP             gcrefRegs,
-                  regMaskTP             byrefRegs,
-                  GenTreeIndir*         indir,
-                  bool                  isJump = false);
-// clang-format on
-
-// clang-format off
-void emitIns_Call(EmitCallType          callType,
-                  CORINFO_METHOD_HANDLE methHnd,
                   INDEBUG_LDISASM_COMMA(CORINFO_SIG_INFO* sigInfo) // used to report call sites to the EE
                   void*                 addr,
                   ssize_t               argSize,

--- a/src/jit/emitxarch.h
+++ b/src/jit/emitxarch.h
@@ -512,8 +512,7 @@ void emitIns_Call(EmitCallType          callType,
                   regMaskTP             gcrefRegs,
                   regMaskTP             byrefRegs,
                   GenTreeIndir*         indir,
-                  bool                  isJump = false,
-                  bool                  isNoGC = false);
+                  bool                  isJump = false);
 // clang-format on
 
 // clang-format off
@@ -532,8 +531,7 @@ void emitIns_Call(EmitCallType          callType,
                   regNumber             xreg     = REG_NA,
                   unsigned              xmul     = 0,
                   ssize_t               disp     = 0,
-                  bool                  isJump   = false,
-                  bool                  isNoGC   = false);
+                  bool                  isJump   = false);
 // clang-format on
 
 #ifdef _TARGET_AMD64_


### PR DESCRIPTION
This PR cleans `emitter::emitIns_Call` by deleting two unnecessary arguments that made it harder to read and check (`isNoGC`, `isProfLeaveCB`).

Also it refactors their code a bit and extracts common parts into platform independent methods.

Found during my work on #19361.

No diffs on x86/x64.