### PR TITLE
During CrossGen allocate MethodDescChunk per MethodDesc

### DIFF
--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -6787,8 +6787,10 @@ VOID MethodTableBuilder::AllocAndInitMethodDescs()
             }
         }
 
+#ifndef CROSSGEN_COMPILE
         if (tokenRange != currentTokenRange ||
             sizeOfMethodDescs + size > MethodDescChunk::MaxSizeOfMethodDescs)
+#endif // CROSSGEN_COMPILE
         {
             if (sizeOfMethodDescs != 0)
             {


### PR DESCRIPTION
During CrossGen allocate `MethodDescChunk` for every `MethodDesc` in `MethodTableBuilder::AllocAndInitMethodDescs`. This is needed to prevent difference in binary outputs of x86_arm and x64_arm crossgen-s due to different iteration order when using `IntroducedMethodIterator` to compose a native image.

@jkotas Can you please review this?