### PR TITLE
Virtual AttributeType property and signature generic types

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Type.cs
+++ b/src/System.Private.CoreLib/shared/System/Type.cs
@@ -346,6 +346,21 @@ namespace System
         public virtual Type MakeGenericType(params Type[] typeArguments) { throw new NotSupportedException(SR.NotSupported_SubclassOverride); }
         public virtual Type MakePointerType() { throw new NotSupportedException(); }
 
+        public static Type MakeGenericSignatureType(Type genericTypeDefinition, params Type[] typeArguments)
+        {
+            if (genericTypeDefinition == null)
+                throw new ArgumentNullException(nameof(genericTypeDefinition));
+            if (typeArguments == null)
+                throw new ArgumentNullException(nameof(typeArguments));
+            for (int i = 0; i < typeArguments.Length; i++)
+            {
+                if (typeArguments[i] == null)
+                    throw new ArgumentNullException();
+            }
+
+            return new SignatureConstructedGenericType(genericTypeDefinition, typeArguments);
+        }
+
         public static Type MakeGenericMethodParameter(int position)
         {
             if (position < 0)

--- a/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -500,7 +500,7 @@ namespace System.Reflection
         #endregion
 
         #region Public Members
-        public Type AttributeType { get { return Constructor.DeclaringType; } }
+        public virtual Type AttributeType { get { return Constructor.DeclaringType; } }
 
         public virtual ConstructorInfo Constructor { get { return m_ctor; } }
 


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/31614


1. This will allow Reflection providers the option
to supply the attribute type without building
an entire constructor.


https://github.com/dotnet/corefx/issues/31798

2. This will permit other Reflection providers
to support Type.MakeGenericMethodParameter()
in their implementations.