### PR TITLE
JIT: add option to dump jit-generated debug info

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -3264,6 +3264,7 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     opts.disDiffable     = false;
     opts.dspCode         = false;
     opts.dspEHTable      = false;
+    opts.dspDebugInfo    = false;
     opts.dspGCtbls       = false;
     opts.disAsm2         = false;
     opts.dspUnwind       = false;
@@ -3311,6 +3312,11 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
             if (JitConfig.NgenEHDump().contains(info.compMethodName, info.compClassName, &info.compMethodInfo->args))
             {
                 opts.dspEHTable = true;
+            }
+
+            if (JitConfig.NgenDebugDump().contains(info.compMethodName, info.compClassName, &info.compMethodInfo->args))
+            {
+                opts.dspDebugInfo = true;
             }
         }
         else
@@ -3372,6 +3378,12 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
                 if (JitConfig.JitEHDump().contains(info.compMethodName, info.compClassName, &info.compMethodInfo->args))
                 {
                     opts.dspEHTable = true;
+                }
+
+                if (JitConfig.JitDebugDump().contains(info.compMethodName, info.compClassName,
+                                                      &info.compMethodInfo->args))
+                {
+                    opts.dspDebugInfo = true;
                 }
             }
         }

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -8165,6 +8165,7 @@ public:
         bool compProcedureSplittingEH; // Separate cold code from hot code for functions with EH
         bool dspCode;                  // Display native code generated
         bool dspEHTable;               // Display the EH table reported to the VM
+        bool dspDebugInfo;             // Display the Debug info reported to the VM
         bool dspInstrs;                // Display the IL instructions intermixed with the native code output
         bool dspEmit;                  // Display emitter output
         bool dspLines;                 // Display source-code lines intermixed with native code output

--- a/src/jit/ee_il_dll.cpp
+++ b/src/jit/ee_il_dll.cpp
@@ -657,7 +657,7 @@ void Compiler::eeSetLVdone()
     assert(opts.compScopeInfo);
 
 #ifdef DEBUG
-    if (verbose)
+    if (verbose || opts.dspDebugInfo)
     {
         eeDispVars(info.compMethodHnd, eeVarsCount, (ICorDebugInfo::NativeVarInfo*)eeVars);
     }
@@ -943,7 +943,7 @@ void Compiler::eeSetLIdone()
     assert(opts.compDbgInfo);
 
 #if defined(DEBUG)
-    if (verbose)
+    if (verbose || opts.dspDebugInfo)
     {
         eeDispLineInfos();
     }

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -151,6 +151,7 @@ CONFIG_METHODSET(JitEHDump, W("JitEHDump"))                  // Dump the EH tabl
 CONFIG_METHODSET(JitExclude, W("JitExclude"))
 CONFIG_METHODSET(JitForceProcedureSplitting, W("JitForceProcedureSplitting"))
 CONFIG_METHODSET(JitGCDump, W("JitGCDump"))
+CONFIG_METHODSET(JitDebugDump, W("JitDebugDump"))
 CONFIG_METHODSET(JitHalt, W("JitHalt")) // Emits break instruction into jitted code
 CONFIG_METHODSET(JitImportBreak, W("JitImportBreak"))
 CONFIG_METHODSET(JitInclude, W("JitInclude"))
@@ -171,6 +172,7 @@ CONFIG_METHODSET(NgenDump, W("NgenDump"))     // Same as JitDump, but for ngen
 CONFIG_METHODSET(NgenDumpIR, W("NgenDumpIR")) // Same as JitDumpIR, but for ngen
 CONFIG_METHODSET(NgenEHDump, W("NgenEHDump")) // Dump the EH table for the method, as reported to the VM
 CONFIG_METHODSET(NgenGCDump, W("NgenGCDump"))
+CONFIG_METHODSET(NgenDebugDump, W("NgenDebugDump"))
 CONFIG_METHODSET(NgenUnwindDump, W("NgenUnwindDump")) // Dump the unwind codes for the method
 ///
 /// JIT


### PR DESCRIPTION
Add dump option for debug info (like the ones we have for gc info,
eh, unwind, etc) so we can more readily verify jit changes that are
might impact debug info generation.