### PR TITLE
TimerHolder shouldn't hold TimerQueueTimer in Finalization queue

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/Timer.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Timer.cs
@@ -658,14 +658,28 @@ namespace System.Threading
 
         public void Close()
         {
-            m_timer.Close();
-            GC.SuppressFinalize(this);
+            TimerQueueTimer timer = m_timer;
+            if (timer != null)
+            {
+                timer.Close();
+                // Don't hold on to Timer while waiting in Finalization queue
+                m_timer = null;
+                GC.SuppressFinalize(this);
+            }
         }
 
         public bool Close(WaitHandle notifyObject)
         {
-            bool result = m_timer.Close(notifyObject);
-            GC.SuppressFinalize(this);
+            bool result = false;
+            TimerQueueTimer timer = m_timer;
+            if (timer != null)
+            {
+                result = timer.Close(notifyObject);
+                // Don't hold on to Timer while waiting in Finalization queue
+                m_timer = null;
+                GC.SuppressFinalize(this);
+            }
+
             return result;
         }
     }


### PR DESCRIPTION
Been doing some investigations on memory "leaks" in ASP.NET Core with @davidfowl an this cropped up:

When a `Timer` is `Dispose`d its `TimerHolder` sits in the Finalization queue until its processed by the Finalization thread (even though `GC.SuppressFinalize` is called on it as it gets added to the queue at `new` rather than at GC)

As it currently holds onto its `TimerQueueTimer` reference that is also kept alive.  `TimerQueueTimer` then holds onto the `TimerCallback`, `object state` and `ExecutionContext`.

In ASP.NET Core the `ExecutionContext` can then hold onto logging contexts and `HttpContext` which can then hold onto a whole web of stuff.

This breaks the reference to `TimerQueueTimer` when the timer is `Dispose`d so that memory won't remain for an unexpected amount of time.

Resolves https://github.com/dotnet/coreclr/issues/19816

/cc @jkotas @stephentoub 