### PR TITLE
add a regression test for Linux GC segfault.

### DIFF
--- a/tests/src/JIT/Regression/JitBlue/GitHub_19361/GitHub_19361.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_19361/GitHub_19361.cs
@@ -89,7 +89,7 @@ namespace Repro
         {
             Console.WriteLine("Starting stress loop");
             var compositeSources = GetCompositeSources();
-            var res = Parallel.For(0, 20, i =>
+            var res = Parallel.For(0, 10, i =>
             {
                 int seed;
                 lock (Rng)

--- a/tests/src/JIT/Regression/JitBlue/GitHub_19361/GitHub_19361.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_19361/GitHub_19361.csproj
@@ -10,6 +10,7 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>


### PR DESCRIPTION
Add test written by @corruptmem for #19361.

The test reproes segfault on Linux x64. The number of iteration was reduced to take no longer than 30 seconds to run this test in ci. It hits the original issue pretty consistently even without GCStress.