### PR TITLE
Cross-bitness changes in value numbering

### DIFF
--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -1901,8 +1901,12 @@ public:
         Compiler* comp, struct ArrayInfo* arrayInfo, GenTree** pArr, ValueNum* pInxVN, FieldSeqNode** pFldSeq);
 
     // Helper method for the above.
-    void ParseArrayAddressWork(
-        Compiler* comp, ssize_t inputMul, GenTree** pArr, ValueNum* pInxVN, ssize_t* pOffset, FieldSeqNode** pFldSeq);
+    void ParseArrayAddressWork(Compiler*       comp,
+                               target_ssize_t  inputMul,
+                               GenTree**       pArr,
+                               ValueNum*       pInxVN,
+                               target_ssize_t* pOffset,
+                               FieldSeqNode**  pFldSeq);
 
     // Requires "this" to be a GT_IND.  Requires the outermost caller to set "*pFldSeq" to nullptr.
     // Returns true if it is an array index expression, or access to a (sequence of) struct field(s)

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -7691,7 +7691,8 @@ void Compiler::fgValueNumberHelperCallFunc(GenTreeCall* call, VNFunc vnf, ValueN
 #ifdef FEATURE_READYTORUN_COMPILER
         if (useEntryPointAddrAsArg0)
         {
-            ValueNum callAddrVN = vnStore->VNForPtrSizeIntCon((ssize_t)call->gtCall.gtEntryPoint.addr);
+            ssize_t  addrValue  = (ssize_t)call->gtEntryPoint.addr;
+            ValueNum callAddrVN = vnStore->VNForHandle(addrValue, GTF_ICON_FTN_ADDR);
             vnp0                = ValueNumPair(callAddrVN, callAddrVN);
         }
         else


### PR DESCRIPTION
1. Changes in **src/jit/gentree.cpp** **src/jit/gentree.h** are replacing ssize_t with target_ssize_t in GenTree::ParseArrayAddress and GenTree::ParseArrayAddressWork and adding castings for gtIconVal to target_ssize_t. This is needed to get rid of compilation warnings.

2. Changes in **src/jit/valuenum.cpp** is using VNForHandle(addrValue, GTF_ICON_FTN_ADDR) instead of VNForPtrSizeIntCon for function address. As far as I understood, VNForPtrSizeIntCon should be left target-specific and used only for target IntPtr sized (non-relocatable) constants.

@briansull Can you please review this?